### PR TITLE
Do not cache the number of parameters for functions and signatures

### DIFF
--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -1230,6 +1230,22 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
     pub fn needs_gc_heap(&self) -> bool {
         self.needs_gc_heap
     }
+
+    /// Get the number of Wasm parameters for the given function.
+    pub(crate) fn num_params_for_func(&self, function_index: FuncIndex) -> usize {
+        let ty = self.module.functions[function_index]
+            .signature
+            .unwrap_module_type_index();
+        self.types[ty].unwrap_func().params().len()
+    }
+
+    /// Get the number of Wasm parameters for the given function type.
+    ///
+    /// Panics on non-function types.
+    pub(crate) fn num_params_for_function_type(&self, type_index: TypeIndex) -> usize {
+        let ty = self.module.types[type_index].unwrap_module_type_index();
+        self.types[ty].unwrap_func().params().len()
+    }
 }
 
 struct Call<'a, 'func, 'module_env> {

--- a/crates/cranelift/src/translate/code_translator.rs
+++ b/crates/cranelift/src/translate/code_translator.rs
@@ -623,7 +623,8 @@ pub fn translate_operator(
          ************************************************************************************/
         Operator::Call { function_index } => {
             let function_index = FuncIndex::from_u32(*function_index);
-            let (fref, num_args) = state.get_direct_func(builder.func, function_index, environ)?;
+            let fref = state.get_direct_func(builder.func, function_index, environ)?;
+            let num_args = environ.num_params_for_func(function_index);
 
             // Bitcast any vector arguments to their default type, I8X16, before calling.
             let args = state.peekn_mut(num_args);
@@ -654,7 +655,8 @@ pub fn translate_operator(
             // `table_index` is the index of the table to search the function
             // in.
             let type_index = TypeIndex::from_u32(*type_index);
-            let (sigref, num_args) = state.get_indirect_sig(builder.func, type_index, environ)?;
+            let sigref = state.get_indirect_sig(builder.func, type_index, environ)?;
+            let num_args = environ.num_params_for_function_type(type_index);
             let callee = state.pop1();
 
             // Bitcast any vector arguments to their default type, I8X16, before calling.
@@ -695,7 +697,8 @@ pub fn translate_operator(
          ************************************************************************************/
         Operator::ReturnCall { function_index } => {
             let function_index = FuncIndex::from_u32(*function_index);
-            let (fref, num_args) = state.get_direct_func(builder.func, function_index, environ)?;
+            let fref = state.get_direct_func(builder.func, function_index, environ)?;
+            let num_args = environ.num_params_for_func(function_index);
 
             // Bitcast any vector arguments to their default type, I8X16, before calling.
             let args = state.peekn_mut(num_args);
@@ -719,7 +722,8 @@ pub fn translate_operator(
             // `table_index` is the index of the table to search the function
             // in.
             let type_index = TypeIndex::from_u32(*type_index);
-            let (sigref, num_args) = state.get_indirect_sig(builder.func, type_index, environ)?;
+            let sigref = state.get_indirect_sig(builder.func, type_index, environ)?;
+            let num_args = environ.num_params_for_function_type(type_index);
             let callee = state.pop1();
 
             // Bitcast any vector arguments to their default type, I8X16, before calling.
@@ -744,7 +748,8 @@ pub fn translate_operator(
             // `index` is the index of the function's signature and `table_index` is the index of
             // the table to search the function in.
             let type_index = TypeIndex::from_u32(*type_index);
-            let (sigref, num_args) = state.get_indirect_sig(builder.func, type_index, environ)?;
+            let sigref = state.get_indirect_sig(builder.func, type_index, environ)?;
+            let num_args = environ.num_params_for_function_type(type_index);
             let callee = state.pop1();
 
             // Bitcast any vector arguments to their default type, I8X16, before calling.
@@ -2485,7 +2490,8 @@ pub fn translate_operator(
             // `index` is the index of the function's signature and `table_index` is the index of
             // the table to search the function in.
             let type_index = TypeIndex::from_u32(*type_index);
-            let (sigref, num_args) = state.get_indirect_sig(builder.func, type_index, environ)?;
+            let sigref = state.get_indirect_sig(builder.func, type_index, environ)?;
+            let num_args = environ.num_params_for_function_type(type_index);
             let callee = state.pop1();
 
             // Bitcast any vector arguments to their default type, I8X16, before calling.


### PR DESCRIPTION
We already have easy access to the function types themselves, and asking for their parameter length is cheap once we have a reference to them.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
