### PR TITLE
Fix linker error for downstream project

### DIFF
--- a/crates/c-api/CMakeLists.txt
+++ b/crates/c-api/CMakeLists.txt
@@ -96,7 +96,8 @@ else()
         target_link_libraries(wasmtime INTERFACE ${WASMTIME_STATIC_FILES}
             ws2_32 advapi32 userenv ntdll shell32 ole32 bcrypt)
     elseif(WASMTIME_TARGET MATCHES "darwin")
-        target_link_libraries(wasmtime INTERFACE ${WASMTIME_STATIC_FILES})
+        target_link_libraries(wasmtime INTERFACE ${WASMTIME_STATIC_FILES}
+            "-framework CoreFoundation")
     else()
         target_link_libraries(wasmtime INTERFACE ${WASMTIME_STATIC_FILES}
             pthread dl m)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -24,9 +24,6 @@ function(CREATE_TARGET TARGET TARGET_PATH)
 
   target_include_directories(wasmtime-${TARGET} PUBLIC wasmtime)
   target_link_libraries(wasmtime-${TARGET} PUBLIC wasmtime)
-  if(APPLE)
-    target_link_libraries(wasmtime-${TARGET} PRIVATE "-framework CoreFoundation")
-  endif()
   add_test(NAME ${TARGET}-c COMMAND wasmtime-${TARGET} WORKING_DIRECTORY ../..)
 endfunction()
 


### PR DESCRIPTION
```
Undefined symbols for architecture arm64:
  "_CFRelease", referenced from:
      _$LT$iana_time_zone..platform..system_time_zone..SystemTimeZone$u20$as$u20$core..ops..drop..Drop$GT$::drop::hbe05ab81c8aa1895 in libwasmtime.a[770](iana_time_zone-751748d2983d7843.iana_time_zone.76c62ed0e50067e-cgu.0.rcgu.o)
  "_CFStringGetBytes", referenced from:
      iana_time_zone::platform::string_ref::StringRef$LT$T$GT$::to_utf8::h49322ae39bd5c38e in libwasmtime.a[770](iana_time_zone-751748d2983d7843.iana_time_zone.76c62ed0e50067e-cgu.0.rcgu.o)
  "_CFStringGetCStringPtr", referenced from:
      iana_time_zone::platform::string_ref::StringRef$LT$T$GT$::as_utf8::h4b4b4b7548589d47 in libwasmtime.a[770](iana_time_zone-751748d2983d7843.iana_time_zone.76c62ed0e50067e-cgu.0.rcgu.o)
  "_CFStringGetLength", referenced from:
      iana_time_zone::platform::string_ref::StringRef$LT$T$GT$::to_utf8::h49322ae39bd5c38e in libwasmtime.a[770](iana_time_zone-751748d2983d7843.iana_time_zone.76c62ed0e50067e-cgu.0.rcgu.o)
  "_CFTimeZoneCopySystem", referenced from:
      iana_time_zone::platform::system_time_zone::SystemTimeZone::new::h3b802fbfcb488c18 in libwasmtime.a[770](iana_time_zone-751748d2983d7843.iana_time_zone.76c62ed0e50067e-cgu.0.rcgu.o)
  "_CFTimeZoneGetName", referenced from:
      iana_time_zone::platform::system_time_zone::SystemTimeZone::name::h92132c16acf40afe in libwasmtime.a[770](iana_time_zone-751748d2983d7843.iana_time_zone.76c62ed0e50067e-cgu.0.rcgu.o)
```