### PR TITLE
Rename `Instance::run_with` to `Instance::run_concurrent`

### DIFF
--- a/crates/misc/component-async-tests/tests/scenario/borrowing.rs
+++ b/crates/misc/component-async-tests/tests/scenario/borrowing.rs
@@ -107,7 +107,7 @@ pub async fn test_run_bool(components: &[&str], v: bool) -> Result<()> {
         component_async_tests::borrowing_host::bindings::BorrowingHost::new(&mut store, &instance)?;
 
     instance
-        .run_with(&mut store, async move |accessor| {
+        .run_concurrent(&mut store, async move |accessor| {
             // Start three concurrent calls and then join them all:
             let mut futures = FuturesUnordered::new();
             for _ in 0..3 {

--- a/crates/misc/component-async-tests/tests/scenario/round_trip_direct.rs
+++ b/crates/misc/component-async-tests/tests/scenario/round_trip_direct.rs
@@ -66,7 +66,7 @@ async fn test_round_trip_direct(
         )?;
 
         instance
-            .run_with(&mut store, {
+            .run_concurrent(&mut store, {
                 let input = input.to_owned();
                 let expected_output = expected_output.to_owned();
                 async move |accessor| {
@@ -116,7 +116,7 @@ async fn test_round_trip_direct(
 
         // Start three concurrent calls and then join them all:
         instance
-            .run_with(&mut store, async |store| -> wasmtime::Result<_> {
+            .run_concurrent(&mut store, async |store| -> wasmtime::Result<_> {
                 let mut futures = FuturesUnordered::new();
                 for _ in 0..3 {
                     futures.push(

--- a/crates/misc/component-async-tests/tests/scenario/round_trip_many.rs
+++ b/crates/misc/component-async-tests/tests/scenario/round_trip_many.rs
@@ -252,7 +252,7 @@ async fn test_round_trip_many(
 
         if call_style == 0 {
             instance
-                .run_with(&mut store, {
+                .run_concurrent(&mut store, {
                     let c = c.clone();
                     let e = e.clone();
                     let f = f.clone();
@@ -402,7 +402,7 @@ async fn test_round_trip_many(
 
         if call_style == 2 {
             instance
-                .run_with(&mut store, async |store| -> wasmtime::Result<_> {
+                .run_concurrent(&mut store, async |store| -> wasmtime::Result<_> {
                     // Start three concurrent calls and then join them all:
                     let mut futures = FuturesUnordered::new();
                     for (input, output) in inputs_and_outputs {

--- a/crates/misc/component-async-tests/tests/scenario/transmit.rs
+++ b/crates/misc/component-async-tests/tests/scenario/transmit.rs
@@ -127,7 +127,7 @@ async fn test_cancel(mode: Mode) -> Result<()> {
     let instance = linker.instantiate_async(&mut store, &component).await?;
     let cancel_host = cancel::CancelHost::new(&mut store, &instance)?;
     instance
-        .run_with(&mut store, async move |accessor| {
+        .run_concurrent(&mut store, async move |accessor| {
             cancel_host
                 .local_local_cancel()
                 .call_run(accessor, mode, cancel_delay())
@@ -366,7 +366,7 @@ async fn test_transmit_with<Test: TransmitTest + 'static>(component: &str) -> Re
     let (_caller_future2_tx, caller_future2_rx) = instance.future(|| unreachable!(), &mut store)?;
 
     instance
-        .run_with(&mut store, async move |accessor| {
+        .run_concurrent(&mut store, async move |accessor| {
             let mut futures = FuturesUnordered::<
                 Pin<Box<dyn Future<Output = Result<Event<Test>>> + Send>>,
             >::new();

--- a/crates/misc/component-async-tests/tests/scenario/util.rs
+++ b/crates/misc/component-async-tests/tests/scenario/util.rs
@@ -215,7 +215,7 @@ pub async fn test_run_with_count(components: &[&str], count: usize) -> Result<()
 
     // Start `count` concurrent calls and then join them all:
     instance
-        .run_with(&mut store, async |store| {
+        .run_concurrent(&mut store, async |store| {
             let mut futures = FuturesUnordered::new();
             for _ in 0..count {
                 futures.push(yield_host.local_local_run().call_run(store));

--- a/crates/wasi/src/p3/bindings.rs
+++ b/crates/wasi/src/p3/bindings.rs
@@ -222,7 +222,7 @@ pub use self::generated::wasi::*;
 ///     // Instantiate the component and we're off to the races.
 ///     let instance = linker.instantiate_async(&mut store, &component).await?;
 ///     let command = Command::new(&mut store, &instance)?;
-///     let program_result = instance.run_with(&mut store, async move |store| {
+///     let program_result = instance.run_concurrent(&mut store, async move |store| {
 ///         command.wasi_cli_run().call_run(store).await
 ///     }).await??;
 ///     match program_result {

--- a/crates/wasi/tests/all/p3/mod.rs
+++ b/crates/wasi/tests/all/p3/mod.rs
@@ -78,7 +78,7 @@ async fn run(path: &str) -> anyhow::Result<()> {
     let command =
         Command::new(&mut store, &instance).context("failed to instantiate `wasi:cli/command`")?;
     instance
-        .run_with(&mut store, async move |store| {
+        .run_concurrent(&mut store, async move |store| {
             command.wasi_cli_run().call_run(store).await
         })
         .await

--- a/crates/wasmtime/src/runtime/component/concurrent.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent.rs
@@ -12,9 +12,9 @@
 //! between guest tasks and any host tasks they create.  Each
 //! `ComponentInstance` will have at most one event loop running at any given
 //! time, and that loop may be suspended and resumed by the host embedder using
-//! e.g. `Instance::run`.  The `ComponentInstance::poll_until` function contains
-//! the loop itself, while the `ComponentInstance::concurrent_state` field holds
-//! its state.
+//! e.g. `Instance::run_concurrent`.  The `ComponentInstance::poll_until`
+//! function contains the loop itself, while the
+//! `ComponentInstance::concurrent_state` field holds its state.
 //!
 //! # Public API Overview
 //!
@@ -23,7 +23,7 @@
 //! - `[Typed]Func::call_concurrent`: Start a host->guest call to an
 //! async-lifted or sync-lifted import, creating a guest task.
 //!
-//! - `Instance::run[_with]`: Run the event loop for the specified instance,
+//! - `Instance::run_concurrent`: Run the event loop for the specified instance,
 //! allowing any and all tasks belonging to that instance to make progress.
 //!
 //! - `Instance::spawn`: Run a background task as part of the event loop for the
@@ -344,8 +344,8 @@ where
 /// `Accessor<T, D>` it can still be passed to a function which just needs a
 /// store accessor.
 ///
-/// Acquiring an [`Accessor`] can be done through [`Instance::run_with`] for
-/// example or in a host function through
+/// Acquiring an [`Accessor`] can be done through [`Instance::run_concurrent`]
+/// for example or in a host function through
 /// [`Linker::func_wrap_concurrent`](crate::component::Linker::func_wrap_concurrent).
 pub trait AsAccessor {
     /// The `T` in `Store<T>` that this accessor refers to.
@@ -1232,46 +1232,6 @@ impl Instance {
         assert!(state.global_error_context_ref_counts.is_empty());
     }
 
-    /// Poll the specified future as part of this instance's event loop until it
-    /// yields a result _or_ no further progress can be made.
-    ///
-    /// This is intended for use in the top-level code of a host embedding with
-    /// `Future`s which depend (directly or indirectly) on previously-started
-    /// concurrent tasks: e.g. the `Future`s returned by
-    /// `TypedFunc::call_concurrent`, `StreamReader::read`, etc., or `Future`s
-    /// derived from those.
-    ///
-    /// Such `Future`s can only usefully be polled in the context of the event
-    /// loop of the instance from which they originated; they will panic if
-    /// polled elsewhere.  `Future`s returned by host functions registered using
-    /// `LinkerInstance::func_wrap_concurrent` are always polled as part of the
-    /// event loop, so this function is not needed in that case.  However,
-    /// top-level code which needs to poll `Future`s involving concurrent tasks
-    /// must use either this function, `Instance::run_with`, or
-    /// `Instance::spawn` to ensure they are polled as part of the correct event
-    /// loop.
-    ///
-    /// Note that this function will return a "deadlock" error in either of the
-    /// following scenarios:
-    ///
-    /// - One or more guest tasks are still pending (i.e. have not yet returned,
-    /// or, in the case of async-lifted exports with callbacks, have not yet
-    /// returned `CALLBACK_CODE_EXIT`) even though all host tasks have completed
-    /// all host-owned stream and future handles have been dropped, etc.
-    ///
-    /// - Any and all guest tasks complete normally, but the future passed to
-    /// this function continues to return `Pending` when polled.  In that case,
-    /// the future presumably does not depend on any guest task making further
-    /// progress (since no futher progress can be made) and thus is not an
-    /// appropriate future to poll using this function.
-    pub async fn run<F>(&self, mut store: impl AsContextMut, fut: F) -> Result<F::Output>
-    where
-        F: Future,
-    {
-        check_recursive_run();
-        self.poll_until(store.as_context_mut(), fut).await
-    }
-
     /// Run the specified closure `fun` to completion as part of this instance's
     /// event loop.
     ///
@@ -1316,7 +1276,7 @@ impl Instance {
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn run_with<T, R>(
+    pub async fn run_concurrent<T, R>(
         self,
         mut store: impl AsContextMut<Data = T>,
         fun: impl AsyncFnOnce(&Accessor<T>) -> R,
@@ -1327,11 +1287,12 @@ impl Instance {
         check_recursive_run();
         let mut store = store.as_context_mut();
         let token = StoreToken::new(store.as_context_mut());
-        let future = async move {
+
+        self.poll_until(store.as_context_mut(), async move {
             let accessor = Accessor::new(token, self);
             fun(&accessor).await
-        };
-        self.run(store, future).await
+        })
+        .await
     }
 
     /// Spawn a background task to run as part of this instance's event loop.
@@ -1456,12 +1417,13 @@ impl Instance {
                             //
                             // Note that we'd also reach this point if the host
                             // embedder passed e.g. a `std::future::Pending` to
-                            // `Instance::run`, in which case we'd return a
-                            // "deadlock" error even when any and all tasks have
-                            // completed normally.  However, that's not how
-                            // `Instance::run` is intended (and documented) to
-                            // be used, so it seems reasonable to lump that case
-                            // in with "real" deadlocks.
+                            // `Instance::run_concurrent`, in which case we'd
+                            // return a "deadlock" error even when any and all
+                            // tasks have completed normally.  However, that's
+                            // not how `Instance::run_concurrent` is intended
+                            // (and documented) to be used, so it seems
+                            // reasonable to lump that case in with "real"
+                            // deadlocks.
                             //
                             // TODO: Once we've added host APIs for cancelling
                             // in-progress tasks, we can return some other,
@@ -4360,7 +4322,7 @@ fn for_any_lift<
 /// Wrap the specified future in a `poll_fn` which asserts that the future is
 /// only polled from the event loop of the specified `Instance`.
 ///
-/// See `Instance::run` for details.
+/// See `Instance::run_concurrent` for details.
 fn checked<F: Future + Send + 'static>(
     instance: Instance,
     fut: F,
@@ -4393,12 +4355,12 @@ fn checked<F: Future + Send + 'static>(
     }
 }
 
-/// Assert that `Instance::run[_with]` has not been called from within an
+/// Assert that `Instance::run_concurrent` has not been called from within an
 /// instance's event loop.
 fn check_recursive_run() {
     tls::try_get(|store| {
         if !matches!(store, tls::TryGet::None) {
-            panic!("Recursive `Instance::run[_with]` calls not supported")
+            panic!("Recursive `Instance::run_concurrent` calls not supported")
         }
     });
 }
@@ -4567,8 +4529,8 @@ pub(crate) fn prepare_call<T, R>(
 /// the associated `ComponentInstance`'s event loop.
 ///
 /// The returned future will resolve to the result once it is available, but
-/// must only be polled via the instance's event loop.  See `Instance::run` for
-/// details.
+/// must only be polled via the instance's event loop. See
+/// `Instance::run_concurrent` for details.
 pub(crate) fn queue_call<T: 'static, R: Send + 'static>(
     mut store: StoreContextMut<T>,
     prepared: PreparedCall<R>,

--- a/crates/wasmtime/src/runtime/component/concurrent.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent.rs
@@ -1266,7 +1266,7 @@ impl Instance {
     /// # let instance = linker.instantiate_async(&mut store, &component).await?;
     /// # let foo = instance.get_typed_func::<(Resource<MyResource>,), (Resource<MyResource>,)>(&mut store, "foo")?;
     /// # let bar = instance.get_typed_func::<(u32,), ()>(&mut store, "bar")?;
-    /// instance.run_with(&mut store, async |accessor| -> wasmtime::Result<_> {
+    /// instance.run_concurrent(&mut store, async |accessor| -> wasmtime::Result<_> {
     ///    let resource = accessor.with(|mut access| access.get().table.push(MyResource(42)))?;
     ///    let (another_resource,) = foo.call_concurrent(accessor, (resource,)).await?;
     ///    let value = accessor.with(|mut access| access.get().table.delete(another_resource))?;
@@ -4334,7 +4334,7 @@ fn checked<F: Future + Send + 'static>(
                 `Future`s which depend on asynchronous component tasks, streams, or \
                 futures to complete may only be polled from the event loop of the \
                 instance from which they originated.  Please use \
-                `Instance::{run,run_with,spawn}` to poll or await them.\
+                `Instance::{run_concurrent,spawn}` to poll or await them.\
             ";
             tls::try_get(|store| {
                 let matched = match store {

--- a/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams.rs
@@ -538,7 +538,7 @@ impl<T> FutureWriter<T> {
 
     /// Wait for the read end of this `future` is dropped.
     ///
-    /// The [`Accessor`] provided can be acquired from [`Instance::run_with`] or
+    /// The [`Accessor`] provided can be acquired from [`Instance::run_concurrent`] or
     /// from within a host function for example.
     ///
     /// # Panics
@@ -789,7 +789,7 @@ impl<T> FutureReader<T> {
     /// The returned `Future` will yield `None` if the guest has trapped
     /// before it could produce a result.
     ///
-    /// The [`Accessor`] provided can be acquired from [`Instance::run_with`] or
+    /// The [`Accessor`] provided can be acquired from [`Instance::run_concurrent`] or
     /// from within a host function for example.
     ///
     /// # Panics
@@ -825,8 +825,8 @@ impl<T> FutureReader<T> {
 
     /// Wait for the write end of this `future` to be dropped.
     ///
-    /// The [`Accessor`] provided can be acquired from [`Instance::run_with`] or
-    /// from within a host function for example.
+    /// The [`Accessor`] provided can be acquired from
+    /// [`Instance::run_concurrent`] or from within a host function for example.
     ///
     /// # Panics
     ///

--- a/crates/wasmtime/src/runtime/component/func/typed.rs
+++ b/crates/wasmtime/src/runtime/component/func/typed.rs
@@ -232,7 +232,7 @@ where
             let result = concurrent::queue_call(wrapper.store.as_context_mut(), prepared)?;
             self.func
                 .instance
-                .run(wrapper.store.as_context_mut(), result)
+                .run_concurrent(wrapper.store.as_context_mut(), async |_| result.await)
                 .await?
         }
         #[cfg(not(feature = "component-model-async"))]
@@ -250,13 +250,12 @@ where
     /// made using this method may run concurrently with other calls to the same
     /// instance.  In addition, the runtime will call the `post-return` function
     /// (if any) automatically when the guest task completes -- no need to
-    /// explicitly call `Func::post_return` afterward.
+    /// explicitly cll `Func::post_return` afterward.
     ///
-    /// Note that the `Future` returned by this method will panic if polled or
-    /// `.await`ed outside of the event loop of the component instance this
-    /// function belongs to; use `Instance::run`, `Instance::run_with`, or
-    /// `Instance::spawn` to poll it from within the event loop.  See
-    /// [`Instance::run`] for examples.
+    /// # Panics
+    ///
+    /// Panics if the store that the [`Accessor`] is derived from does not own
+    /// this function.
     #[cfg(feature = "component-model-async")]
     pub async fn call_concurrent(
         self,

--- a/crates/wasmtime/src/runtime/component/func/typed.rs
+++ b/crates/wasmtime/src/runtime/component/func/typed.rs
@@ -250,7 +250,7 @@ where
     /// made using this method may run concurrently with other calls to the same
     /// instance.  In addition, the runtime will call the `post-return` function
     /// (if any) automatically when the guest task completes -- no need to
-    /// explicitly cll `Func::post_return` afterward.
+    /// explicitly call `Func::post_return` afterward.
     ///
     /// # Panics
     ///

--- a/tests/all/component_model/bindgen.rs
+++ b/tests/all/component_model/bindgen.rs
@@ -126,7 +126,7 @@ mod no_imports_concurrent {
         let instance = linker.instantiate_async(&mut store, &component).await?;
         let no_imports = NoImports::new(&mut store, &instance)?;
         instance
-            .run_with(&mut store, async move |accessor| {
+            .run_concurrent(&mut store, async move |accessor| {
                 let mut futures = FuturesUnordered::new();
                 futures.push(no_imports.call_bar(accessor).boxed());
                 futures.push(no_imports.foo().call_foo(accessor).boxed());
@@ -294,7 +294,7 @@ mod one_import_concurrent {
         let instance = linker.instantiate_async(&mut store, &component).await?;
         let no_imports = NoImports::new(&mut store, &instance)?;
         instance
-            .run_with(&mut store, async move |accessor| {
+            .run_concurrent(&mut store, async move |accessor| {
                 no_imports.call_bar(accessor).await
             })
             .await??;

--- a/tests/all/component_model/func.rs
+++ b/tests/all/component_model/func.rs
@@ -921,7 +921,7 @@ async fn async_reentrance() -> Result<()> {
     let func = instance.get_typed_func::<(u32,), (u32,)>(&mut store, "export")?;
     let message = "cannot enter component instance";
     match instance
-        .run_with(&mut store, async move |accessor| {
+        .run_concurrent(&mut store, async move |accessor| {
             func.call_concurrent(accessor, (42,)).await
         })
         .await
@@ -1051,7 +1051,7 @@ async fn task_return_trap(component: &str, substring: &str) -> Result<()> {
 
     let func = instance.get_typed_func::<(), ()>(&mut store, "foo")?;
     match instance
-        .run_with(&mut store, async move |accessor| {
+        .run_concurrent(&mut store, async move |accessor| {
             func.call_concurrent(accessor, ()).await
         })
         .await
@@ -1249,7 +1249,7 @@ async fn test_many_parameters(dynamic: bool, concurrent: bool) -> Result<()> {
 
         let mut results = if concurrent {
             instance
-                .run_with(&mut store, async |store| {
+                .run_concurrent(&mut store, async |store| {
                     func.call_concurrent(store, input).await
                 })
                 .await??
@@ -1296,7 +1296,7 @@ async fn test_many_parameters(dynamic: bool, concurrent: bool) -> Result<()> {
 
         if concurrent {
             instance
-                .run_with(&mut store, async move |accessor| {
+                .run_concurrent(&mut store, async move |accessor| {
                     func.call_concurrent(accessor, input).await
                 })
                 .await??
@@ -1684,7 +1684,7 @@ async fn test_many_results(dynamic: bool, concurrent: bool) -> Result<()> {
 
         let mut results = if concurrent {
             instance
-                .run_with(&mut store, async |store| {
+                .run_concurrent(&mut store, async |store| {
                     func.call_concurrent(store, Vec::new()).await
                 })
                 .await??
@@ -1775,7 +1775,7 @@ async fn test_many_results(dynamic: bool, concurrent: bool) -> Result<()> {
 
         if concurrent {
             instance
-                .run_with(&mut store, async move |accessor| {
+                .run_concurrent(&mut store, async move |accessor| {
                     func.call_concurrent(accessor, ()).await
                 })
                 .await??

--- a/tests/all/component_model/import.rs
+++ b/tests/all/component_model/import.rs
@@ -834,7 +834,7 @@ async fn test_stack_and_heap_args_and_rets(concurrent: bool) -> Result<()> {
 
     if concurrent {
         instance
-            .run_with(&mut store, async move |accessor| {
+            .run_concurrent(&mut store, async move |accessor| {
                 run.call_concurrent(accessor, ()).await
             })
             .await??;
@@ -958,7 +958,7 @@ async fn test_stack_and_heap_args_and_rets(concurrent: bool) -> Result<()> {
 
     if concurrent {
         instance
-            .run_with(&mut store, async |store| {
+            .run_concurrent(&mut store, async |store| {
                 run.call_concurrent(store, Vec::new()).await
             })
             .await??;

--- a/tests/all/pulley.rs
+++ b/tests/all/pulley.rs
@@ -486,28 +486,28 @@ async fn pulley_provenance_test_async_components() -> Result<()> {
 
         let run = instance.get_typed_func::<(), ()>(&mut store, "run-stackless")?;
         instance
-            .run_with(&mut store, async move |accessor| {
+            .run_concurrent(&mut store, async move |accessor| {
                 run.call_concurrent(accessor, ()).await
             })
             .await??;
 
         let run = instance.get_typed_func::<(), ()>(&mut store, "run-stackful")?;
         instance
-            .run_with(&mut store, async move |accessor| {
+            .run_concurrent(&mut store, async move |accessor| {
                 run.call_concurrent(accessor, ()).await
             })
             .await??;
 
         let run = instance.get_typed_func::<(), ()>(&mut store, "run-stackless-stackless")?;
         instance
-            .run_with(&mut store, async move |accessor| {
+            .run_concurrent(&mut store, async move |accessor| {
                 run.call_concurrent(accessor, ()).await
             })
             .await??;
 
         let run = instance.get_typed_func::<(), ()>(&mut store, "run-stackful-stackful")?;
         instance
-            .run_with(&mut store, async move |accessor| {
+            .run_concurrent(&mut store, async move |accessor| {
                 run.call_concurrent(accessor, ()).await
             })
             .await??;


### PR DESCRIPTION
This commit renames `run_with` to `run_concurrent` and additionally deletes the `Instance::run` method. With `Accessor`-related changes there's no need to have a "just run with a future" method as almost everything is going to require `run_concurrent` anyway to acquire an accessor.

Closes #11224

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
