### PR TITLE
Add reciprocal instructions to new assembler

### DIFF
--- a/cranelift/assembler-x64/meta/src/instructions.rs
+++ b/cranelift/assembler-x64/meta/src/instructions.rs
@@ -22,6 +22,7 @@ mod nop;
 mod or;
 mod pack;
 mod pmadd;
+mod recip;
 mod round;
 mod setcc;
 mod shift;
@@ -59,6 +60,7 @@ pub fn list() -> Vec<Inst> {
     all.extend(or::list());
     all.extend(pack::list());
     all.extend(pmadd::list());
+    all.extend(recip::list());
     all.extend(round::list());
     all.extend(setcc::list());
     all.extend(shift::list());

--- a/cranelift/assembler-x64/meta/src/instructions/recip.rs
+++ b/cranelift/assembler-x64/meta/src/instructions/recip.rs
@@ -1,0 +1,17 @@
+use crate::dsl::{Feature::*, Inst, Location::*, VexLength::*};
+use crate::dsl::{align, fmt, inst, r, rex, vex, w};
+
+#[rustfmt::skip] // Keeps instructions on a single line.
+pub fn list() -> Vec<Inst> {
+    vec![
+        inst("rcpps", fmt("RM", [w(xmm1), r(align(xmm_m128))]), rex([0x0F, 0x53]).r(), _64b | compat | sse).alt(avx, "vrcpps_rm"),
+        inst("rcpss", fmt("RM", [w(xmm1), r(xmm_m32)]), rex([0xF3, 0x0F, 0x53]).r(), _64b | compat | sse),
+        inst("rsqrtps", fmt("RM", [w(xmm1), r(align(xmm_m128))]), rex([0x0F, 0x52]).r(), _64b | compat | sse).alt(avx, "vrsqrtps_rm"),
+        inst("rsqrtss", fmt("RM", [w(xmm1), r(xmm_m32)]), rex([0xF3, 0x0F, 0x52]).r(), _64b | compat | sse),
+
+        inst("vrcpps", fmt("RM", [w(xmm1), r(xmm_m128)]), vex(L128)._0f().op(0x53).r(), _64b | compat | avx),
+        inst("vrcpss", fmt("RVM", [w(xmm1), r(xmm2), r(xmm_m32)]), vex(LIG)._f3()._0f().op(0x53).r(), _64b | compat | avx),
+        inst("vrsqrtps", fmt("RM", [w(xmm1), r(xmm_m128)]), vex(L128)._0f().op(0x52).r(), _64b | compat | avx),
+        inst("vrsqrtss", fmt("RVM", [w(xmm1), r(xmm2), r(xmm_m32)]), vex(LIG)._f3()._0f().op(0x52).r(), _64b | compat | avx),
+       ]
+}

--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -464,8 +464,6 @@
       (enum Insertps
             Pshufb
             Ptest
-            Rcpss
-            Rsqrtss
             Shufps
           ))
 
@@ -3286,6 +3284,33 @@
 ;; Helper for creating `sqrtpd` instructions.
 (decl x64_sqrtpd (XmmMem) Xmm)
 (rule (x64_sqrtpd x) (x64_sqrtpd_a_or_avx x))
+
+;; Helper for creating `reciprocal` instructions.
+;;
+;; Helper for creating `rcpps` instructions.
+(decl x64_rcpps (XmmMem) Xmm)
+(rule (x64_rcpps x) (x64_rcpps_rm_or_avx x))
+
+;; Helper for creating `rcpss` instructions.
+(decl x64_rcpss (XmmMem) Xmm)
+(rule (x64_rcpss x) (x64_rcpss_rm x))
+
+;; Helper for creating `vrsqrtss` instructions.
+(decl x64_vrcpss (Xmm XmmMem) Xmm)
+(rule (x64_vrcpss x y) (x64_vrcpss_rvm x y))
+
+;; Helper for creating `rsqrtps` instructions.
+(decl x64_rsqrtps (XmmMem) Xmm)
+(rule (x64_rsqrtps x) (x64_rsqrtps_rm_or_avx x))
+
+;; Helper for creating `rsqrtss` instructions.
+(decl x64_rsqrtss (XmmMem) Xmm)
+(rule (x64_rsqrtss x) (x64_rsqrtss_rm x))
+
+;; Helper for creating `vrsqrtss` instructions.
+(decl x64_vrsqrtss (Xmm XmmMem) Xmm)
+(rule (x64_vrsqrtss x y) (x64_vrsqrtss_rvm x y))
+
 
 ;; Helper for creating `cvtss2sd` instructions.
 ;;


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
