### PR TITLE
x64: Refactor backend condition handling

### DIFF
--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -2560,74 +2560,12 @@
 (rule 1 (cmove $I64 (CC.P) c a) (x64_cmovpq_rm a c))
 (rule 1 (cmove $I64 (CC.NP) c a) (x64_cmovnpq_rm a c))
 
-(decl cmove128 (CC ValueRegs ValueRegs) ConsumesFlags)
-(rule (cmove128 cc cons alt)
-  (consumes_flags_concat
-    (cmove $I64 cc (value_regs_get_gpr cons 0) (value_regs_get_gpr alt 0))
-    (cmove $I64 cc (value_regs_get_gpr cons 1) (value_regs_get_gpr alt 1))))
-
 (decl cmove_xmm (Type CC Xmm Xmm) ConsumesFlags)
 (rule (cmove_xmm ty cc consequent alternative)
       (let ((dst WritableXmm (temp_writable_xmm)))
         (ConsumesFlags.ConsumesFlagsReturnsReg
          (MInst.XmmCmove ty cc consequent alternative dst)
          dst)))
-
-;; Helper for creating `cmove` instructions directly from values. This allows us
-;; to special-case the `I128` types and default to the `cmove` helper otherwise.
-;; It also eliminates some `put_in_reg*` boilerplate in the lowering ISLE code.
-(decl cmove_from_values (Type CC Value Value) ConsumesFlags)
-(rule (cmove_from_values (is_multi_register_gpr_type $I128) cc consequent alternative)
-  (cmove128 cc consequent alternative))
-
-(rule (cmove_from_values (is_single_register_gpr_type ty) cc consequent alternative)
-      (cmove ty cc consequent alternative))
-
-(rule (cmove_from_values (is_xmm_type ty) cc consequent alternative)
-      (cmove_xmm ty cc consequent alternative))
-
-;; Helper for creating `cmove` instructions with the logical OR of multiple
-;; flags. Note that these instructions will always result in more than one
-;; emitted x86 instruction.
-(decl cmove_or (Type CC CC GprMem Gpr) ConsumesFlags)
-(rule (cmove_or ty cc1 cc2 consequent alternative)
-  (let ((c1 ConsumesFlags (cmove ty cc1 consequent alternative))
-        (tmp Gpr (consumes_flags_get_reg c1))
-        (c2 ConsumesFlags (cmove ty cc2 consequent tmp)))
-    (consumes_flags_return_last c1 c2)))
-
-(decl cmove_or_xmm (Type CC CC Xmm Xmm) ConsumesFlags)
-(rule (cmove_or_xmm ty cc1 cc2 consequent alternative)
-  (let ((c1 ConsumesFlags (cmove_xmm ty cc1 consequent alternative))
-        (tmp Xmm (consumes_flags_get_reg c1))
-        (c2 ConsumesFlags (cmove_xmm ty cc2 consequent tmp)))
-    (consumes_flags_return_last c1 c2)))
-
-(decl consumes_flags_return_last (ConsumesFlags ConsumesFlags) ConsumesFlags)
-(rule (consumes_flags_return_last
-        (ConsumesFlags.ConsumesFlagsReturnsReg inst1 _)
-        (ConsumesFlags.ConsumesFlagsReturnsReg inst2 dst))
-  (ConsumesFlags.ConsumesFlagsTwiceReturnsValueRegs inst1 inst2 dst))
-(rule (consumes_flags_return_last
-        (ConsumesFlags.ConsumesFlagsTwiceReturnsValueRegs i1 i2 _)
-        (ConsumesFlags.ConsumesFlagsTwiceReturnsValueRegs i3 i4 dst))
-  (ConsumesFlags.ConsumesFlagsFourTimesReturnsValueRegs i1 i2 i3 i4 dst))
-
-;; Helper for creating `cmove_or` instructions directly from values. This allows
-;; us to special-case the `I128` types and default to the `cmove_or` helper
-;; otherwise.
-(decl cmove_or_from_values (Type CC CC Value Value) ConsumesFlags)
-(rule (cmove_or_from_values (is_multi_register_gpr_type $I128) cc1 cc2 consequent alternative)
-  (let ((c1 ConsumesFlags (cmove128 cc1 consequent alternative))
-        (tmp ValueRegs (consumes_flags_get_regs c1))
-        (c2 ConsumesFlags (cmove128 cc2 consequent tmp)))
-    (consumes_flags_return_last c1 c2)))
-
-(rule (cmove_or_from_values (is_single_register_gpr_type ty) cc1 cc2 consequent alternative)
-      (cmove_or ty cc1 cc2 consequent alternative))
-
-(rule (cmove_or_from_values (is_xmm_type ty) cc1 cc2 consequent alternative)
-      (cmove_or_xmm ty cc1 cc2 consequent alternative))
 
 ;; Helper for creating `MInst.Setcc` instructions.
 (decl x64_setcc (CC) ConsumesFlags)
@@ -4174,41 +4112,6 @@
 (rule (trap_if_or cc1 cc2 tc)
       (ConsumesFlags.ConsumesFlagsSideEffect (MInst.TrapIfOr cc1 cc2 tc)))
 
-(decl trap_if_icmp (IcmpCondResult TrapCode) SideEffectNoResult)
-(rule (trap_if_icmp (IcmpCondResult.Condition producer cc) tc)
-      (with_flags_side_effect producer (trap_if cc tc)))
-
-(decl trap_if_fcmp (FcmpCondResult TrapCode) SideEffectNoResult)
-(rule (trap_if_fcmp (FcmpCondResult.Condition producer cc) tc)
-      (with_flags_side_effect producer (trap_if cc tc)))
-(rule (trap_if_fcmp (FcmpCondResult.AndCondition producer cc1 cc2) tc)
-      (with_flags_side_effect producer (trap_if_and cc1 cc2 tc)))
-(rule (trap_if_fcmp (FcmpCondResult.OrCondition producer cc1 cc2) tc)
-      (with_flags_side_effect producer (trap_if_or cc1 cc2 tc)))
-
-;; Trap if zero/not zero
-(type ZeroCond
-      (enum
-       Zero
-       NonZero))
-
-(decl zero_cond_to_cc (ZeroCond) CC)
-(rule (zero_cond_to_cc (ZeroCond.Zero)) (CC.Z))
-(rule (zero_cond_to_cc (ZeroCond.NonZero)) (CC.NZ))
-
-(decl trap_if_val (ZeroCond Value TrapCode) SideEffectNoResult)
-(rule (trap_if_val zero_cond a @ (value_type (fits_in_64 ty)) tc)
-  (let ((a Gpr (put_in_reg a))
-        (producer ProducesFlags (x64_test ty a a)))
-        (with_flags_side_effect producer (trap_if (zero_cond_to_cc zero_cond) tc))))
-
-(rule 1 (trap_if_val zero_cond a @ (value_type $I128) tc)
-  (let ((a_lo Gpr (value_regs_get_gpr a 0))
-        (a_hi Gpr (value_regs_get_gpr a 1))
-        (a_or Gpr (x64_or $I64 a_hi a_lo))
-        (producer ProducesFlags (x64_testq_mr a_or a_or)))
-        (with_flags_side_effect producer (trap_if (zero_cond_to_cc zero_cond) tc))))
-
 ;; Helper for creating `movddup` instructions
 (decl x64_movddup (XmmMem) Xmm)
 (rule (x64_movddup src) (x64_movddup_a src))
