### PR TITLE
[Cranelift] add remainder numeric operators

### DIFF
--- a/cranelift/codegen/meta/src/gen_isle.rs
+++ b/cranelift/codegen/meta/src/gen_isle.rs
@@ -694,6 +694,16 @@ impl NumericOp<'_> {
                 body: r#"a.checked_div(b).unwrap_or_else(|| panic!("div failure: {a} / {b}"))"#,
                 ..binop.clone()
             },
+            NumericOp {
+                name: "checked_rem",
+                body: "a.checked_rem(b)",
+                ..partial_binop.clone()
+            },
+            NumericOp {
+                name: "rem",
+                body: r#"a.checked_rem(b).unwrap_or_else(|| panic!("rem failure: {a} % {b}"))"#,
+                ..binop.clone()
+            },
             // Bitwise operations.
             //
             // When applicable (e.g. shifts) we have checked, wrapping, and


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->

This add the missing remainder operations to ISLE.