### PR TITLE
 x64: Refactor emission of LoadExtName 

### DIFF
--- a/cranelift/assembler-x64/meta/src/generate.rs
+++ b/cranelift/assembler-x64/meta/src/generate.rs
@@ -83,17 +83,14 @@ fn generate_inst_display_impl(f: &mut Formatter, insts: &[dsl::Inst]) {
 /// `impl Inst { fn encode... }`
 fn generate_inst_encode_impl(f: &mut Formatter, insts: &[dsl::Inst]) {
     f.add_block("impl<R: Registers> Inst<R>", |f| {
-        f.add_block(
-            "pub fn encode(&self, b: &mut impl CodeSink, o: &impl KnownOffsetTable)",
-            |f| {
-                f.add_block("match self", |f| {
-                    for inst in insts {
-                        let variant_name = inst.name();
-                        fmtln!(f, "Self::{variant_name}(i) => i.encode(b, o),");
-                    }
-                });
-            },
-        );
+        f.add_block("pub fn encode(&self, b: &mut impl CodeSink)", |f| {
+            f.add_block("match self", |f| {
+                for inst in insts {
+                    let variant_name = inst.name();
+                    fmtln!(f, "Self::{variant_name}(i) => i.encode(b),");
+                }
+            });
+        });
     });
 }
 

--- a/cranelift/assembler-x64/meta/src/generate/format.rs
+++ b/cranelift/assembler-x64/meta/src/generate/format.rs
@@ -335,7 +335,7 @@ impl dsl::Format {
                 }
                 fmtln!(
                     f,
-                    "self.{rm}.encode_rex_suffixes(buf, off, reg, {bytes_at_end});"
+                    "self.{rm}.encode_rex_suffixes(buf, reg, {bytes_at_end});"
                 );
             }
             ModRmStyle::Reg { reg, rm } => {

--- a/cranelift/assembler-x64/meta/src/generate/inst.rs
+++ b/cranelift/assembler-x64/meta/src/generate/inst.rs
@@ -118,18 +118,11 @@ impl dsl::Inst {
     fn generate_encode_function(&self, f: &mut Formatter) {
         use dsl::Customization::*;
 
-        let off = if self.format.uses_memory().is_some() || self.custom.contains(Encode) {
-            "off"
-        } else {
-            "_"
-        };
         f.add_block(
-            &format!(
-                "pub fn encode(&self, buf: &mut impl CodeSink, {off}: &impl KnownOffsetTable)"
-            ),
+            &format!("pub fn encode(&self, buf: &mut impl CodeSink)"),
             |f| {
                 if self.custom.contains(Encode) {
-                    fmtln!(f, "crate::custom::encode::{}(self, buf, off);", self.name());
+                    fmtln!(f, "crate::custom::encode::{}(self, buf);", self.name());
                 } else {
                     self.generate_possible_trap(f);
                     match &self.encoding {

--- a/cranelift/assembler-x64/src/api.rs
+++ b/cranelift/assembler-x64/src/api.rs
@@ -2,9 +2,9 @@
 
 use crate::gpr;
 use crate::xmm;
-use crate::{Amode, GprMem, XmmMem};
+use crate::{Amode, DeferredTarget, GprMem, XmmMem};
 use std::fmt;
-use std::{num::NonZeroU8, ops::Index, vec::Vec};
+use std::{num::NonZeroU8, vec::Vec};
 
 /// Describe how an instruction is emitted into a code buffer.
 pub trait CodeSink {
@@ -24,17 +24,13 @@ pub trait CodeSink {
     /// required for assembling memory accesses.
     fn add_trap(&mut self, code: TrapCode);
 
-    /// Return the byte offset of the current location in the code buffer;
-    /// required for assembling RIP-relative memory accesses.
-    fn current_offset(&self) -> u32;
+    /// Inform the code buffer of a use of `target` is about to happen within
+    /// this buffer at the current offset. After this method is called bytes are
+    /// then placed at this offset.
+    fn use_target(&mut self, target: DeferredTarget);
 
-    /// Inform the code buffer of a use of `label` at `offset`; required for
-    /// assembling RIP-relative memory accesses.
-    fn use_label_at_offset(&mut self, offset: u32, label: Label);
-
-    /// Return the label for a constant `id`; required for assembling
-    /// RIP-relative memory accesses of constants.
-    fn get_label_for_constant(&mut self, id: Constant) -> Label;
+    /// Resolves a `KnownOffset` value to the actual signed offset.
+    fn known_offset(&self, offset: KnownOffset) -> i32;
 }
 
 /// Provide a convenient implementation for testing.
@@ -57,14 +53,10 @@ impl CodeSink for Vec<u8> {
 
     fn add_trap(&mut self, _: TrapCode) {}
 
-    fn current_offset(&self) -> u32 {
-        self.len().try_into().unwrap()
-    }
+    fn use_target(&mut self, _: DeferredTarget) {}
 
-    fn use_label_at_offset(&mut self, _: u32, _: Label) {}
-
-    fn get_label_for_constant(&mut self, c: Constant) -> Label {
-        Label(c.0)
+    fn known_offset(&self, offset: KnownOffset) -> i32 {
+        panic!("unknown offset {offset:?}")
     }
 }
 
@@ -88,20 +80,6 @@ impl fmt::Display for TrapCode {
         write!(f, "trap={}", self.0)
     }
 }
-
-/// A table mapping `KnownOffset` identifiers to their `i32` offset values.
-///
-/// When encoding instructions, Cranelift may not know all of the information
-/// needed to construct an immediate. Specifically, addressing modes that
-/// require knowing the size of the tail arguments or outgoing arguments (see
-/// `SyntheticAmode::finalize`) will not know these sizes until emission.
-///
-/// This table allows up to do a "late" look up of these values by their
-/// `KnownOffset`.
-pub trait KnownOffsetTable: Index<usize, Output = i32> {}
-impl KnownOffsetTable for Vec<i32> {}
-/// Provide a convenient implementation for testing.
-impl KnownOffsetTable for [i32; 2] {}
 
 /// A `KnownOffset` is a unique identifier for a specific offset known only at
 /// emission time.

--- a/cranelift/assembler-x64/src/api.rs
+++ b/cranelift/assembler-x64/src/api.rs
@@ -24,9 +24,11 @@ pub trait CodeSink {
     /// required for assembling memory accesses.
     fn add_trap(&mut self, code: TrapCode);
 
-    /// Inform the code buffer of a use of `target` is about to happen within
-    /// this buffer at the current offset. After this method is called bytes are
-    /// then placed at this offset.
+    /// Inform the code buffer that a use of `target` is about to happen at the
+    /// current offset.
+    ///
+    /// After this method is called the bytes of the target are then expected to
+    /// be placed using one of the above `put*` methods.
     fn use_target(&mut self, target: DeferredTarget);
 
     /// Resolves a `KnownOffset` value to the actual signed offset.

--- a/cranelift/assembler-x64/src/custom.rs
+++ b/cranelift/assembler-x64/src/custom.rs
@@ -1,26 +1,26 @@
 pub mod encode {
-    use crate::{CodeSink, KnownOffsetTable, inst};
+    use crate::{CodeSink, inst};
 
     /// `NOP`
-    pub fn nop_1b(_: &inst::nop_1b, buf: &mut impl CodeSink, _: &impl KnownOffsetTable) {
+    pub fn nop_1b(_: &inst::nop_1b, buf: &mut impl CodeSink) {
         buf.put1(0x90);
     }
 
     /// `66 NOP`
-    pub fn nop_2b(_: &inst::nop_2b, buf: &mut impl CodeSink, _: &impl KnownOffsetTable) {
+    pub fn nop_2b(_: &inst::nop_2b, buf: &mut impl CodeSink) {
         buf.put1(0x66);
         buf.put1(0x90);
     }
 
     /// `NOP DWORD ptr [EAX]`
-    pub fn nop_3b(_: &inst::nop_3b, buf: &mut impl CodeSink, _: &impl KnownOffsetTable) {
+    pub fn nop_3b(_: &inst::nop_3b, buf: &mut impl CodeSink) {
         buf.put1(0x0F);
         buf.put1(0x1F);
         buf.put1(0x00);
     }
 
     /// `NOP DWORD ptr [EAX + 00H]`
-    pub fn nop_4b(_: &inst::nop_4b, buf: &mut impl CodeSink, _: &impl KnownOffsetTable) {
+    pub fn nop_4b(_: &inst::nop_4b, buf: &mut impl CodeSink) {
         buf.put1(0x0F);
         buf.put1(0x1F);
         buf.put1(0x40);
@@ -28,7 +28,7 @@ pub mod encode {
     }
 
     /// `NOP DWORD ptr [EAX + EAX*1 + 00H]`
-    pub fn nop_5b(_: &inst::nop_5b, buf: &mut impl CodeSink, _: &impl KnownOffsetTable) {
+    pub fn nop_5b(_: &inst::nop_5b, buf: &mut impl CodeSink) {
         buf.put1(0x0F);
         buf.put1(0x1F);
         buf.put1(0x44);
@@ -36,7 +36,7 @@ pub mod encode {
     }
 
     /// `66 NOP DWORD ptr [EAX + EAX*1 + 00H]`
-    pub fn nop_6b(_: &inst::nop_6b, buf: &mut impl CodeSink, _: &impl KnownOffsetTable) {
+    pub fn nop_6b(_: &inst::nop_6b, buf: &mut impl CodeSink) {
         buf.put1(0x66);
         buf.put1(0x0F);
         buf.put1(0x1F);
@@ -45,7 +45,7 @@ pub mod encode {
     }
 
     /// `NOP DWORD ptr [EAX + 00000000H]`
-    pub fn nop_7b(_: &inst::nop_7b, buf: &mut impl CodeSink, _: &impl KnownOffsetTable) {
+    pub fn nop_7b(_: &inst::nop_7b, buf: &mut impl CodeSink) {
         buf.put1(0x0F);
         buf.put1(0x1F);
         buf.put1(0x80);
@@ -53,7 +53,7 @@ pub mod encode {
     }
 
     /// `NOP DWORD ptr [EAX + EAX*1 + 00000000H]`
-    pub fn nop_8b(_: &inst::nop_8b, buf: &mut impl CodeSink, _: &impl KnownOffsetTable) {
+    pub fn nop_8b(_: &inst::nop_8b, buf: &mut impl CodeSink) {
         buf.put1(0x0F);
         buf.put1(0x1F);
         buf.put1(0x84);
@@ -62,7 +62,7 @@ pub mod encode {
     }
 
     /// `66 NOP DWORD ptr [EAX + EAX*1 + 00000000H]`
-    pub fn nop_9b(_: &inst::nop_9b, buf: &mut impl CodeSink, _: &impl KnownOffsetTable) {
+    pub fn nop_9b(_: &inst::nop_9b, buf: &mut impl CodeSink) {
         buf.put1(0x66);
         buf.put1(0x0F);
         buf.put1(0x1F);

--- a/cranelift/assembler-x64/src/fuzz.rs
+++ b/cranelift/assembler-x64/src/fuzz.rs
@@ -5,8 +5,8 @@
 //! unconditionally (use the `fuzz` feature instead).
 
 use crate::{
-    AmodeOffset, AmodeOffsetPlusKnownOffset, AsReg, CodeSink, Constant, Fixed, Gpr, Inst, Label,
-    NonRspGpr, Registers, TrapCode, Xmm,
+    AmodeOffset, AmodeOffsetPlusKnownOffset, AsReg, CodeSink, DeferredTarget, Fixed, Gpr, Inst,
+    KnownOffset, NonRspGpr, Registers, TrapCode, Xmm,
 };
 use arbitrary::{Arbitrary, Result, Unstructured};
 use capstone::{Capstone, arch::BuildsCapstone, arch::BuildsCapstoneSyntax, arch::x86};
@@ -44,8 +44,7 @@ pub fn roundtrip(inst: &Inst<FuzzRegs>) {
 /// single-instruction disassembly we're doing here.
 fn assemble(inst: &Inst<FuzzRegs>) -> Vec<u8> {
     let mut sink = TestCodeSink::default();
-    let offsets: Vec<i32> = Vec::new();
-    inst.encode(&mut sink, &offsets);
+    inst.encode(&mut sink);
     sink.patch_labels_as_if_they_referred_to_end();
     sink.buf
 }
@@ -53,7 +52,7 @@ fn assemble(inst: &Inst<FuzzRegs>) -> Vec<u8> {
 #[derive(Default)]
 struct TestCodeSink {
     buf: Vec<u8>,
-    offsets_using_label: Vec<u32>,
+    offsets_using_label: Vec<usize>,
 }
 
 impl TestCodeSink {
@@ -74,7 +73,7 @@ impl TestCodeSink {
     fn patch_labels_as_if_they_referred_to_end(&mut self) {
         let len = i32::try_from(self.buf.len()).unwrap();
         for offset in self.offsets_using_label.iter() {
-            let range = self.buf[*offset as usize..].first_chunk_mut::<4>().unwrap();
+            let range = self.buf[*offset..].first_chunk_mut::<4>().unwrap();
             let offset = i32::try_from(*offset).unwrap() + 4;
             let rel_distance = len - offset;
             *range = (i32::from_le_bytes(*range) + rel_distance).to_le_bytes();
@@ -101,16 +100,13 @@ impl CodeSink for TestCodeSink {
 
     fn add_trap(&mut self, _: TrapCode) {}
 
-    fn current_offset(&self) -> u32 {
-        self.buf.len().try_into().unwrap()
-    }
-
-    fn use_label_at_offset(&mut self, offset: u32, _: Label) {
+    fn use_target(&mut self, _: DeferredTarget) {
+        let offset = self.buf.len();
         self.offsets_using_label.push(offset);
     }
 
-    fn get_label_for_constant(&mut self, c: Constant) -> Label {
-        Label(c.0)
+    fn known_offset(&self, target: KnownOffset) -> i32 {
+        panic!("unsupported known target {target:?}")
     }
 }
 

--- a/cranelift/assembler-x64/src/inst.rs
+++ b/cranelift/assembler-x64/src/inst.rs
@@ -4,7 +4,7 @@
 //! See also: [`Inst`], an `enum` containing all these instructions.
 
 use crate::Fixed;
-use crate::api::{AsReg, CodeSink, KnownOffsetTable, RegisterVisitor, Registers, TrapCode};
+use crate::api::{AsReg, CodeSink, RegisterVisitor, Registers, TrapCode};
 use crate::gpr::{self, Gpr, Size};
 use crate::imm::{Extension, Imm8, Imm16, Imm32, Imm64, Simm8, Simm32};
 use crate::mem::{Amode, GprMem, XmmMem};

--- a/cranelift/assembler-x64/src/lib.rs
+++ b/cranelift/assembler-x64/src/lib.rs
@@ -29,10 +29,9 @@
 //! // Now we can encode this sequence into a code buffer, checking that each
 //! // instruction is valid in 64-bit mode.
 //! let mut buffer = vec![];
-//! let offsets = vec![];
 //! for inst in seq {
 //!     if inst.features().contains(&Feature::_64b) {
-//!         inst.encode(&mut buffer, &offsets);
+//!         inst.encode(&mut buffer);
 //!     }
 //! }
 //! assert_eq!(buffer, vec![0x24, 0b10101010]);
@@ -79,8 +78,7 @@ pub use inst::Inst;
 pub use inst::Feature;
 
 pub use api::{
-    AsReg, CodeSink, Constant, KnownOffset, KnownOffsetTable, Label, RegisterVisitor, Registers,
-    TrapCode,
+    AsReg, CodeSink, Constant, KnownOffset, Label, RegisterVisitor, Registers, TrapCode,
 };
 pub use fixed::Fixed;
 pub use gpr::{Gpr, NonRspGpr, Size};

--- a/cranelift/assembler-x64/src/mem.rs
+++ b/cranelift/assembler-x64/src/mem.rs
@@ -1,6 +1,6 @@
 //! Memory operands to instructions.
 
-use crate::api::{AsReg, CodeSink, Constant, KnownOffset, KnownOffsetTable, Label, TrapCode};
+use crate::api::{AsReg, CodeSink, Constant, KnownOffset, Label, TrapCode};
 use crate::gpr::{self, NonRspGpr, Size};
 use crate::rex::{Disp, RexPrefix, encode_modrm, encode_sib};
 
@@ -53,11 +53,10 @@ impl<R: AsReg> Amode<R> {
     pub(crate) fn encode_rex_suffixes(
         &self,
         sink: &mut impl CodeSink,
-        offsets: &impl KnownOffsetTable,
         enc_reg: u8,
         bytes_at_end: u8,
     ) {
-        emit_modrm_sib_disp(sink, offsets, enc_reg, self, bytes_at_end, None);
+        emit_modrm_sib_disp(sink, enc_reg, self, bytes_at_end, None);
     }
 
     /// Return the registers for encoding the `b` and `x` bits (e.g., in a VEX
@@ -144,9 +143,9 @@ impl AmodeOffsetPlusKnownOffset {
     ///
     /// Panics if the sum of the immediate and the known offset value overflows.
     #[must_use]
-    pub fn value(&self, offsets: &impl KnownOffsetTable) -> i32 {
+    pub fn value(&self, sink: &impl CodeSink) -> i32 {
         let known_offset = match self.offset {
-            Some(offset) => offsets[usize::from(offset)],
+            Some(offset) => sink.known_offset(offset),
             None => 0,
         };
         known_offset
@@ -285,7 +284,6 @@ impl<R: AsReg, M: AsReg> GprMem<R, M> {
     pub(crate) fn encode_rex_suffixes(
         &self,
         sink: &mut impl CodeSink,
-        offsets: &impl KnownOffsetTable,
         enc_reg: u8,
         bytes_at_end: u8,
     ) {
@@ -294,7 +292,7 @@ impl<R: AsReg, M: AsReg> GprMem<R, M> {
                 sink.put1(encode_modrm(0b11, enc_reg & 0b111, gpr.enc() & 0b111));
             }
             GprMem::Mem(amode) => {
-                amode.encode_rex_suffixes(sink, offsets, enc_reg, bytes_at_end);
+                amode.encode_rex_suffixes(sink, enc_reg, bytes_at_end);
             }
         }
     }
@@ -354,7 +352,6 @@ impl<R: AsReg, M: AsReg> XmmMem<R, M> {
     pub(crate) fn encode_rex_suffixes(
         &self,
         sink: &mut impl CodeSink,
-        offsets: &impl KnownOffsetTable,
         enc_reg: u8,
         bytes_at_end: u8,
     ) {
@@ -363,7 +360,7 @@ impl<R: AsReg, M: AsReg> XmmMem<R, M> {
                 sink.put1(encode_modrm(0b11, enc_reg & 0b111, xmm.enc() & 0b111));
             }
             XmmMem::Mem(amode) => {
-                amode.encode_rex_suffixes(sink, offsets, enc_reg, bytes_at_end);
+                amode.encode_rex_suffixes(sink, enc_reg, bytes_at_end);
             }
         }
     }
@@ -397,7 +394,6 @@ impl<R: AsReg, M: AsReg> From<Amode<M>> for XmmMem<R, M> {
 /// Emit the ModRM/SIB/displacement sequence for a memory operand.
 pub fn emit_modrm_sib_disp<R: AsReg>(
     sink: &mut impl CodeSink,
-    offsets: &impl KnownOffsetTable,
     enc_g: u8,
     mem_e: &Amode<R>,
     bytes_at_end: u8,
@@ -406,7 +402,7 @@ pub fn emit_modrm_sib_disp<R: AsReg>(
     match *mem_e {
         Amode::ImmReg { simm32, base, .. } => {
             let enc_e = base.enc();
-            let mut imm = Disp::new(simm32.value(offsets), evex_scaling);
+            let mut imm = Disp::new(simm32.value(sink), evex_scaling);
 
             // Most base registers allow for a single ModRM byte plus an
             // optional immediate. If rsp is the base register, however, then a
@@ -469,15 +465,10 @@ pub fn emit_modrm_sib_disp<R: AsReg>(
             // RIP-relative is mod=00, rm=101.
             sink.put1(encode_modrm(0b00, enc_g & 7, 0b101));
 
-            let offset = sink.current_offset();
-            match target {
-                DeferredTarget::Label(label) => sink.use_label_at_offset(offset, label),
-                DeferredTarget::Constant(constant) => {
-                    let label = sink.get_label_for_constant(constant);
-                    sink.use_label_at_offset(offset, label);
-                }
-                DeferredTarget::None => {}
-            }
+            // Inform the code sink about the RIP-relative `target` at the
+            // current offset, emitting a `LabelUse`, a relocation, or etc as
+            // appropriate.
+            sink.use_target(target);
 
             // N.B.: some instructions (XmmRmRImm format for example)
             // have bytes *after* the RIP-relative offset. The

--- a/cranelift/codegen/src/isa/x64/abi.rs
+++ b/cranelift/codegen/src/isa/x64/abi.rs
@@ -821,7 +821,7 @@ impl ABIMachineSpec for X64ABIMachineSpec {
         // information about the libcall `RelocDistance` here, so we
         // conservatively use the more flexible calling sequence.
         insts.push(Inst::LoadExtName {
-            dst: temp2,
+            dst: temp2.map(Gpr::unwrap_new),
             name: Box::new(ExternalName::LibCall(LibCall::Memcpy)),
             offset: 0,
             distance: RelocDistance::Far,

--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -297,7 +297,7 @@
        ;; movq $name@GOTPCREL(%rip), dst    if PIC is enabled, or
        ;; lea $name($rip), dst              if distance is near, or
        ;; movabsq $name, dst                otherwise.
-       (LoadExtName (dst WritableReg)
+       (LoadExtName (dst WritableGpr)
                     (name BoxExternalName)
                     (offset i64)
                     (distance RelocDistance))
@@ -1383,7 +1383,7 @@
         dst))
 
 ;; Helper for constructing a LoadExtName instruction.
-(decl load_ext_name (ExternalName i64 RelocDistance) Reg)
+(decl load_ext_name (ExternalName i64 RelocDistance) Gpr)
 (rule (load_ext_name extname offset distance)
       (let ((dst WritableGpr (temp_writable_gpr))
             (_ Unit (emit (MInst.LoadExtName dst extname offset distance))))

--- a/cranelift/codegen/src/isa/x64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit.rs
@@ -2502,19 +2502,25 @@ pub(crate) fn emit(
         }
 
         Inst::External { inst } => {
-            let mut known_offsets = [0, 0];
-            // These values are transcribed from what is happening in
-            // `SyntheticAmode::finalize`. This, plus the `Into` logic
-            // converting a `SyntheticAmode` to its external counterpart, are
-            // necessary to communicate Cranelift's internal offsets to the
-            // assembler; due to when Cranelift determines these offsets, this
-            // happens quite late (i.e., here during emission).
             let frame = state.frame_layout();
-            known_offsets[usize::from(external::offsets::KEY_INCOMING_ARG)] =
-                i32::try_from(frame.tail_args_size + frame.setup_area_size).unwrap();
-            known_offsets[usize::from(external::offsets::KEY_SLOT_OFFSET)] =
-                i32::try_from(frame.outgoing_args_size).unwrap();
-            emit_maybe_shrink(inst, sink, &known_offsets);
+            emit_maybe_shrink(
+                inst,
+                &mut external::AsmCodeSink {
+                    sink,
+
+                    // These values are transcribed from what is happening in
+                    // `SyntheticAmode::finalize`. This, plus the `Into` logic
+                    // converting a `SyntheticAmode` to its external counterpart, are
+                    // necessary to communicate Cranelift's internal offsets to the
+                    // assembler; due to when Cranelift determines these offsets, this
+                    // happens quite late (i.e., here during emission).
+                    incoming_arg_offset: i32::try_from(
+                        frame.tail_args_size + frame.setup_area_size,
+                    )
+                    .unwrap(),
+                    slot_offset: i32::try_from(frame.outgoing_args_size).unwrap(),
+                },
+            );
         }
     }
 
@@ -2607,7 +2613,7 @@ where
 /// has a smaller encoding for `AND AL, imm8` than it does for `AND r/m8, imm8`.
 /// Here the instructions are matched against and if regalloc state indicates
 /// that a smaller variant is available then that's swapped to instead.
-fn emit_maybe_shrink(inst: &AsmInst, sink: &mut MachBuffer<Inst>, table: &[i32; 2]) {
+fn emit_maybe_shrink(inst: &AsmInst, sink: &mut impl asm::CodeSink) {
     use cranelift_assembler_x64::GprMem;
     use cranelift_assembler_x64::inst::*;
 
@@ -2620,183 +2626,167 @@ fn emit_maybe_shrink(inst: &AsmInst, sink: &mut MachBuffer<Inst>, table: &[i32; 
 
     match *inst {
         // and
-        Inst::andb_mi(andb_mi { rm8: RAX_RM, imm8 }) => {
-            andb_i::<R>::new(RAX, imm8).encode(sink, table)
-        }
+        Inst::andb_mi(andb_mi { rm8: RAX_RM, imm8 }) => andb_i::<R>::new(RAX, imm8).encode(sink),
         Inst::andw_mi(andw_mi {
             rm16: RAX_RM,
             imm16,
-        }) => andw_i::<R>::new(RAX, imm16).encode(sink, table),
+        }) => andw_i::<R>::new(RAX, imm16).encode(sink),
         Inst::andl_mi(andl_mi {
             rm32: RAX_RM,
             imm32,
-        }) => andl_i::<R>::new(RAX, imm32).encode(sink, table),
+        }) => andl_i::<R>::new(RAX, imm32).encode(sink),
         Inst::andq_mi_sxl(andq_mi_sxl {
             rm64: RAX_RM,
             imm32,
-        }) => andq_i_sxl::<R>::new(RAX, imm32).encode(sink, table),
+        }) => andq_i_sxl::<R>::new(RAX, imm32).encode(sink),
 
         // or
-        Inst::orb_mi(orb_mi { rm8: RAX_RM, imm8 }) => {
-            orb_i::<R>::new(RAX, imm8).encode(sink, table)
-        }
+        Inst::orb_mi(orb_mi { rm8: RAX_RM, imm8 }) => orb_i::<R>::new(RAX, imm8).encode(sink),
         Inst::orw_mi(orw_mi {
             rm16: RAX_RM,
             imm16,
-        }) => orw_i::<R>::new(RAX, imm16).encode(sink, table),
+        }) => orw_i::<R>::new(RAX, imm16).encode(sink),
         Inst::orl_mi(orl_mi {
             rm32: RAX_RM,
             imm32,
-        }) => orl_i::<R>::new(RAX, imm32).encode(sink, table),
+        }) => orl_i::<R>::new(RAX, imm32).encode(sink),
         Inst::orq_mi_sxl(orq_mi_sxl {
             rm64: RAX_RM,
             imm32,
-        }) => orq_i_sxl::<R>::new(RAX, imm32).encode(sink, table),
+        }) => orq_i_sxl::<R>::new(RAX, imm32).encode(sink),
 
         // xor
-        Inst::xorb_mi(xorb_mi { rm8: RAX_RM, imm8 }) => {
-            xorb_i::<R>::new(RAX, imm8).encode(sink, table)
-        }
+        Inst::xorb_mi(xorb_mi { rm8: RAX_RM, imm8 }) => xorb_i::<R>::new(RAX, imm8).encode(sink),
         Inst::xorw_mi(xorw_mi {
             rm16: RAX_RM,
             imm16,
-        }) => xorw_i::<R>::new(RAX, imm16).encode(sink, table),
+        }) => xorw_i::<R>::new(RAX, imm16).encode(sink),
         Inst::xorl_mi(xorl_mi {
             rm32: RAX_RM,
             imm32,
-        }) => xorl_i::<R>::new(RAX, imm32).encode(sink, table),
+        }) => xorl_i::<R>::new(RAX, imm32).encode(sink),
         Inst::xorq_mi_sxl(xorq_mi_sxl {
             rm64: RAX_RM,
             imm32,
-        }) => xorq_i_sxl::<R>::new(RAX, imm32).encode(sink, table),
+        }) => xorq_i_sxl::<R>::new(RAX, imm32).encode(sink),
 
         // add
-        Inst::addb_mi(addb_mi { rm8: RAX_RM, imm8 }) => {
-            addb_i::<R>::new(RAX, imm8).encode(sink, table)
-        }
+        Inst::addb_mi(addb_mi { rm8: RAX_RM, imm8 }) => addb_i::<R>::new(RAX, imm8).encode(sink),
         Inst::addw_mi(addw_mi {
             rm16: RAX_RM,
             imm16,
-        }) => addw_i::<R>::new(RAX, imm16).encode(sink, table),
+        }) => addw_i::<R>::new(RAX, imm16).encode(sink),
         Inst::addl_mi(addl_mi {
             rm32: RAX_RM,
             imm32,
-        }) => addl_i::<R>::new(RAX, imm32).encode(sink, table),
+        }) => addl_i::<R>::new(RAX, imm32).encode(sink),
         Inst::addq_mi_sxl(addq_mi_sxl {
             rm64: RAX_RM,
             imm32,
-        }) => addq_i_sxl::<R>::new(RAX, imm32).encode(sink, table),
+        }) => addq_i_sxl::<R>::new(RAX, imm32).encode(sink),
 
         // adc
-        Inst::adcb_mi(adcb_mi { rm8: RAX_RM, imm8 }) => {
-            adcb_i::<R>::new(RAX, imm8).encode(sink, table)
-        }
+        Inst::adcb_mi(adcb_mi { rm8: RAX_RM, imm8 }) => adcb_i::<R>::new(RAX, imm8).encode(sink),
         Inst::adcw_mi(adcw_mi {
             rm16: RAX_RM,
             imm16,
-        }) => adcw_i::<R>::new(RAX, imm16).encode(sink, table),
+        }) => adcw_i::<R>::new(RAX, imm16).encode(sink),
         Inst::adcl_mi(adcl_mi {
             rm32: RAX_RM,
             imm32,
-        }) => adcl_i::<R>::new(RAX, imm32).encode(sink, table),
+        }) => adcl_i::<R>::new(RAX, imm32).encode(sink),
         Inst::adcq_mi_sxl(adcq_mi_sxl {
             rm64: RAX_RM,
             imm32,
-        }) => adcq_i_sxl::<R>::new(RAX, imm32).encode(sink, table),
+        }) => adcq_i_sxl::<R>::new(RAX, imm32).encode(sink),
 
         // sub
-        Inst::subb_mi(subb_mi { rm8: RAX_RM, imm8 }) => {
-            subb_i::<R>::new(RAX, imm8).encode(sink, table)
-        }
+        Inst::subb_mi(subb_mi { rm8: RAX_RM, imm8 }) => subb_i::<R>::new(RAX, imm8).encode(sink),
         Inst::subw_mi(subw_mi {
             rm16: RAX_RM,
             imm16,
-        }) => subw_i::<R>::new(RAX, imm16).encode(sink, table),
+        }) => subw_i::<R>::new(RAX, imm16).encode(sink),
         Inst::subl_mi(subl_mi {
             rm32: RAX_RM,
             imm32,
-        }) => subl_i::<R>::new(RAX, imm32).encode(sink, table),
+        }) => subl_i::<R>::new(RAX, imm32).encode(sink),
         Inst::subq_mi_sxl(subq_mi_sxl {
             rm64: RAX_RM,
             imm32,
-        }) => subq_i_sxl::<R>::new(RAX, imm32).encode(sink, table),
+        }) => subq_i_sxl::<R>::new(RAX, imm32).encode(sink),
 
         // sbb
-        Inst::sbbb_mi(sbbb_mi { rm8: RAX_RM, imm8 }) => {
-            sbbb_i::<R>::new(RAX, imm8).encode(sink, table)
-        }
+        Inst::sbbb_mi(sbbb_mi { rm8: RAX_RM, imm8 }) => sbbb_i::<R>::new(RAX, imm8).encode(sink),
         Inst::sbbw_mi(sbbw_mi {
             rm16: RAX_RM,
             imm16,
-        }) => sbbw_i::<R>::new(RAX, imm16).encode(sink, table),
+        }) => sbbw_i::<R>::new(RAX, imm16).encode(sink),
         Inst::sbbl_mi(sbbl_mi {
             rm32: RAX_RM,
             imm32,
-        }) => sbbl_i::<R>::new(RAX, imm32).encode(sink, table),
+        }) => sbbl_i::<R>::new(RAX, imm32).encode(sink),
         Inst::sbbq_mi_sxl(sbbq_mi_sxl {
             rm64: RAX_RM,
             imm32,
-        }) => sbbq_i_sxl::<R>::new(RAX, imm32).encode(sink, table),
+        }) => sbbq_i_sxl::<R>::new(RAX, imm32).encode(sink),
 
         // cmp
         Inst::cmpb_mi(cmpb_mi {
             rm8: GprMem::Gpr(Gpr::RAX),
             imm8,
-        }) => cmpb_i::<R>::new(Gpr::RAX, imm8).encode(sink, table),
+        }) => cmpb_i::<R>::new(Gpr::RAX, imm8).encode(sink),
         Inst::cmpw_mi(cmpw_mi {
             rm16: GprMem::Gpr(Gpr::RAX),
             imm16,
-        }) => cmpw_i::<R>::new(Gpr::RAX, imm16).encode(sink, table),
+        }) => cmpw_i::<R>::new(Gpr::RAX, imm16).encode(sink),
         Inst::cmpl_mi(cmpl_mi {
             rm32: GprMem::Gpr(Gpr::RAX),
             imm32,
-        }) => cmpl_i::<R>::new(Gpr::RAX, imm32).encode(sink, table),
+        }) => cmpl_i::<R>::new(Gpr::RAX, imm32).encode(sink),
         Inst::cmpq_mi(cmpq_mi {
             rm64: GprMem::Gpr(Gpr::RAX),
             imm32,
-        }) => cmpq_i::<R>::new(Gpr::RAX, imm32).encode(sink, table),
+        }) => cmpq_i::<R>::new(Gpr::RAX, imm32).encode(sink),
 
         // test
         Inst::testb_mi(testb_mi {
             rm8: GprMem::Gpr(Gpr::RAX),
             imm8,
-        }) => testb_i::<R>::new(Gpr::RAX, imm8).encode(sink, table),
+        }) => testb_i::<R>::new(Gpr::RAX, imm8).encode(sink),
         Inst::testw_mi(testw_mi {
             rm16: GprMem::Gpr(Gpr::RAX),
             imm16,
-        }) => testw_i::<R>::new(Gpr::RAX, imm16).encode(sink, table),
+        }) => testw_i::<R>::new(Gpr::RAX, imm16).encode(sink),
         Inst::testl_mi(testl_mi {
             rm32: GprMem::Gpr(Gpr::RAX),
             imm32,
-        }) => testl_i::<R>::new(Gpr::RAX, imm32).encode(sink, table),
+        }) => testl_i::<R>::new(Gpr::RAX, imm32).encode(sink),
         Inst::testq_mi(testq_mi {
             rm64: GprMem::Gpr(Gpr::RAX),
             imm32,
-        }) => testq_i::<R>::new(Gpr::RAX, imm32).encode(sink, table),
+        }) => testq_i::<R>::new(Gpr::RAX, imm32).encode(sink),
 
         // lea
         Inst::leal_rm(leal_rm { r32, m32 }) => emit_lea(
             r32,
             m32,
             sink,
-            table,
-            |dst, amode, s, t| leal_rm::<R>::new(dst, amode).encode(s, t),
-            |dst, simm32, s, t| addl_mi::<R>::new(dst, simm32.unsigned()).encode(s, t),
-            |dst, reg, s, t| addl_rm::<R>::new(dst, reg).encode(s, t),
+            |dst, amode, s| leal_rm::<R>::new(dst, amode).encode(s),
+            |dst, simm32, s| addl_mi::<R>::new(dst, simm32.unsigned()).encode(s),
+            |dst, reg, s| addl_rm::<R>::new(dst, reg).encode(s),
         ),
         Inst::leaq_rm(leaq_rm { r64, m64 }) => emit_lea(
             r64,
             m64,
             sink,
-            table,
-            |dst, amode, s, t| leaq_rm::<R>::new(dst, amode).encode(s, t),
-            |dst, simm32, s, t| addq_mi_sxl::<R>::new(dst, simm32).encode(s, t),
-            |dst, reg, s, t| addq_rm::<R>::new(dst, reg).encode(s, t),
+            |dst, amode, s| leaq_rm::<R>::new(dst, amode).encode(s),
+            |dst, simm32, s| addq_mi_sxl::<R>::new(dst, simm32).encode(s),
+            |dst, reg, s| addq_rm::<R>::new(dst, reg).encode(s),
         ),
 
         // All other instructions fall through to here and cannot be shrunk, so
         // return `false` to emit them as usual.
