### PR TITLE
x64: Optimize branch-with-`band`

### DIFF
--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -4248,6 +4248,8 @@
 (rule 2 (is_nonzero_cmp (vall_true vec)) (is_vall_true vec))
 (rule 2 (is_nonzero_cmp (vany_true vec)) (is_vany_true vec))
 (rule 2 (is_nonzero_cmp (uextend val)) (is_nonzero_cmp val))
+(rule 2 (is_nonzero_cmp (band a @ (value_type (ty_int (fits_in_64 ty))) b))
+  (CondResult.CC (x64_test ty a b) (CC.NZ)))
 
 ;; Lower a CondResult to a boolean value in a register.
 (decl lower_cond_bool (CondResult) Gpr)
@@ -4311,6 +4313,13 @@
         (emit_cmp_i128 (CC.B)   b_hi b_lo a_hi a_lo))
 (rule 2 (emit_cmp_i128 (CC.BE)  a_hi a_lo b_hi b_lo)
         (emit_cmp_i128 (CC.NB)  b_hi b_lo a_hi a_lo))
+
+;; For direct equality comparisons to zero transform the other operand into a
+;; nonzero comparison and then invert the whole conditional to test for zero.
+(rule 5 (emit_cmp (IntCC.Equal) a (u64_from_iconst 0))
+  (cond_invert (is_nonzero_cmp a)))
+(rule 6 (emit_cmp (IntCC.Equal) (u64_from_iconst 0) a)
+  (cond_invert (is_nonzero_cmp a)))
 
 ;; 128-bit strict equality/inequality can't be easily tested using subtraction
 ;; but we can quickly determine whether any bits are different instead.

--- a/cranelift/filetests/filetests/isa/x64/branches.clif
+++ b/cranelift/filetests/filetests/isa/x64/branches.clif
@@ -1116,3 +1116,104 @@ block1(v5: i32):
 ;   popq %rbp
 ;   retq
 
+function %br_and_operand(i32, i32) -> i32 {
+block0(v0: i32, v1: i32):
+  v2 = band v0, v1
+  brif v2, block1, block2
+
+block1:
+  v3 = iconst.i32 100
+  return v3
+
+block2:
+  v4 = iconst.i32 200
+  return v4
+}
+
+; VCode:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0:
+;   testl %edi, %esi
+;   jnz     label2; j label1
+; block1:
+;   movl $0xc8, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+; block2:
+;   movl $0x64, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   testl %edi, %esi
+;   jne 0x16
+; block2: ; offset 0xc
+;   movl $0xc8, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+; block3: ; offset 0x16
+;   movl $0x64, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+
+function %br_and_immediate(i32) -> i32 {
+block0(v0: i32):
+  v1 = iconst.i32 300
+  v2 = band v0, v1
+
+  brif v2, block1, block2
+
+block1:
+  v3 = iconst.i32 100
+  return v3
+
+block2:
+  v4 = iconst.i32 200
+  return v4
+}
+
+; VCode:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0:
+;   testl $0x12c, %edi
+;   jnz     label2; j label1
+; block1:
+;   movl $0xc8, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+; block2:
+;   movl $0x64, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   testl $0x12c, %edi
+;   jne 0x1a
+; block2: ; offset 0x10
+;   movl $0xc8, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+; block3: ; offset 0x1a
+;   movl $0x64, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+

--- a/tests/disas/x64-bit-and-condition.wat
+++ b/tests/disas/x64-bit-and-condition.wat
@@ -1,0 +1,54 @@
+;;! target = 'x86_64'
+;;! test = 'compile'
+
+(module
+  (func $if_b20 (param i32) (result i32)
+    (i32.and (local.get 0) (i32.shl (i32.const 1) (i32.const 20)))
+    if (result i32)
+      i32.const 100
+    else
+      i32.const 200
+    end
+  )
+  (func $select_b20 (param i32 i32 i32) (result i32)
+    local.get 1
+    local.get 2
+    (i32.and (local.get 0) (i32.shl (i32.const 1) (i32.const 20)))
+    select
+  )
+  (func $eqz_b20 (param i32) (result i32)
+    (i32.and (local.get 0) (i32.shl (i32.const 1) (i32.const 20)))
+    i32.eqz
+  )
+)
+;; wasm[0]::function[0]::if_b20:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       testl   $0x100000, %edx
+;;       jne     0x1a
+;;   10: movl    $0xc8, %eax
+;;       jmp     0x1f
+;;   1a: movl    $0x64, %eax
+;;       movq    %rbp, %rsp
+;;       popq    %rbp
+;;       retq
+;;
+;; wasm[0]::function[1]::select_b20:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       testl   $0x100000, %edx
+;;       movq    %r8, %rax
+;;       cmovnel %ecx, %eax
+;;       movq    %rbp, %rsp
+;;       popq    %rbp
+;;       retq
+;;
+;; wasm[0]::function[2]::eqz_b20:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       testl   $0x100000, %edx
+;;       sete    %r8b
+;;       movzbl  %r8b, %eax
+;;       movq    %rbp, %rsp
+;;       popq    %rbp
+;;       retq

--- a/tests/misc_testsuite/bit-and-conditions.wast
+++ b/tests/misc_testsuite/bit-and-conditions.wast
@@ -1,0 +1,27 @@
+(module
+  (func (export "if_b20") (param i32) (result i32)
+    (i32.and (local.get 0) (i32.shl (i32.const 1) (i32.const 20)))
+    if (result i32)
+      i32.const 100
+    else
+      i32.const 200
+    end
+  )
+  (func (export "select_b20") (param i32 i32 i32) (result i32)
+    local.get 1
+    local.get 2
+    (i32.and (local.get 0) (i32.shl (i32.const 1) (i32.const 20)))
+    select
+  )
+  (func (export "eqz_b20") (param i32) (result i32)
+    (i32.and (local.get 0) (i32.shl (i32.const 1) (i32.const 20)))
+    i32.eqz
+  )
+)
+
+(assert_return (invoke "if_b20" (i32.const 0)) (i32.const 200))
+(assert_return (invoke "if_b20" (i32.const 0x100000)) (i32.const 100))
+(assert_return (invoke "select_b20" (i32.const 0) (i32.const 100) (i32.const 200)) (i32.const 200))
+(assert_return (invoke "select_b20" (i32.const 0x100000) (i32.const 100) (i32.const 200)) (i32.const 100))
+(assert_return (invoke "eqz_b20" (i32.const 0)) (i32.const 1))
+(assert_return (invoke "eqz_b20" (i32.const 0x100000)) (i32.const 0))


### PR DESCRIPTION
This commit adds new lowering patterns for the x64 backend to optimize conditional branches with `band` patterns as the conditional. This builds on the infrastructure in the previous commit to funnel `icmp`-equals-zero back up to the top-level `is_nonzero_cmp` and then adding rules to `is_nonzero_cmp` for `band` to convert that to a `test` instruction which performs the `band` and sets the ZF which is what we're interested in.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
