### PR TITLE
[33.0.2] backport `fd_renumber` fixes

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,14 @@
+## 33.0.2
+
+Released 2025-07-18.
+
+### Fixed
+
+* Fix a panic in the host caused by preview1 guests using `fd_renumber`.
+  [GHSA-fm79-3f68-h2fc](https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-fm79-3f68-h2fc).
+
+* Fix a panic in the preview1 adapter caused by guests using `fd_renumber`.
+
 ## 33.0.1
 
 Released 2025-06-24.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -8,6 +8,7 @@ Released 2025-07-18.
   [CVE-2025-53901](https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-fm79-3f68-h2fc).
 
 * Fix a panic in the preview1 adapter caused by guests using `fd_renumber`.
+  [#11277](https://github.com/bytecodealliance/wasmtime/pull/11277)
 
 ## 33.0.1
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -5,7 +5,7 @@ Released 2025-07-18.
 ### Fixed
 
 * Fix a panic in the host caused by preview1 guests using `fd_renumber`.
-  [GHSA-fm79-3f68-h2fc](https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-fm79-3f68-h2fc).
+  [CVE-2025-53901](https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-fm79-3f68-h2fc).
 
 * Fix a panic in the preview1 adapter caused by guests using `fd_renumber`.
 

--- a/crates/test-programs/src/bin/preview1_renumber.rs
+++ b/crates/test-programs/src/bin/preview1_renumber.rs
@@ -91,7 +91,15 @@ unsafe fn test_renumber(dir_fd: wasip1::Fd) {
         "file descriptor range check",
     );
 
-    wasip1::fd_renumber(fd_file3, u32::MAX).expect("renumbering file FD to `u32::MAX`");
+    wasip1::fd_renumber(fd_file3, 127).expect("renumbering FD to 127");
+    match wasip1::fd_renumber(127, u32::MAX) {
+        Err(wasip1::ERRNO_NOMEM) => {
+            // The preview1 adapter cannot handle more than 128 descriptors
+            eprintln!("fd_renumber({fd_file3}, {}) returned NOMEM", u32::MAX)
+        }
+        res => res.expect("renumbering FD to `u32::MAX`"),
+    }
+
     let fd_file4 = wasip1::path_open(
         dir_fd,
         0,

--- a/crates/test-programs/src/bin/preview1_renumber.rs
+++ b/crates/test-programs/src/bin/preview1_renumber.rs
@@ -74,6 +74,38 @@ unsafe fn test_renumber(dir_fd: wasip1::Fd) {
     );
 
     wasip1::fd_close(fd_to).expect("closing a file");
+
+    wasip1::fd_renumber(0, 0).expect("renumbering 0 to 0");
+    let fd_file3 = wasip1::path_open(
+        dir_fd,
+        0,
+        "file3",
+        wasip1::OFLAGS_CREAT,
+        wasip1::RIGHTS_FD_READ | wasip1::RIGHTS_FD_WRITE,
+        0,
+        0,
+    )
+    .expect("opening a file");
+    assert!(
+        fd_file3 > libc::STDERR_FILENO as wasip1::Fd,
+        "file descriptor range check",
+    );
+
+    wasip1::fd_renumber(fd_file3, u32::MAX).expect("renumbering file FD to `u32::MAX`");
+    let fd_file4 = wasip1::path_open(
+        dir_fd,
+        0,
+        "file4",
+        wasip1::OFLAGS_CREAT,
+        wasip1::RIGHTS_FD_READ | wasip1::RIGHTS_FD_WRITE,
+        0,
+        0,
+    )
+    .expect("opening a file");
+    assert!(
+        fd_file4 > libc::STDERR_FILENO as wasip1::Fd,
+        "file descriptor range check",
+    );
 }
 
 fn main() {


### PR DESCRIPTION
This a security advisory fix PR moved from https://github.com/bytecodealliance/wasmtime-ghsa-fm79-3f68-h2fc/pull/5

this includes #11277 and #11276 