### PR TITLE
Update macOS runners to `macos-15`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -613,7 +613,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-24.04, macos-14, windows-2025]
+        os: [ubuntu-24.04, macos-15, windows-2025]
 
     steps:
     - uses: actions/checkout@v4

--- a/ci/build-build-matrix.js
+++ b/ci/build-build-matrix.js
@@ -6,7 +6,7 @@
 
 const ubuntu = 'ubuntu-24.04';
 const windows = 'windows-2025';
-const macos = 'macos-14';
+const macos = 'macos-15';
 
 const array = [
   {

--- a/ci/build-test-matrix.js
+++ b/ci/build-test-matrix.js
@@ -17,7 +17,7 @@ const SINGLE_CRATE_BUCKETS = ["wasmtime", "wasmtime-cli", "wasmtime-wasi"];
 
 const ubuntu = 'ubuntu-24.04';
 const windows = 'windows-2025';
-const macos = 'macos-14';
+const macos = 'macos-15';
 
 // This is the small, fast-to-execute matrix we use for PRs before they enter
 // the merge queue. Same schema as `FULL_MATRIX`.


### PR DESCRIPTION
This updates to the latest runners on GitHub Actions. This shouldn't affect binary compatibility and is otherwise keeping up-to-date.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
