### PR TITLE
Remove cargo command for building examples/hello.c

### DIFF
--- a/examples/hello.c
+++ b/examples/hello.c
@@ -2,22 +2,7 @@
 Example of instantiating of the WebAssembly module and invoking its exported
 function.
 
-You can compile and run this example on Linux with:
-
-   cargo build --release -p wasmtime-c-api
-   cmake -S examples -B examples/build
-   cc examples/hello.c \
-       -I examples/build/include \
-       target/release/libwasmtime.a \
-       -lpthread -ldl -lm \
-       -o hello
-   ./hello
-
-Note that on Windows and macOS the command will be similar, but you'll need
-to tweak the `-lpthread` and such annotations as well as the name of the
-`libwasmtime.a` file on Windows.
-
-You can also build using cmake:
+You can build using cmake:
 
 mkdir build && cd build && cmake .. && cmake --build . --target wasmtime-hello
 */

--- a/examples/hello.c
+++ b/examples/hello.c
@@ -5,8 +5,9 @@ function.
 You can compile and run this example on Linux with:
 
    cargo build --release -p wasmtime-c-api
+   cmake -S examples -B examples/build
    cc examples/hello.c \
-       -I crates/c-api/include \
+       -I examples/build/include \
        target/release/libwasmtime.a \
        -lpthread -ldl -lm \
        -o hello


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->

Related issue: https://github.com/bytecodealliance/wasmtime/issues/11117

This PR fixes the build error explained in the issue above. 
This removed the command with cargo and cc in [`examples/hello.c`](https://github.com/bytecodealliance/wasmtime/blob/main/examples/hello.c). This is because the cargo command invokes CMake internally[`crates/c-api/build.rs`](https://github.com/bytecodealliance/wasmtime/blob/main/crates/c-api/build.rs), and the [`README.md`](https://github.com/bytecodealliance/wasmtime/blob/main/examples/README.md) only specifies the CMake command.

If this is a good fix, I will apply the same fix to the other example C programs.

Thanks!