### PR TITLE
Bump Wasmtime to 36.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,7 +277,7 @@ dependencies = [
 
 [[package]]
 name = "byte-array-literals"
-version = "35.0.0"
+version = "36.0.0"
 
 [[package]]
 name = "byteorder"
@@ -663,7 +663,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift"
-version = "0.122.0"
+version = "0.123.0"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",
@@ -676,7 +676,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.122.0"
+version = "0.123.0"
 dependencies = [
  "arbitrary",
  "arbtest",
@@ -694,21 +694,21 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.122.0"
+version = "0.123.0"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.122.0"
+version = "0.123.0"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.122.0"
+version = "0.123.0"
 dependencies = [
  "arbitrary",
  "serde",
@@ -717,7 +717,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.122.0"
+version = "0.123.0"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -752,7 +752,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.122.0"
+version = "0.123.0"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -762,18 +762,18 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.122.0"
+version = "0.123.0"
 
 [[package]]
 name = "cranelift-control"
-version = "0.122.0"
+version = "0.123.0"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.122.0"
+version = "0.123.0"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.122.0"
+version = "0.123.0"
 dependencies = [
  "cranelift-codegen",
  "env_logger 0.11.5",
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-interpreter"
-version = "0.122.0"
+version = "0.123.0"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -851,7 +851,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.122.0"
+version = "0.123.0"
 dependencies = [
  "codespan-reporting",
  "log",
@@ -860,7 +860,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-jit"
-version = "0.122.0"
+version = "0.123.0"
 dependencies = [
  "anyhow",
  "cranelift",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-module"
-version = "0.122.0"
+version = "0.123.0"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -894,7 +894,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.122.0"
+version = "0.123.0"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -903,7 +903,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-object"
-version = "0.122.0"
+version = "0.123.0"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-reader"
-version = "0.122.0"
+version = "0.123.0"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -928,7 +928,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-serde"
-version = "0.122.0"
+version = "0.123.0"
 dependencies = [
  "clap",
  "cranelift-codegen",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.122.0"
+version = "0.123.0"
 
 [[package]]
 name = "cranelift-tools"
@@ -1192,7 +1192,7 @@ checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
 
 [[package]]
 name = "embedding"
-version = "35.0.0"
+version = "36.0.0"
 dependencies = [
  "anyhow",
  "dlmalloc",
@@ -2301,7 +2301,7 @@ dependencies = [
 
 [[package]]
 name = "min-platform-host"
-version = "35.0.0"
+version = "36.0.0"
 dependencies = [
  "anyhow",
  "libloading",
@@ -2734,7 +2734,7 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "35.0.0"
+version = "36.0.0"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -2758,7 +2758,7 @@ dependencies = [
 
 [[package]]
 name = "pulley-macros"
-version = "35.0.0"
+version = "36.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3932,7 +3932,7 @@ version = "0.1.0"
 
 [[package]]
 name = "verify-component-adapter"
-version = "35.0.0"
+version = "36.0.0"
 dependencies = [
  "anyhow",
  "wasmparser 0.235.0",
@@ -4000,7 +4000,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-common"
-version = "35.0.0"
+version = "36.0.0"
 dependencies = [
  "anyhow",
  "bitflags 2.6.0",
@@ -4039,7 +4039,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-preview1-component-adapter"
-version = "35.0.0"
+version = "36.0.0"
 dependencies = [
  "bitflags 2.6.0",
  "byte-array-literals",
@@ -4255,7 +4255,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "35.0.0"
+version = "36.0.0"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -4320,7 +4320,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-bench-api"
-version = "35.0.0"
+version = "36.0.0"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -4336,14 +4336,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-c-api"
-version = "35.0.0"
+version = "36.0.0"
 dependencies = [
  "wasmtime-c-api-impl",
 ]
 
 [[package]]
 name = "wasmtime-c-api-impl"
-version = "35.0.0"
+version = "36.0.0"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -4360,7 +4360,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli"
-version = "35.0.0"
+version = "36.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4434,7 +4434,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli-flags"
-version = "35.0.0"
+version = "36.0.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -4449,7 +4449,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "35.0.0"
+version = "36.0.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -4551,14 +4551,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-asm-macros"
-version = "35.0.0"
+version = "36.0.0"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "wasmtime-internal-c-api-macros"
-version = "35.0.0"
+version = "36.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4566,7 +4566,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cache"
-version = "35.0.0"
+version = "36.0.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -4587,7 +4587,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-macro"
-version = "35.0.0"
+version = "36.0.0"
 dependencies = [
  "anyhow",
  "component-macro-test-helpers",
@@ -4607,11 +4607,11 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-util"
-version = "35.0.0"
+version = "36.0.0"
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "35.0.0"
+version = "36.0.0"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4636,7 +4636,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-explorer"
-version = "35.0.0"
+version = "36.0.0"
 dependencies = [
  "anyhow",
  "capstone",
@@ -4651,7 +4651,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-fiber"
-version = "35.0.0"
+version = "36.0.0"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -4666,7 +4666,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-debug"
-version = "35.0.0"
+version = "36.0.0"
 dependencies = [
  "cc",
  "object",
@@ -4676,7 +4676,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "35.0.0"
+version = "36.0.0"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4686,18 +4686,18 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-math"
-version = "35.0.0"
+version = "36.0.0"
 dependencies = [
  "libm",
 ]
 
 [[package]]
 name = "wasmtime-internal-slab"
-version = "35.0.0"
+version = "36.0.0"
 
 [[package]]
 name = "wasmtime-internal-unwinder"
-version = "35.0.0"
+version = "36.0.0"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4708,7 +4708,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
-version = "35.0.0"
+version = "36.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4717,7 +4717,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-winch"
-version = "35.0.0"
+version = "36.0.0"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -4732,7 +4732,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-wit-bindgen"
-version = "35.0.0"
+version = "36.0.0"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -4742,7 +4742,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-wmemcheck"
-version = "35.0.0"
+version = "36.0.0"
 
 [[package]]
 name = "wasmtime-test-macros"
@@ -4757,7 +4757,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-test-util"
-version = "35.0.0"
+version = "36.0.0"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -4775,7 +4775,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "35.0.0"
+version = "36.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4809,7 +4809,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-config"
-version = "35.0.0"
+version = "36.0.0"
 dependencies = [
  "anyhow",
  "test-programs-artifacts",
@@ -4820,7 +4820,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-http"
-version = "35.0.0"
+version = "36.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4847,7 +4847,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-io"
-version = "35.0.0"
+version = "36.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4858,7 +4858,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-keyvalue"
-version = "35.0.0"
+version = "36.0.0"
 dependencies = [
  "anyhow",
  "test-programs-artifacts",
@@ -4869,7 +4869,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-nn"
-version = "35.0.0"
+version = "36.0.0"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -4890,7 +4890,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-threads"
-version = "35.0.0"
+version = "36.0.0"
 dependencies = [
  "anyhow",
  "log",
@@ -4902,7 +4902,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-tls"
-version = "35.0.0"
+version = "36.0.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4918,7 +4918,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-tls-nativetls"
-version = "35.0.0"
+version = "36.0.0"
 dependencies = [
  "anyhow",
  "futures",
@@ -4933,7 +4933,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wast"
-version = "35.0.0"
+version = "36.0.0"
 dependencies = [
  "anyhow",
  "log",
@@ -5007,7 +5007,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "35.0.0"
+version = "36.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5024,7 +5024,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "35.0.0"
+version = "36.0.0"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -5036,7 +5036,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "35.0.0"
+version = "36.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5091,7 +5091,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "35.0.0"
+version = "36.0.0"
 dependencies = [
  "anyhow",
  "cranelift-assembler-x64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -175,7 +175,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "35.0.0"
+version = "36.0.0"
 authors = ["The Wasmtime Project Developers"]
 edition = "2024"
 # Wasmtime's current policy is that this number can be no larger than the
@@ -227,19 +227,19 @@ redundant_field_names = 'warn'
 # tooling but aren't intended to be widely depended on.
 #
 # All of these crates are supported though in the sense that
-wasmtime = { path = "crates/wasmtime", version = "35.0.0", default-features = false }
-wasmtime-cli-flags = { path = "crates/cli-flags", version = "=35.0.0" }
-wasmtime-environ = { path = "crates/environ", version = "=35.0.0" }
-wasmtime-wasi = { path = "crates/wasi", version = "35.0.0", default-features = false }
-wasmtime-wasi-io = { path = "crates/wasi-io", version = "35.0.0", default-features = false }
-wasmtime-wasi-http = { path = "crates/wasi-http", version = "35.0.0", default-features = false }
-wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "35.0.0" }
-wasmtime-wasi-config = { path = "crates/wasi-config", version = "35.0.0" }
-wasmtime-wasi-keyvalue = { path = "crates/wasi-keyvalue", version = "35.0.0" }
-wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "35.0.0" }
-wasmtime-wasi-tls = { path = "crates/wasi-tls", version = "35.0.0" }
-wasmtime-wasi-tls-nativetls = { path = "crates/wasi-tls-nativetls", version = "35.0.0" }
-wasmtime-wast = { path = "crates/wast", version = "=35.0.0" }
+wasmtime = { path = "crates/wasmtime", version = "36.0.0", default-features = false }
+wasmtime-cli-flags = { path = "crates/cli-flags", version = "=36.0.0" }
+wasmtime-environ = { path = "crates/environ", version = "=36.0.0" }
+wasmtime-wasi = { path = "crates/wasi", version = "36.0.0", default-features = false }
+wasmtime-wasi-io = { path = "crates/wasi-io", version = "36.0.0", default-features = false }
+wasmtime-wasi-http = { path = "crates/wasi-http", version = "36.0.0", default-features = false }
+wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "36.0.0" }
+wasmtime-wasi-config = { path = "crates/wasi-config", version = "36.0.0" }
+wasmtime-wasi-keyvalue = { path = "crates/wasi-keyvalue", version = "36.0.0" }
+wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "36.0.0" }
+wasmtime-wasi-tls = { path = "crates/wasi-tls", version = "36.0.0" }
+wasmtime-wasi-tls-nativetls = { path = "crates/wasi-tls-nativetls", version = "36.0.0" }
+wasmtime-wast = { path = "crates/wast", version = "=36.0.0" }
 
 # Internal Wasmtime-specific crates.
 #
@@ -248,54 +248,54 @@ wasmtime-wast = { path = "crates/wast", version = "=35.0.0" }
 # that these are internal unsupported crates for external use. These exist as
 # part of the project organization of other public crates in Wasmtime and are
 # otherwise not supported in terms of CVEs for example.
-wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=35.0.0", package = 'wasmtime-internal-wmemcheck' }
-wasmtime-c-api-macros = { path = "crates/c-api-macros", version = "=35.0.0", package = 'wasmtime-internal-c-api-macros' }
-wasmtime-cache = { path = "crates/cache", version = "=35.0.0", package = 'wasmtime-internal-cache' }
-wasmtime-cranelift = { path = "crates/cranelift", version = "=35.0.0", package = 'wasmtime-internal-cranelift' }
-wasmtime-winch = { path = "crates/winch", version = "=35.0.0", package = 'wasmtime-internal-winch'  }
-wasmtime-explorer = { path = "crates/explorer", version = "=35.0.0", package = 'wasmtime-internal-explorer'  }
-wasmtime-fiber = { path = "crates/fiber", version = "=35.0.0", package = 'wasmtime-internal-fiber' }
-wasmtime-jit-debug = { path = "crates/jit-debug", version = "=35.0.0", package = 'wasmtime-internal-jit-debug' }
-wasmtime-component-util = { path = "crates/component-util", version = "=35.0.0", package = 'wasmtime-internal-component-util' }
-wasmtime-component-macro = { path = "crates/component-macro", version = "=35.0.0", package = 'wasmtime-internal-component-macro' }
-wasmtime-asm-macros = { path = "crates/asm-macros", version = "=35.0.0", package = 'wasmtime-internal-asm-macros' }
-wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=35.0.0", package = 'wasmtime-internal-versioned-export-macros' }
-wasmtime-slab = { path = "crates/slab", version = "=35.0.0", package = 'wasmtime-internal-slab' }
-wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=35.0.0", package = 'wasmtime-internal-jit-icache-coherence' }
-wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=35.0.0", package = 'wasmtime-internal-wit-bindgen' }
-wasmtime-math = { path = "crates/math", version = "=35.0.0", package = 'wasmtime-internal-math'  }
-wasmtime-unwinder = { path = "crates/unwinder", version = "=35.0.0", package = 'wasmtime-internal-unwinder' }
+wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=36.0.0", package = 'wasmtime-internal-wmemcheck' }
+wasmtime-c-api-macros = { path = "crates/c-api-macros", version = "=36.0.0", package = 'wasmtime-internal-c-api-macros' }
+wasmtime-cache = { path = "crates/cache", version = "=36.0.0", package = 'wasmtime-internal-cache' }
+wasmtime-cranelift = { path = "crates/cranelift", version = "=36.0.0", package = 'wasmtime-internal-cranelift' }
+wasmtime-winch = { path = "crates/winch", version = "=36.0.0", package = 'wasmtime-internal-winch'  }
+wasmtime-explorer = { path = "crates/explorer", version = "=36.0.0", package = 'wasmtime-internal-explorer'  }
+wasmtime-fiber = { path = "crates/fiber", version = "=36.0.0", package = 'wasmtime-internal-fiber' }
+wasmtime-jit-debug = { path = "crates/jit-debug", version = "=36.0.0", package = 'wasmtime-internal-jit-debug' }
+wasmtime-component-util = { path = "crates/component-util", version = "=36.0.0", package = 'wasmtime-internal-component-util' }
+wasmtime-component-macro = { path = "crates/component-macro", version = "=36.0.0", package = 'wasmtime-internal-component-macro' }
+wasmtime-asm-macros = { path = "crates/asm-macros", version = "=36.0.0", package = 'wasmtime-internal-asm-macros' }
+wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=36.0.0", package = 'wasmtime-internal-versioned-export-macros' }
+wasmtime-slab = { path = "crates/slab", version = "=36.0.0", package = 'wasmtime-internal-slab' }
+wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=36.0.0", package = 'wasmtime-internal-jit-icache-coherence' }
+wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=36.0.0", package = 'wasmtime-internal-wit-bindgen' }
+wasmtime-math = { path = "crates/math", version = "=36.0.0", package = 'wasmtime-internal-math'  }
+wasmtime-unwinder = { path = "crates/unwinder", version = "=36.0.0", package = 'wasmtime-internal-unwinder' }
 
 # Miscellaneous crates without a `wasmtime-*` prefix in their name but still
 # used in the `wasmtime-*` family of crates depending on various features/etc.
-wiggle = { path = "crates/wiggle", version = "=35.0.0", default-features = false }
-wiggle-macro = { path = "crates/wiggle/macro", version = "=35.0.0" }
-wiggle-generate = { path = "crates/wiggle/generate", version = "=35.0.0" }
-wasi-common = { path = "crates/wasi-common", version = "=35.0.0", default-features = false }
-pulley-interpreter = { path = 'pulley', version = "=35.0.0" }
-pulley-macros = { path = 'pulley/macros', version = "=35.0.0" }
+wiggle = { path = "crates/wiggle", version = "=36.0.0", default-features = false }
+wiggle-macro = { path = "crates/wiggle/macro", version = "=36.0.0" }
+wiggle-generate = { path = "crates/wiggle/generate", version = "=36.0.0" }
+wasi-common = { path = "crates/wasi-common", version = "=36.0.0", default-features = false }
+pulley-interpreter = { path = 'pulley', version = "=36.0.0" }
+pulley-macros = { path = 'pulley/macros', version = "=36.0.0" }
 
 # Cranelift crates in this workspace
-cranelift-assembler-x64 = { path = "cranelift/assembler-x64", version = "0.122.0" }
-cranelift-codegen = { path = "cranelift/codegen", version = "0.122.0", default-features = false, features = ["std", "unwind"] }
-cranelift-frontend = { path = "cranelift/frontend", version = "0.122.0" }
-cranelift-entity = { path = "cranelift/entity", version = "0.122.0" }
-cranelift-native = { path = "cranelift/native", version = "0.122.0" }
-cranelift-module = { path = "cranelift/module", version = "0.122.0" }
-cranelift-interpreter = { path = "cranelift/interpreter", version = "0.122.0" }
-cranelift-reader = { path = "cranelift/reader", version = "0.122.0" }
+cranelift-assembler-x64 = { path = "cranelift/assembler-x64", version = "0.123.0" }
+cranelift-codegen = { path = "cranelift/codegen", version = "0.123.0", default-features = false, features = ["std", "unwind"] }
+cranelift-frontend = { path = "cranelift/frontend", version = "0.123.0" }
+cranelift-entity = { path = "cranelift/entity", version = "0.123.0" }
+cranelift-native = { path = "cranelift/native", version = "0.123.0" }
+cranelift-module = { path = "cranelift/module", version = "0.123.0" }
+cranelift-interpreter = { path = "cranelift/interpreter", version = "0.123.0" }
+cranelift-reader = { path = "cranelift/reader", version = "0.123.0" }
 cranelift-filetests = { path = "cranelift/filetests" }
-cranelift-object = { path = "cranelift/object", version = "0.122.0" }
-cranelift-jit = { path = "cranelift/jit", version = "0.122.0" }
+cranelift-object = { path = "cranelift/object", version = "0.123.0" }
+cranelift-jit = { path = "cranelift/jit", version = "0.123.0" }
 cranelift-fuzzgen = { path = "cranelift/fuzzgen" }
-cranelift-bforest = { path = "cranelift/bforest", version = "0.122.0" }
-cranelift-bitset = { path = "cranelift/bitset", version = "0.122.0" }
-cranelift-control = { path = "cranelift/control", version = "0.122.0" }
-cranelift-srcgen = { path = "cranelift/srcgen", version = "0.122.0" }
-cranelift = { path = "cranelift/umbrella", version = "0.122.0" }
+cranelift-bforest = { path = "cranelift/bforest", version = "0.123.0" }
+cranelift-bitset = { path = "cranelift/bitset", version = "0.123.0" }
+cranelift-control = { path = "cranelift/control", version = "0.123.0" }
+cranelift-srcgen = { path = "cranelift/srcgen", version = "0.123.0" }
+cranelift = { path = "cranelift/umbrella", version = "0.123.0" }
 
 # Winch crates in this workspace.
-winch-codegen = { path = "winch/codegen", version = "=35.0.0" }
+winch-codegen = { path = "winch/codegen", version = "=36.0.0" }
 
 # Internal crates not published to crates.io used in testing, builds, etc
 wasi-preview1-component-adapter = { path = "crates/wasi-preview1-component-adapter" }

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,4 +1,4 @@
-## 35.0.0
+## 36.0.0
 
 Unreleased.
 
@@ -12,6 +12,7 @@ Release notes for previous releases of Wasmtime can be found on the respective
 release branches of the Wasmtime repository.
 
 <!-- ARCHIVE_START -->
+* [35.0.x](https://github.com/bytecodealliance/wasmtime/blob/release-35.0.0/RELEASES.md)
 * [34.0.x](https://github.com/bytecodealliance/wasmtime/blob/release-34.0.0/RELEASES.md)
 * [33.0.x](https://github.com/bytecodealliance/wasmtime/blob/release-33.0.0/RELEASES.md)
 * [32.0.x](https://github.com/bytecodealliance/wasmtime/blob/release-32.0.0/RELEASES.md)

--- a/cranelift/assembler-x64/Cargo.toml
+++ b/cranelift/assembler-x64/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-assembler-x64"
 description = "A Cranelift-specific x64 assembler"
-version = "0.122.0"
+version = "0.123.0"
 license = "Apache-2.0 WITH LLVM-exception"
 edition.workspace = true
 rust-version.workspace = true
@@ -16,7 +16,7 @@ arbtest = "0.3.1"
 capstone = { workspace = true }
 
 [build-dependencies]
-cranelift-assembler-x64-meta = { path = "meta", version = "0.122.0" }
+cranelift-assembler-x64-meta = { path = "meta", version = "0.123.0" }
 
 [lints]
 workspace = true

--- a/cranelift/assembler-x64/meta/Cargo.toml
+++ b/cranelift/assembler-x64/meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-assembler-x64-meta"
 description = "Generate a Cranelift-specific assembler for x64 instructions"
-version = "0.122.0"
+version = "0.123.0"
 license = "Apache-2.0 WITH LLVM-exception"
 edition.workspace = true
 rust-version.workspace = true

--- a/cranelift/bforest/Cargo.toml
+++ b/cranelift/bforest/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bforest"
-version = "0.122.0"
+version = "0.123.0"
 description = "A forest of B+-trees"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-bforest"

--- a/cranelift/bitset/Cargo.toml
+++ b/cranelift/bitset/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bitset"
-version = "0.122.0"
+version = "0.123.0"
 description = "Various bitset stuff for use inside Cranelift"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-bitset"

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen"
-version = "0.122.0"
+version = "0.123.0"
 description = "Low-level code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-codegen"
@@ -25,7 +25,7 @@ anyhow = { workspace = true, optional = true, features = ['std'] }
 bumpalo = "3"
 capstone = { workspace = true, optional = true }
 cranelift-assembler-x64 = { workspace = true }
-cranelift-codegen-shared = { path = "./shared", version = "0.122.0" }
+cranelift-codegen-shared = { path = "./shared", version = "0.123.0" }
 cranelift-entity = { workspace = true }
 cranelift-bforest = { workspace = true }
 cranelift-bitset = { workspace = true }
@@ -56,8 +56,8 @@ env_logger = { workspace = true }
 proptest = { workspace = true }
 
 [build-dependencies]
-cranelift-codegen-meta = { path = "meta", version = "0.122.0" }
-cranelift-isle = { path = "../isle/isle", version = "=0.122.0" }
+cranelift-codegen-meta = { path = "meta", version = "0.123.0" }
+cranelift-isle = { path = "../isle/isle", version = "=0.123.0" }
 
 [features]
 default = ["std", "unwind", "host-arch", "timing"]

--- a/cranelift/codegen/meta/Cargo.toml
+++ b/cranelift/codegen/meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-codegen-meta"
 authors = ["The Cranelift Project Developers"]
-version = "0.122.0"
+version = "0.123.0"
 description = "Metaprogram for cranelift-codegen code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
@@ -17,8 +17,8 @@ rustdoc-args = ["--document-private-items"]
 
 [dependencies]
 cranelift-srcgen = { workspace = true }
-cranelift-assembler-x64-meta = { path = "../../assembler-x64/meta", version = "0.122.0" }
-cranelift-codegen-shared = { path = "../shared", version = "0.122.0" }
+cranelift-assembler-x64-meta = { path = "../../assembler-x64/meta", version = "0.123.0" }
+cranelift-codegen-shared = { path = "../shared", version = "0.123.0" }
 pulley-interpreter = { workspace = true, optional = true }
 
 [features]

--- a/cranelift/codegen/shared/Cargo.toml
+++ b/cranelift/codegen/shared/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen-shared"
-version = "0.122.0"
+version = "0.123.0"
 description = "For code shared between cranelift-codegen-meta and cranelift-codegen"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/control/Cargo.toml
+++ b/cranelift/control/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-control"
-version = "0.122.0"
+version = "0.123.0"
 description = "White-box fuzz testing framework"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/entity/Cargo.toml
+++ b/cranelift/entity/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-entity"
-version = "0.122.0"
+version = "0.123.0"
 description = "Data structures using entity references as mapping keys"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-entity"

--- a/cranelift/frontend/Cargo.toml
+++ b/cranelift/frontend/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-frontend"
-version = "0.122.0"
+version = "0.123.0"
 description = "Cranelift IR builder helper"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-frontend"

--- a/cranelift/interpreter/Cargo.toml
+++ b/cranelift/interpreter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-interpreter"
-version = "0.122.0"
+version = "0.123.0"
 authors = ["The Cranelift Project Developers"]
 description = "Interpret Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/isle/isle/Cargo.toml
+++ b/cranelift/isle/isle/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 name = "cranelift-isle"
 readme = "../README.md"
 repository = "https://github.com/bytecodealliance/wasmtime/tree/main/cranelift/isle"
-version = "0.122.0"
+version = "0.123.0"
 
 [lints]
 workspace = true

--- a/cranelift/jit/Cargo.toml
+++ b/cranelift/jit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-jit"
-version = "0.122.0"
+version = "0.123.0"
 authors = ["The Cranelift Project Developers"]
 description = "A JIT library backed by Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/module/Cargo.toml
+++ b/cranelift/module/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-module"
-version = "0.122.0"
+version = "0.123.0"
 authors = ["The Cranelift Project Developers"]
 description = "Support for linking functions and data with Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/native/Cargo.toml
+++ b/cranelift/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-native"
-version = "0.122.0"
+version = "0.123.0"
 authors = ["The Cranelift Project Developers"]
 description = "Support for targeting the host with Cranelift"
 documentation = "https://docs.rs/cranelift-native"

--- a/cranelift/object/Cargo.toml
+++ b/cranelift/object/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-object"
-version = "0.122.0"
+version = "0.123.0"
 authors = ["The Cranelift Project Developers"]
 description = "Emit Cranelift output to native object files with `object`"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/reader/Cargo.toml
+++ b/cranelift/reader/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-reader"
-version = "0.122.0"
+version = "0.123.0"
 description = "Cranelift textual IR reader"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-reader"

--- a/cranelift/serde/Cargo.toml
+++ b/cranelift/serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-serde"
-version = "0.122.0"
+version = "0.123.0"
 authors = ["The Cranelift Project Developers"]
 description = "Serializer/Deserializer for Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/srcgen/Cargo.toml
+++ b/cranelift/srcgen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-srcgen"
-version = "0.122.0"
+version = "0.123.0"
 authors = ["The Wasmtime Project Developers"]
 description = "Helper functions for generating Rust and ISLE files"
 license = "Apache-2.0 WITH LLVM-exception"

--- a/cranelift/umbrella/Cargo.toml
+++ b/cranelift/umbrella/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift"
-version = "0.122.0"
+version = "0.123.0"
 description = "Umbrella for commonly-used cranelift crates"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift"

--- a/crates/c-api/include/wasmtime.h
+++ b/crates/c-api/include/wasmtime.h
@@ -213,11 +213,11 @@
 /**
  * \brief Wasmtime version string.
  */
-#define WASMTIME_VERSION "35.0.0"
+#define WASMTIME_VERSION "36.0.0"
 /**
  * \brief Wasmtime major version number.
  */
-#define WASMTIME_VERSION_MAJOR 35
+#define WASMTIME_VERSION_MAJOR 36
 /**
  * \brief Wasmtime minor version number.
  */

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -9,6 +9,10 @@ audited_as = "0.120.0"
 version = "0.122.0"
 audited_as = "0.120.0"
 
+[[unpublished.cranelift]]
+version = "0.123.0"
+audited_as = "0.121.1"
+
 [[unpublished.cranelift-assembler-x64]]
 version = "0.121.0"
 audited_as = "0.120.0"
@@ -16,6 +20,10 @@ audited_as = "0.120.0"
 [[unpublished.cranelift-assembler-x64]]
 version = "0.122.0"
 audited_as = "0.120.0"
+
+[[unpublished.cranelift-assembler-x64]]
+version = "0.123.0"
+audited_as = "0.121.1"
 
 [[unpublished.cranelift-assembler-x64-meta]]
 version = "0.121.0"
@@ -25,6 +33,10 @@ audited_as = "0.120.0"
 version = "0.122.0"
 audited_as = "0.120.0"
 
+[[unpublished.cranelift-assembler-x64-meta]]
+version = "0.123.0"
+audited_as = "0.121.1"
+
 [[unpublished.cranelift-bforest]]
 version = "0.121.0"
 audited_as = "0.120.0"
@@ -32,6 +44,10 @@ audited_as = "0.120.0"
 [[unpublished.cranelift-bforest]]
 version = "0.122.0"
 audited_as = "0.120.0"
+
+[[unpublished.cranelift-bforest]]
+version = "0.123.0"
+audited_as = "0.121.1"
 
 [[unpublished.cranelift-bitset]]
 version = "0.121.0"
@@ -41,6 +57,10 @@ audited_as = "0.120.0"
 version = "0.122.0"
 audited_as = "0.120.0"
 
+[[unpublished.cranelift-bitset]]
+version = "0.123.0"
+audited_as = "0.121.1"
+
 [[unpublished.cranelift-codegen]]
 version = "0.121.0"
 audited_as = "0.120.0"
@@ -48,6 +68,10 @@ audited_as = "0.120.0"
 [[unpublished.cranelift-codegen]]
 version = "0.122.0"
 audited_as = "0.120.0"
+
+[[unpublished.cranelift-codegen]]
+version = "0.123.0"
+audited_as = "0.121.1"
 
 [[unpublished.cranelift-codegen-meta]]
 version = "0.121.0"
@@ -57,6 +81,10 @@ audited_as = "0.120.0"
 version = "0.122.0"
 audited_as = "0.120.0"
 
+[[unpublished.cranelift-codegen-meta]]
+version = "0.123.0"
+audited_as = "0.121.1"
+
 [[unpublished.cranelift-codegen-shared]]
 version = "0.121.0"
 audited_as = "0.120.0"
@@ -64,6 +92,10 @@ audited_as = "0.120.0"
 [[unpublished.cranelift-codegen-shared]]
 version = "0.122.0"
 audited_as = "0.120.0"
+
+[[unpublished.cranelift-codegen-shared]]
+version = "0.123.0"
+audited_as = "0.121.1"
 
 [[unpublished.cranelift-control]]
 version = "0.121.0"
@@ -73,6 +105,10 @@ audited_as = "0.120.0"
 version = "0.122.0"
 audited_as = "0.120.0"
 
+[[unpublished.cranelift-control]]
+version = "0.123.0"
+audited_as = "0.121.1"
+
 [[unpublished.cranelift-entity]]
 version = "0.121.0"
 audited_as = "0.120.0"
@@ -80,6 +116,10 @@ audited_as = "0.120.0"
 [[unpublished.cranelift-entity]]
 version = "0.122.0"
 audited_as = "0.120.0"
+
+[[unpublished.cranelift-entity]]
+version = "0.123.0"
+audited_as = "0.121.1"
 
 [[unpublished.cranelift-frontend]]
 version = "0.121.0"
@@ -89,6 +129,10 @@ audited_as = "0.120.0"
 version = "0.122.0"
 audited_as = "0.120.0"
 
+[[unpublished.cranelift-frontend]]
+version = "0.123.0"
+audited_as = "0.121.1"
+
 [[unpublished.cranelift-interpreter]]
 version = "0.121.0"
 audited_as = "0.120.0"
@@ -96,6 +140,10 @@ audited_as = "0.120.0"
 [[unpublished.cranelift-interpreter]]
 version = "0.122.0"
 audited_as = "0.120.0"
+
+[[unpublished.cranelift-interpreter]]
+version = "0.123.0"
+audited_as = "0.121.1"
 
 [[unpublished.cranelift-isle]]
 version = "0.121.0"
@@ -105,6 +153,10 @@ audited_as = "0.120.0"
 version = "0.122.0"
 audited_as = "0.120.0"
 
+[[unpublished.cranelift-isle]]
+version = "0.123.0"
+audited_as = "0.121.1"
+
 [[unpublished.cranelift-jit]]
 version = "0.121.0"
 audited_as = "0.120.0"
@@ -112,6 +164,10 @@ audited_as = "0.120.0"
 [[unpublished.cranelift-jit]]
 version = "0.122.0"
 audited_as = "0.120.0"
+
+[[unpublished.cranelift-jit]]
+version = "0.123.0"
+audited_as = "0.121.1"
 
 [[unpublished.cranelift-module]]
 version = "0.121.0"
@@ -121,6 +177,10 @@ audited_as = "0.120.0"
 version = "0.122.0"
 audited_as = "0.120.0"
 
+[[unpublished.cranelift-module]]
+version = "0.123.0"
+audited_as = "0.121.1"
+
 [[unpublished.cranelift-native]]
 version = "0.121.0"
 audited_as = "0.120.0"
@@ -128,6 +188,10 @@ audited_as = "0.120.0"
 [[unpublished.cranelift-native]]
 version = "0.122.0"
 audited_as = "0.120.0"
+
+[[unpublished.cranelift-native]]
+version = "0.123.0"
+audited_as = "0.121.1"
 
 [[unpublished.cranelift-object]]
 version = "0.121.0"
@@ -137,6 +201,10 @@ audited_as = "0.120.0"
 version = "0.122.0"
 audited_as = "0.120.0"
 
+[[unpublished.cranelift-object]]
+version = "0.123.0"
+audited_as = "0.121.1"
+
 [[unpublished.cranelift-reader]]
 version = "0.121.0"
 audited_as = "0.120.0"
@@ -144,6 +212,10 @@ audited_as = "0.120.0"
 [[unpublished.cranelift-reader]]
 version = "0.122.0"
 audited_as = "0.120.0"
+
+[[unpublished.cranelift-reader]]
+version = "0.123.0"
+audited_as = "0.121.1"
 
 [[unpublished.cranelift-serde]]
 version = "0.121.0"
@@ -153,6 +225,10 @@ audited_as = "0.120.0"
 version = "0.122.0"
 audited_as = "0.120.0"
 
+[[unpublished.cranelift-serde]]
+version = "0.123.0"
+audited_as = "0.121.1"
+
 [[unpublished.cranelift-srcgen]]
 version = "0.121.0"
 audited_as = "0.120.0"
@@ -160,6 +236,10 @@ audited_as = "0.120.0"
 [[unpublished.cranelift-srcgen]]
 version = "0.122.0"
 audited_as = "0.120.0"
+
+[[unpublished.cranelift-srcgen]]
+version = "0.123.0"
+audited_as = "0.121.1"
 
 [[unpublished.pulley-interpreter]]
 version = "34.0.0"
@@ -168,11 +248,19 @@ audited_as = "33.0.0"
 [[unpublished.pulley-interpreter]]
 version = "35.0.0"
 audited_as = "33.0.0"
+
+[[unpublished.pulley-interpreter]]
+version = "36.0.0"
+audited_as = "34.0.1"
 
 [[unpublished.pulley-macros]]
 version = "35.0.0"
 audited_as = "34.0.0"
 
+[[unpublished.pulley-macros]]
+version = "36.0.0"
+audited_as = "34.0.1"
+
 [[unpublished.wasi-common]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -181,6 +269,10 @@ audited_as = "33.0.0"
 version = "35.0.0"
 audited_as = "33.0.0"
 
+[[unpublished.wasi-common]]
+version = "36.0.0"
+audited_as = "34.0.1"
+
 [[unpublished.wasmtime]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -188,6 +280,10 @@ audited_as = "33.0.0"
 [[unpublished.wasmtime]]
 version = "35.0.0"
 audited_as = "33.0.0"
+
+[[unpublished.wasmtime]]
+version = "36.0.0"
+audited_as = "34.0.1"
 
 [[unpublished.wasmtime-asm-macros]]
 version = "34.0.0"
@@ -213,6 +309,10 @@ audited_as = "33.0.0"
 version = "35.0.0"
 audited_as = "33.0.0"
 
+[[unpublished.wasmtime-cli]]
+version = "36.0.0"
+audited_as = "34.0.1"
+
 [[unpublished.wasmtime-cli-flags]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -220,6 +320,10 @@ audited_as = "33.0.0"
 [[unpublished.wasmtime-cli-flags]]
 version = "35.0.0"
 audited_as = "33.0.0"
+
+[[unpublished.wasmtime-cli-flags]]
+version = "36.0.0"
+audited_as = "34.0.1"
 
 [[unpublished.wasmtime-component-macro]]
 version = "34.0.0"
@@ -252,6 +356,10 @@ audited_as = "33.0.0"
 [[unpublished.wasmtime-environ]]
 version = "35.0.0"
 audited_as = "33.0.0"
+
+[[unpublished.wasmtime-environ]]
+version = "36.0.0"
+audited_as = "34.0.1"
 
 [[unpublished.wasmtime-explorer]]
 version = "34.0.0"
@@ -309,6 +417,10 @@ audited_as = "33.0.0"
 version = "35.0.0"
 audited_as = "33.0.0"
 
+[[unpublished.wasmtime-wasi]]
+version = "36.0.0"
+audited_as = "34.0.1"
+
 [[unpublished.wasmtime-wasi-config]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -316,6 +428,10 @@ audited_as = "33.0.0"
 [[unpublished.wasmtime-wasi-config]]
 version = "35.0.0"
 audited_as = "33.0.0"
+
+[[unpublished.wasmtime-wasi-config]]
+version = "36.0.0"
+audited_as = "34.0.1"
 
 [[unpublished.wasmtime-wasi-http]]
 version = "34.0.0"
@@ -325,6 +441,10 @@ audited_as = "33.0.0"
 version = "35.0.0"
 audited_as = "33.0.0"
 
+[[unpublished.wasmtime-wasi-http]]
+version = "36.0.0"
+audited_as = "34.0.1"
+
 [[unpublished.wasmtime-wasi-io]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -332,6 +452,10 @@ audited_as = "33.0.0"
 [[unpublished.wasmtime-wasi-io]]
 version = "35.0.0"
 audited_as = "33.0.0"
+
+[[unpublished.wasmtime-wasi-io]]
+version = "36.0.0"
+audited_as = "34.0.1"
 
 [[unpublished.wasmtime-wasi-keyvalue]]
 version = "34.0.0"
@@ -341,6 +465,10 @@ audited_as = "33.0.0"
 version = "35.0.0"
 audited_as = "33.0.0"
 
+[[unpublished.wasmtime-wasi-keyvalue]]
+version = "36.0.0"
+audited_as = "34.0.1"
+
 [[unpublished.wasmtime-wasi-nn]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -348,6 +476,10 @@ audited_as = "33.0.0"
 [[unpublished.wasmtime-wasi-nn]]
 version = "35.0.0"
 audited_as = "33.0.0"
+
+[[unpublished.wasmtime-wasi-nn]]
+version = "36.0.0"
+audited_as = "34.0.1"
 
 [[unpublished.wasmtime-wasi-threads]]
 version = "34.0.0"
@@ -357,6 +489,10 @@ audited_as = "33.0.0"
 version = "35.0.0"
 audited_as = "33.0.0"
 
+[[unpublished.wasmtime-wasi-threads]]
+version = "36.0.0"
+audited_as = "34.0.1"
+
 [[unpublished.wasmtime-wasi-tls]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -365,6 +501,10 @@ audited_as = "33.0.0"
 version = "35.0.0"
 audited_as = "33.0.0"
 
+[[unpublished.wasmtime-wasi-tls]]
+version = "36.0.0"
+audited_as = "34.0.1"
+
 [[unpublished.wasmtime-wast]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -372,6 +512,10 @@ audited_as = "33.0.0"
 [[unpublished.wasmtime-wast]]
 version = "35.0.0"
 audited_as = "33.0.0"
+
+[[unpublished.wasmtime-wast]]
+version = "36.0.0"
+audited_as = "34.0.1"
 
 [[unpublished.wasmtime-winch]]
 version = "34.0.0"
@@ -405,6 +549,10 @@ audited_as = "33.0.0"
 version = "35.0.0"
 audited_as = "33.0.0"
 
+[[unpublished.wiggle]]
+version = "36.0.0"
+audited_as = "34.0.1"
+
 [[unpublished.wiggle-generate]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -413,6 +561,10 @@ audited_as = "33.0.0"
 version = "35.0.0"
 audited_as = "33.0.0"
 
+[[unpublished.wiggle-generate]]
+version = "36.0.0"
+audited_as = "34.0.1"
+
 [[unpublished.wiggle-macro]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -420,6 +572,10 @@ audited_as = "33.0.0"
 [[unpublished.wiggle-macro]]
 version = "35.0.0"
 audited_as = "33.0.0"
+
+[[unpublished.wiggle-macro]]
+version = "36.0.0"
+audited_as = "34.0.1"
 
 [[unpublished.wiggle-test]]
 version = "0.0.0"
@@ -432,6 +588,10 @@ audited_as = "33.0.0"
 [[unpublished.winch-codegen]]
 version = "35.0.0"
 audited_as = "33.0.0"
+
+[[unpublished.winch-codegen]]
+version = "36.0.0"
+audited_as = "34.0.1"
 
 [[publisher.aho-corasick]]
 version = "1.0.2"
@@ -637,122 +797,122 @@ user-login = "jrmuizel"
 user-name = "Jeff Muizelaar"
 
 [[publisher.cranelift]]
-version = "0.120.0"
-when = "2025-05-20"
+version = "0.121.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-assembler-x64]]
-version = "0.120.0"
-when = "2025-05-20"
+version = "0.121.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-assembler-x64-meta]]
-version = "0.120.0"
-when = "2025-05-20"
+version = "0.121.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-bforest]]
-version = "0.120.0"
-when = "2025-05-20"
+version = "0.121.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-bitset]]
-version = "0.120.0"
-when = "2025-05-20"
+version = "0.121.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-codegen]]
-version = "0.120.0"
-when = "2025-05-20"
+version = "0.121.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-codegen-meta]]
-version = "0.120.0"
-when = "2025-05-20"
+version = "0.121.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-codegen-shared]]
-version = "0.120.0"
-when = "2025-05-20"
+version = "0.121.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-control]]
-version = "0.120.0"
-when = "2025-05-20"
+version = "0.121.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-entity]]
-version = "0.120.0"
-when = "2025-05-20"
+version = "0.121.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-frontend]]
-version = "0.120.0"
-when = "2025-05-20"
+version = "0.121.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-interpreter]]
-version = "0.120.0"
-when = "2025-05-20"
+version = "0.121.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-isle]]
-version = "0.120.0"
-when = "2025-05-20"
+version = "0.121.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-jit]]
-version = "0.120.0"
-when = "2025-05-20"
+version = "0.121.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-module]]
-version = "0.120.0"
-when = "2025-05-20"
+version = "0.121.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-native]]
-version = "0.120.0"
-when = "2025-05-20"
+version = "0.121.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-object]]
-version = "0.120.0"
-when = "2025-05-20"
+version = "0.121.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-reader]]
-version = "0.120.0"
-when = "2025-05-20"
+version = "0.121.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-serde]]
-version = "0.120.0"
-when = "2025-05-20"
+version = "0.121.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-srcgen]]
-version = "0.120.0"
-when = "2025-05-20"
+version = "0.121.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -960,14 +1120,14 @@ user-login = "dtolnay"
 user-name = "David Tolnay"
 
 [[publisher.pulley-interpreter]]
-version = "33.0.0"
-when = "2025-05-20"
+version = "34.0.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.pulley-macros]]
-version = "34.0.0"
-when = "2025-06-20"
+version = "34.0.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1238,8 +1398,8 @@ user-login = "sunfishcode"
 user-name = "Dan Gohman"
 
 [[publisher.wasi-common]]
-version = "33.0.0"
-when = "2025-05-20"
+version = "34.0.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1327,80 +1487,80 @@ user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime]]
-version = "33.0.0"
-when = "2025-05-20"
+version = "34.0.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-cli]]
-version = "33.0.0"
-when = "2025-05-20"
+version = "34.0.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-cli-flags]]
-version = "33.0.0"
-when = "2025-05-20"
+version = "34.0.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-environ]]
-version = "33.0.0"
-when = "2025-05-20"
+version = "34.0.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi]]
-version = "33.0.0"
-when = "2025-05-20"
+version = "34.0.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-config]]
-version = "33.0.0"
-when = "2025-05-20"
+version = "34.0.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-http]]
-version = "33.0.0"
-when = "2025-05-20"
+version = "34.0.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-io]]
-version = "33.0.0"
-when = "2025-05-20"
+version = "34.0.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-keyvalue]]
-version = "33.0.0"
-when = "2025-05-20"
+version = "34.0.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-nn]]
-version = "33.0.0"
-when = "2025-05-20"
+version = "34.0.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-threads]]
-version = "33.0.0"
-when = "2025-05-20"
+version = "34.0.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-tls]]
-version = "33.0.0"
-when = "2025-05-20"
+version = "34.0.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wast]]
-version = "33.0.0"
-when = "2025-05-20"
+version = "34.0.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1424,20 +1584,20 @@ user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
 [[publisher.wiggle]]
-version = "33.0.0"
-when = "2025-05-20"
+version = "34.0.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wiggle-generate]]
-version = "33.0.0"
-when = "2025-05-20"
+version = "34.0.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wiggle-macro]]
-version = "33.0.0"
-when = "2025-05-20"
+version = "34.0.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1456,8 +1616,8 @@ user-login = "BurntSushi"
 user-name = "Andrew Gallant"
 
 [[publisher.winch-codegen]]
-version = "33.0.0"
-when = "2025-05-20"
+version = "34.0.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 


### PR DESCRIPTION
This is an [automated pull request][process] from CI which indicates that the next [`release-35.0.0` branch][branch] has been created and the `main` branch is getting its version number bumped from 35.0.0 to 36.0.0.

Maintainers should take a moment to review the [release notes][RELEASES.md] for 35.0.0 and any updates should be made directly to the [release branch][branch].

Another automated PR will be made in roughly 2 weeks time when for the actual release itself.

If any issues arise on the `main` branch before the release is made then the issue should first be fixed on `main` and then backport to the `release-35.0.0` branch.

[RELEASES.md]: https://github.com/bytecodealliance/wasmtime/blob/release-35.0.0/RELEASES.md
[branch]: https://github.com/bytecodealliance/wasmtime/tree/release-35.0.0
[process]: https://docs.wasmtime.dev/contributing-release-process.html
