### PR TITLE
Raise `unsafe_op_in_unsafe_fn` further in Wasmtime

### DIFF
--- a/crates/wasmtime/src/runtime.rs
+++ b/crates/wasmtime/src/runtime.rs
@@ -25,6 +25,10 @@
 // explanation of why truncation shouldn't be happening at runtime. This
 // situation should be pretty rare though.
 #![warn(clippy::cast_possible_truncation)]
+#![warn(
+    unsafe_op_in_unsafe_fn,
+    reason = "opt-in until the crate opts-in as a whole -- #11180"
+)]
 
 #[macro_use]
 pub(crate) mod func;

--- a/crates/wasmtime/src/runtime/code_memory.rs
+++ b/crates/wasmtime/src/runtime/code_memory.rs
@@ -394,12 +394,14 @@ impl CodeMemory {
         {
             let text = self.text();
             let unwind_info = &self.mmap[self.unwind.clone()];
-            let registration = crate::runtime::vm::UnwindRegistration::new(
-                text.as_ptr(),
-                unwind_info.as_ptr(),
-                unwind_info.len(),
-            )
-            .context("failed to create unwind info registration")?;
+            let registration = unsafe {
+                crate::runtime::vm::UnwindRegistration::new(
+                    text.as_ptr(),
+                    unwind_info.as_ptr(),
+                    unwind_info.len(),
+                )
+                .context("failed to create unwind info registration")?
+            };
             self.unwind_registration = Some(registration);
             return Ok(());
         }

--- a/crates/wasmtime/src/runtime/component/component.rs
+++ b/crates/wasmtime/src/runtime/component/component.rs
@@ -223,7 +223,9 @@ impl Component {
     /// lives for as long as the module and is nevery externally modified for
     /// the lifetime of the deserialized module.
     pub unsafe fn deserialize_raw(engine: &Engine, memory: NonNull<[u8]>) -> Result<Component> {
-        let code = engine.load_code_raw(memory, ObjectKind::Component)?;
+        // SAFETY: the contract required by `load_code_raw` is the same as this
+        // function.
+        let code = unsafe { engine.load_code_raw(memory, ObjectKind::Component)? };
         Component::from_parts(engine, code, None)
     }
 

--- a/crates/wasmtime/src/runtime/component/concurrent.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent.rs
@@ -1,5 +1,3 @@
-#![deny(unsafe_op_in_unsafe_fn)]
-
 //! Runtime support for the Component Model Async ABI.
 //!
 //! This module and its submodules provide host runtime support for Component

--- a/crates/wasmtime/src/runtime/component/func/typed.rs
+++ b/crates/wasmtime/src/runtime/component/func/typed.rs
@@ -2404,8 +2404,8 @@ pub unsafe fn lower_payload<P, T>(
     let typed = typed_payload(payload);
     lower(typed)?;
 
-    let typed_len = storage_as_slice(typed).len();
-    let payload = storage_as_slice_mut(payload);
+    let typed_len = unsafe { storage_as_slice(typed).len() };
+    let payload = unsafe { storage_as_slice_mut(payload) };
     for slot in payload[typed_len..].iter_mut() {
         slot.write(ValRaw::u64(0));
     }

--- a/crates/wasmtime/src/runtime/component/storage.rs
+++ b/crates/wasmtime/src/runtime/component/storage.rs
@@ -12,20 +12,24 @@ fn assert_raw_slice_compat<T>() {
 pub unsafe fn storage_as_slice<T>(storage: &T) -> &[ValRaw] {
     assert_raw_slice_compat::<T>();
 
-    slice::from_raw_parts(
-        (storage as *const T).cast(),
-        mem::size_of_val(storage) / mem::size_of::<ValRaw>(),
-    )
+    unsafe {
+        slice::from_raw_parts(
+            (storage as *const T).cast(),
+            mem::size_of_val(storage) / mem::size_of::<ValRaw>(),
+        )
+    }
 }
 
 /// Same as `storage_as_slice`, but mutable.
 pub unsafe fn storage_as_slice_mut<T>(storage: &mut MaybeUninit<T>) -> &mut [MaybeUninit<ValRaw>] {
     assert_raw_slice_compat::<T>();
 
-    slice::from_raw_parts_mut(
-        (storage as *mut MaybeUninit<T>).cast(),
-        mem::size_of_val(storage) / mem::size_of::<ValRaw>(),
-    )
+    unsafe {
+        slice::from_raw_parts_mut(
+            (storage as *mut MaybeUninit<T>).cast(),
+            mem::size_of_val(storage) / mem::size_of::<ValRaw>(),
+        )
+    }
 }
 
 /// Same as `storage_as_slice`, but in reverse and mutable.
@@ -44,7 +48,7 @@ pub unsafe fn slice_to_storage_mut<T>(slice: &mut [MaybeUninit<ValRaw>]) -> &mut
         mem::size_of_val(slice)
     );
 
-    &mut *slice.as_mut_ptr().cast()
+    unsafe { &mut *slice.as_mut_ptr().cast() }
 }
 
 /// Same as `storage_as_slice`, but in reverse
@@ -61,5 +65,5 @@ pub unsafe fn slice_to_storage<T>(slice: &[ValRaw]) -> &T {
         mem::size_of_val(slice)
     );
 
-    &*slice.as_ptr().cast()
+    unsafe { &*slice.as_ptr().cast() }
 }

--- a/crates/wasmtime/src/runtime/fiber.rs
+++ b/crates/wasmtime/src/runtime/fiber.rs
@@ -1,5 +1,3 @@
-#![deny(unsafe_op_in_unsafe_fn)]
-
 use crate::prelude::*;
 use crate::store::{Executor, StoreId, StoreInner, StoreOpaque};
 use crate::vm::mpk::{self, ProtectionMask};

--- a/crates/wasmtime/src/runtime/store.rs
+++ b/crates/wasmtime/src/runtime/store.rs
@@ -2300,7 +2300,7 @@ unsafe impl<T> vm::VMStore for StoreInner<T> {
         root: Option<VMGcRef>,
         bytes_needed: Option<u64>,
     ) -> Result<Option<VMGcRef>> {
-        self.inner.maybe_async_gc(root, bytes_needed)
+        unsafe { self.inner.maybe_async_gc(root, bytes_needed) }
     }
 
     #[cfg(not(feature = "gc"))]

--- a/crates/wasmtime/src/runtime/store/gc.rs
+++ b/crates/wasmtime/src/runtime/store/gc.rs
@@ -194,7 +194,11 @@ impl StoreOpaque {
             Err(e) => match e.downcast::<crate::GcHeapOutOfMemory<T>>() {
                 Ok(oom) => {
                     let (value, oom) = oom.take_inner();
-                    self.maybe_async_gc(None, Some(oom.bytes_needed()))?;
+                    // SAFETY: it's the caller's responsibility to ensure that
+                    // this is on a fiber stack if necessary.
+                    unsafe {
+                        self.maybe_async_gc(None, Some(oom.bytes_needed()))?;
+                    }
                     alloc_func(self, value)
                 }
                 Err(e) => Err(e),

--- a/crates/wasmtime/src/runtime/trampoline/memory.rs
+++ b/crates/wasmtime/src/runtime/trampoline/memory.rs
@@ -197,8 +197,10 @@ unsafe impl InstanceAllocatorImpl for SingleMemoryInstance<'_> {
         allocation_index: MemoryAllocationIndex,
         memory: Memory,
     ) {
-        self.ondemand
-            .deallocate_memory(memory_index, allocation_index, memory)
+        unsafe {
+            self.ondemand
+                .deallocate_memory(memory_index, allocation_index, memory)
+        }
     }
 
     fn allocate_table(
@@ -217,8 +219,10 @@ unsafe impl InstanceAllocatorImpl for SingleMemoryInstance<'_> {
         allocation_index: TableAllocationIndex,
         table: Table,
     ) {
-        self.ondemand
-            .deallocate_table(table_index, allocation_index, table)
+        unsafe {
+            self.ondemand
+                .deallocate_table(table_index, allocation_index, table)
+        }
     }
 
     #[cfg(feature = "async")]

--- a/crates/wasmtime/src/runtime/vm.rs
+++ b/crates/wasmtime/src/runtime/vm.rs
@@ -4,10 +4,6 @@
 // See documentation in crates/wasmtime/src/runtime.rs for why this is
 // selectively enabled here.
 #![warn(clippy::cast_sign_loss)]
-#![warn(
-    unsafe_op_in_unsafe_fn,
-    reason = "opt-in until the crate opts-in as a whole -- #11180"
-)]
 
 // Polyfill `std::simd::i8x16` etc. until they're stable.
 #[cfg(all(target_arch = "x86_64", target_feature = "sse"))]


### PR DESCRIPTION
Now it's at `wasmtime::runtime`, not just `wasmtime::runtime::vm`.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
