### PR TITLE
Cranelift: introduce a function inliner

### DIFF
--- a/cranelift/codegen/src/context.rs
+++ b/cranelift/codegen/src/context.rs
@@ -14,6 +14,7 @@ use crate::dominator_tree::DominatorTree;
 use crate::dominator_tree::DominatorTreePreorder;
 use crate::egraph::EgraphPass;
 use crate::flowgraph::ControlFlowGraph;
+use crate::inline::{Inline, do_inlining};
 use crate::ir::Function;
 use crate::isa::TargetIsa;
 use crate::legalizer::simple_legalize;
@@ -191,6 +192,13 @@ impl Context {
         }
 
         Ok(())
+    }
+
+    /// Perform function call inlining.
+    ///
+    /// Returns `true` if any function call was inlined, `false` otherwise.
+    pub fn inline(&mut self, inliner: impl Inline) -> CodegenResult<bool> {
+        do_inlining(&mut self.func, inliner)
     }
 
     /// Compile the function,

--- a/cranelift/codegen/src/inline.rs
+++ b/cranelift/codegen/src/inline.rs
@@ -1,0 +1,1501 @@
+//! Function inlining infrastructure.
+//!
+//! This module provides "inlining as a library" to Cranelift users; it does
+//! _not_ provide a complete, off-the-shelf inlining solution. Cranelift's
+//! compilation context is per-function and does not encompass the full call
+//! graph. It does not know which functions are hot and which are cold, which
+//! have been marked the equivalent of `#[inline(never)]`, etc... Only the
+//! Cranelift user can understand these aspects of the full compilation
+//! pipeline, and these things can be very different between (say) Wasmtime and
+//! `cg_clif`. Therefore, this module does not attempt to define hueristics for
+//! when inlining a particular call is likely beneficial. This module only
+//! provides hooks for the Cranelift user to define whether a given call should
+//! be inlined or not, and the mechanics to inline a callee into a particular
+//! call site when directed to do so by the Cranelift user.
+//!
+//! The top-level inlining entry point during Cranelift compilation is
+//! [`Context::inline`][crate::Context::inline]. It takes an [`Inline`] trait
+//! implementation, which is authored by the Cranelift user and directs
+//! Cranelift whether to inline a particular call, and, when inlining, gives
+//! Cranelift the body of the callee that is to be inlined.
+
+use crate::cursor::{Cursor as _, FuncCursor};
+use crate::ir::{self, InstBuilder as _};
+use crate::result::CodegenResult;
+use crate::trace;
+use crate::traversals::Dfs;
+use alloc::vec::Vec;
+use cranelift_entity::{SecondaryMap, packed_option::PackedOption};
+use smallvec::SmallVec;
+
+type SmallValueVec = SmallVec<[ir::Value; 8]>;
+type SmallBlockArgVec = SmallVec<[ir::BlockArg; 8]>;
+type SmallBlockCallVec = SmallVec<[ir::BlockCall; 8]>;
+
+/// A command directing Cranelift whether or not to inline a particular call.
+pub enum InlineCommand<'a> {
+    /// Keep the call as-is, out-of-line, and do not inline the callee.
+    KeepCall,
+    /// Inline the call, using this function as the body of the callee.
+    ///
+    /// It is the `Inline` implementor's responsibility to ensure that this
+    /// function is the correct callee. Providing the wrong function may result
+    /// in panics during compilation or incorrect runtime behavior.
+    Inline(&'a ir::Function),
+}
+
+/// A trait for directing Cranelift whether to inline a particular call or not.
+///
+/// Used in combination with the [`Context::inline`][crate::Context::inline]
+/// method.
+pub trait Inline {
+    /// A hook invoked for each direct call instruction in a function, whose
+    /// result determines whether Cranelift should inline a given call.
+    ///
+    /// The Cranelift user is responsible for defining their own hueristics and
+    /// deciding whether inlining the call is beneficial.
+    ///
+    /// It is the `Inline` implementor's responsibility to ensure that, when
+    /// directing Cranelift to inline a call, the provided callee function is
+    /// the correct function. Providing the wrong function may result in panics
+    /// during compilation (e.g. due to signature type mismatches) or incorrect
+    /// runtime behavior.
+    fn inline(
+        &self,
+        caller: &ir::Function,
+        call_inst: ir::Inst,
+        call_opcode: ir::Opcode,
+        callee: ir::FuncRef,
+        call_args: &[ir::Value],
+    ) -> InlineCommand<'_>;
+}
+
+impl<'a, T> Inline for &'a T
+where
+    T: Inline,
+{
+    fn inline(
+        &self,
+        caller: &ir::Function,
+        inst: ir::Inst,
+        opcode: ir::Opcode,
+        callee: ir::FuncRef,
+        args: &[ir::Value],
+    ) -> InlineCommand<'_> {
+        (*self).inline(caller, inst, opcode, callee, args)
+    }
+}
+
+/// Walk the given function, invoke the `Inline` implementation for each call
+/// instruction, and inline the callee when directed to do so.
+///
+/// Returns whether any call was inlined.
+pub(crate) fn do_inlining(func: &mut ir::Function, inliner: impl Inline) -> CodegenResult<bool> {
+    let mut inlined_any = false;
+    let mut allocs = InliningAllocs::default();
+
+    let mut cursor = FuncCursor::new(func);
+    while let Some(block) = cursor.next_block() {
+        // Always keep track of our previous cursor position. After we inline a
+        // call, replacing the current position with an arbitrary sub-CFG, we
+        // back up to this previous position. This makes sure our cursor is
+        // always at a position that is inserted in the layout and also enables
+        // multi-level inlining, if desired by the user, where we consider any
+        // newly-inlined call instructions for further inlining.
+        let mut prev_pos;
+
+        while let Some(inst) = {
+            prev_pos = cursor.position();
+            cursor.next_inst()
+        } {
+            match cursor.func.dfg.insts[inst] {
+                ir::InstructionData::Call {
+                    opcode: opcode @ ir::Opcode::Call | opcode @ ir::Opcode::ReturnCall,
+                    args: _,
+                    func_ref,
+                } => {
+                    let args = cursor.func.dfg.inst_args(inst);
+                    match inliner.inline(&cursor.func, inst, opcode, func_ref, args) {
+                        InlineCommand::KeepCall => continue,
+                        InlineCommand::Inline(callee) => {
+                            inline_one(
+                                &mut allocs,
+                                cursor.func,
+                                func_ref,
+                                block,
+                                inst,
+                                opcode,
+                                callee,
+                                None,
+                            );
+                            inlined_any = true;
+                            cursor.set_position(prev_pos);
+                        }
+                    }
+                }
+                ir::InstructionData::TryCall {
+                    opcode: opcode @ ir::Opcode::TryCall,
+                    args: _,
+                    func_ref,
+                    exception,
+                } => {
+                    let args = cursor.func.dfg.inst_args(inst);
+                    match inliner.inline(&cursor.func, inst, opcode, func_ref, args) {
+                        InlineCommand::KeepCall => continue,
+                        InlineCommand::Inline(callee) => {
+                            inline_one(
+                                &mut allocs,
+                                cursor.func,
+                                func_ref,
+                                block,
+                                inst,
+                                opcode,
+                                callee,
+                                Some(exception),
+                            );
+                            inlined_any = true;
+                            cursor.set_position(prev_pos);
+                        }
+                    }
+                }
+                _ => continue,
+            }
+        }
+    }
+
+    Ok(inlined_any)
+}
+
+#[derive(Default)]
+struct InliningAllocs {
+    /// Map from callee value to inlined caller value.
+    values: SecondaryMap<ir::Value, PackedOption<ir::Value>>,
+
+    /// The set of _callee_ global values that are derived (directly or
+    /// transitively) from the `vmctx`.
+    ///
+    /// Because the `vmctx` of the callee might not be the same as the `vmctx`
+    /// of the caller, we translate these globals differently from others, so we
+    /// must know which globals these are.
+    vmctx_global_values: SecondaryMap<ir::GlobalValue, PackedOption<ir::Value>>,
+
+    /// Map from callee constant to inlined caller constant.
+    constants: SecondaryMap<ir::Constant, PackedOption<ir::Constant>>,
+
+    /// The set of _caller_ inlined call instructions that need exception table
+    /// fixups at the end of inlining.
+    ///
+    /// This includes all kinds of non-returning calls, not just the literal
+    /// `call` instruction: `call_indirect`, `try_call`, `try_call_indirect`,
+    /// etc... However, it does not include `return_call` and
+    /// `return_call_indirect` instructions because the caller cannot catch
+    /// exceptions that those calls throw because the caller is no longer on the
+    /// stack as soon as they are executed.
+    ///
+    /// Note: this is a simple `Vec`, and not an `EntitySet`, because it is very
+    /// sparse: most of the caller's instructions are not inlined call
+    /// instructions. Additionally, we require deterministic iteration order and
+    /// do not require set-membership testing, so a hash set is not a good
+    /// choice either.
+    calls_needing_exception_table_fixup: Vec<ir::Inst>,
+
+    /// The set of existing tags already caught by an inlined `try_call`
+    /// instruction's exception table, for filtering out duplicate tags when
+    /// merging exception tables.
+    ///
+    /// Note: this is a `HashSet`, and not an `EntitySet`, because tags indices
+    /// are completely arbitrary and there is no guarantee that they start from
+    /// zero or are contiguous.
+    existing_exception_tags: crate::HashSet<Option<ir::ExceptionTag>>,
+}
+
+impl InliningAllocs {
+    fn reset(&mut self, callee: &ir::Function) {
+        let InliningAllocs {
+            values,
+            vmctx_global_values,
+            constants,
+            calls_needing_exception_table_fixup,
+            existing_exception_tags,
+        } = self;
+
+        values.clear();
+        values.resize(callee.dfg.len_values());
+
+        // Note: We do not reserve capacity for `vmctx_global_values` because it
+        // is a sparse set and we don't know how large it needs to be ahead of
+        // time.
+        vmctx_global_values.clear();
+
+        constants.clear();
+        constants.resize(callee.dfg.constants.len());
+
+        // Note: We do not reserve capacity for
+        // `calls_needing_exception_table_fixup` because it is a sparse set and
+        // we don't know how large it needs to be ahead of time.
+        calls_needing_exception_table_fixup.clear();
+
+        // Note: We do not reserve capacity for `existing_exception_tags`
+        // because it is a sparse set and we don't know how large it needs to be
+        // ahead of time.
+        existing_exception_tags.clear();
+    }
+}
+
+/// Inline one particular function call.
+fn inline_one(
+    allocs: &mut InliningAllocs,
+    func: &mut ir::Function,
+    callee_func_ref: ir::FuncRef,
+    call_block: ir::Block,
+    call_inst: ir::Inst,
+    call_opcode: ir::Opcode,
+    callee: &ir::Function,
+    call_exception_table: Option<ir::ExceptionTable>,
+) {
+    trace!(
+        "Inlining call {call_inst:?}: {}\n\
+         with callee = {callee:?}",
+        func.dfg.display_inst(call_inst)
+    );
+
+    // Type check callee signature.
+    let expected_callee_sig = func.dfg.ext_funcs[callee_func_ref].signature;
+    let expected_callee_sig = &func.dfg.signatures[expected_callee_sig];
+    assert_eq!(expected_callee_sig, &callee.signature);
+
+    allocs.reset(callee);
+
+    // First, append various callee entity arenas to the end of the caller's
+    // entity arenas.
+    let entity_map = create_entities(allocs, func, callee);
+
+    // Inlined prologue: split the call instruction's block at the point of the
+    // call and replace the call with a jump.
+    let return_block = split_off_return_block(func, call_inst, call_opcode, callee);
+    let (call_stack_map, vmctx) =
+        replace_call_with_jump(allocs, func, call_inst, callee, &entity_map);
+    debug_assert!(allocs.vmctx_global_values.is_empty() || vmctx.is_some());
+
+    // Prepare for translating the actual instructions by inserting the inlined
+    // blocks into the caller's layout in the same order that they appear in the
+    // callee, and define any vmctx-based global values in the inlined entry
+    // block.
+    inline_block_layout(func, call_block, callee, &entity_map);
+    define_vmctx_global_values(allocs, func, callee, vmctx, &entity_map);
+
+    // Translate each instruction from the callee into the caller,
+    // appending them to their associated block in the caller.
+    //
+    // Note that we iterate over the callee with a pre-order traversal so that
+    // we see value defs before uses.
+    for callee_block in Dfs::new().pre_order_iter(callee) {
+        let inlined_block = entity_map.inlined_block(callee_block);
+        trace!(
+            "Processing instructions in callee block {callee_block:?} (inlined block {inlined_block:?}"
+        );
+
+        let mut next_callee_inst = callee.layout.first_inst(callee_block);
+        while let Some(callee_inst) = next_callee_inst {
+            trace!(
+                "Processing callee instruction {callee_inst:?}: {}",
+                callee.dfg.display_inst(callee_inst)
+            );
+
+            // Special case for `global_value` instructions that reference a
+            // global value that is defined in terms of the the callee's
+            // `vmctx`. We cannot translate these to `global_value` instructions
+            // in the caller, because the caller's `vmctx` might not be the same
+            // as the callee's `vmctx`, if it even has one. Instead, use the
+            // pre-defined values for these globals in the `vmctx_global_values`
+            // map.
+            if let ir::InstructionData::UnaryGlobalValue {
+                opcode: ir::Opcode::GlobalValue,
+                global_value,
+            } = &callee.dfg.insts[callee_inst]
+            {
+                if let Some(inlined_value) = allocs
+                    .vmctx_global_values
+                    .get(*global_value)
+                    .and_then(|o| o.expand())
+                {
+                    let callee_value = callee.dfg.first_result(callee_inst);
+                    trace!(
+                        "  --> use of vmctx-based global value; callee {callee_value:?} = inlined {inlined_value:?}"
+                    );
+                    allocs.values[callee_value] = Some(inlined_value).into();
+
+                    next_callee_inst = callee.layout.next_inst(callee_inst);
+                    continue;
+                }
+            }
+
+            // General case: remap the callee instruction's entities and insert
+            // it into the caller's DFG.
+            let inlined_inst_data = callee.dfg.insts[callee_inst].map(InliningInstRemapper {
+                allocs: &allocs,
+                func,
+                callee,
+                entity_map: &entity_map,
+            });
+            let inlined_inst = func.dfg.make_inst(inlined_inst_data);
+            func.layout.append_inst(inlined_inst, inlined_block);
+
+            let opcode = callee.dfg.insts[callee_inst].opcode();
+            if opcode.is_return() {
+                // Instructions that return do not define any values, so we
+                // don't need to worry about that, but we do need to fix them up
+                // so that they return by jumping to our control-flow join
+                // block, rather than returning from the caller.
+                if let Some(return_block) = return_block {
+                    fixup_inst_that_returns(
+                        allocs,
+                        func,
+                        callee,
+                        &entity_map,
+                        call_opcode,
+                        inlined_inst,
+                        callee_inst,
+                        return_block,
+                        call_stack_map.as_ref().map(|es| &**es),
+                    );
+                } else {
+                    // If we are inlining a callee that was invoked via
+                    // `return_call`, we leave inlined return instructions
+                    // as-is: there is no logical caller frame on the stack to
+                    // continue to.
+                    debug_assert_eq!(call_opcode, ir::Opcode::ReturnCall);
+                }
+            } else {
+                // Make the instruction's result values.
+                let ctrl_typevar = callee.dfg.ctrl_typevar(callee_inst);
+                func.dfg.make_inst_results(inlined_inst, ctrl_typevar);
+
+                // Update the value map for this instruction's defs.
+                let callee_results = callee.dfg.inst_results(callee_inst);
+                let inlined_results = func.dfg.inst_results(inlined_inst);
+                debug_assert_eq!(callee_results.len(), inlined_results.len());
+                for (callee_val, inlined_val) in callee_results.iter().zip(inlined_results) {
+                    trace!("  --> callee {callee_val:?} = inlined {inlined_val:?}");
+                    allocs.values[*callee_val] = Some(*inlined_val).into();
+                }
+
+                if opcode.is_call() {
+                    append_stack_map_entries(
+                        func,
+                        callee,
+                        &entity_map,
+                        call_stack_map.as_deref(),
+                        inlined_inst,
+                        callee_inst,
+                    );
+
+                    // When we are inlining a `try_call` call site, we need to merge
+                    // the call site's exception table into the inlined calls'
+                    // exception tables. This can involve rewriting regular `call`s
+                    // into `try_call`s, which requires mutating the CFG because
+                    // `try_call` is a block terminator. However, we can't mutate
+                    // the CFG in the middle of this traversal because we rely on
+                    // the existence of a one-to-one mapping between the callee
+                    // layout and the inlined layout. Instead, we record the set of
+                    // inlined call instructions that will need fixing up, and
+                    // perform that possibly-CFG-mutating exception table merging in
+                    // a follow up pass, when we no longer rely on that one-to-one
+                    // layout mapping.
+                    debug_assert_eq!(
+                        call_opcode == ir::Opcode::TryCall,
+                        call_exception_table.is_some()
+                    );
+                    if call_opcode == ir::Opcode::TryCall {
+                        allocs
+                            .calls_needing_exception_table_fixup
+                            .push(inlined_inst);
+                    }
+                }
+            }
+
+            trace!(
+                "  --> inserted inlined instruction {inlined_inst:?}: {}",
+                func.dfg.display_inst(inlined_inst)
+            );
+
+            next_callee_inst = callee.layout.next_inst(callee_inst);
+        }
+    }
+
+    // Final step: fixup the exception tables of any inlined calls when we are
+    // inlining a `try_call` site.
+    //
+    // Subtly, this requires rewriting non-catching `call[_indirect]`
+    // instructions into `try_call[_indirect]` instructions so that exceptions
+    // that unwound through the original callee frame and were caught by the
+    // caller's `try_call` do not unwind past this inlined frame. And turning a
+    // `call` into a `try_call` mutates the CFG, breaking our one-to-one mapping
+    // between callee blocks and inlined blocks, so we delay these fixups to
+    // this final step, when we no longer rely on that mapping.
+    debug_assert!(
+        allocs.calls_needing_exception_table_fixup.is_empty() || call_exception_table.is_some()
+    );
+    debug_assert_eq!(
+        call_opcode == ir::Opcode::TryCall,
+        call_exception_table.is_some()
+    );
+    if let Some(call_exception_table) = call_exception_table {
+        fixup_inlined_call_exception_tables(allocs, func, call_exception_table);
+    }
+}
+
+/// Append stack map entries from the caller and callee to the given inlined
+/// instruction.
+fn append_stack_map_entries(
+    func: &mut ir::Function,
+    callee: &ir::Function,
+    entity_map: &EntityMap,
+    call_stack_map: Option<&[ir::UserStackMapEntry]>,
+    inlined_inst: ir::Inst,
+    callee_inst: ir::Inst,
+) {
+    // Add the caller's stack map to this call. These entries
+    // already refer to caller entities and do not need further
+    // translation.
+    func.dfg.append_user_stack_map_entries(
+        inlined_inst,
+        call_stack_map
+            .iter()
+            .flat_map(|entries| entries.iter().cloned()),
+    );
+
+    // Append the callee's stack map to this call. These entries
+    // refer to callee entities and therefore do require
+    // translation into the caller's index space.
+    func.dfg.append_user_stack_map_entries(
+        inlined_inst,
+        callee
+            .dfg
+            .user_stack_map_entries(callee_inst)
+            .iter()
+            .flat_map(|entries| entries.iter())
+            .map(|entry| ir::UserStackMapEntry {
+                ty: entry.ty,
+                slot: entity_map.inlined_stack_slot(entry.slot),
+                offset: entry.offset,
+            }),
+    );
+}
+
+/// Create or update the exception tables for any inlined call instructions:
+/// when inlining at a `try_call` site, we must forward our exceptional edges
+/// into each inlined call instruction.
+fn fixup_inlined_call_exception_tables(
+    allocs: &mut InliningAllocs,
+    func: &mut ir::Function,
+    call_exception_table: ir::ExceptionTable,
+) {
+    // Split a block at a `call[_indirect]` instruction, detach the
+    // instruction's results, and alias them to the new block's parameters.
+    let split_block_for_new_try_call = |func: &mut ir::Function, inst: ir::Inst| -> ir::Block {
+        debug_assert!(func.dfg.insts[inst].opcode().is_call());
+        debug_assert!(!func.dfg.insts[inst].opcode().is_terminator());
+
+        // Split the block.
+        let next_inst = func
+            .layout
+            .next_inst(inst)
+            .expect("inst is not a terminator, should have a successor");
+        let new_block = func.dfg.blocks.add();
+        func.layout.split_block(new_block, next_inst);
+
+        // `try_call[_indirect]` instructions do not define values themselves;
+        // the normal-return block has parameters for the results. So remove
+        // this instruction's results, create an associated block parameter for
+        // each of them, and alias them to the new block parameter.
+        let old_results = SmallValueVec::from_iter(func.dfg.inst_results(inst).iter().copied());
+        func.dfg.detach_inst_results(inst);
+        for old_result in old_results {
+            let ty = func.dfg.value_type(old_result);
+            let new_block_param = func.dfg.append_block_param(new_block, ty);
+            func.dfg.change_to_alias(old_result, new_block_param);
+        }
+
+        new_block
+    };
+
+    // Clone the caller's exception table, updating it for use in the current
+    // `call[_indirect]` instruction as it becomes a `try_call[_indirect]`.
+    let clone_exception_table_for_this_call = |func: &mut ir::Function,
+                                               signature: ir::SigRef,
+                                               new_block: ir::Block|
+     -> ir::ExceptionTable {
+        let mut exception = func.stencil.dfg.exception_tables[call_exception_table]
+            .deep_clone(&mut func.stencil.dfg.value_lists);
+
+        *exception.signature_mut() = signature;
+
+        let returns_len = func.dfg.signatures[signature].returns.len();
+        let returns_len = u32::try_from(returns_len).unwrap();
+
+        *exception.normal_return_mut() = ir::BlockCall::new(
+            new_block,
+            (0..returns_len).map(|i| ir::BlockArg::TryCallRet(i)),
+            &mut func.dfg.value_lists,
+        );
+
+        func.dfg.exception_tables.push(exception)
+    };
+
+    for inst in allocs.calls_needing_exception_table_fixup.drain(..) {
+        debug_assert!(func.dfg.insts[inst].opcode().is_call());
+        debug_assert!(!func.dfg.insts[inst].opcode().is_return());
+        match func.dfg.insts[inst] {
+            //     current_block:
+            //         preds...
+            //         rets... = call f(args...)
+            //         succs...
+            //
+            // becomes
+            //
+            //     current_block:
+            //         preds...
+            //         try_call f(args...), new_block(rets...), [call_exception_table...]
+            //     new_block(rets...):
+            //         succs...
+            ir::InstructionData::Call {
+                opcode: ir::Opcode::Call,
+                args,
+                func_ref,
+            } => {
+                let new_block = split_block_for_new_try_call(func, inst);
+                let signature = func.dfg.ext_funcs[func_ref].signature;
+                let exception = clone_exception_table_for_this_call(func, signature, new_block);
+                func.dfg.insts[inst] = ir::InstructionData::TryCall {
+                    opcode: ir::Opcode::TryCall,
+                    args,
+                    func_ref,
+                    exception,
+                };
+            }
+
+            //     current_block:
+            //         preds...
+            //         rets... = call_indirect sig, val(args...)
+            //         succs...
+            //
+            // becomes
+            //
+            //     current_block:
+            //         preds...
+            //         try_call_indirect sig, val(args...), new_block(rets...), [call_exception_table...]
+            //     new_block(rets...):
+            //         succs...
+            ir::InstructionData::CallIndirect {
+                opcode: ir::Opcode::CallIndirect,
+                args,
+                sig_ref,
+            } => {
+                let new_block = split_block_for_new_try_call(func, inst);
+                let exception = clone_exception_table_for_this_call(func, sig_ref, new_block);
+                func.dfg.insts[inst] = ir::InstructionData::TryCallIndirect {
+                    opcode: ir::Opcode::TryCallIndirect,
+                    args,
+                    exception,
+                };
+            }
+
+            // For `try_call[_indirect]` instructions, we just need to merge the
+            // exception tables.
+            ir::InstructionData::TryCall {
+                opcode: ir::Opcode::TryCall,
+                exception,
+                ..
+            }
+            | ir::InstructionData::TryCallIndirect {
+                opcode: ir::Opcode::TryCallIndirect,
+                exception,
+                ..
+            } => {
+                // Gather the set of tags that this instruction's exception
+                // table already has entries for.
+                allocs.existing_exception_tags.clear();
+                allocs.existing_exception_tags.extend(
+                    func.dfg.exception_tables[exception]
+                        .catches()
+                        .map(|(c, _)| c),
+                );
+
+                // Add only the catch edges from our original `try_call`'s
+                // exception table that are not already handled by this
+                // instruction.
+                for i in 0..func.dfg.exception_tables[call_exception_table].len_catches() {
+                    let exception_tables = &mut func.stencil.dfg.exception_tables;
+                    let value_lists = &mut func.stencil.dfg.value_lists;
+
+                    let (tag, block_call) =
+                        exception_tables[call_exception_table].get_catch(i).unwrap();
+                    if allocs.existing_exception_tags.contains(&tag) {
+                        continue;
+                    }
+
+                    let block_call = block_call.deep_clone(value_lists);
+                    exception_tables[exception].push_catch(tag, block_call);
+                }
+            }
+
+            otherwise => unreachable!("unknown non-return call instruction: {otherwise:?}"),
+        }
+    }
+}
+
+/// After having created an inlined version of a callee instruction that returns
+/// in the caller, we need to fix it up so that it doesn't actually return
+/// (since we are already in the caller's frame) and instead just jumps to the
+/// control-flow join point.
+fn fixup_inst_that_returns(
+    allocs: &mut InliningAllocs,
+    func: &mut ir::Function,
+    callee: &ir::Function,
+    entity_map: &EntityMap,
+    call_opcode: ir::Opcode,
+    inlined_inst: ir::Inst,
+    callee_inst: ir::Inst,
+    return_block: ir::Block,
+    call_stack_map: Option<&[ir::UserStackMapEntry]>,
+) {
+    debug_assert!(func.dfg.insts[inlined_inst].opcode().is_return());
+    match func.dfg.insts[inlined_inst] {
+        //     return rets...
+        //
+        // becomes
+        //
+        //     jump return_block(rets...)
+        ir::InstructionData::MultiAry {
+            opcode: ir::Opcode::Return,
+            args,
+        } => {
+            let rets = SmallBlockArgVec::from_iter(
+                args.as_slice(&func.dfg.value_lists)
+                    .iter()
+                    .copied()
+                    .map(|v| v.into()),
+            );
+            func.dfg.replace(inlined_inst).jump(return_block, &rets);
+        }
+
+        //     return_call f(args...)
+        //
+        // becomes
+        //
+        //     rets... = call f(args...)
+        //     jump return_block(rets...)
+        ir::InstructionData::Call {
+            opcode: ir::Opcode::ReturnCall,
+            args,
+            func_ref,
+        } => {
+            func.dfg.insts[inlined_inst] = ir::InstructionData::Call {
+                opcode: ir::Opcode::Call,
+                args,
+                func_ref,
+            };
+            func.dfg.make_inst_results(inlined_inst, ir::types::INVALID);
+
+            append_stack_map_entries(
+                func,
+                callee,
+                &entity_map,
+                call_stack_map,
+                inlined_inst,
+                callee_inst,
+            );
+
+            let rets = SmallBlockArgVec::from_iter(
+                func.dfg
+                    .inst_results(inlined_inst)
+                    .iter()
+                    .copied()
+                    .map(|v| v.into()),
+            );
+            let mut cursor = FuncCursor::new(func);
+            cursor.goto_after_inst(inlined_inst);
+            cursor.ins().jump(return_block, &rets);
+
+            if call_opcode == ir::Opcode::TryCall {
+                allocs
+                    .calls_needing_exception_table_fixup
+                    .push(inlined_inst);
+            }
+        }
+
+        //     return_call_indirect val(args...)
+        //
+        // becomes
+        //
+        //     rets... = call_indirect val(args...)
+        //     jump return_block(rets...)
+        ir::InstructionData::CallIndirect {
+            opcode: ir::Opcode::ReturnCallIndirect,
+            args,
+            sig_ref,
+        } => {
+            func.dfg.insts[inlined_inst] = ir::InstructionData::CallIndirect {
+                opcode: ir::Opcode::CallIndirect,
+                args,
+                sig_ref,
+            };
+            func.dfg.make_inst_results(inlined_inst, ir::types::INVALID);
+
+            append_stack_map_entries(
+                func,
+                callee,
+                &entity_map,
+                call_stack_map,
+                inlined_inst,
+                callee_inst,
+            );
+
+            let rets = SmallBlockArgVec::from_iter(
+                func.dfg
+                    .inst_results(inlined_inst)
+                    .iter()
+                    .copied()
+                    .map(|v| v.into()),
+            );
+            let mut cursor = FuncCursor::new(func);
+            cursor.goto_after_inst(inlined_inst);
+            cursor.ins().jump(return_block, &rets);
+
+            if call_opcode == ir::Opcode::TryCall {
+                allocs
+                    .calls_needing_exception_table_fixup
+                    .push(inlined_inst);
+            }
+        }
+
+        inst_data => unreachable!(
+            "should have handled all `is_return() == true` instructions above; \
+             got {inst_data:?}"
+        ),
+    }
+}
+
+/// An `InstructionMapper` implementation that remaps a callee instruction's
+/// entity references to their new indices in the caller function.
+struct InliningInstRemapper<'a> {
+    allocs: &'a InliningAllocs,
+    func: &'a mut ir::Function,
+    callee: &'a ir::Function,
+    entity_map: &'a EntityMap,
+}
+
+impl<'a> ir::instructions::InstructionMapper for InliningInstRemapper<'a> {
+    fn map_value(&mut self, value: ir::Value) -> ir::Value {
+        self.allocs
+            .values
+            .get(value)
+            .and_then(|opt| opt.expand())
+            .expect(
+                "defs come before uses; we should have already inlined all values \
+                 used by an instruction",
+            )
+    }
+
+    fn map_value_list(&mut self, value_list: ir::ValueList) -> ir::ValueList {
+        let mut inlined_list = ir::ValueList::new();
+        for callee_val in value_list.as_slice(&self.callee.dfg.value_lists) {
+            let inlined_val = self.map_value(*callee_val);
+            inlined_list.push(inlined_val, &mut self.func.dfg.value_lists);
+        }
+        inlined_list
+    }
+
+    fn map_global_value(&mut self, global_value: ir::GlobalValue) -> ir::GlobalValue {
+        debug_assert!(
+            self.allocs
+                .vmctx_global_values
+                .get(global_value)
+                .and_then(|o| o.expand())
+                .is_none(),
+            "vmctx-based globals are handled via a special case"
+        );
+        self.entity_map.inlined_global_value(global_value)
+    }
+
+    fn map_jump_table(&mut self, jump_table: ir::JumpTable) -> ir::JumpTable {
+        let inlined_default =
+            self.map_block_call(self.callee.dfg.jump_tables[jump_table].default_block());
+        let inlined_table = self.callee.dfg.jump_tables[jump_table]
+            .as_slice()
+            .iter()
+            .map(|callee_block_call| self.map_block_call(*callee_block_call))
+            .collect::<SmallBlockCallVec>();
+        self.func
+            .dfg
+            .jump_tables
+            .push(ir::JumpTableData::new(inlined_default, &inlined_table))
+    }
+
+    fn map_exception_table(&mut self, exception_table: ir::ExceptionTable) -> ir::ExceptionTable {
+        let exception_table = &self.callee.dfg.exception_tables[exception_table];
+        let inlined_sig_ref = self.map_sig_ref(exception_table.signature());
+        let inlined_normal_return = self.map_block_call(*exception_table.normal_return());
+        let inlined_table = exception_table
+            .catches()
+            .map(|(tag, callee_block_call)| (tag, self.map_block_call(*callee_block_call)))
+            .collect::<SmallVec<[_; 8]>>();
+        self.func
+            .dfg
+            .exception_tables
+            .push(ir::ExceptionTableData::new(
+                inlined_sig_ref,
+                inlined_normal_return,
+                inlined_table,
+            ))
+    }
+
+    fn map_block_call(&mut self, block_call: ir::BlockCall) -> ir::BlockCall {
+        let callee_block = block_call.block(&self.callee.dfg.value_lists);
+        let inlined_block = self.entity_map.inlined_block(callee_block);
+        let args = block_call
+            .args(&self.callee.dfg.value_lists)
+            .map(|arg| match arg {
+                ir::BlockArg::Value(value) => self.map_value(value).into(),
+                ir::BlockArg::TryCallRet(_) | ir::BlockArg::TryCallExn(_) => arg,
+            })
+            .collect::<SmallBlockArgVec>();
+        ir::BlockCall::new(inlined_block, args, &mut self.func.dfg.value_lists)
+    }
+
+    fn map_func_ref(&mut self, func_ref: ir::FuncRef) -> ir::FuncRef {
+        self.entity_map.inlined_func_ref(func_ref)
+    }
+
+    fn map_sig_ref(&mut self, sig_ref: ir::SigRef) -> ir::SigRef {
+        self.entity_map.inlined_sig_ref(sig_ref)
+    }
+
+    fn map_stack_slot(&mut self, stack_slot: ir::StackSlot) -> ir::StackSlot {
+        self.entity_map.inlined_stack_slot(stack_slot)
+    }
+
+    fn map_dynamic_stack_slot(
+        &mut self,
+        dynamic_stack_slot: ir::DynamicStackSlot,
+    ) -> ir::DynamicStackSlot {
+        self.entity_map
+            .inlined_dynamic_stack_slot(dynamic_stack_slot)
+    }
+
+    fn map_constant(&mut self, constant: ir::Constant) -> ir::Constant {
+        self.allocs
+            .constants
+            .get(constant)
+            .and_then(|o| o.expand())
+            .expect("should have inlined all callee constants")
+    }
+
+    fn map_immediate(&mut self, immediate: ir::Immediate) -> ir::Immediate {
+        self.entity_map.inlined_immediate(immediate)
+    }
+}
+
+/// Inline the callee's layout into the caller's layout.
+fn inline_block_layout(
+    func: &mut ir::Function,
+    call_block: ir::Block,
+    callee: &ir::Function,
+    entity_map: &EntityMap,
+) {
+    // Iterate over callee blocks in layout order, inserting their associated
+    // inlined block into the caller's layout.
+    let mut prev_inlined_block = call_block;
+    let mut next_callee_block = callee.layout.entry_block();
+    while let Some(callee_block) = next_callee_block {
+        let inlined_block = entity_map.inlined_block(callee_block);
+        func.layout
+            .insert_block_after(inlined_block, prev_inlined_block);
+
+        prev_inlined_block = inlined_block;
+        next_callee_block = callee.layout.next_block(callee_block);
+    }
+}
+
+/// Split the call instruction's block just after the call instruction to create
+/// the point where control-flow joins after the inlined callee "returns".
+///
+/// Note that tail calls do not return to the caller and therefore do not have a
+/// control-flow join point.
+fn split_off_return_block(
+    func: &mut ir::Function,
+    call_inst: ir::Inst,
+    opcode: ir::Opcode,
+    callee: &ir::Function,
+) -> Option<ir::Block> {
+    // When the `call_inst` is not a block terminator, we need to split the
+    // block.
+    let return_block = func.layout.next_inst(call_inst).map(|next_inst| {
+        let return_block = func.dfg.blocks.add();
+        func.layout.split_block(return_block, next_inst);
+
+        // Add block parameters for each return value and alias the call
+        // instruction's results to them.
+        let old_results =
+            SmallValueVec::from_iter(func.dfg.inst_results(call_inst).iter().copied());
+        debug_assert_eq!(old_results.len(), callee.signature.returns.len());
+        func.dfg.detach_inst_results(call_inst);
+        for (abi, old_val) in callee.signature.returns.iter().zip(old_results) {
+            debug_assert_eq!(abi.value_type, func.dfg.value_type(old_val));
+            let ret_param = func.dfg.append_block_param(return_block, abi.value_type);
+            func.dfg.change_to_alias(old_val, ret_param);
+        }
+
+        return_block
+    });
+
+    // When the `call_inst` is a block terminator, then it is either a
+    // `return_call` or a `try_call`:
+    //
+    // * For `return_call`s, we don't have a control-flow join point, because
+    //   the caller permanently transfers control to the callee.
+    //
+    // * For `try_call`s, we probably already have a block for the control-flow
+    //   join point, but it isn't guaranteed: the `try_call` might ignore the
+    //   call's returns and not forward them to the normal-return block or it
+    //   might also pass additional arguments. We can only reuse the existing
+    //   normal-return block when the `try_call` forwards exactly our callee's
+    //   returns to that block (and therefore that block's parameter types also
+    //   exactly match the callee's return types). Otherwise, we must create a new
+    //   return block that forwards to the existing normal-return
+    //   block. (Elsewhere, at the end of inlining, we will also update any
+    //   inlined calls to forward any raised exceptions to the caller's
+    //   exception table, as necessary).
+    debug_assert_eq!(
+        return_block.is_none(),
+        opcode == ir::Opcode::ReturnCall || opcode == ir::Opcode::TryCall,
+    );
+    return_block.or_else(|| match func.dfg.insts[call_inst] {
+        ir::InstructionData::TryCall {
+            opcode: ir::Opcode::TryCall,
+            args: _,
+            func_ref: _,
+            exception,
+        } => {
+            let normal_return = func.dfg.exception_tables[exception].normal_return();
+            let normal_return_block = normal_return.block(&func.dfg.value_lists);
+
+            // Check to see if we can reuse the existing normal-return block.
+            {
+                let normal_return_args = normal_return.args(&func.dfg.value_lists);
+                if normal_return_args.len() == callee.signature.returns.len()
+                    && normal_return_args.enumerate().all(|(i, arg)| {
+                        let i = u32::try_from(i).unwrap();
+                        arg == ir::BlockArg::TryCallRet(i)
+                    })
+                {
+                    return Some(normal_return_block);
+                }
+            }
+
+            // Okay, we cannot reuse the normal-return block. Create a new block
+            // that has the expected block parameter types and have it jump to
+            // the normal-return block.
+            let return_block = func.dfg.blocks.add();
+            func.layout.insert_block(return_block, normal_return_block);
+
+            let return_block_params = callee
+                .signature
+                .returns
+                .iter()
+                .map(|abi| func.dfg.append_block_param(return_block, abi.value_type))
+                .collect::<SmallValueVec>();
+
+            let normal_return_args = func.dfg.exception_tables[exception]
+                .normal_return()
+                .args(&func.dfg.value_lists)
+                .collect::<SmallBlockArgVec>();
+            let jump_args = normal_return_args
+                .into_iter()
+                .map(|arg| match arg {
+                    ir::BlockArg::Value(value) => ir::BlockArg::Value(value),
+                    ir::BlockArg::TryCallRet(i) => {
+                        let i = usize::try_from(i).unwrap();
+                        ir::BlockArg::Value(return_block_params[i])
+                    }
+                    ir::BlockArg::TryCallExn(_) => {
+                        unreachable!("normal-return edges cannot use exceptional results")
+                    }
+                })
+                .collect::<SmallBlockArgVec>();
+
+            let mut cursor = FuncCursor::new(func);
+            cursor.goto_first_insertion_point(return_block);
+            cursor.ins().jump(normal_return_block, &jump_args);
+
+            Some(return_block)
+        }
+        _ => None,
+    })
+}
+
+/// Replace the caller's call instruction with a jump to the caller's inlined
+/// copy of the callee's entry block.
+///
+/// Also associates the callee's parameters with the caller's arguments in our
+/// value map.
+///
+/// Returns the caller's stack map entries and argument value that is associated
+/// with the callee's `vmctx` parameter, if any.
+fn replace_call_with_jump(
+    allocs: &mut InliningAllocs,
+    func: &mut ir::Function,
+    call_inst: ir::Inst,
+    callee: &ir::Function,
+    entity_map: &EntityMap,
+) -> (Option<ir::UserStackMapEntryVec>, Option<ir::Value>) {
+    trace!("Replacing `call` with `jump`");
+    trace!(
+        "  --> call instruction: {call_inst:?}: {}",
+        func.dfg.display_inst(call_inst)
+    );
+
+    let callee_entry_block = callee
+        .layout
+        .entry_block()
+        .expect("callee function should have an entry block");
+    let callee_param_values = callee.dfg.block_params(callee_entry_block);
+    let caller_arg_values = SmallValueVec::from_iter(func.dfg.inst_args(call_inst).iter().copied());
+    debug_assert_eq!(callee_param_values.len(), caller_arg_values.len());
+    debug_assert_eq!(callee_param_values.len(), callee.signature.params.len());
+    let mut inlined_vmctx = None;
+    for (abi, (callee_param_value, caller_arg_value)) in callee
+        .signature
+        .params
+        .iter()
+        .zip(callee_param_values.into_iter().zip(caller_arg_values))
+    {
+        debug_assert_eq!(abi.value_type, callee.dfg.value_type(*callee_param_value));
+        debug_assert_eq!(abi.value_type, func.dfg.value_type(caller_arg_value));
+
+        if abi.purpose == ir::ArgumentPurpose::VMContext {
+            debug_assert!(inlined_vmctx.is_none());
+            inlined_vmctx = Some(caller_arg_value);
+        }
+
+        trace!("  --> callee {callee_param_value:?} = inlined {caller_arg_value:?}");
+        allocs.values[*callee_param_value] = Some(caller_arg_value).into();
+    }
+
+    // Replace the caller's call instruction with a jump to the caller's inlined
+    // copy of the callee's entry block.
+    //
+    // Note that the call block dominates the inlined entry block (and also all
+    // other inlined blocks) so we can reference the arguments directly, and do
+    // not need to add block parameters to the inlined entry block.
+    let inlined_entry_block = entity_map.inlined_block(callee_entry_block);
+    func.dfg.replace(call_inst).jump(inlined_entry_block, &[]);
+    trace!(
+        "  --> replaced with jump instruction: {call_inst:?}: {}",
+        func.dfg.display_inst(call_inst)
+    );
+
+    let stack_map_entries = func.dfg.take_user_stack_map_entries(call_inst);
+    (stack_map_entries, inlined_vmctx)
+}
+
+/// Keeps track of mapping callee entities to their associated inlined caller
+/// entities.
+#[derive(Default)]
+struct EntityMap {
+    // Rather than doing an implicit, demand-based, DCE'ing translation of
+    // entities, which would require maps from each callee entity to its
+    // associated caller entity, we copy all entities into the caller, remember
+    // each entity's initial offset, and then mapping from the callee to the
+    // inlined caller entity is just adding that initial offset to the callee's
+    // index. This should be both faster and simpler than the alternative. Most
+    // of these sets are relatively small, and they rarely have too much dead
+    // code in practice, so this is a good trade off.
+    //
+    // Note that there are a few kinds of entities that are excluded from the
+    // `EntityMap`, and for which we do actually take the demand-based approach:
+    // values and value lists being the notable ones.
+    block_offset: Option<u32>,
+    global_value_offset: Option<u32>,
+    sig_ref_offset: Option<u32>,
+    func_ref_offset: Option<u32>,
+    stack_slot_offset: Option<u32>,
+    dynamic_type_offset: Option<u32>,
+    dynamic_stack_slot_offset: Option<u32>,
+    immediate_offset: Option<u32>,
+}
+
+impl EntityMap {
+    fn inlined_block(&self, callee_block: ir::Block) -> ir::Block {
+        let offset = self
+            .block_offset
+            .expect("must create inlined `ir::Block`s before calling `EntityMap::inlined_block`");
+        ir::Block::from_u32(offset + callee_block.as_u32())
+    }
+
+    fn inlined_global_value(&self, callee_global_value: ir::GlobalValue) -> ir::GlobalValue {
+        let offset = self
+            .global_value_offset
+            .expect("must create inlined `ir::GlobalValue`s before calling `EntityMap::inlined_global_value`");
+        ir::GlobalValue::from_u32(offset + callee_global_value.as_u32())
+    }
+
+    fn inlined_sig_ref(&self, callee_sig_ref: ir::SigRef) -> ir::SigRef {
+        let offset = self.sig_ref_offset.expect(
+            "must create inlined `ir::SigRef`s before calling `EntityMap::inlined_sig_ref`",
+        );
+        ir::SigRef::from_u32(offset + callee_sig_ref.as_u32())
+    }
+
+    fn inlined_func_ref(&self, callee_func_ref: ir::FuncRef) -> ir::FuncRef {
+        let offset = self.func_ref_offset.expect(
+            "must create inlined `ir::FuncRef`s before calling `EntityMap::inlined_func_ref`",
+        );
+        ir::FuncRef::from_u32(offset + callee_func_ref.as_u32())
+    }
+
+    fn inlined_stack_slot(&self, callee_stack_slot: ir::StackSlot) -> ir::StackSlot {
+        let offset = self.stack_slot_offset.expect(
+            "must create inlined `ir::StackSlot`s before calling `EntityMap::inlined_stack_slot`",
+        );
+        ir::StackSlot::from_u32(offset + callee_stack_slot.as_u32())
+    }
+
+    fn inlined_dynamic_type(&self, callee_dynamic_type: ir::DynamicType) -> ir::DynamicType {
+        let offset = self.dynamic_type_offset.expect(
+            "must create inlined `ir::DynamicType`s before calling `EntityMap::inlined_dynamic_type`",
+        );
+        ir::DynamicType::from_u32(offset + callee_dynamic_type.as_u32())
+    }
+
+    fn inlined_dynamic_stack_slot(
+        &self,
+        callee_dynamic_stack_slot: ir::DynamicStackSlot,
+    ) -> ir::DynamicStackSlot {
+        let offset = self.dynamic_stack_slot_offset.expect(
+            "must create inlined `ir::DynamicStackSlot`s before calling `EntityMap::inlined_dynamic_stack_slot`",
+        );
+        ir::DynamicStackSlot::from_u32(offset + callee_dynamic_stack_slot.as_u32())
+    }
+
+    fn inlined_immediate(&self, callee_immediate: ir::Immediate) -> ir::Immediate {
+        let offset = self.immediate_offset.expect(
+            "must create inlined `ir::Immediate`s before calling `EntityMap::inlined_immediate`",
+        );
+        ir::Immediate::from_u32(offset + callee_immediate.as_u32())
+    }
+}
+
+/// Translate all of the callee's various entities into the caller, producing an
+/// `EntityMap` that can be used to translate callee entity references into
+/// inlined caller entity references.
+fn create_entities(
+    allocs: &mut InliningAllocs,
+    func: &mut ir::Function,
+    callee: &ir::Function,
+) -> EntityMap {
+    let mut entity_map = EntityMap::default();
+
+    entity_map.block_offset = Some(create_blocks(allocs, func, callee));
+    entity_map.global_value_offset = Some(create_global_values(func, callee));
+    entity_map.sig_ref_offset = Some(create_sig_refs(func, callee));
+    entity_map.func_ref_offset = Some(create_func_refs(func, callee, &entity_map));
+    entity_map.stack_slot_offset = Some(create_stack_slots(func, callee));
+    entity_map.dynamic_type_offset = Some(create_dynamic_types(func, callee, &entity_map));
+    entity_map.dynamic_stack_slot_offset =
+        Some(create_dynamic_stack_slots(func, callee, &entity_map));
+    entity_map.immediate_offset = Some(create_immediates(func, callee));
+
+    // `ir::ConstantData` is deduplicated, so we cannot use our offset scheme
+    // for `ir::Constant`s. Nonetheless, we still insert them into the caller
+    // now, at the same time as the rest of our entities.
+    create_constants(allocs, func, callee);
+
+    entity_map
+}
+
+/// Create inlined blocks in the caller for every block in the callee.
+fn create_blocks(
+    allocs: &mut InliningAllocs,
+    func: &mut ir::Function,
+    callee: &ir::Function,
+) -> u32 {
+    let offset = func.dfg.blocks.len();
+    let offset = u32::try_from(offset).unwrap();
+
+    func.dfg.blocks.reserve(callee.dfg.blocks.len());
+    for callee_block in callee.dfg.blocks.iter() {
+        let caller_block = func.dfg.blocks.add();
+        trace!("Callee {callee_block:?} = inlined {caller_block:?}");
+
+        if callee.layout.is_cold(callee_block) {
+            func.layout.set_cold(caller_block);
+        }
+
+        // Note: the entry block does not need parameters because the only
+        // predecessor is the call block and we associate the callee's
+        // parameters with the caller's arguments directly.
+        if callee.layout.entry_block() != Some(callee_block) {
+            for callee_param in callee.dfg.blocks[callee_block].params(&callee.dfg.value_lists) {
+                let ty = callee.dfg.value_type(*callee_param);
+                let caller_param = func.dfg.append_block_param(caller_block, ty);
+
+                trace!(
+                    "  --> added inlined block param: callee {callee_param:?} = inlined {caller_param:?}"
+                );
+                debug_assert!(allocs.values[*callee_param].is_none());
+                allocs.values[*callee_param] = Some(caller_param).into();
+            }
+        }
+    }
+
+    offset
+}
+
+/// Copy and translate global values from the callee into the caller.
+fn create_global_values(func: &mut ir::Function, callee: &ir::Function) -> u32 {
+    let gv_offset = func.global_values.len();
+    let gv_offset = u32::try_from(gv_offset).unwrap();
+
+    func.global_values.reserve(callee.global_values.len());
+    for gv in callee.global_values.values() {
+        func.global_values.push(match gv {
+            // These kinds of global values reference other global values, so we
+            // need to fixup that reference.
+            ir::GlobalValueData::Load {
+                base,
+                offset,
+                global_type,
+                flags,
+            } => ir::GlobalValueData::Load {
+                base: ir::GlobalValue::from_u32(base.as_u32() + gv_offset),
+                offset: *offset,
+                global_type: *global_type,
+                flags: *flags,
+            },
+            ir::GlobalValueData::IAddImm {
+                base,
+                offset,
+                global_type,
+            } => ir::GlobalValueData::IAddImm {
+                base: ir::GlobalValue::from_u32(base.as_u32() + gv_offset),
+                offset: *offset,
+                global_type: *global_type,
+            },
+
+            // These kinds of global values do not reference other global
+            // values, so we can just clone them.
+            ir::GlobalValueData::VMContext
+            | ir::GlobalValueData::Symbol { .. }
+            | ir::GlobalValueData::DynScaleTargetConst { .. } => gv.clone(),
+        });
+    }
+
+    gv_offset
+}
+
+/// Eagerly define `ir::Value`s for all `ir::GlobalValue`s that depend on the
+/// `vmctx` at the start of the inlined entry block.
+///
+/// References to these globals cannot simply be translated into the inlined
+/// versions because the `vmctx` of the caller might be different from the
+/// `vmctx` of the callee.
+fn define_vmctx_global_values(
+    allocs: &mut InliningAllocs,
+    func: &mut ir::Function,
+    callee: &ir::Function,
+    vmctx: Option<ir::Value>,
+    entity_map: &EntityMap,
+) {
+    trace!("Defining values for vmctx-based global values");
+
+    let callee_entry_block = callee.layout.entry_block().unwrap();
+    let inlined_entry_block = entity_map.inlined_block(callee_entry_block);
+
+    let mut cursor = FuncCursor::new(func);
+    cursor.goto_first_insertion_point(inlined_entry_block);
+
+    for (gv, gv_data) in callee.global_values.iter() {
+        debug_assert!(
+            allocs
+                .vmctx_global_values
+                .get(gv)
+                .and_then(|o| o.expand())
+                .is_none(),
+            "should not have already processed this global value"
+        );
+        match gv_data {
+            ir::GlobalValueData::VMContext => {
+                let vmctx = vmctx
+                    .expect("should have a vmctx argument value if we have a vmctx global value");
+                trace!("  --> callee vmctx global {gv:?} = inlined {vmctx:?}");
+                allocs.vmctx_global_values[gv] = Some(vmctx).into();
+            }
+            ir::GlobalValueData::Load {
+                base,
+                offset,
+                global_type,
+                flags,
+            } => {
+                if let Some(base) = allocs
+                    .vmctx_global_values
+                    .get(*base)
+                    .and_then(|o| o.expand())
+                {
+                    let val = cursor.ins().load(*global_type, *flags, base, *offset);
+                    trace!(
+                        "  --> callee vmctx-based global {gv:?} = inlined {}",
+                        cursor.func.dfg.display_value_inst(val)
+                    );
+                    allocs.vmctx_global_values[gv] = Some(val).into();
+                }
+            }
+            ir::GlobalValueData::IAddImm {
+                base,
+                offset,
+                global_type,
+            } => {
+                if let Some(base) = allocs
+                    .vmctx_global_values
+                    .get(*base)
+                    .and_then(|o| o.expand())
+                {
+                    let offset = cursor.ins().iconst(*global_type, *offset);
+                    let val = cursor.ins().iadd(base, offset);
+                    trace!(
+                        "  --> callee vmctx-based global {gv:?} = inlined {}",
+                        cursor.func.dfg.display_value_inst(val)
+                    );
+                    allocs.vmctx_global_values[gv] = Some(val).into();
+                }
+            }
+
+            // These global values do not reference the `vmctx`.
+            ir::GlobalValueData::Symbol {
+                name: _,
+                offset: _,
+                colocated: _,
+                tls: _,
+            }
+            | ir::GlobalValueData::DynScaleTargetConst { vector_type: _ } => continue,
+        }
+    }
+}
+
+/// Copy `ir::SigRef`s from the callee into the caller.
+fn create_sig_refs(func: &mut ir::Function, callee: &ir::Function) -> u32 {
+    let offset = func.dfg.signatures.len();
+    let offset = u32::try_from(offset).unwrap();
+
+    func.dfg.signatures.reserve(callee.dfg.signatures.len());
+    for sig in callee.dfg.signatures.values() {
+        func.dfg.signatures.push(sig.clone());
+    }
+
+    offset
+}
+
+/// Translate `ir::FuncRef`s from the callee into the caller.
+fn create_func_refs(func: &mut ir::Function, callee: &ir::Function, entity_map: &EntityMap) -> u32 {
+    let offset = func.dfg.ext_funcs.len();
+    let offset = u32::try_from(offset).unwrap();
+
+    func.dfg.ext_funcs.reserve(callee.dfg.ext_funcs.len());
+    for ir::ExtFuncData {
+        name,
+        signature,
+        colocated,
+    } in callee.dfg.ext_funcs.values()
+    {
+        func.dfg.ext_funcs.push(ir::ExtFuncData {
+            name: name.clone(),
+            signature: entity_map.inlined_sig_ref(*signature),
+            colocated: *colocated,
+        });
+    }
+
+    offset
+}
+
+/// Copy stack slots from the callee into the caller.
+fn create_stack_slots(func: &mut ir::Function, callee: &ir::Function) -> u32 {
+    let offset = func.sized_stack_slots.len();
+    let offset = u32::try_from(offset).unwrap();
+
+    func.sized_stack_slots
+        .reserve(callee.sized_stack_slots.len());
+    for slot in callee.sized_stack_slots.values() {
+        func.sized_stack_slots.push(slot.clone());
+    }
+
+    offset
+}
+
+/// Copy dynamic types from the callee into the caller.
+fn create_dynamic_types(
+    func: &mut ir::Function,
+    callee: &ir::Function,
+    entity_map: &EntityMap,
+) -> u32 {
+    let offset = func.dynamic_stack_slots.len();
+    let offset = u32::try_from(offset).unwrap();
+
+    func.dfg
+        .dynamic_types
+        .reserve(callee.dfg.dynamic_types.len());
+    for ir::DynamicTypeData {
+        base_vector_ty,
+        dynamic_scale,
+    } in callee.dfg.dynamic_types.values()
+    {
+        func.dfg.dynamic_types.push(ir::DynamicTypeData {
+            base_vector_ty: *base_vector_ty,
+            dynamic_scale: entity_map.inlined_global_value(*dynamic_scale),
+        });
+    }
+
+    offset
+}
+
+/// Copy dynamic stack slots from the callee into the caller.
+fn create_dynamic_stack_slots(
+    func: &mut ir::Function,
+    callee: &ir::Function,
+    entity_map: &EntityMap,
+) -> u32 {
+    let offset = func.dynamic_stack_slots.len();
+    let offset = u32::try_from(offset).unwrap();
+
+    func.dynamic_stack_slots
+        .reserve(callee.dynamic_stack_slots.len());
+    for ir::DynamicStackSlotData { kind, dyn_ty } in callee.dynamic_stack_slots.values() {
+        func.dynamic_stack_slots.push(ir::DynamicStackSlotData {
+            kind: *kind,
+            dyn_ty: entity_map.inlined_dynamic_type(*dyn_ty),
+        });
+    }
+
+    offset
+}
+
+/// Copy immediates from the callee into the caller.
+fn create_immediates(func: &mut ir::Function, callee: &ir::Function) -> u32 {
+    let offset = func.dfg.immediates.len();
+    let offset = u32::try_from(offset).unwrap();
+
+    func.dfg.immediates.reserve(callee.dfg.immediates.len());
+    for imm in callee.dfg.immediates.values() {
+        func.dfg.immediates.push(imm.clone());
+    }
+
+    offset
+}
+
+/// Copy constants from the callee into the caller.
+fn create_constants(allocs: &mut InliningAllocs, func: &mut ir::Function, callee: &ir::Function) {
+    for (callee_constant, data) in callee.dfg.constants.iter() {
+        let inlined_constant = func.dfg.constants.insert(data.clone());
+        allocs.constants[*callee_constant] = Some(inlined_constant).into();
+    }
+}

