### PR TITLE
Release Wasmtime 24.0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,7 +216,7 @@ checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
 name = "byte-array-literals"
-version = "24.0.3"
+version = "24.0.4"
 
 [[package]]
 name = "byteorder"
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift"
-version = "0.111.3"
+version = "0.111.4"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",
@@ -569,14 +569,14 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.111.3"
+version = "0.111.4"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.111.3"
+version = "0.111.4"
 dependencies = [
  "serde",
  "serde_derive",
@@ -584,7 +584,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.111.3"
+version = "0.111.4"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -615,25 +615,25 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.111.3"
+version = "0.111.4"
 dependencies = [
  "cranelift-codegen-shared",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.111.3"
+version = "0.111.4"
 
 [[package]]
 name = "cranelift-control"
-version = "0.111.3"
+version = "0.111.4"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.111.3"
+version = "0.111.4"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -671,7 +671,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.111.3"
+version = "0.111.4"
 dependencies = [
  "cranelift-codegen",
  "env_logger",
@@ -696,7 +696,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-interpreter"
-version = "0.111.3"
+version = "0.111.4"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -710,7 +710,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.111.3"
+version = "0.111.4"
 dependencies = [
  "codespan-reporting",
  "log",
@@ -719,7 +719,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-jit"
-version = "0.111.3"
+version = "0.111.4"
 dependencies = [
  "anyhow",
  "cranelift",
@@ -740,7 +740,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-module"
-version = "0.111.3"
+version = "0.111.4"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -752,7 +752,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.111.3"
+version = "0.111.4"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-object"
-version = "0.111.3"
+version = "0.111.4"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-reader"
-version = "0.111.3"
+version = "0.111.4"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -786,7 +786,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-serde"
-version = "0.111.3"
+version = "0.111.4"
 dependencies = [
  "clap",
  "cranelift-codegen",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.111.3"
+version = "0.111.4"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -1045,7 +1045,7 @@ checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
 
 [[package]]
 name = "embedding"
-version = "24.0.3"
+version = "24.0.4"
 dependencies = [
  "anyhow",
  "dlmalloc",
@@ -1847,7 +1847,7 @@ dependencies = [
 
 [[package]]
 name = "min-platform-host"
-version = "24.0.3"
+version = "24.0.4"
 dependencies = [
  "anyhow",
  "libloading",
@@ -3089,7 +3089,7 @@ checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "verify-component-adapter"
-version = "24.0.3"
+version = "24.0.4"
 dependencies = [
  "anyhow",
  "wasmparser",
@@ -3139,7 +3139,7 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasi-common"
-version = "24.0.3"
+version = "24.0.4"
 dependencies = [
  "anyhow",
  "bitflags 2.4.1",
@@ -3179,7 +3179,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-preview1-component-adapter"
-version = "24.0.3"
+version = "24.0.4"
 dependencies = [
  "bitflags 2.4.1",
  "byte-array-literals",
@@ -3373,7 +3373,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "24.0.3"
+version = "24.0.4"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -3433,14 +3433,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-asm-macros"
-version = "24.0.3"
+version = "24.0.4"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "wasmtime-bench-api"
-version = "24.0.3"
+version = "24.0.4"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -3456,14 +3456,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-c-api"
-version = "24.0.3"
+version = "24.0.4"
 dependencies = [
  "wasmtime-c-api-impl",
 ]
 
 [[package]]
 name = "wasmtime-c-api-impl"
-version = "24.0.3"
+version = "24.0.4"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -3481,7 +3481,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-c-api-macros"
-version = "24.0.3"
+version = "24.0.4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3489,7 +3489,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cache"
-version = "24.0.3"
+version = "24.0.4"
 dependencies = [
  "anyhow",
  "base64",
@@ -3511,7 +3511,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli"
-version = "24.0.3"
+version = "24.0.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3579,7 +3579,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli-flags"
-version = "24.0.3"
+version = "24.0.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -3592,7 +3592,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-macro"
-version = "24.0.3"
+version = "24.0.4"
 dependencies = [
  "anyhow",
  "component-macro-test-helpers",
@@ -3612,11 +3612,11 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-util"
-version = "24.0.3"
+version = "24.0.4"
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "24.0.3"
+version = "24.0.4"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3638,7 +3638,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "24.0.3"
+version = "24.0.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -3680,7 +3680,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-explorer"
-version = "24.0.3"
+version = "24.0.4"
 dependencies = [
  "anyhow",
  "capstone",
@@ -3695,7 +3695,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-fiber"
-version = "24.0.3"
+version = "24.0.4"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -3767,7 +3767,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-debug"
-version = "24.0.3"
+version = "24.0.4"
 dependencies = [
  "object",
  "once_cell",
@@ -3777,7 +3777,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-icache-coherence"
-version = "24.0.3"
+version = "24.0.4"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3787,7 +3787,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-slab"
-version = "24.0.3"
+version = "24.0.4"
 
 [[package]]
 name = "wasmtime-test-macros"
@@ -3801,7 +3801,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-types"
-version = "24.0.3"
+version = "24.0.4"
 dependencies = [
  "anyhow",
  "cranelift-entity",
@@ -3813,7 +3813,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-versioned-export-macros"
-version = "24.0.3"
+version = "24.0.4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3822,7 +3822,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "24.0.3"
+version = "24.0.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3855,7 +3855,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-http"
-version = "24.0.3"
+version = "24.0.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3881,7 +3881,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-keyvalue"
-version = "24.0.3"
+version = "24.0.4"
 dependencies = [
  "anyhow",
  "test-programs-artifacts",
@@ -3892,7 +3892,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-nn"
-version = "24.0.3"
+version = "24.0.4"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -3912,7 +3912,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-runtime-config"
-version = "24.0.3"
+version = "24.0.4"
 dependencies = [
  "anyhow",
  "test-programs-artifacts",
@@ -3923,7 +3923,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-threads"
-version = "24.0.3"
+version = "24.0.4"
 dependencies = [
  "anyhow",
  "log",
@@ -3934,7 +3934,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wast"
-version = "24.0.3"
+version = "24.0.4"
 dependencies = [
  "anyhow",
  "log",
@@ -3944,7 +3944,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-winch"
-version = "24.0.3"
+version = "24.0.4"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -3959,7 +3959,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wit-bindgen"
-version = "24.0.3"
+version = "24.0.4"
 dependencies = [
  "anyhow",
  "heck 0.4.0",
@@ -3969,7 +3969,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wmemcheck"
-version = "24.0.3"
+version = "24.0.4"
 
 [[package]]
 name = "wast"
@@ -4036,7 +4036,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "24.0.3"
+version = "24.0.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4053,7 +4053,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "24.0.3"
+version = "24.0.4"
 dependencies = [
  "anyhow",
  "heck 0.4.0",
@@ -4066,7 +4066,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "24.0.3"
+version = "24.0.4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4121,7 +4121,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "0.22.3"
+version = "0.22.4"
 dependencies = [
  "anyhow",
  "cranelift-codegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,7 +156,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "24.0.3"
+version = "24.0.4"
 authors = ["The Wasmtime Project Developers"]
 edition = "2021"
 # Wasmtime's current policy is that this number can be no larger than the
@@ -183,60 +183,60 @@ manual_strip = 'warn'
 
 [workspace.dependencies]
 arbitrary = { version = "1.3.1" }
-wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=24.0.3" }
-wasmtime = { path = "crates/wasmtime", version = "24.0.3", default-features = false }
-wasmtime-c-api-macros = { path = "crates/c-api-macros", version = "=24.0.3" }
-wasmtime-cache = { path = "crates/cache", version = "=24.0.3" }
-wasmtime-cli-flags = { path = "crates/cli-flags", version = "=24.0.3" }
-wasmtime-cranelift = { path = "crates/cranelift", version = "=24.0.3" }
-wasmtime-winch = { path = "crates/winch", version = "=24.0.3" }
-wasmtime-environ = { path = "crates/environ", version = "=24.0.3" }
-wasmtime-explorer = { path = "crates/explorer", version = "=24.0.3" }
-wasmtime-fiber = { path = "crates/fiber", version = "=24.0.3" }
-wasmtime-types = { path = "crates/types", version = "24.0.3" }
-wasmtime-jit-debug = { path = "crates/jit-debug", version = "=24.0.3" }
-wasmtime-wast = { path = "crates/wast", version = "=24.0.3" }
-wasmtime-wasi = { path = "crates/wasi", version = "24.0.3", default-features = false }
-wasmtime-wasi-http = { path = "crates/wasi-http", version = "=24.0.3", default-features = false }
-wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "24.0.3" }
-wasmtime-wasi-runtime-config = { path = "crates/wasi-runtime-config", version = "24.0.3" }
-wasmtime-wasi-keyvalue = { path = "crates/wasi-keyvalue", version = "24.0.3" }
-wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "24.0.3" }
-wasmtime-component-util = { path = "crates/component-util", version = "=24.0.3" }
-wasmtime-component-macro = { path = "crates/component-macro", version = "=24.0.3" }
-wasmtime-asm-macros = { path = "crates/asm-macros", version = "=24.0.3" }
-wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=24.0.3" }
-wasmtime-slab = { path = "crates/slab", version = "=24.0.3" }
+wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=24.0.4" }
+wasmtime = { path = "crates/wasmtime", version = "24.0.4", default-features = false }
+wasmtime-c-api-macros = { path = "crates/c-api-macros", version = "=24.0.4" }
+wasmtime-cache = { path = "crates/cache", version = "=24.0.4" }
+wasmtime-cli-flags = { path = "crates/cli-flags", version = "=24.0.4" }
+wasmtime-cranelift = { path = "crates/cranelift", version = "=24.0.4" }
+wasmtime-winch = { path = "crates/winch", version = "=24.0.4" }
+wasmtime-environ = { path = "crates/environ", version = "=24.0.4" }
+wasmtime-explorer = { path = "crates/explorer", version = "=24.0.4" }
+wasmtime-fiber = { path = "crates/fiber", version = "=24.0.4" }
+wasmtime-types = { path = "crates/types", version = "24.0.4" }
+wasmtime-jit-debug = { path = "crates/jit-debug", version = "=24.0.4" }
+wasmtime-wast = { path = "crates/wast", version = "=24.0.4" }
+wasmtime-wasi = { path = "crates/wasi", version = "24.0.4", default-features = false }
+wasmtime-wasi-http = { path = "crates/wasi-http", version = "=24.0.4", default-features = false }
+wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "24.0.4" }
+wasmtime-wasi-runtime-config = { path = "crates/wasi-runtime-config", version = "24.0.4" }
+wasmtime-wasi-keyvalue = { path = "crates/wasi-keyvalue", version = "24.0.4" }
+wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "24.0.4" }
+wasmtime-component-util = { path = "crates/component-util", version = "=24.0.4" }
+wasmtime-component-macro = { path = "crates/component-macro", version = "=24.0.4" }
+wasmtime-asm-macros = { path = "crates/asm-macros", version = "=24.0.4" }
+wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=24.0.4" }
+wasmtime-slab = { path = "crates/slab", version = "=24.0.4" }
 component-test-util = { path = "crates/misc/component-test-util" }
 component-fuzz-util = { path = "crates/misc/component-fuzz-util" }
-wiggle = { path = "crates/wiggle", version = "=24.0.3", default-features = false }
-wiggle-macro = { path = "crates/wiggle/macro", version = "=24.0.3" }
-wiggle-generate = { path = "crates/wiggle/generate", version = "=24.0.3" }
-wasi-common = { path = "crates/wasi-common", version = "=24.0.3", default-features = false }
+wiggle = { path = "crates/wiggle", version = "=24.0.4", default-features = false }
+wiggle-macro = { path = "crates/wiggle/macro", version = "=24.0.4" }
+wiggle-generate = { path = "crates/wiggle/generate", version = "=24.0.4" }
+wasi-common = { path = "crates/wasi-common", version = "=24.0.4", default-features = false }
 wasmtime-fuzzing = { path = "crates/fuzzing" }
-wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=24.0.3" }
-wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=24.0.3" }
+wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=24.0.4" }
+wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=24.0.4" }
 test-programs-artifacts = { path = 'crates/test-programs/artifacts' }
 pulley-interpreter-fuzz = { path = 'pulley/fuzz' }
 
-cranelift-wasm = { path = "cranelift/wasm", version = "0.111.3" }
-cranelift-codegen = { path = "cranelift/codegen", version = "0.111.3", default-features = false, features = ["std", "unwind", "trace-log"] }
-cranelift-frontend = { path = "cranelift/frontend", version = "0.111.3" }
-cranelift-entity = { path = "cranelift/entity", version = "0.111.3" }
-cranelift-native = { path = "cranelift/native", version = "0.111.3" }
-cranelift-module = { path = "cranelift/module", version = "0.111.3" }
-cranelift-interpreter = { path = "cranelift/interpreter", version = "0.111.3" }
-cranelift-reader = { path = "cranelift/reader", version = "0.111.3" }
+cranelift-wasm = { path = "cranelift/wasm", version = "0.111.4" }
+cranelift-codegen = { path = "cranelift/codegen", version = "0.111.4", default-features = false, features = ["std", "unwind", "trace-log"] }
+cranelift-frontend = { path = "cranelift/frontend", version = "0.111.4" }
+cranelift-entity = { path = "cranelift/entity", version = "0.111.4" }
+cranelift-native = { path = "cranelift/native", version = "0.111.4" }
+cranelift-module = { path = "cranelift/module", version = "0.111.4" }
+cranelift-interpreter = { path = "cranelift/interpreter", version = "0.111.4" }
+cranelift-reader = { path = "cranelift/reader", version = "0.111.4" }
 cranelift-filetests = { path = "cranelift/filetests" }
-cranelift-object = { path = "cranelift/object", version = "0.111.3" }
-cranelift-jit = { path = "cranelift/jit", version = "0.111.3" }
+cranelift-object = { path = "cranelift/object", version = "0.111.4" }
+cranelift-jit = { path = "cranelift/jit", version = "0.111.4" }
 cranelift-fuzzgen = { path = "cranelift/fuzzgen" }
-cranelift-bforest = { path = "cranelift/bforest", version = "0.111.3" }
-cranelift-bitset = { path = "cranelift/bitset", version = "0.111.3" }
-cranelift-control = { path = "cranelift/control", version = "0.111.3" }
-cranelift = { path = "cranelift/umbrella", version = "0.111.3" }
+cranelift-bforest = { path = "cranelift/bforest", version = "0.111.4" }
+cranelift-bitset = { path = "cranelift/bitset", version = "0.111.4" }
+cranelift-control = { path = "cranelift/control", version = "0.111.4" }
+cranelift = { path = "cranelift/umbrella", version = "0.111.4" }
 
-winch-codegen = { path = "winch/codegen", version = "=0.22.3" }
+winch-codegen = { path = "winch/codegen", version = "=0.22.4" }
 
 wasi-preview1-component-adapter = { path = "crates/wasi-preview1-component-adapter" }
 byte-array-literals = { path = "crates/wasi-preview1-component-adapter/byte-array-literals" }

--- a/cranelift/bforest/Cargo.toml
+++ b/cranelift/bforest/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bforest"
-version = "0.111.3"
+version = "0.111.4"
 description = "A forest of B+-trees"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-bforest"

--- a/cranelift/bitset/Cargo.toml
+++ b/cranelift/bitset/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bitset"
-version = "0.111.3"
+version = "0.111.4"
 description = "Various bitset stuff for use inside Cranelift"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-bitset"

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen"
-version = "0.111.3"
+version = "0.111.4"
 description = "Low-level code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-codegen"
@@ -19,7 +19,7 @@ workspace = true
 anyhow = { workspace = true, optional = true, features = ['std'] }
 bumpalo = "3"
 capstone = { workspace = true, optional = true }
-cranelift-codegen-shared = { path = "./shared", version = "0.111.3" }
+cranelift-codegen-shared = { path = "./shared", version = "0.111.4" }
 cranelift-entity = { workspace = true }
 cranelift-bforest = { workspace = true }
 cranelift-bitset = { workspace = true }
@@ -47,8 +47,8 @@ similar = "2.1.0"
 env_logger = { workspace = true }
 
 [build-dependencies]
-cranelift-codegen-meta = { path = "meta", version = "0.111.3" }
-cranelift-isle = { path = "../isle/isle", version = "=0.111.3" }
+cranelift-codegen-meta = { path = "meta", version = "0.111.4" }
+cranelift-isle = { path = "../isle/isle", version = "=0.111.4" }
 
 [features]
 default = ["std", "unwind", "host-arch", "timing"]

--- a/cranelift/codegen/meta/Cargo.toml
+++ b/cranelift/codegen/meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-codegen-meta"
 authors = ["The Cranelift Project Developers"]
-version = "0.111.3"
+version = "0.111.4"
 description = "Metaprogram for cranelift-codegen code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
@@ -15,4 +15,4 @@ workspace = true
 rustdoc-args = [ "--document-private-items" ]
 
 [dependencies]
-cranelift-codegen-shared = { path = "../shared", version = "0.111.3" }
+cranelift-codegen-shared = { path = "../shared", version = "0.111.4" }

--- a/cranelift/codegen/shared/Cargo.toml
+++ b/cranelift/codegen/shared/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen-shared"
-version = "0.111.3"
+version = "0.111.4"
 description = "For code shared between cranelift-codegen-meta and cranelift-codegen"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/control/Cargo.toml
+++ b/cranelift/control/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-control"
-version = "0.111.3"
+version = "0.111.4"
 description = "White-box fuzz testing framework"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/entity/Cargo.toml
+++ b/cranelift/entity/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-entity"
-version = "0.111.3"
+version = "0.111.4"
 description = "Data structures using entity references as mapping keys"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-entity"

--- a/cranelift/frontend/Cargo.toml
+++ b/cranelift/frontend/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-frontend"
-version = "0.111.3"
+version = "0.111.4"
 description = "Cranelift IR builder helper"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-frontend"

--- a/cranelift/interpreter/Cargo.toml
+++ b/cranelift/interpreter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-interpreter"
-version = "0.111.3"
+version = "0.111.4"
 authors = ["The Cranelift Project Developers"]
 description = "Interpret Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/isle/isle/Cargo.toml
+++ b/cranelift/isle/isle/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 name = "cranelift-isle"
 readme = "../README.md"
 repository = "https://github.com/bytecodealliance/wasmtime/tree/main/cranelift/isle"
-version = "0.111.3"
+version = "0.111.4"
 
 [lints]
 workspace = true

--- a/cranelift/jit/Cargo.toml
+++ b/cranelift/jit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-jit"
-version = "0.111.3"
+version = "0.111.4"
 authors = ["The Cranelift Project Developers"]
 description = "A JIT library backed by Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/module/Cargo.toml
+++ b/cranelift/module/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-module"
-version = "0.111.3"
+version = "0.111.4"
 authors = ["The Cranelift Project Developers"]
 description = "Support for linking functions and data with Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/native/Cargo.toml
+++ b/cranelift/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-native"
-version = "0.111.3"
+version = "0.111.4"
 authors = ["The Cranelift Project Developers"]
 description = "Support for targeting the host with Cranelift"
 documentation = "https://docs.rs/cranelift-native"

--- a/cranelift/object/Cargo.toml
+++ b/cranelift/object/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-object"
-version = "0.111.3"
+version = "0.111.4"
 authors = ["The Cranelift Project Developers"]
 description = "Emit Cranelift output to native object files with `object`"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/reader/Cargo.toml
+++ b/cranelift/reader/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-reader"
-version = "0.111.3"
+version = "0.111.4"
 description = "Cranelift textual IR reader"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-reader"

--- a/cranelift/serde/Cargo.toml
+++ b/cranelift/serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-serde"
-version = "0.111.3"
+version = "0.111.4"
 authors = ["The Cranelift Project Developers"]
 description = "Serializer/Deserializer for Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/umbrella/Cargo.toml
+++ b/cranelift/umbrella/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift"
-version = "0.111.3"
+version = "0.111.4"
 description = "Umbrella for commonly-used cranelift crates"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift"

--- a/cranelift/wasm/Cargo.toml
+++ b/cranelift/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-wasm"
-version = "0.111.3"
+version = "0.111.4"
 authors = ["The Cranelift Project Developers"]
 description = "Translator from WebAssembly to Cranelift IR"
 documentation = "https://docs.rs/cranelift-wasm"

--- a/crates/c-api/include/wasmtime.h
+++ b/crates/c-api/include/wasmtime.h
@@ -206,7 +206,7 @@
 /**
  * \brief Wasmtime version string.
  */
-#define WASMTIME_VERSION "24.0.3"
+#define WASMTIME_VERSION "24.0.4"
 /**
  * \brief Wasmtime major version number.
  */
@@ -218,7 +218,7 @@
 /**
  * \brief Wasmtime patch version number.
  */
-#define WASMTIME_VERSION_PATCH 3
+#define WASMTIME_VERSION_PATCH 4
 
 #ifdef __cplusplus
 extern "C" {

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -17,6 +17,10 @@ audited_as = "0.111.1"
 version = "0.111.3"
 audited_as = "0.111.2"
 
+[[unpublished.cranelift]]
+version = "0.111.4"
+audited_as = "0.111.3"
+
 [[unpublished.cranelift-bforest]]
 version = "0.111.0"
 audited_as = "0.110.1"
@@ -32,6 +36,10 @@ audited_as = "0.111.1"
 [[unpublished.cranelift-bforest]]
 version = "0.111.3"
 audited_as = "0.111.2"
+
+[[unpublished.cranelift-bforest]]
+version = "0.111.4"
+audited_as = "0.111.3"
 
 [[unpublished.cranelift-bitset]]
 version = "0.111.0"
@@ -49,6 +57,10 @@ audited_as = "0.111.1"
 version = "0.111.3"
 audited_as = "0.111.2"
 
+[[unpublished.cranelift-bitset]]
+version = "0.111.4"
+audited_as = "0.111.3"
+
 [[unpublished.cranelift-codegen]]
 version = "0.111.0"
 audited_as = "0.110.1"
@@ -64,6 +76,10 @@ audited_as = "0.111.1"
 [[unpublished.cranelift-codegen]]
 version = "0.111.3"
 audited_as = "0.111.2"
+
+[[unpublished.cranelift-codegen]]
+version = "0.111.4"
+audited_as = "0.111.3"
 
 [[unpublished.cranelift-codegen-meta]]
 version = "0.111.0"
@@ -81,6 +97,10 @@ audited_as = "0.111.1"
 version = "0.111.3"
 audited_as = "0.111.2"
 
+[[unpublished.cranelift-codegen-meta]]
+version = "0.111.4"
+audited_as = "0.111.3"
+
 [[unpublished.cranelift-codegen-shared]]
 version = "0.111.0"
 audited_as = "0.110.1"
@@ -96,6 +116,10 @@ audited_as = "0.111.1"
 [[unpublished.cranelift-codegen-shared]]
 version = "0.111.3"
 audited_as = "0.111.2"
+
+[[unpublished.cranelift-codegen-shared]]
+version = "0.111.4"
+audited_as = "0.111.3"
 
 [[unpublished.cranelift-control]]
 version = "0.111.0"
@@ -113,6 +137,10 @@ audited_as = "0.111.1"
 version = "0.111.3"
 audited_as = "0.111.2"
 
+[[unpublished.cranelift-control]]
+version = "0.111.4"
+audited_as = "0.111.3"
+
 [[unpublished.cranelift-entity]]
 version = "0.111.0"
 audited_as = "0.110.1"
@@ -128,6 +156,10 @@ audited_as = "0.111.1"
 [[unpublished.cranelift-entity]]
 version = "0.111.3"
 audited_as = "0.111.2"
+
+[[unpublished.cranelift-entity]]
+version = "0.111.4"
+audited_as = "0.111.3"
 
 [[unpublished.cranelift-frontend]]
 version = "0.111.0"
@@ -145,6 +177,10 @@ audited_as = "0.111.1"
 version = "0.111.3"
 audited_as = "0.111.2"
 
+[[unpublished.cranelift-frontend]]
+version = "0.111.4"
+audited_as = "0.111.3"
+
 [[unpublished.cranelift-interpreter]]
 version = "0.111.0"
 audited_as = "0.110.1"
@@ -160,6 +196,10 @@ audited_as = "0.111.1"
 [[unpublished.cranelift-interpreter]]
 version = "0.111.3"
 audited_as = "0.111.2"
+
+[[unpublished.cranelift-interpreter]]
+version = "0.111.4"
+audited_as = "0.111.3"
 
 [[unpublished.cranelift-isle]]
 version = "0.111.0"
@@ -177,6 +217,10 @@ audited_as = "0.111.1"
 version = "0.111.3"
 audited_as = "0.111.2"
 
+[[unpublished.cranelift-isle]]
+version = "0.111.4"
+audited_as = "0.111.3"
+
 [[unpublished.cranelift-jit]]
 version = "0.111.0"
 audited_as = "0.110.1"
@@ -192,6 +236,10 @@ audited_as = "0.111.1"
 [[unpublished.cranelift-jit]]
 version = "0.111.3"
 audited_as = "0.111.2"
+
+[[unpublished.cranelift-jit]]
+version = "0.111.4"
+audited_as = "0.111.3"
 
 [[unpublished.cranelift-module]]
 version = "0.111.0"
@@ -209,6 +257,10 @@ audited_as = "0.111.1"
 version = "0.111.3"
 audited_as = "0.111.2"
 
+[[unpublished.cranelift-module]]
+version = "0.111.4"
+audited_as = "0.111.3"
+
 [[unpublished.cranelift-native]]
 version = "0.111.0"
 audited_as = "0.110.1"
@@ -224,6 +276,10 @@ audited_as = "0.111.1"
 [[unpublished.cranelift-native]]
 version = "0.111.3"
 audited_as = "0.111.2"
+
+[[unpublished.cranelift-native]]
+version = "0.111.4"
+audited_as = "0.111.3"
 
 [[unpublished.cranelift-object]]
 version = "0.111.0"
@@ -241,6 +297,10 @@ audited_as = "0.111.1"
 version = "0.111.3"
 audited_as = "0.111.2"
 
+[[unpublished.cranelift-object]]
+version = "0.111.4"
+audited_as = "0.111.3"
+
 [[unpublished.cranelift-reader]]
 version = "0.111.0"
 audited_as = "0.110.1"
@@ -257,6 +317,10 @@ audited_as = "0.111.1"
 version = "0.111.3"
 audited_as = "0.111.2"
 
+[[unpublished.cranelift-reader]]
+version = "0.111.4"
+audited_as = "0.111.3"
+
 [[unpublished.cranelift-serde]]
 version = "0.111.0"
 audited_as = "0.110.1"
@@ -273,6 +337,10 @@ audited_as = "0.111.1"
 version = "0.111.3"
 audited_as = "0.111.2"
 
+[[unpublished.cranelift-serde]]
+version = "0.111.4"
+audited_as = "0.111.3"
+
 [[unpublished.cranelift-wasm]]
 version = "0.111.0"
 audited_as = "0.110.1"
@@ -289,6 +357,10 @@ audited_as = "0.111.1"
 version = "0.111.3"
 audited_as = "0.111.2"
 
+[[unpublished.cranelift-wasm]]
+version = "0.111.4"
+audited_as = "0.111.3"
+
 [[unpublished.wasi-common]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -304,6 +376,10 @@ audited_as = "24.0.1"
 [[unpublished.wasi-common]]
 version = "24.0.3"
 audited_as = "24.0.2"
+
+[[unpublished.wasi-common]]
+version = "24.0.4"
+audited_as = "24.0.3"
 
 [[unpublished.wasmtime]]
 version = "24.0.0"
@@ -321,6 +397,10 @@ audited_as = "24.0.1"
 version = "24.0.3"
 audited_as = "24.0.2"
 
+[[unpublished.wasmtime]]
+version = "24.0.4"
+audited_as = "24.0.3"
+
 [[unpublished.wasmtime-asm-macros]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -336,6 +416,10 @@ audited_as = "24.0.1"
 [[unpublished.wasmtime-asm-macros]]
 version = "24.0.3"
 audited_as = "24.0.2"
+
+[[unpublished.wasmtime-asm-macros]]
+version = "24.0.4"
+audited_as = "24.0.3"
 
 [[unpublished.wasmtime-cache]]
 version = "24.0.0"
@@ -353,6 +437,10 @@ audited_as = "24.0.1"
 version = "24.0.3"
 audited_as = "24.0.2"
 
+[[unpublished.wasmtime-cache]]
+version = "24.0.4"
+audited_as = "24.0.3"
+
 [[unpublished.wasmtime-cli]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -368,6 +456,10 @@ audited_as = "24.0.1"
 [[unpublished.wasmtime-cli]]
 version = "24.0.3"
 audited_as = "24.0.2"
+
+[[unpublished.wasmtime-cli]]
+version = "24.0.4"
+audited_as = "24.0.3"
 
 [[unpublished.wasmtime-cli-flags]]
 version = "24.0.0"
@@ -385,6 +477,10 @@ audited_as = "24.0.1"
 version = "24.0.3"
 audited_as = "24.0.2"
 
+[[unpublished.wasmtime-cli-flags]]
+version = "24.0.4"
+audited_as = "24.0.3"
+
 [[unpublished.wasmtime-component-macro]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -400,6 +496,10 @@ audited_as = "24.0.1"
 [[unpublished.wasmtime-component-macro]]
 version = "24.0.3"
 audited_as = "24.0.2"
+
+[[unpublished.wasmtime-component-macro]]
+version = "24.0.4"
+audited_as = "24.0.3"
 
 [[unpublished.wasmtime-component-util]]
 version = "24.0.0"
@@ -417,6 +517,10 @@ audited_as = "24.0.1"
 version = "24.0.3"
 audited_as = "24.0.2"
 
+[[unpublished.wasmtime-component-util]]
+version = "24.0.4"
+audited_as = "24.0.3"
+
 [[unpublished.wasmtime-cranelift]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -432,6 +536,10 @@ audited_as = "24.0.1"
 [[unpublished.wasmtime-cranelift]]
 version = "24.0.3"
 audited_as = "24.0.2"
+
+[[unpublished.wasmtime-cranelift]]
+version = "24.0.4"
+audited_as = "24.0.3"
 
 [[unpublished.wasmtime-environ]]
 version = "24.0.0"
@@ -449,6 +557,10 @@ audited_as = "24.0.1"
 version = "24.0.3"
 audited_as = "24.0.2"
 
+[[unpublished.wasmtime-environ]]
+version = "24.0.4"
+audited_as = "24.0.3"
+
 [[unpublished.wasmtime-explorer]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -464,6 +576,10 @@ audited_as = "24.0.1"
 [[unpublished.wasmtime-explorer]]
 version = "24.0.3"
 audited_as = "24.0.2"
+
+[[unpublished.wasmtime-explorer]]
+version = "24.0.4"
+audited_as = "24.0.3"
 
 [[unpublished.wasmtime-fiber]]
 version = "24.0.0"
@@ -481,6 +597,10 @@ audited_as = "24.0.1"
 version = "24.0.3"
 audited_as = "24.0.2"
 
+[[unpublished.wasmtime-fiber]]
+version = "24.0.4"
+audited_as = "24.0.3"
+
 [[unpublished.wasmtime-jit-debug]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -496,6 +616,10 @@ audited_as = "24.0.1"
 [[unpublished.wasmtime-jit-debug]]
 version = "24.0.3"
 audited_as = "24.0.2"
+
+[[unpublished.wasmtime-jit-debug]]
+version = "24.0.4"
+audited_as = "24.0.3"
 
 [[unpublished.wasmtime-jit-icache-coherence]]
 version = "24.0.0"
@@ -513,6 +637,10 @@ audited_as = "24.0.1"
 version = "24.0.3"
 audited_as = "24.0.2"
 
+[[unpublished.wasmtime-jit-icache-coherence]]
+version = "24.0.4"
+audited_as = "24.0.3"
+
 [[unpublished.wasmtime-slab]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -528,6 +656,10 @@ audited_as = "24.0.1"
 [[unpublished.wasmtime-slab]]
 version = "24.0.3"
 audited_as = "24.0.2"
+
+[[unpublished.wasmtime-slab]]
+version = "24.0.4"
+audited_as = "24.0.3"
 
 [[unpublished.wasmtime-types]]
 version = "24.0.0"
@@ -545,6 +677,10 @@ audited_as = "24.0.1"
 version = "24.0.3"
 audited_as = "24.0.2"
 
+[[unpublished.wasmtime-types]]
+version = "24.0.4"
+audited_as = "24.0.3"
+
 [[unpublished.wasmtime-wasi]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -561,6 +697,10 @@ audited_as = "24.0.1"
 version = "24.0.3"
 audited_as = "24.0.2"
 
+[[unpublished.wasmtime-wasi]]
+version = "24.0.4"
+audited_as = "24.0.3"
+
 [[unpublished.wasmtime-wasi-http]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -576,6 +716,10 @@ audited_as = "24.0.1"
 [[unpublished.wasmtime-wasi-http]]
 version = "24.0.3"
 audited_as = "24.0.2"
+
+[[unpublished.wasmtime-wasi-http]]
+version = "24.0.4"
+audited_as = "24.0.3"
 
 [[unpublished.wasmtime-wasi-keyvalue]]
 version = "24.0.1"
@@ -589,6 +733,10 @@ audited_as = "24.0.1"
 version = "24.0.3"
 audited_as = "24.0.2"
 
+[[unpublished.wasmtime-wasi-keyvalue]]
+version = "24.0.4"
+audited_as = "24.0.3"
+
 [[unpublished.wasmtime-wasi-nn]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -604,6 +752,10 @@ audited_as = "24.0.1"
 [[unpublished.wasmtime-wasi-nn]]
 version = "24.0.3"
 audited_as = "24.0.2"
+
+[[unpublished.wasmtime-wasi-nn]]
+version = "24.0.4"
+audited_as = "24.0.3"
 
 [[unpublished.wasmtime-wasi-runtime-config]]
 version = "24.0.1"
@@ -617,6 +769,10 @@ audited_as = "24.0.1"
 version = "24.0.3"
 audited_as = "24.0.2"
 
+[[unpublished.wasmtime-wasi-runtime-config]]
+version = "24.0.4"
+audited_as = "24.0.3"
+
 [[unpublished.wasmtime-wasi-threads]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -632,6 +788,10 @@ audited_as = "24.0.1"
 [[unpublished.wasmtime-wasi-threads]]
 version = "24.0.3"
 audited_as = "24.0.2"
+
+[[unpublished.wasmtime-wasi-threads]]
+version = "24.0.4"
+audited_as = "24.0.3"
 
 [[unpublished.wasmtime-wast]]
 version = "24.0.0"
@@ -649,6 +809,10 @@ audited_as = "24.0.1"
 version = "24.0.3"
 audited_as = "24.0.2"
 
+[[unpublished.wasmtime-wast]]
+version = "24.0.4"
+audited_as = "24.0.3"
+
 [[unpublished.wasmtime-winch]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -664,6 +828,10 @@ audited_as = "24.0.1"
 [[unpublished.wasmtime-winch]]
 version = "24.0.3"
 audited_as = "24.0.2"
+
+[[unpublished.wasmtime-winch]]
+version = "24.0.4"
+audited_as = "24.0.3"
 
 [[unpublished.wasmtime-wit-bindgen]]
 version = "24.0.0"
@@ -681,6 +849,10 @@ audited_as = "24.0.1"
 version = "24.0.3"
 audited_as = "24.0.2"
 
+[[unpublished.wasmtime-wit-bindgen]]
+version = "24.0.4"
+audited_as = "24.0.3"
+
 [[unpublished.wasmtime-wmemcheck]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -696,6 +868,10 @@ audited_as = "24.0.1"
 [[unpublished.wasmtime-wmemcheck]]
 version = "24.0.3"
 audited_as = "24.0.2"
+
+[[unpublished.wasmtime-wmemcheck]]
+version = "24.0.4"
+audited_as = "24.0.3"
 
 [[unpublished.wiggle]]
 version = "24.0.0"
@@ -713,6 +889,10 @@ audited_as = "24.0.1"
 version = "24.0.3"
 audited_as = "24.0.2"
 
+[[unpublished.wiggle]]
+version = "24.0.4"
+audited_as = "24.0.3"
+
 [[unpublished.wiggle-generate]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -729,6 +909,10 @@ audited_as = "24.0.1"
 version = "24.0.3"
 audited_as = "24.0.2"
 
+[[unpublished.wiggle-generate]]
+version = "24.0.4"
+audited_as = "24.0.3"
+
 [[unpublished.wiggle-macro]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -744,6 +928,10 @@ audited_as = "24.0.1"
 [[unpublished.wiggle-macro]]
 version = "24.0.3"
 audited_as = "24.0.2"
+
+[[unpublished.wiggle-macro]]
+version = "24.0.4"
+audited_as = "24.0.3"
 
 [[unpublished.wiggle-test]]
 version = "0.0.0"
@@ -764,6 +952,10 @@ audited_as = "0.22.1"
 [[unpublished.winch-codegen]]
 version = "0.22.3"
 audited_as = "0.22.2"
+
+[[unpublished.winch-codegen]]
+version = "0.22.4"
+audited_as = "0.22.3"
 
 [[publisher.aho-corasick]]
 version = "1.0.2"
@@ -1006,6 +1198,12 @@ when = "2024-11-05"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift]]
+version = "0.111.3"
+when = "2025-06-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-bforest]]
 version = "0.110.1"
 when = "2024-07-22"
@@ -1027,6 +1225,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-bforest]]
 version = "0.111.2"
 when = "2024-11-05"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-bforest]]
+version = "0.111.3"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1054,6 +1258,12 @@ when = "2024-11-05"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-bitset]]
+version = "0.111.3"
+when = "2025-06-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-codegen]]
 version = "0.110.1"
 when = "2024-07-22"
@@ -1075,6 +1285,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-codegen]]
 version = "0.111.2"
 when = "2024-11-05"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-codegen]]
+version = "0.111.3"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1102,6 +1318,12 @@ when = "2024-11-05"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-codegen-meta]]
+version = "0.111.3"
+when = "2025-06-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-codegen-shared]]
 version = "0.110.1"
 when = "2024-07-22"
@@ -1123,6 +1345,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-codegen-shared]]
 version = "0.111.2"
 when = "2024-11-05"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-codegen-shared]]
+version = "0.111.3"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1150,6 +1378,12 @@ when = "2024-11-05"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-control]]
+version = "0.111.3"
+when = "2025-06-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-entity]]
 version = "0.110.1"
 when = "2024-07-22"
@@ -1171,6 +1405,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-entity]]
 version = "0.111.2"
 when = "2024-11-05"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-entity]]
+version = "0.111.3"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1198,6 +1438,12 @@ when = "2024-11-05"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-frontend]]
+version = "0.111.3"
+when = "2025-06-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-interpreter]]
 version = "0.110.1"
 when = "2024-07-22"
@@ -1219,6 +1465,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-interpreter]]
 version = "0.111.2"
 when = "2024-11-05"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-interpreter]]
+version = "0.111.3"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1246,6 +1498,12 @@ when = "2024-11-05"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-isle]]
+version = "0.111.3"
+when = "2025-06-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-jit]]
 version = "0.110.1"
 when = "2024-07-22"
@@ -1267,6 +1525,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-jit]]
 version = "0.111.2"
 when = "2024-11-05"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-jit]]
+version = "0.111.3"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1294,6 +1558,12 @@ when = "2024-11-05"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-module]]
+version = "0.111.3"
+when = "2025-06-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-native]]
 version = "0.110.1"
 when = "2024-07-22"
