### PR TITLE
make `component-model[-async]` two separate features in `wast`

### DIFF
--- a/crates/wast/Cargo.toml
+++ b/crates/wast/Cargo.toml
@@ -21,4 +21,5 @@ log = { workspace = true }
 tokio = { workspace = true, features = ['rt'] }
 
 [features]
-component-model = ['wasmtime/component-model', 'wasmtime/component-model-async']
+component-model = ['wasmtime/component-model']
+component-model-async = ['wasmtime/component-model-async']


### PR DESCRIPTION
I noticed that `cargo build -p wasmtime-cli` was enabling the `component-model-async` feature in `wasmtime` by default, despite that feature being off by default for `wasmtime-cli`.  I traced it down to the `wast` crate, which was enabling `wasmtime/component-model-async` whenever the `component-model` feature was enabled.  This commit separates them into distinct features.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
