### PR TITLE
Move Wasm-to-CLIF entity translation out of `FuncTranslationState` and into `FuncEnvironment`

### DIFF
--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -2,7 +2,7 @@ mod gc;
 
 use crate::compiler::Compiler;
 use crate::translate::{
-    FuncTranslationState, GlobalVariable, Heap, HeapData, StructFieldsVec, TableData, TableSize,
+    FuncTranslationStacks, GlobalVariable, Heap, HeapData, StructFieldsVec, TableData, TableSize,
     TargetEnvironment,
 };
 use crate::{BuiltinFunctionSignatures, TRAP_INTERNAL_ASSERT};
@@ -14,7 +14,7 @@ use cranelift_codegen::ir::types::*;
 use cranelift_codegen::ir::{self, types};
 use cranelift_codegen::ir::{ArgumentPurpose, ConstantData, Function, InstBuilder, MemFlags};
 use cranelift_codegen::isa::{TargetFrontendConfig, TargetIsa};
-use cranelift_entity::packed_option::ReservedValue;
+use cranelift_entity::packed_option::{PackedOption, ReservedValue};
 use cranelift_entity::{EntityRef, PrimaryMap, SecondaryMap};
 use cranelift_frontend::Variable;
 use cranelift_frontend::{FuncInstBuilder, FunctionBuilder};
@@ -100,6 +100,7 @@ pub struct FuncEnvironment<'module_environment> {
     wasm_func_ty: &'module_environment WasmFuncType,
     sig_ref_to_ty: SecondaryMap<ir::SigRef, Option<&'module_environment WasmFuncType>>,
     needs_gc_heap: bool,
+    entities: WasmEntities,
 
     #[cfg(feature = "gc")]
     ty_to_gc_layout: std::collections::HashMap<
@@ -122,9 +123,6 @@ pub struct FuncEnvironment<'module_environment> {
 
     /// Heaps implementing WebAssembly linear memories.
     heaps: PrimaryMap<Heap, HeapData>,
-
-    /// Cranelift tables we have created to implement Wasm tables.
-    tables: SecondaryMap<TableIndex, Option<TableData>>,
 
     /// The Cranelift global holding the vmctx address.
     vmctx: Option<ir::GlobalValue>,
@@ -197,6 +195,7 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
             wasm_func_ty,
             sig_ref_to_ty: SecondaryMap::default(),
             needs_gc_heap: false,
+            entities: WasmEntities::default(),
 
             #[cfg(feature = "gc")]
             ty_to_gc_layout: std::collections::HashMap::new(),
@@ -208,7 +207,6 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
             gc_heap_bound: None,
 
             heaps: PrimaryMap::default(),
-            tables: SecondaryMap::default(),
             vmctx: None,
             vm_store_context: None,
             pcc_vmctx_memtype: None,
@@ -802,89 +800,6 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
         }
     }
 
-    /// Set up the necessary preamble definitions in `func` to access the table identified
-    /// by `index`.
-    ///
-    /// The index space covers both imported and locally declared tables.
-    fn ensure_table_exists(&mut self, func: &mut ir::Function, index: TableIndex) {
-        if self.tables[index].is_some() {
-            return;
-        }
-
-        let pointer_type = self.pointer_type();
-
-        let (ptr, base_offset, current_elements_offset) = {
-            let vmctx = self.vmctx(func);
-            if let Some(def_index) = self.module.defined_table_index(index) {
-                let base_offset =
-                    i32::try_from(self.offsets.vmctx_vmtable_definition_base(def_index)).unwrap();
-                let current_elements_offset = i32::try_from(
-                    self.offsets
-                        .vmctx_vmtable_definition_current_elements(def_index),
-                )
-                .unwrap();
-                (vmctx, base_offset, current_elements_offset)
-            } else {
-                let from_offset = self.offsets.vmctx_vmtable_from(index);
-                let table = func.create_global_value(ir::GlobalValueData::Load {
-                    base: vmctx,
-                    offset: Offset32::new(i32::try_from(from_offset).unwrap()),
-                    global_type: pointer_type,
-                    flags: MemFlags::trusted().with_readonly().with_can_move(),
-                });
-                let base_offset = i32::from(self.offsets.vmtable_definition_base());
-                let current_elements_offset =
-                    i32::from(self.offsets.vmtable_definition_current_elements());
-                (table, base_offset, current_elements_offset)
-            }
-        };
-
-        let table = &self.module.tables[index];
-        let element_size = if table.ref_type.is_vmgcref_type() {
-            // For GC-managed references, tables store `Option<VMGcRef>`s.
-            ir::types::I32.bytes()
-        } else {
-            self.reference_type(table.ref_type.heap_type).0.bytes()
-        };
-
-        let base_gv = func.create_global_value(ir::GlobalValueData::Load {
-            base: ptr,
-            offset: Offset32::new(base_offset),
-            global_type: pointer_type,
-            flags: if Some(table.limits.min) == table.limits.max {
-                // A fixed-size table can't be resized so its base address won't
-                // change.
-                MemFlags::trusted().with_readonly().with_can_move()
-            } else {
-                MemFlags::trusted()
-            },
-        });
-
-        let bound = if Some(table.limits.min) == table.limits.max {
-            TableSize::Static {
-                bound: table.limits.min,
-            }
-        } else {
-            TableSize::Dynamic {
-                bound_gv: func.create_global_value(ir::GlobalValueData::Load {
-                    base: ptr,
-                    offset: Offset32::new(current_elements_offset),
-                    global_type: ir::Type::int(
-                        u16::from(self.offsets.size_of_vmtable_definition_current_elements()) * 8,
-                    )
-                    .unwrap(),
-                    flags: MemFlags::trusted(),
-                }),
-            }
-        };
-
-        self.tables[index] = Some(TableData {
-            base_gv,
-            bound,
-            element_size,
-        });
-    }
-
     fn get_or_init_func_ref_table_elem(
         &mut self,
         builder: &mut FunctionBuilder,
@@ -893,8 +808,7 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
         cold_blocks: bool,
     ) -> ir::Value {
         let pointer_type = self.pointer_type();
-        self.ensure_table_exists(builder.func, table_index);
-        let table_data = self.tables[table_index].clone().unwrap();
+        let table_data = self.get_or_create_table(builder.func, table_index);
 
         // To support lazy initialization of table
         // contents, we check for a null entry here, and
@@ -1245,6 +1159,431 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
     pub(crate) fn num_params_for_function_type(&self, type_index: TypeIndex) -> usize {
         let ty = self.module.types[type_index].unwrap_module_type_index();
         self.types[ty].unwrap_func().params().len()
+    }
+}
+
+#[derive(Default)]
+pub(crate) struct WasmEntities {
+    /// Map from a Wasm global index from this module to its implementation in
+    /// the Cranelift function we are building.
+    pub(crate) globals: SecondaryMap<GlobalIndex, Option<GlobalVariable>>,
+
+    /// Map from a Wasm memory index to its `Heap` implementation in the
+    /// Cranelift function we are building.
+    pub(crate) memories: SecondaryMap<MemoryIndex, PackedOption<Heap>>,
+
+    /// Map from an (interned) Wasm type index from this module to its
+    /// `ir::SigRef` in the Cranelift function we are building.
+    pub(crate) sig_refs: SecondaryMap<ModuleInternedTypeIndex, PackedOption<ir::SigRef>>,
+
+    /// Map from a Wasm function index to its associated function reference in
+    /// the Cranelift function we are building.
+    pub(crate) func_refs: SecondaryMap<FuncIndex, PackedOption<ir::FuncRef>>,
+
+    /// Map from a Wasm table index to its associated implementation in the
+    /// Cranelift function we are building.
+    pub(crate) tables: SecondaryMap<TableIndex, Option<TableData>>,
+}
+
+macro_rules! define_get_or_create_methods {
+    ( $( $name:ident ( $map:ident ) : $create:ident : $key:ty => $val:ty ; )* ) => {
+        $(
+            pub(crate) fn $name(&mut self, func: &mut ir::Function, key: $key) -> $val {
+                match self.entities.$map[key].clone().into() {
+                    Some(val) => val,
+                    None => {
+                        let val = self.$create(func, key);
+                        self.entities.$map[key] = Some(val.clone()).into();
+                        val
+                    }
+                }
+            }
+        )*
+    };
+}
+
+impl FuncEnvironment<'_> {
+    define_get_or_create_methods! {
+        get_or_create_global(globals) : make_global : GlobalIndex => GlobalVariable;
+        get_or_create_heap(memories) : make_heap : MemoryIndex => Heap;
+        get_or_create_interned_sig_ref(sig_refs) : make_sig_ref : ModuleInternedTypeIndex => ir::SigRef;
+        get_or_create_func_ref(func_refs) : make_func_ref : FuncIndex => ir::FuncRef;
+        get_or_create_table(tables) : make_table : TableIndex => TableData;
+    }
+
+    fn make_global(&mut self, func: &mut ir::Function, index: GlobalIndex) -> GlobalVariable {
+        let ty = self.module.globals[index].wasm_ty;
+
+        if ty.is_vmgcref_type() {
+            // Although reference-typed globals live at the same memory location as
+            // any other type of global at the same index would, getting or
+            // setting them requires ref counting barriers. Therefore, we need
+            // to use `GlobalVariable::Custom`, as that is the only kind of
+            // `GlobalVariable` for which translation supports custom
+            // access translation.
+            return GlobalVariable::Custom;
+        }
+
+        let (gv, offset) = self.get_global_location(func, index);
+        GlobalVariable::Memory {
+            gv,
+            offset: offset.into(),
+            ty: super::value_type(self.isa, ty),
+        }
+    }
+
+    pub(crate) fn get_or_create_sig_ref(
+        &mut self,
+        func: &mut ir::Function,
+        ty: TypeIndex,
+    ) -> ir::SigRef {
+        let ty = self.module.types[ty].unwrap_module_type_index();
+        self.get_or_create_interned_sig_ref(func, ty)
+    }
+
+    fn make_sig_ref(
+        &mut self,
+        func: &mut ir::Function,
+        index: ModuleInternedTypeIndex,
+    ) -> ir::SigRef {
+        let wasm_func_ty = self.types[index].unwrap_func();
+        let sig = crate::wasm_call_signature(self.isa, wasm_func_ty, &self.tunables);
+        let sig_ref = func.import_signature(sig);
+        self.sig_ref_to_ty[sig_ref] = Some(wasm_func_ty);
+        sig_ref
+    }
+
+    fn make_func_ref(&mut self, func: &mut ir::Function, index: FuncIndex) -> ir::FuncRef {
+        let sig = self.module.functions[index]
+            .signature
+            .unwrap_module_type_index();
+        let wasm_func_ty = self.types[sig].unwrap_func();
+        let sig = crate::wasm_call_signature(self.isa, wasm_func_ty, &self.tunables);
+        let signature = func.import_signature(sig);
+        self.sig_ref_to_ty[signature] = Some(wasm_func_ty);
+        let name =
+            ir::ExternalName::User(func.declare_imported_user_function(ir::UserExternalName {
+                namespace: crate::NS_WASM_FUNC,
+                index: index.as_u32(),
+            }));
+        func.import_function(ir::ExtFuncData {
+            name,
+            signature,
+
+            // the value of this flag determines the codegen for calls to this
+            // function. if this flag is `false` then absolute relocations will
+            // be generated for references to the function, which requires
+            // load-time relocation resolution. if this flag is set to `true`
+            // then relative relocations are emitted which can be resolved at
+            // object-link-time, just after all functions are compiled.
+            //
+            // this flag is set to `true` for functions defined in the object
+            // we'll be defining in this compilation unit, or everything local
+            // to the wasm module. this means that between functions in a wasm
+            // module there's relative calls encoded. all calls external to a
+            // wasm module (e.g. imports or libcalls) are either encoded through
+            // the `vmcontext` as relative jumps (hence no relocations) or
+            // they're libcalls with absolute relocations.
+            colocated: self.module.defined_func_index(index).is_some()
+                || self.translation.known_imported_functions[index].is_some(),
+        })
+    }
+
+    fn make_heap(&mut self, func: &mut ir::Function, index: MemoryIndex) -> Heap {
+        let pointer_type = self.pointer_type();
+        let memory = self.module.memories[index];
+        let is_shared = memory.shared;
+
+        let (base_ptr, base_offset, current_length_offset, ptr_memtype) = {
+            let vmctx = self.vmctx(func);
+            if let Some(def_index) = self.module.defined_memory_index(index) {
+                if is_shared {
+                    // As with imported memory, the `VMMemoryDefinition` for a
+                    // shared memory is stored elsewhere. We store a `*mut
+                    // VMMemoryDefinition` to it and dereference that when
+                    // atomically growing it.
+                    let from_offset = self.offsets.vmctx_vmmemory_pointer(def_index);
+                    let (memory, def_mt) = self.global_load_from_vmctx_with_memory_type(
+                        func,
+                        from_offset,
+                        ir::MemFlags::trusted().with_readonly().with_can_move(),
+                    );
+                    let base_offset = i32::from(self.offsets.ptr.vmmemory_definition_base());
+                    let current_length_offset =
+                        i32::from(self.offsets.ptr.vmmemory_definition_current_length());
+                    (memory, base_offset, current_length_offset, def_mt)
+                } else {
+                    let owned_index = self.module.owned_memory_index(def_index);
+                    let owned_base_offset =
+                        self.offsets.vmctx_vmmemory_definition_base(owned_index);
+                    let owned_length_offset = self
+                        .offsets
+                        .vmctx_vmmemory_definition_current_length(owned_index);
+                    let current_base_offset = i32::try_from(owned_base_offset).unwrap();
+                    let current_length_offset = i32::try_from(owned_length_offset).unwrap();
+                    (
+                        vmctx,
+                        current_base_offset,
+                        current_length_offset,
+                        self.pcc_vmctx_memtype,
+                    )
+                }
+            } else {
+                let from_offset = self.offsets.vmctx_vmmemory_import_from(index);
+                let (memory, def_mt) = self.global_load_from_vmctx_with_memory_type(
+                    func,
+                    from_offset,
+                    ir::MemFlags::trusted().with_readonly().with_can_move(),
+                );
+                let base_offset = i32::from(self.offsets.ptr.vmmemory_definition_base());
+                let current_length_offset =
+                    i32::from(self.offsets.ptr.vmmemory_definition_current_length());
+                (memory, base_offset, current_length_offset, def_mt)
+            }
+        };
+
+        let bound = func.create_global_value(ir::GlobalValueData::Load {
+            base: base_ptr,
+            offset: Offset32::new(current_length_offset),
+            global_type: pointer_type,
+            flags: MemFlags::trusted(),
+        });
+
+        let (base_fact, pcc_memory_type) = self.make_pcc_base_fact_and_type_for_memory(
+            func,
+            memory,
+            base_offset,
+            current_length_offset,
+            ptr_memtype,
+            bound,
+        );
+
+        let base = self.make_heap_base(func, memory, base_ptr, base_offset, base_fact);
+
+        self.heaps.push(HeapData {
+            base,
+            bound,
+            pcc_memory_type,
+            memory,
+        })
+    }
+
+    pub(crate) fn make_heap_base(
+        &self,
+        func: &mut Function,
+        memory: Memory,
+        ptr: ir::GlobalValue,
+        offset: i32,
+        fact: Option<Fact>,
+    ) -> ir::GlobalValue {
+        let pointer_type = self.pointer_type();
+
+        let mut flags = ir::MemFlags::trusted().with_checked().with_can_move();
+        if !memory.memory_may_move(self.tunables) {
+            flags.set_readonly();
+        }
+
+        let heap_base = func.create_global_value(ir::GlobalValueData::Load {
+            base: ptr,
+            offset: Offset32::new(offset),
+            global_type: pointer_type,
+            flags,
+        });
+        func.global_value_facts[heap_base] = fact;
+        heap_base
+    }
+
+    pub(crate) fn make_pcc_base_fact_and_type_for_memory(
+        &mut self,
+        func: &mut Function,
+        memory: Memory,
+        base_offset: i32,
+        current_length_offset: i32,
+        ptr_memtype: Option<ir::MemoryType>,
+        heap_bound: ir::GlobalValue,
+    ) -> (Option<Fact>, Option<ir::MemoryType>) {
+        // If we have a declared maximum, we can make this a "static" heap, which is
+        // allocated up front and never moved.
+        let host_page_size_log2 = self.target_config().page_size_align_log2;
+        let (base_fact, memory_type) = if !memory
+            .can_elide_bounds_check(self.tunables, host_page_size_log2)
+        {
+            if let Some(ptr_memtype) = ptr_memtype {
+                // Create a memtype representing the untyped memory region.
+                let data_mt = func.create_memory_type(ir::MemoryTypeData::DynamicMemory {
+                    gv: heap_bound,
+                    size: self.tunables.memory_guard_size,
+                });
+                // This fact applies to any pointer to the start of the memory.
+                let base_fact = ir::Fact::dynamic_base_ptr(data_mt);
+                // This fact applies to the length.
+                let length_fact = ir::Fact::global_value(
+                    u16::try_from(self.isa.pointer_type().bits()).unwrap(),
+                    heap_bound,
+                );
+                // Create a field in the vmctx for the base pointer.
+                match &mut func.memory_types[ptr_memtype] {
+                    ir::MemoryTypeData::Struct { size, fields } => {
+                        let base_offset = u64::try_from(base_offset).unwrap();
+                        fields.push(ir::MemoryTypeField {
+                            offset: base_offset,
+                            ty: self.isa.pointer_type(),
+                            // Read-only field from the PoV of PCC checks:
+                            // don't allow stores to this field. (Even if
+                            // it is a dynamic memory whose base can
+                            // change, that update happens inside the
+                            // runtime, not in generated code.)
+                            readonly: true,
+                            fact: Some(base_fact.clone()),
+                        });
+                        let current_length_offset = u64::try_from(current_length_offset).unwrap();
+                        fields.push(ir::MemoryTypeField {
+                            offset: current_length_offset,
+                            ty: self.isa.pointer_type(),
+                            // As above, read-only; only the runtime modifies it.
+                            readonly: true,
+                            fact: Some(length_fact),
+                        });
+
+                        let pointer_size = u64::from(self.isa.pointer_type().bytes());
+                        let fields_end = std::cmp::max(
+                            base_offset + pointer_size,
+                            current_length_offset + pointer_size,
+                        );
+                        *size = std::cmp::max(*size, fields_end);
+                    }
+                    _ => {
+                        panic!("Bad memtype");
+                    }
+                }
+                // Apply a fact to the base pointer.
+                (Some(base_fact), Some(data_mt))
+            } else {
+                (None, None)
+            }
+        } else {
+            if let Some(ptr_memtype) = ptr_memtype {
+                // Create a memtype representing the untyped memory region.
+                let data_mt = func.create_memory_type(ir::MemoryTypeData::Memory {
+                    size: self
+                        .tunables
+                        .memory_reservation
+                        .checked_add(self.tunables.memory_guard_size)
+                        .expect("Memory plan has overflowing size plus guard"),
+                });
+                // This fact applies to any pointer to the start of the memory.
+                let base_fact = Fact::Mem {
+                    ty: data_mt,
+                    min_offset: 0,
+                    max_offset: 0,
+                    nullable: false,
+                };
+                // Create a field in the vmctx for the base pointer.
+                match &mut func.memory_types[ptr_memtype] {
+                    ir::MemoryTypeData::Struct { size, fields } => {
+                        let offset = u64::try_from(base_offset).unwrap();
+                        fields.push(ir::MemoryTypeField {
+                            offset,
+                            ty: self.isa.pointer_type(),
+                            // Read-only field from the PoV of PCC checks:
+                            // don't allow stores to this field. (Even if
+                            // it is a dynamic memory whose base can
+                            // change, that update happens inside the
+                            // runtime, not in generated code.)
+                            readonly: true,
+                            fact: Some(base_fact.clone()),
+                        });
+                        *size = std::cmp::max(
+                            *size,
+                            offset + u64::from(self.isa.pointer_type().bytes()),
+                        );
+                    }
+                    _ => {
+                        panic!("Bad memtype");
+                    }
+                }
+                // Apply a fact to the base pointer.
+                (Some(base_fact), Some(data_mt))
+            } else {
+                (None, None)
+            }
+        };
+        (base_fact, memory_type)
+    }
+
+    fn make_table(&mut self, func: &mut ir::Function, index: TableIndex) -> TableData {
+        let pointer_type = self.pointer_type();
+
+        let (ptr, base_offset, current_elements_offset) = {
+            let vmctx = self.vmctx(func);
+            if let Some(def_index) = self.module.defined_table_index(index) {
+                let base_offset =
+                    i32::try_from(self.offsets.vmctx_vmtable_definition_base(def_index)).unwrap();
+                let current_elements_offset = i32::try_from(
+                    self.offsets
+                        .vmctx_vmtable_definition_current_elements(def_index),
+                )
+                .unwrap();
+                (vmctx, base_offset, current_elements_offset)
+            } else {
+                let from_offset = self.offsets.vmctx_vmtable_from(index);
+                let table = func.create_global_value(ir::GlobalValueData::Load {
+                    base: vmctx,
+                    offset: Offset32::new(i32::try_from(from_offset).unwrap()),
+                    global_type: pointer_type,
+                    flags: MemFlags::trusted().with_readonly().with_can_move(),
+                });
+                let base_offset = i32::from(self.offsets.vmtable_definition_base());
+                let current_elements_offset =
+                    i32::from(self.offsets.vmtable_definition_current_elements());
+                (table, base_offset, current_elements_offset)
+            }
+        };
+
+        let table = &self.module.tables[index];
+        let element_size = if table.ref_type.is_vmgcref_type() {
+            // For GC-managed references, tables store `Option<VMGcRef>`s.
+            ir::types::I32.bytes()
+        } else {
+            self.reference_type(table.ref_type.heap_type).0.bytes()
+        };
+
+        let base_gv = func.create_global_value(ir::GlobalValueData::Load {
+            base: ptr,
+            offset: Offset32::new(base_offset),
+            global_type: pointer_type,
+            flags: if Some(table.limits.min) == table.limits.max {
+                // A fixed-size table can't be resized so its base address won't
+                // change.
+                MemFlags::trusted().with_readonly().with_can_move()
+            } else {
+                MemFlags::trusted()
+            },
+        });
+
+        let bound = if Some(table.limits.min) == table.limits.max {
+            TableSize::Static {
+                bound: table.limits.min,
+            }
+        } else {
+            TableSize::Dynamic {
+                bound_gv: func.create_global_value(ir::GlobalValueData::Load {
+                    base: ptr,
+                    offset: Offset32::new(current_elements_offset),
+                    global_type: ir::Type::int(
+                        u16::from(self.offsets.size_of_vmtable_definition_current_elements()) * 8,
+                    )
+                    .unwrap(),
+                    flags: MemFlags::trusted(),
+                }),
+            }
+        };
+
+        TableData {
+            base_gv,
+            bound,
+            element_size,
+        }
     }
 }
 
