### PR TITLE
Enable tracing for p3 generated bindings

### DIFF
--- a/crates/wasi/src/p3/bindings.rs
+++ b/crates/wasi/src/p3/bindings.rs
@@ -117,9 +117,7 @@ mod generated {
     wasmtime::component::bindgen!({
         path: "src/p3/wit",
         world: "wasi:cli/command",
-        // TODO: Enable `tracing` once fixed:
-        // https://github.com/bytecodealliance/wasmtime/issues/11245
-        //tracing: true,
+        tracing: true,
         trappable_imports: true,
         concurrent_exports: true,
         concurrent_imports: true,

--- a/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams.rs
@@ -671,6 +671,14 @@ impl<T> HostFuture<T> {
     }
 }
 
+impl<T> fmt::Debug for HostFuture<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("HostFuture")
+            .field("rep", &self.rep)
+            .finish()
+    }
+}
+
 /// Transfer ownership of the read end of a future from the host to a guest.
 pub(crate) fn lower_future_to_index<U>(
     rep: u32,
@@ -1058,6 +1066,14 @@ impl<T> HostStream<T> {
             }
             _ => func::bad_type_info(),
         }
+    }
+}
+
+impl<T> fmt::Debug for HostStream<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("HostStream")
+            .field("rep", &self.rep)
+            .finish()
     }
 }
 


### PR DESCRIPTION
This adds missing `Debug` implementations for `Host{Future,Stream}` which enables turning on `tracing`.

Closes #11245

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