@@ -1315,6 +1585,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-native]]
 version = "0.111.2"
 when = "2024-11-05"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-native]]
+version = "0.111.3"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1342,6 +1618,12 @@ when = "2024-11-05"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-object]]
+version = "0.111.3"
+when = "2025-06-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-reader]]
 version = "0.110.1"
 when = "2024-07-22"
@@ -1366,6 +1648,12 @@ when = "2024-11-05"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-reader]]
+version = "0.111.3"
+when = "2025-06-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-serde]]
 version = "0.110.1"
 when = "2024-07-22"
@@ -1390,6 +1678,12 @@ when = "2024-11-05"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-serde]]
+version = "0.111.3"
+when = "2025-06-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-wasm]]
 version = "0.110.1"
 when = "2024-07-22"
@@ -1411,6 +1705,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-wasm]]
 version = "0.111.2"
 when = "2024-11-05"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-wasm]]
+version = "0.111.3"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1822,6 +2122,12 @@ when = "2024-11-05"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasi-common]]
+version = "24.0.3"
+when = "2025-06-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasm-bindgen]]
 version = "0.2.87"
 when = "2023-06-12"
@@ -1929,6 +2235,12 @@ when = "2024-11-05"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime]]
+version = "24.0.3"
+when = "2025-06-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-asm-macros]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -1950,6 +2262,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-asm-macros]]
 version = "24.0.2"
 when = "2024-11-05"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-asm-macros]]