--- a/cranelift/codegen/src/ir/mod.rs
+++ b/cranelift/codegen/src/ir/mod.rs
@@ -68,6 +68,7 @@ pub use crate::ir::stackslot::{
 };
 pub use crate::ir::trapcode::TrapCode;
 pub use crate::ir::types::Type;
+pub(crate) use crate::ir::user_stack_maps::UserStackMapEntryVec;
 pub use crate::ir::user_stack_maps::{UserStackMap, UserStackMapEntry};
 
 use crate::entity::{PrimaryMap, SecondaryMap, entity_impl};

--- a/cranelift/codegen/src/lib.rs
+++ b/cranelift/codegen/src/lib.rs
@@ -21,9 +21,9 @@ extern crate alloc;
 extern crate std;
 
 #[cfg(not(feature = "std"))]
-use hashbrown::{HashMap, hash_map};
+use hashbrown::{HashMap, HashSet, hash_map};
 #[cfg(feature = "std")]
-use std::collections::{HashMap, hash_map};
+use std::collections::{HashMap, HashSet, hash_map};
 
 pub use crate::context::Context;
 pub use crate::value_label::{LabelValueLoc, ValueLabelsRanges, ValueLocRange};
@@ -50,6 +50,7 @@ pub mod data_value;
 pub mod dbg;
 pub mod dominator_tree;
 pub mod flowgraph;