@@ -4247,21 +4150,13 @@
 (rule (jmp_cond_or cc1 cc2 taken not_taken)
       (ConsumesFlags.ConsumesFlagsSideEffect (MInst.JmpCondOr cc1 cc2 taken not_taken)))
 
-;; Conditional jump based on the result of an icmp.
-(decl jmp_cond_icmp (IcmpCondResult MachLabel MachLabel) SideEffectNoResult)
-(rule (jmp_cond_icmp (IcmpCondResult.Condition producer cc) taken not_taken)
+;; Conditional jump based on a `CondResult`
+(decl jmp_cond_result (CondResult MachLabel MachLabel) SideEffectNoResult)
+(rule (jmp_cond_result (CondResult.CC producer cc) taken not_taken)
       (with_flags_side_effect producer (jmp_cond cc taken not_taken)))
-
-;; Conditional jump based on the result of an fcmp.
-(decl jmp_cond_fcmp (FcmpCondResult MachLabel MachLabel) SideEffectNoResult)
-(rule (jmp_cond_fcmp (FcmpCondResult.Condition producer cc) taken not_taken)
-      (with_flags_side_effect producer (jmp_cond cc taken not_taken)))
-(rule (jmp_cond_fcmp (FcmpCondResult.AndCondition producer cc1 cc2) taken not_taken)
-      (with_flags_side_effect producer
-                              ;; DeMorgan's rule: to get cc1 AND cc2, we do NOT (NOT cc1 OR NOT cc2).
-                              ;; The outer NOT comes from flipping `not_taken` and `taken`.
-                              (jmp_cond_or (cc_invert cc1) (cc_invert cc2) not_taken taken)))
-(rule (jmp_cond_fcmp (FcmpCondResult.OrCondition producer cc1 cc2) taken not_taken)
+(rule (jmp_cond_result cond @ (CondResult.And _ _ _) taken not_taken)
+      (jmp_cond_result (cond_invert cond) not_taken taken))
+(rule (jmp_cond_result (CondResult.Or producer cc1 cc2) taken not_taken)
       (with_flags_side_effect producer
                               (jmp_cond_or cc1 cc2 taken not_taken)))
 
@@ -4296,54 +4191,106 @@
 
 ;;;; Comparisons ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(type IcmpCondResult (enum (Condition (producer ProducesFlags) (cc CC))))
+;; Representation of the result of a conditional instruction.
+;;
+;; Each variant here has what produces some condition flags in addition to
+;; what condition code is being tested as a result of whatever produced the
+;; flags.
+;;
+;; This type is intended to be a "narrow waist" for anything producing a
+;; conditional which `icmp` might flow into for example. The `is_nonzero_cmp`
+;; constructor is the main constructor of this type which takes any arbitrary
+;; value used in a conditional-like location. There are further refined
+;; constructors such as `emit_{cmp,fcmp}` which work specifically on the shapes
+;; of `icmp` and `fcmp` CLIF instructions. Everything produces this type, and
+;; then decisions about what instructions to emit flow from this type.
+(type CondResult
+      (enum
+        ;; The given condition code must be set.
+        (CC (producer ProducesFlags) (cc CC))
 
-(decl icmp_cond_result (ProducesFlags CC) IcmpCondResult)
-(rule (icmp_cond_result producer cc) (IcmpCondResult.Condition producer cc))
+        ;; Both condition codes must be set.
+        (And (producer ProducesFlags) (cc1 CC) (cc2 CC))
 
-(decl invert_icmp_cond_result (IcmpCondResult) IcmpCondResult)
-(rule (invert_icmp_cond_result (IcmpCondResult.Condition producer cc))
-      (icmp_cond_result producer (cc_invert cc)))
+        ;; Either of the conditions codes must be set.
+        (Or (producer ProducesFlags) (cc1 CC) (cc2 CC))))
 
-;; Lower an Icmp result into a boolean value in a register.
-(decl lower_icmp_bool (IcmpCondResult) ValueRegs)
-(rule (lower_icmp_bool (IcmpCondResult.Condition producer cc))
-      (with_flags producer (x64_setcc cc)))
+;; Inverts a `CondResult` to have the opposite meaning.
+(decl cond_invert (CondResult) CondResult)
+(rule (cond_invert (CondResult.CC flags cc)) (CondResult.CC flags (cc_invert cc)))
+(rule (cond_invert (CondResult.Or flags cc1 cc2)) (CondResult.And flags (cc_invert cc1) (cc_invert cc2)))
+(rule (cond_invert (CondResult.And flags cc1 cc2)) (CondResult.Or flags (cc_invert cc1) (cc_invert cc2)))
 
-;; Emit a conditional move based on the result of an icmp.
-(decl select_icmp (IcmpCondResult Value Value) ValueRegs)
+;; Converts a `Value` to a `CondResult` with the condition being tested if
+;; `Value` is nonzero.
+;;
+;; Note that this is used as the base entry case for instruction lowering such
+;; as `select` and `brif`. The `Value` here is expected to, via CLIF validation,
+;; have an integer type (and it can be I128)
+(decl is_nonzero_cmp (Value) CondResult)
 
-;; Ensure that we put the `x` argument into a register for single-register
-;; gpr-typed arguments, as we rely on this for the legalization of heap_addr and
-;; loading easily computed constants (like 0) from memory is too expensive.
-(rule 1 (select_icmp (IcmpCondResult.Condition producer cc) x @ (value_type (is_single_register_gpr_type ty)) y)
-      (with_flags producer (cmove ty cc (put_in_gpr x) y)))
+;; Base case: fits in one GPR, use `x64_test`
+(rule (is_nonzero_cmp val @ (value_type (is_single_register_gpr_type ty)))
+  (let ((gpr Gpr val)) (CondResult.CC (x64_test ty gpr gpr) (CC.NZ))))
 
-;; Otherwise, fall back on the behavior of `cmove_from_values`.
-(rule 0 (select_icmp (IcmpCondResult.Condition producer cc) x @ (value_type ty) y)
-      (with_flags producer (cmove_from_values ty cc x y)))
+;; Base case: i128
+(rule 1 (is_nonzero_cmp val @ (value_type $I128))
+      (let ((lo Gpr (value_regs_get_gpr val 0))
+            (hi Gpr (value_regs_get_gpr val 1)))
+          (CondResult.CC
+            (x64_produce_flags_side_effect (ProduceFlagsSideEffectOp.Or) $I64 lo hi)
+            (CC.NZ))))
 
-(decl emit_cmp (IntCC Value Value) IcmpCondResult)
+;; Special case some instructions where lowerings directly produce condition
+;; codes.
+(rule 2 (is_nonzero_cmp (fcmp cc a b)) (emit_fcmp cc a b))
+(rule 2 (is_nonzero_cmp (icmp cc a b)) (emit_cmp cc a b))
+(rule 2 (is_nonzero_cmp (vall_true vec)) (is_vall_true vec))
+(rule 2 (is_nonzero_cmp (vany_true vec)) (is_vany_true vec))
+(rule 2 (is_nonzero_cmp (uextend val)) (is_nonzero_cmp val))
 
-;; For GPR-held values we only need to emit `CMP + SETCC`. We rely here on
-;; Cranelift's verification that `a` and `b` are of the same type.
-(rule 0 (emit_cmp cc a @ (value_type ty) b)
-        (icmp_cond_result (x64_cmp ty a b) cc))
+;; Lower a CondResult to a boolean value in a register.
+(decl lower_cond_bool (CondResult) Gpr)
+(rule (lower_cond_bool (CondResult.CC producer cc))
+  (value_regs_get_gpr (with_flags producer (x64_setcc cc)) 0))
+(rule (lower_cond_bool (CondResult.And producer cc1 cc2))
+      (let ((maybe ValueRegs (with_flags producer
+                                         (consumes_flags_concat
+                                           (x64_setcc cc1)
+                                           (x64_setcc cc2))))
+            (maybe0 Gpr (value_regs_get_gpr maybe 0))
+            (maybe1 Gpr (value_regs_get_gpr maybe 1)))
+        (x64_and $I8 maybe0 maybe1)))
+(rule (lower_cond_bool (CondResult.Or producer cc1 cc2))
+      (let ((maybe ValueRegs (with_flags producer
+                                         (consumes_flags_concat
+                                           (x64_setcc cc1)
+                                           (x64_setcc cc2))))
+            (maybe0 Gpr (value_regs_get_gpr maybe 0))
+            (maybe1 Gpr (value_regs_get_gpr maybe 1)))
+        (x64_or $I8 maybe0 maybe1)))
+
+;; Helper to transform an `icmp` node into a `CondResult`.
+;;
+;; Note that via CLIF validation the two values here should have the same type.
+(decl emit_cmp (IntCC Value Value) CondResult)
+
+;; For GPR-held values we only need to emit `CMP`.
+(rule 0 (emit_cmp cc a @ (value_type ty) b) (CondResult.CC (x64_cmp ty a b) cc))
 
 ;; As a special case, swap the arguments to the comparison when the LHS is a
 ;; constant. This ensures that we avoid moving the constant into a register when
 ;; performing the comparison.
 (rule 1 (emit_cmp cc (and (simm32_from_value a) (value_type ty)) b)
-        (icmp_cond_result (x64_cmp ty b a) (intcc_swap_args cc)))
+        (CondResult.CC (x64_cmp ty b a) (intcc_swap_args cc)))
 
 ;; Special case: use the test instruction for comparisons with 0.
 (rule 2 (emit_cmp cc a @ (value_type ty) (u64_from_iconst 0))
       (let ((a Gpr (put_in_reg a)))
-        (icmp_cond_result (x64_test ty a a) cc)))
-
+        (CondResult.CC (x64_test ty a a) cc)))
 (rule 3 (emit_cmp cc (u64_from_iconst 0) b @ (value_type ty))
       (let ((b Gpr (put_in_reg b)))
-        (icmp_cond_result (x64_test ty b b) (intcc_swap_args cc))))
+        (CondResult.CC (x64_test ty b b) (intcc_swap_args cc))))
 
 ;; For I128 values (held in two GPRs), the instruction sequences depend on what
 ;; kind of condition is tested.
