### PR TITLE
allow configurable forbidden header

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -6,6 +6,8 @@ Unreleased.
 
 ### Changed
 
+Users who implemented `WasiHttpView::is_forbidden_header` from `wasmtime-wasi-http` now need to include `DEFAULT_FORBIDDEN_HEADERS`, e.g. `DEFAULT_FORBIDDEN_HEADERS.contains(name) || name.as_str() == "custom-forbidden-header"` #11292
+
 ### Fixed
 
 * Fix a panic in the host caused by preview1 guests using `fd_renumber`.

--- a/crates/wasi-http/src/types_impl.rs
+++ b/crates/wasi-http/src/types_impl.rs
@@ -7,7 +7,7 @@ use crate::{
     types::{
         FieldMap, HostFields, HostFutureIncomingResponse, HostIncomingRequest,
         HostIncomingResponse, HostOutgoingRequest, HostOutgoingResponse, HostResponseOutparam,
-        is_forbidden_header, remove_forbidden_headers,
+        remove_forbidden_headers,
     },
 };
 use anyhow::{Context, anyhow};
@@ -125,7 +125,7 @@ where
                 Err(_) => return Ok(Err(types::HeaderError::InvalidSyntax)),
             };
 
-            if is_forbidden_header(self, &header) {
+            if self.is_forbidden_header(&header) {
                 return Ok(Err(types::HeaderError::Forbidden));
             }
 
@@ -196,7 +196,7 @@ where
             Err(_) => return Ok(Err(types::HeaderError::InvalidSyntax)),
         };
 
-        if is_forbidden_header(self, &header) {
+        if self.is_forbidden_header(&header) {
             return Ok(Err(types::HeaderError::Forbidden));
         }
 
@@ -228,7 +228,7 @@ where
             Err(_) => return Ok(Err(types::HeaderError::InvalidSyntax)),
         };
 
-        if is_forbidden_header(self, &header) {
+        if self.is_forbidden_header(&header) {
             return Ok(Err(types::HeaderError::Forbidden));
         }
 
@@ -248,7 +248,7 @@ where
             Err(_) => return Ok(Err(types::HeaderError::InvalidSyntax)),
         };
 
-        if is_forbidden_header(self, &header) {
+        if self.is_forbidden_header(&header) {
             return Ok(Err(types::HeaderError::Forbidden));
         }
 

--- a/crates/wasi-http/tests/all/p2.rs
+++ b/crates/wasi-http/tests/all/p2.rs
@@ -72,7 +72,8 @@ impl WasiHttpView for Ctx {
     }
 
     fn is_forbidden_header(&mut self, name: &hyper::header::HeaderName) -> bool {
-        name.as_str() == "custom-forbidden-header"
+        types::DEFAULT_FORBIDDEN_HEADERS.contains(name)
+            || name.as_str() == "custom-forbidden-header"
     }
 }
 


### PR DESCRIPTION
When the HTTP library is not used as a proxy, removing of the forbidden headers by default may not make sense. This change makes it configurable via the `WasiHttpView`, which keeps the default behavior.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
