### PR TITLE
Switch blanket impls for WASI traits

### DIFF
--- a/crates/wasi/src/clocks.rs
+++ b/crates/wasi/src/clocks.rs
@@ -20,18 +20,6 @@ pub trait WasiClocksView: Send {
     fn clocks(&mut self) -> &mut WasiClocksCtx;
 }
 
-impl<T: WasiClocksView> WasiClocksView for &mut T {
-    fn clocks(&mut self) -> &mut WasiClocksCtx {
-        T::clocks(self)
-    }
-}
-
-impl<T: WasiClocksView> WasiClocksView for Box<T> {
-    fn clocks(&mut self) -> &mut WasiClocksCtx {
-        T::clocks(self)
-    }
-}
-
 impl WasiClocksView for WasiClocksCtx {
     fn clocks(&mut self) -> &mut WasiClocksCtx {
         self

--- a/crates/wasi/src/p3/cli/mod.rs
+++ b/crates/wasi/src/p3/cli/mod.rs
@@ -13,18 +13,6 @@ pub struct WasiCliCtxView<'a> {
     pub table: &'a mut ResourceTable,
 }
 
-impl<T: WasiCliView> WasiCliView for &mut T {
-    fn cli(&mut self) -> WasiCliCtxView<'_> {
-        T::cli(self)
-    }
-}
-
-impl<T: WasiCliView> WasiCliView for Box<T> {
-    fn cli(&mut self) -> WasiCliCtxView<'_> {
-        T::cli(self)
-    }
-}
-
 pub trait WasiCliView: Send {
     fn cli(&mut self) -> WasiCliCtxView<'_>;
 }
@@ -100,7 +88,7 @@ where
     T: WasiCliView + 'static,
 {
     let exit_options = cli::exit::LinkOptions::default();
-    add_to_linker_impl(linker, &exit_options, T::cli)
+    add_to_linker_with_options(linker, &exit_options)
 }
 
 /// Similar to [`add_to_linker`], but with the ability to enable unstable features.
