### PR TITLE
Use `trappable_error_type` in WASIp3 sockets

### DIFF
--- a/crates/wasi/src/p2/network.rs
+++ b/crates/wasi/src/p2/network.rs
@@ -1,8 +1,7 @@
-use core::net::SocketAddr;
-
 use crate::p2::bindings::sockets::network::ErrorCode;
 use crate::sockets::SocketAddrCheck;
 use crate::{SocketAddrUse, TrappableError};
+use core::net::SocketAddr;
 
 pub type SocketResult<T> = Result<T, SocketError>;
 

--- a/crates/wasi/src/p3/bindings.rs
+++ b/crates/wasi/src/p3/bindings.rs
@@ -96,7 +96,10 @@ mod generated {
             "wasi:cli/terminal-output/terminal-output": crate::p3::cli::TerminalOutput,
             "wasi:sockets/types/tcp-socket": crate::p3::sockets::tcp::TcpSocket,
             "wasi:sockets/types/udp-socket": crate::p3::sockets::udp::UdpSocket,
-        }
+        },
+        trappable_error_type: {
+            "wasi:sockets/types/error-code" => crate::p3::sockets::SocketError,
+        },
     });
 }
 pub use self::generated::LinkOptions;

--- a/crates/wasi/src/p3/sockets/host/types/mod.rs
+++ b/crates/wasi/src/p3/sockets/host/types/mod.rs
@@ -1,15 +1,17 @@
-use core::net::SocketAddr;
-
-use wasmtime::component::Accessor;
-
-use crate::p3::bindings::sockets::types::Host;
-use crate::p3::sockets::WasiSockets;
+use crate::p3::bindings::sockets::types::{ErrorCode, Host};
+use crate::p3::sockets::{SocketError, WasiSockets};
 use crate::sockets::{SocketAddrCheck, SocketAddrUse, WasiSocketsCtxView};
+use core::net::SocketAddr;
+use wasmtime::component::Accessor;
 
 mod tcp;
 mod udp;
 
-impl Host for WasiSocketsCtxView<'_> {}
+impl Host for WasiSocketsCtxView<'_> {
+    fn convert_error_code(&mut self, error: SocketError) -> anyhow::Result<ErrorCode> {
+        error.downcast()
+    }
+}
 
 fn get_socket_addr_check<T>(store: &Accessor<T, WasiSockets>) -> SocketAddrCheck {
     store.with(|mut view| view.get().ctx.socket_addr_check.clone())

--- a/crates/wasi/src/p3/sockets/host/types/udp.rs
+++ b/crates/wasi/src/p3/sockets/host/types/udp.rs
@@ -1,14 +1,13 @@
-use core::net::SocketAddr;
-
-use anyhow::Context as _;
-use wasmtime::component::{Accessor, Resource, ResourceTable};
-
+use crate::TrappableError;
 use crate::p3::bindings::sockets::types::{
     ErrorCode, HostUdpSocket, HostUdpSocketWithStore, IpAddressFamily, IpSocketAddress,
 };
-use crate::p3::sockets::WasiSockets;
 use crate::p3::sockets::udp::UdpSocket;
+use crate::p3::sockets::{SocketResult, WasiSockets};
 use crate::sockets::{MAX_UDP_DATAGRAM_SIZE, SocketAddrUse, WasiSocketsCtxView};
+use anyhow::Context as _;
+use core::net::SocketAddr;
+use wasmtime::component::{Accessor, Resource, ResourceTable};
 
 use super::is_addr_allowed;
 
@@ -19,19 +18,21 @@ fn is_udp_allowed<T>(store: &Accessor<T, WasiSockets>) -> bool {
 fn get_socket<'a>(
     table: &'a ResourceTable,
     socket: &'a Resource<UdpSocket>,
-) -> wasmtime::Result<&'a UdpSocket> {
+) -> SocketResult<&'a UdpSocket> {
     table
         .get(socket)
         .context("failed to get socket resource from table")
+        .map_err(TrappableError::trap)
 }
 
 fn get_socket_mut<'a>(
     table: &'a mut ResourceTable,
     socket: &'a Resource<UdpSocket>,
-) -> wasmtime::Result<&'a mut UdpSocket> {
+) -> SocketResult<&'a mut UdpSocket> {
     table
         .get_mut(socket)
         .context("failed to get socket resource from table")
