### PR TITLE
Add new example that uses WIT resource

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1288,6 +1288,13 @@ name = "example-fib-debug-wasm"
 version = "0.0.0"
 
 [[package]]
+name = "example-resource-component-wasm"
+version = "0.1.0"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
 name = "example-tokio-wasm"
 version = "0.0.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -163,6 +163,7 @@ members = [
   "examples/wasm",
   "examples/tokio/wasm",
   "examples/component/wasm",
+  "examples/resource-component/wasm",
   "examples/min-platform",
   "examples/min-platform/embedding",
   "fuzz",

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -50,6 +50,7 @@ create_rust_wasm(tokio wasm32-wasip1)
 create_rust_wasm(wasi wasm32-wasip1)
 create_rust_wasm(wasi wasm32-wasip2)
 create_rust_wasm(component wasm32-unknown-unknown)
+create_rust_wasm(resource-component wasm32-wasip2)
 
 # C/C++ examples/tests
 create_target(anyref anyref.c)
@@ -96,3 +97,4 @@ create_rust_test(wasip2)
 create_rust_test(wasip2-async)
 create_rust_test(tokio wasi-common/tokio)
 create_rust_test(component)
+create_rust_test(resource-component)

--- a/examples/resource-component/kv-store.wit
+++ b/examples/resource-component/kv-store.wit
@@ -1,0 +1,17 @@
+package example:kv-store;
+
+interface kvdb {
+  resource connection {
+    constructor();
+    get: func(key: string) -> option<string>;
+    set: func(key: string, value: string);
+    remove: func(key: string) -> option<string>;
+    clear: func();
+  }
+}
+
+world kv-database {
+  import kvdb;
+  import log: func(msg: string);
+  export replace-value: func(key: string, value: string) -> option<string>;
+}