@@ -1858,8 +2197,7 @@ impl FuncEnvironment<'_> {
         index: ir::Value,
     ) -> WasmResult<ir::Value> {
         let table = self.module.tables[table_index];
-        self.ensure_table_exists(builder.func, table_index);
-        let table_data = self.tables[table_index].clone().unwrap();
+        let table_data = self.get_or_create_table(builder.func, table_index);
         let heap_ty = table.ref_type.heap_type;
         match heap_ty.top() {
             // GC-managed types.
@@ -1892,8 +2230,7 @@ impl FuncEnvironment<'_> {
         index: ir::Value,
     ) -> WasmResult<()> {
         let table = self.module.tables[table_index];
-        self.ensure_table_exists(builder.func, table_index);
-        let table_data = self.tables[table_index].clone().unwrap();
+        let table_data = self.get_or_create_table(builder.func, table_index);
         let heap_ty = table.ref_type.heap_type;
         match heap_ty.top() {
             // GC-managed types.
@@ -2316,364 +2653,100 @@ impl FuncEnvironment<'_> {
         Ok(pos.func.dfg.first_result(call_inst))
     }
 
-    pub fn translate_custom_global_get(
+    pub(crate) fn translate_global_get(
         &mut self,
-        builder: &mut FunctionBuilder,
-        index: GlobalIndex,
+        builder: &mut FunctionBuilder<'_>,
+        global_index: GlobalIndex,
     ) -> WasmResult<ir::Value> {
-        let global_ty = self.module.globals[index];
-        let wasm_ty = global_ty.wasm_ty;
-        debug_assert!(
-            wasm_ty.is_vmgcref_type(),
-            "We only use GlobalVariable::Custom for VMGcRef types"
-        );
-        let WasmValType::Ref(ref_ty) = wasm_ty else {
-            unreachable!()
-        };
-
-        let (gv, offset) = self.get_global_location(builder.func, index);
-        let gv = builder.ins().global_value(self.pointer_type(), gv);
-        let src = builder.ins().iadd_imm(gv, i64::from(offset));
-
-        gc::gc_compiler(self)?.translate_read_gc_reference(
-            self,
-            builder,
-            ref_ty,
-            src,
-            if global_ty.mutability {
-                ir::MemFlags::trusted()
-            } else {
-                ir::MemFlags::trusted().with_readonly().with_can_move()
-            },
-        )
-    }
-
-    pub fn translate_custom_global_set(
-        &mut self,
-        builder: &mut FunctionBuilder,
-        index: GlobalIndex,
-        value: ir::Value,
-    ) -> WasmResult<()> {
-        let ty = self.module.globals[index].wasm_ty;
-        debug_assert!(
-            ty.is_vmgcref_type(),
-            "We only use GlobalVariable::Custom for VMGcRef types"
-        );
-        let WasmValType::Ref(ty) = ty else {
-            unreachable!()
-        };
-
-        let (gv, offset) = self.get_global_location(builder.func, index);
-        let gv = builder.ins().global_value(self.pointer_type(), gv);
-        let src = builder.ins().iadd_imm(gv, i64::from(offset));
-
-        gc::gc_compiler(self)?.translate_write_gc_reference(
-            self,
-            builder,
-            ty,
-            src,
-            value,
-            ir::MemFlags::trusted(),
-        )
-    }
-
-    pub fn make_heap(&mut self, func: &mut ir::Function, index: MemoryIndex) -> WasmResult<Heap> {
-        let pointer_type = self.pointer_type();
-        let memory = self.module.memories[index];
-        let is_shared = memory.shared;
-
-        let (base_ptr, base_offset, current_length_offset, ptr_memtype) = {
-            let vmctx = self.vmctx(func);
-            if let Some(def_index) = self.module.defined_memory_index(index) {
-                if is_shared {
-                    // As with imported memory, the `VMMemoryDefinition` for a
-                    // shared memory is stored elsewhere. We store a `*mut
-                    // VMMemoryDefinition` to it and dereference that when
-                    // atomically growing it.
-                    let from_offset = self.offsets.vmctx_vmmemory_pointer(def_index);
-                    let (memory, def_mt) = self.global_load_from_vmctx_with_memory_type(
-                        func,
-                        from_offset,
-                        ir::MemFlags::trusted().with_readonly().with_can_move(),
-                    );
-                    let base_offset = i32::from(self.offsets.ptr.vmmemory_definition_base());
-                    let current_length_offset =
-                        i32::from(self.offsets.ptr.vmmemory_definition_current_length());
-                    (memory, base_offset, current_length_offset, def_mt)
-                } else {
-                    let owned_index = self.module.owned_memory_index(def_index);
-                    let owned_base_offset =
-                        self.offsets.vmctx_vmmemory_definition_base(owned_index);
-                    let owned_length_offset = self
-                        .offsets
-                        .vmctx_vmmemory_definition_current_length(owned_index);
-                    let current_base_offset = i32::try_from(owned_base_offset).unwrap();
-                    let current_length_offset = i32::try_from(owned_length_offset).unwrap();
-                    (
-                        vmctx,
-                        current_base_offset,
-                        current_length_offset,
-                        self.pcc_vmctx_memtype,
-                    )
+        match self.get_or_create_global(builder.func, global_index) {
+            GlobalVariable::Memory { gv, offset, ty } => {
+                let addr = builder.ins().global_value(self.pointer_type(), gv);
+                let mut flags = ir::MemFlags::trusted();
+                // Store vector globals in little-endian format to avoid
+                // byte swaps on big-endian platforms since at-rest vectors
+                // should already be in little-endian format anyway.
+                if ty.is_vector() {
+                    flags.set_endianness(ir::Endianness::Little);
                 }
-            } else {
-                let from_offset = self.offsets.vmctx_vmmemory_import_from(index);
-                let (memory, def_mt) = self.global_load_from_vmctx_with_memory_type(
-                    func,
-                    from_offset,
-                    ir::MemFlags::trusted().with_readonly().with_can_move(),
-                );
-                let base_offset = i32::from(self.offsets.ptr.vmmemory_definition_base());
-                let current_length_offset =
-                    i32::from(self.offsets.ptr.vmmemory_definition_current_length());
-                (memory, base_offset, current_length_offset, def_mt)
+                // Put globals in the "table" abstract heap category as well.
+                flags.set_alias_region(Some(ir::AliasRegion::Table));
+                Ok(builder.ins().load(ty, flags, addr, offset))
             }
-        };
-
-        let bound = func.create_global_value(ir::GlobalValueData::Load {
-            base: base_ptr,
-            offset: Offset32::new(current_length_offset),
-            global_type: pointer_type,
-            flags: MemFlags::trusted(),
-        });
-
-        let (base_fact, pcc_memory_type) = self.make_pcc_base_fact_and_type_for_memory(
-            func,
-            memory,
-            base_offset,
-            current_length_offset,
-            ptr_memtype,
-            bound,
-        );
-
-        let base = self.make_heap_base(func, memory, base_ptr, base_offset, base_fact);
-
-        Ok(self.heaps.push(HeapData {
-            base,
-            bound,
-            pcc_memory_type,
-            memory,
-        }))
-    }
-
-    pub(crate) fn make_heap_base(
-        &self,
-        func: &mut Function,
-        memory: Memory,
-        ptr: ir::GlobalValue,
-        offset: i32,
-        fact: Option<Fact>,
-    ) -> ir::GlobalValue {
-        let pointer_type = self.pointer_type();
-
-        let mut flags = ir::MemFlags::trusted().with_checked().with_can_move();
-        if !memory.memory_may_move(self.tunables) {
-            flags.set_readonly();
-        }
-
-        let heap_base = func.create_global_value(ir::GlobalValueData::Load {
-            base: ptr,
-            offset: Offset32::new(offset),
-            global_type: pointer_type,
-            flags,
-        });
-        func.global_value_facts[heap_base] = fact;
-        heap_base
-    }
-
-    pub(crate) fn make_pcc_base_fact_and_type_for_memory(
-        &mut self,
-        func: &mut Function,
-        memory: Memory,
-        base_offset: i32,
-        current_length_offset: i32,
-        ptr_memtype: Option<ir::MemoryType>,
-        heap_bound: ir::GlobalValue,
-    ) -> (Option<Fact>, Option<ir::MemoryType>) {
-        // If we have a declared maximum, we can make this a "static" heap, which is
-        // allocated up front and never moved.
-        let host_page_size_log2 = self.target_config().page_size_align_log2;
-        let (base_fact, memory_type) = if !memory
-            .can_elide_bounds_check(self.tunables, host_page_size_log2)
-        {
-            if let Some(ptr_memtype) = ptr_memtype {
-                // Create a memtype representing the untyped memory region.
-                let data_mt = func.create_memory_type(ir::MemoryTypeData::DynamicMemory {
-                    gv: heap_bound,
-                    size: self.tunables.memory_guard_size,
-                });
-                // This fact applies to any pointer to the start of the memory.
-                let base_fact = ir::Fact::dynamic_base_ptr(data_mt);
-                // This fact applies to the length.
-                let length_fact = ir::Fact::global_value(
-                    u16::try_from(self.isa.pointer_type().bits()).unwrap(),
-                    heap_bound,
+            GlobalVariable::Custom => {
+                let global_ty = self.module.globals[global_index];
+                let wasm_ty = global_ty.wasm_ty;
+                debug_assert!(
+                    wasm_ty.is_vmgcref_type(),
+                    "We only use GlobalVariable::Custom for VMGcRef types"
                 );
-                // Create a field in the vmctx for the base pointer.
-                match &mut func.memory_types[ptr_memtype] {
-                    ir::MemoryTypeData::Struct { size, fields } => {
-                        let base_offset = u64::try_from(base_offset).unwrap();
-                        fields.push(ir::MemoryTypeField {
-                            offset: base_offset,
-                            ty: self.isa.pointer_type(),
-                            // Read-only field from the PoV of PCC checks:
-                            // don't allow stores to this field. (Even if
-                            // it is a dynamic memory whose base can
-                            // change, that update happens inside the
-                            // runtime, not in generated code.)
-                            readonly: true,
-                            fact: Some(base_fact.clone()),
-                        });
-                        let current_length_offset = u64::try_from(current_length_offset).unwrap();
-                        fields.push(ir::MemoryTypeField {
-                            offset: current_length_offset,
-                            ty: self.isa.pointer_type(),
-                            // As above, read-only; only the runtime modifies it.
-                            readonly: true,
-                            fact: Some(length_fact),
-                        });
-
-                        let pointer_size = u64::from(self.isa.pointer_type().bytes());
-                        let fields_end = std::cmp::max(
-                            base_offset + pointer_size,
-                            current_length_offset + pointer_size,
-                        );
-                        *size = std::cmp::max(*size, fields_end);
-                    }
-                    _ => {
-                        panic!("Bad memtype");
-                    }
-                }
-                // Apply a fact to the base pointer.
-                (Some(base_fact), Some(data_mt))
-            } else {
-                (None, None)
-            }
-        } else {
-            if let Some(ptr_memtype) = ptr_memtype {
-                // Create a memtype representing the untyped memory region.
-                let data_mt = func.create_memory_type(ir::MemoryTypeData::Memory {
-                    size: self
-                        .tunables
-                        .memory_reservation
-                        .checked_add(self.tunables.memory_guard_size)
-                        .expect("Memory plan has overflowing size plus guard"),
-                });
-                // This fact applies to any pointer to the start of the memory.
-                let base_fact = Fact::Mem {
-                    ty: data_mt,
-                    min_offset: 0,
-                    max_offset: 0,
-                    nullable: false,
+                let WasmValType::Ref(ref_ty) = wasm_ty else {
+                    unreachable!()
                 };
-                // Create a field in the vmctx for the base pointer.
-                match &mut func.memory_types[ptr_memtype] {
-                    ir::MemoryTypeData::Struct { size, fields } => {
-                        let offset = u64::try_from(base_offset).unwrap();
-                        fields.push(ir::MemoryTypeField {
-                            offset,
-                            ty: self.isa.pointer_type(),
-                            // Read-only field from the PoV of PCC checks:
-                            // don't allow stores to this field. (Even if
-                            // it is a dynamic memory whose base can
-                            // change, that update happens inside the
-                            // runtime, not in generated code.)
-                            readonly: true,
-                            fact: Some(base_fact.clone()),
-                        });
-                        *size = std::cmp::max(
-                            *size,
-                            offset + u64::from(self.isa.pointer_type().bytes()),
-                        );
-                    }
-                    _ => {
-                        panic!("Bad memtype");
-                    }
-                }
-                // Apply a fact to the base pointer.
-                (Some(base_fact), Some(data_mt))
-            } else {
-                (None, None)
+
+                let (gv, offset) = self.get_global_location(builder.func, global_index);
+                let gv = builder.ins().global_value(self.pointer_type(), gv);
+                let src = builder.ins().iadd_imm(gv, i64::from(offset));
+
+                gc::gc_compiler(self)?.translate_read_gc_reference(
+                    self,
+                    builder,
+                    ref_ty,
+                    src,
+                    if global_ty.mutability {
+                        ir::MemFlags::trusted()
+                    } else {
+                        ir::MemFlags::trusted().with_readonly().with_can_move()
+                    },
+                )
             }
-        };
-        (base_fact, memory_type)
-    }
-
-    pub fn make_global(
-        &mut self,
-        func: &mut ir::Function,
-        index: GlobalIndex,
-    ) -> WasmResult<GlobalVariable> {
-        let ty = self.module.globals[index].wasm_ty;
-
-        if ty.is_vmgcref_type() {
-            // Although reference-typed globals live at the same memory location as
-            // any other type of global at the same index would, getting or
-            // setting them requires ref counting barriers. Therefore, we need
-            // to use `GlobalVariable::Custom`, as that is the only kind of
-            // `GlobalVariable` for which translation supports custom
-            // access translation.
-            return Ok(GlobalVariable::Custom);
         }
-
-        let (gv, offset) = self.get_global_location(func, index);
-        Ok(GlobalVariable::Memory {
-            gv,
-            offset: offset.into(),
-            ty: super::value_type(self.isa, ty),
-        })
     }
 
-    pub fn make_indirect_sig(
+    pub(crate) fn translate_global_set(
         &mut self,
-        func: &mut ir::Function,
-        index: ModuleInternedTypeIndex,
-    ) -> WasmResult<ir::SigRef> {
-        let wasm_func_ty = self.types[index].unwrap_func();
-        let sig = crate::wasm_call_signature(self.isa, wasm_func_ty, &self.tunables);
-        let sig_ref = func.import_signature(sig);
-        self.sig_ref_to_ty[sig_ref] = Some(wasm_func_ty);
-        Ok(sig_ref)
-    }
+        builder: &mut FunctionBuilder<'_>,
+        global_index: GlobalIndex,
+        val: ir::Value,
+    ) -> WasmResult<()> {
+        match self.get_or_create_global(builder.func, global_index) {
+            GlobalVariable::Memory { gv, offset, ty } => {
+                let addr = builder.ins().global_value(self.pointer_type(), gv);
+                let mut flags = ir::MemFlags::trusted();
+                // Like `global.get`, store globals in little-endian format.
+                if ty.is_vector() {
+                    flags.set_endianness(ir::Endianness::Little);
+                }
+                // Put globals in the "table" abstract heap category as well.
+                flags.set_alias_region(Some(ir::AliasRegion::Table));
+                debug_assert_eq!(ty, builder.func.dfg.value_type(val));
+                builder.ins().store(flags, val, addr, offset);
+                self.update_global(builder, global_index, val);
+            }
+            GlobalVariable::Custom => {
+                let ty = self.module.globals[global_index].wasm_ty;
+                debug_assert!(
+                    ty.is_vmgcref_type(),
+                    "We only use GlobalVariable::Custom for VMGcRef types"
+                );
+                let WasmValType::Ref(ty) = ty else {
+                    unreachable!()
+                };
 
-    pub fn make_direct_func(
-        &mut self,
-        func: &mut ir::Function,
-        index: FuncIndex,
-    ) -> WasmResult<ir::FuncRef> {
-        let sig = self.module.functions[index]
-            .signature
-            .unwrap_module_type_index();
-        let wasm_func_ty = self.types[sig].unwrap_func();
-        let sig = crate::wasm_call_signature(self.isa, wasm_func_ty, &self.tunables);
-        let signature = func.import_signature(sig);
-        self.sig_ref_to_ty[signature] = Some(wasm_func_ty);
-        let name =
-            ir::ExternalName::User(func.declare_imported_user_function(ir::UserExternalName {
-                namespace: crate::NS_WASM_FUNC,
-                index: index.as_u32(),
-            }));
-        Ok(func.import_function(ir::ExtFuncData {
-            name,
-            signature,
+                let (gv, offset) = self.get_global_location(builder.func, global_index);
+                let gv = builder.ins().global_value(self.pointer_type(), gv);
+                let src = builder.ins().iadd_imm(gv, i64::from(offset));
 
-            // the value of this flag determines the codegen for calls to this
-            // function. if this flag is `false` then absolute relocations will
-            // be generated for references to the function, which requires
-            // load-time relocation resolution. if this flag is set to `true`
-            // then relative relocations are emitted which can be resolved at
-            // object-link-time, just after all functions are compiled.
-            //
-            // this flag is set to `true` for functions defined in the object
-            // we'll be defining in this compilation unit, or everything local
-            // to the wasm module. this means that between functions in a wasm
-            // module there's relative calls encoded. all calls external to a
-            // wasm module (e.g. imports or libcalls) are either encoded through
-            // the `vmcontext` as relative jumps (hence no relocations) or
-            // they're libcalls with absolute relocations.
-            colocated: self.module.defined_func_index(index).is_some()
-                || self.translation.known_imported_functions[index].is_some(),
-        }))
+                gc::gc_compiler(self)?.translate_write_gc_reference(
+                    self,
+                    builder,
+                    ty,
+                    src,
+                    val,
+                    ir::MemFlags::trusted(),
+                )?
+            }
+        }
+        Ok(())
     }
 
     pub fn translate_call_indirect(
@@ -3047,8 +3120,7 @@ impl FuncEnvironment<'_> {
         pos: FuncCursor,
         table_index: TableIndex,
     ) -> WasmResult<ir::Value> {
-        self.ensure_table_exists(pos.func, table_index);
-        let table_data = self.tables[table_index].as_ref().unwrap();
+        let table_data = self.get_or_create_table(pos.func, table_index);
         let index_type = index_type_to_ir_type(self.table(table_index).idx_type);
         Ok(table_data.bound.bound(&*self.isa, pos, index_type))
     }
@@ -3216,7 +3288,7 @@ impl FuncEnvironment<'_> {
         op: &Operator,
         _operand_types: Option<&[WasmValType]>,
         builder: &mut FunctionBuilder,
-        state: &FuncTranslationState,
+        state: &FuncTranslationStacks,
     ) -> WasmResult<()> {
         if self.tunables.consume_fuel {
             self.fuel_before_op(op, builder, state.reachable());
@@ -3229,7 +3301,7 @@ impl FuncEnvironment<'_> {
         op: &Operator,
         _operand_types: Option<&[WasmValType]>,
         builder: &mut FunctionBuilder,
-        state: &FuncTranslationState,
+        state: &FuncTranslationStacks,
     ) -> WasmResult<()> {
         if self.tunables.consume_fuel && state.reachable() {
             self.fuel_after_op(op, builder);
@@ -3247,7 +3319,7 @@ impl FuncEnvironment<'_> {
     pub fn before_translate_function(
         &mut self,
         builder: &mut FunctionBuilder,
-        _state: &FuncTranslationState,
+        _state: &FuncTranslationStacks,
     ) -> WasmResult<()> {
         // If an explicit stack limit is requested, emit one here at the start
         // of the function.
@@ -3284,7 +3356,7 @@ impl FuncEnvironment<'_> {
     pub fn after_translate_function(
         &mut self,
         builder: &mut FunctionBuilder,
-        state: &FuncTranslationState,
+        state: &FuncTranslationStacks,
     ) -> WasmResult<()> {
         if self.tunables.consume_fuel && state.reachable() {
             self.fuel_function_exit(builder);

--- a/crates/cranelift/src/lib.rs
+++ b/crates/cranelift/src/lib.rs
@@ -455,7 +455,7 @@ const I31_REF_DISCRIMINANT: u32 = 1;
 /// from reachable to unreachable state and the like from callees to callers.
 ///
 /// Marked `must_use` to force callers to update
-/// `FuncTranslationState::reachable` as necessary.
+/// `FuncTranslationStacks::reachable` as necessary.
 #[derive(PartialEq, Eq)]
 #[must_use]
 enum Reachability<T> {
@@ -463,6 +463,6 @@ enum Reachability<T> {
     Reachable(T),
     /// The Wasm execution state has been determined to be statically
     /// unreachable. It is the receiver of this value's responsibility to update
-    /// `FuncTranslationState::reachable` as necessary.
+    /// `FuncTranslationStacks::reachable` as necessary.
     Unreachable,
 }

--- a/crates/cranelift/src/translate/code_translator.rs
+++ b/crates/cranelift/src/translate/code_translator.rs
@@ -74,8 +74,8 @@
 use crate::Reachability;
 use crate::bounds_checks::{BoundsCheck, bounds_check_and_compute_addr};
 use crate::func_environ::{Extension, FuncEnvironment};
-use crate::translate::environ::{GlobalVariable, StructFieldsVec};
-use crate::translate::state::{ControlStackFrame, ElseData, FuncTranslationState};
+use crate::translate::environ::StructFieldsVec;
+use crate::translate::stack::{ControlStackFrame, ElseData, FuncTranslationStacks};
 use crate::translate::translation_utils::{
     block_with_params, blocktype_params_results, f32_translation, f64_translation,
 };
@@ -121,13 +121,13 @@ pub fn translate_operator(
     op: &Operator,
     operand_types: Option<&[WasmValType]>,
     builder: &mut FunctionBuilder,
-    state: &mut FuncTranslationState,
+    stack: &mut FuncTranslationStacks,
     environ: &mut FuncEnvironment<'_>,
 ) -> WasmResult<()> {
     log::trace!("Translating Wasm opcode: {op:?}");
 
-    if !state.reachable {
-        translate_unreachable_operator(validator, &op, builder, state, environ)?;
+    if !stack.reachable {
+        translate_unreachable_operator(validator, &op, builder, stack, environ)?;
         return Ok(());
     }
 
@@ -146,12 +146,12 @@ pub fn translate_operator(
          ***********************************************************************************/
         Operator::LocalGet { local_index } => {
             let val = builder.use_var(Variable::from_u32(*local_index));
-            state.push1(val);
+            stack.push1(val);
             let label = ValueLabel::from_u32(*local_index);
             builder.set_val_label(val, label);
         }
         Operator::LocalSet { local_index } => {
-            let mut val = state.pop1();
+            let mut val = stack.pop1();
 
             // Ensure SIMD values are cast to their default Cranelift type, I8x16.
             let ty = builder.func.dfg.value_type(val);
@@ -164,7 +164,7 @@ pub fn translate_operator(
             builder.set_val_label(val, label);
         }
         Operator::LocalTee { local_index } => {
-            let mut val = state.peek1();
+            let mut val = stack.peek1();
 
             // Ensure SIMD values are cast to their default Cranelift type, I8x16.
             let ty = builder.func.dfg.value_type(val);
@@ -181,88 +181,53 @@ pub fn translate_operator(
          ***********************************************************************************/
         Operator::GlobalGet { global_index } => {
             let global_index = GlobalIndex::from_u32(*global_index);
-            let val = match state.get_global(builder.func, global_index, environ)? {
-                GlobalVariable::Memory { gv, offset, ty } => {
-                    let addr = builder.ins().global_value(environ.pointer_type(), gv);
-                    let mut flags = ir::MemFlags::trusted();
-                    // Store vector globals in little-endian format to avoid
-                    // byte swaps on big-endian platforms since at-rest vectors
-                    // should already be in little-endian format anyway.
-                    if ty.is_vector() {
-                        flags.set_endianness(ir::Endianness::Little);
-                    }
-                    // Put globals in the "table" abstract heap category as well.
-                    flags.set_alias_region(Some(ir::AliasRegion::Table));
-                    builder.ins().load(ty, flags, addr, offset)
-                }
-                GlobalVariable::Custom => {
-                    environ.translate_custom_global_get(builder, global_index)?
-                }
-            };
-            state.push1(val);
+            let val = environ.translate_global_get(builder, global_index)?;
+            stack.push1(val);
         }
         Operator::GlobalSet { global_index } => {
             let global_index = GlobalIndex::from_u32(*global_index);
-            match state.get_global(builder.func, global_index, environ)? {
-                GlobalVariable::Memory { gv, offset, ty } => {
-                    let addr = builder.ins().global_value(environ.pointer_type(), gv);
-                    let mut flags = ir::MemFlags::trusted();
-                    // Like `global.get`, store globals in little-endian format.
-                    if ty.is_vector() {
-                        flags.set_endianness(ir::Endianness::Little);
-                    }
-                    // Put globals in the "table" abstract heap category as well.
-                    flags.set_alias_region(Some(ir::AliasRegion::Table));
-                    let mut val = state.pop1();
-                    // Ensure SIMD values are cast to their default Cranelift type, I8x16.
-                    if ty.is_vector() {
-                        val = optionally_bitcast_vector(val, I8X16, builder);
-                    }
-                    debug_assert_eq!(ty, builder.func.dfg.value_type(val));
-                    builder.ins().store(flags, val, addr, offset);
-                    environ.update_global(builder, global_index, val);
-                }
-                GlobalVariable::Custom => {
-                    let val = state.pop1();
-                    environ.translate_custom_global_set(builder, global_index, val)?;
-                }
+            let mut val = stack.pop1();
+            // Ensure SIMD values are cast to their default Cranelift type, I8x16.
+            if builder.func.dfg.value_type(val).is_vector() {
+                val = optionally_bitcast_vector(val, I8X16, builder);
             }
+            environ.translate_global_set(builder, global_index, val)?;
         }
         /********************************* Stack misc ***************************************
          *  `drop`, `nop`, `unreachable` and `select`.
          ***********************************************************************************/
         Operator::Drop => {
-            state.pop1();
+            stack.pop1();
         }
         Operator::Select => {
-            let (mut arg1, mut arg2, cond) = state.pop3();
+            let (mut arg1, mut arg2, cond) = stack.pop3();
             if builder.func.dfg.value_type(arg1).is_vector() {
                 arg1 = optionally_bitcast_vector(arg1, I8X16, builder);
             }
             if builder.func.dfg.value_type(arg2).is_vector() {
                 arg2 = optionally_bitcast_vector(arg2, I8X16, builder);
             }
-            state.push1(builder.ins().select(cond, arg1, arg2));
+            stack.push1(builder.ins().select(cond, arg1, arg2));
         }
         Operator::TypedSelect { ty: _ } => {
             // We ignore the explicit type parameter as it is only needed for
             // validation, which we require to have been performed before
             // translation.
-            let (mut arg1, mut arg2, cond) = state.pop3();
+            let (mut arg1, mut arg2, cond) = stack.pop3();
             if builder.func.dfg.value_type(arg1).is_vector() {
                 arg1 = optionally_bitcast_vector(arg1, I8X16, builder);
             }
             if builder.func.dfg.value_type(arg2).is_vector() {
                 arg2 = optionally_bitcast_vector(arg2, I8X16, builder);
             }
-            state.push1(builder.ins().select(cond, arg1, arg2));
+            stack.push1(builder.ins().select(cond, arg1, arg2));
         }
         Operator::Nop => {
             // We do nothing
         }
         Operator::Unreachable => {
             environ.trap(builder, crate::TRAP_UNREACHABLE);
-            state.reachable = false;
+            stack.reachable = false;
         }
         /***************************** Control flow blocks **********************************
          *  When starting a control flow block, we create a new `Block` that will hold the code
@@ -278,19 +243,19 @@ pub fn translate_operator(
         Operator::Block { blockty } => {
             let (params, results) = blocktype_params_results(validator, *blockty)?;
             let next = block_with_params(builder, results.clone(), environ)?;
-            state.push_block(next, params.len(), results.len());
+            stack.push_block(next, params.len(), results.len());
         }
         Operator::Loop { blockty } => {
             let (params, results) = blocktype_params_results(validator, *blockty)?;
             let loop_body = block_with_params(builder, params.clone(), environ)?;
             let next = block_with_params(builder, results.clone(), environ)?;
-            canonicalise_then_jump(builder, loop_body, state.peekn(params.len()));
-            state.push_loop(loop_body, next, params.len(), results.len());
+            canonicalise_then_jump(builder, loop_body, stack.peekn(params.len()));
+            stack.push_loop(loop_body, next, params.len(), results.len());
 
             // Pop the initial `Block` actuals and replace them with the `Block`'s
             // params since control flow joins at the top of the loop.
-            state.popn(params.len());
-            state
+            stack.popn(params.len());
+            stack
                 .stack
                 .extend_from_slice(builder.block_params(loop_body));
 
@@ -298,7 +263,7 @@ pub fn translate_operator(
             environ.translate_loop_header(builder)?;
         }
         Operator::If { blockty } => {
-            let val = state.pop1();
+            let val = stack.pop1();
 
             let next_block = builder.create_block();
             let (params, results) = blocktype_params_results(validator, *blockty)?;
@@ -316,7 +281,7 @@ pub fn translate_operator(
                     next_block,
                     &[],
                     destination,
-                    state.peekn(params.len()),
+                    stack.peekn(params.len()),
                 );
                 (
                     destination,
@@ -336,7 +301,7 @@ pub fn translate_operator(
                     next_block,
                     &[],
                     else_block,
-                    state.peekn(params.len()),
+                    stack.peekn(params.len()),
                 );
                 builder.seal_block(else_block);
                 (destination, ElseData::WithElse { else_block })
@@ -351,7 +316,7 @@ pub fn translate_operator(
             //   and we add nothing;
             // - either the If have an Else clause, in that case the destination of this jump
             //   instruction will be changed later when we translate the Else operator.
-            state.push_if(
+            stack.push_if(
                 destination,
                 else_data,
                 params.len(),
@@ -360,8 +325,8 @@ pub fn translate_operator(
             );
         }
         Operator::Else => {
-            let i = state.control_stack.len() - 1;
-            match state.control_stack[i] {
+            let i = stack.control_stack.len() - 1;
+            match stack.control_stack[i] {
                 ControlStackFrame::If {
                     ref else_data,
                     head_is_reachable,
@@ -374,11 +339,11 @@ pub fn translate_operator(
                     // We finished the consequent, so record its final
                     // reachability state.
                     debug_assert!(consequent_ends_reachable.is_none());
-                    *consequent_ends_reachable = Some(state.reachable);
+                    *consequent_ends_reachable = Some(stack.reachable);
 
                     if head_is_reachable {
                         // We have a branch from the head of the `if` to the `else`.
-                        state.reachable = true;
+                        stack.reachable = true;
 
                         // Ensure we have a block for the `else` block (it may have
                         // already been pre-allocated, see `ElseData` for details).
@@ -395,9 +360,9 @@ pub fn translate_operator(
                                 canonicalise_then_jump(
                                     builder,
                                     destination,
-                                    state.peekn(params.len()),
+                                    stack.peekn(params.len()),
                                 );
-                                state.popn(params.len());
+                                stack.popn(params.len());
 
                                 builder.change_jump_destination(
                                     branch_inst,
@@ -411,9 +376,9 @@ pub fn translate_operator(
                                 canonicalise_then_jump(
                                     builder,
                                     destination,
-                                    state.peekn(num_return_values),
+                                    stack.peekn(num_return_values),
                                 );
-                                state.popn(num_return_values);
+                                stack.popn(num_return_values);
                                 else_block
                             }
                         };
@@ -438,10 +403,10 @@ pub fn translate_operator(
             }
         }
         Operator::End => {
-            let frame = state.control_stack.pop().unwrap();
+            let frame = stack.control_stack.pop().unwrap();
             let next_block = frame.following_code();
             let return_count = frame.num_return_values();
-            let return_args = state.peekn_mut(return_count);
+            let return_args = stack.peekn_mut(return_count);
 
             canonicalise_then_jump(builder, next_block, return_args);
             // You might expect that if we just finished an `if` block that
@@ -459,8 +424,8 @@ pub fn translate_operator(
                 builder.seal_block(header)
             }
 
-            frame.truncate_value_stack_to_original_size(&mut state.stack);
-            state
+            frame.truncate_value_stack_to_original_size(&mut stack.stack);
+            stack
                 .stack
                 .extend_from_slice(builder.block_params(next_block));
         }
@@ -486,9 +451,9 @@ pub fn translate_operator(
          * `br_table`.
          ***********************************************************************************/
         Operator::Br { relative_depth } => {
-            let i = state.control_stack.len() - 1 - (*relative_depth as usize);
+            let i = stack.control_stack.len() - 1 - (*relative_depth as usize);
             let (return_count, br_destination) = {
-                let frame = &mut state.control_stack[i];
+                let frame = &mut stack.control_stack[i];
                 // We signal that all the code that follows until the next End is unreachable
                 frame.set_branched_to_exit();
                 let return_count = if frame.is_loop() {
@@ -498,12 +463,12 @@ pub fn translate_operator(
                 };
                 (return_count, frame.br_destination())
             };
-            let destination_args = state.peekn_mut(return_count);
+            let destination_args = stack.peekn_mut(return_count);
             canonicalise_then_jump(builder, br_destination, destination_args);
-            state.popn(return_count);
-            state.reachable = false;
+            stack.popn(return_count);
+            stack.reachable = false;
         }
-        Operator::BrIf { relative_depth } => translate_br_if(*relative_depth, builder, state),
+        Operator::BrIf { relative_depth } => translate_br_if(*relative_depth, builder, stack),
         Operator::BrTable { targets } => {
             let default = targets.default();
             let mut min_depth = default;
@@ -514,31 +479,31 @@ pub fn translate_operator(
                 }
             }
             let jump_args_count = {
-                let i = state.control_stack.len() - 1 - (min_depth as usize);
-                let min_depth_frame = &state.control_stack[i];
+                let i = stack.control_stack.len() - 1 - (min_depth as usize);
+                let min_depth_frame = &stack.control_stack[i];
                 if min_depth_frame.is_loop() {
                     min_depth_frame.num_param_values()
                 } else {
                     min_depth_frame.num_return_values()
                 }
             };
-            let val = state.pop1();
+            let val = stack.pop1();
             let mut data = Vec::with_capacity(targets.len() as usize);
             if jump_args_count == 0 {
                 // No jump arguments
                 for depth in targets.targets() {
                     let depth = depth?;
                     let block = {
-                        let i = state.control_stack.len() - 1 - (depth as usize);
-                        let frame = &mut state.control_stack[i];
+                        let i = stack.control_stack.len() - 1 - (depth as usize);
+                        let frame = &mut stack.control_stack[i];
                         frame.set_branched_to_exit();
                         frame.br_destination()
                     };
                     data.push(builder.func.dfg.block_call(block, &[]));
                 }
                 let block = {
-                    let i = state.control_stack.len() - 1 - (default as usize);
-                    let frame = &mut state.control_stack[i];
+                    let i = stack.control_stack.len() - 1 - (default as usize);
+                    let frame = &mut stack.control_stack[i];
                     frame.set_branched_to_exit();
                     frame.br_destination()
                 };
@@ -578,31 +543,31 @@ pub fn translate_operator(
                     builder.switch_to_block(dest_block);
                     builder.seal_block(dest_block);
                     let real_dest_block = {
-                        let i = state.control_stack.len() - 1 - depth;
-                        let frame = &mut state.control_stack[i];
+                        let i = stack.control_stack.len() - 1 - depth;
+                        let frame = &mut stack.control_stack[i];
                         frame.set_branched_to_exit();
                         frame.br_destination()
                     };
-                    let destination_args = state.peekn_mut(return_count);
+                    let destination_args = stack.peekn_mut(return_count);
                     canonicalise_then_jump(builder, real_dest_block, destination_args);
                 }
-                state.popn(return_count);
+                stack.popn(return_count);
             }
-            state.reachable = false;
+            stack.reachable = false;
         }
         Operator::Return => {
             let return_count = {
-                let frame = &mut state.control_stack[0];
+                let frame = &mut stack.control_stack[0];
                 frame.num_return_values()
             };
             {
-                let return_args = state.peekn_mut(return_count);
+                let return_args = stack.peekn_mut(return_count);
                 environ.handle_before_return(&return_args, builder);
                 bitcast_wasm_returns(return_args, builder);
                 builder.ins().return_(return_args);
             }
-            state.popn(return_count);
-            state.reachable = false;
+            stack.popn(return_count);
+            stack.reachable = false;
         }
         /********************************** Exception handing **********************************/
         Operator::Try { .. }
@@ -623,11 +588,11 @@ pub fn translate_operator(
          ************************************************************************************/
         Operator::Call { function_index } => {
             let function_index = FuncIndex::from_u32(*function_index);
-            let fref = state.get_direct_func(builder.func, function_index, environ)?;
+            let fref = environ.get_or_create_func_ref(builder.func, function_index);
             let num_args = environ.num_params_for_func(function_index);
 
             // Bitcast any vector arguments to their default type, I8X16, before calling.
-            let args = state.peekn_mut(num_args);
+            let args = stack.peekn_mut(num_args);
             bitcast_wasm_params(
                 environ,
                 builder.func.dfg.ext_funcs[fref].signature,
@@ -644,8 +609,8 @@ pub fn translate_operator(
                     .len(),
                 "translate_call results should match the call signature"
             );
-            state.popn(num_args);
-            state.pushn(inst_results);
+            stack.popn(num_args);
+            stack.pushn(inst_results);
         }
         Operator::CallIndirect {
             type_index,
@@ -655,12 +620,12 @@ pub fn translate_operator(
             // `table_index` is the index of the table to search the function
             // in.
             let type_index = TypeIndex::from_u32(*type_index);
-            let sigref = state.get_indirect_sig(builder.func, type_index, environ)?;
+            let sigref = environ.get_or_create_sig_ref(builder.func, type_index);
             let num_args = environ.num_params_for_function_type(type_index);
-            let callee = state.pop1();
+            let callee = stack.pop1();
 
             // Bitcast any vector arguments to their default type, I8X16, before calling.
-            let args = state.peekn_mut(num_args);
+            let args = stack.peekn_mut(num_args);
             bitcast_wasm_params(environ, sigref, args, builder);
 
             let call = environ.translate_call_indirect(
@@ -670,12 +635,12 @@ pub fn translate_operator(
                 type_index,
                 sigref,
                 callee,
-                state.peekn(num_args),
+                stack.peekn(num_args),
             )?;
             let call = match call {
                 Some(call) => call,
                 None => {
-                    state.reachable = false;
+                    stack.reachable = false;
                     return Ok(());
                 }
             };
@@ -685,8 +650,8 @@ pub fn translate_operator(
                 builder.func.dfg.signatures[sigref].returns.len(),
                 "translate_call_indirect results should match the call signature"
             );
-            state.popn(num_args);
-            state.pushn(inst_results);
+            stack.popn(num_args);
+            stack.pushn(inst_results);
         }
         /******************************* Tail Calls ******************************************
          * The tail call instructions pop their arguments from the stack and
@@ -697,11 +662,11 @@ pub fn translate_operator(
          ************************************************************************************/
         Operator::ReturnCall { function_index } => {
             let function_index = FuncIndex::from_u32(*function_index);
-            let fref = state.get_direct_func(builder.func, function_index, environ)?;
+            let fref = environ.get_or_create_func_ref(builder.func, function_index);
             let num_args = environ.num_params_for_func(function_index);
 
             // Bitcast any vector arguments to their default type, I8X16, before calling.
-            let args = state.peekn_mut(num_args);
+            let args = stack.peekn_mut(num_args);
             bitcast_wasm_params(
                 environ,
                 builder.func.dfg.ext_funcs[fref].signature,
@@ -711,8 +676,8 @@ pub fn translate_operator(
 
             environ.translate_return_call(builder, function_index, fref, args)?;
 
-            state.popn(num_args);
-            state.reachable = false;
+            stack.popn(num_args);
+            stack.reachable = false;
         }
         Operator::ReturnCallIndirect {
             type_index,
@@ -722,12 +687,12 @@ pub fn translate_operator(
             // `table_index` is the index of the table to search the function
             // in.
             let type_index = TypeIndex::from_u32(*type_index);
-            let sigref = state.get_indirect_sig(builder.func, type_index, environ)?;
+            let sigref = environ.get_or_create_sig_ref(builder.func, type_index);
             let num_args = environ.num_params_for_function_type(type_index);
-            let callee = state.pop1();
+            let callee = stack.pop1();
 
             // Bitcast any vector arguments to their default type, I8X16, before calling.
-            let args = state.peekn_mut(num_args);
+            let args = stack.peekn_mut(num_args);
             bitcast_wasm_params(environ, sigref, args, builder);
 
             environ.translate_return_call_indirect(
@@ -737,29 +702,29 @@ pub fn translate_operator(
                 type_index,
                 sigref,
                 callee,
-                state.peekn(num_args),
+                stack.peekn(num_args),
             )?;
 
-            state.popn(num_args);
-            state.reachable = false;
+            stack.popn(num_args);
+            stack.reachable = false;
         }
         Operator::ReturnCallRef { type_index } => {
             // Get function signature
             // `index` is the index of the function's signature and `table_index` is the index of
             // the table to search the function in.
             let type_index = TypeIndex::from_u32(*type_index);
-            let sigref = state.get_indirect_sig(builder.func, type_index, environ)?;
+            let sigref = environ.get_or_create_sig_ref(builder.func, type_index);
             let num_args = environ.num_params_for_function_type(type_index);
-            let callee = state.pop1();
+            let callee = stack.pop1();
 
             // Bitcast any vector arguments to their default type, I8X16, before calling.
-            let args = state.peekn_mut(num_args);
+            let args = stack.peekn_mut(num_args);
             bitcast_wasm_params(environ, sigref, args, builder);
 
-            environ.translate_return_call_ref(builder, sigref, callee, state.peekn(num_args))?;
+            environ.translate_return_call_ref(builder, sigref, callee, stack.peekn(num_args))?;
 
-            state.popn(num_args);
-            state.reachable = false;
+            stack.popn(num_args);
+            stack.reachable = false;
         }
         /******************************* Memory management ***********************************
          * Memory management is handled by environment. It is usually translated into calls to
@@ -769,15 +734,15 @@ pub fn translate_operator(
             // The WebAssembly MVP only supports one linear memory, but we expect the reserved
             // argument to be a memory index.
             let mem = MemoryIndex::from_u32(*mem);
-            let _heap = state.get_heap(builder.func, mem, environ)?;
-            let val = state.pop1();
+            let _heap = environ.get_or_create_heap(builder.func, mem);
+            let val = stack.pop1();
             environ.before_memory_grow(builder, val, mem);
-            state.push1(environ.translate_memory_grow(builder, mem, val)?)
+            stack.push1(environ.translate_memory_grow(builder, mem, val)?)
         }
         Operator::MemorySize { mem } => {
             let mem = MemoryIndex::from_u32(*mem);
-            let _heap = state.get_heap(builder.func, mem, environ)?;
-            state.push1(environ.translate_memory_size(builder.cursor(), mem)?);
+            let _heap = environ.get_or_create_heap(builder.func, mem);
+            stack.push1(environ.translate_memory_size(builder.cursor(), mem)?);
         }
         /******************************* Load instructions ***********************************
          * Wasm specifies an integer alignment flag but we drop it in Cranelift.
@@ -785,142 +750,142 @@ pub fn translate_operator(
          ************************************************************************************/
         Operator::I32Load8U { memarg } => {
             unwrap_or_return_unreachable_state!(
-                state,
-                translate_load(memarg, ir::Opcode::Uload8, I32, builder, state, environ)?
+                stack,
+                translate_load(memarg, ir::Opcode::Uload8, I32, builder, stack, environ)?
             );
         }
         Operator::I32Load16U { memarg } => {
             unwrap_or_return_unreachable_state!(
-                state,
-                translate_load(memarg, ir::Opcode::Uload16, I32, builder, state, environ)?
+                stack,
+                translate_load(memarg, ir::Opcode::Uload16, I32, builder, stack, environ)?
             );
         }
         Operator::I32Load8S { memarg } => {
             unwrap_or_return_unreachable_state!(
-                state,
-                translate_load(memarg, ir::Opcode::Sload8, I32, builder, state, environ)?
+                stack,
+                translate_load(memarg, ir::Opcode::Sload8, I32, builder, stack, environ)?
             );
         }
         Operator::I32Load16S { memarg } => {
             unwrap_or_return_unreachable_state!(
-                state,
-                translate_load(memarg, ir::Opcode::Sload16, I32, builder, state, environ)?
+                stack,
+                translate_load(memarg, ir::Opcode::Sload16, I32, builder, stack, environ)?
             );
         }
         Operator::I64Load8U { memarg } => {
             unwrap_or_return_unreachable_state!(
-                state,
-                translate_load(memarg, ir::Opcode::Uload8, I64, builder, state, environ)?
+                stack,
+                translate_load(memarg, ir::Opcode::Uload8, I64, builder, stack, environ)?
             );
         }
         Operator::I64Load16U { memarg } => {
             unwrap_or_return_unreachable_state!(
-                state,
-                translate_load(memarg, ir::Opcode::Uload16, I64, builder, state, environ)?
+                stack,
+                translate_load(memarg, ir::Opcode::Uload16, I64, builder, stack, environ)?
             );
         }
         Operator::I64Load8S { memarg } => {
             unwrap_or_return_unreachable_state!(
-                state,
-                translate_load(memarg, ir::Opcode::Sload8, I64, builder, state, environ)?
+                stack,
+                translate_load(memarg, ir::Opcode::Sload8, I64, builder, stack, environ)?
             );
         }
         Operator::I64Load16S { memarg } => {
             unwrap_or_return_unreachable_state!(
-                state,
-                translate_load(memarg, ir::Opcode::Sload16, I64, builder, state, environ)?
+                stack,
+                translate_load(memarg, ir::Opcode::Sload16, I64, builder, stack, environ)?
             );
         }
         Operator::I64Load32S { memarg } => {
             unwrap_or_return_unreachable_state!(
-                state,
-                translate_load(memarg, ir::Opcode::Sload32, I64, builder, state, environ)?
+                stack,
+                translate_load(memarg, ir::Opcode::Sload32, I64, builder, stack, environ)?
             );
         }
         Operator::I64Load32U { memarg } => {
             unwrap_or_return_unreachable_state!(
-                state,
-                translate_load(memarg, ir::Opcode::Uload32, I64, builder, state, environ)?
+                stack,
+                translate_load(memarg, ir::Opcode::Uload32, I64, builder, stack, environ)?
             );
         }
         Operator::I32Load { memarg } => {
             unwrap_or_return_unreachable_state!(
-                state,
-                translate_load(memarg, ir::Opcode::Load, I32, builder, state, environ)?
+                stack,
+                translate_load(memarg, ir::Opcode::Load, I32, builder, stack, environ)?
             );
         }
         Operator::F32Load { memarg } => {
             unwrap_or_return_unreachable_state!(
-                state,
-                translate_load(memarg, ir::Opcode::Load, F32, builder, state, environ)?
+                stack,
+                translate_load(memarg, ir::Opcode::Load, F32, builder, stack, environ)?
             );
         }
         Operator::I64Load { memarg } => {
             unwrap_or_return_unreachable_state!(
-                state,
-                translate_load(memarg, ir::Opcode::Load, I64, builder, state, environ)?
+                stack,
+                translate_load(memarg, ir::Opcode::Load, I64, builder, stack, environ)?
             );
         }
         Operator::F64Load { memarg } => {
             unwrap_or_return_unreachable_state!(
-                state,
-                translate_load(memarg, ir::Opcode::Load, F64, builder, state, environ)?
+                stack,
+                translate_load(memarg, ir::Opcode::Load, F64, builder, stack, environ)?
             );
         }
         Operator::V128Load { memarg } => {
             unwrap_or_return_unreachable_state!(
-                state,
-                translate_load(memarg, ir::Opcode::Load, I8X16, builder, state, environ)?
+                stack,
+                translate_load(memarg, ir::Opcode::Load, I8X16, builder, stack, environ)?
             );
         }
         Operator::V128Load8x8S { memarg } => {
             //TODO(#6829): add before_load() and before_store() hooks for SIMD loads and stores.
             let (flags, _, base) = unwrap_or_return_unreachable_state!(
-                state,
-                prepare_addr(memarg, 8, builder, state, environ)?
+                stack,
+                prepare_addr(memarg, 8, builder, stack, environ)?
             );
             let loaded = builder.ins().sload8x8(flags, base, 0);
-            state.push1(loaded);
+            stack.push1(loaded);
         }
         Operator::V128Load8x8U { memarg } => {
             let (flags, _, base) = unwrap_or_return_unreachable_state!(
-                state,
-                prepare_addr(memarg, 8, builder, state, environ)?
+                stack,
+                prepare_addr(memarg, 8, builder, stack, environ)?
             );
             let loaded = builder.ins().uload8x8(flags, base, 0);
-            state.push1(loaded);
+            stack.push1(loaded);
         }
         Operator::V128Load16x4S { memarg } => {
             let (flags, _, base) = unwrap_or_return_unreachable_state!(
-                state,
-                prepare_addr(memarg, 8, builder, state, environ)?
+                stack,
+                prepare_addr(memarg, 8, builder, stack, environ)?
             );
             let loaded = builder.ins().sload16x4(flags, base, 0);
-            state.push1(loaded);
+            stack.push1(loaded);
         }
         Operator::V128Load16x4U { memarg } => {
             let (flags, _, base) = unwrap_or_return_unreachable_state!(
-                state,
-                prepare_addr(memarg, 8, builder, state, environ)?
+                stack,
+                prepare_addr(memarg, 8, builder, stack, environ)?
             );
             let loaded = builder.ins().uload16x4(flags, base, 0);
-            state.push1(loaded);
+            stack.push1(loaded);
         }
         Operator::V128Load32x2S { memarg } => {
             let (flags, _, base) = unwrap_or_return_unreachable_state!(
-                state,
-                prepare_addr(memarg, 8, builder, state, environ)?
+                stack,
+                prepare_addr(memarg, 8, builder, stack, environ)?
             );
             let loaded = builder.ins().sload32x2(flags, base, 0);
-            state.push1(loaded);
+            stack.push1(loaded);
         }
         Operator::V128Load32x2U { memarg } => {
             let (flags, _, base) = unwrap_or_return_unreachable_state!(
-                state,
-                prepare_addr(memarg, 8, builder, state, environ)?
+                stack,
+                prepare_addr(memarg, 8, builder, stack, environ)?
             );
             let loaded = builder.ins().uload32x2(flags, base, 0);
-            state.push1(loaded);
+            stack.push1(loaded);
         }
         /****************************** Store instructions ***********************************
          * Wasm specifies an integer alignment flag but we drop it in Cranelift.
@@ -930,347 +895,347 @@ pub fn translate_operator(
         | Operator::I64Store { memarg }
         | Operator::F32Store { memarg }
         | Operator::F64Store { memarg } => {
-            translate_store(memarg, ir::Opcode::Store, builder, state, environ)?;
+            translate_store(memarg, ir::Opcode::Store, builder, stack, environ)?;
         }
         Operator::I32Store8 { memarg } | Operator::I64Store8 { memarg } => {
-            translate_store(memarg, ir::Opcode::Istore8, builder, state, environ)?;
+            translate_store(memarg, ir::Opcode::Istore8, builder, stack, environ)?;
         }
         Operator::I32Store16 { memarg } | Operator::I64Store16 { memarg } => {
-            translate_store(memarg, ir::Opcode::Istore16, builder, state, environ)?;
+            translate_store(memarg, ir::Opcode::Istore16, builder, stack, environ)?;
         }
         Operator::I64Store32 { memarg } => {
-            translate_store(memarg, ir::Opcode::Istore32, builder, state, environ)?;
+            translate_store(memarg, ir::Opcode::Istore32, builder, stack, environ)?;
         }
         Operator::V128Store { memarg } => {
-            translate_store(memarg, ir::Opcode::Store, builder, state, environ)?;
+            translate_store(memarg, ir::Opcode::Store, builder, stack, environ)?;
         }
         /****************************** Nullary Operators ************************************/
         Operator::I32Const { value } => {
-            state.push1(builder.ins().iconst(I32, i64::from(value.unsigned())));
+            stack.push1(builder.ins().iconst(I32, i64::from(value.unsigned())));
         }
-        Operator::I64Const { value } => state.push1(builder.ins().iconst(I64, *value)),
+        Operator::I64Const { value } => stack.push1(builder.ins().iconst(I64, *value)),
         Operator::F32Const { value } => {
-            state.push1(builder.ins().f32const(f32_translation(*value)));
+            stack.push1(builder.ins().f32const(f32_translation(*value)));
         }
         Operator::F64Const { value } => {
-            state.push1(builder.ins().f64const(f64_translation(*value)));
+            stack.push1(builder.ins().f64const(f64_translation(*value)));
         }
         /******************************* Unary Operators *************************************/
         Operator::I32Clz | Operator::I64Clz => {
-            let arg = state.pop1();
-            state.push1(builder.ins().clz(arg));
+            let arg = stack.pop1();
+            stack.push1(builder.ins().clz(arg));
         }
         Operator::I32Ctz | Operator::I64Ctz => {
-            let arg = state.pop1();
-            state.push1(builder.ins().ctz(arg));
+            let arg = stack.pop1();
+            stack.push1(builder.ins().ctz(arg));
         }
         Operator::I32Popcnt | Operator::I64Popcnt => {
-            let arg = state.pop1();
-            state.push1(builder.ins().popcnt(arg));
+            let arg = stack.pop1();
+            stack.push1(builder.ins().popcnt(arg));
         }
         Operator::I64ExtendI32S => {
-            let val = state.pop1();
-            state.push1(builder.ins().sextend(I64, val));
+            let val = stack.pop1();
+            stack.push1(builder.ins().sextend(I64, val));
         }
         Operator::I64ExtendI32U => {
-            let val = state.pop1();
-            state.push1(builder.ins().uextend(I64, val));
+            let val = stack.pop1();
+            stack.push1(builder.ins().uextend(I64, val));
         }
         Operator::I32WrapI64 => {
-            let val = state.pop1();
-            state.push1(builder.ins().ireduce(I32, val));
+            let val = stack.pop1();
+            stack.push1(builder.ins().ireduce(I32, val));
         }
         Operator::F32Sqrt | Operator::F64Sqrt => {
-            let arg = state.pop1();
-            state.push1(builder.ins().sqrt(arg));
+            let arg = stack.pop1();
+            stack.push1(builder.ins().sqrt(arg));
         }
         Operator::F32Ceil => {
-            let arg = state.pop1();
-            state.push1(environ.ceil_f32(builder, arg));
+            let arg = stack.pop1();
+            stack.push1(environ.ceil_f32(builder, arg));
         }
         Operator::F64Ceil => {
-            let arg = state.pop1();
-            state.push1(environ.ceil_f64(builder, arg));
+            let arg = stack.pop1();
+            stack.push1(environ.ceil_f64(builder, arg));
         }
         Operator::F32Floor => {
-            let arg = state.pop1();
-            state.push1(environ.floor_f32(builder, arg));
+            let arg = stack.pop1();
+            stack.push1(environ.floor_f32(builder, arg));
         }
         Operator::F64Floor => {
-            let arg = state.pop1();
-            state.push1(environ.floor_f64(builder, arg));
+            let arg = stack.pop1();
+            stack.push1(environ.floor_f64(builder, arg));
         }
         Operator::F32Trunc => {
-            let arg = state.pop1();
-            state.push1(environ.trunc_f32(builder, arg));
+            let arg = stack.pop1();
+            stack.push1(environ.trunc_f32(builder, arg));
         }
         Operator::F64Trunc => {
-            let arg = state.pop1();
-            state.push1(environ.trunc_f64(builder, arg));
+            let arg = stack.pop1();
+            stack.push1(environ.trunc_f64(builder, arg));
         }
         Operator::F32Nearest => {
-            let arg = state.pop1();
-            state.push1(environ.nearest_f32(builder, arg));
+            let arg = stack.pop1();
+            stack.push1(environ.nearest_f32(builder, arg));
         }
         Operator::F64Nearest => {
-            let arg = state.pop1();
-            state.push1(environ.nearest_f64(builder, arg));
+            let arg = stack.pop1();
+            stack.push1(environ.nearest_f64(builder, arg));
         }
         Operator::F32Abs | Operator::F64Abs => {
-            let val = state.pop1();
-            state.push1(builder.ins().fabs(val));
+            let val = stack.pop1();
+            stack.push1(builder.ins().fabs(val));
         }
         Operator::F32Neg | Operator::F64Neg => {
-            let arg = state.pop1();
-            state.push1(builder.ins().fneg(arg));
+            let arg = stack.pop1();
+            stack.push1(builder.ins().fneg(arg));
         }
         Operator::F64ConvertI64U | Operator::F64ConvertI32U => {
-            let val = state.pop1();
-            state.push1(builder.ins().fcvt_from_uint(F64, val));
+            let val = stack.pop1();
+            stack.push1(builder.ins().fcvt_from_uint(F64, val));
         }
         Operator::F64ConvertI64S | Operator::F64ConvertI32S => {
-            let val = state.pop1();
-            state.push1(builder.ins().fcvt_from_sint(F64, val));
+            let val = stack.pop1();
+            stack.push1(builder.ins().fcvt_from_sint(F64, val));
         }
         Operator::F32ConvertI64S | Operator::F32ConvertI32S => {
-            let val = state.pop1();
-            state.push1(builder.ins().fcvt_from_sint(F32, val));
+            let val = stack.pop1();
+            stack.push1(builder.ins().fcvt_from_sint(F32, val));
         }
         Operator::F32ConvertI64U | Operator::F32ConvertI32U => {
-            let val = state.pop1();
-            state.push1(builder.ins().fcvt_from_uint(F32, val));
+            let val = stack.pop1();
+            stack.push1(builder.ins().fcvt_from_uint(F32, val));
         }
         Operator::F64PromoteF32 => {
-            let val = state.pop1();
-            state.push1(builder.ins().fpromote(F64, val));
+            let val = stack.pop1();
+            stack.push1(builder.ins().fpromote(F64, val));
         }
         Operator::F32DemoteF64 => {
-            let val = state.pop1();
-            state.push1(builder.ins().fdemote(F32, val));
+            let val = stack.pop1();
+            stack.push1(builder.ins().fdemote(F32, val));
         }
         Operator::I64TruncF64S | Operator::I64TruncF32S => {
-            let val = state.pop1();
-            state.push1(environ.translate_fcvt_to_sint(builder, I64, val));
+            let val = stack.pop1();
+            stack.push1(environ.translate_fcvt_to_sint(builder, I64, val));
         }
         Operator::I32TruncF64S | Operator::I32TruncF32S => {
-            let val = state.pop1();
-            state.push1(environ.translate_fcvt_to_sint(builder, I32, val));
+            let val = stack.pop1();
+            stack.push1(environ.translate_fcvt_to_sint(builder, I32, val));
         }
         Operator::I64TruncF64U | Operator::I64TruncF32U => {
-            let val = state.pop1();
-            state.push1(environ.translate_fcvt_to_uint(builder, I64, val));
+            let val = stack.pop1();
+            stack.push1(environ.translate_fcvt_to_uint(builder, I64, val));
         }
         Operator::I32TruncF64U | Operator::I32TruncF32U => {
-            let val = state.pop1();
-            state.push1(environ.translate_fcvt_to_uint(builder, I32, val));
+            let val = stack.pop1();
+            stack.push1(environ.translate_fcvt_to_uint(builder, I32, val));
         }
         Operator::I64TruncSatF64S | Operator::I64TruncSatF32S => {
-            let val = state.pop1();
-            state.push1(builder.ins().fcvt_to_sint_sat(I64, val));
+            let val = stack.pop1();
+            stack.push1(builder.ins().fcvt_to_sint_sat(I64, val));
         }
         Operator::I32TruncSatF64S | Operator::I32TruncSatF32S => {
-            let val = state.pop1();
-            state.push1(builder.ins().fcvt_to_sint_sat(I32, val));
+            let val = stack.pop1();
+            stack.push1(builder.ins().fcvt_to_sint_sat(I32, val));
         }
         Operator::I64TruncSatF64U | Operator::I64TruncSatF32U => {
-            let val = state.pop1();
-            state.push1(builder.ins().fcvt_to_uint_sat(I64, val));
+            let val = stack.pop1();
+            stack.push1(builder.ins().fcvt_to_uint_sat(I64, val));
         }
         Operator::I32TruncSatF64U | Operator::I32TruncSatF32U => {
-            let val = state.pop1();
-            state.push1(builder.ins().fcvt_to_uint_sat(I32, val));
+            let val = stack.pop1();
+            stack.push1(builder.ins().fcvt_to_uint_sat(I32, val));
         }
         Operator::F32ReinterpretI32 => {
-            let val = state.pop1();
-            state.push1(builder.ins().bitcast(F32, MemFlags::new(), val));
+            let val = stack.pop1();
+            stack.push1(builder.ins().bitcast(F32, MemFlags::new(), val));
         }
         Operator::F64ReinterpretI64 => {
-            let val = state.pop1();
-            state.push1(builder.ins().bitcast(F64, MemFlags::new(), val));
+            let val = stack.pop1();
+            stack.push1(builder.ins().bitcast(F64, MemFlags::new(), val));
         }
         Operator::I32ReinterpretF32 => {
-            let val = state.pop1();
-            state.push1(builder.ins().bitcast(I32, MemFlags::new(), val));
+            let val = stack.pop1();
+            stack.push1(builder.ins().bitcast(I32, MemFlags::new(), val));
         }
         Operator::I64ReinterpretF64 => {
-            let val = state.pop1();
-            state.push1(builder.ins().bitcast(I64, MemFlags::new(), val));
+            let val = stack.pop1();
+            stack.push1(builder.ins().bitcast(I64, MemFlags::new(), val));
         }
         Operator::I32Extend8S => {
-            let val = state.pop1();
-            state.push1(builder.ins().ireduce(I8, val));
-            let val = state.pop1();
-            state.push1(builder.ins().sextend(I32, val));
+            let val = stack.pop1();
+            stack.push1(builder.ins().ireduce(I8, val));
+            let val = stack.pop1();
+            stack.push1(builder.ins().sextend(I32, val));
         }
         Operator::I32Extend16S => {
-            let val = state.pop1();
-            state.push1(builder.ins().ireduce(I16, val));
-            let val = state.pop1();
-            state.push1(builder.ins().sextend(I32, val));
+            let val = stack.pop1();
+            stack.push1(builder.ins().ireduce(I16, val));
+            let val = stack.pop1();
+            stack.push1(builder.ins().sextend(I32, val));
         }
         Operator::I64Extend8S => {
-            let val = state.pop1();
-            state.push1(builder.ins().ireduce(I8, val));
-            let val = state.pop1();
-            state.push1(builder.ins().sextend(I64, val));
+            let val = stack.pop1();
+            stack.push1(builder.ins().ireduce(I8, val));
+            let val = stack.pop1();
+            stack.push1(builder.ins().sextend(I64, val));
         }
         Operator::I64Extend16S => {
-            let val = state.pop1();
-            state.push1(builder.ins().ireduce(I16, val));
-            let val = state.pop1();
-            state.push1(builder.ins().sextend(I64, val));
+            let val = stack.pop1();
+            stack.push1(builder.ins().ireduce(I16, val));
+            let val = stack.pop1();
+            stack.push1(builder.ins().sextend(I64, val));
         }
         Operator::I64Extend32S => {
-            let val = state.pop1();
-            state.push1(builder.ins().ireduce(I32, val));
-            let val = state.pop1();
-            state.push1(builder.ins().sextend(I64, val));
+            let val = stack.pop1();
+            stack.push1(builder.ins().ireduce(I32, val));
+            let val = stack.pop1();
+            stack.push1(builder.ins().sextend(I64, val));
         }
         /****************************** Binary Operators ************************************/
         Operator::I32Add | Operator::I64Add => {
-            let (arg1, arg2) = state.pop2();
-            state.push1(builder.ins().iadd(arg1, arg2));
+            let (arg1, arg2) = stack.pop2();
+            stack.push1(builder.ins().iadd(arg1, arg2));
         }
         Operator::I32And | Operator::I64And => {
-            let (arg1, arg2) = state.pop2();
-            state.push1(builder.ins().band(arg1, arg2));
+            let (arg1, arg2) = stack.pop2();
+            stack.push1(builder.ins().band(arg1, arg2));
         }
         Operator::I32Or | Operator::I64Or => {
-            let (arg1, arg2) = state.pop2();
-            state.push1(builder.ins().bor(arg1, arg2));
+            let (arg1, arg2) = stack.pop2();
+            stack.push1(builder.ins().bor(arg1, arg2));
         }
         Operator::I32Xor | Operator::I64Xor => {
-            let (arg1, arg2) = state.pop2();
-            state.push1(builder.ins().bxor(arg1, arg2));
+            let (arg1, arg2) = stack.pop2();
+            stack.push1(builder.ins().bxor(arg1, arg2));
         }
         Operator::I32Shl | Operator::I64Shl => {
-            let (arg1, arg2) = state.pop2();
-            state.push1(builder.ins().ishl(arg1, arg2));
+            let (arg1, arg2) = stack.pop2();
+            stack.push1(builder.ins().ishl(arg1, arg2));
         }
         Operator::I32ShrS | Operator::I64ShrS => {
-            let (arg1, arg2) = state.pop2();
-            state.push1(builder.ins().sshr(arg1, arg2));
+            let (arg1, arg2) = stack.pop2();
+            stack.push1(builder.ins().sshr(arg1, arg2));
         }
         Operator::I32ShrU | Operator::I64ShrU => {
-            let (arg1, arg2) = state.pop2();
-            state.push1(builder.ins().ushr(arg1, arg2));
+            let (arg1, arg2) = stack.pop2();
+            stack.push1(builder.ins().ushr(arg1, arg2));
         }
         Operator::I32Rotl | Operator::I64Rotl => {
-            let (arg1, arg2) = state.pop2();
-            state.push1(builder.ins().rotl(arg1, arg2));
+            let (arg1, arg2) = stack.pop2();
+            stack.push1(builder.ins().rotl(arg1, arg2));
         }
         Operator::I32Rotr | Operator::I64Rotr => {
-            let (arg1, arg2) = state.pop2();
-            state.push1(builder.ins().rotr(arg1, arg2));
+            let (arg1, arg2) = stack.pop2();
+            stack.push1(builder.ins().rotr(arg1, arg2));
         }
         Operator::F32Add | Operator::F64Add => {
-            let (arg1, arg2) = state.pop2();
-            state.push1(builder.ins().fadd(arg1, arg2));
+            let (arg1, arg2) = stack.pop2();
+            stack.push1(builder.ins().fadd(arg1, arg2));
         }
         Operator::I32Sub | Operator::I64Sub => {
-            let (arg1, arg2) = state.pop2();
-            state.push1(builder.ins().isub(arg1, arg2));
+            let (arg1, arg2) = stack.pop2();
+            stack.push1(builder.ins().isub(arg1, arg2));
         }
         Operator::F32Sub | Operator::F64Sub => {
-            let (arg1, arg2) = state.pop2();
-            state.push1(builder.ins().fsub(arg1, arg2));
+            let (arg1, arg2) = stack.pop2();
+            stack.push1(builder.ins().fsub(arg1, arg2));
         }
         Operator::I32Mul | Operator::I64Mul => {
-            let (arg1, arg2) = state.pop2();
-            state.push1(builder.ins().imul(arg1, arg2));
+            let (arg1, arg2) = stack.pop2();
+            stack.push1(builder.ins().imul(arg1, arg2));
         }
         Operator::F32Mul | Operator::F64Mul => {
-            let (arg1, arg2) = state.pop2();
-            state.push1(builder.ins().fmul(arg1, arg2));
+            let (arg1, arg2) = stack.pop2();
+            stack.push1(builder.ins().fmul(arg1, arg2));
         }
         Operator::F32Div | Operator::F64Div => {
-            let (arg1, arg2) = state.pop2();
-            state.push1(builder.ins().fdiv(arg1, arg2));
+            let (arg1, arg2) = stack.pop2();
+            stack.push1(builder.ins().fdiv(arg1, arg2));
         }
         Operator::I32DivS | Operator::I64DivS => {
-            let (arg1, arg2) = state.pop2();
-            state.push1(environ.translate_sdiv(builder, arg1, arg2));
+            let (arg1, arg2) = stack.pop2();
+            stack.push1(environ.translate_sdiv(builder, arg1, arg2));
         }
         Operator::I32DivU | Operator::I64DivU => {
-            let (arg1, arg2) = state.pop2();
-            state.push1(environ.translate_udiv(builder, arg1, arg2));
+            let (arg1, arg2) = stack.pop2();
+            stack.push1(environ.translate_udiv(builder, arg1, arg2));
         }
         Operator::I32RemS | Operator::I64RemS => {
-            let (arg1, arg2) = state.pop2();
-            state.push1(environ.translate_srem(builder, arg1, arg2));
+            let (arg1, arg2) = stack.pop2();
+            stack.push1(environ.translate_srem(builder, arg1, arg2));
         }
         Operator::I32RemU | Operator::I64RemU => {
-            let (arg1, arg2) = state.pop2();
-            state.push1(environ.translate_urem(builder, arg1, arg2));
+            let (arg1, arg2) = stack.pop2();
+            stack.push1(environ.translate_urem(builder, arg1, arg2));
         }
         Operator::F32Min | Operator::F64Min => {
-            let (arg1, arg2) = state.pop2();
-            state.push1(builder.ins().fmin(arg1, arg2));
+            let (arg1, arg2) = stack.pop2();
+            stack.push1(builder.ins().fmin(arg1, arg2));
         }
         Operator::F32Max | Operator::F64Max => {
-            let (arg1, arg2) = state.pop2();
-            state.push1(builder.ins().fmax(arg1, arg2));
+            let (arg1, arg2) = stack.pop2();
+            stack.push1(builder.ins().fmax(arg1, arg2));
         }
         Operator::F32Copysign | Operator::F64Copysign => {
-            let (arg1, arg2) = state.pop2();
-            state.push1(builder.ins().fcopysign(arg1, arg2));
+            let (arg1, arg2) = stack.pop2();
+            stack.push1(builder.ins().fcopysign(arg1, arg2));
         }
         /**************************** Comparison Operators **********************************/
         Operator::I32LtS | Operator::I64LtS => {
-            translate_icmp(IntCC::SignedLessThan, builder, state)
+            translate_icmp(IntCC::SignedLessThan, builder, stack)
         }
         Operator::I32LtU | Operator::I64LtU => {
-            translate_icmp(IntCC::UnsignedLessThan, builder, state)
+            translate_icmp(IntCC::UnsignedLessThan, builder, stack)
         }
         Operator::I32LeS | Operator::I64LeS => {
-            translate_icmp(IntCC::SignedLessThanOrEqual, builder, state)
+            translate_icmp(IntCC::SignedLessThanOrEqual, builder, stack)
         }
         Operator::I32LeU | Operator::I64LeU => {
-            translate_icmp(IntCC::UnsignedLessThanOrEqual, builder, state)
+            translate_icmp(IntCC::UnsignedLessThanOrEqual, builder, stack)
         }
         Operator::I32GtS | Operator::I64GtS => {
-            translate_icmp(IntCC::SignedGreaterThan, builder, state)
+            translate_icmp(IntCC::SignedGreaterThan, builder, stack)
         }
         Operator::I32GtU | Operator::I64GtU => {
-            translate_icmp(IntCC::UnsignedGreaterThan, builder, state)
+            translate_icmp(IntCC::UnsignedGreaterThan, builder, stack)
         }
         Operator::I32GeS | Operator::I64GeS => {
-            translate_icmp(IntCC::SignedGreaterThanOrEqual, builder, state)
+            translate_icmp(IntCC::SignedGreaterThanOrEqual, builder, stack)
         }
         Operator::I32GeU | Operator::I64GeU => {
-            translate_icmp(IntCC::UnsignedGreaterThanOrEqual, builder, state)
+            translate_icmp(IntCC::UnsignedGreaterThanOrEqual, builder, stack)
         }
         Operator::I32Eqz | Operator::I64Eqz => {
-            let arg = state.pop1();
+            let arg = stack.pop1();
             let val = builder.ins().icmp_imm(IntCC::Equal, arg, 0);
-            state.push1(builder.ins().uextend(I32, val));
+            stack.push1(builder.ins().uextend(I32, val));
         }
-        Operator::I32Eq | Operator::I64Eq => translate_icmp(IntCC::Equal, builder, state),
-        Operator::F32Eq | Operator::F64Eq => translate_fcmp(FloatCC::Equal, builder, state),
-        Operator::I32Ne | Operator::I64Ne => translate_icmp(IntCC::NotEqual, builder, state),
-        Operator::F32Ne | Operator::F64Ne => translate_fcmp(FloatCC::NotEqual, builder, state),
-        Operator::F32Gt | Operator::F64Gt => translate_fcmp(FloatCC::GreaterThan, builder, state),
+        Operator::I32Eq | Operator::I64Eq => translate_icmp(IntCC::Equal, builder, stack),
+        Operator::F32Eq | Operator::F64Eq => translate_fcmp(FloatCC::Equal, builder, stack),
+        Operator::I32Ne | Operator::I64Ne => translate_icmp(IntCC::NotEqual, builder, stack),
+        Operator::F32Ne | Operator::F64Ne => translate_fcmp(FloatCC::NotEqual, builder, stack),
+        Operator::F32Gt | Operator::F64Gt => translate_fcmp(FloatCC::GreaterThan, builder, stack),
         Operator::F32Ge | Operator::F64Ge => {
-            translate_fcmp(FloatCC::GreaterThanOrEqual, builder, state)
+            translate_fcmp(FloatCC::GreaterThanOrEqual, builder, stack)
         }
-        Operator::F32Lt | Operator::F64Lt => translate_fcmp(FloatCC::LessThan, builder, state),
+        Operator::F32Lt | Operator::F64Lt => translate_fcmp(FloatCC::LessThan, builder, stack),
         Operator::F32Le | Operator::F64Le => {
-            translate_fcmp(FloatCC::LessThanOrEqual, builder, state)
+            translate_fcmp(FloatCC::LessThanOrEqual, builder, stack)
         }
         Operator::RefNull { hty } => {
             let hty = environ.convert_heap_type(*hty)?;
-            state.push1(environ.translate_ref_null(builder.cursor(), hty)?)
+            stack.push1(environ.translate_ref_null(builder.cursor(), hty)?)
         }
         Operator::RefIsNull => {
-            let value = state.pop1();
+            let value = stack.pop1();
             let [WasmValType::Ref(ty)] = operand_types else {
                 unreachable!("validation")
             };
-            state.push1(environ.translate_ref_is_null(builder.cursor(), value, *ty)?);
+            stack.push1(environ.translate_ref_is_null(builder.cursor(), value, *ty)?);
         }
         Operator::RefFunc { function_index } => {
             let index = FuncIndex::from_u32(*function_index);
-            state.push1(environ.translate_ref_func(builder.cursor(), index)?);
+            stack.push1(environ.translate_ref_func(builder.cursor(), index)?);
         }
         Operator::MemoryAtomicWait32 { memarg } | Operator::MemoryAtomicWait64 { memarg } => {
             // The WebAssembly MVP only supports one linear memory and
@@ -1282,11 +1247,11 @@ pub fn translate_operator(
                 _ => unreachable!(),
             };
             let memory_index = MemoryIndex::from_u32(memarg.memory);
-            let heap = state.get_heap(builder.func, memory_index, environ)?;
-            let timeout = state.pop1(); // 64 (fixed)
-            let expected = state.pop1(); // 32 or 64 (per the `Ixx` in `IxxAtomicWait`)
+            let heap = environ.get_or_create_heap(builder.func, memory_index);
+            let timeout = stack.pop1(); // 64 (fixed)
+            let expected = stack.pop1(); // 32 or 64 (per the `Ixx` in `IxxAtomicWait`)
             assert!(builder.func.dfg.value_type(expected) == implied_ty);
-            let addr = state.pop1();
+            let addr = stack.pop1();
             let effective_addr = if memarg.offset == 0 {
                 addr
             } else {
@@ -1304,13 +1269,13 @@ pub fn translate_operator(
                 expected,
                 timeout,
             )?;
-            state.push1(res);
+            stack.push1(res);
         }
         Operator::MemoryAtomicNotify { memarg } => {
             let memory_index = MemoryIndex::from_u32(memarg.memory);
-            let heap = state.get_heap(builder.func, memory_index, environ)?;
-            let count = state.pop1(); // 32 (fixed)
-            let addr = state.pop1();
+            let heap = environ.get_or_create_heap(builder.func, memory_index);
+            let count = stack.pop1(); // 32 (fixed)
+            let addr = stack.pop1();
             let effective_addr = if memarg.offset == 0 {
                 addr
             } else {
@@ -1325,204 +1290,204 @@ pub fn translate_operator(
                 effective_addr,
                 count,
             )?;
-            state.push1(res);
+            stack.push1(res);
         }
         Operator::I32AtomicLoad { memarg } => {
-            translate_atomic_load(I32, I32, memarg, builder, state, environ)?
+            translate_atomic_load(I32, I32, memarg, builder, stack, environ)?
         }
         Operator::I64AtomicLoad { memarg } => {
-            translate_atomic_load(I64, I64, memarg, builder, state, environ)?
+            translate_atomic_load(I64, I64, memarg, builder, stack, environ)?
         }
         Operator::I32AtomicLoad8U { memarg } => {
-            translate_atomic_load(I32, I8, memarg, builder, state, environ)?
+            translate_atomic_load(I32, I8, memarg, builder, stack, environ)?
         }
         Operator::I32AtomicLoad16U { memarg } => {
-            translate_atomic_load(I32, I16, memarg, builder, state, environ)?
+            translate_atomic_load(I32, I16, memarg, builder, stack, environ)?
         }
         Operator::I64AtomicLoad8U { memarg } => {
-            translate_atomic_load(I64, I8, memarg, builder, state, environ)?
+            translate_atomic_load(I64, I8, memarg, builder, stack, environ)?
         }
         Operator::I64AtomicLoad16U { memarg } => {
-            translate_atomic_load(I64, I16, memarg, builder, state, environ)?
+            translate_atomic_load(I64, I16, memarg, builder, stack, environ)?
         }
         Operator::I64AtomicLoad32U { memarg } => {
-            translate_atomic_load(I64, I32, memarg, builder, state, environ)?
+            translate_atomic_load(I64, I32, memarg, builder, stack, environ)?
         }
 
         Operator::I32AtomicStore { memarg } => {
-            translate_atomic_store(I32, memarg, builder, state, environ)?
+            translate_atomic_store(I32, memarg, builder, stack, environ)?
         }
         Operator::I64AtomicStore { memarg } => {
-            translate_atomic_store(I64, memarg, builder, state, environ)?
+            translate_atomic_store(I64, memarg, builder, stack, environ)?
         }
         Operator::I32AtomicStore8 { memarg } => {
-            translate_atomic_store(I8, memarg, builder, state, environ)?
+            translate_atomic_store(I8, memarg, builder, stack, environ)?
         }
         Operator::I32AtomicStore16 { memarg } => {
-            translate_atomic_store(I16, memarg, builder, state, environ)?
+            translate_atomic_store(I16, memarg, builder, stack, environ)?
         }
         Operator::I64AtomicStore8 { memarg } => {
-            translate_atomic_store(I8, memarg, builder, state, environ)?
+            translate_atomic_store(I8, memarg, builder, stack, environ)?
         }
         Operator::I64AtomicStore16 { memarg } => {
-            translate_atomic_store(I16, memarg, builder, state, environ)?
+            translate_atomic_store(I16, memarg, builder, stack, environ)?
         }
         Operator::I64AtomicStore32 { memarg } => {
-            translate_atomic_store(I32, memarg, builder, state, environ)?
+            translate_atomic_store(I32, memarg, builder, stack, environ)?
         }
 
         Operator::I32AtomicRmwAdd { memarg } => {
-            translate_atomic_rmw(I32, I32, AtomicRmwOp::Add, memarg, builder, state, environ)?
+            translate_atomic_rmw(I32, I32, AtomicRmwOp::Add, memarg, builder, stack, environ)?
         }
         Operator::I64AtomicRmwAdd { memarg } => {
-            translate_atomic_rmw(I64, I64, AtomicRmwOp::Add, memarg, builder, state, environ)?
+            translate_atomic_rmw(I64, I64, AtomicRmwOp::Add, memarg, builder, stack, environ)?
         }
         Operator::I32AtomicRmw8AddU { memarg } => {
-            translate_atomic_rmw(I32, I8, AtomicRmwOp::Add, memarg, builder, state, environ)?
+            translate_atomic_rmw(I32, I8, AtomicRmwOp::Add, memarg, builder, stack, environ)?
         }
         Operator::I32AtomicRmw16AddU { memarg } => {
-            translate_atomic_rmw(I32, I16, AtomicRmwOp::Add, memarg, builder, state, environ)?
+            translate_atomic_rmw(I32, I16, AtomicRmwOp::Add, memarg, builder, stack, environ)?
         }
         Operator::I64AtomicRmw8AddU { memarg } => {
-            translate_atomic_rmw(I64, I8, AtomicRmwOp::Add, memarg, builder, state, environ)?
+            translate_atomic_rmw(I64, I8, AtomicRmwOp::Add, memarg, builder, stack, environ)?
         }
         Operator::I64AtomicRmw16AddU { memarg } => {
-            translate_atomic_rmw(I64, I16, AtomicRmwOp::Add, memarg, builder, state, environ)?
+            translate_atomic_rmw(I64, I16, AtomicRmwOp::Add, memarg, builder, stack, environ)?
         }
         Operator::I64AtomicRmw32AddU { memarg } => {
-            translate_atomic_rmw(I64, I32, AtomicRmwOp::Add, memarg, builder, state, environ)?
+            translate_atomic_rmw(I64, I32, AtomicRmwOp::Add, memarg, builder, stack, environ)?
         }
 
         Operator::I32AtomicRmwSub { memarg } => {
-            translate_atomic_rmw(I32, I32, AtomicRmwOp::Sub, memarg, builder, state, environ)?
+            translate_atomic_rmw(I32, I32, AtomicRmwOp::Sub, memarg, builder, stack, environ)?
         }
         Operator::I64AtomicRmwSub { memarg } => {
-            translate_atomic_rmw(I64, I64, AtomicRmwOp::Sub, memarg, builder, state, environ)?
+            translate_atomic_rmw(I64, I64, AtomicRmwOp::Sub, memarg, builder, stack, environ)?
         }
         Operator::I32AtomicRmw8SubU { memarg } => {
-            translate_atomic_rmw(I32, I8, AtomicRmwOp::Sub, memarg, builder, state, environ)?
+            translate_atomic_rmw(I32, I8, AtomicRmwOp::Sub, memarg, builder, stack, environ)?
         }
         Operator::I32AtomicRmw16SubU { memarg } => {
-            translate_atomic_rmw(I32, I16, AtomicRmwOp::Sub, memarg, builder, state, environ)?
+            translate_atomic_rmw(I32, I16, AtomicRmwOp::Sub, memarg, builder, stack, environ)?
         }
         Operator::I64AtomicRmw8SubU { memarg } => {
-            translate_atomic_rmw(I64, I8, AtomicRmwOp::Sub, memarg, builder, state, environ)?
+            translate_atomic_rmw(I64, I8, AtomicRmwOp::Sub, memarg, builder, stack, environ)?
         }
         Operator::I64AtomicRmw16SubU { memarg } => {
-            translate_atomic_rmw(I64, I16, AtomicRmwOp::Sub, memarg, builder, state, environ)?
+            translate_atomic_rmw(I64, I16, AtomicRmwOp::Sub, memarg, builder, stack, environ)?
         }
         Operator::I64AtomicRmw32SubU { memarg } => {
-            translate_atomic_rmw(I64, I32, AtomicRmwOp::Sub, memarg, builder, state, environ)?
+            translate_atomic_rmw(I64, I32, AtomicRmwOp::Sub, memarg, builder, stack, environ)?
         }
 
         Operator::I32AtomicRmwAnd { memarg } => {
-            translate_atomic_rmw(I32, I32, AtomicRmwOp::And, memarg, builder, state, environ)?
+            translate_atomic_rmw(I32, I32, AtomicRmwOp::And, memarg, builder, stack, environ)?
         }
         Operator::I64AtomicRmwAnd { memarg } => {
-            translate_atomic_rmw(I64, I64, AtomicRmwOp::And, memarg, builder, state, environ)?
+            translate_atomic_rmw(I64, I64, AtomicRmwOp::And, memarg, builder, stack, environ)?
         }
         Operator::I32AtomicRmw8AndU { memarg } => {
-            translate_atomic_rmw(I32, I8, AtomicRmwOp::And, memarg, builder, state, environ)?
+            translate_atomic_rmw(I32, I8, AtomicRmwOp::And, memarg, builder, stack, environ)?
         }
         Operator::I32AtomicRmw16AndU { memarg } => {
-            translate_atomic_rmw(I32, I16, AtomicRmwOp::And, memarg, builder, state, environ)?
+            translate_atomic_rmw(I32, I16, AtomicRmwOp::And, memarg, builder, stack, environ)?
         }
         Operator::I64AtomicRmw8AndU { memarg } => {
-            translate_atomic_rmw(I64, I8, AtomicRmwOp::And, memarg, builder, state, environ)?
+            translate_atomic_rmw(I64, I8, AtomicRmwOp::And, memarg, builder, stack, environ)?
         }
         Operator::I64AtomicRmw16AndU { memarg } => {
-            translate_atomic_rmw(I64, I16, AtomicRmwOp::And, memarg, builder, state, environ)?
+            translate_atomic_rmw(I64, I16, AtomicRmwOp::And, memarg, builder, stack, environ)?
         }
         Operator::I64AtomicRmw32AndU { memarg } => {
-            translate_atomic_rmw(I64, I32, AtomicRmwOp::And, memarg, builder, state, environ)?
+            translate_atomic_rmw(I64, I32, AtomicRmwOp::And, memarg, builder, stack, environ)?
         }
 
         Operator::I32AtomicRmwOr { memarg } => {
-            translate_atomic_rmw(I32, I32, AtomicRmwOp::Or, memarg, builder, state, environ)?
+            translate_atomic_rmw(I32, I32, AtomicRmwOp::Or, memarg, builder, stack, environ)?
         }
         Operator::I64AtomicRmwOr { memarg } => {
-            translate_atomic_rmw(I64, I64, AtomicRmwOp::Or, memarg, builder, state, environ)?
+            translate_atomic_rmw(I64, I64, AtomicRmwOp::Or, memarg, builder, stack, environ)?
         }
         Operator::I32AtomicRmw8OrU { memarg } => {
-            translate_atomic_rmw(I32, I8, AtomicRmwOp::Or, memarg, builder, state, environ)?
+            translate_atomic_rmw(I32, I8, AtomicRmwOp::Or, memarg, builder, stack, environ)?
         }
         Operator::I32AtomicRmw16OrU { memarg } => {
-            translate_atomic_rmw(I32, I16, AtomicRmwOp::Or, memarg, builder, state, environ)?
+            translate_atomic_rmw(I32, I16, AtomicRmwOp::Or, memarg, builder, stack, environ)?
         }
         Operator::I64AtomicRmw8OrU { memarg } => {
-            translate_atomic_rmw(I64, I8, AtomicRmwOp::Or, memarg, builder, state, environ)?
+            translate_atomic_rmw(I64, I8, AtomicRmwOp::Or, memarg, builder, stack, environ)?
         }
         Operator::I64AtomicRmw16OrU { memarg } => {
-            translate_atomic_rmw(I64, I16, AtomicRmwOp::Or, memarg, builder, state, environ)?
+            translate_atomic_rmw(I64, I16, AtomicRmwOp::Or, memarg, builder, stack, environ)?
         }
         Operator::I64AtomicRmw32OrU { memarg } => {
-            translate_atomic_rmw(I64, I32, AtomicRmwOp::Or, memarg, builder, state, environ)?
+            translate_atomic_rmw(I64, I32, AtomicRmwOp::Or, memarg, builder, stack, environ)?
         }
 
         Operator::I32AtomicRmwXor { memarg } => {
-            translate_atomic_rmw(I32, I32, AtomicRmwOp::Xor, memarg, builder, state, environ)?
+            translate_atomic_rmw(I32, I32, AtomicRmwOp::Xor, memarg, builder, stack, environ)?
         }
         Operator::I64AtomicRmwXor { memarg } => {
-            translate_atomic_rmw(I64, I64, AtomicRmwOp::Xor, memarg, builder, state, environ)?
+            translate_atomic_rmw(I64, I64, AtomicRmwOp::Xor, memarg, builder, stack, environ)?
         }
         Operator::I32AtomicRmw8XorU { memarg } => {
-            translate_atomic_rmw(I32, I8, AtomicRmwOp::Xor, memarg, builder, state, environ)?
+            translate_atomic_rmw(I32, I8, AtomicRmwOp::Xor, memarg, builder, stack, environ)?
         }
         Operator::I32AtomicRmw16XorU { memarg } => {
-            translate_atomic_rmw(I32, I16, AtomicRmwOp::Xor, memarg, builder, state, environ)?
+            translate_atomic_rmw(I32, I16, AtomicRmwOp::Xor, memarg, builder, stack, environ)?
         }
         Operator::I64AtomicRmw8XorU { memarg } => {
-            translate_atomic_rmw(I64, I8, AtomicRmwOp::Xor, memarg, builder, state, environ)?
+            translate_atomic_rmw(I64, I8, AtomicRmwOp::Xor, memarg, builder, stack, environ)?
         }
         Operator::I64AtomicRmw16XorU { memarg } => {
-            translate_atomic_rmw(I64, I16, AtomicRmwOp::Xor, memarg, builder, state, environ)?
+            translate_atomic_rmw(I64, I16, AtomicRmwOp::Xor, memarg, builder, stack, environ)?
         }
         Operator::I64AtomicRmw32XorU { memarg } => {
-            translate_atomic_rmw(I64, I32, AtomicRmwOp::Xor, memarg, builder, state, environ)?
+            translate_atomic_rmw(I64, I32, AtomicRmwOp::Xor, memarg, builder, stack, environ)?
         }
 
         Operator::I32AtomicRmwXchg { memarg } => {
-            translate_atomic_rmw(I32, I32, AtomicRmwOp::Xchg, memarg, builder, state, environ)?
+            translate_atomic_rmw(I32, I32, AtomicRmwOp::Xchg, memarg, builder, stack, environ)?
         }
         Operator::I64AtomicRmwXchg { memarg } => {
-            translate_atomic_rmw(I64, I64, AtomicRmwOp::Xchg, memarg, builder, state, environ)?
+            translate_atomic_rmw(I64, I64, AtomicRmwOp::Xchg, memarg, builder, stack, environ)?
         }
         Operator::I32AtomicRmw8XchgU { memarg } => {
-            translate_atomic_rmw(I32, I8, AtomicRmwOp::Xchg, memarg, builder, state, environ)?
+            translate_atomic_rmw(I32, I8, AtomicRmwOp::Xchg, memarg, builder, stack, environ)?
         }
         Operator::I32AtomicRmw16XchgU { memarg } => {
-            translate_atomic_rmw(I32, I16, AtomicRmwOp::Xchg, memarg, builder, state, environ)?
+            translate_atomic_rmw(I32, I16, AtomicRmwOp::Xchg, memarg, builder, stack, environ)?
         }
         Operator::I64AtomicRmw8XchgU { memarg } => {
-            translate_atomic_rmw(I64, I8, AtomicRmwOp::Xchg, memarg, builder, state, environ)?
+            translate_atomic_rmw(I64, I8, AtomicRmwOp::Xchg, memarg, builder, stack, environ)?
         }
         Operator::I64AtomicRmw16XchgU { memarg } => {
-            translate_atomic_rmw(I64, I16, AtomicRmwOp::Xchg, memarg, builder, state, environ)?
+            translate_atomic_rmw(I64, I16, AtomicRmwOp::Xchg, memarg, builder, stack, environ)?
         }
         Operator::I64AtomicRmw32XchgU { memarg } => {
-            translate_atomic_rmw(I64, I32, AtomicRmwOp::Xchg, memarg, builder, state, environ)?
+            translate_atomic_rmw(I64, I32, AtomicRmwOp::Xchg, memarg, builder, stack, environ)?
         }
 
         Operator::I32AtomicRmwCmpxchg { memarg } => {
-            translate_atomic_cas(I32, I32, memarg, builder, state, environ)?
+            translate_atomic_cas(I32, I32, memarg, builder, stack, environ)?
         }
         Operator::I64AtomicRmwCmpxchg { memarg } => {
-            translate_atomic_cas(I64, I64, memarg, builder, state, environ)?
+            translate_atomic_cas(I64, I64, memarg, builder, stack, environ)?
         }
         Operator::I32AtomicRmw8CmpxchgU { memarg } => {
-            translate_atomic_cas(I32, I8, memarg, builder, state, environ)?
+            translate_atomic_cas(I32, I8, memarg, builder, stack, environ)?
         }
         Operator::I32AtomicRmw16CmpxchgU { memarg } => {
-            translate_atomic_cas(I32, I16, memarg, builder, state, environ)?
+            translate_atomic_cas(I32, I16, memarg, builder, stack, environ)?
         }
         Operator::I64AtomicRmw8CmpxchgU { memarg } => {
-            translate_atomic_cas(I64, I8, memarg, builder, state, environ)?
+            translate_atomic_cas(I64, I8, memarg, builder, stack, environ)?
         }
         Operator::I64AtomicRmw16CmpxchgU { memarg } => {
-            translate_atomic_cas(I64, I16, memarg, builder, state, environ)?
+            translate_atomic_cas(I64, I16, memarg, builder, stack, environ)?
         }
         Operator::I64AtomicRmw32CmpxchgU { memarg } => {
-            translate_atomic_cas(I64, I32, memarg, builder, state, environ)?
+            translate_atomic_cas(I64, I32, memarg, builder, stack, environ)?
         }
 
         Operator::AtomicFence { .. } => {
@@ -1530,64 +1495,64 @@ pub fn translate_operator(
         }
         Operator::MemoryCopy { src_mem, dst_mem } => {
             let src_index = MemoryIndex::from_u32(*src_mem);
-            let _src_heap = state.get_heap(builder.func, src_index, environ)?;
+            let _src_heap = environ.get_or_create_heap(builder.func, src_index);
 
             let dst_index = MemoryIndex::from_u32(*dst_mem);
-            let _dst_heap = state.get_heap(builder.func, dst_index, environ)?;
+            let _dst_heap = environ.get_or_create_heap(builder.func, dst_index);
 
-            let len = state.pop1();
-            let src_pos = state.pop1();
-            let dst_pos = state.pop1();
+            let len = stack.pop1();
+            let src_pos = stack.pop1();
+            let dst_pos = stack.pop1();
             environ.translate_memory_copy(builder, src_index, dst_index, dst_pos, src_pos, len)?;
         }
         Operator::MemoryFill { mem } => {
             let mem = MemoryIndex::from_u32(*mem);
-            let _heap = state.get_heap(builder.func, mem, environ)?;
-            let len = state.pop1();
-            let val = state.pop1();
-            let dest = state.pop1();
+            let _heap = environ.get_or_create_heap(builder.func, mem);
+            let len = stack.pop1();
+            let val = stack.pop1();
+            let dest = stack.pop1();
             environ.translate_memory_fill(builder, mem, dest, val, len)?;
         }
         Operator::MemoryInit { data_index, mem } => {
             let mem = MemoryIndex::from_u32(*mem);
-            let _heap = state.get_heap(builder.func, mem, environ)?;
-            let len = state.pop1();
-            let src = state.pop1();
-            let dest = state.pop1();
+            let _heap = environ.get_or_create_heap(builder.func, mem);
+            let len = stack.pop1();
+            let src = stack.pop1();
+            let dest = stack.pop1();
             environ.translate_memory_init(builder, mem, *data_index, dest, src, len)?;
         }
         Operator::DataDrop { data_index } => {
             environ.translate_data_drop(builder.cursor(), *data_index)?;
         }
         Operator::TableSize { table: index } => {
-            state.push1(
+            stack.push1(
                 environ.translate_table_size(builder.cursor(), TableIndex::from_u32(*index))?,
             );
         }
         Operator::TableGrow { table: index } => {
             let table_index = TableIndex::from_u32(*index);
-            let delta = state.pop1();
-            let init_value = state.pop1();
-            state.push1(environ.translate_table_grow(builder, table_index, delta, init_value)?);
+            let delta = stack.pop1();
+            let init_value = stack.pop1();
+            stack.push1(environ.translate_table_grow(builder, table_index, delta, init_value)?);
         }
         Operator::TableGet { table: index } => {
             let table_index = TableIndex::from_u32(*index);
-            let index = state.pop1();
-            state.push1(environ.translate_table_get(builder, table_index, index)?);
+            let index = stack.pop1();
+            stack.push1(environ.translate_table_get(builder, table_index, index)?);
         }
         Operator::TableSet { table: index } => {
             let table_index = TableIndex::from_u32(*index);
-            let value = state.pop1();
-            let index = state.pop1();
+            let value = stack.pop1();
+            let index = stack.pop1();
             environ.translate_table_set(builder, table_index, value, index)?;
         }
         Operator::TableCopy {
             dst_table: dst_table_index,
             src_table: src_table_index,
         } => {
-            let len = state.pop1();
-            let src = state.pop1();
-            let dest = state.pop1();
+            let len = stack.pop1();
+            let src = stack.pop1();
+            let dest = stack.pop1();
             environ.translate_table_copy(
                 builder,
                 TableIndex::from_u32(*dst_table_index),
@@ -1599,18 +1564,18 @@ pub fn translate_operator(
         }
         Operator::TableFill { table } => {
             let table_index = TableIndex::from_u32(*table);
-            let len = state.pop1();
-            let val = state.pop1();
-            let dest = state.pop1();
+            let len = stack.pop1();
+            let val = stack.pop1();
+            let dest = stack.pop1();
             environ.translate_table_fill(builder, table_index, dest, val, len)?;
         }
         Operator::TableInit {
             elem_index,
             table: table_index,
         } => {
-            let len = state.pop1();
-            let src = state.pop1();
-            let dest = state.pop1();
+            let len = stack.pop1();
+            let src = stack.pop1();
+            let dest = stack.pop1();
             environ.translate_table_init(
                 builder,
                 *elem_index,
@@ -1629,89 +1594,89 @@ pub fn translate_operator(
             let value = builder.ins().vconst(I8X16, handle);
             // the v128.const is typed in CLIF as a I8x16 but bitcast to a different type
             // before use
-            state.push1(value)
+            stack.push1(value)
         }
         Operator::I8x16Splat | Operator::I16x8Splat => {
-            let reduced = builder.ins().ireduce(type_of(op).lane_type(), state.pop1());
+            let reduced = builder.ins().ireduce(type_of(op).lane_type(), stack.pop1());
             let splatted = builder.ins().splat(type_of(op), reduced);
-            state.push1(splatted)
+            stack.push1(splatted)
         }
         Operator::I32x4Splat
         | Operator::I64x2Splat
         | Operator::F32x4Splat
         | Operator::F64x2Splat => {
-            let splatted = builder.ins().splat(type_of(op), state.pop1());
-            state.push1(splatted)
+            let splatted = builder.ins().splat(type_of(op), stack.pop1());
+            stack.push1(splatted)
         }
         Operator::V128Load8Splat { memarg }
         | Operator::V128Load16Splat { memarg }
         | Operator::V128Load32Splat { memarg }
         | Operator::V128Load64Splat { memarg } => {
             unwrap_or_return_unreachable_state!(
-                state,
+                stack,
                 translate_load(
                     memarg,
                     ir::Opcode::Load,
                     type_of(op).lane_type(),
                     builder,
-                    state,
+                    stack,
                     environ,
                 )?
             );
-            let splatted = builder.ins().splat(type_of(op), state.pop1());
-            state.push1(splatted)
+            let splatted = builder.ins().splat(type_of(op), stack.pop1());
+            stack.push1(splatted)
         }
         Operator::V128Load32Zero { memarg } | Operator::V128Load64Zero { memarg } => {
             unwrap_or_return_unreachable_state!(
-                state,
+                stack,
                 translate_load(
                     memarg,
                     ir::Opcode::Load,
                     type_of(op).lane_type(),
                     builder,
-                    state,
+                    stack,
                     environ,
                 )?
             );
-            let as_vector = builder.ins().scalar_to_vector(type_of(op), state.pop1());
-            state.push1(as_vector)
+            let as_vector = builder.ins().scalar_to_vector(type_of(op), stack.pop1());
+            stack.push1(as_vector)
         }
         Operator::V128Load8Lane { memarg, lane }
         | Operator::V128Load16Lane { memarg, lane }
         | Operator::V128Load32Lane { memarg, lane }
         | Operator::V128Load64Lane { memarg, lane } => {
-            let vector = pop1_with_bitcast(state, type_of(op), builder);
+            let vector = pop1_with_bitcast(stack, type_of(op), builder);
             unwrap_or_return_unreachable_state!(
-                state,
+                stack,
                 translate_load(
                     memarg,
                     ir::Opcode::Load,
                     type_of(op).lane_type(),
                     builder,
-                    state,
+                    stack,
                     environ,
                 )?
             );
-            let replacement = state.pop1();
-            state.push1(builder.ins().insertlane(vector, replacement, *lane))
+            let replacement = stack.pop1();
+            stack.push1(builder.ins().insertlane(vector, replacement, *lane))
         }
         Operator::V128Store8Lane { memarg, lane }
         | Operator::V128Store16Lane { memarg, lane }
         | Operator::V128Store32Lane { memarg, lane }
         | Operator::V128Store64Lane { memarg, lane } => {
-            let vector = pop1_with_bitcast(state, type_of(op), builder);
-            state.push1(builder.ins().extractlane(vector, *lane));
-            translate_store(memarg, ir::Opcode::Store, builder, state, environ)?;
+            let vector = pop1_with_bitcast(stack, type_of(op), builder);
+            stack.push1(builder.ins().extractlane(vector, *lane));
+            translate_store(memarg, ir::Opcode::Store, builder, stack, environ)?;
         }
         Operator::I8x16ExtractLaneS { lane } | Operator::I16x8ExtractLaneS { lane } => {
-            let vector = pop1_with_bitcast(state, type_of(op), builder);
+            let vector = pop1_with_bitcast(stack, type_of(op), builder);
             let extracted = builder.ins().extractlane(vector, *lane);
-            state.push1(builder.ins().sextend(I32, extracted))
+            stack.push1(builder.ins().sextend(I32, extracted))
         }
         Operator::I8x16ExtractLaneU { lane } | Operator::I16x8ExtractLaneU { lane } => {
-            let vector = pop1_with_bitcast(state, type_of(op), builder);
+            let vector = pop1_with_bitcast(stack, type_of(op), builder);
             let extracted = builder.ins().extractlane(vector, *lane);
-            state.push1(builder.ins().uextend(I32, extracted));
+            stack.push1(builder.ins().uextend(I32, extracted));
             // On x86, PEXTRB zeroes the upper bits of the destination register of extractlane so
             // uextend could be elided; for now, uextend is needed for Cranelift's type checks to
             // work.
@@ -1720,233 +1685,233 @@ pub fn translate_operator(
         | Operator::I64x2ExtractLane { lane }
         | Operator::F32x4ExtractLane { lane }
         | Operator::F64x2ExtractLane { lane } => {
-            let vector = pop1_with_bitcast(state, type_of(op), builder);
-            state.push1(builder.ins().extractlane(vector, *lane))
+            let vector = pop1_with_bitcast(stack, type_of(op), builder);
+            stack.push1(builder.ins().extractlane(vector, *lane))
         }
         Operator::I8x16ReplaceLane { lane } | Operator::I16x8ReplaceLane { lane } => {
-            let (vector, replacement) = state.pop2();
+            let (vector, replacement) = stack.pop2();
             let ty = type_of(op);
             let reduced = builder.ins().ireduce(ty.lane_type(), replacement);
             let vector = optionally_bitcast_vector(vector, ty, builder);
-            state.push1(builder.ins().insertlane(vector, reduced, *lane))
+            stack.push1(builder.ins().insertlane(vector, reduced, *lane))
         }
         Operator::I32x4ReplaceLane { lane }
         | Operator::I64x2ReplaceLane { lane }
         | Operator::F32x4ReplaceLane { lane }
         | Operator::F64x2ReplaceLane { lane } => {
-            let (vector, replacement) = state.pop2();
+            let (vector, replacement) = stack.pop2();
             let vector = optionally_bitcast_vector(vector, type_of(op), builder);
-            state.push1(builder.ins().insertlane(vector, replacement, *lane))
+            stack.push1(builder.ins().insertlane(vector, replacement, *lane))
         }
         Operator::I8x16Shuffle { lanes, .. } => {
-            let (a, b) = pop2_with_bitcast(state, I8X16, builder);
-            state.push1(environ.i8x16_shuffle(builder, a, b, lanes));
+            let (a, b) = pop2_with_bitcast(stack, I8X16, builder);
+            stack.push1(environ.i8x16_shuffle(builder, a, b, lanes));
             // At this point the original types of a and b are lost; users of this value (i.e. this
             // WASM-to-CLIF translator) may need to bitcast for type-correctness. This is due
             // to WASM using the less specific v128 type for certain operations and more specific
             // types (e.g. i8x16) for others.
         }
         Operator::I8x16Swizzle => {
-            let (a, b) = pop2_with_bitcast(state, I8X16, builder);
-            state.push1(environ.swizzle(builder, a, b));
+            let (a, b) = pop2_with_bitcast(stack, I8X16, builder);
+            stack.push1(environ.swizzle(builder, a, b));
         }
         Operator::I8x16Add | Operator::I16x8Add | Operator::I32x4Add | Operator::I64x2Add => {
-            let (a, b) = pop2_with_bitcast(state, type_of(op), builder);
-            state.push1(builder.ins().iadd(a, b))
+            let (a, b) = pop2_with_bitcast(stack, type_of(op), builder);
+            stack.push1(builder.ins().iadd(a, b))
         }
         Operator::I8x16AddSatS | Operator::I16x8AddSatS => {
-            let (a, b) = pop2_with_bitcast(state, type_of(op), builder);
-            state.push1(builder.ins().sadd_sat(a, b))
+            let (a, b) = pop2_with_bitcast(stack, type_of(op), builder);
+            stack.push1(builder.ins().sadd_sat(a, b))
         }
         Operator::I8x16AddSatU | Operator::I16x8AddSatU => {
-            let (a, b) = pop2_with_bitcast(state, type_of(op), builder);
-            state.push1(builder.ins().uadd_sat(a, b))
+            let (a, b) = pop2_with_bitcast(stack, type_of(op), builder);
+            stack.push1(builder.ins().uadd_sat(a, b))
         }
         Operator::I8x16Sub | Operator::I16x8Sub | Operator::I32x4Sub | Operator::I64x2Sub => {
-            let (a, b) = pop2_with_bitcast(state, type_of(op), builder);
-            state.push1(builder.ins().isub(a, b))
+            let (a, b) = pop2_with_bitcast(stack, type_of(op), builder);
+            stack.push1(builder.ins().isub(a, b))
         }
         Operator::I8x16SubSatS | Operator::I16x8SubSatS => {
-            let (a, b) = pop2_with_bitcast(state, type_of(op), builder);
-            state.push1(builder.ins().ssub_sat(a, b))
+            let (a, b) = pop2_with_bitcast(stack, type_of(op), builder);
+            stack.push1(builder.ins().ssub_sat(a, b))
         }
         Operator::I8x16SubSatU | Operator::I16x8SubSatU => {
-            let (a, b) = pop2_with_bitcast(state, type_of(op), builder);
-            state.push1(builder.ins().usub_sat(a, b))
+            let (a, b) = pop2_with_bitcast(stack, type_of(op), builder);
+            stack.push1(builder.ins().usub_sat(a, b))
         }
         Operator::I8x16MinS | Operator::I16x8MinS | Operator::I32x4MinS => {
-            let (a, b) = pop2_with_bitcast(state, type_of(op), builder);
-            state.push1(builder.ins().smin(a, b))
+            let (a, b) = pop2_with_bitcast(stack, type_of(op), builder);
+            stack.push1(builder.ins().smin(a, b))
         }
         Operator::I8x16MinU | Operator::I16x8MinU | Operator::I32x4MinU => {
-            let (a, b) = pop2_with_bitcast(state, type_of(op), builder);
-            state.push1(builder.ins().umin(a, b))
+            let (a, b) = pop2_with_bitcast(stack, type_of(op), builder);
+            stack.push1(builder.ins().umin(a, b))
         }
         Operator::I8x16MaxS | Operator::I16x8MaxS | Operator::I32x4MaxS => {
-            let (a, b) = pop2_with_bitcast(state, type_of(op), builder);
-            state.push1(builder.ins().smax(a, b))
+            let (a, b) = pop2_with_bitcast(stack, type_of(op), builder);
+            stack.push1(builder.ins().smax(a, b))
         }
         Operator::I8x16MaxU | Operator::I16x8MaxU | Operator::I32x4MaxU => {
-            let (a, b) = pop2_with_bitcast(state, type_of(op), builder);
-            state.push1(builder.ins().umax(a, b))
+            let (a, b) = pop2_with_bitcast(stack, type_of(op), builder);
+            stack.push1(builder.ins().umax(a, b))
         }
         Operator::I8x16AvgrU | Operator::I16x8AvgrU => {
-            let (a, b) = pop2_with_bitcast(state, type_of(op), builder);
-            state.push1(builder.ins().avg_round(a, b))
+            let (a, b) = pop2_with_bitcast(stack, type_of(op), builder);
+            stack.push1(builder.ins().avg_round(a, b))
         }
         Operator::I8x16Neg | Operator::I16x8Neg | Operator::I32x4Neg | Operator::I64x2Neg => {
-            let a = pop1_with_bitcast(state, type_of(op), builder);
-            state.push1(builder.ins().ineg(a))
+            let a = pop1_with_bitcast(stack, type_of(op), builder);
+            stack.push1(builder.ins().ineg(a))
         }
         Operator::I8x16Abs | Operator::I16x8Abs | Operator::I32x4Abs | Operator::I64x2Abs => {
-            let a = pop1_with_bitcast(state, type_of(op), builder);
-            state.push1(builder.ins().iabs(a))
+            let a = pop1_with_bitcast(stack, type_of(op), builder);
+            stack.push1(builder.ins().iabs(a))
         }
         Operator::I16x8Mul | Operator::I32x4Mul | Operator::I64x2Mul => {
-            let (a, b) = pop2_with_bitcast(state, type_of(op), builder);
-            state.push1(builder.ins().imul(a, b))
+            let (a, b) = pop2_with_bitcast(stack, type_of(op), builder);
+            stack.push1(builder.ins().imul(a, b))
         }
         Operator::V128Or => {
-            let (a, b) = pop2_with_bitcast(state, type_of(op), builder);
-            state.push1(builder.ins().bor(a, b))
+            let (a, b) = pop2_with_bitcast(stack, type_of(op), builder);
+            stack.push1(builder.ins().bor(a, b))
         }
         Operator::V128Xor => {
-            let (a, b) = pop2_with_bitcast(state, type_of(op), builder);
-            state.push1(builder.ins().bxor(a, b))
+            let (a, b) = pop2_with_bitcast(stack, type_of(op), builder);
+            stack.push1(builder.ins().bxor(a, b))
         }
         Operator::V128And => {
-            let (a, b) = pop2_with_bitcast(state, type_of(op), builder);
-            state.push1(builder.ins().band(a, b))
+            let (a, b) = pop2_with_bitcast(stack, type_of(op), builder);
+            stack.push1(builder.ins().band(a, b))
         }
         Operator::V128AndNot => {
-            let (a, b) = pop2_with_bitcast(state, type_of(op), builder);
-            state.push1(builder.ins().band_not(a, b))
+            let (a, b) = pop2_with_bitcast(stack, type_of(op), builder);
+            stack.push1(builder.ins().band_not(a, b))
         }
         Operator::V128Not => {
-            let a = state.pop1();
-            state.push1(builder.ins().bnot(a));
+            let a = stack.pop1();
+            stack.push1(builder.ins().bnot(a));
         }
         Operator::I8x16Shl | Operator::I16x8Shl | Operator::I32x4Shl | Operator::I64x2Shl => {
-            let (a, b) = state.pop2();
+            let (a, b) = stack.pop2();
             let bitcast_a = optionally_bitcast_vector(a, type_of(op), builder);
             // The spec expects to shift with `b mod lanewidth`; This is directly compatible
             // with cranelift's instruction.
-            state.push1(builder.ins().ishl(bitcast_a, b))
+            stack.push1(builder.ins().ishl(bitcast_a, b))
         }
         Operator::I8x16ShrU | Operator::I16x8ShrU | Operator::I32x4ShrU | Operator::I64x2ShrU => {
-            let (a, b) = state.pop2();
+            let (a, b) = stack.pop2();
             let bitcast_a = optionally_bitcast_vector(a, type_of(op), builder);
             // The spec expects to shift with `b mod lanewidth`; This is directly compatible
             // with cranelift's instruction.
-            state.push1(builder.ins().ushr(bitcast_a, b))
+            stack.push1(builder.ins().ushr(bitcast_a, b))
         }
         Operator::I8x16ShrS | Operator::I16x8ShrS | Operator::I32x4ShrS | Operator::I64x2ShrS => {
-            let (a, b) = state.pop2();
+            let (a, b) = stack.pop2();
             let bitcast_a = optionally_bitcast_vector(a, type_of(op), builder);
             // The spec expects to shift with `b mod lanewidth`; This is directly compatible
             // with cranelift's instruction.
-            state.push1(builder.ins().sshr(bitcast_a, b))
+            stack.push1(builder.ins().sshr(bitcast_a, b))
         }
         Operator::V128Bitselect => {
-            let (a, b, c) = pop3_with_bitcast(state, I8X16, builder);
+            let (a, b, c) = pop3_with_bitcast(stack, I8X16, builder);
             // The CLIF operand ordering is slightly different and the types of all three
             // operands must match (hence the bitcast).
-            state.push1(builder.ins().bitselect(c, a, b))
+            stack.push1(builder.ins().bitselect(c, a, b))
         }
         Operator::V128AnyTrue => {
-            let a = pop1_with_bitcast(state, type_of(op), builder);
+            let a = pop1_with_bitcast(stack, type_of(op), builder);
             let bool_result = builder.ins().vany_true(a);
-            state.push1(builder.ins().uextend(I32, bool_result))
+            stack.push1(builder.ins().uextend(I32, bool_result))
         }
         Operator::I8x16AllTrue
         | Operator::I16x8AllTrue
         | Operator::I32x4AllTrue
         | Operator::I64x2AllTrue => {
-            let a = pop1_with_bitcast(state, type_of(op), builder);
+            let a = pop1_with_bitcast(stack, type_of(op), builder);
             let bool_result = builder.ins().vall_true(a);
-            state.push1(builder.ins().uextend(I32, bool_result))
+            stack.push1(builder.ins().uextend(I32, bool_result))
         }
         Operator::I8x16Bitmask
         | Operator::I16x8Bitmask
         | Operator::I32x4Bitmask
         | Operator::I64x2Bitmask => {
-            let a = pop1_with_bitcast(state, type_of(op), builder);
-            state.push1(builder.ins().vhigh_bits(I32, a));
+            let a = pop1_with_bitcast(stack, type_of(op), builder);
+            stack.push1(builder.ins().vhigh_bits(I32, a));
         }
         Operator::I8x16Eq | Operator::I16x8Eq | Operator::I32x4Eq | Operator::I64x2Eq => {
-            translate_vector_icmp(IntCC::Equal, type_of(op), builder, state)
+            translate_vector_icmp(IntCC::Equal, type_of(op), builder, stack)
         }
         Operator::I8x16Ne | Operator::I16x8Ne | Operator::I32x4Ne | Operator::I64x2Ne => {
-            translate_vector_icmp(IntCC::NotEqual, type_of(op), builder, state)
+            translate_vector_icmp(IntCC::NotEqual, type_of(op), builder, stack)
         }
         Operator::I8x16GtS | Operator::I16x8GtS | Operator::I32x4GtS | Operator::I64x2GtS => {
-            translate_vector_icmp(IntCC::SignedGreaterThan, type_of(op), builder, state)
+            translate_vector_icmp(IntCC::SignedGreaterThan, type_of(op), builder, stack)
         }
         Operator::I8x16LtS | Operator::I16x8LtS | Operator::I32x4LtS | Operator::I64x2LtS => {
-            translate_vector_icmp(IntCC::SignedLessThan, type_of(op), builder, state)
+            translate_vector_icmp(IntCC::SignedLessThan, type_of(op), builder, stack)
         }
         Operator::I8x16GtU | Operator::I16x8GtU | Operator::I32x4GtU => {
-            translate_vector_icmp(IntCC::UnsignedGreaterThan, type_of(op), builder, state)
+            translate_vector_icmp(IntCC::UnsignedGreaterThan, type_of(op), builder, stack)
         }
         Operator::I8x16LtU | Operator::I16x8LtU | Operator::I32x4LtU => {
-            translate_vector_icmp(IntCC::UnsignedLessThan, type_of(op), builder, state)
+            translate_vector_icmp(IntCC::UnsignedLessThan, type_of(op), builder, stack)
         }
         Operator::I8x16GeS | Operator::I16x8GeS | Operator::I32x4GeS | Operator::I64x2GeS => {
-            translate_vector_icmp(IntCC::SignedGreaterThanOrEqual, type_of(op), builder, state)
+            translate_vector_icmp(IntCC::SignedGreaterThanOrEqual, type_of(op), builder, stack)
         }
         Operator::I8x16LeS | Operator::I16x8LeS | Operator::I32x4LeS | Operator::I64x2LeS => {
-            translate_vector_icmp(IntCC::SignedLessThanOrEqual, type_of(op), builder, state)
+            translate_vector_icmp(IntCC::SignedLessThanOrEqual, type_of(op), builder, stack)
         }
         Operator::I8x16GeU | Operator::I16x8GeU | Operator::I32x4GeU => translate_vector_icmp(
             IntCC::UnsignedGreaterThanOrEqual,
             type_of(op),
             builder,
-            state,
+            stack,
         ),
         Operator::I8x16LeU | Operator::I16x8LeU | Operator::I32x4LeU => {
-            translate_vector_icmp(IntCC::UnsignedLessThanOrEqual, type_of(op), builder, state)
+            translate_vector_icmp(IntCC::UnsignedLessThanOrEqual, type_of(op), builder, stack)
         }
         Operator::F32x4Eq | Operator::F64x2Eq => {
-            translate_vector_fcmp(FloatCC::Equal, type_of(op), builder, state)
+            translate_vector_fcmp(FloatCC::Equal, type_of(op), builder, stack)
         }
         Operator::F32x4Ne | Operator::F64x2Ne => {
-            translate_vector_fcmp(FloatCC::NotEqual, type_of(op), builder, state)
+            translate_vector_fcmp(FloatCC::NotEqual, type_of(op), builder, stack)
         }
         Operator::F32x4Lt | Operator::F64x2Lt => {
-            translate_vector_fcmp(FloatCC::LessThan, type_of(op), builder, state)
+            translate_vector_fcmp(FloatCC::LessThan, type_of(op), builder, stack)
         }
         Operator::F32x4Gt | Operator::F64x2Gt => {
-            translate_vector_fcmp(FloatCC::GreaterThan, type_of(op), builder, state)
+            translate_vector_fcmp(FloatCC::GreaterThan, type_of(op), builder, stack)
         }
         Operator::F32x4Le | Operator::F64x2Le => {
-            translate_vector_fcmp(FloatCC::LessThanOrEqual, type_of(op), builder, state)
+            translate_vector_fcmp(FloatCC::LessThanOrEqual, type_of(op), builder, stack)
         }
         Operator::F32x4Ge | Operator::F64x2Ge => {
-            translate_vector_fcmp(FloatCC::GreaterThanOrEqual, type_of(op), builder, state)
+            translate_vector_fcmp(FloatCC::GreaterThanOrEqual, type_of(op), builder, stack)
         }
         Operator::F32x4Add | Operator::F64x2Add => {
-            let (a, b) = pop2_with_bitcast(state, type_of(op), builder);
-            state.push1(builder.ins().fadd(a, b))
+            let (a, b) = pop2_with_bitcast(stack, type_of(op), builder);
+            stack.push1(builder.ins().fadd(a, b))
         }
         Operator::F32x4Sub | Operator::F64x2Sub => {
-            let (a, b) = pop2_with_bitcast(state, type_of(op), builder);
-            state.push1(builder.ins().fsub(a, b))
+            let (a, b) = pop2_with_bitcast(stack, type_of(op), builder);
+            stack.push1(builder.ins().fsub(a, b))
         }
         Operator::F32x4Mul | Operator::F64x2Mul => {
-            let (a, b) = pop2_with_bitcast(state, type_of(op), builder);
-            state.push1(builder.ins().fmul(a, b))
+            let (a, b) = pop2_with_bitcast(stack, type_of(op), builder);
+            stack.push1(builder.ins().fmul(a, b))
         }
         Operator::F32x4Div | Operator::F64x2Div => {
-            let (a, b) = pop2_with_bitcast(state, type_of(op), builder);
-            state.push1(builder.ins().fdiv(a, b))
+            let (a, b) = pop2_with_bitcast(stack, type_of(op), builder);
+            stack.push1(builder.ins().fdiv(a, b))
         }
         Operator::F32x4Max | Operator::F64x2Max => {
-            let (a, b) = pop2_with_bitcast(state, type_of(op), builder);
-            state.push1(builder.ins().fmax(a, b))
+            let (a, b) = pop2_with_bitcast(stack, type_of(op), builder);
+            stack.push1(builder.ins().fmax(a, b))
         }
         Operator::F32x4Min | Operator::F64x2Min => {
-            let (a, b) = pop2_with_bitcast(state, type_of(op), builder);
-            state.push1(builder.ins().fmin(a, b))
+            let (a, b) = pop2_with_bitcast(stack, type_of(op), builder);
+            stack.push1(builder.ins().fmin(a, b))
         }
         Operator::F32x4PMax | Operator::F64x2PMax => {
             // Note the careful ordering here with respect to `fcmp` and
@@ -1956,10 +1921,10 @@ pub fn translate_operator(
             //      * If z1 is less than z2 then return z2.
             //      * Else return z1.
             let ty = type_of(op);
-            let (a, b) = pop2_with_bitcast(state, ty, builder);
+            let (a, b) = pop2_with_bitcast(stack, ty, builder);
             let cmp = builder.ins().fcmp(FloatCC::LessThan, a, b);
             let cmp = optionally_bitcast_vector(cmp, ty, builder);
-            state.push1(builder.ins().bitselect(cmp, b, a))
+            stack.push1(builder.ins().bitselect(cmp, b, a))
         }
         Operator::F32x4PMin | Operator::F64x2PMin => {
             // Note the careful ordering here which is similar to `pmax` above:
@@ -1968,60 +1933,60 @@ pub fn translate_operator(
             //      * If z2 is less than z1 then return z2.
             //      * Else return z1.
             let ty = type_of(op);
-            let (a, b) = pop2_with_bitcast(state, ty, builder);
+            let (a, b) = pop2_with_bitcast(stack, ty, builder);
             let cmp = builder.ins().fcmp(FloatCC::LessThan, b, a);
             let cmp = optionally_bitcast_vector(cmp, ty, builder);
-            state.push1(builder.ins().bitselect(cmp, b, a))
+            stack.push1(builder.ins().bitselect(cmp, b, a))
         }
         Operator::F32x4Sqrt | Operator::F64x2Sqrt => {
-            let a = pop1_with_bitcast(state, type_of(op), builder);
-            state.push1(builder.ins().sqrt(a))
+            let a = pop1_with_bitcast(stack, type_of(op), builder);
+            stack.push1(builder.ins().sqrt(a))
         }
         Operator::F32x4Neg | Operator::F64x2Neg => {
-            let a = pop1_with_bitcast(state, type_of(op), builder);
-            state.push1(builder.ins().fneg(a))
+            let a = pop1_with_bitcast(stack, type_of(op), builder);
+            stack.push1(builder.ins().fneg(a))
         }
         Operator::F32x4Abs | Operator::F64x2Abs => {
-            let a = pop1_with_bitcast(state, type_of(op), builder);
-            state.push1(builder.ins().fabs(a))
+            let a = pop1_with_bitcast(stack, type_of(op), builder);
+            stack.push1(builder.ins().fabs(a))
         }
         Operator::F32x4ConvertI32x4S => {
-            let a = pop1_with_bitcast(state, I32X4, builder);
-            state.push1(builder.ins().fcvt_from_sint(F32X4, a))
+            let a = pop1_with_bitcast(stack, I32X4, builder);
+            stack.push1(builder.ins().fcvt_from_sint(F32X4, a))
         }
         Operator::F32x4ConvertI32x4U => {
-            let a = pop1_with_bitcast(state, I32X4, builder);
-            state.push1(builder.ins().fcvt_from_uint(F32X4, a))
+            let a = pop1_with_bitcast(stack, I32X4, builder);
+            stack.push1(builder.ins().fcvt_from_uint(F32X4, a))
         }
         Operator::F64x2ConvertLowI32x4S => {
-            let a = pop1_with_bitcast(state, I32X4, builder);
+            let a = pop1_with_bitcast(stack, I32X4, builder);
             let widened_a = builder.ins().swiden_low(a);
-            state.push1(builder.ins().fcvt_from_sint(F64X2, widened_a));
+            stack.push1(builder.ins().fcvt_from_sint(F64X2, widened_a));
         }
         Operator::F64x2ConvertLowI32x4U => {
-            let a = pop1_with_bitcast(state, I32X4, builder);
+            let a = pop1_with_bitcast(stack, I32X4, builder);
             let widened_a = builder.ins().uwiden_low(a);
-            state.push1(builder.ins().fcvt_from_uint(F64X2, widened_a));
+            stack.push1(builder.ins().fcvt_from_uint(F64X2, widened_a));
         }
         Operator::F64x2PromoteLowF32x4 => {
-            let a = pop1_with_bitcast(state, F32X4, builder);
-            state.push1(builder.ins().fvpromote_low(a));
+            let a = pop1_with_bitcast(stack, F32X4, builder);
+            stack.push1(builder.ins().fvpromote_low(a));
         }
         Operator::F32x4DemoteF64x2Zero => {
-            let a = pop1_with_bitcast(state, F64X2, builder);
-            state.push1(builder.ins().fvdemote(a));
+            let a = pop1_with_bitcast(stack, F64X2, builder);
+            stack.push1(builder.ins().fvdemote(a));
         }
         Operator::I32x4TruncSatF32x4S => {
-            let a = pop1_with_bitcast(state, F32X4, builder);
-            state.push1(builder.ins().fcvt_to_sint_sat(I32X4, a))
+            let a = pop1_with_bitcast(stack, F32X4, builder);
+            stack.push1(builder.ins().fcvt_to_sint_sat(I32X4, a))
         }
         Operator::I32x4TruncSatF64x2SZero => {
-            let a = pop1_with_bitcast(state, F64X2, builder);
+            let a = pop1_with_bitcast(stack, F64X2, builder);
             let converted_a = builder.ins().fcvt_to_sint_sat(I64X2, a);
             let handle = builder.func.dfg.constants.insert(vec![0u8; 16].into());
             let zero = builder.ins().vconst(I64X2, handle);
 
-            state.push1(builder.ins().snarrow(converted_a, zero));
+            stack.push1(builder.ins().snarrow(converted_a, zero));
         }
 
         // FIXME(#5913): the relaxed instructions here are translated the same
@@ -2036,11 +2001,11 @@ pub fn translate_operator(
         // perhaps for other backends too) should be added and the codegen for
         // the relaxed instruction should conditionally be different.
         Operator::I32x4RelaxedTruncF32x4U | Operator::I32x4TruncSatF32x4U => {
-            let a = pop1_with_bitcast(state, F32X4, builder);
-            state.push1(builder.ins().fcvt_to_uint_sat(I32X4, a))
+            let a = pop1_with_bitcast(stack, F32X4, builder);
+            stack.push1(builder.ins().fcvt_to_uint_sat(I32X4, a))
         }
         Operator::I32x4RelaxedTruncF64x2UZero | Operator::I32x4TruncSatF64x2UZero => {
-            let a = pop1_with_bitcast(state, F64X2, builder);
+            let a = pop1_with_bitcast(stack, F64X2, builder);
             let zero_constant = builder.func.dfg.constants.insert(vec![0u8; 16].into());
             let result = if environ.is_x86() && !environ.isa().has_round() {
                 // On x86 the vector lowering for `fcvt_to_uint_sat` requires
@@ -2060,218 +2025,218 @@ pub fn translate_operator(
                 let zero = builder.ins().vconst(I64X2, zero_constant);
                 builder.ins().uunarrow(converted_a, zero)
             };
-            state.push1(result);
+            stack.push1(result);
         }
 
         Operator::I8x16NarrowI16x8S => {
-            let (a, b) = pop2_with_bitcast(state, I16X8, builder);
-            state.push1(builder.ins().snarrow(a, b))
+            let (a, b) = pop2_with_bitcast(stack, I16X8, builder);
+            stack.push1(builder.ins().snarrow(a, b))
         }
         Operator::I16x8NarrowI32x4S => {
-            let (a, b) = pop2_with_bitcast(state, I32X4, builder);
-            state.push1(builder.ins().snarrow(a, b))
+            let (a, b) = pop2_with_bitcast(stack, I32X4, builder);
+            stack.push1(builder.ins().snarrow(a, b))
         }
         Operator::I8x16NarrowI16x8U => {
-            let (a, b) = pop2_with_bitcast(state, I16X8, builder);
-            state.push1(builder.ins().unarrow(a, b))
+            let (a, b) = pop2_with_bitcast(stack, I16X8, builder);
+            stack.push1(builder.ins().unarrow(a, b))
         }
         Operator::I16x8NarrowI32x4U => {
-            let (a, b) = pop2_with_bitcast(state, I32X4, builder);
-            state.push1(builder.ins().unarrow(a, b))
+            let (a, b) = pop2_with_bitcast(stack, I32X4, builder);
+            stack.push1(builder.ins().unarrow(a, b))
         }
         Operator::I16x8ExtendLowI8x16S => {
-            let a = pop1_with_bitcast(state, I8X16, builder);
-            state.push1(builder.ins().swiden_low(a))
+            let a = pop1_with_bitcast(stack, I8X16, builder);
+            stack.push1(builder.ins().swiden_low(a))
         }
         Operator::I16x8ExtendHighI8x16S => {
-            let a = pop1_with_bitcast(state, I8X16, builder);
-            state.push1(builder.ins().swiden_high(a))
+            let a = pop1_with_bitcast(stack, I8X16, builder);
+            stack.push1(builder.ins().swiden_high(a))
         }
         Operator::I16x8ExtendLowI8x16U => {
-            let a = pop1_with_bitcast(state, I8X16, builder);
-            state.push1(builder.ins().uwiden_low(a))
+            let a = pop1_with_bitcast(stack, I8X16, builder);
+            stack.push1(builder.ins().uwiden_low(a))
         }
         Operator::I16x8ExtendHighI8x16U => {
-            let a = pop1_with_bitcast(state, I8X16, builder);
-            state.push1(builder.ins().uwiden_high(a))
+            let a = pop1_with_bitcast(stack, I8X16, builder);
+            stack.push1(builder.ins().uwiden_high(a))
         }
         Operator::I32x4ExtendLowI16x8S => {
-            let a = pop1_with_bitcast(state, I16X8, builder);
-            state.push1(builder.ins().swiden_low(a))
+            let a = pop1_with_bitcast(stack, I16X8, builder);
+            stack.push1(builder.ins().swiden_low(a))
         }
         Operator::I32x4ExtendHighI16x8S => {
-            let a = pop1_with_bitcast(state, I16X8, builder);
-            state.push1(builder.ins().swiden_high(a))
+            let a = pop1_with_bitcast(stack, I16X8, builder);
+            stack.push1(builder.ins().swiden_high(a))
         }
         Operator::I32x4ExtendLowI16x8U => {
-            let a = pop1_with_bitcast(state, I16X8, builder);
-            state.push1(builder.ins().uwiden_low(a))
+            let a = pop1_with_bitcast(stack, I16X8, builder);
+            stack.push1(builder.ins().uwiden_low(a))
         }
         Operator::I32x4ExtendHighI16x8U => {
-            let a = pop1_with_bitcast(state, I16X8, builder);
-            state.push1(builder.ins().uwiden_high(a))
+            let a = pop1_with_bitcast(stack, I16X8, builder);
+            stack.push1(builder.ins().uwiden_high(a))
         }
         Operator::I64x2ExtendLowI32x4S => {
-            let a = pop1_with_bitcast(state, I32X4, builder);
-            state.push1(builder.ins().swiden_low(a))
+            let a = pop1_with_bitcast(stack, I32X4, builder);
+            stack.push1(builder.ins().swiden_low(a))
         }
         Operator::I64x2ExtendHighI32x4S => {
-            let a = pop1_with_bitcast(state, I32X4, builder);
-            state.push1(builder.ins().swiden_high(a))
+            let a = pop1_with_bitcast(stack, I32X4, builder);
+            stack.push1(builder.ins().swiden_high(a))
         }
         Operator::I64x2ExtendLowI32x4U => {
-            let a = pop1_with_bitcast(state, I32X4, builder);
-            state.push1(builder.ins().uwiden_low(a))
+            let a = pop1_with_bitcast(stack, I32X4, builder);
+            stack.push1(builder.ins().uwiden_low(a))
         }
         Operator::I64x2ExtendHighI32x4U => {
-            let a = pop1_with_bitcast(state, I32X4, builder);
-            state.push1(builder.ins().uwiden_high(a))
+            let a = pop1_with_bitcast(stack, I32X4, builder);
+            stack.push1(builder.ins().uwiden_high(a))
         }
         Operator::I16x8ExtAddPairwiseI8x16S => {
-            let a = pop1_with_bitcast(state, I8X16, builder);
+            let a = pop1_with_bitcast(stack, I8X16, builder);
             let widen_low = builder.ins().swiden_low(a);
             let widen_high = builder.ins().swiden_high(a);
-            state.push1(builder.ins().iadd_pairwise(widen_low, widen_high));
+            stack.push1(builder.ins().iadd_pairwise(widen_low, widen_high));
         }
         Operator::I32x4ExtAddPairwiseI16x8S => {
-            let a = pop1_with_bitcast(state, I16X8, builder);
+            let a = pop1_with_bitcast(stack, I16X8, builder);
             let widen_low = builder.ins().swiden_low(a);
             let widen_high = builder.ins().swiden_high(a);
-            state.push1(builder.ins().iadd_pairwise(widen_low, widen_high));
+            stack.push1(builder.ins().iadd_pairwise(widen_low, widen_high));
         }
         Operator::I16x8ExtAddPairwiseI8x16U => {
-            let a = pop1_with_bitcast(state, I8X16, builder);
+            let a = pop1_with_bitcast(stack, I8X16, builder);
             let widen_low = builder.ins().uwiden_low(a);
             let widen_high = builder.ins().uwiden_high(a);
-            state.push1(builder.ins().iadd_pairwise(widen_low, widen_high));
+            stack.push1(builder.ins().iadd_pairwise(widen_low, widen_high));
         }
         Operator::I32x4ExtAddPairwiseI16x8U => {
-            let a = pop1_with_bitcast(state, I16X8, builder);
+            let a = pop1_with_bitcast(stack, I16X8, builder);
             let widen_low = builder.ins().uwiden_low(a);
             let widen_high = builder.ins().uwiden_high(a);
-            state.push1(builder.ins().iadd_pairwise(widen_low, widen_high));
+            stack.push1(builder.ins().iadd_pairwise(widen_low, widen_high));
         }
         Operator::F32x4Ceil => {
-            let arg = pop1_with_bitcast(state, F32X4, builder);
-            state.push1(environ.ceil_f32x4(builder, arg));
+            let arg = pop1_with_bitcast(stack, F32X4, builder);
+            stack.push1(environ.ceil_f32x4(builder, arg));
         }
         Operator::F64x2Ceil => {
-            let arg = pop1_with_bitcast(state, F64X2, builder);
-            state.push1(environ.ceil_f64x2(builder, arg));
+            let arg = pop1_with_bitcast(stack, F64X2, builder);
+            stack.push1(environ.ceil_f64x2(builder, arg));
         }
         Operator::F32x4Floor => {
-            let arg = pop1_with_bitcast(state, F32X4, builder);
-            state.push1(environ.floor_f32x4(builder, arg));
+            let arg = pop1_with_bitcast(stack, F32X4, builder);
+            stack.push1(environ.floor_f32x4(builder, arg));
         }
         Operator::F64x2Floor => {
-            let arg = pop1_with_bitcast(state, F64X2, builder);
-            state.push1(environ.floor_f64x2(builder, arg));
+            let arg = pop1_with_bitcast(stack, F64X2, builder);
+            stack.push1(environ.floor_f64x2(builder, arg));
         }
         Operator::F32x4Trunc => {
-            let arg = pop1_with_bitcast(state, F32X4, builder);
-            state.push1(environ.trunc_f32x4(builder, arg));
+            let arg = pop1_with_bitcast(stack, F32X4, builder);
+            stack.push1(environ.trunc_f32x4(builder, arg));
         }
         Operator::F64x2Trunc => {
-            let arg = pop1_with_bitcast(state, F64X2, builder);
-            state.push1(environ.trunc_f64x2(builder, arg));
+            let arg = pop1_with_bitcast(stack, F64X2, builder);
+            stack.push1(environ.trunc_f64x2(builder, arg));
         }
         Operator::F32x4Nearest => {
-            let arg = pop1_with_bitcast(state, F32X4, builder);
-            state.push1(environ.nearest_f32x4(builder, arg));
+            let arg = pop1_with_bitcast(stack, F32X4, builder);
+            stack.push1(environ.nearest_f32x4(builder, arg));
         }
         Operator::F64x2Nearest => {
-            let arg = pop1_with_bitcast(state, F64X2, builder);
-            state.push1(environ.nearest_f64x2(builder, arg));
+            let arg = pop1_with_bitcast(stack, F64X2, builder);
+            stack.push1(environ.nearest_f64x2(builder, arg));
         }
         Operator::I32x4DotI16x8S => {
-            let (a, b) = pop2_with_bitcast(state, I16X8, builder);
+            let (a, b) = pop2_with_bitcast(stack, I16X8, builder);
             let alow = builder.ins().swiden_low(a);
             let blow = builder.ins().swiden_low(b);
             let low = builder.ins().imul(alow, blow);
             let ahigh = builder.ins().swiden_high(a);
             let bhigh = builder.ins().swiden_high(b);
             let high = builder.ins().imul(ahigh, bhigh);
-            state.push1(builder.ins().iadd_pairwise(low, high));
+            stack.push1(builder.ins().iadd_pairwise(low, high));
         }
         Operator::I8x16Popcnt => {
-            let arg = pop1_with_bitcast(state, type_of(op), builder);
-            state.push1(builder.ins().popcnt(arg));
+            let arg = pop1_with_bitcast(stack, type_of(op), builder);
+            stack.push1(builder.ins().popcnt(arg));
         }
         Operator::I16x8Q15MulrSatS => {
-            let (a, b) = pop2_with_bitcast(state, I16X8, builder);
-            state.push1(builder.ins().sqmul_round_sat(a, b))
+            let (a, b) = pop2_with_bitcast(stack, I16X8, builder);
+            stack.push1(builder.ins().sqmul_round_sat(a, b))
         }
         Operator::I16x8ExtMulLowI8x16S => {
-            let (a, b) = pop2_with_bitcast(state, I8X16, builder);
+            let (a, b) = pop2_with_bitcast(stack, I8X16, builder);
             let a_low = builder.ins().swiden_low(a);
             let b_low = builder.ins().swiden_low(b);
-            state.push1(builder.ins().imul(a_low, b_low));
+            stack.push1(builder.ins().imul(a_low, b_low));
         }
         Operator::I16x8ExtMulHighI8x16S => {
-            let (a, b) = pop2_with_bitcast(state, I8X16, builder);
+            let (a, b) = pop2_with_bitcast(stack, I8X16, builder);
             let a_high = builder.ins().swiden_high(a);
             let b_high = builder.ins().swiden_high(b);
-            state.push1(builder.ins().imul(a_high, b_high));
+            stack.push1(builder.ins().imul(a_high, b_high));
         }
         Operator::I16x8ExtMulLowI8x16U => {
-            let (a, b) = pop2_with_bitcast(state, I8X16, builder);
+            let (a, b) = pop2_with_bitcast(stack, I8X16, builder);
             let a_low = builder.ins().uwiden_low(a);
             let b_low = builder.ins().uwiden_low(b);
-            state.push1(builder.ins().imul(a_low, b_low));
+            stack.push1(builder.ins().imul(a_low, b_low));
         }
         Operator::I16x8ExtMulHighI8x16U => {
-            let (a, b) = pop2_with_bitcast(state, I8X16, builder);
+            let (a, b) = pop2_with_bitcast(stack, I8X16, builder);
             let a_high = builder.ins().uwiden_high(a);
             let b_high = builder.ins().uwiden_high(b);
-            state.push1(builder.ins().imul(a_high, b_high));
+            stack.push1(builder.ins().imul(a_high, b_high));
         }
         Operator::I32x4ExtMulLowI16x8S => {
-            let (a, b) = pop2_with_bitcast(state, I16X8, builder);
+            let (a, b) = pop2_with_bitcast(stack, I16X8, builder);
             let a_low = builder.ins().swiden_low(a);
             let b_low = builder.ins().swiden_low(b);
-            state.push1(builder.ins().imul(a_low, b_low));
+            stack.push1(builder.ins().imul(a_low, b_low));
         }
         Operator::I32x4ExtMulHighI16x8S => {
-            let (a, b) = pop2_with_bitcast(state, I16X8, builder);
+            let (a, b) = pop2_with_bitcast(stack, I16X8, builder);
             let a_high = builder.ins().swiden_high(a);
             let b_high = builder.ins().swiden_high(b);
-            state.push1(builder.ins().imul(a_high, b_high));
+            stack.push1(builder.ins().imul(a_high, b_high));
         }
         Operator::I32x4ExtMulLowI16x8U => {
-            let (a, b) = pop2_with_bitcast(state, I16X8, builder);
+            let (a, b) = pop2_with_bitcast(stack, I16X8, builder);
             let a_low = builder.ins().uwiden_low(a);
             let b_low = builder.ins().uwiden_low(b);
-            state.push1(builder.ins().imul(a_low, b_low));
+            stack.push1(builder.ins().imul(a_low, b_low));
         }
         Operator::I32x4ExtMulHighI16x8U => {
-            let (a, b) = pop2_with_bitcast(state, I16X8, builder);
+            let (a, b) = pop2_with_bitcast(stack, I16X8, builder);
             let a_high = builder.ins().uwiden_high(a);
             let b_high = builder.ins().uwiden_high(b);
-            state.push1(builder.ins().imul(a_high, b_high));
+            stack.push1(builder.ins().imul(a_high, b_high));
         }
         Operator::I64x2ExtMulLowI32x4S => {
-            let (a, b) = pop2_with_bitcast(state, I32X4, builder);
+            let (a, b) = pop2_with_bitcast(stack, I32X4, builder);
             let a_low = builder.ins().swiden_low(a);
             let b_low = builder.ins().swiden_low(b);
-            state.push1(builder.ins().imul(a_low, b_low));
+            stack.push1(builder.ins().imul(a_low, b_low));
         }
         Operator::I64x2ExtMulHighI32x4S => {
-            let (a, b) = pop2_with_bitcast(state, I32X4, builder);
+            let (a, b) = pop2_with_bitcast(stack, I32X4, builder);
             let a_high = builder.ins().swiden_high(a);
             let b_high = builder.ins().swiden_high(b);
-            state.push1(builder.ins().imul(a_high, b_high));
+            stack.push1(builder.ins().imul(a_high, b_high));
         }
         Operator::I64x2ExtMulLowI32x4U => {
-            let (a, b) = pop2_with_bitcast(state, I32X4, builder);
+            let (a, b) = pop2_with_bitcast(stack, I32X4, builder);
             let a_low = builder.ins().uwiden_low(a);
             let b_low = builder.ins().uwiden_low(b);
-            state.push1(builder.ins().imul(a_low, b_low));
+            stack.push1(builder.ins().imul(a_low, b_low));
         }
         Operator::I64x2ExtMulHighI32x4U => {
-            let (a, b) = pop2_with_bitcast(state, I32X4, builder);
+            let (a, b) = pop2_with_bitcast(stack, I32X4, builder);
             let a_high = builder.ins().uwiden_high(a);
             let b_high = builder.ins().uwiden_high(b);
-            state.push1(builder.ins().imul(a_high, b_high));
+            stack.push1(builder.ins().imul(a_high, b_high));
         }
         Operator::MemoryDiscard { .. } => {
             return Err(wasm_unsupported!(
@@ -2282,8 +2247,8 @@ pub fn translate_operator(
 
         Operator::F32x4RelaxedMax | Operator::F64x2RelaxedMax => {
             let ty = type_of(op);
-            let (a, b) = pop2_with_bitcast(state, ty, builder);
-            state.push1(
+            let (a, b) = pop2_with_bitcast(stack, ty, builder);
+            stack.push1(
                 if environ.relaxed_simd_deterministic() || !environ.is_x86() {
                     // Deterministic semantics match the `fmax` instruction, or
                     // the `fAAxBB.max` wasm instruction.
@@ -2301,8 +2266,8 @@ pub fn translate_operator(
 
         Operator::F32x4RelaxedMin | Operator::F64x2RelaxedMin => {
             let ty = type_of(op);
-            let (a, b) = pop2_with_bitcast(state, ty, builder);
-            state.push1(
+            let (a, b) = pop2_with_bitcast(stack, ty, builder);
+            stack.push1(
                 if environ.relaxed_simd_deterministic() || !environ.is_x86() {
                     // Deterministic semantics match the `fmin` instruction, or
                     // the `fAAxBB.min` wasm instruction.
@@ -2319,27 +2284,27 @@ pub fn translate_operator(
         }
 
         Operator::I8x16RelaxedSwizzle => {
-            let (a, b) = pop2_with_bitcast(state, I8X16, builder);
-            state.push1(environ.relaxed_swizzle(builder, a, b));
+            let (a, b) = pop2_with_bitcast(stack, I8X16, builder);
+            stack.push1(environ.relaxed_swizzle(builder, a, b));
         }
 
         Operator::F32x4RelaxedMadd => {
-            let (a, b, c) = pop3_with_bitcast(state, type_of(op), builder);
-            state.push1(environ.fma_f32x4(builder, a, b, c));
+            let (a, b, c) = pop3_with_bitcast(stack, type_of(op), builder);
+            stack.push1(environ.fma_f32x4(builder, a, b, c));
         }
         Operator::F64x2RelaxedMadd => {
-            let (a, b, c) = pop3_with_bitcast(state, type_of(op), builder);
-            state.push1(environ.fma_f64x2(builder, a, b, c));
+            let (a, b, c) = pop3_with_bitcast(stack, type_of(op), builder);
+            stack.push1(environ.fma_f64x2(builder, a, b, c));
         }
         Operator::F32x4RelaxedNmadd => {
-            let (a, b, c) = pop3_with_bitcast(state, type_of(op), builder);
+            let (a, b, c) = pop3_with_bitcast(stack, type_of(op), builder);
             let a = builder.ins().fneg(a);
-            state.push1(environ.fma_f32x4(builder, a, b, c));
+            stack.push1(environ.fma_f32x4(builder, a, b, c));
         }
         Operator::F64x2RelaxedNmadd => {
-            let (a, b, c) = pop3_with_bitcast(state, type_of(op), builder);
+            let (a, b, c) = pop3_with_bitcast(stack, type_of(op), builder);
             let a = builder.ins().fneg(a);
-            state.push1(environ.fma_f64x2(builder, a, b, c));
+            stack.push1(environ.fma_f64x2(builder, a, b, c));
         }
 
         Operator::I8x16RelaxedLaneselect
@@ -2347,11 +2312,11 @@ pub fn translate_operator(
         | Operator::I32x4RelaxedLaneselect
         | Operator::I64x2RelaxedLaneselect => {
             let ty = type_of(op);
-            let (a, b, c) = pop3_with_bitcast(state, ty, builder);
+            let (a, b, c) = pop3_with_bitcast(stack, ty, builder);
             // Note that the variable swaps here are intentional due to
             // the difference of the order of the wasm op and the clif
             // op.
-            state.push1(
+            stack.push1(
                 if environ.relaxed_simd_deterministic()
                     || !environ.use_x86_blendv_for_relaxed_laneselect(ty)
                 {
@@ -2365,8 +2330,8 @@ pub fn translate_operator(
         }
 
         Operator::I32x4RelaxedTruncF32x4S => {
-            let a = pop1_with_bitcast(state, F32X4, builder);
-            state.push1(
+            let a = pop1_with_bitcast(stack, F32X4, builder);
+            stack.push1(
                 if environ.relaxed_simd_deterministic() || !environ.is_x86() {
                     // Deterministic semantics are to match the
                     // `i32x4.trunc_sat_f32x4_s` instruction.
@@ -2377,7 +2342,7 @@ pub fn translate_operator(
             )
         }
         Operator::I32x4RelaxedTruncF64x2SZero => {
-            let a = pop1_with_bitcast(state, F64X2, builder);
+            let a = pop1_with_bitcast(stack, F64X2, builder);
             let converted_a = if environ.relaxed_simd_deterministic() || !environ.is_x86() {
                 // Deterministic semantics are to match the
                 // `i32x4.trunc_sat_f64x2_s_zero` instruction.
@@ -2388,11 +2353,11 @@ pub fn translate_operator(
             let handle = builder.func.dfg.constants.insert(vec![0u8; 16].into());
             let zero = builder.ins().vconst(I64X2, handle);
 
-            state.push1(builder.ins().snarrow(converted_a, zero));
+            stack.push1(builder.ins().snarrow(converted_a, zero));
         }
         Operator::I16x8RelaxedQ15mulrS => {
-            let (a, b) = pop2_with_bitcast(state, I16X8, builder);
-            state.push1(
+            let (a, b) = pop2_with_bitcast(stack, I16X8, builder);
+            stack.push1(
                 if environ.relaxed_simd_deterministic()
                     || !environ.use_x86_pmulhrsw_for_relaxed_q15mul()
                 {
@@ -2405,8 +2370,8 @@ pub fn translate_operator(
             );
         }
         Operator::I16x8RelaxedDotI8x16I7x16S => {
-            let (a, b) = pop2_with_bitcast(state, I8X16, builder);
-            state.push1(
+            let (a, b) = pop2_with_bitcast(stack, I8X16, builder);
+            stack.push1(
                 if environ.relaxed_simd_deterministic() || !environ.use_x86_pmaddubsw_for_dot() {
                     // Deterministic semantics are to treat both operands as
                     // signed integers and perform the dot product.
@@ -2424,8 +2389,8 @@ pub fn translate_operator(
         }
 
         Operator::I32x4RelaxedDotI8x16I7x16AddS => {
-            let c = pop1_with_bitcast(state, I32X4, builder);
-            let (a, b) = pop2_with_bitcast(state, I8X16, builder);
+            let c = pop1_with_bitcast(stack, I32X4, builder);
+            let (a, b) = pop2_with_bitcast(stack, I8X16, builder);
             let dot =
                 if environ.relaxed_simd_deterministic() || !environ.use_x86_pmaddubsw_for_dot() {
                     // Deterministic semantics are to treat both operands as
@@ -2443,22 +2408,22 @@ pub fn translate_operator(
             let dotlo = builder.ins().swiden_low(dot);
             let dothi = builder.ins().swiden_high(dot);
             let dot32 = builder.ins().iadd_pairwise(dotlo, dothi);
-            state.push1(builder.ins().iadd(dot32, c));
+            stack.push1(builder.ins().iadd(dot32, c));
         }
 
         Operator::BrOnNull { relative_depth } => {
-            let r = state.pop1();
+            let r = stack.pop1();
             let [.., WasmValType::Ref(r_ty)] = operand_types else {
                 unreachable!("validation")
             };
-            let (br_destination, inputs) = translate_br_if_args(*relative_depth, state);
+            let (br_destination, inputs) = translate_br_if_args(*relative_depth, stack);
             let is_null = environ.translate_ref_is_null(builder.cursor(), r, *r_ty)?;
             let else_block = builder.create_block();
             canonicalise_brif(builder, is_null, br_destination, inputs, else_block, &[]);
 
             builder.seal_block(else_block); // The only predecessor is the current block.
             builder.switch_to_block(else_block);
-            state.push1(r);
+            stack.push1(r);
         }
         Operator::BrOnNonNull { relative_depth } => {
             // We write this a bit differently from the spec to avoid an extra
@@ -2467,17 +2432,17 @@ pub fn translate_operator(
             // Peek the value val from the stack.
             // If val is ref.null ht, then: pop the value val from the stack.
             // Else: Execute the instruction (br relative_depth).
-            let r = state.peek1();
+            let r = stack.peek1();
             let [.., WasmValType::Ref(r_ty)] = operand_types else {
                 unreachable!("validation")
             };
             let is_null = environ.translate_ref_is_null(builder.cursor(), r, *r_ty)?;
-            let (br_destination, inputs) = translate_br_if_args(*relative_depth, state);
+            let (br_destination, inputs) = translate_br_if_args(*relative_depth, stack);
             let else_block = builder.create_block();
             canonicalise_brif(builder, is_null, else_block, &[], br_destination, inputs);
 
             // In the null case, pop the ref
-            state.pop1();
+            stack.pop1();
 
             builder.seal_block(else_block); // The only predecessor is the current block.
 
@@ -2490,16 +2455,16 @@ pub fn translate_operator(
             // `index` is the index of the function's signature and `table_index` is the index of
             // the table to search the function in.
             let type_index = TypeIndex::from_u32(*type_index);
-            let sigref = state.get_indirect_sig(builder.func, type_index, environ)?;
+            let sigref = environ.get_or_create_sig_ref(builder.func, type_index);
             let num_args = environ.num_params_for_function_type(type_index);
-            let callee = state.pop1();
+            let callee = stack.pop1();
 
             // Bitcast any vector arguments to their default type, I8X16, before calling.
-            let args = state.peekn_mut(num_args);
+            let args = stack.peekn_mut(num_args);
             bitcast_wasm_params(environ, sigref, args, builder);
 
             let call =
-                environ.translate_call_ref(builder, sigref, callee, state.peekn(num_args))?;
+                environ.translate_call_ref(builder, sigref, callee, stack.peekn(num_args))?;
 
             let inst_results = builder.inst_results(call);
             debug_assert_eq!(
@@ -2507,48 +2472,48 @@ pub fn translate_operator(
                 builder.func.dfg.signatures[sigref].returns.len(),
                 "translate_call_ref results should match the call signature"
             );
-            state.popn(num_args);
-            state.pushn(inst_results);
+            stack.popn(num_args);
+            stack.pushn(inst_results);
         }
         Operator::RefAsNonNull => {
-            let r = state.pop1();
+            let r = stack.pop1();
             let [.., WasmValType::Ref(r_ty)] = operand_types else {
                 unreachable!("validation")
             };
             let is_null = environ.translate_ref_is_null(builder.cursor(), r, *r_ty)?;
             environ.trapnz(builder, is_null, crate::TRAP_NULL_REFERENCE);
-            state.push1(r);
+            stack.push1(r);
         }
 
         Operator::RefI31 => {
-            let val = state.pop1();
+            let val = stack.pop1();
             let i31ref = environ.translate_ref_i31(builder.cursor(), val)?;
-            state.push1(i31ref);
+            stack.push1(i31ref);
         }
         Operator::I31GetS => {
-            let i31ref = state.pop1();
+            let i31ref = stack.pop1();
             let val = environ.translate_i31_get_s(builder, i31ref)?;
-            state.push1(val);
+            stack.push1(val);
         }
         Operator::I31GetU => {
-            let i31ref = state.pop1();
+            let i31ref = stack.pop1();
             let val = environ.translate_i31_get_u(builder, i31ref)?;
-            state.push1(val);
+            stack.push1(val);
         }
 
         Operator::StructNew { struct_type_index } => {
             let struct_type_index = TypeIndex::from_u32(*struct_type_index);
             let arity = environ.struct_fields_len(struct_type_index)?;
-            let fields: StructFieldsVec = state.peekn(arity).iter().copied().collect();
-            state.popn(arity);
+            let fields: StructFieldsVec = stack.peekn(arity).iter().copied().collect();
+            stack.popn(arity);
             let struct_ref = environ.translate_struct_new(builder, struct_type_index, fields)?;
-            state.push1(struct_ref);
+            stack.push1(struct_ref);
         }
 
         Operator::StructNewDefault { struct_type_index } => {
             let struct_type_index = TypeIndex::from_u32(*struct_type_index);
             let struct_ref = environ.translate_struct_new_default(builder, struct_type_index)?;
-            state.push1(struct_ref);
+            stack.push1(struct_ref);
         }
 
         Operator::StructSet {
@@ -2556,8 +2521,8 @@ pub fn translate_operator(
             field_index,
         } => {
             let struct_type_index = TypeIndex::from_u32(*struct_type_index);
-            let val = state.pop1();
-            let struct_ref = state.pop1();
+            let val = stack.pop1();
+            let struct_ref = stack.pop1();
             environ.translate_struct_set(
                 builder,
                 struct_type_index,
@@ -2572,7 +2537,7 @@ pub fn translate_operator(
             field_index,
         } => {
             let struct_type_index = TypeIndex::from_u32(*struct_type_index);
-            let struct_ref = state.pop1();
+            let struct_ref = stack.pop1();
             let val = environ.translate_struct_get(
                 builder,
                 struct_type_index,
@@ -2580,7 +2545,7 @@ pub fn translate_operator(
                 struct_ref,
                 Some(Extension::Sign),
             )?;
-            state.push1(val);
+            stack.push1(val);
         }
 
         Operator::StructGetU {
@@ -2588,7 +2553,7 @@ pub fn translate_operator(
             field_index,
         } => {
             let struct_type_index = TypeIndex::from_u32(*struct_type_index);
-            let struct_ref = state.pop1();
+            let struct_ref = stack.pop1();
             let val = environ.translate_struct_get(
                 builder,
                 struct_type_index,
@@ -2596,7 +2561,7 @@ pub fn translate_operator(
                 struct_ref,
                 Some(Extension::Zero),
             )?;
-            state.push1(val);
+            stack.push1(val);
         }
 
         Operator::StructGet {
@@ -2604,7 +2569,7 @@ pub fn translate_operator(
             field_index,
         } => {
             let struct_type_index = TypeIndex::from_u32(*struct_type_index);
-            let struct_ref = state.pop1();
+            let struct_ref = stack.pop1();
             let val = environ.translate_struct_get(
                 builder,
                 struct_type_index,
@@ -2612,7 +2577,7 @@ pub fn translate_operator(
                 struct_ref,
                 None,
             )?;
-            state.push1(val);
+            stack.push1(val);
         }
 
         Operator::TryTable { .. } | Operator::ThrowRef => {
@@ -2623,15 +2588,15 @@ pub fn translate_operator(
 
         Operator::ArrayNew { array_type_index } => {
             let array_type_index = TypeIndex::from_u32(*array_type_index);
-            let (elem, len) = state.pop2();
+            let (elem, len) = stack.pop2();
             let array_ref = environ.translate_array_new(builder, array_type_index, elem, len)?;
-            state.push1(array_ref);
+            stack.push1(array_ref);
         }
         Operator::ArrayNewDefault { array_type_index } => {
             let array_type_index = TypeIndex::from_u32(*array_type_index);
-            let len = state.pop1();
+            let len = stack.pop1();
             let array_ref = environ.translate_array_new_default(builder, array_type_index, len)?;
-            state.push1(array_ref);
+            stack.push1(array_ref);
         }
         Operator::ArrayNewFixed {
             array_type_index,
@@ -2639,10 +2604,10 @@ pub fn translate_operator(
         } => {
             let array_type_index = TypeIndex::from_u32(*array_type_index);
             let array_size = usize::try_from(*array_size).unwrap();
-            let elems = state.peekn(array_size);
+            let elems = stack.peekn(array_size);
             let array_ref = environ.translate_array_new_fixed(builder, array_type_index, elems)?;
-            state.popn(array_size);
-            state.push1(array_ref);
+            stack.popn(array_size);
+            stack.push1(array_ref);
         }
         Operator::ArrayNewData {
             array_type_index,
@@ -2650,7 +2615,7 @@ pub fn translate_operator(
         } => {
             let array_type_index = TypeIndex::from_u32(*array_type_index);
             let array_data_index = DataIndex::from_u32(*array_data_index);
-            let (data_offset, len) = state.pop2();
+            let (data_offset, len) = stack.pop2();
             let array_ref = environ.translate_array_new_data(
                 builder,
                 array_type_index,
@@ -2658,7 +2623,7 @@ pub fn translate_operator(
                 data_offset,
                 len,
             )?;
-            state.push1(array_ref);
+            stack.push1(array_ref);
         }
         Operator::ArrayNewElem {
             array_type_index,
@@ -2666,7 +2631,7 @@ pub fn translate_operator(
         } => {
             let array_type_index = TypeIndex::from_u32(*array_type_index);
             let array_elem_index = ElemIndex::from_u32(*array_elem_index);
-            let (elem_offset, len) = state.pop2();
+            let (elem_offset, len) = stack.pop2();
             let array_ref = environ.translate_array_new_elem(
                 builder,
                 array_type_index,
@@ -2674,7 +2639,7 @@ pub fn translate_operator(
                 elem_offset,
                 len,
             )?;
-            state.push1(array_ref);
+            stack.push1(array_ref);
         }
         Operator::ArrayCopy {
             array_type_index_dst,
@@ -2682,7 +2647,7 @@ pub fn translate_operator(
         } => {
             let array_type_index_dst = TypeIndex::from_u32(*array_type_index_dst);
             let array_type_index_src = TypeIndex::from_u32(*array_type_index_src);
-            let (dst_array, dst_index, src_array, src_index, len) = state.pop5();
+            let (dst_array, dst_index, src_array, src_index, len) = stack.pop5();
             environ.translate_array_copy(
                 builder,
                 array_type_index_dst,
@@ -2696,7 +2661,7 @@ pub fn translate_operator(
         }
         Operator::ArrayFill { array_type_index } => {
             let array_type_index = TypeIndex::from_u32(*array_type_index);
-            let (array, index, val, len) = state.pop4();
+            let (array, index, val, len) = stack.pop4();
             environ.translate_array_fill(builder, array_type_index, array, index, val, len)?;
         }
         Operator::ArrayInitData {
@@ -2705,7 +2670,7 @@ pub fn translate_operator(
         } => {
             let array_type_index = TypeIndex::from_u32(*array_type_index);
             let array_data_index = DataIndex::from_u32(*array_data_index);
-            let (array, dst_index, src_index, len) = state.pop4();
+            let (array, dst_index, src_index, len) = stack.pop4();
             environ.translate_array_init_data(
                 builder,
                 array_type_index,
@@ -2722,7 +2687,7 @@ pub fn translate_operator(
         } => {
             let array_type_index = TypeIndex::from_u32(*array_type_index);
             let array_elem_index = ElemIndex::from_u32(*array_elem_index);
-            let (array, dst_index, src_index, len) = state.pop4();
+            let (array, dst_index, src_index, len) = stack.pop4();
             environ.translate_array_init_elem(
                 builder,
                 array_type_index,
@@ -2734,20 +2699,20 @@ pub fn translate_operator(
             )?;
         }
         Operator::ArrayLen => {
-            let array = state.pop1();
+            let array = stack.pop1();
             let len = environ.translate_array_len(builder, array)?;
-            state.push1(len);
+            stack.push1(len);
         }
         Operator::ArrayGet { array_type_index } => {
             let array_type_index = TypeIndex::from_u32(*array_type_index);
-            let (array, index) = state.pop2();
+            let (array, index) = stack.pop2();
             let elem =
                 environ.translate_array_get(builder, array_type_index, array, index, None)?;
-            state.push1(elem);
+            stack.push1(elem);
         }
         Operator::ArrayGetS { array_type_index } => {
             let array_type_index = TypeIndex::from_u32(*array_type_index);
-            let (array, index) = state.pop2();
+            let (array, index) = stack.pop2();
             let elem = environ.translate_array_get(
                 builder,
                 array_type_index,
@@ -2755,11 +2720,11 @@ pub fn translate_operator(
                 index,
                 Some(Extension::Sign),
             )?;
-            state.push1(elem);
+            stack.push1(elem);
         }
         Operator::ArrayGetU { array_type_index } => {
             let array_type_index = TypeIndex::from_u32(*array_type_index);
-            let (array, index) = state.pop2();
+            let (array, index) = stack.pop2();
             let elem = environ.translate_array_get(
                 builder,
                 array_type_index,
@@ -2767,21 +2732,21 @@ pub fn translate_operator(
                 index,
                 Some(Extension::Zero),
             )?;
-            state.push1(elem);
+            stack.push1(elem);
         }
         Operator::ArraySet { array_type_index } => {
             let array_type_index = TypeIndex::from_u32(*array_type_index);
-            let (array, index, elem) = state.pop3();
+            let (array, index, elem) = stack.pop3();
             environ.translate_array_set(builder, array_type_index, array, index, elem)?;
         }
         Operator::RefEq => {
-            let (r1, r2) = state.pop2();
+            let (r1, r2) = stack.pop2();
             let eq = builder.ins().icmp(ir::condcodes::IntCC::Equal, r1, r2);
             let eq = builder.ins().uextend(ir::types::I32, eq);
-            state.push1(eq);
+            stack.push1(eq);
         }
         Operator::RefTestNonNull { hty } => {
-            let r = state.pop1();
+            let r = stack.pop1();
             let [.., WasmValType::Ref(r_ty)] = operand_types else {
                 unreachable!("validation")
             };
@@ -2795,10 +2760,10 @@ pub fn translate_operator(
                 r,
                 *r_ty,
             )?;
-            state.push1(result);
+            stack.push1(result);
         }
         Operator::RefTestNullable { hty } => {
-            let r = state.pop1();
+            let r = stack.pop1();
             let [.., WasmValType::Ref(r_ty)] = operand_types else {
                 unreachable!("validation")
             };
@@ -2812,10 +2777,10 @@ pub fn translate_operator(
                 r,
                 *r_ty,
             )?;
-            state.push1(result);
+            stack.push1(result);
         }
         Operator::RefCastNonNull { hty } => {
-            let r = state.pop1();
+            let r = stack.pop1();
             let [.., WasmValType::Ref(r_ty)] = operand_types else {
                 unreachable!("validation")
             };
@@ -2830,10 +2795,10 @@ pub fn translate_operator(
                 *r_ty,
             )?;
             environ.trapz(builder, cast_okay, crate::TRAP_CAST_FAILURE);
-            state.push1(r);
+            stack.push1(r);
         }
         Operator::RefCastNullable { hty } => {
-            let r = state.pop1();
+            let r = stack.pop1();
             let [.., WasmValType::Ref(r_ty)] = operand_types else {
                 unreachable!("validation")
             };
@@ -2848,14 +2813,14 @@ pub fn translate_operator(
                 *r_ty,
             )?;
             environ.trapz(builder, cast_okay, crate::TRAP_CAST_FAILURE);
-            state.push1(r);
+            stack.push1(r);
         }
         Operator::BrOnCast {
             relative_depth,
             to_ref_type,
             from_ref_type: _,
         } => {
-            let r = state.peek1();
+            let r = stack.peek1();
             let [.., WasmValType::Ref(r_ty)] = operand_types else {
                 unreachable!("validation")
             };
@@ -2863,7 +2828,7 @@ pub fn translate_operator(
             let to_ref_type = environ.convert_ref_type(*to_ref_type)?;
             let cast_is_okay = environ.translate_ref_test(builder, to_ref_type, r, *r_ty)?;
 
-            let (cast_succeeds_block, inputs) = translate_br_if_args(*relative_depth, state);
+            let (cast_succeeds_block, inputs) = translate_br_if_args(*relative_depth, stack);
             let cast_fails_block = builder.create_block();
             canonicalise_brif(
                 builder,
@@ -2889,7 +2854,7 @@ pub fn translate_operator(
             to_ref_type,
             from_ref_type: _,
         } => {
-            let r = state.peek1();
+            let r = stack.peek1();
             let [.., WasmValType::Ref(r_ty)] = operand_types else {
                 unreachable!("validation")
             };
@@ -2897,7 +2862,7 @@ pub fn translate_operator(
             let to_ref_type = environ.convert_ref_type(*to_ref_type)?;
             let cast_is_okay = environ.translate_ref_test(builder, to_ref_type, r, *r_ty)?;
 
-            let (cast_fails_block, inputs) = translate_br_if_args(*relative_depth, state);
+            let (cast_fails_block, inputs) = translate_br_if_args(*relative_depth, stack);
             let cast_succeeds_block = builder.create_block();
             canonicalise_brif(
                 builder,
@@ -3020,36 +2985,36 @@ pub fn translate_operator(
         }
 
         Operator::I64MulWideS => {
-            let (arg1, arg2) = state.pop2();
+            let (arg1, arg2) = stack.pop2();
             let arg1 = builder.ins().sextend(I128, arg1);
             let arg2 = builder.ins().sextend(I128, arg2);
             let result = builder.ins().imul(arg1, arg2);
             let (lo, hi) = builder.ins().isplit(result);
-            state.push2(lo, hi);
+            stack.push2(lo, hi);
         }
         Operator::I64MulWideU => {
-            let (arg1, arg2) = state.pop2();
+            let (arg1, arg2) = stack.pop2();
             let arg1 = builder.ins().uextend(I128, arg1);
             let arg2 = builder.ins().uextend(I128, arg2);
             let result = builder.ins().imul(arg1, arg2);
             let (lo, hi) = builder.ins().isplit(result);
-            state.push2(lo, hi);
+            stack.push2(lo, hi);
         }
         Operator::I64Add128 => {
-            let (arg1, arg2, arg3, arg4) = state.pop4();
+            let (arg1, arg2, arg3, arg4) = stack.pop4();
             let arg1 = builder.ins().iconcat(arg1, arg2);
             let arg2 = builder.ins().iconcat(arg3, arg4);
             let result = builder.ins().iadd(arg1, arg2);
             let (res1, res2) = builder.ins().isplit(result);
-            state.push2(res1, res2);
+            stack.push2(res1, res2);
         }
         Operator::I64Sub128 => {
-            let (arg1, arg2, arg3, arg4) = state.pop4();
+            let (arg1, arg2, arg3, arg4) = stack.pop4();
             let arg1 = builder.ins().iconcat(arg1, arg2);
             let arg2 = builder.ins().iconcat(arg3, arg4);
             let result = builder.ins().isub(arg1, arg2);
             let (res1, res2) = builder.ins().isplit(result);
-            state.push2(res1, res2);
+            stack.push2(res1, res2);
         }
 
         // catch-all as `Operator` is `#[non_exhaustive]`
@@ -3065,15 +3030,15 @@ fn translate_unreachable_operator(
     validator: &FuncValidator<impl WasmModuleResources>,
     op: &Operator,
     builder: &mut FunctionBuilder,
-    state: &mut FuncTranslationState,
+    stack: &mut FuncTranslationStacks,
     environ: &mut FuncEnvironment<'_>,
 ) -> WasmResult<()> {
-    debug_assert!(!state.reachable);
+    debug_assert!(!stack.reachable);
     match *op {
         Operator::If { blockty } => {
             // Push a placeholder control stack entry. The if isn't reachable,
             // so we don't have any branches anywhere.
-            state.push_if(
+            stack.push_if(
                 ir::Block::reserved_value(),
                 ElseData::NoElse {
                     branch_inst: ir::Inst::reserved_value(),
@@ -3085,11 +3050,11 @@ fn translate_unreachable_operator(
             );
         }
         Operator::Loop { blockty: _ } | Operator::Block { blockty: _ } => {
-            state.push_block(ir::Block::reserved_value(), 0, 0);
+            stack.push_block(ir::Block::reserved_value(), 0, 0);
         }
         Operator::Else => {
-            let i = state.control_stack.len() - 1;
-            match state.control_stack[i] {
+            let i = stack.control_stack.len() - 1;
+            match stack.control_stack[i] {
                 ControlStackFrame::If {
                     ref else_data,
                     head_is_reachable,
@@ -3098,11 +3063,11 @@ fn translate_unreachable_operator(
                     ..
                 } => {
                     debug_assert!(consequent_ends_reachable.is_none());
-                    *consequent_ends_reachable = Some(state.reachable);
+                    *consequent_ends_reachable = Some(stack.reachable);
 
                     if head_is_reachable {
                         // We have a branch from the head of the `if` to the `else`.
-                        state.reachable = true;
+                        stack.reachable = true;
 
                         let else_block = match *else_data {
                             ElseData::NoElse {
@@ -3112,8 +3077,8 @@ fn translate_unreachable_operator(
                                 let (params, _results) =
                                     blocktype_params_results(validator, blocktype)?;
                                 let else_block = block_with_params(builder, params, environ)?;
-                                let frame = state.control_stack.last().unwrap();
-                                frame.truncate_value_stack_to_else_params(&mut state.stack);
+                                let frame = stack.control_stack.last().unwrap();
+                                frame.truncate_value_stack_to_else_params(&mut stack.stack);
 
                                 // We change the target of the branch instruction.
                                 builder.change_jump_destination(
@@ -3125,8 +3090,8 @@ fn translate_unreachable_operator(
                                 else_block
                             }
                             ElseData::WithElse { else_block } => {
-                                let frame = state.control_stack.last().unwrap();
-                                frame.truncate_value_stack_to_else_params(&mut state.stack);
+                                let frame = stack.control_stack.last().unwrap();
+                                frame.truncate_value_stack_to_else_params(&mut stack.stack);
                                 else_block
                             }
                         };
@@ -3143,12 +3108,12 @@ fn translate_unreachable_operator(
             }
         }
         Operator::End => {
-            let stack = &mut state.stack;
-            let control_stack = &mut state.control_stack;
+            let value_stack = &mut stack.stack;
+            let control_stack = &mut stack.control_stack;
             let frame = control_stack.pop().unwrap();
 
             // Pop unused parameters from stack.
-            frame.truncate_value_stack_to_original_size(stack);
+            frame.truncate_value_stack_to_original_size(value_stack);
 
             let reachable_anyway = match frame {
                 // If it is a loop we also have to seal the body loop block
@@ -3185,8 +3150,8 @@ fn translate_unreachable_operator(
 
                 // And add the return values of the block but only if the next block is reachable
                 // (which corresponds to testing if the stack depth is 1)
-                stack.extend_from_slice(builder.block_params(frame.following_code()));
-                state.reachable = true;
+                value_stack.extend_from_slice(builder.block_params(frame.following_code()));
+                stack.reachable = true;
             }
         }
         _ => {
@@ -3213,13 +3178,13 @@ fn prepare_addr(
     memarg: &MemArg,
     access_size: u8,
     builder: &mut FunctionBuilder,
-    state: &mut FuncTranslationState,
+    stack: &mut FuncTranslationStacks,
     environ: &mut FuncEnvironment<'_>,
 ) -> WasmResult<Reachability<(MemFlags, Value, Value)>> {
-    let index = state.pop1();
+    let index = stack.pop1();
 
     let memory_index = MemoryIndex::from_u32(memarg.memory);
-    let heap = state.get_heap(builder.func, memory_index, environ)?;
+    let heap = environ.get_or_create_heap(builder.func, memory_index);
 
     // How exactly the bounds check is performed here and what it's performed
     // on is a bit tricky. Generally we want to rely on access violations (e.g.
@@ -3386,7 +3351,7 @@ fn align_atomic_addr(
     memarg: &MemArg,
     loaded_bytes: u8,
     builder: &mut FunctionBuilder,
-    state: &mut FuncTranslationState,
+    stack: &mut FuncTranslationStacks,
     environ: &mut FuncEnvironment<'_>,
 ) {
     // Atomic addresses must all be aligned correctly, and for now we check
@@ -3400,8 +3365,8 @@ fn align_atomic_addr(
     // alignment check itself. This can probably be optimized better and we
     // should do so in the future as well.
     if loaded_bytes > 1 {
-        let addr = state.pop1(); // "peek" via pop then push
-        state.push1(addr);
+        let addr = stack.pop1(); // "peek" via pop then push
+        stack.push1(addr);
         let effective_addr = if memarg.offset == 0 {
             addr
         } else {
@@ -3423,11 +3388,11 @@ fn prepare_atomic_addr(
     memarg: &MemArg,
     loaded_bytes: u8,
     builder: &mut FunctionBuilder,
-    state: &mut FuncTranslationState,
+    stack: &mut FuncTranslationStacks,
     environ: &mut FuncEnvironment<'_>,
 ) -> WasmResult<Reachability<(MemFlags, Value, Value)>> {
-    align_atomic_addr(memarg, loaded_bytes, builder, state, environ);
-    prepare_addr(memarg, loaded_bytes, builder, state, environ)
+    align_atomic_addr(memarg, loaded_bytes, builder, stack, environ);
+    prepare_addr(memarg, loaded_bytes, builder, stack, environ)
 }
 
 /// Translate a load instruction.
@@ -3438,12 +3403,12 @@ fn translate_load(
     opcode: ir::Opcode,
     result_ty: Type,
     builder: &mut FunctionBuilder,
-    state: &mut FuncTranslationState,
+    stack: &mut FuncTranslationStacks,
     environ: &mut FuncEnvironment<'_>,
 ) -> WasmResult<Reachability<()>> {
     let mem_op_size = mem_op_size(opcode, result_ty);
     let (flags, wasm_index, base) =
-        match prepare_addr(memarg, mem_op_size, builder, state, environ)? {
+        match prepare_addr(memarg, mem_op_size, builder, stack, environ)? {
             Reachability::Unreachable => return Ok(Reachability::Unreachable),
             Reachability::Reachable((f, i, b)) => (f, i, b),
         };
@@ -3453,7 +3418,7 @@ fn translate_load(
     let (load, dfg) = builder
         .ins()
         .Load(opcode, result_ty, flags, Offset32::new(0), base);
-    state.push1(dfg.first_result(load));
+    stack.push1(dfg.first_result(load));
     Ok(Reachability::Reachable(()))
 }
 
@@ -3462,16 +3427,16 @@ fn translate_store(
     memarg: &MemArg,
     opcode: ir::Opcode,
     builder: &mut FunctionBuilder,
-    state: &mut FuncTranslationState,
+    stack: &mut FuncTranslationStacks,
     environ: &mut FuncEnvironment<'_>,
 ) -> WasmResult<()> {
-    let val = state.pop1();
+    let val = stack.pop1();
     let val_ty = builder.func.dfg.value_type(val);
     let mem_op_size = mem_op_size(opcode, val_ty);
 
     let (flags, wasm_index, base) = unwrap_or_return_unreachable_state!(
-        state,
-        prepare_addr(memarg, mem_op_size, builder, state, environ)?
+        stack,
+        prepare_addr(memarg, mem_op_size, builder, stack, environ)?
     );
 
     environ.before_store(builder, mem_op_size, wasm_index, memarg.offset);
@@ -3492,10 +3457,10 @@ fn mem_op_size(opcode: ir::Opcode, ty: Type) -> u8 {
     }
 }
 
-fn translate_icmp(cc: IntCC, builder: &mut FunctionBuilder, state: &mut FuncTranslationState) {
-    let (arg0, arg1) = state.pop2();
+fn translate_icmp(cc: IntCC, builder: &mut FunctionBuilder, stack: &mut FuncTranslationStacks) {
+    let (arg0, arg1) = stack.pop2();
     let val = builder.ins().icmp(cc, arg0, arg1);
-    state.push1(builder.ins().uextend(I32, val));
+    stack.push1(builder.ins().uextend(I32, val));
 }
 
 fn translate_atomic_rmw(
@@ -3504,10 +3469,10 @@ fn translate_atomic_rmw(
     op: AtomicRmwOp,
     memarg: &MemArg,
     builder: &mut FunctionBuilder,
-    state: &mut FuncTranslationState,
+    stack: &mut FuncTranslationStacks,
     environ: &mut FuncEnvironment<'_>,
 ) -> WasmResult<()> {
-    let mut arg2 = state.pop1();
+    let mut arg2 = stack.pop1();
     let arg2_ty = builder.func.dfg.value_type(arg2);
 
     // The operation is performed at type `access_ty`, and the old value is zero-extended
@@ -3533,12 +3498,12 @@ fn translate_atomic_rmw(
     }
 
     let (flags, _, addr) = unwrap_or_return_unreachable_state!(
-        state,
+        stack,
         prepare_atomic_addr(
             memarg,
             u8::try_from(access_ty.bytes()).unwrap(),
             builder,
-            state,
+            stack,
             environ,
         )?
     );
@@ -3547,7 +3512,7 @@ fn translate_atomic_rmw(
     if access_ty != widened_ty {
         res = builder.ins().uextend(widened_ty, res);
     }
-    state.push1(res);
+    stack.push1(res);
     Ok(())
 }
 
@@ -3556,10 +3521,10 @@ fn translate_atomic_cas(
     access_ty: Type,
     memarg: &MemArg,
     builder: &mut FunctionBuilder,
-    state: &mut FuncTranslationState,
+    stack: &mut FuncTranslationStacks,
     environ: &mut FuncEnvironment<'_>,
 ) -> WasmResult<()> {
-    let (mut expected, mut replacement) = state.pop2();
+    let (mut expected, mut replacement) = stack.pop2();
     let expected_ty = builder.func.dfg.value_type(expected);
     let replacement_ty = builder.func.dfg.value_type(replacement);
 
@@ -3590,12 +3555,12 @@ fn translate_atomic_cas(
     }
 
     let (flags, _, addr) = unwrap_or_return_unreachable_state!(
-        state,
+        stack,
         prepare_atomic_addr(
             memarg,
             u8::try_from(access_ty.bytes()).unwrap(),
             builder,
-            state,
+            stack,
             environ,
         )?
     );
@@ -3603,7 +3568,7 @@ fn translate_atomic_cas(
     if access_ty != widened_ty {
         res = builder.ins().uextend(widened_ty, res);
     }
-    state.push1(res);
+    stack.push1(res);
     Ok(())
 }
 
@@ -3612,7 +3577,7 @@ fn translate_atomic_load(
     access_ty: Type,
     memarg: &MemArg,
     builder: &mut FunctionBuilder,
-    state: &mut FuncTranslationState,
+    stack: &mut FuncTranslationStacks,
     environ: &mut FuncEnvironment<'_>,
 ) -> WasmResult<()> {
     // The load is performed at type `access_ty`, and the loaded value is zero extended
@@ -3633,12 +3598,12 @@ fn translate_atomic_load(
     assert!(w_ty_ok && widened_ty.bytes() >= access_ty.bytes());
 
     let (flags, _, addr) = unwrap_or_return_unreachable_state!(
-        state,
+        stack,
         prepare_atomic_addr(
             memarg,
             u8::try_from(access_ty.bytes()).unwrap(),
             builder,
-            state,
+            stack,
             environ,
         )?
     );
@@ -3646,7 +3611,7 @@ fn translate_atomic_load(
     if access_ty != widened_ty {
         res = builder.ins().uextend(widened_ty, res);
     }
-    state.push1(res);
+    stack.push1(res);
     Ok(())
 }
 
@@ -3654,10 +3619,10 @@ fn translate_atomic_store(
     access_ty: Type,
     memarg: &MemArg,
     builder: &mut FunctionBuilder,
-    state: &mut FuncTranslationState,
+    stack: &mut FuncTranslationStacks,
     environ: &mut FuncEnvironment<'_>,
 ) -> WasmResult<()> {
-    let mut data = state.pop1();
+    let mut data = stack.pop1();
     let data_ty = builder.func.dfg.value_type(data);
 
     // The operation is performed at type `access_ty`, and the data to be stored may first
@@ -3682,12 +3647,12 @@ fn translate_atomic_store(
     }
 
     let (flags, _, addr) = unwrap_or_return_unreachable_state!(
-        state,
+        stack,
         prepare_atomic_addr(
             memarg,
             u8::try_from(access_ty.bytes()).unwrap(),
             builder,
-            state,
+            stack,
             environ,
         )?
     );
@@ -3699,39 +3664,39 @@ fn translate_vector_icmp(
     cc: IntCC,
     needed_type: Type,
     builder: &mut FunctionBuilder,
-    state: &mut FuncTranslationState,
+    stack: &mut FuncTranslationStacks,
 ) {
-    let (a, b) = state.pop2();
+    let (a, b) = stack.pop2();
     let bitcast_a = optionally_bitcast_vector(a, needed_type, builder);
     let bitcast_b = optionally_bitcast_vector(b, needed_type, builder);
-    state.push1(builder.ins().icmp(cc, bitcast_a, bitcast_b))
+    stack.push1(builder.ins().icmp(cc, bitcast_a, bitcast_b))
 }
 
-fn translate_fcmp(cc: FloatCC, builder: &mut FunctionBuilder, state: &mut FuncTranslationState) {
-    let (arg0, arg1) = state.pop2();
+fn translate_fcmp(cc: FloatCC, builder: &mut FunctionBuilder, stack: &mut FuncTranslationStacks) {
+    let (arg0, arg1) = stack.pop2();
     let val = builder.ins().fcmp(cc, arg0, arg1);
-    state.push1(builder.ins().uextend(I32, val));
+    stack.push1(builder.ins().uextend(I32, val));
 }
 
 fn translate_vector_fcmp(
     cc: FloatCC,
     needed_type: Type,
     builder: &mut FunctionBuilder,
-    state: &mut FuncTranslationState,
+    stack: &mut FuncTranslationStacks,
 ) {
-    let (a, b) = state.pop2();
+    let (a, b) = stack.pop2();
     let bitcast_a = optionally_bitcast_vector(a, needed_type, builder);
     let bitcast_b = optionally_bitcast_vector(b, needed_type, builder);
-    state.push1(builder.ins().fcmp(cc, bitcast_a, bitcast_b))
+    stack.push1(builder.ins().fcmp(cc, bitcast_a, bitcast_b))
 }
 
 fn translate_br_if(
     relative_depth: u32,
     builder: &mut FunctionBuilder,
-    state: &mut FuncTranslationState,
+    stack: &mut FuncTranslationStacks,
 ) {
-    let val = state.pop1();
-    let (br_destination, inputs) = translate_br_if_args(relative_depth, state);
+    let val = stack.pop1();
+    let (br_destination, inputs) = translate_br_if_args(relative_depth, stack);
     let next_block = builder.create_block();
     canonicalise_brif(builder, val, br_destination, inputs, next_block, &[]);
 
@@ -3741,11 +3706,11 @@ fn translate_br_if(
 
 fn translate_br_if_args(
     relative_depth: u32,
-    state: &mut FuncTranslationState,
+    stack: &mut FuncTranslationStacks,
 ) -> (ir::Block, &mut [ir::Value]) {
-    let i = state.control_stack.len() - 1 - (relative_depth as usize);
+    let i = stack.control_stack.len() - 1 - (relative_depth as usize);
     let (return_count, br_destination) = {
-        let frame = &mut state.control_stack[i];
+        let frame = &mut stack.control_stack[i];
         // The values returned by the branch are still available for the reachable
         // code that comes after it
         frame.set_branched_to_exit();
@@ -3756,7 +3721,7 @@ fn translate_br_if_args(
         };
         (return_count, frame.br_destination())
     };
-    let inputs = state.peekn_mut(return_count);
+    let inputs = stack.peekn_mut(return_count);
     (br_destination, inputs)
 }
 
@@ -4068,33 +4033,33 @@ fn canonicalise_brif(
 /// using v128 (i.e. CLIF's I8x16) we must re-type the values using a bitcast to avoid CLIF
 /// typing issues.
 fn pop1_with_bitcast(
-    state: &mut FuncTranslationState,
+    stack: &mut FuncTranslationStacks,
     needed_type: Type,
     builder: &mut FunctionBuilder,
 ) -> Value {
-    optionally_bitcast_vector(state.pop1(), needed_type, builder)
+    optionally_bitcast_vector(stack.pop1(), needed_type, builder)
 }
 
 /// A helper for popping and bitcasting two values; since SIMD values can lose their type by
 /// using v128 (i.e. CLIF's I8x16) we must re-type the values using a bitcast to avoid CLIF
 /// typing issues.
 fn pop2_with_bitcast(
-    state: &mut FuncTranslationState,
+    stack: &mut FuncTranslationStacks,
     needed_type: Type,
     builder: &mut FunctionBuilder,
 ) -> (Value, Value) {
-    let (a, b) = state.pop2();
+    let (a, b) = stack.pop2();
     let bitcast_a = optionally_bitcast_vector(a, needed_type, builder);
     let bitcast_b = optionally_bitcast_vector(b, needed_type, builder);
     (bitcast_a, bitcast_b)
 }
 
 fn pop3_with_bitcast(
-    state: &mut FuncTranslationState,
+    stack: &mut FuncTranslationStacks,
     needed_type: Type,
     builder: &mut FunctionBuilder,
 ) -> (Value, Value, Value) {
-    let (a, b, c) = state.pop3();
+    let (a, b, c) = stack.pop3();
     let bitcast_a = optionally_bitcast_vector(a, needed_type, builder);
     let bitcast_b = optionally_bitcast_vector(b, needed_type, builder);
     let bitcast_c = optionally_bitcast_vector(c, needed_type, builder);

--- a/crates/cranelift/src/translate/mod.rs
+++ b/crates/cranelift/src/translate/mod.rs
@@ -14,13 +14,13 @@ mod code_translator;
 mod environ;
 mod func_translator;
 mod heap;
-mod state;
+mod stack;
 mod table;
 mod translation_utils;
 
 pub use self::environ::{GlobalVariable, StructFieldsVec, TargetEnvironment};
 pub use self::func_translator::FuncTranslator;
 pub use self::heap::{Heap, HeapData};
-pub use self::state::FuncTranslationState;
+pub use self::stack::FuncTranslationStacks;
 pub use self::table::{TableData, TableSize};
 pub use self::translation_utils::*;


### PR DESCRIPTION
It more naturally lives in the environment, where we already keep track of CLIF entities. That these entities were in `FuncTranslationState` is a throwback to back when `FuncEnvironment` was a trait, and not a concrete type.

Also rename `FuncTranslationState` to `FuncTranslationStacks`, since all it does is manage the value and control stacks now.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
