### PR TITLE
docs: fix typos

### DIFF
--- a/crates/wit-bindgen/src/lib.rs
+++ b/crates/wit-bindgen/src/lib.rs
@@ -172,7 +172,7 @@ pub struct Opts {
     ///
     /// This can also be toggled via the `WASMTIME_DEBUG_BINDGEN` environment
     /// variable, but that will affect _all_ `bindgen!` macro invocations (and
-    /// can sometimes lead to one invocation ovewriting another in unpredictable
+    /// can sometimes lead to one invocation overwriting another in unpredictable
     /// ways), whereas this option lets you specify it on a case-by-case basis.
     pub debug: bool,
 

--- a/docs/examples-deterministic-wasm-execution.md
+++ b/docs/examples-deterministic-wasm-execution.md
@@ -32,7 +32,7 @@ for more details.
 
 The relaxed SIMD proposal gives Wasm programs access to SIMD operations that
 cannot be made to execute both identically and performantly across different
-architecures. The proposal gave up determinism across different achitectures in
+architectures. The proposal gave up determinism across different achitectures in
 order to maintain portable performance.
 
 At the cost of worse runtime performance, Wasmtime can deterministically execute

--- a/tests/misc_testsuite/component-model/fused.wast
+++ b/tests/misc_testsuite/component-model/fused.wast
@@ -1340,7 +1340,7 @@
     (core instance $m (instantiate $m))
 
     ;; This adapter, when fused with itself on the second instantiation of this
-    ;; component, will dependend on the prior instance `$m` so it which means
+    ;; component, will depended on the prior instance `$m` so it which means
     ;; that the adapter module containing this must be placed in the right
     ;; location.
     (core func $execute


### PR DESCRIPTION
### Description

This PR corrects several minor typos in comments and documentation across the codebase. The changes are non-functional and purely textual to improve clarity and maintain a clean, professional codebase.

### Details

- Corrected misspellings:
  - `ovewriting` → `overwriting`
  - `architecures` → `architectures`
  - `dependend` → `depended`

These fixes help enhance readability and eliminate minor distractions during development and code reviews.

### Additional Info

No logic or functionality has been modified. All changes are restricted to comments or non-executable doc annotations.