### PR TITLE
[35.0.0] x64: Fix a missing lowering rule for select_spectre_guard

### DIFF
--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -3618,10 +3618,15 @@
   (lower_select (is_nonzero_cmp cond) x y))
 
 ;; Note that for GPR-based spectre guards everything is forced into a register
-;; so go straight to the `lower_select_gpr` helper forcing `x` to be in a `Gpr`
-;; not `GprMem`.
+;; not `GprMem`. The `lower_select_spectre_gpr` helper below handles "and"
+;; conditions which the `lower_select_gpr` helper does not.
 (rule 1 (lower (has_type (is_single_register_gpr_type ty) (select_spectre_guard cond x y)))
-  (lower_select_gpr ty (is_nonzero_cmp cond) (put_in_gpr x) y))
+  (lower_select_spectre_gpr ty (is_nonzero_cmp cond) (put_in_gpr x) y))
+
+(decl lower_select_spectre_gpr (Type CondResult Gpr Gpr) Gpr)
+(rule 0 (lower_select_spectre_gpr ty cond a b) (lower_select_gpr ty cond a b))
+(rule 1 (lower_select_spectre_gpr ty cond @ (CondResult.And _ _ _) a b)
+  (lower_select_gpr ty (cond_invert cond) b a))
 
 ;; Rules for `fcvt_from_sint` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/cranelift/filetests/filetests/isa/x64/select.clif
+++ b/cranelift/filetests/filetests/isa/x64/select.clif
@@ -193,3 +193,67 @@ block0(v0: i8, v1: f128, v2: f128):
 ;   popq %rbp
 ;   retq
 
+function %select_gpr_with_and_condition(f32, f32, i64, i64) -> i64 {
+block0(v0: f32, v1: f32, v2: i64, v3: i64):
+    v4 = fcmp eq v0, v1
+    v5 = select v4, v2, v3
+    return v5
+}
+
+; VCode:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0:
+;   ucomiss %xmm1, %xmm0
+;   cmovpq %rsi, %rdi
+;   movq %rdi, %rax
+;   cmovneq %rsi, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   ucomiss %xmm1, %xmm0
+;   cmovpq %rsi, %rdi
+;   movq %rdi, %rax
+;   cmovneq %rsi, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %select_spectre_gpr_with_and_condition(f32, f32, i64, i64) -> i64 {
+block0(v0: f32, v1: f32, v2: i64, v3: i64):
+    v4 = fcmp eq v0, v1
+    v5 = select_spectre_guard v4, v2, v3
+    return v5
+}
+
+; VCode:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0:
+;   ucomiss %xmm1, %xmm0
+;   cmovpq %rsi, %rdi
+;   movq %rdi, %rax
+;   cmovneq %rsi, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   ucomiss %xmm1, %xmm0
+;   cmovpq %rsi, %rdi
+;   movq %rdi, %rax
+;   cmovneq %rsi, %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+


### PR DESCRIPTION
Backport of #11242