### PR TITLE
Remove `Arc::clone` when creating `LiftContext`

### DIFF
--- a/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams.rs
@@ -1936,12 +1936,10 @@ impl Instance {
                 }
 
                 let write_handle = transmit.write_handle;
-                let types = self.id().get(store.0).component().types().clone();
-                let lift =
-                    &mut LiftContext::new(store.0.store_opaque_mut(), &options, &types, self);
+                let lift = &mut LiftContext::new(store.0.store_opaque_mut(), &options, self);
                 let code = accept_writer::<T, B, U>(buffer, tx, kind)(Writer::Guest {
+                    ty: payload(ty, lift.types),
                     lift,
-                    ty: payload(ty, &types),
                     address,
                     count,
                 })?;
@@ -2125,12 +2123,8 @@ impl Instance {
                             bail!("write pointer not aligned");
                         }
 
-                        let lift = &mut LiftContext::new(
-                            store.0.store_opaque_mut(),
-                            write_options,
-                            &types,
-                            self,
-                        );
+                        let lift =
+                            &mut LiftContext::new(store.0.store_opaque_mut(), write_options, self);
                         let bytes = lift
                             .memory()
                             .get(write_address..)
@@ -2193,7 +2187,7 @@ impl Instance {
                     }
                 } else {
                     let store_opaque = store.0.store_opaque_mut();
-                    let lift = &mut LiftContext::new(store_opaque, write_options, &types, self);
+                    let lift = &mut LiftContext::new(store_opaque, write_options, self);
                     let ty = types[types[write_ty].ty].payload.unwrap();
                     let abi = lift.types.canonical_abi(&ty);
                     let size = usize::try_from(abi.size32).unwrap();
@@ -2438,12 +2432,10 @@ impl Instance {
                     transmit.done = true;
                 }
 
-                let types = self.id().get(store.0).component().types().clone();
-                let lift =
-                    &mut LiftContext::new(store.0.store_opaque_mut(), &options, &types, self);
+                let lift = &mut LiftContext::new(store.0.store_opaque_mut(), &options, self);
                 accept(Writer::Guest {
+                    ty: payload(ty, lift.types),
                     lift,
-                    ty: payload(ty, &types),
                     address,
                     count,
                 })?
@@ -2762,8 +2754,7 @@ impl Instance {
                 None,
             )
         };
-        let types = self.id().get(store).component().types().clone();
-        let lift_ctx = &mut LiftContext::new(store, &options, &types, self);
+        let lift_ctx = &mut LiftContext::new(store, &options, self);
         //  Read string from guest memory
         let address = usize::try_from(debug_msg_address)?;
         let len = usize::try_from(debug_msg_len)?;

--- a/crates/wasmtime/src/runtime/component/func.rs
+++ b/crates/wasmtime/src/runtime/component/func.rs
@@ -935,10 +935,8 @@ impl Func {
         lift: impl FnOnce(&mut LiftContext, InterfaceType) -> Result<R>,
     ) -> Result<R> {
         let (options, _flags, ty, _) = self.abi_info(store);
-        let types = self.instance.id().get(store).component().types().clone();
-        lift(
-            &mut LiftContext::new(store, &options, &types, self.instance),
-            InterfaceType::Tuple(types[ty].results),
-        )
+        let mut cx = LiftContext::new(store, &options, self.instance);
+        let ty = InterfaceType::Tuple(cx.types[ty].results);
+        lift(&mut cx, ty)
     }
 }

--- a/crates/wasmtime/src/runtime/component/func/host.rs
+++ b/crates/wasmtime/src/runtime/component/func/host.rs
@@ -283,8 +283,7 @@ where
 
             // Lift the parameters, either from flat storage or from linear
             // memory.
-            let lift =
-                &mut LiftContext::new(store.0.store_opaque_mut(), &options, &types, instance);
+            let lift = &mut LiftContext::new(store.0.store_opaque_mut(), &options, instance);
             lift.enter_call();
             let params = storage.lift_params(lift, param_tys)?;
 
