### PR TITLE
Avoid cloning and dropping `Arc`s in `LocalMemory::vmmemory`

### DIFF
--- a/crates/wasmtime/src/runtime/trampoline/memory.rs
+++ b/crates/wasmtime/src/runtime/trampoline/memory.rs
@@ -82,6 +82,10 @@ impl RuntimeLinearMemory for LinearMemoryProxy {
     fn base(&self) -> MemoryBase {
         MemoryBase::new_raw(self.mem.as_ptr())
     }
+
+    fn base_non_null(&self) -> core::ptr::NonNull<u8> {
+        core::ptr::NonNull::new(self.mem.as_ptr()).unwrap()
+    }
 }
 
 #[derive(Clone)]

--- a/crates/wasmtime/src/runtime/trampoline/memory.rs
+++ b/crates/wasmtime/src/runtime/trampoline/memory.rs
@@ -83,8 +83,12 @@ impl RuntimeLinearMemory for LinearMemoryProxy {
         MemoryBase::new_raw(self.mem.as_ptr())
     }
 
-    fn base_non_null(&self) -> core::ptr::NonNull<u8> {
-        core::ptr::NonNull::new(self.mem.as_ptr()).unwrap()
+    fn vmmemory(&self) -> crate::vm::VMMemoryDefinition {
+        let base = core::ptr::NonNull::new(self.mem.as_ptr()).unwrap();
+        crate::vm::VMMemoryDefinition {
+            base: base.into(),
+            current_length: self.mem.byte_size().into(),
+        }
     }
 }
 

