### PR TITLE
pulley: Clean up some iconst lowering

### DIFF
--- a/cranelift/codegen/src/isa/pulley_shared/inst.isle
+++ b/cranelift/codegen/src/isa/pulley_shared/inst.isle
@@ -619,50 +619,18 @@
 ;;;; Materializing Constants ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Lower a constant into a register.
-(decl imm (Type u64) Reg)
+(decl imm (i64) Reg)
 
-(rule 8 (imm (ty_int _) 0) (pulley_xzero))
-(rule 7 (imm (ty_int _) 1) (pulley_xone))
+;; Special case some instructions with no immediates
+(rule 6 (imm 0) (pulley_xzero))
+(rule 5 (imm 1) (pulley_xone))
 
-;; If a value is 8 bits, we always use `xconst8`
-(rule 6 (imm $I8 x) (pulley_xconst8 (u8_cast_signed (u64_truncate_into_u8 x))))
-
-;; If a value can fit into 8 bits, then prioritize that.
-(rule 5 (imm (ty_int ty) x)
-      (if-let y (i64_truncate_into_i8 (u64_cast_signed x)))
-      (if-let true (u64_eq (u64_and (i64_cast_unsigned (i8_into_i64 y)) (ty_mask ty))
-                           (u64_and x (ty_mask ty))))
-      (pulley_xconst8 y))
-
-;; If a value is 16 bits, and we couldn't fit it into 8 bits, then use
-;; `xconst16`.
-(rule 4 (imm $I16 x) (pulley_xconst16 (u16_cast_signed (u64_truncate_into_u16 x))))
-
-;; If a value can fit into 16 bits, then prioritize that.
-(rule 3 (imm (ty_int ty) x)
-      (if-let y (i64_truncate_into_i16 (u64_cast_signed x)))
-      (if-let true (u64_eq (u64_and (i64_cast_unsigned (i16_into_i64 y)) (ty_mask ty))
-                           (u64_and x (ty_mask ty))))
-      (pulley_xconst16 y))
-
-;; If a value is 32 bits, and we couldn't fit it into 8 or 16 bits, then use
-;; `xconst32`.
-(rule 2 (imm $I32 x) (pulley_xconst32 (u32_cast_signed (u64_truncate_into_u32 x))))
-
-;; If a value can fit into 32 bits, then prioritize that.
-(rule 1 (imm (ty_int ty) x)
-      (if-let y (i64_truncate_into_i32 (u64_cast_signed x)))
-      (if-let true (u64_eq (u64_and (i64_cast_unsigned (i32_into_i64 y)) (ty_mask ty))
-                           (u64_and x (ty_mask ty))))
-      (pulley_xconst32 y))
-
-;; If a value is 64 bits, and we couldn't fit it into 8, 16, or 32 bits, then
-;; use `xconst64`.
-(rule 0 (imm $I64 x) (pulley_xconst64 (u64_cast_signed x)))
-
-;; Base cases for floats.
-(rule 0 (imm $F32 (u32_from_u64 c)) (pulley_fconst32 c))
-(rule 0 (imm $F64 c) (pulley_fconst64 c))
+;; For integer constants use the smallest instructions we can that fits the
+;; desired value
+(rule 4 (imm (i8_from_i64 imm)) (pulley_xconst8 imm))
+(rule 3 (imm (i16_from_i64 imm)) (pulley_xconst16 imm))
+(rule 2 (imm (i32_from_i64 imm)) (pulley_xconst32 imm))
+(rule 1 (imm imm) (pulley_xconst64 imm))
 
 ;;;; Instruction Constructors ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/cranelift/codegen/src/isa/pulley_shared/lower.isle
+++ b/cranelift/codegen/src/isa/pulley_shared/lower.isle
@@ -221,16 +221,15 @@
 
 ;;;; Rules for `iconst` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(rule (lower (has_type ty (iconst (u64_from_imm64 n))))
-      (imm ty n))
+(rule (lower (has_type ty (iconst c))) (imm (i64_sextend_imm64 ty c)))
 
 ;;;; Rules for `f32const`;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(rule (lower (f32const (u32_from_ieee32 x))) (imm $F32 x))
+(rule (lower (f32const (u32_from_ieee32 x))) (pulley_fconst32 x))
 
 ;;;; Rules for `f64const`;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(rule (lower (f64const (u64_from_ieee64 x))) (imm $F64 x))
+(rule (lower (f64const (u64_from_ieee64 x))) (pulley_fconst64 x))
 
 ;;;; Rules for `iadd` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -1368,51 +1367,31 @@
 (rule (emit_cond (Cond.IfXult64 src1 src2)) (pulley_xult64 src1 src2))
 (rule (emit_cond (Cond.IfXulteq64 src1 src2)) (pulley_xulteq64 src1 src2))
 
