### PR TITLE
Rename `memory32_grow` builtin to `memory_grow`

### DIFF
--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -2752,7 +2752,7 @@ impl FuncEnvironment<'_> {
         val: ir::Value,
     ) -> WasmResult<ir::Value> {
         let mut pos = builder.cursor();
-        let memory_grow = self.builtin_functions.memory32_grow(&mut pos.func);
+        let memory_grow = self.builtin_functions.memory_grow(&mut pos.func);
         let index_arg = index.index();
 
         let memory_index = pos.ins().iconst(I32, index_arg as i64);

--- a/crates/environ/src/builtin.rs
+++ b/crates/environ/src/builtin.rs
@@ -4,7 +4,7 @@ macro_rules! foreach_builtin_function {
     ($mac:ident) => {
         $mac! {
             // Returns an index for wasm's `memory.grow` builtin function.
-            memory32_grow(vmctx: vmctx, delta: u64, index: u32) -> pointer;
+            memory_grow(vmctx: vmctx, delta: u64, index: u32) -> pointer;
             // Returns an index for wasm's `table.copy` when both tables are locally
             // defined.
             table_copy(vmctx: vmctx, dst_index: u32, src_index: u32, dst: u64, src: u64, len: u64) -> bool;
@@ -377,7 +377,7 @@ impl BuiltinFunctionIndex {
             }};
 
             // Growth-related functions return -2 as a sentinel.
-            (@get memory32_grow pointer) => (TrapSentinel::NegativeTwo);
+            (@get memory_grow pointer) => (TrapSentinel::NegativeTwo);
             (@get table_grow_func_ref pointer) => (TrapSentinel::NegativeTwo);
             (@get table_grow_gc_ref pointer) => (TrapSentinel::NegativeTwo);
             (@get table_grow_cont_obj pointer) => (TrapSentinel::NegativeTwo);

--- a/crates/wasmtime/src/runtime/vm/libcalls.rs
+++ b/crates/wasmtime/src/runtime/vm/libcalls.rs
@@ -162,7 +162,7 @@ pub mod raw {
     wasmtime_environ::foreach_builtin_function!(libcall);
 }
 
-fn memory32_grow(
+fn memory_grow(
     store: &mut dyn VMStore,
     mut instance: Pin<&mut Instance>,
     delta: u64,

--- a/winch/codegen/src/visitor.rs
+++ b/winch/codegen/src/visitor.rs
@@ -1874,7 +1874,7 @@ where
         self.context.stack.extend([mem.try_into()?]);
 
         let heap = self.env.resolve_heap(MemoryIndex::from_u32(mem));
-        let builtin = self.env.builtins.memory32_grow::<M::ABI, M::Ptr>()?;
+        let builtin = self.env.builtins.memory_grow::<M::ABI, M::Ptr>()?;
         FnCall::emit::<M>(
             &mut self.env,
             self.masm,


### PR DESCRIPTION
This builtin is used for both 32 and 64-bit linear memories, no need to bake "32" into the name any more.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
