### PR TITLE
Add `#[inline]` to some small functions

### DIFF
--- a/crates/wasmtime/src/runtime/externals.rs
+++ b/crates/wasmtime/src/runtime/externals.rs
@@ -41,6 +41,7 @@ impl Extern {
     /// Returns the underlying `Func`, if this external is a function.
     ///
     /// Returns `None` if this is not a function.
+    #[inline]
     pub fn into_func(self) -> Option<Func> {
         match self {
             Extern::Func(func) => Some(func),
@@ -51,6 +52,7 @@ impl Extern {
     /// Returns the underlying `Global`, if this external is a global.
     ///
     /// Returns `None` if this is not a global.
+    #[inline]
     pub fn into_global(self) -> Option<Global> {
         match self {
             Extern::Global(global) => Some(global),
@@ -61,6 +63,7 @@ impl Extern {
     /// Returns the underlying `Table`, if this external is a table.
     ///
     /// Returns `None` if this is not a table.
+    #[inline]
     pub fn into_table(self) -> Option<Table> {
         match self {
             Extern::Table(table) => Some(table),
@@ -71,6 +74,7 @@ impl Extern {
     /// Returns the underlying `Memory`, if this external is a memory.
     ///
     /// Returns `None` if this is not a memory.
+    #[inline]
     pub fn into_memory(self) -> Option<Memory> {
         match self {
             Extern::Memory(memory) => Some(memory),
@@ -82,6 +86,7 @@ impl Extern {
     /// memory.
     ///
     /// Returns `None` if this is not a shared memory.
+    #[inline]
     pub fn into_shared_memory(self) -> Option<SharedMemory> {
         match self {
             Extern::SharedMemory(memory) => Some(memory),
@@ -92,6 +97,7 @@ impl Extern {
     /// Returns the underlying `Tag`, if this external is a tag.
     ///
     /// Returns `None` if this is not a tag.
+    #[inline]
     pub fn into_tag(self) -> Option<Tag> {
         match self {
             Extern::Tag(tag) => Some(tag),

--- a/crates/wasmtime/src/runtime/store.rs
+++ b/crates/wasmtime/src/runtime/store.rs
@@ -1290,6 +1290,7 @@ impl StoreOpaque {
     /// Note that if you have a `StoreInstanceId` you should use
     /// `StoreInstanceId::get` instead. This assumes that `id` has been
     /// validated to already belong to this store.
+    #[inline]
     pub fn instance(&self, id: InstanceId) -> &vm::Instance {
         self.instances[id].handle.get()
     }
@@ -1299,6 +1300,7 @@ impl StoreOpaque {
     /// Note that if you have a `StoreInstanceId` you should use
     /// `StoreInstanceId::get_mut` instead. This assumes that `id` has been
     /// validated to already belong to this store.
+    #[inline]
     pub fn instance_mut(&mut self, id: InstanceId) -> Pin<&mut vm::Instance> {
         self.instances[id].handle.get_mut()
     }

--- a/crates/wasmtime/src/runtime/store/data.rs
+++ b/crates/wasmtime/src/runtime/store/data.rs
@@ -236,6 +236,7 @@ impl StoreInstanceId {
     /// # Panics
     ///
     /// Panics if `self` does not belong to `store`.
+    #[inline]
     pub(crate) fn get<'a>(&self, store: &'a StoreOpaque) -> &'a vm::Instance {
         self.assert_belongs_to(store.id());
         store.instance(self.instance)
@@ -246,6 +247,7 @@ impl StoreInstanceId {
     /// # Panics
     ///
     /// Panics if `self` does not belong to `store`.
+    #[inline]
     pub(crate) fn get_mut<'a>(&self, store: &'a mut StoreOpaque) -> Pin<&'a mut vm::Instance> {
         self.assert_belongs_to(store.id());
         store.instance_mut(self.instance)

--- a/crates/wasmtime/src/runtime/vm/instance.rs
+++ b/crates/wasmtime/src/runtime/vm/instance.rs
@@ -425,6 +425,7 @@ impl Instance {
 
     /// Return the indexed `VMMemoryDefinition`, loaded from vmctx memory
     /// already.
+    #[inline]
     pub fn memory(&self, index: DefinedMemoryIndex) -> VMMemoryDefinition {
         unsafe { VMMemoryDefinition::load(self.memory_ptr(index).as_ptr()) }
     }
@@ -440,6 +441,7 @@ impl Instance {
     ///
     /// Note that the returned pointer resides in wasm-code-readable-memory in
     /// the vmctx.
+    #[inline]
     pub fn memory_ptr(&self, index: DefinedMemoryIndex) -> NonNull<VMMemoryDefinition> {
         unsafe {
             self.vmctx_plus_offset::<VmPtr<_>>(self.offsets().vmctx_vmmemory_pointer(index))

--- a/crates/wasmtime/src/runtime/vm/vmcontext.rs
+++ b/crates/wasmtime/src/runtime/vm/vmcontext.rs
@@ -388,12 +388,14 @@ impl VMMemoryDefinition {
     /// `current_length` potentially smaller than what some other thread
     /// observes. Since Wasm memory only grows, this under-estimation may be
     /// acceptable in certain cases.
+    #[inline]
     pub fn current_length(&self) -> usize {
         self.current_length.load(Ordering::Relaxed)
     }
 
     /// Return a copy of the [`VMMemoryDefinition`] using the relaxed value of
     /// `current_length`; see [`VMMemoryDefinition::current_length()`].
+    #[inline]
     pub unsafe fn load(ptr: *mut Self) -> Self {
         let other = &*ptr;
         VMMemoryDefinition {


### PR DESCRIPTION
This adds `#[inline]` to some functions which are otherwise not available for cross-crate inlining. These functions started being more heavily used after historical refactorings such as #10877 so this helps benchmarks which access linear memory in host functions, for example.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
