### PR TITLE
Don't support fallible drop in futures_and_streams

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4979,6 +4979,7 @@ dependencies = [
  "cap-rand",
  "cap-std",
  "cap-time-ext",
+ "env_logger 0.11.5",
  "fs-set-times",
  "futures",
  "io-extras",

--- a/crates/misc/component-async-tests/tests/scenario/streams.rs
+++ b/crates/misc/component-async-tests/tests/scenario/streams.rs
@@ -54,17 +54,16 @@ pub async fn async_watch_streams() -> Result<()> {
         .run_concurrent(&mut store, async |store| {
             futures::join!(tx.watch_reader(store), async { rx.close_with(store) }).1
         })
-        .await??;
+        .await?;
 
     // Test dropping and then watching the read end of a stream.
     let (mut tx, rx) = instance.stream::<u8>(&mut store)?;
     instance
         .run_concurrent(&mut store, async |store| {
-            rx.close_with(store)?;
+            rx.close_with(store);
             tx.watch_reader(store).await;
-            anyhow::Ok(())
         })
-        .await??;
+        .await?;
 
     // Test watching and then dropping the write end of a stream.
     let (tx, mut rx) = instance.stream::<u8>(&mut store)?;
@@ -72,17 +71,16 @@ pub async fn async_watch_streams() -> Result<()> {
         .run_concurrent(&mut store, async |store| {
             futures::join!(rx.watch_writer(store), async { tx.close_with(store) }).1
         })
-        .await??;
+        .await?;
 
     // Test dropping and then watching the write end of a stream.
     let (tx, mut rx) = instance.stream::<u8>(&mut store)?;
     instance
         .run_concurrent(&mut store, async |store| {
-            tx.close_with(store)?;
+            tx.close_with(store);
             rx.watch_writer(store).await;
-            anyhow::Ok(())
         })
-        .await??;
+        .await?;
 
     // Test watching and then dropping the read end of a future.
     let (mut tx, rx) = instance.future::<u8>(&mut store, || 42)?;
@@ -90,17 +88,16 @@ pub async fn async_watch_streams() -> Result<()> {
         .run_concurrent(&mut store, async |store| {
             futures::join!(tx.watch_reader(store), async { rx.close_with(store) }).1
         })
-        .await??;
+        .await?;
 
     // Test dropping and then watching the read end of a future.
     let (mut tx, rx) = instance.future::<u8>(&mut store, || 42)?;
     instance
         .run_concurrent(&mut store, async |store| {
-            rx.close_with(store)?;
+            rx.close_with(store);
             tx.watch_reader(store).await;
-            anyhow::Ok(())
         })
-        .await??;
+        .await?;
 
     // Test watching and then dropping the write end of a future.
     let (tx, mut rx) = instance.future::<u8>(&mut store, || 42)?;
@@ -108,17 +105,16 @@ pub async fn async_watch_streams() -> Result<()> {
         .run_concurrent(&mut store, async |store| {
             futures::join!(rx.watch_writer(store), async { tx.close_with(store) }).1
         })
-        .await??;
+        .await?;
 
     // Test dropping and then watching the write end of a future.
     let (tx, mut rx) = instance.future::<u8>(&mut store, || 42)?;
     instance
         .run_concurrent(&mut store, async |store| {
-            tx.close_with(store)?;
+            tx.close_with(store);
             rx.watch_writer(store).await;
-            anyhow::Ok(())
         })
-        .await??;
+        .await?;
 
     enum Event<'a> {
         Write(Option<GuardedStreamWriter<'a, u8, Ctx>>),

--- a/crates/wasi/Cargo.toml
+++ b/crates/wasi/Cargo.toml
@@ -45,6 +45,7 @@ test-programs-artifacts = { workspace = true }
 tempfile = { workspace = true }
 wasmtime = { workspace = true, features = ['cranelift', 'incremental-cache'] }
 wasmtime-test-util = { workspace = true }
+env_logger = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 rustix = { workspace = true, features = ["event", "fs", "net"] }

--- a/crates/wasi/src/p3/sockets/host/types/tcp.rs
+++ b/crates/wasi/src/p3/sockets/host/types/tcp.rs
@@ -414,8 +414,8 @@ impl HostTcpSocketWithStore for WasiSockets {
                     let (result_tx, result_rx) = instance
                         .future(&mut view, || Err(ErrorCode::InvalidState))
                         .context("failed to create future")?;
-                    result_tx.close(&mut view)?;
-                    data_tx.close(&mut view)?;
+                    result_tx.close(&mut view);
+                    data_tx.close(&mut view);
                     Ok((data_rx, result_rx))
                 }
             }

--- a/crates/wasi/tests/all/p3/mod.rs
+++ b/crates/wasi/tests/all/p3/mod.rs
@@ -46,6 +46,7 @@ impl wasmtime_wasi::p2::IoView for Ctx {
 }
 
 async fn run(path: &str) -> anyhow::Result<()> {
+    let _ = env_logger::try_init();
     let path = Path::new(path);
     let engine = test_programs_artifacts::engine(|config| {
         config.async_support(true);

--- a/crates/wasmtime/src/runtime/component/concurrent.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent.rs
@@ -4277,9 +4277,9 @@ impl ConcurrentState {
         fibers: &mut Vec<StoreFiber<'static>>,
         futures: &mut Vec<FuturesUnordered<HostTaskFuture>>,
     ) {
-        for entry in mem::take(&mut self.table) {
-            if let Ok(set) = entry.downcast::<WaitableSet>() {
-                for mode in set.waiting.into_values() {
+        for entry in self.table.iter_mut() {
+            if let Some(set) = entry.downcast_mut::<WaitableSet>() {
+                for mode in mem::take(&mut set.waiting).into_values() {
                     if let WaitMode::Fiber(fiber) = mode {
                         fibers.push(fiber);
                     }

--- a/crates/wasmtime/src/runtime/component/concurrent/table.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent/table.rs
@@ -356,32 +356,12 @@ impl Table {
         }
         Ok(e)
     }
-}
 
-pub struct TableIterator(vec::IntoIter<Entry>);
-
-impl Iterator for TableIterator {
-    type Item = Box<dyn Any + Send + Sync>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        loop {
-            if let Some(entry) = self.0.next() {
-                if let Entry::Occupied { entry } = entry {
-                    break Some(entry.entry);
-                }
-            } else {
-                break None;
-            }
-        }
-    }
-}
-
-impl IntoIterator for Table {
-    type Item = Box<dyn Any + Send + Sync>;
-    type IntoIter = TableIterator;
-
-    fn into_iter(self) -> TableIterator {
-        TableIterator(self.entries.into_iter())
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut (dyn Any + Send + Sync)> {
+        self.entries.iter_mut().filter_map(|entry| match entry {
+            Entry::Occupied { entry } => Some(&mut *entry.entry),
+            Entry::Free { .. } => None,
+        })
     }
 }
 

--- a/crates/wasmtime/src/runtime/component/concurrent/table.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent/table.rs
@@ -13,7 +13,7 @@ use std::collections::BTreeSet;
 use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::marker::PhantomData;
-use std::vec::{self, Vec};
+use std::vec::Vec;
 
 pub struct TableId<T> {
     rep: u32,


### PR DESCRIPTION
This commit is a refinement of #11325 to use `.unwrap()` internally instead of ignoring errors from dropping futures and streams. Fallible drop isn't supported in Rust and these shouldn't panic assuming the host is properly matching handles to stores.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
