### PR TITLE
c-api: wasip2: Inherit stdin and stderr, append arguments

### DIFF
--- a/crates/c-api/include/wasmtime/wasip2.h
+++ b/crates/c-api/include/wasmtime/wasip2.h
@@ -47,6 +47,13 @@ WASM_API_EXTERN void
 wasmtime_wasip2_config_inherit_stderr(wasmtime_wasip2_config_t *config);
 
 /**
+ * \brief Appends a single argument to get passed to wasm.
+ */
+WASM_API_EXTERN void
+wasmtime_wasip2_config_arg(wasmtime_wasip2_config_t *config, const char *arg,
+                           size_t arg_len);
+
+/**
  * \brief Delete a #wasmtime_wasip2_config_t
  *
  * \note This is not needed if the config is passed to

--- a/crates/c-api/src/wasip2.rs
+++ b/crates/c-api/src/wasip2.rs
@@ -32,4 +32,15 @@ pub unsafe extern "C" fn wasmtime_wasip2_config_inherit_stderr(
 }
 
 #[unsafe(no_mangle)]
+pub unsafe extern "C" fn wasmtime_wasip2_config_arg(
+    config: &mut wasmtime_wasip2_config_t,
+    arg: *const u8,
+    arg_len: usize,
+) {
+    let arg = unsafe { std::slice::from_raw_parts(arg, arg_len) };
+    let arg = std::str::from_utf8(arg).expect("valid utf-8");
+    config.builder.arg(arg);
+}
+
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasmtime_wasip2_config_delete(_: Box<wasmtime_wasip2_config_t>) {}

--- a/crates/c-api/tests/wasip2.cc
+++ b/crates/c-api/tests/wasip2.cc
@@ -19,6 +19,7 @@ TEST(wasip2, smoke) {
   wasmtime_wasip2_config_inherit_stdin(cfg);
   wasmtime_wasip2_config_inherit_stdout(cfg);
   wasmtime_wasip2_config_inherit_stderr(cfg);
+  wasmtime_wasip2_config_arg(cfg, "hello", strlen("hello"));
   wasmtime_context_set_wasip2(context, cfg);
 
   wasmtime_component_t *component = nullptr;


### PR DESCRIPTION
Some more WASIP2 APIs that I needed while test embedding the C-API.

I've also been thinking that a in memory pipe for stdio would be very useful.
I see `wasmtime_wasi::p2::MemoryOutputPipe`, would it make sense to create C bindings for it? Also, does reading from the pipe remove the content from the pipe?

---
I'll also _try_ to get to the resource values at some point...