### PR TITLE
Increase minimum available stacks when fuzzing wast tests

### DIFF
--- a/crates/fuzzing/src/generators/config.rs
+++ b/crates/fuzzing/src/generators/config.rs
@@ -229,6 +229,7 @@ impl Config {
             pooling.component_instance_size = pooling
                 .component_instance_size
                 .max(limits::CORE_INSTANCE_SIZE);
+            pooling.total_stacks = pooling.total_stacks.max(limits::TOTAL_STACKS);
         }
 
         // Return the test configuration that this fuzz configuration represents

--- a/crates/test-util/src/wast.rs
+++ b/crates/test-util/src/wast.rs
@@ -25,6 +25,7 @@ pub mod limits {
     pub const CORE_INSTANCES: u32 = 900;
     pub const TABLE_ELEMENTS: usize = 1000;
     pub const CORE_INSTANCE_SIZE: usize = 64 * 1024;
+    pub const TOTAL_STACKS: u32 = 10;
 }
 
 /// Local all `*.wast` tests under `root` which should be the path to the root


### PR DESCRIPTION
This fixes a fuzz failure with the new async tests which require more than one stack.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
