### PR TITLE
More table safety improvements

### DIFF
--- a/cranelift/entity/src/primary.rs
+++ b/cranelift/entity/src/primary.rs
@@ -7,7 +7,6 @@ use alloc::boxed::Box;
 use alloc::vec::Vec;
 use core::fmt;
 use core::marker::PhantomData;
-use core::mem;
 use core::ops::{Index, IndexMut};
 use core::slice;
 #[cfg(feature = "enable-serde")]
@@ -163,35 +162,11 @@ where
     ///
     /// Returns an error if an element does not exist, or if the same key was passed more than
     /// once.
-    // This implementation is taken from the unstable `get_many_mut`.
-    //
-    // Once it has been stabilised we can call that method directly.
-    pub fn get_many_mut<const N: usize>(
+    pub fn get_disjoint_mut<const N: usize>(
         &mut self,
         indices: [K; N],
-    ) -> Result<[&mut V; N], GetManyMutError<K>> {
-        for (i, &idx) in indices.iter().enumerate() {
-            if idx.index() >= self.len() {
-                return Err(GetManyMutError::DoesNotExist(idx));
-            }
-            for &idx2 in &indices[..i] {
-                if idx == idx2 {
-                    return Err(GetManyMutError::MultipleOf(idx));
-                }
-            }
-        }
-
-        let slice: *mut V = self.elems.as_mut_ptr();
-        let mut arr: mem::MaybeUninit<[&mut V; N]> = mem::MaybeUninit::uninit();
-        let arr_ptr = arr.as_mut_ptr();
-
-        unsafe {
-            for i in 0..N {
-                let idx = *indices.get_unchecked(i);
-                *(*arr_ptr).get_unchecked_mut(i) = &mut *slice.add(idx.index());
-            }
-            Ok(arr.assume_init())
-        }
+    ) -> Result<[&mut V; N], slice::GetDisjointMutError> {
+        self.elems.get_disjoint_mut(indices.map(|k| k.index()))
     }
 
     /// Performs a binary search on the values with a key extraction function.
@@ -234,12 +209,6 @@ where
             None
         }
     }
-}
-
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
-pub enum GetManyMutError<K> {
-    DoesNotExist(K),
-    MultipleOf(K),
 }
 
 impl<K, V> Default for PrimaryMap<K, V>

--- a/cranelift/entity/src/primary.rs
+++ b/cranelift/entity/src/primary.rs
@@ -526,14 +526,14 @@ mod tests {
         let _1 = m.push(1);
         let _2 = m.push(2);
 
-        assert_eq!([&mut 0, &mut 2], m.get_many_mut([_0, _2]).unwrap());
+        assert_eq!([&mut 0, &mut 2], m.get_disjoint_mut([_0, _2]).unwrap());
         assert_eq!(
-            m.get_many_mut([_0, _0]),
-            Err(GetManyMutError::MultipleOf(_0))
+            m.get_disjoint_mut([_0, _0]),
+            Err(slice::GetDisjointMutError::OverlappingIndices)
         );
         assert_eq!(
-            m.get_many_mut([E(4)]),
-            Err(GetManyMutError::DoesNotExist(E(4)))
+            m.get_disjoint_mut([E(4)]),
+            Err(slice::GetDisjointMutError::IndexOutOfBounds)
         );
     }
 }

--- a/crates/wasmtime/src/runtime/externals/table.rs
+++ b/crates/wasmtime/src/runtime/externals/table.rs
@@ -2,7 +2,7 @@ use crate::prelude::*;
 use crate::runtime::vm::{self as runtime, GcStore};
 use crate::store::{AutoAssertNoGc, StoreInstanceId, StoreOpaque};
 use crate::trampoline::generate_table_export;
-use crate::{AnyRef, AsContext, AsContextMut, ExternRef, Func, HeapType, Ref, TableType};
+use crate::{AnyRef, AsContext, AsContextMut, ExternRef, Func, HeapType, Ref, TableType, Trap};
 use core::iter;
 use wasmtime_environ::DefinedTableIndex;
 
