### PR TITLE
Add `CompiledCodeStencil` to public export in machinst, for fixing crate `TargetIsa`

### DIFF
--- a/cranelift/codegen/src/isa/mod.rs
+++ b/cranelift/codegen/src/isa/mod.rs
@@ -420,7 +420,7 @@ pub trait TargetIsa: fmt::Display + Send + Sync {
 
 /// A wrapper around the ISA-dependent flags types which only implements `Hash`.
 #[derive(Hash)]
-pub struct IsaFlagsHashKey<'a>(&'a [u8]);
+pub struct IsaFlagsHashKey<'a>(pub &'a [u8]);
 
 /// Function alignment specifications as required by an ISA, returned by
 /// [`TargetIsa::function_alignment`].

--- a/cranelift/codegen/src/lib.rs
+++ b/cranelift/codegen/src/lib.rs
@@ -68,7 +68,7 @@ pub use crate::machinst::buffer::{
     OpenPatchRegion, PatchRegion,
 };
 pub use crate::machinst::{
-    ABIMachineSpec, ArgPair, ArgsAccumulator, ArgsOrRets, CallInfo, CompiledCode,
+    ABIMachineSpec, ArgPair, ArgsAccumulator, ArgsOrRets, CallInfo, Callee, CompiledCode,
     CompiledCodeStencil, Final, FrameLayout, MachBuffer, MachBufferFinalized, MachInst,
     MachInstEmit, MachInstEmitState, MachInstLabelUse, MachLabel, MachTerminator, RealReg, Reg,
     RegClass, RelocDistance, SmallInstVec, StackAMode, TextSectionBuilder, VCodeConstant,

--- a/cranelift/codegen/src/lib.rs
+++ b/cranelift/codegen/src/lib.rs
@@ -68,7 +68,7 @@ pub use crate::machinst::buffer::{
     OpenPatchRegion, PatchRegion,
 };
 pub use crate::machinst::{
-    ABIMachineSpec, ArgPair, ArgsAccumulator, ArgsOrRets, CallInfo, Callee, CompiledCode,
+    ABIMachineSpec, ArgPair, ArgsAccumulator, ArgsOrRets, CallInfo, CompiledCode,
     CompiledCodeStencil, Final, FrameLayout, MachBuffer, MachBufferFinalized, MachInst,
     MachInstEmit, MachInstEmitState, MachInstLabelUse, MachLabel, MachTerminator, RealReg, Reg,
     RegClass, RelocDistance, SmallInstVec, StackAMode, TextSectionBuilder, VCodeConstant,

--- a/cranelift/codegen/src/lib.rs
+++ b/cranelift/codegen/src/lib.rs
@@ -68,9 +68,11 @@ pub use crate::machinst::buffer::{
     OpenPatchRegion, PatchRegion,
 };
 pub use crate::machinst::{
-    CallInfo, CompiledCode, CompiledCodeStencil, Final, MachBuffer, MachBufferFinalized, MachInst,
-    MachInstEmit, MachInstEmitState, MachLabel, RealReg, Reg, RelocDistance, TextSectionBuilder,
-    VCodeConstant, VCodeConstantData, VCodeConstants, VCodeInst, Writable,
+    ABIMachineSpec, ArgPair, ArgsAccumulator, ArgsOrRets, CallInfo, CompiledCode,
+    CompiledCodeStencil, Final, FrameLayout, MachBuffer, MachBufferFinalized, MachInst,
+    MachInstEmit, MachInstEmitState, MachInstLabelUse, MachLabel, MachTerminator, RealReg, Reg,
+    RegClass, RelocDistance, SmallInstVec, StackAMode, TextSectionBuilder, VCodeConstant,
+    VCodeConstantData, VCodeConstants, VCodeInst, Writable,
 };
 
 mod alias_analysis;

--- a/cranelift/codegen/src/lib.rs
+++ b/cranelift/codegen/src/lib.rs
@@ -68,9 +68,9 @@ pub use crate::machinst::buffer::{
     OpenPatchRegion, PatchRegion,
 };
 pub use crate::machinst::{
-    CallInfo, CompiledCode, Final, MachBuffer, MachBufferFinalized, MachInst, MachInstEmit,
-    MachInstEmitState, MachLabel, RealReg, Reg, RelocDistance, TextSectionBuilder, VCodeConstant,
-    VCodeConstantData, VCodeConstants, VCodeInst, Writable,
+    CallInfo, CompiledCode, CompiledCodeStencil, Final, MachBuffer, MachBufferFinalized, MachInst,
+    MachInstEmit, MachInstEmitState, MachLabel, RealReg, Reg, RelocDistance, TextSectionBuilder,
+    VCodeConstant, VCodeConstantData, VCodeConstants, VCodeInst, Writable,
 };
 
 mod alias_analysis;

--- a/cranelift/codegen/src/lib.rs
+++ b/cranelift/codegen/src/lib.rs
@@ -68,11 +68,9 @@ pub use crate::machinst::buffer::{
     OpenPatchRegion, PatchRegion,
 };
 pub use crate::machinst::{
-    ABIMachineSpec, ArgPair, ArgsAccumulator, ArgsOrRets, CallInfo, CompiledCode,
-    CompiledCodeStencil, Final, FrameLayout, MachBuffer, MachBufferFinalized, MachInst,
-    MachInstEmit, MachInstEmitState, MachInstLabelUse, MachLabel, MachTerminator, RealReg, Reg,
-    RegClass, RelocDistance, SmallInstVec, StackAMode, TextSectionBuilder, VCodeConstant,
-    VCodeConstantData, VCodeConstants, VCodeInst, Writable,
+    CallInfo, CompiledCode, CompiledCodeStencil, Final, MachBuffer, MachBufferFinalized, MachInst,
+    MachInstEmit, MachInstEmitState, MachLabel, RealReg, Reg, RelocDistance, TextSectionBuilder,
+    VCodeConstant, VCodeConstantData, VCodeConstants, VCodeInst, Writable,
 };
 
 mod alias_analysis;


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->

Crate `TargetIsa` have method `compile_function`, what return type is `CodegenResult<CompiledCodeStencil>`.
`CompiledCodeStencil` is not public exported, so i just cant use this crate for custom external isa..