+        .map_err(TrappableError::trap)
 }
 
 impl HostUdpSocketWithStore for WasiSockets {
@@ -39,16 +40,17 @@ impl HostUdpSocketWithStore for WasiSockets {
         store: &Accessor<T, Self>,
         socket: Resource<UdpSocket>,
         local_address: IpSocketAddress,
-    ) -> wasmtime::Result<Result<(), ErrorCode>> {
+    ) -> SocketResult<()> {
         let local_address = SocketAddr::from(local_address);
         if !is_udp_allowed(store)
             || !is_addr_allowed(store, local_address, SocketAddrUse::UdpBind).await
         {
-            return Ok(Err(ErrorCode::AccessDenied));
+            return Err(ErrorCode::AccessDenied.into());
         }
         store.with(|mut view| {
             let socket = get_socket_mut(view.get().table, &socket)?;
-            Ok(socket.bind(local_address))
+            socket.bind(local_address)?;
+            Ok(())
         })
     }
 
@@ -56,16 +58,17 @@ impl HostUdpSocketWithStore for WasiSockets {
         store: &Accessor<T, Self>,
         socket: Resource<UdpSocket>,
         remote_address: IpSocketAddress,
-    ) -> wasmtime::Result<Result<(), ErrorCode>> {
+    ) -> SocketResult<()> {
         let remote_address = SocketAddr::from(remote_address);
         if !is_udp_allowed(store)
             || !is_addr_allowed(store, remote_address, SocketAddrUse::UdpConnect).await
         {
-            return Ok(Err(ErrorCode::AccessDenied));
+            return Err(ErrorCode::AccessDenied.into());
         }
         store.with(|mut view| {
             let socket = get_socket_mut(view.get().table, &socket)?;
-            Ok(socket.connect(remote_address))
+            socket.connect(remote_address)?;
+            Ok(())
         })
     }
 
@@ -74,40 +77,43 @@ impl HostUdpSocketWithStore for WasiSockets {
         socket: Resource<UdpSocket>,
         data: Vec<u8>,
         remote_address: Option<IpSocketAddress>,
-    ) -> wasmtime::Result<Result<(), ErrorCode>> {
+    ) -> SocketResult<()> {
         if data.len() > MAX_UDP_DATAGRAM_SIZE {
-            return Ok(Err(ErrorCode::DatagramTooLarge));
+            return Err(ErrorCode::DatagramTooLarge.into());
         }
         if !is_udp_allowed(store) {
-            return Ok(Err(ErrorCode::AccessDenied));
+            return Err(ErrorCode::AccessDenied.into());
         }
         if let Some(addr) = remote_address {
             let addr = SocketAddr::from(addr);
             if !is_addr_allowed(store, addr, SocketAddrUse::UdpOutgoingDatagram).await {
-                return Ok(Err(ErrorCode::AccessDenied));
+                return Err(ErrorCode::AccessDenied.into());
             }
             let fut = store.with(|mut view| {
                 get_socket(view.get().table, &socket).map(|sock| sock.send_to(data, addr))
             })?;
-            Ok(fut.await)
+            fut.await?;
+            Ok(())
         } else {
             let fut = store.with(|mut view| {
                 get_socket(view.get().table, &socket).map(|sock| sock.send(data))
             })?;
-            Ok(fut.await)
+            fut.await?;
+            Ok(())
         }
     }
 
     async fn receive<T>(
         store: &Accessor<T, Self>,
         socket: Resource<UdpSocket>,
-    ) -> wasmtime::Result<Result<(Vec<u8>, IpSocketAddress), ErrorCode>> {
+    ) -> SocketResult<(Vec<u8>, IpSocketAddress)> {
         if !is_udp_allowed(store) {
-            return Ok(Err(ErrorCode::AccessDenied));
+            return Err(ErrorCode::AccessDenied.into());
         }
         let fut = store
             .with(|mut view| get_socket(view.get().table, &socket).map(|sock| sock.receive()))?;
-        Ok(fut.await)
+        let (result, addr) = fut.await?;
+        Ok((result, addr))
     }
 }
 
@@ -119,28 +125,20 @@ impl HostUdpSocket for WasiSocketsCtxView<'_> {
             .context("failed to push socket resource to table")
     }
 
