### PR TITLE
x64: Migrate `cmov*` to the new assembler

### DIFF
--- a/cranelift/assembler-x64/meta/src/dsl/format.rs
+++ b/cranelift/assembler-x64/meta/src/dsl/format.rs
@@ -601,6 +601,15 @@ pub enum Eflags {
 }
 
 impl Eflags {
+    /// Returns whether this represents a read of any bit in the EFLAGS
+    /// register.
+    pub fn is_read(&self) -> bool {
+        match self {
+            Eflags::None | Eflags::W => false,
+            Eflags::R | Eflags::RW => true,
+        }
+    }
+
     /// Returns whether this represents a writes to any bit in the EFLAGS
     /// register.
     pub fn is_write(&self) -> bool {

--- a/cranelift/assembler-x64/meta/src/instructions.rs
+++ b/cranelift/assembler-x64/meta/src/instructions.rs
@@ -7,6 +7,7 @@ mod and;
 mod atomic;
 mod avg;
 mod bitmanip;
+mod cmov;
 mod cmp;
 mod cvt;
 mod div;
@@ -41,6 +42,7 @@ pub fn list() -> Vec<Inst> {
     all.extend(atomic::list());
     all.extend(avg::list());
     all.extend(bitmanip::list());
+    all.extend(cmov::list());
     all.extend(cmp::list());
     all.extend(cvt::list());
     all.extend(div::list());

--- a/cranelift/assembler-x64/meta/src/instructions/cmov.rs
+++ b/cranelift/assembler-x64/meta/src/instructions/cmov.rs
@@ -1,0 +1,73 @@
+use crate::dsl::{Eflags::*, Feature::*, Inst, Location::*};
+use crate::dsl::{fmt, inst, r, rex, rw};
+
+#[rustfmt::skip] // Keeps instructions on a single line.
+pub fn list() -> Vec<Inst> {
+    vec![
+        // Note that the Intel manual lists many mnemonics for this family of
+        // instructions which are duplicates of other mnemonics. The order here
+        // matches the order in the manual and comments are left when variants
+        // are omitted due to the instructions being duplicates of another.
+        inst("cmovaw", fmt("RM", [rw(r16), r(rm16)]).flags(R), rex([0x66, 0x0f, 0x47]).r(), _64b | compat),
+        inst("cmoval", fmt("RM", [rw(r32), r(rm32)]).flags(R), rex([0x0f, 0x47]).r(), _64b | compat),
+        inst("cmovaq", fmt("RM", [rw(r64), r(rm64)]).flags(R), rex([0x0f, 0x47]).w().r(), _64b),
+        inst("cmovaew", fmt("RM", [rw(r16), r(rm16)]).flags(R), rex([0x66, 0x0f, 0x43]).r(), _64b | compat),
+        inst("cmovael", fmt("RM", [rw(r32), r(rm32)]).flags(R), rex([0x0f, 0x43]).r(), _64b | compat),
+        inst("cmovaeq", fmt("RM", [rw(r64), r(rm64)]).flags(R), rex([0x0f, 0x43]).w().r(), _64b),
+        inst("cmovbw", fmt("RM", [rw(r16), r(rm16)]).flags(R), rex([0x66, 0x0f, 0x42]).r(), _64b | compat),
+        inst("cmovbl", fmt("RM", [rw(r32), r(rm32)]).flags(R), rex([0x0f, 0x42]).r(), _64b | compat),
+        inst("cmovbq", fmt("RM", [rw(r64), r(rm64)]).flags(R), rex([0x0f, 0x42]).w().r(), _64b),
+        inst("cmovbew", fmt("RM", [rw(r16), r(rm16)]).flags(R), rex([0x66, 0x0f, 0x46]).r(), _64b | compat),
+        inst("cmovbel", fmt("RM", [rw(r32), r(rm32)]).flags(R), rex([0x0f, 0x46]).r(), _64b | compat),
+        inst("cmovbeq", fmt("RM", [rw(r64), r(rm64)]).flags(R), rex([0x0f, 0x46]).w().r(), _64b),
+        // NB: cmovc* is omitted here as it has the same encoding as cmovb*
+        inst("cmovew", fmt("RM", [rw(r16), r(rm16)]).flags(R), rex([0x66, 0x0f, 0x44]).r(), _64b | compat),
+        inst("cmovel", fmt("RM", [rw(r32), r(rm32)]).flags(R), rex([0x0f, 0x44]).r(), _64b | compat),
+        inst("cmoveq", fmt("RM", [rw(r64), r(rm64)]).flags(R), rex([0x0f, 0x44]).w().r(), _64b),
+        inst("cmovgw", fmt("RM", [rw(r16), r(rm16)]).flags(R), rex([0x66, 0x0f, 0x4f]).r(), _64b | compat),
+        inst("cmovgl", fmt("RM", [rw(r32), r(rm32)]).flags(R), rex([0x0f, 0x4f]).r(), _64b | compat),
+        inst("cmovgq", fmt("RM", [rw(r64), r(rm64)]).flags(R), rex([0x0f, 0x4f]).w().r(), _64b),
+        inst("cmovgew", fmt("RM", [rw(r16), r(rm16)]).flags(R), rex([0x66, 0x0f, 0x4d]).r(), _64b | compat),
+        inst("cmovgel", fmt("RM", [rw(r32), r(rm32)]).flags(R), rex([0x0f, 0x4d]).r(), _64b | compat),
+        inst("cmovgeq", fmt("RM", [rw(r64), r(rm64)]).flags(R), rex([0x0f, 0x4d]).w().r(), _64b),
+        inst("cmovlw", fmt("RM", [rw(r16), r(rm16)]).flags(R), rex([0x66, 0x0f, 0x4c]).r(), _64b | compat),
+        inst("cmovll", fmt("RM", [rw(r32), r(rm32)]).flags(R), rex([0x0f, 0x4c]).r(), _64b | compat),
+        inst("cmovlq", fmt("RM", [rw(r64), r(rm64)]).flags(R), rex([0x0f, 0x4c]).w().r(), _64b),
+        inst("cmovlew", fmt("RM", [rw(r16), r(rm16)]).flags(R), rex([0x66, 0x0f, 0x4e]).r(), _64b | compat),
+        inst("cmovlel", fmt("RM", [rw(r32), r(rm32)]).flags(R), rex([0x0f, 0x4e]).r(), _64b | compat),
+        inst("cmovleq", fmt("RM", [rw(r64), r(rm64)]).flags(R), rex([0x0f, 0x4e]).w().r(), _64b),
+        // NB: cmovna* is omitted here as it has the same encoding as cmovbe*
+        // NB: cmovnb* is omitted here as it has the same encoding as cmovae*
+        // NB: cmovnbe* is omitted here as it has the same encoding as cmova*
+        // NB: cmovnc* is omitted here as it has the same encoding as cmovae*
+        inst("cmovnew", fmt("RM", [rw(r16), r(rm16)]).flags(R), rex([0x66, 0x0f, 0x45]).r(), _64b | compat),
+        inst("cmovnel", fmt("RM", [rw(r32), r(rm32)]).flags(R), rex([0x0f, 0x45]).r(), _64b | compat),
+        inst("cmovneq", fmt("RM", [rw(r64), r(rm64)]).flags(R), rex([0x0f, 0x45]).w().r(), _64b),
+        // NB: cmovng* is omitted here as it has the same encoding as cmovle*
+        // NB: cmovnge* is omitted here as it has the same encoding as cmovl*
+        // NB: cmovnl* is omitted here as it has the same encoding as cmovge*
+        // NB: cmovnle* is omitted here as it has the same encoding as cmovg*
+        inst("cmovnow", fmt("RM", [rw(r16), r(rm16)]).flags(R), rex([0x66, 0x0f, 0x41]).r(), _64b | compat),
+        inst("cmovnol", fmt("RM", [rw(r32), r(rm32)]).flags(R), rex([0x0f, 0x41]).r(), _64b | compat),
+        inst("cmovnoq", fmt("RM", [rw(r64), r(rm64)]).flags(R), rex([0x0f, 0x41]).w().r(), _64b),
+        inst("cmovnpw", fmt("RM", [rw(r16), r(rm16)]).flags(R), rex([0x66, 0x0f, 0x4b]).r(), _64b | compat),
+        inst("cmovnpl", fmt("RM", [rw(r32), r(rm32)]).flags(R), rex([0x0f, 0x4b]).r(), _64b | compat),
+        inst("cmovnpq", fmt("RM", [rw(r64), r(rm64)]).flags(R), rex([0x0f, 0x4b]).w().r(), _64b),
+        inst("cmovnsw", fmt("RM", [rw(r16), r(rm16)]).flags(R), rex([0x66, 0x0f, 0x49]).r(), _64b | compat),
+        inst("cmovnsl", fmt("RM", [rw(r32), r(rm32)]).flags(R), rex([0x0f, 0x49]).r(), _64b | compat),
+        inst("cmovnsq", fmt("RM", [rw(r64), r(rm64)]).flags(R), rex([0x0f, 0x49]).w().r(), _64b),
+        // NB: cmovnz* is omitted here as it has the same encoding as cmovne*
+        inst("cmovow", fmt("RM", [rw(r16), r(rm16)]).flags(R), rex([0x66, 0x0f, 0x40]).r(), _64b | compat),
+        inst("cmovol", fmt("RM", [rw(r32), r(rm32)]).flags(R), rex([0x0f, 0x40]).r(), _64b | compat),
+        inst("cmovoq", fmt("RM", [rw(r64), r(rm64)]).flags(R), rex([0x0f, 0x40]).w().r(), _64b),
+        inst("cmovpw", fmt("RM", [rw(r16), r(rm16)]).flags(R), rex([0x66, 0x0f, 0x4a]).r(), _64b | compat),
+        inst("cmovpl", fmt("RM", [rw(r32), r(rm32)]).flags(R), rex([0x0f, 0x4a]).r(), _64b | compat),
+        inst("cmovpq", fmt("RM", [rw(r64), r(rm64)]).flags(R), rex([0x0f, 0x4a]).w().r(), _64b),
+        // NB: cmovpe* is omitted here as it has the same encoding as cmovp*
+        // NB: cmovpo* is omitted here as it has the same encoding as cmovnp*
+        inst("cmovsw", fmt("RM", [rw(r16), r(rm16)]).flags(R), rex([0x66, 0x0f, 0x48]).r(), _64b | compat),
+        inst("cmovsl", fmt("RM", [rw(r32), r(rm32)]).flags(R), rex([0x0f, 0x48]).r(), _64b | compat),
+        inst("cmovsq", fmt("RM", [rw(r64), r(rm64)]).flags(R), rex([0x0f, 0x48]).w().r(), _64b),
+        // NB: cmovz* is omitted here as it has the same encoding as cmove*
+    ]
+}

--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -46,13 +46,6 @@
        ;; =========================================
        ;; Conditional moves.
 
-       ;; GPR conditional move; overwrites the destination register.
-       (Cmove (size OperandSize)
-              (cc CC)
-              (consequent GprMem)
-              (alternative Gpr)
-              (dst WritableGpr))
-
        ;; XMM conditional move; overwrites the destination register.
        (XmmCmove (ty Type)
                  (cc CC)
@@ -1971,6 +1964,10 @@
 (rule (asm_consume_flags (AssemblerOutputs.RetGpr inst gpr))
       (ConsumesFlags.ConsumesFlagsReturnsResultWithProducer inst gpr))
 
+(decl asm_consumes_flags_returns_gpr (AssemblerOutputs) ConsumesFlags)
+(rule (asm_consumes_flags_returns_gpr (AssemblerOutputs.RetGpr inst gpr))
+      (ConsumesFlags.ConsumesFlagsReturnsReg inst gpr))
+
 
 
 ;;;; Instruction Constructors ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -2544,13 +2541,55 @@
 ;; Helper for creating `cmove` instructions. Note that these instructions do not
 ;; always result in a single emitted x86 instruction; e.g., XmmCmove uses jumps
 ;; to conditionally move the selected value into an XMM register.
+;;
+;; Also note that 8/16-bit conditional moves use the 32-bit instruction variant
+;; since that is semantically equivalent and helps break data dependencies by
+;; defining the entire register.
+;;
+;; Also note that the mnemonics used in `CC` don't always match those used in
+;; the instruction variants and that is intentiona. This is due to the fact
+;; that the Intel manual (and assemblers) support multiple mnemonics for the
+;; same instruction but disassemblers only print one mnemonic and that's the
+;; name used here.
 (decl cmove (Type CC GprMem Gpr) ConsumesFlags)
-(rule (cmove ty cc consequent alternative)
-      (let ((dst WritableGpr (temp_writable_gpr))
-            (size OperandSize (operand_size_of_type_32_64 ty)))
-        (ConsumesFlags.ConsumesFlagsReturnsReg
-         (MInst.Cmove size cc consequent alternative dst)
-         dst)))
+(rule 0 (cmove (fits_in_32 _) (CC.O) c a) (x64_cmovol_rm a c))
+(rule 0 (cmove (fits_in_32 _) (CC.NO) c a) (x64_cmovnol_rm a c))
+(rule 0 (cmove (fits_in_32 _) (CC.B) c a) (x64_cmovbl_rm a c))
+(rule 0 (cmove (fits_in_32 _) (CC.NB) c a) (x64_cmovael_rm a c)) ;;  nb == ae
+(rule 0 (cmove (fits_in_32 _) (CC.Z) c a) (x64_cmovel_rm a c))   ;;   z ==  e
+(rule 0 (cmove (fits_in_32 _) (CC.NZ) c a) (x64_cmovnel_rm a c)) ;;  nz == ne
+(rule 0 (cmove (fits_in_32 _) (CC.BE) c a) (x64_cmovbel_rm a c))
+(rule 0 (cmove (fits_in_32 _) (CC.NBE) c a) (x64_cmoval_rm a c)) ;; nbe ==  a
+(rule 0 (cmove (fits_in_32 _) (CC.S) c a) (x64_cmovsl_rm a c))
+(rule 0 (cmove (fits_in_32 _) (CC.NS) c a) (x64_cmovnsl_rm a c))
+(rule 0 (cmove (fits_in_32 _) (CC.L) c a) (x64_cmovll_rm a c))
+(rule 0 (cmove (fits_in_32 _) (CC.NL) c a) (x64_cmovgel_rm a c)) ;;  nl == ge
+(rule 0 (cmove (fits_in_32 _) (CC.LE) c a) (x64_cmovlel_rm a c))
+(rule 0 (cmove (fits_in_32 _) (CC.NLE) c a) (x64_cmovgl_rm a c)) ;; nle ==  g
+(rule 0 (cmove (fits_in_32 _) (CC.P) c a) (x64_cmovpl_rm a c))
+(rule 0 (cmove (fits_in_32 _) (CC.NP) c a) (x64_cmovnpl_rm a c))
+(rule 1 (cmove $I64 (CC.O) c a) (x64_cmovoq_rm a c))
+(rule 1 (cmove $I64 (CC.NO) c a) (x64_cmovnoq_rm a c))
+(rule 1 (cmove $I64 (CC.B) c a) (x64_cmovbq_rm a c))
+(rule 1 (cmove $I64 (CC.NB) c a) (x64_cmovaeq_rm a c)) ;;  nb == ae
+(rule 1 (cmove $I64 (CC.Z) c a) (x64_cmoveq_rm a c))   ;;   z ==  e
+(rule 1 (cmove $I64 (CC.NZ) c a) (x64_cmovneq_rm a c)) ;;  nz == ne
+(rule 1 (cmove $I64 (CC.BE) c a) (x64_cmovbeq_rm a c))
+(rule 1 (cmove $I64 (CC.NBE) c a) (x64_cmovaq_rm a c)) ;; nbe ==  a
+(rule 1 (cmove $I64 (CC.S) c a) (x64_cmovsq_rm a c))
+(rule 1 (cmove $I64 (CC.NS) c a) (x64_cmovnsq_rm a c))
+(rule 1 (cmove $I64 (CC.L) c a) (x64_cmovlq_rm a c))
+(rule 1 (cmove $I64 (CC.NL) c a) (x64_cmovgeq_rm a c)) ;;  nl == ge
+(rule 1 (cmove $I64 (CC.LE) c a) (x64_cmovleq_rm a c))
+(rule 1 (cmove $I64 (CC.NLE) c a) (x64_cmovgq_rm a c)) ;; nle ==  g
+(rule 1 (cmove $I64 (CC.P) c a) (x64_cmovpq_rm a c))
+(rule 1 (cmove $I64 (CC.NP) c a) (x64_cmovnpq_rm a c))
+
+(decl cmove128 (CC ValueRegs ValueRegs) ConsumesFlags)
+(rule (cmove128 cc cons alt)
+  (consumes_flags_concat
+    (cmove $I64 cc (value_regs_get_gpr cons 0) (value_regs_get_gpr alt 0))
+    (cmove $I64 cc (value_regs_get_gpr cons 1) (value_regs_get_gpr alt 1))))
 
 (decl cmove_xmm (Type CC Xmm Xmm) ConsumesFlags)
 (rule (cmove_xmm ty cc consequent alternative)
@@ -2564,25 +2603,7 @@
 ;; It also eliminates some `put_in_reg*` boilerplate in the lowering ISLE code.
 (decl cmove_from_values (Type CC Value Value) ConsumesFlags)
 (rule (cmove_from_values (is_multi_register_gpr_type $I128) cc consequent alternative)
-      (let ((cons ValueRegs consequent)
-            (alt ValueRegs alternative)
-            (dst1 WritableGpr (temp_writable_gpr))
-            (dst2 WritableGpr (temp_writable_gpr))
-            (size OperandSize (OperandSize.Size64))
-            (lower_cmove MInst (MInst.Cmove
-                                size cc
-                                (value_regs_get_gpr cons 0)
-                                (value_regs_get_gpr alt 0)
-                                dst1))
-            (upper_cmove MInst (MInst.Cmove
-                                size cc
-                                (value_regs_get_gpr cons 1)
-                                (value_regs_get_gpr alt 1)
-                                dst2)))
-        (ConsumesFlags.ConsumesFlagsTwiceReturnsValueRegs
-         lower_cmove
-         upper_cmove
-         (value_regs dst1 dst2))))
+  (cmove128 cc consequent alternative))
 
 (rule (cmove_from_values (is_single_register_gpr_type ty) cc consequent alternative)
       (cmove ty cc consequent alternative))
@@ -2595,49 +2616,37 @@
 ;; emitted x86 instruction.
 (decl cmove_or (Type CC CC GprMem Gpr) ConsumesFlags)
 (rule (cmove_or ty cc1 cc2 consequent alternative)
-      (let ((dst WritableGpr (temp_writable_gpr))
-            (tmp WritableGpr (temp_writable_gpr))
-            (size OperandSize (operand_size_of_type_32_64 ty))
-            (cmove1 MInst (MInst.Cmove size cc1 consequent alternative tmp))
-            (cmove2 MInst (MInst.Cmove size cc2 consequent tmp dst)))
-        (ConsumesFlags.ConsumesFlagsTwiceReturnsValueRegs
-         cmove1
-         cmove2
-         dst)))
+  (let ((c1 ConsumesFlags (cmove ty cc1 consequent alternative))
+        (tmp Gpr (consumes_flags_get_reg c1))
+        (c2 ConsumesFlags (cmove ty cc2 consequent tmp)))
+    (consumes_flags_return_last c1 c2)))
 
 (decl cmove_or_xmm (Type CC CC Xmm Xmm) ConsumesFlags)
 (rule (cmove_or_xmm ty cc1 cc2 consequent alternative)
-      (let ((dst WritableXmm (temp_writable_xmm))
-            (tmp WritableXmm (temp_writable_xmm))
-            (cmove1 MInst (MInst.XmmCmove ty cc1 consequent alternative tmp))
-            (cmove2 MInst (MInst.XmmCmove ty cc2 consequent tmp dst)))
-        (ConsumesFlags.ConsumesFlagsTwiceReturnsValueRegs
-         cmove1
-         cmove2
-         dst)))
+  (let ((c1 ConsumesFlags (cmove_xmm ty cc1 consequent alternative))
+        (tmp Xmm (consumes_flags_get_reg c1))
+        (c2 ConsumesFlags (cmove_xmm ty cc2 consequent tmp)))
+    (consumes_flags_return_last c1 c2)))
+
+(decl consumes_flags_return_last (ConsumesFlags ConsumesFlags) ConsumesFlags)
+(rule (consumes_flags_return_last
+        (ConsumesFlags.ConsumesFlagsReturnsReg inst1 _)
+        (ConsumesFlags.ConsumesFlagsReturnsReg inst2 dst))
+  (ConsumesFlags.ConsumesFlagsTwiceReturnsValueRegs inst1 inst2 dst))
+(rule (consumes_flags_return_last
+        (ConsumesFlags.ConsumesFlagsTwiceReturnsValueRegs i1 i2 _)
+        (ConsumesFlags.ConsumesFlagsTwiceReturnsValueRegs i3 i4 dst))
+  (ConsumesFlags.ConsumesFlagsFourTimesReturnsValueRegs i1 i2 i3 i4 dst))
 
 ;; Helper for creating `cmove_or` instructions directly from values. This allows
 ;; us to special-case the `I128` types and default to the `cmove_or` helper
 ;; otherwise.
 (decl cmove_or_from_values (Type CC CC Value Value) ConsumesFlags)
 (rule (cmove_or_from_values (is_multi_register_gpr_type $I128) cc1 cc2 consequent alternative)
-      (let ((cons ValueRegs consequent)
-            (alt ValueRegs alternative)
-            (dst1 WritableGpr (temp_writable_gpr))
-            (dst2 WritableGpr (temp_writable_gpr))
-            (tmp1 WritableGpr (temp_writable_gpr))
-            (tmp2 WritableGpr (temp_writable_gpr))
-            (size OperandSize (OperandSize.Size64))
-            (cmove1 MInst (MInst.Cmove size cc1 (value_regs_get_gpr cons 0) (value_regs_get_gpr alt 0) tmp1))
-            (cmove2 MInst (MInst.Cmove size cc2 (value_regs_get_gpr cons 0) tmp1 dst1))
-            (cmove3 MInst (MInst.Cmove size cc1 (value_regs_get_gpr cons 1) (value_regs_get_gpr alt 1) tmp2))
-            (cmove4 MInst (MInst.Cmove size cc2 (value_regs_get_gpr cons 1) tmp2 dst2)))
-        (ConsumesFlags.ConsumesFlagsFourTimesReturnsValueRegs
-         cmove1
-         cmove2
-         cmove3
-         cmove4
-         (value_regs dst1 dst2))))
+  (let ((c1 ConsumesFlags (cmove128 cc1 consequent alternative))
+        (tmp ValueRegs (consumes_flags_get_regs c1))
+        (c2 ConsumesFlags (cmove128 cc2 consequent tmp)))
+    (consumes_flags_return_last c1 c2)))
 
 (rule (cmove_or_from_values (is_single_register_gpr_type ty) cc1 cc2 consequent alternative)
       (cmove_or ty cc1 cc2 consequent alternative))

--- a/cranelift/codegen/src/isa/x64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit.rs
@@ -282,35 +282,6 @@ pub(crate) fn emit(
             );
         }
 
