### PR TITLE
Take typed Wasm indices in `FuncTranslationState::get_*` methods

### DIFF
--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -2823,7 +2823,6 @@ impl FuncEnvironment<'_> {
         &mut self,
         builder: &mut FunctionBuilder<'_>,
         index: MemoryIndex,
-        _heap: Heap,
         val: ir::Value,
     ) -> WasmResult<ir::Value> {
         let mut pos = builder.cursor();
@@ -2855,7 +2854,6 @@ impl FuncEnvironment<'_> {
         &mut self,
         mut pos: FuncCursor<'_>,
         index: MemoryIndex,
-        _heap: Heap,
     ) -> WasmResult<ir::Value> {
         let pointer_type = self.pointer_type();
         let vmctx = self.vmctx(&mut pos.func);
@@ -2940,9 +2938,7 @@ impl FuncEnvironment<'_> {
         &mut self,
         builder: &mut FunctionBuilder<'_>,
         src_index: MemoryIndex,
-        _src_heap: Heap,
         dst_index: MemoryIndex,
-        _dst_heap: Heap,
         dst: ir::Value,
         src: ir::Value,
         len: ir::Value,
@@ -2977,7 +2973,6 @@ impl FuncEnvironment<'_> {
         &mut self,
         builder: &mut FunctionBuilder<'_>,
         memory_index: MemoryIndex,
-        _heap: Heap,
         dst: ir::Value,
         val: ir::Value,
         len: ir::Value,
@@ -3001,7 +2996,6 @@ impl FuncEnvironment<'_> {
         &mut self,
         builder: &mut FunctionBuilder<'_>,
         memory_index: MemoryIndex,
-        _heap: Heap,
         seg_index: u32,
         dst: ir::Value,
         src: ir::Value,
@@ -3366,12 +3360,12 @@ impl FuncEnvironment<'_> {
     pub fn update_global(
         &mut self,
         builder: &mut FunctionBuilder,
-        global_index: u32,
+        global_index: GlobalIndex,
         value: ir::Value,
     ) {
         #[cfg(feature = "wmemcheck")]
         if self.compiler.wmemcheck {
-            if global_index == 0 {
+            if global_index.index() == 0 {
                 // We are making the assumption that global 0 is the auxiliary stack pointer.
                 let update_stack_pointer =
                     self.builtin_functions.update_stack_pointer(builder.func);

--- a/crates/cranelift/src/translate/state.rs
+++ b/crates/cranelift/src/translate/state.rs
@@ -470,10 +470,9 @@ impl FuncTranslationState {
     pub(crate) fn get_global(
         &mut self,
         func: &mut ir::Function,
-        index: u32,
+        index: GlobalIndex,
         environ: &mut FuncEnvironment<'_>,
     ) -> WasmResult<GlobalVariable> {
-        let index = GlobalIndex::from_u32(index);
         match self.globals[index] {
             Some(g) => Ok(g),
             None => {
@@ -489,10 +488,9 @@ impl FuncTranslationState {
     pub(crate) fn get_heap(
         &mut self,
         func: &mut ir::Function,
-        index: u32,
+        index: MemoryIndex,
         environ: &mut FuncEnvironment<'_>,
     ) -> WasmResult<Heap> {
-        let index = MemoryIndex::from_u32(index);
         match self.memory_to_heap[index].expand() {
             Some(heap) => Ok(heap),
             None => {
@@ -510,10 +508,9 @@ impl FuncTranslationState {
     pub(crate) fn get_indirect_sig(
         &mut self,
         func: &mut ir::Function,
-        index: u32,
+        index: TypeIndex,
         environ: &mut FuncEnvironment<'_>,
     ) -> WasmResult<(ir::SigRef, usize)> {
-        let index = TypeIndex::from_u32(index);
         match self.signatures[index] {
             Some((sig, num_params)) => Ok((sig, num_params)),
             None => {
@@ -532,10 +529,9 @@ impl FuncTranslationState {
     pub(crate) fn get_direct_func(
         &mut self,
         func: &mut ir::Function,
-        index: u32,
+        index: FuncIndex,
         environ: &mut FuncEnvironment<'_>,
     ) -> WasmResult<(ir::FuncRef, usize)> {
-        let index = FuncIndex::from_u32(index);
         match self.functions[index] {
             Some((fref, num_args)) => Ok((fref, num_args)),
             None => {


### PR DESCRIPTION
These methods get-or-create various entities given some kind of Wasm index. Those Wasm indices were previously passed as `u32`s, but are now typed indices (e.g. `MemoryIndex` instead of `u32`). This makes it more difficult to pass the wrong index to these methods.

I also removed some unused arguments from a few `FuncEnvironment` methods that the results of `FuncTranslationState::get_*` calls were feeding into. These were left over from when `FuncEnvironment` was a trait and not a single type.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
