### PR TITLE
make `memory` option optional for `{future,stream}.{read,write}`

### DIFF
--- a/crates/cranelift/src/compiler/component.rs
+++ b/crates/cranelift/src/compiler/component.rs
@@ -1314,7 +1314,7 @@ impl<'a> TrampolineCompiler<'a> {
             };
 
             // memory: *mut VMMemoryDefinition
-            callee_args.push(self.load_memory(vmctx, mem_opts.memory.unwrap()));
+            callee_args.push(self.load_optional_memory(vmctx, mem_opts.memory));
             // realloc: *mut VMFuncRef
             callee_args.push(self.load_realloc(vmctx, mem_opts.realloc));
             // string_encoding: StringEncoding

--- a/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams.rs
@@ -2275,8 +2275,9 @@ impl Instance {
 
     /// Write to the specified stream or future from the guest.
     ///
-    /// SAFETY: `memory` and `realloc` must be valid pointers to their
-    /// respective guest entities.
+    /// SAFETY: `memory` and `realloc` must be either be valid pointers to their
+    /// respective guest entities or null if not applicable (e.g. for a future
+    /// or stream with no payload type).
     pub(super) unsafe fn guest_write<T: 'static>(
         self,
         mut store: StoreContextMut<T>,
@@ -2297,7 +2298,7 @@ impl Instance {
         let address = usize::try_from(address).unwrap();
         let count = usize::try_from(count).unwrap();
         // SAFETY: Per this function's contract, `memory` and `realloc` are
-        // valid.
+        // either valid or null.
         let options = unsafe {
             Options::new(
                 store.0.store_opaque().id(),
@@ -2510,8 +2511,9 @@ impl Instance {
 
     /// Read from the specified stream or future from the guest.
     ///
-    /// SAFETY: `memory` and `realloc` must be valid pointers to their
-    /// respective guest entities.
+    /// SAFETY: `memory` and `realloc` must be either be valid pointers to their
+    /// respective guest entities or null if not applicable (e.g. for a future
+    /// or stream with no payload type).
     pub(super) unsafe fn guest_read<T: 'static>(
         self,
         mut store: StoreContextMut<T>,
@@ -2531,7 +2533,7 @@ impl Instance {
 
         let address = usize::try_from(address).unwrap();
         // SAFETY: Per this function's contract, `memory` and `realloc` must be
-        // valid.
+        // valid or null.
         let options = unsafe {
             Options::new(
                 store.0.store_opaque().id(),

--- a/tests/misc_testsuite/component-model-async/empty-wait.wast
+++ b/tests/misc_testsuite/component-model-async/empty-wait.wast
@@ -96,8 +96,8 @@
     (canon waitable-set.new (core func $waitable-set.new))
     (canon waitable-set.wait (memory $memory "mem") (core func $waitable-set.wait))
     (canon future.new $FT (core func $future.new))
-    (canon future.read $FT async (memory $memory "mem") (core func $future.read))
-    (canon future.write $FT async (memory $memory "mem") (core func $future.write))
+    (canon future.read $FT async (core func $future.read))
+    (canon future.write $FT async (core func $future.write))
     (canon future.drop-readable $FT (core func $future.drop-readable))
     (canon future.drop-writable $FT (core func $future.drop-writable))
     (core instance $cm (instantiate $CM (with "" (instance


### PR DESCRIPTION
Per the Component Model async ABI spec, this option need not be present for payload-less streams and futures.

Fixes #11251

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