-        Inst::Cmove {
-            size,
-            cc,
-            consequent,
-            alternative,
-            dst,
-        } => {
-            let alternative = alternative.to_reg();
-            let dst = dst.to_reg().to_reg();
-            debug_assert_eq!(alternative, dst);
-            let rex_flags = RexFlags::from(*size);
-            let prefix = match size {
-                OperandSize::Size16 => LegacyPrefixes::_66,
-                OperandSize::Size32 => LegacyPrefixes::None,
-                OperandSize::Size64 => LegacyPrefixes::None,
-                _ => unreachable!("invalid size spec for cmove"),
-            };
-            let opcode = 0x0F40 + cc.get_enc() as u32;
-            match consequent.clone().to_reg_mem() {
-                RegMem::Reg { reg } => {
-                    emit_std_reg_reg(sink, prefix, opcode, 2, dst, reg, rex_flags);
-                }
-                RegMem::Mem { addr } => {
-                    let addr = &addr.finalize(state.frame_layout(), sink).clone();
-                    emit_std_reg_mem(sink, prefix, opcode, 2, dst, addr, rex_flags, 0);
-                }
-            }
-        }
-
         Inst::XmmCmove {
             ty,
             cc,
@@ -2305,15 +2276,21 @@ pub(crate) fn emit(
                     }
 
                     // cmovcc %r_operand, %r_temp
-                    let cc = match op {
-                        RmwOp::Umin => CC::BE,
-                        RmwOp::Umax => CC::NB,
-                        RmwOp::Smin => CC::LE,
-                        RmwOp::Smax => CC::NL,
+                    match op {
+                        RmwOp::Umin => {
+                            asm::inst::cmovbeq_rm::new(temp_r, *operand).emit(sink, info, state)
+                        }
+                        RmwOp::Umax => {
+                            asm::inst::cmovaeq_rm::new(temp_r, *operand).emit(sink, info, state)
+                        }
+                        RmwOp::Smin => {
+                            asm::inst::cmovleq_rm::new(temp_r, *operand).emit(sink, info, state)
+                        }
+                        RmwOp::Smax => {
+                            asm::inst::cmovgeq_rm::new(temp_r, *operand).emit(sink, info, state)
+                        }
                         _ => unreachable!(),
-                    };
-                    let i4 = Inst::cmove(OperandSize::Size64, cc, RegMem::reg(*operand), temp_r);
-                    i4.emit(sink, info, state);
+                    }
                 }
                 RmwOp::And => {
                     // andq %r_operand, %r_temp
@@ -2402,19 +2379,33 @@ pub(crate) fn emit(
                     // Restore the clobbered value
                     asm::inst::movq_mr::new(temp_high, dst_old_high.to_reg())
                         .emit(sink, info, state);
-                    let cc = match op {
-                        RmwOp::Umin => CC::NB,
-                        RmwOp::Umax => CC::B,
-                        RmwOp::Smin => CC::NL,
-                        RmwOp::Smax => CC::L,
+                    match op {
+                        RmwOp::Umin => {
+                            asm::inst::cmovaeq_rm::new(temp_low, operand_low)
+                                .emit(sink, info, state);
+                            asm::inst::cmovaeq_rm::new(temp_high, operand_high)
+                                .emit(sink, info, state);
+                        }
+                        RmwOp::Umax => {
+                            asm::inst::cmovbq_rm::new(temp_low, operand_low)
+                                .emit(sink, info, state);
+                            asm::inst::cmovbq_rm::new(temp_high, operand_high)
+                                .emit(sink, info, state);
+                        }
+                        RmwOp::Smin => {
+                            asm::inst::cmovgeq_rm::new(temp_low, operand_low)
+                                .emit(sink, info, state);
+                            asm::inst::cmovgeq_rm::new(temp_high, operand_high)
+                                .emit(sink, info, state);
+                        }
+                        RmwOp::Smax => {
+                            asm::inst::cmovlq_rm::new(temp_low, operand_low)
+                                .emit(sink, info, state);
+                            asm::inst::cmovlq_rm::new(temp_high, operand_high)
+                                .emit(sink, info, state);
+                        }
                         _ => unreachable!(),
-                    };
-                    let temp_low = temp_low.map(|r| *r);
-                    let temp_high = temp_high.map(|r| *r);
-                    Inst::cmove(OperandSize::Size64, cc, (*operand_low).into(), temp_low)
-                        .emit(sink, info, state);
-                    Inst::cmove(OperandSize::Size64, cc, (*operand_high).into(), temp_high)
-                        .emit(sink, info, state);
+                    }
                 }
                 RmwOp::Add => {
                     asm::inst::addq_rm::new(temp_low, operand_low).emit(sink, info, state);

--- a/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
@@ -96,7 +96,7 @@ fn test_x64_emit() {
     let rcx = regs::rcx();
     let rdx = regs::rdx();
     let rsi = regs::rsi();
-    let rdi = regs::rdi();
+    let _rdi = regs::rdi();
     let rsp = regs::rsp();
     let rbp = regs::rbp();
     let r8 = regs::r8();
@@ -135,7 +135,7 @@ fn test_x64_emit() {
     let w_r9 = Writable::<Reg>::from_reg(r9);
     let w_r11 = Writable::<Reg>::from_reg(r11);
     let w_r14 = Writable::<Reg>::from_reg(r14);
-    let w_r15 = Writable::<Reg>::from_reg(r15);
+    let _w_r15 = Writable::<Reg>::from_reg(r15);
 
     let w_xmm0 = Writable::<Reg>::from_reg(xmm0);
     let w_xmm1 = Writable::<Reg>::from_reg(xmm1);
@@ -168,59 +168,6 @@ fn test_x64_emit() {
     insns.push((Inst::setcc(CC::LE, w_r14), "410F9EC6", "setle   %r14b"));
     insns.push((Inst::setcc(CC::P, w_r9), "410F9AC1", "setp    %r9b"));
     insns.push((Inst::setcc(CC::NP, w_r8), "410F9BC0", "setnp   %r8b"));
-
-    // ========================================================
-    // Cmove
-    insns.push((
-        Inst::cmove(OperandSize::Size16, CC::O, RegMem::reg(rdi), w_rsi),
-        "660F40F7",
-        "cmovow  %di, %si, %si",
-    ));
-    insns.push((
-        Inst::cmove(
-            OperandSize::Size16,
-            CC::NO,
-            RegMem::mem(Amode::imm_reg_reg_shift(
-                37,
-                Gpr::unwrap_new(rdi),
-                Gpr::unwrap_new(rsi),
-                2,
-            )),
-            w_r15,
-        ),
-        "66440F417CB725",
-        "cmovnow 37(%rdi,%rsi,4), %r15w, %r15w",
-    ));
-    insns.push((
-        Inst::cmove(OperandSize::Size32, CC::LE, RegMem::reg(rdi), w_rsi),
-        "0F4EF7",
-        "cmovlel %edi, %esi, %esi",
-    ));
-    insns.push((
-        Inst::cmove(
-            OperandSize::Size32,
-            CC::NLE,
-            RegMem::mem(Amode::imm_reg(0, r15)),
-            w_rsi,
-        ),
-        "410F4F37",
-        "cmovnlel 0(%r15), %esi, %esi",
-    ));
-    insns.push((
-        Inst::cmove(OperandSize::Size64, CC::Z, RegMem::reg(rdi), w_r14),
-        "4C0F44F7",
-        "cmovzq  %rdi, %r14, %r14",
-    ));
-    insns.push((
-        Inst::cmove(
-            OperandSize::Size64,
-            CC::NZ,
-            RegMem::mem(Amode::imm_reg(13, rdi)),
-            w_r14,
-        ),
-        "4C0F45770D",
-        "cmovnzq 13(%rdi), %r14, %r14",
-    ));
 
     // ========================================================
     // CallKnown

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -79,7 +79,6 @@ impl Inst {
             | Inst::ReturnCallUnknown { .. }
             | Inst::CheckedSRemSeq { .. }
             | Inst::CheckedSRemSeq8 { .. }
-            | Inst::Cmove { .. }
             | Inst::CvtFloatToSintSeq { .. }
             | Inst::CvtFloatToUintSeq { .. }
             | Inst::CvtUint64ToFloatSeq { .. }
@@ -352,22 +351,6 @@ impl Inst {
         Inst::TrapIf { cc, trap_code }
     }
 
-    pub(crate) fn cmove(size: OperandSize, cc: CC, src: RegMem, dst: Writable<Reg>) -> Inst {
-        debug_assert!(size.is_one_of(&[
-            OperandSize::Size16,
-            OperandSize::Size32,
-            OperandSize::Size64
-        ]));
-        debug_assert!(dst.to_reg().class() == RegClass::Int);
-        Inst::Cmove {
-            size,
-            cc,
-            consequent: GprMem::unwrap_new(src),
-            alternative: Gpr::unwrap_new(dst.to_reg()),
-            dst: WritableGpr::from_writable_reg(dst).unwrap(),
-        }
-    }
-
     pub(crate) fn call_known(info: Box<CallInfo<ExternalName>>) -> Inst {
         Inst::CallKnown { info }
     }
@@ -510,15 +493,6 @@ impl PrettyPrint for Inst {
 
         fn ljustify2(s1: String, s2: String) -> String {
             ljustify(s1 + &s2)
-        }
-
-        fn suffix_bwlq(size: OperandSize) -> String {
-            match size {
-                OperandSize::Size8 => "b".to_string(),
-                OperandSize::Size16 => "w".to_string(),
-                OperandSize::Size32 => "l".to_string(),
-                OperandSize::Size64 => "q".to_string(),
-            }
         }
 
         match self {
@@ -862,20 +836,6 @@ impl PrettyPrint for Inst {
                 let dst = pretty_print_reg(dst.to_reg().to_reg(), 1);
                 let op = ljustify2("set".to_string(), cc.to_string());
                 format!("{op} {dst}")
-            }
-
-            Inst::Cmove {
-                size,
-                cc,
-                consequent,
-                alternative,
-                dst,
-            } => {
-                let alternative = pretty_print_reg(alternative.to_reg(), size.to_bytes());
-                let dst = pretty_print_reg(dst.to_reg().to_reg(), size.to_bytes());
-                let consequent = consequent.pretty_print(size.to_bytes());
-                let op = ljustify(format!("cmov{}{}", cc.to_string(), suffix_bwlq(*size)));
-                format!("{op} {consequent}, {alternative}, {dst}")
             }
 
             Inst::XmmCmove {
@@ -1383,16 +1343,6 @@ fn x64_get_operands(inst: &mut Inst, collector: &mut impl OperandVisitor) {
 
         Inst::Setcc { dst, .. } => {
             collector.reg_def(dst);
-        }
-        Inst::Cmove {
-            consequent,
-            alternative,
-            dst,
-            ..
-        } => {
-            collector.reg_use(alternative);
-            collector.reg_reuse_def(dst, 0);
-            consequent.get_operands(collector);
         }
         Inst::XmmCmove {
             consequent,

--- a/cranelift/codegen/src/isa/x64/pcc.rs
+++ b/cranelift/codegen/src/isa/x64/pcc.rs
@@ -4,9 +4,7 @@ use crate::ir::pcc::*;
 use crate::ir::types::*;
 use crate::isa::x64::args::AvxOpcode;
 use crate::isa::x64::inst::Inst;
-use crate::isa::x64::inst::args::{
-    Amode, CC, Gpr, RegMem, RegMemImm, SyntheticAmode, ToWritableReg,
-};
+use crate::isa::x64::inst::args::{Amode, Gpr, RegMem, RegMemImm, SyntheticAmode, ToWritableReg};
 use crate::machinst::pcc::*;
 use crate::machinst::{InsnIndex, VCode};
 use crate::machinst::{Reg, Writable};
@@ -50,7 +48,7 @@ pub(crate) fn check(
     // can't exhaustively enumerate all flags-effecting ops; so take
     // the `cmp_state` here and perhaps use it below but don't let it
     // remain.
-    let cmp_flags = state.cmp_flags.take();
+    let _cmp_flags = state.cmp_flags.take();
 
     match vcode[inst_idx] {
         Inst::Args { .. } => {
@@ -76,46 +74,6 @@ pub(crate) fn check(
         Inst::MovToPReg { .. } => Ok(()),
 
         Inst::Setcc { dst, .. } => undefined_result(ctx, vcode, dst, 64, 64),
-
-        Inst::Cmove {
-            size,
-            dst,
-            ref consequent,
-            alternative,
-            cc,
-            ..
-        } => match <&RegMem>::from(consequent) {
-            RegMem::Mem { addr } => {
-                check_load(ctx, None, addr, vcode, size.to_type(), 64)?;
-                Ok(())
-            }
-            RegMem::Reg { reg } if (cc == CC::NB || cc == CC::NBE) && cmp_flags.is_some() => {
-                let (cmp_lhs, cmp_rhs) = cmp_flags.unwrap();
-                trace!("lhs = {:?} rhs = {:?}", cmp_lhs, cmp_rhs);
-                let reg = *reg;
-                check_output(ctx, vcode, dst.to_writable_reg(), &[], |vcode| {
-                    // See comments in aarch64::pcc CSel for more details on this.
-                    let in_true = get_fact_or_default(vcode, reg, 64);
-                    let in_true_kind = match cc {
-                        CC::NB => InequalityKind::Loose,
-                        CC::NBE => InequalityKind::Strict,
-                        _ => unreachable!(),
-                    };
-                    let in_true = ctx.apply_inequality(&in_true, &cmp_lhs, &cmp_rhs, in_true_kind);
-                    let in_false = get_fact_or_default(vcode, alternative.to_reg(), 64);
-                    let in_false_kind = match cc {
-                        CC::NB => InequalityKind::Strict,
-                        CC::NBE => InequalityKind::Loose,
-                        _ => unreachable!(),
-                    };
-                    let in_false =
-                        ctx.apply_inequality(&in_false, &cmp_rhs, &cmp_lhs, in_false_kind);
-                    let union = ctx.union(&in_true, &in_false);
-                    clamp_range(ctx, 64, 64, union)
-                })
-            }
-            _ => undefined_result(ctx, vcode, dst, 64, 64),
-        },
 
         Inst::XmmCmove { dst, .. } => ensure_no_fact(vcode, dst.to_writable_reg().to_reg()),
 

--- a/cranelift/codegen/src/prelude_lower.isle
+++ b/cranelift/codegen/src/prelude_lower.isle
@@ -557,6 +557,12 @@
         (ConsumesFlags.ConsumesFlagsSideEffect inst2))
       (ConsumesFlags.ConsumesFlagsSideEffect2 inst1 inst2))
 
+;; Get the produced register out of a ConsumesFlags.
+(decl consumes_flags_get_reg (ConsumesFlags) Reg)
+(rule (consumes_flags_get_reg (ConsumesFlags.ConsumesFlagsReturnsReg _ reg)) reg)
+(decl consumes_flags_get_regs (ConsumesFlags) ValueRegs)
+(rule (consumes_flags_get_regs (ConsumesFlags.ConsumesFlagsTwiceReturnsValueRegs _ _ regs)) regs)
+
 ;; Combine flags-producing and -consuming instructions together, ensuring that
 ;; they are emitted back-to-back and no other instructions can be emitted
 ;; between them and potentially clobber the flags.

--- a/cranelift/filetests/filetests/isa/x64/branches.clif
+++ b/cranelift/filetests/filetests/isa/x64/branches.clif
@@ -316,7 +316,7 @@ block2:
 ;   movl $0x2, %r10d
 ;   movl %edi, %r11d
 ;   cmpl %r10d, %r11d
-;   cmovbl  %r11d, %r10d, %r10d
+;   cmovbl %r11d, %r10d
 ;   br_table %r10, %rcx, %rdx
 ; block1:
 ;   jmp     label4
@@ -963,7 +963,7 @@ block5(v5: i32):
 ;   movl $0x4, %eax
 ;   movl %edi, %ecx
 ;   cmpl %eax, %ecx
-;   cmovbl  %ecx, %eax, %eax
+;   cmovbl %ecx, %eax
 ;   br_table %rax, %r9, %r10
 ; block1:
 ;   jmp     label4
@@ -1050,7 +1050,7 @@ block1(v5: i32):
 ;   movl $0x4, %esi
 ;   movl %edi, %edi
 ;   cmpl %esi, %edi
-;   cmovbl  %edi, %esi, %esi
+;   cmovbl %edi, %esi
 ;   br_table %rsi, %r10, %r9
 ; block1:
 ;   jmp     label6

--- a/cranelift/filetests/filetests/isa/x64/clz-lzcnt.clif
+++ b/cranelift/filetests/filetests/isa/x64/clz-lzcnt.clif
@@ -17,7 +17,7 @@ block0(v0: i128):
 ;   lzcntq %rdi, %rax
 ;   addq $0x40, %rax
 ;   cmpq $0x40, %rcx
-;   cmovnzq %rcx, %rax, %rax
+;   cmovneq %rcx, %rax
 ;   uninit  %rdx
 ;   xorq %rdx, %rdx
 ;   movq %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/clz.clif
+++ b/cranelift/filetests/filetests/isa/x64/clz.clif
@@ -16,17 +16,17 @@ block0(v0: i128):
 ;   movq %rdi, %r8
 ;   movq $0xffffffffffffffff, %rcx
 ;   bsrq %rsi, %r9
-;   cmovzq  %rcx, %r9, %r9
+;   cmoveq %rcx, %r9
 ;   movl $0x3f, %edi
 ;   subq %r9, %rdi
 ;   movq $0xffffffffffffffff, %rdx
 ;   bsrq %r8, %r10
-;   cmovzq  %rdx, %r10, %r10
+;   cmoveq %rdx, %r10
 ;   movl $0x3f, %eax
 ;   subq %r10, %rax
 ;   addq $0x40, %rax
 ;   cmpq $0x40, %rdi
-;   cmovnzq %rdi, %rax, %rax
+;   cmovneq %rdi, %rax
 ;   uninit  %rdx
 ;   xorq %rdx, %rdx
 ;   movq %rbp, %rsp
@@ -69,7 +69,7 @@ block0(v0: i64):
 ; block0:
 ;   movq $0xffffffffffffffff, %rax
 ;   bsrq %rdi, %r8
-;   cmovzq  %rax, %r8, %r8
+;   cmoveq %rax, %r8
 ;   movl $0x3f, %eax
 ;   subq %r8, %rax
 ;   movq %rbp, %rsp
@@ -102,7 +102,7 @@ block0(v0: i32):
 ; block0:
 ;   movq $0xffffffffffffffff, %rax
 ;   bsrl %edi, %r8d
-;   cmovzl  %eax, %r8d, %r8d
+;   cmovel %eax, %r8d
 ;   movl $0x1f, %eax
 ;   subl %r8d, %eax
 ;   movq %rbp, %rsp
@@ -136,7 +136,7 @@ block0(v0: i16):
 ;   movzwq %di, %rax
 ;   movq $0xffffffffffffffff, %rdx
 ;   bsrq %rax, %r10
-;   cmovzq  %rdx, %r10, %r10
+;   cmoveq %rdx, %r10
 ;   movl $0x3f, %eax
 ;   subq %r10, %rax
 ;   subq $0x30, %rax
@@ -173,7 +173,7 @@ block0(v0: i8):
 ;   movzbq %dil, %rax
 ;   movq $0xffffffffffffffff, %rdx
 ;   bsrq %rax, %r10
-;   cmovzq  %rdx, %r10, %r10
+;   cmoveq %rdx, %r10
 ;   movl $0x3f, %eax
 ;   subq %r10, %rax
 ;   subq $0x38, %rax

--- a/cranelift/filetests/filetests/isa/x64/cmp-mem-bug.clif
+++ b/cranelift/filetests/filetests/isa/x64/cmp-mem-bug.clif
@@ -20,7 +20,7 @@ block0(v0: i64, v1: i64):
 ;   movzbq %r10b, %rax
 ;   cmpq %r9, %rdi
 ;   movq %rsi, %rdx
-;   cmovzq  %rdi, %rdx, %rdx
+;   cmoveq %rdi, %rdx
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq

--- a/cranelift/filetests/filetests/isa/x64/conditional-values.clif
+++ b/cranelift/filetests/filetests/isa/x64/conditional-values.clif
@@ -13,7 +13,7 @@ block0(v0: i8, v1: i32, v2: i32):
 ; block0:
 ;   testb %dil, %dil
 ;   movq %rdx, %rax
-;   cmovnzl %esi, %eax, %eax
+;   cmovnel %esi, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq

--- a/cranelift/filetests/filetests/isa/x64/ctz-bmi1.clif
+++ b/cranelift/filetests/filetests/isa/x64/ctz-bmi1.clif
@@ -17,7 +17,7 @@ block0(v0: i128):
 ;   tzcntq %rsi, %r9
 ;   addq $0x40, %r9
 ;   cmpq $0x40, %rax
-;   cmovzq  %r9, %rax, %rax
+;   cmoveq %r9, %rax
 ;   uninit  %rdx
 ;   xorq %rdx, %rdx
 ;   movq %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/ctz.clif
+++ b/cranelift/filetests/filetests/isa/x64/ctz.clif
@@ -15,13 +15,13 @@ block0(v0: i128):
 ; block0:
 ;   movl $0x40, %ecx
 ;   bsfq %rdi, %rax
-;   cmovzq  %rcx, %rax, %rax
+;   cmoveq %rcx, %rax
 ;   movl $0x40, %edi
 ;   bsfq %rsi, %rdx
-;   cmovzq  %rdi, %rdx, %rdx
+;   cmoveq %rdi, %rdx
 ;   addq $0x40, %rdx
 ;   cmpq $0x40, %rax
-;   cmovzq  %rdx, %rax, %rax
+;   cmoveq %rdx, %rax
 ;   uninit  %rdx
 ;   xorq %rdx, %rdx
 ;   movq %rbp, %rsp
@@ -59,7 +59,7 @@ block0(v0: i64):
 ; block0:
 ;   movl $0x40, %ecx
 ;   bsfq %rdi, %rax
-;   cmovzq  %rcx, %rax, %rax
+;   cmoveq %rcx, %rax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -88,7 +88,7 @@ block0(v0: i32):
 ; block0:
 ;   movl $0x20, %ecx
 ;   bsfl %edi, %eax
-;   cmovzl  %ecx, %eax, %eax
+;   cmovel %ecx, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -119,7 +119,7 @@ block0(v0: i16):
 ;   orl $0x10000, %ecx
 ;   movl $0x10, %r9d
 ;   bsfl %ecx, %eax
-;   cmovzl  %r9d, %eax, %eax
+;   cmovel %r9d, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -152,7 +152,7 @@ block0(v0: i8):
 ;   orl $0x100, %ecx
 ;   movl $0x8, %r9d
 ;   bsfl %ecx, %eax
-;   cmovzl  %r9d, %eax, %eax
+;   cmovel %r9d, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq

--- a/cranelift/filetests/filetests/isa/x64/i128.clif
+++ b/cranelift/filetests/filetests/isa/x64/i128.clif
@@ -1343,17 +1343,17 @@ block0(v0: i128):
 ;   movq %rdi, %r8
 ;   movq $0xffffffffffffffff, %rcx
 ;   bsrq %rsi, %r9
-;   cmovzq  %rcx, %r9, %r9
+;   cmoveq %rcx, %r9
 ;   movl $0x3f, %edi
 ;   subq %r9, %rdi
 ;   movq $0xffffffffffffffff, %rdx
 ;   bsrq %r8, %r10
-;   cmovzq  %rdx, %r10, %r10
+;   cmoveq %rdx, %r10
 ;   movl $0x3f, %eax
 ;   subq %r10, %rax
 ;   addq $0x40, %rax
 ;   cmpq $0x40, %rdi
-;   cmovnzq %rdi, %rax, %rax
+;   cmovneq %rdi, %rax
 ;   uninit  %rdx
 ;   xorq %rdx, %rdx
 ;   movq %rbp, %rsp
@@ -1396,13 +1396,13 @@ block0(v0: i128):
 ; block0:
 ;   movl $0x40, %ecx
 ;   bsfq %rdi, %rax
-;   cmovzq  %rcx, %rax, %rax
+;   cmoveq %rcx, %rax
 ;   movl $0x40, %edi
 ;   bsfq %rsi, %rdx
-;   cmovzq  %rdi, %rdx, %rdx
+;   cmoveq %rdi, %rdx
 ;   addq $0x40, %rdx
 ;   cmpq $0x40, %rax
-;   cmovzq  %rdx, %rax, %rax
+;   cmoveq %rdx, %rax
 ;   uninit  %rdx
 ;   xorq %rdx, %rdx
 ;   movq %rbp, %rsp
@@ -1482,11 +1482,11 @@ block0(v0: i128, v1: i128):
 ;   uninit  %rax
 ;   xorq %rax, %rax
 ;   testq $0x7f, %r8
-;   cmovzq  %rax, %rdi, %rdi
+;   cmoveq %rax, %rdi
 ;   orq %rsi, %rdi
 ;   testq $0x40, %r8
-;   cmovzq  %rdx, %rax, %rax
-;   cmovzq  %rdi, %rdx, %rdx
+;   cmoveq %rdx, %rax
+;   cmoveq %rdi, %rdx
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -1540,12 +1540,12 @@ block0(v0: i128, v1: i128):
 ;   uninit  %rdx
 ;   xorq %rdx, %rdx
 ;   testq $0x7f, %rax
-;   cmovzq  %rdx, %rsi, %rsi
+;   cmoveq %rdx, %rsi
 ;   orq %rdi, %rsi
 ;   testq $0x40, %rax
 ;   movq %r10, %rax
-;   cmovzq  %rsi, %rax, %rax
-;   cmovzq  %r10, %rdx, %rdx
+;   cmoveq %rsi, %rax
+;   cmoveq %r10, %rdx
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -1601,14 +1601,14 @@ block0(v0: i128, v1: i128):
 ;   uninit  %rax
 ;   xorq %rax, %rax
 ;   testq $0x7f, %rdx
-;   cmovzq  %rax, %r11, %r11
+;   cmoveq %rax, %r11
 ;   orq %r11, %rdi
 ;   sarq $0x3f, %rsi
 ;   testq $0x40, %rdx
 ;   movq %r10, %rax
-;   cmovzq  %rdi, %rax, %rax
+;   cmoveq %rdi, %rax
 ;   movq %rsi, %rdx
-;   cmovzq  %r10, %rdx, %rdx
+;   cmoveq %r10, %rdx
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -1669,11 +1669,11 @@ block0(v0: i128, v1: i128):
 ;   xorq %rax, %rax
 ;   movq %r9, %rcx
 ;   testq $0x7f, %rcx
-;   cmovzq  %rax, %r11, %r11
+;   cmoveq %rax, %r11
 ;   orq %r10, %r11
 ;   testq $0x40, %rcx
-;   cmovzq  %rdx, %rax, %rax
-;   cmovzq  %r11, %rdx, %rdx
+;   cmoveq %rdx, %rax
+;   cmoveq %r11, %rdx
 ;   movl $0x80, %ecx
 ;   subq %r8, %rcx
 ;   shrq %cl, %rdi
@@ -1686,12 +1686,12 @@ block0(v0: i128, v1: i128):
 ;   uninit  %r8
 ;   xorq %r8, %r8
 ;   testq $0x7f, %r10
-;   cmovzq  %r8, %rsi, %rsi
+;   cmoveq %r8, %rsi
 ;   orq %rdi, %rsi
 ;   testq $0x40, %r10
 ;   movq %r11, %rdi
-;   cmovzq  %rsi, %rdi, %rdi
-;   cmovzq  %r11, %r8, %r8
+;   cmoveq %rsi, %rdi
+;   cmoveq %r11, %r8
 ;   orq %rdi, %rax
 ;   orq %r8, %rdx
 ;   movq %rbp, %rsp
@@ -1772,12 +1772,12 @@ block0(v0: i128, v1: i128):
 ;   xorq %rdx, %rdx
 ;   movq %r9, %rcx
 ;   testq $0x7f, %rcx
-;   cmovzq  %rdx, %r11, %r11
+;   cmoveq %rdx, %r11
 ;   orq %r8, %r11
 ;   testq $0x40, %rcx
 ;   movq %r10, %rax
-;   cmovzq  %r11, %rax, %rax
-;   cmovzq  %r10, %rdx, %rdx
+;   cmoveq %r11, %rax
+;   cmoveq %r10, %rdx
 ;   movl $0x80, %ecx
 ;   movq %r9, %r8
 ;   subq %r8, %rcx
@@ -1791,11 +1791,11 @@ block0(v0: i128, v1: i128):
 ;   uninit  %r8
 ;   xorq %r8, %r8
 ;   testq $0x7f, %r11
-;   cmovzq  %r8, %rdi, %rdi
+;   cmoveq %r8, %rdi
 ;   orq %rsi, %rdi
 ;   testq $0x40, %r11
-;   cmovzq  %r10, %r8, %r8
-;   cmovzq  %rdi, %r10, %r10
+;   cmoveq %r10, %r8
+;   cmoveq %rdi, %r10
 ;   orq %r8, %rax
 ;   orq %r10, %rdx
 ;   movq %rbp, %rsp
@@ -1868,8 +1868,8 @@ block0(v0: i128):
 ;   movq %rsi, %rdx
 ;   adcq %r8, %rdx
 ;   negq %rdx
-;   cmovsq  %rdi, %rax, %rax
-;   cmovsq  %rsi, %rdx, %rdx
+;   cmovsq %rdi, %rax
+;   cmovsq %rsi, %rdx
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -2174,7 +2174,7 @@ block0(v0: i128, v1: i128):
 ;   movl $0xc8, %eax
 ;   cmpq %rdx, %rdi
 ;   sbbq %rcx, %rsi
-;   cmovbl  const(0), %eax, %eax
+;   cmovbl (%rip), %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq

--- a/cranelift/filetests/filetests/isa/x64/iabs.clif
+++ b/cranelift/filetests/filetests/isa/x64/iabs.clif
@@ -13,7 +13,7 @@ block0(v0: i8):
 ; block0:
 ;   movq %rdi, %rax
 ;   negb %al
-;   cmovsl  %edi, %eax, %eax
+;   cmovsl %edi, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -42,7 +42,7 @@ block0(v0: i16):
 ; block0:
 ;   movq %rdi, %rax
 ;   negw %ax
-;   cmovsl  %edi, %eax, %eax
+;   cmovsl %edi, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -71,7 +71,7 @@ block0(v0: i32):
 ; block0:
 ;   movq %rdi, %rax
 ;   negl %eax
-;   cmovsl  %edi, %eax, %eax
+;   cmovsl %edi, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -100,7 +100,7 @@ block0(v0: i64):
 ; block0:
 ;   movq %rdi, %rax
 ;   negq %rax
-;   cmovsq  %rdi, %rax, %rax
+;   cmovsq %rdi, %rax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq

--- a/cranelift/filetests/filetests/isa/x64/ishl.clif
+++ b/cranelift/filetests/filetests/isa/x64/ishl.clif
@@ -30,11 +30,11 @@ block0(v0: i128, v1: i8):
 ;   uninit  %rax
 ;   xorq %rax, %rax
 ;   testq $0x7f, %r8
-;   cmovzq  %rax, %rdi, %rdi
+;   cmoveq %rax, %rdi
 ;   orq %rsi, %rdi
 ;   testq $0x40, %r8
-;   cmovzq  %rdx, %rax, %rax
-;   cmovzq  %rdi, %rdx, %rdx
+;   cmoveq %rdx, %rax
+;   cmoveq %rdi, %rdx
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -87,11 +87,11 @@ block0(v0: i128, v1: i64):
 ;   uninit  %rax
 ;   xorq %rax, %rax
 ;   testq $0x7f, %r8
-;   cmovzq  %rax, %rdi, %rdi
+;   cmoveq %rax, %rdi
 ;   orq %rsi, %rdi
 ;   testq $0x40, %r8
-;   cmovzq  %rdx, %rax, %rax
-;   cmovzq  %rdi, %rdx, %rdx
+;   cmoveq %rdx, %rax
+;   cmoveq %rdi, %rdx
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -145,11 +145,11 @@ block0(v0: i128, v1: i32):
 ;   uninit  %rax
 ;   xorq %rax, %rax
 ;   testq $0x7f, %r8
-;   cmovzq  %rax, %rdi, %rdi
+;   cmoveq %rax, %rdi
 ;   orq %rsi, %rdi
 ;   testq $0x40, %r8
-;   cmovzq  %rdx, %rax, %rax
-;   cmovzq  %rdi, %rdx, %rdx
+;   cmoveq %rdx, %rax
+;   cmoveq %rdi, %rdx
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -203,11 +203,11 @@ block0(v0: i128, v1: i16):
 ;   uninit  %rax
 ;   xorq %rax, %rax
 ;   testq $0x7f, %r8
-;   cmovzq  %rax, %rdi, %rdi
+;   cmoveq %rax, %rdi
 ;   orq %rsi, %rdi
 ;   testq $0x40, %r8
-;   cmovzq  %rdx, %rax, %rax
-;   cmovzq  %rdi, %rdx, %rdx
+;   cmoveq %rdx, %rax
+;   cmoveq %rdi, %rdx
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -261,11 +261,11 @@ block0(v0: i128, v1: i8):
 ;   uninit  %rax
 ;   xorq %rax, %rax
 ;   testq $0x7f, %r8
-;   cmovzq  %rax, %rdi, %rdi
+;   cmoveq %rax, %rdi
 ;   orq %rsi, %rdi
 ;   testq $0x40, %r8
-;   cmovzq  %rdx, %rax, %rax
-;   cmovzq  %rdi, %rdx, %rdx
+;   cmoveq %rdx, %rax
+;   cmoveq %rdi, %rdx
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq

--- a/cranelift/filetests/filetests/isa/x64/select-i128.clif
+++ b/cranelift/filetests/filetests/isa/x64/select-i128.clif
@@ -16,10 +16,10 @@ block0(v0: i32, v1: i128, v2: i128):
 ; block0:
 ;   cmpl $0x2a, %edi
 ;   movq %rcx, %rax
-;   cmovzq  %rsi, %rax, %rax
+;   cmoveq %rsi, %rax
 ;   movq %rdx, %rdi
 ;   movq %r8, %rdx
-;   cmovzq  %rdi, %rdx, %rdx
+;   cmoveq %rdi, %rdx
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -51,12 +51,12 @@ block0(v0: f32, v1: i128, v2: i128):
 ;   movq %rsp, %rbp
 ; block0:
 ;   ucomiss %xmm0, %xmm0
-;   cmovpq  %rdx, %rdi, %rdi
+;   cmovpq %rdx, %rdi
+;   cmovpq %rcx, %rsi
 ;   movq %rdi, %rax
-;   cmovnzq %rdx, %rax, %rax
-;   cmovpq  %rcx, %rsi, %rsi
+;   cmovneq %rdx, %rax
 ;   movq %rsi, %rdx
-;   cmovnzq %rcx, %rdx, %rdx
+;   cmovneq %rcx, %rdx
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -68,9 +68,9 @@ block0(v0: f32, v1: i128, v2: i128):
 ; block1: ; offset 0x4
 ;   ucomiss %xmm0, %xmm0
 ;   cmovpq %rdx, %rdi
+;   cmovpq %rcx, %rsi
 ;   movq %rdi, %rax
 ;   cmovneq %rdx, %rax
-;   cmovpq %rcx, %rsi
 ;   movq %rsi, %rdx
 ;   cmovneq %rcx, %rdx
 ;   movq %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/select-issue-3744.clif
+++ b/cranelift/filetests/filetests/isa/x64/select-issue-3744.clif
@@ -18,8 +18,8 @@ block0(v0: f32, v1: f32):
 ; block0:
 ;   movl $0x1, %eax
 ;   ucomiss %xmm1, %xmm0
-;   cmovpl  const(0), %eax, %eax
-;   cmovnzl const(0), %eax, %eax
+;   cmovpl (%rip), %eax
+;   cmovnel (%rip), %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq

--- a/cranelift/filetests/filetests/isa/x64/select.clif
+++ b/cranelift/filetests/filetests/isa/x64/select.clif
@@ -15,7 +15,7 @@ block0(v0: i32, v1: i32, v2: i64, v3: i64):
 ; block0:
 ;   cmpl %esi, %edi
 ;   movq %rcx, %rax
-;   cmovzq  %rdx, %rax, %rax
+;   cmoveq %rdx, %rax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -45,9 +45,9 @@ block0(v0: f32, v1: f32, v2: i64, v3: i64):
 ;   movq %rsp, %rbp
 ; block0:
 ;   ucomiss %xmm1, %xmm0
-;   cmovpq  %rsi, %rdi, %rdi
+;   cmovpq %rsi, %rdi
 ;   movq %rdi, %rax
-;   cmovnzq %rsi, %rax, %rax
+;   cmovneq %rsi, %rax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq

--- a/cranelift/filetests/filetests/isa/x64/sshr.clif
+++ b/cranelift/filetests/filetests/isa/x64/sshr.clif
@@ -30,14 +30,14 @@ block0(v0: i128, v1: i8):
 ;   uninit  %rax
 ;   xorq %rax, %rax
 ;   testq $0x7f, %rdx
-;   cmovzq  %rax, %r11, %r11
+;   cmoveq %rax, %r11
 ;   orq %r11, %rdi
 ;   sarq $0x3f, %rsi
 ;   testq $0x40, %rdx
 ;   movq %r10, %rax
-;   cmovzq  %rdi, %rax, %rax
+;   cmoveq %rdi, %rax
 ;   movq %rsi, %rdx
-;   cmovzq  %r10, %rdx, %rdx
+;   cmoveq %r10, %rdx
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -95,14 +95,14 @@ block0(v0: i128, v1: i64):
 ;   uninit  %r11
 ;   xorq %r11, %r11
 ;   testq $0x7f, %rax
-;   cmovzq  %r11, %r10, %r10
+;   cmoveq %r11, %r10
 ;   orq %r10, %rdi
 ;   sarq $0x3f, %rsi
 ;   testq $0x40, %rax
 ;   movq %r9, %rax
-;   cmovzq  %rdi, %rax, %rax
+;   cmoveq %rdi, %rax
 ;   movq %rsi, %rdx
-;   cmovzq  %r9, %rdx, %rdx
+;   cmoveq %r9, %rdx
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -161,14 +161,14 @@ block0(v0: i128, v1: i32):
 ;   uninit  %r11
 ;   xorq %r11, %r11
 ;   testq $0x7f, %rax
-;   cmovzq  %r11, %r10, %r10
+;   cmoveq %r11, %r10
 ;   orq %r10, %rdi
 ;   sarq $0x3f, %rsi
 ;   testq $0x40, %rax
 ;   movq %r9, %rax
-;   cmovzq  %rdi, %rax, %rax
+;   cmoveq %rdi, %rax
 ;   movq %rsi, %rdx
-;   cmovzq  %r9, %rdx, %rdx
+;   cmoveq %r9, %rdx
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -227,14 +227,14 @@ block0(v0: i128, v1: i16):
 ;   uninit  %r11
 ;   xorq %r11, %r11
 ;   testq $0x7f, %rax
-;   cmovzq  %r11, %r10, %r10
+;   cmoveq %r11, %r10
 ;   orq %r10, %rdi
 ;   sarq $0x3f, %rsi
 ;   testq $0x40, %rax
 ;   movq %r9, %rax
-;   cmovzq  %rdi, %rax, %rax
+;   cmoveq %rdi, %rax
 ;   movq %rsi, %rdx
-;   cmovzq  %r9, %rdx, %rdx
+;   cmoveq %r9, %rdx
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -293,14 +293,14 @@ block0(v0: i128, v1: i8):
 ;   uninit  %r11
 ;   xorq %r11, %r11
 ;   testq $0x7f, %rax
-;   cmovzq  %r11, %r10, %r10
+;   cmoveq %r11, %r10
 ;   orq %r10, %rdi
 ;   sarq $0x3f, %rsi
 ;   testq $0x40, %rax
 ;   movq %r9, %rax
-;   cmovzq  %rdi, %rax, %rax
+;   cmoveq %rdi, %rax
 ;   movq %rsi, %rdx
-;   cmovzq  %r9, %rdx, %rdx
+;   cmoveq %r9, %rdx
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq

--- a/cranelift/filetests/filetests/isa/x64/umax-bug.clif
+++ b/cranelift/filetests/filetests/isa/x64/umax-bug.clif
@@ -15,7 +15,7 @@ block0(v1: i32, v2: i64):
 ;   movl (%rsi), %edx
 ;   cmpl %edi, %edx
 ;   movq %rdi, %rax
-;   cmovnbl %edx, %eax, %eax
+;   cmovael %edx, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq

--- a/cranelift/filetests/filetests/isa/x64/ushr.clif
+++ b/cranelift/filetests/filetests/isa/x64/ushr.clif
@@ -28,12 +28,12 @@ block0(v0: i128, v1: i8):
 ;   uninit  %rdx
 ;   xorq %rdx, %rdx
 ;   testq $0x7f, %rax
-;   cmovzq  %rdx, %rsi, %rsi
+;   cmoveq %rdx, %rsi
 ;   orq %rdi, %rsi
 ;   testq $0x40, %rax
 ;   movq %r10, %rax
-;   cmovzq  %rsi, %rax, %rax
-;   cmovzq  %r10, %rdx, %rdx
+;   cmoveq %rsi, %rax
+;   cmoveq %r10, %rdx
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -87,12 +87,12 @@ block0(v0: i128, v1: i64):
 ;   uninit  %rdx
 ;   xorq %rdx, %rdx
 ;   testq $0x7f, %rax
-;   cmovzq  %rdx, %rsi, %rsi
+;   cmoveq %rdx, %rsi
 ;   orq %rdi, %rsi
 ;   testq $0x40, %rax
 ;   movq %r9, %rax
-;   cmovzq  %rsi, %rax, %rax
-;   cmovzq  %r9, %rdx, %rdx
+;   cmoveq %rsi, %rax
+;   cmoveq %r9, %rdx
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -147,12 +147,12 @@ block0(v0: i128, v1: i32):
 ;   uninit  %rdx
 ;   xorq %rdx, %rdx
 ;   testq $0x7f, %rax
-;   cmovzq  %rdx, %rsi, %rsi
+;   cmoveq %rdx, %rsi
 ;   orq %rdi, %rsi
 ;   testq $0x40, %rax
 ;   movq %r9, %rax
-;   cmovzq  %rsi, %rax, %rax
-;   cmovzq  %r9, %rdx, %rdx
+;   cmoveq %rsi, %rax
+;   cmoveq %r9, %rdx
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -207,12 +207,12 @@ block0(v0: i128, v1: i16):
 ;   uninit  %rdx
 ;   xorq %rdx, %rdx
 ;   testq $0x7f, %rax
-;   cmovzq  %rdx, %rsi, %rsi
+;   cmoveq %rdx, %rsi
 ;   orq %rdi, %rsi
 ;   testq $0x40, %rax
 ;   movq %r9, %rax
-;   cmovzq  %rsi, %rax, %rax
-;   cmovzq  %r9, %rdx, %rdx
+;   cmoveq %rsi, %rax
+;   cmoveq %r9, %rdx
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -267,12 +267,12 @@ block0(v0: i128, v1: i8):
 ;   uninit  %rdx
 ;   xorq %rdx, %rdx
 ;   testq $0x7f, %rax
-;   cmovzq  %rdx, %rsi, %rsi
+;   cmoveq %rdx, %rsi
 ;   orq %rdi, %rsi
 ;   testq $0x40, %rax
 ;   movq %r9, %rax
-;   cmovzq  %rsi, %rax, %rax
-;   cmovzq  %r9, %rdx, %rdx
+;   cmoveq %rsi, %rax
+;   cmoveq %r9, %rdx
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq

--- a/cranelift/filetests/filetests/isa/x64/very-carefully-sink-loads-in-float-compares.clif
+++ b/cranelift/filetests/filetests/isa/x64/very-carefully-sink-loads-in-float-compares.clif
@@ -28,9 +28,9 @@ block0(v0: f32, v1: i64, v2: i32, v3: i32):
 ;   movq %rsp, %rbp
 ; block0:
 ;   ucomiss (%rdi), %xmm0
-;   cmovpl  %edx, %esi, %esi
+;   cmovpl %edx, %esi
 ;   movq %rsi, %rax
-;   cmovnzl %edx, %eax, %eax
+;   cmovnel %edx, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -62,9 +62,9 @@ block0(v0: f32, v1: i64, v2: i32, v3: i32):
 ; block0:
 ;   movss (%rdi), %xmm7
 ;   ucomiss %xmm0, %xmm7
-;   cmovpl  %edx, %esi, %esi
+;   cmovpl %edx, %esi
 ;   movq %rsi, %rax
-;   cmovnzl %edx, %eax, %eax
+;   cmovnel %edx, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -100,11 +100,11 @@ block0(v0: f32, v1: i64, v2: i32, v3: i32):
 ;   movss (%rdi), %xmm1
 ;   ucomiss %xmm1, %xmm0
 ;   movq %rsi, %rax
-;   cmovpl  %edx, %eax, %eax
-;   cmovnzl %edx, %eax, %eax
+;   cmovpl %edx, %eax
+;   cmovnel %edx, %eax
 ;   ucomiss %xmm1, %xmm0
-;   cmovpl  %esi, %edx, %edx
-;   cmovnzl %esi, %edx, %edx
+;   cmovpl %esi, %edx
+;   cmovnel %esi, %edx
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -143,11 +143,11 @@ block0(v0: f32, v1: i64, v2: i32, v3: i32):
 ;   movss (%rdi), %xmm1
 ;   ucomiss %xmm0, %xmm1
 ;   movq %rsi, %rax
-;   cmovpl  %edx, %eax, %eax
-;   cmovnzl %edx, %eax, %eax
+;   cmovpl %edx, %eax
+;   cmovnel %edx, %eax
 ;   ucomiss %xmm0, %xmm1
-;   cmovpl  %esi, %edx, %edx
-;   cmovnzl %esi, %edx, %edx
+;   cmovpl %esi, %edx
+;   cmovnel %esi, %edx
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -402,8 +402,8 @@ block1(v7: i32):
 ;   movss (%rdi), %xmm1
 ;   ucomiss %xmm1, %xmm0
 ;   movq %rsi, %rax
-;   cmovpl  %edx, %eax, %eax
-;   cmovnzl %edx, %eax, %eax
+;   cmovpl %edx, %eax
+;   cmovnel %edx, %eax
 ;   ucomiss %xmm1, %xmm0
 ;   jp,nz   label2; j label1
 ; block1:
@@ -453,8 +453,8 @@ block1(v7: i32):
 ;   movss (%rdi), %xmm1
 ;   ucomiss %xmm0, %xmm1
 ;   movq %rsi, %rax
-;   cmovpl  %edx, %eax, %eax
-;   cmovnzl %edx, %eax, %eax
+;   cmovpl %edx, %eax
+;   cmovnel %edx, %eax
 ;   ucomiss %xmm0, %xmm1
 ;   jp,nz   label2; j label1
 ; block1:


### PR DESCRIPTION
This commit adds all `cmov*` variants from the Intel manual to the new assembler. This then additionally removes the `Cmove` pseudo-inst in favor of these new instructions. One difference from before is that the naming in the `CC` enum does not exactly match what mnemonics Capstone uses to disassemble. For example `CC.NB` in ISLE corresponds to the Intel instruction `CMOVNB`. This instruction, however, has the same encoding as `CMOVAE` and Capstone disassembles as `CMOVAE`. This means that the instruction selection in ISLE isn't a 1:1 match with mnemonics.

This additionally adds support in the assembler ISLE generation to understand that instructions which read EFLAGS generate a `ConsumesFlags` variant in their instruction helpers.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
