### PR TITLE
Package component model options in an index

### DIFF
--- a/crates/environ/src/component.rs
+++ b/crates/environ/src/component.rs
@@ -100,15 +100,15 @@ macro_rules! foreach_builtin_component_function {
             #[cfg(feature = "component-model-async")]
             backpressure_set(vmctx: vmctx, caller_instance: u32, enabled: u32) -> bool;
             #[cfg(feature = "component-model-async")]
-            task_return(vmctx: vmctx, ty: u32, memory: ptr_u8, string_encoding: u8, storage: ptr_u8, storage_len: size) -> bool;
+            task_return(vmctx: vmctx, ty: u32, options: u32, storage: ptr_u8, storage_len: size) -> bool;
             #[cfg(feature = "component-model-async")]
             task_cancel(vmctx: vmctx, caller_instance: u32) -> bool;
             #[cfg(feature = "component-model-async")]
             waitable_set_new(vmctx: vmctx, caller_instance: u32) -> u64;
             #[cfg(feature = "component-model-async")]
-            waitable_set_wait(vmctx: vmctx, caller_instance: u32, async_: u8, memory: ptr_u8, set: u32, payload: u32) -> u64;
+            waitable_set_wait(vmctx: vmctx, options: u32, set: u32, payload: u32) -> u64;
             #[cfg(feature = "component-model-async")]
-            waitable_set_poll(vmctx: vmctx, caller_instance: u32, async_: u8, memory: ptr_u8, set: u32, payload: u32) -> u64;
+            waitable_set_poll(vmctx: vmctx, options: u32, set: u32, payload: u32) -> u64;
             #[cfg(feature = "component-model-async")]
             waitable_set_drop(vmctx: vmctx, caller_instance: u32, set: u32) -> bool;
             #[cfg(feature = "component-model-async")]
@@ -134,15 +134,15 @@ macro_rules! foreach_builtin_component_function {
                 storage_len: size
             ) -> bool;
             #[cfg(feature = "component-model-async")]
-            sync_start(vmctx: vmctx, callback: ptr_u8, callee: ptr_u8, param_count: u32, storage: ptr_u8, storage_len: size) -> bool;
+            sync_start(vmctx: vmctx, callback: ptr_u8, storage: ptr_u8, storage_len: size, callee: ptr_u8, param_count: u32) -> bool;
             #[cfg(feature = "component-model-async")]
             async_start(vmctx: vmctx, callback: ptr_u8, post_return: ptr_u8, callee: ptr_u8, param_count: u32, result_count: u32, flags: u32) -> u64;
             #[cfg(feature = "component-model-async")]
             future_new(vmctx: vmctx, ty: u32) -> u64;
             #[cfg(feature = "component-model-async")]
-            future_write(vmctx: vmctx, memory: ptr_u8, realloc: ptr_u8, string_encoding: u8, async_: u8, ty: u32, future: u32, address: u32) -> u64;
+            future_write(vmctx: vmctx, ty: u32, options: u32, future: u32, address: u32) -> u64;
             #[cfg(feature = "component-model-async")]
-            future_read(vmctx: vmctx, memory: ptr_u8, realloc: ptr_u8, string_encoding: u8, async_: u8, ty: u32, future: u32, address: u32) -> u64;
+            future_read(vmctx: vmctx, ty: u32, options: u32, future: u32, address: u32) -> u64;
             #[cfg(feature = "component-model-async")]
             future_cancel_write(vmctx: vmctx, ty: u32, async_: u8, writer: u32) -> u64;
             #[cfg(feature = "component-model-async")]
@@ -154,9 +154,9 @@ macro_rules! foreach_builtin_component_function {
             #[cfg(feature = "component-model-async")]
             stream_new(vmctx: vmctx, ty: u32) -> u64;
             #[cfg(feature = "component-model-async")]
-            stream_write(vmctx: vmctx, memory: ptr_u8, realloc: ptr_u8, string_encoding: u8, async_: u8, ty: u32, stream: u32, address: u32, count: u32) -> u64;
+            stream_write(vmctx: vmctx, ty: u32, options: u32, stream: u32, address: u32, count: u32) -> u64;
             #[cfg(feature = "component-model-async")]
-            stream_read(vmctx: vmctx, memory: ptr_u8, realloc: ptr_u8, string_encoding: u8, async_: u8, ty: u32, stream: u32, address: u32, count: u32) -> u64;
+            stream_read(vmctx: vmctx, ty: u32, options: u32, stream: u32, address: u32, count: u32) -> u64;
             #[cfg(feature = "component-model-async")]
             stream_cancel_write(vmctx: vmctx, ty: u32, async_: u8, writer: u32) -> u64;
             #[cfg(feature = "component-model-async")]
@@ -166,13 +166,13 @@ macro_rules! foreach_builtin_component_function {
             #[cfg(feature = "component-model-async")]
             stream_drop_readable(vmctx: vmctx, ty: u32, reader: u32) -> bool;
             #[cfg(feature = "component-model-async")]
-            flat_stream_write(vmctx: vmctx, memory: ptr_u8, realloc: ptr_u8, async_: u8, ty: u32, payload_size: u32, payload_align: u32, stream: u32, address: u32, count: u32) -> u64;
+            flat_stream_write(vmctx: vmctx, ty: u32, options:u32, payload_size: u32, payload_align: u32, stream: u32, address: u32, count: u32) -> u64;
             #[cfg(feature = "component-model-async")]
-            flat_stream_read(vmctx: vmctx, memory: ptr_u8, realloc: ptr_u8, async_: u8, ty: u32, payload_size: u32, payload_align: u32, stream: u32, address: u32, count: u32) -> u64;
+            flat_stream_read(vmctx: vmctx, ty: u32, options: u32, payload_size: u32, payload_align: u32, stream: u32, address: u32, count: u32) -> u64;
             #[cfg(feature = "component-model-async")]
-            error_context_new(vmctx: vmctx, memory: ptr_u8, realloc: ptr_u8, string_encoding: u8, ty: u32, debug_msg_address: u32, debug_msg_len: u32) -> u64;
+            error_context_new(vmctx: vmctx, ty: u32, options: u32, debug_msg_address: u32, debug_msg_len: u32) -> u64;
             #[cfg(feature = "component-model-async")]
-            error_context_debug_message(vmctx: vmctx, memory: ptr_u8, realloc: ptr_u8, string_encoding: u8, ty: u32, err_ctx_handle: u32, debug_msg_address: u32) -> bool;
+            error_context_debug_message(vmctx: vmctx, ty: u32, options: u32, err_ctx_handle: u32, debug_msg_address: u32) -> bool;
             #[cfg(feature = "component-model-async")]
             error_context_drop(vmctx: vmctx, ty: u32, err_ctx_handle: u32) -> bool;
             #[cfg(feature = "component-model-async")]
@@ -186,7 +186,7 @@ macro_rules! foreach_builtin_component_function {
             #[cfg(feature = "component-model-async")]
             context_set(vmctx: vmctx, slot: u32, val: u32) -> bool;
 
-            trap(vmctx: vmctx, code: u8);
+            trap(vmctx: vmctx, code: u8) -> bool;
 
             utf8_to_utf8(vmctx: vmctx, src: ptr_u8, len: size, dst: ptr_u8) -> bool;
             utf16_to_utf16(vmctx: vmctx, src: ptr_u16, len: size, dst: ptr_u16) -> bool;

--- a/crates/environ/src/component/dfg.rs
+++ b/crates/environ/src/component/dfg.rs
@@ -138,6 +138,9 @@ pub struct ComponentDfg {
     /// of this component by idnicating what order operations should be
     /// performed during instantiation.
     pub side_effects: Vec<SideEffect>,
+
+    /// TODO
+    pub options: Intern<OptionsId, CanonicalOptions>,
 }
 
 /// Possible side effects that are possible with instantiating this component.
@@ -211,6 +214,7 @@ id! {
     pub struct AdapterId(u32);
     pub struct PostReturnId(u32);
     pub struct AdapterModuleId(u32);
+    pub struct OptionsId(u32);
 }
 
 /// Same as `info::InstantiateModule`
@@ -229,7 +233,7 @@ pub enum Export {
     LiftedFunction {
         ty: TypeFuncIndex,
         func: CoreDef,
-        options: CanonicalOptions,
+        options: OptionsId,
     },
     ModuleStatic {
         ty: ComponentCoreModuleTypeId,
@@ -300,7 +304,7 @@ impl<T> CoreExport<T> {
 pub enum Trampoline {
     LowerImport {
         import: RuntimeImportIndex,
-        options: CanonicalOptions,
+        options: OptionsId,
         lower_ty: TypeFuncIndex,
     },
     Transcoder {
@@ -319,7 +323,7 @@ pub enum Trampoline {
     },
     TaskReturn {
         results: TypeTupleIndex,
-        options: CanonicalOptions,
+        options: OptionsId,
     },
     TaskCancel {
         instance: RuntimeComponentInstanceIndex,
@@ -328,14 +332,10 @@ pub enum Trampoline {
         instance: RuntimeComponentInstanceIndex,
     },
     WaitableSetWait {
-        instance: RuntimeComponentInstanceIndex,
-        async_: bool,
-        memory: MemoryId,
+        options: OptionsId,
     },
     WaitableSetPoll {
-        instance: RuntimeComponentInstanceIndex,
-        async_: bool,
-        memory: MemoryId,
+        options: OptionsId,
     },
     WaitableSetDrop {
         instance: RuntimeComponentInstanceIndex,
@@ -358,11 +358,11 @@ pub enum Trampoline {
     },
     StreamRead {
         ty: TypeStreamTableIndex,
-        options: CanonicalOptions,
+        options: OptionsId,
     },
     StreamWrite {
         ty: TypeStreamTableIndex,
-        options: CanonicalOptions,
+        options: OptionsId,
     },
     StreamCancelRead {
         ty: TypeStreamTableIndex,
@@ -383,11 +383,11 @@ pub enum Trampoline {
     },
     FutureRead {
         ty: TypeFutureTableIndex,
-        options: CanonicalOptions,
+        options: OptionsId,
     },
     FutureWrite {
         ty: TypeFutureTableIndex,
-        options: CanonicalOptions,
+        options: OptionsId,
     },
     FutureCancelRead {
         ty: TypeFutureTableIndex,
@@ -405,11 +405,11 @@ pub enum Trampoline {
     },
     ErrorContextNew {
         ty: TypeComponentLocalErrorContextTableIndex,
-        options: CanonicalOptions,
+        options: OptionsId,
     },
     ErrorContextDebugMessage {
         ty: TypeComponentLocalErrorContextTableIndex,
-        options: CanonicalOptions,
+        options: OptionsId,
     },
     ErrorContextDrop {
         ty: TypeComponentLocalErrorContextTableIndex,
@@ -554,6 +554,8 @@ impl ComponentDfg {
             trampolines: Default::default(),
             trampoline_defs: Default::default(),
             trampoline_map: Default::default(),
+            options: Default::default(),
+            options_map: Default::default(),
         };
 
         // Handle all side effects of this component in the order that they're
@@ -585,6 +587,7 @@ impl ComponentDfg {
                 initializers: linearize.initializers,
                 trampolines: linearize.trampolines,
                 num_lowerings: linearize.num_lowerings,
+                options: linearize.options,
 
                 num_runtime_memories: linearize.runtime_memories.len() as u32,
                 num_runtime_tables: linearize.runtime_tables.len() as u32,
@@ -621,6 +624,7 @@ struct LinearizeDfg<'a> {
     initializers: Vec<GlobalInitializer>,
     trampolines: PrimaryMap<TrampolineIndex, ModuleInternedTypeIndex>,
     trampoline_defs: PrimaryMap<TrampolineIndex, info::Trampoline>,
+    options: PrimaryMap<OptionsIndex, info::CanonicalOptions>,
     trampoline_map: HashMap<TrampolineIndex, TrampolineIndex>,
     runtime_memories: HashMap<MemoryId, RuntimeMemoryIndex>,
     runtime_tables: HashMap<TableId, RuntimeTableIndex>,
@@ -628,6 +632,7 @@ struct LinearizeDfg<'a> {
     runtime_callbacks: HashMap<CallbackId, RuntimeCallbackIndex>,
     runtime_post_return: HashMap<PostReturnId, RuntimePostReturnIndex>,
     runtime_instances: HashMap<RuntimeInstance, RuntimeInstanceIndex>,
+    options_map: HashMap<OptionsId, OptionsIndex>,
     num_lowerings: u32,
 }
 
@@ -699,7 +704,7 @@ impl LinearizeDfg<'_> {
         let item = match export {
             Export::LiftedFunction { ty, func, options } => {
                 let func = self.core_def(func);
-                let options = self.options(options);
+                let options = self.options(*options);
                 info::Export::LiftedFunction {
                     ty: *ty,
                     func,
@@ -731,7 +736,16 @@ impl LinearizeDfg<'_> {
         Ok(items.push(item))
     }
 
-    fn options(&mut self, options: &CanonicalOptions) -> info::CanonicalOptions {
+    fn options(&mut self, options: OptionsId) -> OptionsIndex {
+        self.intern_no_init(
+            options,
+            |me| &mut me.options_map,
+            |me, options| me.convert_options(options),
+        )
+    }
+
+    fn convert_options(&mut self, options: OptionsId) -> OptionsIndex {
+        let options = &self.dfg.options[options];
         let data_model = match options.data_model {
             CanonicalOptionsDataModel::Gc {} => info::CanonicalOptionsDataModel::Gc {},
             CanonicalOptionsDataModel::LinearMemory { memory, realloc } => {
@@ -743,7 +757,7 @@ impl LinearizeDfg<'_> {
         };
         let callback = options.callback.map(|mem| self.runtime_callback(mem));
         let post_return = options.post_return.map(|mem| self.runtime_post_return(mem));
-        info::CanonicalOptions {
+        let options = info::CanonicalOptions {
             instance: options.instance,
             string_encoding: options.string_encoding,
             callback,
@@ -751,7 +765,8 @@ impl LinearizeDfg<'_> {
             async_: options.async_,
             core_type: options.core_type,
             data_model,
-        }
+        };
+        self.options.push(options)
     }
 
     fn runtime_memory(&mut self, mem: MemoryId) -> RuntimeMemoryIndex {
@@ -818,7 +833,7 @@ impl LinearizeDfg<'_> {
                 });
                 info::Trampoline::LowerImport {
                     index,
-                    options: self.options(options),
+                    options: self.options(*options),
                     lower_ty: *lower_ty,
                 }
             }
@@ -844,7 +859,7 @@ impl LinearizeDfg<'_> {
             },
             Trampoline::TaskReturn { results, options } => info::Trampoline::TaskReturn {
                 results: *results,
-                options: self.options(options),
+                options: self.options(*options),
             },
             Trampoline::TaskCancel { instance } => info::Trampoline::TaskCancel {
                 instance: *instance,
@@ -852,23 +867,11 @@ impl LinearizeDfg<'_> {
             Trampoline::WaitableSetNew { instance } => info::Trampoline::WaitableSetNew {
                 instance: *instance,
             },
-            Trampoline::WaitableSetWait {
-                instance,
-                async_,
-                memory,
-            } => info::Trampoline::WaitableSetWait {
-                instance: *instance,
-                async_: *async_,
-                memory: self.runtime_memory(*memory),
+            Trampoline::WaitableSetWait { options } => info::Trampoline::WaitableSetWait {
+                options: self.options(*options),
             },
-            Trampoline::WaitableSetPoll {
-                instance,
-                async_,
-                memory,
-            } => info::Trampoline::WaitableSetPoll {
-                instance: *instance,
-                async_: *async_,
-                memory: self.runtime_memory(*memory),
+            Trampoline::WaitableSetPoll { options } => info::Trampoline::WaitableSetPoll {
+                options: self.options(*options),
             },
             Trampoline::WaitableSetDrop { instance } => info::Trampoline::WaitableSetDrop {
                 instance: *instance,
@@ -887,11 +890,11 @@ impl LinearizeDfg<'_> {
             Trampoline::StreamNew { ty } => info::Trampoline::StreamNew { ty: *ty },
             Trampoline::StreamRead { ty, options } => info::Trampoline::StreamRead {
                 ty: *ty,
-                options: self.options(options),
+                options: self.options(*options),
             },
             Trampoline::StreamWrite { ty, options } => info::Trampoline::StreamWrite {
                 ty: *ty,
-                options: self.options(options),
+                options: self.options(*options),
             },
             Trampoline::StreamCancelRead { ty, async_ } => info::Trampoline::StreamCancelRead {
                 ty: *ty,
@@ -910,11 +913,11 @@ impl LinearizeDfg<'_> {
             Trampoline::FutureNew { ty } => info::Trampoline::FutureNew { ty: *ty },
             Trampoline::FutureRead { ty, options } => info::Trampoline::FutureRead {
                 ty: *ty,
-                options: self.options(options),
+                options: self.options(*options),
             },
             Trampoline::FutureWrite { ty, options } => info::Trampoline::FutureWrite {
                 ty: *ty,
-                options: self.options(options),
+                options: self.options(*options),
             },
             Trampoline::FutureCancelRead { ty, async_ } => info::Trampoline::FutureCancelRead {
                 ty: *ty,
@@ -932,12 +935,12 @@ impl LinearizeDfg<'_> {
             }
             Trampoline::ErrorContextNew { ty, options } => info::Trampoline::ErrorContextNew {
                 ty: *ty,
-                options: self.options(options),
+                options: self.options(*options),
             },
             Trampoline::ErrorContextDebugMessage { ty, options } => {
                 info::Trampoline::ErrorContextDebugMessage {
                     ty: *ty,
-                    options: self.options(options),
+                    options: self.options(*options),
                 }
             }
             Trampoline::ErrorContextDrop { ty } => info::Trampoline::ErrorContextDrop { ty: *ty },
@@ -1038,12 +1041,41 @@ impl LinearizeDfg<'_> {
         K: Hash + Eq + Copy,
         V: EntityRef,
     {
+        self.intern_(key, map, generate, |me, key, val| {
+            me.initializers.push(init(key, val));
+        })
+    }
+
+    fn intern_no_init<K, V, T>(
+        &mut self,
+        key: K,
+        map: impl Fn(&mut Self) -> &mut HashMap<K, V>,
+        generate: impl FnOnce(&mut Self, K) -> T,
+    ) -> V
+    where
+        K: Hash + Eq + Copy,
+        V: EntityRef,
+    {
+        self.intern_(key, map, generate, |_me, _key, _val| {})
+    }
+
+    fn intern_<K, V, T>(
+        &mut self,
+        key: K,
+        map: impl Fn(&mut Self) -> &mut HashMap<K, V>,
+        generate: impl FnOnce(&mut Self, K) -> T,
+        init: impl FnOnce(&mut Self, V, T),
+    ) -> V
+    where
+        K: Hash + Eq + Copy,
+        V: EntityRef,
+    {
         if let Some(val) = map(self).get(&key) {
             return *val;
         }
         let tmp = generate(self, key);
         let index = V::new(map(self).len());
-        self.initializers.push(init(index, tmp));
+        init(self, index, tmp);
         let prev = map(self).insert(key, index);
         assert!(prev.is_none());
         index

--- a/crates/environ/src/component/dfg.rs
+++ b/crates/environ/src/component/dfg.rs
@@ -139,7 +139,8 @@ pub struct ComponentDfg {
     /// performed during instantiation.
     pub side_effects: Vec<SideEffect>,
 
-    /// TODO
+    /// Interned map of id-to-`CanonicalOptions`, or all sets-of-options used by
+    /// this component.
     pub options: Intern<OptionsId, CanonicalOptions>,
 }
 

--- a/crates/environ/src/component/info.rs
+++ b/crates/environ/src/component/info.rs
@@ -195,7 +195,8 @@ pub struct Component {
     /// testing reentrance.
     pub defined_resource_instances: PrimaryMap<DefinedResourceIndex, RuntimeComponentInstanceIndex>,
 
-    /// TODO
+    /// All canonical options used by this component. Stored as a table here
+    /// from index-to-options so the options can be consulted at runtime.
     pub options: PrimaryMap<OptionsIndex, CanonicalOptions>,
 }
 

--- a/crates/environ/src/component/info.rs
+++ b/crates/environ/src/component/info.rs
@@ -194,6 +194,9 @@ pub struct Component {
     /// This is used to determine which set of instance flags are inspected when
     /// testing reentrance.
     pub defined_resource_instances: PrimaryMap<DefinedResourceIndex, RuntimeComponentInstanceIndex>,
+
+    /// TODO
+    pub options: PrimaryMap<OptionsIndex, CanonicalOptions>,
 }
 
 impl Component {
@@ -451,7 +454,7 @@ pub enum Export {
         /// Which core WebAssembly export is being lifted.
         func: CoreDef,
         /// Any options, if present, associated with this lifting.
-        options: CanonicalOptions,
+        options: OptionsIndex,
     },
     /// A module defined within this component is exported.
     ModuleStatic {
@@ -673,7 +676,7 @@ pub enum Trampoline {
 
         /// The canonical ABI options used when lowering this function specified
         /// in the original component.
-        options: CanonicalOptions,
+        options: OptionsIndex,
     },
 
     /// Information about a string transcoding function required by an adapter
@@ -734,7 +737,7 @@ pub enum Trampoline {
         results: TypeTupleIndex,
 
         /// The canonical ABI options specified for this intrinsic.
-        options: CanonicalOptions,
+        options: OptionsIndex,
     },
 
     /// A `task.cancel` intrinsic, which acknowledges a `CANCELLED` event
@@ -755,24 +758,16 @@ pub enum Trampoline {
     /// outstanding async task/stream/future to make progress, returning the
     /// first such event.
     WaitableSetWait {
-        /// The specific component instance which is calling the intrinsic.
-        instance: RuntimeComponentInstanceIndex,
-        /// If `true`, indicates the caller instance maybe reentered.
-        async_: bool,
-        /// Memory to use when storing the event.
-        memory: RuntimeMemoryIndex,
+        /// Configuration options for this intrinsic call.
+        options: OptionsIndex,
     },
 
     /// A `waitable-set.poll` intrinsic, which checks whether any outstanding
     /// async task/stream/future has made progress.  Unlike `task.wait`, this
     /// does not block and may return nothing if no such event has occurred.
     WaitableSetPoll {
-        /// The specific component instance which is calling the intrinsic.
-        instance: RuntimeComponentInstanceIndex,
-        /// If `true`, indicates the caller instance maybe reentered.
-        async_: bool,
-        /// Memory to use when storing the event.
-        memory: RuntimeMemoryIndex,
+        /// Configuration options for this intrinsic call.
+        options: OptionsIndex,
     },
 
     /// A `waitable-set.drop` intrinsic.
@@ -823,7 +818,7 @@ pub enum Trampoline {
 
         /// Any options (e.g. string encoding) to use when storing values to
         /// memory.
-        options: CanonicalOptions,
+        options: OptionsIndex,
     },
 
     /// A `stream.write` intrinsic to write to a `stream` of the specified type.
@@ -833,7 +828,7 @@ pub enum Trampoline {
 
         /// Any options (e.g. string encoding) to use when storing values to
         /// memory.
-        options: CanonicalOptions,
+        options: OptionsIndex,
     },
 
     /// A `stream.cancel-read` intrinsic to cancel an in-progress read from a
@@ -884,7 +879,7 @@ pub enum Trampoline {
 
         /// Any options (e.g. string encoding) to use when storing values to
         /// memory.
-        options: CanonicalOptions,
+        options: OptionsIndex,
     },
 
     /// A `future.write` intrinsic to write to a `future` of the specified type.
@@ -894,7 +889,7 @@ pub enum Trampoline {
 
         /// Any options (e.g. string encoding) to use when storing values to
         /// memory.
-        options: CanonicalOptions,
+        options: OptionsIndex,
     },
 
     /// A `future.cancel-read` intrinsic to cancel an in-progress read from a
@@ -937,7 +932,7 @@ pub enum Trampoline {
         /// The table index for the `error-context` type in the caller instance.
         ty: TypeComponentLocalErrorContextTableIndex,
         /// String encoding, memory, etc. to use when loading debug message.
-        options: CanonicalOptions,
+        options: OptionsIndex,
     },
 
     /// A `error-context.debug-message` intrinsic to get the debug message for a
@@ -949,7 +944,7 @@ pub enum Trampoline {
         /// The table index for the `error-context` type in the caller instance.
         ty: TypeComponentLocalErrorContextTableIndex,
         /// String encoding, memory, etc. to use when storing debug message.
-        options: CanonicalOptions,
+        options: OptionsIndex,
     },
 
     /// A `error-context.drop` intrinsic to drop a specified `error-context`.

--- a/crates/environ/src/component/translate.rs
+++ b/crates/environ/src/component/translate.rs
@@ -204,14 +204,10 @@ enum LocalInitializer<'data> {
         func: ModuleInternedTypeIndex,
     },
     WaitableSetWait {
-        func: ModuleInternedTypeIndex,
-        async_: bool,
-        memory: MemoryIndex,
+        options: LocalCanonicalOptions,
     },
     WaitableSetPoll {
-        func: ModuleInternedTypeIndex,
-        async_: bool,
-        memory: MemoryIndex,
+        options: LocalCanonicalOptions,
     },
     WaitableSetDrop {
         func: ModuleInternedTypeIndex,
@@ -844,21 +840,37 @@ impl<'a, 'data> Translator<'a, 'data> {
                             LocalInitializer::WaitableSetNew { func }
                         }
                         wasmparser::CanonicalFunction::WaitableSetWait { async_, memory } => {
-                            let func = self.core_func_signature(core_func_index)?;
+                            let core_type = self.core_func_signature(core_func_index)?;
                             core_func_index += 1;
                             LocalInitializer::WaitableSetWait {
-                                func,
-                                async_,
-                                memory: MemoryIndex::from_u32(memory),
+                                options: LocalCanonicalOptions {
+                                    core_type,
+                                    async_,
+                                    data_model: LocalDataModel::LinearMemory {
+                                        memory: Some(MemoryIndex::from_u32(memory)),
+                                        realloc: None,
+                                    },
+                                    post_return: None,
+                                    callback: None,
+                                    string_encoding: StringEncoding::Utf8,
+                                },
                             }
                         }
                         wasmparser::CanonicalFunction::WaitableSetPoll { async_, memory } => {
-                            let func = self.core_func_signature(core_func_index)?;
+                            let core_type = self.core_func_signature(core_func_index)?;
                             core_func_index += 1;
                             LocalInitializer::WaitableSetPoll {
-                                func,
-                                async_,
-                                memory: MemoryIndex::from_u32(memory),
+                                options: LocalCanonicalOptions {
+                                    core_type,
+                                    async_,
+                                    data_model: LocalDataModel::LinearMemory {
+                                        memory: Some(MemoryIndex::from_u32(memory)),
+                                        realloc: None,
+                                    },
+                                    post_return: None,
+                                    callback: None,
+                                    string_encoding: StringEncoding::Utf8,
+                                },
                             }
                         }
                         wasmparser::CanonicalFunction::WaitableSetDrop => {

--- a/crates/environ/src/component/types.rs
+++ b/crates/environ/src/component/types.rs
@@ -240,6 +240,9 @@ indices! {
 
     /// An index into `Component::export_items` at the end of compilation.
     pub struct ExportIndex(u32);
+
+    /// An index into `Component::options` at the end of compilation.
+    pub struct OptionsIndex(u32);
 }
 
 // Reexport for convenience some core-wasm indices which are also used in the

--- a/crates/wasmtime/src/runtime/component/component.rs
+++ b/crates/wasmtime/src/runtime/component/component.rs
@@ -17,8 +17,8 @@ use core::ptr::NonNull;
 use std::path::Path;
 use wasmtime_environ::TypeTrace;
 use wasmtime_environ::component::{
-    AllCallFunc, CanonicalOptions, CompiledComponentInfo, ComponentArtifacts, ComponentTypes,
-    CoreDef, Export, ExportIndex, GlobalInitializer, InstantiateModule, NameMapNoIntern,
+    AllCallFunc, CompiledComponentInfo, ComponentArtifacts, ComponentTypes, CoreDef, Export,
+    ExportIndex, GlobalInitializer, InstantiateModule, NameMapNoIntern, OptionsIndex,
     StaticModuleIndex, TrampolineIndex, TypeComponentIndex, TypeFuncIndex, VMComponentOffsets,
 };
 use wasmtime_environ::{FunctionLoc, HostPtr, ObjectKind, PrimaryMap};
@@ -836,9 +836,10 @@ impl Component {
     pub(crate) fn export_lifted_function(
         &self,
         export: ExportIndex,
-    ) -> (TypeFuncIndex, &CoreDef, &CanonicalOptions) {
-        match &self.env_component().export_items[export] {
-            Export::LiftedFunction { ty, func, options } => (*ty, func, options),
+    ) -> (TypeFuncIndex, &CoreDef, OptionsIndex) {
+        let component = self.env_component();
+        match &component.export_items[export] {
+            Export::LiftedFunction { ty, func, options } => (*ty, func, *options),
             _ => unreachable!(),
         }
     }

--- a/crates/wasmtime/src/runtime/vm/component.rs
+++ b/crates/wasmtime/src/runtime/vm/component.rs
@@ -138,17 +138,8 @@ pub struct ComponentInstance {
 ///   which this function pointer was registered.
 /// * `ty` - the type index, relative to the tables in `vmctx`, that is the
 ///   type of the function being called.
-/// * `caller_instance` - the `RuntimeComponentInstanceIndex` representing the
-///   caller component instance, used to track the owner of an async host task.
-/// * `flags` - the component flags for may_enter/leave corresponding to the
-///   component instance that the lowering happened within.
-/// * `opt_memory` - this nullable pointer represents the memory configuration
-///   option for the canonical ABI options.
-/// * `opt_realloc` - this nullable pointer represents the realloc configuration
-///   option for the canonical ABI options.
-/// * `string_encoding` - this is the configured string encoding for the
-///   canonical ABI this lowering corresponds to.
-/// * `async_` - whether the caller is using the async ABI.
+/// * `options` - the `OptionsIndex` which indicates the canonical ABI options
+///   in use for this call.
 /// * `args_and_results` - pointer to stack-allocated space in the caller where
 ///   all the arguments are stored as well as where the results will be written
 ///   to. The size and initialized bytes of this depends on the core wasm type
@@ -159,21 +150,11 @@ pub struct ComponentInstance {
 /// This function returns a `bool` which indicates whether the call succeeded
 /// or not. On failure this function records trap information in TLS which
 /// should be suitable for reading later.
-//
-// FIXME: 11 arguments is probably too many. The `data` through `string-encoding`
-// parameters should probably get packaged up into the `VMComponentContext`.
-// Needs benchmarking one way or another though to figure out what the best
-// balance is here.
 pub type VMLoweringCallee = extern "C" fn(
     vmctx: NonNull<VMOpaqueContext>,
     data: NonNull<u8>,
     ty: u32,
-    caller_instance: u32,
-    flags: NonNull<VMGlobalDefinition>,
-    opt_memory: *mut VMMemoryDefinition,
-    opt_realloc: *mut VMFuncRef,
-    string_encoding: u8,
-    async_: u8,
+    options: u32,
     args_and_results: NonNull<mem::MaybeUninit<ValRaw>>,
     nargs_and_results: usize,
 ) -> bool;

--- a/crates/wasmtime/src/runtime/vm/interpreter.rs
+++ b/crates/wasmtime/src/runtime/vm/interpreter.rs
@@ -423,7 +423,7 @@ impl InterpreterRef<'_> {
             use wasmtime_environ::component::ComponentBuiltinFunctionIndex;
 
             if id == const { HostCall::ComponentLowerImport.index() } {
-                call!(@host VMLoweringCallee(nonnull, nonnull, u32, u32, nonnull, ptr, ptr, u8, u8, nonnull, size) -> bool);
+                call!(@host VMLoweringCallee(nonnull, nonnull, u32, u32, nonnull, size) -> bool);
             }
 
             macro_rules! component {


### PR DESCRIPTION
This commit is a refactoring of how canonical ABI options are handled during compilation and runtime. Previously options were "exploded" meaning that options were all passed around as parameters but this was a bummer for a few reasons:

* This is `unsafe`-prone as options have raw pointers such as memory and functions. This meant that all functions/operations working with options were fundamentally `unsafe`.

* This was unwieldy as the set of options continues to grow larger over time. The `VMLoweringCallee` function previously had 10+ parameters, most of which were canonical ABI options.

To solve these two problems options are now intern'd at compile time to an `OptionsIndex`, a 32-bit value. This is stored as a new table in component metadata and consulted at runtime. This means that `OptionsIndex` can be passed around with an instance for a much safer means of threading options around. Additionally there's no need to pass around all parameters individually and instead just one parameter, `OptionsIndex`, need be threaded through.

This commit additionally overhauls trampoline generation for the component compiler to avoid a function-per-intrinsic and instead have a single function that all intrinsics use. I found this easier to understand and helps codify that all intrinsics are basically the same with some minor details differing between them.

The end result of this is (hopefully) a net simplification of the component compiler in addition to a large amount of removal of `unsafe` code in the async implementation as only safe types are passed around now instead of raw pointers.

Closes #10143
Closes #11188

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
