### PR TITLE
x64: Match capstone disassembling `callq 5`

### DIFF
--- a/cranelift/assembler-x64/src/custom.rs
+++ b/cranelift/assembler-x64/src/custom.rs
@@ -195,7 +195,12 @@ pub mod display {
 
     pub fn callq_d(f: &mut fmt::Formatter, inst: &inst::callq_d) -> fmt::Result {
         let inst::callq_d { imm32 } = inst;
-        write!(f, "callq {:#x}", i64::from(imm32.value()) + 5)
+        let displacement = i64::from(imm32.value()) + 5;
+        if displacement >= 0 && displacement < 10 {
+            write!(f, "callq {displacement:}")
+        } else {
+            write!(f, "callq {displacement:#x}")
+        }
     }
 
     pub fn callq_m<R: Registers>(f: &mut fmt::Formatter, inst: &inst::callq_m<R>) -> fmt::Result {

--- a/cranelift/assembler-x64/src/fuzz.rs
+++ b/cranelift/assembler-x64/src/fuzz.rs
@@ -380,4 +380,13 @@ mod test {
         // This will run the `roundtrip` fuzzer for one second. To repeatably
         // test a single input, append `.seed(0x<failing seed>)`.
     }
+
+    #[test]
+    fn callq() {
+        for i in -500..500 {
+            println!("immediate: {i}");
+            let inst = crate::inst::callq_d::new(i);
+            roundtrip(&inst.into());
+        }
+    }
 }


### PR DESCRIPTION
Apparently Capstone doesn't print a hexadecimal number for targets between 0 and 10. Unclear, but match it to prevent the fuzzer from tripping over this.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
