### PR TITLE
docs: fix typos

### DIFF
--- a/winch/codegen/src/codegen/context.rs
+++ b/winch/codegen/src/codegen/context.rs
@@ -691,7 +691,7 @@ impl<'a> CodeGenContext<'a, Emission> {
         // To:
         //  - Verify that `maybe_pop_results` popped exactly the right
         //    amount relative to the base offset.
-        //  - Accomodate for multi-branch cases (i.e., `br_table`) in which
+        //  - Accommodate for multi-branch cases (i.e., `br_table`) in which
         //    result handling happens only once and _could_ happen outside of
         //    `maybe_pop_results` callback.
         //
@@ -733,7 +733,7 @@ impl<'a> CodeGenContext<'a, Emission> {
         // results by emitting a [`MacroAssembler::memmove`]
         // instruction, prior to claiming any excess stack space.
         //
-        // Depening on the branch state, the compiler might enter in an
+        // Depending on the branch state, the compiler might enter in an
         // unreachable state; instead of immediately truncating the value stack
         // to the expected length of the destination branch, we let the
         // reachability analysis code decide what should happen with the length

--- a/winch/codegen/src/codegen/error.rs
+++ b/winch/codegen/src/codegen/error.rs
@@ -67,7 +67,7 @@ pub(crate) enum InternalError {
     /// Expects a specific state in the value stack.
     #[error("Unexpected value in value stack")]
     UnexpectedValueInValueStack,
-    /// A mismatch occured in the control frame state.
+    /// A mismatch occurred in the control frame state.
     #[error("Mismatch in control frame state")]
     ControlFrameStateMismatch,
     /// Expected a specific table element value.

--- a/winch/codegen/src/codegen/mod.rs
+++ b/winch/codegen/src/codegen/mod.rs
@@ -749,7 +749,7 @@ where
             // type since we want to check for overflow; even though the
             // offset and access size are guaranteed to be bounded by the heap
             // type, when added, if used with the wrong operand size, their
-            // result could be clamped, resulting in an erroneus overflow
+            // result could be clamped, resulting in an erroneous overflow
             // check.
             self.masm.checked_uadd(
                 writable!(index_offset_and_access_size),
@@ -850,7 +850,7 @@ where
                         // Similar to the dynamic heap case, even though the
                         // offset and access size are bound through the heap
                         // type, when added they can overflow, resulting in
-                        // an erroneus comparison, therfore we rely on the
+                        // an erroneous comparison, therfore we rely on the
                         // target pointer size.
                         ptr_size,
                     )?;

--- a/winch/codegen/src/isa/aarch64/abi.rs
+++ b/winch/codegen/src/isa/aarch64/abi.rs
@@ -18,7 +18,7 @@ pub(crate) struct Aarch64ABI;
 /// any callee-saved registers.
 ///
 /// Note that 16 bytes are used to save the shadow stack pointer register even
-/// though only 8 are needed. 16 is used for simplicitly to ensure that the
+/// though only 8 are needed. 16 is used for simplicity to ensure that the
 /// 16-byte alignment requirement for memory addressing is met at the function's
 /// prologue and epilogue.
 pub const SHADOW_STACK_POINTER_SLOT_SIZE: u8 = 16;


### PR DESCRIPTION
### Description

This PR corrects several minor typos in comments and documentation across the codebase. The changes are non-functional and purely textual to improve clarity and maintain a clean, professional codebase.

### Details

- Corrected misspellings such as:
  - `Accomodate` → `Accommodate`
  - `Depening` → `Depending`
  - `occured` → `occurred`
  - `erroneus` → `erroneous`
  - `simplicitly` → `simplicity`

These fixes help enhance readability and eliminate minor distractions during development and code reviews.

### Additional Info

No logic or functionality has been modified. All changes are restricted to comments or non-executable doc annotations.
