### PR TITLE
Add more domains to tls_sample_application

### DIFF
--- a/crates/wasi-tls/tests/main.rs
+++ b/crates/wasi-tls/tests/main.rs
@@ -27,6 +27,7 @@ async fn run_test(path: &str) -> Result<()> {
     let ctx = Ctx {
         table: ResourceTable::new(),
         wasi_ctx: WasiCtxBuilder::new()
+            .inherit_stdout()
             .inherit_stderr()
             .inherit_network()
             .allow_ip_name_lookup(true)


### PR DESCRIPTION
Both our current domains failed in
https://github.com/bytecodealliance/wasmtime/actions/runs/16349123310/job/46190913918 so add a few more.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