+pub mod inline;
 pub mod ir;
 pub mod isa;
 pub mod loop_analysis;

--- a/cranelift/filetests/Cargo.toml
+++ b/cranelift/filetests/Cargo.toml
@@ -14,7 +14,7 @@ rust-version.workspace = true
 workspace = true
 
 [dependencies]
-cranelift-codegen = { workspace = true, features = ["disas"] }
+cranelift-codegen = { workspace = true, features = ["disas", "timing"] }
 cranelift-frontend = { workspace = true }
 cranelift-interpreter = { workspace = true }
 cranelift-native = { workspace = true }

--- a/cranelift/filetests/filetests/inline/basic.clif
+++ b/cranelift/filetests/filetests/inline/basic.clif
@@ -1,0 +1,35 @@
+test inline precise-output
+
+function %f0(i32, i32) -> i32 {
+block0(v0: i32, v1: i32):
+    v2 = iadd v0, v1
+    return v2
+}
+
+; (no functions inlined into %f0)
+
+function %f1() -> i32 {
+    fn0 = %f0(i32, i32) -> i32
+block0():
+    v0 = iconst.i32 10
+    v1 = call fn0(v0, v0)
+    return v1
+}
+
+; function %f1() -> i32 fast {
+;     sig0 = (i32, i32) -> i32 fast
+;     fn0 = %f0 sig0
+;
+; block0:
+;     v0 = iconst.i32 10
+;     jump block1
+;
+; block1:
+;     v3 = iadd.i32 v0, v0  ; v0 = 10, v0 = 10
+;     jump block2(v3)
+;
+; block2(v2: i32):
+;     v1 -> v2
+;     return v1
+; }
+

