### PR TITLE
x64: Add EVEX shifts to the new assembler

### DIFF
--- a/cranelift/assembler-x64/meta/src/dsl.rs
+++ b/cranelift/assembler-x64/meta/src/dsl.rs
@@ -13,7 +13,7 @@ pub use custom::{Custom, Customization};
 pub use encoding::{Encoding, ModRmKind, OpcodeMod};
 pub use encoding::{Evex, Length, Vex, VexEscape, VexPrefix, evex, vex};
 pub use encoding::{
-    Group1Prefix, Group2Prefix, Group3Prefix, Group4Prefix, Opcodes, Prefixes, Rex, rex,
+    Group1Prefix, Group2Prefix, Group3Prefix, Group4Prefix, Opcodes, Prefixes, Rex, TupleType, rex,
 };
 pub use features::{ALL_FEATURES, Feature, Features};
 pub use format::{Eflags, Extension, Format, Location, Mutability, Operand, OperandKind, RegClass};

--- a/cranelift/assembler-x64/meta/src/generate/format.rs
+++ b/cranelift/assembler-x64/meta/src/generate/format.rs
@@ -18,7 +18,11 @@ enum ModRmStyle {
 
     /// The R/M bits are encoded with `rm` which is a `GprMem` or `XmmMem`, and
     /// the Reg/Opcode bits are encoded with `reg`.
-    RegMem { reg: ModRmReg, rm: dsl::Location },
+    RegMem {
+        reg: ModRmReg,
+        rm: dsl::Location,
+        evex_scaling: Option<i8>,
+    },
 
     /// Same as `RegMem` above except that this is also used for VEX-encoded
     /// instructios with "/is4" which indicates that the 4th register operand
@@ -27,6 +31,7 @@ enum ModRmStyle {
         reg: ModRmReg,
         rm: dsl::Location,
         is4: dsl::Location,
+        evex_scaling: Option<i8>,
     },
 }
 
@@ -183,6 +188,7 @@ impl dsl::Format {
                 ModRmStyle::RegMem {
                     reg: ModRmReg::Digit(digit),
                     rm: *mem,
+                    evex_scaling: None,
                 }
             }
             [Reg(reg), RegMem(mem) | Mem(mem)]
