### PR TITLE
Update the `log` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2204,9 +2204,9 @@ checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "logos"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -351,7 +351,7 @@ addr2line = { version = "0.24.1", default-features = false }
 anyhow = { version = "1.0.93", default-features = false }
 windows-sys = "0.59.0"
 env_logger = "0.11.5"
-log = { version = "0.4.8", default-features = false }
+log = { version = "0.4.27", default-features = false }
 clap = { version = "4.5.17", default-features = false, features = ["std", "derive"] }
 clap_complete = "4.4.7"
 hashbrown = { version = "0.15", default-features = false }

--- a/cranelift/codegen/src/egraph.rs
+++ b/cranelift/codegen/src/egraph.rs
@@ -198,12 +198,7 @@ where
 
             self.available_block[result] = self.get_available_block(inst);
             let opt_value = self.optimize_pure_enode(inst);
-            log::trace!(
-                "optimizing inst {} orig result {} gave {}",
-                inst,
-                result,
-                opt_value
-            );
+            log::trace!("optimizing inst {inst} orig result {result} gave {opt_value}");
 
             let gvn_context = GVNContext {
                 value_lists: &self.func.dfg.value_lists,

--- a/cranelift/codegen/src/isa/aarch64/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/mod.rs
@@ -81,7 +81,7 @@ impl TargetIsa for AArch64Backend {
         let dynamic_stackslot_offsets = emit_result.dynamic_stackslot_offsets;
 
         if let Some(disasm) = emit_result.disasm.as_ref() {
-            log::debug!("disassembly:\n{}", disasm);
+            log::debug!("disassembly:\n{disasm}");
         }
 
         Ok(CompiledCodeStencil {

--- a/cranelift/codegen/src/isa/pulley_shared/mod.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/mod.rs
@@ -183,7 +183,7 @@ where
         let dynamic_stackslot_offsets = emit_result.dynamic_stackslot_offsets;
 
         if let Some(disasm) = emit_result.disasm.as_ref() {
-            log::debug!("disassembly:\n{}", disasm);
+            log::debug!("disassembly:\n{disasm}");
         }
 
         Ok(CompiledCodeStencil {

--- a/cranelift/codegen/src/isa/riscv64/mod.rs
+++ b/cranelift/codegen/src/isa/riscv64/mod.rs
@@ -80,7 +80,7 @@ impl TargetIsa for Riscv64Backend {
         let dynamic_stackslot_offsets = emit_result.dynamic_stackslot_offsets;
 
         if let Some(disasm) = emit_result.disasm.as_ref() {
-            log::debug!("disassembly:\n{}", disasm);
+            log::debug!("disassembly:\n{disasm}");
         }
 
         Ok(CompiledCodeStencil {

--- a/cranelift/codegen/src/isa/s390x/mod.rs
+++ b/cranelift/codegen/src/isa/s390x/mod.rs
@@ -81,7 +81,7 @@ impl TargetIsa for S390xBackend {
         let dynamic_stackslot_offsets = emit_result.dynamic_stackslot_offsets;
 
         if let Some(disasm) = emit_result.disasm.as_ref() {
-            log::debug!("disassembly:\n{}", disasm);
+            log::debug!("disassembly:\n{disasm}");
         }
 
         Ok(CompiledCodeStencil {

--- a/cranelift/codegen/src/machinst/compile.rs
+++ b/cranelift/codegen/src/machinst/compile.rs
@@ -73,10 +73,7 @@ pub fn compile<B: LowerBackend + TargetIsa>(
         regalloc2::run(&vcode, vcode.abi.machine_env(), &options)
             .map_err(|err| {
                 log::error!(
-                    "Register allocation error for vcode\n{:?}\nError: {:?}\nCLIF for error:\n{:?}",
-                    vcode,
-                    err,
-                    f,
+                    "Register allocation error for vcode\n{vcode:?}\nError: {err:?}\nCLIF for error:\n{f:?}",
                 );
                 err
             })
@@ -91,11 +88,7 @@ pub fn compile<B: LowerBackend + TargetIsa>(
         checker
             .run()
             .map_err(|err| {
-                log::error!(
-                    "Register allocation checker errors:\n{:?}\nfor vcode:\n{:?}",
-                    err,
-                    vcode
-                );
+                log::error!("Register allocation checker errors:\n{err:?}\nfor vcode:\n{vcode:?}");
                 err
             })
             .expect("register allocation checker");

--- a/cranelift/codegen/src/timing.rs
+++ b/cranelift/codegen/src/timing.rs
@@ -232,7 +232,7 @@ mod enabled {
     impl Profiler for DefaultProfiler {
         fn start_pass(&self, pass: Pass) -> Box<dyn Any> {
             let prev = CURRENT_PASS.with(|p| p.replace(pass));
-            log::debug!("timing: Starting {}, (during {})", pass, prev);
+            log::debug!("timing: Starting {pass}, (during {prev})");
             Box::new(DefaultTimingToken {
                 start: Instant::now(),
                 pass,

--- a/cranelift/filetests/src/concurrent.rs
+++ b/cranelift/filetests/src/concurrent.rs
@@ -160,7 +160,7 @@ fn worker_thread(
                     });
 
                 if let Err(ref msg) = result {
-                    error!("FAIL: {}", msg);
+                    error!("FAIL: {msg}");
                 }
 
                 replies.send(Reply::Done { jobid, result }).unwrap();

--- a/cranelift/filetests/src/test_compile.rs
+++ b/cranelift/filetests/src/test_compile.rs
@@ -70,7 +70,7 @@ impl SubTest for TestCompile {
 
         let vcode = compiled_code.vcode.as_ref().unwrap();
 
-        info!("Generated {} bytes of code:\n{}", total_size, vcode);
+        info!("Generated {total_size} bytes of code:\n{vcode}");
 
         if self.precise_output {
             let dis = match isa.triple().architecture {

--- a/cranelift/filetests/src/test_interpret.rs
+++ b/cranelift/filetests/src/test_interpret.rs
@@ -79,7 +79,7 @@ impl SubTest for TestInterpret {
 fn run_test(func_store: &FunctionStore, func: &Function, details: &Details) -> anyhow::Result<()> {
     for comment in details.comments.iter() {
         if let Some(command) = parse_run_command(comment.text, &func.signature)? {
-            trace!("Parsed run command: {}", command);
+            trace!("Parsed run command: {command}");
 
             command
                 .run(|func_name, run_args| {

--- a/cranelift/filetests/src/test_run.rs
+++ b/cranelift/filetests/src/test_run.rs
@@ -180,7 +180,7 @@ fn run_test(
 ) -> anyhow::Result<()> {
     for comment in context.details.comments.iter() {
         if let Some(command) = parse_run_command(comment.text, &func.signature)? {
-            trace!("Parsed run command: {}", command);
+            trace!("Parsed run command: {command}");
 
             command
                 .run(|_, run_args| {
@@ -237,7 +237,7 @@ impl SubTest for TestRun {
         // Check that the host machine can run this test case (i.e. has all extensions)
         let host_isa = build_host_isa(true, flags.clone(), vec![]).ok();
         if let Err(e) = is_isa_compatible(file_path, host_isa.as_deref(), isa.unwrap()) {
-            log::info!("{}", e);
+            log::info!("{e}");
             return Ok(());
         }
 

--- a/cranelift/frontend/src/frontend/safepoints.rs
+++ b/cranelift/frontend/src/frontend/safepoints.rs
@@ -610,10 +610,7 @@ impl SafepointSpiller {
     /// rewrite the function's instructions to spill and reload them as
     /// necessary.
     pub fn run(&mut self, func: &mut Function, stack_map_values: &EntitySet<ir::Value>) {
-        log::trace!(
-            "values needing inclusion in stack maps: {:?}",
-            stack_map_values
-        );
+        log::trace!("values needing inclusion in stack maps: {stack_map_values:?}");
         log::trace!(
             "before inserting safepoint spills and reloads:\n{}",
             func.display()

--- a/cranelift/frontend/src/switch.rs
+++ b/cranelift/frontend/src/switch.rs
@@ -94,10 +94,7 @@ impl Switch {
             last_index = Some(index);
         }
 
-        log::trace!(
-            "build_contiguous_case_ranges after: {:#?}",
-            contiguous_case_ranges
-        );
+        log::trace!("build_contiguous_case_ranges after: {contiguous_case_ranges:#?}");
 
         contiguous_case_ranges
     }

--- a/cranelift/interpreter/src/frame.rs
+++ b/cranelift/interpreter/src/frame.rs
@@ -34,7 +34,7 @@ impl<'a> Frame<'a> {
     #[inline]
     pub fn get(&self, name: ValueRef) -> &DataValue {
         assert!(name.index() < self.registers.len());
-        trace!("Get {}", name);
+        trace!("Get {name}");
         &self
             .registers
             .get(name.index())
@@ -68,7 +68,7 @@ impl<'a> Frame<'a> {
     #[inline]
     pub fn set(&mut self, name: ValueRef, value: DataValue) -> Option<DataValue> {
         assert!(name.index() < self.registers.len());
-        trace!("Set {} -> {}", name, value);
+        trace!("Set {name} -> {value}");
         std::mem::replace(&mut self.registers[name.index()], Some(value))
     }
 
@@ -85,7 +85,7 @@ impl<'a> Frame<'a> {
     /// could be removed if we copied the values in the right order (i.e. when modifying in place,
     /// we need to avoid changing a value before it is referenced).
     pub fn rename(&mut self, old_names: &[ValueRef], new_names: &[ValueRef]) {
-        trace!("Renaming {:?} -> {:?}", old_names, new_names);
+        trace!("Renaming {old_names:?} -> {new_names:?}");
         assert_eq!(old_names.len(), new_names.len());
         let new_registers = vec![None; self.registers.len()];
         let mut old_registers = std::mem::replace(&mut self.registers, new_registers);

--- a/cranelift/interpreter/src/interpreter.rs
+++ b/cranelift/interpreter/src/interpreter.rs
@@ -91,7 +91,7 @@ impl<'a> Interpreter<'a> {
     /// Interpret a [Block] in a [Function]. This drives the interpretation over sequences of
     /// instructions, which may continue in other blocks, until the function returns.
     fn block(&mut self, block: Block) -> Result<ControlFlow<'a>, InterpreterError> {
-        trace!("Block: {}", block);
+        trace!("Block: {block}");
         let function = self.state.current_frame_mut().function();
         let layout = &function.layout;
         let mut maybe_inst = layout.first_inst(block);
@@ -110,7 +110,7 @@ impl<'a> Interpreter<'a> {
                 }
                 ControlFlow::Continue => maybe_inst = layout.next_inst(inst),
                 ControlFlow::ContinueAt(block, block_arguments) => {
-                    trace!("Block: {}", block);
+                    trace!("Block: {block}");
                     self.state
                         .current_frame_mut()
                         .set_all(function.dfg.block_params(block), block_arguments.to_vec());

--- a/cranelift/isle/fuzz/fuzz_targets/compile.rs
+++ b/cranelift/isle/fuzz/fuzz_targets/compile.rs
@@ -9,14 +9,14 @@ fuzz_target!(|src: &str| {
     let _ = env_logger::try_init();
 
     let lexer = cranelift_isle::lexer::Lexer::new(0, src);
-    log::debug!("lexer = {:?}", lexer);
+    log::debug!("lexer = {lexer:?}");
     let lexer = match lexer {
         Ok(l) => l,
         Err(_) => return,
     };
 
     let defs = cranelift_isle::parser::parse(lexer);
-    log::debug!("defs = {:?}", defs);
+    log::debug!("defs = {defs:?}");
     let defs = match defs {
         Ok(d) => d,
         Err(_) => return,
@@ -28,7 +28,7 @@ fuzz_target!(|src: &str| {
     )]));
 
     let code = cranelift_isle::compile::compile(files, &defs, &Default::default());
-    log::debug!("code = {:?}", code);
+    log::debug!("code = {code:?}");
     let code = match code {
         Ok(c) => c,
         Err(_) => return,

--- a/cranelift/isle/veri/veri_engine/src/solver.rs
+++ b/cranelift/isle/veri/veri_engine/src/solver.rs
@@ -1765,7 +1765,7 @@ fn resolve_dynamic_widths(
                     }
 
                     if unresolved_widths.contains(&width_name) {
-                        log::debug!("\tResolved width: {}, {}", width_name, width_int);
+                        log::debug!("\tResolved width: {width_name}, {width_int}");
                         width_resolutions.insert(width_name, width_int);
                         cur_tyctx
                             .tymap
@@ -1940,12 +1940,12 @@ pub fn run_solver_with_static_widths(
         }
         (None, None) => (),
         (Some(_), None) => {
-            log::error!("Verification failed for {}, {}", rulename, widthname);
+            log::error!("Verification failed for {rulename}, {widthname}");
             log::error!("Left hand side has load statement but right hand side does not.");
             return VerificationResult::Failure(Counterexample {});
         }
         (None, Some(_)) => {
-            log::error!("Verification failed for {}, {}", rulename, widthname);
+            log::error!("Verification failed for {rulename}, {widthname}");
             log::error!("Right hand side has load statement but left hand side does not.");
             return VerificationResult::Failure(Counterexample {});
         }
@@ -1967,12 +1967,12 @@ pub fn run_solver_with_static_widths(
         }
         (None, None) => (),
         (Some(_), None) => {
-            log::error!("Verification failed for {}, {}", rulename, widthname);
+            log::error!("Verification failed for {rulename}, {widthname}");
             log::error!("Left hand side has store statement but right hand side does not.");
             return VerificationResult::Failure(Counterexample {});
         }
         (None, Some(_)) => {
-            log::error!("Verification failed for {}, {}", rulename, widthname);
+            log::error!("Verification failed for {rulename}, {widthname}");
             log::error!("Right hand side has store statement but left hand side does not.");
             return VerificationResult::Failure(Counterexample {});
         }

--- a/cranelift/isle/veri/veri_engine/src/type_inference.rs
+++ b/cranelift/isle/veri/veri_engine/src/type_inference.rs
@@ -1511,13 +1511,13 @@ fn add_rule_constraints(
             let term_name = typeenv.syms[term.name.index()].clone();
 
             // Print term for debugging
-            log::trace!(" {}", term_name);
+            log::trace!(" {term_name}");
 
             tree.quantified_vars
                 .insert((curr.ident.clone(), curr.type_var));
             let a = annotation_env.get_annotation_for_term(term_id);
             if a.is_none() {
-                log::error!("\nSkipping rule with unannotated term: {}", term_name);
+                log::error!("\nSkipping rule with unannotated term: {term_name}");
                 return None;
             }
             let annotation = a.unwrap();

--- a/cranelift/isle/veri/veri_engine/src/verify.rs
+++ b/cranelift/isle/veri/veri_engine/src/verify.rs
@@ -112,7 +112,7 @@ pub fn verify_rules_for_term(
             if !names.contains(name) {
                 continue;
             } else {
-                log::debug!("Verifying rule: {}", name);
+                log::debug!("Verifying rule: {name}");
             }
         }
         let ctx = Context::new(typesols);
@@ -121,7 +121,7 @@ pub fn verify_rules_for_term(
         }
         let rule_sem = &ctx.typesols[&rule.id];
         log::debug!("Term: {}", config.term);
-        log::debug!("Type instantiation: {}", types);
+        log::debug!("Type instantiation: {types}");
         let result = run_solver(rule_sem, rule, termenv, typeenv, concrete, config, &types);
         rules_checked += 1;
         if result != VerificationResult::Success {

--- a/cranelift/isle/veri/veri_engine/tests/utils/mod.rs
+++ b/cranelift/isle/veri/veri_engine/tests/utils/mod.rs
@@ -148,7 +148,7 @@ fn test_rules_with_term(inputs: Vec<PathBuf>, tr: TestResult, config: Config) {
     };
 
     for (type_instantiation, expected_result) in instantiations {
-        log::debug!("Expected result: {:?}", expected_result);
+        log::debug!("Expected result: {expected_result:?}");
         let type_sols = type_rules_with_term_and_types(
             &termenv,
             &typeenv,

--- a/cranelift/jit/src/backend.rs
+++ b/cranelift/jit/src/backend.rs
@@ -543,7 +543,7 @@ impl Module for JITModule {
         bytes: &[u8],
         relocs: &[ModuleReloc],
     ) -> ModuleResult<()> {
-        info!("defining function {} with bytes", id);
+        info!("defining function {id} with bytes");
         let decl = self.declarations.get_function_decl(id);
         if !decl.linkage.is_definable() {
             return Err(ModuleError::InvalidImportDefinition(

--- a/cranelift/object/src/backend.rs
+++ b/cranelift/object/src/backend.rs
@@ -482,7 +482,7 @@ impl ObjectModule {
         bytes: &[u8],
         relocs: Vec<ObjectRelocRecord>,
     ) -> Result<(), ModuleError> {
-        info!("defining function {} with bytes", func_id);
+        info!("defining function {func_id} with bytes");
         let decl = self.declarations.get_function_decl(func_id);
         let decl_name = decl.linkage_name(func_id);
         if !decl.linkage.is_definable() {

--- a/crates/cache/src/config.rs
+++ b/crates/cache/src/config.rs
@@ -116,7 +116,7 @@ impl Default for CacheConfig {
 /// Creates a new configuration file at specified path, or default path if None is passed.
 /// Fails if file already exists.
 pub fn create_new_config<P: AsRef<Path> + Debug>(config_file: Option<P>) -> Result<PathBuf> {
-    trace!("Creating new config file, path: {:?}", config_file);
+    trace!("Creating new config file, path: {config_file:?}");
 
     let config_file = match config_file {
         Some(path) => path.as_ref().to_path_buf(),

--- a/crates/cache/src/lib.rs
+++ b/crates/cache/src/lib.rs
@@ -265,7 +265,7 @@ impl<'cache> ModuleCacheEntryInner<'cache> {
         trace!("get_data() for path: {}", mod_cache_path.display());
         let compressed_cache_bytes = fs::read(&mod_cache_path).ok()?;
         let cache_bytes = zstd::decode_all(&compressed_cache_bytes[..])
-            .map_err(|err| warn!("Failed to decompress cached code: {}", err))
+            .map_err(|err| warn!("Failed to decompress cached code: {err}"))
             .ok()?;
         Some(cache_bytes)
     }
@@ -277,7 +277,7 @@ impl<'cache> ModuleCacheEntryInner<'cache> {
             &serialized_data[..],
             self.cache.baseline_compression_level(),
         )
-        .map_err(|err| warn!("Failed to compress cached code: {}", err))
+        .map_err(|err| warn!("Failed to compress cached code: {err}"))
         .ok()?;
 
         // Optimize syscalls: first, try writing to disk. It should succeed in most cases.

--- a/crates/cache/src/worker.rs
+++ b/crates/cache/src/worker.rs
@@ -110,8 +110,7 @@ impl Worker {
         if let Err(ref err) = sent_event {
             info!(
                 "Failed to send asynchronously message to worker thread, \
-                 event: {:?}, error: {}",
-                event, err
+                 event: {event:?}, error: {err}"
             );
         }
 
@@ -260,12 +259,11 @@ impl WorkerThread {
 
         match rustix::process::nice(NICE_DELTA_FOR_BACKGROUND_TASKS) {
             Ok(current_nice) => {
-                debug!("New nice value of worker thread: {}", current_nice);
+                debug!("New nice value of worker thread: {current_nice}");
             }
             Err(err) => {
                 warn!(
-                    "Failed to lower worker thread priority ({:?}). It might affect application performance.",
-                    err
+                    "Failed to lower worker thread priority ({err:?}). It might affect application performance."
                 );
             }
         };

--- a/crates/cranelift/src/compiler.rs
+++ b/crates/cranelift/src/compiler.rs
@@ -280,7 +280,7 @@ impl wasmtime_environ::Compiler for Compiler {
 
         let timing = cranelift_codegen::timing::take_current();
         log::debug!("{:?} translated in {:?}", func_index, timing.total());
-        log::trace!("{:?} timing info\n{}", func_index, timing);
+        log::trace!("{func_index:?} timing info\n{timing}");
 
         Ok(CompiledFunctionBody {
             code: Box::new(func),

--- a/crates/cranelift/src/debug/transform/mod.rs
+++ b/crates/cranelift/src/debug/transform/mod.rs
@@ -135,7 +135,7 @@ fn read_dwarf_package_from_bytes<'data>(
     match load_dwp(translation, buffer) {
         Ok(package) => Some(package),
         Err(err) => {
-            log::warn!("Failed to load Dwarf package {}", err);
+            log::warn!("Failed to load Dwarf package {err}");
             None
         }
     }

--- a/crates/environ/src/compile/module_environ.rs
+++ b/crates/environ/src/compile/module_environ.rs
@@ -676,7 +676,7 @@ and for re-adding support for interface types you can see this issue:
             KnownCustom::Name(name) => {
                 let result = self.name_section(name);
                 if let Err(e) = result {
-                    log::warn!("failed to parse name section {:?}", e);
+                    log::warn!("failed to parse name section {e:?}");
                 }
             }
             _ => {
@@ -730,7 +730,7 @@ and for re-adding support for interface types you can see this issue:
             // We don't use these at the moment.
             ".debug_aranges" | ".debug_pubnames" | ".debug_pubtypes" => return,
             other => {
-                log::warn!("unknown debug section `{}`", other);
+                log::warn!("unknown debug section `{other}`");
                 return;
             }
         }

--- a/crates/environ/src/component/translate/adapt.rs
+++ b/crates/environ/src/component/translate/adapt.rs
@@ -220,8 +220,8 @@ impl<'data> Translator<'_, 'data> {
             let wasm = &*self.scope_vec.push(wasm);
             if log::log_enabled!(log::Level::Trace) {
                 match wasmprinter::print_bytes(wasm) {
-                    Ok(s) => log::trace!("generated adapter module:\n{}", s),
-                    Err(e) => log::trace!("failed to print adapter module: {}", e),
+                    Ok(s) => log::trace!("generated adapter module:\n{s}"),
+                    Err(e) => log::trace!("failed to print adapter module: {e}"),
                 }
             }
 

--- a/crates/environ/src/stack_map.rs
+++ b/crates/environ/src/stack_map.rs
@@ -115,7 +115,7 @@ impl<'a> StackMap<'a> {
     /// map is associated with.
     pub unsafe fn live_gc_refs(&self, sp: *mut usize) -> impl Iterator<Item = *mut u32> + '_ {
         self.offsets().map(move |i| {
-            log::trace!("Live GC ref in frame at frame offset {:#x}", i);
+            log::trace!("Live GC ref in frame at frame offset {i:#x}");
             let i = usize::try_from(i).unwrap();
             let ptr_to_gc_ref = unsafe { sp.byte_add(i) };
 

--- a/crates/fuzzing/src/generators/component_types.rs
+++ b/crates/fuzzing/src/generators/component_types.rs
@@ -163,7 +163,7 @@ where
                 let data: &(P, R) = cx.data().downcast_ref().unwrap();
                 let (expected_params, result) = data;
                 assert_eq!(params, *expected_params);
-                log::trace!("returning result {:?}", result);
+                log::trace!("returning result {result:?}");
                 Ok(result.clone())
             },
         )
@@ -180,7 +180,7 @@ where
         *store.data_mut() = Box::new((params.clone(), result.clone()));
         log::trace!("passing in parameters {params:?}");
         let actual = func.call(&mut store, params).unwrap();
-        log::trace!("got result {:?}", actual);
+        log::trace!("got result {actual:?}");
         assert_eq!(actual, result);
         func.post_return(&mut store).unwrap();
     }

--- a/crates/fuzzing/src/oracles.rs
+++ b/crates/fuzzing/src/oracles.rs
@@ -51,7 +51,7 @@ pub fn log_wasm(wasm: &[u8]) {
     let i = CNT.fetch_add(1, SeqCst);
     let name = format!("testcase{i}.wasm");
     std::fs::write(&name, wasm).expect("failed to write wasm file");
-    log::debug!("wrote wasm file to `{}`", name);
+    log::debug!("wrote wasm file to `{name}`");
     let wat = format!("testcase{i}.wat");
     match wasmprinter::print_bytes(wasm) {
         Ok(s) => std::fs::write(&wat, s).expect("failed to write wat file"),
@@ -282,7 +282,7 @@ pub fn instantiate_many(
         match command {
             Command::Instantiate(index) => {
                 let index = *index % modules.len();
-                log::info!("instantiating {}", index);
+                log::info!("instantiating {index}");
                 let module = &modules[index];
                 let mut store = Store::new(&engine, limits.clone());
                 config.configure_store(&mut store);
@@ -299,7 +299,7 @@ pub fn instantiate_many(
                 }
                 let index = *index % stores.len();
 
-                log::info!("dropping {}", index);
+                log::info!("dropping {index}");
                 stores.swap_remove(index);
             }
         }
@@ -452,7 +452,7 @@ pub fn differential(
     args: &[DiffValue],
     result_tys: &[DiffValueType],
 ) -> anyhow::Result<bool> {
-    log::debug!("Evaluating: `{}` with {:?}", name, args);
+    log::debug!("Evaluating: `{name}` with {args:?}");
     let lhs_results = match lhs.evaluate(name, args, result_tys) {
         Ok(Some(results)) => Ok(results),
         Err(e) => Err(e),
@@ -617,7 +617,7 @@ pub fn make_api_calls(api: generators::api::ApiCalls) {
             }
 
             ApiCall::ModuleNew { id, wasm } => {
-                log::debug!("creating module: {}", id);
+                log::debug!("creating module: {id}");
                 log_wasm(&wasm);
                 let module = match Module::new(store.as_ref().unwrap().engine(), &wasm) {
                     Ok(m) => m,
@@ -628,12 +628,12 @@ pub fn make_api_calls(api: generators::api::ApiCalls) {
             }
 
             ApiCall::ModuleDrop { id } => {
-                log::trace!("dropping module: {}", id);
+                log::trace!("dropping module: {id}");
                 drop(modules.remove(&id));
             }
 
             ApiCall::InstanceNew { id, module } => {
-                log::trace!("instantiating module {} as {}", module, id);
+                log::trace!("instantiating module {module} as {id}");
                 let module = match modules.get(&module) {
                     Some(m) => m,
                     None => continue,
@@ -646,12 +646,12 @@ pub fn make_api_calls(api: generators::api::ApiCalls) {
             }
 
             ApiCall::InstanceDrop { id } => {
-                log::trace!("dropping instance {}", id);
+                log::trace!("dropping instance {id}");
                 instances.remove(&id);
             }
 
             ApiCall::CallExportedFunc { instance, nth } => {
-                log::trace!("calling instance export {} / {}", instance, nth);
+                log::trace!("calling instance export {instance} / {nth}");
                 let instance = match instances.get(&instance) {
                     Some(i) => i,
                     None => {
@@ -827,7 +827,7 @@ pub fn table_ops(
                     CountDrops::new(&expected_drops, num_dropped.clone()),
                 )?;
 
-                log::info!("table_ops: gc() -> ({:?}, {:?}, {:?})", a, b, c);
+                log::info!("table_ops: gc() -> ({a:?}, {b:?}, {c:?})");
                 results[0] = Some(a).into();
                 results[1] = Some(b).into();
                 results[2] = Some(c).into();
@@ -903,7 +903,7 @@ pub fn table_ops(
                     CountDrops::new(&expected_drops, num_dropped.clone()),
                 )?;
 
-                log::info!("table_ops: make_refs() -> ({:?}, {:?}, {:?})", a, b, c);
+                log::info!("table_ops: make_refs() -> ({a:?}, {b:?}, {c:?})");
 
                 results[0] = Some(a).into();
                 results[1] = Some(b).into();
@@ -1162,7 +1162,7 @@ pub fn call_async(wasm: &[u8], config: &generators::Config, mut poll_amts: &[u32
                     let ty = ty.clone();
                     Box::new(async move {
                         caller.engine().increment_epoch();
-                        log::info!("yielding {} times in import", poll_amt);
+                        log::info!("yielding {poll_amt} times in import");
                         YieldN(poll_amt).await;
                         for (ret_ty, result) in ty.results().zip(results) {
                             *result = ret_ty.default_value().unwrap();
@@ -1230,7 +1230,7 @@ pub fn call_async(wasm: &[u8], config: &generators::Config, mut poll_amts: &[u32
             .map(|ty| ty.default_value().unwrap())
             .collect::<Vec<_>>();
 
-        log::info!("invoking export {:?}", name);
+        log::info!("invoking export {name:?}");
         let future = func.call_async(&mut store, &params, &mut results);
         match run(Timeout {
             future,

--- a/crates/fuzzing/src/oracles/diff_v8.rs
+++ b/crates/fuzzing/src/oracles/diff_v8.rs
@@ -139,7 +139,7 @@ impl DiffEngine for V8Engine {
                     "divide result unrepresentable",
                 ]);
             }
-            other => log::debug!("unknown code {:?}", other),
+            other => log::debug!("unknown code {other:?}"),
         }
 
         verify_wasmtime("not possibly present in an error, just panic please");

--- a/crates/fuzzing/src/oracles/stacks.rs
+++ b/crates/fuzzing/src/oracles/stacks.rs
@@ -61,9 +61,9 @@ pub fn check_stacks(stacks: Stacks) -> usize {
 
     let mut max_stack_depth = 0;
     for input in stacks.inputs().iter().copied() {
-        log::debug!("input: {}", input);
+        log::debug!("input: {input}");
         if let Err(trap) = run.call(&mut store, (input.into(),)) {
-            log::debug!("trap: {:?}", trap);
+            log::debug!("trap: {trap:?}");
             let get_stack = instance
                 .get_typed_func::<(), (u32, u32)>(&mut store, "get_stack")
                 .expect("should export `get_stack` function as expected");
@@ -120,7 +120,7 @@ fn assert_stack_matches(
         host_trace
     };
 
-    log::debug!("Wasm thinks its stack is: {:?}", wasm_trace);
+    log::debug!("Wasm thinks its stack is: {wasm_trace:?}");
     log::debug!(
         "Host thinks the stack is: {:?}",
         host_trace

--- a/crates/unwinder/src/stackwalk.rs
+++ b/crates/unwinder/src/stackwalk.rs
@@ -102,9 +102,9 @@ pub unsafe fn visit_frames<R>(
     mut f: impl FnMut(Frame) -> ControlFlow<R>,
 ) -> ControlFlow<R> {
     log::trace!("=== Tracing through contiguous sequence of Wasm frames ===");
-    log::trace!("trampoline_fp = 0x{:016x}", trampoline_fp);
-    log::trace!("   initial pc = 0x{:016x}", pc);
-    log::trace!("   initial fp = 0x{:016x}", fp);
+    log::trace!("trampoline_fp = 0x{trampoline_fp:016x}");
+    log::trace!("   initial pc = 0x{pc:016x}");
+    log::trace!("   initial fp = 0x{fp:016x}");
 
     // Safety requirements documented above.
     assert_ne!(pc, 0);

--- a/crates/wasi-threads/src/lib.rs
+++ b/crates/wasi-threads/src/lib.rs
@@ -83,10 +83,7 @@ impl<T: Clone + Send + 'static> WasiThreadsCtx<T> {
                 // what the user expects from the CLI but probably not in a
                 // Wasmtime embedding.
                 log::trace!(
-                    "spawned thread id = {}; calling start function `{}` with: {}",
-                    wasi_thread_id,
-                    WASI_ENTRY_POINT,
-                    thread_start_arg
+                    "spawned thread id = {wasi_thread_id}; calling start function `{WASI_ENTRY_POINT}` with: {thread_start_arg}"
                 );
                 let res = if instance_pre.module().engine().is_async() {
                     wasmtime_wasi::runtime::in_tokio(
@@ -97,9 +94,9 @@ impl<T: Clone + Send + 'static> WasiThreadsCtx<T> {
                     thread_entry_point.call(&mut store, (wasi_thread_id, thread_start_arg))
                 };
                 match res {
-                    Ok(_) => log::trace!("exiting thread id = {} normally", wasi_thread_id),
+                    Ok(_) => log::trace!("exiting thread id = {wasi_thread_id} normally"),
                     Err(e) => {
-                        log::trace!("exiting thread id = {} due to error", wasi_thread_id);
+                        log::trace!("exiting thread id = {wasi_thread_id} due to error");
                         let e = wasi_common::maybe_exit_on_error(e);
                         eprintln!("Error: {e:?}");
                         std::process::exit(1);
@@ -158,7 +155,7 @@ pub fn add_to_linker<T: Clone + Send + 'static>(
                     thread_id
                 }
                 Err(e) => {
-                    log::error!("failed to spawn thread: {}", e);
+                    log::error!("failed to spawn thread: {e}");
                     -1
                 }
             }

--- a/crates/wasmtime/src/runtime/vm/const_expr.rs
+++ b/crates/wasmtime/src/runtime/vm/const_expr.rs
@@ -164,7 +164,7 @@ impl ConstExprEvaluator {
         context: &mut ConstEvalContext,
         expr: &ConstExpr,
     ) -> Result<ValRaw> {
-        log::trace!("evaluating const expr: {:?}", expr);
+        log::trace!("evaluating const expr: {expr:?}");
 
         self.stack.clear();
 

--- a/crates/wasmtime/src/runtime/vm/gc/enabled/drc.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/enabled/drc.rs
@@ -386,7 +386,7 @@ impl DrcHeap {
                 continue;
             }
 
-            log::trace!("Found GC reference on the stack: {:#p}", gc_ref);
+            log::trace!("Found GC reference on the stack: {gc_ref:#p}");
 
             debug_assert!(
                 over_approx_set.contains(&gc_ref),

--- a/crates/wasmtime/src/runtime/vm/stack_switching.rs
+++ b/crates/wasmtime/src/runtime/vm/stack_switching.rs
@@ -346,7 +346,7 @@ pub fn cont_new(
     csi.state = VMStackState::Fresh;
     csi.limits = limits;
 
-    log::trace!("Created contref @ {:p}", contref);
+    log::trace!("Created contref @ {contref:p}");
     Ok(contref)
 }
 

--- a/examples/mpk.rs
+++ b/examples/mpk.rs
@@ -41,7 +41,7 @@ use wasmtime::*;
 fn main() -> Result<()> {
     env_logger::init();
     let args = Args::parse();
-    info!("{:?}", args);
+    info!("{args:?}");
 
     let without_mpk = probe_engine_size(&args, MpkEnabled::Disable)?;
     println!("without MPK:\t{}", without_mpk.to_string());
@@ -101,7 +101,7 @@ fn probe_engine_size(args: &Args, mpk: MpkEnabled) -> Result<Pool> {
                 search.record(true)
             }
             Err(e) => {
-                warn!("failed engine allocation, continuing search: {:?}", e);
+                warn!("failed engine allocation, continuing search: {e:?}");
                 search.record(false)
             }
         }
@@ -210,10 +210,7 @@ fn build_engine(args: &Args, num_memories: u32, enable_mpk: MpkEnabled) -> Resul
     engine.increment_epoch();
 
     let mapped_bytes = mapped_bytes_after - mapped_bytes_before;
-    info!(
-        "{}-slot pool ({:?}): {} bytes mapped",
-        num_memories, enable_mpk, mapped_bytes
-    );
+    info!("{num_memories}-slot pool ({enable_mpk:?}): {mapped_bytes} bytes mapped");
     Ok(mapped_bytes)
 }
 

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -760,7 +760,7 @@ async fn handle_request(
             .call_handle(&mut store, req, out)
             .await
         {
-            log::error!("[{req_id}] :: {:?}", e);
+            log::error!("[{req_id}] :: {e:?}");
             return Err(e);
         }
 

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -2470,6 +2470,12 @@ criteria = "safe-to-deploy"
 delta = "0.4.20 -> 0.4.22"
 notes = "Mostly updates around the key-value implementation of this crate, but nothing out of place."
 
+[[audits.log]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.4.22 -> 0.4.27"
+notes = "Lots of minor updates to macros and such, nothing touching `unsafe`"
+
 [[audits.mach2]]
 who = "Nick Fitzgerald <fitzgen@gmail.com>"
 criteria = "safe-to-deploy"

--- a/tests/pcc_memory.rs
+++ b/tests/pcc_memory.rs
@@ -79,8 +79,8 @@ mod pcc_memory_tests {
                 for guard_size in [2 * GIB] {
                     for enable_spectre in [true /* not yet supported by PCC: false */] {
                         for _memory_bits in [32 /* not yet supported by PCC: 64 */] {
-                            log::trace!("test:\n{}\n", test);
-                            log::trace!("static {:x} guard {:x}", memory_reservation, guard_size);
+                            log::trace!("test:\n{test}\n");
+                            log::trace!("static {memory_reservation:x} guard {guard_size:x}");
                             let mut cfg = Config::new();
                             cfg.memory_reservation(memory_reservation);
                             cfg.memory_guard_size(guard_size);


### PR DESCRIPTION
This enables getting warnings about formatting strings in the `log` crate directives which are then additionally fixed here as well.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
