### PR TITLE
optimize host stream/future writes for flat payloads

### DIFF
--- a/crates/wasmtime/src/runtime/component/func/typed.rs
+++ b/crates/wasmtime/src/runtime/component/func/typed.rs
@@ -687,6 +687,9 @@ pub unsafe trait ComponentType: Send + Sync {
     #[doc(hidden)]
     const IS_RUST_UNIT_TYPE: bool = false;
 
+    #[doc(hidden)]
+    const IS_FLAT_TYPE: bool = false;
+
     /// Returns the number of core wasm abi values will be used to represent
     /// this type in its lowered form.
     ///
@@ -1015,6 +1018,8 @@ macro_rules! integers {
             type Lower = ValRaw;
 
             const ABI: CanonicalAbiInfo = CanonicalAbiInfo::$abi;
+
+            const IS_FLAT_TYPE: bool = true;
 
             fn typecheck(ty: &InterfaceType, _types: &InstanceType<'_>) -> Result<()> {
                 match ty {

--- a/crates/wasmtime/src/runtime/component/func/typed.rs
+++ b/crates/wasmtime/src/runtime/component/func/typed.rs
@@ -687,8 +687,15 @@ pub unsafe trait ComponentType: Send + Sync {
     #[doc(hidden)]
     const IS_RUST_UNIT_TYPE: bool = false;
 
+    /// Whether this type might require a call to the guest's realloc function
+    /// to allocate linear memory when lowering (e.g. a non-empty `string`).
+    ///
+    /// If this is `false`, Wasmtime may optimize lowering by using
+    /// `LowerContext::new_without_realloc` and lowering values outside of any
+    /// fiber.  That will panic if the lowering process ends up needing realloc
+    /// after all, so `true` is a conservative default.
     #[doc(hidden)]
-    const IS_FLAT_TYPE: bool = false;
+    const MAY_REQUIRE_REALLOC: bool = true;
 
     /// Returns the number of core wasm abi values will be used to represent
     /// this type in its lowered form.
@@ -1019,7 +1026,7 @@ macro_rules! integers {
 
             const ABI: CanonicalAbiInfo = CanonicalAbiInfo::$abi;
 
-            const IS_FLAT_TYPE: bool = true;
+            const MAY_REQUIRE_REALLOC: bool = false;
 
             fn typecheck(ty: &InterfaceType, _types: &InstanceType<'_>) -> Result<()> {
                 match ty {


### PR DESCRIPTION
When we know statically that a payload will not require any guest realloc calls to lower, there's no need to defer the lowering to a fiber -- we can just do it immediately.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
