### PR TITLE
Relax ELF alignment requirement internally

### DIFF
--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -49,7 +49,7 @@ postcard = { workspace = true }
 indexmap = { workspace = true }
 once_cell = { version = "1.12.0", optional = true }
 rayon = { version = "1.0", optional = true }
-object = { workspace = true }
+object = { workspace = true, features = ['unaligned'] }
 async-trait = { workspace = true, optional = true }
 trait-variant = { workspace = true, optional = true }
 encoding_rs = { version = "0.8.31", optional = true }


### PR DESCRIPTION
This commit relaxes the requirement that all `*.cwasm` images are aligned for their ELF header by enabling the `unaligned` feature of the `object` crate. This is useful in scenarios where paging isn't in use and shouldn't, in theory, impact preexisting scenarios where everything happens to already be aligned.

Closes #11300

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
