### PR TITLE
Allow compiling debug-builtins in no_std environment to enable gdb jit

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -510,7 +510,7 @@ jobs:
           os: ubuntu-latest
           test: >
             cargo check -p wasmtime --no-default-features --features runtime,component-model &&
-            cargo check -p wasmtime --no-default-features --features runtime,gc,component-model,async &&
+            cargo check -p wasmtime --no-default-features --features runtime,gc,component-model,async,debug-builtins &&
             cargo check -p cranelift-control --no-default-features &&
             cargo check -p pulley-interpreter --features encode,decode,disas,interp &&
             cargo check -p wasmtime-wasi-io --no-default-features

--- a/crates/jit-debug/Cargo.toml
+++ b/crates/jit-debug/Cargo.toml
@@ -26,5 +26,6 @@ wasmtime-versioned-export-macros = { workspace = true }
 rustix = { workspace = true, features = ["mm", "time"], optional = true }
 
 [features]
+std = []
 gdb_jit_int = []
-perf_jitdump = ["rustix", "object"]
+perf_jitdump = ["rustix", "object", "std"]

--- a/crates/jit-debug/src/gdb_jit_int.rs
+++ b/crates/jit-debug/src/gdb_jit_int.rs
@@ -2,12 +2,10 @@
 //! the __jit_debug_register_code() and __jit_debug_descriptor to register
 //! or unregister generated object images with debuggers.
 
-#[cfg(not(feature = "std"))]
+extern crate alloc;
+
 use alloc::{boxed::Box, vec::Vec};
-#[cfg(not(feature = "std"))]
 use core::{pin::Pin, ptr};
-#[cfg(feature = "std")]
-use std::{boxed::Box, pin::Pin, ptr, vec::Vec};
 use wasmtime_versioned_export_macros::versioned_link;
 
 #[repr(C)]

--- a/crates/jit-debug/src/lib.rs
+++ b/crates/jit-debug/src/lib.rs
@@ -4,6 +4,12 @@
 //! > you're interested in using this feel free to file an issue on the
 //! > Wasmtime repository to start a discussion about doing so, but otherwise
 //! > be aware that your usage of this crate is not supported.
+#![no_std]
+
+#[cfg(all(feature = "gdb_jit_int", not(feature = "std")))]
+extern crate alloc;
+#[cfg(feature = "std")]
+extern crate std;
 
 #[cfg(feature = "gdb_jit_int")]
 pub mod gdb_jit_int;

--- a/crates/jit-debug/src/lib.rs
+++ b/crates/jit-debug/src/lib.rs
@@ -6,8 +6,6 @@
 //! > be aware that your usage of this crate is not supported.
 #![no_std]
 
-#[cfg(all(feature = "gdb_jit_int", not(feature = "std")))]
-extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
 

--- a/crates/jit-debug/src/perf_jitdump.rs
+++ b/crates/jit-debug/src/perf_jitdump.rs
@@ -16,6 +16,8 @@ use std::io;
 use std::io::Write;
 use std::path::Path;
 use std::ptr;
+use std::string::String;
+use std::vec::Vec;
 use std::{mem, process};
 
 /// Defines jitdump record types

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -19,7 +19,7 @@ all-features = true
 [dependencies]
 wasmtime-asm-macros = { workspace = true, optional = true }
 wasmtime-environ = { workspace = true }
-wasmtime-jit-debug = { workspace = true, features = ["gdb_jit_int", "perf_jitdump"], optional = true }
+wasmtime-jit-debug = { workspace = true, features = [], optional = true }
 wasmtime-jit-icache-coherence = { workspace = true, optional = true }
 wasmtime-cache = { workspace = true, optional = true }
 wasmtime-fiber = { workspace = true, optional = true }
