### PR TITLE
x64: Add lowerings for the `bt` instruction

### DIFF
--- a/cranelift/assembler-x64/meta/src/instructions/bitmanip.rs
+++ b/cranelift/assembler-x64/meta/src/instructions/bitmanip.rs
@@ -1,4 +1,4 @@
-use crate::dsl::{Feature::*, Inst, Location::*, VexLength::*};
+use crate::dsl::{Eflags::*, Feature::*, Inst, Location::*, VexLength::*};
 use crate::dsl::{fmt, implicit, inst, r, rex, rw, vex, w};
 
 #[rustfmt::skip] // Keeps instructions on a single line.
@@ -23,6 +23,13 @@ pub fn list() -> Vec<Inst> {
         inst("popcntw", fmt("RM", [w(r16), r(rm16)]), rex([0x66, 0xF3, 0x0F, 0xB8]).r(), _64b | compat | popcnt),
         inst("popcntl", fmt("RM", [w(r32), r(rm32)]), rex([0xF3, 0x0F, 0xB8]).r(), _64b | compat | popcnt),
         inst("popcntq", fmt("RM", [w(r64), r(rm64)]), rex([0xF3, 0x0F, 0xB8]).r().w(), _64b | popcnt),
+
+        inst("btw", fmt("MR", [r(rm16), r(r16)]).flags(W), rex([0x66, 0x0F, 0xA3]).r(), _64b | compat),
+        inst("btl", fmt("MR", [r(rm32), r(r32)]).flags(W), rex([0x0F, 0xA3]).r(), _64b | compat),
+        inst("btq", fmt("MR", [r(rm64), r(r64)]).flags(W), rex([0x0F, 0xA3]).w().r(), _64b),
+        inst("btw", fmt("MI", [r(rm16), r(imm8)]).flags(W), rex([0x66, 0x0F, 0xBA]).digit(4).ib(), _64b | compat),
+        inst("btl", fmt("MI", [r(rm32), r(imm8)]).flags(W), rex([0x0F, 0xBA]).digit(4).ib(), _64b | compat),
+        inst("btq", fmt("MI", [r(rm64), r(imm8)]).flags(W), rex([0x0F, 0xBA]).w().digit(4).ib(), _64b),
 
         // Note that the Intel manual calls has different names for these
         // instructions than Capstone gives them:

--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -4292,9 +4292,14 @@
 (rule 1 (is_nonzero_band $I64 a (u64_from_iconst (bt_imm n)))
   (CondResult.CC (x64_bt_imm $I64 a n) (CC.B)))
 
-;; LLVM looks to favor `test` over `bt`, so if the right-hand-side is a 32-bit
-;; constant always use `test` for this to get prioritized over the `bt` rule
-;; above.
+;; If what we're testing against is a 32-bit integer then this is a candidate
+;; for both the `test` and `bt` instructions (only `bt` if the integer as one
+;; bit set). According to [1] the `test` instruction has a higher throughput
+;; at least historically than the `bt` instruction so here `test` is explicitly
+;; favored over `bt`, even if `bt` were applicable. Note that LLVM also looks to
+;; favor `bt` as well.
+;;
+;; [1]: https://github.com/bytecodealliance/wasmtime/pull/11128#discussion_r2164888415
 (rule 2 (is_nonzero_band ty a b @ (i32_from_iconst _))
   (CondResult.CC (x64_test ty a b) (CC.NZ)))
 

--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -3647,6 +3647,18 @@
 (rule (x64_blsr $I32 src) (x64_blsrl_vm src))
 (rule (x64_blsr $I64 src) (x64_blsrq_vm src))
 
+;; Helper for creating `bt` instructions.
+(decl x64_bt (Type GprMem Gpr) ProducesFlags)
+(rule (x64_bt $I16 src1 src2) (x64_btw_mr src1 src2))
+(rule (x64_bt $I32 src1 src2) (x64_btl_mr src1 src2))
+(rule (x64_bt $I64 src1 src2) (x64_btq_mr src1 src2))
+
+;; Helper for creating `bt` instructions.
+(decl x64_bt_imm (Type GprMem u8) ProducesFlags)
+(rule (x64_bt_imm $I16 src imm) (x64_btw_mi src imm))
+(rule (x64_bt_imm $I32 src imm) (x64_btl_mi src imm))
+(rule (x64_bt_imm $I64 src imm) (x64_btq_mi src imm))
+
 ;; Helper for creating `sarx` instructions.
 (decl x64_sarx (Type GprMem Gpr) Gpr)
 (rule (x64_sarx $I32 val amt) (x64_sarxl_rmv val amt))
@@ -4262,7 +4274,35 @@
 (rule 2 (is_nonzero_cmp (vany_true vec)) (is_vany_true vec))
 (rule 2 (is_nonzero_cmp (uextend val)) (is_nonzero_cmp val))
 (rule 2 (is_nonzero_cmp (band a @ (value_type (ty_int (fits_in_64 ty))) b))
+  (is_nonzero_band ty a b))
+
+(decl is_nonzero_band (Type Value Value) CondResult)
+(rule 0 (is_nonzero_band ty a b) (CondResult.CC (x64_test ty a b) (CC.NZ)))
+
+;; If a value is and'd with an immediate that has exactly one bit set then this
+;; can pattern-match to the native `bt` instruction. Note that to have the
+;; same semantics this requires that `a` is in a register which forces `bt` to
+;; use modulo semantics for the second operand `b`, thus `put_in_gpr` is
+;; manually used.
+(rule 1 (is_nonzero_band (ty_32_or_64 ty) a (ishl (u64_from_iconst 1) b))
+  (CondResult.CC (x64_bt ty (put_in_gpr a) b) (CC.B)))
+
+;; If a value is and'd one shifted by a variable value that matches `bt` as
+;; well.
+(rule 1 (is_nonzero_band $I64 a (u64_from_iconst (bt_imm n)))
+  (CondResult.CC (x64_bt_imm $I64 a n) (CC.B)))
+
+;; LLVM looks to favor `test` over `bt`, so if the right-hand-side is a 32-bit
+;; constant always use `test` for this to get prioritized over the `bt` rule
+;; above.
+(rule 2 (is_nonzero_band ty a b @ (i32_from_iconst _))
   (CondResult.CC (x64_test ty a b) (CC.NZ)))
+
+;; Helper to test whether the `u64` input has a single bit set, and if so
+;; yields the bit position of where that bit is set. Used in the lowering of
+;; `x64_bt_imm` above.
+(decl bt_imm (u8) u64)
+(extern extractor bt_imm bt_imm)
 
 ;; Lower a CondResult to a boolean value in a register.
 (decl lower_cond_bool (CondResult) Gpr)
@@ -4329,10 +4369,10 @@
 
 ;; For direct equality comparisons to zero transform the other operand into a
 ;; nonzero comparison and then invert the whole conditional to test for zero.
-(rule 5 (emit_cmp (IntCC.Equal) a (u64_from_iconst 0))
-  (cond_invert (is_nonzero_cmp a)))
-(rule 6 (emit_cmp (IntCC.Equal) (u64_from_iconst 0) a)
-  (cond_invert (is_nonzero_cmp a)))
+(rule 5 (emit_cmp (IntCC.Equal) a (u64_from_iconst 0)) (cond_invert (is_nonzero_cmp a)))
+(rule 6 (emit_cmp (IntCC.Equal) (u64_from_iconst 0) a) (cond_invert (is_nonzero_cmp a)))
+(rule 5 (emit_cmp (IntCC.NotEqual) a (u64_from_iconst 0)) (is_nonzero_cmp a))
+(rule 6 (emit_cmp (IntCC.NotEqual) (u64_from_iconst 0) a) (is_nonzero_cmp a))
 
 ;; 128-bit strict equality/inequality can't be easily tested using subtraction
 ;; but we can quickly determine whether any bits are different instead.

--- a/cranelift/codegen/src/isa/x64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/x64/lower/isle.rs
@@ -1080,6 +1080,15 @@ impl Context for IsleContext<'_, '_, MInst, X64Backend> {
         self.emit(&MInst::External { inst: inst.into() });
         ret.to_reg()
     }
+
+    fn bt_imm(&mut self, val: u64) -> Option<u8> {
+        let trailing_zeros = u8::try_from(val.trailing_zeros()).unwrap();
+        if val == 1 << trailing_zeros {
+            Some(trailing_zeros)
+        } else {
+            None
+        }
+    }
 }
 
 impl IsleContext<'_, '_, MInst, X64Backend> {

--- a/cranelift/codegen/src/isa/x64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/x64/lower/isle.rs
@@ -1082,9 +1082,8 @@ impl Context for IsleContext<'_, '_, MInst, X64Backend> {
     }
 
     fn bt_imm(&mut self, val: u64) -> Option<u8> {
-        let trailing_zeros = u8::try_from(val.trailing_zeros()).unwrap();
-        if val == 1 << trailing_zeros {
-            Some(trailing_zeros)
+        if val.count_ones() == 1 {
+            Some(u8::try_from(val.trailing_zeros()).unwrap())
         } else {
             None
         }

--- a/cranelift/filetests/filetests/isa/x64/branches.clif
+++ b/cranelift/filetests/filetests/isa/x64/branches.clif
@@ -1217,3 +1217,316 @@ block2:
 ;   popq %rbp
 ;   retq
 
+
+function %test_bit5(i32) -> i32 {
+block0(v0: i32):
+  v1 = iconst.i32 32
+  v2 = band v0, v1
+
+  brif v2, block1, block2
+
+block1:
+  v3 = iconst.i32 100
+  return v3
+
+block2:
+  v4 = iconst.i32 200
+  return v4
+}
+
+; VCode:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0:
+;   testl $0x20, %edi
+;   jnz     label2; j label1
+; block1:
+;   movl $0xc8, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+; block2:
+;   movl $0x64, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   testl $0x20, %edi
+;   jne 0x1a
+; block2: ; offset 0x10
+;   movl $0xc8, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+; block3: ; offset 0x1a
+;   movl $0x64, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+
+function %test_bit29(i32) -> i32 {
+block0(v0: i32):
+  v1 = iconst.i32 0x20000000
+  v2 = band v0, v1
+
+  brif v2, block1, block2
+
+block1:
+  v3 = iconst.i32 100
+  return v3
+
+block2:
+  v4 = iconst.i32 200
+  return v4
+}
+
+; VCode:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0:
+;   testl $0x20000000, %edi
+;   jnz     label2; j label1
+; block1:
+;   movl $0xc8, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+; block2:
+;   movl $0x64, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   testl $0x20000000, %edi
+;   jne 0x1a
+; block2: ; offset 0x10
+;   movl $0xc8, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+; block3: ; offset 0x1a
+;   movl $0x64, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+
+function %test_bit32(i64) -> i32 {
+block0(v0: i64):
+  v1 = iconst.i64 0x100000000
+  v2 = band v0, v1
+
+  brif v2, block1, block2
+
+block1:
+  v3 = iconst.i32 100
+  return v3
+
+block2:
+  v4 = iconst.i32 200
+  return v4
+}
+
+; VCode:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0:
+;   btq $0x20, %rdi
+;   jb      label2; j label1
+; block1:
+;   movl $0xc8, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+; block2:
+;   movl $0x64, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   btq $0x20, %rdi
+;   jb 0x19
+; block2: ; offset 0xf
+;   movl $0xc8, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+; block3: ; offset 0x19
+;   movl $0x64, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+
+function %test_bit55(i64) -> i32 {
+block0(v0: i64):
+  v1 = iconst.i64 0x80000000000000
+  v2 = band v0, v1
+
+  brif v2, block1, block2
+
+block1:
+  v3 = iconst.i32 100
+  return v3
+
+block2:
+  v4 = iconst.i32 200
+  return v4
+}
+
+; VCode:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0:
+;   btq $0x37, %rdi
+;   jb      label2; j label1
+; block1:
+;   movl $0xc8, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+; block2:
+;   movl $0x64, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   btq $0x37, %rdi
+;   jb 0x19
+; block2: ; offset 0xf
+;   movl $0xc8, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+; block3: ; offset 0x19
+;   movl $0x64, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %test_variable_bit32(i32, i32) -> i32 {
+block0(v0: i32, v1: i32):
+  v2 = iconst.i32 1
+  v3 = ishl v2, v1
+  v4 = band v0, v3
+
+  brif v4, block1, block2
+
+block1:
+  v5 = iconst.i32 100
+  return v5
+
+block2:
+  v6 = iconst.i32 200
+  return v6
+}
+
+; VCode:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0:
+;   btl %esi, %edi
+;   jb      label2; j label1
+; block1:
+;   movl $0xc8, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+; block2:
+;   movl $0x64, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   btl %esi, %edi
+;   jb 0x17
+; block2: ; offset 0xd
+;   movl $0xc8, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+; block3: ; offset 0x17
+;   movl $0x64, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+
+function %test_variable_bit64(i64, i64) -> i32 {
+block0(v0: i64, v1: i64):
+  v2 = iconst.i64 1
+  v3 = ishl v2, v1
+  v4 = band v0, v3
+
+  brif v4, block1, block2
+
+block1:
+  v5 = iconst.i32 100
+  return v5
+
+block2:
+  v6 = iconst.i32 200
+  return v6
+}
+
+; VCode:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0:
+;   btq %rsi, %rdi
+;   jb      label2; j label1
+; block1:
+;   movl $0xc8, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+; block2:
+;   movl $0x64, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   btq %rsi, %rdi
+;   jb 0x18
+; block2: ; offset 0xe
+;   movl $0xc8, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+; block3: ; offset 0x18
+;   movl $0x64, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+

--- a/tests/disas/trunc.wat
+++ b/tests/disas/trunc.wat
@@ -12,90 +12,77 @@
 ;;       movq    %rsp, %rbp
 ;;       subq    $0x20, %rsp
 ;;       movq    %r14, 0x10(%rsp)
-;;       movq    8(%rdi), %rdx
+;;       movq    8(%rdi), %r11
 ;;       movq    %rdi, %r14
-;;       movq    0x10(%rdx), %rdx
-;;       movq    %rsp, %r8
-;;       cmpq    %rdx, %r8
-;;       jb      0x12c
+;;       movq    0x10(%r11), %r11
+;;       movq    %rsp, %rsi
+;;       cmpq    %r11, %rsi
+;;       jb      0x118
 ;;   24: ucomisd %xmm0, %xmm0
 ;;       movdqu  %xmm0, (%rsp)
-;;       setp    %r10b
-;;       setne   %r11b
-;;       orl     %r11d, %r10d
-;;       testb   %r10b, %r10b
-;;       jne     0x115
-;;   41: movq    %r14, %rdi
+;;       jp      0x101
+;;       jne     0x101
+;;   39: movq    %r14, %rdi
 ;;       movdqu  (%rsp), %xmm0
-;;       callq   0x244
-;;       movabsq $13830554455654793216, %r11
-;;       movq    %r11, %xmm4
-;;       ucomisd %xmm0, %xmm4
-;;       setae   %dil
-;;       testb   %dil, %dil
-;;       jne     0xfe
-;;   6e: ucomisd 0xda(%rip), %xmm0
-;;       setae   %dl
-;;       testb   %dl, %dl
-;;       jne     0xe7
-;;   81: movdqu  (%rsp), %xmm2
-;;       movabsq $0x43e0000000000000, %r9
-;;       movq    %r9, %xmm7
-;;       ucomisd %xmm7, %xmm2
-;;       jae     0xb6
-;;       jp      0x140
-;;   a5: cvttsd2si %xmm2, %rax
+;;       callq   0x224
+;;       movabsq $13830554455654793216, %rax
+;;       movq    %rax, %xmm6
+;;       ucomisd %xmm0, %xmm6
+;;       jae     0xea
+;;   5f: ucomisd 0xc9(%rip), %xmm0
+;;       jae     0xd3
+;;   6d: movdqu  (%rsp), %xmm1
+;;       movabsq $0x43e0000000000000, %r10
+;;       movq    %r10, %xmm7
+;;       ucomisd %xmm7, %xmm1
+;;       jae     0xa2
+;;       jp      0x12c
+;;   91: cvttsd2si %xmm1, %rax
 ;;       cmpq    $0, %rax
-;;       jge     0xd9
-;;   b4: ud2
-;;       movaps  %xmm2, %xmm0
+;;       jge     0xc5
+;;   a0: ud2
+;;       movaps  %xmm1, %xmm0
 ;;       subsd   %xmm7, %xmm0
 ;;       cvttsd2si %xmm0, %rax
 ;;       cmpq    $0, %rax
-;;       jl      0x142
-;;   cc: movabsq $9223372036854775808, %r9
-;;       addq    %r9, %rax
+;;       jl      0x12e
+;;   b8: movabsq $9223372036854775808, %r10
+;;       addq    %r10, %rax
 ;;       movq    0x10(%rsp), %r14
 ;;       addq    $0x20, %rsp
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   e7: movl    $6, %esi
-;;   ec: movq    %r14, %rdi
-;;   ef: callq   0x283
-;;   f4: movq    %r14, %rdi
-;;   f7: callq   0x2c6
-;;   fc: ud2
-;;   fe: movl    $6, %esi
-;;  103: movq    %r14, %rdi
-;;  106: callq   0x283
-;;  10b: movq    %r14, %rdi
-;;  10e: callq   0x2c6
-;;  113: ud2
-;;  115: movl    $8, %esi
+;;   d3: movl    $6, %esi
+;;   d8: movq    %r14, %rdi
+;;   db: callq   0x263
+;;   e0: movq    %r14, %rdi
+;;   e3: callq   0x2a6
+;;   e8: ud2
+;;   ea: movl    $6, %esi
+;;   ef: movq    %r14, %rdi
+;;   f2: callq   0x263
+;;   f7: movq    %r14, %rdi
+;;   fa: callq   0x2a6
+;;   ff: ud2
+;;  101: movl    $8, %esi
+;;  106: movq    %r14, %rdi
+;;  109: callq   0x263
+;;  10e: movq    %r14, %rdi
+;;  111: callq   0x2a6
+;;  116: ud2
+;;  118: xorl    %esi, %esi
 ;;  11a: movq    %r14, %rdi
-;;  11d: callq   0x283
+;;  11d: callq   0x263
 ;;  122: movq    %r14, %rdi
-;;  125: callq   0x2c6
+;;  125: callq   0x2a6
 ;;  12a: ud2
-;;  12c: xorl    %esi, %esi
-;;  12e: movq    %r14, %rdi
-;;  131: callq   0x283
-;;  136: movq    %r14, %rdi
-;;  139: callq   0x2c6
-;;  13e: ud2
-;;  140: ud2
-;;  142: ud2
-;;  144: addb    %al, (%rax)
-;;  146: addb    %al, (%rax)
-;;  148: addb    %al, (%rax)
-;;  14a: addb    %al, (%rax)
-;;  14c: addb    %al, (%rax)
-;;  14e: addb    %al, (%rax)
-;;  150: addb    %al, (%rax)
-;;  152: addb    %al, (%rax)
-;;  154: addb    %al, (%rax)
-;;  156: lock addb %al, (%r8)
-;;  15a: addb    %al, (%rax)
-;;  15c: addb    %al, (%rax)
-;;  15e: addb    %al, (%rax)
+;;  12c: ud2
+;;  12e: ud2
+;;  130: addb    %al, (%rax)
+;;  132: addb    %al, (%rax)
+;;  134: addb    %al, (%rax)
+;;  136: lock addb %al, (%r8)
+;;  13a: addb    %al, (%rax)
+;;  13c: addb    %al, (%rax)
+;;  13e: addb    %al, (%rax)

--- a/tests/disas/trunc32.wat
+++ b/tests/disas/trunc32.wat
@@ -11,184 +11,85 @@
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       subq    $0x20, %rsp
-;;       movq    %r14, 0x10(%rsp)
-;;       movq    8(%rdi), %rdx
-;;       movq    %rdi, %r14
-;;       movq    0x10(%rdx), %rdx
-;;       movq    %rsp, %r8
-;;       cmpq    %rdx, %r8
-;;       jb      0x12d
-;;   24: ucomisd %xmm0, %xmm0
-;;       movdqu  %xmm0, (%rsp)
-;;       setp    %r10b
-;;       setne   %r11b
-;;       orl     %r11d, %r10d
-;;       testb   %r10b, %r10b
-;;       jne     0x116
-;;   41: movq    %r14, %rdi
-;;       movdqu  (%rsp), %xmm0
-;;       callq   0x244
-;;       movabsq $13830554455654793216, %r11
-;;       movq    %r11, %xmm4
-;;       ucomisd %xmm0, %xmm4
-;;       setae   %dil
-;;       testb   %dil, %dil
-;;       jne     0xff
-;;   6e: ucomisd 0xda(%rip), %xmm0
-;;       setae   %dl
-;;       testb   %dl, %dl
-;;       jne     0xe8
-;;   82: movdqu  (%rsp), %xmm2
-;;       movabsq $0x43e0000000000000, %r9
-;;       movq    %r9, %xmm7
-;;       ucomisd %xmm7, %xmm2
-;;       jae     0xb7
-;;       jp      0x141
-;;   a6: cvttsd2si %xmm2, %rax
-;;       cmpq    $0, %rax
-;;       jge     0xda
-;;   b5: ud2
-;;       movaps  %xmm2, %xmm0
-;;       subsd   %xmm7, %xmm0
-;;       cvttsd2si %xmm0, %rax
-;;       cmpq    $0, %rax
-;;       jl      0x143
-;;   cd: movabsq $9223372036854775808, %r9
-;;       addq    %r9, %rax
-;;       movq    0x10(%rsp), %r14
-;;       addq    $0x20, %rsp
-;;       movq    %rbp, %rsp
-;;       popq    %rbp
-;;       retq
-;;   e8: movl    $6, %esi
-;;   ed: movq    %r14, %rdi
-;;   f0: callq   0x284
-;;   f5: movq    %r14, %rdi
-;;   f8: callq   0x2c8
-;;   fd: ud2
-;;   ff: movl    $6, %esi
-;;  104: movq    %r14, %rdi
-;;  107: callq   0x284
-;;  10c: movq    %r14, %rdi
-;;  10f: callq   0x2c8
-;;  114: ud2
-;;  116: movl    $8, %esi
-;;  11b: movq    %r14, %rdi
-;;  11e: callq   0x284
-;;  123: movq    %r14, %rdi
-;;  126: callq   0x2c8
-;;  12b: ud2
-;;  12d: xorl    %esi, %esi
-;;  12f: movq    %r14, %rdi
-;;  132: callq   0x284
-;;  137: movq    %r14, %rdi
-;;  13a: callq   0x2c8
-;;  13f: ud2
-;;  141: ud2
-;;  143: ud2
-;;  145: addb    %al, (%rax)
-;;  147: addb    %al, (%rax)
-;;  149: addb    %al, (%rax)
-;;  14b: addb    %al, (%rax)
-;;  14d: addb    %al, (%rax)
-;;  14f: addb    %al, (%rax)
-;;  151: addb    %al, (%rax)
-;;  153: addb    %al, (%rax)
-;;  155: addb    %dh, %al
-;;  157: addb    %al, (%r8)
-;;  15a: addb    %al, (%rax)
-;;  15c: addb    %al, (%rax)
-;;  15e: addb    %al, (%rax)
-
-;; wasm[0]::function[0]:
-;;       pushq   %rbp
-;;       movq    %rsp, %rbp
-;;       subq    $0x20, %rsp
 ;;       movq    %r12, 0x10(%rsp)
 ;;       movdqu  %xmm0, (%rsp)
-;;       movq    8(%rdi), %r10
+;;       movq    8(%rdi), %rax
 ;;       movq    %rdi, %r12
-;;       movq    0x10(%r10), %r10
-;;       movq    %rsp, %r11
-;;       cmpq    %r10, %r11
-;;       jb      0x11f
+;;       movq    0x10(%rax), %rax
+;;       movq    %rsp, %rcx
+;;       cmpq    %rax, %rcx
+;;       jb      0x10d
 ;;   29: xorpd   %xmm0, %xmm0
-;;       movdqu  (%rsp), %xmm4
-;;       cvtss2sd %xmm4, %xmm0
+;;       movdqu  (%rsp), %xmm3
+;;       cvtss2sd %xmm3, %xmm0
 ;;       ucomisd %xmm0, %xmm0
-;;       setp    %dil
-;;       setne   %al
-;;       orl     %eax, %edi
-;;       testb   %dil, %dil
-;;       jne     0x108
-;;   4c: movq    %r12, %rdi
-;;       callq   0x232
-;;       movabsq $13830554455654793216, %rax
-;;       movq    %rax, %xmm7
-;;       ucomisd %xmm0, %xmm7
-;;       setae   %dl
-;;       testb   %dl, %dl
-;;       jne     0xf1
-;;   72: ucomisd 0xc6(%rip), %xmm0
-;;       setae   %r10b
-;;       testb   %r10b, %r10b
-;;       jne     0xda
-;;   87: movdqu  (%rsp), %xmm4
-;;       movl    $0x4f000000, %esi
-;;       movd    %esi, %xmm2
-;;       ucomiss %xmm2, %xmm4
-;;       jae     0xb3
-;;       jp      0x133
-;;   a4: cvttss2si %xmm4, %eax
+;;       jp      0xf6
+;;       jne     0xf6
+;;   46: movq    %r12, %rdi
+;;       callq   0x222
+;;       movabsq $13830554455654793216, %r8
+;;       movq    %r8, %xmm1
+;;       ucomisd %xmm0, %xmm1
+;;       jae     0xdf
+;;   67: ucomisd 0xc1(%rip), %xmm0
+;;       jae     0xc8
+;;   75: movdqu  (%rsp), %xmm7
+;;       movl    $0x4f000000, %edi
+;;       movd    %edi, %xmm2
+;;       ucomiss %xmm2, %xmm7
+;;       jae     0xa1
+;;       jp      0x121
+;;   92: cvttss2si %xmm7, %eax
 ;;       cmpl    $0, %eax
-;;       jge     0xcc
-;;   b1: ud2
-;;       movaps  %xmm4, %xmm3
+;;       jge     0xba
+;;   9f: ud2
+;;       movaps  %xmm7, %xmm3
 ;;       subss   %xmm2, %xmm3
 ;;       cvttss2si %xmm3, %eax
 ;;       cmpl    $0, %eax
-;;       jl      0x135
-;;   c7: addl    $0x80000000, %eax
+;;       jl      0x123
+;;   b5: addl    $0x80000000, %eax
 ;;       movq    0x10(%rsp), %r12
 ;;       addq    $0x20, %rsp
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   da: movl    $6, %esi
-;;   df: movq    %r12, %rdi
-;;   e2: callq   0x271
-;;   e7: movq    %r12, %rdi
-;;   ea: callq   0x2b4
-;;   ef: ud2
-;;   f1: movl    $6, %esi
-;;   f6: movq    %r12, %rdi
-;;   f9: callq   0x271
-;;   fe: movq    %r12, %rdi
-;;  101: callq   0x2b4
-;;  106: ud2
-;;  108: movl    $8, %esi
-;;  10d: movq    %r12, %rdi
-;;  110: callq   0x271
-;;  115: movq    %r12, %rdi
-;;  118: callq   0x2b4
-;;  11d: ud2
-;;  11f: xorl    %esi, %esi
-;;  121: movq    %r12, %rdi
-;;  124: callq   0x271
-;;  129: movq    %r12, %rdi
-;;  12c: callq   0x2b4
-;;  131: ud2
-;;  133: ud2
-;;  135: ud2
-;;  137: addb    %al, (%rax)
-;;  139: addb    %al, (%rax)
-;;  13b: addb    %al, (%rax)
-;;  13d: addb    %al, (%rax)
-;;  13f: addb    %al, (%rax)
-;;  141: addb    %al, (%rax)
-;;  143: addb    %al, (%rax)
-;;  145: addb    %dh, %al
-;;  147: addb    %al, (%r8)
-;;  14a: addb    %al, (%rax)
-;;  14c: addb    %al, (%rax)
-;;  14e: addb    %al, (%rax)
+;;   c8: movl    $6, %esi
+;;   cd: movq    %r12, %rdi
+;;   d0: callq   0x261
+;;   d5: movq    %r12, %rdi
+;;   d8: callq   0x2a4
+;;   dd: ud2
+;;   df: movl    $6, %esi
+;;   e4: movq    %r12, %rdi
+;;   e7: callq   0x261
+;;   ec: movq    %r12, %rdi
+;;   ef: callq   0x2a4
+;;   f4: ud2
+;;   f6: movl    $8, %esi
+;;   fb: movq    %r12, %rdi
+;;   fe: callq   0x261
+;;  103: movq    %r12, %rdi
+;;  106: callq   0x2a4
+;;  10b: ud2
+;;  10d: xorl    %esi, %esi
+;;  10f: movq    %r12, %rdi
+;;  112: callq   0x261
+;;  117: movq    %r12, %rdi
+;;  11a: callq   0x2a4
+;;  11f: ud2
+;;  121: ud2
+;;  123: ud2
+;;  125: addb    %al, (%rax)
+;;  127: addb    %al, (%rax)
+;;  129: addb    %al, (%rax)
+;;  12b: addb    %al, (%rax)
+;;  12d: addb    %al, (%rax)
+;;  12f: addb    %al, (%rax)
+;;  131: addb    %al, (%rax)
+;;  133: addb    %al, (%rax)
+;;  135: addb    %dh, %al
+;;  137: addb    %al, (%r8)
+;;  13a: addb    %al, (%rax)
+;;  13c: addb    %al, (%rax)
+;;  13e: addb    %al, (%rax)

--- a/tests/disas/x64-bit-and-condition.wat
+++ b/tests/disas/x64-bit-and-condition.wat
@@ -20,6 +20,71 @@
     (i32.and (local.get 0) (i32.shl (i32.const 1) (i32.const 20)))
     i32.eqz
   )
+
+  (func $if_b40 (param i64) (result i64)
+    (i64.and (local.get 0) (i64.shl (i64.const 1) (i64.const 40)))
+    i64.const 0
+    i64.ne
+    if (result i64)
+      i64.const 100
+    else
+      i64.const 400
+    end
+  )
+  (func $select_b40 (param i64 i64 i64) (result i64)
+    local.get 1
+    local.get 2
+    (i64.and (local.get 0) (i64.shl (i64.const 1) (i64.const 40)))
+    i64.const 0
+    i64.ne
+    select
+  )
+  (func $eqz_b40 (param i64) (result i32)
+    (i64.and (local.get 0) (i64.shl (i64.const 1) (i64.const 40)))
+    i64.eqz
+  )
+
+  (func $if_bit32 (param i32 i32) (result i32)
+    (i32.and (local.get 0) (i32.shl (i32.const 1) (local.get 1)))
+    if (result i32)
+      i32.const 100
+    else
+      i32.const 200
+    end
+  )
+  (func $select_bit32 (param i32 i32 i32 i32) (result i32)
+    local.get 2
+    local.get 3
+    (i32.and (local.get 0) (i32.shl (i32.const 1) (local.get 1)))
+    select
+  )
+  (func $eqz_bit32 (param i32 i32) (result i32)
+    (i32.and (local.get 0) (i32.shl (i32.const 1) (local.get 1)))
+    i32.eqz
+  )
+
+  (func $if_bit64 (param i64 i64) (result i64)
+    (i64.and (local.get 0) (i64.shl (i64.const 1) (local.get 1)))
+    i64.const 0
+    i64.ne
+    if (result i64)
+      i64.const 100
+    else
+      i64.const 200
+    end
+  )
+  (func $select_bit64 (param i64 i64 i64 i64) (result i64)
+    local.get 2
+    local.get 3
+    (i64.and (local.get 0) (i64.shl (i64.const 1) (local.get 1)))
+    i64.const 0
+    i64.ne
+    select
+  )
+  (func $eqz_bit64 (param i64 i64) (result i32)
+    (i64.and (local.get 0) (i64.shl (i64.const 1) (local.get 1)))
+    i64.eqz
+  )
 )
 ;; wasm[0]::function[0]::if_b20:
 ;;       pushq   %rbp
@@ -49,6 +114,102 @@
 ;;       testl   $0x100000, %edx
 ;;       sete    %r8b
 ;;       movzbl  %r8b, %eax
+;;       movq    %rbp, %rsp
+;;       popq    %rbp
+;;       retq
+;;
+;; wasm[0]::function[3]::if_b40:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       btq     $0x28, %rdx
+;;       jb      0x99
+;;   8f: movl    $0x190, %eax
+;;       jmp     0x9e
+;;   99: movl    $0x64, %eax
+;;       movq    %rbp, %rsp
+;;       popq    %rbp
+;;       retq
+;;
+;; wasm[0]::function[4]::select_b40:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       btq     $0x28, %rdx
+;;       movq    %r8, %rax
+;;       cmovbq  %rcx, %rax
+;;       movq    %rbp, %rsp
+;;       popq    %rbp
+;;       retq
+;;
+;; wasm[0]::function[5]::eqz_b40:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       btq     $0x28, %rdx
+;;       setae   %r8b
+;;       movzbl  %r8b, %eax
+;;       movq    %rbp, %rsp
+;;       popq    %rbp
+;;       retq
+;;
+;; wasm[0]::function[6]::if_bit32:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       btl     %ecx, %edx
+;;       jb      0x117
+;;  10d: movl    $0xc8, %eax
+;;       jmp     0x11c
+;;  117: movl    $0x64, %eax
+;;       movq    %rbp, %rsp
+;;       popq    %rbp
+;;       retq
+;;
+;; wasm[0]::function[7]::select_bit32:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       btl     %ecx, %edx
+;;       movq    %r9, %rax
+;;       cmovbl  %r8d, %eax
+;;       movq    %rbp, %rsp
+;;       popq    %rbp
+;;       retq
+;;
+;; wasm[0]::function[8]::eqz_bit32:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       btl     %ecx, %edx
+;;       setae   %r9b
+;;       movzbl  %r9b, %eax
+;;       movq    %rbp, %rsp
+;;       popq    %rbp
+;;       retq
+;;
+;; wasm[0]::function[9]::if_bit64:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       btq     %rcx, %rdx
+;;       jb      0x198
+;;  18e: movl    $0xc8, %eax
+;;       jmp     0x19d
+;;  198: movl    $0x64, %eax
+;;       movq    %rbp, %rsp
+;;       popq    %rbp
+;;       retq
+;;
+;; wasm[0]::function[10]::select_bit64:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       btq     %rcx, %rdx
+;;       movq    %r9, %rax
+;;       cmovbq  %r8, %rax
+;;       movq    %rbp, %rsp
+;;       popq    %rbp
+;;       retq
+;;
+;; wasm[0]::function[11]::eqz_bit64:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       btq     %rcx, %rdx
+;;       setae   %r9b
+;;       movzbl  %r9b, %eax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq

--- a/tests/misc_testsuite/bit-and-conditions.wast
+++ b/tests/misc_testsuite/bit-and-conditions.wast
@@ -17,6 +17,49 @@
     (i32.and (local.get 0) (i32.shl (i32.const 1) (i32.const 20)))
     i32.eqz
   )