-    fn disconnect(
-        &mut self,
-        socket: Resource<UdpSocket>,
-    ) -> wasmtime::Result<Result<(), ErrorCode>> {
+    fn disconnect(&mut self, socket: Resource<UdpSocket>) -> SocketResult<()> {
         let socket = get_socket_mut(self.table, &socket)?;
-        Ok(socket.disconnect())
+        socket.disconnect()?;
+        Ok(())
     }
 
-    fn local_address(
-        &mut self,
-        socket: Resource<UdpSocket>,
-    ) -> wasmtime::Result<Result<IpSocketAddress, ErrorCode>> {
+    fn local_address(&mut self, socket: Resource<UdpSocket>) -> SocketResult<IpSocketAddress> {
         let sock = get_socket(self.table, &socket)?;
-        Ok(sock.local_address())
+        Ok(sock.local_address()?)
     }
 
-    fn remote_address(
-        &mut self,
-        socket: Resource<UdpSocket>,
-    ) -> wasmtime::Result<Result<IpSocketAddress, ErrorCode>> {
+    fn remote_address(&mut self, socket: Resource<UdpSocket>) -> SocketResult<IpSocketAddress> {
         let sock = get_socket(self.table, &socket)?;
-        Ok(sock.remote_address())
+        Ok(sock.remote_address()?)
     }
 
     fn address_family(&mut self, socket: Resource<UdpSocket>) -> wasmtime::Result<IpAddressFamily> {
@@ -148,55 +146,49 @@ impl HostUdpSocket for WasiSocketsCtxView<'_> {
         Ok(sock.address_family())
     }
 
-    fn unicast_hop_limit(
-        &mut self,
-        socket: Resource<UdpSocket>,
-    ) -> wasmtime::Result<Result<u8, ErrorCode>> {
+    fn unicast_hop_limit(&mut self, socket: Resource<UdpSocket>) -> SocketResult<u8> {
         let sock = get_socket(self.table, &socket)?;
-        Ok(sock.unicast_hop_limit())
+        Ok(sock.unicast_hop_limit()?)
     }
 
     fn set_unicast_hop_limit(
         &mut self,
         socket: Resource<UdpSocket>,
         value: u8,
-    ) -> wasmtime::Result<Result<(), ErrorCode>> {
+    ) -> SocketResult<()> {
         let sock = get_socket(self.table, &socket)?;
-        Ok(sock.set_unicast_hop_limit(value))
+        sock.set_unicast_hop_limit(value)?;
+        Ok(())
     }
 
-    fn receive_buffer_size(
-        &mut self,
-        socket: Resource<UdpSocket>,
-    ) -> wasmtime::Result<Result<u64, ErrorCode>> {
+    fn receive_buffer_size(&mut self, socket: Resource<UdpSocket>) -> SocketResult<u64> {
         let sock = get_socket(self.table, &socket)?;
-        Ok(sock.receive_buffer_size())
+        Ok(sock.receive_buffer_size()?)
     }
 
     fn set_receive_buffer_size(
         &mut self,
         socket: Resource<UdpSocket>,
         value: u64,
-    ) -> wasmtime::Result<Result<(), ErrorCode>> {
+    ) -> SocketResult<()> {
         let sock = get_socket(self.table, &socket)?;
-        Ok(sock.set_receive_buffer_size(value))
+        sock.set_receive_buffer_size(value)?;
+        Ok(())
     }
 
-    fn send_buffer_size(
-        &mut self,
-        socket: Resource<UdpSocket>,
-    ) -> wasmtime::Result<Result<u64, ErrorCode>> {
+    fn send_buffer_size(&mut self, socket: Resource<UdpSocket>) -> SocketResult<u64> {
         let sock = get_socket(self.table, &socket)?;
-        Ok(sock.send_buffer_size())
+        Ok(sock.send_buffer_size()?)
     }
 
     fn set_send_buffer_size(
         &mut self,
         socket: Resource<UdpSocket>,
         value: u64,
-    ) -> wasmtime::Result<Result<(), ErrorCode>> {
+    ) -> SocketResult<()> {
         let sock = get_socket(self.table, &socket)?;
-        Ok(sock.set_send_buffer_size(value))
+        sock.set_send_buffer_size(value)?;
+        Ok(())
     }
 
     fn drop(&mut self, sock: Resource<UdpSocket>) -> wasmtime::Result<()> {

--- a/crates/wasi/src/p3/sockets/mod.rs
+++ b/crates/wasi/src/p3/sockets/mod.rs
@@ -1,3 +1,4 @@
+use crate::TrappableError;
 use crate::p3::bindings::sockets;
 use crate::sockets::{WasiSocketsCtxView, WasiSocketsView};
 use wasmtime::component::{HasData, Linker};
@@ -6,6 +7,9 @@ mod conv;
 mod host;
 pub mod tcp;
 pub mod udp;
+
+pub type SocketResult<T> = Result<T, SocketError>;
+pub type SocketError = TrappableError<sockets::types::ErrorCode>;
 
 /// Add all WASI interfaces from this module into the `linker` provided.
 ///

--- a/crates/wit-bindgen/src/lib.rs
+++ b/crates/wit-bindgen/src/lib.rs
@@ -2559,11 +2559,16 @@ impl<'a> InterfaceGenerator<'a> {
                 None => format!("Host"),
             };
             let convert = format!("{}::convert_{}", convert_trait, err_name.to_snake_case());
+            let convert = if flags.contains(FunctionFlags::STORE) {
+                format!("accessor.with(|mut host| {convert}(&mut host.get(), e))?")
+            } else {
+                format!("{convert}(host, e)?")
+            };
             uwrite!(
                 self.src,
                 "Ok((match r {{
                     Ok(a) => Ok(a),
-                    Err(e) => Err({convert}(host, e)?),
+                    Err(e) => Err({convert}),
                 }},))"
             );
         } else if func.result.is_some() {


### PR DESCRIPTION
This commit updates to using the `trappable_error_type` in bindings generated for WASIp3 to mirror what happens in WASIp2, removing an extra `Result<Result<..>>` layer to only have one layer of results.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