@@ -139,6 +139,8 @@ default = [
   'addr2line',
   'coredump',
   'debug-builtins',
+  'wasmtime-jit-debug/perf_jitdump',
+  'wasmtime-jit-debug/std',
   'runtime',
   'component-model',
   'threads',
@@ -175,12 +177,14 @@ incremental-cache = ["wasmtime-cranelift?/incremental-cache", "std"]
 # Enables support for profiling guest modules.
 profiling = [
   "dep:fxprof-processed-profile",
-  "dep:wasmtime-jit-debug",
   "dep:ittapi",
   "dep:rustix",
   "rustix/thread",
   "dep:serde_json",
   "std",
+  "wasmtime-jit-debug/gdb_jit_int",
+  "wasmtime-jit-debug/perf_jitdump",
+  "wasmtime-jit-debug/std",
 ]
 
 # Enables parallel compilation of WebAssembly code.
@@ -243,7 +247,9 @@ coredump = ["dep:wasm-encoder", "runtime", "std"]
 
 # Export some symbols from the final binary to assist in debugging
 # Cranelift-generated code with native debuggers like GDB and LLDB.
-debug-builtins = ["dep:wasmtime-jit-debug", "std"]
+debug-builtins = [
+  "wasmtime-jit-debug/gdb_jit_int",
+]
 
 # Enable support for executing compiled Wasm modules.
 runtime = [

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -180,9 +180,7 @@ profiling = [
   "rustix/thread",
   "dep:serde_json",
   "std",
-  "wasmtime-jit-debug/gdb_jit_int",
   "wasmtime-jit-debug/perf_jitdump",
-  "wasmtime-jit-debug/std",
 ]
 
 # Enables parallel compilation of WebAssembly code.
@@ -338,6 +336,7 @@ std = [
   'addr2line?/std',
   "dep:rustix",
   "wasmtime-jit-icache-coherence",
+  "wasmtime-jit-debug?/std",
 ]
 
 # Enables support for the `Store::call_hook` API which enables injecting custom

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -19,7 +19,7 @@ all-features = true
 [dependencies]
 wasmtime-asm-macros = { workspace = true, optional = true }
 wasmtime-environ = { workspace = true }
-wasmtime-jit-debug = { workspace = true, features = [], optional = true }
+wasmtime-jit-debug = { workspace = true, optional = true }
 wasmtime-jit-icache-coherence = { workspace = true, optional = true }
 wasmtime-cache = { workspace = true, optional = true }
 wasmtime-fiber = { workspace = true, optional = true }

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -139,8 +139,6 @@ default = [
   'addr2line',
   'coredump',
   'debug-builtins',
-  'wasmtime-jit-debug/perf_jitdump',
-  'wasmtime-jit-debug/std',
   'runtime',
   'component-model',
   'threads',

--- a/crates/wasmtime/build.rs
+++ b/crates/wasmtime/build.rs
@@ -27,10 +27,10 @@ fn main() {
     custom_cfg("has_virtual_memory", has_virtual_memory);
     custom_cfg("has_host_compiler_backend", has_host_compiler_backend);
 
-    // If this OS isn't supported or if Cranelift doesn't support the host then
-    // there's no need to build these helpers.
+    // If this OS isn't supported and no debug-builtins or if Cranelift doesn't support
+    // the host or there's no need to build these helpers.
     #[cfg(feature = "runtime")]
-    if supported_os && has_host_compiler_backend {
+    if has_host_compiler_backend && (supported_os || cfg!(feature = "debug-builtins")) {
         build_c_helpers();
     }
 

--- a/crates/wasmtime/src/engine.rs
+++ b/crates/wasmtime/src/engine.rs
@@ -109,7 +109,7 @@ impl Engine {
             #[cfg(has_native_signals)]
             crate::runtime::vm::init_traps(config.macos_use_mach_ports);
             if !cfg!(miri) {
-                #[cfg(feature = "debug-builtins")]
+                #[cfg(all(has_host_compiler_backend, feature = "debug-builtins"))]
                 crate::runtime::vm::debug_builtins::init();
             }
         }

--- a/crates/wasmtime/src/engine.rs
+++ b/crates/wasmtime/src/engine.rs
@@ -109,7 +109,7 @@ impl Engine {
             #[cfg(has_native_signals)]
             crate::runtime::vm::init_traps(config.macos_use_mach_ports);
             if !cfg!(miri) {
-                #[cfg(all(has_host_compiler_backend, feature = "debug-builtins"))]
+                #[cfg(feature = "debug-builtins")]
                 crate::runtime::vm::debug_builtins::init();
             }
         }

--- a/crates/wasmtime/src/runtime/vm/debug_builtins.rs
+++ b/crates/wasmtime/src/runtime/vm/debug_builtins.rs
@@ -14,7 +14,7 @@ static mut VMCTX_AND_MEMORY: (NonNull<VMContext>, usize) = (NonNull::dangling(),
 #[versioned_export]
 pub unsafe extern "C" fn resolve_vmctx_memory_ptr(p: *const u32) -> *const u8 {
     unsafe {
-        let ptr = std::ptr::read(p);
+        let ptr = core::ptr::read(p);
         assert!(
             VMCTX_AND_MEMORY.0 != NonNull::dangling(),
             "must call `__vmctx->set()` before resolving Wasm pointers"


### PR DESCRIPTION
## Description
This PR takes care of enabling the compilation of `gdb_jit_int` module in the `jit-debug` crate to ensure the native debugging also works in `no_std` environments.

My aim is to have this in for the LTS version 36.0.0 😃 

This work has been discussed in [#wasmtime > Debugging a wasm module in a hyperlight guest](https://bytecodealliance.zulipchat.com/#narrow/channel/217126-wasmtime/topic/Debugging.20a.20wasm.20module.20in.20a.20hyperlight.20guest).

## Summary
- Make `jit-debug` crate `#![no_std]` when `perf_jitdebug` is not enabled
- Make `gdb_jit_int` module build in `no_std` environment
- Use std when `perf_jitdebug` is enabled because the `perf_jitdebug` module does not run in `no_std` environment
- Split `debug-builtins` feature into `debug-builtins` and `perf-builtins` to individually toggle:
    - the `no_std` `gdb_jit_int` module by using `debug-builtins`
    - the std `perf_jitdebug` module using `perf-builtins`. NOTE: They can be both enabled, but it won't support `no_std`.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
