### PR TITLE
Delete `vm::Instance::table_grow`

### DIFF
--- a/crates/environ/src/vmoffsets.rs
+++ b/crates/environ/src/vmoffsets.rs
@@ -706,6 +706,18 @@ impl<P: PtrSize> VMOffsets<P> {
         0 * self.pointer_size()
     }
 
+    /// The offset of the `vmctx` field.
+    #[inline]
+    pub fn vmtable_import_vmctx(&self) -> u8 {
+        1 * self.pointer_size()
+    }
+
+    /// The offset of the `index` field.
+    #[inline]
+    pub fn vmtable_import_index(&self) -> u8 {
+        2 * self.pointer_size()
+    }
+
     /// Return the size of `VMTableImport`.
     #[inline]
     pub fn size_of_vmtable_import(&self) -> u8 {

--- a/crates/wasmtime/src/runtime/vm/instance.rs
+++ b/crates/wasmtime/src/runtime/vm/instance.rs
@@ -719,19 +719,7 @@ impl Instance {
     ///
     /// Returns `None` if table can't be grown by the specified amount of
     /// elements, or if `init_value` is the wrong type of table element.
-    pub(crate) fn table_grow(
-        self: Pin<&mut Self>,
-        store: &mut dyn VMStore,
-        table_index: TableIndex,
-        delta: u64,
-        init_value: TableElement,
-    ) -> Result<Option<usize>, Error> {
-        self.with_defined_table_index_and_instance(table_index, |i, instance| {
-            instance.defined_table_grow(store, i, delta, init_value)
-        })
-    }
-
-    fn defined_table_grow(
+    pub(crate) fn defined_table_grow(
         mut self: Pin<&mut Self>,
         store: &mut dyn VMStore,
         table_index: DefinedTableIndex,

--- a/crates/wasmtime/src/runtime/vm/vmcontext.rs
+++ b/crates/wasmtime/src/runtime/vm/vmcontext.rs
@@ -179,6 +179,14 @@ mod test_vmtable {
             offset_of!(VMTableImport, from),
             usize::from(offsets.vmtable_import_from())
         );
+        assert_eq!(
+            offset_of!(VMTableImport, vmctx),
+            usize::from(offsets.vmtable_import_vmctx())
+        );
+        assert_eq!(
+            offset_of!(VMTableImport, index),
+            usize::from(offsets.vmtable_import_index())
+        );
     }
 
     #[test]

--- a/winch/codegen/src/visitor.rs
+++ b/winch/codegen/src/visitor.rs
@@ -1718,14 +1718,10 @@ where
         // but the builtin function expects the init value as the last
         // argument.
         self.context.stack.inner_mut().swap(len - 1, len - 2);
-        self.context.stack.insert_many(at, &[table.try_into()?]);
 
-        FnCall::emit::<M>(
-            &mut self.env,
-            self.masm,
-            &mut self.context,
-            Callee::Builtin(builtin.clone()),
-        )?;
+        let builtin = self.prepare_builtin_defined_table_arg(table_index, at, builtin)?;
+
+        FnCall::emit::<M>(&mut self.env, self.masm, &mut self.context, builtin)?;
 
         Ok(())
     }


### PR DESCRIPTION
This commit is a further inch towards #11179 by removing internal reliance on reading `VMContext` pointers and casting them to `Pin<&mut Instance>` in various contexts. Notably now only a defined table needs to be grown, which simplifies the internals of `vm::Instance` ever so slightly. This is a similar change as #11211 which transitions libcalls to using `DefinedTableIndex` instead of `TableIndex`.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
