### PR TITLE
Change signature of `Func::call_concurrent`

### DIFF
--- a/crates/misc/component-async-tests/tests/scenario/round_trip.rs
+++ b/crates/misc/component-async-tests/tests/scenario/round_trip.rs
@@ -389,11 +389,17 @@ pub async fn test_round_trip(
                     let mut futures = FuturesUnordered::new();
                     for (input, output) in inputs_and_outputs {
                         let output = (*output).to_owned();
-                        futures.push(
+                        futures.push(async move {
+                            let mut results = vec![Val::Bool(false)];
                             foo_function
-                                .call_concurrent(store, vec![Val::String((*input).to_owned())])
-                                .map(move |v| v.map(move |v| (v, output))),
-                        );
+                                .call_concurrent(
+                                    store,
+                                    &[Val::String((*input).to_owned())],
+                                    &mut results,
+                                )
+                                .await?;
+                            anyhow::Ok((results, output))
+                        });
                     }
 
                     while let Some((actual, expected)) = futures.try_next().await? {

--- a/crates/misc/component-async-tests/tests/scenario/round_trip_many.rs
+++ b/crates/misc/component-async-tests/tests/scenario/round_trip_many.rs
@@ -407,11 +407,13 @@ async fn test_round_trip_many(
                     let mut futures = FuturesUnordered::new();
                     for (input, output) in inputs_and_outputs {
                         let output = (*output).to_owned();
-                        futures.push(
+                        futures.push(async move {
+                            let mut result = vec![Val::Bool(false)];
                             foo_function
-                                .call_concurrent(store, make(input))
-                                .map(move |v| v.map(move |v| (v, output))),
-                        );
+                                .call_concurrent(store, &make(input), &mut result)
+                                .await?;
+                            anyhow::Ok((result, output))
+                        });
                     }
 
                     while let Some((actual, expected)) = futures.try_next().await? {

--- a/crates/wasmtime/src/runtime/component/func.rs
+++ b/crates/wasmtime/src/runtime/component/func.rs
@@ -17,10 +17,6 @@ use wasmtime_environ::component::{
 
 #[cfg(feature = "component-model-async")]
 use crate::component::concurrent::{self, AsAccessor, PreparedCall};
-#[cfg(feature = "component-model-async")]
-use core::future::Future;
-#[cfg(feature = "component-model-async")]
-use core::pin::Pin;
 
 mod host;
 mod options;
@@ -280,36 +276,51 @@ impl Func {
         results: &mut [Val],
     ) -> Result<()> {
         let mut store = store.as_context_mut();
-        assert!(
-            store.0.async_support(),
-            "cannot use `call_async` without enabling async support in the config"
-        );
+
         #[cfg(feature = "component-model-async")]
         {
-            let future =
-                self.call_concurrent_dynamic(store.as_context_mut(), params.to_vec(), false);
-            let run_results = self
-                .instance
-                .run_concurrent(store, async |_| future.await)
-                .await??;
-            assert_eq!(run_results.len(), results.len());
-            for (result, slot) in run_results.into_iter().zip(results) {
-                *slot = result;
-            }
-            Ok(())
+            self.instance
+                .run_concurrent(&mut store, async |store| {
+                    self.call_concurrent_dynamic(store, params, results, false)
+                        .await
+                })
+                .await?
         }
         #[cfg(not(feature = "component-model-async"))]
         {
+            assert!(
+                store.0.async_support(),
+                "cannot use `call_async` without enabling async support in the config"
+            );
             store
                 .on_fiber(|store| self.call_impl(store, params, results))
                 .await?
         }
     }
 
-    fn check_param_count<T>(&self, store: StoreContextMut<T>, count: usize) -> Result<()> {
+    fn check_params_results<T>(
+        &self,
+        store: StoreContextMut<T>,
+        params: &[Val],
+        results: &mut [Val],
+    ) -> Result<()> {
         let param_tys = self.params(&store);
-        if param_tys.len() != count {
-            bail!("expected {} argument(s), got {count}", param_tys.len());
+        if param_tys.len() != params.len() {
+            bail!(
+                "expected {} argument(s), got {}",
+                param_tys.len(),
+                params.len(),
+            );
+        }
+
+        let result_tys = self.results(&store);
+
+        if result_tys.len() != results.len() {
+            bail!(
+                "expected {} result(s), got {}",
+                result_tys.len(),
+                results.len(),
+            );
         }
 
         Ok(())
@@ -332,40 +343,43 @@ impl Func {
     pub async fn call_concurrent(
         self,
         accessor: impl AsAccessor<Data: Send>,
-        params: Vec<Val>,
-    ) -> Result<Vec<Val>> {
-        let accessor = accessor.as_accessor();
-        let result = accessor.with(|mut access| {
-            let store = access.as_context_mut();
-            assert!(
-                store.0.async_support(),
-                "cannot use `call_concurrent` when async support is not enabled on the config"
-            );
-
-            self.call_concurrent_dynamic(store, params, true)
-        });
-        result.await
+        params: &[Val],
+        results: &mut [Val],
+    ) -> Result<()> {
+        self.call_concurrent_dynamic(accessor.as_accessor(), params, results, true)
+            .await
     }
 
     /// Internal helper function for `call_async` and `call_concurrent`.
     #[cfg(feature = "component-model-async")]
-    fn call_concurrent_dynamic<'a, T: Send + 'static>(
+    async fn call_concurrent_dynamic(
         self,
-        mut store: StoreContextMut<'a, T>,
-        params: Vec<Val>,
+        store: impl AsAccessor<Data: Send>,
+        params: &[Val],
+        results: &mut [Val],
         call_post_return_automatically: bool,
-    ) -> Pin<Box<dyn Future<Output = Result<Vec<Val>>> + Send + 'static>> {
-        let result = (|| {
-            self.check_param_count(store.as_context_mut(), params.len())?;
+    ) -> Result<()> {
+        let store = store.as_accessor();
+        let result = store.with(|mut store| {
+            assert!(
+                store.as_context_mut().0.async_support(),
+                "cannot use `call_concurrent` when async support is not enabled on the config"
+            );
+            self.check_params_results(store.as_context_mut(), params, results)?;
             let prepared = self.prepare_call_dynamic(
                 store.as_context_mut(),
-                params,
+                params.to_vec(),
                 call_post_return_automatically,
             )?;
-            concurrent::queue_call(store, prepared)
-        })();
+            concurrent::queue_call(store.as_context_mut(), prepared)
+        })?;
 
-        Box::pin(async move { result?.await })
+        let run_results = result.await?;
+        assert_eq!(run_results.len(), results.len());
+        for (result, slot) in run_results.into_iter().zip(results) {
+            *slot = result;
+        }
+        Ok(())
     }
 
     /// Calls `concurrent::prepare_call` with monomorphized functions for
@@ -412,17 +426,7 @@ impl Func {
     ) -> Result<()> {
         let mut store = store.as_context_mut();
 
-        self.check_param_count(store.as_context_mut(), params.len())?;
-
-        let result_tys = self.results(&store);
-
-        if result_tys.len() != results.len() {
-            bail!(
-                "expected {} result(s), got {}",
-                result_tys.len(),
-                results.len()
-            );
-        }
+        self.check_params_results(store.as_context_mut(), params, results)?;
 
         if self.abi_async(store.0) {
             unreachable!(

--- a/tests/all/component_model/func.rs
+++ b/tests/all/component_model/func.rs
@@ -1247,19 +1247,17 @@ async fn test_many_parameters(dynamic: bool, concurrent: bool) -> Result<()> {
         ];
         let func = instance.get_func(&mut store, "many-param").unwrap();
 
-        let mut results = if concurrent {
+        let mut results = vec![Val::Bool(false)];
+        if concurrent {
             instance
                 .run_concurrent(&mut store, async |store| {
-                    func.call_concurrent(store, input).await
+                    func.call_concurrent(store, &input, &mut results).await
                 })
-                .await??
-                .into_iter()
+                .await??;
         } else {
-            let mut results = vec![Val::Bool(false)];
             func.call_async(&mut store, &input, &mut results).await?;
-            results.into_iter()
         };
-
+        let mut results = results.into_iter();
         let Some(Val::Tuple(results)) = results.next() else {
             panic!()
         };
@@ -1682,18 +1680,17 @@ async fn test_many_results(dynamic: bool, concurrent: bool) -> Result<()> {
     let actual = if dynamic {
         let func = instance.get_func(&mut store, "many-results").unwrap();
 
-        let mut results = if concurrent {
+        let mut results = vec![Val::Bool(false)];
+        if concurrent {
             instance
                 .run_concurrent(&mut store, async |store| {
-                    func.call_concurrent(store, Vec::new()).await
+                    func.call_concurrent(store, &[], &mut results).await
                 })
-                .await??
-                .into_iter()
+                .await??;
         } else {
-            let mut results = vec![Val::Bool(false)];
             func.call_async(&mut store, &[], &mut results).await?;
-            results.into_iter()
         };
+        let mut results = results.into_iter();
 
         let Some(Val::Tuple(results)) = results.next() else {
             panic!()

--- a/tests/all/component_model/import.rs
+++ b/tests/all/component_model/import.rs
@@ -959,7 +959,7 @@ async fn test_stack_and_heap_args_and_rets(concurrent: bool) -> Result<()> {
     if concurrent {
         instance
             .run_concurrent(&mut store, async |store| {
-                run.call_concurrent(store, Vec::new()).await
+                run.call_concurrent(store, &[], &mut []).await
             })
             .await??;
     } else {


### PR DESCRIPTION
Update it to use slices in a similar manner to `Func::call_async`.

Closes #11218

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
