### PR TITLE
fix typos in Runtime VM Source Files

### DIFF
--- a/crates/wasmtime/src/runtime/vm/debug_builtins.rs
+++ b/crates/wasmtime/src/runtime/vm/debug_builtins.rs
@@ -8,7 +8,7 @@ use wasmtime_versioned_export_macros::versioned_export;
 
 static mut VMCTX_AND_MEMORY: (NonNull<VMContext>, usize) = (NonNull::dangling(), 0);
 
-// These implementatations are referenced from C code in "helpers.c". The symbols defined
+// These implementations are referenced from C code in "helpers.c". The symbols defined
 // there (prefixed by "wasmtime_") are the real 'public' interface used in the debug info.
 
 #[versioned_export]

--- a/crates/wasmtime/src/runtime/vm/libcalls.rs
+++ b/crates/wasmtime/src/runtime/vm/libcalls.rs
@@ -281,7 +281,7 @@ unsafe fn table_grow_cont_obj(
     mut instance: Pin<&mut Instance>,
     table_index: u32,
     delta: u64,
-    // The following two values together form the intitial Option<VMContObj>.
+    // The following two values together form the initial Option<VMContObj>.
     // A None value is indicated by the pointer being null.
     init_value_contref: *mut u8,
     init_value_revision: u64,

--- a/crates/wasmtime/src/runtime/vm/stack_switching.rs
+++ b/crates/wasmtime/src/runtime/vm/stack_switching.rs
@@ -204,7 +204,7 @@ pub struct VMContRef {
     /// that case, this points to the end of the stack chain (i.e., the
     /// continuation in the parent chain whose own `parent_chain` field is
     /// `VMStackChain::Absent`).
-    /// Note that this may be a pointer to iself (if the state is `Fresh`, this is always the case).
+    /// Note that this may be a pointer to itself (if the state is `Fresh`, this is always the case).
     pub last_ancestor: *mut VMContRef,
 
     /// Revision counter.
@@ -335,7 +335,7 @@ pub fn cont_new(
     // Now that the initial stack pointer was set by the initialization
     // function, use it to determine stack limit.
     let stack_pointer = contref.stack.control_context_stack_pointer();
-    // Same caveat regarding stack_limit here as descibed in
+    // Same caveat regarding stack_limit here as described in
     // `wasmtime::runtime::func::EntryStoreContext::enter_wasm`.
     let wasm_stack_limit = core::cmp::max(
         stack_pointer - store.engine().config().max_wasm_stack,


### PR DESCRIPTION


---



## Description
This pull request corrects several typographical errors in the following files:
- `debug_builtins.rs`
- `libcalls.rs`
- `stack_switching.rs`


---