### PR TITLE
Fixed bugs in the C thread example program and updated some comments for build command.

### DIFF
--- a/examples/anyref.c
+++ b/examples/anyref.c
@@ -1,22 +1,7 @@
 /*
 Example of using `anyref` values.
 
-You can compile and run this example on Linux with:
-
-   cargo build --release -p wasmtime-c-api
-   cc examples/anyref.c \
-       -I crates/c-api/include \
-       -I crates/c-api/wasm-c-api/include \
-       target/release/libwasmtime.a \
-       -lpthread -ldl -lm \
-       -o anyref
-   ./anyref
-
-Note that on Windows and macOS the command will be similar, but you'll need
-to tweak the `-lpthread` and such annotations as well as the name of the
-`libwasmtime.a` file on Windows.
-
-You can also build using cmake:
+You can build using cmake:
 
 mkdir build && cd build && cmake .. && \
   cmake --build . --target wasmtime-anyref

--- a/examples/externref.c
+++ b/examples/externref.c
@@ -1,22 +1,7 @@
 /*
 Example of using `externref` values.
 
-You can compile and run this example on Linux with:
-
-   cargo build --release -p wasmtime-c-api
-   cc examples/externref.c \
-       -I crates/c-api/include \
-       -I crates/c-api/wasm-c-api/include \
-       target/release/libwasmtime.a \
-       -lpthread -ldl -lm \
-       -o externref
-   ./externref
-
-Note that on Windows and macOS the command will be similar, but you'll need
-to tweak the `-lpthread` and such annotations as well as the name of the
-`libwasmtime.a` file on Windows.
-
-You can also build using cmake:
+You can build using cmake:
 
 mkdir build && cd build && cmake .. && \
   cmake --build . --target wasmtime-externref

--- a/examples/fuel.c
+++ b/examples/fuel.c
@@ -2,20 +2,7 @@
 Example of instantiating of the WebAssembly module and invoking its exported
 function.
 
-You can compile and run this example on Linux with:
-
-   cargo build --release -p wasmtime-c-api
-   cc examples/fuel.c \
-       -I crates/c-api/include \
-       target/release/libwasmtime.a \
-       -lpthread -ldl -lm \
-       -o fuel
-   ./fuel
-
-Note that on Windows and macOS the command will be similar, but you'll need
-to tweak the `-lpthread` and such annotations.
-
-You can also build using cmake:
+You can build using cmake:
 
 mkdir build && cd build && cmake .. && cmake --build . --target wasmtime-fuel
 */

--- a/examples/gcd.c
+++ b/examples/gcd.c
@@ -2,20 +2,7 @@
 Example of instantiating of the WebAssembly module and invoking its exported
 function.
 
-You can compile and run this example on Linux with:
-
-   cargo build --release -p wasmtime-c-api
-   cc examples/gcd.c \
-       -I crates/c-api/include \
-       target/release/libwasmtime.a \
-       -lpthread -ldl -lm \
-       -o gcd
-   ./gcd
-
-Note that on Windows and macOS the command will be similar, but you'll need
-to tweak the `-lpthread` and such annotations.
-
-You can also build using cmake:
+You can build using cmake:
 
 mkdir build && cd build && cmake .. && cmake --build . --target wasmtime-gcd
 */

--- a/examples/interrupt.c
+++ b/examples/interrupt.c
@@ -2,21 +2,7 @@
 Example of instantiating of the WebAssembly module and invoking its exported
 function.
 
-You can compile and run this example on Linux with:
-
-   cargo build --release -p wasmtime-c-api
-   cc examples/interrupt.c \
-       -I crates/c-api/include \
-       target/release/libwasmtime.a \
-       -lpthread -ldl -lm \
-       -o interrupt
-   ./interrupt
-
-Note that on Windows and macOS the command will be similar, but you'll need
-to tweak the `-lpthread` and such annotations as well as the name of the
-`libwasmtime.a` file on Windows.
-
-You can also build using cmake:
+You can build using cmake:
 
 mkdir build && cd build && cmake .. && \
   cmake --build . --target wasmtime-interrupt