--- a/cranelift/filetests/filetests/inline/br-table.clif
+++ b/cranelift/filetests/filetests/inline/br-table.clif
@@ -1,0 +1,57 @@
+test inline precise-output
+
+function %f0(i32, i32) -> i32 tail {
+    fn0 = %whatever(i32, i32) -> i32 tail
+block0(v0: i32, v1: i32):
+    br_table v0, block3, [block1(v1), block2]
+block1(v2: i32):
+    return v2
+block2:
+    v3 = iconst.i32 0
+    return v3
+block3:
+    return v0
+}
+
+; (no functions inlined into %f0)
+
+function %f1() -> i32 tail {
+    fn0 = %f0(i32, i32) -> i32 tail
+block0:
+    v0 = iconst.i32 42
+    v1 = call fn0(v0, v0)
+    v2 = iconst.i32 1
+    v3 = iadd v1, v2
+    return v3
+}
+
+; function %f1() -> i32 tail {
+;     sig0 = (i32, i32) -> i32 tail
+;     sig1 = (i32, i32) -> i32 tail
+;     fn0 = %f0 sig0
+;     fn1 = %whatever sig1
+;
+; block0:
+;     v0 = iconst.i32 42
+;     jump block1
+;
+; block1:
+;     br_table v0, block4, [block2(v0), block3]  ; v0 = 42, v0 = 42
+;
+; block2(v4: i32):
+;     jump block5(v4)
+;
+; block3:
+;     v6 = iconst.i32 0
+;     jump block5(v6)  ; v6 = 0
+;
+; block4:
+;     jump block5(v0)  ; v0 = 42
+;
+; block5(v5: i32):
+;     v1 -> v5
+;     v2 = iconst.i32 1
+;     v3 = iadd v1, v2  ; v2 = 1
+;     return v3
+; }
+

