### PR TITLE
x64: convert `vpextr*` instructions

### DIFF
--- a/cranelift/assembler-x64/meta/src/generate/format.rs
+++ b/cranelift/assembler-x64/meta/src/generate/format.rs
@@ -282,7 +282,7 @@ impl dsl::Format {
                     }
                 }
             },
-            [Reg(reg), Reg(rm)] => {
+            [Reg(reg), Reg(rm)] | [Reg(reg), Reg(rm), Imm(_)] => {
                 assert!(!vex.is4);
                 fmtln!(f, "let reg = self.{reg}.enc();");
                 fmtln!(f, "let rm = self.{rm}.encode_bx_regs();");
@@ -292,7 +292,7 @@ impl dsl::Format {
                     rm: *rm,
                 }
             }
-            [Reg(reg), Mem(rm)] | [Mem(rm), Reg(reg)] => {
+            [Reg(reg), Mem(rm)] | [Mem(rm), Reg(reg)] | [RegMem(rm), Reg(reg), Imm(_)] => {
                 assert!(!vex.is4);
                 fmtln!(f, "let reg = self.{reg}.enc();");
                 fmtln!(f, "let rm = self.{rm}.encode_bx_regs();");

--- a/cranelift/assembler-x64/meta/src/instructions.rs
+++ b/cranelift/assembler-x64/meta/src/instructions.rs
@@ -146,8 +146,16 @@ fn check_sse_matches_avx(sse_inst: &Inst, avx_inst: &Inst) {
             ],
         ) => {}
         (
-            [(Write, Reg(_)), (Read, Reg(_) | RegMem(_)), (Read, Imm(_))],
-            [(Write, Reg(_)), (Read, Reg(_) | RegMem(_)), (Read, Imm(_))],
+            [
+                (Write, Reg(_) | RegMem(_)),
+                (Read, Reg(_) | RegMem(_)),
+                (Read, Imm(_)),
+            ],
+            [
+                (Write, Reg(_) | RegMem(_)),
+                (Read, Reg(_) | RegMem(_)),
+                (Read, Imm(_)),
+            ],
         ) => {}
         (
             [(ReadWrite, Reg(_)), (Read, RegMem(_)), (Read, Imm(_))],

--- a/cranelift/assembler-x64/meta/src/instructions/lanes.rs
+++ b/cranelift/assembler-x64/meta/src/instructions/lanes.rs
@@ -6,17 +6,22 @@ pub fn list() -> Vec<Inst> {
     // Note that `p{extr,ins}r{w,b}` below operate on 32-bit registers but a
     // smaller-width memory location. This means that disassembly in Capstone
     // doesn't match `rm8`, for example. For now pretend both of these are
-    // `rm32` to get diassembly matching Capstone.
+    // `rm32` to get disassembly matching Capstone.
     let r32m8 = rm32;
     let r32m16 = rm32;
 
     vec![
         // Extract from a single XMM lane.
-        inst("pextrb", fmt("A", [w(r32m8), r(xmm2), r(imm8)]), rex([0x66, 0x0F, 0x3A, 0x14]).r().ib(), _64b | compat | sse41),
-        inst("pextrw", fmt("A", [w(r32), r(xmm2), r(imm8)]), rex([0x66, 0x0F, 0xC5]).r().ib(), _64b | compat | sse2),
-        inst("pextrw", fmt("B", [w(r32m16), r(xmm2), r(imm8)]), rex([0x66, 0x0F, 0x3A, 0x15]).r().ib(), _64b | compat | sse41),
-        inst("pextrd", fmt("A", [w(rm32), r(xmm2), r(imm8)]), rex([0x66, 0x0F, 0x3A, 0x16]).r().ib(), _64b | compat | sse41),
-        inst("pextrq", fmt("A", [w(rm64), r(xmm2), r(imm8)]), rex([0x66, 0x0F, 0x3A, 0x16]).w().r().ib(), _64b | sse41),
+        inst("pextrb", fmt("A", [w(r32m8), r(xmm2), r(imm8)]), rex([0x66, 0x0F, 0x3A, 0x14]).r().ib(), _64b | compat | sse41).alt(avx, "vpextrb_a"),
+        inst("pextrw", fmt("A", [w(r32), r(xmm2), r(imm8)]), rex([0x66, 0x0F, 0xC5]).r().ib(), _64b | compat | sse2).alt(avx, "vpextrw_a"),
+        inst("pextrw", fmt("B", [w(r32m16), r(xmm2), r(imm8)]), rex([0x66, 0x0F, 0x3A, 0x15]).r().ib(), _64b | compat | sse41).alt(avx, "vpextrw_b"),
+        inst("pextrd", fmt("A", [w(rm32), r(xmm2), r(imm8)]), rex([0x66, 0x0F, 0x3A, 0x16]).r().ib(), _64b | compat | sse41).alt(avx, "vpextrd_a"),
+        inst("pextrq", fmt("A", [w(rm64), r(xmm2), r(imm8)]), rex([0x66, 0x0F, 0x3A, 0x16]).w().r().ib(), _64b | sse41).alt(avx, "vpextrq_a"),
+        inst("vpextrb", fmt("A", [w(r32m8), r(xmm2), r(imm8)]), vex(L128)._66()._0f3a().w0().op(0x14).r().ib(), _64b | compat | avx),
+        inst("vpextrw", fmt("A", [w(r32), r(xmm2), r(imm8)]), vex(L128)._66()._0f().w0().op(0xC5).r().ib(), _64b | compat | avx),
+        inst("vpextrw", fmt("B", [w(r32m16), r(xmm2), r(imm8)]), vex(L128)._66()._0f3a().w0().op(0x15).r().ib(), _64b | compat | avx),
+        inst("vpextrd", fmt("A", [w(rm32), r(xmm2), r(imm8)]), vex(L128)._66()._0f3a().w0().op(0x16).r().ib(), _64b | compat | avx),
+        inst("vpextrq", fmt("A", [w(rm64), r(xmm2), r(imm8)]), vex(L128)._66()._0f3a().w1().op(0x16).r().ib(), _64b | compat | avx),
 
         // Insert into a single XMM lane.
         inst("pinsrb", fmt("A", [rw(xmm1), r(r32m8), r(imm8)]), rex([0x66, 0x0F, 0x3A, 0x20]).r().ib(), _64b | compat | sse41),

--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -112,16 +112,6 @@
        (XmmMovRMVex (op AvxOpcode)
                     (src Xmm)
                     (dst SyntheticAmode))
-       (XmmMovRMImmVex (op AvxOpcode)
-                       (src Xmm)
-                       (dst SyntheticAmode)
-                       (imm u8))
-
-       ;; XMM (scalar) unary op (from xmm to integer reg): vpextr{w,b,d,q}
-       (XmmToGprImmVex (op AvxOpcode)
-                       (src Xmm)
-                       (dst WritableGpr)
-                       (imm u8))
 
        ;; Float comparisons/tests: cmp (b w l q) (reg addr imm) reg.
        (XmmCmpRmRVex (op AvxOpcode)
@@ -929,10 +919,6 @@
             Vmovups
             Vmovupd
             Vmovdqu
-            Vpextrb
-            Vpextrw
-            Vpextrd
-            Vpextrq
             Vpblendw
             Vsqrtss
             Vsqrtsd
@@ -1471,13 +1457,6 @@
             (_ Unit (emit (MInst.XmmUnaryRmRImmEvex op src dst imm))))
         dst))
 
-;; Helper for creating `MInst.XmmToGprImmVex` instructions.
-(decl xmm_to_gpr_imm_vex (AvxOpcode Xmm u8) Gpr)
-(rule (xmm_to_gpr_imm_vex op src imm)
-      (let ((dst WritableGpr (temp_writable_gpr))
-            (_ Unit (emit (MInst.XmmToGprImmVex op src dst imm))))
-        dst))
-
 ;; Helper for creating `xmm_min_max_seq` pseudo-instructions.
 (decl xmm_min_max_seq (Type bool Xmm Xmm) Xmm)
 (rule (xmm_min_max_seq ty is_min lhs rhs)
@@ -1902,10 +1881,6 @@
 (decl xmm_movrm_vex (AvxOpcode SyntheticAmode Xmm) SideEffectNoResult)
 (rule (xmm_movrm_vex op addr data)
       (SideEffectNoResult.Inst (MInst.XmmMovRMVex op data addr)))
-
-(decl xmm_movrm_imm_vex (AvxOpcode SyntheticAmode Xmm u8) SideEffectNoResult)
-(rule (xmm_movrm_imm_vex op addr data imm)
-      (SideEffectNoResult.Inst (MInst.XmmMovRMImmVex op data addr imm)))
 
 ;; Load a constant into an XMM register.
 (decl x64_xmm_load_const (Type VCodeConstant) Xmm)
@@ -3573,57 +3548,30 @@
 (rule (x64_vpsraq_imm src imm)
       (xmm_unary_rm_r_imm_evex (Avx512Opcode.VpsraqImm) src imm))
 
-;; Helper for creating `pextrb` instructions.
+;; Helper for creating `pextr*` instructions.
 (decl x64_pextrb (Xmm u8) Gpr)
-(rule (x64_pextrb src lane) (x64_pextrb_a src lane))
-(rule 1 (x64_pextrb src lane)
-        (if-let true (use_avx))
-        (xmm_to_gpr_imm_vex (AvxOpcode.Vpextrb) src lane))
+(rule (x64_pextrb src lane) (x64_pextrb_a_or_avx src lane))
 
 (decl x64_pextrb_store (Amode Xmm u8) SideEffectNoResult)
-(rule (x64_pextrb_store addr src lane) (x64_pextrb_a_mem addr src lane))
-(rule 1 (x64_pextrb_store addr src lane)
-        (if-let true (use_avx))
-        (xmm_movrm_imm_vex (AvxOpcode.Vpextrb) addr src lane))
+(rule (x64_pextrb_store addr src lane) (x64_pextrb_a_mem_or_avx addr src lane))
 
-;; Helper for creating `pextrw` instructions.
 (decl x64_pextrw (Xmm u8) Gpr)
-(rule (x64_pextrw src lane) (x64_pextrw_a src lane))
-(rule 1 (x64_pextrw src lane)
-        (if-let true (use_avx))
-        (xmm_to_gpr_imm_vex (AvxOpcode.Vpextrw) src lane))
+(rule (x64_pextrw src lane) (x64_pextrw_a_or_avx src lane))
 
 (decl x64_pextrw_store (Amode Xmm u8) SideEffectNoResult)
-(rule (x64_pextrw_store addr src lane) (x64_pextrw_b_mem addr src lane))
-(rule 1 (x64_pextrw_store addr src lane)
-        (if-let true (use_avx))
-        (xmm_movrm_imm_vex (AvxOpcode.Vpextrw) addr src lane))
+(rule (x64_pextrw_store addr src lane) (x64_pextrw_b_mem_or_avx addr src lane))
 
-;; Helper for creating `pextrd` instructions.
 (decl x64_pextrd (Xmm u8) Gpr)
-(rule (x64_pextrd src lane) (x64_pextrd_a src lane))
-(rule 1 (x64_pextrd src lane)
-        (if-let true (use_avx))
-        (xmm_to_gpr_imm_vex (AvxOpcode.Vpextrd) src lane))
+(rule (x64_pextrd src lane) (x64_pextrd_a_or_avx src lane))
 
 (decl x64_pextrd_store (Amode Xmm u8) SideEffectNoResult)
-(rule (x64_pextrd_store addr src lane) (x64_pextrd_a_mem addr src lane))
-(rule 1 (x64_pextrd_store addr src lane)
-        (if-let true (use_avx))
-        (xmm_movrm_imm_vex (AvxOpcode.Vpextrd) addr src lane))
+(rule (x64_pextrd_store addr src lane) (x64_pextrd_a_mem_or_avx addr src lane))
 
-;; Helper for creating `pextrq` instructions.
 (decl x64_pextrq (Xmm u8) Gpr)
-(rule (x64_pextrq src lane) (x64_pextrq_a src lane))
-(rule 1 (x64_pextrq src lane)
-        (if-let true (use_avx))
-        (xmm_to_gpr_imm_vex (AvxOpcode.Vpextrq) src lane))
+(rule (x64_pextrq src lane) (x64_pextrq_a_or_avx src lane))
 
 (decl x64_pextrq_store (Amode Xmm u8) SideEffectNoResult)
-(rule (x64_pextrq_store addr src lane) (x64_pextrq_a_mem addr src lane))
-(rule 1 (x64_pextrq_store addr src lane)
-        (if-let true (use_avx))
-        (xmm_movrm_imm_vex (AvxOpcode.Vpextrq) addr src lane))
+(rule (x64_pextrq_store addr src lane) (x64_pextrq_a_mem_or_avx addr src lane))
 
 ;; Helper for creating `pmovmskb` instructions.
 (decl x64_pmovmskb (Xmm) Gpr)

--- a/cranelift/codegen/src/isa/x64/inst/args.rs
+++ b/cranelift/codegen/src/isa/x64/inst/args.rs
@@ -1078,10 +1078,6 @@ impl AvxOpcode {
             | AvxOpcode::Vmovups
             | AvxOpcode::Vmovupd
             | AvxOpcode::Vmovdqu
-            | AvxOpcode::Vpextrb
-            | AvxOpcode::Vpextrw
-            | AvxOpcode::Vpextrd
-            | AvxOpcode::Vpextrq
             | AvxOpcode::Vpblendw
             | AvxOpcode::Vsqrtss
             | AvxOpcode::Vsqrtsd

--- a/cranelift/codegen/src/isa/x64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit.rs
@@ -1397,52 +1397,6 @@ pub(crate) fn emit(
                 .encode(sink);
         }
 
-        Inst::XmmMovRMImmVex { op, src, dst, imm } => {
-            let src = src.to_reg();
-            let dst = dst.clone().finalize(state.frame_layout(), sink);
-
-            let (w, prefix, map, opcode) = match op {
-                AvxOpcode::Vpextrb => (false, LegacyPrefixes::_66, OpcodeMap::_0F3A, 0x14),
-                AvxOpcode::Vpextrw => (false, LegacyPrefixes::_66, OpcodeMap::_0F3A, 0x15),
-                AvxOpcode::Vpextrd => (false, LegacyPrefixes::_66, OpcodeMap::_0F3A, 0x16),
-                AvxOpcode::Vpextrq => (true, LegacyPrefixes::_66, OpcodeMap::_0F3A, 0x16),
-                _ => unimplemented!("Opcode {:?} not implemented", op),
-            };
-            VexInstruction::new()
-                .length(VexVectorLength::V128)
-                .w(w)
-                .prefix(prefix)
-                .map(map)
-                .opcode(opcode)
-                .rm(dst)
-                .reg(src.to_real_reg().unwrap().hw_enc())
-                .imm(*imm)
-                .encode(sink);
-        }
-
-        Inst::XmmToGprImmVex { op, src, dst, imm } => {
-            let src = src.to_reg();
-            let dst = dst.to_reg().to_reg();
-
-            let (w, prefix, map, opcode) = match op {
-                AvxOpcode::Vpextrb => (false, LegacyPrefixes::_66, OpcodeMap::_0F3A, 0x14),
-                AvxOpcode::Vpextrw => (false, LegacyPrefixes::_66, OpcodeMap::_0F3A, 0x15),
-                AvxOpcode::Vpextrd => (false, LegacyPrefixes::_66, OpcodeMap::_0F3A, 0x16),
-                AvxOpcode::Vpextrq => (true, LegacyPrefixes::_66, OpcodeMap::_0F3A, 0x16),
-                _ => unimplemented!("Opcode {:?} not implemented", op),
-            };
-            VexInstruction::new()
-                .length(VexVectorLength::V128)
-                .w(w)
-                .prefix(prefix)
-                .map(map)
-                .opcode(opcode)
-                .rm(dst.to_real_reg().unwrap().hw_enc())
-                .reg(src.to_real_reg().unwrap().hw_enc())
-                .imm(*imm)
-                .encode(sink);
-        }
-
         Inst::XmmCmpRmRVex { op, src1, src2 } => {
             let src1 = src1.to_reg();
             let src2 = match src2.clone().to_reg_mem().clone() {

--- a/cranelift/codegen/src/isa/x64/pcc.rs
+++ b/cranelift/codegen/src/isa/x64/pcc.rs
@@ -195,11 +195,7 @@ pub(crate) fn check(
             ensure_no_fact(vcode, dst.to_writable_reg().to_reg())
         }
 
-        Inst::XmmMovRMVex { ref dst, .. } | Inst::XmmMovRMImmVex { ref dst, .. } => {
-            check_store(ctx, None, dst, vcode, I8X16)
-        }
-
-        Inst::XmmToGprImmVex { dst, .. } => ensure_no_fact(vcode, dst.to_writable_reg().to_reg()),
+        Inst::XmmMovRMVex { ref dst, .. } => check_store(ctx, None, dst, vcode, I8X16),
 
         Inst::CvtUint64ToFloatSeq {
             dst,

--- a/cranelift/filetests/filetests/isa/x64/extractlane-avx.clif
+++ b/cranelift/filetests/filetests/isa/x64/extractlane-avx.clif
@@ -11,7 +11,7 @@ block0(v0: i8x16):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block0:
-;   vpextrb $1, %xmm0, %rax
+;   vpextrb $0x1, %xmm0, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -36,7 +36,7 @@ block0(v0: i16x8):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block0:
-;   vpextrw $1, %xmm0, %rax
+;   vpextrw $0x1, %xmm0, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -61,7 +61,7 @@ block0(v0: i32x4):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block0:
-;   vpextrd $1, %xmm0, %rax
+;   vpextrd $0x1, %xmm0, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -86,7 +86,7 @@ block0(v0: i64x2):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block0:
-;   vpextrq $1, %xmm0, %rax
+;   vpextrq $0x1, %xmm0, %rax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -162,7 +162,7 @@ block0(v0: i8x16, v1: i64):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block0:
-;   vpextrb $0, %xmm0, 0(%rdi)
+;   vpextrb $0x0, %xmm0, (%rdi)
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -188,7 +188,7 @@ block0(v0: i16x8, v1: i64):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block0:
-;   vpextrw $0, %xmm0, 0(%rdi)
+;   vpextrw $0x0, %xmm0, (%rdi)
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -214,7 +214,7 @@ block0(v0: i32x4, v1: i64):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block0:
-;   vpextrd $0, %xmm0, 0(%rdi)
+;   vpextrd $0x0, %xmm0, (%rdi)
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -266,7 +266,7 @@ block0(v0: i64x2, v1: i64):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block0:
-;   vpextrq $0, %xmm0, 0(%rdi)
+;   vpextrq $0x0, %xmm0, (%rdi)
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq

--- a/tests/disas/winch/x64/i16x8/extract_lane_s/const_avx.wat
+++ b/tests/disas/winch/x64/i16x8/extract_lane_s/const_avx.wat
@@ -14,7 +14,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x49
+;;       ja      0x48
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -25,12 +25,13 @@
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   49: ud2
-;;   4b: addb    %al, (%rax)
-;;   4d: addb    %al, (%rax)
-;;   4f: addb    %al, (%rax)
-;;   51: addb    %al, (%rcx)
-;;   53: addb    %al, (%rdx)
-;;   55: addb    %al, (%rbx)
-;;   57: addb    %al, (%rax, %rax)
+;;   48: ud2
+;;   4a: addb    %al, (%rax)
+;;   4c: addb    %al, (%rax)
+;;   4e: addb    %al, (%rax)
+;;   50: addb    %al, (%rax)
+;;   52: addl    %eax, (%rax)
+;;   54: addb    (%rax), %al
+;;   56: addl    (%rax), %eax
+;;   58: addb    $0, %al
 ;;   5a: addl    $0x7000600, %eax

--- a/tests/disas/winch/x64/i16x8/extract_lane_u/const.wat
+++ b/tests/disas/winch/x64/i16x8/extract_lane_u/const.wat
@@ -14,7 +14,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x46
+;;       ja      0x45
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -24,14 +24,14 @@
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   46: ud2
-;;   48: addb    %al, (%rax)
-;;   4a: addb    %al, (%rax)
-;;   4c: addb    %al, (%rax)
-;;   4e: addb    %al, (%rax)
-;;   50: addb    %al, (%rax)
-;;   52: addl    %eax, (%rax)
-;;   54: addb    (%rax), %al
-;;   56: addl    (%rax), %eax
-;;   58: addb    $0, %al
+;;   45: ud2
+;;   47: addb    %al, (%rax)
+;;   49: addb    %al, (%rax)
+;;   4b: addb    %al, (%rax)
+;;   4d: addb    %al, (%rax)
+;;   4f: addb    %al, (%rax)
+;;   51: addb    %al, (%rcx)
+;;   53: addb    %al, (%rdx)
+;;   55: addb    %al, (%rbx)
+;;   57: addb    %al, (%rax, %rax)
 ;;   5a: addl    $0x7000600, %eax

--- a/winch/codegen/src/isa/x64/masm.rs
+++ b/winch/codegen/src/isa/x64/masm.rs
@@ -281,7 +281,7 @@ impl Masm for MacroAssembler {
             StoreKind::VectorLane(LaneSelector { lane, size }) => {
                 self.ensure_has_avx()?;
                 self.asm
-                    .xmm_vpextr_rm(&dst, src, lane, size, UNTRUSTED_FLAGS)?;
+                    .xmm_vpextr_rm(&dst, src, lane, size, UNTRUSTED_FLAGS);
             }
         }
 


### PR DESCRIPTION
This replaces all AVX versions of XMM lane extraction to use the new assembler. This removes the `Inst::XmmMovRMImmVex` and `Inst::XmmToGprImmVex` variants.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