--- a/examples/linking.c
+++ b/examples/linking.c
@@ -2,20 +2,7 @@
 Example of compiling, instantiating, and linking two WebAssembly modules
 together.
 
-You can compile and run this example on Linux with:
-
-   cargo build --release -p wasmtime-c-api
-   cc examples/linking.c \
-       -I crates/c-api/include \
-       target/release/libwasmtime.a \
-       -lpthread -ldl -lm \
-       -o linking
-   ./linking
-
-Note that on Windows and macOS the command will be similar, but you'll need
-to tweak the `-lpthread` and such annotations.
-
-You can also build using cmake:
+You can build using cmake:
 
 mkdir build && cd build && cmake .. && cmake --build . --target wasmtime-linking
 */

--- a/examples/memory.c
+++ b/examples/memory.c
@@ -2,20 +2,7 @@
 Example of instantiating of the WebAssembly module and invoking its exported
 function.
 
-You can compile and run this example on Linux with:
-
-   cargo build --release -p wasmtime-c-api
-   cc examples/memory.c \
-       -I crates/c-api/include \
-       target/release/libwasmtime.a \
-       -lpthread -ldl -lm \
-       -o memory
-   ./memory
-
-Note that on Windows and macOS the command will be similar, but you'll need
-to tweak the `-lpthread` and such annotations.
-
-You can also build using cmake:
+You can build using cmake:
 
 mkdir build && cd build && cmake .. && cmake --build . --target wasmtime-memory
 

--- a/examples/multi.c
+++ b/examples/multi.c
@@ -2,20 +2,7 @@
 Example of instantiating of the WebAssembly module and invoking its exported
 function.
 
-You can compile and run this example on Linux with:
-
-   cargo build --release -p wasmtime-c-api
-   cc examples/multi.c \
-       -I crates/c-api/include \
-       target/release/libwasmtime.a \
-       -lpthread -ldl -lm \
-       -o multi
-   ./multi
-
-Note that on Windows and macOS the command will be similar, but you'll need
-to tweak the `-lpthread` and such annotations.
-
-You can also build using cmake:
+You can build using cmake:
 
 mkdir build && cd build && cmake .. && cmake --build . --target wasmtime-multi
 

--- a/examples/multimemory.c
+++ b/examples/multimemory.c
@@ -1,20 +1,7 @@
 /*
 An example of how to interact with multiple memories.
 
-You can compile and run this example on Linux with:
-
-   cargo build --release -p wasmtime-c-api
-   cc examples/multimemory.c \
-       -I crates/c-api/include \
-       target/release/libwasmtime.a \
-       -lpthread -ldl -lm \
-       -o multimemory
-   ./multimemory
-
-Note that on Windows and macOS the command will be similar, but you'll need
-to tweak the `-lpthread` and such annotations.
-
-You can also build using cmake:
+You can build using cmake:
 
 mkdir build && cd build && cmake .. && \
   cmake --build . --target wasmtime-multimemory

--- a/examples/serialize.c
+++ b/examples/serialize.c
@@ -2,21 +2,7 @@
 Example of instantiating of the WebAssembly module and invoking its exported
 function.
 
-You can compile and run this example on Linux with:
-
-   cargo build --release -p wasmtime-c-api
-   cc examples/hello.c \
-       -I crates/c-api/include \
-       target/release/libwasmtime.a \
-       -lpthread -ldl -lm \
-       -o hello
-   ./hello
-
-Note that on Windows and macOS the command will be similar, but you'll need
-to tweak the `-lpthread` and such annotations as well as the name of the
-`libwasmtime.a` file on Windows.
-
-You can also build using cmake:
+You can build using cmake:
 
 mkdir build && cd build && cmake .. && \
   cmake --build . --target wasmtime-serialize

--- a/examples/threads.c
+++ b/examples/threads.c
@@ -27,6 +27,7 @@ const int N_THREADS = 10;
 const int N_REPS = 3;
 
 #if defined(__linux__)
+#define _GNU_SOURCE
 #include <sys/syscall.h>
 uint64_t get_thread_id() { return (uint64_t)syscall(SYS_gettid); }
 

--- a/examples/threads.c
+++ b/examples/threads.c
@@ -2,21 +2,7 @@
 Example of instantiating of the WebAssembly module and invoking its exported
 function in a separate thread.
 
-You can compile and run this example on Linux with:
-
-   cargo build --release -p wasmtime-c-api
-   cc examples/threads.c \
-       -I crates/c-api/include \
-       target/release/libwasmtime.a \
-       -lpthread -ldl -lm \
-       -o threads
-   ./threads
-
-Note that on Windows and macOS the command will be similar, but you'll need
-to tweak the `-lpthread` and such annotations as well as the name of the
-`libwasmtime.a` file on Windows.
-
-You can also build using cmake:
+You can build using cmake:
 
 mkdir build && cd build && cmake .. && cmake --build . --target wasmtime-threads
 */