--- a/cranelift/filetests/filetests/inline/control-flow.clif
+++ b/cranelift/filetests/filetests/inline/control-flow.clif
@@ -1,0 +1,63 @@
+test inline precise-output
+
+function %f0(i32, i32) -> i32 {
+block0(v0: i32, v1: i32):
+    v2 = iconst.i32 0
+    jump block1(v2, v2)
+
+block1(v3: i32, v4: i32):
+    v5 = icmp eq v1, v4
+    brif v4, block3, block2
+
+block2:
+    v6 = iadd v3, v0
+    v7 = iconst.i32 1
+    v8 = iadd v4, v7
+    jump block1(v6, v8)
+
+block3:
+    return v3
+}
+
+; (no functions inlined into %f0)
+
+function %f1() -> i32 {
+    fn0 = %f0(i32, i32) -> i32
+block0:
+    v0 = iconst.i32 42
+    v1 = iconst.i32 10
+    v2 = call fn0(v0, v1)
+    return v2
+}
+
+; function %f1() -> i32 fast {
+;     sig0 = (i32, i32) -> i32 fast
+;     fn0 = %f0 sig0
+;
+; block0:
+;     v0 = iconst.i32 42
+;     v1 = iconst.i32 10
+;     jump block1
+;
+; block1:
+;     v6 = iconst.i32 0
+;     jump block2(v6, v6)  ; v6 = 0, v6 = 0
+;
+; block2(v3: i32, v4: i32):
+;     v7 = icmp.i32 eq v1, v4  ; v1 = 10
+;     brif v4, block4, block3
+;
+; block3:
+;     v8 = iadd.i32 v3, v0  ; v0 = 42
+;     v9 = iconst.i32 1
+;     v10 = iadd.i32 v4, v9  ; v9 = 1
+;     jump block2(v8, v10)
+;
+; block4:
+;     jump block5(v3)
+;
+; block5(v5: i32):
+;     v2 -> v5
+;     return v2
+; }
+

--- a/cranelift/filetests/filetests/inline/dynamic-stack-slots.clif
+++ b/cranelift/filetests/filetests/inline/dynamic-stack-slots.clif
@@ -1,0 +1,53 @@
+test inline precise-output
+target x86_64
+
+function %f0(i32) {
+    gv0 = dyn_scale_target_const.i32x4
+    dt0 = i32x4*gv0
+    dss0 = explicit_dynamic_slot dt0
+block0(v0: i32):
+    v1 = splat.dt0 v0
+    dynamic_stack_store.dt0 v1, dss0
+    return
+}
+
+; (no functions inlined into %f0)
+
+function %f1() {
+    gv0 = dyn_scale_target_const.i64x2
+    dt0 = i64x2*gv0
+    dss0 = explicit_dynamic_slot dt0
+    fn0 = %f0(i32)
+block0:
+    v0 = iconst.i64 99
+    v1 = splat.dt0 v0
+    dynamic_stack_store.dt0 v1, dss0
+    v2 = iconst.i32 1
+    call fn0(v2)
+    return
+}
+
+; function %f1() fast {
+;     dss0 = explicit_dynamic_slot dt0
+;     dss1 = explicit_dynamic_slot dt1
+;     gv0 = dyn_scale_target_const.i64x2
+;     gv1 = dyn_scale_target_const.i32x4
+;     sig0 = (i32) fast
+;     fn0 = %f0 sig0
+;
+; block0:
+;     v0 = iconst.i64 99
+;     v1 = splat.types::I64x2xN v0  ; v0 = 99
+;     dynamic_stack_store v1, dss0
+;     v2 = iconst.i32 1
+;     jump block1
+;
+; block1:
+;     v3 = splat.types::I32x4xN v2  ; v2 = 1
+;     dynamic_stack_store v3, dss1
+;     jump block2
+;
+; block2:
+;     return
+; }
+

