### PR TITLE
Document subtlety of safety conditions for `vm::Instance::sibling_vmctx_mut`

### DIFF
--- a/crates/wasmtime/src/runtime/vm/instance.rs
+++ b/crates/wasmtime/src/runtime/vm/instance.rs
@@ -354,6 +354,14 @@ impl Instance {
     ///
     /// This function requires that the `vmctx` pointer is indeed valid and
     /// from the store that `self` belongs to.
+    ///
+    /// (Note that it is *NOT* required that `vmctx` be distinct from this
+    /// instance's `vmctx`, or that usage of the resulting instance is limited
+    /// to its defined items! The returned borrow has the same lifetime as
+    /// `self`, which means that this instance cannot be used while the
+    /// resulting instance is in use, and we therefore do not need to worry
+    /// about mutable aliasing between this instance and the resulting
+    /// instance.)
     #[inline]
     unsafe fn sibling_vmctx_mut<'a>(
         self: Pin<&'a mut Self>,


### PR DESCRIPTION
I initially thought that the documentation was missing a safety invariant that callers must uphold, and then realized that it was a little subtler than I originally thought, so I updated the documentation to clarify this for future readers.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
