### PR TITLE
Change `wasmtime wast` to be powered from JSON AST

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1026,6 +1026,7 @@ jobs:
           - crate: "wasmtime-environ --all-features"
           - crate: "pulley-interpreter --all-features"
           - script: ./ci/miri-provenance-test.sh
+          - script: ./ci/miri-wast.sh ./tests/spec_testsuite/table.wast
     needs: determine
     if: needs.determine.outputs.test-miri && github.repository == 'bytecodealliance/wasmtime'
     name: Miri

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2172,6 +2172,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "json-from-wast"
+version = "0.236.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be48c53af281152b0d01019f15b87b9f37f92c3a3c11b003a5ee3ccf2901bb35"
+dependencies = [
+ "anyhow",
+ "serde",
+ "serde_derive",
+ "wast 236.0.0",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5113,8 +5125,12 @@ name = "wasmtime-wast"
 version = "36.0.0"
 dependencies = [
  "anyhow",
+ "json-from-wast",
  "log",
+ "object 0.37.1",
+ "serde_json",
  "tokio",
+ "wasmparser 0.236.0",
  "wasmtime",
  "wast 236.0.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -339,6 +339,7 @@ wit-parser = "0.236.0"
 wit-component = "0.236.0"
 wasm-wave = "0.236.0"
 wasm-compose = "0.236.0"
+json-from-wast = "0.236.0"
 
 # Non-Bytecode Alliance maintained dependencies:
 # --------------------------

--- a/ci/miri-wast.sh
+++ b/ci/miri-wast.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Helper script to execute a `*.wast` test in Miri. This is only lightly used on
+# CI and is provided here to assist with development of anything that ends up
+# using unsafe for example.
+
+set -ex
+
+rm -rf ./miri-wast
+mkdir ./miri-wast
+cargo run -- wast --target pulley64 --precompile-save ./miri-wast "$@" \
+  -O memory-reservation=$((1 << 20)) \
+  -O memory-guard-size=0 \
+  -O signals-based-traps=n \
+  -O memory-init-cow=n
+
+MIRIFLAGS="$MIRIFLAGS -Zmiri-disable-isolation -Zmiri-permissive-provenance" \
+  cargo miri run -- wast -Ccache=n --target pulley64 --precompile-load ./miri-wast "$@" \
+  -O memory-init-cow=n

--- a/ci/miri-wast.sh
+++ b/ci/miri-wast.sh
@@ -3,6 +3,13 @@
 # Helper script to execute a `*.wast` test in Miri. This is only lightly used on
 # CI and is provided here to assist with development of anything that ends up
 # using unsafe for example.
+#
+# Example usage is:
+#
+#   ./ci/miri-wast.sh ./tests/spec_testsuite/br_if.wast
+#
+# extra flags to this script are passed to `cargo run wast` which means they
+# must be suitable flags for the `wast` subcommand.
 
 set -ex
 

--- a/crates/cranelift/src/func_environ/gc.rs
+++ b/crates/cranelift/src/func_environ/gc.rs
@@ -26,6 +26,7 @@ pub use imp::*;
 
 /// How to initialize a newly-allocated array's elements.
 #[derive(Clone, Copy)]
+#[cfg_attr(not(feature = "gc"), expect(dead_code))]
 pub enum ArrayInit<'a> {
     /// Initialize the array's elements with the given values.
     Elems(&'a [ir::Value]),

--- a/crates/cranelift/src/func_environ/gc.rs
+++ b/crates/cranelift/src/func_environ/gc.rs
@@ -26,7 +26,6 @@ pub use imp::*;
 
 /// How to initialize a newly-allocated array's elements.
 #[derive(Clone, Copy)]
-#[cfg_attr(not(any(feature = "gc-null", feature = "gc-drc")), allow(dead_code))]
 pub enum ArrayInit<'a> {
     /// Initialize the array's elements with the given values.
     Elems(&'a [ir::Value]),

--- a/crates/cranelift/src/func_environ/gc/enabled.rs
+++ b/crates/cranelift/src/func_environ/gc/enabled.rs
@@ -58,7 +58,10 @@ pub fn gc_compiler(func_env: &mut FuncEnvironment<'_>) -> WasmResult<Box<dyn GcC
     }
 }
 
-#[cfg_attr(not(feature = "gc-drc"), allow(dead_code))]
+#[cfg_attr(
+    not(feature = "gc-drc"),
+    expect(dead_code, reason = "easier to define")
+)]
 fn unbarriered_load_gc_ref(
     builder: &mut FunctionBuilder,
     ty: WasmHeapType,
@@ -73,7 +76,10 @@ fn unbarriered_load_gc_ref(
     Ok(gc_ref)
 }
 
-#[cfg_attr(not(any(feature = "gc-drc", feature = "gc-null")), allow(dead_code))]
+#[cfg_attr(
+    not(any(feature = "gc-drc", feature = "gc-null")),
+    expect(dead_code, reason = "easier to define")
+)]
 fn unbarriered_store_gc_ref(
     builder: &mut FunctionBuilder,
     ty: WasmHeapType,
@@ -461,7 +467,10 @@ pub fn translate_array_new_fixed(
 
 impl ArrayInit<'_> {
     /// Get the length (as an `i32`-typed `ir::Value`) of these array elements.
-    #[cfg_attr(not(any(feature = "gc-drc", feature = "gc-null")), allow(dead_code))]
+    #[cfg_attr(
+        not(any(feature = "gc-drc", feature = "gc-null")),
+        expect(dead_code, reason = "easier to define")
+    )]
     fn len(self, pos: &mut FuncCursor) -> ir::Value {
         match self {
             ArrayInit::Fill { len, .. } => len,
@@ -473,7 +482,10 @@ impl ArrayInit<'_> {
     }
 
     /// Initialize a newly-allocated array's elements.
-    #[cfg_attr(not(any(feature = "gc-drc", feature = "gc-null")), allow(dead_code))]
+    #[cfg_attr(
+        not(any(feature = "gc-drc", feature = "gc-null")),
+        expect(dead_code, reason = "easier to define")
+    )]
     fn initialize(
         self,
         func_env: &mut FuncEnvironment<'_>,
@@ -1140,7 +1152,10 @@ fn uextend_i32_to_pointer_type(
 /// in its initialization.
 ///
 /// Traps if the size overflows.
-#[cfg_attr(not(any(feature = "gc-drc", feature = "gc-null")), allow(dead_code))]
+#[cfg_attr(
+    not(any(feature = "gc-drc", feature = "gc-null")),
+    expect(dead_code, reason = "easier to define")
+)]
 fn emit_array_size(
     func_env: &mut FuncEnvironment<'_>,
     builder: &mut FunctionBuilder<'_>,
@@ -1185,7 +1200,10 @@ fn emit_array_size(
 
 /// Common helper for struct-field initialization that can be reused across
 /// collectors.
-#[cfg_attr(not(any(feature = "gc-drc", feature = "gc-null")), allow(dead_code))]
+#[cfg_attr(
+    not(any(feature = "gc-drc", feature = "gc-null")),
+    expect(dead_code, reason = "easier to define")
+)]
 fn initialize_struct_fields(
     func_env: &mut FuncEnvironment<'_>,
     builder: &mut FunctionBuilder<'_>,
@@ -1386,7 +1404,10 @@ impl FuncEnvironment<'_> {
     /// reference is null or is an `i31ref`; otherwise, it will be zero.
     ///
     /// This method is collector-agnostic.
-    #[cfg_attr(not(feature = "gc-drc"), allow(dead_code))]
+    #[cfg_attr(
+        not(feature = "gc-drc"),
+        expect(dead_code, reason = "easier to define")
+    )]
     fn gc_ref_is_null_or_i31(
         &mut self,
         builder: &mut FunctionBuilder,

--- a/crates/fuzzing/src/oracles.rs
+++ b/crates/fuzzing/src/oracles.rs
@@ -764,7 +764,7 @@ pub fn wast_test(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<()> {
         })
         .unwrap();
     wast_context
-        .run_buffer(test.path.to_str().unwrap(), test.contents.as_bytes())
+        .run_wast(test.path.to_str().unwrap(), test.contents.as_bytes())
         .unwrap();
     Ok(())
 }

