### PR TITLE
Account for concurrent resource destructors

### DIFF
--- a/crates/wit-bindgen/src/config.rs
+++ b/crates/wit-bindgen/src/config.rs
@@ -102,14 +102,7 @@ impl FunctionConfig {
         resource_name: &str,
     ) -> FunctionFlags {
         let mut ret = FunctionFlags::empty();
-
         self.add_function_flags(resolve, ns, &format!("[drop]{resource_name}"), &mut ret);
-
-        // FIXME: this currently isn't supported and fools the rest of the
-        // bindings generation to thinking a `*WithStore` trait is needed when
-        // it isn't, so forcibly remove it. This'll need updating after #11325.
-        ret.remove(FunctionFlags::STORE);
-
         ret
     }
 


### PR DESCRIPTION
This fixes a minor merge conflict between #11325 and #11328 which isn't currently exercised by in-repo WASI bindings but will be soon once wasip3-prototyping is finished merging.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
