### PR TITLE
Make `vm::Instance::get_defined_table_with_lazy_init` return a reference

### DIFF
--- a/crates/wasmtime/src/runtime/store.rs
+++ b/crates/wasmtime/src/runtime/store.rs
@@ -1305,18 +1305,12 @@ impl StoreOpaque {
         self.instances[id].handle.get_mut()
     }
 
-    /// Pair of `Self::gc_store_mut` and `Self::instance_mut`
-    pub fn gc_store_and_instance_mut(
+    /// Pair of `Self::optional_gc_store_mut` and `Self::instance_mut`
+    pub fn optional_gc_store_and_instance_mut(
         &mut self,
         id: InstanceId,
-    ) -> Result<(&mut GcStore, Pin<&mut vm::Instance>)> {
-        // Fill in `self.gc_store`, then proceed below to the point where we
-        // convince the borrow checker that we're accessing disjoint fields.
-        self.gc_store_mut()?;
-        Ok((
-            self.gc_store.as_mut().unwrap(),
-            self.instances[id].handle.get_mut(),
-        ))
+    ) -> (Option<&mut GcStore>, Pin<&mut vm::Instance>) {
+        (self.gc_store.as_mut(), self.instances[id].handle.get_mut())
     }
 
     /// Get all instances (ignoring dummy instances) within this store.

--- a/crates/wasmtime/src/runtime/vm/instance/allocator.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator.rs
@@ -615,8 +615,10 @@ fn initialize_tables(
                 let idx = module.table_index(table);
                 match module.tables[idx].ref_type.heap_type.top() {
                     WasmHeapTopType::Extern => {
+                        store.gc_store_mut()?;
                         let (gc_store, instance) =
-                            store.gc_store_and_instance_mut(context.instance)?;
+                            store.optional_gc_store_and_instance_mut(context.instance);
+                        let gc_store = gc_store.unwrap();
                         let table = instance.get_defined_table(table);
                         let gc_ref = VMGcRef::from_raw_u32(raw.get_externref());
                         let items = (0..table.size())
@@ -625,8 +627,10 @@ fn initialize_tables(
                     }
 
                     WasmHeapTopType::Any => {
+                        store.gc_store_mut()?;
                         let (gc_store, instance) =
-                            store.gc_store_and_instance_mut(context.instance)?;
+                            store.optional_gc_store_and_instance_mut(context.instance);
+                        let gc_store = gc_store.unwrap();
                         let table = instance.get_defined_table(table);
                         let gc_ref = VMGcRef::from_raw_u32(raw.get_anyref());
                         let items = (0..table.size())
@@ -635,10 +639,12 @@ fn initialize_tables(
                     }
 
                     WasmHeapTopType::Exn => {
+                        store.gc_store_mut()?;
                         let (gc_store, instance) =
-                            store.gc_store_and_instance_mut(context.instance)?;
+                            store.optional_gc_store_and_instance_mut(context.instance);
+                        let gc_store = gc_store.unwrap();
                         let table = instance.get_defined_table(table);
-                        let gc_ref = VMGcRef::from_raw_u32(raw.get_anyref());
+                        let gc_ref = VMGcRef::from_raw_u32(raw.get_exnref());
                         let items = (0..table.size())
                             .map(|_| gc_ref.as_ref().map(|r| gc_store.clone_gc_ref(r)));
                         table.init_gc_refs(0, items)?;


### PR DESCRIPTION
This commit updates the `get_defined_table_with_lazy_init` method to return a safe reference instead of a raw reference. This then cascaded outwards to updating more locations to handle this new safe reference as well. While this makes some further progress on #11179 there are a number of locations that will require using raw pointers until more refactoring is done.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