--- a/examples/resource-component/main.rs
+++ b/examples/resource-component/main.rs
@@ -1,0 +1,147 @@
+//! Example of instantiating a WASIp2 component with the use of resource
+
+/*
+You can execute this example with:
+    cmake examples/
+    cargo run --example resource-component
+*/
+
+use std::collections::HashMap;
+
+use wasmtime::component::{Component, Linker, ResourceTable};
+use wasmtime::{Config, Engine, Result, Store};
+use wasmtime_wasi::p2::add_to_linker_async;
+use wasmtime_wasi::p2::{IoView, WasiCtx, WasiCtxBuilder, WasiView};
+use wasmtime::component::bindgen;
+use wasmtime::component::{HasSelf, Resource};
+
+pub struct ComponentRunStates {
+    // These two are required basically as a standard way to enable the impl of IoView and
+    // WasiView.
+    // impl of WasiView is required by [`wasmtime_wasi::p2::add_to_linker_sync`]
+    pub wasi_ctx: WasiCtx,
+    pub resource_table: ResourceTable,
+    // You can add other custom host states if needed
+}
+
+impl IoView for ComponentRunStates {
+    fn table(&mut self) -> &mut ResourceTable {
+        &mut self.resource_table
+    }
+}
+impl WasiView for ComponentRunStates {
+    fn ctx(&mut self) -> &mut WasiCtx {
+        &mut self.wasi_ctx
+    }
+}
+
+impl ComponentRunStates {
+    pub fn new() -> Self {
+        // Create a WASI context and put it in a Store; all instances in the store
+        // share this context. `WasiCtxBuilder` provides a number of ways to
+        // configure what the target program will have access to.
+        ComponentRunStates {
+            wasi_ctx: WasiCtxBuilder::new().build(),
+            resource_table: ResourceTable::new(),
+        }
+    }
+}
+
+bindgen!({
+    path: "./examples/resource-component/kv-store.wit",
+    world: "kv-database",
+    async: true,
+    with: {
+        "example:kv-store/kvdb/connection": Connection
+    },
+    // Interactions with `ResourceTable` can possibly trap so enable the ability
+    // to return traps from generated functions.
+    trappable_imports: true,
+});
+
+pub struct Connection {
+    pub storage: HashMap<String, String>,
+}
+
+impl KvDatabaseImports for ComponentRunStates {
+    async fn log(&mut self, msg: String) -> Result<(), wasmtime::Error> {
+        // provide host function to the component
+        println!("Log: {}", msg);
+        Ok(())
+    }
+}
+
+impl example::kv_store::kvdb::Host for ComponentRunStates {}
+
+impl example::kv_store::kvdb::HostConnection for ComponentRunStates {
+    async fn new(&mut self) -> Result<Resource<Connection>, wasmtime::Error> {
+        Ok(self.resource_table.push(Connection {
+            storage: HashMap::new(),
+        })?)
+    }
+
+    async fn get(
+        &mut self,
+        resource: Resource<Connection>,
+        key: String,
+    ) -> Result<Option<String>, wasmtime::Error> {
+        let connection = self.resource_table.get(&resource)?;
+        Ok(connection.storage.get(&key).map(String::clone))
+    }
+
+    async fn set(
+        &mut self,
+        resource: Resource<Connection>,
+        key: String,
+        value: String,
+    ) -> Result<()> {
+        let connection = self.resource_table.get_mut(&resource)?;
+        connection.storage.insert(key, value);
+        Ok(())
+    }
+
+    async fn remove(
+        &mut self,
+        resource: Resource<Connection>,
+        key: String,
+    ) -> Result<Option<String>> {
+        let connection = self.resource_table.get_mut(&resource)?;
+        Ok(connection.storage.remove(&key))
+    }
+
+    async fn clear(&mut self, resource: Resource<Connection>) -> Result<(), wasmtime::Error> {
+        let large_string = self.resource_table.get_mut(&resource)?;
+        large_string.storage.clear();
+        Ok(())
+    }
+
+    async fn drop(&mut self, resource: Resource<Connection>) -> Result<()> {
+        let _ = self.resource_table.delete(resource)?;
+        Ok(())
+    }
+}
+
+
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Construct the wasm engine with async support enabled.
+    let mut config = Config::new();
+    config.async_support(true);
+    let engine = Engine::new(&config)?;
+    let mut linker = Linker::new(&engine);
+    let state = ComponentRunStates::new();
+    let mut store = Store::new(&engine, state);
+
+    KvDatabase::add_to_linker::<_, HasSelf<_>>(&mut linker, |s| s)?;
+    add_to_linker_async(&mut linker)?;
+
+    // Instantiate our component with the imports we've created, and run its function
+    let component = Component::from_file(&engine, "target/wasm32-wasip2/debug/guest_kvdb.wasm")?;
+    let bindings = KvDatabase::instantiate_async(&mut store, &component, &linker).await?;
+    let result = bindings.call_replace_value(&mut store, "hello", "world").await?;
+    assert_eq!(result, None);
+    let result = bindings.call_replace_value(&mut store, "hello", "wasmtime").await?;
+    assert_eq!(result, Some("world".to_string()));
+    Ok(())
+}

--- a/examples/resource-component/main.rs
+++ b/examples/resource-component/main.rs
@@ -8,12 +8,12 @@ You can execute this example with:
 
 use std::collections::HashMap;
 
+use wasmtime::component::bindgen;
 use wasmtime::component::{Component, Linker, ResourceTable};
+use wasmtime::component::{HasSelf, Resource};
 use wasmtime::{Config, Engine, Result, Store};
 use wasmtime_wasi::p2::add_to_linker_async;
 use wasmtime_wasi::p2::{IoView, WasiCtx, WasiCtxBuilder, WasiView};
-use wasmtime::component::bindgen;
-use wasmtime::component::{HasSelf, Resource};
 
 pub struct ComponentRunStates {
     // These two are required basically as a standard way to enable the impl of IoView and
@@ -121,8 +121,6 @@ impl example::kv_store::kvdb::HostConnection for ComponentRunStates {
     }
 }
 