+version = "24.0.3"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1977,6 +2295,12 @@ when = "2024-11-05"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-cache]]
+version = "24.0.3"
+when = "2025-06-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-cli]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -1998,6 +2322,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-cli]]
 version = "24.0.2"
 when = "2024-11-05"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-cli]]
+version = "24.0.3"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2025,6 +2355,12 @@ when = "2024-11-05"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-cli-flags]]
+version = "24.0.3"
+when = "2025-06-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-component-macro]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -2046,6 +2382,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-component-macro]]
 version = "24.0.2"
 when = "2024-11-05"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-component-macro]]
+version = "24.0.3"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2073,6 +2415,12 @@ when = "2024-11-05"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-component-util]]
+version = "24.0.3"
+when = "2025-06-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-cranelift]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -2094,6 +2442,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-cranelift]]
 version = "24.0.2"
 when = "2024-11-05"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-cranelift]]
+version = "24.0.3"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2121,6 +2475,12 @@ when = "2024-11-05"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-environ]]
+version = "24.0.3"
+when = "2025-06-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-explorer]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -2142,6 +2502,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-explorer]]
 version = "24.0.2"
 when = "2024-11-05"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-explorer]]
+version = "24.0.3"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2169,6 +2535,12 @@ when = "2024-11-05"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-fiber]]
+version = "24.0.3"
+when = "2025-06-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-jit-debug]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -2193,6 +2565,12 @@ when = "2024-11-05"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-jit-debug]]
+version = "24.0.3"
+when = "2025-06-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-jit-icache-coherence]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -2214,6 +2592,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-jit-icache-coherence]]
 version = "24.0.2"
 when = "2024-11-05"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-jit-icache-coherence]]