@@ -344,24 +344,74 @@ impl Table {
                  destination table's element type",
             )?;
 
-        let (dst_table, _) = dst_table.wasmtime_table(store, iter::empty());
-        // FIXME(#11179) shouldn't need to subvert the borrow checker
-        let dst_table: *mut _ = dst_table;
-        let src_range = src_index..(src_index.checked_add(len).unwrap_or(u64::MAX));
-        let (src_table, _) = src_table.wasmtime_table(store, src_range);
-        // FIXME(#11179) shouldn't need to subvert the borrow checker
-        let src_table: *mut _ = src_table;
+        // SAFETY: the the two tables have the same type, as type-checked above.
         unsafe {
-            runtime::Table::copy(
-                store.optional_gc_store_mut(),
-                dst_table,
-                src_table,
+            Self::copy_raw(store, dst_table, dst_index, src_table, src_index, len)?;
+        }
+        Ok(())
+    }
+
+    /// Copies the elements of `src_table` to `dst_table`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the either table doesn't belong to `store`.
+    ///
+    /// # Safety
+    ///
+    /// Requires that the two tables have previously been type-checked to have
+    /// the same type.
+    pub(crate) unsafe fn copy_raw(
+        store: &mut StoreOpaque,
+        dst_table: &Table,
+        dst_index: u64,
+        src_table: &Table,
+        src_index: u64,
+        len: u64,
+    ) -> Result<(), Trap> {
+        // Handle lazy initialization of the source table first before doing
+        // anything else.
+        let src_range = src_index..(src_index.checked_add(len).unwrap_or(u64::MAX));
+        src_table.wasmtime_table(store, src_range);
+
+        // validate `dst_table` belongs to `store`.
+        dst_table.wasmtime_table(store, iter::empty());
+
+        // Figure out which of the three cases we're in:
+        //
+        // 1. Cross-instance table copy.
+        // 2. Intra-instance table copy.
+        // 3. Intra-table copy.
+        let src_instance = src_table.instance.instance();
+        let dst_instance = dst_table.instance.instance();
+        if src_instance != dst_instance {
+            // SAFETY: accessing two instances requires only accessing defined items
+            // on each instance which is done below with `get_defined_*` methods.
+            let (gc_store, [src_instance, dst_instance]) =
+                unsafe { store.optional_gc_store_and_instances_mut([src_instance, dst_instance]) };
+            src_instance.get_defined_table(src_table.index).copy_to(
+                dst_instance.get_defined_table(dst_table.index),
+                gc_store,
                 dst_index,
                 src_index,
                 len,
-            )?;
+            )
+        } else if src_table.index != dst_table.index {
+            assert_eq!(src_instance, dst_instance);
+            let (gc_store, instance) = store.optional_gc_store_and_instance_mut(src_instance);
+            let [(_, src_table), (_, dst_table)] = instance
+                .tables_mut()
+                .get_disjoint_mut([src_table.index, dst_table.index])
+                .unwrap();
+            src_table.copy_to(dst_table, gc_store, dst_index, src_index, len)
+        } else {
+            assert_eq!(src_instance, dst_instance);
+            assert_eq!(src_table.index, dst_table.index);
+            let (gc_store, instance) = store.optional_gc_store_and_instance_mut(src_instance);
+            instance
+                .get_defined_table(src_table.index)
+                .copy_within(gc_store, dst_index, src_index, len)
         }
-        Ok(())
     }
 
     /// Fill `table[dst..(dst + len)]` with the given value.

--- a/crates/wasmtime/src/runtime/vm/debug_builtins.rs
+++ b/crates/wasmtime/src/runtime/vm/debug_builtins.rs
@@ -1,6 +1,6 @@
 #![doc(hidden)]
 
-use crate::runtime::vm::instance::Instance;
+use crate::runtime::vm::instance::InstanceAndStore;
 use crate::runtime::vm::vmcontext::VMContext;
 use core::ptr::NonNull;
 use wasmtime_environ::{EntityRef, MemoryIndex};
