### PR TITLE
Wasmtime: Add (optional) bottom-up function inlining to Wasm compilation

### DIFF
--- a/cranelift/codegen/src/ir/dfg.rs
+++ b/cranelift/codegen/src/ir/dfg.rs
@@ -333,6 +333,16 @@ impl<'a> Iterator for Values<'a> {
             .find(|kv| valid_valuedata(*kv.1))
             .map(|kv| kv.0)
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
+}
+
+impl ExactSizeIterator for Values<'_> {
+    fn len(&self) -> usize {
+        self.inner.len()
+    }
 }
 
 /// Handling values.

--- a/cranelift/entity/src/primary.rs
+++ b/cranelift/entity/src/primary.rs
@@ -306,6 +306,15 @@ where
     }
 }
 
+impl<K, V> From<PrimaryMap<K, V>> for Vec<V>
+where
+    K: EntityRef,
+{
+    fn from(map: PrimaryMap<K, V>) -> Self {
+        map.elems
+    }
+}
+
 impl<K: EntityRef + fmt::Debug, V: fmt::Debug> fmt::Debug for PrimaryMap<K, V> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut struct_ = f.debug_struct("PrimaryMap");

--- a/cranelift/filetests/src/test_inline.rs
+++ b/cranelift/filetests/src/test_inline.rs
@@ -121,7 +121,7 @@ struct Inliner<'a>(Ref<'a, HashMap<ir::UserFuncName, ir::Function>>);
 
 impl<'a> Inline for Inliner<'a> {
     fn inline(
-        &self,
+        &mut self,
         caller: &ir::Function,
         _inst: ir::Inst,
         _opcode: ir::Opcode,

--- a/crates/cli-flags/src/lib.rs
+++ b/crates/cli-flags/src/lib.rs
@@ -111,6 +111,27 @@ wasmtime_option_group! {
         /// dense.
         pub memory_guaranteed_dense_image_size: Option<u64>,
 
+        /// Whether to perform function inlining during compilation.
+        pub compiler_inlining: Option<bool>,
+
+        /// Whether to perform function inlining within the same core Wasm
+        /// module or only for calls from one module into a different
+        /// module. Only exposed for fuzzing.
+        #[doc(hidden)]
+        #[serde(default)]
+        #[serde(deserialize_with = "crate::opt::cli_parse_wrapper")]
+        pub compiler_inlining_intra_module: Option<wasmtime::IntraModuleInlining>,
+
+        /// Configure the "small-callee" size for function inlining
+        /// heuristics. Only exposed for fuzzing.
+        #[doc(hidden)]
+        pub compiler_inlining_small_callee_size: Option<u32>,
+
+        /// Configure the "sum size threshold" for function inlining
+        /// heuristics. Only exposed for fuzzing.
+        #[doc(hidden)]
+        pub compiler_inlining_sum_size_threshold: Option<u32>,
+
         /// The maximum number of WebAssembly instances which can be created
         /// with the pooling allocator.
         pub pooling_total_core_instances: Option<u32>,
@@ -815,6 +836,18 @@ impl CommonOptions {
         }
         if let Some(size) = self.opts.memory_guaranteed_dense_image_size {
             config.memory_guaranteed_dense_image_size(size);
+        }
+        if let Some(enable) = self.opts.compiler_inlining {
+            config.compiler_inlining(enable);
+        }
+        if let Some(cfg) = self.opts.compiler_inlining_intra_module {
+            config.compiler_inlining_intra_module(cfg);
+        }
+        if let Some(size) = self.opts.compiler_inlining_small_callee_size {
+            config.compiler_inlining_small_callee_size(size);
+        }
+        if let Some(size) = self.opts.compiler_inlining_sum_size_threshold {
+            config.compiler_inlining_sum_size_threshold(size);
         }
         if let Some(enable) = self.opts.signals_based_traps {
             config.signals_based_traps(enable);

--- a/crates/cli-flags/src/lib.rs
+++ b/crates/cli-flags/src/lib.rs
@@ -240,14 +240,6 @@ wasmtime_option_group! {
         /// Whether to perform function inlining during compilation.
         pub inlining: Option<bool>,
 
-        /// Whether to perform function inlining within the same core Wasm
-        /// module or only for calls from one module into a different
-        /// module. Only exposed for fuzzing.
-        #[doc(hidden)]
-        #[serde(default)]
-        #[serde(deserialize_with = "crate::opt::cli_parse_wrapper")]
-        pub inlining_intra_module: Option<wasmtime::IntraModuleInlining>,
-
         /// Configure the "small-callee" size for function inlining
         /// heuristics. Only exposed for fuzzing.
         #[doc(hidden)]
@@ -845,15 +837,6 @@ impl CommonOptions {
         }
         if let Some(enable) = self.codegen.inlining {
             config.compiler_inlining(enable);
-        }
-        if let Some(cfg) = self.codegen.inlining_intra_module {
-            config.compiler_inlining_intra_module(cfg);
-        }
-        if let Some(size) = self.codegen.inlining_small_callee_size {
-            config.compiler_inlining_small_callee_size(size);
-        }
-        if let Some(size) = self.codegen.inlining_sum_size_threshold {
-            config.compiler_inlining_sum_size_threshold(size);
         }
 
         // async_stack_size enabled by either async or stack-switching, so

--- a/crates/cli-flags/src/lib.rs
+++ b/crates/cli-flags/src/lib.rs
@@ -111,27 +111,6 @@ wasmtime_option_group! {
         /// dense.
         pub memory_guaranteed_dense_image_size: Option<u64>,
 
-        /// Whether to perform function inlining during compilation.
-        pub compiler_inlining: Option<bool>,
-
-        /// Whether to perform function inlining within the same core Wasm
-        /// module or only for calls from one module into a different
-        /// module. Only exposed for fuzzing.
-        #[doc(hidden)]
-        #[serde(default)]
-        #[serde(deserialize_with = "crate::opt::cli_parse_wrapper")]
-        pub compiler_inlining_intra_module: Option<wasmtime::IntraModuleInlining>,
-
-        /// Configure the "small-callee" size for function inlining
-        /// heuristics. Only exposed for fuzzing.
-        #[doc(hidden)]
-        pub compiler_inlining_small_callee_size: Option<u32>,
-
-        /// Configure the "sum size threshold" for function inlining
-        /// heuristics. Only exposed for fuzzing.
-        #[doc(hidden)]
-        pub compiler_inlining_sum_size_threshold: Option<u32>,
-
         /// The maximum number of WebAssembly instances which can be created
         /// with the pooling allocator.
         pub pooling_total_core_instances: Option<u32>,
@@ -257,6 +236,27 @@ wasmtime_option_group! {
         /// Controls whether native unwind information is present in compiled
         /// object files.
         pub native_unwind_info: Option<bool>,
+
+        /// Whether to perform function inlining during compilation.
+        pub inlining: Option<bool>,
+
+        /// Whether to perform function inlining within the same core Wasm
+        /// module or only for calls from one module into a different
+        /// module. Only exposed for fuzzing.
+        #[doc(hidden)]
+        #[serde(default)]
+        #[serde(deserialize_with = "crate::opt::cli_parse_wrapper")]
+        pub inlining_intra_module: Option<wasmtime::IntraModuleInlining>,
+
+        /// Configure the "small-callee" size for function inlining
+        /// heuristics. Only exposed for fuzzing.
+        #[doc(hidden)]
+        pub inlining_small_callee_size: Option<u32>,
+
+        /// Configure the "sum size threshold" for function inlining
+        /// heuristics. Only exposed for fuzzing.
+        #[doc(hidden)]
+        pub inlining_sum_size_threshold: Option<u32>,
 
         #[prefixed = "cranelift"]
         #[serde(default)]
@@ -837,23 +837,23 @@ impl CommonOptions {
         if let Some(size) = self.opts.memory_guaranteed_dense_image_size {
             config.memory_guaranteed_dense_image_size(size);
         }
-        if let Some(enable) = self.opts.compiler_inlining {
-            config.compiler_inlining(enable);
-        }
-        if let Some(cfg) = self.opts.compiler_inlining_intra_module {
-            config.compiler_inlining_intra_module(cfg);
-        }
-        if let Some(size) = self.opts.compiler_inlining_small_callee_size {
-            config.compiler_inlining_small_callee_size(size);
-        }
-        if let Some(size) = self.opts.compiler_inlining_sum_size_threshold {
-            config.compiler_inlining_sum_size_threshold(size);
-        }
         if let Some(enable) = self.opts.signals_based_traps {
             config.signals_based_traps(enable);
         }
         if let Some(enable) = self.codegen.native_unwind_info {
             config.native_unwind_info(enable);
+        }
+        if let Some(enable) = self.codegen.inlining {
+            config.compiler_inlining(enable);
+        }
+        if let Some(cfg) = self.codegen.inlining_intra_module {
+            config.compiler_inlining_intra_module(cfg);
+        }
+        if let Some(size) = self.codegen.inlining_small_callee_size {
+            config.compiler_inlining_small_callee_size(size);
+        }
+        if let Some(size) = self.codegen.inlining_sum_size_threshold {
+            config.compiler_inlining_sum_size_threshold(size);
         }
 
         // async_stack_size enabled by either async or stack-switching, so

--- a/crates/cli-flags/src/lib.rs
+++ b/crates/cli-flags/src/lib.rs
@@ -240,16 +240,6 @@ wasmtime_option_group! {
         /// Whether to perform function inlining during compilation.
         pub inlining: Option<bool>,
 
-        /// Configure the "small-callee" size for function inlining
-        /// heuristics. Only exposed for fuzzing.
-        #[doc(hidden)]
-        pub inlining_small_callee_size: Option<u32>,
-
-        /// Configure the "sum size threshold" for function inlining
-        /// heuristics. Only exposed for fuzzing.
-        #[doc(hidden)]
-        pub inlining_sum_size_threshold: Option<u32>,
-
         #[prefixed = "cranelift"]
         #[serde(default)]
         /// Set a cranelift-specific option. Use `wasmtime settings` to see

--- a/crates/cli-flags/src/opt.rs
+++ b/crates/cli-flags/src/opt.rs
@@ -558,30 +558,6 @@ impl WasmtimeOptionValue for wasmtime::MpkEnabled {
     }
 }
 
-impl WasmtimeOptionValue for wasmtime::IntraModuleInlining {
-    const VAL_HELP: &'static str = "[=y|n|gc]";
-
-    fn parse(val: Option<&str>) -> Result<Self> {
-        match val {
-            None | Some("n") | Some("no") | Some("false") => Ok(wasmtime::IntraModuleInlining::Yes),
-            Some("y") | Some("yes") | Some("true") => Ok(wasmtime::IntraModuleInlining::No),
-            Some("gc") => Ok(wasmtime::IntraModuleInlining::WhenUsingGc),
-            Some(s) => bail!(
-                "unknown compiler intra-module inlining flag `{s}`, \
-                 only yes,no,gc,<nothing> accepted"
-            ),
-        }
-    }
-
-    fn display(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            wasmtime::IntraModuleInlining::Yes => f.write_str("y"),
-            wasmtime::IntraModuleInlining::No => f.write_str("n"),
-            wasmtime::IntraModuleInlining::WhenUsingGc => f.write_str("gc"),
-        }
-    }
-}
-
 impl WasmtimeOptionValue for WasiNnGraph {
     const VAL_HELP: &'static str = "=<format>::<dir>";
     fn parse(val: Option<&str>) -> Result<Self> {

--- a/crates/cli-flags/src/opt.rs
+++ b/crates/cli-flags/src/opt.rs
@@ -23,6 +23,7 @@ macro_rules! wasmtime_option_group {
         pub struct $opts:ident {
             $(
                 $(#[doc = $doc:tt])*
+                $(#[doc($doc_attr:meta)])?
                 $(#[serde($serde_attr:meta)])*
                 pub $opt:ident: $container:ident<$payload:ty>,
             )+
@@ -31,6 +32,7 @@ macro_rules! wasmtime_option_group {
                 #[prefixed = $prefix:tt]
                 $(#[serde($serde_attr2:meta)])*
                 $(#[doc = $prefixed_doc:tt])*
+                $(#[doc($prefixed_doc_attr:meta)])?
                 pub $prefixed:ident: Vec<(String, Option<String>)>,
             )?
         }
@@ -43,6 +45,7 @@ macro_rules! wasmtime_option_group {
         pub struct $opts {
             $(
                 $(#[serde($serde_attr)])*
+                $(#[doc($doc_attr)])?
                 pub $opt: $container<$payload>,
             )+
             $(
@@ -551,6 +554,30 @@ impl WasmtimeOptionValue for wasmtime::MpkEnabled {
             wasmtime::MpkEnabled::Enable => f.write_str("y"),
             wasmtime::MpkEnabled::Disable => f.write_str("n"),
             wasmtime::MpkEnabled::Auto => f.write_str("auto"),
+        }
+    }
+}
+
+impl WasmtimeOptionValue for wasmtime::IntraModuleInlining {
+    const VAL_HELP: &'static str = "[=y|n|gc]";
+
+    fn parse(val: Option<&str>) -> Result<Self> {
+        match val {
+            None | Some("n") | Some("no") | Some("false") => Ok(wasmtime::IntraModuleInlining::Yes),
+            Some("y") | Some("yes") | Some("true") => Ok(wasmtime::IntraModuleInlining::No),
+            Some("gc") => Ok(wasmtime::IntraModuleInlining::WhenUsingGc),
+            Some(s) => bail!(
+                "unknown compiler intra-module inlining flag `{s}`, \
+                 only yes,no,gc,<nothing> accepted"
+            ),
+        }
+    }
+
+    fn display(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            wasmtime::IntraModuleInlining::Yes => f.write_str("y"),
+            wasmtime::IntraModuleInlining::No => f.write_str("n"),
+            wasmtime::IntraModuleInlining::WhenUsingGc => f.write_str("gc"),
         }
     }
 }

--- a/crates/cranelift/src/builder.rs
+++ b/crates/cranelift/src/builder.rs
@@ -65,16 +65,27 @@ impl CompilerBuilder for Builder {
 
     fn set(&mut self, name: &str, value: &str) -> Result<()> {
         // Special wasmtime-cranelift-only settings first
-        if name == "wasmtime_linkopt_padding_between_functions" {
-            self.linkopts.padding_between_functions = value.parse()?;
-            return Ok(());
+        match name {
+            "wasmtime_linkopt_padding_between_functions" => {
+                self.linkopts.padding_between_functions = value.parse()?;
+            }
+            "wasmtime_linkopt_force_jump_veneer" => {
+                self.linkopts.force_jump_veneers = value.parse()?;
+            }
+            "wasmtime_inlining_intra_module" => {
+                self.tunables.as_mut().unwrap().inlining_intra_module = value.parse()?;
+            }
+            "wasmtime_inlining_small_callee_size" => {
+                self.tunables.as_mut().unwrap().inlining_small_callee_size = value.parse()?;
+            }
+            "wasmtime_inlining_sum_size_threshold" => {
+                self.tunables.as_mut().unwrap().inlining_sum_size_threshold = value.parse()?;
+            }
+            _ => {
+                self.inner.set(name, value)?;
+            }
         }
-        if name == "wasmtime_linkopt_force_jump_veneer" {
-            self.linkopts.force_jump_veneers = value.parse()?;
-            return Ok(());
-        }
-
-        self.inner.set(name, value)
+        Ok(())
     }
 
     fn enable(&mut self, name: &str) -> Result<()> {

--- a/crates/cranelift/src/compiler.rs
+++ b/crates/cranelift/src/compiler.rs
@@ -6,6 +6,7 @@ use crate::{BuiltinFunctionSignatures, builder::LinkOptions, wasm_call_signature
 use crate::{CompiledFunction, ModuleTextBuilder, array_call_signature};
 use anyhow::{Context as _, Result};
 use cranelift_codegen::binemit::CodeOffset;
+use cranelift_codegen::inline::InlineCommand;
 use cranelift_codegen::ir::condcodes::IntCC;
 use cranelift_codegen::ir::{self, InstBuilder, MemFlags, UserExternalName, UserFuncName, Value};
 use cranelift_codegen::isa::{
@@ -19,6 +20,7 @@ use cranelift_frontend::FunctionBuilder;
 use object::write::{Object, StandardSegment, SymbolId};
 use object::{RelocationEncoding, RelocationFlags, RelocationKind, SectionKind};
 use std::any::Any;
+use std::borrow::Cow;
 use std::cmp;
 use std::collections::HashMap;
 use std::mem;
@@ -28,9 +30,10 @@ use std::sync::{Arc, Mutex};
 use wasmparser::{FuncValidatorAllocations, FunctionBody};
 use wasmtime_environ::{
     AddressMapSection, BuiltinFunctionIndex, CacheStore, CompileError, CompiledFunctionBody,
-    DefinedFuncIndex, FlagValue, FunctionBodyData, FunctionLoc, HostCall, ModuleTranslation,
-    ModuleTypesBuilder, PtrSize, RelocationTarget, StackMapSection, StaticModuleIndex,
-    TrapEncodingBuilder, TrapSentinel, TripleExt, Tunables, VMOffsets, WasmFuncType, WasmValType,
+    DefinedFuncIndex, FlagValue, FuncIndex, FunctionBodyData, FunctionLoc, HostCall,
+    InliningCompiler, ModuleTranslation, ModuleTypesBuilder, PtrSize, RelocationTarget,
+    StackMapSection, StaticModuleIndex, TrapEncodingBuilder, TrapSentinel, TripleExt, Tunables,
+    VMOffsets, WasmFuncType, WasmValType,
 };
 
 #[cfg(feature = "component-model")]
@@ -43,11 +46,21 @@ struct IncrementalCacheContext {
     num_cached: usize,
 }
 
+/// ABI signature of functions that are generated here.
+#[derive(Debug, Copy, Clone)]
+enum Abi {
+    /// The "wasm" ABI, or suitable to be a `wasm_call` field of a `VMFuncRef`.
+    Wasm,
+    /// The "array" ABI, or suitable to be an `array_call` field.
+    Array,
+}
+
 struct CompilerContext {
     func_translator: FuncTranslator,
     codegen_context: Context,
     incremental_cache_ctx: Option<IncrementalCacheContext>,
     validator_allocations: FuncValidatorAllocations,
+    abi: Option<Abi>,
 }
 
 impl Default for CompilerContext {
@@ -57,6 +70,7 @@ impl Default for CompilerContext {
             codegen_context: Context::new(),
             incremental_cache_ctx: None,
             validator_allocations: Default::default(),
+            abi: None,
         }
     }
 }
@@ -181,6 +195,10 @@ impl Compiler {
 }
 
 impl wasmtime_environ::Compiler for Compiler {
+    fn inlining_compiler(&self) -> Option<&dyn wasmtime_environ::InliningCompiler> {
+        Some(self)
+    }
+
     fn compile_function(
         &self,
         translation: &ModuleTranslation<'_>,
@@ -276,14 +294,20 @@ impl wasmtime_environ::Compiler for Compiler {
             &mut func_env,
         )?;
 
-        let func = compiler.finish_with_info(Some((&body, &self.tunables)), symbol)?;
+        if self.tunables.inlining {
+            compiler
+                .cx
+                .codegen_context
+                .legalize(isa)
+                .map_err(|e| CompileError::Codegen(e.to_string()))?;
+        }
 
         let timing = cranelift_codegen::timing::take_current();
-        log::debug!("{:?} translated in {:?}", func_index, timing.total());
-        log::trace!("{func_index:?} timing info\n{timing}");
+        log::debug!("`{symbol}` translated to CLIF in {:?}", timing.total());
+        log::trace!("`{symbol}` timing info\n{timing}");
 
         Ok(CompiledFunctionBody {
-            code: Box::new(func),
+            code: Box::new(Some(compiler.cx)),
             needs_gc_heap: func_env.needs_gc_heap(),
         })
     }
@@ -293,7 +317,7 @@ impl wasmtime_environ::Compiler for Compiler {
         translation: &ModuleTranslation<'_>,
         types: &ModuleTypesBuilder,
         def_func_index: DefinedFuncIndex,
-        symbol: &str,
+        _symbol: &str,
     ) -> Result<CompiledFunctionBody, CompileError> {
         let func_index = translation.module.func_index(def_func_index);
         let sig = translation.module.functions[func_index]
@@ -362,7 +386,7 @@ impl wasmtime_environ::Compiler for Compiler {
         builder.finalize();
 
         Ok(CompiledFunctionBody {
-            code: Box::new(compiler.finish(symbol)?),
+            code: Box::new(Some(compiler.cx)),
             needs_gc_heap: false,
         })
     }
@@ -370,7 +394,7 @@ impl wasmtime_environ::Compiler for Compiler {
     fn compile_wasm_to_array_trampoline(
         &self,
         wasm_func_ty: &WasmFuncType,
-        symbol: &str,
+        _symbol: &str,
     ) -> Result<CompiledFunctionBody, CompileError> {
         let isa = &*self.isa;
         let pointer_type = isa.pointer_type();
@@ -436,7 +460,7 @@ impl wasmtime_environ::Compiler for Compiler {
         builder.finalize();
 
         Ok(CompiledFunctionBody {
-            code: Box::new(compiler.finish(&symbol)?),
+            code: Box::new(Some(compiler.cx)),
             needs_gc_heap: false,
         })
     }
@@ -444,7 +468,7 @@ impl wasmtime_environ::Compiler for Compiler {
     fn append_code(
         &self,
         obj: &mut Object<'static>,
-        funcs: &[(String, Box<dyn Any + Send>)],
+        funcs: &[(String, Box<dyn Any + Send + Sync>)],
         resolve_reloc: &dyn Fn(usize, RelocationTarget) -> usize,
     ) -> Result<Vec<(SymbolId, FunctionLoc)>> {
         let mut builder =
@@ -517,7 +541,7 @@ impl wasmtime_environ::Compiler for Compiler {
         get_func: &'a dyn Fn(
             StaticModuleIndex,
             DefinedFuncIndex,
-        ) -> (SymbolId, &'a (dyn Any + Send)),
+        ) -> (SymbolId, &'a (dyn Any + Send + Sync)),
         dwarf_package_bytes: Option<&'a [u8]>,
         tunables: &'a Tunables,
     ) -> Result<()> {
@@ -586,7 +610,7 @@ impl wasmtime_environ::Compiler for Compiler {
     fn compile_wasm_to_builtin(
         &self,
         index: BuiltinFunctionIndex,
-        symbol: &str,
+        _symbol: &str,
     ) -> Result<CompiledFunctionBody, CompileError> {
         let isa = &*self.isa;
         let ptr_size = isa.pointer_bytes();
@@ -657,7 +681,7 @@ impl wasmtime_environ::Compiler for Compiler {
         builder.finalize();
 
         Ok(CompiledFunctionBody {
-            code: Box::new(compiler.finish(&symbol)?),
+            code: Box::new(Some(compiler.cx)),
             needs_gc_heap: false,
         })
     }
@@ -668,6 +692,126 @@ impl wasmtime_environ::Compiler for Compiler {
     ) -> Box<dyn Iterator<Item = RelocationTarget> + 'a> {
         let func = func.downcast_ref::<CompiledFunction>().unwrap();
         Box::new(func.relocations().map(|r| r.reloc_target))
+    }
+}
+
+impl InliningCompiler for Compiler {
+    fn calls(&self, func_body: &CompiledFunctionBody, calls: &mut Vec<FuncIndex>) -> Result<()> {
+        let cx = func_body
+            .code
+            .downcast_ref::<Option<CompilerContext>>()
+            .unwrap()
+            .as_ref()
+            .unwrap();
+        let func = &cx.codegen_context.func;
+        calls.extend(
+            func.params
+                .user_named_funcs()
+                .values()
+                .filter(|name| name.namespace == crate::NS_WASM_FUNC)
+                .map(|name| FuncIndex::from_u32(name.index)),
+        );
+        Ok(())
+    }
+
+    fn size(&self, func_body: &CompiledFunctionBody) -> u32 {
+        let cx = func_body
+            .code
+            .downcast_ref::<Option<CompilerContext>>()
+            .unwrap()
+            .as_ref()
+            .unwrap();
+        let func = &cx.codegen_context.func;
+        let size = func.dfg.values().len();
+        u32::try_from(size).unwrap()
+    }
+
+    fn inline<'a>(
+        &self,
+        func_body: &mut CompiledFunctionBody,
+        get_callee: &'a mut dyn FnMut(FuncIndex) -> Option<&'a CompiledFunctionBody>,
+    ) -> Result<()> {
+        let code = func_body
+            .code
+            .downcast_mut::<Option<CompilerContext>>()
+            .unwrap();
+        let cx = code.as_mut().unwrap();
+
+        cx.codegen_context.inline(Inliner(get_callee))?;
+        return Ok(());
+
+        struct Inliner<'a>(&'a mut dyn FnMut(FuncIndex) -> Option<&'a CompiledFunctionBody>);
+
+        impl cranelift_codegen::inline::Inline for Inliner<'_> {
+            fn inline(
+                &mut self,
+                caller: &ir::Function,
+                _call_inst: ir::Inst,
+                _call_opcode: ir::Opcode,
+                callee: ir::FuncRef,
+                _call_args: &[ir::Value],
+            ) -> InlineCommand<'_> {
+                let callee = &caller.dfg.ext_funcs[callee].name;
+                let callee = match callee {
+                    ir::ExternalName::User(callee) => *callee,
+                    ir::ExternalName::TestCase(_)
+                    | ir::ExternalName::LibCall(_)
+                    | ir::ExternalName::KnownSymbol(_) => return InlineCommand::KeepCall,
+                };
+                let callee = &caller.params.user_named_funcs()[callee];
+                let callee = if callee.namespace == crate::NS_WASM_FUNC {
+                    FuncIndex::from_u32(callee.index)
+                } else {
+                    return InlineCommand::KeepCall;
+                };
+                match (self.0)(callee) {
+                    None => InlineCommand::KeepCall,
+                    Some(func_body) => {
+                        let cx = func_body
+                            .code
+                            .downcast_ref::<Option<CompilerContext>>()
+                            .unwrap();
+                        InlineCommand::Inline(Cow::Borrowed(
+                            &cx.as_ref().unwrap().codegen_context.func,
+                        ))
+                    }
+                }
+            }
+        }
+    }
+
+    fn finish_compiling(
+        &self,
+        func_body: &mut CompiledFunctionBody,
+        input: Option<wasmparser::FunctionBody<'_>>,
+        symbol: &str,
+    ) -> Result<()> {
+        let cx = func_body
+            .code
+            .downcast_mut::<Option<CompilerContext>>()
+            .unwrap()
+            .take()
+            .unwrap();
+        let compiler = FunctionCompiler { compiler: self, cx };
+
+        let symbol = match compiler.cx.abi {
+            None => Cow::Borrowed(symbol),
+            Some(Abi::Wasm) => Cow::Owned(format!("{symbol}_wasm_call")),
+            Some(Abi::Array) => Cow::Owned(format!("{symbol}_array_call")),
+        };
+
+        let compiled_func = if let Some(input) = input {
+            compiler.finish_with_info(Some((&input, &self.tunables)), &symbol)?
+        } else {
+            compiler.finish(&symbol)?
+        };
+
+        let timing = cranelift_codegen::timing::take_current();
+        log::debug!("`{symbol}` compiled in {:?}", timing.total());
+        log::trace!("`{symbol}` timing info\n{timing}");
+
+        func_body.code = Box::new(compiled_func);
+        Ok(())
     }
 }
 

--- a/crates/cranelift/src/compiler.rs
+++ b/crates/cranelift/src/compiler.rs
@@ -700,7 +700,11 @@ impl wasmtime_environ::Compiler for Compiler {
 }
 
 impl InliningCompiler for Compiler {
-    fn calls(&self, func_body: &CompiledFunctionBody, calls: &mut Vec<FuncIndex>) -> Result<()> {
+    fn calls(
+        &self,
+        func_body: &CompiledFunctionBody,
+        calls: &mut wasmtime_environ::prelude::IndexSet<FuncIndex>,
+    ) -> Result<()> {
         let cx = func_body
             .code
             .downcast_ref::<Option<CompilerContext>>()

--- a/crates/cranelift/src/compiler.rs
+++ b/crates/cranelift/src/compiler.rs
@@ -48,6 +48,10 @@ struct IncrementalCacheContext {
 
 /// ABI signature of functions that are generated here.
 #[derive(Debug, Copy, Clone)]
+#[cfg_attr(
+    not(feature = "component-model"),
+    expect(dead_code, reason = "only used with component model compiler")
+)]
 enum Abi {
     /// The "wasm" ABI, or suitable to be a `wasm_call` field of a `VMFuncRef`.
     Wasm,

--- a/crates/environ/src/compile/mod.rs
+++ b/crates/environ/src/compile/mod.rs
@@ -469,7 +469,7 @@ pub trait Compiler: Send + Sync {
 /// An inlining compiler.
 pub trait InliningCompiler: Sync + Send {
     /// Enumerate the function calls that the given `func` makes.
-    fn calls(&self, func: &CompiledFunctionBody, calls: &mut Vec<FuncIndex>) -> Result<()>;
+    fn calls(&self, func: &CompiledFunctionBody, calls: &mut IndexSet<FuncIndex>) -> Result<()>;
 
     /// Get the abstract size of the given function, for the purposes of
     /// inlining heuristics.

--- a/crates/environ/src/compile/mod.rs
+++ b/crates/environ/src/compile/mod.rs
@@ -180,7 +180,7 @@ pub enum SettingKind {
 pub struct CompiledFunctionBody {
     /// The code. This is whatever type the `Compiler` implementation wants it
     /// to be, we just shepherd it around.
-    pub code: Box<dyn Any + Send>,
+    pub code: Box<dyn Any + Send + Sync>,
     /// Whether the compiled function needs a GC heap to run; that is, whether
     /// it reads a struct field, allocates, an array, or etc...
     pub needs_gc_heap: bool,
@@ -188,7 +188,69 @@ pub struct CompiledFunctionBody {
 
 /// An implementation of a compiler which can compile WebAssembly functions to
 /// machine code and perform other miscellaneous tasks needed by the JIT runtime.
+///
+/// The diagram below depicts typical usage of this trait:
+///
+/// ```ignore
+///                     +------+
+///                     | Wasm |
+///                     +------+
+///                        |
+///                        |
+///           Compiler::compile_function()
+///                        |
+///                        |
+///                        V
+///             +----------------------+
+///             | CompiledFunctionBody |
+///             +----------------------+
+///               |                  |
+///               |                  |
+///               |                When
+///               |       Compiler::inlining_compiler()
+///               |               is some
+///               |                  |
+///             When                 |
+/// Compiler::inlining_compiler()    |-----------------.
+///             is none              |                 |
+///               |                  |                 |
+///               |           Optionally call          |
+///               |        InliningCompiler::inline()  |
+///               |                  |                 |
+///               |                  |                 |
+///               |                  |-----------------'
+///               |                  |
+///               |                  |
+///               |                  V
+///               |     InliningCompiler::finish_compiling()
+///               |                  |
+///               |                  |
+///               |------------------'
+///               |
+///               |
+///   Compiler::append_code()
+///               |
+///               |
+///               V
+///           +--------+
+///           | Object |
+///           +--------+
+/// ```
 pub trait Compiler: Send + Sync {
+    /// Get this compiler's inliner.
+    ///
+    /// Consumers of this trait **must** check for when when this method returns
+    /// `Some(_)`, and **must** call `InliningCompiler::finish_compiling` on all
+    /// `CompiledFunctionBody`s produced by this compiler in that case before
+    /// passing the the compiled functions to `Compiler::append_code`, even if
+    /// the consumer does not actually intend to do any inlining. This allows
+    /// implementations of the trait to only translate to an internal
+    /// representation in `Compiler::compile_*` methods so that they can then
+    /// perform inlining afterwards if the consumer desires, and then finally
+    /// proceed with compilng that internal representation to native code in
+    /// `InliningCompiler::finish_compiling`.
+    fn inlining_compiler(&self) -> Option<&dyn InliningCompiler>;
+
     /// Compiles the function `index` within `translation`.
     ///
     /// The body of the function is available in `data` and configuration
@@ -279,7 +341,7 @@ pub trait Compiler: Send + Sync {
     fn append_code(
         &self,
         obj: &mut Object<'static>,
-        funcs: &[(String, Box<dyn Any + Send>)],
+        funcs: &[(String, Box<dyn Any + Send + Sync>)],
         resolve_reloc: &dyn Fn(usize, RelocationTarget) -> usize,
     ) -> Result<Vec<(SymbolId, FunctionLoc)>>;
 
@@ -390,7 +452,7 @@ pub trait Compiler: Send + Sync {
         get_func: &'a dyn Fn(
             StaticModuleIndex,
             DefinedFuncIndex,
-        ) -> (SymbolId, &'a (dyn Any + Send)),
+        ) -> (SymbolId, &'a (dyn Any + Send + Sync)),
         dwarf_package_bytes: Option<&'a [u8]>,
         tunables: &'a Tunables,
     ) -> Result<()>;
@@ -402,4 +464,37 @@ pub trait Compiler: Send + Sync {
         // By default, an ISA cannot create a System V CIE.
         None
     }
+}
+
+/// An inlining compiler.
+pub trait InliningCompiler: Sync + Send {
+    /// Enumerate the function calls that the given `func` makes.
+    fn calls(&self, func: &CompiledFunctionBody, calls: &mut Vec<FuncIndex>) -> Result<()>;
+
+    /// Get the abstract size of the given function, for the purposes of
+    /// inlining heuristics.
+    fn size(&self, func: &CompiledFunctionBody) -> u32;
+
+    /// Process this function for inlining.
+    ///
+    /// Implementations should call `get_callee` for each of their direct
+    /// function call sites and if `get_callee` returns `Some(_)`, they should
+    /// inline the given function body into that call site.
+    fn inline<'a>(
+        &self,
+        func: &mut CompiledFunctionBody,
+        get_callee: &'a mut dyn FnMut(FuncIndex) -> Option<&'a CompiledFunctionBody>,
+    ) -> Result<()>;
+
+    /// Finish compiling the given function.
+    ///
+    /// This method **must** be called before passing the
+    /// `CompiledFunctionBody`'s contents to `Compiler::append_code`, even if no
+    /// inlining was performed.
+    fn finish_compiling(
+        &self,
+        func: &mut CompiledFunctionBody,
+        input: Option<wasmparser::FunctionBody<'_>>,
+        symbol: &str,
+    ) -> Result<()>;
 }

--- a/crates/environ/src/tunables.rs
+++ b/crates/environ/src/tunables.rs
@@ -1,6 +1,6 @@
 use crate::{IndexType, Limits, Memory, TripleExt};
-use anyhow::{Result, anyhow, bail};
-use core::fmt;
+use anyhow::{Error, Result, anyhow, bail};
+use core::{fmt, str::FromStr};
 use serde_derive::{Deserialize, Serialize};
 use target_lexicon::{PointerWidth, Triple};
 
@@ -294,4 +294,20 @@ pub enum IntraModuleInlining {
     Yes,
     No,
     WhenUsingGc,
+}
+
+impl FromStr for IntraModuleInlining {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "y" | "yes" | "true" => Ok(Self::Yes),
+            "n" | "no" | "false" => Ok(Self::No),
+            "gc" => Ok(Self::WhenUsingGc),
+            _ => bail!(
+                "invalid intra-module inlining option string: `{s}`, \
+                 only yes,no,gc accepted"
+            ),
+        }
+    }
 }

--- a/crates/environ/src/tunables.rs
+++ b/crates/environ/src/tunables.rs
@@ -121,6 +121,21 @@ define_tunables! {
 
         /// Whether CoW images might be used to initialize linear memories.
         pub memory_init_cow: bool,
+
+        /// Whether to enable inlining in Wasmtime's compilation orchestration
+        /// or not.
+        pub inlining: bool,
+
+        /// Whether to inline calls within the same core Wasm module or not.
+        pub inlining_intra_module: IntraModuleInlining,
+
+        /// The size of "small callees" that can be inlined regardless of the
+        /// caller's size.
+        pub inlining_small_callee_size: u32,
+
+        /// The general size threshold for the sum of the caller's and callee's
+        /// sizes, past which we will generally not inline calls anymore.
+        pub inlining_sum_size_threshold: u32,
     }
 
     pub struct ConfigTunables {
@@ -191,6 +206,10 @@ impl Tunables {
             winch_callable: false,
             signals_based_traps: false,
             memory_init_cow: true,
+            inlining: false,
+            inlining_intra_module: IntraModuleInlining::WhenUsingGc,
+            inlining_small_callee_size: 50,
+            inlining_sum_size_threshold: 2000,
         }
     }
 
@@ -266,4 +285,13 @@ impl fmt::Display for Collector {
             Collector::Null => write!(f, "null"),
         }
     }
+}
+
+/// Whether to inline function calls within the same module.
+#[derive(Clone, Copy, Hash, Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[expect(missing_docs, reason = "self-describing variants")]
+pub enum IntraModuleInlining {
+    Yes,
+    No,
+    WhenUsingGc,
 }

--- a/crates/fuzzing/src/generators/config.rs
+++ b/crates/fuzzing/src/generators/config.rs
@@ -267,28 +267,6 @@ impl Config {
             Some(cfg!(target_os = "windows") || self.wasmtime.native_unwind_info);
         cfg.codegen.parallel_compilation = Some(false);
 
-        cfg.codegen.inlining = self.wasmtime.inlining;
-        if let Some(option) = self.wasmtime.inlining_intra_module {
-            cfg.codegen.cranelift.push((
-                "wasmtime_inlining_intra_module".to_string(),
-                Some(option.to_string()),
-            ));
-        }
-        if let Some(size) = self.wasmtime.inlining_small_callee_size {
-            cfg.codegen.cranelift.push((
-                "wasmtime_inlining_small_callee_size".to_string(),
-                // Clamp to avoid extreme code size blow up.
-                Some(std::cmp::min(1000, size).to_string()),
-            ));
-        }
-        if let Some(size) = self.wasmtime.inlining_sum_size_threshold {
-            cfg.codegen.cranelift.push((
-                "wasmtime_inlining_sum_size_threshold".to_string(),
-                // Clamp to avoid extreme code size blow up.
-                Some(std::cmp::min(1000, size).to_string()),
-            ));
-        }
-
         cfg.debug.address_map = Some(self.wasmtime.generate_address_map);
         cfg.opts.opt_level = Some(self.wasmtime.opt_level.to_wasmtime());
         cfg.opts.regalloc_algorithm = Some(self.wasmtime.regalloc_algorithm.to_wasmtime());
@@ -349,9 +327,32 @@ impl Config {
             && self.wasmtime.pcc
             && !self.module_config.config.memory64_enabled;
 
+        cfg.codegen.inlining = self.wasmtime.inlining;
+
         // Only set cranelift specific flags when the Cranelift strategy is
         // chosen.
         if cranelift_strategy {
+            if let Some(option) = self.wasmtime.inlining_intra_module {
+                cfg.codegen.cranelift.push((
+                    "wasmtime_inlining_intra_module".to_string(),
+                    Some(option.to_string()),
+                ));
+            }
+            if let Some(size) = self.wasmtime.inlining_small_callee_size {
+                cfg.codegen.cranelift.push((
+                    "wasmtime_inlining_small_callee_size".to_string(),
+                    // Clamp to avoid extreme code size blow up.
+                    Some(std::cmp::min(1000, size).to_string()),
+                ));
+            }
+            if let Some(size) = self.wasmtime.inlining_sum_size_threshold {
+                cfg.codegen.cranelift.push((
+                    "wasmtime_inlining_sum_size_threshold".to_string(),
+                    // Clamp to avoid extreme code size blow up.
+                    Some(std::cmp::min(1000, size).to_string()),
+                ));
+            }
+
             // If the wasm-smith-generated module use nan canonicalization then we
             // don't need to enable it, but if it doesn't enable it already then we
             // enable this codegen option.

--- a/crates/fuzzing/src/generators/config.rs
+++ b/crates/fuzzing/src/generators/config.rs
@@ -266,6 +266,19 @@ impl Config {
         cfg.codegen.native_unwind_info =
             Some(cfg!(target_os = "windows") || self.wasmtime.native_unwind_info);
         cfg.codegen.parallel_compilation = Some(false);
+        cfg.codegen.inlining = Some(self.wasmtime.compiler_inlining);
+        cfg.codegen.inlining_intra_module =
+            Some(self.wasmtime.compiler_inlining_intra_module.to_wasmtime());
+        cfg.codegen.inlining_small_callee_size = Some(std::cmp::min(
+            // Clamp to avoid extreme code size blow up.
+            1000,
+            self.wasmtime.compiler_inlining_small_callee_size,
+        ));
+        cfg.codegen.inlining_sum_size_threshold = Some(std::cmp::min(
+            // Clamp to avoid extreme code size blow up.
+            10_000,
+            self.wasmtime.compiler_inlining_sum_size_threshold,
+        ));
         cfg.debug.address_map = Some(self.wasmtime.generate_address_map);
         cfg.opts.opt_level = Some(self.wasmtime.opt_level.to_wasmtime());
         cfg.opts.regalloc_algorithm = Some(self.wasmtime.regalloc_algorithm.to_wasmtime());
@@ -275,19 +288,6 @@ impl Config {
             // images during fuzzing.
             16 << 20,
             self.wasmtime.memory_guaranteed_dense_image_size,
-        ));
-        cfg.opts.compiler_inlining = Some(self.wasmtime.compiler_inlining);
-        cfg.opts.compiler_inlining_intra_module =
-            Some(self.wasmtime.compiler_inlining_intra_module.to_wasmtime());
-        cfg.opts.compiler_inlining_small_callee_size = Some(std::cmp::min(
-            // Clamp to avoid extreme code size blow up.
-            1000,
-            self.wasmtime.compiler_inlining_small_callee_size,
-        ));
-        cfg.opts.compiler_inlining_sum_size_threshold = Some(std::cmp::min(
-            // Clamp to avoid extreme code size blow up.
-            10_000,
-            self.wasmtime.compiler_inlining_sum_size_threshold,
         ));
         cfg.wasm.async_stack_zeroing = Some(self.wasmtime.async_stack_zeroing);
         cfg.wasm.bulk_memory = Some(true);

--- a/crates/wasmtime/src/compile/call_graph.rs
+++ b/crates/wasmtime/src/compile/call_graph.rs
@@ -10,8 +10,6 @@
 //! schedule. For best results, however, every direct call that is potentially
 //! inlinable should be reported when constructing these call graphs.
 
-#![cfg_attr(not(test), expect(dead_code, reason = "used in upcoming PRs"))]
-
 use super::*;
 use core::{
     fmt::{self, Debug},
@@ -71,7 +69,7 @@ where
     /// calls.
     pub fn new(
         funcs: impl IntoIterator<Item = Node>,
-        get_calls: impl Fn(Node, &mut Vec<Node>) -> Result<()>,
+        mut get_calls: impl FnMut(Node, &mut Vec<Node>) -> Result<()>,
     ) -> Result<Self> {
         let funcs = funcs.into_iter();
 

--- a/crates/wasmtime/src/compile/scc.rs
+++ b/crates/wasmtime/src/compile/scc.rs
@@ -11,8 +11,6 @@
 //!
 //! [Tarjan's algorithm]: https://en.wikipedia.org/wiki/Tarjan%27s_strongly_connected_components_algorithm
 
-#![cfg_attr(not(test), expect(dead_code, reason = "used in upcoming PRs"))]
-
 use super::*;
 use std::{
     collections::BTreeSet,
@@ -213,6 +211,7 @@ where
     ///
     /// Iteration happens in reverse-topological order (successors are visited
     /// before predecessors in the resulting SCC DAG).
+    #[cfg(test)]
     pub fn values(&self) -> impl ExactSizeIterator<Item = &[Node]> + '_ {
         self.components
             .values()

--- a/crates/wasmtime/src/compile/stratify.rs
+++ b/crates/wasmtime/src/compile/stratify.rs
@@ -50,8 +50,6 @@
 //! dependencies each component has, and a component is ready for inclusion in a
 //! layer once its unprocessed-dependencies count reaches zero.
 
-#![cfg_attr(not(test), expect(dead_code, reason = "used in upcoming PRs"))]
-
 use super::{
     call_graph::CallGraph,
     scc::{Scc, StronglyConnectedComponents},
@@ -77,7 +75,7 @@ impl<Node: Debug> Debug for Strata<Node> {
             fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                 let mut f = f.debug_list();
                 for layer in self.0.layers() {
-                    f.entries(layer);
+                    f.entry(&layer);
                 }
                 f.finish()
             }

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -2046,33 +2046,6 @@ impl Config {
         self
     }
 
-    /// Whether to inline function calls within the same module or not.
-    ///
-    /// Only exposed for fuzzing.
-    #[doc(hidden)]
-    pub fn compiler_inlining_intra_module(&mut self, inlining: IntraModuleInlining) -> &mut Self {
-        self.tunables.inlining_intra_module = Some(inlining.to_env());
-        self
-    }
-
-    /// Set the "small-callee" size for the function inlining heuristic.
-    ///
-    /// Only exposed for fuzzing.
-    #[doc(hidden)]
-    pub fn compiler_inlining_small_callee_size(&mut self, size: u32) -> &mut Self {
-        self.tunables.inlining_small_callee_size = Some(size);
-        self
-    }
-
-    /// Set the "sum size threshold" for the function inlining heuristic.
-    ///
-    /// Only exposed for fuzzing.
-    #[doc(hidden)]
-    pub fn compiler_inlining_sum_size_threshold(&mut self, size: u32) -> &mut Self {
-        self.tunables.inlining_sum_size_threshold = Some(size);
-        self
-    }
-
     /// Returns the set of features that the currently selected compiler backend
     /// does not support at all and may panic on.
     ///
@@ -2890,27 +2863,6 @@ impl Collector {
                  collectors are available; enable one of the following \
                  features: `gc-drc`, `gc-null`",
             ),
-        }
-    }
-}
-
-/// Whether to inline function calls within the same module.
-///
-/// Only exposed for fuzzing.
-#[doc(hidden)]
-#[derive(PartialEq, Eq, Clone, Debug, Copy)]
-pub enum IntraModuleInlining {
-    Yes,
-    No,
-    WhenUsingGc,
-}
-
-impl IntraModuleInlining {
-    fn to_env(&self) -> wasmtime_environ::IntraModuleInlining {
-        match self {
-            IntraModuleInlining::Yes => wasmtime_environ::IntraModuleInlining::Yes,
-            IntraModuleInlining::No => wasmtime_environ::IntraModuleInlining::No,
-            IntraModuleInlining::WhenUsingGc => wasmtime_environ::IntraModuleInlining::WhenUsingGc,
         }
     }
 }

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -2027,6 +2027,52 @@ impl Config {
         self
     }
 
+    /// Whether to enable function inlining during compilation or not.
+    ///
+    /// This may result in faster execution at runtime, but adds additional
+    /// compilation time. Inlining may also enlarge the size of compiled
+    /// artifacts (for example, the size of the result of
+    /// [`Engine::precompile_component`]).
+    ///
+    /// Inlining is not supported by all of Wasmtime's compilation strategies;
+    /// currently, it only Cranelift supports it. This setting will be ignored
+    /// when using a compilation strategy that does not support inlining, like
+    /// Winch.
+    ///
+    /// Note that inlining is still somewhat experimental at the moment (as of
+    /// the Wasmtime version 36).
+    pub fn compiler_inlining(&mut self, inlining: bool) -> &mut Self {
+        self.tunables.inlining = Some(inlining);
+        self
+    }
+
+    /// Whether to inline function calls within the same module or not.
+    ///
+    /// Only exposed for fuzzing.
+    #[doc(hidden)]
+    pub fn compiler_inlining_intra_module(&mut self, inlining: IntraModuleInlining) -> &mut Self {
+        self.tunables.inlining_intra_module = Some(inlining.to_env());
+        self
+    }
+
+    /// Set the "small-callee" size for the function inlining heuristic.
+    ///
+    /// Only exposed for fuzzing.
+    #[doc(hidden)]
+    pub fn compiler_inlining_small_callee_size(&mut self, size: u32) -> &mut Self {
+        self.tunables.inlining_small_callee_size = Some(size);
+        self
+    }
+
+    /// Set the "sum size threshold" for the function inlining heuristic.
+    ///
+    /// Only exposed for fuzzing.
+    #[doc(hidden)]
+    pub fn compiler_inlining_sum_size_threshold(&mut self, size: u32) -> &mut Self {
+        self.tunables.inlining_sum_size_threshold = Some(size);
+        self
+    }
+
     /// Returns the set of features that the currently selected compiler backend
     /// does not support at all and may panic on.
     ///
@@ -2844,6 +2890,27 @@ impl Collector {
                  collectors are available; enable one of the following \
                  features: `gc-drc`, `gc-null`",
             ),
+        }
+    }
+}
+
+/// Whether to inline function calls within the same module.
+///
+/// Only exposed for fuzzing.
+#[doc(hidden)]
+#[derive(PartialEq, Eq, Clone, Debug, Copy)]
+pub enum IntraModuleInlining {
+    Yes,
+    No,
+    WhenUsingGc,
+}
+
+impl IntraModuleInlining {
+    fn to_env(&self) -> wasmtime_environ::IntraModuleInlining {
+        match self {
+            IntraModuleInlining::Yes => wasmtime_environ::IntraModuleInlining::Yes,
+            IntraModuleInlining::No => wasmtime_environ::IntraModuleInlining::No,
+            IntraModuleInlining::WhenUsingGc => wasmtime_environ::IntraModuleInlining::WhenUsingGc,
         }
     }
 }

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -2516,6 +2516,7 @@ impl Config {
         }
 
         // Apply compiler settings and flags
+        compiler.set_tunables(tunables.clone())?;
         for (k, v) in self.compiler_config.settings.iter() {
             compiler.set(k, v)?;
         }
@@ -2528,7 +2529,6 @@ impl Config {
             compiler.enable_incremental_compilation(cache_store.clone())?;
         }
 
-        compiler.set_tunables(tunables.clone())?;
         compiler.wmemcheck(self.compiler_config.wmemcheck);
 
         Ok((self, compiler.build()?))

--- a/crates/winch/src/compiler.rs
+++ b/crates/winch/src/compiler.rs
@@ -25,7 +25,7 @@ struct CompilationContext {
 
 pub(crate) struct Compiler {
     isa: Box<dyn TargetIsa>,
-    trampolines: Box<dyn wasmtime_environ::Compiler>,
+    trampolines: NoInlineCompiler,
     contexts: Mutex<Vec<CompilationContext>>,
     tunables: Tunables,
 }
@@ -38,7 +38,7 @@ impl Compiler {
     ) -> Self {
         Self {
             isa,
-            trampolines,
+            trampolines: NoInlineCompiler(trampolines),
             contexts: Mutex::new(Vec::new()),
             tunables,
         }
@@ -225,5 +225,155 @@ impl wasmtime_environ::Compiler for Compiler {
         func: &'a dyn Any,
     ) -> Box<dyn Iterator<Item = RelocationTarget> + 'a> {
         self.trampolines.compiled_function_relocation_targets(func)
+    }
+}
+
+/// A wrapper around another `Compiler` implementation that may or may not be an
+/// inlining compiler and turns it into a non-inlining compiler.
+struct NoInlineCompiler(Box<dyn wasmtime_environ::Compiler>);
+
+impl wasmtime_environ::Compiler for NoInlineCompiler {
+    fn inlining_compiler(&self) -> Option<&dyn wasmtime_environ::InliningCompiler> {
+        None
+    }
+
+    fn compile_function(
+        &self,
+        translation: &ModuleTranslation<'_>,
+        index: DefinedFuncIndex,
+        data: FunctionBodyData<'_>,
+        types: &ModuleTypesBuilder,
+        symbol: &str,
+    ) -> Result<CompiledFunctionBody, CompileError> {
+        let input = data.body.clone();
+        let mut body = self
+            .0
+            .compile_function(translation, index, data, types, symbol)?;
+        if let Some(c) = self.0.inlining_compiler() {
+            c.finish_compiling(&mut body, Some(input), symbol)
+                .map_err(|e| CompileError::Codegen(e.to_string()))?;
+        }
+        Ok(body)
+    }
+
+    fn compile_array_to_wasm_trampoline(
+        &self,
+        translation: &ModuleTranslation<'_>,
+        types: &ModuleTypesBuilder,
+        index: DefinedFuncIndex,
+        symbol: &str,
+    ) -> Result<CompiledFunctionBody, CompileError> {
+        let mut body =
+            self.0
+                .compile_array_to_wasm_trampoline(translation, types, index, symbol)?;
+        if let Some(c) = self.0.inlining_compiler() {
+            c.finish_compiling(&mut body, None, symbol)
+                .map_err(|e| CompileError::Codegen(e.to_string()))?;
+        }
+        Ok(body)
+    }
+
+    fn compile_wasm_to_array_trampoline(
+        &self,
+        wasm_func_ty: &wasmtime_environ::WasmFuncType,
+        symbol: &str,
+    ) -> Result<CompiledFunctionBody, CompileError> {
+        let mut body = self
+            .0
+            .compile_wasm_to_array_trampoline(wasm_func_ty, symbol)?;
+        if let Some(c) = self.0.inlining_compiler() {
+            c.finish_compiling(&mut body, None, symbol)
+                .map_err(|e| CompileError::Codegen(e.to_string()))?;
+        }
+        Ok(body)
+    }
+
+    fn compile_wasm_to_builtin(
+        &self,
+        index: BuiltinFunctionIndex,
+        symbol: &str,
+    ) -> Result<CompiledFunctionBody, CompileError> {
+        let mut body = self.0.compile_wasm_to_builtin(index, symbol)?;
+        if let Some(c) = self.0.inlining_compiler() {
+            c.finish_compiling(&mut body, None, symbol)
+                .map_err(|e| CompileError::Codegen(e.to_string()))?;
+        }
+        Ok(body)
+    }
+
+    fn compiled_function_relocation_targets<'a>(
+        &'a self,
+        func: &'a dyn Any,
+    ) -> Box<dyn Iterator<Item = RelocationTarget> + 'a> {
+        self.0.compiled_function_relocation_targets(func)
+    }
+
+    fn append_code(
+        &self,
+        obj: &mut Object<'static>,
+        funcs: &[(String, Box<dyn Any + Send + Sync>)],
+        resolve_reloc: &dyn Fn(usize, RelocationTarget) -> usize,
+    ) -> Result<Vec<(SymbolId, FunctionLoc)>> {
+        self.0.append_code(obj, funcs, resolve_reloc)
+    }
+
+    fn triple(&self) -> &target_lexicon::Triple {
+        self.0.triple()
+    }
+
+    fn flags(&self) -> Vec<(&'static str, wasmtime_environ::FlagValue<'static>)> {
+        self.0.flags()
+    }
+
+    fn isa_flags(&self) -> Vec<(&'static str, wasmtime_environ::FlagValue<'static>)> {
+        self.0.isa_flags()
+    }
+
+    fn is_branch_protection_enabled(&self) -> bool {
+        self.0.is_branch_protection_enabled()
+    }
+
+    #[cfg(feature = "component-model")]
+    fn component_compiler(&self) -> &dyn wasmtime_environ::component::ComponentCompiler {
+        self
+    }
+
+    fn append_dwarf<'a>(
+        &self,
+        obj: &mut Object<'_>,
+        translations: &'a PrimaryMap<StaticModuleIndex, ModuleTranslation<'a>>,
+        get_func: &'a dyn Fn(
+            StaticModuleIndex,
+            DefinedFuncIndex,
+        ) -> (SymbolId, &'a (dyn Any + Send + Sync)),
+        dwarf_package_bytes: Option<&'a [u8]>,
+        tunables: &'a Tunables,
+    ) -> Result<()> {
+        self.0
+            .append_dwarf(obj, translations, get_func, dwarf_package_bytes, tunables)
+    }
+}
+
+#[cfg(feature = "component-model")]
+impl wasmtime_environ::component::ComponentCompiler for NoInlineCompiler {
+    fn compile_trampoline(
+        &self,
+        component: &wasmtime_environ::component::ComponentTranslation,
+        types: &wasmtime_environ::component::ComponentTypesBuilder,
+        trampoline: wasmtime_environ::component::TrampolineIndex,
+        tunables: &Tunables,
+        symbol: &str,
+    ) -> Result<wasmtime_environ::component::AllCallFunc<CompiledFunctionBody>> {
+        let mut body = self
+            .0
+            .component_compiler()
+            .compile_trampoline(component, types, trampoline, tunables, symbol)?;
+        if let Some(c) = self.0.inlining_compiler() {
+            c.finish_compiling(&mut body.array_call, None, symbol)
+                .map_err(|e| CompileError::Codegen(e.to_string()))?;
+            c.finish_compiling(&mut body.wasm_call, None, symbol)
+                .map_err(|e| CompileError::Codegen(e.to_string()))?;
+        }
+        Ok(body)
     }
 }

--- a/crates/winch/src/compiler.rs
+++ b/crates/winch/src/compiler.rs
@@ -89,6 +89,10 @@ impl Compiler {
 }
 
 impl wasmtime_environ::Compiler for Compiler {
+    fn inlining_compiler(&self) -> Option<&dyn wasmtime_environ::InliningCompiler> {
+        None
+    }
+
     fn compile_function(
         &self,
         translation: &ModuleTranslation<'_>,
@@ -163,7 +167,7 @@ impl wasmtime_environ::Compiler for Compiler {
     fn append_code(
         &self,
         obj: &mut Object<'static>,
-        funcs: &[(String, Box<dyn Any + Send>)],
+        funcs: &[(String, Box<dyn Any + Send + Sync>)],
         resolve_reloc: &dyn Fn(usize, wasmtime_environ::RelocationTarget) -> usize,
     ) -> Result<Vec<(SymbolId, FunctionLoc)>> {
         self.trampolines.append_code(obj, funcs, resolve_reloc)
@@ -197,7 +201,7 @@ impl wasmtime_environ::Compiler for Compiler {
         _get_func: &'a dyn Fn(
             StaticModuleIndex,
             DefinedFuncIndex,
-        ) -> (SymbolId, &'a (dyn Any + Send)),
+        ) -> (SymbolId, &'a (dyn Any + Send + Sync)),
         _dwarf_package_bytes: Option<&'a [u8]>,
         _tunables: &'a Tunables,
     ) -> Result<()> {

--- a/tests/disas/component-model/direct-adapter-calls-inlining.wat
+++ b/tests/disas/component-model/direct-adapter-calls-inlining.wat
@@ -1,7 +1,7 @@
 ;;! target = "x86_64"
 ;;! test = "optimize"
 ;;! filter = "wasm[1]--function"
-;;! flags = "-O compiler-inlining=y"
+;;! flags = "-C inlining=y"
 
 ;; Same as `direct-adapter-calls.wat`, except we have enabled function inlining
 ;; so all the direct calls should get inlined.

--- a/tests/disas/component-model/direct-adapter-calls-inlining.wat
+++ b/tests/disas/component-model/direct-adapter-calls-inlining.wat
@@ -1,0 +1,145 @@
+;;! target = "x86_64"
+;;! test = "optimize"
+;;! filter = "wasm[1]--function"
+;;! flags = "-O compiler-inlining=y"
+
+;; Same as `direct-adapter-calls.wat`, except we have enabled function inlining
+;; so all the direct calls should get inlined.
+
+(component
+  (component $A
+    (core module $M
+      (func (export "f'") (param i32) (result i32)
+        (i32.add (local.get 0) (i32.const 42))
+      )
+    )
+
+    (core instance $m (instantiate $M))
+
+    (func (export "f") (param "x" u32) (result u32)
+      (canon lift (core func $m "f'"))
+    )
+  )
+
+  (component $B
+    (import "f" (func $f (param "x" u32) (result u32)))
+
+    (core func $f' (canon lower (func $f)))
+
+    (core module $N
+      (import "" "f'" (func $f' (param i32) (result i32)))
+      (func (export "g'") (result i32)
+        (call $f' (i32.const 1234))
+      )
+    )
+
+    (core instance $n
+      (instantiate $N
+        (with "" (instance (export "f'" (func $f'))))
+      )
+    )
+
+    (func (export "g") (result u32)
+      (canon lift (core func $n "g'"))
+    )
+  )
+
+  (instance $a (instantiate $A))
+  (instance $b
+    (instantiate $B
+      (with "f" (func $a "f"))
+    )
+  )
+
+  (export "g" (func $b "g"))
+)
+
+;; function u0:1(i64 vmctx, i64) -> i32 tail {
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv2 = load.i64 notrap aligned gv1+16
+;;     gv3 = vmctx
+;;     gv4 = vmctx
+;;     gv5 = load.i64 notrap aligned readonly gv4+8
+;;     gv6 = load.i64 notrap aligned gv5+16
+;;     gv7 = vmctx
+;;     gv8 = load.i64 notrap aligned readonly can_move gv7+96
+;;     gv9 = load.i64 notrap aligned readonly can_move gv7+72
+;;     gv10 = vmctx
+;;     gv11 = load.i64 notrap aligned readonly gv10+8
+;;     gv12 = load.i64 notrap aligned gv11+16
+;;     sig0 = (i64 vmctx, i64, i32) -> i32 tail
+;;     sig1 = (i64 vmctx, i64, i32) -> i32 tail
+;;     fn0 = colocated u0:0 sig0
+;;     fn1 = colocated u0:0 sig1
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64):
+;; @00ee                               jump block2
+;;
+;;                                 block2:
+;; @00ee                               v5 = load.i64 notrap aligned readonly can_move v0+64
+;;                                     v12 = load.i64 notrap aligned readonly can_move v5+96
+;;                                     v13 = load.i32 notrap aligned table v12
+;;                                     v14 = iconst.i32 1
+;;                                     v15 = band v13, v14  ; v14 = 1
+;;                                     v11 = iconst.i32 0
+;;                                     v17 = icmp eq v15, v11  ; v11 = 0
+;;                                     v18 = uextend.i32 v17
+;;                                     trapnz v18, user11
+;;                                     jump block5
+;;
+;;                                 block5:
+;;                                     v19 = load.i64 notrap aligned readonly can_move v5+72
+;;                                     v20 = load.i32 notrap aligned table v19
+;;                                     v21 = iconst.i32 2
+;;                                     v22 = band v20, v21  ; v21 = 2
+;;                                     v79 = iconst.i32 0
+;;                                     v80 = icmp eq v22, v79  ; v79 = 0
+;;                                     v25 = uextend.i32 v80
+;;                                     trapnz v25, user11
+;;                                     jump block7
+;;
+;;                                 block7:
+;;                                     v27 = load.i32 notrap aligned table v19
+;;                                     v28 = iconst.i32 -3
+;;                                     v29 = band v27, v28  ; v28 = -3
+;;                                     store notrap aligned table v29, v19
+;;                                     v60 = iconst.i32 -4
+;;                                     v66 = band v27, v60  ; v60 = -4
+;;                                     store notrap aligned table v66, v19
+;;                                     v81 = iconst.i32 1
+;;                                     v82 = bor v29, v81  ; v81 = 1
+;;                                     store notrap aligned table v82, v19
+;;                                     jump block8
+;;
+;;                                 block8:
+;;                                     jump block9
+;;
+;;                                 block9:
+;;                                     jump block10
+;;
+;;                                 block10:
+;;                                     v45 = load.i32 notrap aligned table v12
+;;                                     v33 = iconst.i32 -2
+;;                                     v47 = band v45, v33  ; v33 = -2
+;;                                     store notrap aligned table v47, v12
+;;                                     v83 = iconst.i32 1
+;;                                     v84 = bor v45, v83  ; v83 = 1
+;;                                     store notrap aligned table v84, v12
+;;                                     v55 = load.i32 notrap aligned table v19
+;;                                     v85 = iconst.i32 2
+;;                                     v86 = bor v55, v85  ; v85 = 2
+;;                                     store notrap aligned table v86, v19
+;;                                     jump block3
+;;
+;;                                 block3:
+;;                                     jump block11
+;;
+;;                                 block11:
+;; @00f0                               jump block1
+;;
+;;                                 block1:
+;;                                     v70 = iconst.i32 1276
+;; @00f0                               return v70  ; v70 = 1276
+;; }

--- a/tests/disas/component-model/direct-adapter-calls-x64.wat
+++ b/tests/disas/component-model/direct-adapter-calls-x64.wat
@@ -1,6 +1,7 @@
 ;;! target = "x86_64"
 ;;! test = 'compile'
 ;;! filter = "function"
+;;! flags = "-C inlining=n"
 
 ;; Same as `direct-adapter-calls.wat` but shows full compilation down to x86_64
 ;; so that we can exercise our linker's ability to resolve relocations for

--- a/tests/disas/component-model/direct-adapter-calls.wat
+++ b/tests/disas/component-model/direct-adapter-calls.wat
@@ -1,6 +1,7 @@
 ;;! target = "x86_64"
-;;! test = 'optimize'
+;;! test = "optimize"
 ;;! filter = "function"
+;;! flags = "-O compiler-inlining=n"
 
 ;; The following component links two sub-components together and each are only
 ;; instantiated the once, so we statically know what their core modules'

--- a/tests/disas/component-model/direct-adapter-calls.wat
+++ b/tests/disas/component-model/direct-adapter-calls.wat
@@ -1,7 +1,7 @@
 ;;! target = "x86_64"
 ;;! test = "optimize"
 ;;! filter = "function"
-;;! flags = "-O compiler-inlining=n"
+;;! flags = "-C inlining=n"
 
 ;; The following component links two sub-components together and each are only
 ;; instantiated the once, so we statically know what their core modules'


### PR DESCRIPTION
This commit plumbs together two pieces of recently-added infrastructure:

1. function inlining in Cranelift, and
2. the parallel bottom-up inlining scheduler in Wasmtime.

Sprinkle some very simple inlining heuristics on top, and this gives us function
inlining in Wasm compilation.

The default Wasmtime configuration does not enable inlining, and when we do
enable it, we only enable it for cross-component calls by default (since
presumably the toolchain that produced a particular core Wasm module, like LLVM,
already performed any inlining that was beneficial within that module, but that
toolchain couldn't know how that Wasm module would be getting linked together
with other modules via component composition, and so it could not have done any
cross-component inlining). For what it is worth, there is a config knob to
enable intra-module function inlining, but this is primarily for use by our
fuzzers, so that they can easily excercise and explore this new inlining
functionality.

All this plumbing required some changes to the `wasmtime_environ::Compiler`
trait, since Winch cannot do inlining but Cranelift can. This is mostly
encapsulated in the new `wasmtime_environ::InliningCompiler` trait, for the most
part. Additionally, we take care not to construct the call graph, or any other
data structures required only by the inliner and not regular compilation, both
when using Winch and when using Cranelift with inlining disabled.

Finally, we add a `disas` test to verify that we successfully inline a series of
calls from a function in one component, to a cross-component adapter function,
to a function in another component. Most test coverage is expected to come from
our fuzzing, however.


Depends on https://github.com/bytecodealliance/wasmtime/pull/11282