### PR TITLE
Release Wasmtime 34.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,7 +277,7 @@ dependencies = [
 
 [[package]]
 name = "byte-array-literals"
-version = "34.0.1"
+version = "34.0.2"
 
 [[package]]
 name = "byteorder"
@@ -653,7 +653,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift"
-version = "0.121.1"
+version = "0.121.2"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",
@@ -666,7 +666,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.121.1"
+version = "0.121.2"
 dependencies = [
  "arbitrary",
  "arbtest",
@@ -684,21 +684,21 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.121.1"
+version = "0.121.2"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.121.1"
+version = "0.121.2"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.121.1"
+version = "0.121.2"
 dependencies = [
  "arbitrary",
  "serde",
@@ -707,7 +707,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.121.1"
+version = "0.121.2"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.121.1"
+version = "0.121.2"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -751,18 +751,18 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.121.1"
+version = "0.121.2"
 
 [[package]]
 name = "cranelift-control"
-version = "0.121.1"
+version = "0.121.2"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.121.1"
+version = "0.121.2"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.121.1"
+version = "0.121.2"
 dependencies = [
  "cranelift-codegen",
  "env_logger 0.11.5",
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-interpreter"
-version = "0.121.1"
+version = "0.121.2"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -839,7 +839,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.121.1"
+version = "0.121.2"
 dependencies = [
  "codespan-reporting",
  "log",
@@ -848,7 +848,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-jit"
-version = "0.121.1"
+version = "0.121.2"
 dependencies = [
  "anyhow",
  "cranelift",
@@ -869,7 +869,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-module"
-version = "0.121.1"
+version = "0.121.2"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -881,7 +881,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.121.1"
+version = "0.121.2"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -890,7 +890,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-object"
-version = "0.121.1"
+version = "0.121.2"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -905,7 +905,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-reader"
-version = "0.121.1"
+version = "0.121.2"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -915,7 +915,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-serde"
-version = "0.121.1"
+version = "0.121.2"
 dependencies = [
  "clap",
  "cranelift-codegen",
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.121.1"
+version = "0.121.2"
 
 [[package]]
 name = "cranelift-tools"
@@ -1179,7 +1179,7 @@ checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
 
 [[package]]
 name = "embedding"
-version = "34.0.1"
+version = "34.0.2"
 dependencies = [
  "anyhow",
  "dlmalloc",
@@ -2266,7 +2266,7 @@ dependencies = [
 
 [[package]]
 name = "min-platform-host"
-version = "34.0.1"
+version = "34.0.2"
 dependencies = [
  "anyhow",
  "libloading",
@@ -2639,7 +2639,7 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "34.0.1"
+version = "34.0.2"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -2663,7 +2663,7 @@ dependencies = [
 
 [[package]]
 name = "pulley-macros"
-version = "34.0.1"
+version = "34.0.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3789,7 +3789,7 @@ version = "0.1.0"
 
 [[package]]
 name = "verify-component-adapter"
-version = "34.0.1"
+version = "34.0.2"
 dependencies = [
  "anyhow",
  "wasmparser 0.233.0",
@@ -3857,7 +3857,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-common"
-version = "34.0.1"
+version = "34.0.2"
 dependencies = [
  "anyhow",
  "bitflags 2.6.0",
@@ -3896,7 +3896,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-preview1-component-adapter"
-version = "34.0.1"
+version = "34.0.2"
 dependencies = [
  "bitflags 2.6.0",
  "byte-array-literals",
@@ -4146,7 +4146,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "34.0.1"
+version = "34.0.2"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -4211,14 +4211,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-asm-macros"
-version = "34.0.1"
+version = "34.0.2"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "wasmtime-bench-api"
-version = "34.0.1"
+version = "34.0.2"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -4234,14 +4234,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-c-api"
-version = "34.0.1"
+version = "34.0.2"
 dependencies = [
  "wasmtime-c-api-impl",
 ]
 
 [[package]]
 name = "wasmtime-c-api-impl"
-version = "34.0.1"
+version = "34.0.2"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -4258,7 +4258,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-c-api-macros"
-version = "34.0.1"
+version = "34.0.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4266,7 +4266,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cache"
-version = "34.0.1"
+version = "34.0.2"
 dependencies = [
  "anyhow",
  "base64",
@@ -4287,7 +4287,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli"
-version = "34.0.1"
+version = "34.0.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4360,7 +4360,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli-flags"
-version = "34.0.1"
+version = "34.0.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -4375,7 +4375,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-macro"
-version = "34.0.1"
+version = "34.0.2"
 dependencies = [
  "anyhow",
  "component-macro-test-helpers",
@@ -4395,11 +4395,11 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-util"
-version = "34.0.1"
+version = "34.0.2"
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "34.0.1"
+version = "34.0.2"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4424,7 +4424,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "34.0.1"
+version = "34.0.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -4466,7 +4466,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-explorer"
-version = "34.0.1"
+version = "34.0.2"
 dependencies = [
  "anyhow",
  "capstone",
@@ -4481,7 +4481,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-fiber"
-version = "34.0.1"
+version = "34.0.2"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -4554,7 +4554,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-debug"
-version = "34.0.1"
+version = "34.0.2"
 dependencies = [
  "cc",
  "object",
@@ -4564,7 +4564,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-icache-coherence"
-version = "34.0.1"
+version = "34.0.2"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4574,14 +4574,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-math"
-version = "34.0.1"
+version = "34.0.2"
 dependencies = [
  "libm",
 ]
 
 [[package]]
 name = "wasmtime-slab"
-version = "34.0.1"
+version = "34.0.2"
 
 [[package]]
 name = "wasmtime-test-macros"
@@ -4596,7 +4596,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-test-util"
-version = "34.0.1"
+version = "34.0.2"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -4614,7 +4614,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-versioned-export-macros"
-version = "34.0.1"
+version = "34.0.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4623,7 +4623,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "34.0.1"
+version = "34.0.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4657,7 +4657,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-config"
-version = "34.0.1"
+version = "34.0.2"
 dependencies = [
  "anyhow",
  "test-programs-artifacts",
@@ -4668,7 +4668,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-http"
-version = "34.0.1"
+version = "34.0.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4695,7 +4695,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-io"
-version = "34.0.1"
+version = "34.0.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4706,7 +4706,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-keyvalue"
-version = "34.0.1"
+version = "34.0.2"
 dependencies = [
  "anyhow",
  "test-programs-artifacts",
@@ -4717,7 +4717,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-nn"
-version = "34.0.1"
+version = "34.0.2"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -4738,7 +4738,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-threads"
-version = "34.0.1"
+version = "34.0.2"
 dependencies = [
  "anyhow",
  "log",
@@ -4750,7 +4750,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-tls"
-version = "34.0.1"
+version = "34.0.2"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4766,7 +4766,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wast"
-version = "34.0.1"
+version = "34.0.2"
 dependencies = [
  "anyhow",
  "log",
@@ -4777,7 +4777,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-winch"
-version = "34.0.1"
+version = "34.0.2"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -4792,7 +4792,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wit-bindgen"
-version = "34.0.1"
+version = "34.0.2"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -4802,7 +4802,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wmemcheck"
-version = "34.0.1"
+version = "34.0.2"
 
 [[package]]
 name = "wast"
@@ -4869,7 +4869,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "34.0.1"
+version = "34.0.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4886,7 +4886,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "34.0.1"
+version = "34.0.2"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -4898,7 +4898,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "34.0.1"
+version = "34.0.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4953,7 +4953,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "34.0.1"
+version = "34.0.2"
 dependencies = [
  "anyhow",
  "cranelift-assembler-x64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -172,7 +172,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "34.0.1"
+version = "34.0.2"
 authors = ["The Wasmtime Project Developers"]
 edition = "2024"
 # Wasmtime's current policy is that this number can be no larger than the
@@ -216,65 +216,65 @@ from_over_into = 'warn'
 
 [workspace.dependencies]
 arbitrary = { version = "1.4.0" }
-wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=34.0.1" }
-wasmtime = { path = "crates/wasmtime", version = "34.0.1", default-features = false }
-wasmtime-c-api-macros = { path = "crates/c-api-macros", version = "=34.0.1" }
-wasmtime-cache = { path = "crates/cache", version = "=34.0.1" }
-wasmtime-cli-flags = { path = "crates/cli-flags", version = "=34.0.1" }
-wasmtime-cranelift = { path = "crates/cranelift", version = "=34.0.1" }
-wasmtime-winch = { path = "crates/winch", version = "=34.0.1" }
-wasmtime-environ = { path = "crates/environ", version = "=34.0.1" }
-wasmtime-explorer = { path = "crates/explorer", version = "=34.0.1" }
-wasmtime-fiber = { path = "crates/fiber", version = "=34.0.1" }
-wasmtime-jit-debug = { path = "crates/jit-debug", version = "=34.0.1" }
-wasmtime-wast = { path = "crates/wast", version = "=34.0.1" }
-wasmtime-wasi = { path = "crates/wasi", version = "34.0.1", default-features = false }
-wasmtime-wasi-io = { path = "crates/wasi-io", version = "34.0.1", default-features = false }
-wasmtime-wasi-http = { path = "crates/wasi-http", version = "34.0.1", default-features = false }
-wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "34.0.1" }
-wasmtime-wasi-config = { path = "crates/wasi-config", version = "34.0.1" }
-wasmtime-wasi-keyvalue = { path = "crates/wasi-keyvalue", version = "34.0.1" }
-wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "34.0.1" }
-wasmtime-component-util = { path = "crates/component-util", version = "=34.0.1" }
-wasmtime-component-macro = { path = "crates/component-macro", version = "=34.0.1" }
-wasmtime-asm-macros = { path = "crates/asm-macros", version = "=34.0.1" }
-wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=34.0.1" }
-wasmtime-slab = { path = "crates/slab", version = "=34.0.1" }
-wasmtime-wasi-tls = { path = "crates/wasi-tls", version = "34.0.1" }
-wiggle = { path = "crates/wiggle", version = "=34.0.1", default-features = false }
-wiggle-macro = { path = "crates/wiggle/macro", version = "=34.0.1" }
-wiggle-generate = { path = "crates/wiggle/generate", version = "=34.0.1" }
-wasi-common = { path = "crates/wasi-common", version = "=34.0.1", default-features = false }
+wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=34.0.2" }
+wasmtime = { path = "crates/wasmtime", version = "34.0.2", default-features = false }
+wasmtime-c-api-macros = { path = "crates/c-api-macros", version = "=34.0.2" }
+wasmtime-cache = { path = "crates/cache", version = "=34.0.2" }
+wasmtime-cli-flags = { path = "crates/cli-flags", version = "=34.0.2" }
+wasmtime-cranelift = { path = "crates/cranelift", version = "=34.0.2" }
+wasmtime-winch = { path = "crates/winch", version = "=34.0.2" }
+wasmtime-environ = { path = "crates/environ", version = "=34.0.2" }
+wasmtime-explorer = { path = "crates/explorer", version = "=34.0.2" }
+wasmtime-fiber = { path = "crates/fiber", version = "=34.0.2" }
+wasmtime-jit-debug = { path = "crates/jit-debug", version = "=34.0.2" }
+wasmtime-wast = { path = "crates/wast", version = "=34.0.2" }
+wasmtime-wasi = { path = "crates/wasi", version = "34.0.2", default-features = false }
+wasmtime-wasi-io = { path = "crates/wasi-io", version = "34.0.2", default-features = false }
+wasmtime-wasi-http = { path = "crates/wasi-http", version = "34.0.2", default-features = false }
+wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "34.0.2" }
+wasmtime-wasi-config = { path = "crates/wasi-config", version = "34.0.2" }
+wasmtime-wasi-keyvalue = { path = "crates/wasi-keyvalue", version = "34.0.2" }
+wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "34.0.2" }
+wasmtime-component-util = { path = "crates/component-util", version = "=34.0.2" }
+wasmtime-component-macro = { path = "crates/component-macro", version = "=34.0.2" }
+wasmtime-asm-macros = { path = "crates/asm-macros", version = "=34.0.2" }
+wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=34.0.2" }
+wasmtime-slab = { path = "crates/slab", version = "=34.0.2" }
+wasmtime-wasi-tls = { path = "crates/wasi-tls", version = "34.0.2" }
+wiggle = { path = "crates/wiggle", version = "=34.0.2", default-features = false }
+wiggle-macro = { path = "crates/wiggle/macro", version = "=34.0.2" }
+wiggle-generate = { path = "crates/wiggle/generate", version = "=34.0.2" }
+wasi-common = { path = "crates/wasi-common", version = "=34.0.2", default-features = false }
 wasmtime-fuzzing = { path = "crates/fuzzing" }
-wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=34.0.1" }
-wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=34.0.1" }
-wasmtime-math = { path = "crates/math", version = "=34.0.1" }
+wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=34.0.2" }
+wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=34.0.2" }
+wasmtime-math = { path = "crates/math", version = "=34.0.2" }
 test-programs-artifacts = { path = 'crates/test-programs/artifacts' }
 wasmtime-test-util = { path = "crates/test-util" }
 
-pulley-interpreter = { path = 'pulley', version = "=34.0.1" }
+pulley-interpreter = { path = 'pulley', version = "=34.0.2" }
 pulley-interpreter-fuzz = { path = 'pulley/fuzz' }
-pulley-macros = { path = 'pulley/macros', version = "=34.0.1" }
+pulley-macros = { path = 'pulley/macros', version = "=34.0.2" }
 
-cranelift-assembler-x64 = { path = "cranelift/assembler-x64", version = "0.121.1" }
-cranelift-codegen = { path = "cranelift/codegen", version = "0.121.1", default-features = false, features = ["std", "unwind"] }
-cranelift-frontend = { path = "cranelift/frontend", version = "0.121.1" }
-cranelift-entity = { path = "cranelift/entity", version = "0.121.1" }
-cranelift-native = { path = "cranelift/native", version = "0.121.1" }
-cranelift-module = { path = "cranelift/module", version = "0.121.1" }
-cranelift-interpreter = { path = "cranelift/interpreter", version = "0.121.1" }
-cranelift-reader = { path = "cranelift/reader", version = "0.121.1" }
+cranelift-assembler-x64 = { path = "cranelift/assembler-x64", version = "0.121.2" }
+cranelift-codegen = { path = "cranelift/codegen", version = "0.121.2", default-features = false, features = ["std", "unwind"] }
+cranelift-frontend = { path = "cranelift/frontend", version = "0.121.2" }
+cranelift-entity = { path = "cranelift/entity", version = "0.121.2" }
+cranelift-native = { path = "cranelift/native", version = "0.121.2" }
+cranelift-module = { path = "cranelift/module", version = "0.121.2" }
+cranelift-interpreter = { path = "cranelift/interpreter", version = "0.121.2" }
+cranelift-reader = { path = "cranelift/reader", version = "0.121.2" }
 cranelift-filetests = { path = "cranelift/filetests" }
-cranelift-object = { path = "cranelift/object", version = "0.121.1" }
-cranelift-jit = { path = "cranelift/jit", version = "0.121.1" }
+cranelift-object = { path = "cranelift/object", version = "0.121.2" }
+cranelift-jit = { path = "cranelift/jit", version = "0.121.2" }
 cranelift-fuzzgen = { path = "cranelift/fuzzgen" }
-cranelift-bforest = { path = "cranelift/bforest", version = "0.121.1" }
-cranelift-bitset = { path = "cranelift/bitset", version = "0.121.1" }
-cranelift-control = { path = "cranelift/control", version = "0.121.1" }
-cranelift-srcgen = { path = "cranelift/srcgen", version = "0.121.1" }
-cranelift = { path = "cranelift/umbrella", version = "0.121.1" }
+cranelift-bforest = { path = "cranelift/bforest", version = "0.121.2" }
+cranelift-bitset = { path = "cranelift/bitset", version = "0.121.2" }
+cranelift-control = { path = "cranelift/control", version = "0.121.2" }
+cranelift-srcgen = { path = "cranelift/srcgen", version = "0.121.2" }
+cranelift = { path = "cranelift/umbrella", version = "0.121.2" }
 
-winch-codegen = { path = "winch/codegen", version = "=34.0.1" }
+winch-codegen = { path = "winch/codegen", version = "=34.0.2" }
 
 wasi-preview1-component-adapter = { path = "crates/wasi-preview1-component-adapter" }
 byte-array-literals = { path = "crates/wasi-preview1-component-adapter/byte-array-literals" }

--- a/cranelift/assembler-x64/Cargo.toml
+++ b/cranelift/assembler-x64/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-assembler-x64"
 description = "A Cranelift-specific x64 assembler"
-version = "0.121.1"
+version = "0.121.2"
 license = "Apache-2.0 WITH LLVM-exception"
 edition.workspace = true
 rust-version.workspace = true
@@ -16,7 +16,7 @@ arbtest = "0.3.1"
 capstone = { workspace = true }
 
 [build-dependencies]
-cranelift-assembler-x64-meta = { path = "meta", version = "0.121.1" }
+cranelift-assembler-x64-meta = { path = "meta", version = "0.121.2" }
 
 [lints]
 workspace = true

--- a/cranelift/assembler-x64/meta/Cargo.toml
+++ b/cranelift/assembler-x64/meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-assembler-x64-meta"
 description = "Generate a Cranelift-specific assembler for x64 instructions"
-version = "0.121.1"
+version = "0.121.2"
 license = "Apache-2.0 WITH LLVM-exception"
 edition.workspace = true
 rust-version.workspace = true

--- a/cranelift/bforest/Cargo.toml
+++ b/cranelift/bforest/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bforest"
-version = "0.121.1"
+version = "0.121.2"
 description = "A forest of B+-trees"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-bforest"

--- a/cranelift/bitset/Cargo.toml
+++ b/cranelift/bitset/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bitset"
-version = "0.121.1"
+version = "0.121.2"
 description = "Various bitset stuff for use inside Cranelift"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-bitset"

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen"
-version = "0.121.1"
+version = "0.121.2"
 description = "Low-level code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-codegen"
@@ -25,7 +25,7 @@ anyhow = { workspace = true, optional = true, features = ['std'] }
 bumpalo = "3"
 capstone = { workspace = true, optional = true }
 cranelift-assembler-x64 = { workspace = true }
-cranelift-codegen-shared = { path = "./shared", version = "0.121.1" }
+cranelift-codegen-shared = { path = "./shared", version = "0.121.2" }
 cranelift-entity = { workspace = true }
 cranelift-bforest = { workspace = true }
 cranelift-bitset = { workspace = true }
@@ -55,8 +55,8 @@ similar = "2.1.0"
 env_logger = { workspace = true }
 
 [build-dependencies]
-cranelift-codegen-meta = { path = "meta", version = "0.121.1" }
-cranelift-isle = { path = "../isle/isle", version = "=0.121.1" }
+cranelift-codegen-meta = { path = "meta", version = "0.121.2" }
+cranelift-isle = { path = "../isle/isle", version = "=0.121.2" }
 
 [features]
 default = ["std", "unwind", "host-arch", "timing"]

--- a/cranelift/codegen/meta/Cargo.toml
+++ b/cranelift/codegen/meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-codegen-meta"
 authors = ["The Cranelift Project Developers"]
-version = "0.121.1"
+version = "0.121.2"
 description = "Metaprogram for cranelift-codegen code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
@@ -17,8 +17,8 @@ rustdoc-args = ["--document-private-items"]
 
 [dependencies]
 cranelift-srcgen = { workspace = true }
-cranelift-assembler-x64-meta = { path = "../../assembler-x64/meta", version = "0.121.1" }
-cranelift-codegen-shared = { path = "../shared", version = "0.121.1" }
+cranelift-assembler-x64-meta = { path = "../../assembler-x64/meta", version = "0.121.2" }
+cranelift-codegen-shared = { path = "../shared", version = "0.121.2" }
 pulley-interpreter = { workspace = true, optional = true }
 
 [features]

--- a/cranelift/codegen/shared/Cargo.toml
+++ b/cranelift/codegen/shared/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen-shared"
-version = "0.121.1"
+version = "0.121.2"
 description = "For code shared between cranelift-codegen-meta and cranelift-codegen"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/control/Cargo.toml
+++ b/cranelift/control/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-control"
-version = "0.121.1"
+version = "0.121.2"
 description = "White-box fuzz testing framework"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/entity/Cargo.toml
+++ b/cranelift/entity/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-entity"
-version = "0.121.1"
+version = "0.121.2"
 description = "Data structures using entity references as mapping keys"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-entity"

--- a/cranelift/frontend/Cargo.toml
+++ b/cranelift/frontend/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-frontend"
-version = "0.121.1"
+version = "0.121.2"
 description = "Cranelift IR builder helper"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-frontend"

--- a/cranelift/interpreter/Cargo.toml
+++ b/cranelift/interpreter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-interpreter"
-version = "0.121.1"
+version = "0.121.2"
 authors = ["The Cranelift Project Developers"]
 description = "Interpret Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/isle/isle/Cargo.toml
+++ b/cranelift/isle/isle/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 name = "cranelift-isle"
 readme = "../README.md"
 repository = "https://github.com/bytecodealliance/wasmtime/tree/main/cranelift/isle"
-version = "0.121.1"
+version = "0.121.2"
 
 [lints]
 workspace = true

--- a/cranelift/jit/Cargo.toml
+++ b/cranelift/jit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-jit"
-version = "0.121.1"
+version = "0.121.2"
 authors = ["The Cranelift Project Developers"]
 description = "A JIT library backed by Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/module/Cargo.toml
+++ b/cranelift/module/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-module"
-version = "0.121.1"
+version = "0.121.2"
 authors = ["The Cranelift Project Developers"]
 description = "Support for linking functions and data with Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/native/Cargo.toml
+++ b/cranelift/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-native"
-version = "0.121.1"
+version = "0.121.2"
 authors = ["The Cranelift Project Developers"]
 description = "Support for targeting the host with Cranelift"
 documentation = "https://docs.rs/cranelift-native"

--- a/cranelift/object/Cargo.toml
+++ b/cranelift/object/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-object"
-version = "0.121.1"
+version = "0.121.2"
 authors = ["The Cranelift Project Developers"]
 description = "Emit Cranelift output to native object files with `object`"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/reader/Cargo.toml
+++ b/cranelift/reader/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-reader"
-version = "0.121.1"
+version = "0.121.2"
 description = "Cranelift textual IR reader"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-reader"

--- a/cranelift/serde/Cargo.toml
+++ b/cranelift/serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-serde"
-version = "0.121.1"
+version = "0.121.2"
 authors = ["The Cranelift Project Developers"]
 description = "Serializer/Deserializer for Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/srcgen/Cargo.toml
+++ b/cranelift/srcgen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-srcgen"
-version = "0.121.1"
+version = "0.121.2"
 authors = ["The Wasmtime Project Developers"]
 description = "Helper functions for generating Rust and ISLE files"
 license = "Apache-2.0 WITH LLVM-exception"

--- a/cranelift/umbrella/Cargo.toml
+++ b/cranelift/umbrella/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift"
-version = "0.121.1"
+version = "0.121.2"
 description = "Umbrella for commonly-used cranelift crates"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift"

--- a/crates/c-api/include/wasmtime.h
+++ b/crates/c-api/include/wasmtime.h
@@ -212,7 +212,7 @@
 /**
  * \brief Wasmtime version string.
  */
-#define WASMTIME_VERSION "34.0.1"
+#define WASMTIME_VERSION "34.0.2"
 /**
  * \brief Wasmtime major version number.
  */
@@ -224,6 +224,6 @@
 /**
  * \brief Wasmtime patch version number.
  */
-#define WASMTIME_VERSION_PATCH 1
+#define WASMTIME_VERSION_PATCH 2
 
 #endif // WASMTIME_API_H

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -9,6 +9,10 @@ audited_as = "0.120.0"
 version = "0.121.1"
 audited_as = "0.121.0"
 
+[[unpublished.cranelift]]
+version = "0.121.2"
+audited_as = "0.121.1"
+
 [[unpublished.cranelift-assembler-x64]]
 version = "0.121.0"
 audited_as = "0.120.0"
@@ -16,6 +20,10 @@ audited_as = "0.120.0"
 [[unpublished.cranelift-assembler-x64]]
 version = "0.121.1"
 audited_as = "0.121.0"
+
+[[unpublished.cranelift-assembler-x64]]
+version = "0.121.2"
+audited_as = "0.121.1"
 
 [[unpublished.cranelift-assembler-x64-meta]]
 version = "0.121.0"
@@ -25,6 +33,10 @@ audited_as = "0.120.0"
 version = "0.121.1"
 audited_as = "0.121.0"
 
+[[unpublished.cranelift-assembler-x64-meta]]
+version = "0.121.2"
+audited_as = "0.121.1"
+
 [[unpublished.cranelift-bforest]]
 version = "0.121.0"
 audited_as = "0.120.0"
@@ -32,6 +44,10 @@ audited_as = "0.120.0"
 [[unpublished.cranelift-bforest]]
 version = "0.121.1"
 audited_as = "0.121.0"
+
+[[unpublished.cranelift-bforest]]
+version = "0.121.2"
+audited_as = "0.121.1"
 
 [[unpublished.cranelift-bitset]]
 version = "0.121.0"
@@ -41,6 +57,10 @@ audited_as = "0.120.0"
 version = "0.121.1"
 audited_as = "0.121.0"
 
+[[unpublished.cranelift-bitset]]
+version = "0.121.2"
+audited_as = "0.121.1"
+
 [[unpublished.cranelift-codegen]]
 version = "0.121.0"
 audited_as = "0.120.0"
@@ -48,6 +68,10 @@ audited_as = "0.120.0"
 [[unpublished.cranelift-codegen]]
 version = "0.121.1"
 audited_as = "0.121.0"
+
+[[unpublished.cranelift-codegen]]
+version = "0.121.2"
+audited_as = "0.121.1"
 
 [[unpublished.cranelift-codegen-meta]]
 version = "0.121.0"
@@ -57,6 +81,10 @@ audited_as = "0.120.0"
 version = "0.121.1"
 audited_as = "0.121.0"
 
+[[unpublished.cranelift-codegen-meta]]
+version = "0.121.2"
+audited_as = "0.121.1"
+
 [[unpublished.cranelift-codegen-shared]]
 version = "0.121.0"
 audited_as = "0.120.0"
@@ -64,6 +92,10 @@ audited_as = "0.120.0"
 [[unpublished.cranelift-codegen-shared]]
 version = "0.121.1"
 audited_as = "0.121.0"
+
+[[unpublished.cranelift-codegen-shared]]
+version = "0.121.2"
+audited_as = "0.121.1"
 
 [[unpublished.cranelift-control]]
 version = "0.121.0"
@@ -73,6 +105,10 @@ audited_as = "0.120.0"
 version = "0.121.1"
 audited_as = "0.121.0"
 
+[[unpublished.cranelift-control]]
+version = "0.121.2"
+audited_as = "0.121.1"
+
 [[unpublished.cranelift-entity]]
 version = "0.121.0"
 audited_as = "0.120.0"
@@ -80,6 +116,10 @@ audited_as = "0.120.0"
 [[unpublished.cranelift-entity]]
 version = "0.121.1"
 audited_as = "0.121.0"
+
+[[unpublished.cranelift-entity]]
+version = "0.121.2"
+audited_as = "0.121.1"
 
 [[unpublished.cranelift-frontend]]
 version = "0.121.0"
@@ -89,6 +129,10 @@ audited_as = "0.120.0"
 version = "0.121.1"
 audited_as = "0.121.0"
 
+[[unpublished.cranelift-frontend]]
+version = "0.121.2"
+audited_as = "0.121.1"
+
 [[unpublished.cranelift-interpreter]]
 version = "0.121.0"
 audited_as = "0.120.0"
@@ -96,6 +140,10 @@ audited_as = "0.120.0"
 [[unpublished.cranelift-interpreter]]
 version = "0.121.1"
 audited_as = "0.121.0"
+
+[[unpublished.cranelift-interpreter]]
+version = "0.121.2"
+audited_as = "0.121.1"
 
 [[unpublished.cranelift-isle]]
 version = "0.121.0"
@@ -105,6 +153,10 @@ audited_as = "0.120.0"
 version = "0.121.1"
 audited_as = "0.121.0"
 
+[[unpublished.cranelift-isle]]
+version = "0.121.2"
+audited_as = "0.121.1"
+
 [[unpublished.cranelift-jit]]
 version = "0.121.0"
 audited_as = "0.120.0"
@@ -112,6 +164,10 @@ audited_as = "0.120.0"
 [[unpublished.cranelift-jit]]
 version = "0.121.1"
 audited_as = "0.121.0"
+
+[[unpublished.cranelift-jit]]
+version = "0.121.2"
+audited_as = "0.121.1"
 
 [[unpublished.cranelift-module]]
 version = "0.121.0"
@@ -121,6 +177,10 @@ audited_as = "0.120.0"
 version = "0.121.1"
 audited_as = "0.121.0"
 
+[[unpublished.cranelift-module]]
+version = "0.121.2"
+audited_as = "0.121.1"
+
 [[unpublished.cranelift-native]]
 version = "0.121.0"
 audited_as = "0.120.0"
@@ -128,6 +188,10 @@ audited_as = "0.120.0"
 [[unpublished.cranelift-native]]
 version = "0.121.1"
 audited_as = "0.121.0"
+
+[[unpublished.cranelift-native]]
+version = "0.121.2"
+audited_as = "0.121.1"
 
 [[unpublished.cranelift-object]]
 version = "0.121.0"
@@ -137,6 +201,10 @@ audited_as = "0.120.0"
 version = "0.121.1"
 audited_as = "0.121.0"
 
+[[unpublished.cranelift-object]]
+version = "0.121.2"
+audited_as = "0.121.1"
+
 [[unpublished.cranelift-reader]]
 version = "0.121.0"
 audited_as = "0.120.0"
@@ -144,6 +212,10 @@ audited_as = "0.120.0"
 [[unpublished.cranelift-reader]]
 version = "0.121.1"
 audited_as = "0.121.0"
+
+[[unpublished.cranelift-reader]]
+version = "0.121.2"
+audited_as = "0.121.1"
 
 [[unpublished.cranelift-serde]]
 version = "0.121.0"
@@ -153,6 +225,10 @@ audited_as = "0.120.0"
 version = "0.121.1"
 audited_as = "0.121.0"
 
+[[unpublished.cranelift-serde]]
+version = "0.121.2"
+audited_as = "0.121.1"
+
 [[unpublished.cranelift-srcgen]]
 version = "0.121.0"
 audited_as = "0.120.0"
@@ -160,6 +236,10 @@ audited_as = "0.120.0"
 [[unpublished.cranelift-srcgen]]
 version = "0.121.1"
 audited_as = "0.121.0"
+
+[[unpublished.cranelift-srcgen]]
+version = "0.121.2"
+audited_as = "0.121.1"
 
 [[unpublished.pulley-interpreter]]
 version = "34.0.0"
@@ -168,11 +248,19 @@ audited_as = "33.0.0"
 [[unpublished.pulley-interpreter]]
 version = "34.0.1"
 audited_as = "34.0.0"
+
+[[unpublished.pulley-interpreter]]
+version = "34.0.2"
+audited_as = "34.0.1"
 
 [[unpublished.pulley-macros]]
 version = "34.0.1"
 audited_as = "34.0.0"
 
+[[unpublished.pulley-macros]]
+version = "34.0.2"
+audited_as = "34.0.1"
+
 [[unpublished.wasi-common]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -180,6 +268,10 @@ audited_as = "33.0.0"
 [[unpublished.wasi-common]]
 version = "34.0.1"
 audited_as = "34.0.0"
+
+[[unpublished.wasi-common]]
+version = "34.0.2"
+audited_as = "34.0.1"
 
 [[unpublished.wasmtime]]
 version = "34.0.0"
@@ -189,6 +281,10 @@ audited_as = "33.0.0"
 version = "34.0.1"
 audited_as = "34.0.0"
 
+[[unpublished.wasmtime]]
+version = "34.0.2"
+audited_as = "34.0.1"
+
 [[unpublished.wasmtime-asm-macros]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -196,6 +292,10 @@ audited_as = "33.0.0"
 [[unpublished.wasmtime-asm-macros]]
 version = "34.0.1"
 audited_as = "34.0.0"
+
+[[unpublished.wasmtime-asm-macros]]
+version = "34.0.2"
+audited_as = "34.0.1"
 
 [[unpublished.wasmtime-cache]]
 version = "34.0.0"
@@ -205,6 +305,10 @@ audited_as = "33.0.0"
 version = "34.0.1"
 audited_as = "34.0.0"
 
+[[unpublished.wasmtime-cache]]
+version = "34.0.2"
+audited_as = "34.0.1"
+
 [[unpublished.wasmtime-cli]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -212,6 +316,10 @@ audited_as = "33.0.0"
 [[unpublished.wasmtime-cli]]
 version = "34.0.1"
 audited_as = "34.0.0"
+
+[[unpublished.wasmtime-cli]]
+version = "34.0.2"
+audited_as = "34.0.1"
 
 [[unpublished.wasmtime-cli-flags]]
 version = "34.0.0"
@@ -221,6 +329,10 @@ audited_as = "33.0.0"
 version = "34.0.1"
 audited_as = "34.0.0"
 
+[[unpublished.wasmtime-cli-flags]]
+version = "34.0.2"
+audited_as = "34.0.1"
+
 [[unpublished.wasmtime-component-macro]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -228,6 +340,10 @@ audited_as = "33.0.0"
 [[unpublished.wasmtime-component-macro]]
 version = "34.0.1"
 audited_as = "34.0.0"
+
+[[unpublished.wasmtime-component-macro]]
+version = "34.0.2"
+audited_as = "34.0.1"
 
 [[unpublished.wasmtime-component-util]]
 version = "34.0.0"
@@ -237,6 +353,10 @@ audited_as = "33.0.0"
 version = "34.0.1"
 audited_as = "34.0.0"
 
+[[unpublished.wasmtime-component-util]]
+version = "34.0.2"
+audited_as = "34.0.1"
+
 [[unpublished.wasmtime-cranelift]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -244,6 +364,10 @@ audited_as = "33.0.0"
 [[unpublished.wasmtime-cranelift]]
 version = "34.0.1"
 audited_as = "34.0.0"
+
+[[unpublished.wasmtime-cranelift]]
+version = "34.0.2"
+audited_as = "34.0.1"
 
 [[unpublished.wasmtime-environ]]
 version = "34.0.0"
@@ -253,6 +377,10 @@ audited_as = "33.0.0"
 version = "34.0.1"
 audited_as = "34.0.0"
 
+[[unpublished.wasmtime-environ]]
+version = "34.0.2"
+audited_as = "34.0.1"
+
 [[unpublished.wasmtime-explorer]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -260,6 +388,10 @@ audited_as = "33.0.0"
 [[unpublished.wasmtime-explorer]]
 version = "34.0.1"
 audited_as = "34.0.0"
+
+[[unpublished.wasmtime-explorer]]
+version = "34.0.2"
+audited_as = "34.0.1"
 
 [[unpublished.wasmtime-fiber]]
 version = "34.0.0"
@@ -269,6 +401,10 @@ audited_as = "33.0.0"
 version = "34.0.1"
 audited_as = "34.0.0"
 
+[[unpublished.wasmtime-fiber]]
+version = "34.0.2"
+audited_as = "34.0.1"
+
 [[unpublished.wasmtime-jit-debug]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -276,6 +412,10 @@ audited_as = "33.0.0"
 [[unpublished.wasmtime-jit-debug]]
 version = "34.0.1"
 audited_as = "34.0.0"
+
+[[unpublished.wasmtime-jit-debug]]
+version = "34.0.2"
+audited_as = "34.0.1"
 
 [[unpublished.wasmtime-jit-icache-coherence]]
 version = "34.0.0"
@@ -285,6 +425,10 @@ audited_as = "33.0.0"
 version = "34.0.1"
 audited_as = "34.0.0"
 
+[[unpublished.wasmtime-jit-icache-coherence]]
+version = "34.0.2"
+audited_as = "34.0.1"
+
 [[unpublished.wasmtime-math]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -292,6 +436,10 @@ audited_as = "33.0.0"
 [[unpublished.wasmtime-math]]
 version = "34.0.1"
 audited_as = "34.0.0"
+
+[[unpublished.wasmtime-math]]
+version = "34.0.2"
+audited_as = "34.0.1"
 
 [[unpublished.wasmtime-slab]]
 version = "34.0.0"
@@ -301,6 +449,10 @@ audited_as = "33.0.0"
 version = "34.0.1"
 audited_as = "34.0.0"
 
+[[unpublished.wasmtime-slab]]
+version = "34.0.2"
+audited_as = "34.0.1"
+
 [[unpublished.wasmtime-wasi]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -308,6 +460,10 @@ audited_as = "33.0.0"
 [[unpublished.wasmtime-wasi]]
 version = "34.0.1"
 audited_as = "34.0.0"
+
+[[unpublished.wasmtime-wasi]]
+version = "34.0.2"
+audited_as = "34.0.1"
 
 [[unpublished.wasmtime-wasi-config]]
 version = "34.0.0"
@@ -317,6 +473,10 @@ audited_as = "33.0.0"
 version = "34.0.1"
 audited_as = "34.0.0"
 
+[[unpublished.wasmtime-wasi-config]]
+version = "34.0.2"
+audited_as = "34.0.1"
+
 [[unpublished.wasmtime-wasi-http]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -324,6 +484,10 @@ audited_as = "33.0.0"
 [[unpublished.wasmtime-wasi-http]]
 version = "34.0.1"
 audited_as = "34.0.0"
+
+[[unpublished.wasmtime-wasi-http]]
+version = "34.0.2"
+audited_as = "34.0.1"
 
 [[unpublished.wasmtime-wasi-io]]
 version = "34.0.0"
@@ -333,6 +497,10 @@ audited_as = "33.0.0"
 version = "34.0.1"
 audited_as = "34.0.0"
 
+[[unpublished.wasmtime-wasi-io]]
+version = "34.0.2"
+audited_as = "34.0.1"
+
 [[unpublished.wasmtime-wasi-keyvalue]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -340,6 +508,10 @@ audited_as = "33.0.0"
 [[unpublished.wasmtime-wasi-keyvalue]]
 version = "34.0.1"
 audited_as = "34.0.0"
+
+[[unpublished.wasmtime-wasi-keyvalue]]
+version = "34.0.2"
+audited_as = "34.0.1"
 
 [[unpublished.wasmtime-wasi-nn]]
 version = "34.0.0"
@@ -349,6 +521,10 @@ audited_as = "33.0.0"
 version = "34.0.1"
 audited_as = "34.0.0"
 
+[[unpublished.wasmtime-wasi-nn]]
+version = "34.0.2"
+audited_as = "34.0.1"
+
 [[unpublished.wasmtime-wasi-threads]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -356,6 +532,10 @@ audited_as = "33.0.0"
 [[unpublished.wasmtime-wasi-threads]]
 version = "34.0.1"
 audited_as = "34.0.0"
+
+[[unpublished.wasmtime-wasi-threads]]
+version = "34.0.2"
+audited_as = "34.0.1"
 
 [[unpublished.wasmtime-wasi-tls]]
 version = "34.0.0"
@@ -365,6 +545,10 @@ audited_as = "33.0.0"
 version = "34.0.1"
 audited_as = "34.0.0"
 
+[[unpublished.wasmtime-wasi-tls]]
+version = "34.0.2"
+audited_as = "34.0.1"
+
 [[unpublished.wasmtime-wast]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -372,6 +556,10 @@ audited_as = "33.0.0"
 [[unpublished.wasmtime-wast]]
 version = "34.0.1"
 audited_as = "34.0.0"
+
+[[unpublished.wasmtime-wast]]
+version = "34.0.2"
+audited_as = "34.0.1"
 
 [[unpublished.wasmtime-winch]]
 version = "34.0.0"
@@ -381,6 +569,10 @@ audited_as = "33.0.0"
 version = "34.0.1"
 audited_as = "34.0.0"
 
+[[unpublished.wasmtime-winch]]
+version = "34.0.2"
+audited_as = "34.0.1"
+
 [[unpublished.wasmtime-wit-bindgen]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -388,6 +580,10 @@ audited_as = "33.0.0"
 [[unpublished.wasmtime-wit-bindgen]]
 version = "34.0.1"
 audited_as = "34.0.0"
+
+[[unpublished.wasmtime-wit-bindgen]]
+version = "34.0.2"
+audited_as = "34.0.1"
 
 [[unpublished.wasmtime-wmemcheck]]
 version = "34.0.0"
@@ -397,6 +593,10 @@ audited_as = "33.0.0"
 version = "34.0.1"
 audited_as = "34.0.0"
 
+[[unpublished.wasmtime-wmemcheck]]
+version = "34.0.2"
+audited_as = "34.0.1"
+
 [[unpublished.wiggle]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -404,6 +604,10 @@ audited_as = "33.0.0"
 [[unpublished.wiggle]]
 version = "34.0.1"
 audited_as = "34.0.0"
+
+[[unpublished.wiggle]]
+version = "34.0.2"
+audited_as = "34.0.1"
 
 [[unpublished.wiggle-generate]]
 version = "34.0.0"
@@ -413,6 +617,10 @@ audited_as = "33.0.0"
 version = "34.0.1"
 audited_as = "34.0.0"
 
+[[unpublished.wiggle-generate]]
+version = "34.0.2"
+audited_as = "34.0.1"
+
 [[unpublished.wiggle-macro]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -420,6 +628,10 @@ audited_as = "33.0.0"
 [[unpublished.wiggle-macro]]
 version = "34.0.1"
 audited_as = "34.0.0"
+
+[[unpublished.wiggle-macro]]
+version = "34.0.2"
+audited_as = "34.0.1"
 
 [[unpublished.wiggle-test]]
 version = "0.0.0"
@@ -432,6 +644,10 @@ audited_as = "33.0.0"
 [[unpublished.winch-codegen]]
 version = "34.0.1"
 audited_as = "34.0.0"
+
+[[unpublished.winch-codegen]]
+version = "34.0.2"
+audited_as = "34.0.1"
 
 [[publisher.aho-corasick]]
 version = "1.0.2"
@@ -630,122 +846,122 @@ user-login = "jrmuizel"
 user-name = "Jeff Muizelaar"
 
 [[publisher.cranelift]]
-version = "0.121.0"
-when = "2025-06-20"
+version = "0.121.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-assembler-x64]]
-version = "0.121.0"
-when = "2025-06-20"
+version = "0.121.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-assembler-x64-meta]]
-version = "0.121.0"
-when = "2025-06-20"
+version = "0.121.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-bforest]]
-version = "0.121.0"
-when = "2025-06-20"
+version = "0.121.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-bitset]]
-version = "0.121.0"
-when = "2025-06-20"
+version = "0.121.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-codegen]]
-version = "0.121.0"
-when = "2025-06-20"
+version = "0.121.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-codegen-meta]]
-version = "0.121.0"
-when = "2025-06-20"
+version = "0.121.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-codegen-shared]]
-version = "0.121.0"
-when = "2025-06-20"
+version = "0.121.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-control]]
-version = "0.121.0"
-when = "2025-06-20"
+version = "0.121.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-entity]]
-version = "0.121.0"
-when = "2025-06-20"
+version = "0.121.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-frontend]]
-version = "0.121.0"
-when = "2025-06-20"
+version = "0.121.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-interpreter]]
-version = "0.121.0"
-when = "2025-06-20"
+version = "0.121.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-isle]]
-version = "0.121.0"
-when = "2025-06-20"
+version = "0.121.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-jit]]
-version = "0.121.0"
-when = "2025-06-20"
+version = "0.121.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-module]]
-version = "0.121.0"
-when = "2025-06-20"
+version = "0.121.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-native]]
-version = "0.121.0"
-when = "2025-06-20"
+version = "0.121.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-object]]
-version = "0.121.0"
-when = "2025-06-20"
+version = "0.121.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-reader]]
-version = "0.121.0"
-when = "2025-06-20"
+version = "0.121.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-serde]]
-version = "0.121.0"
-when = "2025-06-20"
+version = "0.121.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-srcgen]]
-version = "0.121.0"
-when = "2025-06-20"
+version = "0.121.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -946,14 +1162,14 @@ user-login = "dtolnay"
 user-name = "David Tolnay"
 
 [[publisher.pulley-interpreter]]
-version = "34.0.0"
-when = "2025-06-20"
+version = "34.0.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.pulley-macros]]
-version = "34.0.0"
-when = "2025-06-20"
+version = "34.0.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1224,8 +1440,8 @@ user-login = "sunfishcode"
 user-name = "Dan Gohman"
 
 [[publisher.wasi-common]]
-version = "34.0.0"
-when = "2025-06-20"
+version = "34.0.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1313,164 +1529,164 @@ user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime]]
-version = "34.0.0"
-when = "2025-06-20"
+version = "34.0.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-asm-macros]]
-version = "34.0.0"
-when = "2025-06-20"
+version = "34.0.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-cache]]
-version = "34.0.0"
-when = "2025-06-20"
+version = "34.0.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-cli]]
-version = "34.0.0"
-when = "2025-06-20"
+version = "34.0.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-cli-flags]]
-version = "34.0.0"
-when = "2025-06-20"
+version = "34.0.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-component-macro]]
-version = "34.0.0"
-when = "2025-06-20"
+version = "34.0.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-component-util]]
-version = "34.0.0"
-when = "2025-06-20"
+version = "34.0.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-cranelift]]
-version = "34.0.0"
-when = "2025-06-20"
+version = "34.0.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-environ]]
-version = "34.0.0"
-when = "2025-06-20"
+version = "34.0.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-explorer]]
-version = "34.0.0"
-when = "2025-06-20"
+version = "34.0.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-fiber]]
-version = "34.0.0"
-when = "2025-06-20"
+version = "34.0.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-jit-debug]]
-version = "34.0.0"
-when = "2025-06-20"
+version = "34.0.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-jit-icache-coherence]]
-version = "34.0.0"
-when = "2025-06-20"
+version = "34.0.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-math]]
-version = "34.0.0"
-when = "2025-06-20"
+version = "34.0.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-slab]]
-version = "34.0.0"
-when = "2025-06-20"
+version = "34.0.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi]]
-version = "34.0.0"
-when = "2025-06-20"
+version = "34.0.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-config]]
-version = "34.0.0"
-when = "2025-06-20"
+version = "34.0.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-http]]
-version = "34.0.0"
-when = "2025-06-20"
+version = "34.0.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-io]]
-version = "34.0.0"
-when = "2025-06-20"
+version = "34.0.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-keyvalue]]
-version = "34.0.0"
-when = "2025-06-20"
+version = "34.0.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-nn]]
-version = "34.0.0"
-when = "2025-06-20"
+version = "34.0.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-threads]]
-version = "34.0.0"
-when = "2025-06-20"
+version = "34.0.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-tls]]
-version = "34.0.0"
-when = "2025-06-20"
+version = "34.0.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wast]]
-version = "34.0.0"
-when = "2025-06-20"
+version = "34.0.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-winch]]
-version = "34.0.0"
-when = "2025-06-20"
+version = "34.0.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wit-bindgen]]
-version = "34.0.0"
-when = "2025-06-20"
+version = "34.0.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wmemcheck]]
-version = "34.0.0"
-when = "2025-06-20"
+version = "34.0.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1494,20 +1710,20 @@ user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
 [[publisher.wiggle]]
-version = "34.0.0"
-when = "2025-06-20"
+version = "34.0.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wiggle-generate]]
-version = "34.0.0"
-when = "2025-06-20"
+version = "34.0.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wiggle-macro]]
-version = "34.0.0"
-when = "2025-06-20"
+version = "34.0.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1526,8 +1742,8 @@ user-login = "BurntSushi"
 user-name = "Andrew Gallant"
 
 [[publisher.winch-codegen]]
-version = "34.0.0"
-when = "2025-06-20"
+version = "34.0.1"
+when = "2025-06-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 


### PR DESCRIPTION
This is an [automated pull request][process] from CI to create a patch release for Wasmtime 34.0.2, requested by @rvolosatovs.

It's recommended that maintainers double-check that [RELEASES.md] is up-to-date and that there are no known issues before merging this PR. When this PR is merged a release tag will automatically be created, crates will be published, and CI artifacts will be produced.

[RELEASES.md]: https://github.com/bytecodealliance/wasmtime/blob/release-34.0.2/RELEASES.md
[process]: https://docs.wasmtime.dev/contributing-release-process.html
