### PR TITLE
Bump Wasmtime to 37.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -289,7 +289,7 @@ dependencies = [
 
 [[package]]
 name = "byte-array-literals"
-version = "36.0.0"
+version = "37.0.0"
 
 [[package]]
 name = "byteorder"
@@ -693,7 +693,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift"
-version = "0.123.0"
+version = "0.124.0"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",
@@ -706,7 +706,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.123.0"
+version = "0.124.0"
 dependencies = [
  "arbitrary",
  "arbtest",
@@ -724,21 +724,21 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.123.0"
+version = "0.124.0"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.123.0"
+version = "0.124.0"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.123.0"
+version = "0.124.0"
 dependencies = [
  "arbitrary",
  "serde",
@@ -747,7 +747,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.123.0"
+version = "0.124.0"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -782,7 +782,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.123.0"
+version = "0.124.0"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -793,18 +793,18 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.123.0"
+version = "0.124.0"
 
 [[package]]
 name = "cranelift-control"
-version = "0.123.0"
+version = "0.124.0"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.123.0"
+version = "0.124.0"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.123.0"
+version = "0.124.0"
 dependencies = [
  "cranelift-codegen",
  "env_logger 0.11.5",
@@ -869,7 +869,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-interpreter"
-version = "0.123.0"
+version = "0.124.0"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.123.0"
+version = "0.124.0"
 dependencies = [
  "codespan-reporting",
  "log",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-jit"
-version = "0.123.0"
+version = "0.124.0"
 dependencies = [
  "anyhow",
  "cranelift",
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-module"
-version = "0.123.0"
+version = "0.124.0"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -926,7 +926,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.123.0"
+version = "0.124.0"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-object"
-version = "0.123.0"
+version = "0.124.0"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -950,7 +950,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-reader"
-version = "0.123.0"
+version = "0.124.0"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -960,7 +960,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-serde"
-version = "0.123.0"
+version = "0.124.0"
 dependencies = [
  "clap",
  "cranelift-codegen",
@@ -970,7 +970,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.123.0"
+version = "0.124.0"
 
 [[package]]
 name = "cranelift-tools"
@@ -1221,7 +1221,7 @@ checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
 
 [[package]]
 name = "embedding"
-version = "36.0.0"
+version = "37.0.0"
 dependencies = [
  "anyhow",
  "dlmalloc",
@@ -2373,7 +2373,7 @@ dependencies = [
 
 [[package]]
 name = "min-platform-host"
-version = "36.0.0"
+version = "37.0.0"
 dependencies = [
  "anyhow",
  "libloading",
@@ -2816,7 +2816,7 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "36.0.0"
+version = "37.0.0"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -2840,7 +2840,7 @@ dependencies = [
 
 [[package]]
 name = "pulley-macros"
-version = "36.0.0"
+version = "37.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4066,7 +4066,7 @@ version = "0.1.0"
 
 [[package]]
 name = "verify-component-adapter"
-version = "36.0.0"
+version = "37.0.0"
 dependencies = [
  "anyhow",
  "wasmparser 0.236.0",
@@ -4134,7 +4134,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-common"
-version = "36.0.0"
+version = "37.0.0"
 dependencies = [
  "anyhow",
  "bitflags 2.6.0",
@@ -4173,7 +4173,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-preview1-component-adapter"
-version = "36.0.0"
+version = "37.0.0"
 dependencies = [
  "bitflags 2.6.0",
  "byte-array-literals",
@@ -4444,7 +4444,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "36.0.0"
+version = "37.0.0"
 dependencies = [
  "addr2line 0.25.0",
  "anyhow",
@@ -4509,7 +4509,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-bench-api"
-version = "36.0.0"
+version = "37.0.0"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -4525,14 +4525,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-c-api"
-version = "36.0.0"
+version = "37.0.0"
 dependencies = [
  "wasmtime-c-api-impl",
 ]
 
 [[package]]
 name = "wasmtime-c-api-impl"
-version = "36.0.0"
+version = "37.0.0"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -4549,7 +4549,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli"
-version = "36.0.0"
+version = "37.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4622,7 +4622,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli-flags"
-version = "36.0.0"
+version = "37.0.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -4637,7 +4637,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "36.0.0"
+version = "37.0.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -4743,14 +4743,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-asm-macros"
-version = "36.0.0"
+version = "37.0.0"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "wasmtime-internal-c-api-macros"
-version = "36.0.0"
+version = "37.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4758,7 +4758,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cache"
-version = "36.0.0"
+version = "37.0.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -4779,7 +4779,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-macro"
-version = "36.0.0"
+version = "37.0.0"
 dependencies = [
  "anyhow",
  "component-macro-test-helpers",
@@ -4799,11 +4799,11 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-util"
-version = "36.0.0"
+version = "37.0.0"
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "36.0.0"
+version = "37.0.0"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4828,7 +4828,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-explorer"
-version = "36.0.0"
+version = "37.0.0"
 dependencies = [
  "anyhow",
  "capstone",
@@ -4843,7 +4843,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-fiber"
-version = "36.0.0"
+version = "37.0.0"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -4858,7 +4858,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-debug"
-version = "36.0.0"
+version = "37.0.0"
 dependencies = [
  "cc",
  "object 0.37.1",
@@ -4868,7 +4868,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "36.0.0"
+version = "37.0.0"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4878,18 +4878,18 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-math"
-version = "36.0.0"
+version = "37.0.0"
 dependencies = [
  "libm",
 ]
 
 [[package]]
 name = "wasmtime-internal-slab"
-version = "36.0.0"
+version = "37.0.0"
 
 [[package]]
 name = "wasmtime-internal-unwinder"
-version = "36.0.0"
+version = "37.0.0"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4900,7 +4900,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
-version = "36.0.0"
+version = "37.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4909,7 +4909,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-winch"
-version = "36.0.0"
+version = "37.0.0"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -4924,7 +4924,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-wit-bindgen"
-version = "36.0.0"
+version = "37.0.0"
 dependencies = [
  "anyhow",
  "bitflags 2.6.0",
@@ -4935,7 +4935,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-wmemcheck"
-version = "36.0.0"
+version = "37.0.0"
 
 [[package]]
 name = "wasmtime-test-macros"
@@ -4950,7 +4950,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-test-util"
-version = "36.0.0"
+version = "37.0.0"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -4968,7 +4968,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "36.0.0"
+version = "37.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5003,7 +5003,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-config"
-version = "36.0.0"
+version = "37.0.0"
 dependencies = [
  "anyhow",
  "test-programs-artifacts",
@@ -5014,7 +5014,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-http"
-version = "36.0.0"
+version = "37.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5041,7 +5041,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-io"
-version = "36.0.0"
+version = "37.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5052,7 +5052,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-keyvalue"
-version = "36.0.0"
+version = "37.0.0"
 dependencies = [
  "anyhow",
  "test-programs-artifacts",
@@ -5063,7 +5063,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-nn"
-version = "36.0.0"
+version = "37.0.0"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -5084,7 +5084,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-threads"
-version = "36.0.0"
+version = "37.0.0"
 dependencies = [
  "anyhow",
  "log",
@@ -5096,7 +5096,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-tls"
-version = "36.0.0"
+version = "37.0.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -5112,7 +5112,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-tls-nativetls"
-version = "36.0.0"
+version = "37.0.0"
 dependencies = [
  "anyhow",
  "futures",
@@ -5127,7 +5127,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wast"
-version = "36.0.0"
+version = "37.0.0"
 dependencies = [
  "anyhow",
  "json-from-wast",
@@ -5205,7 +5205,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "36.0.0"
+version = "37.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5222,7 +5222,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "36.0.0"
+version = "37.0.0"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -5234,7 +5234,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "36.0.0"
+version = "37.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5289,7 +5289,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "36.0.0"
+version = "37.0.0"
 dependencies = [
  "anyhow",
  "cranelift-assembler-x64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -174,7 +174,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "36.0.0"
+version = "37.0.0"
 authors = ["The Wasmtime Project Developers"]
 edition = "2024"
 # Wasmtime's current policy is that this number can be no larger than the
@@ -226,19 +226,19 @@ redundant_field_names = 'warn'
 # tooling but aren't intended to be widely depended on.
 #
 # All of these crates are supported though in the sense that
-wasmtime = { path = "crates/wasmtime", version = "36.0.0", default-features = false }
-wasmtime-cli-flags = { path = "crates/cli-flags", version = "=36.0.0" }
-wasmtime-environ = { path = "crates/environ", version = "=36.0.0" }
-wasmtime-wasi = { path = "crates/wasi", version = "36.0.0", default-features = false }
-wasmtime-wasi-io = { path = "crates/wasi-io", version = "36.0.0", default-features = false }
-wasmtime-wasi-http = { path = "crates/wasi-http", version = "36.0.0", default-features = false }
-wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "36.0.0" }
-wasmtime-wasi-config = { path = "crates/wasi-config", version = "36.0.0" }
-wasmtime-wasi-keyvalue = { path = "crates/wasi-keyvalue", version = "36.0.0" }
-wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "36.0.0" }
-wasmtime-wasi-tls = { path = "crates/wasi-tls", version = "36.0.0" }
-wasmtime-wasi-tls-nativetls = { path = "crates/wasi-tls-nativetls", version = "36.0.0" }
-wasmtime-wast = { path = "crates/wast", version = "=36.0.0" }
+wasmtime = { path = "crates/wasmtime", version = "37.0.0", default-features = false }
+wasmtime-cli-flags = { path = "crates/cli-flags", version = "=37.0.0" }
+wasmtime-environ = { path = "crates/environ", version = "=37.0.0" }
+wasmtime-wasi = { path = "crates/wasi", version = "37.0.0", default-features = false }
+wasmtime-wasi-io = { path = "crates/wasi-io", version = "37.0.0", default-features = false }
+wasmtime-wasi-http = { path = "crates/wasi-http", version = "37.0.0", default-features = false }
+wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "37.0.0" }
+wasmtime-wasi-config = { path = "crates/wasi-config", version = "37.0.0" }
+wasmtime-wasi-keyvalue = { path = "crates/wasi-keyvalue", version = "37.0.0" }
+wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "37.0.0" }
+wasmtime-wasi-tls = { path = "crates/wasi-tls", version = "37.0.0" }
+wasmtime-wasi-tls-nativetls = { path = "crates/wasi-tls-nativetls", version = "37.0.0" }
+wasmtime-wast = { path = "crates/wast", version = "=37.0.0" }
 
 # Internal Wasmtime-specific crates.
 #
@@ -247,54 +247,54 @@ wasmtime-wast = { path = "crates/wast", version = "=36.0.0" }
 # that these are internal unsupported crates for external use. These exist as
 # part of the project organization of other public crates in Wasmtime and are
 # otherwise not supported in terms of CVEs for example.
-wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=36.0.0", package = 'wasmtime-internal-wmemcheck' }
-wasmtime-c-api-macros = { path = "crates/c-api-macros", version = "=36.0.0", package = 'wasmtime-internal-c-api-macros' }
-wasmtime-cache = { path = "crates/cache", version = "=36.0.0", package = 'wasmtime-internal-cache' }
-wasmtime-cranelift = { path = "crates/cranelift", version = "=36.0.0", package = 'wasmtime-internal-cranelift' }
-wasmtime-winch = { path = "crates/winch", version = "=36.0.0", package = 'wasmtime-internal-winch'  }
-wasmtime-explorer = { path = "crates/explorer", version = "=36.0.0", package = 'wasmtime-internal-explorer'  }
-wasmtime-fiber = { path = "crates/fiber", version = "=36.0.0", package = 'wasmtime-internal-fiber' }
-wasmtime-jit-debug = { path = "crates/jit-debug", version = "=36.0.0", package = 'wasmtime-internal-jit-debug' }
-wasmtime-component-util = { path = "crates/component-util", version = "=36.0.0", package = 'wasmtime-internal-component-util' }
-wasmtime-component-macro = { path = "crates/component-macro", version = "=36.0.0", package = 'wasmtime-internal-component-macro' }
-wasmtime-asm-macros = { path = "crates/asm-macros", version = "=36.0.0", package = 'wasmtime-internal-asm-macros' }
-wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=36.0.0", package = 'wasmtime-internal-versioned-export-macros' }
-wasmtime-slab = { path = "crates/slab", version = "=36.0.0", package = 'wasmtime-internal-slab' }
-wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=36.0.0", package = 'wasmtime-internal-jit-icache-coherence' }
-wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=36.0.0", package = 'wasmtime-internal-wit-bindgen' }
-wasmtime-math = { path = "crates/math", version = "=36.0.0", package = 'wasmtime-internal-math'  }
-wasmtime-unwinder = { path = "crates/unwinder", version = "=36.0.0", package = 'wasmtime-internal-unwinder' }
+wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=37.0.0", package = 'wasmtime-internal-wmemcheck' }
+wasmtime-c-api-macros = { path = "crates/c-api-macros", version = "=37.0.0", package = 'wasmtime-internal-c-api-macros' }
+wasmtime-cache = { path = "crates/cache", version = "=37.0.0", package = 'wasmtime-internal-cache' }
+wasmtime-cranelift = { path = "crates/cranelift", version = "=37.0.0", package = 'wasmtime-internal-cranelift' }
+wasmtime-winch = { path = "crates/winch", version = "=37.0.0", package = 'wasmtime-internal-winch'  }
+wasmtime-explorer = { path = "crates/explorer", version = "=37.0.0", package = 'wasmtime-internal-explorer'  }
+wasmtime-fiber = { path = "crates/fiber", version = "=37.0.0", package = 'wasmtime-internal-fiber' }
+wasmtime-jit-debug = { path = "crates/jit-debug", version = "=37.0.0", package = 'wasmtime-internal-jit-debug' }
+wasmtime-component-util = { path = "crates/component-util", version = "=37.0.0", package = 'wasmtime-internal-component-util' }
+wasmtime-component-macro = { path = "crates/component-macro", version = "=37.0.0", package = 'wasmtime-internal-component-macro' }
+wasmtime-asm-macros = { path = "crates/asm-macros", version = "=37.0.0", package = 'wasmtime-internal-asm-macros' }
+wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=37.0.0", package = 'wasmtime-internal-versioned-export-macros' }
+wasmtime-slab = { path = "crates/slab", version = "=37.0.0", package = 'wasmtime-internal-slab' }
+wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=37.0.0", package = 'wasmtime-internal-jit-icache-coherence' }
+wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=37.0.0", package = 'wasmtime-internal-wit-bindgen' }
+wasmtime-math = { path = "crates/math", version = "=37.0.0", package = 'wasmtime-internal-math'  }
+wasmtime-unwinder = { path = "crates/unwinder", version = "=37.0.0", package = 'wasmtime-internal-unwinder' }
 
 # Miscellaneous crates without a `wasmtime-*` prefix in their name but still
 # used in the `wasmtime-*` family of crates depending on various features/etc.
-wiggle = { path = "crates/wiggle", version = "=36.0.0", default-features = false }
-wiggle-macro = { path = "crates/wiggle/macro", version = "=36.0.0" }
-wiggle-generate = { path = "crates/wiggle/generate", version = "=36.0.0" }
-wasi-common = { path = "crates/wasi-common", version = "=36.0.0", default-features = false }
-pulley-interpreter = { path = 'pulley', version = "=36.0.0" }
-pulley-macros = { path = 'pulley/macros', version = "=36.0.0" }
+wiggle = { path = "crates/wiggle", version = "=37.0.0", default-features = false }
+wiggle-macro = { path = "crates/wiggle/macro", version = "=37.0.0" }
+wiggle-generate = { path = "crates/wiggle/generate", version = "=37.0.0" }
+wasi-common = { path = "crates/wasi-common", version = "=37.0.0", default-features = false }
+pulley-interpreter = { path = 'pulley', version = "=37.0.0" }
+pulley-macros = { path = 'pulley/macros', version = "=37.0.0" }
 
 # Cranelift crates in this workspace
-cranelift-assembler-x64 = { path = "cranelift/assembler-x64", version = "0.123.0" }
-cranelift-codegen = { path = "cranelift/codegen", version = "0.123.0", default-features = false, features = ["std", "unwind"] }
-cranelift-frontend = { path = "cranelift/frontend", version = "0.123.0" }
-cranelift-entity = { path = "cranelift/entity", version = "0.123.0" }
-cranelift-native = { path = "cranelift/native", version = "0.123.0" }
-cranelift-module = { path = "cranelift/module", version = "0.123.0" }
-cranelift-interpreter = { path = "cranelift/interpreter", version = "0.123.0" }
-cranelift-reader = { path = "cranelift/reader", version = "0.123.0" }
+cranelift-assembler-x64 = { path = "cranelift/assembler-x64", version = "0.124.0" }
+cranelift-codegen = { path = "cranelift/codegen", version = "0.124.0", default-features = false, features = ["std", "unwind"] }
+cranelift-frontend = { path = "cranelift/frontend", version = "0.124.0" }
+cranelift-entity = { path = "cranelift/entity", version = "0.124.0" }
+cranelift-native = { path = "cranelift/native", version = "0.124.0" }
+cranelift-module = { path = "cranelift/module", version = "0.124.0" }
+cranelift-interpreter = { path = "cranelift/interpreter", version = "0.124.0" }
+cranelift-reader = { path = "cranelift/reader", version = "0.124.0" }
 cranelift-filetests = { path = "cranelift/filetests" }
-cranelift-object = { path = "cranelift/object", version = "0.123.0" }
-cranelift-jit = { path = "cranelift/jit", version = "0.123.0" }
+cranelift-object = { path = "cranelift/object", version = "0.124.0" }
+cranelift-jit = { path = "cranelift/jit", version = "0.124.0" }
 cranelift-fuzzgen = { path = "cranelift/fuzzgen" }
-cranelift-bforest = { path = "cranelift/bforest", version = "0.123.0" }
-cranelift-bitset = { path = "cranelift/bitset", version = "0.123.0" }
-cranelift-control = { path = "cranelift/control", version = "0.123.0" }
-cranelift-srcgen = { path = "cranelift/srcgen", version = "0.123.0" }
-cranelift = { path = "cranelift/umbrella", version = "0.123.0" }
+cranelift-bforest = { path = "cranelift/bforest", version = "0.124.0" }
+cranelift-bitset = { path = "cranelift/bitset", version = "0.124.0" }
+cranelift-control = { path = "cranelift/control", version = "0.124.0" }
+cranelift-srcgen = { path = "cranelift/srcgen", version = "0.124.0" }
+cranelift = { path = "cranelift/umbrella", version = "0.124.0" }
 
 # Winch crates in this workspace.
-winch-codegen = { path = "winch/codegen", version = "=36.0.0" }
+winch-codegen = { path = "winch/codegen", version = "=37.0.0" }
 
 # Internal crates not published to crates.io used in testing, builds, etc
 wasi-preview1-component-adapter = { path = "crates/wasi-preview1-component-adapter" }

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,4 +1,4 @@
-## 36.0.0
+## 37.0.0
 
 Unreleased.
 
@@ -6,22 +6,13 @@ Unreleased.
 
 ### Changed
 
-Users who implemented `WasiHttpView::is_forbidden_header` from `wasmtime-wasi-http` now need to include `DEFAULT_FORBIDDEN_HEADERS`, e.g. `DEFAULT_FORBIDDEN_HEADERS.contains(name) || name.as_str() == "custom-forbidden-header"` #11292
-
-### Fixed
-
-* Fix a panic in the host caused by preview1 guests using `fd_renumber`.
-  [CVE-2025-53901](https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-fm79-3f68-h2fc).
-
-* Fix a panic in the preview1 adapter caused by guests using `fd_renumber`.
-  [#11277](https://github.com/bytecodealliance/wasmtime/pull/11277)
-
 --------------------------------------------------------------------------------
 
 Release notes for previous releases of Wasmtime can be found on the respective
 release branches of the Wasmtime repository.
 
 <!-- ARCHIVE_START -->
+* [36.0.x](https://github.com/bytecodealliance/wasmtime/blob/release-36.0.0/RELEASES.md)
 * [35.0.x](https://github.com/bytecodealliance/wasmtime/blob/release-35.0.0/RELEASES.md)
 * [34.0.x](https://github.com/bytecodealliance/wasmtime/blob/release-34.0.0/RELEASES.md)
 * [33.0.x](https://github.com/bytecodealliance/wasmtime/blob/release-33.0.0/RELEASES.md)

--- a/cranelift/assembler-x64/Cargo.toml
+++ b/cranelift/assembler-x64/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-assembler-x64"
 description = "A Cranelift-specific x64 assembler"
-version = "0.123.0"
+version = "0.124.0"
 license = "Apache-2.0 WITH LLVM-exception"
 edition.workspace = true
 rust-version.workspace = true
@@ -16,7 +16,7 @@ arbtest = "0.3.1"
 capstone = { workspace = true }
 
 [build-dependencies]
-cranelift-assembler-x64-meta = { path = "meta", version = "0.123.0" }
+cranelift-assembler-x64-meta = { path = "meta", version = "0.124.0" }
 
 [lints]
 workspace = true

--- a/cranelift/assembler-x64/meta/Cargo.toml
+++ b/cranelift/assembler-x64/meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-assembler-x64-meta"
 description = "Generate a Cranelift-specific assembler for x64 instructions"
-version = "0.123.0"
+version = "0.124.0"
 license = "Apache-2.0 WITH LLVM-exception"
 edition.workspace = true
 rust-version.workspace = true

--- a/cranelift/bforest/Cargo.toml
+++ b/cranelift/bforest/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bforest"
-version = "0.123.0"
+version = "0.124.0"
 description = "A forest of B+-trees"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-bforest"

--- a/cranelift/bitset/Cargo.toml
+++ b/cranelift/bitset/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bitset"
-version = "0.123.0"
+version = "0.124.0"
 description = "Various bitset stuff for use inside Cranelift"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-bitset"

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen"
-version = "0.123.0"
+version = "0.124.0"
 description = "Low-level code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-codegen"
@@ -25,7 +25,7 @@ anyhow = { workspace = true, optional = true, features = ['std'] }
 bumpalo = "3"
 capstone = { workspace = true, optional = true }
 cranelift-assembler-x64 = { workspace = true }
-cranelift-codegen-shared = { path = "./shared", version = "0.123.0" }
+cranelift-codegen-shared = { path = "./shared", version = "0.124.0" }
 cranelift-entity = { workspace = true }
 cranelift-bforest = { workspace = true }
 cranelift-bitset = { workspace = true }
@@ -56,8 +56,8 @@ env_logger = { workspace = true }
 proptest = { workspace = true }
 
 [build-dependencies]
-cranelift-codegen-meta = { path = "meta", version = "0.123.0" }
-cranelift-isle = { path = "../isle/isle", version = "=0.123.0" }
+cranelift-codegen-meta = { path = "meta", version = "0.124.0" }
+cranelift-isle = { path = "../isle/isle", version = "=0.124.0" }
 
 [features]
 default = ["std", "unwind", "host-arch", "timing"]

--- a/cranelift/codegen/meta/Cargo.toml
+++ b/cranelift/codegen/meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-codegen-meta"
 authors = ["The Cranelift Project Developers"]
-version = "0.123.0"
+version = "0.124.0"
 description = "Metaprogram for cranelift-codegen code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
@@ -17,8 +17,8 @@ rustdoc-args = ["--document-private-items"]
 
 [dependencies]
 cranelift-srcgen = { workspace = true }
-cranelift-assembler-x64-meta = { path = "../../assembler-x64/meta", version = "0.123.0" }
-cranelift-codegen-shared = { path = "../shared", version = "0.123.0" }
+cranelift-assembler-x64-meta = { path = "../../assembler-x64/meta", version = "0.124.0" }
+cranelift-codegen-shared = { path = "../shared", version = "0.124.0" }
 pulley-interpreter = { workspace = true, optional = true }
 heck = "0.5.0"
 

--- a/cranelift/codegen/shared/Cargo.toml
+++ b/cranelift/codegen/shared/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen-shared"
-version = "0.123.0"
+version = "0.124.0"
 description = "For code shared between cranelift-codegen-meta and cranelift-codegen"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/control/Cargo.toml
+++ b/cranelift/control/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-control"
-version = "0.123.0"
+version = "0.124.0"
 description = "White-box fuzz testing framework"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/entity/Cargo.toml
+++ b/cranelift/entity/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-entity"
-version = "0.123.0"
+version = "0.124.0"
 description = "Data structures using entity references as mapping keys"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-entity"

--- a/cranelift/frontend/Cargo.toml
+++ b/cranelift/frontend/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-frontend"
-version = "0.123.0"
+version = "0.124.0"
 description = "Cranelift IR builder helper"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-frontend"

--- a/cranelift/interpreter/Cargo.toml
+++ b/cranelift/interpreter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-interpreter"
-version = "0.123.0"
+version = "0.124.0"
 authors = ["The Cranelift Project Developers"]
 description = "Interpret Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/isle/isle/Cargo.toml
+++ b/cranelift/isle/isle/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 name = "cranelift-isle"
 readme = "../README.md"
 repository = "https://github.com/bytecodealliance/wasmtime/tree/main/cranelift/isle"
-version = "0.123.0"
+version = "0.124.0"
 
 [lints]
 workspace = true

--- a/cranelift/jit/Cargo.toml
+++ b/cranelift/jit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-jit"
-version = "0.123.0"
+version = "0.124.0"
 authors = ["The Cranelift Project Developers"]
 description = "A JIT library backed by Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/module/Cargo.toml
+++ b/cranelift/module/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-module"
-version = "0.123.0"
+version = "0.124.0"
 authors = ["The Cranelift Project Developers"]
 description = "Support for linking functions and data with Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/native/Cargo.toml
+++ b/cranelift/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-native"
-version = "0.123.0"
+version = "0.124.0"
 authors = ["The Cranelift Project Developers"]
 description = "Support for targeting the host with Cranelift"
 documentation = "https://docs.rs/cranelift-native"

--- a/cranelift/object/Cargo.toml
+++ b/cranelift/object/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-object"
-version = "0.123.0"
+version = "0.124.0"
 authors = ["The Cranelift Project Developers"]
 description = "Emit Cranelift output to native object files with `object`"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/reader/Cargo.toml
+++ b/cranelift/reader/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-reader"
-version = "0.123.0"
+version = "0.124.0"
 description = "Cranelift textual IR reader"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-reader"

--- a/cranelift/serde/Cargo.toml
+++ b/cranelift/serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-serde"
-version = "0.123.0"
+version = "0.124.0"
 authors = ["The Cranelift Project Developers"]
 description = "Serializer/Deserializer for Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/srcgen/Cargo.toml
+++ b/cranelift/srcgen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-srcgen"
-version = "0.123.0"
+version = "0.124.0"
 authors = ["The Wasmtime Project Developers"]
 description = "Helper functions for generating Rust and ISLE files"
 license = "Apache-2.0 WITH LLVM-exception"

--- a/cranelift/umbrella/Cargo.toml
+++ b/cranelift/umbrella/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift"
-version = "0.123.0"
+version = "0.124.0"
 description = "Umbrella for commonly-used cranelift crates"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift"

--- a/crates/c-api/include/wasmtime.h
+++ b/crates/c-api/include/wasmtime.h
@@ -213,11 +213,11 @@
 /**
  * \brief Wasmtime version string.
  */
-#define WASMTIME_VERSION "36.0.0"
+#define WASMTIME_VERSION "37.0.0"
 /**
  * \brief Wasmtime major version number.
  */
-#define WASMTIME_VERSION_MAJOR 36
+#define WASMTIME_VERSION_MAJOR 37
 /**
  * \brief Wasmtime minor version number.
  */

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -13,6 +13,10 @@ audited_as = "0.120.0"
 version = "0.123.0"
 audited_as = "0.121.1"
 
+[[unpublished.cranelift]]
+version = "0.124.0"
+audited_as = "0.122.0"
+
 [[unpublished.cranelift-assembler-x64]]
 version = "0.121.0"
 audited_as = "0.120.0"
@@ -24,6 +28,10 @@ audited_as = "0.120.0"
 [[unpublished.cranelift-assembler-x64]]
 version = "0.123.0"
 audited_as = "0.121.1"
+
+[[unpublished.cranelift-assembler-x64]]
+version = "0.124.0"
+audited_as = "0.122.0"
 
 [[unpublished.cranelift-assembler-x64-meta]]
 version = "0.121.0"
@@ -37,6 +45,10 @@ audited_as = "0.120.0"
 version = "0.123.0"
 audited_as = "0.121.1"
 
+[[unpublished.cranelift-assembler-x64-meta]]
+version = "0.124.0"
+audited_as = "0.122.0"
+
 [[unpublished.cranelift-bforest]]
 version = "0.121.0"
 audited_as = "0.120.0"
@@ -48,6 +60,10 @@ audited_as = "0.120.0"
 [[unpublished.cranelift-bforest]]
 version = "0.123.0"
 audited_as = "0.121.1"
+
+[[unpublished.cranelift-bforest]]
+version = "0.124.0"
+audited_as = "0.122.0"
 
 [[unpublished.cranelift-bitset]]
 version = "0.121.0"
@@ -61,6 +77,10 @@ audited_as = "0.120.0"
 version = "0.123.0"
 audited_as = "0.121.1"
 
+[[unpublished.cranelift-bitset]]
+version = "0.124.0"
+audited_as = "0.122.0"
+
 [[unpublished.cranelift-codegen]]
 version = "0.121.0"
 audited_as = "0.120.0"
@@ -72,6 +92,10 @@ audited_as = "0.120.0"
 [[unpublished.cranelift-codegen]]
 version = "0.123.0"
 audited_as = "0.121.1"
+
+[[unpublished.cranelift-codegen]]
+version = "0.124.0"
+audited_as = "0.122.0"
 
 [[unpublished.cranelift-codegen-meta]]
 version = "0.121.0"
@@ -85,6 +109,10 @@ audited_as = "0.120.0"
 version = "0.123.0"
 audited_as = "0.121.1"
 
+[[unpublished.cranelift-codegen-meta]]
+version = "0.124.0"
+audited_as = "0.122.0"
+
 [[unpublished.cranelift-codegen-shared]]
 version = "0.121.0"
 audited_as = "0.120.0"
@@ -96,6 +124,10 @@ audited_as = "0.120.0"
 [[unpublished.cranelift-codegen-shared]]
 version = "0.123.0"
 audited_as = "0.121.1"
+
+[[unpublished.cranelift-codegen-shared]]
+version = "0.124.0"
+audited_as = "0.122.0"
 
 [[unpublished.cranelift-control]]
 version = "0.121.0"
@@ -109,6 +141,10 @@ audited_as = "0.120.0"
 version = "0.123.0"
 audited_as = "0.121.1"
 
+[[unpublished.cranelift-control]]
+version = "0.124.0"
+audited_as = "0.122.0"
+
 [[unpublished.cranelift-entity]]
 version = "0.121.0"
 audited_as = "0.120.0"
@@ -120,6 +156,10 @@ audited_as = "0.120.0"
 [[unpublished.cranelift-entity]]
 version = "0.123.0"
 audited_as = "0.121.1"
+
+[[unpublished.cranelift-entity]]
+version = "0.124.0"
+audited_as = "0.122.0"
 
 [[unpublished.cranelift-frontend]]
 version = "0.121.0"
@@ -133,6 +173,10 @@ audited_as = "0.120.0"
 version = "0.123.0"
 audited_as = "0.121.1"
 
+[[unpublished.cranelift-frontend]]
+version = "0.124.0"
+audited_as = "0.122.0"
+
 [[unpublished.cranelift-interpreter]]
 version = "0.121.0"
 audited_as = "0.120.0"
@@ -144,6 +188,10 @@ audited_as = "0.120.0"
 [[unpublished.cranelift-interpreter]]
 version = "0.123.0"
 audited_as = "0.121.1"
+
+[[unpublished.cranelift-interpreter]]
+version = "0.124.0"
+audited_as = "0.122.0"
 
 [[unpublished.cranelift-isle]]
 version = "0.121.0"
@@ -157,6 +205,10 @@ audited_as = "0.120.0"
 version = "0.123.0"
 audited_as = "0.121.1"
 
+[[unpublished.cranelift-isle]]
+version = "0.124.0"
+audited_as = "0.122.0"
+
 [[unpublished.cranelift-jit]]
 version = "0.121.0"
 audited_as = "0.120.0"
@@ -168,6 +220,10 @@ audited_as = "0.120.0"
 [[unpublished.cranelift-jit]]
 version = "0.123.0"
 audited_as = "0.121.1"
+
+[[unpublished.cranelift-jit]]
+version = "0.124.0"
+audited_as = "0.122.0"
 
 [[unpublished.cranelift-module]]
 version = "0.121.0"
@@ -181,6 +237,10 @@ audited_as = "0.120.0"
 version = "0.123.0"
 audited_as = "0.121.1"
 
+[[unpublished.cranelift-module]]
+version = "0.124.0"
+audited_as = "0.122.0"
+
 [[unpublished.cranelift-native]]
 version = "0.121.0"
 audited_as = "0.120.0"
@@ -192,6 +252,10 @@ audited_as = "0.120.0"
 [[unpublished.cranelift-native]]
 version = "0.123.0"
 audited_as = "0.121.1"
+
+[[unpublished.cranelift-native]]
+version = "0.124.0"
+audited_as = "0.122.0"
 
 [[unpublished.cranelift-object]]
 version = "0.121.0"
@@ -205,6 +269,10 @@ audited_as = "0.120.0"
 version = "0.123.0"
 audited_as = "0.121.1"
 
+[[unpublished.cranelift-object]]
+version = "0.124.0"
+audited_as = "0.122.0"
+
 [[unpublished.cranelift-reader]]
 version = "0.121.0"
 audited_as = "0.120.0"
@@ -216,6 +284,10 @@ audited_as = "0.120.0"
 [[unpublished.cranelift-reader]]
 version = "0.123.0"
 audited_as = "0.121.1"
+
+[[unpublished.cranelift-reader]]
+version = "0.124.0"
+audited_as = "0.122.0"
 
 [[unpublished.cranelift-serde]]
 version = "0.121.0"
@@ -229,6 +301,10 @@ audited_as = "0.120.0"
 version = "0.123.0"
 audited_as = "0.121.1"
 
+[[unpublished.cranelift-serde]]
+version = "0.124.0"
+audited_as = "0.122.0"
+
 [[unpublished.cranelift-srcgen]]
 version = "0.121.0"
 audited_as = "0.120.0"
@@ -240,6 +316,10 @@ audited_as = "0.120.0"
 [[unpublished.cranelift-srcgen]]
 version = "0.123.0"
 audited_as = "0.121.1"
+
+[[unpublished.cranelift-srcgen]]
+version = "0.124.0"
+audited_as = "0.122.0"
 
 [[unpublished.pulley-interpreter]]
 version = "34.0.0"
@@ -252,6 +332,10 @@ audited_as = "33.0.0"
 [[unpublished.pulley-interpreter]]
 version = "36.0.0"
 audited_as = "34.0.1"
+
+[[unpublished.pulley-interpreter]]
+version = "37.0.0"
+audited_as = "35.0.0"
 
 [[unpublished.pulley-macros]]
 version = "35.0.0"
@@ -261,6 +345,10 @@ audited_as = "34.0.0"
 version = "36.0.0"
 audited_as = "34.0.1"
 
+[[unpublished.pulley-macros]]
+version = "37.0.0"
+audited_as = "35.0.0"
+
 [[unpublished.wasi-common]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -273,6 +361,10 @@ audited_as = "33.0.0"
 version = "36.0.0"
 audited_as = "34.0.1"
 
+[[unpublished.wasi-common]]
+version = "37.0.0"
+audited_as = "35.0.0"
+
 [[unpublished.wasmtime]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -284,6 +376,10 @@ audited_as = "33.0.0"
 [[unpublished.wasmtime]]
 version = "36.0.0"
 audited_as = "34.0.1"
+
+[[unpublished.wasmtime]]
+version = "37.0.0"
+audited_as = "35.0.0"
 
 [[unpublished.wasmtime-asm-macros]]
 version = "34.0.0"
@@ -313,6 +409,10 @@ audited_as = "33.0.0"
 version = "36.0.0"
 audited_as = "34.0.1"
 
+[[unpublished.wasmtime-cli]]
+version = "37.0.0"
+audited_as = "35.0.0"
+
 [[unpublished.wasmtime-cli-flags]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -324,6 +424,10 @@ audited_as = "33.0.0"
 [[unpublished.wasmtime-cli-flags]]
 version = "36.0.0"
 audited_as = "34.0.1"
+
+[[unpublished.wasmtime-cli-flags]]
+version = "37.0.0"
+audited_as = "35.0.0"
 
 [[unpublished.wasmtime-component-macro]]
 version = "34.0.0"
@@ -360,6 +464,10 @@ audited_as = "33.0.0"
 [[unpublished.wasmtime-environ]]
 version = "36.0.0"
 audited_as = "34.0.1"
+
+[[unpublished.wasmtime-environ]]
+version = "37.0.0"
+audited_as = "35.0.0"
 
 [[unpublished.wasmtime-explorer]]
 version = "34.0.0"
@@ -381,70 +489,138 @@ audited_as = "33.0.0"
 version = "36.0.0"
 audited_as = "35.0.0"
 
+[[unpublished.wasmtime-internal-asm-macros]]
+version = "37.0.0"
+audited_as = "35.0.0"
+
 [[unpublished.wasmtime-internal-c-api-macros]]
 version = "36.0.0"
+audited_as = "35.0.0"
+
+[[unpublished.wasmtime-internal-c-api-macros]]
+version = "37.0.0"
 audited_as = "35.0.0"
 
 [[unpublished.wasmtime-internal-cache]]
 version = "36.0.0"
 audited_as = "35.0.0"
 
+[[unpublished.wasmtime-internal-cache]]
+version = "37.0.0"
+audited_as = "35.0.0"
+
 [[unpublished.wasmtime-internal-component-macro]]
 version = "36.0.0"
+audited_as = "35.0.0"
+
+[[unpublished.wasmtime-internal-component-macro]]
+version = "37.0.0"
 audited_as = "35.0.0"
 
 [[unpublished.wasmtime-internal-component-util]]
 version = "36.0.0"
 audited_as = "35.0.0"
 
+[[unpublished.wasmtime-internal-component-util]]
+version = "37.0.0"
+audited_as = "35.0.0"
+
 [[unpublished.wasmtime-internal-cranelift]]
 version = "36.0.0"
+audited_as = "35.0.0"
+
+[[unpublished.wasmtime-internal-cranelift]]
+version = "37.0.0"
 audited_as = "35.0.0"
 
 [[unpublished.wasmtime-internal-explorer]]
 version = "36.0.0"
 audited_as = "35.0.0"
 
+[[unpublished.wasmtime-internal-explorer]]
+version = "37.0.0"
+audited_as = "35.0.0"
+
 [[unpublished.wasmtime-internal-fiber]]
 version = "36.0.0"
+audited_as = "35.0.0"
+
+[[unpublished.wasmtime-internal-fiber]]
+version = "37.0.0"
 audited_as = "35.0.0"
 
 [[unpublished.wasmtime-internal-jit-debug]]
 version = "36.0.0"
 audited_as = "35.0.0"
 
+[[unpublished.wasmtime-internal-jit-debug]]
+version = "37.0.0"
+audited_as = "35.0.0"
+
 [[unpublished.wasmtime-internal-jit-icache-coherence]]
 version = "36.0.0"
+audited_as = "35.0.0"
+
+[[unpublished.wasmtime-internal-jit-icache-coherence]]
+version = "37.0.0"
 audited_as = "35.0.0"
 
 [[unpublished.wasmtime-internal-math]]
 version = "36.0.0"
 audited_as = "35.0.0"
 
+[[unpublished.wasmtime-internal-math]]
+version = "37.0.0"
+audited_as = "35.0.0"
+
 [[unpublished.wasmtime-internal-slab]]
 version = "36.0.0"
+audited_as = "35.0.0"
+
+[[unpublished.wasmtime-internal-slab]]
+version = "37.0.0"
 audited_as = "35.0.0"
 
 [[unpublished.wasmtime-internal-unwinder]]
 version = "36.0.0"
 audited_as = "35.0.0"
 
+[[unpublished.wasmtime-internal-unwinder]]
+version = "37.0.0"
+audited_as = "35.0.0"
+
 [[unpublished.wasmtime-internal-versioned-export-macros]]
 version = "36.0.0"
+audited_as = "35.0.0"
+
+[[unpublished.wasmtime-internal-versioned-export-macros]]
+version = "37.0.0"
 audited_as = "35.0.0"
 
 [[unpublished.wasmtime-internal-winch]]
 version = "36.0.0"
 audited_as = "35.0.0"
 
+[[unpublished.wasmtime-internal-winch]]
+version = "37.0.0"
+audited_as = "35.0.0"
+
 [[unpublished.wasmtime-internal-wit-bindgen]]
 version = "36.0.0"
+audited_as = "35.0.0"
+
+[[unpublished.wasmtime-internal-wit-bindgen]]
+version = "37.0.0"
 audited_as = "35.0.0"
 
 [[unpublished.wasmtime-internal-wmemcheck]]
 version = "36.0.0"
 audited_as = "35.0.0"
 
+[[unpublished.wasmtime-internal-wmemcheck]]
+version = "37.0.0"
+audited_as = "35.0.0"
+
 [[unpublished.wasmtime-jit-debug]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -489,6 +665,10 @@ audited_as = "33.0.0"
 version = "36.0.0"
 audited_as = "34.0.1"
 
+[[unpublished.wasmtime-wasi]]
+version = "37.0.0"
+audited_as = "35.0.0"
+
 [[unpublished.wasmtime-wasi-config]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -500,6 +680,10 @@ audited_as = "33.0.0"
 [[unpublished.wasmtime-wasi-config]]
 version = "36.0.0"
 audited_as = "34.0.1"
+
+[[unpublished.wasmtime-wasi-config]]
+version = "37.0.0"
+audited_as = "35.0.0"
 
 [[unpublished.wasmtime-wasi-http]]
 version = "34.0.0"
@@ -513,6 +697,10 @@ audited_as = "33.0.0"
 version = "36.0.0"
 audited_as = "34.0.1"
 
+[[unpublished.wasmtime-wasi-http]]
+version = "37.0.0"
+audited_as = "35.0.0"
+
 [[unpublished.wasmtime-wasi-io]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -524,6 +712,10 @@ audited_as = "33.0.0"
 [[unpublished.wasmtime-wasi-io]]
 version = "36.0.0"
 audited_as = "34.0.1"
+
+[[unpublished.wasmtime-wasi-io]]
+version = "37.0.0"
+audited_as = "35.0.0"
 
 [[unpublished.wasmtime-wasi-keyvalue]]
 version = "34.0.0"
@@ -537,6 +729,10 @@ audited_as = "33.0.0"
 version = "36.0.0"
 audited_as = "34.0.1"
 
+[[unpublished.wasmtime-wasi-keyvalue]]
+version = "37.0.0"
+audited_as = "35.0.0"
+
 [[unpublished.wasmtime-wasi-nn]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -548,6 +744,10 @@ audited_as = "33.0.0"
 [[unpublished.wasmtime-wasi-nn]]
 version = "36.0.0"
 audited_as = "34.0.1"
+
+[[unpublished.wasmtime-wasi-nn]]
+version = "37.0.0"
+audited_as = "35.0.0"
 
 [[unpublished.wasmtime-wasi-threads]]
 version = "34.0.0"
@@ -561,6 +761,10 @@ audited_as = "33.0.0"
 version = "36.0.0"
 audited_as = "34.0.1"
 
+[[unpublished.wasmtime-wasi-threads]]
+version = "37.0.0"
+audited_as = "35.0.0"
+
 [[unpublished.wasmtime-wasi-tls]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -572,9 +776,17 @@ audited_as = "33.0.0"
 [[unpublished.wasmtime-wasi-tls]]
 version = "36.0.0"
 audited_as = "34.0.1"
+
+[[unpublished.wasmtime-wasi-tls]]
+version = "37.0.0"
+audited_as = "35.0.0"
 
 [[unpublished.wasmtime-wasi-tls-nativetls]]
 version = "36.0.0"
+audited_as = "35.0.0"
+
+[[unpublished.wasmtime-wasi-tls-nativetls]]
+version = "37.0.0"
 audited_as = "35.0.0"
 
 [[unpublished.wasmtime-wast]]
@@ -589,6 +801,10 @@ audited_as = "33.0.0"
 version = "36.0.0"
 audited_as = "34.0.1"
 
+[[unpublished.wasmtime-wast]]
+version = "37.0.0"
+audited_as = "35.0.0"
+
 [[unpublished.wasmtime-winch]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -625,6 +841,10 @@ audited_as = "33.0.0"
 version = "36.0.0"
 audited_as = "34.0.1"
 
+[[unpublished.wiggle]]
+version = "37.0.0"
+audited_as = "35.0.0"
+
 [[unpublished.wiggle-generate]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -637,6 +857,10 @@ audited_as = "33.0.0"
 version = "36.0.0"
 audited_as = "34.0.1"
 
+[[unpublished.wiggle-generate]]
+version = "37.0.0"
+audited_as = "35.0.0"
+
 [[unpublished.wiggle-macro]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -648,6 +872,10 @@ audited_as = "33.0.0"
 [[unpublished.wiggle-macro]]
 version = "36.0.0"
 audited_as = "34.0.1"
+
+[[unpublished.wiggle-macro]]
+version = "37.0.0"
+audited_as = "35.0.0"
 
 [[unpublished.wiggle-test]]
 version = "0.0.0"
@@ -664,6 +892,10 @@ audited_as = "33.0.0"
 [[unpublished.winch-codegen]]
 version = "36.0.0"
 audited_as = "34.0.1"
+
+[[unpublished.winch-codegen]]
+version = "37.0.0"
+audited_as = "35.0.0"
 
 [[publisher.aho-corasick]]
 version = "1.0.2"
@@ -868,122 +1100,122 @@ user-login = "jrmuizel"
 user-name = "Jeff Muizelaar"
 
 [[publisher.cranelift]]
-version = "0.121.1"
-when = "2025-06-24"
+version = "0.122.0"
+when = "2025-07-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-assembler-x64]]
-version = "0.121.1"
-when = "2025-06-24"
+version = "0.122.0"
+when = "2025-07-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-assembler-x64-meta]]
-version = "0.121.1"
-when = "2025-06-24"
+version = "0.122.0"
+when = "2025-07-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-bforest]]
-version = "0.121.1"
-when = "2025-06-24"
+version = "0.122.0"
+when = "2025-07-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-bitset]]
-version = "0.121.1"
-when = "2025-06-24"
+version = "0.122.0"
+when = "2025-07-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-codegen]]
-version = "0.121.1"
-when = "2025-06-24"
+version = "0.122.0"
+when = "2025-07-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-codegen-meta]]
-version = "0.121.1"
-when = "2025-06-24"
+version = "0.122.0"
+when = "2025-07-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-codegen-shared]]
-version = "0.121.1"
-when = "2025-06-24"
+version = "0.122.0"
+when = "2025-07-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-control]]
-version = "0.121.1"
-when = "2025-06-24"
+version = "0.122.0"
+when = "2025-07-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-entity]]
-version = "0.121.1"
-when = "2025-06-24"
+version = "0.122.0"
+when = "2025-07-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-frontend]]
-version = "0.121.1"
-when = "2025-06-24"
+version = "0.122.0"
+when = "2025-07-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-interpreter]]
-version = "0.121.1"
-when = "2025-06-24"
+version = "0.122.0"
+when = "2025-07-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-isle]]
-version = "0.121.1"
-when = "2025-06-24"
+version = "0.122.0"
+when = "2025-07-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-jit]]
-version = "0.121.1"
-when = "2025-06-24"
+version = "0.122.0"
+when = "2025-07-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-module]]
-version = "0.121.1"
-when = "2025-06-24"
+version = "0.122.0"
+when = "2025-07-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-native]]
-version = "0.121.1"
-when = "2025-06-24"
+version = "0.122.0"
+when = "2025-07-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-object]]
-version = "0.121.1"
-when = "2025-06-24"
+version = "0.122.0"
+when = "2025-07-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-reader]]
-version = "0.121.1"
-when = "2025-06-24"
+version = "0.122.0"
+when = "2025-07-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-serde]]
-version = "0.121.1"
-when = "2025-06-24"
+version = "0.122.0"
+when = "2025-07-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-srcgen]]
-version = "0.121.1"
-when = "2025-06-24"
+version = "0.122.0"
+when = "2025-07-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1197,14 +1429,14 @@ user-login = "dtolnay"
 user-name = "David Tolnay"
 
 [[publisher.pulley-interpreter]]
-version = "34.0.1"
-when = "2025-06-24"
+version = "35.0.0"
+when = "2025-07-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.pulley-macros]]
-version = "34.0.1"
-when = "2025-06-24"
+version = "35.0.0"
+when = "2025-07-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1475,8 +1707,8 @@ user-login = "sunfishcode"
 user-name = "Dan Gohman"
 
 [[publisher.wasi-common]]
-version = "34.0.1"
-when = "2025-06-24"
+version = "33.0.0"
+when = "2025-05-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1570,26 +1802,26 @@ user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime]]
-version = "34.0.1"
-when = "2025-06-24"
+version = "33.0.0"
+when = "2025-05-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-cli]]
-version = "34.0.1"
-when = "2025-06-24"
+version = "33.0.0"
+when = "2025-05-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-cli-flags]]
-version = "34.0.1"
-when = "2025-06-24"
+version = "33.0.0"
+when = "2025-05-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-environ]]
-version = "34.0.1"
-when = "2025-06-24"
+version = "35.0.0"
+when = "2025-07-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1701,50 +1933,50 @@ user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi]]
-version = "34.0.1"
-when = "2025-06-24"
+version = "35.0.0"
+when = "2025-07-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-config]]
-version = "34.0.1"
-when = "2025-06-24"
+version = "35.0.0"
+when = "2025-07-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-http]]
-version = "34.0.1"
-when = "2025-06-24"
+version = "35.0.0"
+when = "2025-07-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-io]]
-version = "34.0.1"
-when = "2025-06-24"
+version = "35.0.0"
+when = "2025-07-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-keyvalue]]
-version = "34.0.1"
-when = "2025-06-24"
+version = "35.0.0"
+when = "2025-07-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-nn]]
-version = "34.0.1"
-when = "2025-06-24"
+version = "35.0.0"
+when = "2025-07-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-threads]]
-version = "34.0.1"
-when = "2025-06-24"
+version = "35.0.0"
+when = "2025-07-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-tls]]
-version = "34.0.1"
-when = "2025-06-24"
+version = "35.0.0"
+when = "2025-07-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1756,8 +1988,8 @@ user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
 [[publisher.wasmtime-wast]]
-version = "34.0.1"
-when = "2025-06-24"
+version = "33.0.0"
+when = "2025-05-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1781,20 +2013,20 @@ user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
 [[publisher.wiggle]]
-version = "34.0.1"
-when = "2025-06-24"
+version = "33.0.0"
+when = "2025-05-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wiggle-generate]]
-version = "34.0.1"
-when = "2025-06-24"
+version = "35.0.0"
+when = "2025-07-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wiggle-macro]]
-version = "34.0.1"
-when = "2025-06-24"
+version = "35.0.0"
+when = "2025-07-22"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1813,8 +2045,8 @@ user-login = "BurntSushi"
 user-name = "Andrew Gallant"
 
 [[publisher.winch-codegen]]
-version = "34.0.1"
-when = "2025-06-24"
+version = "33.0.0"
+when = "2025-05-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 


### PR DESCRIPTION
This is an [automated pull request][process] from CI which indicates that the next [`release-36.0.0` branch][branch] has been created and the `main` branch is getting its version number bumped from 36.0.0 to 37.0.0.

Maintainers should take a moment to review the [release notes][RELEASES.md] for 36.0.0 and any updates should be made directly to the [release branch][branch].

Another automated PR will be made in roughly 2 weeks time when for the actual release itself.

If any issues arise on the `main` branch before the release is made then the issue should first be fixed on `main` and then backport to the `release-36.0.0` branch.

[RELEASES.md]: https://github.com/bytecodealliance/wasmtime/blob/release-36.0.0/RELEASES.md
[branch]: https://github.com/bytecodealliance/wasmtime/tree/release-36.0.0
[process]: https://docs.wasmtime.dev/contributing-release-process.html
