### PR TITLE
ensure component value lowerings are run on a worker fiber

### DIFF
--- a/crates/wasmtime/src/runtime/component/func/options.rs
+++ b/crates/wasmtime/src/runtime/component/func/options.rs
@@ -241,6 +241,12 @@ impl<'a, T: 'static> LowerContext<'a, T> {
         types: &'a ComponentTypes,
         instance: Instance,
     ) -> LowerContext<'a, T> {
+        #[cfg(all(debug_assertions, feature = "component-model-async"))]
+        if store.engine().config().async_support {
+            // Assert that we're running on a fiber, which is necessary in
+            // case we call the guest's realloc function.
+            store.0.with_blocking(|_, _| {});
+        }
         LowerContext {
             store,
             options,


### PR DESCRIPTION
This is necessary because lowering a component value may require calling realloc, which may involve epoch interruption, which may require suspending the current fiber.  Which obviously doesn't work if we're not running in a fiber. Also, we need to make sure there are no host frames on the stack.

Note the use of `Mutex` for `WorkItem::WorkerFunction` and `WorkerItem::Function`.  We never lock the mutex -- it's only used to plumb through the inner, non-`Sync` value while satisfying the compiler that `Store` is `Sync`.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