+
+  (func (export "if_b40") (param i64) (result i64)
+    (i64.and (local.get 0) (i64.shl (i64.const 1) (i64.const 40)))
+    i64.const 0
+    i64.ne
+    if (result i64)
+      i64.const 100
+    else
+      i64.const 200
+    end
+  )
+  (func (export "select_b40") (param i64 i64 i64) (result i64)
+    local.get 1
+    local.get 2
+    (i64.and (local.get 0) (i64.shl (i64.const 1) (i64.const 40)))
+    i64.const 0
+    i64.ne
+    select
+  )
+  (func (export "eqz_b40") (param i64) (result i32)
+    (i64.and (local.get 0) (i64.shl (i64.const 1) (i64.const 40)))
+    i64.eqz
+  )
+
+  (func (export "if_bit32") (param i32 i32) (result i32)
+    (i32.and (local.get 0) (i32.shl (i32.const 1) (local.get 1)))
+    if (result i32)
+      i32.const 100
+    else
+      i32.const 200
+    end
+  )
+
+  (func (export "if_bit64") (param i64 i64) (result i64)
+    (i64.and (local.get 0) (i64.shl (i64.const 1) (local.get 1)))
+    i64.const 0
+    i64.ne
+    if (result i64)
+      i64.const 100
+    else
+      i64.const 200
+    end
+  )
 )
 
 (assert_return (invoke "if_b20" (i32.const 0)) (i32.const 200))
