### PR TITLE
Add shuf and pshuf variants to the new assembler

### DIFF
--- a/cranelift/assembler-x64/meta/src/instructions/lanes.rs
+++ b/cranelift/assembler-x64/meta/src/instructions/lanes.rs
@@ -62,9 +62,15 @@ pub fn list() -> Vec<Inst> {
         inst("vblendvpd", fmt("RVMR", [w(xmm1), r(xmm2), r(xmm_m128), r(xmm3)]), vex(L128)._66()._0f3a().w0().op(0x4B).r().is4(), _64b | compat | avx),
 
         // Shuffle lanes in various ways.
+        inst("shufpd", fmt("A", [rw(xmm1), r(align(xmm_m128)), r(imm8)]), rex([0x66, 0x0F, 0xC6]).ib(), _64b | compat | sse2).alt(avx, "vshufpd_b"),
+        inst("vshufpd", fmt("B", [w(xmm1), r(xmm2), r(xmm_m128), r(imm8)]), vex(L128)._66()._0f().ib().op(0xC6), _64b | compat | avx),
+        inst("shufps", fmt("A", [rw(xmm1), r(align(xmm_m128)), r(imm8)]), rex([0x0F, 0xC6]).ib(), _64b | compat | sse).alt(avx, "vshufps_b"),
+        inst("vshufps", fmt("B", [w(xmm1), r(xmm2), r(xmm_m128), r(imm8)]), vex(L128)._0f().ib().op(0xC6), _64b | compat | avx),
+        inst("pshufb", fmt("A", [rw(xmm1), r(align(xmm_m128))]), rex([0x66, 0x0F, 0x38, 0x00]), _64b | compat | ssse3).alt(avx, "vpshufb_b"),
         inst("pshufd", fmt("A", [w(xmm1), r(align(xmm_m128)), r(imm8)]), rex([0x66, 0x0F, 0x70]).r().ib(), _64b | compat | sse2).alt(avx, "vpshufd_a"),
         inst("pshuflw", fmt("A", [w(xmm1), r(align(xmm_m128)), r(imm8)]), rex([0xF2, 0x0F, 0x70]).r().ib(), _64b | compat | sse2).alt(avx, "vpshuflw_a"),
         inst("pshufhw", fmt("A", [w(xmm1), r(align(xmm_m128)), r(imm8)]), rex([0xF3, 0x0F, 0x70]).r().ib(), _64b | compat | sse2).alt(avx, "vpshufhw_a"),
+        inst("vpshufb", fmt("B", [w(xmm1), r(xmm2), r(xmm_m128)]), vex(L128)._66()._0f38().op(0x00), _64b | compat | avx),
         inst("vpshufd", fmt("A", [w(xmm1), r(xmm_m128), r(imm8)]), vex(L128)._66()._0f().op(0x70).r().ib(), _64b | compat | avx),
         inst("vpshuflw", fmt("A", [w(xmm1), r(xmm_m128), r(imm8)]), vex(L128)._f2()._0f().op(0x70).r().ib(), _64b | compat | avx),
         inst("vpshufhw", fmt("A", [w(xmm1), r(xmm_m128), r(imm8)]), vex(L128)._f3()._0f().op(0x70).r().ib(), _64b | compat | avx),

--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -460,11 +460,7 @@
 (rule (operand_size_bits (OperandSize.Size32)) 32)
 (rule (operand_size_bits (OperandSize.Size64)) 64)
 
-(type SseOpcode extern
-      (enum Insertps
-            Pshufb
-            Shufps
-          ))
+(type SseOpcode extern (enum Insertps))
 
 (type RegMemImm extern
       (enum
@@ -2881,11 +2877,15 @@
 
 ;; Helper for creating `pshufb` instructions.
 (decl x64_pshufb (Xmm XmmMem) Xmm)
-(rule 0 (x64_pshufb src1 src2)
-      (xmm_rm_r (SseOpcode.Pshufb) src1 src2))
-(rule 1 (x64_pshufb src1 src2)
-      (if-let true (use_avx))
-      (xmm_rmir_vex (AvxOpcode.Vpshufb) src1 src2))
+(rule (x64_pshufb src1 src2) (x64_pshufb_a_or_avx src1 src2))
+
+;; Helper for creating `shufpd` instructions.
+(decl x64_shufpd (Xmm XmmMem u8) Xmm)
+(rule (x64_shufpd src1 src2 byte) (x64_shufpd_a_or_avx src1 src2 byte))
+
+;; Helper for creating `shufps` instructions.
+(decl x64_shufps (Xmm XmmMem u8) Xmm)
+(rule (x64_shufps src1 src2 byte) (x64_shufps_a_or_avx src1 src2 byte))
 
 ;; Helper for creating `pshuflw` instructions.
 (decl x64_pshuflw (XmmMem u8) Xmm)
@@ -2901,17 +2901,7 @@
       (if-let true (use_avx))
       (x64_vpshufhw_a src imm))
 
-;; Helper for creating `shufps` instructions.
-(decl x64_shufps (Xmm XmmMem u8) Xmm)
-(rule 0 (x64_shufps src1 src2 byte)
-      (xmm_rm_r_imm (SseOpcode.Shufps)
-                    src1
-                    src2
-                    byte
-                    (OperandSize.Size32)))
-(rule 1 (x64_shufps src1 src2 byte)
-      (if-let true (use_avx))
-      (xmm_rmr_imm_vex (AvxOpcode.Vshufps) src1 src2 byte))
+
 
 ;; Helper for creating `vcvtudq2ps` instructions.
 (decl x64_vcvtudq2ps (XmmMem) Xmm)

--- a/cranelift/filetests/filetests/isa/aarch64/nan-canonicalization.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/nan-canonicalization.clif
@@ -15,7 +15,7 @@ block0(v0: f32x4, v1: f32x4):
 ;   addps %xmm1, %xmm0
 ;   movl $0x7fc00000, %r10d
 ;   movd %r10d, %xmm7
-;   shufps  $0, %xmm7, const(0), %xmm7
+;   shufps $0x0, (%rip), %xmm7
 ;   movdqa %xmm0, %xmm1
 ;   cmpunordps %xmm0, %xmm1
 ;   movdqa %xmm0, %xmm2

--- a/cranelift/filetests/filetests/isa/x64/nan-canonicalization-sse41.clif
+++ b/cranelift/filetests/filetests/isa/x64/nan-canonicalization-sse41.clif
@@ -15,7 +15,7 @@ block0(v0: f32x4, v1: f32x4):
 ;   addps %xmm1, %xmm0
 ;   movl $0x7fc00000, %r10d
 ;   movd %r10d, %xmm7
-;   shufps  $0, %xmm7, const(0), %xmm7
+;   shufps $0x0, (%rip), %xmm7
 ;   movdqa %xmm0, %xmm1
 ;   cmpunordps %xmm0, %xmm1
 ;   movdqa %xmm0, %xmm2

--- a/cranelift/filetests/filetests/isa/x64/nan-canonicalization.clif
+++ b/cranelift/filetests/filetests/isa/x64/nan-canonicalization.clif
@@ -16,7 +16,7 @@ block0(v0: f32x4, v1: f32x4):
 ;   movdqa %xmm0, %xmm1
 ;   movl $0x7fc00000, %esi
 ;   movd %esi, %xmm5
-;   shufps  $0, %xmm5, const(0), %xmm5
+;   shufps $0x0, (%rip), %xmm5
 ;   cmpunordps %xmm1, %xmm0
 ;   andps %xmm0, %xmm5
 ;   andnps %xmm1, %xmm0

--- a/cranelift/filetests/filetests/isa/x64/shuffle.clif
+++ b/cranelift/filetests/filetests/isa/x64/shuffle.clif
@@ -204,7 +204,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block0:
-;   shufps  $94, %xmm0, %xmm1, %xmm0
+;   shufps $0x5e, %xmm1, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -344,7 +344,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block0:
-;   shufps  $251, %xmm0, %xmm1, %xmm0
+;   shufps $0xfb, %xmm1, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -374,7 +374,7 @@ block0(v0: i32x4, v1: i32x4):
 ; block0:
 ;   movdqa %xmm0, %xmm4
 ;   movdqa %xmm1, %xmm0
-;   shufps  $6, %xmm0, %xmm4, %xmm0
+;   shufps $0x6, %xmm4, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -627,7 +627,7 @@ block0(v0: i8x16, v1: i8x16):
 ; block0:
 ;   uninit  %xmm4
 ;   pxor %xmm4, %xmm4
-;   pshufb  %xmm0, %xmm4, %xmm0
+;   pshufb %xmm4, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq

--- a/cranelift/filetests/filetests/isa/x64/simd-arith-avx.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-arith-avx.clif
@@ -1312,7 +1312,7 @@ block0(v0: i8):
 ;   vmovd %edi, %xmm2
 ;   uninit  %xmm4
 ;   vpxor %xmm4, %xmm4, %xmm6
-;   vpshufb %xmm2, %xmm6, %xmm0
+;   vpshufb %xmm6, %xmm2, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -1347,7 +1347,7 @@ block0(v0: f64x2):
 ;   vminpd (%rip), %xmm6, %xmm0
 ;   vroundpd $0x3, %xmm0, %xmm2
 ;   vaddpd (%rip), %xmm2, %xmm5
-;   vshufps $136, %xmm5, %xmm4, %xmm0
+;   vshufps $0x88, %xmm4, %xmm5, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq

--- a/cranelift/filetests/filetests/isa/x64/simd-lane-access-compile.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-lane-access-compile.clif
@@ -18,8 +18,8 @@ block0:
 ;   uninit  %xmm0
 ;   pxor %xmm0, %xmm0
 ;   movdqu (%rip), %xmm3
-;   pshufb  %xmm0, const(0), %xmm0
-;   pshufb  %xmm3, const(1), %xmm3
+;   pshufb (%rip), %xmm0
+;   pshufb (%rip), %xmm3
 ;   por %xmm3, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -71,7 +71,7 @@ block0:
 ;   movq %rsp, %rbp
 ; block0:
 ;   movdqu (%rip), %xmm0
-;   pshufb  %xmm0, const(0), %xmm0
+;   pshufb (%rip), %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -121,7 +121,7 @@ block0:
 ;   movdqu (%rip), %xmm0
 ;   movdqu (%rip), %xmm1
 ;   paddusb (%rip), %xmm1
-;   pshufb  %xmm0, %xmm1, %xmm0
+;   pshufb %xmm1, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -160,7 +160,7 @@ block0(v0: i8):
 ;   movd %edi, %xmm0
 ;   uninit  %xmm5
 ;   pxor %xmm5, %xmm5
-;   pshufb  %xmm0, %xmm5, %xmm0
+;   pshufb %xmm5, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq

--- a/cranelift/filetests/filetests/isa/x64/simd-splat-avx.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-splat-avx.clif
@@ -14,7 +14,7 @@ block0(v0: i8):
 ;   vmovd %edi, %xmm2
 ;   uninit  %xmm4
 ;   vpxor %xmm4, %xmm4, %xmm6
-;   vpshufb %xmm2, %xmm6, %xmm0
+;   vpshufb %xmm6, %xmm2, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -124,7 +124,7 @@ block0(v0: f32):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block0:
-;   vshufps $0, %xmm0, %xmm0, %xmm0
+;   vshufps $0x0, %xmm0, %xmm0, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -179,7 +179,7 @@ block0(v0: i64):
 ;   vpinsrb $0x0, (%rdi), %xmm2, %xmm4
 ;   uninit  %xmm6
 ;   vpxor %xmm6, %xmm6, %xmm0
-;   vpshufb %xmm4, %xmm0, %xmm0
+;   vpshufb %xmm0, %xmm4, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq

--- a/cranelift/filetests/filetests/isa/x64/simd-splat.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-splat.clif
@@ -14,7 +14,7 @@ block0(v0: i8):
 ;   movd %edi, %xmm0
 ;   uninit  %xmm5
 ;   pxor %xmm5, %xmm5
-;   pshufb  %xmm0, %xmm5, %xmm0
+;   pshufb %xmm5, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -124,7 +124,7 @@ block0(v0: f32):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block0:
-;   shufps  $0, %xmm0, %xmm0, %xmm0
+;   shufps $0x0, %xmm0, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -179,7 +179,7 @@ block0(v0: i64):
 ;   pinsrb $0x0, (%rdi), %xmm0
 ;   uninit  %xmm7
 ;   pxor %xmm7, %xmm7
-;   pshufb  %xmm0, %xmm7, %xmm0
+;   pshufb %xmm7, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -239,7 +239,7 @@ block0(v0: i64):
 ;   movq %rsp, %rbp
 ; block0:
 ;   movss (%rdi), %xmm0
-;   shufps  $0, %xmm0, %xmm0, %xmm0
+;   shufps $0x0, %xmm0, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -293,7 +293,7 @@ block0(v0: i64):
 ;   movq %rsp, %rbp
 ; block0:
 ;   movss (%rdi), %xmm0
-;   shufps  $0, %xmm0, %xmm0, %xmm0
+;   shufps $0x0, %xmm0, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq

--- a/cranelift/filetests/filetests/isa/x64/uunarrow.clif
+++ b/cranelift/filetests/filetests/isa/x64/uunarrow.clif
@@ -19,7 +19,7 @@ block0(v0: f64x2):
 ;   minpd (%rip), %xmm0
 ;   roundpd $0x3, %xmm0, %xmm0
 ;   addpd (%rip), %xmm0
-;   shufps  $136, %xmm0, %xmm3, %xmm0
+;   shufps $0x88, %xmm3, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
