### PR TITLE
Add CI job to verify static library build configuration

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1079,6 +1079,41 @@ jobs:
         name: bins-${{ matrix.build }}
         path: dist
 
+  # Independent job to verify that static builds still work.
+  # This catches issues like duplicate symbols or bad linkage
+  # when building Wasmtime with -DWASMEDGE_BUILD_STATIC_LIB=ON.
+  #
+  # This job is intentionally NOT part of the main matrix build.
+  # It runs with hardcoded values and doesn't interfere with
+  # release artifacts or build cache.
+  build-static-lib:
+    name: Static Library Build
+    runs-on: ubuntu-latest
+    needs: determine
+    if: needs.determine.outputs.run-full
+    steps:
+      # Checkout source code with submodules
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      # Install Ninja (required by some CMake builds)
+      - uses: ./.github/actions/install-ninja
+
+      # Install the Rust toolchain
+      - uses: ./.github/actions/install-rust
+        with:
+          toolchain: stable
+
+      # Add required Rust components and targets
+      - run: |
+          rustup component add rust-src
+          rustup target add x86_64-unknown-linux-gnu
+
+      # Build the project with the static lib flag enabled
+      - name: Build Wasmtime as a static library
+        run: static=true ./ci/build-release-artifacts.sh release x86_64-unknown-linux-gnu
+
   # This is a "join node" which depends on all prior workflows. The merge queue,
   # for example, gates on this to ensure that everything has executed
   # successfully.

--- a/ci/build-release-artifacts.sh
+++ b/ci/build-release-artifacts.sh
@@ -63,6 +63,12 @@ else
   bin_flags="--features all-arch,component-model"
 fi
 
+# Enable static library build mode if the "static" flag is set to true
+if [[ "$static" == "true" ]]; then
+  # This flag tells CMake to build the project as a static library
+  cmake_flags="$cmake_flags -DWASMEDGE_BUILD_STATIC_LIB=ON"
+fi
+
 if [[ "$target" = "x86_64-pc-windows-msvc" ]]; then
   # Avoid emitting `/DEFAULTLIB:MSVCRT` into the static library by using clang.
   export CC=clang


### PR DESCRIPTION
This PR introduces a dedicated CI job (`build-static-lib`) that verifies the static library build of Wasmtime by passing `-DWASMEDGE_BUILD_STATIC_LIB=ON` to CMake.

### Changes:

* Added a standalone `build-static-lib` job in `.github/workflows/main.yml`, triggered alongside regular builds.
* This job uses a fixed Rust toolchain (`stable`) and target (`x86_64-unknown-linux-gnu`).
* It runs independently of the main matrix-based `build` job to avoid cache conflicts or artifact overrides.
* Static build logic is activated via `static=true` passed to `ci/build-release-artifacts.sh`.

### Motivation:

Static library builds can fail due to symbol collisions or source file name conflicts. CI coverage ensures we catch such regressions early.

### Related:

Fixes [#3608](https://github.com/WasmEdge/WasmEdge/issues/3608)
Refs [this comment](https://github.com/WasmEdge/WasmEdge/pull/3607#issuecomment-2254381977) suggesting the need for a `STATIC_LIB=ON` build in CI.