-        _ => inst.encode(sink, table),
+        _ => inst.encode(sink),
     }
 }
 
@@ -2815,15 +2805,16 @@ fn emit_maybe_shrink(inst: &AsmInst, sink: &mut MachBuffer<Inst>, table: &[i32; 
 /// of `lea` should "attempt" to put the `base` in the same register as `dst`
 /// but not at the expense of generating a `mov` instruction. Currently that's
 /// not possible but perhaps one day it may be worth it.
-fn emit_lea(
+fn emit_lea<S>(
     dst: asm::Gpr<WritableGpr>,
     addr: asm::Amode<Gpr>,
-    sink: &mut MachBuffer<Inst>,
-    table: &[i32; 2],
-    lea: fn(WritableGpr, asm::Amode<Gpr>, &mut MachBuffer<Inst>, &[i32; 2]),
-    add_mi: fn(PairedGpr, i32, &mut MachBuffer<Inst>, &[i32; 2]),
-    add_rm: fn(PairedGpr, Gpr, &mut MachBuffer<Inst>, &[i32; 2]),
-) {
+    sink: &mut S,
+    lea: fn(WritableGpr, asm::Amode<Gpr>, &mut S),
+    add_mi: fn(PairedGpr, i32, &mut S),
+    add_rm: fn(PairedGpr, Gpr, &mut S),
+) where
+    S: asm::CodeSink,
+{
     match addr {
         // If `base == dst` then this is `add dst, $imm`, so encode that
         // instead.
@@ -2842,7 +2833,6 @@ fn emit_lea(
             },
             simm32.value(),
             sink,
-            table,
         ),
 
         // If the offset is 0 and the shift is a scale of 1, then:
@@ -2864,7 +2854,6 @@ fn emit_lea(
                     },
                     *index.as_ref(),
                     sink,
-                    table,
                 )
             } else if dst.as_ref().to_reg() == *index.as_ref() {
                 add_rm(
@@ -2874,13 +2863,12 @@ fn emit_lea(
                     },
                     base,
                     sink,
-                    table,
                 )
             } else {
-                lea(*dst.as_ref(), addr, sink, table)
+                lea(*dst.as_ref(), addr, sink)
             }
         }
 
-        _ => lea(*dst.as_ref(), addr, sink, table),
+        _ => lea(*dst.as_ref(), addr, sink),
     }
 }