@@ -4354,7 +4301,7 @@
             (b_hi Gpr (value_regs_get_gpr b 1)))
       (emit_cmp_i128 cc a_hi a_lo b_hi b_lo)))
 
-(decl emit_cmp_i128 (CC Gpr Gpr Gpr Gpr) IcmpCondResult)
+(decl emit_cmp_i128 (CC Gpr Gpr Gpr Gpr) CondResult)
 ;; Eliminate cases which compare something "or equal" by swapping arguments.
 (rule 2 (emit_cmp_i128 (CC.NLE) a_hi a_lo b_hi b_lo)
         (emit_cmp_i128 (CC.L)   b_hi b_lo a_hi a_lo))
@@ -4370,7 +4317,7 @@
 (rule 1 (emit_cmp_i128 (cc_nz_or_z cc) a_hi a_lo b_hi b_lo)
         (let ((same_lo Reg (x64_xor $I64 a_lo b_lo))
               (same_hi Reg (x64_xor $I64 a_hi b_hi)))
-          (icmp_cond_result
+          (CondResult.CC
             (x64_produce_flags_side_effect (ProduceFlagsSideEffectOp.Or) $I64 same_lo same_hi)
             cc)))
 
@@ -4378,105 +4325,68 @@
 ;; sequence. But since we don't care about anything but the flags we can
 ;; replace the sub with cmp, which avoids clobbering one of the registers.
 (rule 0 (emit_cmp_i128 cc a_hi a_lo b_hi b_lo)
-        (icmp_cond_result
+        (CondResult.CC
           (produces_flags_concat
             (x64_cmpq_rm a_lo b_lo)
             (x64_produce_flags_side_effect (ProduceFlagsSideEffectOp.Sbb) $I64 a_hi b_hi))
           cc))
 
-(type FcmpCondResult
-      (enum
-        ;; The given condition code must be set.
-        (Condition (producer ProducesFlags) (cc CC))
-
-        ;; Both condition codes must be set.
-        (AndCondition (producer ProducesFlags) (cc1 CC) (cc2 CC))
-
-        ;; Either of the conditions codes must be set.
-        (OrCondition (producer ProducesFlags) (cc1 CC) (cc2 CC))))
-
-;; Lower a FcmpCondResult to a boolean value in a register.
-(decl lower_fcmp_bool (FcmpCondResult) ValueRegs)
-
-(rule (lower_fcmp_bool (FcmpCondResult.Condition producer cc))
-      (with_flags producer (x64_setcc cc)))
-
-(rule (lower_fcmp_bool (FcmpCondResult.AndCondition producer cc1 cc2))
-      (let ((maybe ValueRegs (with_flags producer
-                                         (consumes_flags_concat
-                                           (x64_setcc cc1)
-                                           (x64_setcc cc2))))
-            (maybe0 Gpr (value_regs_get_gpr maybe 0))
-            (maybe1 Gpr (value_regs_get_gpr maybe 1)))
-        (value_reg (x64_and $I8 maybe0 maybe1))))
-
-(rule (lower_fcmp_bool (FcmpCondResult.OrCondition producer cc1 cc2))
-      (let ((maybe ValueRegs (with_flags producer
-                                         (consumes_flags_concat
-                                           (x64_setcc cc1)
-                                           (x64_setcc cc2))))
-            (maybe0 Gpr (value_regs_get_gpr maybe 0))
-            (maybe1 Gpr (value_regs_get_gpr maybe 1)))
-        (value_reg (x64_or $I8 maybe0 maybe1))))
-
 ;; CLIF's `fcmp` instruction always operates on XMM registers--both scalar and
 ;; vector. For the scalar versions, we use the flag-setting behavior of the
-;; `UCOMIS*` instruction to `SETcc` a 0 or 1 in a GPR register. Note that CLIF's
-;; `select` uses the same kind of flag-setting behavior but chooses values other
-;; than 0 or 1.
+;; `UCOMIS*`.
 ;;
 ;; Checking the result of `UCOMIS*` is unfortunately difficult in some cases
-;; because we do not have `SETcc` instructions that explicitly check
-;; simultaneously for the condition (i.e., `eq`, `le`, `gt`, etc.) *and*
-;; orderedness. Instead, we must check the flags multiple times. The UCOMIS*
-;; documentation (see Intel's Software Developer's Manual, volume 2, chapter 4)
+;; because we do not have a single condition code to check for the condition
+;; (i.e., `eq`, `le`, `gt`, etc.) *and* orderedness. Instead, we must check
+;; the flags multiple times. The UCOMIS* documentation (see Intel's Software
+;; Developer's Manual, volume 2, chapter 4)
 ;; is helpful:
 ;;  - unordered assigns    Z = 1, P = 1, C = 1
 ;;  - greater than assigns Z = 0, P = 0, C = 0
 ;;  - less than assigns    Z = 0, P = 0, C = 1
 ;;  - equal assigns        Z = 1, P = 0, C = 0
-(decl emit_fcmp (FloatCC Value Value) FcmpCondResult)
+(decl emit_fcmp (FloatCC Value Value) CondResult)
 
 (rule (emit_fcmp (FloatCC.Equal) a @ (value_type (ty_scalar_float ty)) b)
-      (FcmpCondResult.AndCondition (x64_ucomis ty a b) (CC.NP) (CC.Z)))
+      (CondResult.And (x64_ucomis ty a b) (CC.NP) (CC.Z)))
 
 (rule (emit_fcmp (FloatCC.NotEqual) a @ (value_type (ty_scalar_float ty)) b)
-      (FcmpCondResult.OrCondition (x64_ucomis ty a b) (CC.P) (CC.NZ)))
+      (CondResult.Or (x64_ucomis ty a b) (CC.P) (CC.NZ)))
 
 ;; Some scalar lowerings correspond to one condition code.
 
 (rule (emit_fcmp (FloatCC.Ordered) a @ (value_type (ty_scalar_float ty)) b)
-      (FcmpCondResult.Condition (x64_ucomis ty a b) (CC.NP)))
+      (CondResult.CC (x64_ucomis ty a b) (CC.NP)))
 (rule (emit_fcmp (FloatCC.Unordered) a @ (value_type (ty_scalar_float ty)) b)
-      (FcmpCondResult.Condition (x64_ucomis ty a b) (CC.P)))
+      (CondResult.CC (x64_ucomis ty a b) (CC.P)))
 (rule (emit_fcmp (FloatCC.OrderedNotEqual) a @ (value_type (ty_scalar_float ty)) b)
-      (FcmpCondResult.Condition (x64_ucomis ty a b) (CC.NZ)))
+      (CondResult.CC (x64_ucomis ty a b) (CC.NZ)))
 (rule (emit_fcmp (FloatCC.UnorderedOrEqual) a @ (value_type (ty_scalar_float ty)) b)
-      (FcmpCondResult.Condition (x64_ucomis ty a b) (CC.Z)))
+      (CondResult.CC (x64_ucomis ty a b) (CC.Z)))
 (rule (emit_fcmp (FloatCC.GreaterThan) a @ (value_type (ty_scalar_float ty)) b)
-      (FcmpCondResult.Condition (x64_ucomis ty a b) (CC.NBE)))
+      (CondResult.CC (x64_ucomis ty a b) (CC.NBE)))
 (rule (emit_fcmp (FloatCC.GreaterThanOrEqual) a @ (value_type (ty_scalar_float ty)) b)
-      (FcmpCondResult.Condition (x64_ucomis ty a b) (CC.NB)))
+      (CondResult.CC (x64_ucomis ty a b) (CC.NB)))
 (rule (emit_fcmp (FloatCC.UnorderedOrLessThan) a @ (value_type (ty_scalar_float ty)) b)
-      (FcmpCondResult.Condition (x64_ucomis ty a b) (CC.B)))
+      (CondResult.CC (x64_ucomis ty a b) (CC.B)))
 (rule (emit_fcmp (FloatCC.UnorderedOrLessThanOrEqual) a @ (value_type (ty_scalar_float ty)) b)
-      (FcmpCondResult.Condition (x64_ucomis ty a b) (CC.BE)))
+      (CondResult.CC (x64_ucomis ty a b) (CC.BE)))
 
 ;; Other scalar lowerings are made possible by flipping the operands and
 ;; reversing the condition code.
 
 (rule (emit_fcmp (FloatCC.LessThan) a @ (value_type (ty_scalar_float ty)) b)
       ;; Same flags as `GreaterThan`.
-      (FcmpCondResult.Condition (x64_ucomis ty b a) (CC.NBE)))
+      (CondResult.CC (x64_ucomis ty b a) (CC.NBE)))
 (rule (emit_fcmp (FloatCC.LessThanOrEqual) a @ (value_type (ty_scalar_float ty)) b)
       ;; Same flags as `GreaterThanOrEqual`.
-      (FcmpCondResult.Condition (x64_ucomis ty b a) (CC.NB)))
+      (CondResult.CC (x64_ucomis ty b a) (CC.NB)))
 (rule (emit_fcmp (FloatCC.UnorderedOrGreaterThan) a @ (value_type (ty_scalar_float ty)) b)
       ;; Same flags as `UnorderedOrLessThan`.
-      (FcmpCondResult.Condition (x64_ucomis ty b a) (CC.B)))
+      (CondResult.CC (x64_ucomis ty b a) (CC.B)))
 (rule (emit_fcmp (FloatCC.UnorderedOrGreaterThanOrEqual) a @ (value_type (ty_scalar_float ty)) b)
       ;; Same flags as `UnorderedOrLessThanOrEqual`.
-      (FcmpCondResult.Condition (x64_ucomis ty b a) (CC.BE)))
+      (CondResult.CC (x64_ucomis ty b a) (CC.BE)))
 
 ;;;; Type Guards ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -1891,25 +1891,21 @@
 
 ;;;; Rules for `trapz` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(rule 0 (lower (trapz (maybe_uextend val) code))
-        (side_effect (trap_if_val (ZeroCond.Zero) val code)))
+(rule (lower (trapz val code))
+  (side_effect (trap_if_cond (cond_invert (is_nonzero_cmp val)) code)))
 
