### PR TITLE
Release Wasmtime 32.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -289,7 +289,7 @@ dependencies = [
 
 [[package]]
 name = "byte-array-literals"
-version = "32.0.0"
+version = "32.0.1"
 
 [[package]]
 name = "byteorder"
@@ -664,7 +664,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift"
-version = "0.119.0"
+version = "0.119.1"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",
@@ -677,7 +677,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.119.0"
+version = "0.119.1"
 dependencies = [
  "arbitrary",
  "arbtest",
@@ -695,21 +695,21 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.119.0"
+version = "0.119.1"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.119.0"
+version = "0.119.1"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.119.0"
+version = "0.119.1"
 dependencies = [
  "arbitrary",
  "serde",
@@ -718,7 +718,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.119.0"
+version = "0.119.1"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.119.0"
+version = "0.119.1"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -761,18 +761,18 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.119.0"
+version = "0.119.1"
 
 [[package]]
 name = "cranelift-control"
-version = "0.119.0"
+version = "0.119.1"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.119.0"
+version = "0.119.1"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -811,7 +811,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.119.0"
+version = "0.119.1"
 dependencies = [
  "cranelift-codegen",
  "env_logger 0.11.5",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-interpreter"
-version = "0.119.0"
+version = "0.119.1"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -849,7 +849,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.119.0"
+version = "0.119.1"
 dependencies = [
  "codespan-reporting",
  "log",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-jit"
-version = "0.119.0"
+version = "0.119.1"
 dependencies = [
  "anyhow",
  "cranelift",
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-module"
-version = "0.119.0"
+version = "0.119.1"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.119.0"
+version = "0.119.1"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -900,7 +900,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-object"
-version = "0.119.0"
+version = "0.119.1"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -915,7 +915,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-reader"
-version = "0.119.0"
+version = "0.119.1"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-serde"
-version = "0.119.0"
+version = "0.119.1"
 dependencies = [
  "clap",
  "cranelift-codegen",
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.119.0"
+version = "0.119.1"
 
 [[package]]
 name = "cranelift-tools"
@@ -1199,7 +1199,7 @@ checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
 
 [[package]]
 name = "embedding"
-version = "32.0.0"
+version = "32.0.1"
 dependencies = [
  "anyhow",
  "dlmalloc",
@@ -2271,7 +2271,7 @@ dependencies = [
 
 [[package]]
 name = "min-platform-host"
-version = "32.0.0"
+version = "32.0.1"
 dependencies = [
  "anyhow",
  "libloading",
@@ -2654,7 +2654,7 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "32.0.0"
+version = "32.0.1"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -3822,7 +3822,7 @@ version = "0.1.0"
 
 [[package]]
 name = "verify-component-adapter"
-version = "32.0.0"
+version = "32.0.1"
 dependencies = [
  "anyhow",
  "wasmparser 0.228.0",
@@ -3881,7 +3881,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-common"
-version = "32.0.0"
+version = "32.0.1"
 dependencies = [
  "anyhow",
  "bitflags 2.6.0",
@@ -3920,7 +3920,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-preview1-component-adapter"
-version = "32.0.0"
+version = "32.0.1"
 dependencies = [
  "bitflags 2.6.0",
  "byte-array-literals",
@@ -4164,7 +4164,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "32.0.0"
+version = "32.0.1"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -4230,14 +4230,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-asm-macros"
-version = "32.0.0"
+version = "32.0.1"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "wasmtime-bench-api"
-version = "32.0.0"
+version = "32.0.1"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -4253,14 +4253,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-c-api"
-version = "32.0.0"
+version = "32.0.1"
 dependencies = [
  "wasmtime-c-api-impl",
 ]
 
 [[package]]
 name = "wasmtime-c-api-impl"
-version = "32.0.0"
+version = "32.0.1"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -4277,7 +4277,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-c-api-macros"
-version = "32.0.0"
+version = "32.0.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4285,7 +4285,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cache"
-version = "32.0.0"
+version = "32.0.1"
 dependencies = [
  "anyhow",
  "base64",
@@ -4306,7 +4306,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli"
-version = "32.0.0"
+version = "32.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4379,7 +4379,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli-flags"
-version = "32.0.0"
+version = "32.0.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -4394,7 +4394,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-macro"
-version = "32.0.0"
+version = "32.0.1"
 dependencies = [
  "anyhow",
  "component-macro-test-helpers",
@@ -4414,11 +4414,11 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-util"
-version = "32.0.0"
+version = "32.0.1"
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "32.0.0"
+version = "32.0.1"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4442,7 +4442,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "32.0.0"
+version = "32.0.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -4484,7 +4484,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-explorer"
-version = "32.0.0"
+version = "32.0.1"
 dependencies = [
  "anyhow",
  "capstone",
@@ -4499,7 +4499,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-fiber"
-version = "32.0.0"
+version = "32.0.1"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -4570,7 +4570,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-debug"
-version = "32.0.0"
+version = "32.0.1"
 dependencies = [
  "cc",
  "object",
@@ -4580,7 +4580,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-icache-coherence"
-version = "32.0.0"
+version = "32.0.1"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4590,14 +4590,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-math"
-version = "32.0.0"
+version = "32.0.1"
 dependencies = [
  "libm",
 ]
 
 [[package]]
 name = "wasmtime-slab"
-version = "32.0.0"
+version = "32.0.1"
 
 [[package]]
 name = "wasmtime-test-macros"
@@ -4612,7 +4612,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-test-util"
-version = "32.0.0"
+version = "32.0.1"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -4630,7 +4630,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-versioned-export-macros"
-version = "32.0.0"
+version = "32.0.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4639,7 +4639,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "32.0.0"
+version = "32.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4673,7 +4673,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-config"
-version = "32.0.0"
+version = "32.0.1"
 dependencies = [
  "anyhow",
  "test-programs-artifacts",
@@ -4684,7 +4684,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-http"
-version = "32.0.0"
+version = "32.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4710,7 +4710,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-io"
-version = "32.0.0"
+version = "32.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4721,7 +4721,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-keyvalue"
-version = "32.0.0"
+version = "32.0.1"
 dependencies = [
  "anyhow",
  "test-programs-artifacts",
@@ -4732,7 +4732,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-nn"
-version = "32.0.0"
+version = "32.0.1"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -4753,7 +4753,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-threads"
-version = "32.0.0"
+version = "32.0.1"
 dependencies = [
  "anyhow",
  "log",
@@ -4765,7 +4765,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-tls"
-version = "32.0.0"
+version = "32.0.1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4781,7 +4781,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wast"
-version = "32.0.0"
+version = "32.0.1"
 dependencies = [
  "anyhow",
  "log",
@@ -4792,7 +4792,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-winch"
-version = "32.0.0"
+version = "32.0.1"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -4807,7 +4807,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wit-bindgen"
-version = "32.0.0"
+version = "32.0.1"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -4817,7 +4817,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wmemcheck"
-version = "32.0.0"
+version = "32.0.1"
 
 [[package]]
 name = "wast"
@@ -4883,7 +4883,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "32.0.0"
+version = "32.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4900,7 +4900,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "32.0.0"
+version = "32.0.1"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -4913,7 +4913,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "32.0.0"
+version = "32.0.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4968,7 +4968,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "32.0.0"
+version = "32.0.1"
 dependencies = [
  "anyhow",
  "cranelift-codegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,7 +169,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "32.0.0"
+version = "32.0.1"
 authors = ["The Wasmtime Project Developers"]
 edition = "2021"
 # Wasmtime's current policy is that this number can be no larger than the
@@ -222,64 +222,64 @@ allow_attributes_without_reason = 'warn'
 
 [workspace.dependencies]
 arbitrary = { version = "1.4.0" }
-wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=32.0.0" }
-wasmtime = { path = "crates/wasmtime", version = "32.0.0", default-features = false }
-wasmtime-c-api-macros = { path = "crates/c-api-macros", version = "=32.0.0" }
-wasmtime-cache = { path = "crates/cache", version = "=32.0.0" }
-wasmtime-cli-flags = { path = "crates/cli-flags", version = "=32.0.0" }
-wasmtime-cranelift = { path = "crates/cranelift", version = "=32.0.0" }
-wasmtime-winch = { path = "crates/winch", version = "=32.0.0" }
-wasmtime-environ = { path = "crates/environ", version = "=32.0.0" }
-wasmtime-explorer = { path = "crates/explorer", version = "=32.0.0" }
-wasmtime-fiber = { path = "crates/fiber", version = "=32.0.0" }
-wasmtime-jit-debug = { path = "crates/jit-debug", version = "=32.0.0" }
-wasmtime-wast = { path = "crates/wast", version = "=32.0.0" }
-wasmtime-wasi = { path = "crates/wasi", version = "32.0.0", default-features = false }
-wasmtime-wasi-io = { path = "crates/wasi-io", version = "32.0.0", default-features = false }
-wasmtime-wasi-http = { path = "crates/wasi-http", version = "32.0.0", default-features = false }
-wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "32.0.0" }
-wasmtime-wasi-config = { path = "crates/wasi-config", version = "32.0.0" }
-wasmtime-wasi-keyvalue = { path = "crates/wasi-keyvalue", version = "32.0.0" }
-wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "32.0.0" }
-wasmtime-component-util = { path = "crates/component-util", version = "=32.0.0" }
-wasmtime-component-macro = { path = "crates/component-macro", version = "=32.0.0" }
-wasmtime-asm-macros = { path = "crates/asm-macros", version = "=32.0.0" }
-wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=32.0.0" }
-wasmtime-slab = { path = "crates/slab", version = "=32.0.0" }
-wasmtime-wasi-tls = { path = "crates/wasi-tls", version = "32.0.0" }
-wiggle = { path = "crates/wiggle", version = "=32.0.0", default-features = false }
-wiggle-macro = { path = "crates/wiggle/macro", version = "=32.0.0" }
-wiggle-generate = { path = "crates/wiggle/generate", version = "=32.0.0" }
-wasi-common = { path = "crates/wasi-common", version = "=32.0.0", default-features = false }
+wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=32.0.1" }
+wasmtime = { path = "crates/wasmtime", version = "32.0.1", default-features = false }
+wasmtime-c-api-macros = { path = "crates/c-api-macros", version = "=32.0.1" }
+wasmtime-cache = { path = "crates/cache", version = "=32.0.1" }
+wasmtime-cli-flags = { path = "crates/cli-flags", version = "=32.0.1" }
+wasmtime-cranelift = { path = "crates/cranelift", version = "=32.0.1" }
+wasmtime-winch = { path = "crates/winch", version = "=32.0.1" }
+wasmtime-environ = { path = "crates/environ", version = "=32.0.1" }
+wasmtime-explorer = { path = "crates/explorer", version = "=32.0.1" }
+wasmtime-fiber = { path = "crates/fiber", version = "=32.0.1" }
+wasmtime-jit-debug = { path = "crates/jit-debug", version = "=32.0.1" }
+wasmtime-wast = { path = "crates/wast", version = "=32.0.1" }
+wasmtime-wasi = { path = "crates/wasi", version = "32.0.1", default-features = false }
+wasmtime-wasi-io = { path = "crates/wasi-io", version = "32.0.1", default-features = false }
+wasmtime-wasi-http = { path = "crates/wasi-http", version = "32.0.1", default-features = false }
+wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "32.0.1" }
+wasmtime-wasi-config = { path = "crates/wasi-config", version = "32.0.1" }
+wasmtime-wasi-keyvalue = { path = "crates/wasi-keyvalue", version = "32.0.1" }
+wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "32.0.1" }
+wasmtime-component-util = { path = "crates/component-util", version = "=32.0.1" }
+wasmtime-component-macro = { path = "crates/component-macro", version = "=32.0.1" }
+wasmtime-asm-macros = { path = "crates/asm-macros", version = "=32.0.1" }
+wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=32.0.1" }
+wasmtime-slab = { path = "crates/slab", version = "=32.0.1" }
+wasmtime-wasi-tls = { path = "crates/wasi-tls", version = "32.0.1" }
+wiggle = { path = "crates/wiggle", version = "=32.0.1", default-features = false }
+wiggle-macro = { path = "crates/wiggle/macro", version = "=32.0.1" }
+wiggle-generate = { path = "crates/wiggle/generate", version = "=32.0.1" }
+wasi-common = { path = "crates/wasi-common", version = "=32.0.1", default-features = false }
 wasmtime-fuzzing = { path = "crates/fuzzing" }
-wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=32.0.0" }
-wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=32.0.0" }
-wasmtime-math = { path = "crates/math", version = "=32.0.0" }
+wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=32.0.1" }
+wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=32.0.1" }
+wasmtime-math = { path = "crates/math", version = "=32.0.1" }
 test-programs-artifacts = { path = 'crates/test-programs/artifacts' }
 wasmtime-test-util = { path = "crates/test-util" }
 
-pulley-interpreter = { path = 'pulley', version = "=32.0.0" }
+pulley-interpreter = { path = 'pulley', version = "=32.0.1" }
 pulley-interpreter-fuzz = { path = 'pulley/fuzz' }
 
-cranelift-assembler-x64 = { path = "cranelift/assembler-x64", version = "0.119.0" }
-cranelift-codegen = { path = "cranelift/codegen", version = "0.119.0", default-features = false, features = ["std", "unwind"] }
-cranelift-frontend = { path = "cranelift/frontend", version = "0.119.0" }
-cranelift-entity = { path = "cranelift/entity", version = "0.119.0" }
-cranelift-native = { path = "cranelift/native", version = "0.119.0" }
-cranelift-module = { path = "cranelift/module", version = "0.119.0" }
-cranelift-interpreter = { path = "cranelift/interpreter", version = "0.119.0" }
-cranelift-reader = { path = "cranelift/reader", version = "0.119.0" }
+cranelift-assembler-x64 = { path = "cranelift/assembler-x64", version = "0.119.1" }
+cranelift-codegen = { path = "cranelift/codegen", version = "0.119.1", default-features = false, features = ["std", "unwind"] }
+cranelift-frontend = { path = "cranelift/frontend", version = "0.119.1" }
+cranelift-entity = { path = "cranelift/entity", version = "0.119.1" }
+cranelift-native = { path = "cranelift/native", version = "0.119.1" }
+cranelift-module = { path = "cranelift/module", version = "0.119.1" }
+cranelift-interpreter = { path = "cranelift/interpreter", version = "0.119.1" }
+cranelift-reader = { path = "cranelift/reader", version = "0.119.1" }
 cranelift-filetests = { path = "cranelift/filetests" }
-cranelift-object = { path = "cranelift/object", version = "0.119.0" }
-cranelift-jit = { path = "cranelift/jit", version = "0.119.0" }
+cranelift-object = { path = "cranelift/object", version = "0.119.1" }
+cranelift-jit = { path = "cranelift/jit", version = "0.119.1" }
 cranelift-fuzzgen = { path = "cranelift/fuzzgen" }
-cranelift-bforest = { path = "cranelift/bforest", version = "0.119.0" }
-cranelift-bitset = { path = "cranelift/bitset", version = "0.119.0" }
-cranelift-control = { path = "cranelift/control", version = "0.119.0" }
-cranelift-srcgen = { path = "cranelift/srcgen", version = "0.119.0" }
-cranelift = { path = "cranelift/umbrella", version = "0.119.0" }
+cranelift-bforest = { path = "cranelift/bforest", version = "0.119.1" }
+cranelift-bitset = { path = "cranelift/bitset", version = "0.119.1" }
+cranelift-control = { path = "cranelift/control", version = "0.119.1" }
+cranelift-srcgen = { path = "cranelift/srcgen", version = "0.119.1" }
+cranelift = { path = "cranelift/umbrella", version = "0.119.1" }
 
-winch-codegen = { path = "winch/codegen", version = "=32.0.0" }
+winch-codegen = { path = "winch/codegen", version = "=32.0.1" }
 
 wasi-preview1-component-adapter = { path = "crates/wasi-preview1-component-adapter" }
 byte-array-literals = { path = "crates/wasi-preview1-component-adapter/byte-array-literals" }

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,15 @@
+## 32.0.1
+
+Released 2025-06-24.
+
+### Fixed
+
+* Fix a panic with host-defined tables/globals and concrete reference
+  types.
+  [#11103](https://github.com/bytecodealliance/wasmtime/pull/11103)
+
+--------------------------------------------------------------------------------
+
 ## 32.0.0
 
 Released 2025-04-21.

--- a/cranelift/assembler-x64/Cargo.toml
+++ b/cranelift/assembler-x64/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-assembler-x64"
 description = "A Cranelift-specific x64 assembler"
-version = "0.119.0"
+version = "0.119.1"
 license = "Apache-2.0 WITH LLVM-exception"
 edition.workspace = true
 rust-version.workspace = true
@@ -16,7 +16,7 @@ arbtest = "0.3.1"
 capstone = { workspace = true }
 
 [build-dependencies]
-cranelift-assembler-x64-meta = { path = "meta", version = "0.119.0" }
+cranelift-assembler-x64-meta = { path = "meta", version = "0.119.1" }
 
 [lints]
 workspace = true

--- a/cranelift/assembler-x64/meta/Cargo.toml
+++ b/cranelift/assembler-x64/meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-assembler-x64-meta"
 description = "Generate a Cranelift-specific assembler for x64 instructions"
-version = "0.119.0"
+version = "0.119.1"
 license = "Apache-2.0 WITH LLVM-exception"
 edition.workspace = true
 rust-version.workspace = true

--- a/cranelift/bforest/Cargo.toml
+++ b/cranelift/bforest/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bforest"
-version = "0.119.0"
+version = "0.119.1"
 description = "A forest of B+-trees"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-bforest"

--- a/cranelift/bitset/Cargo.toml
+++ b/cranelift/bitset/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bitset"
-version = "0.119.0"
+version = "0.119.1"
 description = "Various bitset stuff for use inside Cranelift"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-bitset"

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen"
-version = "0.119.0"
+version = "0.119.1"
 description = "Low-level code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-codegen"
@@ -25,7 +25,7 @@ anyhow = { workspace = true, optional = true, features = ['std'] }
 bumpalo = "3"
 capstone = { workspace = true, optional = true }
 cranelift-assembler-x64 = { workspace = true }
-cranelift-codegen-shared = { path = "./shared", version = "0.119.0" }
+cranelift-codegen-shared = { path = "./shared", version = "0.119.1" }
 cranelift-entity = { workspace = true }
 cranelift-bforest = { workspace = true }
 cranelift-bitset = { workspace = true }
@@ -54,8 +54,8 @@ similar = "2.1.0"
 env_logger = { workspace = true }
 
 [build-dependencies]
-cranelift-codegen-meta = { path = "meta", version = "0.119.0" }
-cranelift-isle = { path = "../isle/isle", version = "=0.119.0" }
+cranelift-codegen-meta = { path = "meta", version = "0.119.1" }
+cranelift-isle = { path = "../isle/isle", version = "=0.119.1" }
 
 [features]
 default = ["std", "unwind", "host-arch", "timing"]

--- a/cranelift/codegen/meta/Cargo.toml
+++ b/cranelift/codegen/meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-codegen-meta"
 authors = ["The Cranelift Project Developers"]
-version = "0.119.0"
+version = "0.119.1"
 description = "Metaprogram for cranelift-codegen code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
@@ -17,8 +17,8 @@ rustdoc-args = ["--document-private-items"]
 
 [dependencies]
 cranelift-srcgen = { workspace = true }
-cranelift-assembler-x64-meta = { path = "../../assembler-x64/meta", version = "0.119.0" }
-cranelift-codegen-shared = { path = "../shared", version = "0.119.0" }
+cranelift-assembler-x64-meta = { path = "../../assembler-x64/meta", version = "0.119.1" }
+cranelift-codegen-shared = { path = "../shared", version = "0.119.1" }
 pulley-interpreter = { workspace = true, optional = true }
 
 [features]

--- a/cranelift/codegen/shared/Cargo.toml
+++ b/cranelift/codegen/shared/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen-shared"
-version = "0.119.0"
+version = "0.119.1"
 description = "For code shared between cranelift-codegen-meta and cranelift-codegen"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/control/Cargo.toml
+++ b/cranelift/control/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-control"
-version = "0.119.0"
+version = "0.119.1"
 description = "White-box fuzz testing framework"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/entity/Cargo.toml
+++ b/cranelift/entity/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-entity"
-version = "0.119.0"
+version = "0.119.1"
 description = "Data structures using entity references as mapping keys"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-entity"

--- a/cranelift/frontend/Cargo.toml
+++ b/cranelift/frontend/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-frontend"
-version = "0.119.0"
+version = "0.119.1"
 description = "Cranelift IR builder helper"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-frontend"

--- a/cranelift/interpreter/Cargo.toml
+++ b/cranelift/interpreter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-interpreter"
-version = "0.119.0"
+version = "0.119.1"
 authors = ["The Cranelift Project Developers"]
 description = "Interpret Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/isle/isle/Cargo.toml
+++ b/cranelift/isle/isle/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 name = "cranelift-isle"
 readme = "../README.md"
 repository = "https://github.com/bytecodealliance/wasmtime/tree/main/cranelift/isle"
-version = "0.119.0"
+version = "0.119.1"
 
 [lints]
 workspace = true

--- a/cranelift/jit/Cargo.toml
+++ b/cranelift/jit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-jit"
-version = "0.119.0"
+version = "0.119.1"
 authors = ["The Cranelift Project Developers"]
 description = "A JIT library backed by Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/module/Cargo.toml
+++ b/cranelift/module/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-module"
-version = "0.119.0"
+version = "0.119.1"
 authors = ["The Cranelift Project Developers"]
 description = "Support for linking functions and data with Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/native/Cargo.toml
+++ b/cranelift/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-native"
-version = "0.119.0"
+version = "0.119.1"
 authors = ["The Cranelift Project Developers"]
 description = "Support for targeting the host with Cranelift"
 documentation = "https://docs.rs/cranelift-native"

--- a/cranelift/object/Cargo.toml
+++ b/cranelift/object/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-object"
-version = "0.119.0"
+version = "0.119.1"
 authors = ["The Cranelift Project Developers"]
 description = "Emit Cranelift output to native object files with `object`"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/reader/Cargo.toml
+++ b/cranelift/reader/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-reader"
-version = "0.119.0"
+version = "0.119.1"
 description = "Cranelift textual IR reader"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-reader"

--- a/cranelift/serde/Cargo.toml
+++ b/cranelift/serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-serde"
-version = "0.119.0"
+version = "0.119.1"
 authors = ["The Cranelift Project Developers"]
 description = "Serializer/Deserializer for Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/srcgen/Cargo.toml
+++ b/cranelift/srcgen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-srcgen"
-version = "0.119.0"
+version = "0.119.1"
 authors = ["The Wasmtime Project Developers"]
 description = "Helper functions for generating Rust and ISLE files"
 license = "Apache-2.0 WITH LLVM-exception"

--- a/cranelift/umbrella/Cargo.toml
+++ b/cranelift/umbrella/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift"
-version = "0.119.0"
+version = "0.119.1"
 description = "Umbrella for commonly-used cranelift crates"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift"

--- a/crates/c-api/include/wasmtime.h
+++ b/crates/c-api/include/wasmtime.h
@@ -206,7 +206,7 @@
 /**
  * \brief Wasmtime version string.
  */
-#define WASMTIME_VERSION "32.0.0"
+#define WASMTIME_VERSION "32.0.1"
 /**
  * \brief Wasmtime major version number.
  */
@@ -218,7 +218,7 @@
 /**
  * \brief Wasmtime patch version number.
  */
-#define WASMTIME_VERSION_PATCH 0
+#define WASMTIME_VERSION_PATCH 1
 
 #ifdef __cplusplus
 extern "C" {

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -5,201 +5,409 @@
 version = "0.119.0"
 audited_as = "0.117.2"
 
+[[unpublished.cranelift]]
+version = "0.119.1"
+audited_as = "0.119.0"
+
 [[unpublished.cranelift-assembler-x64]]
 version = "0.119.0"
 audited_as = "0.117.2"
+
+[[unpublished.cranelift-assembler-x64]]
+version = "0.119.1"
+audited_as = "0.119.0"
 
 [[unpublished.cranelift-assembler-x64-meta]]
 version = "0.119.0"
 audited_as = "0.117.2"
 
+[[unpublished.cranelift-assembler-x64-meta]]
+version = "0.119.1"
+audited_as = "0.119.0"
+
 [[unpublished.cranelift-bforest]]
 version = "0.119.0"
 audited_as = "0.117.2"
+
+[[unpublished.cranelift-bforest]]
+version = "0.119.1"
+audited_as = "0.119.0"
 
 [[unpublished.cranelift-bitset]]
 version = "0.119.0"
 audited_as = "0.117.2"
 
+[[unpublished.cranelift-bitset]]
+version = "0.119.1"
+audited_as = "0.119.0"
+
 [[unpublished.cranelift-codegen]]
 version = "0.119.0"
 audited_as = "0.117.2"
+
+[[unpublished.cranelift-codegen]]
+version = "0.119.1"
+audited_as = "0.119.0"
 
 [[unpublished.cranelift-codegen-meta]]
 version = "0.119.0"
 audited_as = "0.117.2"
 
+[[unpublished.cranelift-codegen-meta]]
+version = "0.119.1"
+audited_as = "0.119.0"
+
 [[unpublished.cranelift-codegen-shared]]
 version = "0.119.0"
 audited_as = "0.117.2"
+
+[[unpublished.cranelift-codegen-shared]]
+version = "0.119.1"
+audited_as = "0.119.0"
 
 [[unpublished.cranelift-control]]
 version = "0.119.0"
 audited_as = "0.117.2"
 
+[[unpublished.cranelift-control]]
+version = "0.119.1"
+audited_as = "0.119.0"
+
 [[unpublished.cranelift-entity]]
 version = "0.119.0"
 audited_as = "0.117.2"
+
+[[unpublished.cranelift-entity]]
+version = "0.119.1"
+audited_as = "0.119.0"
 
 [[unpublished.cranelift-frontend]]
 version = "0.119.0"
 audited_as = "0.117.2"
 
+[[unpublished.cranelift-frontend]]
+version = "0.119.1"
+audited_as = "0.119.0"
+
 [[unpublished.cranelift-interpreter]]
 version = "0.119.0"
 audited_as = "0.117.2"
+
+[[unpublished.cranelift-interpreter]]
+version = "0.119.1"
+audited_as = "0.119.0"
 
 [[unpublished.cranelift-isle]]
 version = "0.119.0"
 audited_as = "0.117.2"
 
+[[unpublished.cranelift-isle]]
+version = "0.119.1"
+audited_as = "0.119.0"
+
 [[unpublished.cranelift-jit]]
 version = "0.119.0"
 audited_as = "0.117.2"
+
+[[unpublished.cranelift-jit]]
+version = "0.119.1"
+audited_as = "0.119.0"
 
 [[unpublished.cranelift-module]]
 version = "0.119.0"
 audited_as = "0.117.2"
 
+[[unpublished.cranelift-module]]
+version = "0.119.1"
+audited_as = "0.119.0"
+
 [[unpublished.cranelift-native]]
 version = "0.119.0"
 audited_as = "0.117.2"
+
+[[unpublished.cranelift-native]]
+version = "0.119.1"
+audited_as = "0.119.0"
 
 [[unpublished.cranelift-object]]
 version = "0.119.0"
 audited_as = "0.117.2"
 
+[[unpublished.cranelift-object]]
+version = "0.119.1"
+audited_as = "0.119.0"
+
 [[unpublished.cranelift-reader]]
 version = "0.119.0"
 audited_as = "0.117.2"
+
+[[unpublished.cranelift-reader]]
+version = "0.119.1"
+audited_as = "0.119.0"
 
 [[unpublished.cranelift-serde]]
 version = "0.119.0"
 audited_as = "0.117.2"
 
+[[unpublished.cranelift-serde]]
+version = "0.119.1"
+audited_as = "0.119.0"
+
+[[unpublished.cranelift-srcgen]]
+version = "0.119.1"
+audited_as = "0.119.0"
+
 [[unpublished.pulley-interpreter]]
 version = "32.0.0"
 audited_as = "30.0.2"
+
+[[unpublished.pulley-interpreter]]
+version = "32.0.1"
+audited_as = "32.0.0"
 
 [[unpublished.wasi-common]]
 version = "32.0.0"
 audited_as = "30.0.2"
 
+[[unpublished.wasi-common]]
+version = "32.0.1"
+audited_as = "32.0.0"
+
 [[unpublished.wasmtime]]
 version = "32.0.0"
 audited_as = "30.0.2"
+
+[[unpublished.wasmtime]]
+version = "32.0.1"
+audited_as = "32.0.0"
 
 [[unpublished.wasmtime-asm-macros]]
 version = "32.0.0"
 audited_as = "30.0.2"
 
+[[unpublished.wasmtime-asm-macros]]
+version = "32.0.1"
+audited_as = "32.0.0"
+
 [[unpublished.wasmtime-cache]]
 version = "32.0.0"
 audited_as = "30.0.2"
+
+[[unpublished.wasmtime-cache]]
+version = "32.0.1"
+audited_as = "32.0.0"
 
 [[unpublished.wasmtime-cli]]
 version = "32.0.0"
 audited_as = "30.0.2"
 
+[[unpublished.wasmtime-cli]]
+version = "32.0.1"
+audited_as = "32.0.0"
+
 [[unpublished.wasmtime-cli-flags]]
 version = "32.0.0"
 audited_as = "30.0.2"
+
+[[unpublished.wasmtime-cli-flags]]
+version = "32.0.1"
+audited_as = "32.0.0"
 
 [[unpublished.wasmtime-component-macro]]
 version = "32.0.0"
 audited_as = "30.0.2"
 
+[[unpublished.wasmtime-component-macro]]
+version = "32.0.1"
+audited_as = "32.0.0"
+
 [[unpublished.wasmtime-component-util]]
 version = "32.0.0"
 audited_as = "30.0.2"
+
+[[unpublished.wasmtime-component-util]]
+version = "32.0.1"
+audited_as = "32.0.0"
 
 [[unpublished.wasmtime-cranelift]]
 version = "32.0.0"
 audited_as = "30.0.2"
 
+[[unpublished.wasmtime-cranelift]]
+version = "32.0.1"
+audited_as = "32.0.0"
+
 [[unpublished.wasmtime-environ]]
 version = "32.0.0"
 audited_as = "30.0.2"
+
+[[unpublished.wasmtime-environ]]
+version = "32.0.1"
+audited_as = "32.0.0"
 
 [[unpublished.wasmtime-explorer]]
 version = "32.0.0"
 audited_as = "30.0.2"
 
+[[unpublished.wasmtime-explorer]]
+version = "32.0.1"
+audited_as = "32.0.0"
+
 [[unpublished.wasmtime-fiber]]
 version = "32.0.0"
 audited_as = "30.0.2"
+
+[[unpublished.wasmtime-fiber]]
+version = "32.0.1"
+audited_as = "32.0.0"
 
 [[unpublished.wasmtime-jit-debug]]
 version = "32.0.0"
 audited_as = "30.0.2"
 
+[[unpublished.wasmtime-jit-debug]]
+version = "32.0.1"
+audited_as = "32.0.0"
+
 [[unpublished.wasmtime-jit-icache-coherence]]
 version = "32.0.0"
 audited_as = "30.0.2"
+
+[[unpublished.wasmtime-jit-icache-coherence]]
+version = "32.0.1"
+audited_as = "32.0.0"
 
 [[unpublished.wasmtime-math]]
 version = "32.0.0"
 audited_as = "30.0.2"
 
+[[unpublished.wasmtime-math]]
+version = "32.0.1"
+audited_as = "32.0.0"
+
 [[unpublished.wasmtime-slab]]
 version = "32.0.0"
 audited_as = "30.0.2"
+
+[[unpublished.wasmtime-slab]]
+version = "32.0.1"
+audited_as = "32.0.0"
 
 [[unpublished.wasmtime-wasi]]
 version = "32.0.0"
 audited_as = "30.0.2"
 
+[[unpublished.wasmtime-wasi]]
+version = "32.0.1"
+audited_as = "32.0.0"
+
 [[unpublished.wasmtime-wasi-config]]
 version = "32.0.0"
 audited_as = "30.0.2"
+
+[[unpublished.wasmtime-wasi-config]]
+version = "32.0.1"
+audited_as = "32.0.0"
 
 [[unpublished.wasmtime-wasi-http]]
 version = "32.0.0"
 audited_as = "30.0.2"
 
+[[unpublished.wasmtime-wasi-http]]
+version = "32.0.1"
+audited_as = "32.0.0"
+
 [[unpublished.wasmtime-wasi-io]]
 version = "32.0.0"
 audited_as = "30.0.2"
+
+[[unpublished.wasmtime-wasi-io]]
+version = "32.0.1"
+audited_as = "32.0.0"
 
 [[unpublished.wasmtime-wasi-keyvalue]]
 version = "32.0.0"
 audited_as = "30.0.2"
 
+[[unpublished.wasmtime-wasi-keyvalue]]
+version = "32.0.1"
+audited_as = "32.0.0"
+
 [[unpublished.wasmtime-wasi-nn]]
 version = "32.0.0"
 audited_as = "30.0.2"
+
+[[unpublished.wasmtime-wasi-nn]]
+version = "32.0.1"
+audited_as = "32.0.0"
 
 [[unpublished.wasmtime-wasi-threads]]
 version = "32.0.0"
 audited_as = "30.0.2"
 
+[[unpublished.wasmtime-wasi-threads]]
+version = "32.0.1"
+audited_as = "32.0.0"
+
+[[unpublished.wasmtime-wasi-tls]]
+version = "32.0.1"
+audited_as = "32.0.0"
+
 [[unpublished.wasmtime-wast]]
 version = "32.0.0"
 audited_as = "30.0.2"
+
+[[unpublished.wasmtime-wast]]
+version = "32.0.1"
+audited_as = "32.0.0"
 
 [[unpublished.wasmtime-winch]]
 version = "32.0.0"
 audited_as = "30.0.2"
 
+[[unpublished.wasmtime-winch]]
+version = "32.0.1"
+audited_as = "32.0.0"
+
 [[unpublished.wasmtime-wit-bindgen]]
 version = "32.0.0"
 audited_as = "30.0.2"
+
+[[unpublished.wasmtime-wit-bindgen]]
+version = "32.0.1"
+audited_as = "32.0.0"
 
 [[unpublished.wasmtime-wmemcheck]]
 version = "32.0.0"
 audited_as = "30.0.2"
 
+[[unpublished.wasmtime-wmemcheck]]
+version = "32.0.1"
+audited_as = "32.0.0"
+
 [[unpublished.wiggle]]
 version = "32.0.0"
 audited_as = "30.0.2"
+
+[[unpublished.wiggle]]
+version = "32.0.1"
+audited_as = "32.0.0"
 
 [[unpublished.wiggle-generate]]
 version = "32.0.0"
 audited_as = "30.0.2"
 
+[[unpublished.wiggle-generate]]
+version = "32.0.1"
+audited_as = "32.0.0"
+
 [[unpublished.wiggle-macro]]
 version = "32.0.0"
 audited_as = "30.0.2"
+
+[[unpublished.wiggle-macro]]
+version = "32.0.1"
+audited_as = "32.0.0"
 
 [[unpublished.wiggle-test]]
 version = "0.0.0"
@@ -208,6 +416,10 @@ audited_as = "0.1.0"
 [[unpublished.winch-codegen]]
 version = "32.0.0"
 audited_as = "30.0.2"
+
+[[unpublished.winch-codegen]]
+version = "32.0.1"
+audited_as = "32.0.0"
 
 [[publisher.aho-corasick]]
 version = "1.0.2"
@@ -399,116 +611,116 @@ user-login = "jrmuizel"
 user-name = "Jeff Muizelaar"
 
 [[publisher.cranelift]]
-version = "0.117.2"
-when = "2025-02-25"
+version = "0.119.0"
+when = "2025-04-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-assembler-x64]]
-version = "0.117.2"
-when = "2025-02-25"
+version = "0.119.0"
+when = "2025-04-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-assembler-x64-meta]]
-version = "0.117.2"
-when = "2025-02-25"
+version = "0.119.0"
+when = "2025-04-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-bforest]]
-version = "0.117.2"
-when = "2025-02-25"
+version = "0.119.0"
+when = "2025-04-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-bitset]]
-version = "0.117.2"
-when = "2025-02-25"
+version = "0.119.0"
+when = "2025-04-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-codegen]]
-version = "0.117.2"
-when = "2025-02-25"
+version = "0.119.0"
+when = "2025-04-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-codegen-meta]]
-version = "0.117.2"
-when = "2025-02-25"
+version = "0.119.0"
+when = "2025-04-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-codegen-shared]]
-version = "0.117.2"
-when = "2025-02-25"
+version = "0.119.0"
+when = "2025-04-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-control]]
-version = "0.117.2"
-when = "2025-02-25"
+version = "0.119.0"
+when = "2025-04-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-entity]]
-version = "0.117.2"
-when = "2025-02-25"
+version = "0.119.0"
+when = "2025-04-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-frontend]]
-version = "0.117.2"
-when = "2025-02-25"
+version = "0.119.0"
+when = "2025-04-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-interpreter]]
-version = "0.117.2"
-when = "2025-02-25"
+version = "0.119.0"
+when = "2025-04-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-isle]]
-version = "0.117.2"
-when = "2025-02-25"
+version = "0.119.0"
+when = "2025-04-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-jit]]
-version = "0.117.2"
-when = "2025-02-25"
+version = "0.119.0"
+when = "2025-04-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-module]]
-version = "0.117.2"
-when = "2025-02-25"
+version = "0.119.0"
+when = "2025-04-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-native]]
-version = "0.117.2"
-when = "2025-02-25"
+version = "0.119.0"
+when = "2025-04-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-object]]
-version = "0.117.2"
-when = "2025-02-25"
+version = "0.119.0"
+when = "2025-04-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-reader]]
-version = "0.117.2"
-when = "2025-02-25"
+version = "0.119.0"
+when = "2025-04-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-serde]]
-version = "0.117.2"
-when = "2025-02-25"
+version = "0.119.0"
+when = "2025-04-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -722,8 +934,8 @@ user-login = "dtolnay"
 user-name = "David Tolnay"
 
 [[publisher.pulley-interpreter]]
-version = "30.0.2"
-when = "2025-02-25"
+version = "32.0.0"
+when = "2025-04-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -993,8 +1205,8 @@ user-login = "sunfishcode"
 user-name = "Dan Gohman"
 
 [[publisher.wasi-common]]
-version = "30.0.2"
-when = "2025-02-25"
+version = "32.0.0"
+when = "2025-04-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1082,134 +1294,134 @@ user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime]]
-version = "30.0.2"
-when = "2025-02-25"
+version = "32.0.0"
+when = "2025-04-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-asm-macros]]
-version = "30.0.2"
-when = "2025-02-25"
+version = "32.0.0"
+when = "2025-04-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-cache]]
-version = "30.0.2"
-when = "2025-02-25"
+version = "32.0.0"
+when = "2025-04-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-cli]]
-version = "30.0.2"
-when = "2025-02-25"
+version = "32.0.0"
+when = "2025-04-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-cli-flags]]
-version = "30.0.2"
-when = "2025-02-25"
+version = "32.0.0"
+when = "2025-04-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-component-macro]]
-version = "30.0.2"
-when = "2025-02-25"
+version = "32.0.0"
+when = "2025-04-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-component-util]]
-version = "30.0.2"
-when = "2025-02-25"
+version = "32.0.0"
+when = "2025-04-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-cranelift]]
-version = "30.0.2"
-when = "2025-02-25"
+version = "32.0.0"
+when = "2025-04-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-environ]]
-version = "30.0.2"
-when = "2025-02-25"
+version = "32.0.0"
+when = "2025-04-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-explorer]]
-version = "30.0.2"
-when = "2025-02-25"
+version = "32.0.0"
+when = "2025-04-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-fiber]]
-version = "30.0.2"
-when = "2025-02-25"
+version = "32.0.0"
+when = "2025-04-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-jit-debug]]
-version = "30.0.2"
-when = "2025-02-25"
+version = "32.0.0"
+when = "2025-04-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-jit-icache-coherence]]
-version = "30.0.2"
-when = "2025-02-25"
+version = "32.0.0"
+when = "2025-04-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-math]]
-version = "30.0.2"
-when = "2025-02-25"
+version = "32.0.0"
+when = "2025-04-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-slab]]
-version = "30.0.2"
-when = "2025-02-25"
+version = "32.0.0"
+when = "2025-04-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi]]
-version = "30.0.2"
-when = "2025-02-25"
+version = "32.0.0"
+when = "2025-04-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-config]]
-version = "30.0.2"
-when = "2025-02-25"
+version = "32.0.0"
+when = "2025-04-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-http]]
-version = "30.0.2"
-when = "2025-02-25"
+version = "32.0.0"
+when = "2025-04-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-io]]
-version = "30.0.2"
-when = "2025-02-25"
+version = "32.0.0"
+when = "2025-04-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-keyvalue]]
-version = "30.0.2"
-when = "2025-02-25"
+version = "32.0.0"
+when = "2025-04-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-nn]]
-version = "30.0.2"
-when = "2025-02-25"
+version = "32.0.0"
+when = "2025-04-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-threads]]
-version = "30.0.2"
-when = "2025-02-25"
+version = "32.0.0"
+when = "2025-04-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1220,26 +1432,26 @@ user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wast]]
-version = "30.0.2"
-when = "2025-02-25"
+version = "32.0.0"
+when = "2025-04-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-winch]]
-version = "30.0.2"
-when = "2025-02-25"
+version = "32.0.0"
+when = "2025-04-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wit-bindgen]]
-version = "30.0.2"
-when = "2025-02-25"
+version = "32.0.0"
+when = "2025-04-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wmemcheck]]
-version = "30.0.2"
-when = "2025-02-25"
+version = "32.0.0"
+when = "2025-04-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1263,20 +1475,20 @@ user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
 [[publisher.wiggle]]
-version = "30.0.2"
-when = "2025-02-25"
+version = "32.0.0"
+when = "2025-04-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wiggle-generate]]
-version = "30.0.2"
-when = "2025-02-25"
+version = "32.0.0"
+when = "2025-04-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wiggle-macro]]
-version = "30.0.2"
-when = "2025-02-25"
+version = "32.0.0"
+when = "2025-04-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1295,8 +1507,8 @@ user-login = "BurntSushi"
 user-name = "Andrew Gallant"
 
 [[publisher.winch-codegen]]
-version = "30.0.2"
-when = "2025-02-25"
+version = "32.0.0"
+when = "2025-04-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 


### PR DESCRIPTION
This is an [automated pull request][process] from CI to create a patch release for Wasmtime 32.0.1, requested by @alexcrichton.

It's recommended that maintainers double-check that [RELEASES.md] is up-to-date and that there are no known issues before merging this PR. When this PR is merged a release tag will automatically be created, crates will be published, and CI artifacts will be produced.

[RELEASES.md]: https://github.com/bytecodealliance/wasmtime/blob/release-32.0.1/RELEASES.md
[process]: https://docs.wasmtime.dev/contributing-release-process.html
