### PR TITLE
Make `Val::to_raw` a safe function

### DIFF
--- a/crates/wasmtime/src/runtime/gc/disabled/anyref.rs
+++ b/crates/wasmtime/src/runtime/gc/disabled/anyref.rs
@@ -61,17 +61,17 @@ impl AnyRef {
         unreachable!()
     }
 
-    pub unsafe fn from_raw(_store: impl AsContextMut, raw: u32) -> Option<Rooted<Self>> {
+    pub fn from_raw(_store: impl AsContextMut, raw: u32) -> Option<Rooted<Self>> {
         assert_eq!(raw, 0);
         None
     }
 
-    pub unsafe fn _from_raw(_store: &mut AutoAssertNoGc<'_>, raw: u32) -> Option<Rooted<Self>> {
+    pub fn _from_raw(_store: &mut AutoAssertNoGc<'_>, raw: u32) -> Option<Rooted<Self>> {
         assert_eq!(raw, 0);
         None
     }
 
-    pub unsafe fn to_raw(&self, _store: impl AsContextMut) -> Result<u32> {
+    pub fn to_raw(&self, _store: impl AsContextMut) -> Result<u32> {
         match *self {}
     }
 

--- a/crates/wasmtime/src/runtime/gc/disabled/exnref.rs
+++ b/crates/wasmtime/src/runtime/gc/disabled/exnref.rs
@@ -16,7 +16,7 @@ pub enum ExnRef {}
 impl GcRefImpl for ExnRef {}
 
 impl ExnRef {
-    pub unsafe fn from_raw(_store: impl AsContextMut, _raw: u32) -> Option<Rooted<Self>> {
+    pub fn from_raw(_store: impl AsContextMut, _raw: u32) -> Option<Rooted<Self>> {
         None
     }
 
@@ -24,11 +24,11 @@ impl ExnRef {
         None
     }
 
-    pub unsafe fn to_raw(&self, _store: impl AsContextMut) -> Result<u32> {
+    pub fn to_raw(&self, _store: impl AsContextMut) -> Result<u32> {
         Ok(0)
     }
 
-    pub(crate) unsafe fn _to_raw(&self, _store: &mut AutoAssertNoGc<'_>) -> Result<u32> {
+    pub(crate) fn _to_raw(&self, _store: &mut AutoAssertNoGc<'_>) -> Result<u32> {
         Ok(0)
     }
 

--- a/crates/wasmtime/src/runtime/gc/disabled/externref.rs
+++ b/crates/wasmtime/src/runtime/gc/disabled/externref.rs
@@ -38,17 +38,17 @@ impl ExternRef {
         match *self {}
     }
 
-    pub unsafe fn from_raw(_store: impl AsContextMut, raw: u32) -> Option<Rooted<Self>> {
+    pub fn from_raw(_store: impl AsContextMut, raw: u32) -> Option<Rooted<Self>> {
         assert_eq!(raw, 0);
         None
     }
 
-    pub unsafe fn _from_raw(_store: &mut AutoAssertNoGc<'_>, raw: u32) -> Option<Rooted<Self>> {
+    pub fn _from_raw(_store: &mut AutoAssertNoGc<'_>, raw: u32) -> Option<Rooted<Self>> {
         assert_eq!(raw, 0);
         None
     }
 
-    pub unsafe fn to_raw(&self, _store: impl AsContextMut) -> Result<u32> {
+    pub fn to_raw(&self, _store: impl AsContextMut) -> Result<u32> {
         match *self {}
     }
 }

--- a/crates/wasmtime/src/runtime/gc/enabled/anyref.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/anyref.rs
@@ -249,27 +249,30 @@ impl AnyRef {
     /// This function assumes that `raw` is an `anyref` value which is currently
     /// rooted within the [`Store`].
     ///
-    /// # Unsafety
+    /// # Correctness
     ///
-    /// This function is particularly `unsafe` because `raw` not only must be a
-    /// valid `anyref` value produced prior by [`AnyRef::to_raw`] but it must
-    /// also be correctly rooted within the store. When arguments are provided
-    /// to a callback with [`Func::new_unchecked`], for example, or returned via
-    /// [`Func::call_unchecked`], if a GC is performed within the store then
-    /// floating `anyref` values are not rooted and will be GC'd, meaning that
-    /// this function will no longer be safe to call with the values cleaned up.
-    /// This function must be invoked *before* possible GC operations can happen
-    /// (such as calling Wasm).
+    /// This function is tricky to get right because `raw` not only must be a
+    /// valid `anyref` value produced prior by [`AnyRef::to_raw`] but it
+    /// must also be correctly rooted within the store. When arguments are
+    /// provided to a callback with [`Func::new_unchecked`], for example, or
+    /// returned via [`Func::call_unchecked`], if a GC is performed within the
+    /// store then floating `anyref` values are not rooted and will be GC'd,
+    /// meaning that this function will no longer be correct to call with the
+    /// values cleaned up. This function must be invoked *before* possible GC
+    /// operations can happen (such as calling Wasm).
     ///
-    /// When in doubt try to not use this. Instead use the safe Rust APIs of
-    /// [`TypedFunc`] and friends.
+    ///
+    /// When in doubt try to not use this. Instead use the Rust APIs of
+    /// [`TypedFunc`] and friends. Note though that this function is not
+    /// `unsafe` as any value can be passed in. Incorrect values can result in
+    /// runtime panics, however, so care must still be taken with this method.
     ///
     /// [`Func::call_unchecked`]: crate::Func::call_unchecked
     /// [`Func::new_unchecked`]: crate::Func::new_unchecked
     /// [`Store`]: crate::Store
     /// [`TypedFunc`]: crate::TypedFunc
     /// [`ValRaw`]: crate::ValRaw
-    pub unsafe fn from_raw(mut store: impl AsContextMut, raw: u32) -> Option<Rooted<Self>> {
+    pub fn from_raw(mut store: impl AsContextMut, raw: u32) -> Option<Rooted<Self>> {
         let mut store = AutoAssertNoGc::new(store.as_context_mut().0);
         Self::_from_raw(&mut store, raw)
     }
@@ -320,19 +323,19 @@ impl AnyRef {
     ///
     /// Returns an error if this `anyref` has been unrooted.
     ///
-    /// # Unsafety
+    /// # Correctness
     ///
-    /// Produces a raw value which is only safe to pass into a store if a GC
+    /// Produces a raw value which is only valid to pass into a store if a GC
     /// doesn't happen between when the value is produce and when it's passed
     /// into the store.
     ///
     /// [`ValRaw`]: crate::ValRaw
-    pub unsafe fn to_raw(&self, mut store: impl AsContextMut) -> Result<u32> {
+    pub fn to_raw(&self, mut store: impl AsContextMut) -> Result<u32> {
         let mut store = AutoAssertNoGc::new(store.as_context_mut().0);
         self._to_raw(&mut store)
     }
 
-    pub(crate) unsafe fn _to_raw(&self, store: &mut AutoAssertNoGc<'_>) -> Result<u32> {
+    pub(crate) fn _to_raw(&self, store: &mut AutoAssertNoGc<'_>) -> Result<u32> {
         let gc_ref = self.inner.try_clone_gc_ref(store)?;
         let raw = if gc_ref.is_i31() {
             gc_ref.as_raw_non_zero_u32()

--- a/crates/wasmtime/src/runtime/gc/enabled/externref.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/externref.rs
@@ -548,27 +548,30 @@ impl ExternRef {
     /// This function assumes that `raw` is an externref value which is
     /// currently rooted within the [`Store`].
     ///
-    /// # Unsafety
+    /// # Correctness
     ///
-    /// This function is particularly `unsafe` because `raw` not only must be a
-    /// valid externref value produced prior by `to_raw` but it must also be
-    /// correctly rooted within the store. When arguments are provided to a
-    /// callback with [`Func::new_unchecked`], for example, or returned via
-    /// [`Func::call_unchecked`], if a GC is performed within the store then
-    /// floating externref values are not rooted and will be GC'd, meaning that
-    /// this function will no longer be safe to call with the values cleaned up.
-    /// This function must be invoked *before* possible GC operations can happen
-    /// (such as calling wasm).
+    /// This function is tricky to get right because `raw` not only must be a
+    /// valid `externref` value produced prior by [`ExternRef::to_raw`] but it
+    /// must also be correctly rooted within the store. When arguments are
+    /// provided to a callback with [`Func::new_unchecked`], for example, or
+    /// returned via [`Func::call_unchecked`], if a GC is performed within the
+    /// store then floating `externref` values are not rooted and will be GC'd,
+    /// meaning that this function will no longer be correct to call with the
+    /// values cleaned up. This function must be invoked *before* possible GC
+    /// operations can happen (such as calling Wasm).
     ///
-    /// When in doubt try to not use this. Instead use the safe Rust APIs of
-    /// [`TypedFunc`] and friends.
+    ///
+    /// When in doubt try to not use this. Instead use the Rust APIs of
+    /// [`TypedFunc`] and friends. Note though that this function is not
+    /// `unsafe` as any value can be passed in. Incorrect values can result in
+    /// runtime panics, however, so care must still be taken with this method.
     ///
     /// [`Func::call_unchecked`]: crate::Func::call_unchecked
     /// [`Func::new_unchecked`]: crate::Func::new_unchecked
     /// [`Store`]: crate::Store
     /// [`TypedFunc`]: crate::TypedFunc
     /// [`ValRaw`]: crate::ValRaw
-    pub unsafe fn from_raw(mut store: impl AsContextMut, raw: u32) -> Option<Rooted<ExternRef>> {
+    pub fn from_raw(mut store: impl AsContextMut, raw: u32) -> Option<Rooted<ExternRef>> {
         let mut store = AutoAssertNoGc::new(store.as_context_mut().0);
         Self::_from_raw(&mut store, raw)
     }
@@ -585,14 +588,14 @@ impl ExternRef {
     ///
     /// Returns an error if this `externref` has been unrooted.
     ///
-    /// # Unsafety
+    /// # Correctness
     ///
-    /// Produces a raw value which is only safe to pass into a store if a GC
+    /// Produces a raw value which is only valid to pass into a store if a GC
     /// doesn't happen between when the value is produce and when it's passed
     /// into the store.
     ///
     /// [`ValRaw`]: crate::ValRaw
-    pub unsafe fn to_raw(&self, mut store: impl AsContextMut) -> Result<u32> {
+    pub fn to_raw(&self, mut store: impl AsContextMut) -> Result<u32> {
         let mut store = AutoAssertNoGc::new(store.as_context_mut().0);
         self._to_raw(&mut store)
     }

--- a/crates/wasmtime/src/runtime/values.rs
+++ b/crates/wasmtime/src/runtime/values.rs
@@ -230,11 +230,12 @@ impl Val {
     /// Returns an error if this value is a GC reference and the GC reference
     /// has been unrooted.
     ///
-    /// # Unsafety
+    /// # Safety
     ///
-    /// This method is unsafe for the reasons that [`ExternRef::to_raw`] and
-    /// [`Func::to_raw`] are unsafe.
-    pub unsafe fn to_raw(&self, store: impl AsContextMut) -> Result<ValRaw> {
+    /// The returned [`ValRaw`] does not carry type information and is only safe
+    /// to use within the context of this store itself. For more information see
+    /// [`ExternRef::to_raw`] and [`Func::to_raw`].
+    pub fn to_raw(&self, store: impl AsContextMut) -> Result<ValRaw> {
         match self {
             Val::I32(i) => Ok(ValRaw::i32(*i)),
             Val::I64(i) => Ok(ValRaw::i64(*i)),

--- a/crates/wasmtime/src/runtime/vm/const_expr.rs
+++ b/crates/wasmtime/src/runtime/vm/const_expr.rs
@@ -88,7 +88,7 @@ impl ConstEvalContext {
 
         let allocator = StructRefPre::_new(store, struct_ty);
         let struct_ref = unsafe { StructRef::new_maybe_async(store, &allocator, &fields)? };
-        let raw = unsafe { struct_ref.to_anyref()._to_raw(store)? };
+        let raw = struct_ref.to_anyref()._to_raw(store)?;
         Ok(ValRaw::anyref(raw))
     }
 
@@ -293,7 +293,7 @@ impl ConstExprEvaluator {
                     let array = unsafe { ArrayRef::new_maybe_async(&mut store, &pre, &elem, len)? };
 
                     self.stack
-                        .push(unsafe { ValRaw::anyref(array.to_anyref()._to_raw(&mut store)?) });
+                        .push(ValRaw::anyref(array.to_anyref()._to_raw(&mut store)?));
                 }
 
                 #[cfg(feature = "gc")]
@@ -311,7 +311,7 @@ impl ConstExprEvaluator {
                     let array = unsafe { ArrayRef::new_maybe_async(&mut store, &pre, &elem, len)? };
 
                     self.stack
-                        .push(unsafe { ValRaw::anyref(array.to_anyref()._to_raw(&mut store)?) });
+                        .push(ValRaw::anyref(array.to_anyref()._to_raw(&mut store)?));
                 }
 
                 #[cfg(feature = "gc")]
@@ -347,7 +347,7 @@ impl ConstExprEvaluator {
                         unsafe { ArrayRef::new_fixed_maybe_async(&mut store, &pre, &elems)? };
 
                     self.stack
-                        .push(unsafe { ValRaw::anyref(array.to_anyref()._to_raw(&mut store)?) });
+                        .push(ValRaw::anyref(array.to_anyref()._to_raw(&mut store)?));
                 }
 
                 #[cfg(feature = "gc")]
@@ -363,13 +363,12 @@ impl ConstExprEvaluator {
 
                 #[cfg(feature = "gc")]
                 ConstOp::AnyConvertExtern => {
-                    let result = match ExternRef::_from_raw(&mut store, self.pop()?.get_externref())
-                    {
-                        Some(externref) => unsafe {
-                            AnyRef::_convert_extern(&mut store, externref)?._to_raw(&mut store)?
-                        },
-                        None => 0,
-                    };
+                    let result =
+                        match ExternRef::_from_raw(&mut store, self.pop()?.get_externref()) {
+                            Some(externref) => AnyRef::_convert_extern(&mut store, externref)?
+                                ._to_raw(&mut store)?,
+                            None => 0,
+                        };
                     self.stack.push(ValRaw::anyref(result));
                 }
             }

--- a/tests/all/gc.rs
+++ b/tests/all/gc.rs
@@ -818,8 +818,8 @@ fn to_raw_from_raw_doesnt_leak() -> Result<()> {
     {
         let mut scope = RootScope::new(&mut store);
         let x = ExternRef::new(&mut scope, SetFlagOnDrop(flag.clone()))?;
-        let raw = unsafe { x.to_raw(&mut scope)? };
-        let _x = unsafe { ExternRef::from_raw(&mut scope, raw) };
+        let raw = x.to_raw(&mut scope)?;
+        let _x = ExternRef::from_raw(&mut scope, raw);
     }
 
     store.gc(None);

--- a/tests/all/i31ref.rs
+++ b/tests/all/i31ref.rs
@@ -33,8 +33,8 @@ fn i31ref_to_raw_round_trip() -> Result<()> {
     // back again even though we have not forced the allocation of the `GcStore`
     // yet.
     let anyref = AnyRef::from_i31(&mut store, I31::wrapping_u32(42));
-    let raw = unsafe { anyref.to_raw(&mut store)? };
-    let anyref = unsafe { AnyRef::from_raw(&mut store, raw).expect("should be non-null") };
+    let raw = anyref.to_raw(&mut store)?;
+    let anyref = AnyRef::from_raw(&mut store, raw).expect("should be non-null");
     assert!(anyref.is_i31(&store)?);
     assert_eq!(anyref.as_i31(&store)?.unwrap().get_u32(), 42);
 


### PR DESCRIPTION
This commit updates Wasmtime's core `Val::to_raw` function a safe function. This was previously marked as `unsafe` with documentation that the raw pointer could be invalid, but that's not a reason for the function itself to be `unsafe`. Usage of the returned value is still `unsafe`, but simply acquiring the value is not itself an unsafe operation.

This additionally marks a number of GC-related `from_raw` functions as safe. Wasmtime's GC is safe in the face of heap corruption, so it's memory safe to pass in any 32-bit value. Documentation still indicates that panics are possible, however.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