-(rule 1 (lower (trapz (maybe_uextend (icmp cc a b)) code))
-        (side_effect (trap_if_icmp (emit_cmp (intcc_complement cc) a b) code)))
-
-(rule 1 (lower (trapz (maybe_uextend (fcmp cc a b)) code))
-        (side_effect (trap_if_fcmp (emit_fcmp (floatcc_complement cc) a b) code)))
+(decl trap_if_cond (CondResult TrapCode) SideEffectNoResult)
+(rule (trap_if_cond (CondResult.CC producer cc) tc)
+      (with_flags_side_effect producer (trap_if cc tc)))
+(rule (trap_if_cond (CondResult.And producer cc1 cc2) tc)
+      (with_flags_side_effect producer (trap_if_and cc1 cc2 tc)))
+(rule (trap_if_cond (CondResult.Or producer cc1 cc2) tc)
+      (with_flags_side_effect producer (trap_if_or cc1 cc2 tc)))
 
 ;;;; Rules for `trapnz` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(rule 0 (lower (trapnz (maybe_uextend val) code))
-        (side_effect (trap_if_val (ZeroCond.NonZero) val code)))
-
-(rule 1 (lower (trapnz (maybe_uextend (icmp cc a b)) code))
-        (side_effect (trap_if_icmp (emit_cmp cc a b) code)))
-
-(rule 1 (lower (trapnz (maybe_uextend (fcmp cc a b)) code))
-        (side_effect (trap_if_fcmp (emit_fcmp cc a b) code)))
+(rule (lower (trapnz val code))
+  (side_effect (trap_if_cond (is_nonzero_cmp val) code)))
 
 ;;;; Rules for `uadd_overflow_trap` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -1942,10 +1938,10 @@
 ;;;; Rules for `icmp` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule -2 (lower (icmp cc a @ (value_type (fits_in_64 ty)) b))