+version = "24.0.3"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2265,6 +2649,12 @@ when = "2024-11-05"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-types]]
+version = "24.0.3"
+when = "2025-06-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-wasi]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -2289,6 +2679,12 @@ when = "2024-11-05"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-wasi]]
+version = "24.0.3"
+when = "2025-06-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-wasi-http]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -2310,6 +2706,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-wasi-http]]
 version = "24.0.2"
 when = "2024-11-05"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-wasi-http]]
+version = "24.0.3"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2331,6 +2733,12 @@ when = "2024-11-05"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-wasi-keyvalue]]
+version = "24.0.3"
+when = "2025-06-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-wasi-nn]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -2352,6 +2760,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-wasi-nn]]
 version = "24.0.2"
 when = "2024-11-05"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-wasi-nn]]
+version = "24.0.3"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2373,6 +2787,12 @@ when = "2024-11-05"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-wasi-runtime-config]]
+version = "24.0.3"
+when = "2025-06-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-wasi-threads]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -2394,6 +2814,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-wasi-threads]]
 version = "24.0.2"
 when = "2024-11-05"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-wasi-threads]]
+version = "24.0.3"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2421,6 +2847,12 @@ when = "2024-11-05"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-wast]]
+version = "24.0.3"
+when = "2025-06-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-winch]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -2445,6 +2877,12 @@ when = "2024-11-05"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-winch]]
+version = "24.0.3"
+when = "2025-06-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-wit-bindgen]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -2469,6 +2907,12 @@ when = "2024-11-05"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-wit-bindgen]]
+version = "24.0.3"
+when = "2025-06-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-wmemcheck]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -2490,6 +2934,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-wmemcheck]]
 version = "24.0.2"
 when = "2024-11-05"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-wmemcheck]]