--- a/crates/wasmtime/src/runtime/vm/memory.rs
+++ b/crates/wasmtime/src/runtime/vm/memory.rs
@@ -169,13 +169,8 @@ pub trait RuntimeLinearMemory: Send + Sync {
     /// offset within it.
     fn base(&self) -> MemoryBase;
 
-    /// Returns a raw pointer to the base of this linear memory allocation.
-    ///
-    /// This is for use in scenarios where the caller does not need to hold a
-    /// strong reference to the underlying mmap (if any) and therefore does not
-    /// desire to pay the cost of creating and then dropping that strong mmap
-    /// reference (an `Arc` clone and drop).
-    fn base_non_null(&self) -> NonNull<u8>;
+    /// Get a `VMMemoryDefinition` for this linear memory.
+    fn vmmemory(&self) -> VMMemoryDefinition;
 
     /// Internal method for Wasmtime when used in conjunction with CoW images.
     /// This is used to inform the underlying memory that the size of memory has
@@ -710,14 +705,7 @@ impl LocalMemory {
     }
 
     pub fn vmmemory(&self) -> VMMemoryDefinition {
-        // NB: use `self.alloc.base_non_null()` instead of
-        // `self.alloc.base().as_non_null()` here to avoid cloning and
-        // dropping a strong mmap reference.
-        let base = self.alloc.base_non_null().into();
-        VMMemoryDefinition {
-            base,
-            current_length: self.alloc.byte_size().into(),
-        }
+        self.alloc.vmmemory()
     }
 
     pub fn byte_size(&self) -> usize {

--- a/crates/wasmtime/src/runtime/vm/memory.rs
+++ b/crates/wasmtime/src/runtime/vm/memory.rs
@@ -169,6 +169,14 @@ pub trait RuntimeLinearMemory: Send + Sync {
     /// offset within it.
     fn base(&self) -> MemoryBase;
 
+    /// Returns a raw pointer to the base of this linear memory allocation.
+    ///
+    /// This is for use in scenarios where the caller does not need to hold a
+    /// strong reference to the underlying mmap (if any) and therefore does not
+    /// desire to pay the cost of creating and then dropping that strong mmap
+    /// reference (an `Arc` clone and drop).
+    fn base_non_null(&self) -> NonNull<u8>;
+
     /// Internal method for Wasmtime when used in conjunction with CoW images.
     /// This is used to inform the underlying memory that the size of memory has
     /// changed.
@@ -702,8 +710,12 @@ impl LocalMemory {
     }
 
     pub fn vmmemory(&self) -> VMMemoryDefinition {
+        // NB: use `self.alloc.base_non_null()` instead of
+        // `self.alloc.base().as_non_null()` here to avoid cloning and
+        // dropping a strong mmap reference.
+        let base = self.alloc.base_non_null().into();
         VMMemoryDefinition {
-            base: self.alloc.base().as_non_null().into(),
+            base,
             current_length: self.alloc.byte_size().into(),
         }
     }

--- a/crates/wasmtime/src/runtime/vm/memory/malloc.rs
+++ b/crates/wasmtime/src/runtime/vm/memory/malloc.rs
@@ -84,8 +84,12 @@ impl RuntimeLinearMemory for MallocMemory {
         MemoryBase::Raw(self.base_ptr)
     }
 
-    fn base_non_null(&self) -> NonNull<u8> {
-        self.base_ptr.as_non_null()
+    fn vmmemory(&self) -> crate::vm::VMMemoryDefinition {
+        let base = self.base_ptr.as_non_null();
+        crate::vm::VMMemoryDefinition {
+            base: base.into(),
+            current_length: self.byte_len.into(),
+        }
     }
 }
 

--- a/crates/wasmtime/src/runtime/vm/memory/malloc.rs
+++ b/crates/wasmtime/src/runtime/vm/memory/malloc.rs
@@ -83,6 +83,10 @@ impl RuntimeLinearMemory for MallocMemory {
     fn base(&self) -> MemoryBase {
         MemoryBase::Raw(self.base_ptr)
     }
+
+    fn base_non_null(&self) -> NonNull<u8> {
+        self.base_ptr.as_non_null()
+    }
 }
 
 fn byte_size_to_element_len(byte_size: usize) -> usize {

--- a/crates/wasmtime/src/runtime/vm/memory/mmap.rs
+++ b/crates/wasmtime/src/runtime/vm/memory/mmap.rs
@@ -233,14 +233,19 @@ impl RuntimeLinearMemory for MmapMemory {
         )
     }
 
-    fn base_non_null(&self) -> core::ptr::NonNull<u8> {
+    fn vmmemory(&self) -> crate::vm::VMMemoryDefinition {
         let pre_guard_size = self.pre_guard_size.byte_count();
         assert!(pre_guard_size <= self.mmap.len());
         let pre_guard_size = isize::try_from(pre_guard_size).unwrap();
         let mmap = self.mmap.as_non_null();
-        unsafe {
+        let base = unsafe {
             // Safety: `pre_guard_size` is within the mmap allocation.
             mmap.offset(pre_guard_size)
+        };
+
+        crate::vm::VMMemoryDefinition {
+            base: base.into(),
+            current_length: self.len.into(),
         }
     }
 }

--- a/crates/wasmtime/src/runtime/vm/memory/mmap.rs
+++ b/crates/wasmtime/src/runtime/vm/memory/mmap.rs
@@ -232,4 +232,15 @@ impl RuntimeLinearMemory for MmapMemory {
                 .expect("pre_guard_size is in bounds"),
         )
     }
+
+    fn base_non_null(&self) -> core::ptr::NonNull<u8> {
+        let pre_guard_size = self.pre_guard_size.byte_count();
+        assert!(pre_guard_size <= self.mmap.len());
+        let pre_guard_size = isize::try_from(pre_guard_size).unwrap();
+        let mmap = self.mmap.as_non_null();
+        unsafe {
+            // Safety: `pre_guard_size` is within the mmap allocation.
+            mmap.offset(pre_guard_size)
+        }
+    }
 }

--- a/crates/wasmtime/src/runtime/vm/memory/static_.rs
+++ b/crates/wasmtime/src/runtime/vm/memory/static_.rs
@@ -75,4 +75,8 @@ impl RuntimeLinearMemory for StaticMemory {
     fn base(&self) -> MemoryBase {
         self.base.clone()
     }
+
+    fn base_non_null(&self) -> core::ptr::NonNull<u8> {
+        self.base.as_non_null()
+    }
 }

--- a/crates/wasmtime/src/runtime/vm/memory/static_.rs
+++ b/crates/wasmtime/src/runtime/vm/memory/static_.rs
@@ -76,7 +76,10 @@ impl RuntimeLinearMemory for StaticMemory {
         self.base.clone()
     }
 
-    fn base_non_null(&self) -> core::ptr::NonNull<u8> {
-        self.base.as_non_null()
+    fn vmmemory(&self) -> crate::vm::VMMemoryDefinition {
+        crate::vm::VMMemoryDefinition {
+            base: self.base.as_non_null().into(),
+            current_length: self.size.into(),
+        }
     }
 }


### PR DESCRIPTION
Getting the base pointer from the underlying `dyn RuntimeLinearMemory` involved getting a `MemoryBase` which is potentially an `MmapOffset` which itself contains an `Arc<Mmap>`, and we would then call `base.as_non_null()` to turn this into a raw pointer, and then we would drop the `MemoryBase` which ultimately drops the `Arc<Mmap>`. So that's an `Arc` clone and drop just to get a `VMMemoryDefinition`, which is just a pointer and a length, essentially a slice of the linear memory. And, among other places, we call `LocalMemory::vmmemory` to get the GC heap's memory base and bound every time we access a GC object from Rust (for example, during collections).

Altogether, this removes another 30% of runtime from the testcase in https://github.com/bytecodealliance/wasmtime/issues/11141

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