-(rule (emit_cond (Cond.IfXeq32I32 src1 src2))
-  (pulley_xeq32 src1 (imm $I32 (i64_cast_unsigned src2))))
-(rule (emit_cond (Cond.IfXneq32I32 src1 src2))
-  (pulley_xneq32 src1 (imm $I32 (i64_cast_unsigned src2))))
-(rule (emit_cond (Cond.IfXslt32I32 src1 src2))
-  (pulley_xslt32 src1 (imm $I32 (i64_cast_unsigned src2))))
-(rule (emit_cond (Cond.IfXslteq32I32 src1 src2))
-  (pulley_xslteq32 src1 (imm $I32 (i64_cast_unsigned src2))))
-(rule (emit_cond (Cond.IfXult32I32 src1 src2))
-  (pulley_xult32 src1 (imm $I32 src2)))
-(rule (emit_cond (Cond.IfXulteq32I32 src1 src2))
-  (pulley_xulteq32 src1 (imm $I32 src2)))
+(rule (emit_cond (Cond.IfXeq32I32 src1 src2)) (pulley_xeq32 src1 (imm src2)))
+(rule (emit_cond (Cond.IfXneq32I32 src1 src2)) (pulley_xneq32 src1 (imm src2)))
+(rule (emit_cond (Cond.IfXslt32I32 src1 src2)) (pulley_xslt32 src1 (imm src2)))
+(rule (emit_cond (Cond.IfXslteq32I32 src1 src2)) (pulley_xslteq32 src1 (imm src2)))
+(rule (emit_cond (Cond.IfXult32I32 src1 src2)) (pulley_xult32 src1 (imm src2)))
+(rule (emit_cond (Cond.IfXulteq32I32 src1 src2)) (pulley_xulteq32 src1 (imm src2)))
 
 ;; Note the operand swaps here
-(rule (emit_cond (Cond.IfXsgt32I32 src1 src2))
-  (pulley_xslt32 (imm $I32 (i64_cast_unsigned src2)) src1))
-(rule (emit_cond (Cond.IfXsgteq32I32 src1 src2))
-  (pulley_xslteq32 (imm $I32 (i64_cast_unsigned src2)) src1))
-(rule (emit_cond (Cond.IfXugt32I32 src1 src2))
-  (pulley_xult32 (imm $I32 src2) src1))
-(rule (emit_cond (Cond.IfXugteq32I32 src1 src2))
-  (pulley_xulteq32 (imm $I32 src2) src1))
+(rule (emit_cond (Cond.IfXsgt32I32 src1 src2)) (pulley_xslt32 (imm src2) src1))
+(rule (emit_cond (Cond.IfXsgteq32I32 src1 src2)) (pulley_xslteq32 (imm src2) src1))
+(rule (emit_cond (Cond.IfXugt32I32 src1 src2)) (pulley_xult32 (imm src2) src1))
+(rule (emit_cond (Cond.IfXugteq32I32 src1 src2)) (pulley_xulteq32 (imm src2) src1))
 
-(rule (emit_cond (Cond.IfXeq64I32 src1 src2))
-  (pulley_xeq64 src1 (imm $I64 (i64_cast_unsigned src2))))
-(rule (emit_cond (Cond.IfXneq64I32 src1 src2))
-  (pulley_xneq64 src1 (imm $I64 (i64_cast_unsigned src2))))
-(rule (emit_cond (Cond.IfXslt64I32 src1 src2))
-  (pulley_xslt64 src1 (imm $I64 (i64_cast_unsigned src2))))
-(rule (emit_cond (Cond.IfXslteq64I32 src1 src2))
-  (pulley_xslteq64 src1 (imm $I64 (i64_cast_unsigned src2))))
-(rule (emit_cond (Cond.IfXult64I32 src1 src2))
-  (pulley_xult64 src1 (imm $I64 src2)))
-(rule (emit_cond (Cond.IfXulteq64I32 src1 src2))
-  (pulley_xulteq64 src1 (imm $I64 src2)))
+(rule (emit_cond (Cond.IfXeq64I32 src1 src2)) (pulley_xeq64 src1 (imm src2)))
+(rule (emit_cond (Cond.IfXneq64I32 src1 src2)) (pulley_xneq64 src1 (imm src2)))
+(rule (emit_cond (Cond.IfXslt64I32 src1 src2)) (pulley_xslt64 src1 (imm src2)))
+(rule (emit_cond (Cond.IfXslteq64I32 src1 src2)) (pulley_xslteq64 src1 (imm src2)))
+(rule (emit_cond (Cond.IfXult64I32 src1 src2)) (pulley_xult64 src1 (imm src2)))
+(rule (emit_cond (Cond.IfXulteq64I32 src1 src2)) (pulley_xulteq64 src1 (imm src2)))
 
 ;; Note the operand swaps here
-(rule (emit_cond (Cond.IfXsgt64I32 src1 src2))
-  (pulley_xslt64 (imm $I64 (i64_cast_unsigned src2)) src1))
-(rule (emit_cond (Cond.IfXsgteq64I32 src1 src2))
-  (pulley_xslteq64 (imm $I64 (i64_cast_unsigned src2)) src1))
-(rule (emit_cond (Cond.IfXugt64I32 src1 src2))
-  (pulley_xult64 (imm $I64 src2) src1))
-(rule (emit_cond (Cond.IfXugteq64I32 src1 src2))
-  (pulley_xulteq64 (imm $I64 src2) src1))
+(rule (emit_cond (Cond.IfXsgt64I32 src1 src2)) (pulley_xslt64 (imm src2) src1))
+(rule (emit_cond (Cond.IfXsgteq64I32 src1 src2)) (pulley_xslteq64 (imm src2) src1))
+(rule (emit_cond (Cond.IfXugt64I32 src1 src2)) (pulley_xult64 (imm src2) src1))
+(rule (emit_cond (Cond.IfXugteq64I32 src1 src2)) (pulley_xulteq64 (imm src2) src1))
 
 ;;;; Rules for `bitcast` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 


### PR DESCRIPTION
Shuffle around where some extends happen and the redefine the `imm` constructor as signed to cut down on the number of casts/calculations done.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
