### PR TITLE
Relax architecture assertions for v128

### DIFF
--- a/crates/wasmtime/src/runtime/v128.rs
+++ b/crates/wasmtime/src/runtime/v128.rs
@@ -1,8 +1,3 @@
-#![cfg_attr(
-    not(any(target_arch = "x86_64", target_arch = "aarch64")),
-    allow(unused_imports)
-)]
-
 use crate::store::{AutoAssertNoGc, StoreOpaque};
 use crate::{Result, ValRaw, ValType, WasmTy};
 use core::cmp::Ordering;
@@ -81,7 +76,6 @@ impl Ord for V128 {
 
 // Note that this trait is conditionally implemented which is intentional. See
 // the documentation above in the `cfg_if!` for why this is conditional.
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 unsafe impl WasmTy for V128 {
     #[inline]
     fn valtype() -> ValType {

--- a/tests/all/func.rs
+++ b/tests/all/func.rs
@@ -2003,7 +2003,6 @@ fn call_wasm_getting_subtype_func_return(config: &mut Config) -> anyhow::Result<
 
 #[wasmtime_test(wasm_features(simd), strategies(not(Winch)))]
 #[cfg_attr(miri, ignore)]
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 fn typed_v128(config: &mut Config) -> anyhow::Result<()> {
     let engine = Engine::new(&config)?;
     let mut store = Store::<()>::new(&engine, ());
@@ -2073,7 +2072,6 @@ fn typed_v128(config: &mut Config) -> anyhow::Result<()> {
 
 #[wasmtime_test(wasm_features(simd))]
 #[cfg_attr(miri, ignore)]
-#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 fn typed_v128_imports(config: &mut Config) -> anyhow::Result<()> {
     let engine = Engine::new(&config)?;
     let mut store = Store::<()>::new(&engine, ());


### PR DESCRIPTION
These were applicable when a native ABI was possible to be used for v128, but nowadays there's no need to limit it to x86_64 and aarch64 as it should work everywhere.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
