### PR TITLE
x64: Add conditional jumps to the new assembler

### DIFF
--- a/cranelift/assembler-x64/meta/src/instructions/jmp.rs
+++ b/cranelift/assembler-x64/meta/src/instructions/jmp.rs
@@ -1,9 +1,66 @@
 use crate::dsl::{Customization::*, Feature::*, Inst, Location::*};
-use crate::dsl::{fmt, inst, r, rex};
+use crate::dsl::{fmt, inst, r, rex, sxq};
 
 #[rustfmt::skip] // Keeps instructions on a single line.
 pub fn list() -> Vec<Inst> {
     vec![
         inst("jmpq", fmt("M", [r(rm64)]), rex([0xFF]).digit(4), _64b).custom(Display),
+
+        inst("jmp", fmt("D8", [r(sxq(imm8))]), rex([0xEB]).ib(), _64b | compat).custom(Display),
+        inst("jmp", fmt("D32", [r(sxq(imm32))]), rex([0xE9]).id(), _64b | compat).custom(Display),
+
+        // Note that the Intel manual lists many mnemonics for this family of
+        // instructions which are duplicates of other mnemonics. The order here
+        // matches the order in the manual and comments are left when variants
+        // are omitted due to the instructions being duplicates of another.
+        inst("ja", fmt("D8", [r(sxq(imm8))]), rex([0x77]).ib(), _64b | compat).custom(Display),
+        inst("ja", fmt("D32", [r(sxq(imm32))]), rex([0x0F, 0x87]).id(), _64b | compat).custom(Display),
+        inst("jae", fmt("D8", [r(sxq(imm8))]), rex([0x73]).ib(), _64b | compat).custom(Display),
+        inst("jae", fmt("D32", [r(sxq(imm32))]), rex([0x0F, 0x83]).id(), _64b | compat).custom(Display),
+        inst("jb", fmt("D8", [r(sxq(imm8))]), rex([0x72]).ib(), _64b | compat).custom(Display),
+        inst("jb", fmt("D32", [r(sxq(imm32))]), rex([0x0F, 0x82]).id(), _64b | compat).custom(Display),
+        inst("jbe", fmt("D8", [r(sxq(imm8))]), rex([0x76]).ib(), _64b | compat).custom(Display),
+        inst("jbe", fmt("D32", [r(sxq(imm32))]), rex([0x0F, 0x86]).id(), _64b | compat).custom(Display),
+        // jc == jb
+        // TODO: jcx
+        // TODO: jecx
+        // TODO: jrcx
+        inst("je", fmt("D8", [r(sxq(imm8))]), rex([0x74]).ib(), _64b | compat).custom(Display),
+        inst("je", fmt("D32", [r(sxq(imm32))]), rex([0x0F, 0x84]).id(), _64b | compat).custom(Display),
+        inst("jg", fmt("D8", [r(sxq(imm8))]), rex([0x7F]).ib(), _64b | compat).custom(Display),
+        inst("jg", fmt("D32", [r(sxq(imm32))]), rex([0x0F, 0x8F]).id(), _64b | compat).custom(Display),
+        inst("jge", fmt("D8", [r(sxq(imm8))]), rex([0x7D]).ib(), _64b | compat).custom(Display),
+        inst("jge", fmt("D32", [r(sxq(imm32))]), rex([0x0F, 0x8D]).id(), _64b | compat).custom(Display),
+        inst("jl", fmt("D8", [r(sxq(imm8))]), rex([0x7C]).ib(), _64b | compat).custom(Display),
+        inst("jl", fmt("D32", [r(sxq(imm32))]), rex([0x0F, 0x8C]).id(), _64b | compat).custom(Display),
+        inst("jle", fmt("D8", [r(sxq(imm8))]), rex([0x7E]).ib(), _64b | compat).custom(Display),
+        inst("jle", fmt("D32", [r(sxq(imm32))]), rex([0x0F, 0x8E]).id(), _64b | compat).custom(Display),
+        // jna == jbe
+        // jnae == jb
+        // jnb == jae
+        // jnbe == ja
+        // jnc == jae
+        inst("jne", fmt("D8", [r(sxq(imm8))]), rex([0x75]).ib(), _64b | compat).custom(Display),
+        inst("jne", fmt("D32", [r(sxq(imm32))]), rex([0x0F, 0x85]).id(), _64b | compat).custom(Display),
+        // jng == jle
+        // jnge == jl
+        // jnl == jge
+        // jnle == jg
+        inst("jno", fmt("D8", [r(sxq(imm8))]), rex([0x71]).ib(), _64b | compat).custom(Display),
+        inst("jno", fmt("D32", [r(sxq(imm32))]), rex([0x0F, 0x81]).id(), _64b | compat).custom(Display),
+        inst("jnp", fmt("D8", [r(sxq(imm8))]), rex([0x7B]).ib(), _64b | compat).custom(Display),
+        inst("jnp", fmt("D32", [r(sxq(imm32))]), rex([0x0F, 0x8B]).id(), _64b | compat).custom(Display),
+        inst("jns", fmt("D8", [r(sxq(imm8))]), rex([0x79]).ib(), _64b | compat).custom(Display),
+        inst("jns", fmt("D32", [r(sxq(imm32))]), rex([0x0F, 0x89]).id(), _64b | compat).custom(Display),
+        // jnz == jne
+        inst("jo", fmt("D8", [r(sxq(imm8))]), rex([0x70]).ib(), _64b | compat).custom(Display),
+        inst("jo", fmt("D32", [r(sxq(imm32))]), rex([0x0F, 0x80]).id(), _64b | compat).custom(Display),
+        inst("jp", fmt("D8", [r(sxq(imm8))]), rex([0x7A]).ib(), _64b | compat).custom(Display),
+        inst("jp", fmt("D32", [r(sxq(imm32))]), rex([0x0F, 0x8A]).id(), _64b | compat).custom(Display),
+        // jpe == jp
+        // jpo == jnp
+        inst("js", fmt("D8", [r(sxq(imm8))]), rex([0x78]).ib(), _64b | compat).custom(Display),
+        inst("js", fmt("D32", [r(sxq(imm32))]), rex([0x0F, 0x88]).id(), _64b | compat).custom(Display),
+        // jz == je
     ]
 }

