### PR TITLE
Make auto-publish script more robust

### DIFF
--- a/scripts/publish.rs
+++ b/scripts/publish.rs
@@ -444,19 +444,18 @@ fn publish(krate: &Crate) -> bool {
 
     // First make sure the crate isn't already published at this version. This
     // script may be re-run and there's no need to re-attempt previous work.
-    let output = cmd_output(Command::new("curl").arg(&format!(
+    let output = curl(&format!(
         "https://crates.io/api/v1/crates/{}/versions",
         krate.name
-    )));
-    if output.status.success()
-        && String::from_utf8_lossy(&output.stdout)
-            .contains(&format!("\"num\":\"{}\"", krate.version))
-    {
-        println!(
-            "skip publish {} because {} is already published",
-            krate.name, krate.version,
-        );
-        return true;
+    ));
+    if let Some(output) = output {
+        if output.contains(&format!("\"num\":\"{}\"", krate.version)) {
+            println!(
+                "skip publish {} because {} is already published",
+                krate.name, krate.version,
+            );
+            return true;
+        }
     }
 
     let status = cmd_status(
@@ -473,18 +472,18 @@ fn publish(krate: &Crate) -> bool {
     // After we've published then make sure that the `wasmtime-publish` group is
     // added to this crate for future publications. If it's already present
     // though we can skip the `cargo owner` modification.
-    let output = cmd_output(Command::new("curl").arg(&format!(
+    let output = curl(&format!(
         "https://crates.io/api/v1/crates/{}/owners",
         krate.name
-    )));
-    if output.status.success()
-        && String::from_utf8_lossy(&output.stdout).contains("wasmtime-publish")
-    {
-        println!(
-            "wasmtime-publish already listed as an owner of {}",
-            krate.name
-        );
-        return true;
+    ));
+    if let Some(output) = output {
+        if output.contains("wasmtime-publish") {
+            println!(
+                "wasmtime-publish already listed as an owner of {}",
+                krate.name
+            );
+            return true;
+        }
     }
 
     // Note that the status is ignored here. This fails most of the time because
@@ -499,6 +498,21 @@ fn publish(krate: &Crate) -> bool {
     );
 
     true
+}
+
+fn curl(url: &str) -> Option<String> {
+    let output = cmd_output(
+        Command::new("curl")
+            .arg("--user-agent")
+            .arg("bytecodealliance/wasmtime auto-publish script")
+            .arg(url),
+    );
+    if !output.status.success() {
+        println!("failed to curl: {}", output.status);
+        println!("stderr: {}", String::from_utf8_lossy(&output.stderr));
+        return None;
+    }
+    Some(String::from_utf8_lossy(&output.stdout).into())
 }
 
 // Verify the current tree is publish-able to crates.io. The intention here is


### PR DESCRIPTION
* Add a helper to run `curl` and get the output
* Print an error if `curl` fails to help diagnose what went wrong in the future
* Pass a custom `--user-agent` which is requested by crates.io's [data access policy](https://crates.io/data-access).

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
