### PR TITLE
x64: Migrate indirect jmp to the new assembler

### DIFF
--- a/cranelift/assembler-x64/meta/src/instructions.rs
+++ b/cranelift/assembler-x64/meta/src/instructions.rs
@@ -12,6 +12,7 @@ mod cmp;
 mod cvt;
 mod div;
 mod fma;
+mod jmp;
 mod lanes;
 mod max;
 mod min;
@@ -51,6 +52,7 @@ pub fn list() -> Vec<Inst> {
     all.extend(cvt::list());
     all.extend(div::list());
     all.extend(fma::list());
+    all.extend(jmp::list());
     all.extend(lanes::list());
     all.extend(max::list());
     all.extend(min::list());

--- a/cranelift/assembler-x64/meta/src/instructions/jmp.rs
+++ b/cranelift/assembler-x64/meta/src/instructions/jmp.rs
@@ -1,0 +1,9 @@
+use crate::dsl::{Customization::*, Feature::*, Inst, Location::*};
+use crate::dsl::{fmt, inst, r, rex};
+
+#[rustfmt::skip] // Keeps instructions on a single line.
+pub fn list() -> Vec<Inst> {
+    vec![
+        inst("jmpq", fmt("M", [r(rm64)]), rex([0xFF]).digit(4), _64b).custom(Display),
+    ]
+}

--- a/cranelift/assembler-x64/src/custom.rs
+++ b/cranelift/assembler-x64/src/custom.rs
@@ -579,6 +579,12 @@ pub mod display {
             GprMem::Mem(_) => write!(f, "{mnemonic} {reg}"),
         }
     }
+
+    pub fn jmpq_m<R: Registers>(f: &mut fmt::Formatter<'_>, jmp: &inst::jmpq_m<R>) -> fmt::Result {
+        let inst::jmpq_m { rm64 } = jmp;
+        let rm64 = rm64.to_string(Size::Quadword);
+        write!(f, "jmpq *{rm64}")
+    }
 }
 
 pub mod visit {

--- a/cranelift/codegen/src/isa/x64/encoding/rex.rs
+++ b/cranelift/codegen/src/isa/x64/encoding/rex.rs
@@ -66,23 +66,11 @@ impl RexFlags {
         Self(1)
     }
 
-    /// True if 64-bit operands are used.
-    #[inline(always)]
-    pub fn must_clear_w(&self) -> bool {
-        (self.0 & 1) != 0
-    }
-
     /// Require that the REX prefix is emitted.
     #[inline(always)]
     pub fn always_emit(&mut self) -> &mut Self {
         self.0 = self.0 | 2;
         self
-    }
-
-    /// True if the REX prefix must always be emitted.
-    #[inline(always)]
-    pub fn must_always_emit(&self) -> bool {
-        (self.0 & 2) != 0
     }
 
     /// Emit the rex prefix if the referenced register would require it for 8-bit operations.
@@ -93,38 +81,6 @@ impl RexFlags {
             self.always_emit();
         }
         self
-    }
-
-    /// Emit a binary instruction.
-    #[inline(always)]
-    pub fn emit_two_op<BS: ByteSink + ?Sized>(&self, sink: &mut BS, enc_g: u8, enc_e: u8) {
-        let w = if self.must_clear_w() { 0 } else { 1 };
-        let r = (enc_g >> 3) & 1;
-        let x = 0;
-        let b = (enc_e >> 3) & 1;
-        let rex = 0x40 | (w << 3) | (r << 2) | (x << 1) | b;
-        if rex != 0x40 || self.must_always_emit() {
-            sink.put1(rex);
-        }
-    }
-
-    /// Emit a ternary instruction.
-    #[inline(always)]
-    pub fn emit_three_op<BS: ByteSink + ?Sized>(
-        &self,
-        sink: &mut BS,
-        enc_g: u8,
-        enc_index: u8,
-        enc_base: u8,
-    ) {
-        let w = if self.must_clear_w() { 0 } else { 1 };
-        let r = (enc_g >> 3) & 1;
-        let x = (enc_index >> 3) & 1;
-        let b = (enc_base >> 3) & 1;
-        let rex = 0x40 | (w << 3) | (r << 2) | (x << 1) | b;
-        if rex != 0x40 || self.must_always_emit() {
-            sink.put1(rex);
-        }
     }
 }
 