@@ -40,10 +26,23 @@ static void exit_with_error(const char *message, wasmtime_error_t *error,
 const int N_THREADS = 10;
 const int N_REPS = 3;
 
+#if defined(__linux__)
+#include <sys/syscall.h>
+uint64_t get_thread_id() { return (uint64_t)syscall(SYS_gettid); }
+
+#elif defined(__APPLE__)
+#include <pthread.h>
+uint64_t get_thread_id() {
+  uint64_t tid;
+  pthread_threadid_np(NULL, &tid);
+  return tid;
+}
+
+#endif
+
 // A function to be called from Wasm code.
 own wasm_trap_t *callback(const wasm_val_vec_t *args, wasm_val_vec_t *results) {
-  assert(args->data[0].kind == WASM_I32);
-  printf("> Thread %d running\n", args->data[0].of.i32);
+  printf("> Thread %lu running\n", (uint64_t)get_thread_id());
   return NULL;
 }
 
@@ -65,21 +64,13 @@ void *run(void *args_abs) {
     usleep(100000);
 
     // Create imports.
-    own wasm_functype_t *func_type =
-        wasm_functype_new_1_0(wasm_valtype_new_i32());
+    own wasm_functype_t *func_type = wasm_functype_new_0_0();
     own wasm_func_t *func = wasm_func_new(store, func_type, callback);
     wasm_functype_delete(func_type);
-
-    wasm_val_t val = {.kind = WASM_I32, .of = {.i32 = (int32_t)args->id}};
-    own wasm_globaltype_t *global_type =
-        wasm_globaltype_new(wasm_valtype_new_i32(), WASM_CONST);
-    own wasm_global_t *global = wasm_global_new(store, global_type, &val);
-    wasm_globaltype_delete(global_type);
 
     // Instantiate.
     wasm_extern_t *imports[] = {
         wasm_func_as_extern(func),
-        wasm_global_as_extern(global),
     };
     wasm_extern_vec_t imports_vec = WASM_ARRAY_VEC(imports);
     own wasm_instance_t *instance =
@@ -90,7 +81,6 @@ void *run(void *args_abs) {
     }
 
     wasm_func_delete(func);
-    wasm_global_delete(global);
 
     // Extract export.
     own wasm_extern_vec_t exports;
@@ -173,7 +163,6 @@ int main(int argc, const char *argv[]) {
   pthread_t threads[N_THREADS];
   for (int i = 0; i < N_THREADS; i++) {
     thread_args *args = malloc(sizeof(thread_args));
-    args->id = i;
     args->engine = engine;
     args->module = shared;
     printf("Initializing thread %d...\n", i);


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->

This PR fixed the bug in [`examples/threads.c`](https://github.com/bytecodealliance/wasmtime/blob/main/examples/threads.c), and removed the cargo build command for all examples/*.c files in the same manner as https://github.com/bytecodealliance/wasmtime/pull/11132.

[`examples/threads.wat`](https://github.com/bytecodealliance/wasmtime/blob/main/examples/threads.wat) imports the `hello` function with no arguments, but in threads.c the imported function was defined to take one argument (i32 type). That occurred the error `> Error instantiating module!\n`, so I fixed the signature and updated it to output the thread ID.