### PR TITLE
Improve debugging of `tls_sample_application`

### DIFF
--- a/crates/test-programs/src/bin/tls_sample_application.rs
+++ b/crates/test-programs/src/bin/tls_sample_application.rs
@@ -34,10 +34,11 @@ fn test_tls_sample_application(domain: &str, ip: IpAddress) -> Result<()> {
         .context("closing tls connection failed")?;
     socket.shutdown(ShutdownType::Both)?;
 
-    if String::from_utf8(response)?.contains("HTTP/1.1 200 OK") {
+    let response = String::from_utf8(response)?;
+    if response.contains("HTTP/1.1 200 OK") {
         Ok(())
     } else {
-        Err(anyhow!("server did not respond with 200 OK"))
+        Err(anyhow!("server did not respond with 200 OK: {response}"))
     }
 }
 


### PR DESCRIPTION
Despite #11265 this test [still failed][failure] during a backport to the 33.0.0 branch. I don't know what all the domains are returning instead of "200 OK" so this is an attempt to add some debugging to that effect and see if we can catch it in the future.

[failure]: https://github.com/bytecodealliance/wasmtime/actions/runs/16447909572/job/46484874418#step:19:687

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
