### PR TITLE
Fix declaration of c-api function wasmtime_component_linker_instance_add_func

### DIFF
--- a/crates/c-api/include/wasmtime/component/linker.h
+++ b/crates/c-api/include/wasmtime/component/linker.h
@@ -134,7 +134,7 @@ typedef wasmtime_error_t *(*wasmtime_component_func_callback_t)(
 WASM_API_EXTERN wasmtime_error_t *wasmtime_component_linker_instance_add_func(
     wasmtime_component_linker_instance_t *linker_instance, const char *name,
     size_t name_len, wasmtime_component_func_callback_t callback, void *data,
-    void (*finalizer)());
+    void (*finalizer)(void *));
 
 #ifdef WASMTIME_FEATURE_WASI
 


### PR DESCRIPTION
I was trying to use the C api and could not figure out how to implement a finalizer that takes no arguments. Turns out, the c declaration simply did not match the rust implementation.

See the rust specification of `finalizer` here:
https://github.com/bytecodealliance/wasmtime/blob/d2f51186ffb9fd2110d8658f215922b8398dd491/crates/c-api/src/component/linker.rs#L105-L112

`extern "C" fn(*mut c_void)>` of course matches `void(*)(void*)`, not `void(*)()`.