### PR TITLE
Start sharing more code in WASI between p2/p3

### DIFF
--- a/crates/wasi/src/p2/ctx.rs
+++ b/crates/wasi/src/p2/ctx.rs
@@ -448,12 +448,7 @@ impl WasiCtxBuilder {
                             wall_clock,
                             monotonic_clock,
                         },
-                    random:
-                        WasiRandomCtx {
-                            random,
-                            insecure_random,
-                            insecure_random_seed,
-                        },
+                    random,
                     sockets:
                         WasiSocketsCtx {
                             socket_addr_check,
@@ -475,8 +470,6 @@ impl WasiCtxBuilder {
             preopens,
             socket_addr_check,
             random,
-            insecure_random,
-            insecure_random_seed,
             wall_clock,
             monotonic_clock,
             allowed_network_uses,
@@ -552,9 +545,7 @@ impl WasiCtxBuilder {
 /// }
 /// ```
 pub struct WasiCtx {
-    pub(crate) random: Box<dyn RngCore + Send>,
-    pub(crate) insecure_random: Box<dyn RngCore + Send>,
-    pub(crate) insecure_random_seed: u128,
+    pub(crate) random: WasiRandomCtx,
     pub(crate) wall_clock: Box<dyn HostWallClock + Send>,
     pub(crate) monotonic_clock: Box<dyn HostMonotonicClock + Send>,
     pub(crate) env: Vec<(String, String)>,

--- a/crates/wasi/src/p2/host/random.rs
+++ b/crates/wasi/src/p2/host/random.rs
@@ -1,45 +1,36 @@
 use crate::p2::bindings::random::{insecure, insecure_seed, random};
-use crate::p2::{WasiImpl, WasiView};
+use crate::random::WasiRandomCtx;
 use cap_rand::{Rng, distributions::Standard};
 
-impl<T> random::Host for WasiImpl<T>
-where
-    T: WasiView,
-{
+impl random::Host for WasiRandomCtx {
     fn get_random_bytes(&mut self, len: u64) -> anyhow::Result<Vec<u8>> {
-        Ok((&mut self.ctx().random)
+        Ok((&mut self.random)
             .sample_iter(Standard)
             .take(len as usize)
             .collect())
     }
 
     fn get_random_u64(&mut self) -> anyhow::Result<u64> {
-        Ok(self.ctx().random.sample(Standard))
+        Ok(self.random.sample(Standard))
     }
 }
 
-impl<T> insecure::Host for WasiImpl<T>
-where
-    T: WasiView,
-{
+impl insecure::Host for WasiRandomCtx {
     fn get_insecure_random_bytes(&mut self, len: u64) -> anyhow::Result<Vec<u8>> {
-        Ok((&mut self.ctx().insecure_random)
+        Ok((&mut self.insecure_random)
             .sample_iter(Standard)
             .take(len as usize)
             .collect())
     }
 
     fn get_insecure_random_u64(&mut self) -> anyhow::Result<u64> {
-        Ok(self.ctx().insecure_random.sample(Standard))
+        Ok(self.insecure_random.sample(Standard))
     }
 }
 
-impl<T> insecure_seed::Host for WasiImpl<T>
-where
-    T: WasiView,
-{
+impl insecure_seed::Host for WasiRandomCtx {
     fn insecure_seed(&mut self) -> anyhow::Result<(u64, u64)> {
-        let seed: u128 = self.ctx().insecure_random_seed;
+        let seed: u128 = self.insecure_random_seed;
         Ok((seed as u64, (seed >> 64) as u64))
     }
 }

--- a/crates/wasi/src/p2/mod.rs
+++ b/crates/wasi/src/p2/mod.rs
@@ -250,6 +250,7 @@ pub use self::stdio::{
     Stdout, StdoutStream, stderr, stdin, stdout,
 };
 pub use self::view::{WasiImpl, WasiView};
+use crate::random::WasiRandom;
 // These contents of wasmtime-wasi-io are re-exported by this module for compatibility:
 // they were originally defined in this module before being factored out, and many
 // users of this module depend on them at these names.
@@ -355,9 +356,9 @@ where
     clocks::wall_clock::add_to_linker::<T, HasWasi<T>>(l, f)?;
     clocks::monotonic_clock::add_to_linker::<T, HasWasi<T>>(l, f)?;
     filesystem::preopens::add_to_linker::<T, HasWasi<T>>(l, f)?;
-    random::random::add_to_linker::<T, HasWasi<T>>(l, f)?;
-    random::insecure::add_to_linker::<T, HasWasi<T>>(l, f)?;
-    random::insecure_seed::add_to_linker::<T, HasWasi<T>>(l, f)?;
+    random::random::add_to_linker::<T, WasiRandom>(l, |t| &mut t.ctx().random)?;
+    random::insecure::add_to_linker::<T, WasiRandom>(l, |t| &mut t.ctx().random)?;
+    random::insecure_seed::add_to_linker::<T, WasiRandom>(l, |t| &mut t.ctx().random)?;
     cli::exit::add_to_linker::<T, HasWasi<T>>(l, &options.into(), f)?;
     cli::environment::add_to_linker::<T, HasWasi<T>>(l, f)?;
     cli::stdin::add_to_linker::<T, HasWasi<T>>(l, f)?;
@@ -404,7 +405,7 @@ fn add_proxy_interfaces_nonblocking<T: WasiView + 'static>(
     let f: fn(&mut T) -> WasiImpl<&mut T> = |t| WasiImpl(IoImpl(t));
     clocks::wall_clock::add_to_linker::<T, HasWasi<T>>(l, f)?;
     clocks::monotonic_clock::add_to_linker::<T, HasWasi<T>>(l, f)?;
-    random::random::add_to_linker::<T, HasWasi<T>>(l, f)?;
+    random::random::add_to_linker::<T, WasiRandom>(l, |t| &mut t.ctx().random)?;
     cli::stdin::add_to_linker::<T, HasWasi<T>>(l, f)?;
     cli::stdout::add_to_linker::<T, HasWasi<T>>(l, f)?;
     cli::stderr::add_to_linker::<T, HasWasi<T>>(l, f)?;

--- a/crates/wasi/src/p3/random/mod.rs
+++ b/crates/wasi/src/p3/random/mod.rs
@@ -1,8 +1,8 @@
 mod host;
 
 use crate::p3::bindings::random;
-use crate::random::{WasiRandomCtx, WasiRandomView};
-use wasmtime::component::{HasData, Linker};
+use crate::random::{WasiRandom, WasiRandomView};
+use wasmtime::component::Linker;
 
 /// Add all WASI interfaces from this module into the `linker` provided.
 ///
@@ -59,10 +59,4 @@ where
     random::insecure::add_to_linker::<_, WasiRandom>(linker, T::random)?;
     random::insecure_seed::add_to_linker::<_, WasiRandom>(linker, T::random)?;
     Ok(())
-}
-
-struct WasiRandom;
-
-impl HasData for WasiRandom {
-    type Data<'a> = &'a mut WasiRandomCtx;
 }

--- a/crates/wasi/src/preview1.rs
+++ b/crates/wasi/src/preview1.rs
@@ -2548,7 +2548,8 @@ impl wasi_snapshot_preview1::WasiSnapshotPreview1 for WasiP1Ctx {
         buf_len: types::Size,
     ) -> Result<(), types::Error> {
         let rand = self
-            .as_wasi_impl()
+            .wasi
+            .random
             .get_random_bytes(buf_len.into())
             .context("failed to call `get-random-bytes`")
             .map_err(types::Error::trap)?;

--- a/crates/wasi/src/random.rs
+++ b/crates/wasi/src/random.rs
@@ -1,4 +1,11 @@
 use cap_rand::{Rng as _, RngCore, SeedableRng as _};
+use wasmtime::component::HasData;
+
+pub(crate) struct WasiRandom;
+
+impl HasData for WasiRandom {
+    type Data<'a> = &'a mut WasiRandomCtx;
+}
 
 pub struct WasiRandomCtx {
     pub random: Box<dyn RngCore + Send>,


### PR DESCRIPTION
Eventually we're going to want significantly more sharing than we have today but while things are still gated in Wasmtime by default this for now starts out by only changing the structure of the implementations such that the impl of `Host` traits are the same for both p2 and p3. Additionally the `WasiCtx` values are brought closer together to ideally unify them eventually too.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
