### PR TITLE
[34.0.0] cargo vet: pulley-macros is audited as crates io 

### DIFF
--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -4638,6 +4638,12 @@ user-id = 696 # Nick Fitzgerald (fitzgen)
 start = "2024-07-30"
 end = "2025-08-08"
 
+[[trusted.pulley-macros]]
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2025-06-20"
+end = "2026-06-20"
+
 [[trusted.quote]]
 criteria = "safe-to-deploy"
 user-id = 3618 # David Tolnay (dtolnay)

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -97,6 +97,9 @@ audit-as-crates-io = true
 [policy.pulley-interpreter-fuzz]
 criteria = []
 
+[policy.pulley-macros]
+audit-as-crates-io = true
+
 [policy.wasi-common]
 audit-as-crates-io = true
 

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -735,6 +735,12 @@ when = "2025-05-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.pulley-macros]]
+version = "34.0.0"
+when = "2025-06-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.quote]]
 version = "1.0.36"
 when = "2024-04-10"


### PR DESCRIPTION
Backport of #11089 to the release branch