@@ -111,24 +99,16 @@ pub fn add_to_linker_with_options<T>(
 where
     T: WasiCliView + 'static,
 {
-    add_to_linker_impl(linker, exit_options, T::cli)
-}
-
-pub(crate) fn add_to_linker_impl<T: Send>(
-    linker: &mut Linker<T>,
-    exit_options: &cli::exit::LinkOptions,
-    host_getter: fn(&mut T) -> WasiCliCtxView<'_>,
-) -> wasmtime::Result<()> {
-    cli::exit::add_to_linker::<_, WasiCli>(linker, exit_options, host_getter)?;
-    cli::environment::add_to_linker::<_, WasiCli>(linker, host_getter)?;
-    cli::stdin::add_to_linker::<_, WasiCli>(linker, host_getter)?;
-    cli::stdout::add_to_linker::<_, WasiCli>(linker, host_getter)?;
-    cli::stderr::add_to_linker::<_, WasiCli>(linker, host_getter)?;
-    cli::terminal_input::add_to_linker::<_, WasiCli>(linker, host_getter)?;
-    cli::terminal_output::add_to_linker::<_, WasiCli>(linker, host_getter)?;
-    cli::terminal_stdin::add_to_linker::<_, WasiCli>(linker, host_getter)?;
-    cli::terminal_stdout::add_to_linker::<_, WasiCli>(linker, host_getter)?;
-    cli::terminal_stderr::add_to_linker::<_, WasiCli>(linker, host_getter)?;
+    cli::exit::add_to_linker::<_, WasiCli>(linker, exit_options, T::cli)?;
+    cli::environment::add_to_linker::<_, WasiCli>(linker, T::cli)?;
+    cli::stdin::add_to_linker::<_, WasiCli>(linker, T::cli)?;
+    cli::stdout::add_to_linker::<_, WasiCli>(linker, T::cli)?;
+    cli::stderr::add_to_linker::<_, WasiCli>(linker, T::cli)?;
+    cli::terminal_input::add_to_linker::<_, WasiCli>(linker, T::cli)?;
+    cli::terminal_output::add_to_linker::<_, WasiCli>(linker, T::cli)?;
+    cli::terminal_stdin::add_to_linker::<_, WasiCli>(linker, T::cli)?;
+    cli::terminal_stdout::add_to_linker::<_, WasiCli>(linker, T::cli)?;
+    cli::terminal_stderr::add_to_linker::<_, WasiCli>(linker, T::cli)?;
     Ok(())
 }
 

--- a/crates/wasi/src/p3/clocks/mod.rs
+++ b/crates/wasi/src/p3/clocks/mod.rs
@@ -55,15 +55,8 @@ pub fn add_to_linker<T>(linker: &mut Linker<T>) -> wasmtime::Result<()>
 where
     T: WasiClocksView + 'static,
 {
-    add_to_linker_impl(linker, T::clocks)
-}
-
-pub(crate) fn add_to_linker_impl<T: Send>(
-    linker: &mut Linker<T>,
-    host_getter: fn(&mut T) -> &mut WasiClocksCtx,
-) -> wasmtime::Result<()> {
-    clocks::monotonic_clock::add_to_linker::<_, WasiClocks>(linker, host_getter)?;
-    clocks::wall_clock::add_to_linker::<_, WasiClocks>(linker, host_getter)?;
+    clocks::monotonic_clock::add_to_linker::<_, WasiClocks>(linker, T::clocks)?;
+    clocks::wall_clock::add_to_linker::<_, WasiClocks>(linker, T::clocks)?;
     Ok(())
 }
 

--- a/crates/wasi/src/p3/mod.rs
+++ b/crates/wasi/src/p3/mod.rs
@@ -17,11 +17,8 @@ pub mod random;
 pub mod sockets;
 mod view;
 
-use wasmtime::component::Linker;
-
 use crate::p3::bindings::LinkOptions;
-use crate::p3::cli::WasiCliCtxView;
-use crate::sockets::WasiSocketsCtxView;
+use wasmtime::component::Linker;
 
 pub use self::ctx::{WasiCtx, WasiCtxBuilder};
 pub use self::view::{WasiCtxView, WasiView};
@@ -93,21 +90,9 @@ pub fn add_to_linker_with_options<T>(
 where
     T: WasiView + 'static,
 {
-    cli::add_to_linker_impl(linker, &options.into(), |x| {
-        let WasiCtxView { ctx, table } = x.ctx();
-        WasiCliCtxView {
-            ctx: &mut ctx.cli,
-            table,
-        }
-    })?;
-    clocks::add_to_linker_impl(linker, |x| &mut x.ctx().ctx.clocks)?;
-    random::add_to_linker_impl(linker, |x| &mut x.ctx().ctx.random)?;
-    sockets::add_to_linker_impl(linker, |x| {
-        let WasiCtxView { ctx, table } = x.ctx();
-        WasiSocketsCtxView {
-            ctx: &mut ctx.sockets,
-            table,
-        }
-    })?;
+    cli::add_to_linker_with_options(linker, &options.into())?;
+    clocks::add_to_linker(linker)?;
+    random::add_to_linker(linker)?;
+    sockets::add_to_linker(linker)?;
     Ok(())
 }

--- a/crates/wasi/src/p3/random/mod.rs
+++ b/crates/wasi/src/p3/random/mod.rs
@@ -55,16 +55,9 @@ pub fn add_to_linker<T>(linker: &mut Linker<T>) -> wasmtime::Result<()>
 where
     T: WasiRandomView + 'static,
 {
-    add_to_linker_impl(linker, T::random)
-}
-
-pub(crate) fn add_to_linker_impl<T: Send>(
-    linker: &mut Linker<T>,
-    host_getter: fn(&mut T) -> &mut WasiRandomCtx,
-) -> wasmtime::Result<()> {
-    random::random::add_to_linker::<_, WasiRandom>(linker, host_getter)?;
-    random::insecure::add_to_linker::<_, WasiRandom>(linker, host_getter)?;
-    random::insecure_seed::add_to_linker::<_, WasiRandom>(linker, host_getter)?;
+    random::random::add_to_linker::<_, WasiRandom>(linker, T::random)?;
+    random::insecure::add_to_linker::<_, WasiRandom>(linker, T::random)?;
+    random::insecure_seed::add_to_linker::<_, WasiRandom>(linker, T::random)?;
     Ok(())
 }
 

--- a/crates/wasi/src/p3/sockets/mod.rs
+++ b/crates/wasi/src/p3/sockets/mod.rs
@@ -63,15 +63,8 @@ pub fn add_to_linker<T>(linker: &mut Linker<T>) -> wasmtime::Result<()>
 where
     T: WasiSocketsView + 'static,
 {
-    add_to_linker_impl(linker, T::sockets)
-}
-
-pub(crate) fn add_to_linker_impl<T: Send>(
-    linker: &mut Linker<T>,
-    host_getter: fn(&mut T) -> WasiSocketsCtxView<'_>,
-) -> wasmtime::Result<()> {
-    sockets::ip_name_lookup::add_to_linker::<_, WasiSockets>(linker, host_getter)?;
-    sockets::types::add_to_linker::<_, WasiSockets>(linker, host_getter)?;
+    sockets::ip_name_lookup::add_to_linker::<_, WasiSockets>(linker, T::sockets)?;
+    sockets::types::add_to_linker::<_, WasiSockets>(linker, T::sockets)?;
     Ok(())
 }
 

--- a/crates/wasi/src/p3/view.rs
+++ b/crates/wasi/src/p3/view.rs
@@ -40,19 +40,39 @@ pub trait WasiView: Send {
     fn ctx(&mut self) -> WasiCtxView<'_>;
 }
 
-impl<T: ?Sized + WasiView> WasiView for &mut T {
-    fn ctx(&mut self) -> WasiCtxView<'_> {
-        T::ctx(self)
-    }
-}
-
-impl<T: ?Sized + WasiView> WasiView for Box<T> {
-    fn ctx(&mut self) -> WasiCtxView<'_> {
-        T::ctx(self)
-    }
-}
-
 pub struct WasiCtxView<'a> {
     pub ctx: &'a mut WasiCtx,
     pub table: &'a mut ResourceTable,