--- a/cranelift/assembler-x64/src/custom.rs
+++ b/cranelift/assembler-x64/src/custom.rs
@@ -195,12 +195,7 @@ pub mod display {
 
     pub fn callq_d(f: &mut fmt::Formatter, inst: &inst::callq_d) -> fmt::Result {
         let inst::callq_d { imm32 } = inst;
-        let displacement = i64::from(imm32.value()) + 5;
-        if displacement >= 0 && displacement < 10 {
-            write!(f, "callq {displacement:}")
-        } else {
-            write!(f, "callq {displacement:#x}")
-        }
+        display_displacement(f, "callq", i64::from(imm32.value()) + 5)
     }
 
     pub fn callq_m<R: Registers>(f: &mut fmt::Formatter, inst: &inst::callq_m<R>) -> fmt::Result {
@@ -584,6 +579,61 @@ pub mod display {
         let inst::jmpq_m { rm64 } = jmp;
         let rm64 = rm64.to_string(Size::Quadword);
         write!(f, "jmpq *{rm64}")
+    }
+
+    pub fn jmp_d8(f: &mut fmt::Formatter<'_>, jmp: &inst::jmp_d8) -> fmt::Result {
+        let inst::jmp_d8 { imm8 } = jmp;
+        display_displacement(f, "jmp", i64::from(imm8.value()) + 2)
+    }
+
+    pub fn jmp_d32(f: &mut fmt::Formatter<'_>, jmp: &inst::jmp_d32) -> fmt::Result {
+        let inst::jmp_d32 { imm32 } = jmp;
+        display_displacement(f, "jmp", i64::from(imm32.value()) + 5)
+    }
+
+    macro_rules! jcc {
+        ($($mnemonic:tt = $j8:ident / $j32:ident;)*) => ($(
+            pub fn $j8(f: &mut fmt::Formatter<'_>, jmp: &inst::$j8) -> fmt::Result {
+                let inst::$j8 { imm8 } = jmp;
+                display_displacement(f, $mnemonic, i64::from(imm8.value()) + 2)
+            }
+
+            pub fn $j32(f: &mut fmt::Formatter<'_>, jmp: &inst::$j32) -> fmt::Result {
+                let inst::$j32 { imm32 } = jmp;
+                display_displacement(f, $mnemonic, i64::from(imm32.value()) + 6)
+            }
+        )*)
+    }
+
+    jcc! {
+        "ja" = ja_d8 / ja_d32;
+        "jae" = jae_d8 / jae_d32;
+        "jb" = jb_d8 / jb_d32;
+        "jbe" = jbe_d8 / jbe_d32;
+        "je" = je_d8 / je_d32;
+        "jg" = jg_d8 / jg_d32;
+        "jge" = jge_d8 / jge_d32;
+        "jl" = jl_d8 / jl_d32;
+        "jle" = jle_d8 / jle_d32;
+        "jne" = jne_d8 / jne_d32;
+        "jno" = jno_d8 / jno_d32;
+        "jnp" = jnp_d8 / jnp_d32;
+        "jns" = jns_d8 / jns_d32;
+        "jo" = jo_d8 / jo_d32;
+        "jp" = jp_d8 / jp_d32;
+        "js" = js_d8 / js_d32;
+    }
+
+    fn display_displacement(
+        f: &mut fmt::Formatter<'_>,
+        mnemonic: &str,
+        displacement: i64,
+    ) -> fmt::Result {
+        if displacement >= 0 && displacement < 10 {
+            write!(f, "{mnemonic} {displacement}")
+        } else {
+            write!(f, "{mnemonic} {displacement:#x}")
+        }
     }
 }
 


### PR DESCRIPTION
While this doesn't remove any pseudo insts from ISLE (as was thought might be the case with `WinchJmpIf`) this does clean up some emission code to use some helpers and make it more clear what's happening.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
