### PR TITLE
Fix Typos in Comments and Documentation

### DIFF
--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -767,7 +767,7 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
         val: ir::Value,
         index_type: IndexType,
         // When it is a memory and the memory is using single-byte pages,
-        // we need to handle the tuncation differently. See comments below.
+        // we need to handle the truncation differently. See comments below.
         //
         // When it is a table, this should be set to false.
         single_byte_pages: bool,
@@ -3808,7 +3808,7 @@ fn index_type_to_ir_type(index_type: IndexType) -> ir::Type {
 #[cfg(feature = "stack-switching")]
 #[allow(
     dead_code,
-    reason = "Dummy function to supress more dead code warnings"
+    reason = "Dummy function to suppress more dead code warnings"
 )]
 pub fn use_stack_switching_libcalls() {
     let _ = BuiltinFunctions::cont_new;

--- a/crates/wasmtime/src/runtime/vm/component.rs
+++ b/crates/wasmtime/src/runtime/vm/component.rs
@@ -732,7 +732,7 @@ impl ComponentInstance {
     /// the `arg` specified.
     ///
     /// This function is used in conjunction with function calls to record,
-    /// after a fuction call completes, the optional ABI return value. This
+    /// after a function call completes, the optional ABI return value. This
     /// return value is cached within this instance for future use when the
     /// `post_return` Rust-API-level function is invoked.
     ///


### PR DESCRIPTION


## Description
This pull request corrects several minor typographical errors in comments and documentation across the codebase:
- Fixed spelling mistakes such as "tuncation" → "truncation", "supress" → "suppress", and "fuction" → "function".
- Improved clarity and consistency in code comments.

