### PR TITLE
Cranelift: Support block names

### DIFF
--- a/cranelift/codegen/src/ir/dfg.rs
+++ b/cranelift/codegen/src/ir/dfg.rs
@@ -21,6 +21,7 @@ use core::ops::{Index, IndexMut};
 use core::u16;
 
 use alloc::collections::BTreeMap;
+use alloc::string::String;
 #[cfg(feature = "enable-serde")]
 use serde_derive::{Deserialize, Serialize};
 use smallvec::SmallVec;
@@ -1460,6 +1461,24 @@ impl DataFlowGraph {
             }
         }
     }
+
+    /// Get the block name.
+    pub fn block_name(&self, block: Block) -> Option<&str> {
+        self.blocks[block].name.as_deref()
+    }
+
+    /// Set the block name which is used only in the textual IR representation.
+    ///
+    /// It's recommended to set the block name only for debugging purposes.
+    /// The current implementation is memory inefficient and allocates a [`String'] for each block name.
+    pub fn set_block_name(&mut self, block: Block, name: String) {
+        self.blocks[block].name = Some(name);
+    }
+
+    /// Clear the block name.
+    pub fn clear_block_name(&mut self, block: Block) {
+        self.blocks[block].name = None;
+    }
 }
 
 /// Contents of a basic block.
@@ -1472,12 +1491,16 @@ impl DataFlowGraph {
 pub struct BlockData {
     /// List of parameters to this block.
     params: ValueList,
+
+    /// Block name.
+    name: Option<String>,
 }
 
 impl BlockData {
     fn new() -> Self {
         Self {
             params: ValueList::new(),
+            name: None,
         }
     }
 

--- a/cranelift/frontend/src/frontend.rs
+++ b/cranelift/frontend/src/frontend.rs
@@ -1,6 +1,7 @@
 //! A frontend for building Cranelift IR from other languages.
 use crate::ssa::{SSABuilder, SideEffects};
 use crate::variable::Variable;
+use alloc::string::String;
 use alloc::vec::Vec;
 use core::fmt::{self, Debug};
 use cranelift_codegen::cursor::{Cursor, CursorPosition, FuncCursor};
@@ -351,6 +352,19 @@ impl<'a> FunctionBuilder<'a> {
     /// when lowered to machine code.
     pub fn set_cold_block(&mut self, block: Block) {
         self.func.layout.set_cold(block);
+    }
+
+    /// Set the block name which is used only in the textual IR representation.
+    ///
+    /// It's recommended to set the block name only for debugging purposes.
+    /// The current implementation is memory inefficient and allocates a [`String'] for each block name.
+    pub fn set_block_name(&mut self, block: Block, name: String) {
+        self.func.dfg.set_block_name(block, name);
+    }
+
+    /// Clear the block name.
+    pub fn clear_block_name(&mut self, block: Block) {
+        self.func.dfg.clear_block_name(block);
     }
 
     /// Insert `block` in the layout *after* the existing block `after`.


### PR DESCRIPTION
This PR implements a feature mentioned in #10766 and allows developers to set meaningful names to blocks.

Block names are used only in Cranelift **textual** IR representation.
`print!("{block}")` does not show the block name.

The implementaion is naive and allocates a `String` for each block name.
So, it's recommend to use block names only for debugging purposes at this point.
Someone may implement more memory efficient mechanism for block names (such as `Twine` in LLVM) in the future.