### PR TITLE
Enable `allow_attributes_without_reason`

### DIFF
--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -2281,17 +2281,16 @@ impl Config {
 
         match &self.allocation_strategy {
             InstanceAllocationStrategy::OnDemand => {
-                #[allow(unused_mut)]
-                let mut allocator = Box::new(OnDemandInstanceAllocator::new(
+                let mut _allocator = Box::new(OnDemandInstanceAllocator::new(
                     self.mem_creator.clone(),
                     stack_size,
                     stack_zeroing,
                 ));
                 #[cfg(feature = "async")]
                 if let Some(stack_creator) = &self.stack_creator {
-                    allocator.set_stack_creator(stack_creator.clone());
+                    _allocator.set_stack_creator(stack_creator.clone());
                 }
-                Ok(allocator)
+                Ok(_allocator)
             }
             #[cfg(feature = "pooling-allocator")]
             InstanceAllocationStrategy::Pooling(config) => {
@@ -2317,7 +2316,7 @@ impl Config {
         #[cfg(feature = "gc")]
         #[cfg_attr(
             not(any(feature = "gc-null", feature = "gc-drc")),
-            allow(unused_variables, unreachable_code)
+            expect(unreachable_code, reason = "definitions known to be dummy")
         )]
         {
             Ok(Some(match self.collector.try_not_auto()? {
@@ -3571,7 +3570,10 @@ fn detect_host_feature(feature: &str) -> Option<bool> {
         };
     }
 
-    #[allow(unreachable_code)]
+    #[allow(
+        unreachable_code,
+        reason = "reachable or not depending on if a target above matches"
+    )]
     {
         let _ = feature;
         return None;

--- a/crates/wasmtime/src/engine.rs
+++ b/crates/wasmtime/src/engine.rs
@@ -761,25 +761,6 @@ impl Engine {
         crate::compile::HashedEngineCompileEnv(self)
     }
 
-    /// Executes `f1` and `f2` in parallel if parallel compilation is enabled at
-    /// both runtime and compile time, otherwise runs them synchronously.
-    #[allow(dead_code)] // only used for the component-model feature right now
-    pub(crate) fn join_maybe_parallel<T, U>(
-        &self,
-        f1: impl FnOnce() -> T + Send,
-        f2: impl FnOnce() -> U + Send,
-    ) -> (T, U)
-    where
-        T: Send,
-        U: Send,
-    {
-        if self.config().parallel_compilation {
-            #[cfg(feature = "parallel-compilation")]
-            return rayon::join(f1, f2);
-        }
-        (f1(), f2())
-    }
-
     /// Returns the required alignment for a code image, if we
     /// allocate in a way that is not a system `mmap()` that naturally
     /// aligns it.

--- a/crates/wasmtime/src/lib.rs
+++ b/crates/wasmtime/src/lib.rs
@@ -284,7 +284,7 @@
 // here to get warnings in all configurations of Wasmtime.
 #![cfg_attr(
     any(not(feature = "runtime"), not(feature = "std")),
-    allow(dead_code, unused_imports)
+    expect(dead_code, unused_imports, reason = "list not burned down yet")
 )]
 // Allow broken links when the default features is disabled because most of our
 // documentation is written for the "one build" of the `main` branch which has
@@ -292,7 +292,6 @@
 // and will prevent the doc build from failing.
 #![cfg_attr(feature = "default", warn(rustdoc::broken_intra_doc_links))]
 #![no_std]
-#![expect(clippy::allow_attributes_without_reason, reason = "crate not migrated")]
 #![expect(unsafe_op_in_unsafe_fn, reason = "crate isn't migrated yet")]
 
 #[cfg(feature = "std")]
@@ -333,7 +332,7 @@ pub(crate) use hashbrown::{hash_map, hash_set};
 #[macro_export]
 macro_rules! map_maybe_uninit {
     ($maybe_uninit:ident $($field:tt)*) => ({
-        #[allow(unused_unsafe)]
+        #[allow(unused_unsafe, reason = "macro-generated code")]
         {
             unsafe {
                 use $crate::MaybeUninitExt;
@@ -391,7 +390,6 @@ mod sync_std;
 #[cfg(feature = "std")]
 use sync_std as sync;
 
-#[cfg_attr(feature = "std", allow(dead_code))]
 mod sync_nostd;
 #[cfg(not(feature = "std"))]
 use sync_nostd as sync;

--- a/crates/wasmtime/src/profiling_agent/jitdump.rs
+++ b/crates/wasmtime/src/profiling_agent/jitdump.rs
@@ -17,6 +17,7 @@ use object::elf;
 use std::process;
 use std::sync::Mutex;
 use target_lexicon::Architecture;
+use wasmtime_environ::Unsigned;
 use wasmtime_jit_debug::perf_jitdump::*;
 
 /// Interface for driving the creation of jitdump files
@@ -54,8 +55,7 @@ impl ProfilingAgent for JitDumpAgent {
         let mut jitdump_file = JITDUMP_FILE.lock().unwrap();
         let jitdump_file = jitdump_file.as_mut().unwrap();
         let timestamp = jitdump_file.get_time_stamp();
-        #[allow(trivial_numeric_casts)]
-        let tid = rustix::thread::gettid().as_raw_nonzero().get() as u32;
+        let tid = rustix::thread::gettid().as_raw_nonzero().get().unsigned();
         if let Err(err) = jitdump_file.dump_code_load_record(&name, code, timestamp, self.pid, tid)
         {
             println!("Jitdump: write_code_load_failed_record failed: {err:?}\n");

--- a/crates/wasmtime/src/runtime/component/bindgen_examples/mod.rs
+++ b/crates/wasmtime/src/runtime/component/bindgen_examples/mod.rs
@@ -40,7 +40,10 @@
 //! [`wit_parser::Resolve::push_dir`]: https://docs.rs/wit-parser/latest/wit_parser/struct.Resolve.html#method.push_dir
 //! [open an issue]: https://github.com/bytecodealliance/wasmtime/issues/new
 
-#![allow(missing_docs)]
+#![expect(
+    missing_docs,
+    reason = "bindgen-generated types known to not have docs"
+)]
 
 // This "hack" will shadow the `bindgen` macro in general and be inherited to
 // following modules by default. This enables documenting sources as-is while

--- a/crates/wasmtime/src/runtime/component/component.rs
+++ b/crates/wasmtime/src/runtime/component/component.rs
@@ -466,7 +466,7 @@ impl Component {
         &self.inner.static_modules[idx]
     }
 
-    #[cfg_attr(not(feature = "profiling"), allow(dead_code))]
+    #[cfg(feature = "profiling")]
     pub(crate) fn static_modules(&self) -> impl Iterator<Item = &Module> {
         self.inner.static_modules.values()
     }

--- a/crates/wasmtime/src/runtime/component/concurrent.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent.rs
@@ -25,7 +25,7 @@ pub(crate) use futures_and_streams::{
 
 mod futures_and_streams;
 
-#[allow(dead_code)]
+#[expect(dead_code, reason = "to be used soon")]
 pub enum Status {
     Starting = 0,
     Started = 1,

--- a/crates/wasmtime/src/runtime/component/func/options.rs
+++ b/crates/wasmtime/src/runtime/component/func/options.rs
@@ -49,7 +49,10 @@ pub struct Options {
     async_: bool,
 
     /// The callback for an async-lifted export, if specified.
-    #[cfg_attr(not(feature = "component-model-async"), expect(unused))]
+    #[cfg_attr(
+        not(feature = "component-model-async"),
+        expect(unused, reason = "to be used soon")
+    )]
     callback: Option<NonNull<VMFuncRef>>,
 }
 

--- a/crates/wasmtime/src/runtime/component/func/typed.rs
+++ b/crates/wasmtime/src/runtime/component/func/typed.rs
@@ -1006,7 +1006,7 @@ macro_rules! integers {
 
         unsafe impl Lower for $primitive {
             #[inline]
-            #[allow(trivial_numeric_casts)]
+            #[allow(trivial_numeric_casts, reason = "macro-generated code")]
             fn linear_lower_to_flat<T>(
                 &self,
                 _cx: &mut LowerContext<'_, T>,
@@ -1071,7 +1071,11 @@ macro_rules! integers {
 
         unsafe impl Lift for $primitive {
             #[inline]
-            #[allow(trivial_numeric_casts, clippy::cast_possible_truncation)]
+            #[allow(
+                trivial_numeric_casts,
+                clippy::cast_possible_truncation,
+                reason = "macro-generated code"
+            )]
             fn linear_lift_from_flat(_cx: &mut LiftContext<'_>, ty: InterfaceType, src: &Self::Lower) -> Result<Self> {
                 debug_assert!(matches!(ty, InterfaceType::$ty));
                 Ok(src.$get() as $primitive)
@@ -2645,7 +2649,7 @@ where
 ///
 /// Uses default type parameters to have fields be zero-sized and not present
 /// in memory for smaller tuple values.
-#[allow(non_snake_case)]
+#[expect(non_snake_case, reason = "more amenable to macro-generated code")]
 #[doc(hidden)]
 #[derive(Clone, Copy)]
 #[repr(C)]
@@ -2691,7 +2695,7 @@ pub struct TupleLower<
 
 macro_rules! impl_component_ty_for_tuples {
     ($n:tt $($t:ident)*) => {
-        #[allow(non_snake_case)]
+        #[allow(non_snake_case, reason = "macro-generated code")]
         unsafe impl<$($t,)*> ComponentType for ($($t,)*)
             where $($t: ComponentType),*
         {
@@ -2718,7 +2722,7 @@ macro_rules! impl_component_ty_for_tuples {
             }
         }
 
-        #[allow(non_snake_case)]
+        #[allow(non_snake_case, reason = "macro-generated code")]
         unsafe impl<$($t,)*> Lower for ($($t,)*)
             where $($t: Lower),*
         {
@@ -2762,7 +2766,7 @@ macro_rules! impl_component_ty_for_tuples {
             }
         }
 
-        #[allow(non_snake_case)]
+        #[allow(non_snake_case, reason = "macro-generated code")]
         unsafe impl<$($t,)*> Lift for ($($t,)*)
             where $($t: Lift),*
         {
@@ -2799,7 +2803,7 @@ macro_rules! impl_component_ty_for_tuples {
             }
         }
 
-        #[allow(non_snake_case)]
+        #[allow(non_snake_case, reason = "macro-generated code")]
         unsafe impl<$($t,)*> ComponentNamedList for ($($t,)*)
             where $($t: ComponentType),*
         {}

--- a/crates/wasmtime/src/runtime/component/mod.rs
+++ b/crates/wasmtime/src/runtime/component/mod.rs
@@ -97,8 +97,10 @@
 //!
 //! See the docs for [`bindgen!`] for more information on how to use it.
 
-// rustdoc appears to lie about a warning above, so squelch it for now.
-#![allow(rustdoc::redundant_explicit_links)]
+#![allow(
+    rustdoc::redundant_explicit_links,
+    reason = "rustdoc appears to lie about a warning above, so squelch it for now"
+)]
 
 mod component;
 #[cfg(feature = "component-model-async")]

--- a/crates/wasmtime/src/runtime/component/types.rs
+++ b/crates/wasmtime/src/runtime/component/types.rs
@@ -569,7 +569,7 @@ impl Eq for StreamType {}
 
 /// Represents a component model interface type
 #[derive(Clone, PartialEq, Eq, Debug)]
-#[allow(missing_docs)]
+#[expect(missing_docs, reason = "self-describing variants")]
 pub enum Type {
     Bool,
     S8,

--- a/crates/wasmtime/src/runtime/component/values.rs
+++ b/crates/wasmtime/src/runtime/component/values.rs
@@ -63,7 +63,7 @@ use wasmtime_environ::component::{
 ///
 /// [`Func::call`]: crate::component::Func::call
 #[derive(Debug, Clone)]
-#[allow(missing_docs)]
+#[expect(missing_docs, reason = "self-describing variants")]
 pub enum Val {
     Bool(bool),
     S8(i8),

--- a/crates/wasmtime/src/runtime/externals/global.rs
+++ b/crates/wasmtime/src/runtime/externals/global.rs
@@ -234,7 +234,6 @@ impl Global {
                 Val::ExternRef(e) => {
                     let new = match e {
                         None => None,
-                        #[cfg_attr(not(feature = "gc"), allow(unreachable_patterns))]
                         Some(e) => Some(e.try_gc_ref(&store)?.unchecked_copy()),
                     };
                     let new = new.as_ref();
@@ -243,7 +242,6 @@ impl Global {
                 Val::AnyRef(a) => {
                     let new = match a {
                         None => None,
-                        #[cfg_attr(not(feature = "gc"), allow(unreachable_patterns))]
                         Some(a) => Some(a.try_gc_ref(&store)?.unchecked_copy()),
                     };
                     let new = new.as_ref();

--- a/crates/wasmtime/src/runtime/externals/table.rs
+++ b/crates/wasmtime/src/runtime/externals/table.rs
@@ -179,7 +179,10 @@ impl Table {
                     Some(Ref::null(self._ty(&store).element().heap_type()))
                 }
 
-                #[cfg_attr(not(feature = "gc"), allow(unreachable_code, unused_variables))]
+                #[cfg_attr(
+                    not(feature = "gc"),
+                    expect(unreachable_code, unused_variables, reason = "definitions cfg'd off")
+                )]
                 runtime::TableElement::GcRef(Some(x)) => {
                     match self._ty(&store).element().heap_type().top() {
                         HeapType::Any => {
@@ -452,7 +455,10 @@ impl Table {
     /// Even if the same underlying table definition is added to the
     /// `StoreData` multiple times and becomes multiple `wasmtime::Table`s,
     /// this hash key will be consistent across all of these tables.
-    #[allow(dead_code)] // Not used yet, but added for consistency.
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "Not used yet, but added for consistency")
+    )]
     pub(crate) fn hash_key(&self, store: &StoreOpaque) -> impl core::hash::Hash + Eq + use<'_> {
         store[self.instance].table_ptr(self.index).as_ptr().addr()
     }

--- a/crates/wasmtime/src/runtime/func.rs
+++ b/crates/wasmtime/src/runtime/func.rs
@@ -1458,7 +1458,10 @@ impl Func {
     /// Even if the same underlying function is added to the `StoreData`
     /// multiple times and becomes multiple `wasmtime::Func`s, this hash key
     /// will be consistent across all of these functions.
-    #[allow(dead_code)] // Not used yet, but added for consistency.
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "Not used yet, but added for consistency")
+    )]
     pub(crate) fn hash_key(&self, store: &mut StoreOpaque) -> impl core::hash::Hash + Eq + use<> {
         self.vm_func_ref(store).as_ptr().addr()
     }
@@ -1775,7 +1778,7 @@ where
 
 macro_rules! impl_wasm_host_results {
     ($n:tt $($t:ident)*) => (
-        #[allow(non_snake_case)]
+        #[allow(non_snake_case, reason = "macro-generated code")]
         unsafe impl<$($t),*> WasmRet for ($($t,)*)
         where
             $($t: WasmTy,)*
@@ -1850,7 +1853,7 @@ macro_rules! impl_into_func {
         // Implement for functions without a leading `&Caller` parameter,
         // delegating to the implementation below which does have the leading
         // `Caller` parameter.
-        #[allow(non_snake_case)]
+        #[expect(non_snake_case, reason = "macro-generated code")]
         impl<T, F, $arg, R> IntoFunc<T, $arg, R> for F
         where
             F: Fn($arg) -> R + Send + Sync + 'static,
@@ -1867,7 +1870,7 @@ macro_rules! impl_into_func {
             }
         }
 
-        #[allow(non_snake_case)]
+        #[expect(non_snake_case, reason = "macro-generated code")]
         impl<T, F, $arg, R> IntoFunc<T, (Caller<'_, T>, $arg), R> for F
         where
             F: Fn(Caller<'_, T>, $arg) -> R + Send + Sync + 'static,
@@ -1886,7 +1889,7 @@ macro_rules! impl_into_func {
         // Implement for functions without a leading `&Caller` parameter,
         // delegating to the implementation below which does have the leading
         // `Caller` parameter.
-        #[allow(non_snake_case)]
+        #[allow(non_snake_case, reason = "macro-generated code")]
         impl<T, F, $($args,)* R> IntoFunc<T, ($($args,)*), R> for F
         where
             F: Fn($($args),*) -> R + Send + Sync + 'static,
@@ -1903,7 +1906,7 @@ macro_rules! impl_into_func {
             }
         }
 
-        #[allow(non_snake_case)]
+        #[allow(non_snake_case, reason = "macro-generated code")]
         impl<T, F, $($args,)* R> IntoFunc<T, (Caller<'_, T>, $($args,)*), R> for F
         where
             F: Fn(Caller<'_, T>, $($args),*) -> R + Send + Sync + 'static,
@@ -1944,7 +1947,7 @@ pub unsafe trait WasmTyList {
 
 macro_rules! impl_wasm_ty_list {
     ($num:tt $($args:ident)*) => (
-        #[allow(non_snake_case)]
+        #[allow(non_snake_case, reason = "macro-generated code")]
         unsafe impl<$($args),*> WasmTyList for ($($args,)*)
         where
             $($args: WasmTy,)*
@@ -2229,8 +2232,7 @@ struct HostFuncState<F> {
 
     // NB: We have to keep our `VMSharedTypeIndex` registered in the engine for
     // as long as this function exists.
-    #[allow(dead_code)]
-    ty: RegisteredType,
+    _ty: RegisteredType,
 }
 
 #[doc(hidden)]
@@ -2263,7 +2265,7 @@ impl HostContext {
                 type_index,
                 Box::new(HostFuncState {
                     func,
-                    ty: ty.into_registered_type(),
+                    _ty: ty.into_registered_type(),
                 }),
             )
         };

--- a/crates/wasmtime/src/runtime/func/typed.rs
+++ b/crates/wasmtime/src/runtime/func/typed.rs
@@ -661,7 +661,7 @@ where
 
 macro_rules! impl_wasm_params {
     ($n:tt $($t:ident)*) => {
-        #[allow(non_snake_case)]
+        #[allow(non_snake_case, reason = "macro-generated code")]
         unsafe impl<$($t: WasmTy,)*> WasmParams for ($($t,)*) {
             type ValRawStorage = [ValRaw; $n];
 
@@ -753,11 +753,11 @@ unsafe impl<T: WasmTy> WasmResults for T {
 
 macro_rules! impl_wasm_results {
     ($n:tt $($t:ident)*) => {
-        #[allow(non_snake_case, unused_variables)]
+        #[allow(non_snake_case, reason = "macro-generated code")]
         unsafe impl<$($t: WasmTy,)*> WasmResults for ($($t,)*) {
-            unsafe fn load(store: &mut AutoAssertNoGc<'_>, abi: &Self::ValRawStorage) -> Self {
+            unsafe fn load(_store: &mut AutoAssertNoGc<'_>, abi: &Self::ValRawStorage) -> Self {
                 let [$($t,)*] = abi;
-                ($($t::load(store, $t),)*)
+                ($($t::load(_store, $t),)*)
             }
         }
     };

--- a/crates/wasmtime/src/runtime/gc/disabled.rs
+++ b/crates/wasmtime/src/runtime/gc/disabled.rs
@@ -6,7 +6,7 @@
 //! disabled at compile time. While we implement dummy methods for these types'
 //! public methods, we do not, however, create dummy constructors constructors.
 
-#![allow(missing_docs, unreachable_code)]
+#![expect(missing_docs, unreachable_code, reason = "dummy module")]
 
 mod anyref;
 mod arrayref;

--- a/crates/wasmtime/src/runtime/gc/enabled/anyref.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/anyref.rs
@@ -139,7 +139,6 @@ impl From<ManuallyRooted<ArrayRef>> for ManuallyRooted<AnyRef> {
 }
 
 unsafe impl GcRefImpl for AnyRef {
-    #[allow(private_interfaces)]
     fn transmute_ref(index: &GcRootIndex) -> &Self {
         // Safety: `AnyRef` is a newtype of a `GcRootIndex`.
         let me: &Self = unsafe { mem::transmute(index) };

--- a/crates/wasmtime/src/runtime/gc/enabled/arrayref.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/arrayref.rs
@@ -183,7 +183,6 @@ pub struct ArrayRef {
 }
 
 unsafe impl GcRefImpl for ArrayRef {
-    #[allow(private_interfaces)]
     fn transmute_ref(index: &GcRootIndex) -> &Self {
         // Safety: `ArrayRef` is a newtype of a `GcRootIndex`.
         let me: &Self = unsafe { mem::transmute(index) };

--- a/crates/wasmtime/src/runtime/gc/enabled/eqref.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/eqref.rs
@@ -121,7 +121,6 @@ impl From<ManuallyRooted<ArrayRef>> for ManuallyRooted<EqRef> {
 }
 
 unsafe impl GcRefImpl for EqRef {
-    #[allow(private_interfaces)]
     fn transmute_ref(index: &GcRootIndex) -> &Self {
         // Safety: `EqRef` is a newtype of a `GcRootIndex`.
         let me: &Self = unsafe { mem::transmute(index) };

--- a/crates/wasmtime/src/runtime/gc/enabled/externref.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/externref.rs
@@ -119,7 +119,6 @@ pub struct ExternRef {
 }
 
 unsafe impl GcRefImpl for ExternRef {
-    #[allow(private_interfaces)]
     fn transmute_ref(index: &GcRootIndex) -> &Self {
         // Safety: `ExternRef` is a newtype of a `GcRootIndex`.
         let me: &Self = unsafe { mem::transmute(index) };

--- a/crates/wasmtime/src/runtime/gc/enabled/structref.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/structref.rs
@@ -155,7 +155,6 @@ pub struct StructRef {
 }
 
 unsafe impl GcRefImpl for StructRef {
-    #[allow(private_interfaces)]
     fn transmute_ref(index: &GcRootIndex) -> &Self {
         // Safety: `StructRef` is a newtype of a `GcRootIndex`.
         let me: &Self = unsafe { mem::transmute(index) };

--- a/crates/wasmtime/src/runtime/memory.rs
+++ b/crates/wasmtime/src/runtime/memory.rs
@@ -1031,7 +1031,14 @@ impl SharedMemory {
         wasmtime_export: crate::runtime::vm::ExportMemory,
         store: &StoreOpaque,
     ) -> Self {
-        #[cfg_attr(not(feature = "threads"), allow(unused_variables, unreachable_code))]
+        #[cfg_attr(
+            not(feature = "threads"),
+            expect(
+                unused_variables,
+                unreachable_code,
+                reason = "definitions cfg'd to dummy",
+            )
+        )]
         crate::runtime::vm::Instance::from_vmctx(wasmtime_export.vmctx, |handle| {
             let memory_index = handle.env_module().memory_index(wasmtime_export.index);
             let page_size = handle.memory_page_size(memory_index);

--- a/crates/wasmtime/src/runtime/trampoline/func.rs
+++ b/crates/wasmtime/src/runtime/trampoline/func.rs
@@ -10,8 +10,7 @@ struct TrampolineState<F> {
     func: F,
 
     // Need to keep our `VMSharedTypeIndex` registered in the engine.
-    #[allow(dead_code)]
-    sig: RegisteredType,
+    _sig: RegisteredType,
 }
 
 /// Shim to call a host-defined function that uses the array calling convention.
@@ -60,7 +59,7 @@ where
         Ok(VMArrayCallHostFuncContext::new(
             array_call,
             sig.index(),
-            Box::new(TrampolineState { func, sig }),
+            Box::new(TrampolineState { func, _sig: sig }),
         ))
     }
 }

--- a/crates/wasmtime/src/runtime/trampoline/global.rs
+++ b/crates/wasmtime/src/runtime/trampoline/global.rs
@@ -47,7 +47,6 @@ pub fn generate_global_export(
             Val::ExternRef(x) => {
                 let new = match x {
                     None => None,
-                    #[cfg_attr(not(feature = "gc"), allow(unreachable_patterns))]
                     Some(x) => Some(x.try_gc_ref(&store)?.unchecked_copy()),
                 };
                 let new = new.as_ref();
@@ -56,7 +55,6 @@ pub fn generate_global_export(
             Val::AnyRef(a) => {
                 let new = match a {
                     None => None,
-                    #[cfg_attr(not(feature = "gc"), allow(unreachable_patterns))]
                     Some(a) => Some(a.try_gc_ref(&store)?.unchecked_copy()),
                 };
                 let new = new.as_ref();

--- a/crates/wasmtime/src/runtime/trap.rs
+++ b/crates/wasmtime/src/runtime/trap.rs
@@ -184,8 +184,7 @@ pub struct WasmBacktrace {
     hint_wasm_backtrace_details_env: bool,
     // This is currently only present for the `Debug` implementation for extra
     // context.
-    #[allow(dead_code)]
-    runtime_trace: crate::runtime::vm::Backtrace,
+    _runtime_trace: crate::runtime::vm::Backtrace,
 }
 
 impl WasmBacktrace {
@@ -244,7 +243,7 @@ impl WasmBacktrace {
             WasmBacktrace {
                 wasm_trace: Vec::new(),
                 hint_wasm_backtrace_details_env: false,
-                runtime_trace: crate::runtime::vm::Backtrace::empty(),
+                _runtime_trace: crate::runtime::vm::Backtrace::empty(),
             }
         }
     }
@@ -334,7 +333,7 @@ impl WasmBacktrace {
 
         Self {
             wasm_trace,
-            runtime_trace,
+            _runtime_trace: runtime_trace,
             hint_wasm_backtrace_details_env,
         }
     }

--- a/crates/wasmtime/src/runtime/types/matching.rs
+++ b/crates/wasmtime/src/runtime/types/matching.rs
@@ -70,7 +70,6 @@ fn type_reference(
     Err(concrete_type_mismatch(msg, &expected, &actual))
 }
 
-#[cfg_attr(not(feature = "component-model"), allow(dead_code))]
 pub fn entity_ty(engine: &Engine, expected: &EntityType, actual: &EntityType) -> Result<()> {
     match expected {
         EntityType::Memory(expected) => match actual {

--- a/crates/wasmtime/src/runtime/types/matching.rs
+++ b/crates/wasmtime/src/runtime/types/matching.rs
@@ -70,6 +70,7 @@ fn type_reference(
     Err(concrete_type_mismatch(msg, &expected, &actual))
 }
 
+#[cfg(feature = "component-model")]
 pub fn entity_ty(engine: &Engine, expected: &EntityType, actual: &EntityType) -> Result<()> {
     match expected {
         EntityType::Memory(expected) => match actual {
@@ -403,6 +404,7 @@ fn match_limits(
     )
 }
 
+#[cfg(feature = "component-model")]
 fn entity_desc(ty: &EntityType) -> &'static str {
     match ty {
         EntityType::Global(_) => "global",

--- a/crates/wasmtime/src/runtime/values.rs
+++ b/crates/wasmtime/src/runtime/values.rs
@@ -919,14 +919,12 @@ impl Ref {
             (Ref::Any(Some(a)), HeapType::Struct) => a._is_struct(store)?,
             (Ref::Any(Some(a)), HeapType::ConcreteStruct(_ty)) => match a._as_struct(store)? {
                 None => false,
-                #[cfg_attr(not(feature = "gc"), allow(unreachable_patterns))]
                 Some(s) => s._matches_ty(store, _ty)?,
             },
             (Ref::Any(Some(a)), HeapType::Eq) => a._is_eqref(store)?,
             (Ref::Any(Some(a)), HeapType::Array) => a._is_array(store)?,
             (Ref::Any(Some(a)), HeapType::ConcreteArray(_ty)) => match a._as_array(store)? {
                 None => false,
-                #[cfg_attr(not(feature = "gc"), allow(unreachable_patterns))]
                 Some(a) => a._matches_ty(store, _ty)?,
             },
             (
@@ -996,7 +994,6 @@ impl Ref {
                     assert!(ty.is_nullable());
                     Ok(TableElement::GcRef(None))
                 }
-                #[cfg_attr(not(feature = "gc"), allow(unreachable_patterns))]
                 Some(e) => {
                     let gc_ref = e.try_clone_gc_ref(&mut store)?;
                     Ok(TableElement::GcRef(Some(gc_ref)))
@@ -1008,7 +1005,6 @@ impl Ref {
                     assert!(ty.is_nullable());
                     Ok(TableElement::GcRef(None))
                 }
-                #[cfg_attr(not(feature = "gc"), allow(unreachable_patterns))]
                 Some(a) => {
                     let gc_ref = a.try_clone_gc_ref(&mut store)?;
                     Ok(TableElement::GcRef(Some(gc_ref)))

--- a/crates/wasmtime/src/runtime/vm.rs
+++ b/crates/wasmtime/src/runtime/vm.rs
@@ -7,13 +7,13 @@
 
 // Polyfill `std::simd::i8x16` etc. until they're stable.
 #[cfg(all(target_arch = "x86_64", target_feature = "sse"))]
-#[allow(non_camel_case_types)]
+#[expect(non_camel_case_types, reason = "matching wasm conventions")]
 pub(crate) type i8x16 = core::arch::x86_64::__m128i;
 #[cfg(all(target_arch = "x86_64", target_feature = "sse"))]
-#[allow(non_camel_case_types)]
+#[expect(non_camel_case_types, reason = "matching wasm conventions")]
 pub(crate) type f32x4 = core::arch::x86_64::__m128;
 #[cfg(all(target_arch = "x86_64", target_feature = "sse"))]
-#[allow(non_camel_case_types)]
+#[expect(non_camel_case_types, reason = "matching wasm conventions")]
 pub(crate) type f64x2 = core::arch::x86_64::__m128d;
 
 // On platforms other than x86_64, define i8x16 to a non-constructible type;
@@ -21,15 +21,15 @@ pub(crate) type f64x2 = core::arch::x86_64::__m128d;
 // functions that are awkward to make conditional on the target, but it
 // doesn't need to actually be constructible unless we're on x86_64.
 #[cfg(not(all(target_arch = "x86_64", target_feature = "sse")))]
-#[allow(non_camel_case_types)]
+#[expect(non_camel_case_types, reason = "matching wasm conventions")]
 #[derive(Copy, Clone)]
 pub(crate) struct i8x16(crate::uninhabited::Uninhabited);
 #[cfg(not(all(target_arch = "x86_64", target_feature = "sse")))]
-#[allow(non_camel_case_types)]
+#[expect(non_camel_case_types, reason = "matching wasm conventions")]
 #[derive(Copy, Clone)]
 pub(crate) struct f32x4(crate::uninhabited::Uninhabited);
 #[cfg(not(all(target_arch = "x86_64", target_feature = "sse")))]
-#[allow(non_camel_case_types)]
+#[expect(non_camel_case_types, reason = "matching wasm conventions")]
 #[derive(Copy, Clone)]
 pub(crate) struct f64x2(crate::uninhabited::Uninhabited);
 

--- a/crates/wasmtime/src/runtime/vm/component.rs
+++ b/crates/wasmtime/src/runtime/vm/component.rs
@@ -25,8 +25,10 @@ use core::ptr::NonNull;
 use wasmtime_environ::component::*;
 use wasmtime_environ::{DefinedTableIndex, HostPtr, PrimaryMap, VMSharedTypeIndex};
 
-#[allow(clippy::cast_possible_truncation)] // it's intended this is truncated on
-// 32-bit platforms
+#[allow(
+    clippy::cast_possible_truncation,
+    reason = "it's intended this is truncated on 32-bit platforms"
+)]
 const INVALID_PTR: usize = 0xdead_dead_beef_beef_u64 as usize;
 
 mod libcalls;
@@ -854,12 +856,10 @@ impl VMOpaqueContext {
     }
 }
 
-#[allow(missing_docs)]
 #[repr(transparent)]
 #[derive(Copy, Clone)]
 pub struct InstanceFlags(SendSyncPtr<VMGlobalDefinition>);
 
-#[allow(missing_docs)]
 impl InstanceFlags {
     /// Wraps the given pointer as an `InstanceFlags`
     ///

--- a/crates/wasmtime/src/runtime/vm/component/libcalls.rs
+++ b/crates/wasmtime/src/runtime/vm/component/libcalls.rs
@@ -80,7 +80,6 @@ wasmtime_environ::foreach_builtin_component_function!(define_builtins);
 /// transcoders that are invoked by Cranelift. These functions have a specific
 /// ABI defined by the macro itself and will defer to the actual bodies of each
 /// implementation following this submodule.
-#[allow(improper_ctypes_definitions)]
 mod trampolines {
     use super::{ComponentInstance, VMComponentContext};
     use core::ptr::NonNull;

--- a/crates/wasmtime/src/runtime/vm/const_expr.rs
+++ b/crates/wasmtime/src/runtime/vm/const_expr.rs
@@ -10,7 +10,9 @@ use crate::{
 use smallvec::SmallVec;
 use wasmtime_environ::{ConstExpr, ConstOp, FuncIndex, GlobalIndex};
 #[cfg(feature = "gc")]
-use wasmtime_environ::{VMSharedTypeIndex, WasmCompositeInnerType, WasmCompositeType, WasmSubType};
+use wasmtime_environ::{
+    Unsigned, VMSharedTypeIndex, WasmCompositeInnerType, WasmCompositeType, WasmSubType,
+};
 
 /// An interpreter for const expressions.
 ///
@@ -283,8 +285,7 @@ impl ConstExprEvaluator {
                         .unwrap_engine_type_index();
                     let ty = ArrayType::from_shared_type_index(store.engine(), ty);
 
-                    #[allow(clippy::cast_sign_loss)]
-                    let len = self.pop()?.get_i32() as u32;
+                    let len = self.pop()?.get_i32().unsigned();
 
                     let elem = Val::_from_raw(&mut store, self.pop()?, ty.element_type().unpack());
 
@@ -301,8 +302,7 @@ impl ConstExprEvaluator {
                         .unwrap_engine_type_index();
                     let ty = ArrayType::from_shared_type_index(store.engine(), ty);
 
-                    #[allow(clippy::cast_sign_loss)]
-                    let len = self.pop()?.get_i32() as u32;
+                    let len = self.pop()?.get_i32().unsigned();
 
                     let elem = Val::default_for_ty(ty.element_type().unpack())
                         .expect("type should have a default value");

--- a/crates/wasmtime/src/runtime/vm/cow.rs
+++ b/crates/wasmtime/src/runtime/vm/cow.rs
@@ -1,10 +1,6 @@
 //! Copy-on-write initialization support: creation of backing images for
 //! modules, and logic to support mapping these backing images into memory.
 
-// `MemoryImageSource` is an empty enum on some platforms which triggers some
-// warnings
-#![cfg_attr(any(not(unix), miri), allow(unreachable_patterns))]
-
 use super::sys::DecommitBehavior;
 use crate::prelude::*;
 use crate::runtime::vm::sys::vm::{self, MemoryImageSource};
@@ -497,7 +493,7 @@ impl MemoryImageSlot {
     /// argument is the maximum amount of memory to keep resident in this
     /// process's memory on Linux. Up to that much memory will be `memset` to
     /// zero where the rest of it will be reset or released with `madvise`.
-    #[allow(dead_code)] // ignore warnings as this is only used in some cfgs
+    #[allow(dead_code, reason = "only used in some cfgs")]
     pub(crate) fn clear_and_remain_ready(
         &mut self,
         keep_resident: HostAlignedByteCount,
@@ -513,7 +509,7 @@ impl MemoryImageSlot {
         Ok(())
     }
 
-    #[allow(dead_code)] // ignore warnings as this is only used in some cfgs
+    #[allow(dead_code, reason = "only used in some cfgs")]
     unsafe fn reset_all_memory_contents(
         &mut self,
         keep_resident: HostAlignedByteCount,
@@ -536,7 +532,7 @@ impl MemoryImageSlot {
         }
     }
 
-    #[allow(dead_code)] // ignore warnings as this is only used in some cfgs
+    #[allow(dead_code, reason = "only used in some cfgs")]
     unsafe fn reset_with_original_mapping(
         &mut self,
         keep_resident: HostAlignedByteCount,
@@ -672,7 +668,7 @@ impl MemoryImageSlot {
         }
     }
 
-    #[allow(dead_code)] // ignore warnings as this is only used in some cfgs
+    #[allow(dead_code, reason = "only used in some cfgs")]
     unsafe fn restore_original_mapping(
         &self,
         base: HostAlignedByteCount,
@@ -722,7 +718,7 @@ impl MemoryImageSlot {
         self.image.is_some()
     }
 
-    #[allow(dead_code)] // ignore warnings as this is only used in some cfgs
+    #[allow(dead_code, reason = "only used in some cfgs")]
     pub(crate) fn is_dirty(&self) -> bool {
         self.dirty
     }

--- a/crates/wasmtime/src/runtime/vm/gc.rs
+++ b/crates/wasmtime/src/runtime/vm/gc.rs
@@ -169,7 +169,6 @@ impl GcStore {
     ) -> Result<Result<VMExternRef, (Box<dyn Any + Send + Sync>, u64)>> {
         let host_data_id = self.host_data_table.alloc(value);
         match self.gc_heap.alloc_externref(host_data_id)? {
-            #[cfg_attr(not(feature = "gc"), allow(unreachable_patterns))]
             Ok(x) => Ok(Ok(x)),
             Err(n) => Ok(Err((self.host_data_table.dealloc(host_data_id), n))),
         }

--- a/crates/wasmtime/src/runtime/vm/gc/disabled.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/disabled.rs
@@ -1,7 +1,5 @@
 //! Dummy GC types for when the `gc` cargo feature is disabled.
 
-#![allow(missing_docs)]
-
 pub enum VMExternRef {}
 
 pub enum VMStructRef {}

--- a/crates/wasmtime/src/runtime/vm/gc/enabled.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/enabled.rs
@@ -22,14 +22,19 @@ mod null;
 #[cfg(feature = "gc-null")]
 pub use null::*;
 
-// Explicit methods with `#[allow]` to clearly indicate that truncation is
-// desired when used.
-#[allow(clippy::cast_possible_truncation)]
+// Explicit methods to clearly indicate that truncation is desired when used.
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "that's the purpose of this method"
+)]
 fn truncate_i32_to_i16(a: i32) -> i16 {
     a as i16
 }
 
-#[allow(clippy::cast_possible_truncation)]
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "that's the purpose of this method"
+)]
 fn truncate_i32_to_i8(a: i32) -> i8 {
     a as i8
 }

--- a/crates/wasmtime/src/runtime/vm/gc/enabled/drc.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/enabled/drc.rs
@@ -67,7 +67,7 @@ use wasmtime_environ::{
     GcArrayLayout, GcLayout, GcStructLayout, GcTypeLayouts, VMGcKind, VMSharedTypeIndex,
 };
 
-#[allow(clippy::cast_possible_truncation)]
+#[expect(clippy::cast_possible_truncation, reason = "known to not overflow")]
 const GC_REF_ARRAY_ELEMS_OFFSET: u32 = ARRAY_LENGTH_OFFSET + (mem::size_of::<u32>() as u32);
 
 /// The deferred reference-counting (DRC) collector.

--- a/crates/wasmtime/src/runtime/vm/instance.rs
+++ b/crates/wasmtime/src/runtime/vm/instance.rs
@@ -294,7 +294,7 @@ impl Instance {
                         .unwrap_or(0)
                         * 64
                         * 1024;
-                    Some(Wmemcheck::new(size as usize))
+                    Some(Wmemcheck::new(size.try_into().unwrap()))
                 } else {
                     None
                 }

--- a/crates/wasmtime/src/runtime/vm/instance/allocator.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator.rs
@@ -70,7 +70,7 @@ pub struct InstanceAllocationRequest<'a> {
     pub store: StorePtr,
 
     /// Indicates '--wmemcheck' flag.
-    #[cfg_attr(not(feature = "wmemcheck"), allow(dead_code))]
+    #[cfg(feature = "wmemcheck")]
     pub wmemcheck: bool,
 
     /// Request that the instance's memories be protected by a specific

--- a/crates/wasmtime/src/runtime/vm/instance/allocator/pooling.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/pooling.rs
@@ -305,9 +305,12 @@ pub struct PoolingInstanceAllocator {
     stacks: StackPool,
 }
 
-#[cfg(debug_assertions)]
 impl Drop for PoolingInstanceAllocator {
     fn drop(&mut self) {
+        if !cfg!(debug_assertions) {
+            return;
+        }
+
         // NB: when cfg(not(debug_assertions)) it is okay that we don't flush
         // the queue, as the sub-pools will unmap those ranges anyways, so
         // there's no point in decommitting them. But we do need to flush the

--- a/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/decommit_queue.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/decommit_queue.rs
@@ -16,11 +16,11 @@ use smallvec::SmallVec;
 use wasmtime_fiber::FiberStack;
 
 #[cfg(unix)]
-#[allow(non_camel_case_types)]
+#[expect(non_camel_case_types, reason = "matching libc naming")]
 type iovec = libc::iovec;
 
 #[cfg(not(unix))]
-#[allow(non_camel_case_types)]
+#[expect(non_camel_case_types, reason = "matching libc naming")]
 struct iovec {
     iov_base: *mut libc::c_void,
     iov_len: libc::size_t,

--- a/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/gc_heap_pool.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/gc_heap_pool.rs
@@ -73,7 +73,6 @@ impl GcHeapPool {
     }
 
     /// Are there zero slots in use right now?
-    #[allow(unused)] // some cfgs don't use this
     pub fn is_empty(&self) -> bool {
         self.index_allocator.is_empty()
     }

--- a/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/generic_stack_pool.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/generic_stack_pool.rs
@@ -1,4 +1,7 @@
-#![cfg_attr(not(asan), allow(dead_code))]
+#![cfg_attr(
+    all(unix, not(miri), not(asan)),
+    expect(dead_code, reason = "not used, but typechecked")
+)]
 
 use crate::PoolConcurrencyLimitError;
 use crate::prelude::*;
@@ -34,7 +37,6 @@ impl StackPool {
         })
     }
 
-    #[allow(unused)] // some cfgs don't use this
     pub fn is_empty(&self) -> bool {
         self.live_stacks.load(Ordering::Acquire) == 0
     }

--- a/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/index_allocator.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/index_allocator.rs
@@ -698,4 +698,22 @@ mod test {
         // for good measure make sure id3 is still affine
         assert_eq!(state.alloc(Some(id3)), Some(SlotId(0)));
     }
+
+    #[test]
+    fn test_freelist() {
+        let allocator = SimpleIndexAllocator::new(10);
+        assert_eq!(allocator.testing_freelist(), []);
+        let a = allocator.alloc().unwrap();
+        assert_eq!(allocator.testing_freelist(), []);
+        allocator.free(a);
+        assert_eq!(allocator.testing_freelist(), [a]);
+        assert_eq!(allocator.alloc(), Some(a));
+        assert_eq!(allocator.testing_freelist(), []);
+        let b = allocator.alloc().unwrap();
+        assert_eq!(allocator.testing_freelist(), []);
+        allocator.free(b);
+        assert_eq!(allocator.testing_freelist(), [b]);
+        allocator.free(a);
+        assert_eq!(allocator.testing_freelist(), [b, a]);
+    }
 }

--- a/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/index_allocator.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/index_allocator.rs
@@ -31,7 +31,6 @@ impl SimpleIndexAllocator {
         SimpleIndexAllocator(ModuleAffinityIndexAllocator::new(capacity, 0))
     }
 
-    #[allow(unused)] // some cfgs don't use this
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
     }
@@ -45,7 +44,6 @@ impl SimpleIndexAllocator {
     }
 
     #[cfg(test)]
-    #[allow(unused)]
     pub(crate) fn testing_freelist(&self) -> Vec<SlotId> {
         self.0.testing_freelist()
     }
@@ -176,7 +174,6 @@ impl ModuleAffinityIndexAllocator {
     }
 
     /// Are zero slots in use right now?
-    #[allow(unused)] // some cfgs don't use this
     pub fn is_empty(&self) -> bool {
         let inner = self.0.lock().unwrap();
         !inner
@@ -319,7 +316,6 @@ impl ModuleAffinityIndexAllocator {
     /// For testing only, we want to be able to assert what is on the single
     /// freelist, for the policies that keep just one.
     #[cfg(test)]
-    #[allow(unused)]
     pub(crate) fn testing_freelist(&self) -> Vec<SlotId> {
         let inner = self.0.lock().unwrap();
         inner
@@ -456,7 +452,6 @@ impl List {
     }
 
     #[cfg(test)]
-    #[allow(unused)]
     fn iter<'a>(
         &'a self,
         states: &'a [SlotState],

--- a/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/memory_pool.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/memory_pool.rs
@@ -310,7 +310,6 @@ impl MemoryPool {
     }
 
     /// Are zero slots in use right now?
-    #[allow(unused)] // some cfgs don't use this
     pub fn is_empty(&self) -> bool {
         self.stripes.iter().all(|s| s.allocator.is_empty())
     }

--- a/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/table_pool.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/table_pool.rs
@@ -92,7 +92,6 @@ impl TablePool {
     }
 
     /// Are there zero slots in use right now?
-    #[allow(unused)] // some cfgs don't use this
     pub fn is_empty(&self) -> bool {
         self.index_allocator.is_empty()
     }

--- a/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/unix_stack_pool.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/unix_stack_pool.rs
@@ -85,7 +85,6 @@ impl StackPool {
     }
 
     /// Are there zero slots in use right now?
-    #[allow(unused)] // some cfgs don't use this
     pub fn is_empty(&self) -> bool {
         self.index_allocator.is_empty()
     }

--- a/crates/wasmtime/src/runtime/vm/interpreter.rs
+++ b/crates/wasmtime/src/runtime/vm/interpreter.rs
@@ -290,11 +290,9 @@ impl InterpreterRef<'_> {
         /// `call(@host Ty(ty1, ty2, ...) -> retty)` - invoke a host function
         /// with the type `Ty`. The other types in the macro are checked by
         /// rustc to match the actual `Ty` definition in Rust.
-        ///
-        /// Ignore improper ctypes to permit `__m128i` on x86_64.
         macro_rules! call {
             (@builtin($($param:ident),*) $(-> $result:ident)?) => {{
-                #[allow(improper_ctypes_definitions)]
+                #[allow(improper_ctypes_definitions, reason = "__m128i known not FFI-safe")]
                 type T = unsafe extern "C" fn($(call!(@ty $param)),*) $(-> call!(@ty $result))?;
                 call!(@host T($($param),*) $(-> $result)?);
             }};

--- a/crates/wasmtime/src/runtime/vm/memory/shared_memory_disabled.rs
+++ b/crates/wasmtime/src/runtime/vm/memory/shared_memory_disabled.rs
@@ -1,5 +1,3 @@
-#![allow(missing_docs)]
-
 use crate::prelude::*;
 use crate::runtime::vm::memory::LocalMemory;
 use crate::runtime::vm::{VMMemoryDefinition, VMStore, WaitResult};

--- a/crates/wasmtime/src/runtime/vm/mpk/disabled.rs
+++ b/crates/wasmtime/src/runtime/vm/mpk/disabled.rs
@@ -1,8 +1,6 @@
 //! Noop implementations of MPK primitives for environments that do not support
 //! the feature.
 
-#![allow(missing_docs)]
-
 #[cfg(feature = "pooling-allocator")]
 use crate::prelude::*;
 

--- a/crates/wasmtime/src/runtime/vm/mpk/sys.rs
+++ b/crates/wasmtime/src/runtime/vm/mpk/sys.rs
@@ -41,7 +41,7 @@ pub fn pkey_alloc(flags: u32, access_rights: u32) -> Result<u32> {
 /// Free a kernel protection key ([docs]).
 ///
 /// [docs]: https://man7.org/linux/man-pages/man2/pkey_alloc.2.html
-#[allow(dead_code)]
+#[cfg(test)]
 pub fn pkey_free(key: u32) -> Result<()> {
     let result = unsafe { libc::syscall(libc::SYS_pkey_free, key) };
     if result == 0 {

--- a/crates/wasmtime/src/runtime/vm/stack_switching.rs
+++ b/crates/wasmtime/src/runtime/vm/stack_switching.rs
@@ -544,29 +544,6 @@ pub enum VMStackState {
     Returned = wasmtime_environ::STACK_STATE_RETURNED_DISCRIMINANT,
 }
 
-/// Universal control effect. This structure encodes return signal, resume
-/// signal, suspension signal, and the handler to suspend to in a single variant
-/// type. This instance is used at runtime. There is a codegen counterpart in
-/// `cranelift/src/stack-switching/control_effect.rs`.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-#[repr(u32)]
-#[allow(dead_code)]
-pub enum ControlEffect {
-    /// Used to signal that a continuation has returned and control switches
-    /// back to the parent.
-    Return = wasmtime_environ::CONTROL_EFFECT_RETURN_DISCRIMINANT,
-    /// Used to signal to a continuation that it is being resumed.
-    Resume = wasmtime_environ::CONTROL_EFFECT_RESUME_DISCRIMINANT,
-    /// Used to signal that a continuation has invoked a `suspend` instruction.
-    Suspend {
-        /// The index of the handler to be used in the parent continuation to
-        /// switch back to.
-        handler_index: u32,
-    } = wasmtime_environ::CONTROL_EFFECT_SUSPEND_DISCRIMINANT,
-    /// Used to signal that a continuation has invoked a `suspend` instruction.
-    Switch = wasmtime_environ::CONTROL_EFFECT_SWITCH_DISCRIMINANT,
-}
-
 #[cfg(test)]
 mod tests {
     use core::mem::{offset_of, size_of};

--- a/crates/wasmtime/src/runtime/vm/stack_switching/stack.rs
+++ b/crates/wasmtime/src/runtime/vm/stack_switching/stack.rs
@@ -1,8 +1,6 @@
 //! This module contains a modified version of the `wasmtime_fiber` crate,
 //! specialized for executing stack switching continuations.
 
-#![allow(missing_docs)]
-
 use anyhow::Result;
 use core::ops::Range;
 

--- a/crates/wasmtime/src/runtime/vm/stack_switching/stack/dummy.rs
+++ b/crates/wasmtime/src/runtime/vm/stack_switching/stack/dummy.rs
@@ -11,6 +11,7 @@ use crate::runtime::vm::{VMContext, VMFuncRef, ValRaw};
 pub struct VMContinuationStack {
     _top: *mut u8,
     _len: usize,
+    _match_size_on_unix: u8,
 }
 
 impl VMContinuationStack {

--- a/crates/wasmtime/src/runtime/vm/stack_switching/stack/dummy.rs
+++ b/crates/wasmtime/src/runtime/vm/stack_switching/stack/dummy.rs
@@ -4,13 +4,6 @@ use core::ops::Range;
 use crate::runtime::vm::stack_switching::VMHostArray;
 use crate::runtime::vm::{VMContext, VMFuncRef, ValRaw};
 
-#[allow(dead_code)]
-#[derive(Debug, PartialEq, Eq)]
-pub enum Allocator {
-    Mmap,
-    Custom,
-}
-
 /// Making sure that this has the same size as the non-dummy version, to
 /// make some tests happy.
 #[derive(Debug)]
@@ -18,7 +11,6 @@ pub enum Allocator {
 pub struct VMContinuationStack {
     _top: *mut u8,
     _len: usize,
-    _allocator: Allocator,
 }
 
 impl VMContinuationStack {
@@ -34,7 +26,6 @@ impl VMContinuationStack {
         panic!("Stack switching disabled or not implemented on this platform")
     }
 
-    #[allow(clippy::missing_safety_doc)]
     pub unsafe fn from_raw_parts(_base: *mut u8, _guard_size: usize, _len: usize) -> Result<Self> {
         anyhow::bail!("Stack switching disabled or not implemented on this platform")
     }

--- a/crates/wasmtime/src/runtime/vm/stack_switching/stack/unix.rs
+++ b/crates/wasmtime/src/runtime/vm/stack_switching/stack/unix.rs
@@ -58,8 +58,6 @@
 //! the example above, thus assuming args_capacity = 2) is saved as the `data`
 //! field of the VMContRef's `args` object.
 
-#![allow(unused_macros)]
-
 use core::ptr::NonNull;
 use std::io;
 use std::ops::Range;
@@ -134,7 +132,6 @@ impl VMContinuationStack {
         self.len == 0
     }
 
-    #[allow(clippy::missing_safety_doc)]
     pub unsafe fn from_raw_parts(
         base: *mut u8,
         _guard_size: usize,
@@ -297,7 +294,6 @@ impl Drop for VMContinuationStack {
 }
 
 unsafe extern "C" {
-    #[allow(dead_code)] // only used in inline assembly for some platforms
     fn wasmtime_continuation_start();
 }
 

--- a/crates/wasmtime/src/runtime/vm/sys/custom/capi.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/custom/capi.rs
@@ -1,5 +1,3 @@
-#![expect(non_camel_case_types, reason = "matching C conventions")]
-
 // Flags to either `wasmtime_mmap_{new,remap}` or `wasmtime_mprotect`.
 
 /// Indicates that the memory region should be readable.
@@ -44,12 +42,14 @@ pub use WASMTIME_PROT_WRITE as PROT_WRITE;
 /// When this function does not return it's because `wasmtime_longjmp` is
 /// used to handle a Wasm-based trap.
 #[cfg(has_native_signals)]
+#[expect(non_camel_case_types, reason = "matching C conventions")]
 pub type wasmtime_trap_handler_t =
     extern "C" fn(ip: usize, fp: usize, has_faulting_addr: bool, faulting_addr: usize);
 
 /// Abstract pointer type used in the `wasmtime_memory_image_*` APIs which
 /// is defined by the embedder.
 #[cfg(has_virtual_memory)]
+#[expect(non_camel_case_types, reason = "matching C conventions")]
 pub enum wasmtime_memory_image {}
 
 unsafe extern "C" {

--- a/crates/wasmtime/src/runtime/vm/sys/custom/capi.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/custom/capi.rs
@@ -1,4 +1,4 @@
-#![allow(non_camel_case_types)]
+#![expect(non_camel_case_types, reason = "matching C conventions")]
 
 // Flags to either `wasmtime_mmap_{new,remap}` or `wasmtime_mprotect`.
 

--- a/crates/wasmtime/src/runtime/vm/sys/custom/traphandlers.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/custom/traphandlers.rs
@@ -7,7 +7,6 @@ use core::{mem, ptr::NonNull};
 #[cfg(has_host_compiler_backend)]
 pub use crate::runtime::vm::sys::capi::{self, wasmtime_longjmp};
 
-#[allow(missing_docs)]
 pub type SignalHandler = Box<dyn Fn() + Send + Sync>;
 
 #[cfg(has_host_compiler_backend)]

--- a/crates/wasmtime/src/runtime/vm/sys/custom/unwind.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/custom/unwind.rs
@@ -1,5 +1,3 @@
-#![allow(missing_docs)]
-
 use crate::prelude::*;
 
 pub struct UnwindRegistration {}

--- a/crates/wasmtime/src/runtime/vm/sys/mod.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/mod.rs
@@ -6,7 +6,10 @@
 //! needed is an extra block below and a new platform should be good to go after
 //! filling out the implementation.
 
-#![allow(clippy::cast_sign_loss)] // platforms too fiddly to worry about this
+#![allow(
+    clippy::cast_sign_loss,
+    reason = "platforms too fiddly to worry about this"
+)]
 
 use crate::runtime::vm::SendSyncPtr;
 use core::ptr::{self, NonNull};

--- a/crates/wasmtime/src/runtime/vm/sys/unix/signals.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/unix/signals.rs
@@ -260,8 +260,10 @@ pub fn abort_stack_overflow() -> ! {
     }
 }
 
-#[allow(clippy::cast_possible_truncation)] // too fiddly to handle and wouldn't
-// help much anyway
+#[allow(
+    clippy::cast_possible_truncation,
+    reason = "too fiddly to handle and wouldn't help much anyway"
+)]
 unsafe fn get_trap_registers(cx: *mut libc::c_void, _signum: libc::c_int) -> TrapRegisters {
     cfg_if::cfg_if! {
         if #[cfg(all(any(target_os = "linux", target_os = "android", target_os = "illumos"), target_arch = "x86_64"))] {

--- a/crates/wasmtime/src/runtime/vm/sys/unix/traphandlers.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/unix/traphandlers.rs
@@ -7,7 +7,6 @@ use core::ptr::NonNull;
 #[link(name = "wasmtime-helpers")]
 unsafe extern "C" {
     #[wasmtime_versioned_export_macros::versioned_link]
-    #[allow(improper_ctypes)]
     pub fn wasmtime_setjmp(
         jmp_buf: *mut *const u8,
         callback: extern "C" fn(*mut u8, NonNull<VMContext>) -> bool,

--- a/crates/wasmtime/src/runtime/vm/sys/unix/unwind.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/unix/unwind.rs
@@ -58,7 +58,6 @@ fn using_libunwind() -> bool {
 }
 
 impl UnwindRegistration {
-    #[allow(missing_docs)]
     pub const SECTION_NAME: &'static str = ".eh_frame";
 
     /// Registers precompiled unwinding information with the system.

--- a/crates/wasmtime/src/runtime/vm/sys/windows/traphandlers.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/windows/traphandlers.rs
@@ -7,7 +7,6 @@ use std::ptr::NonNull;
 #[link(name = "wasmtime-helpers")]
 unsafe extern "C" {
     #[wasmtime_versioned_export_macros::versioned_link]
-    #[allow(improper_ctypes)]
     pub fn wasmtime_setjmp(
         jmp_buf: *mut *const u8,
         callback: extern "C" fn(*mut u8, NonNull<VMContext>) -> bool,

--- a/crates/wasmtime/src/runtime/vm/sys/windows/unwind64.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/windows/unwind64.rs
@@ -10,10 +10,8 @@ pub struct UnwindRegistration {
 }
 
 impl UnwindRegistration {
-    #[allow(missing_docs)]
     pub const SECTION_NAME: &'static str = ".pdata";
 
-    #[allow(missing_docs)]
     pub unsafe fn new(
         base_address: *const u8,
         unwind_info: *const u8,

--- a/crates/wasmtime/src/runtime/vm/sys/windows/vectored_exceptions.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/windows/vectored_exceptions.rs
@@ -49,6 +49,10 @@ impl Drop for TrapHandler {
     }
 }
 
+#[allow(
+    clippy::cast_possible_truncation,
+    reason = "too fiddly to handle and wouldn't help much anyway"
+)]
 unsafe extern "system" fn exception_handler(exception_info: *mut EXCEPTION_POINTERS) -> i32 {
     // Check the kind of exception, since we only handle a subset within
     // wasm code. If anything else happens we want to defer to whatever

--- a/crates/wasmtime/src/runtime/vm/table.rs
+++ b/crates/wasmtime/src/runtime/vm/table.rs
@@ -2,8 +2,6 @@
 //!
 //! `Table` is to WebAssembly tables what `LinearMemory` is to WebAssembly linear memories.
 
-#![cfg_attr(feature = "gc", allow(irrefutable_let_patterns))]
-
 use crate::prelude::*;
 use crate::runtime::vm::stack_switching::VMContObj;
 use crate::runtime::vm::vmcontext::{VMFuncRef, VMTableDefinition};

--- a/crates/wasmtime/src/runtime/vm/traphandlers/coredump_enabled.rs
+++ b/crates/wasmtime/src/runtime/vm/traphandlers/coredump_enabled.rs
@@ -12,13 +12,13 @@ pub struct CoreDumpStack {
     /// The locals for each frame in the backtrace.
     ///
     /// This is not currently implemented.
-    #[allow(dead_code)]
+    #[expect(dead_code, reason = "not implemented yet")]
     pub locals: Vec<Vec<CoreDumpValue>>,
 
     /// The operands for each stack frame
     ///
     /// This is not currently implemented.
-    #[allow(dead_code)]
+    #[expect(dead_code, reason = "not implemented yet")]
     pub operand_stack: Vec<Vec<CoreDumpValue>>,
 }
 

--- a/crates/wasmtime/src/runtime/wave/core.rs
+++ b/crates/wasmtime/src/runtime/wave/core.rs
@@ -97,7 +97,7 @@ impl WasmValue for crate::Val {
         let val = f64::from_bits(*unwrap_val!(self, Self::F64, "f64"));
         canonicalize_nan64(val)
     }
-    #[allow(clippy::cast_possible_truncation)]
+    #[expect(clippy::cast_possible_truncation, reason = "handled losslessly here")]
     fn unwrap_tuple(&self) -> Box<dyn Iterator<Item = Cow<'_, Self>> + '_> {
         let v = unwrap_val!(self, Self::V128, "tuple").as_u128();
         let low = v as i64;

--- a/crates/wasmtime/src/sync_nostd.rs
+++ b/crates/wasmtime/src/sync_nostd.rs
@@ -14,6 +14,11 @@
 //!
 //! See a brief overview of this module in `sync_std.rs` as well.
 
+#![cfg_attr(
+    all(feature = "std", not(test)),
+    expect(dead_code, reason = "not used, but typechecked")
+)]
+
 use core::cell::UnsafeCell;
 use core::mem::MaybeUninit;
 use core::ops::{Deref, DerefMut};


### PR DESCRIPTION
This commit enables the `clippy::allow_attributes_without_reason` for the `wasmtime` crate which previously forcibly allowed it. The reason this was allowed was that when the workspace was first migrated the Wasmtime crate had too many instances that I was willing to fix. I've now come back around and tried to fix everything.

In short: ideally delete `#[allow]`, otherwise use `#[expect]`, otherwise use `#[allow]`.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
