### PR TITLE
Cache the `VMMemoryDefinition` in the DRC collector

### DIFF
--- a/crates/wasmtime/src/runtime/vm/gc/gc_runtime.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/gc_runtime.rs
@@ -411,6 +411,7 @@ pub unsafe trait GcHeap: 'static + Send + Sync {
     fn vmmemory(&self) -> VMMemoryDefinition;
 
     /// Get a slice of the raw bytes of the GC heap.
+    #[inline]
     fn heap_slice(&self) -> &[u8] {
         let vmmemory = self.vmmemory();
         let ptr = vmmemory.base.as_ptr().cast_const();
@@ -419,6 +420,7 @@ pub unsafe trait GcHeap: 'static + Send + Sync {
     }
 
     /// Get a mutable slice of the raw bytes of the GC heap.
+    #[inline]
     fn heap_slice_mut(&mut self) -> &mut [u8] {
         let vmmemory = self.vmmemory();
         let ptr = vmmemory.base.as_ptr();

--- a/crates/wasmtime/src/runtime/vm/memory.rs
+++ b/crates/wasmtime/src/runtime/vm/memory.rs
@@ -432,6 +432,11 @@ impl Memory {
         }
     }
 
+    /// Is this a shared memory?
+    pub fn is_shared_memory(&self) -> bool {
+        matches!(self, Memory::Shared(_))
+    }
+
     /// If the [Memory] is a [SharedMemory], unwrap it and return a clone to
     /// that shared memory.
     pub fn as_shared_memory(&mut self) -> Option<&mut SharedMemory> {


### PR DESCRIPTION
Removes about 1/8th of the time spent in the test case in https://github.com/bytecodealliance/wasmtime/issues/11141 for me locally.

Fixes https://github.com/bytecodealliance/wasmtime/issues/11163