@@ -199,28 +155,6 @@ pub enum LegacyPrefixes {
 }
 
 impl LegacyPrefixes {
-    /// Emit the legacy prefix as bytes (e.g. in REX instructions).
-    #[inline(always)]
-    pub(crate) fn emit<BS: ByteSink + ?Sized>(&self, sink: &mut BS) {
-        match self {
-            Self::_66 => sink.put1(0x66),
-            Self::_F0 => sink.put1(0xF0),
-            Self::_66F0 => {
-                // I don't think the order matters, but in any case, this is the same order that
-                // the GNU assembler uses.
-                sink.put1(0x66);
-                sink.put1(0xF0);
-            }
-            Self::_F2 => sink.put1(0xF2),
-            Self::_F3 => sink.put1(0xF3),
-            Self::_66F3 => {
-                sink.put1(0x66);
-                sink.put1(0xF3);
-            }
-            Self::None => (),
-        }
-    }
-
     /// Emit the legacy prefix as bits (e.g. for EVEX instructions).
     #[inline(always)]
     pub(crate) fn bits(&self) -> u8 {
@@ -240,87 +174,6 @@ impl Default for LegacyPrefixes {
     fn default() -> Self {
         Self::None
     }
-}
-
-/// This is the core 'emit' function for instructions that reference memory.
-///
-/// For an instruction that has as operands a reg encoding `enc_g` and a memory address `mem_e`,
-/// create and emit:
-/// - first the legacy prefixes, if any
-/// - then the REX prefix, if needed
-/// - then caller-supplied opcode byte(s) (`opcodes` and `num_opcodes`),
-/// - then the MOD/RM byte,
-/// - then optionally, a SIB byte,
-/// - and finally optionally an immediate that will be derived from the `mem_e` operand.
-///
-/// For most instructions up to and including SSE4.2, that will be the whole instruction: this is
-/// what we call "standard" instructions, and abbreviate "std" in the name here. VEX-prefixed
-/// instructions will require their own emitter functions.
-///
-/// This will also work for 32-bits x86 instructions, assuming no REX prefix is provided.
-///
-/// The opcodes are written bigendianly for the convenience of callers.  For example, if the opcode
-/// bytes to be emitted are, in this order, F3 0F 27, then the caller should pass `opcodes` ==
-/// 0xF3_0F_27 and `num_opcodes` == 3.
-///
-/// The register operand is represented here not as a `Reg` but as its hardware encoding, `enc_g`.
-/// `rex` can specify special handling for the REX prefix.  By default, the REX prefix will
-/// indicate a 64-bit operation and will be deleted if it is redundant (0x40).  Note that for a
-/// 64-bit operation, the REX prefix will normally never be redundant, since REX.W must be 1 to
-/// indicate a 64-bit operation.
-pub(crate) fn emit_std_enc_mem(
-    sink: &mut MachBuffer<Inst>,
-    prefixes: LegacyPrefixes,
-    opcodes: u32,
-    mut num_opcodes: usize,
-    enc_g: u8,
-    mem_e: &Amode,
-    rex: RexFlags,
-    bytes_at_end: u8,
-) {
-    // General comment for this function: the registers in `mem_e` must be
-    // 64-bit integer registers, because they are part of an address
-    // expression.  But `enc_g` can be derived from a register of any class.
-
-    if let Some(trap_code) = mem_e.get_flags().trap_code() {
-        sink.add_trap(trap_code);
-    }
-
-    prefixes.emit(sink);
-
-    // After prefixes, first emit the REX byte depending on the kind of
-    // addressing mode that's being used.
-    match *mem_e {
-        Amode::ImmReg { base, .. } => {
-            let enc_e = int_reg_enc(base);
-            rex.emit_two_op(sink, enc_g, enc_e);
-        }
-
-        Amode::ImmRegRegShift {
-            base: reg_base,
-            index: reg_index,
-            ..
-        } => {
-            let enc_base = int_reg_enc(*reg_base);
-            let enc_index = int_reg_enc(*reg_index);
-            rex.emit_three_op(sink, enc_g, enc_index, enc_base);
-        }
-
-        Amode::RipRelative { .. } => {
-            // note REX.B = 0.
-            rex.emit_two_op(sink, enc_g, 0);
-        }
-    }
-
-    // Now the opcode(s).  These include any other prefixes the caller
-    // hands to us.
-    while num_opcodes > 0 {
-        num_opcodes -= 1;
-        sink.put1(((opcodes >> (num_opcodes << 3)) & 0xFF) as u8);
-    }
-
-    // And finally encode the mod/rm bytes and all further information.
-    emit_modrm_sib_disp(sink, enc_g, mem_e, bytes_at_end, None)
 }
 
 pub(crate) fn emit_modrm_sib_disp(
@@ -477,39 +330,4 @@ impl Imm {
             Imm::Imm32(n) => sink.put4(*n as u32),
         }
     }
-}
-
-/// This is the core 'emit' function for instructions that do not reference memory.
-///
-/// This is conceptually the same as emit_modrm_sib_enc_ge, except it is for the case where the E
-/// operand is a register rather than memory.  Hence it is much simpler.
-pub(crate) fn emit_std_enc_enc<BS: ByteSink + ?Sized>(
-    sink: &mut BS,
-    prefixes: LegacyPrefixes,
-    opcodes: u32,
-    mut num_opcodes: usize,
-    enc_g: u8,
-    enc_e: u8,
-    rex: RexFlags,
-) {
-    // EncG and EncE can be derived from registers of any class, and they
-    // don't even have to be from the same class.  For example, for an
-    // integer-to-FP conversion insn, one might be RegClass::I64 and the other
-    // RegClass::V128.
-
-    // The legacy prefixes.
-    prefixes.emit(sink);
-
-    // The rex byte.
-    rex.emit_two_op(sink, enc_g, enc_e);
-
-    // All other prefixes and opcodes.
-    while num_opcodes > 0 {
-        num_opcodes -= 1;
-        sink.put1(((opcodes >> (num_opcodes << 3)) & 0xFF) as u8);
-    }
-
-    // Now the mod/rm byte.  The instruction we're generating doesn't access
-    // memory, so there is no SIB byte or immediate -- we're done.
-    sink.put1(encode_modrm(0b11, enc_g & 7, enc_e & 7));
 }

--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -196,9 +196,6 @@
                     (default_target MachLabel)
                     (targets BoxVecMachLabel))
 
