### PR TITLE
Add ptest and vptest to the new assembler

### DIFF
--- a/cranelift/assembler-x64/meta/src/instructions/cmp.rs
+++ b/cranelift/assembler-x64/meta/src/instructions/cmp.rs
@@ -37,6 +37,9 @@ pub fn list() -> Vec<Inst> {
         inst("testw", fmt("MR", [r(rm16), r(r16)]).flags(W), rex([0x66, 0x85]), _64b | compat),
         inst("testl", fmt("MR", [r(rm32), r(r32)]).flags(W), rex([0x85]), _64b | compat),
         inst("testq", fmt("MR", [r(rm64), r(r64)]).flags(W), rex([0x85]).w(), _64b | compat),
+        // `AND` xmm and set flags.
+        inst("ptest", fmt("RM", [r(xmm1), r(align(xmm_m128))]).flags(W), rex([0x66, 0x0F, 0x38, 0x17]).r(), _64b | compat | sse41).alt(avx, "vptest_rm"),
+        inst("vptest", fmt("RM", [r(xmm1), r(xmm_m128)]).flags(W), vex(L128)._66()._0f38().op(0x17).r(), _64b | compat | avx),
         // Compare floating point and set flags.
         inst("ucomiss", fmt("A", [r(xmm1), r(xmm_m32)]).flags(W), rex([0x0F, 0x2E]).r(), _64b | compat | sse).alt(avx, "vucomiss_a"),
         inst("ucomisd", fmt("A", [r(xmm1), r(xmm_m64)]).flags(W), rex([0x66, 0x0F, 0x2E]).r(), _64b | compat | sse2).alt(avx, "vucomisd_a"),

--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -463,7 +463,6 @@
 (type SseOpcode extern
       (enum Insertps
             Pshufb
-            Ptest
             Shufps
           ))
 
@@ -2385,11 +2384,7 @@
 
 ;; Helper for creating `ptest` instructions.
 (decl x64_ptest (Xmm XmmMem) ProducesFlags)
-(rule (x64_ptest src1 src2)
-      (xmm_cmp_rm_r (SseOpcode.Ptest) src1 src2))
-(rule 1 (x64_ptest src1 src2)
-        (if-let true (use_avx))
-        (xmm_cmp_rm_r_vex (AvxOpcode.Vptest) src1 src2))
+(rule (x64_ptest src1 src2) (x64_ptest_rm_or_avx src1 src2))
 
 ;; Helper for creating `cmove` instructions. Note that these instructions do not
 ;; always result in a single emitted x86 instruction; e.g., XmmCmove uses jumps

--- a/cranelift/filetests/filetests/isa/x64/simd-logical-compile-avx.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-logical-compile-avx.clif
@@ -11,7 +11,7 @@ block0(v0: i32x4):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block0:
-;   vptest  %xmm0, %xmm0
+;   vptest %xmm0, %xmm0
 ;   setne %al
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -41,7 +41,7 @@ block0(v0: i64x2):
 ;   uninit  %xmm2
 ;   vpxor %xmm2, %xmm2, %xmm4
 ;   vpcmpeqq %xmm4, %xmm0, %xmm6
-;   vptest  %xmm6, %xmm6
+;   vptest %xmm6, %xmm6
 ;   sete %al
 ;   movq %rbp, %rsp
 ;   popq %rbp

--- a/cranelift/filetests/filetests/isa/x64/simd-logical-compile.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-logical-compile.clif
@@ -39,7 +39,7 @@ block0(v0: i32x4):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block0:
-;   ptest   %xmm0, %xmm0
+;   ptest %xmm0, %xmm0
 ;   setne %al
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -69,7 +69,7 @@ block0(v0: i64x2):
 ;   uninit  %xmm3
 ;   pxor %xmm3, %xmm3
 ;   pcmpeqq %xmm3, %xmm0
-;   ptest   %xmm0, %xmm0
+;   ptest %xmm0, %xmm0
 ;   sete %al
 ;   movq %rbp, %rsp
 ;   popq %rbp


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
