### PR TITLE
 Simplify some conditional testing logic for Winch 

### DIFF
--- a/crates/test-util/src/wast.rs
+++ b/crates/test-util/src/wast.rs
@@ -367,7 +367,7 @@ impl Compiler {
                         || config.threads();
                 }
 
-                false
+                true
             }
 
             Compiler::CraneliftPulley => {

--- a/tests/all/memory.rs
+++ b/tests/all/memory.rs
@@ -250,6 +250,7 @@ fn guards_present_pooling(config: &mut Config) -> Result<()> {
 #[wasmtime_test]
 #[cfg_attr(miri, ignore)]
 #[cfg_attr(asan, ignore)]
+#[cfg(target_arch = "x86_64")] // only platform with mpk
 fn guards_present_pooling_mpk(config: &mut Config) -> Result<()> {
     if !wasmtime::PoolingAllocationConfig::are_memory_protection_keys_available() {
         println!("skipping `guards_present_pooling_mpk` test; mpk is not supported");
@@ -676,8 +677,8 @@ fn shared_memory_wait_notify() -> Result<()> {
 #[wasmtime_test]
 #[cfg_attr(miri, ignore)]
 #[cfg(target_pointer_width = "64")] // requires large VM reservation
-fn init_with_negative_segment(_: &mut Config) -> Result<()> {
-    let engine = Engine::default();
+fn init_with_negative_segment(cfg: &mut Config) -> Result<()> {
+    let engine = Engine::new(cfg)?;
     let module = Module::new(
         &engine,
         r#"

--- a/tests/all/winch_engine_features.rs
+++ b/tests/all/winch_engine_features.rs
@@ -1,3 +1,7 @@
+// Skip entirely on unsupported architectures as different error messages will
+// be reported.
+#![cfg(target_arch = "x86_64")]
+
 use wasmtime::*;
 use wasmtime_test_macros::wasmtime_test;
 


### PR DESCRIPTION


Run all tests on all platforms in `#[wasmtime_test]` for Winch without
`#[cfg]` and use the result of `should_fail` to determine whether it
should fail or not (e.g. still expect failure on riscv64/s390x/etc).

