### PR TITLE
x64: Use 8-bit jumps in pseudo-insts

### DIFF
--- a/cranelift/codegen/src/isa/x64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit.rs
@@ -39,6 +39,15 @@ fn one_way_jmp(sink: &mut MachBuffer<Inst>, cc: CC, label: MachLabel) {
     debug_assert_eq!(sink.cur_offset(), cond_disp_off + 4);
 }
 
+/// Like `one_way_jmp` but only used if the destination is <=127 bytes away.
+fn short_one_way_jmp(sink: &mut MachBuffer<Inst>, cc: CC, label: MachLabel) {
+    let cond_start = sink.cur_offset();
+    let cond_disp_off = cond_start + 1;
+    sink.use_label_at_offset(cond_disp_off, label, LabelUse::JmpRel8);
+    emit_short_jcc_no_offset(sink, cc);
+    debug_assert_eq!(sink.cur_offset(), cond_disp_off + 1);
+}
+
 /// Like `one_way_jmp` above emitting a conditional jump, but also using
 /// `MachBuffer::add_cond_branch`.
 fn cond_jmp(sink: &mut MachBuffer<Inst>, cc: CC, label: MachLabel) {
@@ -78,6 +87,34 @@ fn emit_jcc_no_offset(sink: &mut MachBuffer<Inst>, cc: CC) {
         CC::NP => asm::inst::jnp_d32::new(0).into(),
         CC::S => asm::inst::js_d32::new(0).into(),
         CC::NS => asm::inst::jns_d32::new(0).into(),
+    };
+    inst.encode(&mut external::AsmCodeSink {
+        sink,
+        incoming_arg_offset: 0,
+        slot_offset: 0,
+    });
+}
+
+fn emit_short_jcc_no_offset(sink: &mut MachBuffer<Inst>, cc: CC) {
+    // See `emit_jcc_no_offset` above for comments about subtle mismatches in
+    // `CC` and `jcc` naming.
+    let inst: AsmInst = match cc {
+        CC::Z => asm::inst::je_d8::new(0).into(),
+        CC::NZ => asm::inst::jne_d8::new(0).into(),
+        CC::B => asm::inst::jb_d8::new(0).into(),
+        CC::NB => asm::inst::jae_d8::new(0).into(),
+        CC::BE => asm::inst::jbe_d8::new(0).into(),
+        CC::NBE => asm::inst::ja_d8::new(0).into(),
+        CC::L => asm::inst::jl_d8::new(0).into(),
+        CC::LE => asm::inst::jle_d8::new(0).into(),
+        CC::NL => asm::inst::jge_d8::new(0).into(),
+        CC::NLE => asm::inst::jg_d8::new(0).into(),
+        CC::O => asm::inst::jo_d8::new(0).into(),
+        CC::NO => asm::inst::jno_d8::new(0).into(),
+        CC::P => asm::inst::jp_d8::new(0).into(),
+        CC::NP => asm::inst::jnp_d8::new(0).into(),
+        CC::S => asm::inst::js_d8::new(0).into(),
+        CC::NS => asm::inst::jns_d8::new(0).into(),
     };
     inst.encode(&mut external::AsmCodeSink {
         sink,
@@ -253,7 +290,7 @@ pub(crate) fn emit(
             // go to the `idiv`.
             let inst = Inst::cmp_mi_sxb(size, *divisor, -1);
             inst.emit(sink, info, state);
-            one_way_jmp(sink, CC::NZ, do_op);
+            short_one_way_jmp(sink, CC::NZ, do_op);
 
             // ... otherwise the divisor is -1 and the result is always 0. This
             // is written to the destination register which will be %rax for
@@ -343,7 +380,7 @@ pub(crate) fn emit(
             let next = sink.get_label();
 
             // Jump if cc is *not* set.
-            one_way_jmp(sink, cc.invert(), next);
+            short_one_way_jmp(sink, cc.invert(), next);
             Inst::gen_move(dst.map(|r| r.to_reg()), consequent.to_reg(), *ty)
                 .emit(sink, info, state);
 
@@ -421,7 +458,7 @@ pub(crate) fn emit(
             // jne  .loop_start
             // TODO: Encoding the conditional jump as a short jump
             // could save us us 4 bytes here.
-            one_way_jmp(sink, CC::NZ, loop_start);
+            short_one_way_jmp(sink, CC::NZ, loop_start);
 
             // The regular prologue code is going to emit a `sub` after this, so we need to
             // reset the stack pointer
@@ -969,8 +1006,8 @@ pub(crate) fn emit(
 
             cmp_op.emit(sink, info, state);
 
-            one_way_jmp(sink, CC::NZ, do_min_max);
-            one_way_jmp(sink, CC::P, propagate_nan);
+            short_one_way_jmp(sink, CC::NZ, do_min_max);
+            short_one_way_jmp(sink, CC::P, propagate_nan);
 
             // Ordered and equal. The operands are bit-identical unless they are zero
             // and negative zero. These instructions merge the sign bits in that
@@ -987,7 +1024,7 @@ pub(crate) fn emit(
             sink.bind_label(propagate_nan, state.ctrl_plane_mut());
             add_op.emit(sink, info, state);
 
-            one_way_jmp(sink, CC::P, done);
+            short_one_way_jmp(sink, CC::P, done);
 
             sink.bind_label(do_min_max, state.ctrl_plane_mut());
             min_max_op.emit(sink, info, state);
@@ -1050,7 +1087,7 @@ pub(crate) fn emit(
             // TODO use tst src, src here.
             asm::inst::cmpq_mi_sxb::new(src, 0).emit(sink, info, state);
 
-            one_way_jmp(sink, CC::L, handle_negative);
+            short_one_way_jmp(sink, CC::L, handle_negative);
 
             // Handle a positive int64, which is the "easy" case: a signed conversion will do the
             // right thing.
@@ -1189,14 +1226,14 @@ pub(crate) fn emit(
             let inst = Inst::cmp_mi_sxb(*dst_size, Gpr::unwrap_new(dst.to_reg()), 1);
             inst.emit(sink, info, state);
 
-            one_way_jmp(sink, CC::NO, done); // no overflow => done
+            short_one_way_jmp(sink, CC::NO, done); // no overflow => done
 
             // Check for NaN.
             cmp_op.emit(sink, info, state);
 
             if *is_saturating {
                 let not_nan = sink.get_label();
-                one_way_jmp(sink, CC::NP, not_nan); // go to not_nan if not a NaN
+                short_one_way_jmp(sink, CC::NP, not_nan); // go to not_nan if not a NaN
 
                 // For NaN, emit 0.
                 let inst: AsmInst = match *dst_size {
@@ -1224,7 +1261,7 @@ pub(crate) fn emit(
                 inst.emit(sink, info, state);
 
                 // Jump if >= to done.
-                one_way_jmp(sink, CC::NB, done);
+                short_one_way_jmp(sink, CC::NB, done);
 
                 // Otherwise, put INT_MAX.
                 if *dst_size == OperandSize::Size64 {
@@ -1417,12 +1454,12 @@ pub(crate) fn emit(
             inst.emit(sink, info, state);
 
             let handle_large = sink.get_label();
-            one_way_jmp(sink, CC::NB, handle_large); // jump to handle_large if src >= large_threshold
+            short_one_way_jmp(sink, CC::NB, handle_large); // jump to handle_large if src >= large_threshold
 
             if *is_saturating {
                 // If not NaN jump over this 0-return, otherwise return 0
                 let not_nan = sink.get_label();
-                one_way_jmp(sink, CC::NP, not_nan);
+                short_one_way_jmp(sink, CC::NP, not_nan);
 
                 xor_op(dst, dst).emit(sink, info, state);
 
@@ -1443,7 +1480,7 @@ pub(crate) fn emit(
             let inst = Inst::cmp_mi_sxb(*dst_size, Gpr::unwrap_new(dst.to_reg()), 0);
             inst.emit(sink, info, state);
 
-            one_way_jmp(sink, CC::NL, done); // if dst >= 0, jump to done
+            short_one_way_jmp(sink, CC::NL, done); // if dst >= 0, jump to done
 
             if *is_saturating {
                 // The input was "small" (< 2**(width -1)), so the only way to get an integer
@@ -1478,7 +1515,7 @@ pub(crate) fn emit(
 
             if *is_saturating {
                 let next_is_large = sink.get_label();
-                one_way_jmp(sink, CC::NL, next_is_large); // if dst >= 0, jump to next_is_large
+                short_one_way_jmp(sink, CC::NL, next_is_large); // if dst >= 0, jump to next_is_large
 
                 // The input was "large" (>= 2**(width -1)), so the only way to get an integer
                 // overflow is because the input was too large: saturate to the max value.
@@ -1663,7 +1700,7 @@ pub(crate) fn emit(
             inst.emit(sink, info, state);
 
             // jnz again
-            one_way_jmp(sink, CC::NZ, again_label);
+            short_one_way_jmp(sink, CC::NZ, again_label);
         }
 
         Inst::Atomic128RmwSeq {
@@ -1783,7 +1820,7 @@ pub(crate) fn emit(
             .emit(sink, info, state);
 
             // jnz again
-            one_way_jmp(sink, CC::NZ, again_label);
+            short_one_way_jmp(sink, CC::NZ, again_label);
         }
 
         Inst::Atomic128XchgSeq {
@@ -1823,7 +1860,7 @@ pub(crate) fn emit(
             .emit(sink, info, state);
 
             // jnz again
-            one_way_jmp(sink, CC::NZ, again_label);
+            short_one_way_jmp(sink, CC::NZ, again_label);
         }
 
         Inst::ElfTlsGetAddr { symbol, dst } => {

--- a/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
@@ -298,7 +298,7 @@ fn test_x64_emit() {
             temp: w_r11.map(Gpr::unwrap_new),
             dst_old: w_rax.map(Gpr::unwrap_new),
         },
-        "490FB6014989C34D0BDAF0450FB0190F85EFFFFFFF",
+        "490FB6014989C34D0BDAF0450FB01975F3",
         "atomically { 8_bits_at_[%r9] Or= %r10; %rax = old_value_at_[%r9]; %r11, %rflags = trash }",
     ));
     insns.push((
@@ -310,7 +310,7 @@ fn test_x64_emit() {
             temp: w_r11.map(Gpr::unwrap_new),
             dst_old: w_rax.map(Gpr::unwrap_new)
         },
-        "490FB7014989C34D23DAF066450FB1190F85EEFFFFFF",
+        "490FB7014989C34D23DAF066450FB11975F2",
         "atomically { 16_bits_at_[%r9] And= %r10; %rax = old_value_at_[%r9]; %r11, %rflags = trash }"
     ));
     insns.push((
@@ -322,7 +322,7 @@ fn test_x64_emit() {
             temp: w_r11.map(Gpr::unwrap_new),
             dst_old: w_rax.map(Gpr::unwrap_new)
         },
-        "418B014989C34D23DA49F7D3F0450FB1190F85ECFFFFFF",
+        "418B014989C34D23DA49F7D3F0450FB11975F0",
         "atomically { 32_bits_at_[%r9] Nand= %r10; %rax = old_value_at_[%r9]; %r11, %rflags = trash }"
     ));
     insns.push((
@@ -334,7 +334,7 @@ fn test_x64_emit() {
             temp: w_r11.map(Gpr::unwrap_new),
             dst_old: w_rax.map(Gpr::unwrap_new)
         },
-        "418B014989C34539DA4D0F46DAF0450FB1190F85EBFFFFFF",
+        "418B014989C34539DA4D0F46DAF0450FB11975EF",
         "atomically { 32_bits_at_[%r9] Umin= %r10; %rax = old_value_at_[%r9]; %r11, %rflags = trash }"
     ));
     insns.push((
@@ -346,7 +346,7 @@ fn test_x64_emit() {
             temp: w_r11.map(Gpr::unwrap_new),
             dst_old: w_rax.map(Gpr::unwrap_new)
         },
-        "498B014989C34D39DA4D0F4DDAF04D0FB1190F85EBFFFFFF",
+        "498B014989C34D39DA4D0F4DDAF04D0FB11975EF",
         "atomically { 64_bits_at_[%r9] Smax= %r10; %rax = old_value_at_[%r9]; %r11, %rflags = trash }"
     ));
 
@@ -362,7 +362,7 @@ fn test_x64_emit() {
             dst_old_low: w_rax.map(Gpr::unwrap_new),
             dst_old_high: w_rdx.map(Gpr::unwrap_new),
         },
-        "498B01498B51084889C34889D1490BDA490BCBF0490FC7090F85E9FFFFFF",
+        "498B01498B51084889C34889D1490BDA490BCBF0490FC70975ED",
         "atomically { %rdx:%rax = 0(%r9); %rcx:%rbx = %rdx:%rax Or %r11:%r10; 0(%r9) = %rcx:%rbx }",
     ));
     insns.push((
@@ -376,7 +376,7 @@ fn test_x64_emit() {
             dst_old_low: w_rax.map(Gpr::unwrap_new),
             dst_old_high: w_rdx.map(Gpr::unwrap_new),
         },
-        "498B01498B51084889C34889D14923DA4923CBF0490FC7090F85E9FFFFFF",
+        "498B01498B51084889C34889D14923DA4923CBF0490FC70975ED",
         "atomically { %rdx:%rax = 0(%r9); %rcx:%rbx = %rdx:%rax And %r11:%r10; 0(%r9) = %rcx:%rbx }"
     ));
     insns.push((
@@ -390,7 +390,7 @@ fn test_x64_emit() {
             dst_old_low: w_rax.map(Gpr::unwrap_new),
             dst_old_high: w_rdx.map(Gpr::unwrap_new),
         },
-        "498B01498B51084889C34889D14C39D3491BCB4889D1490F43DA490F43CBF0490FC7090F85DEFFFFFF",
+        "498B01498B51084889C34889D14C39D3491BCB4889D1490F43DA490F43CBF0490FC70975E2",
         "atomically { %rdx:%rax = 0(%r9); %rcx:%rbx = %rdx:%rax Umin %r11:%r10; 0(%r9) = %rcx:%rbx }"
     ));
     insns.push((
@@ -404,7 +404,7 @@ fn test_x64_emit() {
             dst_old_low: w_rax.map(Gpr::unwrap_new),
             dst_old_high: w_rdx.map(Gpr::unwrap_new),
         },
-        "498B01498B51084889C34889D14903DA4913CBF0490FC7090F85E9FFFFFF",
+        "498B01498B51084889C34889D14903DA4913CBF0490FC70975ED",
         "atomically { %rdx:%rax = 0(%r9); %rcx:%rbx = %rdx:%rax Add %r11:%r10; 0(%r9) = %rcx:%rbx }"
     ));
     insns.push((
@@ -415,7 +415,7 @@ fn test_x64_emit() {
             dst_old_low: w_rax.map(Gpr::unwrap_new),
             dst_old_high: w_rdx.map(Gpr::unwrap_new),
         },
-        "498B01498B5108F0490FC7090F85F5FFFFFF",
+        "498B01498B5108F0490FC70975F9",
         "atomically { %rdx:%rax = 0(%r9); 0(%r9) = %rcx:%rbx }",
     ));
 

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -1572,6 +1572,14 @@ pub enum LabelUse {
     /// next instruction (so the size of the payload -- 4 bytes -- is subtracted from the payload).
     JmpRel32,
 
+    /// An 8-bit offset from location of relocation itself, added to the
+    /// existing value at that location.
+    ///
+    /// Used for control flow instructions which consider an offset from the
+    /// start of the next instruction (so the size of the payload -- 1 byte --
+    /// is subtracted from the payload).
+    JmpRel8,
+
     /// A 32-bit offset from location of relocation itself, added to the existing value at that
     /// location.
     PCRel32,
@@ -1583,18 +1591,21 @@ impl MachInstLabelUse for LabelUse {
     fn max_pos_range(self) -> CodeOffset {
         match self {
             LabelUse::JmpRel32 | LabelUse::PCRel32 => 0x7fff_ffff,
+            LabelUse::JmpRel8 => 0x7f,
         }
     }
 
     fn max_neg_range(self) -> CodeOffset {
         match self {
             LabelUse::JmpRel32 | LabelUse::PCRel32 => 0x8000_0000,
+            LabelUse::JmpRel8 => 0x80,
         }
     }
 
     fn patch_size(self) -> CodeOffset {
         match self {
             LabelUse::JmpRel32 | LabelUse::PCRel32 => 4,
+            LabelUse::JmpRel8 => 1,
         }
     }
 
@@ -1609,6 +1620,9 @@ impl MachInstLabelUse for LabelUse {
                 let value = pc_rel.wrapping_add(addend).wrapping_sub(4);
                 buffer.copy_from_slice(&value.to_le_bytes()[..]);
             }
+            LabelUse::JmpRel8 => {
+                buffer[0] = buffer[0].wrapping_add(pc_rel as u8).wrapping_sub(1);
+            }
             LabelUse::PCRel32 => {
                 let addend = u32::from_le_bytes([buffer[0], buffer[1], buffer[2], buffer[3]]);
                 let value = pc_rel.wrapping_add(addend);
@@ -1620,12 +1634,21 @@ impl MachInstLabelUse for LabelUse {
     fn supports_veneer(self) -> bool {
         match self {
             LabelUse::JmpRel32 | LabelUse::PCRel32 => false,
+
+            // Technically this is possible to have a veneer because it can jump
+            // to a 32-bit jump which keeps going. That being said at this time
+            // this variant is only used in `emit.rs` for jumps that are already
+            // known to be short so it's a bug if we jump to a jump that's too
+            // far away. In the future if general-purpose basic-block
+            // terminators are switched to using short jumps to get promoted to
+            // a long jump then this may wish to change.
+            LabelUse::JmpRel8 => false,
         }
     }
 
     fn veneer_size(self) -> CodeOffset {
         match self {
-            LabelUse::JmpRel32 | LabelUse::PCRel32 => 0,
+            LabelUse::JmpRel32 | LabelUse::PCRel32 | LabelUse::JmpRel8 => 0,
         }
     }
 
@@ -1635,7 +1658,7 @@ impl MachInstLabelUse for LabelUse {
 
     fn generate_veneer(self, _: &mut [u8], _: CodeOffset) -> (CodeOffset, LabelUse) {
         match self {
-            LabelUse::JmpRel32 | LabelUse::PCRel32 => {
+            LabelUse::JmpRel32 | LabelUse::PCRel32 | LabelUse::JmpRel8 => {
                 panic!("Veneer not supported for JumpRel32 label-use.");
             }
         }

--- a/cranelift/filetests/filetests/isa/x64/cmp-mem-bug.clif
+++ b/cranelift/filetests/filetests/isa/x64/cmp-mem-bug.clif
@@ -81,9 +81,9 @@ block0(v0: f64, v1: i64):
 ;   movzbq %dil, %rax
 ;   ucomisd %xmm1, %xmm0
 ;   movdqa %xmm0, %xmm2
-;   jnp 0x2a
+;   jnp 0x26
 ;   movaps %xmm2, %xmm0
-;   je 0x33
+;   je 0x2b
 ;   movaps %xmm2, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp

--- a/cranelift/filetests/filetests/isa/x64/div-checks.clif
+++ b/cranelift/filetests/filetests/isa/x64/div-checks.clif
@@ -32,9 +32,9 @@ block0(v0: i8, v1: i8):
 ;   movq %rdi, %rax
 ;   cbtw
 ;   cmpb $0xff, %sil
-;   jne 0x1d
+;   jne 0x19
 ;   movl $0, %eax
-;   jmp 0x20
+;   jmp 0x1c
 ;   idivb %sil ; trap: int_divz
 ;   shrq $8, %rax
 ;   movq %rbp, %rsp
@@ -68,9 +68,9 @@ block0(v0: i16, v1: i16):
 ;   movq %rdi, %rax
 ;   cwtd
 ;   cmpw $-1, %si
-;   jne 0x1d
+;   jne 0x19
 ;   movl $0, %edx
-;   jmp 0x20
+;   jmp 0x1c
 ;   idivw %si ; trap: int_divz
 ;   movq %rdx, %rax
 ;   movq %rbp, %rsp
@@ -104,9 +104,9 @@ block0(v0: i32, v1: i32):
 ;   movq %rdi, %rax
 ;   cltd
 ;   cmpl $-1, %esi
-;   jne 0x1b
+;   jne 0x17
 ;   movl $0, %edx
-;   jmp 0x1d
+;   jmp 0x19
 ;   idivl %esi ; trap: int_divz
 ;   movq %rdx, %rax
 ;   movq %rbp, %rsp
@@ -140,9 +140,9 @@ block0(v0: i64, v1: i64):
 ;   movq %rdi, %rax
 ;   cqto
 ;   cmpq $-1, %rsi
-;   jne 0x1d
+;   jne 0x19
 ;   movl $0, %edx
-;   jmp 0x20
+;   jmp 0x1c
 ;   idivq %rsi ; trap: int_divz
 ;   movq %rdx, %rax
 ;   movq %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/fcvt.clif
+++ b/cranelift/filetests/filetests/isa/x64/fcvt.clif
@@ -310,9 +310,9 @@ block0(v0: i8, v1: i16, v2: i32, v3: i64):
 ;   movl %edx, %r8d
 ;   cvtsi2ssq %r8, %xmm7
 ;   cmpq $0, %rcx
-;   jl 0x3b
+;   jl 0x37
 ;   cvtsi2ssq %rcx, %xmm4
-;   jmp 0x55
+;   jmp 0x51
 ;   movq %rcx, %r8
 ;   shrq $1, %r8
 ;   movq %rcx, %rdx
@@ -437,17 +437,17 @@ block0(v0: f32):
 ;   movl $0x4f000000, %r8d
 ;   movd %r8d, %xmm3
 ;   ucomiss %xmm3, %xmm0
-;   jae 0x2d
-;   jp 0x4b
+;   jae 0x25
+;   jp 0x43
 ;   cvttss2si %xmm0, %eax
 ;   cmpl $0, %eax
-;   jge 0x46
+;   jge 0x3e
 ;   ud2 ; trap: int_ovf
 ;   movaps %xmm0, %xmm4
 ;   subss %xmm3, %xmm4
 ;   cvttss2si %xmm4, %eax
 ;   cmpl $0, %eax
-;   jl 0x4d
+;   jl 0x45
 ;   addl $0x80000000, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -478,17 +478,17 @@ block0(v0: f32):
 ;   movl $0x5f000000, %r8d
 ;   movd %r8d, %xmm3
 ;   ucomiss %xmm3, %xmm0
-;   jae 0x2f
-;   jp 0x57
+;   jae 0x27
+;   jp 0x4f
 ;   cvttss2si %xmm0, %rax
 ;   cmpq $0, %rax
-;   jge 0x52
+;   jge 0x4a
 ;   ud2 ; trap: int_ovf
 ;   movaps %xmm0, %xmm4
 ;   subss %xmm3, %xmm4
 ;   cvttss2si %xmm4, %rax
 ;   cmpq $0, %rax
-;   jl 0x59
+;   jl 0x51
 ;   movabsq $9223372036854775808, %r8
 ;   addq %r8, %rax
 ;   movq %rbp, %rsp
@@ -520,17 +520,17 @@ block0(v0: f64):
 ;   movabsq $0x41e0000000000000, %r8
 ;   movq %r8, %xmm3
 ;   ucomisd %xmm3, %xmm0
-;   jae 0x32
-;   jp 0x50
+;   jae 0x2a
+;   jp 0x48
 ;   cvttsd2si %xmm0, %eax
 ;   cmpl $0, %eax
-;   jge 0x4b
+;   jge 0x43
 ;   ud2 ; trap: int_ovf
 ;   movaps %xmm0, %xmm4
 ;   subsd %xmm3, %xmm4
 ;   cvttsd2si %xmm4, %eax
 ;   cmpl $0, %eax
-;   jl 0x52
+;   jl 0x4a
 ;   addl $0x80000000, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -561,17 +561,17 @@ block0(v0: f64):
 ;   movabsq $0x43e0000000000000, %r8
 ;   movq %r8, %xmm3
 ;   ucomisd %xmm3, %xmm0
-;   jae 0x34
-;   jp 0x5c
+;   jae 0x2c
+;   jp 0x54
 ;   cvttsd2si %xmm0, %rax
 ;   cmpq $0, %rax
-;   jge 0x57
+;   jge 0x4f
 ;   ud2 ; trap: int_ovf
 ;   movaps %xmm0, %xmm4
 ;   subsd %xmm3, %xmm4
 ;   cvttsd2si %xmm4, %rax
 ;   cmpq $0, %rax
-;   jl 0x5e
+;   jl 0x56
 ;   movabsq $9223372036854775808, %r8
 ;   addq %r8, %rax
 ;   movq %rbp, %rsp
@@ -603,22 +603,22 @@ block0(v0: f32):
 ;   movl $0x4f000000, %r8d
 ;   movd %r8d, %xmm3
 ;   ucomiss %xmm3, %xmm0
-;   jae 0x39
-;   jnp 0x25
+;   jae 0x2d
+;   jnp 0x1d
 ;   xorl %eax, %eax
-;   jmp 0x5c
+;   jmp 0x4c
 ;   cvttss2si %xmm0, %eax
 ;   cmpl $0, %eax
-;   jge 0x5c
+;   jge 0x4c
 ;   xorl %eax, %eax
-;   jmp 0x5c
+;   jmp 0x4c
 ;   movaps %xmm0, %xmm4
 ;   subss %xmm3, %xmm4
 ;   cvttss2si %xmm4, %eax
 ;   cmpl $0, %eax
-;   jge 0x57
+;   jge 0x47
 ;   movl $0xffffffff, %eax
-;   jmp 0x5c
+;   jmp 0x4c
 ;   addl $0x80000000, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -647,22 +647,22 @@ block0(v0: f32):
 ;   movl $0x5f000000, %r8d
 ;   movd %r8d, %xmm3
 ;   ucomiss %xmm3, %xmm0
-;   jae 0x3d
-;   jnp 0x26
+;   jae 0x31
+;   jnp 0x1e
 ;   xorq %rax, %rax
-;   jmp 0x6c
+;   jmp 0x5c
 ;   cvttss2si %xmm0, %rax
 ;   cmpq $0, %rax
-;   jge 0x6c
+;   jge 0x5c
 ;   xorq %rax, %rax
-;   jmp 0x6c
+;   jmp 0x5c
 ;   movaps %xmm0, %xmm4
 ;   subss %xmm3, %xmm4
 ;   cvttss2si %xmm4, %rax
 ;   cmpq $0, %rax
-;   jge 0x5f
+;   jge 0x4f
 ;   movq $18446744073709551615, %rax
-;   jmp 0x6c
+;   jmp 0x5c
 ;   movabsq $9223372036854775808, %r8
 ;   addq %r8, %rax
 ;   movq %rbp, %rsp
@@ -692,22 +692,22 @@ block0(v0: f64):
 ;   movabsq $0x41e0000000000000, %r8
 ;   movq %r8, %xmm3
 ;   ucomisd %xmm3, %xmm0
-;   jae 0x3e
-;   jnp 0x2a
+;   jae 0x32
+;   jnp 0x22
 ;   xorl %eax, %eax
-;   jmp 0x61
+;   jmp 0x51
 ;   cvttsd2si %xmm0, %eax
 ;   cmpl $0, %eax
-;   jge 0x61
+;   jge 0x51
 ;   xorl %eax, %eax
-;   jmp 0x61
+;   jmp 0x51
 ;   movaps %xmm0, %xmm4
 ;   subsd %xmm3, %xmm4
 ;   cvttsd2si %xmm4, %eax
 ;   cmpl $0, %eax
-;   jge 0x5c
+;   jge 0x4c
 ;   movl $0xffffffff, %eax
-;   jmp 0x61
+;   jmp 0x51
 ;   addl $0x80000000, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -736,22 +736,22 @@ block0(v0: f64):
 ;   movabsq $0x43e0000000000000, %r8
 ;   movq %r8, %xmm3
 ;   ucomisd %xmm3, %xmm0
-;   jae 0x42
-;   jnp 0x2b
+;   jae 0x36
+;   jnp 0x23
 ;   xorq %rax, %rax
-;   jmp 0x71
+;   jmp 0x61
 ;   cvttsd2si %xmm0, %rax
 ;   cmpq $0, %rax
-;   jge 0x71
+;   jge 0x61
 ;   xorq %rax, %rax
-;   jmp 0x71
+;   jmp 0x61
 ;   movaps %xmm0, %xmm4
 ;   subsd %xmm3, %xmm4
 ;   cvttsd2si %xmm4, %rax
 ;   cmpq $0, %rax
-;   jge 0x64
+;   jge 0x54
 ;   movq $18446744073709551615, %rax
-;   jmp 0x71
+;   jmp 0x61
 ;   movabsq $9223372036854775808, %r8
 ;   addq %r8, %rax
 ;   movq %rbp, %rsp
@@ -780,16 +780,16 @@ block0(v0: f32):
 ; block1: ; offset 0x4
 ;   cvttss2si %xmm0, %eax
 ;   cmpl $1, %eax
-;   jno 0x39
+;   jno 0x35
 ;   ucomiss %xmm0, %xmm0
-;   jp 0x3e
+;   jp 0x3a
 ;   movl $0xcf000000, %edx
 ;   movd %edx, %xmm3
 ;   ucomiss %xmm3, %xmm0
-;   jb 0x40
+;   jb 0x3c
 ;   xorpd %xmm3, %xmm3
 ;   ucomiss %xmm0, %xmm3
-;   jb 0x42
+;   jb 0x3e
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -819,16 +819,16 @@ block0(v0: f32):
 ; block1: ; offset 0x4
 ;   cvttss2si %xmm0, %rax
 ;   cmpq $1, %rax
-;   jno 0x3b
+;   jno 0x37
 ;   ucomiss %xmm0, %xmm0
-;   jp 0x40
+;   jp 0x3c
 ;   movl $0xdf000000, %edx
 ;   movd %edx, %xmm3
 ;   ucomiss %xmm3, %xmm0
-;   jb 0x42
+;   jb 0x3e
 ;   xorpd %xmm3, %xmm3
 ;   ucomiss %xmm0, %xmm3
-;   jb 0x44
+;   jb 0x40
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -858,16 +858,16 @@ block0(v0: f64):
 ; block1: ; offset 0x4
 ;   cvttsd2si %xmm0, %eax
 ;   cmpl $1, %eax
-;   jno 0x42
+;   jno 0x3e
 ;   ucomisd %xmm0, %xmm0
-;   jp 0x47
+;   jp 0x43
 ;   movabsq $13970166044105375744, %rdx
 ;   movq %rdx, %xmm3
 ;   ucomisd %xmm3, %xmm0
-;   jbe 0x49
+;   jbe 0x45
 ;   xorpd %xmm3, %xmm3
 ;   ucomisd %xmm0, %xmm3
-;   jb 0x4b
+;   jb 0x47
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -897,16 +897,16 @@ block0(v0: f64):
 ; block1: ; offset 0x4
 ;   cvttsd2si %xmm0, %rax
 ;   cmpq $1, %rax
-;   jno 0x44
+;   jno 0x40
 ;   ucomisd %xmm0, %xmm0
-;   jp 0x49
+;   jp 0x45
 ;   movabsq $14114281232179134464, %rdx
 ;   movq %rdx, %xmm3
 ;   ucomisd %xmm3, %xmm0
-;   jb 0x4b
+;   jb 0x47
 ;   xorpd %xmm3, %xmm3
 ;   ucomisd %xmm0, %xmm3
-;   jb 0x4d
+;   jb 0x49
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -936,14 +936,14 @@ block0(v0: f32):
 ; block1: ; offset 0x4
 ;   cvttss2si %xmm0, %eax
 ;   cmpl $1, %eax
-;   jno 0x33
+;   jno 0x27
 ;   ucomiss %xmm0, %xmm0
-;   jnp 0x21
+;   jnp 0x19
 ;   xorl %eax, %eax
-;   jmp 0x33
+;   jmp 0x27
 ;   xorpd %xmm3, %xmm3
 ;   ucomiss %xmm0, %xmm3
-;   jae 0x33
+;   jae 0x27
 ;   movl $0x7fffffff, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -971,14 +971,14 @@ block0(v0: f32):
 ; block1: ; offset 0x4
 ;   cvttss2si %xmm0, %rax
 ;   cmpq $1, %rax
-;   jno 0x3b
+;   jno 0x2f
 ;   ucomiss %xmm0, %xmm0
-;   jnp 0x24
+;   jnp 0x1c
 ;   xorq %rax, %rax
-;   jmp 0x3b
+;   jmp 0x2f
 ;   xorpd %xmm3, %xmm3
 ;   ucomiss %xmm0, %xmm3
-;   jae 0x3b
+;   jae 0x2f
 ;   movabsq $0x7fffffffffffffff, %rax
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -1006,14 +1006,14 @@ block0(v0: f64):
 ; block1: ; offset 0x4
 ;   cvttsd2si %xmm0, %eax
 ;   cmpl $1, %eax
-;   jno 0x35
+;   jno 0x29
 ;   ucomisd %xmm0, %xmm0
-;   jnp 0x22
+;   jnp 0x1a
 ;   xorl %eax, %eax
-;   jmp 0x35
+;   jmp 0x29
 ;   xorpd %xmm3, %xmm3
 ;   ucomisd %xmm0, %xmm3
-;   jae 0x35
+;   jae 0x29
 ;   movl $0x7fffffff, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -1041,14 +1041,14 @@ block0(v0: f64):
 ; block1: ; offset 0x4
 ;   cvttsd2si %xmm0, %rax
 ;   cmpq $1, %rax
-;   jno 0x3d
+;   jno 0x31
 ;   ucomisd %xmm0, %xmm0
-;   jnp 0x25
+;   jnp 0x1d
 ;   xorq %rax, %rax
-;   jmp 0x3d
+;   jmp 0x31
 ;   xorpd %xmm3, %xmm3
 ;   ucomisd %xmm0, %xmm3
-;   jae 0x3d
+;   jae 0x31
 ;   movabsq $0x7fffffffffffffff, %rax
 ;   movq %rbp, %rsp
 ;   popq %rbp

--- a/cranelift/filetests/filetests/isa/x64/inline-probestack-large.clif
+++ b/cranelift/filetests/filetests/isa/x64/inline-probestack-large.clif
@@ -116,7 +116,7 @@ block0:
 ;   jne 0xe
 ;   addq $0x200000, %rsp
 ;   subq $0x200000, %rsp
-; block1: ; offset 0x2f
+; block1: ; offset 0x2b
 ;   leaq (%rsp), %rax
 ;   addq $0x200000, %rsp
 ;   movq %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/inline-probestack.clif
+++ b/cranelift/filetests/filetests/isa/x64/inline-probestack.clif
@@ -115,7 +115,7 @@ block0:
 ;   jne 0xe
 ;   addq $0x19000, %rsp
 ;   subq $0x186a0, %rsp
-; block1: ; offset 0x2f
+; block1: ; offset 0x2b
 ;   leaq (%rsp), %rax
 ;   addq $0x186a0, %rsp
 ;   movq %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/select.clif
+++ b/cranelift/filetests/filetests/isa/x64/select.clif
@@ -91,7 +91,7 @@ block0(v0: i8, v1: f16, v2: f16):
 ;   testb %dil, %dil
 ;   movdqa %xmm0, %xmm6
 ;   movdqa %xmm1, %xmm0
-;   je 0x18
+;   je 0x14
 ;   movaps %xmm6, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -123,7 +123,7 @@ block0(v0: i8, v1: f32, v2: f32):
 ;   testb %dil, %dil
 ;   movdqa %xmm0, %xmm6
 ;   movdqa %xmm1, %xmm0
-;   je 0x18
+;   je 0x14
 ;   movaps %xmm6, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -155,7 +155,7 @@ block0(v0: i8, v1: f64, v2: f64):
 ;   testb %dil, %dil
 ;   movdqa %xmm0, %xmm6
 ;   movdqa %xmm1, %xmm0
-;   je 0x18
+;   je 0x14
 ;   movaps %xmm6, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -187,7 +187,7 @@ block0(v0: i8, v1: f128, v2: f128):
 ;   testb %dil, %dil
 ;   movdqa %xmm0, %xmm6
 ;   movdqa %xmm1, %xmm0
-;   je 0x19
+;   je 0x15
 ;   movdqa %xmm6, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp

--- a/cranelift/filetests/filetests/isa/x64/srem.clif
+++ b/cranelift/filetests/filetests/isa/x64/srem.clif
@@ -27,9 +27,9 @@ block0(v0: i8, v1: i8):
 ;   movq %rdi, %rax
 ;   cbtw
 ;   cmpb $0xff, %sil
-;   jne 0x1d
+;   jne 0x19
 ;   movl $0, %eax
-;   jmp 0x20
+;   jmp 0x1c
 ;   idivb %sil ; trap: int_divz
 ;   shrq $8, %rax
 ;   movq %rbp, %rsp
@@ -62,9 +62,9 @@ block0(v0: i16, v1: i16):
 ;   movq %rdi, %rax
 ;   cwtd
 ;   cmpw $-1, %si
-;   jne 0x1d
+;   jne 0x19
 ;   movl $0, %edx
-;   jmp 0x20
+;   jmp 0x1c
 ;   idivw %si ; trap: int_divz
 ;   movq %rdx, %rax
 ;   movq %rbp, %rsp
@@ -97,9 +97,9 @@ block0(v0: i32, v1: i32):
 ;   movq %rdi, %rax
 ;   cltd
 ;   cmpl $-1, %esi
-;   jne 0x1b
+;   jne 0x17
 ;   movl $0, %edx
-;   jmp 0x1d
+;   jmp 0x19
 ;   idivl %esi ; trap: int_divz
 ;   movq %rdx, %rax
 ;   movq %rbp, %rsp
@@ -132,9 +132,9 @@ block0(v0: i64, v1: i64):
 ;   movq %rdi, %rax
 ;   cqto
 ;   cmpq $-1, %rsi
-;   jne 0x1d
+;   jne 0x19
 ;   movl $0, %edx
-;   jmp 0x20
+;   jmp 0x1c
 ;   idivq %rsi ; trap: int_divz
 ;   movq %rdx, %rax
 ;   movq %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/stack_switch.clif
+++ b/cranelift/filetests/filetests/isa/x64/stack_switch.clif
@@ -561,9 +561,9 @@ block0(v0: i64, v1: i64):
 ;   movq %rcx, 0x10(%rsi)
 ;   jmpq *%rax
 ;   cmpq $0, %rdi
-;   jl 0x135
+;   jl 0x131
 ;   cvtsi2sdq %rdi, %xmm0
-;   jmp 0x14f
+;   jmp 0x14b
 ;   movq %rdi, %rcx
 ;   shrq $1, %rcx
 ;   movq %rdi, %rdx

--- a/cranelift/filetests/filetests/isa/x64/xmm-select-load.clif
+++ b/cranelift/filetests/filetests/isa/x64/xmm-select-load.clif
@@ -26,7 +26,7 @@ block0(v0: i32, v1: f64, v2: i64):
 ; block1: ; offset 0x4
 ;   movsd (%rsi), %xmm5 ; trap: heap_oob
 ;   testl %edi, %edi
-;   je 0x13
+;   je 0xf
 ;   movaps %xmm5, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp

--- a/tests/disas/trunc.wat
+++ b/tests/disas/trunc.wat
@@ -17,72 +17,73 @@
 ;;       movq    0x10(%r11), %r11
 ;;       movq    %rsp, %rsi
 ;;       cmpq    %r11, %rsi
-;;       jb      0x118
+;;       jb      0x125
 ;;   24: ucomisd %xmm0, %xmm0
 ;;       movdqu  %xmm0, (%rsp)
-;;       jp      0x101
-;;       jne     0x101
+;;       jp      0x10e
+;;       jne     0x10e
 ;;   39: movq    %r14, %rdi
 ;;       movdqu  (%rsp), %xmm0
-;;       callq   0x224
+;;       callq   0x21d
 ;;       movabsq $13830554455654793216, %rax
 ;;       movq    %rax, %xmm6
 ;;       ucomisd %xmm0, %xmm6
-;;       jae     0xea
-;;   5f: ucomisd 0xc9(%rip), %xmm0
-;;       jae     0xd3
+;;       jae     0xf7
+;;   5f: ucomisd 0x69(%rip), %xmm0
+;;       jae     0xe0
 ;;   6d: movdqu  (%rsp), %xmm1
 ;;       movabsq $0x43e0000000000000, %r10
 ;;       movq    %r10, %xmm7
 ;;       ucomisd %xmm7, %xmm1
-;;       jae     0xa2
-;;       jp      0x12c
-;;   91: cvttsd2si %xmm1, %rax
+;;       jae     0x9a
+;;       jp      0xcb
+;;   8d: cvttsd2si %xmm1, %rax
 ;;       cmpq    $0, %rax
-;;       jge     0xc5
-;;   a0: ud2
+;;       jge     0xbd
+;;   98: ud2
 ;;       movaps  %xmm1, %xmm0
 ;;       subsd   %xmm7, %xmm0
 ;;       cvttsd2si %xmm0, %rax
 ;;       cmpq    $0, %rax
-;;       jl      0x12e
-;;   b8: movabsq $9223372036854775808, %r10
+;;       jl      0xcd
+;;   b0: movabsq $9223372036854775808, %r10
 ;;       addq    %r10, %rax
 ;;       movq    0x10(%rsp), %r14
 ;;       addq    $0x20, %rsp
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   d3: movl    $6, %esi
-;;   d8: movq    %r14, %rdi
-;;   db: callq   0x263
-;;   e0: movq    %r14, %rdi
-;;   e3: callq   0x2a6
-;;   e8: ud2
-;;   ea: movl    $6, %esi
-;;   ef: movq    %r14, %rdi
-;;   f2: callq   0x263
-;;   f7: movq    %r14, %rdi
-;;   fa: callq   0x2a6
-;;   ff: ud2
-;;  101: movl    $8, %esi
-;;  106: movq    %r14, %rdi
-;;  109: callq   0x263
-;;  10e: movq    %r14, %rdi
-;;  111: callq   0x2a6
-;;  116: ud2
-;;  118: xorl    %esi, %esi
-;;  11a: movq    %r14, %rdi
-;;  11d: callq   0x263
-;;  122: movq    %r14, %rdi
-;;  125: callq   0x2a6
-;;  12a: ud2
-;;  12c: ud2
-;;  12e: ud2
-;;  130: addb    %al, (%rax)
-;;  132: addb    %al, (%rax)
-;;  134: addb    %al, (%rax)
-;;  136: lock addb %al, (%r8)
-;;  13a: addb    %al, (%rax)
-;;  13c: addb    %al, (%rax)
-;;  13e: addb    %al, (%rax)
+;;   cb: ud2
+;;   cd: ud2
+;;   cf: addb    %al, (%rax)
+;;   d1: addb    %al, (%rax)
+;;   d3: addb    %al, (%rax)
+;;   d5: addb    %dh, %al
+;;   d7: addb    %al, (%r8)
+;;   da: addb    %al, (%rax)
+;;   dc: addb    %al, (%rax)
+;;   de: addb    %al, (%rax)
+;;   e0: movl    $6, %esi
+;;   e5: movq    %r14, %rdi
+;;   e8: callq   0x25c
+;;   ed: movq    %r14, %rdi
+;;   f0: callq   0x29f
+;;   f5: ud2
+;;   f7: movl    $6, %esi
+;;   fc: movq    %r14, %rdi
+;;   ff: callq   0x25c
+;;  104: movq    %r14, %rdi
+;;  107: callq   0x29f
+;;  10c: ud2
+;;  10e: movl    $8, %esi
+;;  113: movq    %r14, %rdi
+;;  116: callq   0x25c
+;;  11b: movq    %r14, %rdi
+;;  11e: callq   0x29f
+;;  123: ud2
+;;  125: xorl    %esi, %esi
+;;  127: movq    %r14, %rdi
+;;  12a: callq   0x25c
+;;  12f: movq    %r14, %rdi
+;;  132: callq   0x29f
+;;  137: ud2

--- a/tests/disas/trunc32.wat
+++ b/tests/disas/trunc32.wat
@@ -18,78 +18,78 @@
 ;;       movq    0x10(%rax), %rax
 ;;       movq    %rsp, %rcx
 ;;       cmpq    %rax, %rcx
-;;       jb      0x10d
+;;       jb      0x125
 ;;   29: xorpd   %xmm0, %xmm0
 ;;       movdqu  (%rsp), %xmm3
 ;;       cvtss2sd %xmm3, %xmm0
 ;;       ucomisd %xmm0, %xmm0
-;;       jp      0xf6
-;;       jne     0xf6
+;;       jp      0x10e
+;;       jne     0x10e
 ;;   46: movq    %r12, %rdi
-;;       callq   0x222
+;;       callq   0x21b
 ;;       movabsq $13830554455654793216, %r8
 ;;       movq    %r8, %xmm1
 ;;       ucomisd %xmm0, %xmm1
-;;       jae     0xdf
-;;   67: ucomisd 0xc1(%rip), %xmm0
-;;       jae     0xc8
+;;       jae     0xf7
+;;   67: ucomisd 0x61(%rip), %xmm0
+;;       jae     0xe0
 ;;   75: movdqu  (%rsp), %xmm7
 ;;       movl    $0x4f000000, %edi
 ;;       movd    %edi, %xmm2
 ;;       ucomiss %xmm2, %xmm7
-;;       jae     0xa1
-;;       jp      0x121
-;;   92: cvttss2si %xmm7, %eax
+;;       jae     0x99
+;;       jp      0xc0
+;;   8e: cvttss2si %xmm7, %eax
 ;;       cmpl    $0, %eax
-;;       jge     0xba
-;;   9f: ud2
+;;       jge     0xb2
+;;   97: ud2
 ;;       movaps  %xmm7, %xmm3
 ;;       subss   %xmm2, %xmm3
 ;;       cvttss2si %xmm3, %eax
 ;;       cmpl    $0, %eax
-;;       jl      0x123
-;;   b5: addl    $0x80000000, %eax
+;;       jl      0xc2
+;;   ad: addl    $0x80000000, %eax
 ;;       movq    0x10(%rsp), %r12
 ;;       addq    $0x20, %rsp
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   c8: movl    $6, %esi
-;;   cd: movq    %r12, %rdi
-;;   d0: callq   0x261
-;;   d5: movq    %r12, %rdi
-;;   d8: callq   0x2a4
-;;   dd: ud2
-;;   df: movl    $6, %esi
-;;   e4: movq    %r12, %rdi
-;;   e7: callq   0x261
-;;   ec: movq    %r12, %rdi
-;;   ef: callq   0x2a4
-;;   f4: ud2
-;;   f6: movl    $8, %esi
-;;   fb: movq    %r12, %rdi
-;;   fe: callq   0x261
-;;  103: movq    %r12, %rdi
-;;  106: callq   0x2a4
-;;  10b: ud2
-;;  10d: xorl    %esi, %esi
-;;  10f: movq    %r12, %rdi
-;;  112: callq   0x261
-;;  117: movq    %r12, %rdi
-;;  11a: callq   0x2a4
-;;  11f: ud2
-;;  121: ud2
+;;   c0: ud2
+;;   c2: ud2
+;;   c4: addb    %al, (%rax)
+;;   c6: addb    %al, (%rax)
+;;   c8: addb    %al, (%rax)
+;;   ca: addb    %al, (%rax)
+;;   cc: addb    %al, (%rax)
+;;   ce: addb    %al, (%rax)
+;;   d0: addb    %al, (%rax)
+;;   d2: addb    %al, (%rax)
+;;   d4: addb    %al, (%rax)
+;;   d6: lock addb %al, (%r8)
+;;   da: addb    %al, (%rax)
+;;   dc: addb    %al, (%rax)
+;;   de: addb    %al, (%rax)
+;;   e0: movl    $6, %esi
+;;   e5: movq    %r12, %rdi
+;;   e8: callq   0x25a
+;;   ed: movq    %r12, %rdi
+;;   f0: callq   0x29d
+;;   f5: ud2
+;;   f7: movl    $6, %esi
+;;   fc: movq    %r12, %rdi
+;;   ff: callq   0x25a
+;;  104: movq    %r12, %rdi
+;;  107: callq   0x29d
+;;  10c: ud2
+;;  10e: movl    $8, %esi
+;;  113: movq    %r12, %rdi
+;;  116: callq   0x25a
+;;  11b: movq    %r12, %rdi
+;;  11e: callq   0x29d
 ;;  123: ud2
-;;  125: addb    %al, (%rax)
-;;  127: addb    %al, (%rax)
-;;  129: addb    %al, (%rax)
-;;  12b: addb    %al, (%rax)
-;;  12d: addb    %al, (%rax)
-;;  12f: addb    %al, (%rax)
-;;  131: addb    %al, (%rax)
-;;  133: addb    %al, (%rax)
-;;  135: addb    %dh, %al
-;;  137: addb    %al, (%r8)
-;;  13a: addb    %al, (%rax)
-;;  13c: addb    %al, (%rax)
-;;  13e: addb    %al, (%rax)
+;;  125: xorl    %esi, %esi
+;;  127: movq    %r12, %rdi
+;;  12a: callq   0x25a
+;;  12f: movq    %r12, %rdi
+;;  132: callq   0x29d
+;;  137: ud2

--- a/tests/disas/winch/x64/atomic/rmw/and/i32_atomic_rmw16_andu.wat
+++ b/tests/disas/winch/x64/atomic/rmw/and/i32_atomic_rmw16_andu.wat
@@ -12,7 +12,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x14, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x8d
+;;       ja      0x89
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -21,7 +21,7 @@
 ;;       movl    $0, %ecx
 ;;       andw    $1, %cx
 ;;       cmpw    $0, %cx
-;;       jne     0x8f
+;;       jne     0x8b
 ;;   48: movl    $0, %ecx
 ;;       movq    0x30(%r14), %r11
 ;;       movq    (%r11), %rdx
@@ -35,9 +35,9 @@
 ;;       andq    %rcx, %r11
 ;;       lock cmpxchgw %r11w, (%rdx)
 ;;       jne     0x6f
-;;   81: movzwl  %ax, %eax
+;;   7d: movzwl  %ax, %eax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   8d: ud2
-;;   8f: ud2
+;;   89: ud2
+;;   8b: ud2

--- a/tests/disas/winch/x64/atomic/rmw/and/i32_atomic_rmw8_andu.wat
+++ b/tests/disas/winch/x64/atomic/rmw/and/i32_atomic_rmw8_andu.wat
@@ -12,7 +12,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x14, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x78
+;;       ja      0x74
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -31,8 +31,8 @@
 ;;       andq    %rcx, %r11
 ;;       lock cmpxchgb %r11b, (%rdx)
 ;;       jne     0x5b
-;;   6c: movzbl  %al, %eax
+;;   68: movzbl  %al, %eax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   78: ud2
+;;   74: ud2

--- a/tests/disas/winch/x64/atomic/rmw/and/i32_atomic_rmw_and.wat
+++ b/tests/disas/winch/x64/atomic/rmw/and/i32_atomic_rmw_and.wat
@@ -12,7 +12,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x14, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x87
+;;       ja      0x83
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -21,7 +21,7 @@
 ;;       movl    $0, %ecx
 ;;       andl    $3, %ecx
 ;;       cmpl    $0, %ecx
-;;       jne     0x89
+;;       jne     0x85
 ;;   48: movl    $0, %ecx
 ;;       movq    0x30(%r14), %r11
 ;;       movq    (%r11), %rdx
@@ -35,8 +35,8 @@
 ;;       andq    %rcx, %r11
 ;;       lock cmpxchgl %r11d, (%rdx)
 ;;       jne     0x6d
-;;   7e: addq    $0x10, %rsp
+;;   7a: addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   87: ud2
-;;   89: ud2
+;;   83: ud2
+;;   85: ud2

--- a/tests/disas/winch/x64/atomic/rmw/and/i64_atomic_rmw16_andu.wat
+++ b/tests/disas/winch/x64/atomic/rmw/and/i64_atomic_rmw16_andu.wat
@@ -12,7 +12,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x18, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x7c
+;;       ja      0x78
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -21,7 +21,7 @@
 ;;       movl    $0, %ecx
 ;;       andw    $1, %cx
 ;;       cmpw    $0, %cx
-;;       jne     0x7e
+;;       jne     0x7a
 ;;   48: movl    $0, %ecx
 ;;       movq    0x30(%r14), %r11
 ;;       movq    (%r11), %rdx
@@ -33,9 +33,9 @@
 ;;       andq    %rcx, %r11
 ;;       lock cmpxchgw %r11w, (%rdx)
 ;;       jne     0x5d
-;;   6f: movzwq  %ax, %rax
+;;   6b: movzwq  %ax, %rax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   7c: ud2
-;;   7e: ud2
+;;   78: ud2
+;;   7a: ud2

--- a/tests/disas/winch/x64/atomic/rmw/and/i64_atomic_rmw32_andu.wat
+++ b/tests/disas/winch/x64/atomic/rmw/and/i64_atomic_rmw32_andu.wat
@@ -12,7 +12,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x18, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x75
+;;       ja      0x71
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -21,7 +21,7 @@
 ;;       movl    $0, %ecx
 ;;       andl    $3, %ecx
 ;;       cmpl    $0, %ecx
-;;       jne     0x77
+;;       jne     0x73
 ;;   48: movl    $0, %ecx
 ;;       movq    0x30(%r14), %r11
 ;;       movq    (%r11), %rdx
@@ -33,8 +33,8 @@
 ;;       andq    %rcx, %r11
 ;;       lock cmpxchgl %r11d, (%rdx)
 ;;       jne     0x5b
-;;   6c: addq    $0x10, %rsp
+;;   68: addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   75: ud2
-;;   77: ud2
+;;   71: ud2
+;;   73: ud2

--- a/tests/disas/winch/x64/atomic/rmw/and/i64_atomic_rmw8_andu.wat
+++ b/tests/disas/winch/x64/atomic/rmw/and/i64_atomic_rmw8_andu.wat
@@ -12,7 +12,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x18, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x67
+;;       ja      0x63
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -29,8 +29,8 @@
 ;;       andq    %rcx, %r11
 ;;       lock cmpxchgb %r11b, (%rdx)
 ;;       jne     0x49
-;;   5a: movzbq  %al, %rax
+;;   56: movzbq  %al, %rax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   67: ud2
+;;   63: ud2

--- a/tests/disas/winch/x64/atomic/rmw/and/i64_atomic_rmw_and.wat
+++ b/tests/disas/winch/x64/atomic/rmw/and/i64_atomic_rmw_and.wat
@@ -12,7 +12,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x18, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x78
+;;       ja      0x74
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -21,7 +21,7 @@
 ;;       movl    $0, %ecx
 ;;       andq    $7, %rcx
 ;;       cmpq    $0, %rcx
-;;       jne     0x7a
+;;       jne     0x76
 ;;   4a: movl    $0, %ecx
 ;;       movq    0x30(%r14), %r11
 ;;       movq    (%r11), %rdx
@@ -33,8 +33,8 @@
 ;;       andq    %rcx, %r11
 ;;       lock cmpxchgq %r11, (%rdx)
 ;;       jne     0x5e
-;;   6f: addq    $0x10, %rsp
+;;   6b: addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   78: ud2
-;;   7a: ud2
+;;   74: ud2
+;;   76: ud2

--- a/tests/disas/winch/x64/atomic/rmw/or/i32_atomic_rmw16_oru.wat
+++ b/tests/disas/winch/x64/atomic/rmw/or/i32_atomic_rmw16_oru.wat
@@ -12,7 +12,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x14, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x8d
+;;       ja      0x89
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -21,7 +21,7 @@
 ;;       movl    $0, %ecx
 ;;       andw    $1, %cx
 ;;       cmpw    $0, %cx
-;;       jne     0x8f
+;;       jne     0x8b
 ;;   48: movl    $0, %ecx
 ;;       movq    0x30(%r14), %r11
 ;;       movq    (%r11), %rdx
@@ -35,9 +35,9 @@
 ;;       orq     %rcx, %r11
 ;;       lock cmpxchgw %r11w, (%rdx)
 ;;       jne     0x6f
-;;   81: movzwl  %ax, %eax
+;;   7d: movzwl  %ax, %eax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   8d: ud2
-;;   8f: ud2
+;;   89: ud2
+;;   8b: ud2

--- a/tests/disas/winch/x64/atomic/rmw/or/i32_atomic_rmw8_oru.wat
+++ b/tests/disas/winch/x64/atomic/rmw/or/i32_atomic_rmw8_oru.wat
@@ -12,7 +12,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x14, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x78
+;;       ja      0x74
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -31,8 +31,8 @@
 ;;       orq     %rcx, %r11
 ;;       lock cmpxchgb %r11b, (%rdx)
 ;;       jne     0x5b
-;;   6c: movzbl  %al, %eax
+;;   68: movzbl  %al, %eax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   78: ud2
+;;   74: ud2

--- a/tests/disas/winch/x64/atomic/rmw/or/i32_atomic_rmw_or.wat
+++ b/tests/disas/winch/x64/atomic/rmw/or/i32_atomic_rmw_or.wat
@@ -12,7 +12,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x14, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x87
+;;       ja      0x83
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -21,7 +21,7 @@
 ;;       movl    $0, %ecx
 ;;       andl    $3, %ecx
 ;;       cmpl    $0, %ecx
-;;       jne     0x89
+;;       jne     0x85
 ;;   48: movl    $0, %ecx
 ;;       movq    0x30(%r14), %r11
 ;;       movq    (%r11), %rdx
@@ -35,8 +35,8 @@
 ;;       orq     %rcx, %r11
 ;;       lock cmpxchgl %r11d, (%rdx)
 ;;       jne     0x6d
-;;   7e: addq    $0x10, %rsp
+;;   7a: addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   87: ud2
-;;   89: ud2
+;;   83: ud2
+;;   85: ud2

--- a/tests/disas/winch/x64/atomic/rmw/or/i64_atomic_rmw16_oru.wat
+++ b/tests/disas/winch/x64/atomic/rmw/or/i64_atomic_rmw16_oru.wat
@@ -12,7 +12,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x18, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x7c
+;;       ja      0x78
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -21,7 +21,7 @@
 ;;       movl    $0, %ecx
 ;;       andw    $1, %cx
 ;;       cmpw    $0, %cx
-;;       jne     0x7e
+;;       jne     0x7a
 ;;   48: movl    $0, %ecx
 ;;       movq    0x30(%r14), %r11
 ;;       movq    (%r11), %rdx
@@ -33,9 +33,9 @@
 ;;       orq     %rcx, %r11
 ;;       lock cmpxchgw %r11w, (%rdx)
 ;;       jne     0x5d
-;;   6f: movzwq  %ax, %rax
+;;   6b: movzwq  %ax, %rax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   7c: ud2
-;;   7e: ud2
+;;   78: ud2
+;;   7a: ud2

--- a/tests/disas/winch/x64/atomic/rmw/or/i64_atomic_rmw32_oru.wat
+++ b/tests/disas/winch/x64/atomic/rmw/or/i64_atomic_rmw32_oru.wat
@@ -12,7 +12,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x18, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x75
+;;       ja      0x71
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -21,7 +21,7 @@
 ;;       movl    $0, %ecx
 ;;       andl    $3, %ecx
 ;;       cmpl    $0, %ecx
-;;       jne     0x77
+;;       jne     0x73
 ;;   48: movl    $0, %ecx
 ;;       movq    0x30(%r14), %r11
 ;;       movq    (%r11), %rdx
@@ -33,8 +33,8 @@
 ;;       orq     %rcx, %r11
 ;;       lock cmpxchgl %r11d, (%rdx)
 ;;       jne     0x5b
-;;   6c: addq    $0x10, %rsp
+;;   68: addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   75: ud2
-;;   77: ud2
+;;   71: ud2
+;;   73: ud2

--- a/tests/disas/winch/x64/atomic/rmw/or/i64_atomic_rmw8_oru.wat
+++ b/tests/disas/winch/x64/atomic/rmw/or/i64_atomic_rmw8_oru.wat
@@ -12,7 +12,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x18, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x67
+;;       ja      0x63
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -29,8 +29,8 @@
 ;;       orq     %rcx, %r11
 ;;       lock cmpxchgb %r11b, (%rdx)
 ;;       jne     0x49
-;;   5a: movzbq  %al, %rax
+;;   56: movzbq  %al, %rax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   67: ud2
+;;   63: ud2

--- a/tests/disas/winch/x64/atomic/rmw/or/i64_atomic_rmw_or.wat
+++ b/tests/disas/winch/x64/atomic/rmw/or/i64_atomic_rmw_or.wat
@@ -12,7 +12,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x18, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x78
+;;       ja      0x74
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -21,7 +21,7 @@
 ;;       movl    $0, %ecx
 ;;       andq    $7, %rcx
 ;;       cmpq    $0, %rcx
-;;       jne     0x7a
+;;       jne     0x76
 ;;   4a: movl    $0, %ecx
 ;;       movq    0x30(%r14), %r11
 ;;       movq    (%r11), %rdx
@@ -33,8 +33,8 @@
 ;;       orq     %rcx, %r11
 ;;       lock cmpxchgq %r11, (%rdx)
 ;;       jne     0x5e
-;;   6f: addq    $0x10, %rsp
+;;   6b: addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   78: ud2
-;;   7a: ud2
+;;   74: ud2
+;;   76: ud2

--- a/tests/disas/winch/x64/atomic/rmw/xor/i32_atomic_rmw16_xoru.wat
+++ b/tests/disas/winch/x64/atomic/rmw/xor/i32_atomic_rmw16_xoru.wat
@@ -12,7 +12,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x14, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x8d
+;;       ja      0x89
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -21,7 +21,7 @@
 ;;       movl    $0, %ecx
 ;;       andw    $1, %cx
 ;;       cmpw    $0, %cx
-;;       jne     0x8f
+;;       jne     0x8b
 ;;   48: movl    $0, %ecx
 ;;       movq    0x30(%r14), %r11
 ;;       movq    (%r11), %rdx
@@ -35,9 +35,9 @@
 ;;       xorq    %rcx, %r11
 ;;       lock cmpxchgw %r11w, (%rdx)
 ;;       jne     0x6f
-;;   81: movzwl  %ax, %eax
+;;   7d: movzwl  %ax, %eax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   8d: ud2
-;;   8f: ud2
+;;   89: ud2
+;;   8b: ud2

--- a/tests/disas/winch/x64/atomic/rmw/xor/i32_atomic_rmw8_xoru.wat
+++ b/tests/disas/winch/x64/atomic/rmw/xor/i32_atomic_rmw8_xoru.wat
@@ -12,7 +12,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x14, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x78
+;;       ja      0x74
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -31,8 +31,8 @@
 ;;       xorq    %rcx, %r11
 ;;       lock cmpxchgb %r11b, (%rdx)
 ;;       jne     0x5b
-;;   6c: movzbl  %al, %eax
+;;   68: movzbl  %al, %eax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   78: ud2
+;;   74: ud2

--- a/tests/disas/winch/x64/atomic/rmw/xor/i32_atomic_rmw_xor.wat
+++ b/tests/disas/winch/x64/atomic/rmw/xor/i32_atomic_rmw_xor.wat
@@ -12,7 +12,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x14, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x87
+;;       ja      0x83
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -21,7 +21,7 @@
 ;;       movl    $0, %ecx
 ;;       andl    $3, %ecx
 ;;       cmpl    $0, %ecx
-;;       jne     0x89
+;;       jne     0x85
 ;;   48: movl    $0, %ecx
 ;;       movq    0x30(%r14), %r11
 ;;       movq    (%r11), %rdx
@@ -35,8 +35,8 @@
 ;;       xorq    %rcx, %r11
 ;;       lock cmpxchgl %r11d, (%rdx)
 ;;       jne     0x6d
-;;   7e: addq    $0x10, %rsp
+;;   7a: addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   87: ud2
-;;   89: ud2
+;;   83: ud2
+;;   85: ud2

--- a/tests/disas/winch/x64/atomic/rmw/xor/i64_atomic_rmw16_xoru.wat
+++ b/tests/disas/winch/x64/atomic/rmw/xor/i64_atomic_rmw16_xoru.wat
@@ -12,7 +12,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x18, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x7c
+;;       ja      0x78
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -21,7 +21,7 @@
 ;;       movl    $0, %ecx
 ;;       andw    $1, %cx
 ;;       cmpw    $0, %cx
-;;       jne     0x7e
+;;       jne     0x7a
 ;;   48: movl    $0, %ecx
 ;;       movq    0x30(%r14), %r11
 ;;       movq    (%r11), %rdx
@@ -33,9 +33,9 @@
 ;;       xorq    %rcx, %r11
 ;;       lock cmpxchgw %r11w, (%rdx)
 ;;       jne     0x5d
-;;   6f: movzwq  %ax, %rax
+;;   6b: movzwq  %ax, %rax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   7c: ud2
-;;   7e: ud2
+;;   78: ud2
+;;   7a: ud2

--- a/tests/disas/winch/x64/atomic/rmw/xor/i64_atomic_rmw32_xoru.wat
+++ b/tests/disas/winch/x64/atomic/rmw/xor/i64_atomic_rmw32_xoru.wat
@@ -12,7 +12,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x18, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x75
+;;       ja      0x71
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -21,7 +21,7 @@
 ;;       movl    $0, %ecx
 ;;       andl    $3, %ecx
 ;;       cmpl    $0, %ecx
-;;       jne     0x77
+;;       jne     0x73
 ;;   48: movl    $0, %ecx
 ;;       movq    0x30(%r14), %r11
 ;;       movq    (%r11), %rdx
@@ -33,8 +33,8 @@
 ;;       xorq    %rcx, %r11
 ;;       lock cmpxchgl %r11d, (%rdx)
 ;;       jne     0x5b
-;;   6c: addq    $0x10, %rsp
+;;   68: addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   75: ud2
-;;   77: ud2
+;;   71: ud2
+;;   73: ud2

--- a/tests/disas/winch/x64/atomic/rmw/xor/i64_atomic_rmw8_xoru.wat
+++ b/tests/disas/winch/x64/atomic/rmw/xor/i64_atomic_rmw8_xoru.wat
@@ -12,7 +12,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x18, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x67
+;;       ja      0x63
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -29,8 +29,8 @@
 ;;       xorq    %rcx, %r11
 ;;       lock cmpxchgb %r11b, (%rdx)
 ;;       jne     0x49
-;;   5a: movzbq  %al, %rax
+;;   56: movzbq  %al, %rax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   67: ud2
+;;   63: ud2

--- a/tests/disas/winch/x64/atomic/rmw/xor/i64_atomic_rmw_xor.wat
+++ b/tests/disas/winch/x64/atomic/rmw/xor/i64_atomic_rmw_xor.wat
@@ -12,7 +12,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x18, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x78
+;;       ja      0x74
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -21,7 +21,7 @@
 ;;       movl    $0, %ecx
 ;;       andq    $7, %rcx
 ;;       cmpq    $0, %rcx
-;;       jne     0x7a
+;;       jne     0x76
 ;;   4a: movl    $0, %ecx
 ;;       movq    0x30(%r14), %r11
 ;;       movq    (%r11), %rdx
@@ -33,8 +33,8 @@
 ;;       xorq    %rcx, %r11
 ;;       lock cmpxchgq %r11, (%rdx)
 ;;       jne     0x5e
-;;   6f: addq    $0x10, %rsp
+;;   6b: addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   78: ud2
-;;   7a: ud2
+;;   74: ud2
+;;   76: ud2

--- a/tests/disas/winch/x64/f32_convert_i32_u/const.wat
+++ b/tests/disas/winch/x64/f32_convert_i32_u/const.wat
@@ -14,7 +14,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x6d
+;;       ja      0x69
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -22,10 +22,10 @@
 ;;       movl    $1, %ecx
 ;;       movl    %ecx, %ecx
 ;;       cmpq    $0, %rcx
-;;       jl      0x4a
-;;   40: cvtsi2ssq %rcx, %xmm0
-;;       jmp     0x64
-;;   4a: movq    %rcx, %r11
+;;       jl      0x46
+;;   3c: cvtsi2ssq %rcx, %xmm0
+;;       jmp     0x60
+;;   46: movq    %rcx, %r11
 ;;       shrq    $1, %r11
 ;;       movq    %rcx, %rax
 ;;       andq    $1, %rax
@@ -35,4 +35,4 @@
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   6d: ud2
+;;   69: ud2

--- a/tests/disas/winch/x64/f32_convert_i32_u/locals.wat
+++ b/tests/disas/winch/x64/f32_convert_i32_u/locals.wat
@@ -16,7 +16,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x20, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x76
+;;       ja      0x72
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
@@ -25,10 +25,10 @@
 ;;       movl    0xc(%rsp), %ecx
 ;;       movl    %ecx, %ecx
 ;;       cmpq    $0, %rcx
-;;       jl      0x53
-;;   49: cvtsi2ssq %rcx, %xmm0
-;;       jmp     0x6d
-;;   53: movq    %rcx, %r11
+;;       jl      0x4f
+;;   45: cvtsi2ssq %rcx, %xmm0
+;;       jmp     0x69
+;;   4f: movq    %rcx, %r11
 ;;       shrq    $1, %r11
 ;;       movq    %rcx, %rax
 ;;       andq    $1, %rax
@@ -38,4 +38,4 @@
 ;;       addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   76: ud2
+;;   72: ud2

--- a/tests/disas/winch/x64/f32_convert_i32_u/params.wat
+++ b/tests/disas/winch/x64/f32_convert_i32_u/params.wat
@@ -14,7 +14,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x20, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x71
+;;       ja      0x6d
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
@@ -23,10 +23,10 @@
 ;;       movl    0xc(%rsp), %ecx
 ;;       movl    %ecx, %ecx
 ;;       cmpq    $0, %rcx
-;;       jl      0x4e
-;;   44: cvtsi2ssq %rcx, %xmm0
-;;       jmp     0x68
-;;   4e: movq    %rcx, %r11
+;;       jl      0x4a
+;;   40: cvtsi2ssq %rcx, %xmm0
+;;       jmp     0x64
+;;   4a: movq    %rcx, %r11
 ;;       shrq    $1, %r11
 ;;       movq    %rcx, %rax
 ;;       andq    $1, %rax
@@ -36,4 +36,4 @@
 ;;       addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   71: ud2
+;;   6d: ud2

--- a/tests/disas/winch/x64/f32_convert_i32_u/spilled.wat
+++ b/tests/disas/winch/x64/f32_convert_i32_u/spilled.wat
@@ -16,7 +16,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x14, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x85
+;;       ja      0x81
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -24,10 +24,10 @@
 ;;       movl    $1, %ecx
 ;;       movl    %ecx, %ecx
 ;;       cmpq    $0, %rcx
-;;       jl      0x4a
-;;   40: cvtsi2ssq %rcx, %xmm0
-;;       jmp     0x64
-;;   4a: movq    %rcx, %r11
+;;       jl      0x46
+;;   3c: cvtsi2ssq %rcx, %xmm0
+;;       jmp     0x60
+;;   46: movq    %rcx, %r11
 ;;       shrq    $1, %r11
 ;;       movq    %rcx, %rax
 ;;       andq    $1, %rax
@@ -41,4 +41,4 @@
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   85: ud2
+;;   81: ud2

--- a/tests/disas/winch/x64/f32_convert_i64_u/const.wat
+++ b/tests/disas/winch/x64/f32_convert_i64_u/const.wat
@@ -14,17 +14,17 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x6b
+;;       ja      0x67
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
 ;;       movl    $1, %ecx
 ;;       cmpq    $0, %rcx
-;;       jl      0x48
-;;   3e: cvtsi2ssq %rcx, %xmm0
-;;       jmp     0x62
-;;   48: movq    %rcx, %r11
+;;       jl      0x44
+;;   3a: cvtsi2ssq %rcx, %xmm0
+;;       jmp     0x5e
+;;   44: movq    %rcx, %r11
 ;;       shrq    $1, %r11
 ;;       movq    %rcx, %rax
 ;;       andq    $1, %rax
@@ -34,4 +34,4 @@
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   6b: ud2
+;;   67: ud2

--- a/tests/disas/winch/x64/f32_convert_i64_u/locals.wat
+++ b/tests/disas/winch/x64/f32_convert_i64_u/locals.wat
@@ -16,7 +16,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x20, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x75
+;;       ja      0x71
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
@@ -24,10 +24,10 @@
 ;;       movq    $0, 8(%rsp)
 ;;       movq    8(%rsp), %rcx
 ;;       cmpq    $0, %rcx
-;;       jl      0x52
-;;   48: cvtsi2ssq %rcx, %xmm0
-;;       jmp     0x6c
-;;   52: movq    %rcx, %r11
+;;       jl      0x4e
+;;   44: cvtsi2ssq %rcx, %xmm0
+;;       jmp     0x68
+;;   4e: movq    %rcx, %r11
 ;;       shrq    $1, %r11
 ;;       movq    %rcx, %rax
 ;;       andq    $1, %rax
@@ -37,4 +37,4 @@
 ;;       addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   75: ud2
+;;   71: ud2

--- a/tests/disas/winch/x64/f32_convert_i64_u/params.wat
+++ b/tests/disas/winch/x64/f32_convert_i64_u/params.wat
@@ -14,7 +14,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x20, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x71
+;;       ja      0x6d
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
@@ -22,10 +22,10 @@
 ;;       movq    %rdx, 8(%rsp)
 ;;       movq    8(%rsp), %rcx
 ;;       cmpq    $0, %rcx
-;;       jl      0x4e
-;;   44: cvtsi2ssq %rcx, %xmm0
-;;       jmp     0x68
-;;   4e: movq    %rcx, %r11
+;;       jl      0x4a
+;;   40: cvtsi2ssq %rcx, %xmm0
+;;       jmp     0x64
+;;   4a: movq    %rcx, %r11
 ;;       shrq    $1, %r11
 ;;       movq    %rcx, %rax
 ;;       andq    $1, %rax
@@ -35,4 +35,4 @@
 ;;       addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   71: ud2
+;;   6d: ud2

--- a/tests/disas/winch/x64/f32_convert_i64_u/spilled.wat
+++ b/tests/disas/winch/x64/f32_convert_i64_u/spilled.wat
@@ -16,17 +16,17 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x14, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x83
+;;       ja      0x7f
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
 ;;       movl    $1, %ecx
 ;;       cmpq    $0, %rcx
-;;       jl      0x48
-;;   3e: cvtsi2ssq %rcx, %xmm0
-;;       jmp     0x62
-;;   48: movq    %rcx, %r11
+;;       jl      0x44
+;;   3a: cvtsi2ssq %rcx, %xmm0
+;;       jmp     0x5e
+;;   44: movq    %rcx, %r11
 ;;       shrq    $1, %r11
 ;;       movq    %rcx, %rax
 ;;       andq    $1, %rax
@@ -40,4 +40,4 @@
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   83: ud2
+;;   7f: ud2

--- a/tests/disas/winch/x64/f32_max/const.wat
+++ b/tests/disas/winch/x64/f32_max/const.wat
@@ -15,31 +15,29 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x70
+;;       ja      0x64
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
-;;       movss   0x41(%rip), %xmm0
-;;       movss   0x41(%rip), %xmm1
+;;       movss   0x31(%rip), %xmm0
+;;       movss   0x31(%rip), %xmm1
 ;;       ucomiss %xmm0, %xmm1
-;;       jne     0x60
-;;       jp      0x56
-;;   4e: andps   %xmm0, %xmm1
-;;       jmp     0x64
-;;   56: addss   %xmm0, %xmm1
-;;       jp      0x64
-;;   60: maxss   %xmm0, %xmm1
+;;       jne     0x54
+;;       jp      0x4e
+;;   46: andps   %xmm0, %xmm1
+;;       jmp     0x58
+;;   4e: addss   %xmm0, %xmm1
+;;       jp      0x58
+;;   54: maxss   %xmm0, %xmm1
 ;;       movaps  %xmm1, %xmm0
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   70: ud2
-;;   72: addb    %al, (%rax)
-;;   74: addb    %al, (%rax)
-;;   76: addb    %al, (%rax)
-;;   78: int     $0xcc
-;;   7a: orb     $0x40, %al
-;;   7c: addb    %al, (%rax)
-;;   7e: addb    %al, (%rax)
-;;   80: int     $0xcc
+;;   64: ud2
+;;   66: addb    %al, (%rax)
+;;   68: int     $0xcc
+;;   6a: orb     $0x40, %al
+;;   6c: addb    %al, (%rax)
+;;   6e: addb    %al, (%rax)
+;;   70: int     $0xcc

--- a/tests/disas/winch/x64/f32_max/locals.wat
+++ b/tests/disas/winch/x64/f32_max/locals.wat
@@ -24,31 +24,29 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x20, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x92
+;;       ja      0x86
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
 ;;       movq    %rsi, 0x10(%rsp)
 ;;       movq    $0, 8(%rsp)
-;;       movss   0x57(%rip), %xmm0
+;;       movss   0x47(%rip), %xmm0
 ;;       movss   %xmm0, 0xc(%rsp)
-;;       movss   0x51(%rip), %xmm0
+;;       movss   0x41(%rip), %xmm0
 ;;       movss   %xmm0, 8(%rsp)
 ;;       movss   8(%rsp), %xmm0
 ;;       movss   0xc(%rsp), %xmm1
 ;;       ucomiss %xmm0, %xmm1
-;;       jne     0x82
-;;       jp      0x78
-;;   70: andps   %xmm0, %xmm1
-;;       jmp     0x86
-;;   78: addss   %xmm0, %xmm1
-;;       jp      0x86
-;;   82: maxss   %xmm0, %xmm1
+;;       jne     0x76
+;;       jp      0x70
+;;   68: andps   %xmm0, %xmm1
+;;       jmp     0x7a
+;;   70: addss   %xmm0, %xmm1
+;;       jp      0x7a
+;;   76: maxss   %xmm0, %xmm1
 ;;       movaps  %xmm1, %xmm0
 ;;       addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   92: ud2
-;;   94: addb    %al, (%rax)
-;;   96: addb    %al, (%rax)
-;;   98: int     $0xcc
+;;   86: ud2
+;;   88: int     $0xcc

--- a/tests/disas/winch/x64/f32_max/params.wat
+++ b/tests/disas/winch/x64/f32_max/params.wat
@@ -15,7 +15,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x20, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x79
+;;       ja      0x6d
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
@@ -25,15 +25,15 @@
 ;;       movss   8(%rsp), %xmm0
 ;;       movss   0xc(%rsp), %xmm1
 ;;       ucomiss %xmm0, %xmm1
-;;       jne     0x69
-;;       jp      0x5f
-;;   57: andps   %xmm0, %xmm1
-;;       jmp     0x6d
-;;   5f: addss   %xmm0, %xmm1
-;;       jp      0x6d
-;;   69: maxss   %xmm0, %xmm1
+;;       jne     0x5d
+;;       jp      0x57
+;;   4f: andps   %xmm0, %xmm1
+;;       jmp     0x61
+;;   57: addss   %xmm0, %xmm1
+;;       jp      0x61
+;;   5d: maxss   %xmm0, %xmm1
 ;;       movaps  %xmm1, %xmm0
 ;;       addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   79: ud2
+;;   6d: ud2

--- a/tests/disas/winch/x64/f32_min/const.wat
+++ b/tests/disas/winch/x64/f32_min/const.wat
@@ -15,31 +15,29 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x70
+;;       ja      0x64
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
-;;       movss   0x41(%rip), %xmm0
-;;       movss   0x41(%rip), %xmm1
+;;       movss   0x31(%rip), %xmm0
+;;       movss   0x31(%rip), %xmm1
 ;;       ucomiss %xmm0, %xmm1
-;;       jne     0x60
-;;       jp      0x56
-;;   4e: orps    %xmm0, %xmm1
-;;       jmp     0x64
-;;   56: addss   %xmm0, %xmm1
-;;       jp      0x64
-;;   60: minss   %xmm0, %xmm1
+;;       jne     0x54
+;;       jp      0x4e
+;;   46: orps    %xmm0, %xmm1
+;;       jmp     0x58
+;;   4e: addss   %xmm0, %xmm1
+;;       jp      0x58
+;;   54: minss   %xmm0, %xmm1
 ;;       movaps  %xmm1, %xmm0
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   70: ud2
-;;   72: addb    %al, (%rax)
-;;   74: addb    %al, (%rax)
-;;   76: addb    %al, (%rax)
-;;   78: int     $0xcc
-;;   7a: orb     $0x40, %al
-;;   7c: addb    %al, (%rax)
-;;   7e: addb    %al, (%rax)
-;;   80: int     $0xcc
+;;   64: ud2
+;;   66: addb    %al, (%rax)
+;;   68: int     $0xcc
+;;   6a: orb     $0x40, %al
+;;   6c: addb    %al, (%rax)
+;;   6e: addb    %al, (%rax)
+;;   70: int     $0xcc

--- a/tests/disas/winch/x64/f32_min/locals.wat
+++ b/tests/disas/winch/x64/f32_min/locals.wat
@@ -24,31 +24,29 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x20, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x92
+;;       ja      0x86
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
 ;;       movq    %rsi, 0x10(%rsp)
 ;;       movq    $0, 8(%rsp)
-;;       movss   0x57(%rip), %xmm0
+;;       movss   0x47(%rip), %xmm0
 ;;       movss   %xmm0, 0xc(%rsp)
-;;       movss   0x51(%rip), %xmm0
+;;       movss   0x41(%rip), %xmm0
 ;;       movss   %xmm0, 8(%rsp)
 ;;       movss   8(%rsp), %xmm0
 ;;       movss   0xc(%rsp), %xmm1
 ;;       ucomiss %xmm0, %xmm1
-;;       jne     0x82
-;;       jp      0x78
-;;   70: orps    %xmm0, %xmm1
-;;       jmp     0x86
-;;   78: addss   %xmm0, %xmm1
-;;       jp      0x86
-;;   82: minss   %xmm0, %xmm1
+;;       jne     0x76
+;;       jp      0x70
+;;   68: orps    %xmm0, %xmm1
+;;       jmp     0x7a
+;;   70: addss   %xmm0, %xmm1
+;;       jp      0x7a
+;;   76: minss   %xmm0, %xmm1
 ;;       movaps  %xmm1, %xmm0
 ;;       addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   92: ud2
-;;   94: addb    %al, (%rax)
-;;   96: addb    %al, (%rax)
-;;   98: int     $0xcc
+;;   86: ud2
+;;   88: int     $0xcc

--- a/tests/disas/winch/x64/f32_min/params.wat
+++ b/tests/disas/winch/x64/f32_min/params.wat
@@ -15,7 +15,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x20, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x79
+;;       ja      0x6d
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
@@ -25,15 +25,15 @@
 ;;       movss   8(%rsp), %xmm0
 ;;       movss   0xc(%rsp), %xmm1
 ;;       ucomiss %xmm0, %xmm1
-;;       jne     0x69
-;;       jp      0x5f
-;;   57: orps    %xmm0, %xmm1
-;;       jmp     0x6d
-;;   5f: addss   %xmm0, %xmm1
-;;       jp      0x6d
-;;   69: minss   %xmm0, %xmm1
+;;       jne     0x5d
+;;       jp      0x57
+;;   4f: orps    %xmm0, %xmm1
+;;       jmp     0x61
+;;   57: addss   %xmm0, %xmm1
+;;       jp      0x61
+;;   5d: minss   %xmm0, %xmm1
 ;;       movaps  %xmm1, %xmm0
 ;;       addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   79: ud2
+;;   6d: ud2

--- a/tests/disas/winch/x64/f64_convert_i32_u/const.wat
+++ b/tests/disas/winch/x64/f64_convert_i32_u/const.wat
@@ -14,7 +14,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x6d
+;;       ja      0x69
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -22,10 +22,10 @@
 ;;       movl    $1, %ecx
 ;;       movl    %ecx, %ecx
 ;;       cmpq    $0, %rcx
-;;       jl      0x4a
-;;   40: cvtsi2sdq %rcx, %xmm0
-;;       jmp     0x64
-;;   4a: movq    %rcx, %r11
+;;       jl      0x46
+;;   3c: cvtsi2sdq %rcx, %xmm0
+;;       jmp     0x60
+;;   46: movq    %rcx, %r11
 ;;       shrq    $1, %r11
 ;;       movq    %rcx, %rax
 ;;       andq    $1, %rax
@@ -35,4 +35,4 @@
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   6d: ud2
+;;   69: ud2

--- a/tests/disas/winch/x64/f64_convert_i32_u/locals.wat
+++ b/tests/disas/winch/x64/f64_convert_i32_u/locals.wat
@@ -16,7 +16,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x20, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x76
+;;       ja      0x72
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
@@ -25,10 +25,10 @@
 ;;       movl    0xc(%rsp), %ecx
 ;;       movl    %ecx, %ecx
 ;;       cmpq    $0, %rcx
-;;       jl      0x53
-;;   49: cvtsi2sdq %rcx, %xmm0
-;;       jmp     0x6d
-;;   53: movq    %rcx, %r11
+;;       jl      0x4f
+;;   45: cvtsi2sdq %rcx, %xmm0
+;;       jmp     0x69
+;;   4f: movq    %rcx, %r11
 ;;       shrq    $1, %r11
 ;;       movq    %rcx, %rax
 ;;       andq    $1, %rax
@@ -38,4 +38,4 @@
 ;;       addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   76: ud2
+;;   72: ud2

--- a/tests/disas/winch/x64/f64_convert_i32_u/params.wat
+++ b/tests/disas/winch/x64/f64_convert_i32_u/params.wat
@@ -14,7 +14,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x20, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x71
+;;       ja      0x6d
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
@@ -23,10 +23,10 @@
 ;;       movl    0xc(%rsp), %ecx
 ;;       movl    %ecx, %ecx
 ;;       cmpq    $0, %rcx
-;;       jl      0x4e
-;;   44: cvtsi2sdq %rcx, %xmm0
-;;       jmp     0x68
-;;   4e: movq    %rcx, %r11
+;;       jl      0x4a
+;;   40: cvtsi2sdq %rcx, %xmm0
+;;       jmp     0x64
+;;   4a: movq    %rcx, %r11
 ;;       shrq    $1, %r11
 ;;       movq    %rcx, %rax
 ;;       andq    $1, %rax
@@ -36,4 +36,4 @@
 ;;       addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   71: ud2
+;;   6d: ud2

--- a/tests/disas/winch/x64/f64_convert_i32_u/spilled.wat
+++ b/tests/disas/winch/x64/f64_convert_i32_u/spilled.wat
@@ -16,7 +16,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x18, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x85
+;;       ja      0x81
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -24,10 +24,10 @@
 ;;       movl    $1, %ecx
 ;;       movl    %ecx, %ecx
 ;;       cmpq    $0, %rcx
-;;       jl      0x4a
-;;   40: cvtsi2sdq %rcx, %xmm0
-;;       jmp     0x64
-;;   4a: movq    %rcx, %r11
+;;       jl      0x46
+;;   3c: cvtsi2sdq %rcx, %xmm0
+;;       jmp     0x60
+;;   46: movq    %rcx, %r11
 ;;       shrq    $1, %r11
 ;;       movq    %rcx, %rax
 ;;       andq    $1, %rax
@@ -41,4 +41,4 @@
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   85: ud2
+;;   81: ud2

--- a/tests/disas/winch/x64/f64_convert_i64_u/const.wat
+++ b/tests/disas/winch/x64/f64_convert_i64_u/const.wat
@@ -14,17 +14,17 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x6b
+;;       ja      0x67
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
 ;;       movl    $1, %ecx
 ;;       cmpq    $0, %rcx
-;;       jl      0x48
-;;   3e: cvtsi2sdq %rcx, %xmm0
-;;       jmp     0x62
-;;   48: movq    %rcx, %r11
+;;       jl      0x44
+;;   3a: cvtsi2sdq %rcx, %xmm0
+;;       jmp     0x5e
+;;   44: movq    %rcx, %r11
 ;;       shrq    $1, %r11
 ;;       movq    %rcx, %rax
 ;;       andq    $1, %rax
@@ -34,4 +34,4 @@
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   6b: ud2
+;;   67: ud2

--- a/tests/disas/winch/x64/f64_convert_i64_u/locals.wat
+++ b/tests/disas/winch/x64/f64_convert_i64_u/locals.wat
@@ -16,7 +16,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x20, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x75
+;;       ja      0x71
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
@@ -24,10 +24,10 @@
 ;;       movq    $0, 8(%rsp)
 ;;       movq    8(%rsp), %rcx
 ;;       cmpq    $0, %rcx
-;;       jl      0x52
-;;   48: cvtsi2sdq %rcx, %xmm0
-;;       jmp     0x6c
-;;   52: movq    %rcx, %r11
+;;       jl      0x4e
+;;   44: cvtsi2sdq %rcx, %xmm0
+;;       jmp     0x68
+;;   4e: movq    %rcx, %r11
 ;;       shrq    $1, %r11
 ;;       movq    %rcx, %rax
 ;;       andq    $1, %rax
@@ -37,4 +37,4 @@
 ;;       addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   75: ud2
+;;   71: ud2

--- a/tests/disas/winch/x64/f64_convert_i64_u/params.wat
+++ b/tests/disas/winch/x64/f64_convert_i64_u/params.wat
@@ -14,7 +14,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x20, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x71
+;;       ja      0x6d
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
@@ -22,10 +22,10 @@
 ;;       movq    %rdx, 8(%rsp)
 ;;       movq    8(%rsp), %rcx
 ;;       cmpq    $0, %rcx
-;;       jl      0x4e
-;;   44: cvtsi2sdq %rcx, %xmm0
-;;       jmp     0x68
-;;   4e: movq    %rcx, %r11
+;;       jl      0x4a
+;;   40: cvtsi2sdq %rcx, %xmm0
+;;       jmp     0x64
+;;   4a: movq    %rcx, %r11
 ;;       shrq    $1, %r11
 ;;       movq    %rcx, %rax
 ;;       andq    $1, %rax
@@ -35,4 +35,4 @@
 ;;       addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   71: ud2
+;;   6d: ud2

--- a/tests/disas/winch/x64/f64_convert_i64_u/spilled.wat
+++ b/tests/disas/winch/x64/f64_convert_i64_u/spilled.wat
@@ -16,17 +16,17 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x18, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x83
+;;       ja      0x7f
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
 ;;       movl    $1, %ecx
 ;;       cmpq    $0, %rcx
-;;       jl      0x48
-;;   3e: cvtsi2sdq %rcx, %xmm0
-;;       jmp     0x62
-;;   48: movq    %rcx, %r11
+;;       jl      0x44
+;;   3a: cvtsi2sdq %rcx, %xmm0
+;;       jmp     0x5e
+;;   44: movq    %rcx, %r11
 ;;       shrq    $1, %r11
 ;;       movq    %rcx, %rax
 ;;       andq    $1, %rax
@@ -40,4 +40,4 @@
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   83: ud2
+;;   7f: ud2

--- a/tests/disas/winch/x64/f64_max/const.wat
+++ b/tests/disas/winch/x64/f64_max/const.wat
@@ -15,25 +15,23 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x72
+;;       ja      0x66
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
-;;       movsd   0x41(%rip), %xmm0
-;;       movsd   0x41(%rip), %xmm1
+;;       movsd   0x31(%rip), %xmm0
+;;       movsd   0x31(%rip), %xmm1
 ;;       ucomisd %xmm0, %xmm1
-;;       jne     0x62
-;;       jp      0x58
-;;   4f: andpd   %xmm0, %xmm1
-;;       jmp     0x66
-;;   58: addsd   %xmm0, %xmm1
-;;       jp      0x66
-;;   62: maxsd   %xmm0, %xmm1
+;;       jne     0x56
+;;       jp      0x50
+;;   47: andpd   %xmm0, %xmm1
+;;       jmp     0x5a
+;;   50: addsd   %xmm0, %xmm1
+;;       jp      0x5a
+;;   56: maxsd   %xmm0, %xmm1
 ;;       movaps  %xmm1, %xmm0
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   72: ud2
-;;   74: addb    %al, (%rax)
-;;   76: addb    %al, (%rax)
+;;   66: ud2

--- a/tests/disas/winch/x64/f64_max/locals.wat
+++ b/tests/disas/winch/x64/f64_max/locals.wat
@@ -24,7 +24,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x20, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x95
+;;       ja      0x89
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
@@ -32,25 +32,27 @@
 ;;       xorq    %r11, %r11
 ;;       movq    %r11, 8(%rsp)
 ;;       movq    %r11, (%rsp)
-;;       movsd   0x54(%rip), %xmm0
+;;       movsd   0x4c(%rip), %xmm0
 ;;       movsd   %xmm0, 8(%rsp)
-;;       movsd   0x4e(%rip), %xmm0
+;;       movsd   0x46(%rip), %xmm0
 ;;       movsd   %xmm0, (%rsp)
 ;;       movsd   (%rsp), %xmm0
 ;;       movsd   8(%rsp), %xmm1
 ;;       ucomisd %xmm0, %xmm1
-;;       jne     0x85
-;;       jp      0x7b
-;;   72: andpd   %xmm0, %xmm1
-;;       jmp     0x89
-;;   7b: addsd   %xmm0, %xmm1
-;;       jp      0x89
-;;   85: maxsd   %xmm0, %xmm1
+;;       jne     0x79
+;;       jp      0x73
+;;   6a: andpd   %xmm0, %xmm1
+;;       jmp     0x7d
+;;   73: addsd   %xmm0, %xmm1
+;;       jp      0x7d
+;;   79: maxsd   %xmm0, %xmm1
 ;;       movaps  %xmm1, %xmm0
 ;;       addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   95: ud2
-;;   97: addb    %bl, -0x66666667(%rdx)
-;;   9d: cltd
-;;   9e: int1
+;;   89: ud2
+;;   8b: addb    %al, (%rax)
+;;   8d: addb    %al, (%rax)
+;;   8f: addb    %bl, -0x66666667(%rdx)
+;;   95: cltd
+;;   96: int1

--- a/tests/disas/winch/x64/f64_max/params.wat
+++ b/tests/disas/winch/x64/f64_max/params.wat
@@ -15,7 +15,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x20, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x79
+;;       ja      0x6d
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
@@ -25,15 +25,15 @@
 ;;       movsd   (%rsp), %xmm0
 ;;       movsd   8(%rsp), %xmm1
 ;;       ucomisd %xmm0, %xmm1
-;;       jne     0x69
-;;       jp      0x5f
-;;   56: andpd   %xmm0, %xmm1
-;;       jmp     0x6d
-;;   5f: addsd   %xmm0, %xmm1
-;;       jp      0x6d
-;;   69: maxsd   %xmm0, %xmm1
+;;       jne     0x5d
+;;       jp      0x57
+;;   4e: andpd   %xmm0, %xmm1
+;;       jmp     0x61
+;;   57: addsd   %xmm0, %xmm1
+;;       jp      0x61
+;;   5d: maxsd   %xmm0, %xmm1
 ;;       movaps  %xmm1, %xmm0
 ;;       addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   79: ud2
+;;   6d: ud2

--- a/tests/disas/winch/x64/f64_min/const.wat
+++ b/tests/disas/winch/x64/f64_min/const.wat
@@ -15,25 +15,23 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x72
+;;       ja      0x66
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
-;;       movsd   0x41(%rip), %xmm0
-;;       movsd   0x41(%rip), %xmm1
+;;       movsd   0x31(%rip), %xmm0
+;;       movsd   0x31(%rip), %xmm1
 ;;       ucomisd %xmm0, %xmm1
-;;       jne     0x62
-;;       jp      0x58
-;;   4f: orpd    %xmm0, %xmm1
-;;       jmp     0x66
-;;   58: addsd   %xmm0, %xmm1
-;;       jp      0x66
-;;   62: minsd   %xmm0, %xmm1
+;;       jne     0x56
+;;       jp      0x50
+;;   47: orpd    %xmm0, %xmm1
+;;       jmp     0x5a
+;;   50: addsd   %xmm0, %xmm1
+;;       jp      0x5a
+;;   56: minsd   %xmm0, %xmm1
 ;;       movaps  %xmm1, %xmm0
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   72: ud2
-;;   74: addb    %al, (%rax)
-;;   76: addb    %al, (%rax)
+;;   66: ud2

--- a/tests/disas/winch/x64/f64_min/locals.wat
+++ b/tests/disas/winch/x64/f64_min/locals.wat
@@ -24,7 +24,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x20, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x95
+;;       ja      0x89
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
@@ -32,25 +32,27 @@
 ;;       xorq    %r11, %r11
 ;;       movq    %r11, 8(%rsp)
 ;;       movq    %r11, (%rsp)
-;;       movsd   0x54(%rip), %xmm0
+;;       movsd   0x4c(%rip), %xmm0
 ;;       movsd   %xmm0, 8(%rsp)
-;;       movsd   0x4e(%rip), %xmm0
+;;       movsd   0x46(%rip), %xmm0
 ;;       movsd   %xmm0, (%rsp)
 ;;       movsd   (%rsp), %xmm0
 ;;       movsd   8(%rsp), %xmm1
 ;;       ucomisd %xmm0, %xmm1
-;;       jne     0x85
-;;       jp      0x7b
-;;   72: orpd    %xmm0, %xmm1
-;;       jmp     0x89
-;;   7b: addsd   %xmm0, %xmm1
-;;       jp      0x89
-;;   85: minsd   %xmm0, %xmm1
+;;       jne     0x79
+;;       jp      0x73
+;;   6a: orpd    %xmm0, %xmm1
+;;       jmp     0x7d
+;;   73: addsd   %xmm0, %xmm1
+;;       jp      0x7d
+;;   79: minsd   %xmm0, %xmm1
 ;;       movaps  %xmm1, %xmm0
 ;;       addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   95: ud2
-;;   97: addb    %bl, -0x66666667(%rdx)
-;;   9d: cltd
-;;   9e: int1
+;;   89: ud2
+;;   8b: addb    %al, (%rax)
+;;   8d: addb    %al, (%rax)
+;;   8f: addb    %bl, -0x66666667(%rdx)
+;;   95: cltd
+;;   96: int1

--- a/tests/disas/winch/x64/f64_min/params.wat
+++ b/tests/disas/winch/x64/f64_min/params.wat
@@ -15,7 +15,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x20, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x79
+;;       ja      0x6d
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
@@ -25,15 +25,15 @@
 ;;       movsd   (%rsp), %xmm0
 ;;       movsd   8(%rsp), %xmm1
 ;;       ucomisd %xmm0, %xmm1
-;;       jne     0x69
-;;       jp      0x5f
-;;   56: orpd    %xmm0, %xmm1
-;;       jmp     0x6d
-;;   5f: addsd   %xmm0, %xmm1
-;;       jp      0x6d
-;;   69: minsd   %xmm0, %xmm1
+;;       jne     0x5d
+;;       jp      0x57
+;;   4e: orpd    %xmm0, %xmm1
+;;       jmp     0x61
+;;   57: addsd   %xmm0, %xmm1
+;;       jp      0x61
+;;   5d: minsd   %xmm0, %xmm1
 ;;       movaps  %xmm1, %xmm0
 ;;       addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   79: ud2
+;;   6d: ud2

--- a/tests/disas/winch/x64/i32_rems/const.wat
+++ b/tests/disas/winch/x64/i32_rems/const.wat
@@ -15,7 +15,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x5a
+;;       ja      0x56
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -24,12 +24,12 @@
 ;;       movl    $7, %eax
 ;;       cltd
 ;;       cmpl    $-1, %ecx
-;;       jne     0x4d
-;;   43: movl    $0, %edx
-;;       jmp     0x4f
-;;   4d: idivl   %ecx
+;;       jne     0x49
+;;   3f: movl    $0, %edx
+;;       jmp     0x4b
+;;   49: idivl   %ecx
 ;;       movl    %edx, %eax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   5a: ud2
+;;   56: ud2

--- a/tests/disas/winch/x64/i32_rems/one_zero.wat
+++ b/tests/disas/winch/x64/i32_rems/one_zero.wat
@@ -15,7 +15,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x5a
+;;       ja      0x56
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -24,12 +24,12 @@
 ;;       movl    $1, %eax
 ;;       cltd
 ;;       cmpl    $-1, %ecx
-;;       jne     0x4d
-;;   43: movl    $0, %edx
-;;       jmp     0x4f
-;;   4d: idivl   %ecx
+;;       jne     0x49
+;;   3f: movl    $0, %edx
+;;       jmp     0x4b
+;;   49: idivl   %ecx
 ;;       movl    %edx, %eax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   5a: ud2
+;;   56: ud2

--- a/tests/disas/winch/x64/i32_rems/overflow.wat
+++ b/tests/disas/winch/x64/i32_rems/overflow.wat
@@ -15,7 +15,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x5a
+;;       ja      0x56
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -24,12 +24,12 @@
 ;;       movl    $0x80000000, %eax
 ;;       cltd
 ;;       cmpl    $-1, %ecx
-;;       jne     0x4d
-;;   43: movl    $0, %edx
-;;       jmp     0x4f
-;;   4d: idivl   %ecx
+;;       jne     0x49
+;;   3f: movl    $0, %edx
+;;       jmp     0x4b
+;;   49: idivl   %ecx
 ;;       movl    %edx, %eax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   5a: ud2
+;;   56: ud2

--- a/tests/disas/winch/x64/i32_rems/params.wat
+++ b/tests/disas/winch/x64/i32_rems/params.wat
@@ -15,7 +15,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x20, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x61
+;;       ja      0x5d
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
@@ -26,12 +26,12 @@
 ;;       movl    0xc(%rsp), %eax
 ;;       cltd
 ;;       cmpl    $-1, %ecx
-;;       jne     0x54
-;;   4a: movl    $0, %edx
-;;       jmp     0x56
-;;   54: idivl   %ecx
+;;       jne     0x50
+;;   46: movl    $0, %edx
+;;       jmp     0x52
+;;   50: idivl   %ecx
 ;;       movl    %edx, %eax
 ;;       addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   61: ud2
+;;   5d: ud2

--- a/tests/disas/winch/x64/i32_rems/zero_zero.wat
+++ b/tests/disas/winch/x64/i32_rems/zero_zero.wat
@@ -15,7 +15,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x5a
+;;       ja      0x56
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -24,12 +24,12 @@
 ;;       movl    $0, %eax
 ;;       cltd
 ;;       cmpl    $-1, %ecx
-;;       jne     0x4d
-;;   43: movl    $0, %edx
-;;       jmp     0x4f
-;;   4d: idivl   %ecx
+;;       jne     0x49
+;;   3f: movl    $0, %edx
+;;       jmp     0x4b
+;;   49: idivl   %ecx
 ;;       movl    %edx, %eax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   5a: ud2
+;;   56: ud2

--- a/tests/disas/winch/x64/i32_trunc_f32_s/const.wat
+++ b/tests/disas/winch/x64/i32_trunc_f32_s/const.wat
@@ -14,32 +14,30 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x7a
+;;       ja      0x76
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
-;;       movss   0x51(%rip), %xmm0
+;;       movss   0x49(%rip), %xmm0
 ;;       cvttss2si %xmm0, %eax
 ;;       cmpl    $1, %eax
-;;       jno     0x71
-;;   44: ucomiss %xmm0, %xmm0
-;;       jp      0x7c
-;;   4d: movl    $0xcf000000, %r11d
+;;       jno     0x6d
+;;   40: ucomiss %xmm0, %xmm0
+;;       jp      0x78
+;;   49: movl    $0xcf000000, %r11d
 ;;       movd    %r11d, %xmm15
 ;;       ucomiss %xmm15, %xmm0
-;;       jb      0x7e
-;;   62: xorpd   %xmm15, %xmm15
+;;       jb      0x7a
+;;   5e: xorpd   %xmm15, %xmm15
 ;;       ucomiss %xmm0, %xmm15
-;;       jb      0x80
-;;   71: addq    $0x10, %rsp
+;;       jb      0x7c
+;;   6d: addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
+;;   76: ud2
+;;   78: ud2
 ;;   7a: ud2
 ;;   7c: ud2
-;;   7e: ud2
-;;   80: ud2
-;;   82: addb    %al, (%rax)
-;;   84: addb    %al, (%rax)
-;;   86: addb    %al, (%rax)
-;;   88: addb    %al, (%rax)
+;;   7e: addb    %al, (%rax)
+;;   80: addb    %al, (%rax)

--- a/tests/disas/winch/x64/i32_trunc_f32_s/locals.wat
+++ b/tests/disas/winch/x64/i32_trunc_f32_s/locals.wat
@@ -16,7 +16,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x20, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x82
+;;       ja      0x7e
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
@@ -25,20 +25,20 @@
 ;;       movss   0xc(%rsp), %xmm0
 ;;       cvttss2si %xmm0, %eax
 ;;       cmpl    $1, %eax
-;;       jno     0x79
-;;   4c: ucomiss %xmm0, %xmm0
-;;       jp      0x84
-;;   55: movl    $0xcf000000, %r11d
+;;       jno     0x75
+;;   48: ucomiss %xmm0, %xmm0
+;;       jp      0x80
+;;   51: movl    $0xcf000000, %r11d
 ;;       movd    %r11d, %xmm15
 ;;       ucomiss %xmm15, %xmm0
-;;       jb      0x86
-;;   6a: xorpd   %xmm15, %xmm15
+;;       jb      0x82
+;;   66: xorpd   %xmm15, %xmm15
 ;;       ucomiss %xmm0, %xmm15
-;;       jb      0x88
-;;   79: addq    $0x20, %rsp
+;;       jb      0x84
+;;   75: addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
+;;   7e: ud2
+;;   80: ud2
 ;;   82: ud2
 ;;   84: ud2
-;;   86: ud2
-;;   88: ud2

--- a/tests/disas/winch/x64/i32_trunc_f32_s/params.wat
+++ b/tests/disas/winch/x64/i32_trunc_f32_s/params.wat
@@ -14,7 +14,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x20, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x7f
+;;       ja      0x7b
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
@@ -23,20 +23,20 @@
 ;;       movss   0xc(%rsp), %xmm0
 ;;       cvttss2si %xmm0, %eax
 ;;       cmpl    $1, %eax
-;;       jno     0x76
-;;   49: ucomiss %xmm0, %xmm0
-;;       jp      0x81
-;;   52: movl    $0xcf000000, %r11d
+;;       jno     0x72
+;;   45: ucomiss %xmm0, %xmm0
+;;       jp      0x7d
+;;   4e: movl    $0xcf000000, %r11d
 ;;       movd    %r11d, %xmm15
 ;;       ucomiss %xmm15, %xmm0
-;;       jb      0x83
-;;   67: xorpd   %xmm15, %xmm15
+;;       jb      0x7f
+;;   63: xorpd   %xmm15, %xmm15
 ;;       ucomiss %xmm0, %xmm15
-;;       jb      0x85
-;;   76: addq    $0x20, %rsp
+;;       jb      0x81
+;;   72: addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
+;;   7b: ud2
+;;   7d: ud2
 ;;   7f: ud2
 ;;   81: ud2
-;;   83: ud2
-;;   85: ud2

--- a/tests/disas/winch/x64/i32_trunc_f32_u/const.wat
+++ b/tests/disas/winch/x64/i32_trunc_f32_u/const.wat
@@ -14,34 +14,34 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x84
+;;       ja      0x7c
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
-;;       movss   0x59(%rip), %xmm1
+;;       movss   0x51(%rip), %xmm1
 ;;       movl    $0x4f000000, %r11d
 ;;       movd    %r11d, %xmm15
 ;;       ucomiss %xmm15, %xmm1
-;;       jae     0x61
-;;       jp      0x86
-;;   52: cvttss2si %xmm1, %eax
+;;       jae     0x59
+;;       jp      0x7e
+;;   4e: cvttss2si %xmm1, %eax
 ;;       cmpl    $0, %eax
-;;       jge     0x7b
-;;   5f: ud2
+;;       jge     0x73
+;;   57: ud2
 ;;       movaps  %xmm1, %xmm0
 ;;       subss   %xmm15, %xmm0
 ;;       cvttss2si %xmm0, %eax
 ;;       cmpl    $0, %eax
-;;       jl      0x88
-;;   76: addl    $0x80000000, %eax
+;;       jl      0x80
+;;   6e: addl    $0x80000000, %eax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   84: ud2
-;;   86: ud2
-;;   88: ud2
-;;   8a: addb    %al, (%rax)
-;;   8c: addb    %al, (%rax)
-;;   8e: addb    %al, (%rax)
-;;   90: addb    %al, (%rax)
+;;   7c: ud2
+;;   7e: ud2
+;;   80: ud2
+;;   82: addb    %al, (%rax)
+;;   84: addb    %al, (%rax)
+;;   86: addb    %al, (%rax)
+;;   88: addb    %al, (%rax)

--- a/tests/disas/winch/x64/i32_trunc_f32_u/locals.wat
+++ b/tests/disas/winch/x64/i32_trunc_f32_u/locals.wat
@@ -16,7 +16,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x20, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x8c
+;;       ja      0x84
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
@@ -26,21 +26,21 @@
 ;;       movl    $0x4f000000, %r11d
 ;;       movd    %r11d, %xmm15
 ;;       ucomiss %xmm15, %xmm1
-;;       jae     0x69
-;;       jp      0x8e
-;;   5a: cvttss2si %xmm1, %eax
+;;       jae     0x61
+;;       jp      0x86
+;;   56: cvttss2si %xmm1, %eax
 ;;       cmpl    $0, %eax
-;;       jge     0x83
-;;   67: ud2
+;;       jge     0x7b
+;;   5f: ud2
 ;;       movaps  %xmm1, %xmm0
 ;;       subss   %xmm15, %xmm0
 ;;       cvttss2si %xmm0, %eax
 ;;       cmpl    $0, %eax
-;;       jl      0x90
-;;   7e: addl    $0x80000000, %eax
+;;       jl      0x88
+;;   76: addl    $0x80000000, %eax
 ;;       addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   8c: ud2
-;;   8e: ud2
-;;   90: ud2
+;;   84: ud2
+;;   86: ud2
+;;   88: ud2

--- a/tests/disas/winch/x64/i32_trunc_f32_u/params.wat
+++ b/tests/disas/winch/x64/i32_trunc_f32_u/params.wat
@@ -14,7 +14,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x20, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x89
+;;       ja      0x81
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
@@ -24,21 +24,21 @@
 ;;       movl    $0x4f000000, %r11d
 ;;       movd    %r11d, %xmm15
 ;;       ucomiss %xmm15, %xmm1
-;;       jae     0x66
-;;       jp      0x8b
-;;   57: cvttss2si %xmm1, %eax
+;;       jae     0x5e
+;;       jp      0x83
+;;   53: cvttss2si %xmm1, %eax
 ;;       cmpl    $0, %eax
-;;       jge     0x80
-;;   64: ud2
+;;       jge     0x78
+;;   5c: ud2
 ;;       movaps  %xmm1, %xmm0
 ;;       subss   %xmm15, %xmm0
 ;;       cvttss2si %xmm0, %eax
 ;;       cmpl    $0, %eax
-;;       jl      0x8d
-;;   7b: addl    $0x80000000, %eax
+;;       jl      0x85
+;;   73: addl    $0x80000000, %eax
 ;;       addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   89: ud2
-;;   8b: ud2
-;;   8d: ud2
+;;   81: ud2
+;;   83: ud2
+;;   85: ud2

--- a/tests/disas/winch/x64/i32_trunc_f64_s/const.wat
+++ b/tests/disas/winch/x64/i32_trunc_f64_s/const.wat
@@ -14,35 +14,33 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x81
+;;       ja      0x7d
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
-;;       movsd   0x59(%rip), %xmm0
+;;       movsd   0x51(%rip), %xmm0
 ;;       cvttsd2si %xmm0, %eax
 ;;       cmpl    $1, %eax
-;;       jno     0x78
-;;   44: ucomisd %xmm0, %xmm0
-;;       jp      0x83
-;;   4e: movabsq $13970166044105375744, %r11
+;;       jno     0x74
+;;   40: ucomisd %xmm0, %xmm0
+;;       jp      0x7f
+;;   4a: movabsq $13970166044105375744, %r11
 ;;       movq    %r11, %xmm15
 ;;       ucomisd %xmm15, %xmm0
-;;       jbe     0x85
-;;   68: xorpd   %xmm15, %xmm15
+;;       jbe     0x81
+;;   64: xorpd   %xmm15, %xmm15
 ;;       ucomisd %xmm0, %xmm15
-;;       jb      0x87
-;;   78: addq    $0x10, %rsp
+;;       jb      0x83
+;;   74: addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
+;;   7d: ud2
+;;   7f: ud2
 ;;   81: ud2
 ;;   83: ud2
-;;   85: ud2
-;;   87: ud2
+;;   85: addb    %al, (%rax)
+;;   87: addb    %al, (%rax)
 ;;   89: addb    %al, (%rax)
 ;;   8b: addb    %al, (%rax)
-;;   8d: addb    %al, (%rax)
-;;   8f: addb    %al, (%rax)
-;;   91: addb    %al, (%rax)
-;;   93: addb    %al, (%rax)
-;;   95: addb    %dh, %al
+;;   8d: addb    %dh, %al

--- a/tests/disas/winch/x64/i32_trunc_f64_s/locals.wat
+++ b/tests/disas/winch/x64/i32_trunc_f64_s/locals.wat
@@ -16,7 +16,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x20, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x89
+;;       ja      0x85
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
@@ -25,20 +25,20 @@
 ;;       movsd   8(%rsp), %xmm0
 ;;       cvttsd2si %xmm0, %eax
 ;;       cmpl    $1, %eax
-;;       jno     0x80
-;;   4c: ucomisd %xmm0, %xmm0
-;;       jp      0x8b
-;;   56: movabsq $13970166044105375744, %r11
+;;       jno     0x7c
+;;   48: ucomisd %xmm0, %xmm0
+;;       jp      0x87
+;;   52: movabsq $13970166044105375744, %r11
 ;;       movq    %r11, %xmm15
 ;;       ucomisd %xmm15, %xmm0
-;;       jbe     0x8d
-;;   70: xorpd   %xmm15, %xmm15
+;;       jbe     0x89
+;;   6c: xorpd   %xmm15, %xmm15
 ;;       ucomisd %xmm0, %xmm15
-;;       jb      0x8f
-;;   80: addq    $0x20, %rsp
+;;       jb      0x8b
+;;   7c: addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
+;;   85: ud2
+;;   87: ud2
 ;;   89: ud2
 ;;   8b: ud2
-;;   8d: ud2
-;;   8f: ud2

--- a/tests/disas/winch/x64/i32_trunc_f64_s/params.wat
+++ b/tests/disas/winch/x64/i32_trunc_f64_s/params.wat
@@ -14,7 +14,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x20, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x86
+;;       ja      0x82
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
@@ -23,20 +23,20 @@
 ;;       movsd   8(%rsp), %xmm0
 ;;       cvttsd2si %xmm0, %eax
 ;;       cmpl    $1, %eax
-;;       jno     0x7d
-;;   49: ucomisd %xmm0, %xmm0
-;;       jp      0x88
-;;   53: movabsq $13970166044105375744, %r11
+;;       jno     0x79
+;;   45: ucomisd %xmm0, %xmm0
+;;       jp      0x84
+;;   4f: movabsq $13970166044105375744, %r11
 ;;       movq    %r11, %xmm15
 ;;       ucomisd %xmm15, %xmm0
-;;       jbe     0x8a
-;;   6d: xorpd   %xmm15, %xmm15
+;;       jbe     0x86
+;;   69: xorpd   %xmm15, %xmm15
 ;;       ucomisd %xmm0, %xmm15
-;;       jb      0x8c
-;;   7d: addq    $0x20, %rsp
+;;       jb      0x88
+;;   79: addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
+;;   82: ud2
+;;   84: ud2
 ;;   86: ud2
 ;;   88: ud2
-;;   8a: ud2
-;;   8c: ud2

--- a/tests/disas/winch/x64/i32_trunc_f64_u/const.wat
+++ b/tests/disas/winch/x64/i32_trunc_f64_u/const.wat
@@ -14,34 +14,34 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x89
+;;       ja      0x81
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
-;;       movsd   0x59(%rip), %xmm1
+;;       movsd   0x51(%rip), %xmm1
 ;;       movabsq $0x41e0000000000000, %r11
 ;;       movq    %r11, %xmm15
 ;;       ucomisd %xmm15, %xmm1
-;;       jae     0x66
-;;       jp      0x8b
-;;   57: cvttsd2si %xmm1, %eax
+;;       jae     0x5e
+;;       jp      0x83
+;;   53: cvttsd2si %xmm1, %eax
 ;;       cmpl    $0, %eax
-;;       jge     0x80
-;;   64: ud2
+;;       jge     0x78
+;;   5c: ud2
 ;;       movaps  %xmm1, %xmm0
 ;;       subsd   %xmm15, %xmm0
 ;;       cvttsd2si %xmm0, %eax
 ;;       cmpl    $0, %eax
-;;       jl      0x8d
-;;   7b: addl    $0x80000000, %eax
+;;       jl      0x85
+;;   73: addl    $0x80000000, %eax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   89: ud2
-;;   8b: ud2
-;;   8d: ud2
-;;   8f: addb    %al, (%rax)
-;;   91: addb    %al, (%rax)
-;;   93: addb    %al, (%rax)
-;;   95: addb    %dh, %al
+;;   81: ud2
+;;   83: ud2
+;;   85: ud2
+;;   87: addb    %al, (%rax)
+;;   89: addb    %al, (%rax)
+;;   8b: addb    %al, (%rax)
+;;   8d: addb    %dh, %al

--- a/tests/disas/winch/x64/i32_trunc_f64_u/locals.wat
+++ b/tests/disas/winch/x64/i32_trunc_f64_u/locals.wat
@@ -16,7 +16,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x20, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x91
+;;       ja      0x89
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
@@ -26,21 +26,21 @@
 ;;       movabsq $0x41e0000000000000, %r11
 ;;       movq    %r11, %xmm15
 ;;       ucomisd %xmm15, %xmm1
-;;       jae     0x6e
-;;       jp      0x93
-;;   5f: cvttsd2si %xmm1, %eax
+;;       jae     0x66
+;;       jp      0x8b
+;;   5b: cvttsd2si %xmm1, %eax
 ;;       cmpl    $0, %eax
-;;       jge     0x88
-;;   6c: ud2
+;;       jge     0x80
+;;   64: ud2
 ;;       movaps  %xmm1, %xmm0
 ;;       subsd   %xmm15, %xmm0
 ;;       cvttsd2si %xmm0, %eax
 ;;       cmpl    $0, %eax
-;;       jl      0x95
-;;   83: addl    $0x80000000, %eax
+;;       jl      0x8d
+;;   7b: addl    $0x80000000, %eax
 ;;       addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   91: ud2
-;;   93: ud2
-;;   95: ud2
+;;   89: ud2
+;;   8b: ud2
+;;   8d: ud2

--- a/tests/disas/winch/x64/i32_trunc_f64_u/params.wat
+++ b/tests/disas/winch/x64/i32_trunc_f64_u/params.wat
@@ -14,7 +14,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x20, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x8e
+;;       ja      0x86
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
@@ -24,21 +24,21 @@
 ;;       movabsq $0x41e0000000000000, %r11
 ;;       movq    %r11, %xmm15
 ;;       ucomisd %xmm15, %xmm1
-;;       jae     0x6b
-;;       jp      0x90
-;;   5c: cvttsd2si %xmm1, %eax
+;;       jae     0x63
+;;       jp      0x88
+;;   58: cvttsd2si %xmm1, %eax
 ;;       cmpl    $0, %eax
-;;       jge     0x85
-;;   69: ud2
+;;       jge     0x7d
+;;   61: ud2
 ;;       movaps  %xmm1, %xmm0
 ;;       subsd   %xmm15, %xmm0
 ;;       cvttsd2si %xmm0, %eax
 ;;       cmpl    $0, %eax
-;;       jl      0x92
-;;   80: addl    $0x80000000, %eax
+;;       jl      0x8a
+;;   78: addl    $0x80000000, %eax
 ;;       addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   8e: ud2
-;;   90: ud2
-;;   92: ud2
+;;   86: ud2
+;;   88: ud2
+;;   8a: ud2

--- a/tests/disas/winch/x64/i64_rems/const.wat
+++ b/tests/disas/winch/x64/i64_rems/const.wat
@@ -15,7 +15,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x5e
+;;       ja      0x5a
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -24,12 +24,12 @@
 ;;       movl    $7, %eax
 ;;       cqto
 ;;       cmpq    $-1, %rcx
-;;       jne     0x4f
-;;   45: movl    $0, %edx
-;;       jmp     0x52
-;;   4f: idivq   %rcx
+;;       jne     0x4b
+;;   41: movl    $0, %edx
+;;       jmp     0x4e
+;;   4b: idivq   %rcx
 ;;       movq    %rdx, %rax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   5e: ud2
+;;   5a: ud2

--- a/tests/disas/winch/x64/i64_rems/one_zero.wat
+++ b/tests/disas/winch/x64/i64_rems/one_zero.wat
@@ -15,7 +15,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x5e
+;;       ja      0x5a
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -24,12 +24,12 @@
 ;;       movl    $1, %eax
 ;;       cqto
 ;;       cmpq    $-1, %rcx
-;;       jne     0x4f
-;;   45: movl    $0, %edx
-;;       jmp     0x52
-;;   4f: idivq   %rcx
+;;       jne     0x4b
+;;   41: movl    $0, %edx
+;;       jmp     0x4e
+;;   4b: idivq   %rcx
 ;;       movq    %rdx, %rax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   5e: ud2
+;;   5a: ud2

--- a/tests/disas/winch/x64/i64_rems/overflow.wat
+++ b/tests/disas/winch/x64/i64_rems/overflow.wat
@@ -15,7 +15,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x65
+;;       ja      0x61
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -24,12 +24,12 @@
 ;;       movabsq $9223372036854775808, %rax
 ;;       cqto
 ;;       cmpq    $-1, %rcx
-;;       jne     0x56
-;;   4c: movl    $0, %edx
-;;       jmp     0x59
-;;   56: idivq   %rcx
+;;       jne     0x52
+;;   48: movl    $0, %edx
+;;       jmp     0x55
+;;   52: idivq   %rcx
 ;;       movq    %rdx, %rax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   65: ud2
+;;   61: ud2

--- a/tests/disas/winch/x64/i64_rems/params.wat
+++ b/tests/disas/winch/x64/i64_rems/params.wat
@@ -15,7 +15,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x20, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x67
+;;       ja      0x63
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
@@ -26,12 +26,12 @@
 ;;       movq    8(%rsp), %rax
 ;;       cqto
 ;;       cmpq    $-1, %rcx
-;;       jne     0x58
-;;   4e: movl    $0, %edx
-;;       jmp     0x5b
-;;   58: idivq   %rcx
+;;       jne     0x54
+;;   4a: movl    $0, %edx
+;;       jmp     0x57
+;;   54: idivq   %rcx
 ;;       movq    %rdx, %rax
 ;;       addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   67: ud2
+;;   63: ud2

--- a/tests/disas/winch/x64/i64_rems/zero_zero.wat
+++ b/tests/disas/winch/x64/i64_rems/zero_zero.wat
@@ -15,7 +15,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x5e
+;;       ja      0x5a
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -24,12 +24,12 @@
 ;;       movl    $0, %eax
 ;;       cqto
 ;;       cmpq    $-1, %rcx
-;;       jne     0x4f
-;;   45: movl    $0, %edx
-;;       jmp     0x52
-;;   4f: idivq   %rcx
+;;       jne     0x4b
+;;   41: movl    $0, %edx
+;;       jmp     0x4e
+;;   4b: idivq   %rcx
 ;;       movq    %rdx, %rax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   5e: ud2
+;;   5a: ud2

--- a/tests/disas/winch/x64/i64_trunc_f32_s/const.wat
+++ b/tests/disas/winch/x64/i64_trunc_f32_s/const.wat
@@ -14,31 +14,29 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x7c
+;;       ja      0x78
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
-;;       movss   0x51(%rip), %xmm0
+;;       movss   0x49(%rip), %xmm0
 ;;       cvttss2si %xmm0, %rax
 ;;       cmpq    $1, %rax
-;;       jno     0x73
-;;   46: ucomiss %xmm0, %xmm0
-;;       jp      0x7e
-;;   4f: movl    $0xdf000000, %r11d
+;;       jno     0x6f
+;;   42: ucomiss %xmm0, %xmm0
+;;       jp      0x7a
+;;   4b: movl    $0xdf000000, %r11d
 ;;       movd    %r11d, %xmm15
 ;;       ucomiss %xmm15, %xmm0
-;;       jb      0x80
-;;   64: xorpd   %xmm15, %xmm15
+;;       jb      0x7c
+;;   60: xorpd   %xmm15, %xmm15
 ;;       ucomiss %xmm0, %xmm15
-;;       jb      0x82
-;;   73: addq    $0x10, %rsp
+;;       jb      0x7e
+;;   6f: addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
+;;   78: ud2
+;;   7a: ud2
 ;;   7c: ud2
 ;;   7e: ud2
-;;   80: ud2
-;;   82: ud2
-;;   84: addb    %al, (%rax)
-;;   86: addb    %al, (%rax)
-;;   88: addb    %al, (%rax)
+;;   80: addb    %al, (%rax)

--- a/tests/disas/winch/x64/i64_trunc_f32_s/locals.wat
+++ b/tests/disas/winch/x64/i64_trunc_f32_s/locals.wat
@@ -16,7 +16,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x20, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x84
+;;       ja      0x80
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
@@ -25,20 +25,20 @@
 ;;       movss   0xc(%rsp), %xmm0
 ;;       cvttss2si %xmm0, %rax
 ;;       cmpq    $1, %rax
-;;       jno     0x7b
-;;   4e: ucomiss %xmm0, %xmm0
-;;       jp      0x86
-;;   57: movl    $0xdf000000, %r11d
+;;       jno     0x77
+;;   4a: ucomiss %xmm0, %xmm0
+;;       jp      0x82
+;;   53: movl    $0xdf000000, %r11d
 ;;       movd    %r11d, %xmm15
 ;;       ucomiss %xmm15, %xmm0
-;;       jb      0x88
-;;   6c: xorpd   %xmm15, %xmm15
+;;       jb      0x84
+;;   68: xorpd   %xmm15, %xmm15
 ;;       ucomiss %xmm0, %xmm15
-;;       jb      0x8a
-;;   7b: addq    $0x20, %rsp
+;;       jb      0x86
+;;   77: addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
+;;   80: ud2
+;;   82: ud2
 ;;   84: ud2
 ;;   86: ud2
-;;   88: ud2
-;;   8a: ud2

--- a/tests/disas/winch/x64/i64_trunc_f32_s/params.wat
+++ b/tests/disas/winch/x64/i64_trunc_f32_s/params.wat
@@ -14,7 +14,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x20, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x81
+;;       ja      0x7d
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
@@ -23,20 +23,20 @@
 ;;       movss   0xc(%rsp), %xmm0
 ;;       cvttss2si %xmm0, %rax
 ;;       cmpq    $1, %rax
-;;       jno     0x78
-;;   4b: ucomiss %xmm0, %xmm0
-;;       jp      0x83
-;;   54: movl    $0xdf000000, %r11d
+;;       jno     0x74
+;;   47: ucomiss %xmm0, %xmm0
+;;       jp      0x7f
+;;   50: movl    $0xdf000000, %r11d
 ;;       movd    %r11d, %xmm15
 ;;       ucomiss %xmm15, %xmm0
-;;       jb      0x85
-;;   69: xorpd   %xmm15, %xmm15
+;;       jb      0x81
+;;   65: xorpd   %xmm15, %xmm15
 ;;       ucomiss %xmm0, %xmm15
-;;       jb      0x87
-;;   78: addq    $0x20, %rsp
+;;       jb      0x83
+;;   74: addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
+;;   7d: ud2
+;;   7f: ud2
 ;;   81: ud2
 ;;   83: ud2
-;;   85: ud2
-;;   87: ud2

--- a/tests/disas/winch/x64/i64_trunc_f32_u/const.wat
+++ b/tests/disas/winch/x64/i64_trunc_f32_u/const.wat
@@ -14,33 +14,33 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x90
+;;       ja      0x88
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
-;;       movss   0x61(%rip), %xmm1
+;;       movss   0x59(%rip), %xmm1
 ;;       movl    $0x5f000000, %r11d
 ;;       movd    %r11d, %xmm15
 ;;       ucomiss %xmm15, %xmm1
-;;       jae     0x63
-;;       jp      0x92
-;;   52: cvttss2si %xmm1, %rax
+;;       jae     0x5b
+;;       jp      0x8a
+;;   4e: cvttss2si %xmm1, %rax
 ;;       cmpq    $0, %rax
-;;       jge     0x87
-;;   61: ud2
+;;       jge     0x7f
+;;   59: ud2
 ;;       movaps  %xmm1, %xmm0
 ;;       subss   %xmm15, %xmm0
 ;;       cvttss2si %xmm0, %rax
 ;;       cmpq    $0, %rax
-;;       jl      0x94
-;;   7a: movabsq $9223372036854775808, %r11
+;;       jl      0x8c
+;;   72: movabsq $9223372036854775808, %r11
 ;;       addq    %r11, %rax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   90: ud2
-;;   92: ud2
-;;   94: ud2
-;;   96: addb    %al, (%rax)
-;;   98: addb    %al, (%rax)
+;;   88: ud2
+;;   8a: ud2
+;;   8c: ud2
+;;   8e: addb    %al, (%rax)
+;;   90: addb    %al, (%rax)

--- a/tests/disas/winch/x64/i64_trunc_f32_u/locals.wat
+++ b/tests/disas/winch/x64/i64_trunc_f32_u/locals.wat
@@ -16,7 +16,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x20, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x98
+;;       ja      0x90
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
@@ -26,22 +26,22 @@
 ;;       movl    $0x5f000000, %r11d
 ;;       movd    %r11d, %xmm15
 ;;       ucomiss %xmm15, %xmm1
-;;       jae     0x6b
-;;       jp      0x9a
-;;   5a: cvttss2si %xmm1, %rax
+;;       jae     0x63
+;;       jp      0x92
+;;   56: cvttss2si %xmm1, %rax
 ;;       cmpq    $0, %rax
-;;       jge     0x8f
-;;   69: ud2
+;;       jge     0x87
+;;   61: ud2
 ;;       movaps  %xmm1, %xmm0
 ;;       subss   %xmm15, %xmm0
 ;;       cvttss2si %xmm0, %rax
 ;;       cmpq    $0, %rax
-;;       jl      0x9c
-;;   82: movabsq $9223372036854775808, %r11
+;;       jl      0x94
+;;   7a: movabsq $9223372036854775808, %r11
 ;;       addq    %r11, %rax
 ;;       addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   98: ud2
-;;   9a: ud2
-;;   9c: ud2
+;;   90: ud2
+;;   92: ud2
+;;   94: ud2

--- a/tests/disas/winch/x64/i64_trunc_f32_u/params.wat
+++ b/tests/disas/winch/x64/i64_trunc_f32_u/params.wat
@@ -14,7 +14,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x20, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x95
+;;       ja      0x8d
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
@@ -24,22 +24,22 @@
 ;;       movl    $0x5f000000, %r11d
 ;;       movd    %r11d, %xmm15
 ;;       ucomiss %xmm15, %xmm1
-;;       jae     0x68
-;;       jp      0x97
-;;   57: cvttss2si %xmm1, %rax
+;;       jae     0x60
+;;       jp      0x8f
+;;   53: cvttss2si %xmm1, %rax
 ;;       cmpq    $0, %rax
-;;       jge     0x8c
-;;   66: ud2
+;;       jge     0x84
+;;   5e: ud2
 ;;       movaps  %xmm1, %xmm0
 ;;       subss   %xmm15, %xmm0
 ;;       cvttss2si %xmm0, %rax
 ;;       cmpq    $0, %rax
-;;       jl      0x99
-;;   7f: movabsq $9223372036854775808, %r11
+;;       jl      0x91
+;;   77: movabsq $9223372036854775808, %r11
 ;;       addq    %r11, %rax
 ;;       addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   95: ud2
-;;   97: ud2
-;;   99: ud2
+;;   8d: ud2
+;;   8f: ud2
+;;   91: ud2

--- a/tests/disas/winch/x64/i64_trunc_f64_s/const.wat
+++ b/tests/disas/winch/x64/i64_trunc_f64_s/const.wat
@@ -14,34 +14,32 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x83
+;;       ja      0x7f
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
-;;       movsd   0x59(%rip), %xmm0
+;;       movsd   0x51(%rip), %xmm0
 ;;       cvttsd2si %xmm0, %rax
 ;;       cmpq    $1, %rax
-;;       jno     0x7a
-;;   46: ucomisd %xmm0, %xmm0
-;;       jp      0x85
-;;   50: movabsq $14114281232179134464, %r11
+;;       jno     0x76
+;;   42: ucomisd %xmm0, %xmm0
+;;       jp      0x81
+;;   4c: movabsq $14114281232179134464, %r11
 ;;       movq    %r11, %xmm15
 ;;       ucomisd %xmm15, %xmm0
-;;       jb      0x87
-;;   6a: xorpd   %xmm15, %xmm15
+;;       jb      0x83
+;;   66: xorpd   %xmm15, %xmm15
 ;;       ucomisd %xmm0, %xmm15
-;;       jb      0x89
-;;   7a: addq    $0x10, %rsp
+;;       jb      0x85
+;;   76: addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
+;;   7f: ud2
+;;   81: ud2
 ;;   83: ud2
 ;;   85: ud2
-;;   87: ud2
-;;   89: ud2
+;;   87: addb    %al, (%rax)
+;;   89: addb    %al, (%rax)
 ;;   8b: addb    %al, (%rax)
-;;   8d: addb    %al, (%rax)
-;;   8f: addb    %al, (%rax)
-;;   91: addb    %al, (%rax)
-;;   93: addb    %al, (%rax)
-;;   95: addb    %dh, %al
+;;   8d: addb    %dh, %al

--- a/tests/disas/winch/x64/i64_trunc_f64_s/locals.wat
+++ b/tests/disas/winch/x64/i64_trunc_f64_s/locals.wat
@@ -16,7 +16,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x20, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x8b
+;;       ja      0x87
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
@@ -25,20 +25,20 @@
 ;;       movsd   8(%rsp), %xmm0
 ;;       cvttsd2si %xmm0, %rax
 ;;       cmpq    $1, %rax
-;;       jno     0x82
-;;   4e: ucomisd %xmm0, %xmm0
-;;       jp      0x8d
-;;   58: movabsq $14114281232179134464, %r11
+;;       jno     0x7e
+;;   4a: ucomisd %xmm0, %xmm0
+;;       jp      0x89
+;;   54: movabsq $14114281232179134464, %r11
 ;;       movq    %r11, %xmm15
 ;;       ucomisd %xmm15, %xmm0
-;;       jb      0x8f
-;;   72: xorpd   %xmm15, %xmm15
+;;       jb      0x8b
+;;   6e: xorpd   %xmm15, %xmm15
 ;;       ucomisd %xmm0, %xmm15
-;;       jb      0x91
-;;   82: addq    $0x20, %rsp
+;;       jb      0x8d
+;;   7e: addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
+;;   87: ud2
+;;   89: ud2
 ;;   8b: ud2
 ;;   8d: ud2
-;;   8f: ud2
-;;   91: ud2

--- a/tests/disas/winch/x64/i64_trunc_f64_s/params.wat
+++ b/tests/disas/winch/x64/i64_trunc_f64_s/params.wat
@@ -14,7 +14,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x20, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x88
+;;       ja      0x84
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
@@ -23,20 +23,20 @@
 ;;       movsd   8(%rsp), %xmm0
 ;;       cvttsd2si %xmm0, %rax
 ;;       cmpq    $1, %rax
-;;       jno     0x7f
-;;   4b: ucomisd %xmm0, %xmm0
-;;       jp      0x8a
-;;   55: movabsq $14114281232179134464, %r11
+;;       jno     0x7b
+;;   47: ucomisd %xmm0, %xmm0
+;;       jp      0x86
+;;   51: movabsq $14114281232179134464, %r11
 ;;       movq    %r11, %xmm15
 ;;       ucomisd %xmm15, %xmm0
-;;       jb      0x8c
-;;   6f: xorpd   %xmm15, %xmm15
+;;       jb      0x88
+;;   6b: xorpd   %xmm15, %xmm15
 ;;       ucomisd %xmm0, %xmm15
-;;       jb      0x8e
-;;   7f: addq    $0x20, %rsp
+;;       jb      0x8a
+;;   7b: addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
+;;   84: ud2
+;;   86: ud2
 ;;   88: ud2
 ;;   8a: ud2
-;;   8c: ud2
-;;   8e: ud2

--- a/tests/disas/winch/x64/i64_trunc_f64_u/const.wat
+++ b/tests/disas/winch/x64/i64_trunc_f64_u/const.wat
@@ -14,37 +14,37 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x95
+;;       ja      0x8d
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
-;;       movsd   0x69(%rip), %xmm1
+;;       movsd   0x61(%rip), %xmm1
 ;;       movabsq $0x43e0000000000000, %r11
 ;;       movq    %r11, %xmm15
 ;;       ucomisd %xmm15, %xmm1
-;;       jae     0x68
-;;       jp      0x97
-;;   57: cvttsd2si %xmm1, %rax
+;;       jae     0x60
+;;       jp      0x8f
+;;   53: cvttsd2si %xmm1, %rax
 ;;       cmpq    $0, %rax
-;;       jge     0x8c
-;;   66: ud2
+;;       jge     0x84
+;;   5e: ud2
 ;;       movaps  %xmm1, %xmm0
 ;;       subsd   %xmm15, %xmm0
 ;;       cvttsd2si %xmm0, %rax
 ;;       cmpq    $0, %rax
-;;       jl      0x99
-;;   7f: movabsq $9223372036854775808, %r11
+;;       jl      0x91
+;;   77: movabsq $9223372036854775808, %r11
 ;;       addq    %r11, %rax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   95: ud2
-;;   97: ud2
-;;   99: ud2
+;;   8d: ud2
+;;   8f: ud2
+;;   91: ud2
+;;   93: addb    %al, (%rax)
+;;   95: addb    %al, (%rax)
+;;   97: addb    %al, (%rax)
+;;   99: addb    %al, (%rax)
 ;;   9b: addb    %al, (%rax)
-;;   9d: addb    %al, (%rax)
-;;   9f: addb    %al, (%rax)
-;;   a1: addb    %al, (%rax)
-;;   a3: addb    %al, (%rax)
-;;   a5: addb    %dh, %al
+;;   9d: addb    %dh, %al

--- a/tests/disas/winch/x64/i64_trunc_f64_u/locals.wat
+++ b/tests/disas/winch/x64/i64_trunc_f64_u/locals.wat
@@ -16,7 +16,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x20, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x9d
+;;       ja      0x95
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
@@ -26,22 +26,22 @@
 ;;       movabsq $0x43e0000000000000, %r11
 ;;       movq    %r11, %xmm15
 ;;       ucomisd %xmm15, %xmm1
-;;       jae     0x70
-;;       jp      0x9f
-;;   5f: cvttsd2si %xmm1, %rax
+;;       jae     0x68
+;;       jp      0x97
+;;   5b: cvttsd2si %xmm1, %rax
 ;;       cmpq    $0, %rax
-;;       jge     0x94
-;;   6e: ud2
+;;       jge     0x8c
+;;   66: ud2
 ;;       movaps  %xmm1, %xmm0
 ;;       subsd   %xmm15, %xmm0
 ;;       cvttsd2si %xmm0, %rax
 ;;       cmpq    $0, %rax
-;;       jl      0xa1
-;;   87: movabsq $9223372036854775808, %r11
+;;       jl      0x99
+;;   7f: movabsq $9223372036854775808, %r11
 ;;       addq    %r11, %rax
 ;;       addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   9d: ud2
-;;   9f: ud2
-;;   a1: ud2
+;;   95: ud2
+;;   97: ud2
+;;   99: ud2

--- a/tests/disas/winch/x64/i64_trunc_f64_u/params.wat
+++ b/tests/disas/winch/x64/i64_trunc_f64_u/params.wat
@@ -14,7 +14,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x20, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x9a
+;;       ja      0x92
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
@@ -24,22 +24,22 @@
 ;;       movabsq $0x43e0000000000000, %r11
 ;;       movq    %r11, %xmm15
 ;;       ucomisd %xmm15, %xmm1
-;;       jae     0x6d
-;;       jp      0x9c
-;;   5c: cvttsd2si %xmm1, %rax
+;;       jae     0x65
+;;       jp      0x94
+;;   58: cvttsd2si %xmm1, %rax
 ;;       cmpq    $0, %rax
-;;       jge     0x91
-;;   6b: ud2
+;;       jge     0x89
+;;   63: ud2
 ;;       movaps  %xmm1, %xmm0
 ;;       subsd   %xmm15, %xmm0
 ;;       cvttsd2si %xmm0, %rax
 ;;       cmpq    $0, %rax
-;;       jl      0x9e
-;;   84: movabsq $9223372036854775808, %r11
+;;       jl      0x96
+;;   7c: movabsq $9223372036854775808, %r11
 ;;       addq    %r11, %rax
 ;;       addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   9a: ud2
-;;   9c: ud2
-;;   9e: ud2
+;;   92: ud2
+;;   94: ud2
+;;   96: ud2

--- a/tests/disas/winch/x64/select/f32.wat
+++ b/tests/disas/winch/x64/select/f32.wat
@@ -14,7 +14,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x20, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x65
+;;       ja      0x61
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
@@ -26,9 +26,9 @@
 ;;       movss   8(%rsp), %xmm0
 ;;       movss   0xc(%rsp), %xmm1
 ;;       cmpl    $0, %eax
-;;       je      0x5c
-;;   59: movaps  %xmm1, %xmm0
+;;       je      0x58
+;;   55: movaps  %xmm1, %xmm0
 ;;       addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   65: ud2
+;;   61: ud2

--- a/tests/disas/winch/x64/select/f64.wat
+++ b/tests/disas/winch/x64/select/f64.wat
@@ -14,7 +14,7 @@
 ;;       movq    0x10(%r11), %r11
 ;;       addq    $0x30, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x65
+;;       ja      0x61
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x30, %rsp
 ;;       movq    %rdi, 0x28(%rsp)
@@ -26,9 +26,9 @@
 ;;       movsd   0x10(%rsp), %xmm0
 ;;       movsd   0x18(%rsp), %xmm1
 ;;       cmpl    $0, %eax
-;;       je      0x5c
-;;   59: movaps  %xmm1, %xmm0
+;;       je      0x58
+;;   55: movaps  %xmm1, %xmm0
 ;;       addq    $0x30, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   65: ud2
+;;   61: ud2


### PR DESCRIPTION
Cranelift does not currently implement any form of "relaxation" of instructions where, for example, a 32-bit jump is shrunk to an 8-bit jump if the destination actually fits. In lieu of this Cranelift pessimistically emits 32-bit jumps on x64, for example, for all jumps between basic blocks. This is a difficult problem to solve in general but for pseudo-instructions it's a much more targeted problem which should be easier to solve.

This commit updates all pseudo-instructions in the x64 backend to use 8-bit jumps instead of full 32-bit jumps within their code bodies. It's statically known that the instructions bodies being generate are all small enough to fit in 8 bits. This helps shrink the generated code for a number of instructions whenever a pseudo-inst is used instead of basic blocks.

Optimizing jumps between basic blocks is left as a future optimization as it's likely to be much more difficult to implement than this.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