+version = "24.0.3"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2541,6 +2991,12 @@ when = "2024-11-05"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wiggle]]
+version = "24.0.3"
+when = "2025-06-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wiggle-generate]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -2565,6 +3021,12 @@ when = "2024-11-05"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wiggle-generate]]
+version = "24.0.3"
+when = "2025-06-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wiggle-macro]]
 version = "23.0.1"
 when = "2024-07-22"
@@ -2586,6 +3048,12 @@ user-login = "wasmtime-publish"
 [[publisher.wiggle-macro]]
 version = "24.0.2"
 when = "2024-11-05"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wiggle-macro]]
+version = "24.0.3"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2624,6 +3092,12 @@ user-login = "wasmtime-publish"
 [[publisher.winch-codegen]]
 version = "0.22.2"
 when = "2024-11-05"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.winch-codegen]]
+version = "0.22.3"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 

--- a/winch/codegen/Cargo.toml
+++ b/winch/codegen/Cargo.toml
@@ -4,7 +4,7 @@ name = "winch-codegen"
 description = "Winch code generation library"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
-version = "0.22.3"
+version = "0.22.4"
 edition.workspace = true
 
 [lints]


### PR DESCRIPTION
This is an [automated pull request][process] from CI to create a patch release for Wasmtime 24.0.4, requested by @rvolosatovs.

It's recommended that maintainers double-check that [RELEASES.md] is up-to-date and that there are no known issues before merging this PR. When this PR is merged a release tag will automatically be created, crates will be published, and CI artifacts will be produced.

[RELEASES.md]: https://github.com/bytecodealliance/wasmtime/blob/release-24.0.4/RELEASES.md
[process]: https://docs.wasmtime.dev/contributing-release-process.html
