### PR TITLE
Add support for the Linux PAGEMAP_SCAN ioctl

### DIFF
--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -113,6 +113,10 @@ wasmtime-versioned-export-macros = { workspace = true, optional = true }
 name = "host_segfault"
 harness = false
 
+[[test]]
+name = "engine_across_forks"
+harness = false
+
 # =============================================================================
 #
 # Features for the Wasmtime crate.

--- a/crates/wasmtime/src/runtime/module.rs
+++ b/crates/wasmtime/src/runtime/module.rs
@@ -1,7 +1,7 @@
 use crate::prelude::*;
 #[cfg(feature = "std")]
 use crate::runtime::vm::open_file_for_mmap;
-use crate::runtime::vm::{CompiledModuleId, ModuleMemoryImages, VMWasmCallFunction};
+use crate::runtime::vm::{CompiledModuleId, MmapVec, ModuleMemoryImages, VMWasmCallFunction};
 use crate::sync::OnceLock;
 use crate::{
     Engine,
@@ -1114,7 +1114,7 @@ impl Module {
         let images = self
             .inner
             .memory_images
-            .get_or_try_init(|| memory_images(&self.inner.engine, &self.inner.module))?
+            .get_or_try_init(|| memory_images(&self.inner))?
             .as_ref();
         Ok(images)
     }
@@ -1164,21 +1164,30 @@ fn _assert_send_sync() {
 
 /// Helper method to construct a `ModuleMemoryImages` for an associated
 /// `CompiledModule`.
-fn memory_images(engine: &Engine, module: &CompiledModule) -> Result<Option<ModuleMemoryImages>> {
+fn memory_images(inner: &Arc<ModuleInner>) -> Result<Option<ModuleMemoryImages>> {
     // If initialization via copy-on-write is explicitly disabled in
     // configuration then this path is skipped entirely.
-    if !engine.tunables().memory_init_cow {
+    if !inner.engine.tunables().memory_init_cow {
         return Ok(None);
     }
 
     // ... otherwise logic is delegated to the `ModuleMemoryImages::new`
     // constructor.
-    let mmap = if engine.config().force_memory_init_memfd {
-        None
-    } else {
-        Some(module.mmap())
-    };
-    ModuleMemoryImages::new(module.module(), module.code_memory().wasm_data(), mmap)
+    ModuleMemoryImages::new(inner.module.module(), inner)
+}
+
+impl crate::vm::ModuleMemoryImageSource for ModuleInner {
+    fn wasm_data(&self) -> &[u8] {
+        self.code.code_memory().wasm_data()
+    }
+
+    fn mmap(&self) -> Option<&MmapVec> {
+        if self.engine.config().force_memory_init_memfd {
+            None
+        } else {
+            Some(self.module.mmap())
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/wasmtime/src/runtime/module.rs
+++ b/crates/wasmtime/src/runtime/module.rs
@@ -1173,20 +1173,20 @@ fn memory_images(inner: &Arc<ModuleInner>) -> Result<Option<ModuleMemoryImages>>
 
     // ... otherwise logic is delegated to the `ModuleMemoryImages::new`
     // constructor.
-    ModuleMemoryImages::new(inner.module.module(), inner)
+    ModuleMemoryImages::new(
+        &inner.engine,
+        inner.module.module(),
+        inner.code.code_memory(),
+    )
 }
 
-impl crate::vm::ModuleMemoryImageSource for ModuleInner {
+impl crate::vm::ModuleMemoryImageSource for CodeMemory {
     fn wasm_data(&self) -> &[u8] {
-        self.code.code_memory().wasm_data()
+        <Self>::wasm_data(self)
     }
 
     fn mmap(&self) -> Option<&MmapVec> {
-        if self.engine.config().force_memory_init_memfd {
-            None
-        } else {
-            Some(self.module.mmap())
-        }
+        Some(<Self>::mmap(self))
     }
 }
 

--- a/crates/wasmtime/src/runtime/vm.rs
+++ b/crates/wasmtime/src/runtime/vm.rs
@@ -60,6 +60,7 @@ mod imports;
 mod instance;
 mod memory;
 mod mmap_vec;
+#[cfg(has_virtual_memory)]
 mod pagemap_disabled;
 mod provenance;
 mod send_sync_ptr;

--- a/crates/wasmtime/src/runtime/vm.rs
+++ b/crates/wasmtime/src/runtime/vm.rs
@@ -60,6 +60,7 @@ mod imports;
 mod instance;
 mod memory;
 mod mmap_vec;
+mod pagemap_disabled;
 mod provenance;
 mod send_sync_ptr;
 mod stack_switching;
@@ -159,6 +160,17 @@ cfg_if::cfg_if! {
     } else {
         pub use self::cow_disabled::{MemoryImage, MemoryImageSlot, ModuleMemoryImages};
     }
+}
+
+/// Source of data used for [`MemoryImage`]
+pub trait ModuleMemoryImageSource: Send + Sync + 'static {
+    /// Returns this image's slice of all wasm data for a module which is then
+    /// further sub-sliced for a particular initialization segment.
+    fn wasm_data(&self) -> &[u8];
+
+    /// Optionally returns the backing mmap. Used for using the backing mmap's
+    /// file to perform other mmaps, for example.
+    fn mmap(&self) -> Option<&MmapVec>;
 }
 
 /// Dynamic runtime functionality needed by this crate throughout the execution

--- a/crates/wasmtime/src/runtime/vm/cow.rs
+++ b/crates/wasmtime/src/runtime/vm/cow.rs
@@ -3,18 +3,13 @@
 
 use super::sys::DecommitBehavior;
 use crate::prelude::*;
+use crate::runtime::vm::sys::pagemap::dirty_pages_in_region;
 use crate::runtime::vm::sys::vm::{self, MemoryImageSource};
 use crate::runtime::vm::{HostAlignedByteCount, MmapOffset, MmapVec, host_page_size};
 use alloc::sync::Arc;
 use core::ops::Range;
 use core::ptr;
-use std::fs::File;
-use std::fmt;
-use std::mem::MaybeUninit;
-use std::os::raw::c_void;
 use std::os::unix::fs::FileExt;
-use std::sync::LazyLock;
-use rustix::ioctl::{ioctl, opcode, Ioctl, IoctlOutput, Opcode};
 use wasmtime_environ::{DefinedMemoryIndex, MemoryInitialization, Module, PrimaryMap, Tunables};
 
 /// Backing images for memories in a module.
@@ -332,146 +327,6 @@ pub struct MemoryImageSlot {
     clear_on_drop: bool,
 }
 
-bitflags::bitflags! {
-    #[derive(Debug)]
-    struct PageMapBits: u64 {
-        const PRESENT = 1 << 63;
-        const SWAPPED = 1 << 62;
-        const FILE = 1 << 61;
-        const GUARD = 1 << 58;
-        const WP = 1 << 57;
-        const EXCL = 1 << 56;
-        const SOFT_DIRTY = 1 << 55;
-    }
-}
-
-impl fmt::Display for PageMapBits {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        bitflags::parser::to_writer(self, f)
-    }
-}
-
-bitflags::bitflags! {
-    #[derive(Copy, Clone)]
-    #[repr(transparent)]
-    struct Categories: u64 {
-        const WPALLOWED = 1 << 0;
-        const WRITTEN = 1 << 1;
-        const FILE = 1 << 2;
-        const PRESENT = 1 << 3;
-        const SWAPPED = 1 << 4;
-        const PFNZERO = 1 << 5;
-        const HUGE = 1 << 6;
-        const SOFT_DIRTY = 1 << 7;
-    }
-}
-
-impl fmt::Debug for Categories {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        bitflags::parser::to_writer(self, f)
-    }
-}
-impl fmt::Display for Categories {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        bitflags::parser::to_writer(self, f)
-    }
-}
-
-struct PageMapScan<'a> {
-    pm_scan_arg: pm_scan_arg,
-    _regions: &'a mut [MaybeUninit<page_region>],
-}
-
-impl<'a> PageMapScan<'a> {
-    fn new(region: *const [u8], regions: &'a mut [MaybeUninit<page_region>]) -> PageMapScan<'a> {
-        PageMapScan {
-            pm_scan_arg: pm_scan_arg {
-                size: size_of::<pm_scan_arg>() as u64,
-                flags: 0,
-                start: unsafe { (*region).as_ptr() as u64 },
-                end: unsafe { (*region).as_ptr().wrapping_add((*region).len()) as u64 },
-                walk_end: 0,
-                vec: regions.as_mut_ptr() as u64,
-                vec_len: regions.len() as u64,
-                max_pages: 0,
-                category_inverted: Categories::FILE | Categories::PFNZERO,
-                category_anyof_mask: Categories::empty(),
-                category_mask: Categories::WRITTEN | Categories::FILE | Categories::PFNZERO,
-                return_mask: Categories::all(),
-            },
-            _regions: regions,
-        }
-    }
-}
-
-#[derive(Debug)]
-#[allow(dead_code)]
-struct PageMapScanResult<'a> {
-    walk_end: usize,
-    regions: &'a mut [page_region],
-}
-
-#[repr(C)]
-struct pm_scan_arg {
-    size: u64,
-    flags: u64,
-    start: u64,
-    end: u64,
-    walk_end: u64,
-    vec: u64,
-    vec_len: u64,
-    max_pages: u64,
-    category_inverted: Categories,
-    category_mask: Categories,
-    category_anyof_mask: Categories,
-    return_mask: Categories,
-}
-
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-struct page_region {
-    start: u64,
-    end: u64,
-    categories: Categories,
-}
-
-const PAGEMAP_SCAN: Opcode = opcode::read_write::<pm_scan_arg>(b'f', 16);
-
-unsafe impl<'a> Ioctl for PageMapScan<'a> {
-    type Output = PageMapScanResult<'a>;
-
-    const IS_MUTATING: bool = true;
-
-    fn opcode(&self) -> Opcode {
-        PAGEMAP_SCAN
-    }
-
-    fn as_ptr(&mut self) -> *mut c_void {
-        (&raw mut self.pm_scan_arg).cast()
-    }
-
-    unsafe fn output_from_ptr(
-        out: IoctlOutput,
-        extract_output: *mut c_void,
-    ) -> rustix::io::Result<Self::Output> {
-        let extract_output = extract_output.cast::<pm_scan_arg>();
-        let len = usize::try_from(out).unwrap();
-        let regions = unsafe {
-            assert!((len as u64) <= (*extract_output).vec_len);
-            std::slice::from_raw_parts_mut((*extract_output).vec as *mut page_region, len)
-        };
-        Ok(PageMapScanResult {
-            regions,
-            walk_end: unsafe { (*extract_output).walk_end.try_into().unwrap() },
-        })
-    }
-}
-
-// #[cfg(target_os = "linux")]
-static PAGEMAP: LazyLock<File> = LazyLock::new(|| {
-    File::open("/proc/self/pagemap").expect("failed to open /proc/self/pagemap")
-});
-
 impl MemoryImageSlot {
     /// Create a new MemoryImageSlot. Assumes that there is an anonymous
     /// mmap backing in the given range to start.
@@ -691,55 +546,86 @@ impl MemoryImageSlot {
         keep_resident: HostAlignedByteCount,
         mut decommit: impl FnMut(*mut u8, usize),
     ) {
-        #[cfg(target_os = "linux")]
-        {
-            let heap_base = self.base.as_mut_ptr();
-            let heap_start = heap_base as u64;
-            let len = self.accessible.byte_count();
-            let heap_end = heap_start + len as u64;
-            // TODO: settle on a number of pages to report and bound storage to that.
-            let mut storage = vec![MaybeUninit::uninit(); len / host_page_size()];
-            let scan_arg = PageMapScan::new(
-                ptr::slice_from_raw_parts(heap_base, len),
-                &mut storage,
-            );
-            if let Ok(result) = ioctl(&*PAGEMAP, scan_arg) {
+        // If possible, use `dirty_pages_in_region` to find specific dirty pages instead of
+        // unconditionally keeping the first `keep_resident` resident.
+        if !keep_resident.is_zero() {
+            let dirty_pages =
+                dirty_pages_in_region(self.base.as_mut_ptr(), self.accessible, keep_resident);
+            if let Ok(dirty_pages) = dirty_pages {
                 let (image_start, image_end, image_source_offset, file) = match &self.image {
                     Some(image) => {
-                        let image_start = heap_base.add(image.linear_memory_offset.byte_count()) as u64;
+                        let image_start = self
+                            .base
+                            .as_mut_ptr()
+                            .add(image.linear_memory_offset.byte_count())
+                            .addr() as u64;
                         let image_end = image_start
                             .checked_add(image.len.byte_count() as u64)
                             .expect("image is in bounds");
                         let file = match &image.source {
-                            MemoryImageSource::Mmap(mmap) => {
-                                mmap
-                            }
-                            MemoryImageSource::Memfd(memfd) => {
-                                memfd.as_file()
-                            }
+                            MemoryImageSource::Mmap(mmap) => mmap,
+                            #[cfg(target_os = "linux")]
+                            MemoryImageSource::Memfd(memfd) => memfd.as_file(),
                         };
                         (image_start, image_end, image.source_offset, Some(file))
                     }
-                    None => { (heap_end, heap_end, 0, None) }
+                    None => {
+                        // To simplify things in the loop below, treat an absent image
+                        // as though it starts at the end of the heap.
+                        let heap_end = self
+                            .base
+                            .as_mut_ptr()
+                            .add(self.accessible.byte_count())
+                            .addr() as u64;
+                        (heap_end, heap_end, 0, None)
+                    }
                 };
-                for region in result.regions.iter() {
-                    let region_len = region.end - region.start;
-                    let mut region_slice =
-                        core::slice::from_raw_parts_mut(region.start as *mut u8, region_len as usize);
-                    if region.end < image_start || region.start >= image_end {
-                        // If the region doesn't overlap with the image, zero it out.
-                        region_slice.fill(0);
-                    } else if region.start >= image_start && region.end <= image_end {
-                        // If the region is fully contained within the image, copy the original
-                        // bytes from the image.
-                        let image_offset = region.start - image_start + image_source_offset;
-                        // TODO: Can we avoid this syscall by doing a memcpy from the mapped region instead?
-                        file.unwrap().read_exact_at(&mut region_slice, image_offset)
+                for region in dirty_pages.regions.iter() {
+                    let region_len = (region.end - region.start) as usize;
+                    let region_slice =
+                        core::slice::from_raw_parts_mut(region.start as *mut u8, region_len);
+
+                    // Each region might start and end before or after the image, so we need to
+                    // do up to three different operations to restore the original contents:
+
+                    // 1. Zero out the part before the image (if any).
+                    if region.start < image_start {
+                        let len = region.end.min(image_start) - region.start;
+                        region_slice[..len as usize].fill(0);
+                    }
+
+                    // 2. Copy the original bytes from the image for the part that overlaps with the image.
+                    if region.start < image_end && region.end > image_start {
+                        let start = region.start.max(image_start);
+                        let end = region.end.min(image_end);
+                        let mut region_slice = core::slice::from_raw_parts_mut(
+                            start as *mut u8,
+                            (end - start) as usize,
+                        );
+                        let image_offset = start - image_start + image_source_offset;
+                        // TODO: Make the memfd's underlying bytes accessible and memcpy them.
+                        file.expect("region overlapping image")
+                            .read_exact_at(&mut region_slice, image_offset)
                             .expect("failed to read from image");
-                    } else {
-                        unreachable!("Regions partially overlapping images not yet supported");
+                    }
+
+                    // 3. Zero out the part after the image (if any).
+                    if region.end > image_end {
+                        let offset = region.start.max(image_end) - region.start;
+                        region_slice[offset as usize..].fill(0);
                     }
                 }
+
+                let remaining_offset = HostAlignedByteCount::new(dirty_pages.checked_bytes)
+                    .expect("checked_bytes is always aligned");
+                self.restore_original_mapping(
+                    remaining_offset,
+                    self.accessible
+                        .checked_sub(remaining_offset)
+                        .expect("keep_resident is a subset of accessible memory"),
+                    decommit,
+                );
+
                 return;
             }
         }

--- a/crates/wasmtime/src/runtime/vm/cow.rs
+++ b/crates/wasmtime/src/runtime/vm/cow.rs
@@ -226,7 +226,7 @@ impl ModuleMemoryImages {
             let offset = HostAlignedByteCount::new(offset_usize)
                 .expect("memory init offset is a multiple of the host page size");
 
-            // If this creation files then we fail creating
+            // If this creation fails then we fail creating
             // `ModuleMemoryImages` since this memory couldn't be represented.
             let image = match MemoryImage::new(engine, page_size, offset, source, data_range)? {
                 Some(image) => image,

--- a/crates/wasmtime/src/runtime/vm/cow.rs
+++ b/crates/wasmtime/src/runtime/vm/cow.rs
@@ -3,13 +3,13 @@
 
 use super::sys::DecommitBehavior;
 use crate::prelude::*;
-use crate::runtime::vm::sys::pagemap::dirty_pages_in_region;
-use crate::runtime::vm::sys::vm::{self, MemoryImageSource};
-use crate::runtime::vm::{HostAlignedByteCount, MmapOffset, MmapVec, host_page_size};
+use crate::runtime::vm::sys::vm::{self, MemoryImageSource, PageMap, reset_with_pagemap};
+use crate::runtime::vm::{
+    HostAlignedByteCount, MmapOffset, ModuleMemoryImageSource, host_page_size,
+};
 use alloc::sync::Arc;
+use core::fmt;
 use core::ops::Range;
-use core::ptr;
-use std::io::Write;
 use wasmtime_environ::{DefinedMemoryIndex, MemoryInitialization, Module, PrimaryMap, Tunables};
 
 /// Backing images for memories in a module.
@@ -28,7 +28,6 @@ impl ModuleMemoryImages {
 }
 
 /// One backing image for one memory.
-#[derive(Debug, PartialEq)]
 pub struct MemoryImage {
     /// The platform-specific source of this image.
     ///
@@ -36,8 +35,6 @@ pub struct MemoryImage {
     /// `Memfd` as an anonymous file in memory on Linux. In either case this is
     /// used as the backing-source for the CoW image.
     source: MemoryImageSource,
-
-    source_ptr: usize,
 
     /// Length of image, in bytes.
     ///
@@ -64,20 +61,28 @@ pub struct MemoryImage {
     ///
     /// Must be a multiple of the system page size.
     linear_memory_offset: HostAlignedByteCount,
+
+    /// The original source of data that this image is derived from.
+    module_source: Arc<dyn ModuleMemoryImageSource>,
+
+    /// The offset, within `module_source.wasm_data()`, that this image starts
+    /// at.
+    module_source_offset: usize,
 }
 
 impl MemoryImage {
     fn new(
         page_size: u32,
         linear_memory_offset: HostAlignedByteCount,
-        data: &[u8],
-        mmap: Option<&MmapVec>,
+        module_source: &Arc<impl ModuleMemoryImageSource>,
+        data_range: Range<usize>,
     ) -> Result<Option<MemoryImage>> {
         let assert_page_aligned = |val: usize| {
             assert_eq!(val % (page_size as usize), 0);
         };
         // Sanity-check that various parameters are page-aligned.
-        let len = HostAlignedByteCount::new(data.len()).expect("memory image data is page-aligned");
+        let len =
+            HostAlignedByteCount::new(data_range.len()).expect("memory image data is page-aligned");
 
         // If a backing `mmap` is present then `data` should be a sub-slice of
         // the `mmap`. The sanity-checks here double-check that. Additionally
@@ -93,7 +98,8 @@ impl MemoryImage {
         // files, but for now this is still a Linux-specific region of Wasmtime.
         // Some work will be needed to get this file compiling for macOS and
         // Windows.
-        if let Some(mmap) = mmap {
+        let data = &module_source.wasm_data()[data_range.clone()];
+        if let Some(mmap) = module_source.mmap() {
             let start = mmap.as_ptr() as usize;
             let end = start + mmap.len();
             let data_start = data.as_ptr() as usize;
@@ -108,10 +114,11 @@ impl MemoryImage {
                 if let Some(source) = MemoryImageSource::from_file(file) {
                     return Ok(Some(MemoryImage {
                         source,
-                        source_ptr: mmap.as_ptr() as usize,
                         source_offset: u64::try_from(data_start - start).unwrap(),
                         linear_memory_offset,
                         len,
+                        module_source: module_source.clone(),
+                        module_source_offset: data_range.start,
                     }));
                 }
             }
@@ -122,10 +129,11 @@ impl MemoryImage {
         if let Some(source) = MemoryImageSource::from_data(data)? {
             return Ok(Some(MemoryImage {
                 source,
-                source_ptr: data.as_ptr() as usize,
                 source_offset: 0,
                 linear_memory_offset,
                 len,
+                module_source: module_source.clone(),
+                module_source_offset: data_range.start,
             }));
         }
 
@@ -160,8 +168,7 @@ impl ModuleMemoryImages {
     /// instantiation and execution by using copy-on-write-backed memories.
     pub fn new(
         module: &Module,
-        wasm_data: &[u8],
-        mmap: Option<&MmapVec>,
+        source: &Arc<impl ModuleMemoryImageSource>,
     ) -> Result<Option<ModuleMemoryImages>> {
         let map = match &module.memory_initialization {
             MemoryInitialization::Static { map } => map,
@@ -189,15 +196,11 @@ impl ModuleMemoryImages {
                 }
             };
 
-            // Get the image for this wasm module  as a subslice of `wasm_data`,
-            // and then use that to try to create the `MemoryImage`. If this
-            // creation files then we fail creating `ModuleMemoryImages` since this
-            // memory couldn't be represented.
-            let data = &wasm_data[init.data.start as usize..init.data.end as usize];
+            let data_range = init.data.start as usize..init.data.end as usize;
             if module.memories[memory_index]
                 .minimum_byte_size()
                 .map_or(false, |mem_initial_len| {
-                    init.offset + u64::try_from(data.len()).unwrap() > mem_initial_len
+                    init.offset + u64::try_from(data_range.len()).unwrap() > mem_initial_len
                 })
             {
                 // The image is rounded up to multiples of the host OS page
@@ -217,7 +220,10 @@ impl ModuleMemoryImages {
             };
             let offset = HostAlignedByteCount::new(offset_usize)
                 .expect("memory init offset is a multiple of the host page size");
-            let image = match MemoryImage::new(page_size, offset, data, mmap)? {
+
+            // If this creation files then we fail creating
+            // `ModuleMemoryImages` since this memory couldn't be represented.
+            let image = match MemoryImage::new(page_size, offset, source, data_range)? {
                 Some(image) => image,
                 None => return Ok(None),
             };
@@ -286,7 +292,6 @@ impl ModuleMemoryImages {
 /// original mappings, effectively resetting everything back to its initial
 /// state. Non-linux platforms will replace all memory below `self.accessible`
 /// with a fresh zero'd mmap, meaning that reuse is effectively not supported.
-#[derive(Debug)]
 pub struct MemoryImageSlot {
     /// The mmap and offset within it that contains the linear memory for this
     /// slot.
@@ -329,6 +334,18 @@ pub struct MemoryImageSlot {
     /// specific to this slot) in place when it is dropped. Default
     /// on, unless the caller knows what they are doing.
     clear_on_drop: bool,
+}
+
+impl fmt::Debug for MemoryImageSlot {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("MemoryImageSlot")
+            .field("base", &self.base)
+            .field("static_size", &self.static_size)
+            .field("accessible", &self.accessible)
+            .field("dirty", &self.dirty)
+            .field("clear_on_drop", &self.clear_on_drop)
+            .finish_non_exhaustive()
+    }
 }
 
 impl MemoryImageSlot {
@@ -429,7 +446,12 @@ impl MemoryImageSlot {
         // Note that this intentionally a "small mmap" which only covers the
         // extent of the prior initialization image in order to preserve
         // resident memory that might come before or after the image.
-        if self.image.as_ref() != maybe_image {
+        let images_equal = match (self.image.as_ref(), maybe_image) {
+            (Some(a), Some(b)) if Arc::ptr_eq(a, b) => true,
+            (None, None) => true,
+            _ => false,
+        };
+        if !images_equal {
             self.remove_image()?;
         }
 
@@ -460,7 +482,7 @@ impl MemoryImageSlot {
         // skipped if `self.image` matches `maybe_image`.
         assert!(initial_size_bytes <= self.accessible.byte_count());
         assert!(initial_size_bytes_page_aligned <= self.accessible);
-        if self.image.as_ref() != maybe_image {
+        if !images_equal {
             if let Some(image) = maybe_image.as_ref() {
                 assert!(
                     image
@@ -506,13 +528,14 @@ impl MemoryImageSlot {
     #[allow(dead_code, reason = "only used in some cfgs")]
     pub(crate) fn clear_and_remain_ready(
         &mut self,
+        pagemap: Option<&PageMap>,
         keep_resident: HostAlignedByteCount,
         decommit: impl FnMut(*mut u8, usize),
     ) -> Result<()> {
         assert!(self.dirty);
 
         unsafe {
-            self.reset_all_memory_contents(keep_resident, decommit)?;
+            self.reset_all_memory_contents(pagemap, keep_resident, decommit)?;
         }
 
         self.dirty = false;
@@ -522,6 +545,7 @@ impl MemoryImageSlot {
     #[allow(dead_code, reason = "only used in some cfgs")]
     unsafe fn reset_all_memory_contents(
         &mut self,
+        pagemap: Option<&PageMap>,
         keep_resident: HostAlignedByteCount,
         decommit: impl FnMut(*mut u8, usize),
     ) -> Result<()> {
@@ -537,7 +561,7 @@ impl MemoryImageSlot {
             }
             DecommitBehavior::RestoreOriginalMapping => {
                 unsafe {
-                    self.reset_with_original_mapping(keep_resident, decommit);
+                    self.reset_with_original_mapping(pagemap, keep_resident, decommit);
                 }
                 Ok(())
             }
@@ -547,252 +571,99 @@ impl MemoryImageSlot {
     #[allow(dead_code, reason = "only used in some cfgs")]
     unsafe fn reset_with_original_mapping(
         &mut self,
+        pagemap: Option<&PageMap>,
         keep_resident: HostAlignedByteCount,
-        mut decommit: impl FnMut(*mut u8, usize),
+        decommit: impl FnMut(*mut u8, usize),
     ) {
-        // If possible, use `dirty_pages_in_region` to find specific dirty pages instead of
-        // unconditionally keeping the first `keep_resident` resident.
-        if !keep_resident.is_zero() {
-            let dirty_pages =
-                dirty_pages_in_region(self.base.as_mut_ptr(), self.accessible, keep_resident);
-            if let Ok(dirty_pages) = dirty_pages {
-                let (image_start, image_end, image_source_offset, file) = match &self.image {
-                    Some(image) => {
-                        let image_start = self
-                            .base
-                            .as_mut_ptr()
-                            .add(image.linear_memory_offset.byte_count())
-                            .addr() as u64;
-                        let image_end = image_start
-                            .checked_add(image.len.byte_count() as u64)
-                            .expect("image is in bounds");
-                        let image_slice =
-                            core::slice::from_raw_parts(image.source_ptr as *const u8, image.len.byte_count());
-                        (image_start, image_end, image.source_offset, Some(image_slice))
-                    }
-                    None => {
-                        // To simplify things in the loop below, treat an absent image
-                        // as though it starts at the end of the heap.
-                        let heap_end = self
-                            .base
-                            .as_mut_ptr()
-                            .add(self.accessible.byte_count())
-                            .addr() as u64;
-                        (heap_end, heap_end, 0, None)
-                    }
-                };
-                for region in dirty_pages.regions.iter() {
-                    let region_len = (region.end - region.start) as usize;
-                    let region_slice =
-                        core::slice::from_raw_parts_mut(region.start as *mut u8, region_len);
-
-                    // Each region might start and end before or after the image, so we need to
-                    // do up to three different operations to restore the original contents:
-
-                    // 1. Zero out the part before the image (if any).
-                    if region.start < image_start {
-                        let len = region.end.min(image_start) - region.start;
-                        region_slice[..len as usize].fill(0);
-                    }
-
-                    // 2. Copy the original bytes from the image for the part that overlaps with the image.
-                    if region.start < image_end && region.end > image_start {
-                        let start = region.start.max(image_start);
-                        let end = region.end.min(image_end);
-                        let mut region_slice = core::slice::from_raw_parts_mut(
-                            start as *mut u8,
-                            (end - start) as usize,
-                        );
-                        let image_offset = start - image_start + image_source_offset;
-                        region_slice.write(&file.unwrap()[image_offset as usize..(image_offset + end - start) as usize]).unwrap();
-                    }
-
-                    // 3. Zero out the part after the image (if any).
-                    if region.end > image_end {
-                        let offset = region.start.max(image_end) - region.start;
-                        region_slice[offset as usize..].fill(0);
-                    }
-                }
-
-                let remaining_offset = HostAlignedByteCount::new(dirty_pages.checked_bytes)
-                    .expect("checked_bytes is always aligned");
-                self.restore_original_mapping(
-                    remaining_offset,
-                    self.accessible
-                        .checked_sub(remaining_offset)
-                        .expect("keep_resident is a subset of accessible memory"),
-                    decommit,
-                );
-
-                return;
-            }
-        }
-
-        match &self.image {
-            Some(image) => {
-                if image.linear_memory_offset < keep_resident {
-                    // If the image starts below the `keep_resident` then
-                    // memory looks something like this:
-                    //
-                    //               up to `keep_resident` bytes
-                    //                          |
-                    //          +--------------------------+  remaining_memset
-                    //          |                          | /
-                    //  <-------------->                <------->
-                    //
-                    //                              image_end
-                    // 0        linear_memory_offset   |             accessible
-                    // |                |              |                  |
-                    // +----------------+--------------+---------+--------+
-                    // |  dirty memory  |    image     |   dirty memory   |
-                    // +----------------+--------------+---------+--------+
-                    //
-                    //  <------+-------> <-----+----->  <---+---> <--+--->
-                    //         |               |            |        |
-                    //         |               |            |        |
-                    //   memset (1)            /            |   madvise (4)
-                    //                  mmadvise (2)       /
-                    //                                    /
-                    //                              memset (3)
-                    //
-                    //
-                    // In this situation there are two disjoint regions that are
-                    // `memset` manually to zero. Note that `memset (3)` may be
-                    // zero bytes large. Furthermore `madvise (4)` may also be
-                    // zero bytes large.
-
-                    let image_end = image
-                        .linear_memory_offset
-                        .checked_add(image.len)
-                        .expect("image is in bounds");
-                    let mem_after_image = self
-                        .accessible
-                        .checked_sub(image_end)
-                        .expect("image_end falls before self.accessible");
-                    let excess = keep_resident
-                        .checked_sub(image.linear_memory_offset)
-                        .expect(
-                            "if statement checks that keep_resident > image.linear_memory_offset",
-                        );
-                    let remaining_memset = excess.min(mem_after_image);
-
-                    // This is memset (1)
-                    unsafe {
-                        ptr::write_bytes(
-                            self.base.as_mut_ptr(),
-                            0u8,
-                            image.linear_memory_offset.byte_count(),
-                        );
-                    }
-
-                    // This is madvise (2)
-                    unsafe {
-                        self.restore_original_mapping(
-                            image.linear_memory_offset,
-                            image.len,
-                            &mut decommit,
-                        );
-                    }
-
-                    // This is memset (3)
-                    unsafe {
-                        ptr::write_bytes(
-                            self.base.as_mut_ptr().add(image_end.byte_count()),
-                            0u8,
-                            remaining_memset.byte_count(),
-                        );
-                    }
-
-                    // This is madvise (4)
-                    unsafe {
-                        self.restore_original_mapping(
-                            image_end
-                                .checked_add(remaining_memset)
-                                .expect("image_end + remaining_memset is in bounds"),
-                            mem_after_image
-                                .checked_sub(remaining_memset)
-                                .expect("remaining_memset defined to be <= mem_after_image"),
-                            &mut decommit,
-                        );
-                    }
-                } else {
-                    // If the image starts after the `keep_resident` threshold
-                    // then we memset the start of linear memory and then use
-                    // madvise below for the rest of it, including the image.
-                    //
-                    // 0             keep_resident                   accessible
-                    // |                |                                 |
-                    // +----------------+---+----------+------------------+
-                    // |  dirty memory      |  image   |   dirty memory   |
-                    // +----------------+---+----------+------------------+
-                    //
-                    //  <------+-------> <-------------+----------------->
-                    //         |                       |
-                    //         |                       |
-                    //   memset (1)                 madvise (2)
-                    //
-                    // Here only a single memset is necessary since the image
-                    // started after the threshold which we're keeping resident.
-                    // Note that the memset may be zero bytes here.
-
-                    // This is memset (1)
-                    unsafe {
-                        ptr::write_bytes(self.base.as_mut_ptr(), 0u8, keep_resident.byte_count());
-                    }
-
-                    // This is madvise (2)
-                    unsafe {
-                        self.restore_original_mapping(
-                            keep_resident,
-                            self.accessible
-                                .checked_sub(keep_resident)
-                                .expect("keep_resident is a subset of accessible memory"),
-                            decommit,
-                        );
-                    }
-                };
-            }
-
-            // If there's no memory image for this slot then memset the first
-            // bytes in the memory back to zero while using `madvise` to purge
-            // the rest.
-            None => {
-                let size_to_memset = keep_resident.min(self.accessible);
-                unsafe {
-                    ptr::write_bytes(self.base.as_mut_ptr(), 0u8, size_to_memset.byte_count());
-                    self.restore_original_mapping(
-                        size_to_memset,
-                        self.accessible
-                            .checked_sub(size_to_memset)
-                            .expect("size_to_memset is defined to be <= self.accessible"),
-                        decommit,
-                    );
-                }
-            }
-        }
-    }
-
-    #[allow(dead_code, reason = "only used in some cfgs")]
-    unsafe fn restore_original_mapping(
-        &self,
-        base: HostAlignedByteCount,
-        len: HostAlignedByteCount,
-        mut decommit: impl FnMut(*mut u8, usize),
-    ) {
-        assert!(base.checked_add(len).unwrap() <= self.accessible);
-        if len == 0 {
-            return;
-        }
-
         assert_eq!(
             vm::decommit_behavior(),
             DecommitBehavior::RestoreOriginalMapping
         );
+
         unsafe {
-            decommit(
-                self.base.as_mut_ptr().add(base.byte_count()),
-                len.byte_count(),
-            );
+            match &self.image {
+                // If there's a backing image then manually resetting a region
+                // is a bit trickier than without an image, so delegate to the
+                // helper function below.
+                Some(image) => {
+                    reset_with_pagemap(
+                        pagemap,
+                        self.base.as_mut_ptr(),
+                        self.accessible,
+                        keep_resident,
+                        |region| {
+                            manually_reset_region(self.base.as_mut_ptr().addr(), image, region)
+                        },
+                        decommit,
+                    );
+                }
+
+                // If there's no memory image for this slot then pages are always
+                // manually reset back to zero or given to `decommit`.
+                None => reset_with_pagemap(
+                    pagemap,
+                    self.base.as_mut_ptr(),
+                    self.accessible,
+                    keep_resident,
+                    |region| region.fill(0),
+                    decommit,
+                ),
+            }
+        }
+
+        /// Manually resets `region` back to its original contents as specified
+        /// in `image`.
+        ///
+        /// This assumes that the original mmap starts at `base_addr` and
+        /// `region` is a subslice within the original mmap.
+        ///
+        /// # Panics
+        ///
+        /// Panics if `base_addr` is not the right index due to the various
+        /// indexing calculations below.
+        fn manually_reset_region(base_addr: usize, image: &MemoryImage, mut region: &mut [u8]) {
+            let image_start = image.linear_memory_offset.byte_count();
+            let image_end = image_start + image.len.byte_count();
+            let mut region_start = region.as_ptr().addr() - base_addr;
+            let region_end = region_start + region.len();
+            let image_bytes = image.module_source.wasm_data();
+            let image_bytes = &image_bytes[image.module_source_offset..][..image.len.byte_count()];
+
+            // 1. Zero out the part before the image (if any).
+            if let Some(len_before_image) = image_start.checked_sub(region_start) {
+                let len = len_before_image.min(region.len());
+                let (a, b) = region.split_at_mut(len);
+                a.fill(0);
+                region = b;
+                region_start += len;
+
+                if region.is_empty() {
+                    return;
+                }
+            }
+
+            debug_assert_eq!(region_end - region_start, region.len());
+            debug_assert!(region_start >= image_start);
+
+            // 2. Copy the original bytes from the image for the part that
+            //    overlaps with the image.
+            if let Some(len_in_image) = image_end.checked_sub(region_start) {
+                let len = len_in_image.min(region.len());
+                let (a, b) = region.split_at_mut(len);
+                a.copy_from_slice(&image_bytes[region_start - image_start..][..len]);
+                region = b;
+                region_start += len;
+
+                if region.is_empty() {
+                    return;
+                }
+            }
+
+            debug_assert_eq!(region_end - region_start, region.len());
+            debug_assert!(region_start >= image_end);
+
+            // 3. Zero out the part after the image.
+            region.fill(0);
         }
     }
 
@@ -893,7 +764,7 @@ mod test {
     use super::*;
     use crate::runtime::vm::mmap::{AlignedLength, Mmap};
     use crate::runtime::vm::sys::vm::decommit_pages;
-    use crate::runtime::vm::{HostAlignedByteCount, host_page_size};
+    use crate::runtime::vm::{HostAlignedByteCount, MmapVec, host_page_size};
     use std::sync::Arc;
     use wasmtime_environ::{IndexType, Limits, Memory};
 
@@ -904,13 +775,32 @@ mod test {
         // The image length is rounded up to the nearest page size
         let image_len = HostAlignedByteCount::new_rounded_up(data.len()).unwrap();
 
-        Ok(MemoryImage {
+        let mut source = TestDataSource {
+            data: vec![0; image_len.byte_count()],
+        };
+        source.data[..data.len()].copy_from_slice(data);
+
+        return Ok(MemoryImage {
             source: MemoryImageSource::from_data(data)?.unwrap(),
-            source_ptr: data.as_ptr() as usize,
             len: image_len,
             source_offset: 0,
             linear_memory_offset,
-        })
+            module_source: Arc::new(source),
+            module_source_offset: 0,
+        });
+
+        struct TestDataSource {
+            data: Vec<u8>,
+        }
+
+        impl ModuleMemoryImageSource for TestDataSource {
+            fn wasm_data(&self) -> &[u8] {
+                &self.data
+            }
+            fn mmap(&self) -> Option<&MmapVec> {
+                None
+            }
+        }
     }
 
     fn dummy_memory() -> Memory {
@@ -988,7 +878,7 @@ mod test {
         // instantiate again; we should see zeroes, even as the
         // reuse-anon-mmap-opt kicks in
         memfd
-            .clear_and_remain_ready(HostAlignedByteCount::ZERO, |ptr, len| unsafe {
+            .clear_and_remain_ready(None, HostAlignedByteCount::ZERO, |ptr, len| unsafe {
                 decommit_pages(ptr, len).unwrap()
             })
             .unwrap();
@@ -1029,7 +919,7 @@ mod test {
 
         // Clear and re-instantiate same image
         memfd
-            .clear_and_remain_ready(HostAlignedByteCount::ZERO, |ptr, len| unsafe {
+            .clear_and_remain_ready(None, HostAlignedByteCount::ZERO, |ptr, len| unsafe {
                 decommit_pages(ptr, len).unwrap()
             })
             .unwrap();
@@ -1041,7 +931,7 @@ mod test {
 
         // Clear and re-instantiate no image
         memfd
-            .clear_and_remain_ready(HostAlignedByteCount::ZERO, |ptr, len| unsafe {
+            .clear_and_remain_ready(None, HostAlignedByteCount::ZERO, |ptr, len| unsafe {
                 decommit_pages(ptr, len).unwrap()
             })
             .unwrap();
@@ -1052,7 +942,7 @@ mod test {
 
         // Clear and re-instantiate image again
         memfd
-            .clear_and_remain_ready(HostAlignedByteCount::ZERO, |ptr, len| unsafe {
+            .clear_and_remain_ready(None, HostAlignedByteCount::ZERO, |ptr, len| unsafe {
                 decommit_pages(ptr, len).unwrap()
             })
             .unwrap();
@@ -1065,7 +955,7 @@ mod test {
         // Create another image with different data.
         let image2 = Arc::new(create_memfd_with_data(page_size, &[10, 11, 12, 13]).unwrap());
         memfd
-            .clear_and_remain_ready(HostAlignedByteCount::ZERO, |ptr, len| unsafe {
+            .clear_and_remain_ready(None, HostAlignedByteCount::ZERO, |ptr, len| unsafe {
                 decommit_pages(ptr, len).unwrap()
             })
             .unwrap();
@@ -1078,7 +968,7 @@ mod test {
         // Instantiate the original image again; we should notice it's
         // a different image and not reuse the mappings.
         memfd
-            .clear_and_remain_ready(HostAlignedByteCount::ZERO, |ptr, len| unsafe {
+            .clear_and_remain_ready(None, HostAlignedByteCount::ZERO, |ptr, len| unsafe {
                 decommit_pages(ptr, len).unwrap()
             })
             .unwrap();
@@ -1126,7 +1016,7 @@ mod test {
                 };
 
                 memfd
-                    .clear_and_remain_ready(amt_to_memset, |ptr, len| unsafe {
+                    .clear_and_remain_ready(None, amt_to_memset, |ptr, len| unsafe {
                         decommit_pages(ptr, len).unwrap()
                     })
                     .unwrap();
@@ -1147,7 +1037,7 @@ mod test {
                 });
             }
             memfd
-                .clear_and_remain_ready(amt_to_memset, |ptr, len| unsafe {
+                .clear_and_remain_ready(None, amt_to_memset, |ptr, len| unsafe {
                     decommit_pages(ptr, len).unwrap()
                 })
                 .unwrap();
@@ -1188,7 +1078,7 @@ mod test {
         }
 
         memfd
-            .clear_and_remain_ready(HostAlignedByteCount::ZERO, |ptr, len| unsafe {
+            .clear_and_remain_ready(None, HostAlignedByteCount::ZERO, |ptr, len| unsafe {
                 decommit_pages(ptr, len).unwrap()
             })
             .unwrap();
@@ -1213,7 +1103,7 @@ mod test {
         }
 
         memfd
-            .clear_and_remain_ready(HostAlignedByteCount::ZERO, |ptr, len| unsafe {
+            .clear_and_remain_ready(None, HostAlignedByteCount::ZERO, |ptr, len| unsafe {
                 decommit_pages(ptr, len).unwrap()
             })
             .unwrap();
@@ -1238,7 +1128,7 @@ mod test {
         }
 
         memfd
-            .clear_and_remain_ready(HostAlignedByteCount::ZERO, |ptr, len| unsafe {
+            .clear_and_remain_ready(None, HostAlignedByteCount::ZERO, |ptr, len| unsafe {
                 decommit_pages(ptr, len).unwrap()
             })
             .unwrap();
@@ -1248,5 +1138,131 @@ mod test {
         assert!(!memfd.has_image());
         assert_eq!(&[0, 0, 0, 0], &slice[page_size..][..4]);
         assert_eq!(&[0, 0], &slice[initial..initial + 2]);
+    }
+
+    #[test]
+    fn reset_with_pagemap() {
+        let page_size = host_page_size();
+        let ty = dummy_memory();
+        let tunables = Tunables {
+            memory_reservation: 100 << 16,
+            ..Tunables::default_miri()
+        };
+        let mmap = mmap_4mib_inaccessible();
+        let mmap_len = page_size * 9;
+        let mut memfd =
+            MemoryImageSlot::create(mmap.zero_offset(), HostAlignedByteCount::ZERO, mmap_len);
+        memfd.no_clear_on_drop();
+        let pagemap = PageMap::new();
+        let pagemap = pagemap.as_ref();
+
+        let mut data = vec![0; 3 * page_size];
+        for (i, chunk) in data.chunks_mut(page_size).enumerate() {
+            for slot in chunk {
+                *slot = (i + 1) as u8;
+            }
+        }
+        let image = Arc::new(create_memfd_with_data(3 * page_size, &data).unwrap());
+
+        memfd
+            .instantiate(mmap_len, Some(&image), &ty, &tunables)
+            .unwrap();
+
+        let keep_resident = HostAlignedByteCount::new(mmap_len).unwrap();
+        let assert_pristine_after_reset = |memfd: &mut MemoryImageSlot| unsafe {
+            // Wipe the image, keeping some bytes resident.
+            memfd
+                .clear_and_remain_ready(pagemap, keep_resident, |ptr, len| {
+                    decommit_pages(ptr, len).unwrap()
+                })
+                .unwrap();
+
+            // Double check that the contents of memory are as expected after
+            // reset.
+            with_slice_mut(&mmap, 0..mmap_len, move |slice| {
+                for (i, chunk) in slice.chunks(page_size).enumerate() {
+                    let expected = match i {
+                        0..3 => 0,
+                        3..6 => (i as u8) - 2,
+                        6..9 => 0,
+                        _ => unreachable!(),
+                    };
+                    for slot in chunk {
+                        assert_eq!(*slot, expected);
+                    }
+                }
+            });
+
+            // Re-instantiate, but then wipe the image entirely by keeping
+            // nothing resident.
+            memfd
+                .instantiate(mmap_len, Some(&image), &ty, &tunables)
+                .unwrap();
+            memfd
+                .clear_and_remain_ready(pagemap, HostAlignedByteCount::ZERO, |ptr, len| {
+                    decommit_pages(ptr, len).unwrap()
+                })
+                .unwrap();
+
+            // Next re-instantiate a final time to get used for the next test.
+            memfd
+                .instantiate(mmap_len, Some(&image), &ty, &tunables)
+                .unwrap();
+        };
+
+        let write_page = |_memfd: &mut MemoryImageSlot, page: usize| unsafe {
+            with_slice_mut(
+                &mmap,
+                page * page_size..(page + 1) * page_size,
+                move |slice| slice.fill(0xff),
+            );
+        };
+
+        // Test various combinations of dirty pages and regions. For example
+        // test a dirty region of memory entirely in the zero-initialized zone
+        // before/after the image and also test when the dirty region straddles
+        // just the start of the image, just the end of the image, both ends,
+        // and is entirely contained in just the image.
+        assert_pristine_after_reset(&mut memfd);
+
+        for i in 0..9 {
+            write_page(&mut memfd, i);
+            assert_pristine_after_reset(&mut memfd);
+        }
+        write_page(&mut memfd, 0);
+        write_page(&mut memfd, 1);
+        assert_pristine_after_reset(&mut memfd);
+        write_page(&mut memfd, 1);
+        assert_pristine_after_reset(&mut memfd);
+        write_page(&mut memfd, 2);
+        write_page(&mut memfd, 3);
+        assert_pristine_after_reset(&mut memfd);
+        write_page(&mut memfd, 3);
+        write_page(&mut memfd, 4);
+        write_page(&mut memfd, 5);
+        assert_pristine_after_reset(&mut memfd);
+        write_page(&mut memfd, 0);
+        write_page(&mut memfd, 1);
+        write_page(&mut memfd, 2);
+        assert_pristine_after_reset(&mut memfd);
+        write_page(&mut memfd, 0);
+        write_page(&mut memfd, 3);
+        write_page(&mut memfd, 6);
+        assert_pristine_after_reset(&mut memfd);
+        write_page(&mut memfd, 2);
+        write_page(&mut memfd, 3);
+        write_page(&mut memfd, 4);
+        write_page(&mut memfd, 5);
+        write_page(&mut memfd, 6);
+        assert_pristine_after_reset(&mut memfd);
+        write_page(&mut memfd, 4);
+        write_page(&mut memfd, 5);
+        write_page(&mut memfd, 6);
+        write_page(&mut memfd, 7);
+        assert_pristine_after_reset(&mut memfd);
+        write_page(&mut memfd, 4);
+        write_page(&mut memfd, 5);
+        write_page(&mut memfd, 8);
+        assert_pristine_after_reset(&mut memfd);
     }
 }

--- a/crates/wasmtime/src/runtime/vm/cow.rs
+++ b/crates/wasmtime/src/runtime/vm/cow.rs
@@ -1159,7 +1159,7 @@ mod test {
         let mut data = vec![0; 3 * page_size];
         for (i, chunk) in data.chunks_mut(page_size).enumerate() {
             for slot in chunk {
-                *slot = (i + 1) as u8;
+                *slot = u8::try_from(i + 1).unwrap();
             }
         }
         let image = Arc::new(create_memfd_with_data(3 * page_size, &data).unwrap());
@@ -1183,7 +1183,7 @@ mod test {
                 for (i, chunk) in slice.chunks(page_size).enumerate() {
                     let expected = match i {
                         0..3 => 0,
-                        3..6 => (i as u8) - 2,
+                        3..6 => u8::try_from(i).unwrap() - 2,
                         6..9 => 0,
                         _ => unreachable!(),
                     };

--- a/crates/wasmtime/src/runtime/vm/cow_disabled.rs
+++ b/crates/wasmtime/src/runtime/vm/cow_disabled.rs
@@ -3,6 +3,7 @@
 
 #![warn(dead_code, unused_imports)]
 
+use crate::Engine;
 use crate::prelude::*;
 use crate::vm::ModuleMemoryImageSource;
 use alloc::sync::Arc;
@@ -24,6 +25,7 @@ pub enum MemoryImage {}
 
 impl ModuleMemoryImages {
     pub fn new(
+        _engine: &Engine,
         _module: &Module,
         _source: &Arc<impl ModuleMemoryImageSource>,
     ) -> Result<Option<ModuleMemoryImages>> {

--- a/crates/wasmtime/src/runtime/vm/cow_disabled.rs
+++ b/crates/wasmtime/src/runtime/vm/cow_disabled.rs
@@ -4,7 +4,7 @@
 #![warn(dead_code, unused_imports)]
 
 use crate::prelude::*;
-use crate::runtime::vm::MmapVec;
+use crate::vm::ModuleMemoryImageSource;
 use alloc::sync::Arc;
 use wasmtime_environ::{DefinedMemoryIndex, Module};
 
@@ -25,8 +25,7 @@ pub enum MemoryImage {}
 impl ModuleMemoryImages {
     pub fn new(
         _module: &Module,
-        _wasm_data: &[u8],
-        _mmap: Option<&MmapVec>,
+        _source: &Arc<impl ModuleMemoryImageSource>,
     ) -> Result<Option<ModuleMemoryImages>> {
         Ok(None)
     }

--- a/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/table_pool.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/table_pool.rs
@@ -224,7 +224,7 @@ impl TablePool {
 
                 // And decommit the rest of it.
                 decommit(
-                    dirty_pages.checked_bytes as *mut u8,
+                    base.add(dirty_pages.checked_bytes),
                     size.byte_count() - dirty_pages.checked_bytes,
                 );
             }

--- a/crates/wasmtime/src/runtime/vm/pagemap_disabled.rs
+++ b/crates/wasmtime/src/runtime/vm/pagemap_disabled.rs
@@ -1,0 +1,46 @@
+use crate::runtime::vm::HostAlignedByteCount;
+use core::slice;
+
+#[derive(Debug)]
+pub enum PageMap {}
+
+impl PageMap {
+    #[allow(dead_code, reason = "not used on linux64")]
+    pub fn new() -> Option<PageMap> {
+        None
+    }
+}
+
+/// Resets `ptr` for `len` bytes.
+///
+/// # Safety
+///
+/// Requires that `ptr` is valid to read and write for `len` bytes.
+pub unsafe fn reset_with_pagemap(
+    _pagemap: Option<&PageMap>,
+    mut ptr: *mut u8,
+    mut len: HostAlignedByteCount,
+    mut keep_resident: HostAlignedByteCount,
+    mut reset_manually: impl FnMut(&mut [u8]),
+    mut decommit: impl FnMut(*mut u8, usize),
+) {
+    keep_resident = keep_resident.min(len);
+
+    // `memset` the first `keep_resident` bytes.
+    //
+    // SAFETY: it's a contract of this function that `ptr` is valid to write for
+    // `len` bytes, and `keep_resident` is less than `len` here.
+    unsafe {
+        reset_manually(slice::from_raw_parts_mut(ptr, keep_resident.byte_count()));
+    }
+
+    // SAFETY: It's a contract of this function that the parameters are valid to
+    // always produce an in-bounds pointer.
+    unsafe {
+        ptr = ptr.add(keep_resident.byte_count());
+    }
+    len = len.checked_sub(keep_resident).unwrap();
+
+    // decommit the rest of it.
+    decommit(ptr, len.byte_count())
+}

--- a/crates/wasmtime/src/runtime/vm/sys/custom/vm.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/custom/vm.rs
@@ -7,6 +7,8 @@ use core::ptr::{self, NonNull};
 #[cfg(feature = "std")]
 use std::{fs::File, sync::Arc};
 
+pub use crate::runtime::vm::pagemap_disabled::{PageMap, reset_with_pagemap};
+
 pub unsafe fn expose_existing_mapping(ptr: *mut u8, len: usize) -> Result<()> {
     unsafe {
         cvt(capi::wasmtime_mprotect(

--- a/crates/wasmtime/src/runtime/vm/sys/miri/vm.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/miri/vm.rs
@@ -3,6 +3,8 @@ use std::fs::File;
 use std::io;
 use std::sync::Arc;
 
+pub use crate::runtime::vm::pagemap_disabled::{PageMap, reset_with_pagemap};
+
 pub unsafe fn expose_existing_mapping(ptr: *mut u8, len: usize) -> io::Result<()> {
     unsafe {
         std::ptr::write_bytes(ptr, 0u8, len);

--- a/crates/wasmtime/src/runtime/vm/sys/unix/mod.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/unix/mod.rs
@@ -12,13 +12,16 @@ pub mod traphandlers;
 pub mod unwind;
 #[cfg(has_virtual_memory)]
 pub mod vm;
-#[cfg(has_virtual_memory)]
-pub mod pagemap;
 
 #[cfg(all(has_native_signals, target_vendor = "apple"))]
 pub mod machports;
 #[cfg(has_native_signals)]
 pub mod signals;
+
+#[cfg(all(target_os = "linux", target_pointer_width = "64", feature = "std"))]
+mod pagemap;
+#[cfg(not(all(target_os = "linux", target_pointer_width = "64", feature = "std")))]
+use crate::vm::pagemap_disabled as pagemap;
 
 std::thread_local!(static TLS: Cell<*mut u8> = const { Cell::new(std::ptr::null_mut()) });
 

--- a/crates/wasmtime/src/runtime/vm/sys/unix/mod.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/unix/mod.rs
@@ -12,6 +12,8 @@ pub mod traphandlers;
 pub mod unwind;
 #[cfg(has_virtual_memory)]
 pub mod vm;
+#[cfg(has_virtual_memory)]
+pub mod pagemap;
 
 #[cfg(all(has_native_signals, target_vendor = "apple"))]
 pub mod machports;

--- a/crates/wasmtime/src/runtime/vm/sys/unix/pagemap.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/unix/pagemap.rs
@@ -346,25 +346,38 @@ mod ioctl {
         /// categories before testing for `category_mask`. That means that if a
         /// bit needs to be zero then it additionally must be specified in one
         /// of `category_mask` or `category_anyof_mask`.
+        ///
+        /// For more detail see the `pagemap_scan_is_interesting_page` function
+        /// in the Linux kernel source.
         pub fn category_inverted(&mut self, flags: Categories) -> &mut PageMapScanBuilder {
             self.pm_scan_arg.category_inverted = flags;
             self
         }
 
-        /// Skip pages for which any category doesn't match.
+        /// Only consider pages for which all `flags` match.
         ///
         /// This mask is applied after `category_inverted` is used to flip bits
         /// in a page's categories. Only pages which match all bits in `flags`
         /// will be considered.
+        ///
+        /// For more detail see the `pagemap_scan_is_interesting_page` function
+        /// in the Linux kernel source.
         pub fn category_mask(&mut self, flags: Categories) -> &mut PageMapScanBuilder {
             self.pm_scan_arg.category_mask = flags;
             self
         }
 
-        /// Skip pages for which no category matches.
+        /// Only consider pages for which any bit of `flags` matches.
         ///
-        /// Like `category_mask` this is applied after pages have had their category
-        /// bits inverted by `category_inverted`.
+        /// After `category_inverted` and `category_mask` have been applied, if
+        /// this option is specified to a non-empty value, then at least one of
+        /// `flags` must be in a page's flags to be considered. That means that
+        /// flags specified in `category_inverted` will already be inverted for
+        /// consideration here. The page categories are and'd with `flags` and
+        /// some bit must be set for the page to be considered.
+        ///
+        /// For more detail see the `pagemap_scan_is_interesting_page` function
+        /// in the Linux kernel source.
         #[expect(dead_code, reason = "bindings for the future if we need them")]
         pub fn category_anyof_mask(&mut self, flags: Categories) -> &mut PageMapScanBuilder {
             self.pm_scan_arg.category_anyof_mask = flags;

--- a/crates/wasmtime/src/runtime/vm/sys/unix/pagemap.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/unix/pagemap.rs
@@ -169,7 +169,7 @@ pub unsafe fn reset_with_pagemap(
         // Keeping less than one page of memory resident when the original
         // mapping itself is also less than a page? Also fall back to the
         // default behavior as this'll just be a simple memcpy.
-        if keep_resident.byte_count() <= host_page_size && len <= host_page_size {
+        if keep_resident.byte_count() <= host_page_size && len.byte_count() <= host_page_size {
             pagemap = None;
         }
     }

--- a/crates/wasmtime/src/runtime/vm/sys/unix/pagemap.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/unix/pagemap.rs
@@ -2,186 +2,279 @@
 //!
 //! For other platforms, a no-op implementation is provided.
 
+use self::ioctl::{Categories, PageMapScanBuilder};
 use crate::prelude::*;
-pub use internal::dirty_pages_in_region;
-use std::fmt;
+use crate::runtime::vm::{HostAlignedByteCount, host_page_size};
+use rustix::ioctl::ioctl;
+use std::fs::File;
 use std::mem::MaybeUninit;
+use std::ptr;
 
-#[allow(dead_code)]
 #[derive(Debug)]
-pub struct DirtyPages<'a> {
-    /// Slice into the initialized portion of region_storage
-    pub regions: &'a [PageRegion],
-    /// The number of bytes checked in the pagemap. Might be less than `len`, in which case
-    /// the pages beyond `checked_bytes` should be treated as potentially dirty.
-    pub checked_bytes: usize,
-    // We hold the storage here to keep it alive while regions points into it
-    region_storage: Vec<MaybeUninit<PageRegion>>,
-}
+pub struct PageMap(File);
 
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct PageRegion {
-    pub start: u64,
-    pub end: u64,
-    categories: Categories,
-}
-
-bitflags::bitflags! {
-    #[derive(Copy, Clone)]
-    #[repr(transparent)]
-    struct Categories: u64 {
-        const WPALLOWED = 1 << 0;
-        const WRITTEN = 1 << 1;
-        const FILE = 1 << 2;
-        const PRESENT = 1 << 3;
-        const SWAPPED = 1 << 4;
-        const PFNZERO = 1 << 5;
-        const HUGE = 1 << 6;
-        const SOFT_DIRTY = 1 << 7;
+impl PageMap {
+    pub fn new() -> Option<PageMap> {
+        let file = File::open("/proc/self/pagemap").ok()?;
+        // Check if the `pagemap_scan` ioctl is supported.
+        let mut regions = vec![MaybeUninit::uninit(); 1];
+        let pm_scan = PageMapScanBuilder::new(ptr::slice_from_raw_parts(ptr::null_mut(), 0))
+            .max_pages(1)
+            .return_mask(Categories::empty())
+            .category_mask(Categories::all())
+            .build(&mut regions);
+        unsafe {
+            ioctl(&file, pm_scan).ok()?;
+        }
+        Some(PageMap(file))
     }
 }
 
-impl fmt::Debug for Categories {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        bitflags::parser::to_writer(self, f)
-    }
-}
-impl fmt::Display for Categories {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        bitflags::parser::to_writer(self, f)
-    }
-}
+/// Resets `ptr` for `len` bytes.
+///
+/// # Safety
+///
+/// Requires that `ptr` is valid to read and write for `len` bytes.
+pub unsafe fn reset_with_pagemap(
+    pagemap: Option<&PageMap>,
+    ptr: *mut u8,
+    len: HostAlignedByteCount,
+    mut keep_resident: HostAlignedByteCount,
+    mut reset_manually: impl FnMut(&mut [u8]),
+    mut decommit: impl FnMut(*mut u8, usize),
+) {
+    keep_resident = keep_resident.min(len);
+    let host_page_size = host_page_size();
 
-#[cfg(not(target_os = "linux"))]
-mod internal {
-    use super::DirtyPages;
-    use crate::prelude::*;
-    use crate::runtime::vm::HostAlignedByteCount;
-    #[allow(unused_variables)]
-    pub fn dirty_pages_in_region<'a>(
-        base: *const u8,
-        len: HostAlignedByteCount,
-        max_bytes: HostAlignedByteCount,
-    ) -> Result<DirtyPages<'a>> {
-        Err(anyhow!("pagemap_scan ioctl not supported on this platform"))
-    }
-}
-
-#[cfg(target_os = "linux")]
-mod internal {
-    use super::{Categories, DirtyPages, PageRegion};
-    use crate::prelude::*;
-    use crate::runtime::vm::{host_page_size, HostAlignedByteCount};
-    use rustix::ioctl::{ioctl, opcode, Ioctl, IoctlOutput, Opcode};
-    use std::fs::File;
-    use std::mem::MaybeUninit;
-    use std::os::raw::c_void;
-    use std::sync::LazyLock;
-    use std::{fmt, ptr};
-
-    pub fn dirty_pages_in_region<'a>(
-        base: *const u8,
-        len: HostAlignedByteCount,
-        max_bytes: HostAlignedByteCount,
-    ) -> Result<DirtyPages<'a>> {
+    let pagemap = match pagemap {
         // The `pagemap_scan` ioctl interprets max_pages == 0 as "no limit",
-        // whereas we want to interpret it as "don't scan any pages".
-        let max_pages = max_bytes.byte_count() / host_page_size();
-        if max_pages == 0 {
-            return Ok(DirtyPages {
-                regions: &[],
-                checked_bytes: 0,
-                region_storage: vec![],
-            });
+        // whereas we want to interpret it as "don't scan any pages", so only
+        // continue further on if we're keeping some bytes resident.
+        //
+        // Additionally fall back to the default behavior if the `keep_resident`
+        // value is just one page of host memory.
+        //
+        Some(pagemap)
+            if keep_resident.byte_count() > 0 && keep_resident.byte_count() > host_page_size =>
+        {
+            pagemap
         }
-        let pagemap = match &*PAGEMAP {
-            Some(pagemap) => pagemap,
-            None => return Err(anyhow!("pagemap_scan ioctl not supported")),
-        };
 
-        let mut storage = vec![MaybeUninit::uninit(); max_pages];
-        let scan_arg = PageMapScan::new(
-            ptr::slice_from_raw_parts(base, len.byte_count()),
-            &mut storage,
-            max_pages,
-        );
-        let result = unsafe { ioctl(pagemap, scan_arg) };
-        match result {
-            Ok(result) => {
-                let regions = unsafe {
-                    std::slice::from_raw_parts(
-                        storage.as_ptr() as *const PageRegion,
-                        result.regions_count,
-                    )
-                };
-                Ok(DirtyPages {
-                    regions,
-                    checked_bytes: result.walk_end - base as usize,
-                    region_storage: storage,
-                })
-            }
-            Err(_) => Err(anyhow!("pagemap_scan ioctl failed")),
+        // SAFETY: the safety requirement of
+        // `pagemap_disabled::reset_with_pagemap` is the same as this function.
+        _ => unsafe {
+            return crate::runtime::vm::pagemap_disabled::reset_with_pagemap(
+                None,
+                ptr,
+                len,
+                keep_resident,
+                reset_manually,
+                decommit,
+            );
+        },
+    };
+
+    // For now use a fixed set of regions on the stack, but in the future this
+    // may want to use a dynamically allocated vector for more regions for
+    // example.
+    const MAX_REGIONS: usize = 32;
+    let mut storage = [MaybeUninit::uninit(); MAX_REGIONS];
+
+    let scan_arg = PageMapScanBuilder::new(ptr::slice_from_raw_parts(ptr, len.byte_count()))
+        .max_pages(keep_resident.byte_count() / host_page_size)
+        // We specifically want pages that are NOT backed by the zero page or
+        // backed by files. Such pages mean that they haven't changed from their
+        // original contents, so they're inverted.
+        .category_inverted(Categories::PFNZERO | Categories::FILE)
+        // Search for pages that are written and present as those are the dirty
+        // pages. Additionally search for the zero page/file page as those are
+        // inverted above meaning we're searching for pages that specifically
+        // don't have those flags.
+        .category_mask(
+            Categories::WRITTEN | Categories::PRESENT | Categories::PFNZERO | Categories::FILE,
+        )
+        // Don't return any categories back. This helps group regions together
+        // since the reported set of categories is always empty and we otherwise
+        // aren't looking for anything in particular.
+        .return_mask(Categories::empty())
+        // Not used, but keep the helper below "used" in case it's needed in the
+        // future.
+        .category_anyof_mask(Categories::empty())
+        .build(&mut storage);
+
+    // SAFETY: this should be a safe ioctl as we control the fd we're operating
+    // on plus all of `scan_arg`, but this relies on `Ioctl` below being the
+    // correct implementation and such.
+    let result = match unsafe { ioctl(&pagemap.0, scan_arg) } {
+        Ok(result) => result,
+
+        // SAFETY: the safety requirement of
+        // `pagemap_disabled::reset_with_pagemap` is the same as this function.
+        Err(err) => unsafe {
+            log::warn!("failed pagemap scan {err}");
+            return crate::runtime::vm::pagemap_disabled::reset_with_pagemap(
+                None,
+                ptr,
+                len,
+                keep_resident,
+                reset_manually,
+                decommit,
+            );
+        },
+    };
+
+    // For all regions that were written in the scan reset them manually, then
+    // afterwards decommit everything else.
+    for region in result.regions() {
+        // not used at this time, but keep it alive as a helper from the `ioctl`
+        // module in case it's needed in the future.
+        let _ = region.categories();
+
+        // SAFETY: we're relying on Linux to pass in valid region ranges within
+        // the `ptr/len` we specified to the original syscall.
+        unsafe {
+            reset_manually(&mut *region.region().cast_mut());
         }
     }
+    let scan_size = result.walk_end().addr() - ptr.addr();
+    decommit(result.walk_end().cast_mut(), len.byte_count() - scan_size);
+}
+
+mod ioctl {
+    use rustix::ioctl::*;
+    use std::ffi::c_void;
+    use std::fmt;
+    use std::marker;
+    use std::mem::MaybeUninit;
+    use std::ptr;
 
     bitflags::bitflags! {
-        #[derive(Debug)]
-        struct PageMapBits: u64 {
-            const PRESENT = 1 << 63;
-            const SWAPPED = 1 << 62;
-            const FILE = 1 << 61;
-            const GUARD = 1 << 58;
-            const WP = 1 << 57;
-            const EXCL = 1 << 56;
-            const SOFT_DIRTY = 1 << 55;
+        /// Categories that can be filtered with [`PageMapScan`]
+        #[derive(Copy, Clone, PartialEq, Eq)]
+        #[repr(transparent)]
+        pub struct Categories: u64 {
+            /// The page has asynchronous write-protection enabled.
+            const WPALLOWED = 1 << 0;
+            /// The page has been written to from the time it was write protected.
+            const WRITTEN = 1 << 1;
+            /// The page is file backed.
+            const FILE = 1 << 2;
+            /// The page is present in the memory.
+            const PRESENT = 1 << 3;
+            /// The page is swapped.
+            const SWAPPED = 1 << 4;
+            /// The page has zero PFN.
+            const PFNZERO = 1 << 5;
+            /// The page is THP or Hugetlb backed.
+            const HUGE = 1 << 6;
+            const SOFT_DIRTY = 1 << 7;
         }
     }
 
-    impl fmt::Display for PageMapBits {
+    impl fmt::Debug for Categories {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             bitflags::parser::to_writer(self, f)
         }
     }
 
-    struct PageMapScan<'a> {
-        pm_scan_arg: pm_scan_arg,
-        _regions: &'a mut [MaybeUninit<PageRegion>],
+    impl fmt::Display for Categories {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            bitflags::parser::to_writer(self, f)
+        }
     }
 
-    impl<'a> PageMapScan<'a> {
-        fn new(
-            region: *const [u8],
-            regions: &'a mut [MaybeUninit<PageRegion>],
-            max_pages: usize,
-        ) -> PageMapScan<'a> {
-            PageMapScan {
+    /// Builder-style structure for building up a [`PageMapScan`] `ioctl` call.
+    pub struct PageMapScanBuilder {
+        pm_scan_arg: pm_scan_arg,
+    }
+
+    impl PageMapScanBuilder {
+        /// Creates a new page map scan that will scan the provided range of memory.
+        pub fn new(region: *const [u8]) -> PageMapScanBuilder {
+            PageMapScanBuilder {
                 pm_scan_arg: pm_scan_arg {
                     size: size_of::<pm_scan_arg>() as u64,
                     flags: 0,
                     start: unsafe { (*region).as_ptr() as u64 },
-                    end: unsafe { (*region).as_ptr().wrapping_add((*region).len()) as u64 },
+                    end: unsafe { (*region).as_ptr().wrapping_add(region.len()) as u64 },
                     walk_end: 0,
-                    vec: regions.as_mut_ptr() as u64,
-                    vec_len: regions.len() as u64,
-                    max_pages: max_pages as u64,
-                    category_inverted: Categories::FILE | Categories::PFNZERO,
+                    vec: 0,
+                    vec_len: 0,
+                    max_pages: 0,
+                    category_inverted: Categories::empty(),
                     category_anyof_mask: Categories::empty(),
-                    category_mask: Categories::WRITTEN | Categories::FILE | Categories::PFNZERO,
-                    return_mask: Categories::all(),
+                    category_mask: Categories::empty(),
+                    return_mask: Categories::empty(),
                 },
-                _regions: regions,
             }
+        }
+
+        /// Configures the maximum number of returned pages in the output regions.
+        ///
+        /// Setting this to 0 disables this maximum.
+        pub fn max_pages(&mut self, max: usize) -> &mut PageMapScanBuilder {
+            self.pm_scan_arg.max_pages = max.try_into().unwrap();
+            self
+        }
+
+        /// Configures categories which values must match if 0 instead of 1.
+        ///
+        /// Note that this is a mask which is xor'd to the page's true
+        /// categories before testing for `category_mask`. That means that if a
+        /// bit needs to be zero then it additionally must be specified in one
+        /// of `category_mask` or `category_anyof_mask`.
+        pub fn category_inverted(&mut self, flags: Categories) -> &mut PageMapScanBuilder {
+            self.pm_scan_arg.category_inverted = flags;
+            self
+        }
+
+        /// Skip pages for which any category doesn't match.
+        ///
+        /// This mask is applied after `category_inverted` is used to flip bits
+        /// in a page's categories. Only pages which match all bits in `flags`
+        /// will be considered.
+        pub fn category_mask(&mut self, flags: Categories) -> &mut PageMapScanBuilder {
+            self.pm_scan_arg.category_mask = flags;
+            self
+        }
+
+        /// Skip pages for which no category matches.
+        ///
+        /// Like `category_mask` this is applied after pages have had their category
+        /// bits inverted by `category_inverted`.
+        pub fn category_anyof_mask(&mut self, flags: Categories) -> &mut PageMapScanBuilder {
+            self.pm_scan_arg.category_anyof_mask = flags;
+            self
+        }
+
+        /// Categories that are to be reported in the regions returned
+        pub fn return_mask(&mut self, flags: Categories) -> &mut PageMapScanBuilder {
+            self.pm_scan_arg.return_mask = flags;
+            self
+        }
+
+        /// Finishes this configuration and flags that the scan results will be
+        /// placed within `dst`. The returned object can be used to perform the
+        /// pagemap scan ioctl.
+        pub fn build<'a>(&self, dst: &'a mut [MaybeUninit<PageRegion>]) -> PageMapScan<'a> {
+            let mut ret = PageMapScan {
+                pm_scan_arg: self.pm_scan_arg,
+                _marker: marker::PhantomData,
+            };
+            ret.pm_scan_arg.vec = dst.as_ptr() as u64;
+            ret.pm_scan_arg.vec_len = dst.len() as u64;
+            return ret;
         }
     }
 
-    #[derive(Debug)]
-    #[allow(dead_code)]
-    struct PageMapScanResult {
-        walk_end: usize,
-        regions_count: usize,
+    /// Return result of [`PageMapScanBuilder::build`] used to perform an `ioctl`.
+    #[repr(transparent)]
+    pub struct PageMapScan<'a> {
+        pm_scan_arg: pm_scan_arg,
+        _marker: marker::PhantomData<&'a mut [MaybeUninit<PageRegion>]>,
     }
 
+    #[derive(Copy, Clone)]
     #[repr(C)]
     struct pm_scan_arg {
         size: u64,
@@ -198,15 +291,88 @@ mod internal {
         return_mask: Categories,
     }
 
-    const PAGEMAP_SCAN: Opcode = opcode::read_write::<pm_scan_arg>(b'f', 16);
+    /// Return result of a [`PageMapScan`] `ioctl`.
+    ///
+    /// This reports where the kernel stopped walking with
+    /// [`PageMapScanResult::walk_end`] and the description of regions found in
+    /// [`PageMapScanResult::regions`].
+    #[derive(Debug)]
+    #[allow(dead_code)]
+    pub struct PageMapScanResult<'a> {
+        walk_end: *const u8,
+        regions: &'a mut [PageRegion],
+    }
+
+    impl PageMapScanResult<'_> {
+        /// Where the kernel stopped walking pages, which may be earlier than the
+        /// end of the requested region
+        pub fn walk_end(&self) -> *const u8 {
+            self.walk_end
+        }
+
+        /// Regions the kernel reported back with categories and such.
+        pub fn regions(&self) -> &[PageRegion] {
+            self.regions
+        }
+    }
+
+    /// Return value of [`PageMapScan`], description of regions in the original scan
+    /// with the categories queried.
+    #[repr(transparent)]
+    #[derive(Copy, Clone)]
+    pub struct PageRegion(page_region);
+
+    #[repr(C)]
+    #[derive(Debug, Copy, Clone)]
+    struct page_region {
+        start: u64,
+        end: u64,
+        categories: Categories,
+    }
+
+    impl PageRegion {
+        /// Returns the region of memory this represents as `*const [u8]`
+        #[inline]
+        pub fn region(&self) -> *const [u8] {
+            ptr::slice_from_raw_parts(self.start(), self.len())
+        }
+
+        /// Returns the base pointer into memory this region represents.
+        #[inline]
+        pub fn start(&self) -> *const u8 {
+            self.0.start as *const u8
+        }
+
+        /// Returns the byte length that this region represents.
+        #[inline]
+        pub fn len(&self) -> usize {
+            usize::try_from(self.0.end - self.0.start).unwrap()
+        }
+
+        /// Returns the category flags associated with this region.
+        #[inline]
+        pub fn categories(&self) -> Categories {
+            self.0.categories
+        }
+    }
+
+    impl fmt::Debug for PageRegion {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.debug_struct("PageRegion")
+                .field("start", &self.start())
+                .field("len", &self.len())
+                .field("categories", &self.0.categories)
+                .finish()
+        }
+    }
 
     unsafe impl<'a> Ioctl for PageMapScan<'a> {
-        type Output = PageMapScanResult;
+        type Output = PageMapScanResult<'a>;
 
-        const IS_MUTATING: bool = false;
+        const IS_MUTATING: bool = true;
 
         fn opcode(&self) -> Opcode {
-            PAGEMAP_SCAN
+            opcode::read_write::<pm_scan_arg>(b'f', 16)
         }
 
         fn as_ptr(&mut self) -> *mut c_void {
@@ -219,27 +385,335 @@ mod internal {
         ) -> rustix::io::Result<Self::Output> {
             let extract_output = extract_output.cast::<pm_scan_arg>();
             let len = usize::try_from(out).unwrap();
+            let regions = unsafe {
+                assert!((len as u64) <= (*extract_output).vec_len);
+                std::slice::from_raw_parts_mut((*extract_output).vec as *mut PageRegion, len)
+            };
             Ok(PageMapScanResult {
-                regions_count: len,
-                walk_end: unsafe { (*extract_output).walk_end.try_into().unwrap() },
+                regions,
+                walk_end: unsafe { (*extract_output).walk_end as *const u8 },
             })
         }
     }
+}
+#[cfg(test)]
+mod tests {
+    use super::ioctl::*;
+    use crate::prelude::*;
+    use rustix::ioctl::*;
+    use rustix::mm::*;
+    use std::fs::File;
+    use std::ptr;
 
-    /// A static reference to the `/proc/self/pagemap` file. `None` if the file
-    /// can't be opened, or if the `pagemap_scan` ioctl is not supported.
-    static PAGEMAP: LazyLock<Option<File>> = LazyLock::new(|| {
-        let file = File::open("/proc/self/pagemap");
-        if file.is_err() {
-            return None;
+    struct MmapAnonymous {
+        ptr: *mut std::ffi::c_void,
+        len: usize,
+    }
+
+    impl MmapAnonymous {
+        fn new(pages: usize) -> MmapAnonymous {
+            let len = pages * rustix::param::page_size();
+            let ptr = unsafe {
+                mmap_anonymous(
+                    ptr::null_mut(),
+                    len,
+                    ProtFlags::READ | ProtFlags::WRITE,
+                    MapFlags::PRIVATE,
+                )
+                .unwrap()
+            };
+            MmapAnonymous { ptr, len }
         }
-        let file = file.unwrap();
-        // Check if the `pagemap_scan` ioctl is supported.
-        let mut regions = vec![MaybeUninit::<PageRegion>::uninit(); 0];
-        let pm_scan = PageMapScan::new(ptr::slice_from_raw_parts(ptr::null(), 0), &mut regions, 0);
-        match unsafe { ioctl(&file, pm_scan) } {
-            Ok(_) => Some(file),
-            Err(_) => None,
+
+        fn read(&self, page: usize) {
+            unsafe {
+                let offset = page * rustix::param::page_size();
+                assert!(offset < self.len);
+                std::ptr::read_volatile(self.ptr.cast::<u8>().add(offset));
+            }
         }
-    });
+
+        fn write(&self, page: usize) {
+            unsafe {
+                let offset = page * rustix::param::page_size();
+                assert!(offset < self.len);
+                std::ptr::write_volatile(self.ptr.cast::<u8>().add(offset), 1);
+            }
+        }
+
+        fn region(&self) -> *const [u8] {
+            ptr::slice_from_raw_parts(self.ptr.cast(), self.len)
+        }
+
+        fn page_region(&self, pages: std::ops::Range<usize>) -> *const [u8] {
+            ptr::slice_from_raw_parts(
+                self.ptr
+                    .cast::<u8>()
+                    .wrapping_add(pages.start * rustix::param::page_size()),
+                (pages.end - pages.start) * rustix::param::page_size(),
+            )
+        }
+
+        fn end(&self) -> *const u8 {
+            self.ptr.cast::<u8>().wrapping_add(self.len)
+        }
+
+        fn page_end(&self, page: usize) -> *const u8 {
+            self.ptr
+                .cast::<u8>()
+                .wrapping_add((page + 1) * rustix::param::page_size())
+        }
+    }
+
+    impl Drop for MmapAnonymous {
+        fn drop(&mut self) {
+            unsafe {
+                munmap(self.ptr, self.len).unwrap();
+            }
+        }
+    }
+
+    #[test]
+    fn no_pages_returned() {
+        let mmap = MmapAnonymous::new(10);
+        let mut results = Vec::with_capacity(10);
+        let fd = File::open("/proc/self/pagemap").unwrap();
+
+        let result = unsafe {
+            ioctl(
+                &fd,
+                PageMapScanBuilder::new(mmap.region())
+                    .category_mask(Categories::WRITTEN)
+                    .return_mask(Categories::all())
+                    .build(results.spare_capacity_mut()),
+            )
+            .unwrap()
+        };
+        assert!(result.regions().is_empty());
+        assert_eq!(result.walk_end(), mmap.end());
+    }
+
+    #[test]
+    fn empty_region() {
+        let mut results = Vec::with_capacity(10);
+        let fd = File::open("/proc/self/pagemap").unwrap();
+
+        let empty_region = ptr::slice_from_raw_parts(rustix::param::page_size() as *const u8, 0);
+        let result = unsafe {
+            ioctl(
+                &fd,
+                PageMapScanBuilder::new(empty_region)
+                    .return_mask(Categories::all())
+                    .build(results.spare_capacity_mut()),
+            )
+            .unwrap()
+        };
+        assert!(result.regions().is_empty());
+    }
+
+    #[test]
+    fn basic_page_flags() {
+        let mmap = MmapAnonymous::new(10);
+        let mut results = Vec::with_capacity(10);
+        let fd = File::open("/proc/self/pagemap").unwrap();
+
+        mmap.read(0);
+        mmap.write(1);
+        mmap.write(2);
+        mmap.read(3);
+
+        mmap.read(5);
+        mmap.read(6);
+
+        let result = unsafe {
+            ioctl(
+                &fd,
+                PageMapScanBuilder::new(mmap.region())
+                    .category_mask(Categories::WRITTEN)
+                    .return_mask(Categories::WRITTEN | Categories::PRESENT | Categories::PFNZERO)
+                    .build(results.spare_capacity_mut()),
+            )
+            .unwrap()
+        };
+        assert_eq!(result.regions().len(), 4);
+        assert_eq!(result.walk_end(), mmap.end());
+        assert_eq!(result.regions()[0].region(), mmap.page_region(0..1));
+        assert_eq!(
+            result.regions()[0].categories(),
+            Categories::WRITTEN | Categories::PRESENT | Categories::PFNZERO
+        );
+
+        assert_eq!(result.regions()[1].region(), mmap.page_region(1..3));
+        assert_eq!(
+            result.regions()[1].categories(),
+            Categories::WRITTEN | Categories::PRESENT
+        );
+
+        assert_eq!(result.regions()[2].region(), mmap.page_region(3..4));
+        assert_eq!(
+            result.regions()[2].categories(),
+            Categories::WRITTEN | Categories::PRESENT | Categories::PFNZERO
+        );
+
+        assert_eq!(result.regions()[3].region(), mmap.page_region(5..7));
+        assert_eq!(
+            result.regions()[3].categories(),
+            Categories::WRITTEN | Categories::PRESENT | Categories::PFNZERO
+        );
+    }
+
+    #[test]
+    fn only_written_pages() {
+        let mmap = MmapAnonymous::new(10);
+        let mut results = Vec::with_capacity(10);
+        let fd = File::open("/proc/self/pagemap").unwrap();
+
+        mmap.read(0);
+        mmap.write(1);
+        mmap.write(2);
+        mmap.read(3);
+
+        mmap.read(5);
+        mmap.read(6);
+
+        let result = unsafe {
+            ioctl(
+                &fd,
+                PageMapScanBuilder::new(mmap.region())
+                    .category_inverted(Categories::PFNZERO)
+                    .category_mask(Categories::WRITTEN | Categories::PFNZERO)
+                    .return_mask(Categories::WRITTEN | Categories::PRESENT | Categories::PFNZERO)
+                    .build(results.spare_capacity_mut()),
+            )
+            .unwrap()
+        };
+        assert_eq!(result.regions().len(), 1);
+        assert_eq!(result.walk_end(), mmap.end());
+
+        assert_eq!(result.regions()[0].region(), mmap.page_region(1..3));
+        assert_eq!(
+            result.regions()[0].categories(),
+            Categories::WRITTEN | Categories::PRESENT
+        );
+    }
+
+    #[test]
+    fn region_limit() {
+        let mmap = MmapAnonymous::new(10);
+        let mut results = Vec::with_capacity(1);
+        let fd = File::open("/proc/self/pagemap").unwrap();
+
+        mmap.read(0);
+        mmap.write(1);
+        mmap.read(2);
+        mmap.write(3);
+
+        // Ask for written|pfnzero meaning only-read pages. This should return only
+        // a single region of the first page.
+        let result = unsafe {
+            ioctl(
+                &fd,
+                PageMapScanBuilder::new(mmap.region())
+                    .return_mask(Categories::WRITTEN | Categories::PFNZERO)
+                    .build(results.spare_capacity_mut()),
+            )
+            .unwrap()
+        };
+        assert_eq!(result.regions().len(), 1);
+        assert_eq!(result.walk_end(), mmap.page_end(0));
+
+        assert_eq!(result.regions()[0].region(), mmap.page_region(0..1));
+        assert_eq!(
+            result.regions()[0].categories(),
+            Categories::WRITTEN | Categories::PFNZERO
+        );
+
+        // If we ask for written pages though (which seems synonymous with
+        // present?) then everything should be in one region.
+        let result = unsafe {
+            ioctl(
+                &fd,
+                PageMapScanBuilder::new(mmap.region())
+                    .return_mask(Categories::WRITTEN)
+                    .build(results.spare_capacity_mut()),
+            )
+            .unwrap()
+        };
+        assert_eq!(result.regions().len(), 1);
+        assert_eq!(result.walk_end(), mmap.page_end(3));
+
+        assert_eq!(result.regions()[0].region(), mmap.page_region(0..4));
+        assert_eq!(result.regions()[0].categories(), Categories::WRITTEN);
+    }
+
+    #[test]
+    fn page_limit() {
+        let mmap = MmapAnonymous::new(10);
+        let mut results = Vec::with_capacity(10);
+        let fd = File::open("/proc/self/pagemap").unwrap();
+
+        mmap.read(0);
+        mmap.read(1);
+        mmap.read(2);
+        mmap.read(3);
+
+        // Ask for written|pfnzero meaning only-read pages. This should return only
+        // a single region of the first page.
+        let result = unsafe {
+            ioctl(
+                &fd,
+                PageMapScanBuilder::new(mmap.region())
+                    .return_mask(Categories::WRITTEN | Categories::PFNZERO)
+                    .max_pages(2)
+                    .build(results.spare_capacity_mut()),
+            )
+            .unwrap()
+        };
+        assert_eq!(result.regions().len(), 1);
+        assert_eq!(result.walk_end(), mmap.page_end(1));
+
+        assert_eq!(result.regions()[0].region(), mmap.page_region(0..2));
+        assert_eq!(
+            result.regions()[0].categories(),
+            Categories::WRITTEN | Categories::PFNZERO
+        );
+    }
+
+    #[test]
+    fn page_limit_with_hole() {
+        let mmap = MmapAnonymous::new(10);
+        let mut results = Vec::with_capacity(10);
+        let fd = File::open("/proc/self/pagemap").unwrap();
+
+        mmap.read(0);
+        mmap.read(2);
+        mmap.read(3);
+
+        // Ask for written|pfnzero meaning only-read pages. This should return only
+        // a single region of the first page.
+        let result = unsafe {
+            ioctl(
+                &fd,
+                PageMapScanBuilder::new(mmap.region())
+                    .category_mask(Categories::WRITTEN)
+                    .return_mask(Categories::WRITTEN | Categories::PFNZERO)
+                    .max_pages(2)
+                    .build(results.spare_capacity_mut()),
+            )
+            .unwrap()
+        };
+        assert_eq!(result.regions().len(), 2);
+        assert_eq!(result.walk_end(), mmap.page_end(2));
+
+        assert_eq!(result.regions()[0].region(), mmap.page_region(0..1));
+        assert_eq!(
+            result.regions()[0].categories(),
+            Categories::WRITTEN | Categories::PFNZERO
+        );
+        assert_eq!(result.regions()[1].region(), mmap.page_region(2..3));
+        assert_eq!(
+            result.regions()[1].categories(),
+            Categories::WRITTEN | Categories::PFNZERO
+        );
+    }
 }

--- a/crates/wasmtime/src/runtime/vm/sys/unix/pagemap.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/unix/pagemap.rs
@@ -1,0 +1,236 @@
+//! Module for Linux pagemap based tracking of dirty pages.
+//!
+//! For other platforms, a no-op implementation is provided.
+
+use crate::prelude::*;
+pub use internal::dirty_pages_in_region;
+use std::fmt;
+use std::mem::MaybeUninit;
+
+#[allow(dead_code)]
+#[derive(Debug)]
+pub struct DirtyPages<'a> {
+    /// Slice into the initialized portion of region_storage
+    pub regions: &'a [PageRegion],
+    /// The number of bytes checked in the pagemap. Might be less than `len`, in which case
+    /// the pages beyond `checked_bytes` should be treated as potentially dirty.
+    pub checked_bytes: usize,
+    // We hold the storage here to keep it alive while regions points into it
+    region_storage: Vec<MaybeUninit<PageRegion>>,
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct PageRegion {
+    pub start: u64,
+    pub end: u64,
+    categories: Categories,
+}
+
+bitflags::bitflags! {
+    #[derive(Copy, Clone)]
+    #[repr(transparent)]
+    struct Categories: u64 {
+        const WPALLOWED = 1 << 0;
+        const WRITTEN = 1 << 1;
+        const FILE = 1 << 2;
+        const PRESENT = 1 << 3;
+        const SWAPPED = 1 << 4;
+        const PFNZERO = 1 << 5;
+        const HUGE = 1 << 6;
+        const SOFT_DIRTY = 1 << 7;
+    }
+}
+
+impl fmt::Debug for Categories {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        bitflags::parser::to_writer(self, f)
+    }
+}
+impl fmt::Display for Categories {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        bitflags::parser::to_writer(self, f)
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+mod internal {
+    use super::DirtyPages;
+    use crate::prelude::*;
+    use crate::runtime::vm::HostAlignedByteCount;
+    #[allow(unused_variables)]
+    pub fn dirty_pages_in_region<'a>(
+        base: *const u8,
+        len: HostAlignedByteCount,
+        max_bytes: HostAlignedByteCount,
+    ) -> Result<DirtyPages<'a>> {
+        Err(anyhow!("pagemap_scan ioctl not supported on this platform"))
+    }
+}
+
+#[cfg(target_os = "linux")]
+mod internal {
+    use super::{Categories, DirtyPages, PageRegion};
+    use crate::prelude::*;
+    use crate::runtime::vm::{host_page_size, HostAlignedByteCount};
+    use rustix::ioctl::{ioctl, opcode, Ioctl, IoctlOutput, Opcode};
+    use std::fs::File;
+    use std::mem::MaybeUninit;
+    use std::os::raw::c_void;
+    use std::sync::LazyLock;
+    use std::{fmt, ptr};
+
+    pub fn dirty_pages_in_region<'a>(
+        base: *const u8,
+        len: HostAlignedByteCount,
+        max_bytes: HostAlignedByteCount,
+    ) -> Result<DirtyPages<'a>> {
+        let pagemap = match &*PAGEMAP {
+            Some(pagemap) => pagemap,
+            None => return Err(anyhow!("pagemap_scan ioctl not supported")),
+        };
+
+        let max_pages = max_bytes.byte_count() / host_page_size();
+        let mut storage = vec![MaybeUninit::uninit(); max_pages];
+        let scan_arg = PageMapScan::new(
+            ptr::slice_from_raw_parts(base, len.byte_count()),
+            &mut storage,
+            max_pages,
+        );
+        let result = unsafe { ioctl(pagemap, scan_arg) };
+        match result {
+            Ok(result) => {
+                let regions = unsafe {
+                    std::slice::from_raw_parts(
+                        storage.as_ptr() as *const PageRegion,
+                        result.regions_count,
+                    )
+                };
+                Ok(DirtyPages {
+                    regions,
+                    checked_bytes: result.walk_end - base as usize,
+                    region_storage: storage,
+                })
+            }
+            Err(_) => Err(anyhow!("pagemap_scan ioctl failed")),
+        }
+    }
+
+    bitflags::bitflags! {
+        #[derive(Debug)]
+        struct PageMapBits: u64 {
+            const PRESENT = 1 << 63;
+            const SWAPPED = 1 << 62;
+            const FILE = 1 << 61;
+            const GUARD = 1 << 58;
+            const WP = 1 << 57;
+            const EXCL = 1 << 56;
+            const SOFT_DIRTY = 1 << 55;
+        }
+    }
+
+    impl fmt::Display for PageMapBits {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            bitflags::parser::to_writer(self, f)
+        }
+    }
+
+    struct PageMapScan<'a> {
+        pm_scan_arg: pm_scan_arg,
+        _regions: &'a mut [MaybeUninit<PageRegion>],
+    }
+
+    impl<'a> PageMapScan<'a> {
+        fn new(
+            region: *const [u8],
+            regions: &'a mut [MaybeUninit<PageRegion>],
+            max_pages: usize,
+        ) -> PageMapScan<'a> {
+            PageMapScan {
+                pm_scan_arg: pm_scan_arg {
+                    size: size_of::<pm_scan_arg>() as u64,
+                    flags: 0,
+                    start: unsafe { (*region).as_ptr() as u64 },
+                    end: unsafe { (*region).as_ptr().wrapping_add((*region).len()) as u64 },
+                    walk_end: 0,
+                    vec: regions.as_mut_ptr() as u64,
+                    vec_len: regions.len() as u64,
+                    max_pages: max_pages as u64,
+                    category_inverted: Categories::FILE | Categories::PFNZERO,
+                    category_anyof_mask: Categories::empty(),
+                    category_mask: Categories::WRITTEN | Categories::FILE | Categories::PFNZERO,
+                    return_mask: Categories::all(),
+                },
+                _regions: regions,
+            }
+        }
+    }
+
+    #[derive(Debug)]
+    #[allow(dead_code)]
+    struct PageMapScanResult {
+        walk_end: usize,
+        regions_count: usize,
+    }
+
+    #[repr(C)]
+    struct pm_scan_arg {
+        size: u64,
+        flags: u64,
+        start: u64,
+        end: u64,
+        walk_end: u64,
+        vec: u64,
+        vec_len: u64,
+        max_pages: u64,
+        category_inverted: Categories,
+        category_mask: Categories,
+        category_anyof_mask: Categories,
+        return_mask: Categories,
+    }
+
+    const PAGEMAP_SCAN: Opcode = opcode::read_write::<pm_scan_arg>(b'f', 16);
+
+    unsafe impl<'a> Ioctl for PageMapScan<'a> {
+        type Output = PageMapScanResult;
+
+        const IS_MUTATING: bool = false;
+
+        fn opcode(&self) -> Opcode {
+            PAGEMAP_SCAN
+        }
+
+        fn as_ptr(&mut self) -> *mut c_void {
+            (&raw mut self.pm_scan_arg).cast()
+        }
+
+        unsafe fn output_from_ptr(
+            out: IoctlOutput,
+            extract_output: *mut c_void,
+        ) -> rustix::io::Result<Self::Output> {
+            let extract_output = extract_output.cast::<pm_scan_arg>();
+            let len = usize::try_from(out).unwrap();
+            Ok(PageMapScanResult {
+                regions_count: len,
+                walk_end: unsafe { (*extract_output).walk_end.try_into().unwrap() },
+            })
+        }
+    }
+
+    /// A static reference to the `/proc/self/pagemap` file. `None` if the file
+    /// can't be opened, or if the `pagemap_scan` ioctl is not supported.
+    static PAGEMAP: LazyLock<Option<File>> = LazyLock::new(|| {
+        let file = File::open("/proc/self/pagemap");
+        if file.is_err() {
+            return None;
+        }
+        let file = file.unwrap();
+        // Check if the `pagemap_scan` ioctl is supported.
+        let mut regions = vec![MaybeUninit::<PageRegion>::uninit(); 0];
+        let pm_scan = PageMapScan::new(ptr::slice_from_raw_parts(ptr::null(), 0), &mut regions, 0);
+        match unsafe { ioctl(&file, pm_scan) } {
+            Ok(_) => Some(file),
+            Err(_) => None,
+        }
+    });
+}

--- a/crates/wasmtime/src/runtime/vm/sys/unix/pagemap.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/unix/pagemap.rs
@@ -489,8 +489,27 @@ mod tests {
         }
     }
 
+    fn ioctl_supported() -> bool {
+        let mmap = MmapAnonymous::new(1);
+        let mut results = Vec::with_capacity(1);
+        let fd = File::open("/proc/self/pagemap").unwrap();
+        unsafe {
+            ioctl(
+                &fd,
+                PageMapScanBuilder::new(mmap.region())
+                    .category_mask(Categories::WRITTEN)
+                    .return_mask(Categories::all())
+                    .build(results.spare_capacity_mut()),
+            )
+            .is_ok()
+        }
+    }
+
     #[test]
     fn no_pages_returned() {
+        if !ioctl_supported() {
+            return;
+        }
         let mmap = MmapAnonymous::new(10);
         let mut results = Vec::with_capacity(10);
         let fd = File::open("/proc/self/pagemap").unwrap();
@@ -511,6 +530,9 @@ mod tests {
 
     #[test]
     fn empty_region() {
+        if !ioctl_supported() {
+            return;
+        }
         let mut results = Vec::with_capacity(10);
         let fd = File::open("/proc/self/pagemap").unwrap();
 
@@ -529,6 +551,9 @@ mod tests {
 
     #[test]
     fn basic_page_flags() {
+        if !ioctl_supported() {
+            return;
+        }
         let mmap = MmapAnonymous::new(10);
         let mut results = Vec::with_capacity(10);
         let fd = File::open("/proc/self/pagemap").unwrap();
@@ -580,6 +605,9 @@ mod tests {
 
     #[test]
     fn only_written_pages() {
+        if !ioctl_supported() {
+            return;
+        }
         let mmap = MmapAnonymous::new(10);
         let mut results = Vec::with_capacity(10);
         let fd = File::open("/proc/self/pagemap").unwrap();
@@ -615,6 +643,9 @@ mod tests {
 
     #[test]
     fn region_limit() {
+        if !ioctl_supported() {
+            return;
+        }
         let mmap = MmapAnonymous::new(10);
         let mut results = Vec::with_capacity(1);
         let fd = File::open("/proc/self/pagemap").unwrap();
@@ -664,6 +695,9 @@ mod tests {
 
     #[test]
     fn page_limit() {
+        if !ioctl_supported() {
+            return;
+        }
         let mmap = MmapAnonymous::new(10);
         let mut results = Vec::with_capacity(10);
         let fd = File::open("/proc/self/pagemap").unwrap();
@@ -697,6 +731,9 @@ mod tests {
 
     #[test]
     fn page_limit_with_hole() {
+        if !ioctl_supported() {
+            return;
+        }
         let mmap = MmapAnonymous::new(10);
         let mut results = Vec::with_capacity(10);
         let fd = File::open("/proc/self/pagemap").unwrap();

--- a/crates/wasmtime/src/runtime/vm/sys/unix/pagemap.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/unix/pagemap.rs
@@ -2,8 +2,10 @@
 //!
 //! For other platforms, a no-op implementation is provided.
 
-use self::ioctl::{Categories, PageMapScanBuilder};
+#[cfg(feature = "pooling-allocator")]
 use crate::prelude::*;
+
+use self::ioctl::{Categories, PageMapScanBuilder};
 use crate::runtime::vm::{HostAlignedByteCount, host_page_size};
 use rustix::ioctl::ioctl;
 use std::fs::File;
@@ -14,6 +16,7 @@ use std::ptr;
 pub struct PageMap(File);
 
 impl PageMap {
+    #[cfg(feature = "pooling-allocator")]
     pub fn new() -> Option<PageMap> {
         let file = File::open("/proc/self/pagemap").ok()?;
         // Check if the `pagemap_scan` ioctl is supported.

--- a/crates/wasmtime/src/runtime/vm/sys/unix/vm.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/unix/vm.rs
@@ -6,6 +6,8 @@ use std::io;
 #[cfg(feature = "std")]
 use std::sync::Arc;
 
+pub use super::pagemap::{PageMap, reset_with_pagemap};
+
 pub unsafe fn expose_existing_mapping(ptr: *mut u8, len: usize) -> io::Result<()> {
     unsafe {
         mprotect(ptr.cast(), len, MprotectFlags::READ | MprotectFlags::WRITE)?;

--- a/crates/wasmtime/src/runtime/vm/sys/windows/vm.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/windows/vm.rs
@@ -6,6 +6,8 @@ use std::sync::Arc;
 use windows_sys::Win32::System::Memory::*;
 use windows_sys::Win32::System::SystemInformation::*;
 
+pub use crate::runtime::vm::pagemap_disabled::{PageMap, reset_with_pagemap};
+
 pub unsafe fn expose_existing_mapping(ptr: *mut u8, len: usize) -> io::Result<()> {
     if len == 0 {
         return Ok(());

--- a/crates/wasmtime/tests/engine_across_forks.rs
+++ b/crates/wasmtime/tests/engine_across_forks.rs
@@ -36,7 +36,7 @@ mod unix {
     fn smoke() -> Result<()> {
         let mut config = Config::new();
         config.macos_use_mach_ports(false);
-        let engine = Engine::default();
+        let engine = Engine::new(&config)?;
         let module = Module::new(&engine, r#"(module (func (export "")))"#)?;
         run_in_child(|| {
             let mut store = Store::new(&engine, ());

--- a/crates/wasmtime/tests/engine_across_forks.rs
+++ b/crates/wasmtime/tests/engine_across_forks.rs
@@ -1,0 +1,132 @@
+use wasmtime::Result;
+
+fn main() -> Result<()> {
+    #[cfg(unix)]
+    if true {
+        use libtest_mimic::{Arguments, Trial};
+
+        let mut trials = Vec::new();
+        for (name, test) in linux::TESTS {
+            trials.push(Trial::test(*name, || {
+                test().map_err(|e| format!("{e:?}").into())
+            }));
+        }
+
+        let mut args = Arguments::from_args();
+        // I'll be honest, I'm scared of threads + fork, so I'm just
+        // preemptively disabling threads here.
+        args.test_threads = Some(1);
+        libtest_mimic::run(&args, trials).exit()
+    }
+
+    Ok(())
+}
+
+mod linux {
+    use rustix::fd::AsRawFd;
+    use rustix::process::{Pid, WaitOptions, waitpid};
+    use std::io::{self, BufRead, BufReader};
+    use wasmtime::*;
+
+    pub const TESTS: &[(&str, fn() -> Result<()>)] = &[
+        ("smoke", smoke),
+        ("pooling_allocator_reset", pooling_allocator_reset),
+    ];
+
+    fn smoke() -> Result<()> {
+        let engine = Engine::default();
+        let module = Module::new(&engine, r#"(module (func (export "")))"#)?;
+        run_in_child(|| {
+            let mut store = Store::new(&engine, ());
+            let instance = Instance::new(&mut store, &module, &[])?;
+            let export = instance.get_typed_func::<(), ()>(&mut store, "")?;
+            export.call(&mut store, ())?;
+            Ok(())
+        })?;
+        Ok(())
+    }
+
+    fn pooling_allocator_reset() -> Result<()> {
+        let mut pooling = PoolingAllocationConfig::new();
+        pooling.linear_memory_keep_resident(4096);
+        let mut config = Config::new();
+        config.allocation_strategy(pooling);
+        let engine = Engine::new(&config)?;
+        let module = Module::new(
+            &engine,
+            r#"
+                (module
+                    (memory (export "") 1 1)
+                    (data (i32.const 0) "\0a")
+                )
+            "#,
+        )?;
+
+        let assert_pristine = || {
+            let mut store = Store::new(&engine, ());
+            let instance = Instance::new(&mut store, &module, &[])?;
+            let memory = instance.get_memory(&mut store, "").unwrap();
+            let data = memory.data(&store);
+            assert_eq!(data[0], 0x0a);
+            anyhow::Ok((store, memory))
+        };
+        run_in_child(|| {
+            // Allocate a memory, and then mutate it.
+            let (mut store, memory) = assert_pristine()?;
+            let data = memory.data_mut(&mut store);
+            data[0] = 0;
+            drop(store);
+
+            // Allocating the memory again should reuse the same pooling
+            // allocator slot but it should be reset correctly.
+            assert_pristine()?;
+            assert_pristine()?;
+            Ok(())
+        })?;
+        Ok(())
+    }
+
+    fn run_in_child(closure: impl FnOnce() -> Result<()>) -> Result<()> {
+        let (read, write) = io::pipe()?;
+        let child = match unsafe { libc::fork() } {
+            -1 => return Err(io::Error::last_os_error().into()),
+
+            0 => {
+                // If a panic happens, don't let it go above this stack frame.
+                let _bomb = Bomb;
+
+                drop(read);
+                unsafe {
+                    assert!(libc::dup2(write.as_raw_fd(), 1) == 1);
+                    assert!(libc::dup2(write.as_raw_fd(), 2) == 2);
+                }
+                drop(write);
+
+                closure().unwrap();
+                std::process::exit(0);
+            }
+
+            pid => pid,
+        };
+
+        drop(write);
+
+        for line in BufReader::new(read).lines() {
+            println!("CHILD: {}", line?);
+        }
+
+        let (_pid, status) =
+            waitpid(Some(Pid::from_raw(child).unwrap()), WaitOptions::empty())?.unwrap();
+        assert_eq!(status.as_raw(), 0);
+
+        Ok(())
+    }
+
+    struct Bomb;
+
+    impl Drop for Bomb {
+        fn drop(&mut self) {
+            std::process::exit(1);
+        }
+    }
+}


### PR DESCRIPTION
This series of commits is the brainchild of @tschneidereit who, in his spare time, reads Linux kernel documentation and finds random ioctls. Specifically @tschneidereit discovered the [`PAGEMAP_SCAN` ioctl](https://www.man7.org/linux/man-pages/man2/PAGEMAP_SCAN.2const.html) which has the basic description of:

> This [ioctl(2)](https://www.man7.org/linux/man-pages/man2/ioctl.2.html) is used to get and optionally clear some specific
       flags from page table entries.  The information is returned with
       PAGE_SIZE granularity.

As a bit of background one of the main scaling bottlenecks for Wasmtime-on-the-server is the implementation of resetting WebAssembly instances back to their original state, notably linear memories and tables. Wasmtime employs two separate strategies on Linux for doing this today:

* The `PoolingAllocationConfig` has `*_keep_resident` options which indicates that this much memory will be memset back to the original contents. This options default to 0 bytes.
* Resetting memory beyond `*_keep_resident` is done with `madvise(MADV_DONTNEED)` to reset linear memories and tables back to their original state.

Both of these strategies have drawbacks. For `*_keep_resident` and memset this is a blind memset of the lower addresses in linear memory where lots of memory is set that wasn't either read or written from the guest. As a result this can't be too large lest Wasmtime become a `memset` benchmark. For `madvise(MADV_DONTNEED)` this requires modifying page tables (removing resident pages) which results in IPIs to synchronize other cores. Additionally each invocation of a WebAssembly instance will always incur a page fault on memory accesses (albeit a minor fault, not a major fault), which can add up.

By using the `PAGEMAP_SCAN` ioctl we can take the best of both worlds here and combine these into a more efficient way to reset linear memories and tables back to their original contents. At a high level the ioctl works by:

* A range of virtual memory is specified to "scan". Flags are also configured to indicate what are the interesting bits we care about in the page table.
* The ioctl writes to a user-supplied buffer with page-aligned regions of memory that match the flags specified. 
* Wasmtime uses this to detect, within an entire linear memory, what pages are "dirty" or written to and will memset these while `madvise`-ing any pages above the `*_keep_resident` threshold.

In essence this is almost a tailor-made syscall for Wasmtime and perfectly fits our use case. We can quickly find dirty pages, up to a certain maximum, which segments memory into "manually reset these regions" followed by "decommit these regions". This enables Wasmtime to `memset` only memory written by the guest and, for example, memory that's only read by the guest remains paged in and remains unmodified.

This is an improvement over `*_keep_resident` because only written pages are reset back to their original contents, not all pages in the low addresses of the linear memory address space. This is also an improvement over `madvise(MADV_DONTNEED)` because readonly pages are kept resident over time (no page faults on future invocations, all mapped to the same file-backed readonly page across multiple instances), written pages are kept resident over time (but reset back to original contents after instantiation), and IPIs/TLB shootdowns can be avoided (assuming the working set of written memory is less than `*_keep_resident` and memory isn't grown during execution). Overall this helps combine the best of both worlds and provides another tool in the toolbox of Wasmtime to efficiently reset linear memory back to zero.

In terms of practical impact this enables a 2.5x increase in RPS measured of a simple p2 hello-world server that uses `wasmtime serve`. The server in question only writes two host pages of memory and so resetting a linear memory requires a single syscall and 8192 bytes of memcpy. Tables are memset to zero and don't require an ioctl because their total size is so small (both are less than 1 page of memory).

---

This series of commits was originally written by @tschneidereit who did all the initial exploration and effort. I've rebased the commits and cleaned things up towards the end for integration in Wasmtime. The main technical changes here are to hook into linear memory and table deallocation. The `MemoryImageSlot` has also been refactored to contain an `Arc` pointing to the original image itself in-memory which is used to manually `memset` contents back to their original version. Resetting a `MemoryImageSlot` has been refactored to pretend that page maps are always available which helps simplify the code and ensure thorough testing even when not on Linux.

Wasmtime only uses `PAGEMAP_SCAN` on Linux and this support is disabled on all other platforms. The `PAGEMAP_SCAN` ioctl is also relatively new so Wasmtime also disables this all on Linux at runtime if the kernel isn't new enough to support `PAGEMAP_SCAN`. 

Support for the `PAGEMAP_SCAN` ioctl is in a Linux-specific module and is effectively a copy of [this repository](https://github.com/alexcrichton/linux-pagemap-scan) where I did initial testing of this ioctl. That repository isn't published on crates.io nor do I plan on publishing it on crates.io. The test suite is included here as well in the module for Linux pagemap bits.

A new test is added to `cow.rs` which exercises some of the more interesting cases with `PAGEMAP_SCAN` additionally.