### PR TITLE
Cargo doc fixes

### DIFF
--- a/crates/wasi-http/src/lib.rs
+++ b/crates/wasi-http/src/lib.rs
@@ -94,6 +94,7 @@
 //!     // component that we have. This will make per-request instantiation
 //!     // much quicker.
 //!     let mut linker = Linker::new(&engine);
+//!     wasmtime_wasi::p2::add_to_linker_async(&mut linker)?;
 //!     wasmtime_wasi_http::add_to_linker_async(&mut linker)?;
 //!     let pre = ProxyPre::new(linker.instantiate_pre(&component)?)?;
 //!

--- a/crates/wasi-http/src/lib.rs
+++ b/crates/wasi-http/src/lib.rs
@@ -27,7 +27,7 @@
 //!
 //! All `bindgen!`-generated `Host` traits are implemented in terms of a
 //! [`WasiHttpView`] trait which provides basic access to [`WasiHttpCtx`],
-//! configuration for WASI HTTP, and a [`wasmtime_wasi::p2::ResourceTable`], the
+//! configuration for WASI HTTP, and a [`wasmtime_wasi::ResourceTable`], the
 //! state for all host-defined component model resources.
 //!
 //! The [`WasiHttpView`] trait additionally offers a few other configuration
@@ -55,7 +55,7 @@
 //!      no others. This is useful when working with
 //!      [`wasmtime_wasi::p2::add_to_linker_async`] for example.
 //!    * Add individual interfaces such as with the
-//!      [`bindings::http::outgoing_handler::add_to_linker_get_host`] function.
+//!      [`bindings::http::outgoing_handler::add_to_linker`] function.
 //! 3. Use [`ProxyPre`](bindings::ProxyPre) to pre-instantiate a component
 //!    before serving requests.
 //! 4. When serving requests use

--- a/crates/wasi-http/src/lib.rs
+++ b/crates/wasi-http/src/lib.rs
@@ -95,7 +95,7 @@
 //!     // much quicker.
 //!     let mut linker = Linker::new(&engine);
 //!     wasmtime_wasi::p2::add_to_linker_async(&mut linker)?;
-//!     wasmtime_wasi_http::add_to_linker_async(&mut linker)?;
+//!     wasmtime_wasi_http::add_only_http_to_linker_async(&mut linker)?;
 //!     let pre = ProxyPre::new(linker.instantiate_pre(&component)?)?;
 //!
 //!     // Prepare our server state and start listening for connections.

--- a/crates/wasi/src/preview1.rs
+++ b/crates/wasi/src/preview1.rs
@@ -677,7 +677,7 @@ enum FdWrite {
 /// This method will add WASIp1 functions to `linker`. Access to [`WasiP1Ctx`]
 /// is provided with `f` by projecting from the store-local state of `T` to
 /// [`WasiP1Ctx`]. The closure `f` is invoked every time a WASIp1 function is
-/// called to get access to [`WASIp1`] from `T`. The returned [`WasiP1Ctx`] is
+/// called to get access to [`WasiP1Ctx`] from `T`. The returned [`WasiP1Ctx`] is
 /// used to implement I/O and controls what each function will return.
 ///
 /// It's recommended that [`WasiP1Ctx`] is stored as a field in `T` or that `T =
@@ -751,7 +751,7 @@ pub fn add_to_linker_async<T: Send + 'static>(
 /// This method will add WASIp1 functions to `linker`. Access to [`WasiP1Ctx`]
 /// is provided with `f` by projecting from the store-local state of `T` to
 /// [`WasiP1Ctx`]. The closure `f` is invoked every time a WASIp1 function is
-/// called to get access to [`WASIp1`] from `T`. The returned [`WasiP1Ctx`] is
+/// called to get access to [`WasiP1Ctx`] from `T`. The returned [`WasiP1Ctx`] is
 /// used to implement I/O and controls what each function will return.
 ///
 /// It's recommended that [`WasiP1Ctx`] is stored as a field in `T` or that `T =


### PR DESCRIPTION
* wasmtime-wasi-http: fix docs missing wasmtime_wasi::p2::add_to_linker. This creates the equivelant of `wasmtime serve -Scli`, which is what most guests end up needing. reported in https://bytecodealliance.zulipchat.com/#narrow/channel/219900-wasi/topic/Help.3A.20Wasmtime's.20runner.20for.20WASI-HTTP.20p2.20guest/with/526609626
* fix cargo doc warnings in wasmtime-wasi-http
* fix cargo doc warnings in wasmtime-wasi