### PR TITLE
Update `table.fill` intrinsics to use defined indices

### DIFF
--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -1938,11 +1938,10 @@ impl FuncEnvironment<'_> {
             self.builtin_functions.table_fill_func_ref(&mut pos.func)
         };
 
-        let vmctx = self.vmctx_val(&mut pos);
+        let (table_vmctx, table_index) = self.table_vmctx_and_defined_index(&mut pos, table_index);
 
-        let table_index_arg = pos.ins().iconst(I32, table_index.as_u32() as i64);
         pos.ins()
-            .call(libcall, &[vmctx, table_index_arg, dst, val, len]);
+            .call(libcall, &[table_vmctx, table_index, dst, val, len]);
 
         Ok(())
     }

--- a/crates/wasmtime/src/runtime/vm/libcalls.rs
+++ b/crates/wasmtime/src/runtime/vm/libcalls.rs
@@ -305,8 +305,8 @@ unsafe fn table_fill_func_ref(
     val: *mut u8,
     len: u64,
 ) -> Result<()> {
-    let table_index = TableIndex::from_u32(table_index);
-    let table = &mut *instance.get_table(table_index);
+    let table_index = DefinedTableIndex::from_u32(table_index);
+    let table = instance.get_defined_table(table_index);
     match table.element_type() {
         TableElementType::Func => {
             let val = NonNull::new(val.cast::<VMFuncRef>());
@@ -327,8 +327,8 @@ unsafe fn table_fill_gc_ref(
     val: u32,
     len: u64,
 ) -> Result<()> {
-    let table_index = TableIndex::from_u32(table_index);
-    let table = &mut *instance.get_table(table_index);
+    let table_index = DefinedTableIndex::from_u32(table_index);
+    let table = instance.get_defined_table(table_index);
     match table.element_type() {
         TableElementType::Func => unreachable!(),
         TableElementType::GcRef => {
@@ -353,8 +353,8 @@ unsafe fn table_fill_cont_obj(
     value_revision: u64,
     len: u64,
 ) -> Result<()> {
-    let table_index = TableIndex::from_u32(table_index);
-    let table = &mut *instance.get_table(table_index);
+    let table_index = DefinedTableIndex::from_u32(table_index);
+    let table = instance.get_defined_table(table_index);
     match table.element_type() {
         TableElementType::Cont => {
             let contobj = VMContObj::from_raw_parts(value_contref, value_revision);


### PR DESCRIPTION
Similar to previous refactorings which handles the imported/exported distinction in wasm instead of in host code this updates the `table.fill`-related libcall intrinsics to take a defined table index instead of a general table index, enabling using a currently-safer helper function.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
