### PR TITLE
Fix linker warnings on macOS

### DIFF
--- a/crates/c-api/CMakeLists.txt
+++ b/crates/c-api/CMakeLists.txt
@@ -96,8 +96,7 @@ else()
         target_link_libraries(wasmtime INTERFACE ${WASMTIME_STATIC_FILES}
             ws2_32 advapi32 userenv ntdll shell32 ole32 bcrypt)
     elseif(WASMTIME_TARGET MATCHES "darwin")
-        target_link_libraries(wasmtime INTERFACE ${WASMTIME_STATIC_FILES}
-            "-framework CoreFoundation")
+        target_link_libraries(wasmtime INTERFACE ${WASMTIME_STATIC_FILES})
     else()
         target_link_libraries(wasmtime INTERFACE ${WASMTIME_STATIC_FILES}
             pthread dl m)


### PR DESCRIPTION
Set up MACOSX_DEPLOYMENT_TARGET correctly
```
ld: warning: object file (target/aarch64-apple-darwin/debug/libwasmtime.a[1054](242b1992def1ef0b-helpers.o)) was built for newer 'macOS' version (15.5) than being linked (11.0)
ld: warning: object file (target/aarch64-apple-darwin/debug/libwasmtime.a[1891](44ff4c55aa9e5133-entropy_common.o)) was built for newer 'macOS' version (15.5) than being linked (11.0)
ld: warning: object file (target/aarch64-apple-darwin/debug/libwasmtime.a[1892](44ff4c55aa9e5133-error_private.o)) was built for newer 'macOS' version (15.5) than being linked (11.0)
ld: warning: object file (target/aarch64-apple-darwin/debug/libwasmtime.a[1893](44ff4c55aa9e5133-fse_decompress.o)) was built for newer 'macOS' version (15.5) than being linked (11.0)
ld: warning: object file (target/aarch64-apple-darwin/debug/libwasmtime.a[1896](44ff4c55aa9e5133-zstd_common.o)) was built for newer 'macOS' version (15.5) than being linked (11.0)
ld: warning: object file (target/aarch64-apple-darwin/debug/libwasmtime.a[1897](fb80479a5fb81f6a-fse_compress.o)) was built for newer 'macOS' version (15.5) than being linked (11.0)
ld: warning: object file (target/aarch64-apple-darwin/debug/libwasmtime.a[1898](fb80479a5fb81f6a-hist.o)) was built for newer 'macOS' version (15.5) than being linked (11.0)
ld: warning: object file (target/aarch64-apple-darwin/debug/libwasmtime.a[1899](fb80479a5fb81f6a-huf_compress.o)) was built for newer 'macOS' version (15.5) than being linked (11.0)
ld: warning: object file (target/aarch64-apple-darwin/debug/libwasmtime.a[1900](fb80479a5fb81f6a-zstd_compress.o)) was built for newer 'macOS' version (15.5) than being linked (11.0)
ld: warning: object file (target/aarch64-apple-darwin/debug/libwasmtime.a[1901](fb80479a5fb81f6a-zstd_compress_literals.o)) was built for newer 'macOS' version (15.5) than being linked (11.0)
ld: warning: object file (target/aarch64-apple-darwin/debug/libwasmtime.a[1902](fb80479a5fb81f6a-zstd_compress_sequences.o)) was built for newer 'macOS' version (15.5) than being linked (11.0)
ld: warning: object file (target/aarch64-apple-darwin/debug/libwasmtime.a[1903](fb80479a5fb81f6a-zstd_compress_superblock.o)) was built for newer 'macOS' version (15.5) than being linked (11.0)
ld: warning: object file (target/aarch64-apple-darwin/debug/libwasmtime.a[1904](fb80479a5fb81f6a-zstd_double_fast.o)) was built for newer 'macOS' version (15.5) than being linked (11.0)
ld: warning: object file (target/aarch64-apple-darwin/debug/libwasmtime.a[1905](fb80479a5fb81f6a-zstd_fast.o)) was built for newer 'macOS' version (15.5) than being linked (11.0)
ld: warning: object file (target/aarch64-apple-darwin/debug/libwasmtime.a[1906](fb80479a5fb81f6a-zstd_lazy.o)) was built for newer 'macOS' version (15.5) than being linked (11.0)
ld: warning: object file (target/aarch64-apple-darwin/debug/libwasmtime.a[1907](fb80479a5fb81f6a-zstd_ldm.o)) was built for newer 'macOS' version (15.5) than being linked (11.0)
ld: warning: object file (target/aarch64-apple-darwin/debug/libwasmtime.a[1908](fb80479a5fb81f6a-zstd_opt.o)) was built for newer 'macOS' version (15.5) than being linked (11.0)
ld: warning: object file (target/aarch64-apple-darwin/debug/libwasmtime.a[1910](88f362f13b0528ed-huf_decompress.o)) was built for newer 'macOS' version (15.5) than being linked (11.0)
ld: warning: object file (target/aarch64-apple-darwin/debug/libwasmtime.a[1911](88f362f13b0528ed-zstd_ddict.o)) was built for newer 'macOS' version (15.5) than being linked (11.0)
ld: warning: object file (target/aarch64-apple-darwin/debug/libwasmtime.a[1912](88f362f13b0528ed-zstd_decompress.o)) was built for newer 'macOS' version (15.5) than being linked (11.0)
ld: warning: object file (target/aarch64-apple-darwin/debug/libwasmtime.a[1913](88f362f13b0528ed-zstd_decompress_block.o)) was built for newer 'macOS' version (15.5) than being linked (11.0)
ld: warning: object file (target/aarch64-apple-darwin/debug/libwasmtime.a[1970](db3b6bfb95261072-gdbjit.o)) was built for newer 'macOS' version (15.5) than being linked (11.0)
```