### PR TITLE
Silently skip when generation fails from EmptyChoose seed

### DIFF
--- a/fuzz/fuzz_targets/table_ops.rs
+++ b/fuzz/fuzz_targets/table_ops.rs
@@ -18,8 +18,9 @@ fuzz_target!(|data: &[u8]| {
     rng.fill(&mut buf);
 
     let u = Unstructured::new(&buf);
-    let config = wasmtime_fuzzing::generators::Config::arbitrary_take_rest(u)
-        .expect("should be able to generate config from seed");
+    let Ok(config) = wasmtime_fuzzing::generators::Config::arbitrary_take_rest(u) else {
+        return;
+    };
 
     let _ = table_ops(config, ops);
 });


### PR DESCRIPTION
This resolves one of the mentioned bugs in #11346 by replacing an `expect`
call with a simple `return`, avoiding a panic when `EmptyChoose` is selected.