+}
+
+impl<T: WasiView> crate::sockets::WasiSocketsView for T {
+    fn sockets(&mut self) -> crate::sockets::WasiSocketsCtxView<'_> {
+        let WasiCtxView { ctx, table } = self.ctx();
+        crate::sockets::WasiSocketsCtxView {
+            ctx: &mut ctx.sockets,
+            table,
+        }
+    }
+}
+
+impl<T: WasiView> crate::clocks::WasiClocksView for T {
+    fn clocks(&mut self) -> &mut crate::clocks::WasiClocksCtx {
+        &mut self.ctx().ctx.clocks
+    }
+}
+
+impl<T: WasiView> crate::random::WasiRandomView for T {
+    fn random(&mut self) -> &mut crate::random::WasiRandomCtx {
+        &mut self.ctx().ctx.random
+    }
+}
+
+impl<T: WasiView> crate::p3::cli::WasiCliView for T {
+    fn cli(&mut self) -> crate::p3::cli::WasiCliCtxView<'_> {
+        let WasiCtxView { ctx, table } = self.ctx();
+        crate::p3::cli::WasiCliCtxView {
+            ctx: &mut ctx.cli,
+            table,
+        }
+    }
 }

--- a/crates/wasi/src/random.rs
+++ b/crates/wasi/src/random.rs
@@ -31,18 +31,6 @@ pub trait WasiRandomView: Send {
     fn random(&mut self) -> &mut WasiRandomCtx;
 }
 
-impl<T: WasiRandomView> WasiRandomView for &mut T {
-    fn random(&mut self) -> &mut WasiRandomCtx {
-        T::random(self)
-    }
-}
-
-impl<T: WasiRandomView> WasiRandomView for Box<T> {
-    fn random(&mut self) -> &mut WasiRandomCtx {
-        T::random(self)
-    }
-}
-
 impl WasiRandomView for WasiRandomCtx {
     fn random(&mut self) -> &mut WasiRandomCtx {
         self

--- a/crates/wasi/src/sockets/mod.rs
+++ b/crates/wasi/src/sockets/mod.rs
@@ -32,18 +32,6 @@ pub trait WasiSocketsView: Send {
     fn sockets(&mut self) -> WasiSocketsCtxView<'_>;
 }
 
-impl<T: WasiSocketsView> WasiSocketsView for &mut T {
-    fn sockets(&mut self) -> WasiSocketsCtxView<'_> {
-        T::sockets(self)
-    }
-}
-
-impl<T: WasiSocketsView> WasiSocketsView for Box<T> {
-    fn sockets(&mut self) -> WasiSocketsCtxView<'_> {
-        T::sockets(self)
-    }
-}
-
 #[derive(Copy, Clone)]
 pub struct AllowedNetworkUses {
     pub ip_name_lookup: bool,


### PR DESCRIPTION
This commit removes blanket "forwarding" impls for `&mut T` and `Box<T>` in favor of having forwarding impls of `WasiView` implying specific interfaces such as `WasiRandomView` for example. This is intended to make future integration with wasi-http easier where wasi-http will take a few specific proposals (e.g. not `WasiFilesystemView`) but implementing `WasiView` for a contexet will still be sufficient (as opposed to requiring multiple implementations of separate traits).

The original use case of forwarding impls has more-or-less been refactored away at this point so I don't think it's as critical to preserve them.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