--- a/crates/wast/Cargo.toml
+++ b/crates/wast/Cargo.toml
@@ -19,6 +19,10 @@ wasmtime = { workspace = true, features = ['cranelift', 'wat', 'runtime', 'gc', 
 wast = { workspace = true, features = ['dwarf'] }
 log = { workspace = true }
 tokio = { workspace = true, features = ['rt'] }
+json-from-wast = { workspace = true }
+wasmparser = { workspace = true }
+serde_json = { workspace = true }
+object = { workspace = true, features = ['unaligned'] }
 
 [features]
 component-model = ['wasmtime/component-model']

--- a/crates/wast/src/core.rs
+++ b/crates/wast/src/core.rs
@@ -26,7 +26,7 @@ pub fn val<T>(ctx: &mut WastContext<T>, v: &CoreConst) -> Result<Val> {
         } => Val::ExternRef(if let Some(rt) = ctx.async_runtime.as_ref() {
             Some(rt.block_on(wasmtime::ExternRef::new_async(&mut ctx.store, x.0))?)
         } else {
-            Some(wasmtime::ExternRef::new(&mut ctx.store, *x)?)
+            Some(wasmtime::ExternRef::new(&mut ctx.store, x.0)?)
         }),
 
         AnyRef {
@@ -38,7 +38,7 @@ pub fn val<T>(ctx: &mut WastContext<T>, v: &CoreConst) -> Result<Val> {
             let x = if let Some(rt) = ctx.async_runtime.as_ref() {
                 rt.block_on(wasmtime::ExternRef::new_async(&mut ctx.store, x.0))?
             } else {
-                wasmtime::ExternRef::new(&mut ctx.store, *x)?
+                wasmtime::ExternRef::new(&mut ctx.store, x.0)?
             };
             let x = wasmtime::AnyRef::convert_extern(&mut ctx.store, x)?;
             Val::AnyRef(Some(x))

--- a/crates/wast/src/core.rs
+++ b/crates/wast/src/core.rs
@@ -1,50 +1,49 @@
 use crate::WastContext;
 use anyhow::{Context, Result, anyhow, bail};
+use json_from_wast::{CoreConst, FloatConst, V128};
 use std::fmt::{Display, LowerHex};
-use wasmtime::{AnyRef, ExternRef, Store, Val};
-use wast::core::{AbstractHeapType, HeapType, NanPattern, V128Pattern, WastArgCore, WastRetCore};
-use wast::token::{F32, F64};
+use wasmtime::{Store, Val};
 
 /// Translate from a `script::Value` to a `RuntimeValue`.
-pub fn val<T>(ctx: &mut WastContext<T>, v: &WastArgCore<'_>) -> Result<Val> {
-    use wast::core::WastArgCore::*;
+pub fn val<T>(ctx: &mut WastContext<T>, v: &CoreConst) -> Result<Val> {
+    use CoreConst::*;
 
     Ok(match v {
-        I32(x) => Val::I32(*x),
-        I64(x) => Val::I64(*x),
-        F32(x) => Val::F32(x.bits),
-        F64(x) => Val::F64(x.bits),
-        V128(x) => Val::V128(u128::from_le_bytes(x.to_le_bytes()).into()),
-        RefNull(HeapType::Abstract {
-            ty: AbstractHeapType::Extern,
-            shared: false,
-        }) => Val::ExternRef(None),
-        RefNull(HeapType::Abstract {
-            ty: AbstractHeapType::Func,
-            shared: false,
-        }) => Val::FuncRef(None),
-        RefNull(HeapType::Abstract {
-            ty: AbstractHeapType::Any,
-            shared: false,
-        }) => Val::AnyRef(None),
-        RefNull(HeapType::Abstract {
-            shared: false,
-            ty: AbstractHeapType::None,
-        }) => Val::AnyRef(None),
-        RefExtern(x) => Val::ExternRef(if let Some(rt) = ctx.async_runtime.as_ref() {
-            Some(rt.block_on(ExternRef::new_async(&mut ctx.store, *x))?)
+        I32 { value } => Val::I32(value.0),
+        I64 { value } => Val::I64(value.0),
+        F32 { value } => Val::F32(value.to_bits()),
+        F64 { value } => Val::F64(value.to_bits()),
+        V128(value) => Val::V128(value.to_u128().into()),
+        FuncRef {
+            value: None | Some(json_from_wast::FuncRef::Null),
+        } => Val::FuncRef(None),
+
+        ExternRef {
+            value: None | Some(json_from_wast::ExternRef::Null),
+        } => Val::ExternRef(None),
+        ExternRef {
+            value: Some(json_from_wast::ExternRef::Host(x)),
+        } => Val::ExternRef(if let Some(rt) = ctx.async_runtime.as_ref() {
+            Some(rt.block_on(wasmtime::ExternRef::new_async(&mut ctx.store, x.0))?)
         } else {
-            Some(ExternRef::new(&mut ctx.store, *x)?)
+            Some(wasmtime::ExternRef::new(&mut ctx.store, *x)?)
         }),
-        RefHost(x) => {
+
+        AnyRef {
+            value: None | Some(json_from_wast::AnyRef::Null),
+        } => Val::AnyRef(None),
+        AnyRef {
+            value: Some(json_from_wast::AnyRef::Host(x)),
+        } => {
             let x = if let Some(rt) = ctx.async_runtime.as_ref() {
-                rt.block_on(ExternRef::new_async(&mut ctx.store, *x))?
+                rt.block_on(wasmtime::ExternRef::new_async(&mut ctx.store, x.0))?
             } else {
-                ExternRef::new(&mut ctx.store, *x)?
+                wasmtime::ExternRef::new(&mut ctx.store, *x)?
             };
-            let x = AnyRef::convert_extern(&mut ctx.store, x)?;
+            let x = wasmtime::AnyRef::convert_extern(&mut ctx.store, x)?;
             Val::AnyRef(Some(x))
         }
+        NullRef => Val::AnyRef(None),
         other => bail!("couldn't convert {:?} to a runtime value", other),
     })
 }
@@ -65,62 +64,68 @@ fn extract_lane_as_i64(bytes: u128, lane: usize) -> i64 {
     (bytes >> (lane * 64)) as i64
 }
 
-pub fn match_val<T>(store: &mut Store<T>, actual: &Val, expected: &WastRetCore) -> Result<()> {
+pub fn match_val<T>(store: &mut Store<T>, actual: &Val, expected: &CoreConst) -> Result<()> {
     match (actual, expected) {
-        (_, WastRetCore::Either(expected)) => {
-            for expected in expected {
+        (_, CoreConst::Either { values }) => {
+            for expected in values {
                 if match_val(store, actual, expected).is_ok() {
                     return Ok(());
                 }
             }
-            match_val(store, actual, &expected[0])
+            match_val(store, actual, &values[0])
         }
 
-        (Val::I32(a), WastRetCore::I32(b)) => match_int(a, b),
-        (Val::I64(a), WastRetCore::I64(b)) => match_int(a, b),
+        (Val::I32(a), CoreConst::I32 { value }) => match_int(a, &value.0),
+        (Val::I64(a), CoreConst::I64 { value }) => match_int(a, &value.0),
 
         // Note that these float comparisons are comparing bits, not float
         // values, so we're testing for bit-for-bit equivalence
-        (Val::F32(a), WastRetCore::F32(b)) => match_f32(*a, b),
-        (Val::F64(a), WastRetCore::F64(b)) => match_f64(*a, b),
-        (Val::V128(a), WastRetCore::V128(b)) => match_v128(a.as_u128(), b),
+        (Val::F32(a), CoreConst::F32 { value }) => match_f32(*a, value),
+        (Val::F64(a), CoreConst::F64 { value }) => match_f64(*a, value),
+        (Val::V128(a), CoreConst::V128(value)) => match_v128(a.as_u128(), value),
 
-        // Null references.
-        (
-            Val::FuncRef(None) | Val::ExternRef(None) | Val::AnyRef(None),
-            WastRetCore::RefNull(_),
+        // Null references, or blanket "any reference" assertions
+        (Val::FuncRef(None) | Val::ExternRef(None) | Val::AnyRef(None), CoreConst::RefNull)
+        | (Val::FuncRef(_), CoreConst::FuncRef { value: None })
+        | (Val::AnyRef(_), CoreConst::AnyRef { value: None })
+        | (Val::ExternRef(_), CoreConst::ExternRef { value: None })
+        | (Val::AnyRef(None), CoreConst::NullRef)
+        | (Val::FuncRef(None), CoreConst::NullFuncRef)
+        | (Val::ExternRef(None), CoreConst::NullExternRef)
+        | (
+            Val::FuncRef(None),
+            CoreConst::FuncRef {
+                value: Some(json_from_wast::FuncRef::Null),
+            },
         )
-        | (Val::ExternRef(None), WastRetCore::RefExtern(None)) => Ok(()),
+        | (
+            Val::AnyRef(None),
+            CoreConst::AnyRef {
+                value: Some(json_from_wast::AnyRef::Null),
+            },
+        )
+        | (
+            Val::ExternRef(None),
+            CoreConst::ExternRef {
+                value: Some(json_from_wast::ExternRef::Null),
+            },
+        ) => Ok(()),
 
-        // Null and non-null mismatches.
-        (Val::ExternRef(None), WastRetCore::RefExtern(Some(_))) => {
-            bail!("expected non-null reference, found null")
-        }
+        // Ideally we'd compare the actual index, but Wasmtime doesn't expose
+        // the raw index a function in the embedder API.
+        (
+            Val::FuncRef(Some(_)),
+            CoreConst::FuncRef {
+                value: Some(json_from_wast::FuncRef::Index(_)),
+            },
+        ) => Ok(()),
+
         (
             Val::ExternRef(Some(x)),
-            WastRetCore::RefNull(Some(HeapType::Abstract {
-                ty: AbstractHeapType::Extern,
-                shared: false,
-            })),
+            CoreConst::ExternRef {
+                value: Some(json_from_wast::ExternRef::Host(y)),
+            },
         ) => {
-            match x.data(store)?.map(|x| {
-                x.downcast_ref::<u32>()
-                    .expect("only u32 externrefs created in wast test suites")
-            }) {
-                None => {
-                    bail!("expected null externref, found non-null externref without host data")
-                }
-                Some(x) => bail!("expected null externref, found non-null externref of {x}"),
-            }
-        }
-        (Val::ExternRef(Some(_)) | Val::FuncRef(Some(_)), WastRetCore::RefNull(_)) => {
-            bail!("expected null, found non-null reference: {actual:?}")
-        }
-
-        // Non-null references.
-        (Val::FuncRef(Some(_)), WastRetCore::RefFunc(_)) => Ok(()),
-        (Val::ExternRef(Some(_)), WastRetCore::RefExtern(None)) => Ok(()),
-        (Val::ExternRef(Some(x)), WastRetCore::RefExtern(Some(y))) => {
             let x = x
                 .data(store)?
                 .ok_or_else(|| {
@@ -128,44 +133,48 @@ pub fn match_val<T>(store: &mut Store<T>, actual: &Val, expected: &WastRetCore) 
                 })?
                 .downcast_ref::<u32>()
                 .expect("only u32 externrefs created in wast test suites");
-            if x == y {
+            if *x == y.0 {
                 Ok(())
             } else {
-                bail!("expected {} found {}", y, x);
+                bail!("expected {} found {x}", y.0);
             }
         }
 
-        (Val::AnyRef(Some(_)), WastRetCore::RefAny) => Ok(()),
-        (Val::AnyRef(Some(x)), WastRetCore::RefEq) => {
+        (Val::AnyRef(Some(x)), CoreConst::EqRef) => {
             if x.is_eqref(store)? {
                 Ok(())
             } else {
                 bail!("expected an eqref, found {x:?}");
             }
         }
-        (Val::AnyRef(Some(x)), WastRetCore::RefI31) => {
+        (Val::AnyRef(Some(x)), CoreConst::I31Ref) => {
             if x.is_i31(store)? {
                 Ok(())
             } else {
                 bail!("expected a `(ref i31)`, found {x:?}");
             }
         }
-        (Val::AnyRef(Some(x)), WastRetCore::RefStruct) => {
+        (Val::AnyRef(Some(x)), CoreConst::StructRef) => {
             if x.is_struct(store)? {
                 Ok(())
             } else {
                 bail!("expected a struct reference, found {x:?}")
             }
         }
-        (Val::AnyRef(Some(x)), WastRetCore::RefArray) => {
+        (Val::AnyRef(Some(x)), CoreConst::ArrayRef) => {
             if x.is_array(store)? {
                 Ok(())
             } else {
                 bail!("expected a array reference, found {x:?}")
             }
         }
-        (Val::AnyRef(Some(x)), WastRetCore::RefHost(y)) => {
-            let x = ExternRef::convert_any(&mut *store, *x)?;
+        (
+            Val::AnyRef(Some(x)),
+            CoreConst::AnyRef {
+                value: Some(json_from_wast::AnyRef::Host(y)),
+            },
+        ) => {
+            let x = wasmtime::ExternRef::convert_any(&mut *store, *x)?;
             let x = x
                 .data(&mut *store)?
                 .ok_or_else(|| {
@@ -176,18 +185,17 @@ pub fn match_val<T>(store: &mut Store<T>, actual: &Val, expected: &WastRetCore) 
                 })?
                 .downcast_ref::<u32>()
                 .expect("only u32 externrefs created in wast test suites");
-            if x == y {
+            if *x == y.0 {
                 Ok(())
             } else {
-                bail!("expected anyref of externref of {y}, found anyref of externref of {x}")
+                bail!(
+                    "expected anyref of externref of {}, found anyref of externref of {x}",
+                    y.0
+                )
             }
         }
 
-        _ => bail!(
-            "don't know how to compare {:?} and {:?} yet",
-            actual,
-            expected
-        ),
+        _ => bail!("expected {expected:?} got {actual:?}"),
     }
 }
 
@@ -207,7 +215,7 @@ where
     }
 }
 
-pub fn match_f32(actual: u32, expected: &NanPattern<F32>) -> Result<()> {
+pub fn match_f32(actual: u32, expected: &FloatConst<f32>) -> Result<()> {
     match expected {
         // Check if an f32 (as u32 bits to avoid possible quieting when moving values in registers, e.g.
         // https://developer.arm.com/documentation/ddi0344/i/neon-and-vfp-programmers-model/modes-of-operation/default-nan-mode?lang=en)
@@ -216,7 +224,7 @@ pub fn match_f32(actual: u32, expected: &NanPattern<F32>) -> Result<()> {
         //  - the 8-bit exponent is set to all 1s
         //  - the MSB of the payload is set to 1 (a quieted NaN) and all others to 0.
         // See https://webassembly.github.io/spec/core/syntax/values.html#floating-point.
-        NanPattern::CanonicalNan => {
+        FloatConst::CanonicalNan => {
             let canon_nan = 0x7fc0_0000;
             if (actual & 0x7fff_ffff) == canon_nan {
                 Ok(())
@@ -237,7 +245,7 @@ pub fn match_f32(actual: u32, expected: &NanPattern<F32>) -> Result<()> {
         // set to 1, but one or more of the remaining payload bits MAY BE set to
         // 1 (a canonical NaN specifies all 0s). See
         // https://webassembly.github.io/spec/core/syntax/values.html#floating-point.
-        NanPattern::ArithmeticNan => {
+        FloatConst::ArithmeticNan => {
             const AF32_NAN: u32 = 0x7f80_0000;
             let is_nan = actual & AF32_NAN == AF32_NAN;
             const AF32_PAYLOAD_MSB: u32 = 0x0040_0000;
@@ -255,15 +263,15 @@ pub fn match_f32(actual: u32, expected: &NanPattern<F32>) -> Result<()> {
                 )
             }
         }
-        NanPattern::Value(expected_value) => {
-            if actual == expected_value.bits {
+        FloatConst::Value(expected_value) => {
+            if actual == expected_value.to_bits() {
                 Ok(())
             } else {
                 bail!(
                     "expected {:10} / {:#010x}\n\
                      actual   {:10} / {:#010x}",
-                    f32::from_bits(expected_value.bits),
-                    expected_value.bits,
+                    expected_value,
+                    expected_value.to_bits(),
                     f32::from_bits(actual),
                     actual,
                 )
@@ -272,7 +280,7 @@ pub fn match_f32(actual: u32, expected: &NanPattern<F32>) -> Result<()> {
     }
 }
 
-pub fn match_f64(actual: u64, expected: &NanPattern<F64>) -> Result<()> {
+pub fn match_f64(actual: u64, expected: &FloatConst<f64>) -> Result<()> {
     match expected {
         // Check if an f64 (as u64 bits to avoid possible quieting when moving values in registers, e.g.
         // https://developer.arm.com/documentation/ddi0344/i/neon-and-vfp-programmers-model/modes-of-operation/default-nan-mode?lang=en)
@@ -281,7 +289,7 @@ pub fn match_f64(actual: u64, expected: &NanPattern<F64>) -> Result<()> {
         //  - the 11-bit exponent is set to all 1s
         //  - the MSB of the payload is set to 1 (a quieted NaN) and all others to 0.
         // See https://webassembly.github.io/spec/core/syntax/values.html#floating-point.
-        NanPattern::CanonicalNan => {
+        FloatConst::CanonicalNan => {
             let canon_nan = 0x7ff8_0000_0000_0000;
             if (actual & 0x7fff_ffff_ffff_ffff) == canon_nan {
                 Ok(())
@@ -301,7 +309,7 @@ pub fn match_f64(actual: u64, expected: &NanPattern<F64>) -> Result<()> {
         // canonical NaN including that the payload MSB is set to 1, but one or more of the remaining
         // payload bits MAY BE set to 1 (a canonical NaN specifies all 0s). See
         // https://webassembly.github.io/spec/core/syntax/values.html#floating-point.
-        NanPattern::ArithmeticNan => {
+        FloatConst::ArithmeticNan => {
             const AF64_NAN: u64 = 0x7ff0_0000_0000_0000;
             let is_nan = actual & AF64_NAN == AF64_NAN;
             const AF64_PAYLOAD_MSB: u64 = 0x0008_0000_0000_0000;
@@ -319,15 +327,15 @@ pub fn match_f64(actual: u64, expected: &NanPattern<F64>) -> Result<()> {
                 )
             }
         }
-        NanPattern::Value(expected_value) => {
-            if actual == expected_value.bits {
+        FloatConst::Value(expected_value) => {
+            if actual == expected_value.to_bits() {
                 Ok(())
             } else {
                 bail!(
                     "expected {:18} / {:#018x}\n\
                      actual   {:18} / {:#018x}",
-                    f64::from_bits(expected_value.bits),
-                    expected_value.bits,
+                    expected_value,
+                    expected_value.to_bits(),
                     f64::from_bits(actual),
                     actual,
                 )
@@ -336,9 +344,9 @@ pub fn match_f64(actual: u64, expected: &NanPattern<F64>) -> Result<()> {
     }
 }
 
-fn match_v128(actual: u128, expected: &V128Pattern) -> Result<()> {
+fn match_v128(actual: u128, expected: &V128) -> Result<()> {
     match expected {
-        V128Pattern::I8x16(expected) => {
+        V128::I8 { value } => {
             let actual = [
                 extract_lane_as_i8(actual, 0),
                 extract_lane_as_i8(actual, 1),
@@ -357,7 +365,7 @@ fn match_v128(actual: u128, expected: &V128Pattern) -> Result<()> {
                 extract_lane_as_i8(actual, 14),
                 extract_lane_as_i8(actual, 15),
             ];
-            if actual == *expected {
+            if actual == value.map(|i| i.0) {
                 return Ok(());
             }
             bail!(
@@ -370,7 +378,7 @@ fn match_v128(actual: u128, expected: &V128Pattern) -> Result<()> {
                 actual,
             )
         }
-        V128Pattern::I16x8(expected) => {
+        V128::I16 { value } => {
             let actual = [
                 extract_lane_as_i16(actual, 0),
                 extract_lane_as_i16(actual, 1),
@@ -381,7 +389,7 @@ fn match_v128(actual: u128, expected: &V128Pattern) -> Result<()> {
                 extract_lane_as_i16(actual, 6),
                 extract_lane_as_i16(actual, 7),
             ];
-            if actual == *expected {
+            if actual == value.map(|i| i.0) {
                 return Ok(());
             }
             bail!(
@@ -394,14 +402,14 @@ fn match_v128(actual: u128, expected: &V128Pattern) -> Result<()> {
                 actual,
             )
         }
-        V128Pattern::I32x4(expected) => {
+        V128::I32 { value } => {
             let actual = [
                 extract_lane_as_i32(actual, 0),
                 extract_lane_as_i32(actual, 1),
                 extract_lane_as_i32(actual, 2),
                 extract_lane_as_i32(actual, 3),
             ];
-            if actual == *expected {
+            if actual == value.map(|i| i.0) {
                 return Ok(());
             }
             bail!(
@@ -414,12 +422,12 @@ fn match_v128(actual: u128, expected: &V128Pattern) -> Result<()> {
                 actual,
             )
         }
-        V128Pattern::I64x2(expected) => {
+        V128::I64 { value } => {
             let actual = [
                 extract_lane_as_i64(actual, 0),
                 extract_lane_as_i64(actual, 1),
             ];
-            if actual == *expected {
+            if actual == value.map(|i| i.0) {
                 return Ok(());
             }
             bail!(
@@ -432,15 +440,15 @@ fn match_v128(actual: u128, expected: &V128Pattern) -> Result<()> {
                 actual,
             )
         }
-        V128Pattern::F32x4(expected) => {
-            for (i, expected) in expected.iter().enumerate() {
+        V128::F32 { value } => {
+            for (i, expected) in value.iter().enumerate() {
                 let a = extract_lane_as_i32(actual, i) as u32;
                 match_f32(a, expected).with_context(|| format!("difference in lane {i}"))?;
             }
             Ok(())
         }
-        V128Pattern::F64x2(expected) => {
-            for (i, expected) in expected.iter().enumerate() {
+        V128::F64 { value } => {
+            for (i, expected) in value.iter().enumerate() {
                 let a = extract_lane_as_i64(actual, i) as u64;
                 match_f64(a, expected).with_context(|| format!("difference in lane {i}"))?;
             }

--- a/crates/wast/src/spectest.rs
+++ b/crates/wast/src/spectest.rs
@@ -105,16 +105,18 @@ pub fn link_component_spectest<T>(linker: &mut component::Linker<T>) -> Result<(
     i.instance("nested")?
         .func_wrap("return-four", |_, _: ()| Ok((4u32,)))?;
 
-    let module = Module::new(
-        &engine,
-        r#"
-            (module
-                (global (export "g") i32 i32.const 100)
-                (func (export "f") (result i32) i32.const 101)
-            )
-        "#,
-    )?;
-    i.module("simple-module", &module)?;
+    if !cfg!(miri) {
+        let module = Module::new(
+            &engine,
+            r#"
+                (module
+                    (global (export "g") i32 i32.const 100)
+                    (func (export "f") (result i32) i32.const 101)
+                )
+            "#,
+        )?;
+        i.module("simple-module", &module)?;
+    }
 
     struct Resource1;
     struct Resource2;

--- a/crates/wast/src/wast.rs
+++ b/crates/wast/src/wast.rs
@@ -354,11 +354,16 @@ where
                             unsafe { Module::deserialize_file(self.store.engine(), &cwasm)? };
                         Ok(ModuleKind::Core(module))
                     }
+                    #[cfg(feature = "component-model")]
                     Some(Precompiled::Component) => {
                         let component = unsafe {
                             component::Component::deserialize_file(self.store.engine(), &cwasm)?
                         };
                         Ok(ModuleKind::Component(component))
+                    }
+                    #[cfg(not(feature = "component-model"))]
+                    Some(Precompiled::Component) => {
+                        bail!("support for components disabled at compile time")
                     }
                     None => bail!("expected a cwasm file"),
                 }

--- a/crates/wast/src/wast.rs
+++ b/crates/wast/src/wast.rs
@@ -3,15 +3,15 @@ use crate::component;
 use crate::core;
 use crate::spectest::*;
 use anyhow::{Context as _, anyhow, bail};
+use json_from_wast::{Action, Command, Const, WasmFile, WasmFileType};
 use std::collections::HashMap;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::str;
+use std::sync::Arc;
 use std::thread;
 use wasmtime::*;
-use wast::core::{EncodeOptions, GenerateDwarf};
 use wast::lexer::Lexer;
 use wast::parser::{self, ParseBuffer};
-use wast::{QuoteWat, Wast, WastArg, WastDirective, WastExecute, WastInvoke, WastRet, Wat};
 
 /// The wast test script language allows modules to be defined and actions
 /// to be performed on them.
@@ -26,6 +26,10 @@ pub struct WastContext<T: 'static> {
     pub(crate) store: Store<T>,
     pub(crate) async_runtime: Option<tokio::runtime::Runtime>,
     generate_dwarf: bool,
+    precompile_save: Option<PathBuf>,
+    precompile_load: Option<PathBuf>,
+
+    modules_by_filename: Arc<HashMap<String, Vec<u8>>>,
 }
 
 enum Outcome<T = Results> {
@@ -121,7 +125,24 @@ where
                 None
             },
             generate_dwarf: true,
+            precompile_save: None,
+            precompile_load: None,
+            modules_by_filename: Arc::default(),
         }
+    }
+
+    /// Saves precompiled modules/components into `path` instead of executing
+    /// test directives.
+    pub fn precompile_save(&mut self, path: impl AsRef<Path>) -> &mut Self {
+        self.precompile_save = Some(path.as_ref().into());
+        self
+    }
+
+    /// Loads precompiled modules/components from `path` instead of compiling
+    /// natively.
+    pub fn precompile_load(&mut self, path: impl AsRef<Path>) -> &mut Self {
+        self.precompile_load = Some(path.as_ref().into());
+        self
     }
 
     fn get_export(&mut self, module: Option<&str>, name: &str) -> Result<Export> {
@@ -190,88 +211,71 @@ where
     }
 
     /// Perform the action portion of a command.
-    fn perform_execute(
-        &mut self,
-        exec: WastExecute<'_>,
-        filename: &str,
-        wast: &str,
-    ) -> Result<Outcome> {
-        match exec {
-            WastExecute::Invoke(invoke) => self.perform_invoke(invoke),
-            WastExecute::Wat(module) => Ok(
-                match self.module_definition(QuoteWat::Wat(module), filename, wast)? {
-                    (_, ModuleKind::Core(module)) => self
-                        .instantiate_module(&module)?
-                        .map(|_| Results::Core(Vec::new())),
-                    #[cfg(feature = "component-model")]
-                    (_, ModuleKind::Component(component)) => self
-                        .instantiate_component(&component)?
-                        .map(|_| Results::Component(Vec::new())),
-                },
-            ),
-            WastExecute::Get { module, global, .. } => self.get(module.map(|s| s.name()), global),
-        }
-    }
+    fn perform_action(&mut self, action: &Action<'_>) -> Result<Outcome> {
+        match action {
+            Action::Invoke {
+                module,
+                field,
+                args,
+            } => match self.get_export(module.as_deref(), field)? {
+                Export::Core(export) => {
+                    let func = export
+                        .into_func()
+                        .ok_or_else(|| anyhow!("no function named `{field}`"))?;
+                    let values = args
+                        .iter()
+                        .map(|v| match v {
+                            Const::Core(v) => core::val(self, v),
+                            _ => bail!("expected core function, found other other argument {v:?}"),
+                        })
+                        .collect::<Result<Vec<_>>>()?;
 
-    fn perform_invoke(&mut self, exec: WastInvoke<'_>) -> Result<Outcome> {
-        match self.get_export(exec.module.map(|i| i.name()), exec.name)? {
-            Export::Core(export) => {
-                let func = export
-                    .into_func()
-                    .ok_or_else(|| anyhow!("no function named `{}`", exec.name))?;
-                let values = exec
-                    .args
-                    .iter()
-                    .map(|v| match v {
-                        WastArg::Core(v) => core::val(self, v),
-                        _ => bail!("expected core function, found other other argument {v:?}"),
-                    })
-                    .collect::<Result<Vec<_>>>()?;
-
-                let mut results = vec![Val::null_func_ref(); func.ty(&self.store).results().len()];
-                let result = match &self.async_runtime {
-                    Some(rt) => {
-                        rt.block_on(func.call_async(&mut self.store, &values, &mut results))
-                    }
-                    None => func.call(&mut self.store, &values, &mut results),
-                };
-
-                Ok(match result {
-                    Ok(()) => Outcome::Ok(Results::Core(results)),
-                    Err(e) => Outcome::Trap(e),
-                })
-            }
-            #[cfg(feature = "component-model")]
-            Export::Component(func) => {
-                let values = exec
-                    .args
-                    .iter()
-                    .map(|v| match v {
-                        WastArg::Component(v) => component::val(v),
-                        _ => bail!("expected component function, found other argument {v:?}"),
-                    })
-                    .collect::<Result<Vec<_>>>()?;
-
-                let mut results =
-                    vec![component::Val::Bool(false); func.results(&self.store).len()];
-                let result = match &self.async_runtime {
-                    Some(rt) => {
-                        rt.block_on(func.call_async(&mut self.store, &values, &mut results))
-                    }
-                    None => func.call(&mut self.store, &values, &mut results),
-                };
-                Ok(match result {
-                    Ok(()) => {
-                        match &self.async_runtime {
-                            Some(rt) => rt.block_on(func.post_return_async(&mut self.store))?,
-                            None => func.post_return(&mut self.store)?,
+                    let mut results =
+                        vec![Val::null_func_ref(); func.ty(&self.store).results().len()];
+                    let result = match &self.async_runtime {
+                        Some(rt) => {
+                            rt.block_on(func.call_async(&mut self.store, &values, &mut results))
                         }
+                        None => func.call(&mut self.store, &values, &mut results),
+                    };
 
-                        Outcome::Ok(Results::Component(results))
-                    }
-                    Err(e) => Outcome::Trap(e),
-                })
-            }
+                    Ok(match result {
+                        Ok(()) => Outcome::Ok(Results::Core(results)),
+                        Err(e) => Outcome::Trap(e),
+                    })
+                }
+                #[cfg(feature = "component-model")]
+                Export::Component(func) => {
+                    let values = args
+                        .iter()
+                        .map(|v| match v {
+                            Const::Component(v) => component::val(v),
+                            _ => bail!("expected component function, found other argument {v:?}"),
+                        })
+                        .collect::<Result<Vec<_>>>()?;
+
+                    let mut results =
+                        vec![component::Val::Bool(false); func.results(&self.store).len()];
+                    let result = match &self.async_runtime {
+                        Some(rt) => {
+                            rt.block_on(func.call_async(&mut self.store, &values, &mut results))
+                        }
+                        None => func.call(&mut self.store, &values, &mut results),
+                    };
+                    Ok(match result {
+                        Ok(()) => {
+                            match &self.async_runtime {
+                                Some(rt) => rt.block_on(func.post_return_async(&mut self.store))?,
+                                None => func.post_return(&mut self.store)?,
+                            }
+
+                            Outcome::Ok(Results::Component(results))
+                        }
+                        Err(e) => Outcome::Trap(e),
+                    })
+                }
+            },
+            Action::Get { module, field, .. } => self.get(module.as_deref(), field),
         }
     }
 
@@ -330,39 +334,51 @@ where
     /// it, if any.
     ///
     /// This will not register the name within `self.modules`.
-    fn module_definition<'a>(
-        &mut self,
-        mut wat: QuoteWat<'a>,
-        filename: &str,
-        wast: &str,
-    ) -> Result<(Option<&'a str>, ModuleKind)> {
-        let (is_module, name) = match &wat {
-            QuoteWat::Wat(Wat::Module(m)) => (true, m.id),
-            QuoteWat::QuoteModule(..) => (true, None),
-            QuoteWat::Wat(Wat::Component(m)) => (false, m.id),
-            QuoteWat::QuoteComponent(..) => (false, None),
+    fn module_definition(&mut self, file: &WasmFile) -> Result<ModuleKind> {
+        let name = match file.module_type {
+            WasmFileType::Text => file
+                .binary_filename
+                .as_ref()
+                .ok_or_else(|| anyhow!("cannot compile module that isn't a valid binary"))?,
+            WasmFileType::Binary => &file.filename,
         };
-        let bytes = match &mut wat {
-            QuoteWat::Wat(wat) => {
-                let mut opts = EncodeOptions::new();
-                if self.generate_dwarf {
-                    opts.dwarf(filename.as_ref(), wast, GenerateDwarf::Lines);
+
+        match &self.precompile_load {
+            Some(path) => {
+                let cwasm = path.join(&name[..]).with_extension("cwasm");
+                match Engine::detect_precompiled_file(&cwasm)
+                    .with_context(|| format!("failed to read {cwasm:?}"))?
+                {
+                    Some(Precompiled::Module) => {
+                        let module =
+                            unsafe { Module::deserialize_file(self.store.engine(), &cwasm)? };
+                        Ok(ModuleKind::Core(module))
+                    }
+                    Some(Precompiled::Component) => {
+                        let component = unsafe {
+                            component::Component::deserialize_file(self.store.engine(), &cwasm)?
+                        };
+                        Ok(ModuleKind::Component(component))
+                    }
+                    None => bail!("expected a cwasm file"),
                 }
-                opts.encode_wat(wat)?
             }
-            _ => wat.encode()?,
-        };
-        if is_module {
-            let module = Module::new(self.store.engine(), &bytes)?;
-            Ok((name.map(|n| n.name()), ModuleKind::Core(module)))
-        } else {
-            #[cfg(feature = "component-model")]
-            {
-                let component = component::Component::new(self.store.engine(), &bytes)?;
-                Ok((name.map(|n| n.name()), ModuleKind::Component(component)))
+            None => {
+                let bytes = &self.modules_by_filename[&name[..]];
+
+                if wasmparser::Parser::is_core_wasm(&bytes) {
+                    let module = Module::new(self.store.engine(), &bytes)?;
+                    Ok(ModuleKind::Core(module))
+                } else {
+                    #[cfg(feature = "component-model")]
+                    {
+                        let component = component::Component::new(self.store.engine(), &bytes)?;
+                        Ok(ModuleKind::Component(component))
+                    }
+                    #[cfg(not(feature = "component-model"))]
+                    bail!("component-model support not enabled");
+                }
             }
-            #[cfg(not(feature = "component-model"))]
-            bail!("component-model support not enabled");
         }
     }
 
@@ -404,7 +420,7 @@ where
         ])))
     }
 
-    fn assert_return(&mut self, result: Outcome, results: &[WastRet<'_>]) -> Result<()> {
+    fn assert_return(&mut self, result: Outcome, results: &[Const]) -> Result<()> {
         match result.into_result()? {
             Results::Core(values) => {
                 if values.len() != results.len() {
@@ -412,7 +428,7 @@ where
                 }
                 for (i, (v, e)) in values.iter().zip(results).enumerate() {
                     let e = match e {
-                        WastRet::Core(core) => core,
+                        Const::Core(core) => core,
                         _ => bail!("expected core value found other value {e:?}"),
                     };
                     core::match_val(&mut self.store, v, e)
@@ -426,7 +442,7 @@ where
                 }
                 for (i, (v, e)) in values.iter().zip(results).enumerate() {
                     let e = match e {
-                        WastRet::Component(val) => val,
+                        Const::Component(val) => val,
                         _ => bail!("expected component value found other value {e:?}"),
                     };
                     component::match_val(e, v)
@@ -459,7 +475,7 @@ where
     }
 
     /// Run a wast script from a byte buffer.
-    pub fn run_buffer(&mut self, filename: &str, wast: &[u8]) -> Result<()> {
+    pub fn run_wast(&mut self, filename: &str, wast: &[u8]) -> Result<()> {
         let wast = str::from_utf8(wast)?;
 
         let adjust_wast = |mut err: wast::Error| {
@@ -472,40 +488,56 @@ where
         lexer.allow_confusing_unicode(filename.ends_with("names.wast"));
         let mut buf = ParseBuffer::new_with_lexer(lexer).map_err(adjust_wast)?;
         buf.track_instr_spans(self.generate_dwarf);
-        let ast = parser::parse::<Wast>(&buf).map_err(adjust_wast)?;
+        let ast = parser::parse::<wast::Wast>(&buf).map_err(adjust_wast)?;
 
-        self.run_directives(ast.directives, filename, wast)
+        let mut ast = json_from_wast::Opts::default()
+            .dwarf(self.generate_dwarf)
+            .convert(filename, wast, ast)?;
+        let modules_by_filename = Arc::get_mut(&mut self.modules_by_filename).unwrap();
+        for (name, bytes) in ast.wasms.drain(..) {
+            let prev = modules_by_filename.insert(name, bytes);
+            assert!(prev.is_none());
+        }
+
+        match &self.precompile_save {
+            Some(path) => {
+                let json_path = path
+                    .join(Path::new(filename).file_name().unwrap())
+                    .with_extension("json");
+                let json = serde_json::to_string(&ast)?;
+                std::fs::write(&json_path, json)
+                    .with_context(|| format!("failed to write {json_path:?}"))?;
+                for (name, bytes) in self.modules_by_filename.iter() {
+                    let cwasm_path = path.join(name).with_extension("cwasm");
+                    let cwasm = if wasmparser::Parser::is_core_wasm(&bytes) {
+                        self.store.engine().precompile_module(bytes)
+                    } else {
+                        #[cfg(feature = "component-model")]
+                        {
+                            self.store.engine().precompile_component(bytes)
+                        }
+                        #[cfg(not(feature = "component-model"))]
+                        bail!("component-model support not enabled");
+                    };
+                    if let Ok(cwasm) = cwasm {
+                        std::fs::write(&cwasm_path, cwasm)
+                            .with_context(|| format!("failed to write {cwasm_path:?}"))?;
+                    }
+                }
+                Ok(())
+            }
+            None => self.run_directives(ast.commands, filename),
+        }
     }
 
-    fn run_directives(
-        &mut self,
-        directives: Vec<WastDirective<'_>>,
-        filename: &str,
-        wast: &str,
-    ) -> Result<()> {
-        let adjust_wast = |mut err: wast::Error| {
-            err.set_path(filename.as_ref());
-            err.set_text(wast);
-            err
-        };
-
+    fn run_directives(&mut self, directives: Vec<Command<'_>>, filename: &str) -> Result<()> {
         thread::scope(|scope| {
             let mut threads = HashMap::new();
             for directive in directives {
-                let sp = directive.span();
-                if log::log_enabled!(log::Level::Debug) {
-                    let (line, col) = sp.linecol_in(wast);
-                    log::debug!("running directive on {}:{}:{}", filename, line + 1, col);
-                }
-                self.run_directive(directive, filename, wast, &scope, &mut threads)
-                    .map_err(|e| match e.downcast() {
-                        Ok(err) => adjust_wast(err).into(),
-                        Err(e) => e,
-                    })
-                    .with_context(|| {
-                        let (line, col) = sp.linecol_in(wast);
-                        format!("failed directive on {}:{}:{}", filename, line + 1, col)
-                    })?;
+                let line = directive.line();
+                log::debug!("running directive on {filename}:{line}");
+                self.run_directive(directive, filename, &scope, &mut threads)
+                    .with_context(|| format!("failed directive on {filename}:{line}"))?;
             }
             Ok(())
         })
@@ -513,129 +545,146 @@ where
 
     fn run_directive<'a>(
         &mut self,
-        directive: WastDirective<'a>,
+        directive: Command<'a>,
         filename: &'a str,
-        wast: &'a str,
+        // wast: &'a str,
         scope: &'a thread::Scope<'a, '_>,
-        threads: &mut HashMap<&'a str, thread::ScopedJoinHandle<'a, Result<()>>>,
+        threads: &mut HashMap<String, thread::ScopedJoinHandle<'a, Result<()>>>,
     ) -> Result<()>
     where
         T: 'a,
     {
-        use wast::WastDirective::*;
+        use Command::*;
 
         match directive {
-            Module(module) => {
-                let (name, module) = self.module_definition(module, filename, wast)?;
-                self.module(name, &module)?;
+            Module {
+                name,
+                file,
+                line: _,
+            } => {
+                let module = self.module_definition(&file)?;
+                self.module(name.as_deref(), &module)?;
             }
-            ModuleDefinition(module) => {
-                let (name, module) = self.module_definition(module, filename, wast)?;
+            ModuleDefinition {
+                name,
+                file,
+                line: _,
+            } => {
+                let module = self.module_definition(&file)?;
                 if let Some(name) = name {
-                    self.modules.insert(name.to_string(), module.clone());
+                    self.modules.insert(name.to_string(), module);
                 }
             }
             ModuleInstance {
                 instance,
                 module,
-                span: _,
+                line: _,
             } => {
                 let module = module
-                    .and_then(|n| self.modules.get(n.name()))
+                    .as_deref()
+                    .and_then(|n| self.modules.get(n))
                     .cloned()
                     .ok_or_else(|| anyhow!("no module named {module:?}"))?;
-                self.module(instance.map(|n| n.name()), &module)?;
+                self.module(instance.as_deref(), &module)?;
             }
-            Register {
-                span: _,
-                name,
-                module,
-            } => {
-                self.register(module.map(|s| s.name()), name)?;
+            Register { line: _, name, as_ } => {
+                self.register(name.as_deref(), &as_)?;
             }
-            Invoke(i) => {
-                self.perform_invoke(i)?;
+            Action { action, line: _ } => {
+                self.perform_action(&action)?;
             }
             AssertReturn {
-                span: _,
-                exec,
-                results,
+                action,
+                expected,
+                line: _,
             } => {
-                let result = self.perform_execute(exec, filename, wast)?;
-                self.assert_return(result, &results)?;
+                let result = self.perform_action(&action)?;
+                self.assert_return(result, &expected)?;
             }
             AssertTrap {
-                span: _,
-                exec,
-                message,
+                action,
+                text,
+                line: _,
             } => {
-                let result = self.perform_execute(exec, filename, wast)?;
-                self.assert_trap(result, message)?;
+                let result = self.perform_action(&action)?;
+                self.assert_trap(result, &text)?;
+            }
+            AssertUninstantiable {
+                file,
+                text,
+                line: _,
+            } => {
+                let result = match self.module_definition(&file)? {
+                    ModuleKind::Core(module) => self
+                        .instantiate_module(&module)?
+                        .map(|_| Results::Core(Vec::new())),
+                    #[cfg(feature = "component-model")]
+                    ModuleKind::Component(component) => self
+                        .instantiate_component(&component)?
+                        .map(|_| Results::Component(Vec::new())),
+                };
+                self.assert_trap(result, &text)?;
             }
             AssertExhaustion {
-                span: _,
-                call,
-                message,
+                action,
+                text,
+                line: _,
             } => {
-                let result = self.perform_invoke(call)?;
-                self.assert_trap(result, message)?;
+                let result = self.perform_action(&action)?;
+                self.assert_trap(result, &text)?;
             }
             AssertInvalid {
-                span: _,
-                module,
-                message,
+                file,
+                text,
+                line: _,
             } => {
-                let err = match self.module_definition(module, filename, wast) {
+                let err = match self.module_definition(&file) {
                     Ok(_) => bail!("expected module to fail to build"),
                     Err(e) => e,
                 };
                 let error_message = format!("{err:?}");
-                if !is_matching_assert_invalid_error_message(filename, &message, &error_message) {
-                    bail!(
-                        "assert_invalid: expected \"{}\", got \"{}\"",
-                        message,
-                        error_message
-                    )
+                if !is_matching_assert_invalid_error_message(filename, &text, &error_message) {
+                    bail!("assert_invalid: expected \"{text}\", got \"{error_message}\"",)
                 }
             }
             AssertMalformed {
-                module,
-                span: _,
-                message: _,
+                file,
+                text: _,
+                line: _,
             } => {
-                if let Ok(_) = self.module_definition(module, filename, wast) {
+                if let Ok(_) = self.module_definition(&file) {
                     bail!("expected malformed module to fail to instantiate");
                 }
             }
             AssertUnlinkable {
-                span: _,
-                module,
-                message,
+                file,
+                text,
+                line: _,
             } => {
-                let (name, module) =
-                    self.module_definition(QuoteWat::Wat(module), filename, wast)?;
-                let err = match self.module(name, &module) {
+                let module = self.module_definition(&file)?;
+                let err = match self.module(None, &module) {
                     Ok(_) => bail!("expected module to fail to link"),
                     Err(e) => e,
                 };
                 let error_message = format!("{err:?}");
-                if !error_message.contains(&message) {
-                    bail!(
-                        "assert_unlinkable: expected {}, got {}",
-                        message,
-                        error_message
-                    )
+                if !error_message.contains(&text[..]) {
+                    bail!("assert_unlinkable: expected {text}, got {error_message}",)
                 }
             }
             AssertException { .. } => bail!("unimplemented assert_exception"),
 
-            Thread(thread) => {
+            Thread {
+                name,
+                shared_module,
+                commands,
+                line: _,
+            } => {
                 let mut core_linker = Linker::new(self.store.engine());
-                if let Some(id) = thread.shared_module {
+                if let Some(id) = shared_module {
                     let items = self
                         .core_linker
                         .iter(&mut self.store)
-                        .filter(|(module, _, _)| *module == id.name())
+                        .filter(|(module, _, _)| *module == &id[..])
                         .collect::<Vec<_>>();
                     for (module, name, item) in items {
                         core_linker.define(&mut self.store, module, name, item)?;
@@ -654,18 +703,17 @@ where
                             .unwrap()
                     }),
                     generate_dwarf: self.generate_dwarf,
+                    modules_by_filename: self.modules_by_filename.clone(),
+                    precompile_load: self.precompile_load.clone(),
+                    precompile_save: self.precompile_save.clone(),
                 };
-                let name = thread.name.name();
-                let child =
-                    scope.spawn(move || child_cx.run_directives(thread.directives, filename, wast));
-                threads.insert(name, child);
+                let child = scope.spawn(move || child_cx.run_directives(commands, filename));
+                threads.insert(name.to_string(), child);
             }
-
             Wait { thread, .. } => {
-                let name = thread.name();
                 threads
-                    .remove(name)
-                    .ok_or_else(|| anyhow!("no thread named `{name}`"))?
+                    .remove(&thread[..])
+                    .ok_or_else(|| anyhow!("no thread named `{thread}`"))?
                     .join()
                     .unwrap()?;
             }
@@ -680,9 +728,22 @@ where
 
     /// Run a wast script from a file.
     pub fn run_file(&mut self, path: &Path) -> Result<()> {
-        let bytes =
-            std::fs::read(path).with_context(|| format!("failed to read `{}`", path.display()))?;
-        self.run_buffer(path.to_str().unwrap(), &bytes)
+        match &self.precompile_load {
+            Some(precompile) => {
+                let file = precompile
+                    .join(path.file_name().unwrap())
+                    .with_extension("json");
+                let json = std::fs::read_to_string(&file)
+                    .with_context(|| format!("failed to read {file:?}"))?;
+                let wast = serde_json::from_str::<json_from_wast::Wast<'_>>(&json)?;
+                self.run_directives(wast.commands, &wast.source_filename)
+            }
+            None => {
+                let bytes = std::fs::read(path)
+                    .with_context(|| format!("failed to read `{}`", path.display()))?;
+                self.run_wast(path.to_str().unwrap(), &bytes)
+            }
+        }
     }
 
     /// Whether or not to generate DWARF debugging information in custom

--- a/src/commands/wast.rs
+++ b/src/commands/wast.rs
@@ -21,6 +21,16 @@ pub struct WastCommand {
     /// transformations to show line numbers in backtraces.
     #[arg(long, require_equals = true, value_name = "true|false")]
     generate_dwarf: Option<Option<bool>>,
+
+    /// Saves precompiled versions of modules to this path instead of running
+    /// tests.
+    #[arg(long)]
+    precompile_save: Option<PathBuf>,
+
+    /// Load precompiled modules from the specified directory instead of
+    /// compiling natively.
+    #[arg(long)]
+    precompile_load: Option<PathBuf>,
 }
 
 impl WastCommand {
@@ -48,10 +58,17 @@ impl WastCommand {
             })
             .expect("error instantiating \"spectest\"");
 
+        if let Some(path) = &self.precompile_save {
+            wast_context.precompile_save(path);
+        }
+        if let Some(path) = &self.precompile_load {
+            wast_context.precompile_load(path);
+        }
+
         for script in self.scripts.iter() {
             wast_context
                 .run_file(script)
-                .with_context(|| format!("failed to run script file '{}'", script.display()))?
+                .with_context(|| format!("failed to run script file '{}'", script.display()))?;
         }
 
         Ok(())

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -184,6 +184,16 @@ start = "2020-01-14"
 end = "2025-07-30"
 notes = "I am an author of this crate"
 
+[[wildcard-audits.json-from-wast]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2025-07-28"
+end = "2026-07-28"
+notes = """
+The Bytecode Alliance is the author of this crate.
+"""
+
 [[wildcard-audits.mutatis]]
 who = "Nick Fitzgerald <fitzgen@gmail.com>"
 criteria = "safe-to-deploy"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1134,6 +1134,12 @@ user-id = 1
 user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
+[[publisher.json-from-wast]]
+version = "0.236.0"
+when = "2025-07-28"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.libc]]
 version = "0.2.146"
 when = "2023-06-06"

--- a/tests/wast.rs
+++ b/tests/wast.rs
@@ -244,7 +244,7 @@ fn run_wast(test: &WastTest, config: WastConfig) -> anyhow::Result<()> {
                 suppress_prints: true,
             })?;
             wast_context
-                .run_buffer(test.path.to_str().unwrap(), test.contents.as_bytes())
+                .run_wast(test.path.to_str().unwrap(), test.contents.as_bytes())
                 .with_context(|| format!("failed to run spec test with {desc} engine"))
         });
 


### PR DESCRIPTION
This commit is a refactoring of the `wasmtime-wast` crate to use the `json-from-wast` crate added in bytecodealliance/wasm-tools#2247 instead of the `wast` crate directly. The primary motivation for this PR is to make spec tests more suitable for running inside of Miri. There are two primary factors in how Miri is slow with wast tests today:

* Compiling WebAssembly modules. These are all embedded throughout `*.wast` files and basically need to be precompiled to run in Miri.

* Parsing the `*.wast` script itself. The scripts are generally quite large in the upstream spec test suite and parsing the script requires parsing all modules as well, so this can take quite some time.

The goal of this commit was to leverage `json-from-wast` to perform much of the heavy lifting on the host and then have a "cheap" parse step in Miri which deserializes the JSON and runs precompiled `*.cwasm` files. The main change then required of `wasmtime-wast` was to use the JSON AST as its "IR" instead of `wast` directly. The actual transformation of the `wasmtime-wast` crate isn't too bad, mostly just some refactorings here and there.

A new `./ci/miri-wast.sh` script is added which first runs on native with `wasmtime wast --precompile-save` and then runs in Miri with `wasmtime wast --precompile-load`. In this manner I was able to get a number of spec test `*.wast` files running in Miri.

Unfortunately, though, Miri is still far too slow to run in CI. One major bottleneck is that the `*.json` files are pretty large and take a nontrivial amount of time to parse. Another issue is that these tests run a fair bit of code which with Miri's ~million-x slowdown. For the first problem I tried using other more-binary serialization formats but the JSON AST is unfortunately not compatible with many of them (e.g. `postcard`, which we use for Wasmtime, is not compatible with the JSON AST's structure in Rust types). For the latter I'm not sure what to do...

In the end I figured this might be a reasonable refactoring to go ahead and land anyway. It at least enables running `*.wast` tests in Miri while removing a large part of the runtime slowdown. We can in theory still allow-list some tests to run as they don't all take forever. Some future breakthrough is still going to be required though to run everything through Miri.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