--- a/cranelift/filetests/filetests/inline/globals.clif
+++ b/cranelift/filetests/filetests/inline/globals.clif
@@ -1,0 +1,44 @@
+test inline precise-output
+target x86_64
+
+function %f0() -> i64 {
+    gv0 = symbol %sym
+    gv1 = load.i64 notrap aligned gv0
+block0:
+    v0 = symbol_value.i64 gv0
+    v1 = global_value.i64 gv1
+    v2 = iadd v0, v1
+    return v2
+}
+
+; (no functions inlined into %f0)
+
+function %f1() -> i64 {
+    gv0 = symbol %other_sym
+    fn0 = %f0() -> i64
+block0:
+    v1 = call fn0()
+    return v1
+}
+
+; function %f1() -> i64 fast {
+;     gv0 = symbol %other_sym
+;     gv1 = symbol %sym
+;     gv2 = load.i64 notrap aligned gv1
+;     sig0 = () -> i64 fast
+;     fn0 = %f0 sig0
+;
+; block0:
+;     jump block1
+;
+; block1:
+;     v3 = symbol_value.i64 gv1
+;     v4 = global_value.i64 gv2
+;     v5 = iadd v3, v4
+;     jump block2(v5)
+;
+; block2(v2: i64):
+;     v1 -> v2
+;     return v1
+; }
+

--- a/cranelift/filetests/filetests/inline/return-call-indirect.clif
+++ b/cranelift/filetests/filetests/inline/return-call-indirect.clif
@@ -1,0 +1,71 @@
+test inline precise-output
+target x86_64
+
+function %f0(i64, i32) -> i32 tail {
+    sig0 = (i32) -> i32 tail
+block0(v0: i64, v1: i32):
+    ;; This should become a `call_indirect; jump` upon inlining into a regular
+    ;; call. It can remain a `return_call_indirect` when inlined at a
+    ;; `return_call` site.
+    return_call_indirect sig0, v0(v1)
+}
+
+; (no functions inlined into %f0)
+
+function %f1() -> i32 tail {
+    gv0 = symbol %foo
+    fn0 = %f0(i64, i32) -> i32 tail
+block0:
+    v0 = symbol_value.i64 gv0
+    v1 = iconst.i32 10
+    v2 = call fn0(v0, v1)
+    v3 = iconst.i32 1
+    v4 = iadd v2, v3
+    return v4
+}
+
+; function %f1() -> i32 tail {
+;     gv0 = symbol %foo
+;     sig0 = (i64, i32) -> i32 tail
+;     sig1 = (i32) -> i32 tail
+;     fn0 = %f0 sig0
+;
+; block0:
+;     v0 = symbol_value.i64 gv0
+;     v1 = iconst.i32 10
+;     jump block1
+;
+; block1:
+;     v6 = call_indirect.i64 sig1, v0(v1)  ; v1 = 10
+;     jump block2(v6)
+;
+; block2(v5: i32):
+;     v2 -> v5
+;     v3 = iconst.i32 1
+;     v4 = iadd v2, v3  ; v3 = 1
+;     return v4
+; }
+
+function %f2() -> i32 tail {
+    gv0 = symbol %foo
+    fn0 = %f0(i64, i32) -> i32 tail
+block0:
+    v0 = symbol_value.i64 gv0
+    v1 = iconst.i32 10
+    return_call fn0(v0, v1)
+}
+
+; function %f2() -> i32 tail {
+;     gv0 = symbol %foo
+;     sig0 = (i64, i32) -> i32 tail
+;     sig1 = (i32) -> i32 tail
+;     fn0 = %f0 sig0
+;
+; block0:
+;     v0 = symbol_value.i64 gv0
+;     v1 = iconst.i32 10
+;     jump block1
+;
+; block1:
+;     return_call_indirect.i64 sig1, v0(v1)  ; v1 = 10
+; }

--- a/cranelift/filetests/filetests/inline/return-call.clif
+++ b/cranelift/filetests/filetests/inline/return-call.clif
@@ -1,0 +1,70 @@
+test inline precise-output
+
+function %f0(i32, i32) -> i32 tail {
+    fn0 = %whatever(i32, i32) -> i32 tail
+block0(v0: i32, v1: i32):
+    ;; This should become a `call; jump` upon inlining into a regular call. It
+    ;; can remain a `return_call` when inlined at a `return_call` site.
+    return_call fn0(v0, v1)
+}
+
+; (no functions inlined into %f0)
+
+function %f1() -> i32 tail {
+    fn0 = %f0(i32, i32) -> i32 tail
+block0:
+    v0 = iconst.i32 42
+    v1 = iconst.i32 10
+    v2 = call fn0(v0, v1)
+    v3 = iconst.i32 1
+    v4 = iadd v2, v3
+    return v4
+}
+
+; function %f1() -> i32 tail {
+;     sig0 = (i32, i32) -> i32 tail
+;     sig1 = (i32, i32) -> i32 tail
+;     fn0 = %f0 sig0
+;     fn1 = %whatever sig1
+;
+; block0:
+;     v0 = iconst.i32 42
+;     v1 = iconst.i32 10
+;     jump block1
+;
+; block1:
+;     v6 = call fn1(v0, v1)  ; v0 = 42, v1 = 10
+;     jump block2(v6)
+;
+; block2(v5: i32):
+;     v2 -> v5
+;     v3 = iconst.i32 1
+;     v4 = iadd v2, v3  ; v3 = 1
+;     return v4
+; }
+
+function %f2() -> i32 tail {
+    gv0 = symbol %foo
+    fn0 = %f0(i32, i32) -> i32 tail
+block0:
+    v0 = iconst.i32 42
+    v1 = iconst.i32 10
+    return_call fn0(v0, v1)
+}
+
+; function %f2() -> i32 tail {
+;     gv0 = symbol %foo
+;     sig0 = (i32, i32) -> i32 tail
+;     sig1 = (i32, i32) -> i32 tail
+;     fn0 = %f0 sig0
+;     fn1 = %whatever sig1
+;
+; block0:
+;     v0 = iconst.i32 42
+;     v1 = iconst.i32 10
+;     jump block1
+;
+; block1:
+;     return_call fn1(v0, v1)  ; v0 = 42, v1 = 10
+; }
+

--- a/cranelift/filetests/filetests/inline/shuffle.clif
+++ b/cranelift/filetests/filetests/inline/shuffle.clif
@@ -1,0 +1,36 @@
+;; Test that `ir::Immediate` entities, used by `shuffle`, are properly inlined.
+
+test inline precise-output
+
+function %f0(i8x16, i8x16) -> i8x16 {
+block0(v0: i8x16, v1: i8x16):
+    v2 = shuffle v0, v1, 0x01010101010101010101010101010101
+    return v2
+}
+
+; (no functions inlined into %f0)
+
+function %f1(i8x16, i8x16) -> i8x16 {
+    fn0 = %f0(i8x16, i8x16) -> i8x16
+block0(v0: i8x16, v1: i8x16):
+    v2 = shuffle v0, v1, 0x02020202020202020202020202020202
+    v3 = call fn0(v1, v2)
+    return v3
+}
+
+; function %f1(i8x16, i8x16) -> i8x16 fast {
+;     sig0 = (i8x16, i8x16) -> i8x16 fast
+;     fn0 = %f0 sig0
+;
+; block0(v0: i8x16, v1: i8x16):
+;     v2 = shuffle v0, v1, 0x02020202020202020202020202020202
+;     jump block1
+;
+; block1:
+;     v5 = shuffle v1, v2, 0x01010101010101010101010101010101
+;     jump block2(v5)
+;
+; block2(v4: i8x16):
+;     v3 -> v4
+;     return v3
+; }

--- a/cranelift/filetests/filetests/inline/stack-maps-opt.clif
+++ b/cranelift/filetests/filetests/inline/stack-maps-opt.clif
@@ -1,0 +1,44 @@
+test inline precise-output optimize
+set opt_level=speed_and_size
+target x86_64
+
+;; Test that, after inlining, alias analysis can boil away some GC ref stack
+;; reloads.
+
+function %f0() -> i32 {
+block0:
+    v0 = iconst.i32 1234
+    return v0
+}
+
+; (no functions inlined into %f0)
+
+function %f1(i32) -> i32 {
+    ss0 = explicit_slot 4
+    fn0 = %f0() -> i32
+block0(v0: i32):
+    stack_store v0, ss0
+    v1 = call fn0(), stack_map=[i32 @ ss0+0]
+    v2 = stack_load.i32 ss0
+    v3 = iadd v2, v1
+    return v3
+}
+
+; function %f1(i32) -> i32 fast {
+;     ss0 = explicit_slot 4
+;     sig0 = () -> i32 fast
+;     fn0 = %f0 sig0
+;
+; block0(v0: i32):
+;     v7 = stack_addr.i64 ss0
+;     store notrap v0, v7
+;     jump block1
+;
+; block1:
+;     jump block2
+;
+; block2:
+;     v5 = iconst.i32 1234
+;     v3 = iadd.i32 v0, v5  ; v5 = 1234
+;     return v3
+; }

