### PR TITLE
docs: add doc comments to default_value helpers (#10437)

### DIFF
--- a/crates/wasmtime/src/runtime/types.rs
+++ b/crates/wasmtime/src/runtime/types.rs
@@ -2677,7 +2677,10 @@ impl GlobalType {
         };
         GlobalType::new(ty, mutability)
     }
+    /// Construct a new global import with this type’s default value.
     ///
+    /// This creates a host `Global` in the given store initialized to the
+    /// type’s zero/null default (e.g. `0` for numeric globals, `null_ref` for refs).
     pub fn default_value(&self, store: impl AsContextMut) -> Result<RuntimeGlobal> {
         let val = self
             .content()
@@ -2819,7 +2822,10 @@ impl TableType {
     pub(crate) fn wasmtime_table(&self) -> &Table {
         &self.ty
     }
+    /// Construct a new table import whose entries are filled with this type’s default.
     ///
+    /// Creates a host `Table` in the store with its initial size and element
+    /// type’s default (e.g. `null_ref` for nullable refs).
     pub fn default_value(&self, store: impl AsContextMut) -> Result<RuntimeTable> {
         let val: ValType = self.element().clone().into();
         let init_val = val
@@ -3160,7 +3166,10 @@ impl MemoryType {
     pub(crate) fn wasmtime_memory(&self) -> &Memory {
         &self.ty
     }
+    /// Construct a new memory import initialized to this memory type’s default state
     ///
+    /// Returns a host `Memory` in the given store with the configured initial
+    /// page size and zeroed contents.
     pub fn default_value(&self, store: impl AsContextMut) -> Result<RuntimeMemory> {
         RuntimeMemory::new(store, self.clone())
     }


### PR DESCRIPTION
**Discussion:**  
This change addresses [issue #10437](https://github.com/bytecodealliance/wasmtime/issues/10437), where it was noted that the `default_value` helper methods lacked API documentation.

**Why this change is needed:**  
Adding these doc comments ensures the public API for `GlobalType::default_value`, `TableType::default_value`, and `MemoryType::default_value` is fully documented in the generated docs, improving discoverability and clarity for users.

---

**What this PR does:**  
- Adds a brief `///` doc comment to each of the three helper methods in `crates/wasmtime/src/runtime/types.rs`:
  - `GlobalType::default_value`
  - `TableType::default_value`
  - `MemoryType::default_value`

**Checklist:**  
- [x] Ran `cargo fmt -- --check`  
- [x] Ran `cargo test -p wasmtime`  

Closes #10437.