-      (lower_icmp_bool (emit_cmp cc a b)))
+      (lower_cond_bool (emit_cmp cc a b)))
 
 (rule -1 (lower (icmp cc a @ (value_type $I128) b))
-      (lower_icmp_bool (emit_cmp cc a b)))
+      (lower_cond_bool (emit_cmp cc a b)))
 
 ;; Peephole optimization for `x < 0`, when x is a signed 64 bit value
 (rule 2 (lower (has_type $I8 (icmp (IntCC.SignedLessThan) x @ (value_type $I64) (u64_from_iconst 0))))
@@ -2135,7 +2131,7 @@
 ;;  - equal assigns        Z = 1, P = 0, C = 0
 
 (rule -1 (lower (fcmp cc a @ (value_type (ty_scalar_float ty)) b))
-      (lower_fcmp_bool (emit_fcmp cc a b)))
+      (lower_cond_bool (emit_fcmp cc a b)))
 
 ;; For vector lowerings, we use `CMPP*` instructions with a 3-bit operand that
 ;; determines the comparison to make. Note that comparisons that succeed will
@@ -2176,61 +2172,80 @@
 
 ;;;; Rules for `select` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;; When a `select` has an `fcmp` as a condition then rely on `emit_fcmp` to
-;; figure out how to perform the comparison.
-;;
-;; Note, though, that the `FloatCC.Equal` requires an "and" to happen for two
-;; condition codes which isn't the easiest thing to lower to a `cmove`
-;; instruction. For this reason a `select (fcmp eq ..) ..` is instead
-;; flipped around to be `select (fcmp ne ..) ..` with all operands reversed.
-;; This will produce a `FcmpCondResult.OrCondition` which is easier to codegen
-;; for.
-(rule (lower (has_type ty (select (maybe_uextend (fcmp cc a b)) x y)))
-      (lower_select_fcmp ty (emit_fcmp cc a b) x y))
-(rule 1 (lower (has_type ty (select (maybe_uextend (fcmp (FloatCC.Equal) a b)) x y)))
-        (lower_select_fcmp ty (emit_fcmp (FloatCC.NotEqual) a b) y x))
+(rule (lower (select cond x y)) (lower_select (is_nonzero_cmp cond) x y))
 
