### PR TITLE
Patch 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Windows or otherwise interested users can download installers and
 binaries directly from the [GitHub
 Releases](https://github.com/bytecodealliance/wasmtime/releases) page.
 
+For additional installation options, refer to the [online book CLI installation page](https://docs.wasmtime.dev/cli-install.html).
+
 Documentation on Wasmtime's currently supported versions can be found [in the
 online book
 documentation](https://docs.wasmtime.dev/stability-release.html#current-versions).

--- a/docs/cli-install.md
+++ b/docs/cli-install.md
@@ -60,6 +60,26 @@ executed normally as the CLI would.
 [`wasmtime-dev-x86_64-macos.tar.xz`]: https://github.com/bytecodealliance/wasmtime/releases/download/dev/wasmtime-dev-x86_64-macos.tar.xz
 [`wasmtime-dev-x86_64-windows.zip`]: https://github.com/bytecodealliance/wasmtime/releases/download/dev/wasmtime-dev-x86_64-windows.zip
 
+## Install via Cargo
+
+If you have [Rust and Cargo](https://www.rust-lang.org/tools/install) available in your system, you can install `wasmtime` from [crates.io](https://crates.io/crates/wasmtime-cli):
+
+```console
+cargo install wasmtime-cli
+```
+
+This compiles and installs wasmtime into your Cargo bin directory (typically `$HOME/.cargo/bin`). Make sure that directory is in your `PATH` before running `wasmtime`. For example, add the following line to `~/.bashrc` or `~/.zshrc`:
+
+```console
+export PATH="$HOME/.cargo/bin:$PATH"'
+```
+
+You can also use [`binstall`](https://github.com/cargo-bins/cargo-binstall):
+
+```
+cargo binstall wasmtime-cli
+```
+
 ## Compiling from Source
 
 If you'd prefer to compile the `wasmtime` CLI from source, you'll want to


### PR DESCRIPTION
Adds `cargo install wasmtime-cli` and `cargo binstall wasmtime-cli` installation options to https://docs.wasmtime.dev/cli-install.html. Also, points to this documentation page in the README.

Closes: #4871 