--- a/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
@@ -199,7 +199,7 @@ fn test_x64_emit() {
     // N.B.: test harness below sets is_pic.
     insns.push((
         Inst::LoadExtName {
-            dst: Writable::from_reg(r11),
+            dst: Writable::from_reg(Gpr::R11),
             name: Box::new(ExternalName::User(UserExternalNameRef::new(0))),
             offset: 0,
             distance: RelocDistance::Far,
@@ -209,7 +209,7 @@ fn test_x64_emit() {
     ));
     insns.push((
         Inst::LoadExtName {
-            dst: Writable::from_reg(r11),
+            dst: Writable::from_reg(Gpr::R11),
             name: Box::new(ExternalName::User(UserExternalNameRef::new(0))),
             offset: 0x12345678,
             distance: RelocDistance::Far,
@@ -219,7 +219,7 @@ fn test_x64_emit() {
     ));
     insns.push((
         Inst::LoadExtName {
-            dst: Writable::from_reg(r11),
+            dst: Writable::from_reg(Gpr::R11),
             name: Box::new(ExternalName::User(UserExternalNameRef::new(0))),
             offset: -0x12345678,
             distance: RelocDistance::Far,

--- a/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
@@ -224,7 +224,7 @@ fn test_x64_emit() {
             offset: -0x12345678,
             distance: RelocDistance::Far,
         },
-        "4C8B1D000000004981EB78563412",
+        "4C8B1D000000004981C388A9CBED",
         "load_ext_name userextname0+-305419896, %r11",
     ));
 

--- a/cranelift/codegen/src/isa/x64/inst/external.rs
+++ b/cranelift/codegen/src/isa/x64/inst/external.rs
@@ -429,37 +429,59 @@ pub mod offsets {
     pub const KEY_SLOT_OFFSET: u8 = 1;
 }
 
-impl asm::CodeSink for MachBuffer<Inst> {
+/// Implementor of the [`asm::CodeSink`] trait.
+pub struct AsmCodeSink<'a> {
+    /// The buffer this is emitting into.
+    pub sink: &'a mut MachBuffer<Inst>,
+    /// The value of `KEY_INCOMING_ARG`.
+    pub incoming_arg_offset: i32,
+    /// The value of `KEY_SLOT_OFFSET`.
+    pub slot_offset: i32,
+}
+
+impl asm::CodeSink for AsmCodeSink<'_> {
     fn put1(&mut self, value: u8) {
-        self.put1(value)
+        self.sink.put1(value)
     }
 
     fn put2(&mut self, value: u16) {
-        self.put2(value)
+        self.sink.put2(value)
     }
 
     fn put4(&mut self, value: u32) {
-        self.put4(value)
+        self.sink.put4(value)
     }
 
     fn put8(&mut self, value: u64) {
-        self.put8(value)
-    }
-
-    fn current_offset(&self) -> u32 {
-        self.cur_offset()
-    }
-
-    fn use_label_at_offset(&mut self, offset: u32, label: asm::Label) {
-        self.use_label_at_offset(offset, label.into(), LabelUse::JmpRel32);
+        self.sink.put8(value)
     }
 
     fn add_trap(&mut self, code: asm::TrapCode) {
-        self.add_trap(code.into());
+        self.sink.add_trap(code.into());
     }
 
-    fn get_label_for_constant(&mut self, c: asm::Constant) -> asm::Label {
-        self.get_label_for_constant(c.into()).into()
+    fn use_target(&mut self, target: asm::DeferredTarget) {
+        let offset = self.sink.cur_offset();
+        match target {
+            asm::DeferredTarget::Label(label) => {
+                self.sink
+                    .use_label_at_offset(offset, label.into(), LabelUse::JmpRel32);
+            }
+            asm::DeferredTarget::Constant(constant) => {
+                let label = self.sink.get_label_for_constant(constant.into());
+                self.sink
+                    .use_label_at_offset(offset, label, LabelUse::JmpRel32);
+            }
+            asm::DeferredTarget::None => {}
+        }
+    }
+
+    fn known_offset(&self, offset: asm::KnownOffset) -> i32 {
+        match offset {
+            offsets::KEY_INCOMING_ARG => self.incoming_arg_offset,
+            offsets::KEY_SLOT_OFFSET => self.slot_offset,
+            _ => unreachable!(),
+        }
     }
 }
 

--- a/cranelift/codegen/src/isa/x64/inst/external.rs
+++ b/cranelift/codegen/src/isa/x64/inst/external.rs
@@ -480,7 +480,7 @@ impl asm::CodeSink for AsmCodeSink<'_> {
         match offset {
             offsets::KEY_INCOMING_ARG => self.incoming_arg_offset,
             offsets::KEY_SLOT_OFFSET => self.slot_offset,
-            _ => unreachable!(),
+            other => panic!("unknown \"known\" offset {other}"),
         }
     }
 }

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -1023,7 +1023,7 @@ impl PrettyPrint for Inst {
             Inst::LoadExtName {
                 dst, name, offset, ..
             } => {
-                let dst = pretty_print_reg(dst.to_reg(), 8);
+                let dst = pretty_print_reg(*dst.to_reg(), 8);
                 let name = name.display(None);
                 let op = ljustify("load_ext_name".into());
                 format!("{op} {name}+{offset}, {dst}")

--- a/cranelift/codegen/src/isa/x64/lower.rs
+++ b/cranelift/codegen/src/isa/x64/lower.rs
@@ -188,7 +188,7 @@ fn emit_vm_call(
     } else {
         let tmp = ctx.alloc_tmp(types::I64).only_reg().unwrap();
         ctx.emit(Inst::LoadExtName {
-            dst: tmp,
+            dst: tmp.map(Gpr::unwrap_new),
             name: Box::new(extname),
             offset: 0,
             distance: RelocDistance::Far,

--- a/cranelift/codegen/src/isa/x64/pcc.rs
+++ b/cranelift/codegen/src/isa/x64/pcc.rs
@@ -287,7 +287,7 @@ pub(crate) fn check(
         }
 
         Inst::LoadExtName { dst, .. } => {
-            ensure_no_fact(vcode, dst.to_reg())?;
+            ensure_no_fact(vcode, *dst.to_reg())?;
             Ok(())
         }
 

--- a/cranelift/filetests/filetests/isa/x64/symbols-pic.clif
+++ b/cranelift/filetests/filetests/isa/x64/symbols-pic.clif
@@ -1,4 +1,5 @@
 test compile precise-output
+set is_pic
 target x86_64
 
 function %func_addr() -> i64 {
@@ -23,7 +24,7 @@ block0:
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movabsq $0, %rax ; reloc_external Abs8 %func0 0
+;   movq (%rip), %rax ; reloc_external GOTPCRel4 %func0 -4
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -50,7 +51,7 @@ block0:
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   leaq (%rip), %rax ; reloc_external CallPCRel4 %func0 -4
+;   movq (%rip), %rax ; reloc_external GOTPCRel4 %func0 -4
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -77,7 +78,7 @@ block0:
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movabsq $0, %rax ; reloc_external Abs8 %global0 0
+;   movq (%rip), %rax ; reloc_external GOTPCRel4 %global0 -4
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -104,7 +105,8 @@ block0:
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movabsq $0, %rax ; reloc_external Abs8 %global0 123
+;   movq (%rip), %rax ; reloc_external GOTPCRel4 %global0 -4
+;   addq $0x7b, %rax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -131,7 +133,8 @@ block0:
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movabsq $0, %rax ; reloc_external Abs8 %global0 -123
+;   movq (%rip), %rax ; reloc_external GOTPCRel4 %global0 -4
+;   subq $0x7b, %rax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -158,7 +161,7 @@ block0:
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   leaq (%rip), %rax ; reloc_external CallPCRel4 %global0 -4
+;   movq (%rip), %rax ; reloc_external GOTPCRel4 %global0 -4
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -185,7 +188,8 @@ block0:
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   leaq (%rip), %rax ; reloc_external CallPCRel4 %global0 -4
+;   movq (%rip), %rax ; reloc_external GOTPCRel4 %global0 -4
+;   addq $0x7b, %rax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -212,7 +216,8 @@ block0:
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   leaq (%rip), %rax ; reloc_external CallPCRel4 %global0 -4
+;   movq (%rip), %rax ; reloc_external GOTPCRel4 %global0 -4
+;   subq $0x7b, %rax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq

--- a/cranelift/filetests/filetests/isa/x64/symbols-pic.clif
+++ b/cranelift/filetests/filetests/isa/x64/symbols-pic.clif
@@ -134,7 +134,7 @@ block0:
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
 ;   movq (%rip), %rax ; reloc_external GOTPCRel4 %global0 -4
-;   subq $0x7b, %rax
+;   addq $-0x7b, %rax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -217,7 +217,7 @@ block0:
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
 ;   movq (%rip), %rax ; reloc_external GOTPCRel4 %global0 -4
-;   subq $0x7b, %rax
+;   addq $-0x7b, %rax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq

--- a/cranelift/filetests/filetests/isa/x64/symbols.clif
+++ b/cranelift/filetests/filetests/isa/x64/symbols.clif
@@ -185,7 +185,7 @@ block0:
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   leaq (%rip), %rax ; reloc_external CallPCRel4 %global0 -4
+;   leaq (%rip), %rax ; reloc_external CallPCRel4 %global0 119
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -212,7 +212,7 @@ block0:
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   leaq (%rip), %rax ; reloc_external CallPCRel4 %global0 -4
+;   leaq (%rip), %rax ; reloc_external CallPCRel4 %global0 -127
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq


### PR DESCRIPTION
Don't use raw bytes when emitting this instruction but instead use
symbolic assembler directives to avoid needing to hardcode bytes. This
additionally fixes an issue where with `colocated` symbols the offset of
the symbol was not taken into account (but for Wasmtime it's always been
0 so this otherwise hasn't come up so far)