### PR TITLE
Fix preview1 fd_seek when whence == Whence::End

### DIFF
--- a/crates/test-programs/src/bin/preview1_file_seek_tell.rs
+++ b/crates/test-programs/src/bin/preview1_file_seek_tell.rs
@@ -63,6 +63,14 @@ unsafe fn test_file_seek_tell(dir_fd: wasip1::Fd) {
         wasip1::ERRNO_INVAL
     );
 
+    // Seek to an offset off the end of the file
+    newoffset = wasip1::fd_seek(file_fd, 1, wasip1::WHENCE_END)
+        .expect("seeking to the end of the file, minus 1");
+    assert_eq!(
+        newoffset, 99,
+        "offset after seeking to the end of the file minus 1 should be at 99"
+    );
+
     // Check that fd_read properly updates the file offset
     wasip1::fd_seek(file_fd, 0, wasip1::WHENCE_SET)
         .expect("seeking to the beginning of the file again");

--- a/crates/wasi-preview1-component-adapter/src/lib.rs
+++ b/crates/wasi-preview1-component-adapter/src/lib.rs
@@ -1611,7 +1611,7 @@ pub unsafe extern "C" fn fd_seek(
                         Some(pos) if pos >= 0 => pos,
                         _ => return Err(ERRNO_INVAL),
                     },
-                    WHENCE_END => match (file.fd.stat()?.size as i64).checked_add(offset) {
+                    WHENCE_END => match (file.fd.stat()?.size as i64).checked_sub(offset) {
                         Some(pos) if pos >= 0 => pos,
                         _ => return Err(ERRNO_INVAL),
                     },

--- a/crates/wasi/src/preview1.rs
+++ b/crates/wasi/src/preview1.rs
@@ -1844,7 +1844,8 @@ impl wasi_snapshot_preview1::WasiSnapshotPreview1 for WasiP1Ctx {
                 .ok_or(types::Errno::Inval)?,
             types::Whence::End => {
                 let filesystem::DescriptorStat { size, .. } = self.as_wasi_impl().stat(fd).await?;
-                size.checked_add_signed(offset).ok_or(types::Errno::Inval)?
+                size.checked_add_signed(-offset)
+                    .ok_or(types::Errno::Inval)?
             }
             _ => return Err(types::Errno::Inval.into()),
         };


### PR DESCRIPTION
Previously, `fd_seek` was adding the offset to the file size when called with `Whence::End`, rather than subtracting it.