-
-
 #[tokio::main]
 async fn main() -> Result<()> {
     // Construct the wasm engine with async support enabled.
@@ -139,9 +137,13 @@ async fn main() -> Result<()> {
     // Instantiate our component with the imports we've created, and run its function
     let component = Component::from_file(&engine, "target/wasm32-wasip2/debug/guest_kvdb.wasm")?;
     let bindings = KvDatabase::instantiate_async(&mut store, &component, &linker).await?;
-    let result = bindings.call_replace_value(&mut store, "hello", "world").await?;
+    let result = bindings
+        .call_replace_value(&mut store, "hello", "world")
+        .await?;
     assert_eq!(result, None);
-    let result = bindings.call_replace_value(&mut store, "hello", "wasmtime").await?;
+    let result = bindings
+        .call_replace_value(&mut store, "hello", "wasmtime")
+        .await?;
     assert_eq!(result, Some("world".to_string()));
     Ok(())
 }

--- a/examples/resource-component/main.rs
+++ b/examples/resource-component/main.rs
@@ -66,7 +66,7 @@ pub struct Connection {
 impl KvDatabaseImports for ComponentRunStates {
     async fn log(&mut self, msg: String) -> Result<(), wasmtime::Error> {
         // provide host function to the component
-        println!("Log: {}", msg);
+        println!("Log: {msg}");
         Ok(())
     }
 }
@@ -86,7 +86,7 @@ impl example::kv_store::kvdb::HostConnection for ComponentRunStates {
         key: String,
     ) -> Result<Option<String>, wasmtime::Error> {
         let connection = self.resource_table.get(&resource)?;
-        Ok(connection.storage.get(&key).map(String::clone))
+        Ok(connection.storage.get(&key).cloned())
     }
 
     async fn set(

--- a/examples/resource-component/wasm/Cargo.toml
+++ b/examples/resource-component/wasm/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "example-resource-component-wasm"
+version = "0.1.0"
+authors = ["The Wasmtime Project Developers"]
+edition = "2024"
+publish = false
+
+[dependencies]
+wit-bindgen = { workspace = true, default-features = true }
+
+[lib]
+path = "guest_kvdb.rs"
+name = "guest_kvdb"
+crate-type = ["cdylib"]

--- a/examples/resource-component/wasm/guest_kvdb.rs
+++ b/examples/resource-component/wasm/guest_kvdb.rs
@@ -6,7 +6,7 @@ wit_bindgen::generate!({
 use crate::example::kv_store::kvdb::Connection;
 use std::sync::LazyLock;
 
-static KV_CONNECTION: LazyLock<Connection> = LazyLock::new(|| Connection::new());
+static KV_CONNECTION: LazyLock<Connection> = LazyLock::new(Connection::new);
 
 struct KVStore;
 

--- a/examples/resource-component/wasm/guest_kvdb.rs
+++ b/examples/resource-component/wasm/guest_kvdb.rs
@@ -1,0 +1,23 @@
+wit_bindgen::generate!({
+    path: "..",
+    world: "kv-database",
+});
+
+use crate::example::kv_store::kvdb::Connection;
+use std::sync::LazyLock;
+
+static KV_CONNECTION: LazyLock<Connection> = LazyLock::new(|| Connection::new());
+
+struct KVStore;
+
+impl Guest for KVStore {
+    // implement the guest function
+    fn replace_value(key: String, value: String) -> Option<String> {
+        // replace
+        let old = KV_CONNECTION.get(&key);
+        KV_CONNECTION.set(&key, &value);
+        old
+    }
+}
+
+export!(KVStore);


### PR DESCRIPTION
This adds a new example, demonstrating how to use WIT resources. This also provides an example of how to use the new APIs introduced in #10770, see the line
```
KvDatabase::add_to_linker::<_, HasSelf<_>>(&mut linker, |s| s)?;
```

Closes #11091