### PR TITLE
s390x: Refactor hardware facility detection

### DIFF
--- a/cranelift/codegen/meta/src/isa/s390x.rs
+++ b/cranelift/codegen/meta/src/isa/s390x.rs
@@ -8,9 +8,9 @@ pub(crate) fn define() -> TargetIsa {
     // so we list only facilities of later processors here.
 
     // z15 (arch13) facilities
-    let has_mie2 = settings.add_bool(
-        "has_mie2",
-        "Has Miscellaneous-Instruction-Extensions Facility 2 support.",
+    let has_mie3 = settings.add_bool(
+        "has_mie3",
+        "Has Miscellaneous-Instruction-Extensions Facility 3 support.",
         "",
         false,
     );
@@ -21,18 +21,54 @@ pub(crate) fn define() -> TargetIsa {
         false,
     );
 
+    // z16 (arch14) has no new facilities that can be exploited by cranelift
+
+    // z17 (arch15) facilities
+    let has_mie4 = settings.add_bool(
+        "has_mie4",
+        "Has Miscellaneous-Instruction-Extensions Facility 4 support.",
+        "",
+        false,
+    );
+    let has_vxrs_ext3 = settings.add_bool(
+        "has_vxrs_ext3",
+        "Has Vector-Enhancements Facility 3 support.",
+        "",
+        false,
+    );
+
     // Architecture level presets
     settings.add_preset(
         "arch13",
         "Thirteenth Edition of the z/Architecture.",
-        preset!(has_mie2 && has_vxrs_ext2),
+        preset!(has_mie3 && has_vxrs_ext2),
+    );
+    settings.add_preset(
+        "arch14",
+        "Fourteenth Edition of the z/Architecture.",
+        preset!(has_mie3 && has_vxrs_ext2),
+    );
+    settings.add_preset(
+        "arch15",
+        "Fifteenth Edition of the z/Architecture.",
+        preset!(has_mie3 && has_mie4 && has_vxrs_ext2 && has_vxrs_ext3),
     );
 
     // Processor presets
     settings.add_preset(
         "z15",
         "IBM z15 processor.",
-        preset!(has_mie2 && has_vxrs_ext2),
+        preset!(has_mie3 && has_vxrs_ext2),
+    );
+    settings.add_preset(
+        "z16",
+        "IBM z16 processor.",
+        preset!(has_mie3 && has_vxrs_ext2),
+    );
+    settings.add_preset(
+        "z17",
+        "IBM z17 processor.",
+        preset!(has_mie3 && has_mie4 && has_vxrs_ext2 && has_vxrs_ext3),
     );
 
     TargetIsa::new("s390x", settings.build())

--- a/cranelift/codegen/src/isa/s390x/inst.isle
+++ b/cranelift/codegen/src/isa/s390x/inst.isle
@@ -1482,10 +1482,10 @@
 
 ;; Helpers for querying enabled ISA extensions ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(decl mie2_enabled () Type)
-(extern extractor mie2_enabled mie2_enabled)
-(decl mie2_disabled () Type)
-(extern extractor mie2_disabled mie2_disabled)
+(decl mie3_enabled () Type)
+(extern extractor mie3_enabled mie3_enabled)
+(decl mie3_disabled () Type)
+(extern extractor mie3_disabled mie3_disabled)
 
 (decl vxrs_ext2_enabled () Type)
 (extern extractor vxrs_ext2_enabled vxrs_ext2_enabled)

--- a/cranelift/codegen/src/isa/s390x/inst/emit.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/emit.rs
@@ -1435,8 +1435,8 @@ impl Inst {
             match iset_requirement {
                 // Baseline ISA is z14
                 InstructionSet::Base => true,
-                // Miscellaneous-Instruction-Extensions Facility 2 (z15)
-                InstructionSet::MIE2 => emit_info.isa_flags.has_mie2(),
+                // Miscellaneous-Instruction-Extensions Facility 3 (z15)
+                InstructionSet::MIE3 => emit_info.isa_flags.has_mie3(),
                 // Vector-Enhancements Facility 2 (z15)
                 InstructionSet::VXRS_EXT2 => emit_info.isa_flags.has_vxrs_ext2(),
             }

--- a/cranelift/codegen/src/isa/s390x/inst/mod.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/mod.rs
@@ -87,8 +87,8 @@ impl WritableRegPair {
 pub(crate) enum InstructionSet {
     /// Baseline ISA for cranelift is z14.
     Base,
-    /// Miscellaneous-Instruction-Extensions Facility 2 (z15)
-    MIE2,
+    /// Miscellaneous-Instruction-Extensions Facility 3 (z15)
+    MIE3,
     /// Vector-Enhancements Facility 2 (z15)
     VXRS_EXT2,
 }
@@ -242,15 +242,15 @@ impl Inst {
 
             // These depend on the opcode
             Inst::AluRRR { alu_op, .. } => match alu_op {
-                ALUOp::NotAnd32 | ALUOp::NotAnd64 => InstructionSet::MIE2,
-                ALUOp::NotOrr32 | ALUOp::NotOrr64 => InstructionSet::MIE2,
-                ALUOp::NotXor32 | ALUOp::NotXor64 => InstructionSet::MIE2,
-                ALUOp::AndNot32 | ALUOp::AndNot64 => InstructionSet::MIE2,
-                ALUOp::OrrNot32 | ALUOp::OrrNot64 => InstructionSet::MIE2,
+                ALUOp::NotAnd32 | ALUOp::NotAnd64 => InstructionSet::MIE3,
+                ALUOp::NotOrr32 | ALUOp::NotOrr64 => InstructionSet::MIE3,
+                ALUOp::NotXor32 | ALUOp::NotXor64 => InstructionSet::MIE3,
+                ALUOp::AndNot32 | ALUOp::AndNot64 => InstructionSet::MIE3,
+                ALUOp::OrrNot32 | ALUOp::OrrNot64 => InstructionSet::MIE3,
                 _ => InstructionSet::Base,
             },
             Inst::UnaryRR { op, .. } => match op {
-                UnaryOp::PopcntReg => InstructionSet::MIE2,
+                UnaryOp::PopcntReg => InstructionSet::MIE3,
                 _ => InstructionSet::Base,
             },
             Inst::FpuRound { op, .. } => match op {

--- a/cranelift/codegen/src/isa/s390x/lower.isle
+++ b/cranelift/codegen/src/isa/s390x/lower.isle
@@ -985,12 +985,12 @@
 ;;;; Rules for `bnot` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; z15 version using a single instruction (NOR).
-(rule 2 (lower (has_type (and (mie2_enabled) (fits_in_64 ty)) (bnot x)))
+(rule 2 (lower (has_type (and (mie3_enabled) (fits_in_64 ty)) (bnot x)))
       (let ((rx Reg x))
         (not_or_reg ty rx rx)))
 
 ;; z14 version using XOR with -1.
-(rule 1 (lower (has_type (and (mie2_disabled) (fits_in_64 ty)) (bnot x)))
+(rule 1 (lower (has_type (and (mie3_disabled) (fits_in_64 ty)) (bnot x)))
       (not_reg ty x))
 
 ;; Vector version using vector NOR.
@@ -999,7 +999,7 @@
 
 ;; With z15 (bnot (bxor ...)) can be a single instruction, similar to the
 ;; (bxor _ (bnot _)) lowering.
-(rule 3 (lower (has_type (and (mie2_enabled) (fits_in_64 ty)) (bnot (bxor x y))))
+(rule 3 (lower (has_type (and (mie3_enabled) (fits_in_64 ty)) (bnot (bxor x y))))
       (not_xor_reg ty x y))
 
 ;; Combine a not/xor operation of vector types into one.
@@ -1038,9 +1038,9 @@
 ;; forms early on.
 
 ;; z15 version using a single instruction.
-(rule 7 (lower (has_type (and (mie2_enabled) (fits_in_64 ty)) (band x (bnot y))))
+(rule 7 (lower (has_type (and (mie3_enabled) (fits_in_64 ty)) (band x (bnot y))))
       (and_not_reg ty x y))
-(rule 8 (lower (has_type (and (mie2_enabled) (fits_in_64 ty)) (band (bnot y) x)))
+(rule 8 (lower (has_type (and (mie3_enabled) (fits_in_64 ty)) (band (bnot y) x)))
       (and_not_reg ty x y))
 
 ;; And-not two vector registers.
@@ -1080,9 +1080,9 @@
 ;; forms early on.
 
 ;; z15 version using a single instruction.
-(rule 7 (lower (has_type (and (mie2_enabled) (fits_in_64 ty)) (bor x (bnot y))))
+(rule 7 (lower (has_type (and (mie3_enabled) (fits_in_64 ty)) (bor x (bnot y))))
       (or_not_reg ty x y))
-(rule 8 (lower (has_type (and (mie2_enabled) (fits_in_64 ty)) (bor (bnot y) x)))
+(rule 8 (lower (has_type (and (mie3_enabled) (fits_in_64 ty)) (bor (bnot y) x)))
       (or_not_reg ty x y))
 
 ;; Or-not two vector registers.
@@ -1119,9 +1119,9 @@
 ;; forms early on.
 
 ;; z15 version using a single instruction.
-(rule 5 (lower (has_type (and (mie2_enabled) (fits_in_64 ty)) (bxor x (bnot y))))
+(rule 5 (lower (has_type (and (mie3_enabled) (fits_in_64 ty)) (bxor x (bnot y))))
       (not_xor_reg ty x y))
-(rule 6 (lower (has_type (and (mie2_enabled) (fits_in_64 ty)) (bxor (bnot y) x)))
+(rule 6 (lower (has_type (and (mie3_enabled) (fits_in_64 ty)) (bxor (bnot y) x)))
       (not_xor_reg ty x y))
 
 ;; Xor-not two vector registers.
@@ -1134,14 +1134,14 @@
 ;;;; Rules for `bitselect` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; z15 version using a NAND instruction.
-(rule 2 (lower (has_type (and (mie2_enabled) (fits_in_64 ty)) (bitselect x y z)))
+(rule 2 (lower (has_type (and (mie3_enabled) (fits_in_64 ty)) (bitselect x y z)))
       (let ((rx Reg x)
             (if_true Reg (and_reg ty y rx))
             (if_false Reg (and_not_reg ty z rx)))
         (or_reg ty if_false if_true)))
 
 ;; z14 version using XOR with -1.
-(rule 1 (lower (has_type (and (mie2_disabled) (fits_in_64 ty)) (bitselect x y z)))
+(rule 1 (lower (has_type (and (mie3_disabled) (fits_in_64 ty)) (bitselect x y z)))
       (let ((rx Reg x)
             (if_true Reg (and_reg ty y rx))
             (if_false Reg (and_reg ty z (not_reg ty rx))))
@@ -1329,7 +1329,7 @@
 
 ;; On z15, the POPCNT instruction has a variant to compute a full 64-bit
 ;; population count, which we also use for 16- and 32-bit types.
-(rule -1 (lower (has_type (and (mie2_enabled) (fits_in_64 ty)) (popcnt x)))
+(rule -1 (lower (has_type (and (mie3_enabled) (fits_in_64 ty)) (popcnt x)))
       (popcnt_reg (put_in_reg_zext64 x)))
 
 ;; On z14, we use the regular POPCNT, which computes the population count
@@ -1340,18 +1340,18 @@
 ;; $I16, where we instead accumulate in the low byte and clear high bits
 ;; via an explicit and operation.)
 
-(rule (lower (has_type (and (mie2_disabled) $I16) (popcnt x)))
+(rule (lower (has_type (and (mie3_disabled) $I16) (popcnt x)))
       (let ((cnt2 Reg (popcnt_byte x))
             (cnt1 Reg (add_reg $I32 cnt2 (lshr_imm $I32 cnt2 8))))
         (and_uimm16shifted $I32 cnt1 (uimm16shifted 255 0))))
 
-(rule (lower (has_type (and (mie2_disabled) $I32) (popcnt x)))
+(rule (lower (has_type (and (mie3_disabled) $I32) (popcnt x)))
       (let ((cnt4 Reg (popcnt_byte x))
             (cnt2 Reg (add_reg $I32 cnt4 (lshl_imm $I32 cnt4 16)))
             (cnt1 Reg (add_reg $I32 cnt2 (lshl_imm $I32 cnt2 8))))
         (lshr_imm $I32 cnt1 24)))
 
-(rule (lower (has_type (and (mie2_disabled) $I64) (popcnt x)))
+(rule (lower (has_type (and (mie3_disabled) $I64) (popcnt x)))
       (let ((cnt8 Reg (popcnt_byte x))
             (cnt4 Reg (add_reg $I64 cnt8 (lshl_imm $I64 cnt8 32)))
             (cnt2 Reg (add_reg $I64 cnt4 (lshl_imm $I64 cnt4 16)))
@@ -3054,17 +3054,17 @@
 ;; On z15 this can use the NN(G)RK instruction.  On z14, perform an And
 ;; operation and invert the result.  In the little-endian case, we can
 ;; simply byte-swap the source operand.
-(rule 4 (atomic_rmw_body ib (and (mie2_enabled) (ty_32_or_64 ty)) (bigendian)
+(rule 4 (atomic_rmw_body ib (and (mie3_enabled) (ty_32_or_64 ty)) (bigendian)
                        (AtomicRmwOp.Nand) tmp val src)
       (push_alu_reg ib (aluop_not_and ty) tmp val src))
-(rule 3 (atomic_rmw_body ib (and (mie2_enabled) (ty_32_or_64 ty)) (littleendian)
+(rule 3 (atomic_rmw_body ib (and (mie3_enabled) (ty_32_or_64 ty)) (littleendian)
                        (AtomicRmwOp.Nand) tmp val src)
       (push_alu_reg ib (aluop_not_and ty) tmp val (bswap_reg ty src)))
-(rule 2 (atomic_rmw_body ib (and (mie2_disabled) (ty_32_or_64 ty)) (bigendian)
+(rule 2 (atomic_rmw_body ib (and (mie3_disabled) (ty_32_or_64 ty)) (bigendian)
                        (AtomicRmwOp.Nand) tmp val src)
       (push_not_reg ib ty tmp
         (push_alu_reg ib (aluop_and ty) tmp val src)))
-(rule 1 (atomic_rmw_body ib (and (mie2_disabled) (ty_32_or_64 ty)) (littleendian)
+(rule 1 (atomic_rmw_body ib (and (mie3_disabled) (ty_32_or_64 ty)) (littleendian)
                        (AtomicRmwOp.Nand) tmp val src)
       (push_not_reg ib ty tmp
         (push_alu_reg ib (aluop_and ty) tmp val (bswap_reg ty src))))

--- a/cranelift/codegen/src/isa/s390x/lower/isle.rs
+++ b/cranelift/codegen/src/isa/s390x/lower/isle.rs
@@ -211,8 +211,8 @@ impl generated_code::Context for IsleContext<'_, '_, MInst, S390xBackend> {
     }
 
     #[inline]
-    fn mie2_enabled(&mut self, _: Type) -> Option<()> {
-        if self.backend.isa_flags.has_mie2() {
+    fn mie3_enabled(&mut self, _: Type) -> Option<()> {
+        if self.backend.isa_flags.has_mie3() {
             Some(())
         } else {
             None
@@ -220,8 +220,8 @@ impl generated_code::Context for IsleContext<'_, '_, MInst, S390xBackend> {
     }
 
     #[inline]
-    fn mie2_disabled(&mut self, _: Type) -> Option<()> {
-        if !self.backend.isa_flags.has_mie2() {
+    fn mie3_disabled(&mut self, _: Type) -> Option<()> {
+        if !self.backend.isa_flags.has_mie3() {
             Some(())
         } else {
             None

--- a/cranelift/filetests/filetests/isa/s390x/bitops-optimized.clif
+++ b/cranelift/filetests/filetests/isa/s390x/bitops-optimized.clif
@@ -1,6 +1,6 @@
 test compile precise-output
 set opt_level=speed
-target s390x has_mie2
+target s390x has_mie3
 
 function %band_not_i32(i32, i32) -> i32 {
 block0(v0: i32, v1: i32):

--- a/cranelift/filetests/filetests/runtests/atomic-rmw-little.clif
+++ b/cranelift/filetests/filetests/runtests/atomic-rmw-little.clif
@@ -1,7 +1,7 @@
 test interpret
 test run
 target s390x
-target s390x has_mie2
+target s390x has_mie3
 target aarch64
 target aarch64 has_lse
 target x86_64

--- a/cranelift/filetests/filetests/runtests/atomic-rmw-subword-big.clif
+++ b/cranelift/filetests/filetests/runtests/atomic-rmw-subword-big.clif
@@ -1,7 +1,7 @@
 test interpret
 test run
 target s390x
-target s390x has_mie2
+target s390x has_mie3
 
 ; We can't test that these instructions are right regarding atomicity, but we can
 ; test if they perform their operation correctly

--- a/cranelift/filetests/filetests/runtests/atomic-rmw-subword-little.clif
+++ b/cranelift/filetests/filetests/runtests/atomic-rmw-subword-little.clif
@@ -1,7 +1,7 @@
 test interpret
 test run
 target s390x
-target s390x has_mie2
+target s390x has_mie3
 target aarch64
 target aarch64 has_lse
 target x86_64

--- a/cranelift/filetests/filetests/runtests/bitops.clif
+++ b/cranelift/filetests/filetests/runtests/bitops.clif
@@ -5,7 +5,7 @@ target aarch64
 target s390x
 target riscv64
 target riscv64 has_c has_zcb
-target s390x has_mie2
+target s390x has_mie3
 target x86_64
 target pulley32
 target pulley32be
@@ -17,7 +17,7 @@ target aarch64
 target s390x
 target riscv64
 target riscv64 has_c has_zcb
-target s390x has_mie2
+target s390x has_mie3
 target x86_64
 target pulley32
 target pulley32be

--- a/cranelift/filetests/filetests/runtests/bitselect.clif
+++ b/cranelift/filetests/filetests/runtests/bitselect.clif
@@ -2,7 +2,7 @@ test run
 set opt_level=none
 target aarch64
 target s390x
-target s390x has_mie2
+target s390x has_mie3
 target riscv64
 target riscv64 has_c has_zcb
 target x86_64
@@ -10,7 +10,7 @@ target x86_64
 set opt_level=speed
 target aarch64
 target s390x
-target s390x has_mie2
+target s390x has_mie3
 target riscv64
 target x86_64
 

--- a/cranelift/filetests/filetests/runtests/i128-bitselect.clif
+++ b/cranelift/filetests/filetests/runtests/i128-bitselect.clif
@@ -4,7 +4,7 @@ set enable_llvm_abi_extensions=true
 target x86_64
 set enable_multi_ret_implicit_sret
 target s390x
-target s390x has_mie2
+target s390x has_mie3
 
 function %bitselect_i128(i128, i128, i128) -> i128 {
 block0(v0: i128, v1: i128, v2: i128):

--- a/cranelift/native/Cargo.toml
+++ b/cranelift/native/Cargo.toml
@@ -15,7 +15,7 @@ rust-version.workspace = true
 cranelift-codegen = { workspace = true }
 target-lexicon = { workspace = true }
 
-[target.'cfg(any(target_arch = "s390x", target_arch = "riscv64"))'.dependencies]
+[target.'cfg(target_arch = "riscv64")'.dependencies]
 libc = { workspace = true }
 
 [features]

--- a/crates/wasmtime/src/engine.rs
+++ b/crates/wasmtime/src/engine.rs
@@ -508,7 +508,9 @@ impl Engine {
 
             // s390x features to detect
             "has_vxrs_ext2" => "vxrs_ext2",
-            "has_mie2" => "mie2",
+            "has_vxrs_ext3" => "vxrs_ext3",
+            "has_mie3" => "mie3",
+            "has_mie4" => "mie4",
 
             // x64 features to detect
             "has_cmpxchg16b" => "cmpxchg16b",


### PR DESCRIPTION
This patch implements a number of changes relating to s390x HW facilities and facility detection:

- Fix a mis-named facility: the z15 (arch13) CPU introduced the Miscellaneous-Instruction-Extensions Facility *3* (not 2). Rename "mie2" to "mie3" throughout the code base.

- Now that we can use inline asm, use the STORE FACILITY LIST EXTENDED instruction rather than HWCAP to detect facilities at run time.  This eliminates the libc crate dependency, and allows for more fine-grained feature detection.

- Add support for the z16 (arch14) CPU names (these do not provide any facilities that would be relevant to cranelift, but it should be possible to use these names as synonyms to z15 at least).

- Add support for the z17 (arch15) CPU names, and two new facilities provided at this level: the Miscellaneous-Instruction-Extensions Facility 4 and the Vector-Enhancements Facility 3.  (Note that no code to exploit these facilities is present in this patch; that will be provided later.)

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
