### PR TITLE
move waitable to original set after moving it to temporary one

### DIFF
--- a/crates/misc/component-async-tests/tests/scenario/transmit.rs
+++ b/crates/misc/component-async-tests/tests/scenario/transmit.rs
@@ -49,6 +49,11 @@ pub async fn async_cancel_caller() -> Result<()> {
 }
 
 #[tokio::test]
+pub async fn async_cancel_caller_leak_task_after_cancel() -> Result<()> {
+    test_cancel(Mode::LeakTaskAfterCancel).await
+}
+
+#[tokio::test]
 pub async fn async_trap_cancel_guest_after_start_cancelled() -> Result<()> {
     test_cancel_trap(Mode::TrapCancelGuestAfterStartCancelled).await
 }

--- a/crates/misc/component-async-tests/wit/test.wit
+++ b/crates/misc/component-async-tests/wit/test.wit
@@ -151,6 +151,7 @@ interface cancel {
     trap-cancel-guest-after-return,
     trap-cancel-host-after-return-cancelled,
     trap-cancel-host-after-return,
+    leak-task-after-cancel,
   }
 
   run: func(mode: mode, cancel-delay-millis: u64);

--- a/crates/test-programs/src/bin/async_cancel_callee.rs
+++ b/crates/test-programs/src/bin/async_cancel_callee.rs
@@ -57,6 +57,7 @@ const _MODE_TRAP_CANCEL_GUEST_AFTER_RETURN_CANCELLED: u8 = 2;
 const _MODE_TRAP_CANCEL_GUEST_AFTER_RETURN: u8 = 3;
 const MODE_TRAP_CANCEL_HOST_AFTER_RETURN_CANCELLED: u8 = 4;
 const MODE_TRAP_CANCEL_HOST_AFTER_RETURN: u8 = 5;
+const MODE_LEAK_TASK_AFTER_CANCEL: u8 = 6;
 
 #[derive(Clone, Copy)]
 struct SleepParams {
@@ -166,7 +167,10 @@ unsafe extern "C" fn callback_sleep_with_options_sleep_millis(
                 }
 
                 waitable_join(*waitable, 0);
-                subtask_drop(*waitable);
+
+                if params.mode != MODE_LEAK_TASK_AFTER_CANCEL {
+                    subtask_drop(*waitable);
+                }
 
                 if params.on_cancel_delay_millis == 0 {
                     match params.on_cancel {


### PR DESCRIPTION
There are a few places in `concurrent.rs` where we use `GuestTask::sync_call_set` to wait on waitables during synchronous calls. However, they may have been members of another set before we joined them to `sync_call_set`, in which case we need to move them back when we're done (or at least remove them from `sync_call_set`).

Prior to this fix, we would panic when dropping a task which had subtasks which had been synchronously cancelled.  I've updated `async_cancel_callee.rs` to cover that case.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