@@ -18,7 +18,8 @@ pub unsafe extern "C" fn resolve_vmctx_memory_ptr(p: *const u32) -> *const u8 {
         VMCTX_AND_MEMORY.0 != NonNull::dangling(),
         "must call `__vmctx->set()` before resolving Wasm pointers"
     );
-    Instance::from_vmctx(VMCTX_AND_MEMORY.0, |handle| {
+    InstanceAndStore::from_vmctx(VMCTX_AND_MEMORY.0, |handle| {
+        let (handle, _) = handle.unpack_mut();
         assert!(
             VMCTX_AND_MEMORY.1 < handle.env_module().memories.len(),
             "memory index for debugger is out of bounds"

--- a/crates/wasmtime/src/runtime/vm/instance.rs
+++ b/crates/wasmtime/src/runtime/vm/instance.rs
@@ -315,39 +315,39 @@ impl Instance {
         ret
     }
 
-    /// Converts the provided `*mut VMContext` to an `Instance` pointer and runs
-    /// the provided closure with the instance.
+    /// Converts the provided `*mut VMContext` to an `Instance` pointer and
+    /// returns it with the same lifetime as `self`.
     ///
-    /// This method will move the `vmctx` pointer backwards to point to the
-    /// original `Instance` that precedes it. The closure is provided a
-    /// temporary version of the `Instance` pointer with a constrained lifetime
-    /// to the closure to ensure it doesn't accidentally escape.
-    ///
-    /// # Unsafety
-    ///
-    /// Callers must validate that the `vmctx` pointer is a valid allocation
-    /// and that it's valid to acquire `Pin<&mut Instance>` at this time. For example
-    /// this can't be called twice on the same `VMContext` to get two active
-    /// pointers to the same `Instance`.
-    #[inline]
-    pub unsafe fn from_vmctx<R>(
-        vmctx: NonNull<VMContext>,
-        f: impl FnOnce(Pin<&mut Instance>) -> R,
-    ) -> R {
-        let mut ptr = vmctx
-            .byte_sub(mem::size_of::<Instance>())
-            .cast::<Instance>();
-        f(Pin::new_unchecked(ptr.as_mut()))
-    }
-
-    /// Returns the `InstanceId` associated with the `vmctx` provided.
+    /// This function can be used when traversing a `VMContext` to reach into
+    /// the context needed for imports, optionally.
     ///
     /// # Safety
     ///
-    /// The `vmctx` pointer must be a valid pointer to read the `InstanceId`
-    /// from.
-    unsafe fn vmctx_instance_id(vmctx: NonNull<VMContext>) -> InstanceId {
-        Instance::from_vmctx(vmctx, |i| i.id)
+    /// This function requires that the `vmctx` pointer is indeed valid and
+    /// from the store that `self` belongs to.
+    #[inline]
+    unsafe fn sibling_vmctx<'a>(&'a self, vmctx: NonNull<VMContext>) -> &'a Instance {
+        let ptr = vmctx
+            .byte_sub(mem::size_of::<Instance>())
+            .cast::<Instance>();
+        ptr.as_ref()
+    }
+
+    /// Same as [`Self::sibling_vmctx`], but the mutable version.
+    ///
+    /// # Safety
+    ///
+    /// This function requires that the `vmctx` pointer is indeed valid and
+    /// from the store that `self` belongs to.
+    #[inline]
+    unsafe fn sibling_vmctx_mut<'a>(
+        self: Pin<&'a mut Self>,
+        vmctx: NonNull<VMContext>,
+    ) -> Pin<&'a mut Instance> {
+        let mut ptr = vmctx
+            .byte_sub(mem::size_of::<Instance>())
+            .cast::<Instance>();
+        Pin::new_unchecked(ptr.as_mut())
     }
 
     pub(crate) fn env_module(&self) -> &Arc<wasmtime_environ::Module> {
@@ -607,7 +607,7 @@ impl Instance {
             // SAFETY: validity of this `Instance` guarantees validity of the
             // `vmctx` pointer being read here to find the transitive
             // `InstanceId` that the import is associated with.
-            let id = unsafe { Instance::vmctx_instance_id(import.vmctx.as_non_null()) };
+            let id = unsafe { self.sibling_vmctx(import.vmctx.as_non_null()).id };
             (id, import.index)
         };
         crate::Table::from_raw(StoreInstanceId::new(store, id), def_index)
@@ -627,7 +627,7 @@ impl Instance {
             // SAFETY: validity of this `Instance` guarantees validity of the
             // `vmctx` pointer being read here to find the transitive
             // `InstanceId` that the import is associated with.
-            let id = unsafe { Instance::vmctx_instance_id(import.vmctx.as_non_null()) };
+            let id = unsafe { self.sibling_vmctx(import.vmctx.as_non_null()).id };
             (id, import.index)
         };
         crate::Memory::from_raw(StoreInstanceId::new(store, id), def_index)
@@ -651,7 +651,7 @@ impl Instance {
                 // imports meaning we can read the id of the vmctx within.
                 let id = unsafe {
                     let vmctx = VMContext::from_opaque(import.vmctx.unwrap().as_non_null());
-                    Instance::vmctx_instance_id(vmctx)
+                    self.sibling_vmctx(vmctx).id
                 };
                 crate::Global::from_core(StoreInstanceId::new(store, id), index)
             }
@@ -686,7 +686,7 @@ impl Instance {
             // SAFETY: validity of this `Instance` guarantees validity of the
             // `vmctx` pointer being read here to find the transitive
             // `InstanceId` that the import is associated with.
-            let id = unsafe { Instance::vmctx_instance_id(import.vmctx.as_non_null()) };
+            let id = unsafe { self.sibling_vmctx(import.vmctx.as_non_null()).id };
             (id, import.index)
         };
         crate::Tag::from_raw(StoreInstanceId::new(store, id), def_index)
@@ -699,19 +699,6 @@ impl Instance {
     /// resolved `lookup_by_declaration`.
     pub fn exports(&self) -> wasmparser::collections::index_map::Iter<'_, String, EntityIndex> {
         self.env_module().exports.iter()
-    }
-
-    /// Return the table index for the given `VMTableDefinition`.
-    pub unsafe fn table_index(&self, table: &VMTableDefinition) -> DefinedTableIndex {
-        let index = DefinedTableIndex::new(
-            usize::try_from(
-                (table as *const VMTableDefinition)
-                    .offset_from(self.table_ptr(DefinedTableIndex::new(0)).as_ptr()),
-            )
-            .unwrap(),
-        );
-        assert!(index.index() < self.tables.len());
-        index
     }
 
     /// Grow memory by the specified amount of pages.
@@ -743,7 +730,7 @@ impl Instance {
         self: Pin<&mut Self>,
         table_index: TableIndex,
     ) -> TableElementType {
-        unsafe { (*self.get_table(table_index)).element_type() }
+        self.get_table(table_index).element_type()
     }
 
     /// Grow table by the specified amount of elements, filling them with
@@ -958,7 +945,7 @@ impl Instance {
 
     pub(crate) fn table_init_segment(
         store: &mut StoreOpaque,
-        id: InstanceId,
+        elements_instance_id: InstanceId,
         const_evaluator: &mut ConstExprEvaluator,
         table_index: TableIndex,
         elements: &TableSegmentElements,
@@ -968,14 +955,56 @@ impl Instance {
     ) -> Result<(), Trap> {
         // https://webassembly.github.io/bulk-memory-operations/core/exec/instructions.html#exec-table-init
 
-        let mut instance = store.instance_mut(id);
-        let table = unsafe { &mut *instance.as_mut().get_table(table_index) };
+        let elements_instance = store.instance_mut(elements_instance_id);
+        let elements_module = elements_instance.env_module();
+        let top = elements_module.tables[table_index].ref_type.heap_type.top();
+        let (defined_table_index, mut table_instance) =
+            elements_instance.defined_table_index_and_instance(table_index);
+        let table_instance_id = table_instance.id;
+
         let src = usize::try_from(src).map_err(|_| Trap::TableOutOfBounds)?;
         let len = usize::try_from(len).map_err(|_| Trap::TableOutOfBounds)?;
-        let module = instance.env_module().clone();
+
+        // In the initialization below we need to simultaneously have a mutable
+        // borrow on the `Table` that we're initializing and the `StoreOpaque`
+        // that it comes from. To solve this the tables are temporarily removed
+        // from the instance at `id` to be re-inserted at the end of this
+        // function via a `Drop` helper. The table and the store are then
+        // accessed through the drop helper below.
+        //
+        // This will cause a runtime panic if the table is actually accessed
+        // during the lifetime of the functions below, but that's a bug if that
+        // happens which needs to be fixed anyway.
+        let tables = mem::replace(table_instance.as_mut().tables_mut(), PrimaryMap::new());
+        let mut replace = ReplaceTables {
+            tables,
+            id: table_instance_id,
+            store,
+        };
+
+        struct ReplaceTables<'a> {
+            tables: PrimaryMap<DefinedTableIndex, (TableAllocationIndex, Table)>,
+            id: InstanceId,
+            store: &'a mut StoreOpaque,
+        }
+
+        impl Drop for ReplaceTables<'_> {
+            fn drop(&mut self) {
+                mem::swap(
+                    self.store.instance_mut(self.id).tables_mut(),
+                    &mut self.tables,
+                );
+                debug_assert!(self.tables.is_empty());
+            }
+        }
+
+        // Reborrow the table/store from `replace` for the below code.
+        let table = &mut replace.tables[defined_table_index].1;
+        let store = &mut *replace.store;
 
         match elements {
             TableSegmentElements::Functions(funcs) => {
+                let mut instance = store.instance_mut(elements_instance_id);
                 let elements = funcs
                     .get(src..)
                     .and_then(|s| s.get(..len))
@@ -992,8 +1021,7 @@ impl Instance {
                     .get(src..)
                     .and_then(|s| s.get(..len))
                     .ok_or(Trap::TableOutOfBounds)?;
-                let top = module.tables[table_index].ref_type.heap_type.top();
-                let mut context = ConstEvalContext::new(id);
+                let mut context = ConstEvalContext::new(elements_instance_id);
                 match top {
                     WasmHeapTopType::Extern => table.init_gc_refs(
                         dst,
@@ -1216,12 +1244,9 @@ impl Instance {
         self: Pin<&mut Self>,
         table_index: TableIndex,
         range: impl Iterator<Item = u64>,
-    ) -> *mut Table {
-        self.with_defined_table_index_and_instance(table_index, |idx, instance| {
-            // FIXME(#11179) shouldn't need to subvert the borrow checker
-            let ret: *mut Table = instance.get_defined_table_with_lazy_init(idx, range);
-            ret
-        })
+    ) -> &mut Table {
+        let (idx, instance) = self.defined_table_index_and_instance(table_index);
+        instance.get_defined_table_with_lazy_init(idx, range)
     }
 
     /// Gets the raw runtime table data structure owned by this instance
@@ -1279,12 +1304,9 @@ impl Instance {
 
     /// Get a table by index regardless of whether it is locally-defined or an
     /// imported, foreign table.
-    pub(crate) fn get_table(self: Pin<&mut Self>, table_index: TableIndex) -> *mut Table {
-        self.with_defined_table_index_and_instance(table_index, |idx, instance| unsafe {
-            // SAFETY: the `unsafe` here is projecting from `*mut (A, B)` to
-            // `*mut A`, which should be a safe operation to do.
-            &raw mut (*instance.tables_mut().get_raw_mut(idx).unwrap()).1
-        })
+    pub(crate) fn get_table(self: Pin<&mut Self>, table_index: TableIndex) -> &mut Table {
+        let (idx, instance) = self.defined_table_index_and_instance(table_index);
+        instance.get_defined_table(idx)
     }
 
     /// Get a locally-defined table.
@@ -1292,22 +1314,22 @@ impl Instance {
         &mut self.tables_mut()[index].1
     }
 
-    pub(crate) fn with_defined_table_index_and_instance<R>(
-        self: Pin<&mut Self>,
+    pub(crate) fn defined_table_index_and_instance<'a>(
+        self: Pin<&'a mut Self>,
         index: TableIndex,
-        f: impl FnOnce(DefinedTableIndex, Pin<&mut Instance>) -> R,
-    ) -> R {
+    ) -> (DefinedTableIndex, Pin<&'a mut Instance>) {
         if let Some(defined_table_index) = self.env_module().defined_table_index(index) {
-            f(defined_table_index, self)
+            (defined_table_index, self)
         } else {
             let import = self.imported_table(index);
-            unsafe {
-                Instance::from_vmctx(import.vmctx.as_non_null(), |foreign_instance| {
-                    let foreign_table_def = import.from.as_ptr();
-                    let foreign_table_index = foreign_instance.table_index(&*foreign_table_def);
-                    f(foreign_table_index, foreign_instance)
-                })
-            }
+            let index = import.index;
+            let vmctx = import.vmctx.as_non_null();
+            // SAFETY: the validity of `self` means that the reachable instances
+            // should also all be owned by the same store and fully initialized,
+            // so it's safe to laterally move from a mutable borrow of this
+            // instance to a mutable borrow of a sibling instance.
+            let foreign_instance = unsafe { self.sibling_vmctx_mut(vmctx) };
+            (index, foreign_instance)
         }
     }
 

--- a/crates/wasmtime/src/runtime/vm/instance.rs
+++ b/crates/wasmtime/src/runtime/vm/instance.rs
@@ -1571,7 +1571,7 @@ impl Instance {
         unsafe { &mut self.get_unchecked_mut().memories }
     }
 
-    fn tables_mut(
+    pub(crate) fn tables_mut(
         self: Pin<&mut Self>,
     ) -> &mut PrimaryMap<DefinedTableIndex, (TableAllocationIndex, Table)> {
         // SAFETY: see `store_mut` above.

--- a/crates/wasmtime/src/runtime/vm/instance/allocator.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator.rs
@@ -572,7 +572,6 @@ fn check_table_init_bounds(
     let mut const_evaluator = ConstExprEvaluator::default();
 
     for segment in module.table_initialization.segments.iter() {
-        let table = unsafe { &*store.instance_mut(instance).get_table(segment.table_index) };
         let mut context = ConstEvalContext::new(instance);
         let start = unsafe {
             const_evaluator
@@ -582,6 +581,7 @@ fn check_table_init_bounds(
         let start = usize::try_from(start.get_u32()).unwrap();
         let end = start.checked_add(usize::try_from(segment.elements.len()).unwrap());
 
+        let table = store.instance_mut(instance).get_table(segment.table_index);
         match end {
             Some(end) if end <= table.size() => {
                 // Initializer is in bounds

--- a/crates/wasmtime/src/runtime/vm/libcalls.rs
+++ b/crates/wasmtime/src/runtime/vm/libcalls.rs
@@ -378,7 +378,9 @@ unsafe fn table_copy(
     let dst_table_index = TableIndex::from_u32(dst_table_index);
     let src_table_index = TableIndex::from_u32(src_table_index);
     let store = store.store_opaque_mut();
-    let dst_table = instance.as_mut().get_table(dst_table_index);
+    // FIXME(#11179) shouldn't use a raw pointer to subvert the borrow checker
+    // here.
+    let dst_table: *mut Table = instance.as_mut().get_table(dst_table_index);
     // Lazy-initialize the whole range in the source table first.
     let src_range = src..(src.checked_add(len).unwrap_or(u64::MAX));
     let src_table = instance.get_table_with_lazy_init(src_table_index, src_range);

--- a/crates/wasmtime/src/runtime/vm/table.rs
+++ b/crates/wasmtime/src/runtime/vm/table.rs
@@ -901,52 +901,79 @@ impl Table {
         Ok(())
     }
 
+    /// Copy `len` elements from `self[src_index..][..len]` into
+    /// `dst_table[dst_index..][..len]`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the range is out of bounds of either the source or
+    /// destination tables.
+    pub fn copy_to(
+        &self,
+        dst: &mut Table,
+        gc_store: Option<&mut GcStore>,
+        dst_index: u64,
+        src_index: u64,
+        len: u64,
+    ) -> Result<(), Trap> {
+        let (src_range, dst_range) = Table::validate_copy(self, dst, dst_index, src_index, len)?;
+        Self::copy_elements(gc_store, dst, self, dst_range, src_range);
+        Ok(())
+    }
+
+    /// Copy `len` elements from `self[src_index..][..len]` into
+    /// `self[dst_index..][..len]`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the range is out of bounds of either the source or
+    /// destination tables.
+    pub fn copy_within(
+        &mut self,
+        gc_store: Option<&mut GcStore>,
+        dst_index: u64,
+        src_index: u64,
+        len: u64,
+    ) -> Result<(), Trap> {
+        let (src_range, dst_range) = Table::validate_copy(self, self, dst_index, src_index, len)?;
+        self.copy_elements_within(gc_store, dst_range, src_range);
+        Ok(())
+    }
+
     /// Copy `len` elements from `src_table[src_index..]` into `dst_table[dst_index..]`.
     ///
     /// # Errors
     ///
     /// Returns an error if the range is out of bounds of either the source or
     /// destination tables.
-    pub unsafe fn copy(
-        gc_store: Option<&mut GcStore>,
-        dst_table: *mut Self,
-        src_table: *mut Self,
+    fn validate_copy(
+        src: &Table,
+        dst: &Table,
         dst_index: u64,
         src_index: u64,
         len: u64,
-    ) -> Result<(), Trap> {
+    ) -> Result<(Range<usize>, Range<usize>), Trap> {
         // https://webassembly.github.io/bulk-memory-operations/core/exec/instructions.html#exec-table-copy
 
         let src_index = usize::try_from(src_index).map_err(|_| Trap::TableOutOfBounds)?;
         let dst_index = usize::try_from(dst_index).map_err(|_| Trap::TableOutOfBounds)?;
         let len = usize::try_from(len).map_err(|_| Trap::TableOutOfBounds)?;
 
-        if src_index
-            .checked_add(len)
-            .map_or(true, |n| n > (*src_table).size())
-            || dst_index
-                .checked_add(len)
-                .map_or(true, |m| m > (*dst_table).size())
+        if src_index.checked_add(len).map_or(true, |n| n > src.size())
+            || dst_index.checked_add(len).map_or(true, |m| m > dst.size())
         {
             return Err(Trap::TableOutOfBounds);
         }
 
         debug_assert!(
-            (*dst_table).element_type() == (*src_table).element_type(),
+            dst.element_type() == src.element_type(),
             "table element type mismatch"
         );
 
         let src_range = src_index..src_index + len;
         let dst_range = dst_index..dst_index + len;
 
-        // Check if the tables are the same as we cannot mutably borrow and also borrow the same `RefCell`
-        if ptr::eq(dst_table, src_table) {
-            (*dst_table).copy_elements_within(gc_store, dst_range, src_range);
-        } else {
-            Self::copy_elements(gc_store, &mut *dst_table, &*src_table, dst_range, src_range);
-        }
-
-        Ok(())
+        Ok((src_range, dst_range))
     }
 
     /// Return a `VMTableDefinition` for exposing the table to compiled wasm code.


### PR DESCRIPTION
This is some more progress on #11179 aimed at improving the safety of management of tables internally within Wasmtime:

* `Instance::table_index` is removed as it can be replaced with data stored directly in the `VMTableImport` now.
* `Instance::get_table` now returns `&mut Table`
* `Instance::get_defined_table_with_lazy_init` now returns `&mut Table`
* `Instance::with_defined_table_index_and_instance` now directly returns `DefinedTableIndex` plus `Pin<&mut Instance>`, codifying the ability to "laterally move" between instances.
* `Instance::table_init_segment` was refactored to "take" the tables during initialization and replace them afterwards, resolving the split borrow issue and removing an `unsafe` block in the function.

Closes #11179

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
