### PR TITLE
Remove unused wiggle GuestError variants

### DIFF
--- a/crates/wasi-common/src/snapshots/preview_1/error.rs
+++ b/crates/wasi-common/src/snapshots/preview_1/error.rs
@@ -249,11 +249,9 @@ impl From<wiggle::GuestError> for Error {
             PtrOverflow { .. } | PtrOutOfBounds { .. } | PtrNotAligned { .. } => {
                 Error::trap(err.into())
             }
-            PtrBorrowed { .. } => Errno::Fault.into(),
             InvalidUtf8 { .. } => Errno::Ilseq.into(),
             TryFromIntError { .. } => Errno::Overflow.into(),
             SliceLengthsDiffer { .. } => Errno::Fault.into(),
-            BorrowCheckerOutOfHandles { .. } => Errno::Fault.into(),
             InFunc { err, .. } => Error::from(*err),
         }
     }

--- a/crates/wasi/src/preview1.rs
+++ b/crates/wasi/src/preview1.rs
@@ -1044,11 +1044,9 @@ impl From<GuestError> for types::Error {
             PtrOverflow { .. } | PtrOutOfBounds { .. } | PtrNotAligned { .. } => {
                 types::Error::trap(err.into())
             }
-            PtrBorrowed { .. } => types::Errno::Fault.into(),
             InvalidUtf8 { .. } => types::Errno::Ilseq.into(),
             TryFromIntError { .. } => types::Errno::Overflow.into(),
             SliceLengthsDiffer { .. } => types::Errno::Fault.into(),
-            BorrowCheckerOutOfHandles { .. } => types::Errno::Fault.into(),
             InFunc { err, .. } => types::Error::from(*err),
         }
     }

--- a/crates/wiggle/src/error.rs
+++ b/crates/wiggle/src/error.rs
@@ -13,10 +13,6 @@ pub enum GuestError {
     PtrOutOfBounds(Region),
     #[error("Pointer not aligned to {1}: {0:?}")]
     PtrNotAligned(Region, u32),
-    #[error("Pointer already borrowed: {0:?}")]
-    PtrBorrowed(Region),
-    #[error("Borrow checker out of handles")]
-    BorrowCheckerOutOfHandles,
     #[error("Slice length mismatch")]
     SliceLengthsDiffer,
     #[error("In func {modulename}::{funcname} at {location}: {err}")]


### PR DESCRIPTION
These variants were related to the runtime borrow checker, and are no longer constructed anywhere since #8277 (for `BorrowCheckerOutOfHandles`) and #8702 (for `PtrBorrowed`).

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