--- a/cranelift/filetests/filetests/inline/stack-maps.clif
+++ b/cranelift/filetests/filetests/inline/stack-maps.clif
@@ -1,0 +1,232 @@
+test inline precise-output
+target x86_64
+
+;; Stack map in the callee, but not the caller: the callee's stack map should be
+;; preserved.
+
+function %f0(i64) -> i64 tail {
+    ss0 = explicit_slot 16
+    fn0 = %whatever(i64)
+block0(v0: i64):
+    stack_store v0, ss0+8
+    call fn0(v0), stack_map=[i64 @ ss0+8]
+    v1 = stack_load.i64 ss0+8
+    return v1
+}
+
+; (no functions inlined into %f0)
+
+function %f1() -> i64 tail {
+    fn0 = %f0(i64) -> i64 tail
+block0:
+    v0 = iconst.i64 0
+    v1 = call fn0(v0)
+    return v1
+}
+
+; function %f1() -> i64 tail {
+;     ss0 = explicit_slot 16
+;     sig0 = (i64) -> i64 tail
+;     sig1 = (i64) fast
+;     fn0 = %f0 sig0
+;     fn1 = %whatever sig1
+;
+; block0:
+;     v0 = iconst.i64 0
+;     jump block1
+;
+; block1:
+;     stack_store.i64 v0, ss0+8  ; v0 = 0
+;     call fn1(v0), stack_map=[i64 @ ss0+8]  ; v0 = 0
+;     v3 = stack_load.i64 ss0+8
+;     jump block2(v3)
+;
+; block2(v2: i64):
+;     v1 -> v2
+;     return v1
+; }
+
+;; Stack map in the caller, but not the callee: caller's stack map should be
+;; used for the callee's calls.
+
+function %f2(i64) -> i64 tail {
+    fn0 = %whatever(i64) -> i64
+block0(v0: i64):
+    v1 = call fn0(v0)
+    return v1
+}
+
+; (no functions inlined into %f2)
+
+function %f3(i64) -> i64 tail {
+    ss0 = explicit_slot 16
+    fn0 = %f2(i64) -> i64 tail
+block0(v0: i64):
+    stack_store v0, ss0+8
+    v1 = call fn0(v0), stack_map=[i64 @ ss0+8]
+    v2 = stack_load.i64 ss0+8
+    v3 = iadd v1, v2
+    return v3
+}
+
+; function %f3(i64) -> i64 tail {
+;     ss0 = explicit_slot 16
+;     sig0 = (i64) -> i64 tail
+;     sig1 = (i64) -> i64 fast
+;     fn0 = %f2 sig0
+;     fn1 = %whatever sig1
+;
+; block0(v0: i64):
+;     stack_store v0, ss0+8
+;     jump block1
+;
+; block1:
+;     v5 = call fn1(v0), stack_map=[i64 @ ss0+8]
+;     jump block2(v5)
+;
+; block2(v4: i64):
+;     v1 -> v4
+;     v2 = stack_load.i64 ss0+8
+;     v3 = iadd v1, v2
+;     return v3
+; }
+
+;; Stack map in both the caller and the callee: the caller's stack map should be
+;; appended onto the callee's stack maps.
+
+function %f4(i64) -> i64 tail {
+    ss0 = explicit_slot 8
+    fn0 = %whatever(i64)
+block0(v0: i64):
+    stack_store v0, ss0
+    call fn0(v0), stack_map=[i64 @ ss0+0]
+    v1 = stack_load.i64 ss0
+    return v1
+}
+
+; (no functions inlined into %f4)
+
+function %f5(i64) -> i64 tail {
+    ss0 = explicit_slot 16
+    fn0 = %f4(i64) -> i64 tail
+block0(v0: i64):
+    stack_store v0, ss0+8
+    v1 = call fn0(v0), stack_map=[i64 @ ss0+8]
+    v2 = stack_load.i64 ss0+8
+    v3 = iadd v1, v2
+    return v3
+}
+
+; function %f5(i64) -> i64 tail {
+;     ss0 = explicit_slot 16
+;     ss1 = explicit_slot 8
+;     sig0 = (i64) -> i64 tail
+;     sig1 = (i64) fast
+;     fn0 = %f4 sig0
+;     fn1 = %whatever sig1
+;
+; block0(v0: i64):
+;     stack_store v0, ss0+8
+;     jump block1
+;
+; block1:
+;     stack_store.i64 v0, ss1
+;     call fn1(v0), stack_map=[i64 @ ss0+8, i64 @ ss1+0]
+;     v5 = stack_load.i64 ss1
+;     jump block2(v5)
+;
+; block2(v4: i64):
+;     v1 -> v4
+;     v2 = stack_load.i64 ss0+8
+;     v3 = iadd v1, v2
+;     return v3
+; }
+
+;; Stack map in the caller, callee ends with `return_call`: the caller's stack
+;; map should be attached to the `call` in the `call; jump` sequence that the
+;; `return_call` is translated into.
+
+function %f6(i64) -> i64 tail {
+    fn0 = %whatever(i64) -> i64 tail
+block0(v0: i64):
+    return_call fn0(v0)
+}
+
+; (no functions inlined into %f6)
+
+function %f7(i64) -> i64 tail {
+    ss0 = explicit_slot 16
+    fn0 = %f6(i64) -> i64 tail
+block0(v0: i64):
+    stack_store v0, ss0+8
+    v1 = call fn0(v0), stack_map=[i64 @ ss0+8]
+    v2 = stack_load.i64 ss0+8
+    v3 = iadd v1, v2
+    return v3
+}
+
+; function %f7(i64) -> i64 tail {
+;     ss0 = explicit_slot 16
+;     sig0 = (i64) -> i64 tail
+;     sig1 = (i64) -> i64 tail
+;     fn0 = %f6 sig0
+;     fn1 = %whatever sig1
+;
+; block0(v0: i64):
+;     stack_store v0, ss0+8
+;     jump block1
+;
+; block1:
+;     v5 = call fn1(v0), stack_map=[i64 @ ss0+8]
+;     jump block2(v5)
+;
+; block2(v4: i64):
+;     v1 -> v4
+;     v2 = stack_load.i64 ss0+8
+;     v3 = iadd v1, v2
+;     return v3
+; }
+
+;; Stack map in the caller, callee ends with `return_call_indirect`: the
+;; caller's stack map should be attached to the `call_indirect` in the
+;; `call_indirect; jump` sequence that the `return_call` is translated into.
+
+function %f8(i64, i64) -> i64 tail {
+    sig0 = (i64) -> i64 tail
+block0(v0: i64, v1: i64):
+    return_call_indirect sig0, v1(v0)
+}
+
+; (no functions inlined into %f8)
+
+function %f9(i64, i64) -> i64 tail {
+    ss0 = explicit_slot 16
+    fn0 = %f8(i64, i64) -> i64 tail
+block0(v0: i64, v1: i64):
+    stack_store v0, ss0+8
+    v2 = call fn0(v0, v1), stack_map=[i64 @ ss0+8]
+    v3 = stack_load.i64 ss0+8
+    v4 = iadd v2, v3
+    return v4
+}
+
+; function %f9(i64, i64) -> i64 tail {
+;     ss0 = explicit_slot 16
+;     sig0 = (i64, i64) -> i64 tail
+;     sig1 = (i64) -> i64 tail
+;     fn0 = %f8 sig0
+;
+; block0(v0: i64, v1: i64):
+;     stack_store v0, ss0+8
+;     jump block1
+;
+; block1:
+;     v6 = call_indirect.i64 sig1, v1(v0), stack_map=[i64 @ ss0+8]
+;     jump block2(v6)
+;
+; block2(v5: i64):
+;     v2 -> v5
+;     v3 = stack_load.i64 ss0+8
+;     v4 = iadd v2, v3
+;     return v4
+; }

--- a/cranelift/filetests/filetests/inline/stack-slots.clif
+++ b/cranelift/filetests/filetests/inline/stack-slots.clif
@@ -1,0 +1,46 @@
+test inline precise-output
+target x86_64
+
+function %f0(i64) -> i64 tail {
+    ss0 = explicit_slot 8
+block0(v0: i64):
+    stack_store v0, ss0
+    v1 = stack_load.i64 ss0
+    return v1
+}
+
+; (no functions inlined into %f0)
+
+function %f1() -> i64 tail {
+    ss0 = explicit_slot 4
+    fn0 = %f0(i64) -> i64 tail
+block0:
+    v0 = stack_addr.i64 ss0
+    v1 = call fn0(v0)
+    v2 = iconst.i64 1
+    v3 = iadd v1, v2
+    return v3
+}
+
+; function %f1() -> i64 tail {
+;     ss0 = explicit_slot 4
+;     ss1 = explicit_slot 8
+;     sig0 = (i64) -> i64 tail
+;     fn0 = %f0 sig0
+;
+; block0:
+;     v0 = stack_addr.i64 ss0
+;     jump block1
+;
+; block1:
+;     stack_store.i64 v0, ss1
+;     v5 = stack_load.i64 ss1
+;     jump block2(v5)
+;
+; block2(v4: i64):
+;     v1 -> v4
+;     v2 = iconst.i64 1
+;     v3 = iadd v1, v2  ; v2 = 1
+;     return v3
+; }
+

--- a/cranelift/filetests/filetests/inline/try-call.clif
+++ b/cranelift/filetests/filetests/inline/try-call.clif
@@ -1,0 +1,338 @@
+test inline precise-output
+target x86_64
+
+;; Inlining a `call` site whose callee contains a `try_call`.
+
+function %f0(i32) -> i64 tail {
+    sig0 = (i32) -> i64 tail
+    fn0 = %foo(i32) -> i64 tail
+block0(v0: i32):
+    v1 = iconst.i32 0
+    v2 = iconst.i32 1
+    try_call fn0(v0), sig0, block1(ret0, v2), [tag1: block1(exn0, v1)]
+block1(v3: i64, v4: i32):
+    v5 = iconst.i64 0
+    v6 = select v4, v3, v5
+    return v6
+}
+
+; (no functions inlined into %f0)
+
+function %f1() -> i64 tail {
+    fn0 = %f0(i32) -> i64 tail
+block0:
+    v0 = iconst.i32 99
+    v1 = call fn0(v0)
+    v2 = iconst.i64 1
+    v3 = iadd v1, v2
+    return v3
+}
+
+; function %f1() -> i64 tail {
+;     sig0 = (i32) -> i64 tail
+;     sig1 = (i32) -> i64 tail
+;     sig2 = (i32) -> i64 tail
+;     fn0 = %f0 sig0
+;     fn1 = %foo sig2
+;
+; block0:
+;     v0 = iconst.i32 99
+;     jump block1
+;
+; block1:
+;     v7 = iconst.i32 0
+;     v8 = iconst.i32 1
+;     try_call fn1(v0), sig1, block2(ret0, v8), [ tag1: block2(exn0, v7) ]  ; v0 = 99, v7 = 0, v8 = 1
+;
+; block2(v4: i64, v5: i32):
+;     v9 = iconst.i64 0
+;     v10 = select v5, v4, v9  ; v9 = 0
+;     jump block3(v10)
+;
+; block3(v6: i64):
+;     v1 -> v6
+;     v2 = iconst.i64 1
+;     v3 = iadd v1, v2  ; v2 = 1
+;     return v3
+; }
+
+;; Inlining a `try_call` site whose callee contains a `try_call`.
+
+function %f2() -> i64 tail {
+    sig0 = (i32) -> i64 tail
+    fn0 = %f0(i32) -> i64 tail
+block0:
+    v0 = iconst.i32 99
+    try_call fn0(v0), sig0, block1(ret0), [default: block2(exn0)]
+block1(v1: i64):
+    v2 = iconst.i64 1
+    v3 = iadd v1, v2
+    return v3
+block2(v4: i64):
+    return v4
+}
+
+; function %f2() -> i64 tail {
+;     sig0 = (i32) -> i64 tail
+;     sig1 = (i32) -> i64 tail
+;     sig2 = (i32) -> i64 tail
+;     sig3 = (i32) -> i64 tail
+;     fn0 = %f0 sig1
+;     fn1 = %foo sig3
+;
+; block0:
+;     v0 = iconst.i32 99
+;     jump block3
+;
+; block3:
+;     v7 = iconst.i32 0
+;     v8 = iconst.i32 1
+;     try_call fn1(v0), sig2, block4(ret0, v8), [ tag1: block4(exn0, v7), default: block2(exn0) ]  ; v0 = 99, v7 = 0, v8 = 1
+;
+; block4(v5: i64, v6: i32):
+;     v9 = iconst.i64 0
+;     v10 = select v6, v5, v9  ; v9 = 0
+;     jump block1(v10)
+;
+; block1(v1: i64):
+;     v2 = iconst.i64 1
+;     v3 = iadd v1, v2  ; v2 = 1
+;     return v3
+;
+; block2(v4: i64):
+;     return v4
+; }
+
+;; Inlining a `try_call` site whose callee contains a `call` and
+;; `call_indirect`.
+
+function %f3() -> i64 tail {
+    sig0 = () -> i64 tail
+    fn0 = %bar(i64) -> i64 tail
+block0:
+    v0 = iconst.i64 36
+    v1 = call fn0(v0)
+    v2 = call_indirect sig0, v1()
+    return v2
+}
+
+; (no functions inlined into %f3)
+
+function %f4() -> i64 tail {
+    sig0 = () -> i64 tail
+    fn0 = %f3() -> i64 tail
+block0:
+    v0 = iconst.i64 0
+    ;; The inliner should rewrite the callee's `call` instructions into
+    ;; `try_call`s and use this `try_call`'s exception table.
+    try_call fn0(), sig0, block1(ret0), [tag1: block2, tag2: block3(v0), default: block3(exn0)]
+block1(v1: i64):
+    return v1
+block2:
+    v2 = iconst.i64 1
+    return v2
+block3(v3: i64):
+    return v3
+}
+
+; function %f4() -> i64 tail {
+;     sig0 = () -> i64 tail
+;     sig1 = () -> i64 tail
+;     sig2 = () -> i64 tail
+;     sig3 = (i64) -> i64 tail
+;     fn0 = %f3 sig1
+;     fn1 = %bar sig3
+;
+; block0:
+;     v0 = iconst.i64 0
+;     jump block4
+;
+; block4:
+;     v4 = iconst.i64 36
+;     try_call fn1(v4), sig3, block5(ret0), [ tag1: block2, tag2: block3(v0), default: block3(exn0) ]  ; v4 = 36, v0 = 0
+;
+; block5(v7: i64):
+;     v5 -> v7
+;     try_call_indirect v5(), sig2, block6(ret0), [ tag1: block2, tag2: block3(v0), default: block3(exn0) ]  ; v0 = 0
+;
+; block6(v8: i64):
+;     v6 -> v8
+;     jump block1(v6)
+;
+; block1(v1: i64):
+;     return v1
+;
+; block2:
+;     v2 = iconst.i64 1
+;     return v2  ; v2 = 1
+;
+; block3(v3: i64):
+;     return v3
+; }
+
+;; Inlining `try_call` sites whose normal-return edge does not simply pass along
+;; the call's return values.
+
+function %f5() -> i64, i64 tail {
+    fn0 = %whatever() -> i64 tail
+block0:
+    v0 = call fn0()
+    v1 = iconst.i64 1
+    v2 = iadd v0, v1
+    return v0, v2
+}
+
+; (no functions inlined into %f5)
+
+function %f6() -> i64, i32 tail {
+    fn0 = %f5() -> i64, i64 tail
+block0:
+    v0 = iconst.i32 42
+    ;; Note: we do not just forward the return values in the normal-return
+    ;; branch! The inlined version of our callee should not attempt to pass
+    ;; arguments directly to `block1`, and should instead create a temporary
+    ;; block for "returns" in front of `block1`.
+    try_call fn0(), sig0, block1(ret1, v0), [default: block2(exn0)]
+block1(v1: i64, v2: i32):
+    return v1, v2
+block2(v3: i64):
+    v4 = iconst.i32 0
+    return v3, v4
+}
+
+; function %f6() -> i64, i32 tail {
+;     sig0 = () -> i64, i64 tail
+;     sig1 = () -> i64 tail
+;     fn0 = %f5 sig0
+;     fn1 = %whatever sig1
+;
+; block0:
+;     v0 = iconst.i32 42
+;     jump block3
+;
+; block3:
+;     try_call fn1(), sig1, block5(ret0), [ default: block2(exn0) ]
+;
+; block5(v10: i64):
+;     v7 -> v10
+;     v8 = iconst.i64 1
+;     v9 = iadd v7, v8  ; v8 = 1
+;     jump block4(v7, v9)
+;
+; block4(v5: i64, v6: i64):
+;     jump block1(v6, v0)  ; v0 = 42
+;
+; block1(v1: i64, v2: i32):
+;     return v1, v2
+;
+; block2(v3: i64):
+;     v4 = iconst.i32 0
+;     return v3, v4  ; v4 = 0
+; }
+
+;; Inlining a `try_call` site whose callee ends in a `return_call`.
+
+function %f7() -> i64 tail {
+    fn0 = %foo() -> i64 tail
+block0:
+    ;; When inlined, this should become a `try_call` followed by a branch to the
+    ;; control-flow join point.
+    return_call fn0()
+}
+
+; (no functions inlined into %f7)
+
+function %f8() -> i32 {
+    sig0 = () -> i64 tail
+    fn0 = %f7 sig0
+block0:
+    try_call fn0(), sig0, block1(ret0), [default: block2(exn0)]
+block1(v0: i64):
+    v1 = ireduce.i32 v0
+    return v1
+block2(v2: i64):
+    v3 = iconst.i32 1
+    v4 = ireduce.i32 v2
+    v5 = iadd v3, v4
+    return v5
+}
+
+; function %f8() -> i32 fast {
+;     sig0 = () -> i64 tail
+;     sig1 = () -> i64 tail
+;     fn0 = %f7 sig0
+;     fn1 = %foo sig1
+;
+; block0:
+;     jump block3
+;
+; block3:
+;     try_call fn1(), sig1, block4(ret0), [ default: block2(exn0) ]
+;
+; block4(v7: i64):
+;     v6 -> v7
+;     jump block1(v6)
+;
+; block1(v0: i64):
+;     v1 = ireduce.i32 v0
+;     return v1
+;
+; block2(v2: i64):
+;     v3 = iconst.i32 1
+;     v4 = ireduce.i32 v2
+;     v5 = iadd v3, v4  ; v3 = 1
+;     return v5
+; }
+
+;; Inlining a `try_call` site whose callee ends in a `return_call_indirect`.
+
+function %f9(i64) -> i64 tail {
+    sig0 = () -> i64 tail
+block0(v0: i64):
+    ;; When inlined, this should become a `try_call_indirect` followed by a
+    ;; branch to the control-flow join point.
+    return_call_indirect sig0, v0()
+}
+
+; (no functions inlined into %f9)
+
+function %f10(i64) -> i32 {
+    sig0 = (i64) -> i64 tail
+    fn0 = %f9 sig0
+block0(v0: i64):
+    try_call fn0(v0), sig0, block1(ret0), [default: block2(exn0)]
+block1(v1: i64):
+    v2 = ireduce.i32 v1
+    return v2
+block2(v3: i64):
+    v4 = iconst.i32 1
+    v5 = ireduce.i32 v3
+    v6 = iadd v4, v5
+    return v6
+}
+
+; function %f10(i64) -> i32 fast {
+;     sig0 = (i64) -> i64 tail
+;     sig1 = () -> i64 tail
+;     fn0 = %f9 sig0
+;
+; block0(v0: i64):
+;     jump block3
+;
+; block3:
+;     try_call_indirect.i64 v0(), sig1, block4(ret0), [ default: block2(exn0) ]
+;
+; block4(v8: i64):
+;     v7 -> v8
+;     jump block1(v7)
+;
+; block1(v1: i64):
+;     v2 = ireduce.i32 v1
+;     return v2
+;
+; block2(v3: i64):
+;     v4 = iconst.i32 1
+;     v5 = ireduce.i32 v3
+;     v6 = iadd v4, v5  ; v4 = 1
+;     return v6
+; }