@@ -25,3 +68,29 @@
 (assert_return (invoke "select_b20" (i32.const 0x100000) (i32.const 100) (i32.const 200)) (i32.const 100))
 (assert_return (invoke "eqz_b20" (i32.const 0)) (i32.const 1))
 (assert_return (invoke "eqz_b20" (i32.const 0x100000)) (i32.const 0))
+
+(assert_return (invoke "if_b40" (i64.const 0)) (i64.const 200))
+(assert_return (invoke "if_b40" (i64.const 0x10000000000)) (i64.const 100))
+(assert_return (invoke "select_b40" (i64.const 0) (i64.const 100) (i64.const 200)) (i64.const 200))
+(assert_return (invoke "select_b40" (i64.const 0x10000000000) (i64.const 100) (i64.const 200)) (i64.const 100))
+(assert_return (invoke "eqz_b40" (i64.const 0)) (i32.const 1))
+(assert_return (invoke "eqz_b40" (i64.const 0x10000000000)) (i32.const 0))
+
+(assert_return (invoke "if_bit32" (i32.const 0) (i32.const 1)) (i32.const 200))
+(assert_return (invoke "if_bit32" (i32.const 0) (i32.const 0)) (i32.const 200))
+(assert_return (invoke "if_bit32" (i32.const 1) (i32.const 1)) (i32.const 200))
+(assert_return (invoke "if_bit32" (i32.const 1) (i32.const 33)) (i32.const 200))
+(assert_return (invoke "if_bit32" (i32.const 1) (i32.const 0)) (i32.const 100))
+(assert_return (invoke "if_bit32" (i32.const 1) (i32.const 32)) (i32.const 100))
+(assert_return (invoke "if_bit32" (i32.const 0x100000) (i32.const 20)) (i32.const 100))
+(assert_return (invoke "if_bit32" (i32.const 0x100000) (i32.const 52)) (i32.const 100))
+
+(assert_return (invoke "if_bit64" (i64.const 0) (i64.const 1)) (i64.const 200))
+(assert_return (invoke "if_bit64" (i64.const 0) (i64.const 0)) (i64.const 200))
+(assert_return (invoke "if_bit64" (i64.const 1) (i64.const 1)) (i64.const 200))
+(assert_return (invoke "if_bit64" (i64.const 1) (i64.const 33)) (i64.const 200))
+(assert_return (invoke "if_bit64" (i64.const 1) (i64.const 0)) (i64.const 100))
+(assert_return (invoke "if_bit64" (i64.const 1) (i64.const 64)) (i64.const 100))
+(assert_return (invoke "if_bit64" (i64.const 0x100000) (i64.const 20)) (i64.const 100))
+(assert_return (invoke "if_bit64" (i64.const 0x100000) (i64.const 52)) (i64.const 200))
+(assert_return (invoke "if_bit64" (i64.const 0x100000) (i64.const 84)) (i64.const 100))


### PR DESCRIPTION
This commit builds on the previous refactorings to leverage the `bt` instruction on x64 which moves a specific bit into the CF bit of EFLAGS which can be useful for comparisons/branches/selects/etc.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
