### PR TITLE
feat(cranelift): Use DominatorTreePreorder in more places

### DIFF
--- a/cranelift/codegen/src/alias_analysis.rs
+++ b/cranelift/codegen/src/alias_analysis.rs
@@ -63,7 +63,7 @@
 
 use crate::{
     cursor::{Cursor, FuncCursor},
-    dominator_tree::DominatorTree,
+    dominator_tree::DominatorTreePreorder,
     inst_predicates::{
         has_memory_fence_semantics, inst_addr_offset_type, inst_store_data, visit_block_succs,
     },
@@ -176,7 +176,7 @@ struct MemoryLoc {
 /// An alias-analysis pass.
 pub struct AliasAnalysis<'a> {
     /// The domtree for the function.
-    domtree: &'a DominatorTree,
+    domtree: &'a DominatorTreePreorder,
 
     /// Input state to a basic block.
     block_input: FxHashMap<Block, LastStores>,
@@ -191,7 +191,7 @@ pub struct AliasAnalysis<'a> {
 
 impl<'a> AliasAnalysis<'a> {
     /// Perform an alias analysis pass.
-    pub fn new(func: &Function, domtree: &'a DominatorTree) -> AliasAnalysis<'a> {
+    pub fn new(func: &Function, domtree: &'a DominatorTreePreorder) -> AliasAnalysis<'a> {
         trace!("alias analysis: input is:\n{:?}", func);
         let mut analysis = AliasAnalysis {
             domtree,
@@ -333,7 +333,7 @@ impl<'a> AliasAnalysis<'a> {
                             value.index(),
                             def_inst.index()
                         );
-                        if self.domtree.dominates(def_inst, inst, &func.layout) {
+                        if self.domtree.dominates_inst(def_inst, inst, &func.layout) {
                             trace!(
                                 " -> dominates; value equiv from v{} to v{} inserted",
                                 load_result.index(),

--- a/cranelift/codegen/src/context.rs
+++ b/cranelift/codegen/src/context.rs
@@ -11,6 +11,7 @@
 
 use crate::alias_analysis::AliasAnalysis;
 use crate::dominator_tree::DominatorTree;
+use crate::dominator_tree::DominatorTreePreorder;
 use crate::egraph::EgraphPass;
 use crate::flowgraph::ControlFlowGraph;
 use crate::ir::Function;
@@ -46,6 +47,9 @@ pub struct Context {
     /// Dominator tree for `func`.
     pub domtree: DominatorTree,
 
+    /// Dominator tree with dominance stored implicitly via visit-order indices for `func`
+    domtree_preorder: DominatorTreePreorder,
+
     /// Loop analysis of `func`.
     pub loop_analysis: LoopAnalysis,
 
@@ -74,6 +78,7 @@ impl Context {
             func,
             cfg: ControlFlowGraph::new(),
             domtree: DominatorTree::new(),
+            domtree_preorder: DominatorTreePreorder::new(),
             loop_analysis: LoopAnalysis::new(),
             compiled_code: None,
             want_disasm: false,
@@ -305,7 +310,8 @@ impl Context {
 
     /// Compute dominator tree.
     pub fn compute_domtree(&mut self) {
-        self.domtree.compute(&self.func, &self.cfg)
+        self.domtree.compute(&self.func, &self.cfg);
+        self.domtree_preorder.compute(&self.domtree);
     }
 
     /// Compute the loop analysis.
@@ -335,7 +341,7 @@ impl Context {
     /// by a store instruction to the same instruction (so-called
     /// "store-to-load forwarding").
     pub fn replace_redundant_loads(&mut self) -> CodegenResult<()> {
-        let mut analysis = AliasAnalysis::new(&self.func, &self.domtree);
+        let mut analysis = AliasAnalysis::new(&self.func, &self.domtree_preorder);
         analysis.compute_and_update_aliases(&mut self.func);
         Ok(())
     }
@@ -367,7 +373,7 @@ impl Context {
         );
         let fisa = fisa.into();
         self.compute_loop_analysis();
-        let mut alias_analysis = AliasAnalysis::new(&self.func, &self.domtree);
+        let mut alias_analysis = AliasAnalysis::new(&self.func, &self.domtree_preorder);
         let mut pass = EgraphPass::new(
             &mut self.func,
             &self.domtree,

--- a/cranelift/codegen/src/dominator_tree.rs
+++ b/cranelift/codegen/src/dominator_tree.rs
@@ -2,7 +2,7 @@
 
 use crate::entity::SecondaryMap;
 use crate::flowgraph::{BlockPredecessor, ControlFlowGraph};
-use crate::ir::{Block, Function, Layout, ProgramPoint};
+use crate::ir::{Block, Function, Inst, Layout, ProgramPoint};
 use crate::packed_option::PackedOption;
 use crate::timing;
 use alloc::vec::Vec;
@@ -581,6 +581,20 @@ impl DominatorTreePreorder {
         let na = &self.nodes[a];
         let nb = &self.nodes[b];
         na.pre_number <= nb.pre_number && na.pre_max >= nb.pre_max
+    }
+
+    /// Checks if one instruction dominates another.
+    pub fn dominates_inst(&self, a: Inst, b: Inst, layout: &Layout) -> bool {
+        match (layout.inst_block(a), layout.inst_block(b)) {
+            (Some(block_a), Some(block_b)) => {
+                if block_a == block_b {
+                    layout.pp_cmp(a, b) != Ordering::Greater
+                } else {
+                    self.dominates(block_a, block_b)
+                }
+            }
+            _ => false,
+        }
     }
 
     /// Compare two blocks according to the dominator pre-order.


### PR DESCRIPTION
**Motivation**
This PR is to audit and reduce usage of `DominatorTree` and its `dominates()` method, as tracked in https://github.com/bytecodealliance/wasmtime/issues/7954.The goal is to replace these with `DominatorTreePreorder` wherever applicable.

**Context**
Recent related work includes:

* [[#8534](https://github.com/bytecodealliance/wasmtime/pull/8534)](https://github.com/bytecodealliance/wasmtime/pull/8534)
* [[#8535](https://github.com/bytecodealliance/wasmtime/pull/8535)](https://github.com/bytecodealliance/wasmtime/pull/8535)
* [[#9213](https://github.com/bytecodealliance/wasmtime/pull/9213)](https://github.com/bytecodealliance/wasmtime/pull/9213)