--- a/cranelift/filetests/filetests/inline/vconst.clif
+++ b/cranelift/filetests/filetests/inline/vconst.clif
@@ -1,0 +1,40 @@
+;; Test that `ir::Constant`s, used by `vconst` and others, are properly inlined.
+
+test inline precise-output
+
+function %f0(i32x4) -> i32x4 {
+block0(v0: i32x4):
+    v1 = vconst.i32x4 0x01
+    v2 = iadd v0, v1
+    return v2
+}
+
+; (no functions inlined into %f0)
+
+function %f1() -> i32x4 {
+    fn0 = %f0(i32x4) -> i32x4
+block0():
+    v0 = vconst.i32x4 0x02
+    v1 = call fn0(v0)
+    return v1
+}
+
+; function %f1() -> i32x4 fast {
+;     sig0 = (i32x4) -> i32x4 fast
+;     fn0 = %f0 sig0
+;     const0 = 0x00000000000000000000000000000002
+;     const1 = 0x00000000000000000000000000000001
+;
+; block0:
+;     v0 = vconst.i32x4 const0
+;     jump block1
+;
+; block1:
+;     v3 = vconst.i32x4 const1
+;     v4 = iadd.i32x4 v0, v3  ; v0 = const0, v3 = const1
+;     jump block2(v4)
+;
+; block2(v2: i32x4):
+;     v1 -> v2
+;     return v1
+; }

--- a/cranelift/filetests/filetests/inline/vmctx.clif
+++ b/cranelift/filetests/filetests/inline/vmctx.clif
@@ -1,0 +1,45 @@
+test inline precise-output
+target x86_64
+
+function %f0(i64 vmctx) -> i64 {
+    gv0 = vmctx
+    gv1 = load.i64 notrap aligned gv0+16
+block0(v0: i64):
+    v1 = global_value.i64 gv1
+    return v1
+}
+
+; (no functions inlined into %f0)
+
+function %f1(i64 vmctx) -> i64 {
+    gv0 = vmctx
+    gv1 = symbol %other_vmctx
+    fn0 = %f0(i64 vmctx) -> i64
+block0(v0: i64):
+    ;; Note: the callee's vmctx is *not* the same as the caller's vmctx!
+    v1 = symbol_value.i64 gv1
+    v2 = call fn0(v1)
+    return v2
+}
+
+; function %f1(i64 vmctx) -> i64 fast {
+;     gv0 = vmctx
+;     gv1 = symbol %other_vmctx
+;     gv2 = vmctx
+;     gv3 = load.i64 notrap aligned gv2+16
+;     sig0 = (i64 vmctx) -> i64 fast
+;     fn0 = %f0 sig0
+;
+; block0(v0: i64):
+;     v1 = symbol_value.i64 gv1
+;     jump block1
+;
+; block1:
+;     v4 = load.i64 notrap aligned v1+16
+;     jump block2(v4)
+;
+; block2(v3: i64):
+;     v2 -> v3
+;     return v2
+; }
+

--- a/cranelift/filetests/src/lib.rs
+++ b/cranelift/filetests/src/lib.rs
@@ -21,6 +21,7 @@ mod test_alias_analysis;
 mod test_cat;
 mod test_compile;
 mod test_domtree;
+mod test_inline;
 mod test_interpret;
 mod test_legalizer;
 mod test_optimize;
@@ -89,6 +90,7 @@ fn new_subtest(parsed: &TestCommand) -> anyhow::Result<Box<dyn subtest::SubTest>
         "cat" => test_cat::subtest(parsed),
         "compile" => test_compile::subtest(parsed),
         "domtree" => test_domtree::subtest(parsed),
+        "inline" => test_inline::subtest(parsed),
         "interpret" => test_interpret::subtest(parsed),
         "legalizer" => test_legalizer::subtest(parsed),
         "optimize" => test_optimize::subtest(parsed),

--- a/cranelift/filetests/src/test_inline.rs
+++ b/cranelift/filetests/src/test_inline.rs
@@ -1,0 +1,143 @@
+//! Test command for testing inlining.
+//!
+//! The `inline` test command inlines all calls, and optionally optimizes each
+//! function before and after the optimization passes. It does not perform
+//! lowering or regalloc. The output for filecheck purposes is the resulting
+//! CLIF.
+//!
+//! Some legalization may be ISA-specific, so this requires an ISA
+//! (for now).
+
+use crate::subtest::{Context, SubTest, check_precise_output, run_filecheck};
+use anyhow::Result;
+use cranelift_codegen::{
+    inline::{Inline, InlineCommand},
+    ir,
+    print_errors::pretty_verifier_error,
+};
+use cranelift_control::ControlPlane;
+use cranelift_reader::{TestCommand, TestOption};
+use std::{
+    borrow::Cow,
+    cell::{Ref, RefCell},
+    collections::HashMap,
+};
+
+#[derive(Default)]
+struct TestInline {
+    /// Flag indicating that the text expectation, comments after the function,
+    /// must be a precise 100% match on the compiled output of the function.
+    /// This test assertion is also automatically-update-able to allow tweaking
+    /// the code generator and easily updating all affected tests.
+    precise_output: bool,
+
+    /// Flag indicating whether to run optimizations on the function after
+    /// inlining.
+    optimize: bool,
+
+    /// The already-defined functions we have seen, available for inlining into
+    /// future functions.
+    funcs: RefCell<HashMap<ir::UserFuncName, ir::Function>>,
+}
+
+pub fn subtest(parsed: &TestCommand) -> Result<Box<dyn SubTest>> {
+    assert_eq!(parsed.command, "inline");
+    let mut test = TestInline::default();
+    for option in parsed.options.iter() {
+        match option {
+            TestOption::Flag("precise-output") => test.precise_output = true,
+            TestOption::Flag("optimize") => test.optimize = true,
+            _ => anyhow::bail!("unknown option on {}", parsed),
+        }
+    }
+    Ok(Box::new(test))
+}
+
+impl SubTest for TestInline {
+    fn name(&self) -> &'static str {
+        "inline"
+    }
+
+    fn is_mutating(&self) -> bool {
+        true
+    }
+
+    fn needs_isa(&self) -> bool {
+        false
+    }
+
+    fn run(&self, func: Cow<ir::Function>, context: &Context) -> Result<()> {
+        // Insert this function in our map for inlining into subsequent
+        // functions.
+        let func_name = func.name.clone();
+        self.funcs
+            .borrow_mut()
+            .insert(func_name, func.clone().into_owned());
+
+        // Run the inliner.
+        let mut comp_ctx = cranelift_codegen::Context::for_function(func.into_owned());
+        let inlined_any = comp_ctx.inline(Inliner(self.funcs.borrow()))?;
+
+        // Verify that the CLIF is still valid.
+        comp_ctx.verify(context.flags_or_isa()).map_err(|errors| {
+            anyhow::Error::msg(pretty_verifier_error(&comp_ctx.func, None, errors))
+                .context("The CLIF failed verification after inlining")
+        })?;
+
+        // If requested, run optimizations.
+        if self.optimize {
+            let isa = context.isa.expect("optimization needs an ISA");
+            comp_ctx
+                .optimize(isa, &mut ControlPlane::default())
+                .map_err(|e| crate::pretty_anyhow_error(&comp_ctx.func, e))?;
+        }
+
+        // Check the filecheck expectations.
+        let actual = if inlined_any {
+            format!("{:?}", comp_ctx.func)
+        } else {
+            format!("(no functions inlined into {})", comp_ctx.func.name)
+        };
+        log::debug!("filecheck input: {actual}");
+        if self.precise_output {
+            let actual: Vec<_> = actual.lines().collect();
+            check_precise_output(&actual, context)
+        } else {
+            run_filecheck(&actual, context)
+        }
+    }
+}
+
+struct Inliner<'a>(Ref<'a, HashMap<ir::UserFuncName, ir::Function>>);
+
+impl<'a> Inline for Inliner<'a> {
+    fn inline(
+        &self,
+        caller: &ir::Function,
+        _inst: ir::Inst,
+        _opcode: ir::Opcode,
+        callee: ir::FuncRef,
+        _args: &[ir::Value],
+    ) -> InlineCommand<'_> {
+        match &caller.dfg.ext_funcs[callee].name {
+            ir::ExternalName::User(name) => match caller
+                .params
+                .user_named_funcs()
+                .get(*name)
+                .and_then(|name| self.0.get(&ir::UserFuncName::User(name.clone())))
+            {
+                None => InlineCommand::KeepCall,
+                Some(f) => InlineCommand::Inline(f),
+            },
+            ir::ExternalName::TestCase(name) => {
+                match self.0.get(&ir::UserFuncName::Testcase(name.clone())) {
+                    None => InlineCommand::KeepCall,
+                    Some(f) => InlineCommand::Inline(f),
+                }
+            }
+            ir::ExternalName::LibCall(_) | ir::ExternalName::KnownSymbol(_) => {
+                InlineCommand::KeepCall
+            }
+        }
+    }
+}


### PR DESCRIPTION
This comit adds "inlining as a library" to Cranelift; it does _not_ provide a complete, off-the-shelf inlining solution. Cranelift's compilation context is per-function and does not encompass the full call graph. It does not know which functions are hot and which are cold, which have been marked the equivalent of `#[inline(always)]` versus `#[inline(never)]`, etc... Only the Cranelift user can understand these aspects of the full compilation pipeline, and these things can be very different between (say) Wasmtime and `cg_clif`. Therefore, this infrastructure does not attempt to define hueristics for when inlining a particular call is likely beneficial. This module only provides hooks for the Cranelift user to tell Cranelift whether a given call should be inlined or not, and the mechanics to inline a callee into a particular call site when the user directs Cranelift to do so.

This commit also creates a new kind of filetest that will always inline calls to functions that have already been defined in the file. This lets us exercise the inliner in filetests.

Fixes https://github.com/bytecodealliance/wasmtime/issues/4127

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
