### PR TITLE
Require `Accessor` on all future/stream functions

### DIFF
--- a/crates/misc/component-async-tests/Cargo.toml
+++ b/crates/misc/component-async-tests/Cargo.toml
@@ -12,7 +12,7 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
-futures = { workspace = true }
+futures = { workspace = true, features = ['async-await'] }
 env_logger = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = [

--- a/crates/misc/component-async-tests/src/resource_stream.rs
+++ b/crates/misc/component-async-tests/src/resource_stream.rs
@@ -51,13 +51,9 @@ impl bindings::local::local::resource_stream::HostConcurrent for Ctx {
             async fn run(self, accessor: &Accessor<T, Ctx>) -> Result<()> {
                 let mut tx = Some(self.tx);
                 for _ in 0..self.count {
-                    tx = accessor
-                        .with(|mut view| {
-                            let item = view.get().table().push(ResourceStreamX)?;
-                            Ok::<_, anyhow::Error>(tx.take().unwrap().write_all(Some(item)))
-                        })?
-                        .await
-                        .0;
+                    let item =
+                        accessor.with(|mut view| view.get().table().push(ResourceStreamX))?;
+                    tx = tx.take().unwrap().write_all(accessor, Some(item)).await.0;
                 }
                 Ok(())
             }

--- a/crates/misc/component-async-tests/tests/scenario/streams.rs
+++ b/crates/misc/component-async-tests/tests/scenario/streams.rs
@@ -3,12 +3,14 @@ use {
     anyhow::Result,
     component_async_tests::{Ctx, closed_streams},
     futures::{
-        future::{self, FutureExt},
+        future::FutureExt,
         stream::{FuturesUnordered, StreamExt, TryStreamExt},
     },
     std::{
         future::Future,
+        pin::pin,
         sync::{Arc, Mutex},
+        task::{Context, Waker},
     },
     wasmtime::{
         Engine, Store,
@@ -44,48 +46,72 @@ pub async fn async_watch_streams() -> Result<()> {
     let instance = linker.instantiate_async(&mut store, &component).await?;
 
     // Test watching and then dropping the read end of a stream.
-    let (tx, rx) = instance.stream::<u8, Option<_>, Option<_>>(&mut store)?;
-    let watch = tx.watch_reader().0;
-    drop(rx);
-    instance.run(&mut store, watch).await?;
+    let (mut tx, rx) = instance.stream::<u8, Option<_>, Option<_>>(&mut store)?;
+    instance
+        .run_with(&mut store, async |store| {
+            futures::join!(tx.watch_reader(store), async {
+                drop(rx);
+            });
+        })
+        .await?;
 
     // Test dropping and then watching the read end of a stream.
-    let (tx, rx) = instance.stream::<u8, Option<_>, Option<_>>(&mut store)?;
+    let (mut tx, rx) = instance.stream::<u8, Option<_>, Option<_>>(&mut store)?;
     drop(rx);
-    instance.run(&mut store, tx.watch_reader().0).await?;
+    instance
+        .run_with(&mut store, async |store| tx.watch_reader(store).await)
+        .await?;
 
     // Test watching and then dropping the write end of a stream.
-    let (tx, rx) = instance.stream::<u8, Option<_>, Option<_>>(&mut store)?;
-    let watch = rx.watch_writer().0;
-    drop(tx);
-    instance.run(&mut store, watch).await?;
+    let (tx, mut rx) = instance.stream::<u8, Option<_>, Option<_>>(&mut store)?;
+    instance
+        .run_with(&mut store, async |store| {
+            futures::join!(rx.watch_writer(store), async {
+                drop(tx);
+            });
+        })
+        .await?;
 
     // Test dropping and then watching the write end of a stream.
-    let (tx, rx) = instance.stream::<u8, Option<_>, Option<_>>(&mut store)?;
+    let (tx, mut rx) = instance.stream::<u8, Option<_>, Option<_>>(&mut store)?;
     drop(tx);
-    instance.run(&mut store, rx.watch_writer().0).await?;
+    instance
+        .run_with(&mut store, async |store| rx.watch_writer(store).await)
+        .await?;
 
     // Test watching and then dropping the read end of a future.
-    let (tx, rx) = instance.future::<u8>(|| 42, &mut store)?;
-    let watch = tx.watch_reader().0;
-    drop(rx);
-    instance.run(&mut store, watch).await?;
+    let (mut tx, rx) = instance.future::<u8>(|| 42, &mut store)?;
+    instance
+        .run_with(&mut store, async |store| {
+            futures::join!(tx.watch_reader(store), async {
+                drop(rx);
+            });
+        })
+        .await?;
 
     // Test dropping and then watching the read end of a future.
-    let (tx, rx) = instance.future::<u8>(|| 42, &mut store)?;
+    let (mut tx, rx) = instance.future::<u8>(|| 42, &mut store)?;
     drop(rx);
-    instance.run(&mut store, tx.watch_reader().0).await?;
+    instance
+        .run_with(&mut store, async |store| tx.watch_reader(store).await)
+        .await?;
 
     // Test watching and then dropping the write end of a future.
-    let (tx, rx) = instance.future::<u8>(|| 42, &mut store)?;
-    let watch = rx.watch_writer().0;
-    drop(tx);
-    instance.run(&mut store, watch).await?;
+    let (tx, mut rx) = instance.future::<u8>(|| 42, &mut store)?;
+    instance
+        .run_with(&mut store, async |store| {
+            futures::join!(rx.watch_writer(store), async {
+                drop(tx);
+            });
+        })
+        .await?;
 
     // Test dropping and then watching the write end of a future.
-    let (tx, rx) = instance.future::<u8>(|| 42, &mut store)?;
+    let (tx, mut rx) = instance.future::<u8>(|| 42, &mut store)?;
     drop(tx);
-    instance.run(&mut store, rx.watch_writer().0).await?;
+    instance
+        .run_with(&mut store, async |store| rx.watch_writer(store).await)
+        .await?;
 
     enum Event {
         Write(Option<StreamWriter<Option<u8>>>),
@@ -94,43 +120,42 @@ pub async fn async_watch_streams() -> Result<()> {
 
     // Test watching, then writing to, then dropping, then writing again to the
     // read end of a stream.
-    let mut futures = FuturesUnordered::new();
-    let (tx, rx) = instance.stream(&mut store)?;
-    let watch = tx.watch_reader().1;
-    futures.push(
-        watch
-            .into_inner()
-            .write_all(Some(42))
-            .map(|(w, _)| Event::Write(w))
-            .boxed(),
-    );
-    futures.push(rx.read(None).map(|(r, b)| Event::Read(r, b)).boxed());
-    let mut rx = None;
-    let mut tx = None;
-    while let Some(event) = instance.run(&mut store, futures.next()).await? {
-        match event {
-            Event::Write(None) => unreachable!(),
-            Event::Write(Some(new_tx)) => tx = Some(new_tx),
-            Event::Read(None, _) => unreachable!(),
-            Event::Read(Some(new_rx), mut buffer) => {
-                assert_eq!(buffer.take(), Some(42));
-                rx = Some(new_rx);
-            }
-        }
-    }
-    drop(rx);
-    let (future, watch) = tx.take().unwrap().watch_reader();
-    let mut future = Box::pin(future);
     instance
-        .run(&mut store, future::poll_fn(|cx| future.as_mut().poll(cx)))
-        .await?;
-    assert!(
-        instance
-            .run(&mut store, watch.into_inner().write_all(Some(42)))
-            .await?
-            .0
-            .is_none()
-    );
+        .run_with(&mut store, async |store| -> wasmtime::Result<_> {
+            let mut futures = FuturesUnordered::new();
+            let (mut tx, rx) = store.with(|s| instance.stream(s))?;
+            assert!(
+                pin!(tx.watch_reader(store))
+                    .poll(&mut Context::from_waker(&Waker::noop()))
+                    .is_pending()
+            );
+            futures.push(
+                tx.write_all(store, Some(42))
+                    .map(|(w, _)| Event::Write(w))
+                    .boxed(),
+            );
+            futures.push(rx.read(store, None).map(|(r, b)| Event::Read(r, b)).boxed());
+            let mut rx = None;
+            let mut tx = None;
+            while let Some(event) = futures.next().await {
+                match event {
+                    Event::Write(None) => unreachable!(),
+                    Event::Write(Some(new_tx)) => tx = Some(new_tx),
+                    Event::Read(None, _) => unreachable!(),
+                    Event::Read(Some(new_rx), mut buffer) => {
+                        assert_eq!(buffer.take(), Some(42));
+                        rx = Some(new_rx);
+                    }
+                }
+            }
+            drop(rx);
+
+            let mut tx = tx.take().unwrap();
+            tx.watch_reader(store).await;
+            assert!(tx.write_all(store, Some(42)).await.0.is_none());
+            Ok(())
+        })
+        .await??;
 
     Ok(())
 }
@@ -189,102 +214,112 @@ pub async fn test_closed_streams(watch: bool) -> Result<()> {
     let value = 42_u8;
 
     // First, test stream host->host
-    {
-        let (tx, rx) = instance.stream(&mut store)?;
+    instance
+        .run_with(&mut store, async |store| -> wasmtime::Result<_> {
+            let (tx, rx) = store.with(|mut s| instance.stream(&mut s))?;
 
-        let mut futures = FuturesUnordered::new();
-        futures.push(
-            tx.write_all(values.clone().into())
-                .map(|(w, _)| StreamEvent::FirstWrite(w))
-                .boxed(),
-        );
-        futures.push(
-            rx.read(Vec::with_capacity(3))
-                .map(|(r, b)| StreamEvent::FirstRead(r, b))
-                .boxed(),
-        );
+            let mut futures = FuturesUnordered::new();
+            futures.push(
+                tx.write_all(store, values.clone().into())
+                    .map(|(w, _)| StreamEvent::FirstWrite(w))
+                    .boxed(),
+            );
+            futures.push(
+                rx.read(store, Vec::with_capacity(3))
+                    .map(|(r, b)| StreamEvent::FirstRead(r, b))
+                    .boxed(),
+            );
 
-        let mut count = 0;
-        while let Some(event) = instance.run(&mut store, futures.next()).await? {
-            count += 1;
-            match event {
-                StreamEvent::FirstWrite(Some(tx)) => {
-                    if watch {
-                        futures.push(
-                            tx.watch_reader()
-                                .0
-                                .map(|()| StreamEvent::SecondWrite(None))
+            let mut count = 0;
+            while let Some(event) = futures.next().await {
+                count += 1;
+                match event {
+                    StreamEvent::FirstWrite(Some(mut tx)) => {
+                        if watch {
+                            futures.push(
+                                async move {
+                                    tx.watch_reader(store).await;
+                                    StreamEvent::SecondWrite(None)
+                                }
                                 .boxed(),
-                        );
-                    } else {
-                        futures.push(
-                            tx.write_all(values.clone().into())
-                                .map(|(w, _)| StreamEvent::SecondWrite(w))
-                                .boxed(),
-                        );
+                            );
+                        } else {
+                            futures.push(
+                                tx.write_all(store, values.clone().into())
+                                    .map(|(w, _)| StreamEvent::SecondWrite(w))
+                                    .boxed(),
+                            );
+                        }
                     }
+                    StreamEvent::FirstWrite(None) => {
+                        panic!("first write should have been accepted")
+                    }
+                    StreamEvent::FirstRead(Some(_), results) => {
+                        assert_eq!(values, results);
+                    }
+                    StreamEvent::FirstRead(None, _) => unreachable!(),
+                    StreamEvent::SecondWrite(None) => {}
+                    StreamEvent::SecondWrite(Some(_)) => {
+                        panic!("second write should _not_ have been accepted")
+                    }
+                    StreamEvent::GuestCompleted => unreachable!(),
                 }
-                StreamEvent::FirstWrite(None) => panic!("first write should have been accepted"),
-                StreamEvent::FirstRead(Some(_), results) => {
-                    assert_eq!(values, results);
-                }
-                StreamEvent::FirstRead(None, _) => unreachable!(),
-                StreamEvent::SecondWrite(None) => {}
-                StreamEvent::SecondWrite(Some(_)) => {
-                    panic!("second write should _not_ have been accepted")
-                }
-                StreamEvent::GuestCompleted => unreachable!(),
             }
-        }
 
-        assert_eq!(count, 3);
-    }
+            assert_eq!(count, 3);
+            Ok(())
+        })
+        .await??;
 
     // Next, test futures host->host
     {
         let (tx, rx) = instance.future(|| unreachable!(), &mut store)?;
-        let (tx_ignored, rx_ignored) = instance.future(|| 42u8, &mut store)?;
+        let (mut tx_ignored, rx_ignored) = instance.future(|| 42u8, &mut store)?;
 
-        let mut futures = FuturesUnordered::new();
-        futures.push(tx.write(value).map(FutureEvent::Write).boxed());
-        futures.push(rx.read().map(FutureEvent::Read).boxed());
-        if watch {
-            futures.push(
-                tx_ignored
-                    .watch_reader()
-                    .0
-                    .map(|()| FutureEvent::WriteIgnored(false))
-                    .boxed(),
-            );
-        } else {
-            futures.push(
-                tx_ignored
-                    .write(value)
-                    .map(FutureEvent::WriteIgnored)
-                    .boxed(),
-            );
-        }
-        drop(rx_ignored);
+        instance
+            .run_with(&mut store, async |store| {
+                let mut futures = FuturesUnordered::new();
+                futures.push(tx.write(store, value).map(FutureEvent::Write).boxed());
+                futures.push(rx.read(store).map(FutureEvent::Read).boxed());
+                if watch {
+                    futures.push(
+                        tx_ignored
+                            .watch_reader(store)
+                            .map(|()| FutureEvent::WriteIgnored(false))
+                            .boxed(),
+                    );
+                } else {
+                    futures.push(
+                        tx_ignored
+                            .write(store, value)
+                            .map(FutureEvent::WriteIgnored)
+                            .boxed(),
+                    );
+                }
+                drop(rx_ignored);
 
-        let mut count = 0;
-        while let Some(event) = instance.run(&mut store, futures.next()).await? {
-            count += 1;
-            match event {
-                FutureEvent::Write(delivered) => {
-                    assert!(delivered);
+                let mut count = 0;
+                while let Some(event) = futures.next().await {
+                    count += 1;
+                    match event {
+                        FutureEvent::Write(delivered) => {
+                            assert!(delivered);
+                        }
+                        FutureEvent::Read(Some(result)) => {
+                            assert_eq!(value, result);
+                        }
+                        FutureEvent::Read(None) => panic!("read should have succeeded"),
+                        FutureEvent::WriteIgnored(delivered) => {
+                            assert!(!delivered);
+                        }
+                        FutureEvent::GuestCompleted => unreachable!(),
+                    }
                 }
-                FutureEvent::Read(Some(result)) => {
-                    assert_eq!(value, result);
-                }
-                FutureEvent::Read(None) => panic!("read should have succeeded"),
-                FutureEvent::WriteIgnored(delivered) => {
-                    assert!(!delivered);
-                }
-                FutureEvent::GuestCompleted => unreachable!(),
-            }
-        }
 
-        assert_eq!(count, 3);
+                assert_eq!(count, 3);
+                anyhow::Ok(())
+            })
+            .await??;
     }
 
     // Next, test stream host->guest
@@ -304,7 +339,7 @@ pub async fn test_closed_streams(watch: bool) -> Result<()> {
                         .boxed(),
                 );
                 futures.push(
-                    tx.write_all(values.clone().into())
+                    tx.write_all(accessor, values.clone().into())
                         .map(|(w, _)| Ok(StreamEvent::FirstWrite(w)))
                         .boxed(),
                 );
@@ -313,17 +348,18 @@ pub async fn test_closed_streams(watch: bool) -> Result<()> {
                 while let Some(event) = futures.try_next().await? {
                     count += 1;
                     match event {
-                        StreamEvent::FirstWrite(Some(tx)) => {
+                        StreamEvent::FirstWrite(Some(mut tx)) => {
                             if watch {
                                 futures.push(
-                                    tx.watch_reader()
-                                        .0
-                                        .map(|()| Ok(StreamEvent::SecondWrite(None)))
-                                        .boxed(),
+                                    async move {
+                                        tx.watch_reader(accessor).await;
+                                        Ok(StreamEvent::SecondWrite(None))
+                                    }
+                                    .boxed(),
                                 );
                             } else {
                                 futures.push(
-                                    tx.write_all(values.clone().into())
+                                    tx.write_all(accessor, values.clone().into())
                                         .map(|(w, _)| Ok(StreamEvent::SecondWrite(w)))
                                         .boxed(),
                                 );
@@ -351,7 +387,7 @@ pub async fn test_closed_streams(watch: bool) -> Result<()> {
     // Next, test futures host->guest
     {
         let (tx, rx) = instance.future(|| unreachable!(), &mut store)?;
-        let (tx_ignored, rx_ignored) = instance.future(|| 0, &mut store)?;
+        let (mut tx_ignored, rx_ignored) = instance.future(|| 0, &mut store)?;
 
         let closed_streams = closed_streams::bindings::ClosedStreams::new(&mut store, &instance)?;
 
@@ -365,19 +401,23 @@ pub async fn test_closed_streams(watch: bool) -> Result<()> {
                         .map(|v| v.map(|()| FutureEvent::GuestCompleted))
                         .boxed(),
                 );
-                futures.push(tx.write(value).map(FutureEvent::Write).map(Ok).boxed());
+                futures.push(
+                    tx.write(accessor, value)
+                        .map(FutureEvent::Write)
+                        .map(Ok)
+                        .boxed(),
+                );
                 if watch {
                     futures.push(
                         tx_ignored
-                            .watch_reader()
-                            .0
+                            .watch_reader(accessor)
                             .map(|()| Ok(FutureEvent::WriteIgnored(false)))
                             .boxed(),
                     );
                 } else {
                     futures.push(
                         tx_ignored
-                            .write(value)
+                            .write(accessor, value)
                             .map(FutureEvent::WriteIgnored)
                             .map(Ok)
                             .boxed(),

--- a/crates/misc/component-async-tests/tests/scenario/transmit.rs
+++ b/crates/misc/component-async-tests/tests/scenario/transmit.rs
@@ -377,14 +377,14 @@ async fn test_transmit_with<Test: TransmitTest + 'static>(component: &str) -> Re
 
             futures.push(
                 control_tx
-                    .write_all(Some(Control::ReadStream("a".into())))
+                    .write_all(accessor, Some(Control::ReadStream("a".into())))
                     .map(|(w, _)| Ok(Event::ControlWriteA(w)))
                     .boxed(),
             );
 
             futures.push(
                 caller_stream_tx
-                    .write_all(Some(String::from("a")))
+                    .write_all(accessor, Some(String::from("a")))
                     .map(|_| Ok(Event::WriteA))
                     .boxed(),
             );
@@ -417,7 +417,7 @@ async fn test_transmit_with<Test: TransmitTest + 'static>(component: &str) -> Re
                     Event::ControlWriteA(tx) => {
                         futures.push(
                             tx.unwrap()
-                                .write_all(Some(Control::ReadFuture("b".into())))
+                                .write_all(accessor, Some(Control::ReadFuture("b".into())))
                                 .map(|(w, _)| Ok(Event::ControlWriteB(w)))
                                 .boxed(),
                         );
@@ -427,7 +427,7 @@ async fn test_transmit_with<Test: TransmitTest + 'static>(component: &str) -> Re
                             caller_future1_tx
                                 .take()
                                 .unwrap()
-                                .write("b".into())
+                                .write(accessor, "b".into())
                                 .map(Event::WriteB)
                                 .map(Ok)
                                 .boxed(),
@@ -436,7 +436,7 @@ async fn test_transmit_with<Test: TransmitTest + 'static>(component: &str) -> Re
                     Event::ControlWriteB(tx) => {
                         futures.push(
                             tx.unwrap()
-                                .write_all(Some(Control::WriteStream("c".into())))
+                                .write_all(accessor, Some(Control::WriteStream("c".into())))
                                 .map(|(w, _)| Ok(Event::ControlWriteC(w)))
                                 .boxed(),
                         );
@@ -447,7 +447,7 @@ async fn test_transmit_with<Test: TransmitTest + 'static>(component: &str) -> Re
                             callee_stream_rx
                                 .take()
                                 .unwrap()
-                                .read(None)
+                                .read(accessor, None)
                                 .map(|(r, b)| Ok(Event::ReadC(r, b)))
                                 .boxed(),
                         );
@@ -455,7 +455,7 @@ async fn test_transmit_with<Test: TransmitTest + 'static>(component: &str) -> Re
                     Event::ControlWriteC(tx) => {
                         futures.push(
                             tx.unwrap()
-                                .write_all(Some(Control::WriteFuture("d".into())))
+                                .write_all(accessor, Some(Control::WriteFuture("d".into())))
                                 .map(|_| Ok(Event::ControlWriteD))
                                 .boxed(),
                         );
@@ -467,7 +467,7 @@ async fn test_transmit_with<Test: TransmitTest + 'static>(component: &str) -> Re
                             callee_future1_rx
                                 .take()
                                 .unwrap()
-                                .read()
+                                .read(accessor)
                                 .map(Event::ReadD)
                                 .map(Ok)
                                 .boxed(),
@@ -482,7 +482,7 @@ async fn test_transmit_with<Test: TransmitTest + 'static>(component: &str) -> Re
                             callee_stream_rx
                                 .take()
                                 .unwrap()
-                                .read(None)
+                                .read(accessor, None)
                                 .map(|(r, _)| Ok(Event::ReadNone(r)))
                                 .boxed(),
                         );

--- a/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams.rs
@@ -7,7 +7,7 @@ use crate::component::concurrent::{ConcurrentState, tls};
 use crate::component::func::{self, LiftContext, LowerContext, Options};
 use crate::component::matching::InstanceType;
 use crate::component::values::{ErrorContextAny, FutureAny, StreamAny};
-use crate::component::{Instance, Lower, Val, WasmList, WasmStr};
+use crate::component::{AsAccessor, Instance, Lower, Val, WasmList, WasmStr};
 use crate::store::{StoreOpaque, StoreToken};
 use crate::vm::{VMFuncRef, VMMemoryDefinition, VMStore};
 use crate::{AsContextMut, StoreContextMut, ValRaw};
@@ -507,13 +507,18 @@ impl<T> FutureWriter<T> {
     /// value; otherwise it will return `false`, meaning the read end was dropped
     /// before the value could be delivered.
     ///
-    /// Note that the returned `Future` must be polled from the event loop of
-    /// the component instance from which this `FutureWriter` originated.  See
-    /// [`Instance::run`] for details.
-    pub fn write(mut self, value: T) -> impl Future<Output = bool> + Send + 'static
+    /// # Panics
+    ///
+    /// Panics if the store that the `accessor` is derived from does not own
+    /// this future.
+    pub async fn write(mut self, accessor: impl AsAccessor, value: T) -> bool
     where
         T: Send + 'static,
     {
+        // FIXME: this is intended to be used in the future to directly
+        // manipulate state for this future within the store without having to
+        // go through an mpsc.
+        let _accessor = accessor.as_accessor();
         let (tx, rx) = oneshot::channel();
         send(
             &mut self.tx.as_mut().unwrap(),
@@ -523,38 +528,35 @@ impl<T> FutureWriter<T> {
             },
         );
         self.default = None;
-        let instance = self.instance;
-        super::checked(
-            instance,
-            rx.map(move |v| {
-                drop(self);
-                match v {
-                    Ok(HostResult { dropped, .. }) => !dropped,
-                    Err(_) => todo!("guarantee buffer recovery if event loop errors or panics"),
-                }
-            }),
-        )
+        let v = rx.await;
+        drop(self);
+        match v {
+            Ok(HostResult { dropped, .. }) => !dropped,
+            Err(_) => todo!("guarantee buffer recovery if event loop errors or panics"),
+        }
     }
 
-    /// Convert this object into a `Future` which will resolve when the read end
-    /// of this `future` is dropped, plus a `Watch` which can be used to retrieve
-    /// the `FutureWriter` again.
+    /// Wait for the read end of this `future` is dropped.
     ///
-    /// Note that calling `Watch::into_inner` on the returned `Watch` will have
-    /// the side effect of causing the `Future` to resolve immediately if it
-    /// hasn't already.
+    /// The [`Accessor`] provided can be acquired from [`Instance::run_with`] or
+    /// from within a host function for example.
     ///
-    /// Also note that the returned `Future` must be polled from the event loop
-    /// of the component instance from which this `FutureWriter` originated.
-    /// See [`Instance::run`] for details.
-    pub fn watch_reader(mut self) -> (impl Future<Output = ()> + Send + 'static, Watch<Self>)
+    /// # Panics
+    ///
+    /// Panics if the store that the [`Accessor`] is derived from does not own
+    /// this future.
+    pub async fn watch_reader(&mut self, accessor: impl AsAccessor)
     where
         T: Send + 'static,
     {
+        // FIXME: this is intended to be used in the future to directly
+        // manipulate state for this future within the store without having to
+        // go through an mpsc.
+        let _accessor = accessor.as_accessor();
         let (tx, rx) = oneshot::channel();
         send(&mut self.tx.as_mut().unwrap(), WriteEvent::Watch { tx });
-        let instance = self.instance;
-        watch(instance, rx, self)
+        let (future, _watch) = watch(self.instance, rx, ());
+        future.await;
     }
 }
 
@@ -787,56 +789,61 @@ impl<T> FutureReader<T> {
     /// The returned `Future` will yield `None` if the guest has trapped
     /// before it could produce a result.
     ///
-    /// Note that the returned `Future` must be polled from the event loop of
-    /// the component instance from which this `FutureReader` originated.  See
-    /// [`Instance::run`] for details.
-    pub fn read(mut self) -> impl Future<Output = Option<T>> + Send + 'static
+    /// The [`Accessor`] provided can be acquired from [`Instance::run_with`] or
+    /// from within a host function for example.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the store that the [`Accessor`] is derived from does not own
+    /// this future.
+    pub async fn read(mut self, accessor: impl AsAccessor) -> Option<T>
     where
         T: Send + 'static,
     {
+        // FIXME: this is intended to be used in the future to directly
+        // manipulate state for this future within the store without having to
+        // go through an mpsc.
+        let _accessor = accessor.as_accessor();
         let (tx, rx) = oneshot::channel();
         send(
             &mut self.tx.as_mut().unwrap(),
             ReadEvent::Read { buffer: None, tx },
         );
-        let instance = self.instance;
-        super::checked(
-            instance,
-            rx.map(move |v| {
-                drop(self);
+        let v = rx.await;
+        drop(self);
 
-                if let Ok(HostResult {
-                    mut buffer,
-                    dropped: false,
-                }) = v
-                {
-                    buffer.take()
-                } else {
-                    None
-                }
-            }),
-        )
+        if let Ok(HostResult {
+            mut buffer,
+            dropped: false,
+        }) = v
+        {
+            buffer.take()
+        } else {
+            None
+        }
     }
 
-    /// Convert this object into a `Future` which will resolve when the write
-    /// end of this `future` is dropped, plus a `Watch` which can be used to
-    /// retrieve the `FutureReader` again.
+    /// Wait for the write end of this `future` to be dropped.
     ///
-    /// Note that calling `Watch::into_inner` on the returned `Watch` will have
-    /// the side effect of causing the `Future` to resolve immediately if it
-    /// hasn't already.
+    /// The [`Accessor`] provided can be acquired from [`Instance::run_with`] or
+    /// from within a host function for example.
     ///
-    /// Also note that the returned `Future` must be polled from the event loop
-    /// of the component instance from which this `FutureReader` originated.
-    /// See [`Instance::run`] for details.
-    pub fn watch_writer(mut self) -> (impl Future<Output = ()> + Send + 'static, Watch<Self>)
+    /// # Panics
+    ///
+    /// Panics if the store that the [`Accessor`] is derived from does not own
+    /// this future.
+    pub async fn watch_writer(&mut self, accessor: impl AsAccessor)
     where
         T: Send + 'static,
     {
+        // FIXME: this is intended to be used in the future to directly
+        // manipulate state for this future within the store without having to
+        // go through an mpsc.
+        let _accessor = accessor.as_accessor();
         let (tx, rx) = oneshot::channel();
         send(&mut self.tx.as_mut().unwrap(), ReadEvent::Watch { tx });
-        let instance = self.instance;
-        watch(instance, rx, self)
+        let (future, _watch) = watch(self.instance, rx, ());
+        future.await
     }
 }
 
@@ -872,26 +879,29 @@ impl<B> StreamWriter<B> {
     /// returned buffer will be the same one passed as a parameter, possibly
     /// mutated to consume any written values.
     ///
-    /// Note that the returned `Future` must be polled from the event loop of
-    /// the component instance from which this `StreamWriter` originated.  See
-    /// [`Instance::run`] for details.
-    pub fn write(
+    /// # Panics
+    ///
+    /// Panics if the store that the `accessor` is derived from does not own
+    /// this future.
+    pub async fn write(
         mut self,
+        accessor: impl AsAccessor,
         buffer: B,
-    ) -> impl Future<Output = (Option<StreamWriter<B>>, B)> + Send + 'static
+    ) -> (Option<StreamWriter<B>>, B)
     where
         B: Send + 'static,
     {
+        // FIXME: this is intended to be used in the future to directly
+        // manipulate state for this future within the store without having to
+        // go through an mpsc.
+        let _accessor = accessor.as_accessor();
         let (tx, rx) = oneshot::channel();
         send(self.tx.as_mut().unwrap(), WriteEvent::Write { buffer, tx });
-        let instance = self.instance;
-        super::checked(
-            instance,
-            rx.map(move |v| match v {
-                Ok(HostResult { buffer, dropped }) => ((!dropped).then_some(self), buffer),
-                Err(_) => todo!("guarantee buffer recovery if event loop errors or panics"),
-            }),
-        )
+        let v = rx.await;
+        match v {
+            Ok(HostResult { buffer, dropped }) => ((!dropped).then_some(self), buffer),
+            Err(_) => todo!("guarantee buffer recovery if event loop errors or panics"),
+        }
     }
 
     /// Write the specified values until either the buffer is drained or the
@@ -903,54 +913,51 @@ impl<B> StreamWriter<B> {
     /// returned buffer will be the same one passed as a parameter, possibly
     /// mutated to consume any written values.
     ///
-    /// Note that the returned `Future` must be polled from the event loop of
-    /// the component instance from which this `StreamWriter` originated.  See
-    /// [`Instance::run`] for details.
-    pub fn write_all<T>(
+    /// # Panics
+    ///
+    /// Panics if the store that the `accessor` is derived from does not own
+    /// this future.
+    pub async fn write_all<T>(
         self,
-        buffer: B,
-    ) -> impl Future<Output = (Option<StreamWriter<B>>, B)> + Send + 'static
+        accessor: impl AsAccessor,
+        mut buffer: B,
+    ) -> (Option<StreamWriter<B>>, B)
     where
         B: WriteBuffer<T>,
     {
-        let instance = self.instance;
-        super::checked(
-            instance,
-            self.write(buffer).then(|(me, buffer)| async move {
-                if let Some(me) = me {
-                    if buffer.remaining().len() > 0 {
-                        // Note the use of `Box::pin` which is required due to
-                        // the recursive nature of this function.
-                        Box::pin(me.write_all(buffer)).await
-                    } else {
-                        (Some(me), buffer)
-                    }
+        let accessor = accessor.as_accessor();
+        let mut maybe_me = Some(self);
+        loop {
+            if let Some(me) = maybe_me {
+                if buffer.remaining().len() > 0 {
+                    (maybe_me, buffer) = me.write(accessor, buffer).await;
                 } else {
-                    (None, buffer)
+                    break (Some(me), buffer);
                 }
-            }),
-        )
+            } else {
+                break (None, buffer);
+            }
+        }
     }
 
-    /// Convert this object into a `Future` which will resolve when the read end
-    /// of this `stream` is dropped, plus a `Watch` which can be used to retrieve
-    /// the `StreamWriter` again.
+    /// Wait for the read end of this `stream` to be dropped.
     ///
-    /// Note that calling `Watch::into_inner` on the returned `Watch` will have
-    /// the side effect of causing the `Future` to resolve immediately if it
-    /// hasn't already.
+    /// # Panics
     ///
-    /// Also note that the returned `Future` must be polled from the event loop
-    /// of the component instance from which this `StreamWriter` originated.
-    /// See [`Instance::run`] for details.
-    pub fn watch_reader(mut self) -> (impl Future<Output = ()> + Send + 'static, Watch<Self>)
+    /// Panics if the store that the `accessor` is derived from does not own
+    /// this future.
+    pub async fn watch_reader(&mut self, accessor: impl AsAccessor)
     where
         B: Send + 'static,
     {
+        // FIXME: this is intended to be used in the future to directly
+        // manipulate state for this future within the store without having to
+        // go through an mpsc.
+        let _accessor = accessor.as_accessor();
         let (tx, rx) = oneshot::channel();
         send(&mut self.tx.as_mut().unwrap(), WriteEvent::Watch { tx });
-        let instance = self.instance;
-        watch(instance, rx, self)
+        let (future, _watch) = watch(self.instance, rx, ());
+        future.await;
     }
 }
 
@@ -1171,53 +1178,55 @@ impl<B> StreamReader<B> {
     ///
     /// The returned `Future` will yield a `(Some(_), _)` if the read completed
     /// (possibly with zero items if the write was empty).  It will return
-    /// `(None, _)` if the read failed due to the closure of the write end.  In
+    /// `(None, _)` if the read failed due to the closure of the write end. In
     /// either case, the returned buffer will be the same one passed as a
     /// parameter, with zero or more items added.
     ///
-    /// Note that the returned `Future` must be polled from the event loop of
-    /// the component instance from which this `StreamReader` originated.  See
-    /// [`Instance::run`] for details.
-    pub fn read(
+    /// # Panics
+    ///
+    /// Panics if the store that the `accessor` is derived from does not own
+    /// this future.
+    pub async fn read(
         mut self,
+        accessor: impl AsAccessor,
         buffer: B,
-    ) -> impl Future<Output = (Option<StreamReader<B>>, B)> + Send + 'static
+    ) -> (Option<StreamReader<B>>, B)
     where
         B: Send + 'static,
     {
+        // FIXME: this is intended to be used in the future to directly
+        // manipulate state for this future within the store without having to
+        // go through an mpsc.
+        let _accessor = accessor.as_accessor();
         let (tx, rx) = oneshot::channel();
         send(self.tx.as_mut().unwrap(), ReadEvent::Read { buffer, tx });
-        let instance = self.instance;
-        super::checked(
-            instance,
-            rx.map(move |v| match v {
-                Ok(HostResult { buffer, dropped }) => ((!dropped).then_some(self), buffer),
-                Err(_) => {
-                    todo!("guarantee buffer recovery if event loop errors or panics")
-                }
-            }),
-        )
+        let v = rx.await;
+        match v {
+            Ok(HostResult { buffer, dropped }) => ((!dropped).then_some(self), buffer),
+            Err(_) => {
+                todo!("guarantee buffer recovery if event loop errors or panics")
+            }
+        }
     }
 
-    /// Convert this object into a `Future` which will resolve when the write
-    /// end of this `stream` is dropped, plus a `Watch` which can be used to
-    /// retrieve the `StreamReader` again.
+    /// Wait until the write end of this `stream` is dropped.
     ///
-    /// Note that calling `Watch::into_inner` on the returned `Watch` will have
-    /// the side effect of causing the `Future` to resolve immediately if it
-    /// hasn't already.
+    /// # Panics
     ///
-    /// Also note that the returned `Future` must be polled from the event loop
-    /// of the component instance from which this `StreamReader` originated.
-    /// See [`Instance::run`] for details.
-    pub fn watch_writer(mut self) -> (impl Future<Output = ()> + Send + 'static, Watch<Self>)
+    /// Panics if the store that the `accessor` is derived from does not own
+    /// this future.
+    pub async fn watch_writer(&mut self, accessor: impl AsAccessor)
     where
         B: Send + 'static,
     {
+        // FIXME: this is intended to be used in the future to directly
+        // manipulate state for this future within the store without having to
+        // go through an mpsc.
+        let _accessor = accessor.as_accessor();
         let (tx, rx) = oneshot::channel();
         send(&mut self.tx.as_mut().unwrap(), ReadEvent::Watch { tx });
-        let instance = self.instance;
-        watch(instance, rx, self)
+        let (future, _) = watch(self.instance, rx, ());
+        future.await
     }
 }
 

--- a/crates/wasmtime/src/runtime/component/func.rs
+++ b/crates/wasmtime/src/runtime/component/func.rs
@@ -16,9 +16,7 @@ use wasmtime_environ::component::{
 };
 
 #[cfg(feature = "component-model-async")]
-use crate::component::HasData;
-#[cfg(feature = "component-model-async")]
-use crate::component::concurrent::{self, Accessor, PreparedCall};
+use crate::component::concurrent::{self, AsAccessor, PreparedCall};
 #[cfg(feature = "component-model-async")]
 use core::future::Future;
 #[cfg(feature = "component-model-async")]
@@ -329,15 +327,12 @@ impl Func {
     /// `Instance::spawn` to poll it from within the event loop.  See
     /// [`Instance::run`] for examples.
     #[cfg(feature = "component-model-async")]
-    pub async fn call_concurrent<T, D>(
+    pub async fn call_concurrent(
         self,
-        accessor: &Accessor<T, D>,
+        accessor: impl AsAccessor<Data: Send>,
         params: Vec<Val>,
-    ) -> Result<Vec<Val>>
-    where
-        T: Send,
-        D: HasData,
-    {
+    ) -> Result<Vec<Val>> {
+        let accessor = accessor.as_accessor();
         let result = accessor.with(|mut access| {
             let store = access.as_context_mut();
             assert!(

--- a/crates/wasmtime/src/runtime/component/func/typed.rs
+++ b/crates/wasmtime/src/runtime/component/func/typed.rs
@@ -17,9 +17,7 @@ use wasmtime_environ::component::{
 };
 
 #[cfg(feature = "component-model-async")]
-use crate::component::HasData;
-#[cfg(feature = "component-model-async")]
-use crate::component::concurrent::{self, Accessor, PreparedCall};
+use crate::component::concurrent::{self, AsAccessor, PreparedCall};
 
 /// A statically-typed version of [`Func`] which takes `Params` as input and
 /// returns `Return`.
@@ -262,17 +260,16 @@ where
     /// `Instance::spawn` to poll it from within the event loop.  See
     /// [`Instance::run`] for examples.
     #[cfg(feature = "component-model-async")]
-    pub async fn call_concurrent<T, D>(
+    pub async fn call_concurrent(
         self,
-        accessor: &Accessor<T, D>,
+        accessor: impl AsAccessor<Data: Send>,
         params: Params,
     ) -> Result<Return>
     where
-        T: Send,
-        D: HasData,
         Params: 'static,
         Return: 'static,
     {
+        let accessor = accessor.as_accessor();
         let result = accessor.with(|mut store| {
             let mut store = store.as_context_mut();
             assert!(

--- a/crates/wasmtime/src/runtime/component/mod.rs
+++ b/crates/wasmtime/src/runtime/component/mod.rs
@@ -119,9 +119,9 @@ mod values;
 pub use self::component::{Component, ComponentExportIndex};
 #[cfg(feature = "component-model-async")]
 pub use self::concurrent::{
-    Access, Accessor, AccessorTask, ErrorContext, FutureReader, FutureWriter, HostFuture,
-    HostStream, ReadBuffer, StreamReader, StreamWriter, VMComponentAsyncStore, VecBuffer, Watch,
-    WriteBuffer,
+    AbortHandle, Access, Accessor, AccessorTask, AsAccessor, ErrorContext, FutureReader,
+    FutureWriter, HostFuture, HostStream, ReadBuffer, StreamReader, StreamWriter,
+    VMComponentAsyncStore, VecBuffer, Watch, WriteBuffer,
 };
 pub use self::func::{
     ComponentNamedList, ComponentType, Func, Lift, Lower, TypedFunc, WasmList, WasmStr,


### PR DESCRIPTION
This is a follow-up to #11238 which adds `&Accessor` arguments to all functions for futures and streams. Like #11238 this is done to make future refactorings easier for the internal implementation but the internal implementations are not updated at this time. Many functions, for example, do not use the argument at all just yet. The purpose of this is to ensure host usage of these functions always provides a store context.

This change required large refactorings of the upcoming wasmtime-wasi-http implementation in the wasip3-prototyping repository. That's all been sorted out now though so the changes are being pulled back here into the Wasmtime repository as well.

This commit additionally changes the `watch_*` functions on the various stream/future types to take `&mut self` instead of `self`-by-value. This is mostly a stylistic change and is more API-driven than anything else. Functionally this behaves the same as before where, while watching, the stream/future cannot be read/written to otherwise.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
