### PR TITLE
Remove the check for ':' when setting authority in wasi-http.

### DIFF
--- a/crates/test-programs/src/bin/http_outbound_request_response_build.rs
+++ b/crates/test-programs/src/bin/http_outbound_request_response_build.rs
@@ -48,9 +48,7 @@ fn main() {
                 .is_err()
         );
 
-        assert!(req.set_authority(Some("bad-port:99999")).is_err());
         assert!(req.set_authority(Some("bad-\nhost")).is_err());
-        assert!(req.set_authority(Some("too-many-ports:80:80:80")).is_err());
 
         assert!(
             req.set_scheme(Some(&http_types::Scheme::Other("bad\nscheme".to_string())))

--- a/crates/test-programs/src/bin/http_outbound_request_response_build.rs
+++ b/crates/test-programs/src/bin/http_outbound_request_response_build.rs
@@ -49,6 +49,9 @@ fn main() {
         );
 
         assert!(req.set_authority(Some("bad-\nhost")).is_err());
+        // IPv6 addresses with and without a port should be allowed
+        assert!(req.set_authority(Some("[::]:443")).is_ok());
+        assert!(req.set_authority(Some("[::]")).is_ok());
 
         assert!(
             req.set_scheme(Some(&http_types::Scheme::Other("bad\nscheme".to_string())))

--- a/crates/wasi-http/src/types_impl.rs
+++ b/crates/wasi-http/src/types_impl.rs
@@ -511,12 +511,7 @@ where
         let req = self.table().get_mut(&request)?;
 
         if let Some(s) = authority.as_ref() {
-            let auth = match http::uri::Authority::from_str(s.as_str()) {
-                Ok(auth) => auth,
-                Err(_) => return Ok(Err(())),
-            };
-
-            if s.contains(':') && auth.port_u16().is_none() {
+            if let Err(_) = http::uri::Authority::from_str(s.as_str()) {
                 return Ok(Err(()));
             }
         }


### PR DESCRIPTION
Authorities can have `:` in them when they are IPV6 addresses. With the current check it is impossible to use ipv6 addresses as authorities for outgoing http requests. 

It's not clear to me why the check was added in the first place, so I might be missing something obvious here why the check is necessary. 