-(decl lower_select_fcmp (Type FcmpCondResult Value Value) InstOutput)
-(rule (lower_select_fcmp ty (FcmpCondResult.Condition flags cc) x y)
-      (with_flags flags (cmove_from_values ty cc x y)))
-(rule (lower_select_fcmp ty (FcmpCondResult.OrCondition flags cc1 cc2) x y)
-      (with_flags flags (cmove_or_from_values ty cc1 cc2 x y)))
+(decl lower_select (CondResult Value Value) InstOutput)
+(rule 0 (lower_select cond a @ (value_type (ty_int (fits_in_64 ty))) b)
+  (lower_select_gpr ty cond a b))
+(rule 1 (lower_select cond a @ (value_type (is_xmm_type ty)) b)
+  (lower_select_xmm ty cond a b))
+(rule 2 (lower_select cond a @ (value_type $I128) b)
+  (lower_select128 cond a b))
+;; Note that for all of the rules below if the condition evaluates to
+;; `CondResult.And` that's swapped to `CondResult.Or` by negating the conditions
+;; and swapping the two values to make codegen a bit easier (only have to do the
+;; "or" case).
+(rule 3 (lower_select cond @ (CondResult.And _ _ _) a b)
+  (lower_select (cond_invert cond) b a))
 
-;; We also can lower `select`s that depend on an `icmp` test, but more simply
-;; than the `fcmp` variants above. In these cases, we lower to a `CMP`
-;; instruction plus a `CMOV`; recall that `cmove_from_values` here may emit more
-;; than one instruction for certain types (e.g., XMM-held, I128).
+(decl lower_select_gpr (Type CondResult GprMem Gpr) Gpr)
+(rule (lower_select_gpr ty (CondResult.CC flags cc) a b)
+  (value_regs_get_gpr (with_flags flags (cmove ty cc a b)) 0))
+(rule (lower_select_gpr ty (CondResult.Or flags cc1 cc2) a b)
+  (let ((c1 ConsumesFlags (cmove ty cc1 a b))
+        (tmp Gpr (consumes_flags_get_reg c1))
+        (c2 ConsumesFlags (cmove ty cc2 a tmp)))
+  (value_regs_get (with_flags flags (consumes_flags_return_last c1 c2)) 0)))
 
-(rule (lower (has_type ty (select (maybe_uextend (icmp cc a b)) x y)))
-      (lower_select_icmp ty (emit_cmp cc a b) x y))
+(decl lower_select_xmm (Type CondResult Xmm Xmm) Xmm)
+(rule (lower_select_xmm ty (CondResult.CC flags cc) a b)
+  (value_regs_get (with_flags flags (cmove_xmm ty cc a b)) 0))
+(rule (lower_select_xmm ty (CondResult.Or flags cc1 cc2) a b)
+  (let ((c1 ConsumesFlags (cmove_xmm ty cc1 a b))
+        (tmp Xmm (consumes_flags_get_reg c1))
+        (c2 ConsumesFlags (cmove_xmm ty cc2 a tmp)))
+  (value_regs_get (with_flags flags (consumes_flags_return_last c1 c2)) 0)))
 
-;; Finally, we lower `select` from a condition value `c`. These rules are meant
-;; to be the final, default lowerings if no other patterns matched above.
+(decl lower_select128 (CondResult ValueRegs ValueRegs) ValueRegs)
+(rule (lower_select128 (CondResult.CC flags cc) a b)
+  (with_flags flags (cmove128 cc a b)))
+(rule (lower_select128 (CondResult.Or flags cc1 cc2) a b)
+  (let ((c1 ConsumesFlags (cmove128 cc1 a b))
+        (tmp ValueRegs (consumes_flags_get_regs c1))
+        (c2 ConsumesFlags (cmove128 cc2 a tmp)))
+    (with_flags flags (consumes_flags_return_last c1 c2))))
 
-(rule -1 (lower (has_type ty (select c @ (value_type (fits_in_64 a_ty)) x y)))
-      (let ( ;; N.B.: disallow load-op fusion, see above. TODO:
-             ;; https://github.com/bytecodealliance/wasmtime/issues/3953.
-            (gpr_c Gpr (put_in_gpr c)))
-           (with_flags (x64_test a_ty gpr_c gpr_c) (cmove_from_values ty (CC.NZ) x y))))
+;; Helper to `lower_select128` above to create two `cmove` instructions based
+;; on the CC provided for the upper/lower halves.
+(decl cmove128 (CC ValueRegs ValueRegs) ConsumesFlags)
+(rule (cmove128 cc cons alt)
+  (consumes_flags_concat
+    (cmove $I64 cc (value_regs_get_gpr cons 0) (value_regs_get_gpr alt 0))
+    (cmove $I64 cc (value_regs_get_gpr cons 1) (value_regs_get_gpr alt 1))))
 
-(rule -2 (lower (has_type ty (select c @ (value_type $I128) x y)))
-      (let ((cond_result IcmpCondResult (cmp_zero_i128 (CC.Z) c)))
-        (select_icmp cond_result x y)))
-
-(decl lower_select_icmp (Type IcmpCondResult Value Value) InstOutput)
-(rule (lower_select_icmp ty (IcmpCondResult.Condition flags cc) x y)
-      (with_flags flags (cmove_from_values ty cc x y)))
+;; Helper to the "Or" conditions above to create a `ConsumesFlags` that is a
+;; sequence of two other `ConsumesFlags` which returns the result of the
+;; second `ConsumesFlags`, the result of the `lower_select*` operation.
+(decl consumes_flags_return_last (ConsumesFlags ConsumesFlags) ConsumesFlags)
+(rule (consumes_flags_return_last
+        (ConsumesFlags.ConsumesFlagsReturnsReg inst1 _)
+        (ConsumesFlags.ConsumesFlagsReturnsReg inst2 dst))
+  (ConsumesFlags.ConsumesFlagsTwiceReturnsValueRegs inst1 inst2 dst))
+(rule (consumes_flags_return_last
+        (ConsumesFlags.ConsumesFlagsTwiceReturnsValueRegs i1 i2 _)
+        (ConsumesFlags.ConsumesFlagsTwiceReturnsValueRegs i3 i4 dst))
+  (ConsumesFlags.ConsumesFlagsFourTimesReturnsValueRegs i1 i2 i3 i4 dst))
 
 ;; Specializations for floating-point compares to generate a `mins*` or a
 ;; `maxs*` instruction. These are equivalent to the "pseudo-m{in,ax}"
 ;; specializations for vectors.