@@ -351,7 +350,7 @@ where
         }
     } else {
         let mut storage = Storage::<'_, Params, Return>::new_sync(storage);
-        let mut lift = LiftContext::new(store.0.store_opaque_mut(), &options, &types, instance);
+        let mut lift = LiftContext::new(store.0.store_opaque_mut(), &options, instance);
         lift.enter_call();
         let params = storage.lift_params(&mut lift, param_tys)?;
 
@@ -752,7 +751,7 @@ where
     let result_tys = &types[func_ty.results];
 
     let mut params_and_results = Vec::new();
-    let mut lift = &mut LiftContext::new(store.0.store_opaque_mut(), &options, &types, instance);
+    let mut lift = &mut LiftContext::new(store.0.store_opaque_mut(), &options, instance);
     lift.enter_call();
     let max_flat = if async_ {
         MAX_FLAT_ASYNC_PARAMS

--- a/crates/wasmtime/src/runtime/component/func/options.rs
+++ b/crates/wasmtime/src/runtime/component/func/options.rs
@@ -438,7 +438,6 @@ impl<'a> LiftContext<'a> {
     pub fn new(
         store: &'a mut StoreOpaque,
         options: &'a Options,
-        types: &'a Arc<ComponentTypes>,
         instance_handle: Instance,
     ) -> LiftContext<'a> {
         // From `&mut StoreOpaque` provided the goal here is to project out
@@ -452,11 +451,12 @@ impl<'a> LiftContext<'a> {
             .map(|_| options.memory(unsafe { &*(store as *const StoreOpaque) }));
         let (calls, host_table, host_resource_data, instance) =
             store.component_resource_state_with_instance(instance_handle);
+        let (component, instance) = instance.component_and_self();
 
         LiftContext {
             memory,
             options,
-            types,
+            types: component.types(),
             instance,
             instance_handle,
             calls,

--- a/crates/wasmtime/src/runtime/component/func/typed.rs
+++ b/crates/wasmtime/src/runtime/component/func/typed.rs
@@ -5,15 +5,13 @@ use crate::component::storage::{storage_as_slice, storage_as_slice_mut};
 use crate::prelude::*;
 use crate::{AsContextMut, StoreContext, StoreContextMut, ValRaw};
 use alloc::borrow::Cow;
-use alloc::sync::Arc;
 use core::fmt;
 use core::iter;
 use core::marker;
 use core::mem::{self, MaybeUninit};
 use core::str;
 use wasmtime_environ::component::{
-    CanonicalAbiInfo, ComponentTypes, InterfaceType, MAX_FLAT_PARAMS, MAX_FLAT_RESULTS,
-    StringEncoding, VariantInfo,
+    CanonicalAbiInfo, InterfaceType, MAX_FLAT_PARAMS, MAX_FLAT_RESULTS, StringEncoding, VariantInfo,
 };
 
 #[cfg(feature = "component-model-async")]
@@ -1845,10 +1843,6 @@ pub struct WasmList<T> {
     len: usize,
     options: Options,
     elem: InterfaceType,
-    // NB: it would probably be more efficient to store a non-atomic index-style
-    // reference to something inside a `StoreOpaque`, but that's not easily
-    // available at this time, so it's left as a future exercise.
-    types: Arc<ComponentTypes>,
     instance: Instance,
     _marker: marker::PhantomData<T>,
 }
@@ -1875,7 +1869,6 @@ impl<T: Lift> WasmList<T> {
             len,
             options: *cx.options,
             elem,
-            types: cx.types.clone(),
             instance: cx.instance_handle(),
             _marker: marker::PhantomData,
         })
@@ -1904,7 +1897,7 @@ impl<T: Lift> WasmList<T> {
     pub fn get(&self, mut store: impl AsContextMut, index: usize) -> Option<Result<T>> {
         let store = store.as_context_mut().0;
         self.options.store_id().assert_belongs_to(store.id());
-        let mut cx = LiftContext::new(store, &self.options, &self.types, self.instance);
+        let mut cx = LiftContext::new(store, &self.options, self.instance);
         self.get_from_store(&mut cx, index)
     }
 
@@ -1932,7 +1925,7 @@ impl<T: Lift> WasmList<T> {
     ) -> impl ExactSizeIterator<Item = Result<T>> + 'a {
         let store = store.into().0;
         self.options.store_id().assert_belongs_to(store.id());
-        let mut cx = LiftContext::new(store, &self.options, &self.types, self.instance);
+        let mut cx = LiftContext::new(store, &self.options, self.instance);
         (0..self.len).map(move |i| self.get_from_store(&mut cx, i).unwrap())
     }
 }

--- a/crates/wasmtime/src/runtime/vm/component.rs
+++ b/crates/wasmtime/src/runtime/vm/component.rs
@@ -640,6 +640,20 @@ impl ComponentInstance {
         &self.component
     }
 
+    /// Same as [`Self::component`] but additionally returns the
+    /// `Pin<&mut Self>` with the same original lifetime.
+    pub fn component_and_self(self: Pin<&mut Self>) -> (&Component, Pin<&mut Self>) {
+        // SAFETY: this function is projecting both `&Component` and the same
+        // pointer both connected to the same lifetime. This is safe because
+        // it's a contract of `Pin<&mut Self>` that the `Component` field is
+        // never written, meaning it's effectively unsafe to have `&mut
+        // Component` projected from `Pin<&mut Self>`. Consequently it's safe to
+        // have a read-only view of the field while still retaining mutable
+        // access to all other fields.
+        let component = unsafe { &*(&raw const self.component) };
+        (component, self)
+    }
+
     /// Returns a reference to the resource type information.
     pub fn resource_types(&self) -> &Arc<PrimaryMap<ResourceIndex, ResourceType>> {
         &self.resource_types


### PR DESCRIPTION
A small amount of `unsafe` code is required to enable this but the recent refactorings to use `Pin<&mut ComponentInstance>` everywhere makes this a much easier piece of `unsafe` code to verify.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
