### PR TITLE
Inch towards making tables safer

### DIFF
--- a/crates/wasmtime/src/runtime/store.rs
+++ b/crates/wasmtime/src/runtime/store.rs
@@ -1296,6 +1296,20 @@ impl StoreOpaque {
         self.instances[id].handle.get_mut()
     }
 
+    /// Pair of `Self::gc_store_mut` and `Self::instance_mut`
+    pub fn gc_store_and_instance_mut(
+        &mut self,
+        id: InstanceId,
+    ) -> Result<(&mut GcStore, Pin<&mut vm::Instance>)> {
+        // Fill in `self.gc_store`, then proceed below to the point where we
+        // convince the borrow checker that we're accessing disjoint fields.
+        self.gc_store_mut()?;
+        Ok((
+            self.gc_store.as_mut().unwrap(),
+            self.instances[id].handle.get_mut(),
+        ))
+    }
+
     /// Get all instances (ignoring dummy instances) within this store.
     pub fn all_instances<'a>(&'a mut self) -> impl ExactSizeIterator<Item = Instance> + 'a {
         let instances = self

--- a/crates/wasmtime/src/runtime/vm/instance.rs
+++ b/crates/wasmtime/src/runtime/vm/instance.rs
@@ -1304,10 +1304,8 @@ impl Instance {
     }
 
     /// Get a locally-defined table.
-    pub(crate) fn get_defined_table(self: Pin<&mut Self>, index: DefinedTableIndex) -> *mut Table {
-        // SAFETY: the `unsafe` here is projecting from `*mut (A, B)` to
-        // `*mut A`, which should be a safe operation to do.
-        unsafe { &raw mut (*self.tables_mut().get_raw_mut(index).unwrap()).1 }
+    pub(crate) fn get_defined_table(self: Pin<&mut Self>, index: DefinedTableIndex) -> &mut Table {
+        &mut self.tables_mut()[index].1
     }
 
     pub(crate) fn with_defined_table_index_and_instance<R>(

--- a/crates/wasmtime/src/runtime/vm/instance/allocator.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator.rs
@@ -613,31 +613,31 @@ fn initialize_tables(
                         .expect("const expression should be valid")
                 };
                 let idx = module.table_index(table);
-                let table = unsafe {
-                    store
-                        .instance_mut(context.instance)
-                        .get_defined_table(table)
-                        .as_mut()
-                        .unwrap()
-                };
                 match module.tables[idx].ref_type.heap_type.top() {
                     WasmHeapTopType::Extern => {
+                        let (gc_store, instance) =
+                            store.gc_store_and_instance_mut(context.instance)?;
+                        let table = instance.get_defined_table(table);
                         let gc_ref = VMGcRef::from_raw_u32(raw.get_externref());
-                        let gc_store = store.gc_store_mut()?;
                         let items = (0..table.size())
                             .map(|_| gc_ref.as_ref().map(|r| gc_store.clone_gc_ref(r)));
                         table.init_gc_refs(0, items)?;
                     }
 
                     WasmHeapTopType::Any => {
+                        let (gc_store, instance) =
+                            store.gc_store_and_instance_mut(context.instance)?;
+                        let table = instance.get_defined_table(table);
                         let gc_ref = VMGcRef::from_raw_u32(raw.get_anyref());
-                        let gc_store = store.gc_store_mut()?;
                         let items = (0..table.size())
                             .map(|_| gc_ref.as_ref().map(|r| gc_store.clone_gc_ref(r)));
                         table.init_gc_refs(0, items)?;
                     }
 
                     WasmHeapTopType::Func => {
+                        let table = store
+                            .instance_mut(context.instance)
+                            .get_defined_table(table);
                         let funcref = NonNull::new(raw.get_funcref().cast::<VMFuncRef>());
                         let items = (0..table.size()).map(|_| funcref);
                         table.init_func(0, items)?;


### PR DESCRIPTION
This is a small step towards #11179 which starts off by making `vm::Instance::get_defined_table` a safe function. That required updating one location which required both a `&mut Table` and a `&mut GcStore` at the same time with a new helper on the store. More of these sorts of helpers are likely going to be necessary but IMO it's a small price to pay for safety.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
