### PR TITLE
Build C API release artifacts with unwind tables

### DIFF
--- a/ci/build-release-artifacts.sh
+++ b/ci/build-release-artifacts.sh
@@ -71,6 +71,12 @@ fi
 
 cargo build --release $flags --target $target -p wasmtime-cli $bin_flags --features run
 
+# For the C API force unwind tables to be emitted to make the generated objects
+# more flexible. Embedders can always build without this but this enables
+# libunwind to produce better backtraces by default when Wasmtime is linked into
+# a different project that wants to unwind.
+export RUSTFLAGS="$RUSTFLAGS -C force-unwind-tables"
+
 mkdir -p target/c-api-build
 cd target/c-api-build
 cmake \


### PR DESCRIPTION
In #11344 it was found that if Wasmtime had a frame on the stack then an application's previous unwinding was broken. This was due to the fact that Wasmtime's C API artifacts do not have unwind information built-in due to being build with `-Cpanic=abort`. This change updates to building the C API artifacts with `-Cforce-unwind-tables` even though Rust itself won't use them to assist with embedders that want to unwind. These should in theory be easily strippable if desired and additionally embedders always have the option to build their own version of the C API too.

Closes #11344

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