-(rule 2 (lower (has_type $F32 (select (maybe_uextend (fcmp (FloatCC.LessThan) x y)) x y)))
+(rule 3 (lower (has_type $F32 (select (maybe_uextend (fcmp (FloatCC.LessThan) x y)) x y)))
         (x64_minss x y))
-(rule 2 (lower (has_type $F64 (select (maybe_uextend (fcmp (FloatCC.LessThan) x y)) x y)))
+(rule 3 (lower (has_type $F64 (select (maybe_uextend (fcmp (FloatCC.LessThan) x y)) x y)))
         (x64_minsd x y))
-(rule 3 (lower (has_type $F32 (select (maybe_uextend (fcmp (FloatCC.LessThan) y x)) x y)))
+(rule 4 (lower (has_type $F32 (select (maybe_uextend (fcmp (FloatCC.LessThan) y x)) x y)))
         (x64_maxss x y))
-(rule 3 (lower (has_type $F64 (select (maybe_uextend (fcmp (FloatCC.LessThan) y x)) x y)))
+(rule 4 (lower (has_type $F64 (select (maybe_uextend (fcmp (FloatCC.LessThan) y x)) x y)))
         (x64_maxsd x y))
 
 ;; Rules for `clz` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -3583,48 +3598,8 @@
 
 ;; Rules for `brif` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(rule 2 (lower_branch (brif (maybe_uextend (icmp cc a b)) _ _) (two_targets then else))
-        (emit_side_effect (jmp_cond_icmp (emit_cmp cc a b) then else)))
-
-(rule 2 (lower_branch (brif (maybe_uextend (fcmp cc a b)) _ _) (two_targets then else))
-        (emit_side_effect (jmp_cond_fcmp (emit_fcmp cc a b) then else)))
-
-(rule 2 (lower_branch (brif (maybe_uextend (vany_true a)) _ _) (two_targets then else))
-        (emit_side_effect (jmp_cond_icmp (emit_vany_true a) then else)))
-
-(rule 2 (lower_branch (brif (maybe_uextend (vall_true a)) _ _) (two_targets then else))
-        (emit_side_effect (jmp_cond_icmp (emit_vall_true a) then else)))
-
-(rule 1 (lower_branch (brif val @ (value_type $I128) _ _)
-                      (two_targets then else))
-      (emit_side_effect (jmp_cond_icmp (cmp_zero_i128 (CC.Z) val) then else)))
-
-(rule (lower_branch (brif val @ (value_type (ty_int_bool_or_ref)) _ _)
-                    (two_targets then else))
-      (emit_side_effect (with_flags_side_effect
-                          (cmp_zero_int_bool_ref val)
-                          (jmp_cond (CC.NZ) then else))))
-
-
-;; Compare an I128 value to zero, returning a flags result suitable for making a
-;; jump decision. The comparison is implemented as `(hi | low) == 0`,
-;; and the result can be interpreted as follows
-;; * CC.Z indicates that the value was non-zero, as one or both of the halves of
-;;   the value were non-zero
-;; * CC.NZ indicates that both halves of the value were 0
-(decl cmp_zero_i128 (CC ValueRegs) IcmpCondResult)
-(rule (cmp_zero_i128 (cc_nz_or_z cc) val)
-      (let ((lo Gpr (value_regs_get_gpr val 0))
-            (hi Gpr (value_regs_get_gpr val 1)))
-          (icmp_cond_result
-            (x64_produce_flags_side_effect (ProduceFlagsSideEffectOp.Or) $I64 lo hi)
-            (cc_invert cc))))
-
-
-(decl cmp_zero_int_bool_ref (Value) ProducesFlags)
-(rule (cmp_zero_int_bool_ref val @ (value_type ty))
-      (let ((src Gpr val))
-        (x64_test ty src src)))
+(rule (lower_branch (brif val _ _) (two_targets then else))
+      (emit_side_effect (jmp_cond_result (is_nonzero_cmp val) then else)))
 
 ;; Rules for `br_table` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -3639,16 +3614,14 @@
 
 ;; Rules for `select_spectre_guard` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(rule (lower (select_spectre_guard (icmp cc a b) x y))
-      (select_icmp (emit_cmp cc a b) x y))
+(rule (lower (select_spectre_guard cond x y))
+  (lower_select (is_nonzero_cmp cond) x y))
 
-(rule -1 (lower (has_type ty (select_spectre_guard c @ (value_type (fits_in_64 a_ty)) x y)))
-      (let ((gpr_c Gpr (put_in_gpr c)))
-        (with_flags (x64_test a_ty gpr_c gpr_c) (cmove_from_values ty (CC.NZ) x y))))
-
-(rule -2 (lower (has_type ty (select_spectre_guard c @ (value_type $I128) x y)))
-      (let ((cond_result IcmpCondResult (cmp_zero_i128 (CC.Z) c)))
-        (select_icmp cond_result x y)))
+;; Note that for GPR-based spectre guards everything is forced into a register
+;; so go straight to the `lower_select_gpr` helper forcing `x` to be in a `Gpr`
+;; not `GprMem`.
+(rule 1 (lower (has_type (is_single_register_gpr_type ty) (select_spectre_guard cond x y)))
+  (lower_select_gpr ty (is_nonzero_cmp cond) (put_in_gpr x) y))
 
 ;; Rules for `fcvt_from_sint` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -4889,48 +4862,43 @@
 
 ;; Rules for `vany_true` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(rule 1 (lower (vany_true val))
-        (if-let true (use_sse41))
-        (let ((val Xmm val))
-          (with_flags (x64_ptest val val) (x64_setcc (CC.NZ)))))
+(rule (lower (vany_true val)) (lower_cond_bool (is_vany_true val)))
 
 ;; Any nonzero byte in `val` means that any lane is true. Compare `val` with a
 ;; zeroed register and extract the high bits to a gpr mask. If the mask is
 ;; 0xffff then every byte was equal to zero, so test if the comparison is
 ;; not-equal or NZ.
-(rule (lower (vany_true val))
-      (lower_icmp_bool (emit_vany_true val)))
-
-(decl emit_vany_true (Value) IcmpCondResult)
-(rule (emit_vany_true val)
+(decl is_vany_true (Value) CondResult)
+(rule (is_vany_true val)
       (let (
           (any_byte_zero Xmm (x64_pcmpeqb val (xmm_zero $I8X16)))
           (mask Gpr (x64_pmovmskb any_byte_zero))
         )
-        (icmp_cond_result (x64_cmpl_mi mask 0xffff)
-                          (CC.NZ))))
+        (CondResult.CC (x64_cmpl_mi mask 0xffff) (CC.NZ))))
+(rule 1 (is_vany_true val)
+  (if-let true (use_sse41))
+  (let ((val Xmm val))
+    (CondResult.CC (x64_ptest val val) (CC.NZ))))
 
 ;; Rules for `vall_true` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(rule (lower (vall_true val))
-      (lower_icmp_bool (emit_vall_true val)))
+(rule (lower (vall_true val)) (lower_cond_bool (is_vall_true val)))
 
-(decl emit_vall_true (Value) IcmpCondResult)
-(rule 1 (emit_vall_true val @ (value_type ty))
+(decl is_vall_true (Value) CondResult)
+(rule 1 (is_vall_true val @ (value_type ty))
         (if-let true (use_sse41))
         (let ((src Xmm val)
               (zeros Xmm (xmm_zero ty))
               (cmp Xmm (x64_pcmpeq (vec_int_type ty) src zeros)))
-          (icmp_cond_result (x64_ptest cmp cmp) (CC.Z))))
+          (CondResult.CC (x64_ptest cmp cmp) (CC.Z))))
 
 ;; Perform an appropriately-sized lane-wise comparison with zero. If the
 ;; result is all 0s then all of them are true because nothing was equal to
 ;; zero.
-(rule (emit_vall_true val @ (value_type ty))
+(rule (is_vall_true val @ (value_type ty))
       (let ((lanes_with_zero Xmm (x64_pcmpeq (vec_int_type ty) val (xmm_zero ty)))
             (mask Gpr (x64_pmovmskb lanes_with_zero)))
-        (icmp_cond_result (x64_testl_mr mask mask)
-                          (CC.Z))))
+        (CondResult.CC (x64_testl_mr mask mask) (CC.Z))))
 
 ;; Rules for `vhigh_bits` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/cranelift/filetests/filetests/isa/x64/traps.clif
+++ b/cranelift/filetests/filetests/isa/x64/traps.clif
@@ -86,8 +86,7 @@ block0(v0: i128):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block0:
-;   orq %rdi, %rsi
-;   testq %rsi, %rsi
+;   orq %rsi, %rdi
 ;   jz #trap=user1
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -98,9 +97,8 @@ block0(v0: i128):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   orq %rdi, %rsi
-;   testq %rsi, %rsi
-;   je 0x15
+;   orq %rsi, %rdi
+;   je 0x12
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -144,8 +142,7 @@ block0(v0: i128):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block0:
-;   orq %rdi, %rsi
-;   testq %rsi, %rsi
+;   orq %rsi, %rdi
 ;   jnz #trap=user1
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -156,9 +153,8 @@ block0(v0: i128):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   orq %rdi, %rsi
-;   testq %rsi, %rsi
-;   jne 0x15
+;   orq %rsi, %rdi
+;   jne 0x12
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq

--- a/tests/disas/x64-simd-test-and-branch.wat
+++ b/tests/disas/x64-simd-test-and-branch.wat
@@ -112,14 +112,11 @@
 ;; wasm[0]::function[4]::v128.any_true:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       pxor    %xmm7, %xmm7
-;;       pcmpeqb %xmm7, %xmm0
-;;       pmovmskb %xmm0, %ecx
-;;       cmpl    $0xffff, %ecx
-;;       jne     0x126
-;;  11c: movl    $0xc8, %eax
-;;       jmp     0x12b
-;;  126: movl    $0x64, %eax
+;;       ptest   %xmm0, %xmm0
+;;       jne     0x119
+;;  10f: movl    $0xc8, %eax
+;;       jmp     0x11e
+;;  119: movl    $0x64, %eax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq


### PR DESCRIPTION
This commit represents a refactor of the x64 backend's handling of condition codes for various instructions with a goal of simplifying conversion of a `Value` to a condition code used for `select` and `brif`. This additionally tries to deduplicate handling of condition codes across `icmp` and `fcmp` for example.

Previously the x64 backend had types such as `IcmpCondResult` and `FcmpCondResult` which respresented the condition codes for the `icmp` and `fcmp` values. When used in `select`, `brif`, or `trap{n,}z` each lowering had to special case `icmp` and `fcmp` to create these `*CondResult` values and call specialized helpers to lower the value back. Furthermore on the `select` instruction this created a matrix of ways-to-produce-the-condition-code along with
ways-to-handle-the-condition-code to conditionally move GPR, XMM, or 128-bit values. The end result was a fair bit of duplication across rules and optimizations on some rules but not others. For example `brif` on a `vall_true` value was optimized but `select` was not.

The design implemented in this commit is inspired/modeled after what the riscv64 backend is currently doing. There is a top-level helper `is_nonzero_cmp` which takes a `Value` and produces a `CondResult`. This `CondResult` is a merging of `IcmpCondResult` and `FcmpCondResult` into one. This centralizes the ability to take any value and produce condition codes, for example this handles `icmp`, `fcmp`, 128-bit integers, `v{all,any}_true`, etc. Once the condition is produced it's then handled separately at each location for jumps, selects, traps, etc. In effect `CondResult` serves as a "narrow waist" through which production of condition codes can all flow meaning that if an optimization is added for production of condition codes all instructions benefit instead of having to hand-update each one.

The goal of this refactoring was to not actually change any lowerings and only refactor internals, but this refactoring exposed a few non-optimal lowerings in the backend which were improved as a result of this change. In the future I plan on additionally adding more ways to pattern-match "produces a condition" which will now equally benefit all of these locations.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
