### PR TITLE
Add contributor docs about our RFC process

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -67,6 +67,7 @@
   - [Cross Compiling](./contributing-cross-compiling.md)
   - [Coding Guidelines](./contributing-coding-guidelines.md)
   - [Development Process](./contributing-development-process.md)
+  - [RFC Process](./contributing-rfc-process.md)
   - [Implementing Wasm Proposals](./contributing-implementing-wasm-proposals.md)
   - [Maintainer Guidelines](./contributing-maintainer-guidelines.md)
     - [Code Review](./contributing-code-review.md)

--- a/docs/contributing-development-process.md
+++ b/docs/contributing-development-process.md
@@ -10,7 +10,9 @@ reviewing code submissions. We triage new issues at each of our bi-weekly
 Consider opening an issue to talk about it. PRs without corresponding issues
 are appropriate for fairly narrow technical matters, not for fixes to
 user-facing bugs or for feature implementations, especially when those features
-might have multiple implementation strategies that usefully could be discussed.
+might have multiple implementation strategies that usefully could be
+discussed. Changes that will significantly affect stakeholders should first be
+proposed in an [RFC](./contributing-rfc-process.md).
 
 Our issue templates might help you through the process.
 

--- a/docs/contributing-rfc-process.md
+++ b/docs/contributing-rfc-process.md
@@ -1,0 +1,50 @@
+# RFC Process
+
+For changes that will significantly affect Wasmtime's or Cranelift's internals,
+downstream projects, contributors, and other stakeholders, a [Bytecode Alliance
+RFC](https://github.com/bytecodealliance/rfcs/) should be used to gather
+feedback on the proposed change's design and implementation, and to build
+consensus.
+
+It is recommended that regular Wasmtime and Cranelift contributors, as well as
+any other project stakeholders, subscribe to notifications in [the RFC
+repository](https://github.com/bytecodealliance/rfcs/) to stay up to date with
+significant change proposals.
+
+## Authoring New RFCs
+
+The RFC repository has two templates that can help you author new proposals:
+
+1. [A draft RFC
+   template](https://github.com/bytecodealliance/rfcs/blob/main/template-draft.md),
+   for seeking early feedback on ideas that aren't yet fully baked. It is
+   expected that as the discussion evolves, these draft RFCs will grow into
+   fully-formed RFCs.
+
+2. [A full RFC
+   template](https://github.com/bytecodealliance/rfcs/blob/main/template-full.md),
+   for building consensus around a mature proposal.
+
+You can also look at historical Wasmtime RFCs in [the repository's `accepted`
+subdirectory](https://github.com/bytecodealliance/rfcs/tree/main/accepted) and
+their associated discussions in its [merged pull
+requests](https://github.com/bytecodealliance/rfcs/pulls?q=is%3Apr+is%3Amerged+)
+to gather inspiration for your new RFC. A few good examples include:
+
+* Add a Long Term Support (LTS) Channel of Releases for Wasmtime -
+  [RFC](https://github.com/bytecodealliance/rfcs/blob/main/accepted/wasmtime-lts.md) -
+  [Discussion](https://github.com/bytecodealliance/rfcs/pull/42)
+* Pulley: A Portable, Optimizing Interpreter for Wasmtime -
+  [RFC](https://github.com/bytecodealliance/rfcs/blob/main/accepted/pulley.md) -
+  [Discussion](https://github.com/bytecodealliance/rfcs/pull/35)
+* Debugging Support in Wasmtime -
+  [RFC](https://github.com/bytecodealliance/rfcs/blob/main/accepted/wasmtime-debugging.md) -
+  [Discussion](https://github.com/bytecodealliance/rfcs/pull/34)
+* Redesign Wasmtime's API -
+  [RFC](https://github.com/bytecodealliance/rfcs/blob/main/accepted/new-api.md) -
+  [Discussion](https://github.com/bytecodealliance/rfcs/pull/11)
+
+After creating a pull request for your new RFC, advertise its existence by
+creating a new thread in the relevant
+[Zulip](https://bytecodealliance.zulipchat.com/) channels (e.g. `#wasmtime` or
+`#cranelift`).


### PR DESCRIPTION
We have some off-hand links to particular RFCs in our docs, but did not have any general information about our usage of the RFC process. I've added that information in this commit.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
