### PR TITLE
fix sending default value when closing host-owned future writer

### DIFF
--- a/crates/misc/component-async-tests/wit/test.wit
+++ b/crates/misc/component-async-tests/wit/test.wit
@@ -126,6 +126,7 @@ interface resource-stream {
 interface closed {
   read-stream: async func(rx: stream<u8>, expected: list<u8>);
   read-future: async func(rx: future<u8>, expected: u8, rx-ignore: future<u8>);
+  read-future-post-return: async func(rx: future<u8>, expected: u8, rx-ignore: future<u8>);
 }
 
 interface sleep {

--- a/crates/test-programs/src/bin/async_closed_streams.rs
+++ b/crates/test-programs/src/bin/async_closed_streams.rs
@@ -11,7 +11,7 @@ mod bindings {
 
 use {
     bindings::exports::local::local::closed::Guest,
-    wit_bindgen_rt::async_support::{FutureReader, StreamReader, StreamResult},
+    wit_bindgen_rt::async_support::{self, FutureReader, StreamReader, StreamResult},
 };
 
 struct Component;
@@ -25,6 +25,16 @@ impl Guest for Component {
 
     async fn read_future(rx: FutureReader<u8>, expected: u8, _rx_ignored: FutureReader<u8>) {
         assert_eq!(rx.await, expected);
+    }
+
+    async fn read_future_post_return(
+        rx: FutureReader<u8>,
+        expected: u8,
+        _rx_ignored: FutureReader<u8>,
+    ) {
+        async_support::spawn(async move {
+            assert_eq!(rx.await, expected);
+        });
     }
 }
 

--- a/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams.rs
@@ -1860,6 +1860,7 @@ impl Instance {
         id: TableId<TransmitHandle>,
         mut buffer: B,
         kind: TransmitKind,
+        post_write: PostWrite,
     ) -> Result<Result<HostResult<B>, oneshot::Receiver<HostResult<B>>>> {
         let transmit_id = self.concurrent_state_mut(store.0).get(id)?.state;
         let transmit = self
@@ -1873,6 +1874,10 @@ impl Instance {
         } else {
             ReadState::Open
         };
+
+        if matches!(post_write, PostWrite::Drop) && !matches!(transmit.read, ReadState::Open) {
+            transmit.write = WriteState::Dropped;
+        }
 
         Ok(match mem::replace(&mut transmit.read, new_state) {
             ReadState::Open => {
@@ -1892,7 +1897,7 @@ impl Instance {
                         _ = tx.send(result);
                         Ok(code)
                     }),
-                    post_write: PostWrite::Continue,
+                    post_write,
                 };
                 self.concurrent_state_mut(store.0)
                     .get_mut(transmit_id)?
@@ -2003,10 +2008,15 @@ impl Instance {
         buffer: B,
         kind: TransmitKind,
     ) -> Result<HostResult<B>> {
-        match accessor
-            .as_accessor()
-            .with(move |mut access| self.host_write(access.as_context_mut(), id, buffer, kind))?
-        {
+        match accessor.as_accessor().with(move |mut access| {
+            self.host_write(
+                access.as_context_mut(),
+                id,
+                buffer,
+                kind,
+                PostWrite::Continue,
+            )
+        })? {
             Ok(result) => Ok(result),
             Err(rx) => Ok(rx.await?),
         }
@@ -2247,7 +2257,6 @@ impl Instance {
         default: Option<&dyn Fn() -> Result<T>>,
     ) -> Result<()> {
         let transmit_id = self.concurrent_state_mut(store.0).get(id)?.state;
-        let token = StoreToken::new(store.as_context_mut());
         let transmit = self
             .concurrent_state_mut(store.0)
             .get_mut(transmit_id)
@@ -2271,32 +2280,27 @@ impl Instance {
                 *post_write = PostWrite::Drop;
             }
             v @ WriteState::Open => {
-                *v = if let (Some(default), false) = (
+                if let (Some(default), false) = (
                     default,
                     transmit.done || matches!(transmit.read, ReadState::Dropped),
                 ) {
                     // This is a future, and we haven't written a value yet --
                     // write the default value.
-                    let default = default()?;
-                    WriteState::HostReady {
-                        accept: Box::new(move |store, instance, reader| {
-                            let (_, code) = accept_reader::<T, Option<T>, U>(
-                                token.as_context_mut(store),
-                                instance,
-                                reader,
-                                Some(default),
-                                TransmitKind::Future,
-                            )?;
-                            Ok(code)
-                        }),
-                        post_write: PostWrite::Drop,
-                    }
+                    _ = self.host_write(
+                        store.as_context_mut(),
+                        id,
+                        Some(default()?),
+                        TransmitKind::Future,
+                        PostWrite::Drop,
+                    )?;
                 } else {
-                    WriteState::Dropped
-                };
+                    *v = WriteState::Dropped;
+                }
             }
             WriteState::Dropped => unreachable!("write state is already dropped"),
         }
+
+        let transmit = self.concurrent_state_mut(store.0).get_mut(transmit_id)?;
 
         // If the existing read state is dropped, then there's nothing to read
         // and we can keep it that way.


### PR DESCRIPTION
My earlier commit didn't handle all the cases, which caused a regression for the wasi-http tests in the `wasip3-prototyping` repo.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
