### PR TITLE
Update nightly rust used in CI

### DIFF
--- a/.github/actions/install-rust/action.yml
+++ b/.github/actions/install-rust/action.yml
@@ -28,7 +28,7 @@ runs:
         elif [ "${{ inputs.toolchain }}" = "msrv" ]; then
           echo "version=1.$msrv.0" >> "$GITHUB_OUTPUT"
         elif [ "${{ inputs.toolchain }}" = "wasmtime-ci-pinned-nightly" ]; then
-          echo "version=nightly-2025-07-08" >> "$GITHUB_OUTPUT"
+          echo "version=nightly-2025-08-06" >> "$GITHUB_OUTPUT"
         else
           echo "version=${{ inputs.toolchain }}" >> "$GITHUB_OUTPUT"
         fi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -590,10 +590,8 @@ jobs:
       with:
         toolchain: wasmtime-ci-pinned-nightly
 
-    # Check that `pulley-interpreter` compiles with tail calls enabled.  Don't
-    # actually run the tests with tail calls enabled, because they are not yet
-    # implemented in rustc and cause an ICE.
-    - run: cargo check -p pulley-interpreter --all-features
+    # Check that `pulley-interpreter` works with tail calls enabled.
+    - run: cargo test -p pulley-interpreter --all-features
       env:
         RUSTFLAGS: "--cfg pulley_tail_calls"
     - run: cargo check -p pulley-interpreter --all-features

--- a/pulley/src/interp/tail_loop.rs
+++ b/pulley/src/interp/tail_loop.rs
@@ -7,9 +7,9 @@
 //! tail-calls.
 //!
 //! At this time this module is more performant but disabled by default. Rust
-//! does not have guaranteed tail call elimination at this time so this is not
-//! a suitable means of writing an interpreter loop. That being said this is
-//! included nonetheless for us to experiment and analyze with.
+//! does not have guaranteed tail call elimination on stable at this time so
+//! this is not a suitable means of writing an interpreter loop. That being said
+//! this is included nonetheless for us to experiment and analyze with.
 //!
 //! There are two methods of using this module:
 //!
@@ -23,8 +23,8 @@
 //! * `RUSTFLAGS=--cfg=pulley_tail_calls` - this compilation flag indicates that
 //!   Rust's nightly-only support for guaranteed tail calls should be used. This
 //!   uses the `become` keyword, for example. At this time this feature of Rust
-//!   is highly experimental and not even complete. It only passes `cargo check`
-//!   at this time but doesn't actually run anywhere.
+//!   is highly experimental and may not be complete. This is only lightly
+//!   tested in CI.
 
 use super::*;
 use crate::ExtendedOpcode;


### PR DESCRIPTION
In addition to keeping things up-to-date this enables testing the `tail_loop` interpreter mode of Pulley using the `become` keyword and native Rust syntax. This still isn't ready for prime-time so it's just as gated as before, but we can promote a `cargo check` to a `cargo test` in CI.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