-       ;; Indirect jump: jmpq (reg mem).
-       (JmpUnknown (target RegMem))
-
        ;; Traps if the condition code is set.
        (TrapIf (cc CC)
                (trap_code TrapCode))

--- a/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
@@ -223,35 +223,6 @@ fn test_x64_emit() {
     // JmpCondCompound isn't a real instruction
 
     // ========================================================
-    // JmpUnknown
-    insns.push((Inst::jmp_unknown(RegMem::reg(rbp)), "FFE5", "jmp     *%rbp"));
-    insns.push((
-        Inst::jmp_unknown(RegMem::reg(r11)),
-        "41FFE3",
-        "jmp     *%r11",
-    ));
-    insns.push((
-        Inst::jmp_unknown(RegMem::mem(Amode::imm_reg_reg_shift(
-            321,
-            Gpr::unwrap_new(rsi),
-            Gpr::unwrap_new(rcx),
-            3,
-        ))),
-        "FFA4CE41010000",
-        "jmp     *321(%rsi,%rcx,8)",
-    ));
-    insns.push((
-        Inst::jmp_unknown(RegMem::mem(Amode::imm_reg_reg_shift(
-            321,
-            Gpr::unwrap_new(r10),
-            Gpr::unwrap_new(rdx),
-            2,
-        ))),
-        "41FFA49241010000",
-        "jmp     *321(%r10,%rdx,4)",
-    ));
-
-    // ========================================================
     // XMM_RM_R: Integer Packed
 
     insns.push((

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -87,7 +87,6 @@ impl Inst {
             | Inst::WinchJmpIf { .. }
             | Inst::JmpKnown { .. }
             | Inst::JmpTableSeq { .. }
-            | Inst::JmpUnknown { .. }
             | Inst::LoadExtName { .. }
             | Inst::MovFromPReg { .. }
             | Inst::MovToPReg { .. }
@@ -309,11 +308,6 @@ impl Inst {
 
     pub(crate) fn jmp_known(dst: MachLabel) -> Inst {
         Inst::JmpKnown { dst }
-    }
-
-    pub(crate) fn jmp_unknown(target: RegMem) -> Inst {
-        target.assert_regclass_is(RegClass::Int);
-        Inst::JmpUnknown { target }
     }
 
     /// Choose which instruction to use for loading a register value from memory. For loads smaller
@@ -815,12 +809,6 @@ impl PrettyPrint for Inst {
                 format!("{op} {idx}, {tmp1}, {tmp2}")
             }
 
-            Inst::JmpUnknown { target } => {
-                let target = target.pretty_print(8);
-                let op = ljustify("jmp".to_string());
-                format!("{op} *{target}")
-            }
-
             Inst::TrapIf { cc, trap_code, .. } => {
                 format!("j{cc} #trap={trap_code}")
             }
@@ -1204,10 +1192,6 @@ fn x64_get_operands(inst: &mut Inst, collector: &mut impl OperandVisitor) {
             // tmp2 is only written after idx is read, so it doesn't need to be
             // an early def.
             collector.reg_def(tmp2);
-        }
-
-        Inst::JmpUnknown { target } => {
-            target.get_operands(collector);
         }
 
         Inst::LoadExtName { dst, .. } => {

--- a/cranelift/codegen/src/isa/x64/pcc.rs
+++ b/cranelift/codegen/src/isa/x64/pcc.rs
@@ -160,15 +160,6 @@ pub(crate) fn check(
             }
             RegMem::Reg { .. } => Ok(()),
         },
-        Inst::JmpUnknown {
-            target: ref dest, ..
-        } => match dest {
-            RegMem::Mem { addr } => {
-                check_load(ctx, None, addr, vcode, I64, 64)?;
-                Ok(())
-            }
-            RegMem::Reg { .. } => Ok(()),
-        },
 
         Inst::JmpTableSeq { tmp1, tmp2, .. } => {
             ensure_no_fact(vcode, tmp1.to_reg())?;


### PR DESCRIPTION
This migrates `JmpUnknown` from ISLE to the new assembler. Other jumps are going to be more complicated so they're deferred to later.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