@@ -194,6 +200,7 @@ impl dsl::Format {
                 ModRmStyle::RegMem {
                     reg: ModRmReg::Reg(*reg),
                     rm: *mem,
+                    evex_scaling: None,
                 }
             }
             [Reg(dst), Reg(src), Imm(_)] | [Reg(dst), Reg(src)] => {
@@ -214,8 +221,6 @@ impl dsl::Format {
     }
 
     fn generate_vex_prefix(&self, f: &mut Formatter, vex: &dsl::Vex) -> ModRmStyle {
-        use dsl::OperandKind::{FixedReg, Imm, Mem, Reg, RegMem};
-
         f.empty_line();
         f.comment("Emit VEX prefix.");
         fmtln!(f, "let len = {:#03b};", vex.length.vex_bits());
@@ -224,13 +229,95 @@ impl dsl::Format {
         fmtln!(f, "let w = {};", vex.w.as_bool());
         let bits = "len, pp, mmmmm, w";
 
+        self.generate_vex_or_evex_prefix(f, "VexPrefix", &bits, vex.is4, None, || {
+            vex.unwrap_digit()
+        })
+    }
+
+    fn generate_evex_prefix(&self, f: &mut Formatter, evex: &dsl::Evex) -> ModRmStyle {
+        f.empty_line();
+        f.comment("Emit EVEX prefix.");
+        let ll = evex.length.evex_bits();
+        fmtln!(f, "let ll = {ll:#04b};");
+        fmtln!(f, "let pp = {:#04b};", evex.pp.map_or(0b00, |pp| pp.bits()));
+        fmtln!(f, "let mmm = {:#07b};", evex.mmm.unwrap().bits());
+        fmtln!(f, "let w = {};", evex.w.as_bool());
+        // NB: when bcast is supported in the future the `evex_scaling`
+        // calculation for `Full` and `Half` below need to be updated.
+        let bcast = false;
+        fmtln!(f, "let bcast = {bcast};");
+        let bits = format!("ll, pp, mmm, w, bcast");
+        let is4 = false;
+
+        let length_bytes = match evex.length {
+            dsl::Length::LZ | dsl::Length::LIG => unimplemented!(),
+            dsl::Length::L128 => 16,
+            dsl::Length::L256 => 32,
+            dsl::Length::L512 => 64,
+        };
+
+        // Figure out, according to table 2-34 and 2-35 in the Intel manual,
+        // what the scaling factor is for 8-bit displacements to pass through to
+        // encoding.
+        let evex_scaling = Some(match evex.tuple_type {
+            dsl::TupleType::Full => {
+                assert!(!bcast);
+                length_bytes
+            }
+            dsl::TupleType::Half => {
+                assert!(!bcast);
+                length_bytes / 2
+            }
+            dsl::TupleType::FullMem => length_bytes,
+            // FIXME: according to table 2-35 this needs to take into account
+            // "InputSize" which isn't accounted for in our `Evex` structure at
+            // this time.
+            dsl::TupleType::Tuple1Scalar => unimplemented!(),
+            dsl::TupleType::Tuple1Fixed => unimplemented!(),
+            dsl::TupleType::Tuple2 => unimplemented!(),
+            dsl::TupleType::Tuple4 => unimplemented!(),
+            dsl::TupleType::Tuple8 => 32,
+            dsl::TupleType::HalfMem => length_bytes / 2,
+            dsl::TupleType::QuarterMem => length_bytes / 4,
+            dsl::TupleType::EigthMem => length_bytes / 8,
+            dsl::TupleType::Mem128 => 16,
+            dsl::TupleType::Movddup => match evex.length {
+                dsl::Length::LZ | dsl::Length::LIG => unimplemented!(),
+                dsl::Length::L128 => 8,
+                dsl::Length::L256 => 32,
+                dsl::Length::L512 => 64,
+            },
+        });
+
+        self.generate_vex_or_evex_prefix(f, "EvexPrefix", &bits, is4, evex_scaling, || {
+            evex.unwrap_digit()
+        })
+    }
+
+    /// Helper function to generate either a vex or evex prefix, mostly handling
+    /// all the operand formats and structures here the same between the two
+    /// forms.
+    fn generate_vex_or_evex_prefix(
+        &self,
+        f: &mut Formatter,
+        prefix_type: &str,
+        bits: &str,
+        is4: bool,
+        evex_scaling: Option<i8>,
+        unwrap_digit: impl Fn() -> Option<u8>,
+    ) -> ModRmStyle {
+        use dsl::OperandKind::{FixedReg, Imm, Mem, Reg, RegMem};
+
         let style = match self.operands_by_kind().as_slice() {
             [Reg(reg), Reg(vvvv), Reg(rm)] => {
-                assert!(!vex.is4);
+                assert!(!is4);
                 fmtln!(f, "let reg = self.{reg}.enc();");
                 fmtln!(f, "let vvvv = self.{vvvv}.enc();");
                 fmtln!(f, "let rm = self.{rm}.encode_bx_regs();");
-                fmtln!(f, "let vex = VexPrefix::three_op(reg, vvvv, rm, {bits});");
+                fmtln!(
+                    f,
+                    "let prefix = {prefix_type}::three_op(reg, vvvv, rm, {bits});"
+                );
                 ModRmStyle::Reg {
                     reg: ModRmReg::Reg(*reg),
                     rm: *rm,
@@ -240,75 +327,91 @@ impl dsl::Format {
             | [Reg(reg), Reg(vvvv), Mem(rm)]
             | [Reg(reg), Reg(vvvv), RegMem(rm), Imm(_) | FixedReg(_)]
             | [Reg(reg), RegMem(rm), Reg(vvvv)] => {
-                assert!(!vex.is4);
+                assert!(!is4);
                 fmtln!(f, "let reg = self.{reg}.enc();");
                 fmtln!(f, "let vvvv = self.{vvvv}.enc();");
                 fmtln!(f, "let rm = self.{rm}.encode_bx_regs();");
-                fmtln!(f, "let vex = VexPrefix::three_op(reg, vvvv, rm, {bits});");
+                fmtln!(
+                    f,
+                    "let prefix = {prefix_type}::three_op(reg, vvvv, rm, {bits});"
+                );
                 ModRmStyle::RegMem {
                     reg: ModRmReg::Reg(*reg),
                     rm: *rm,
+                    evex_scaling,
                 }
             }
-            [Reg(reg), Reg(vvvv), RegMem(rm), Reg(is4)] => {
-                assert!(vex.is4);
+            [Reg(reg), Reg(vvvv), RegMem(rm), Reg(r_is4)] => {
+                assert!(is4);
                 fmtln!(f, "let reg = self.{reg}.enc();");
                 fmtln!(f, "let vvvv = self.{vvvv}.enc();");
                 fmtln!(f, "let rm = self.{rm}.encode_bx_regs();");
-                fmtln!(f, "let vex = VexPrefix::three_op(reg, vvvv, rm, {bits});");
+                fmtln!(
+                    f,
+                    "let prefix = {prefix_type}::three_op(reg, vvvv, rm, {bits});"
+                );
                 ModRmStyle::RegMemIs4 {
                     reg: ModRmReg::Reg(*reg),
                     rm: *rm,
-                    is4: *is4,
+                    is4: *r_is4,
+                    evex_scaling,
                 }
             }
             [Reg(reg_or_vvvv), RegMem(rm)]
             | [RegMem(rm), Reg(reg_or_vvvv)]
-            | [Reg(reg_or_vvvv), RegMem(rm), Imm(_)] => match vex.unwrap_digit() {
+            | [Reg(reg_or_vvvv), RegMem(rm), Imm(_)] => match unwrap_digit() {
                 Some(digit) => {
-                    assert!(!vex.is4);
+                    assert!(!is4);
                     let vvvv = reg_or_vvvv;
                     fmtln!(f, "let reg = {digit:#x};");
                     fmtln!(f, "let vvvv = self.{vvvv}.enc();");
                     fmtln!(f, "let rm = self.{rm}.encode_bx_regs();");
-                    fmtln!(f, "let vex = VexPrefix::three_op(reg, vvvv, rm, {bits});");
+                    fmtln!(
+                        f,
+                        "let prefix = {prefix_type}::three_op(reg, vvvv, rm, {bits});"
+                    );
                     ModRmStyle::RegMem {
                         reg: ModRmReg::Digit(digit),
                         rm: *rm,
+                        evex_scaling,
                     }
                 }
                 None => {
-                    assert!(!vex.is4);
+                    assert!(!is4);
                     let reg = reg_or_vvvv;
                     fmtln!(f, "let reg = self.{reg}.enc();");
                     fmtln!(f, "let rm = self.{rm}.encode_bx_regs();");
-                    fmtln!(f, "let vex = VexPrefix::two_op(reg, rm, {bits});");
+                    fmtln!(f, "let prefix = {prefix_type}::two_op(reg, rm, {bits});");
                     ModRmStyle::RegMem {
                         reg: ModRmReg::Reg(*reg),
                         rm: *rm,
+                        evex_scaling,
                     }
                 }
             },
             [Reg(reg_or_vvvv), Reg(rm)] | [Reg(reg_or_vvvv), Reg(rm), Imm(_)] => {
-                match vex.unwrap_digit() {
+                match unwrap_digit() {
                     Some(digit) => {
-                        assert!(!vex.is4);
+                        assert!(!is4);
                         let vvvv = reg_or_vvvv;
                         fmtln!(f, "let reg = {digit:#x};");
                         fmtln!(f, "let vvvv = self.{vvvv}.enc();");
                         fmtln!(f, "let rm = self.{rm}.encode_bx_regs();");
-                        fmtln!(f, "let vex = VexPrefix::three_op(reg, vvvv, rm, {bits});");
+                        fmtln!(
+                            f,
+                            "let prefix = {prefix_type}::three_op(reg, vvvv, rm, {bits});"
+                        );
                         ModRmStyle::Reg {
                             reg: ModRmReg::Digit(digit),
                             rm: *rm,
                         }
                     }
                     None => {
-                        assert!(!vex.is4);
+                        assert!(!is4);
                         let reg = reg_or_vvvv;
                         fmtln!(f, "let reg = self.{reg}.enc();");
                         fmtln!(f, "let rm = self.{rm}.encode_bx_regs();");
-                        fmtln!(f, "let vex = VexPrefix::two_op(reg, rm, {bits});");
+                        fmtln!(f, "let prefix = {prefix_type}::two_op(reg, rm, {bits});");
                         ModRmStyle::Reg {
                             reg: ModRmReg::Reg(*reg),
                             rm: *rm,
@@ -317,49 +420,20 @@ impl dsl::Format {
                 }
             }
             [Reg(reg), Mem(rm)] | [Mem(rm), Reg(reg)] | [RegMem(rm), Reg(reg), Imm(_)] => {
-                assert!(!vex.is4);
+                assert!(!is4);
                 fmtln!(f, "let reg = self.{reg}.enc();");
                 fmtln!(f, "let rm = self.{rm}.encode_bx_regs();");
-                fmtln!(f, "let vex = VexPrefix::two_op(reg, rm, {bits});");
+                fmtln!(f, "let prefix = {prefix_type}::two_op(reg, rm, {bits});");
                 ModRmStyle::RegMem {
                     reg: ModRmReg::Reg(*reg),
                     rm: *rm,
+                    evex_scaling,
                 }
             }
             unknown => unimplemented!("unknown pattern: {unknown:?}"),
         };
 
-        fmtln!(f, "vex.encode(buf);");
-        style
-    }
-
-    fn generate_evex_prefix(&self, f: &mut Formatter, evex: &dsl::Evex) -> ModRmStyle {
-        use dsl::OperandKind::{Reg, RegMem};
-
-        f.empty_line();
-        f.comment("Emit EVEX prefix.");
-        let ll = evex.length.evex_bits();
-        fmtln!(f, "let ll = {ll:#04b};");
-        fmtln!(f, "let pp = {:#04b};", evex.pp.map_or(0b00, |pp| pp.bits()));
-        fmtln!(f, "let mmm = {:#07b};", evex.mmm.unwrap().bits());
-        fmtln!(f, "let w = {};", evex.w.as_bool());
-        fmtln!(f, "let bcast = false;");
-        let bits = format!("ll, pp, mmm, w, bcast");
-
-        let style = match self.operands_by_kind().as_slice() {
-            [Reg(reg), Reg(vvvv), RegMem(rm)] => {
-                fmtln!(f, "let reg = self.{reg}.enc();");
-                fmtln!(f, "let vvvv = self.{vvvv}.enc();");
-                fmtln!(f, "let rm = self.{rm}.encode_bx_regs();");
-                fmtln!(f, "let evex = EvexPrefix::new(reg, vvvv, rm, {bits});");
-                ModRmStyle::RegMem {
-                    reg: ModRmReg::Reg(*reg),
-                    rm: *rm,
-                }
-            }
-            unknown => unimplemented!("unknown pattern: {unknown:?}"),
-        };
-        fmtln!(f, "evex.encode(buf);");
+        fmtln!(f, "prefix.encode(buf);");
         style
     }
 
@@ -382,14 +456,24 @@ impl dsl::Format {
 
         match modrm_style {
             ModRmStyle::None => {}
-            ModRmStyle::RegMem { reg, rm } | ModRmStyle::RegMemIs4 { reg, rm, is4: _ } => {
+            ModRmStyle::RegMem {
+                reg,
+                rm,
+                evex_scaling,
+            }
+            | ModRmStyle::RegMemIs4 {
+                reg,
+                rm,
+                is4: _,
+                evex_scaling,
+            } => {
                 match reg {
                     ModRmReg::Reg(reg) => fmtln!(f, "let reg = self.{reg}.enc();"),
                     ModRmReg::Digit(digit) => fmtln!(f, "let reg = {digit:#x};"),
                 }
                 fmtln!(
                     f,
-                    "self.{rm}.encode_rex_suffixes(buf, reg, {bytes_at_end});"
+                    "self.{rm}.encode_rex_suffixes(buf, reg, {bytes_at_end}, {evex_scaling:?});"
                 );
             }
             ModRmStyle::Reg { reg, rm } => {

--- a/cranelift/assembler-x64/meta/src/instructions/add.rs
+++ b/cranelift/assembler-x64/meta/src/instructions/add.rs
@@ -1,4 +1,4 @@
-use crate::dsl::{Customization::*, Feature::*, Inst, Length::*, Location::*};
+use crate::dsl::{Customization::*, Feature::*, Inst, Length::*, Location::*, TupleType::*};
 use crate::dsl::{align, evex, fmt, inst, r, rex, rw, sxl, sxq, vex, w};
 
 #[rustfmt::skip] // Keeps instructions on a single line.
@@ -96,6 +96,6 @@ pub fn list() -> Vec<Inst> {
         inst("vpaddusw", fmt("B", [w(xmm1), r(xmm2), r(xmm_m128)]), vex(L128)._66()._0f().op(0xDD).r(), _64b | compat | avx),
         inst("vphaddw", fmt("B", [w(xmm1), r(xmm2), r(xmm_m128)]), vex(L128)._66()._0f38().op(0x01).r(), _64b | compat | avx),
         inst("vphaddd", fmt("B", [w(xmm1), r(xmm2), r(xmm_m128)]), vex(L128)._66()._0f38().op(0x02).r(), _64b | compat | avx),
-        inst("vaddpd", fmt("C", [w(xmm1), r(xmm2), r(xmm_m128)]), evex(L128)._66()._0f().w1().op(0x58).r(), _64b | compat | avx512vl),
+        inst("vaddpd", fmt("C", [w(xmm1), r(xmm2), r(xmm_m128)]), evex(L128, Full)._66()._0f().w1().op(0x58).r(), _64b | compat | avx512vl),
     ]
 }

--- a/cranelift/assembler-x64/meta/src/instructions/shift.rs
+++ b/cranelift/assembler-x64/meta/src/instructions/shift.rs
@@ -1,5 +1,5 @@
-use crate::dsl::{Customization::*, Feature::*, Inst, Length::*, Location::*};
-use crate::dsl::{align, fmt, inst, r, rex, rw, vex, w};
+use crate::dsl::{Customization::*, Feature::*, Inst, Length::*, Location::*, TupleType::*};
+use crate::dsl::{align, evex, fmt, inst, r, rex, rw, vex, w};
 
 #[rustfmt::skip] // Keeps instructions on a single line.
 pub fn list() -> Vec<Inst> {
@@ -98,6 +98,14 @@ pub fn list() -> Vec<Inst> {
         inst("vpslld", fmt("D", [w(xmm1), r(xmm2), r(imm8)]), vex(L128)._66()._0f().op(0x72).digit(6).ib(), _64b | compat | avx),
         inst("vpsllq", fmt("C", [w(xmm1), r(xmm2), r(xmm_m128)]), vex(L128)._66()._0f().op(0xF3).r(), _64b | compat | avx),
         inst("vpsllq", fmt("D", [w(xmm1), r(xmm2), r(imm8)]), vex(L128)._66()._0f().op(0x73).digit(6).ib(), _64b | compat | avx),
+        // FIXME: uncomment once the avx512bw feature is bound
+        // inst("vpsllw", fmt("G", [w(xmm1), r(xmm2), r(xmm_m128)]), evex(L128, Mem128)._66()._0f().wig().op(0xF1).r(), _64b | compat | avx512vl | avx512bw),
+        // inst("vpsllw", fmt("E", [w(xmm1), r(xmm_m128), r(imm8)]), evex(L128, FullMem)._66()._0f().wig().op(0x71).digit(6).ib(), _64b | compat | avx512vl | avx512bw),
+        inst("vpslld", fmt("G", [w(xmm1), r(xmm2), r(xmm_m128)]), evex(L128, Mem128)._66()._0f().w0().op(0xF2).r(), _64b | compat | avx512vl | avx512f),
+        inst("vpslld", fmt("F", [w(xmm1), r(xmm_m128), r(imm8)]), evex(L128, Full)._66()._0f().w0().op(0x72).digit(6).ib(), _64b | compat | avx512vl | avx512f),
+        inst("vpsllq", fmt("G", [w(xmm1), r(xmm2), r(xmm_m128)]), evex(L128, Mem128)._66()._0f().w1().op(0xF3).r(), _64b | compat | avx512vl | avx512f),
+        inst("vpsllq", fmt("F", [w(xmm1), r(xmm_m128), r(imm8)]), evex(L128, Full)._66()._0f().w1().op(0x73).digit(6).ib(), _64b | compat | avx512vl | avx512f),
+
         // Vector instructions (shift right).
         inst("psraw", fmt("A", [rw(xmm1), r(align(xmm_m128))]), rex([0x66, 0x0F, 0xE1]).r(), _64b | compat | sse2).alt(avx, "vpsraw_c"),
         inst("psraw", fmt("B", [rw(xmm1), r(imm8)]), rex([0x66, 0x0F, 0x71]).digit(4).ib(), _64b | compat | sse2).alt(avx, "vpsraw_d"),
@@ -119,5 +127,19 @@ pub fn list() -> Vec<Inst> {
         inst("vpsrld", fmt("D", [w(xmm1), r(xmm2), r(imm8)]), vex(L128)._66()._0f().op(0x72).digit(2).ib(), _64b | compat | avx),
         inst("vpsrlq", fmt("C", [w(xmm1), r(xmm2), r(xmm_m128)]), vex(L128)._66()._0f().op(0xD3).r(), _64b | compat | avx),
         inst("vpsrlq", fmt("D", [w(xmm1), r(xmm2), r(imm8)]), vex(L128)._66()._0f().op(0x73).digit(2).ib(), _64b | compat | avx),
+        // FIXME: uncomment once the avx512bw feature is bound
+        // inst("vpsraw", fmt("G", [w(xmm1), r(xmm2), r(xmm_m128)]), evex(L128, Mem128)._66()._0f().wig().op(0xE1).r(), _64b | compat | avx512vl | avx512bw),
+        // inst("vpsraw", fmt("E", [w(xmm1), r(xmm_m128), r(imm8)]), evex(L128, FullMem)._66()._0f().wig().op(0x71).digit(4).ib(), _64b | compat | avx512vl | avx512bw),
+        inst("vpsrad", fmt("G", [w(xmm1), r(xmm2), r(xmm_m128)]), evex(L128, Mem128)._66()._0f().w0().op(0xE2).r(), _64b | compat | avx512vl | avx512f),
+        inst("vpsrad", fmt("F", [w(xmm1), r(xmm_m128), r(imm8)]), evex(L128, Full)._66()._0f().w0().op(0x72).digit(4).ib(), _64b | compat | avx512vl | avx512f),
+        inst("vpsraq", fmt("G", [w(xmm1), r(xmm2), r(xmm_m128)]), evex(L128, Mem128)._66()._0f().w1().op(0xE2).r(), _64b | compat | avx512vl | avx512f),
+        inst("vpsraq", fmt("F", [w(xmm1), r(xmm_m128), r(imm8)]), evex(L128, Full)._66()._0f().w1().op(0x72).digit(4).ib(), _64b | compat | avx512vl | avx512f),
+        // FIXME: uncomment once the avx512bw feature is bound
+        // inst("vpsrlw", fmt("G", [w(xmm1), r(xmm2), r(xmm_m128)]), evex(L128, Mem128)._66()._0f().wig().op(0xD1).r(), _64b | compat | avx512vl | avx512bw),
+        // inst("vpsrlw", fmt("E", [w(xmm1), r(xmm_m128), r(imm8)]), evex(L128, FullMem)._66()._0f().wig().op(0x71).digit(2).ib(), _64b | compat | avx512vl | avx512bw),
+        inst("vpsrld", fmt("G", [w(xmm1), r(xmm2), r(xmm_m128)]), evex(L128, Mem128)._66()._0f().w0().op(0xD2).r(), _64b | compat | avx512vl | avx512f),
+        inst("vpsrld", fmt("F", [w(xmm1), r(xmm_m128), r(imm8)]), evex(L128, Full)._66()._0f().w0().op(0x72).digit(2).ib(), _64b | compat | avx512vl | avx512f),
+        inst("vpsrlq", fmt("G", [w(xmm1), r(xmm2), r(xmm_m128)]), evex(L128, Mem128)._66()._0f().w1().op(0xD3).r(), _64b | compat | avx512vl | avx512f),
+        inst("vpsrlq", fmt("F", [w(xmm1), r(xmm_m128), r(imm8)]), evex(L128, Full)._66()._0f().w1().op(0x73).digit(2).ib(), _64b | compat | avx512vl | avx512f),
     ]
 }

--- a/cranelift/assembler-x64/src/evex.rs
+++ b/cranelift/assembler-x64/src/evex.rs
@@ -65,6 +65,20 @@ impl EvexPrefix {
         }
     }
 
+    /// Construct the [`EvexPrefix`] for an instruction.
+    pub fn three_op(
+        reg: u8,
+        vvvv: u8,
+        (b, x): (Option<u8>, Option<u8>),
+        ll: u8,
+        pp: u8,
+        mmm: u8,
+        w: bool,
+        broadcast: bool,
+    ) -> Self {
+        EvexPrefix::new(reg, vvvv, (b, x), ll, pp, mmm, w, broadcast)
+    }
+
     pub(crate) fn encode(&self, sink: &mut impl CodeSink) {
         sink.put1(0x62);
         sink.put1(self.byte1);

--- a/cranelift/assembler-x64/src/mem.rs
+++ b/cranelift/assembler-x64/src/mem.rs
@@ -55,8 +55,9 @@ impl<R: AsReg> Amode<R> {
         sink: &mut impl CodeSink,
         enc_reg: u8,
         bytes_at_end: u8,
+        evex_scaling: Option<i8>,
     ) {
-        emit_modrm_sib_disp(sink, enc_reg, self, bytes_at_end, None);
+        emit_modrm_sib_disp(sink, enc_reg, self, bytes_at_end, evex_scaling);
     }
 
     /// Return the registers for encoding the `b` and `x` bits (e.g., in a VEX
@@ -76,7 +77,6 @@ impl<R: AsReg> Amode<R> {
 
 /// A 32-bit immediate for address offsets.
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[cfg_attr(any(test, feature = "fuzz"), derive(arbitrary::Arbitrary))]
 pub struct AmodeOffset(i32);
 
 impl AmodeOffset {
@@ -286,13 +286,14 @@ impl<R: AsReg, M: AsReg> GprMem<R, M> {
         sink: &mut impl CodeSink,
         enc_reg: u8,
         bytes_at_end: u8,
+        evex_scaling: Option<i8>,
     ) {
         match self {
             GprMem::Gpr(gpr) => {
                 sink.put1(encode_modrm(0b11, enc_reg & 0b111, gpr.enc() & 0b111));
             }
             GprMem::Mem(amode) => {
-                amode.encode_rex_suffixes(sink, enc_reg, bytes_at_end);
+                amode.encode_rex_suffixes(sink, enc_reg, bytes_at_end, evex_scaling);
             }
         }
     }
@@ -354,13 +355,14 @@ impl<R: AsReg, M: AsReg> XmmMem<R, M> {
         sink: &mut impl CodeSink,
         enc_reg: u8,
         bytes_at_end: u8,
+        evex_scaling: Option<i8>,
     ) {
         match self {
             XmmMem::Xmm(xmm) => {
                 sink.put1(encode_modrm(0b11, enc_reg & 0b111, xmm.enc() & 0b111));
             }
             XmmMem::Mem(amode) => {
-                amode.encode_rex_suffixes(sink, enc_reg, bytes_at_end);
+                amode.encode_rex_suffixes(sink, enc_reg, bytes_at_end, evex_scaling);
             }
         }
     }

--- a/cranelift/codegen/src/isa/x64/encoding/evex.rs
+++ b/cranelift/codegen/src/isa/x64/encoding/evex.rs
@@ -187,13 +187,6 @@ impl EvexInstruction {
         self
     }
 
-    /// Set the imm byte.
-    #[inline(always)]
-    pub fn imm(mut self, imm: u8) -> Self {
-        self.imm = Some(imm);
-        self
-    }
-
     /// Emit the EVEX-encoded instruction to the code sink:
     ///
     /// - the 4-byte EVEX prefix;

--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -67,12 +67,6 @@
                    (src2 XmmMem)
                    (dst WritableXmm))
 
-       ;; Same as `XmmRmREvex` but for unary operations.
-       (XmmUnaryRmRImmEvex (op Avx512Opcode)
-                           (src XmmMem)
-                           (dst WritableXmm)
-                           (imm u8))
-
        ;; XMM (scalar or vector) binary op that relies on the EVEX
        ;; prefix. Takes three inputs.
        (XmmRmREvex3 (op Avx512Opcode)
@@ -666,9 +660,7 @@
             Vpabsq
             Vpermi2b
             Vpmullq
-            Vpopcntb
-            Vpsraq
-            VpsraqImm))
+            Vpopcntb))
 
 (type FcmpImm extern
       (enum Equal
@@ -1149,13 +1141,6 @@
                                             src1
                                             src2
                                             dst))))
-        dst))
-
-;; Helper for creating `MInst.XmmUnaryRmRImmEvex` instructions.
-(decl xmm_unary_rm_r_imm_evex (Avx512Opcode XmmMem u8) Xmm)
-(rule (xmm_unary_rm_r_imm_evex op src imm)
-      (let ((dst WritableXmm (temp_writable_xmm))
-            (_ Unit (emit (MInst.XmmUnaryRmRImmEvex op src dst imm))))
         dst))
 
 ;; Helper for creating `xmm_min_max_seq` pseudo-instructions.
@@ -2759,13 +2744,11 @@
 
 ;; Helper for creating `vpsraq` instructions.
 (decl x64_vpsraq (Xmm XmmMem) Xmm)
-(rule (x64_vpsraq src1 src2)
-      (xmm_rm_r_evex (Avx512Opcode.Vpsraq) src1 src2))
+(rule (x64_vpsraq src1 src2) (x64_vpsraq_g src1 src2))
 
 ;; Helper for creating `vpsraq` instructions.
 (decl x64_vpsraq_imm (XmmMem u8) Xmm)
-(rule (x64_vpsraq_imm src imm)
-      (xmm_unary_rm_r_imm_evex (Avx512Opcode.VpsraqImm) src imm))
+(rule (x64_vpsraq_imm src imm) (x64_vpsraq_f src imm))
 
 ;; Helper for creating `pextr*` instructions.
 (decl x64_pextrb (Xmm u8) Gpr)

--- a/cranelift/codegen/src/isa/x64/inst/args.rs
+++ b/cranelift/codegen/src/isa/x64/inst/args.rs
@@ -779,10 +779,7 @@ impl Avx512Opcode {
     /// Which `InstructionSet`s support the opcode?
     pub(crate) fn available_from(&self) -> SmallVec<[InstructionSet; 2]> {
         match self {
-            Avx512Opcode::Vcvtudq2ps
-            | Avx512Opcode::Vpabsq
-            | Avx512Opcode::Vpsraq
-            | Avx512Opcode::VpsraqImm => {
+            Avx512Opcode::Vcvtudq2ps | Avx512Opcode::Vpabsq => {
                 smallvec![InstructionSet::AVX512F, InstructionSet::AVX512VL]
             }
             Avx512Opcode::Vpermi2b => {
@@ -806,9 +803,8 @@ impl Avx512Opcode {
         use Avx512TupleType::*;
 
         match self {
-            Vcvtudq2ps | Vpabsq | Vpmullq | VpsraqImm => Full,
+            Vcvtudq2ps | Vpabsq | Vpmullq => Full,
             Vpermi2b | Vpopcntb => FullMem,
-            Vpsraq => Mem128,
         }
     }
 }

--- a/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
@@ -232,12 +232,6 @@ fn test_x64_emit() {
     ));
 
     insns.push((
-        Inst::xmm_rm_r_evex(Avx512Opcode::Vpsraq, xmm10, RegMem::reg(xmm14), w_xmm1),
-        "62D1AD08E2CE",
-        "vpsraq  %xmm14, %xmm10, %xmm1",
-    ));
-
-    insns.push((
         Inst::xmm_rm_r_evex3(
             Avx512Opcode::Vpermi2b,
             xmm1,

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -113,8 +113,7 @@ impl Inst {
 
             Inst::XmmUnaryRmREvex { op, .. }
             | Inst::XmmRmREvex { op, .. }
-            | Inst::XmmRmREvex3 { op, .. }
-            | Inst::XmmUnaryRmRImmEvex { op, .. } => op.available_from(),
+            | Inst::XmmRmREvex3 { op, .. } => op.available_from(),
 
             Inst::External { inst } => {
                 use cranelift_assembler_x64::Feature::*;
@@ -455,15 +454,6 @@ impl PrettyPrint for Inst {
                 let src = src.pretty_print(8);
                 let op = ljustify(op.to_string());
                 format!("{op} {src}, {dst}")
-            }
-
-            Inst::XmmUnaryRmRImmEvex {
-                op, src, dst, imm, ..
-            } => {
-                let dst = pretty_print_reg(dst.to_reg().to_reg(), 8);
-                let src = src.pretty_print(8);
-                let op = ljustify(op.to_string());
-                format!("{op} ${imm}, {src}, {dst}")
             }
 
             Inst::XmmRmREvex {
@@ -958,7 +948,7 @@ fn x64_get_operands(inst: &mut Inst, collector: &mut impl OperandVisitor) {
             collector.reg_fixed_use(dividend, regs::rax());
             collector.reg_fixed_def(dst, regs::rax());
         }
-        Inst::XmmUnaryRmREvex { src, dst, .. } | Inst::XmmUnaryRmRImmEvex { src, dst, .. } => {
+        Inst::XmmUnaryRmREvex { src, dst, .. } => {
             collector.reg_def(dst);
             src.get_operands(collector);
         }

--- a/cranelift/codegen/src/isa/x64/pcc.rs
+++ b/cranelift/codegen/src/isa/x64/pcc.rs
@@ -80,9 +80,6 @@ pub(crate) fn check(
         // verified. The effect of this will be spurious PCC failures when these instructions are
         // involved.
         Inst::XmmRmREvex { dst, ref src2, .. }
-        | Inst::XmmUnaryRmRImmEvex {
-            dst, src: ref src2, ..
-        }
         | Inst::XmmUnaryRmREvex {
             dst, src: ref src2, ..
         }

--- a/cranelift/filetests/filetests/isa/x64/simd-i64x2-shift-avx512.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-i64x2-shift-avx512.clif
@@ -17,10 +17,10 @@ block0(v0: i64x2, v1: i64):
 ;   movq %rdi, %r9
 ;   andq $0x3f, %r9
 ;   vmovd %r9d, %xmm1
-;   vpsraq  %xmm1, %xmm0, %xmm0
+;   vpsraq %xmm1, %xmm0, %xmm0
 ;   andq $0x3f, %rdi
 ;   vmovd %edi, %xmm1
-;   vpsraq  %xmm1, %xmm0, %xmm1
+;   vpsraq %xmm1, %xmm0, %xmm1
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -51,7 +51,7 @@ block0(v0: i64x2):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block0:
-;   vpsraqimm $31, %xmm0, %xmm0
+;   vpsraq $0x1f, %xmm0, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -77,7 +77,7 @@ block0(v0: i64):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block0:
-;   vpsraqimm $31, 0(%rdi), %xmm0
+;   vpsraq $0x1f, (%rdi), %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -103,7 +103,7 @@ block0(v0: i64):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block0:
-;   vpsraqimm $31, 7(%rdi), %xmm0
+;   vpsraq $0x1f, 7(%rdi), %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -129,7 +129,7 @@ block0(v0: i64):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block0:
-;   vpsraqimm $31, 16(%rdi), %xmm0
+;   vpsraq $0x1f, 0x10(%rdi), %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq


### PR DESCRIPTION
This commit adds bindings for the EVEX encodings of `vps{ll,ra,rl}{d,q}` to the new assembler. Currently the 16-bit shifts `vps{ll,ra,rl}w` are omitted due to the `avx512bw` feature not yet being bound in Cranelift. In implementing these instructions a few refactorings/fixes were necessary:

* Primarily all EVEX instructions now need to be defined not only with their vector length but also their "tuple type" found in encoding tables. This is required to correctly handle the 8-bit displacement scaling that happens with EVEX instructions.
* Some small helpers to the `Evex` structure were added such as `Evex::digit` and `Evex::ib`.
* The `evex_scaling` factor is now calculated in `generate_evex_prefix` according to the instruction format itself.
* The VEX and EVEX `generate_*_prefix` functions now delegate to a shared function to handle the same operand formats across both of them.
* Fuzz generation of `AmodeOffset` is now updated to bias to some "interesting" offsets that exercise the cases where EVEX scaling is necessary.
* The ISLE `XmmUnaryRmRImmEvex` instruction format was removed as it's no longer necessary.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
