### PR TITLE
Cranelift: Translate `ir::UserExternalNameRef`s into callers when inlining

### DIFF
--- a/cranelift/filetests/filetests/inline/user-external-name-refs.clif
+++ b/cranelift/filetests/filetests/inline/user-external-name-refs.clif
@@ -1,0 +1,55 @@
+test inline precise-output
+target x86_64
+
+function %callee() -> i32 {
+    sig0 = () -> i32
+    fn0 = colocated u0:36 sig0
+    fn1 = colocated u0:42 sig0
+block0:
+    v0 = call fn0()
+    v1 = call fn1()
+    v2 = iadd v0, v1
+    return v2
+}
+
+; (no functions inlined into %callee)
+
+function %caller(i32) -> i32 {
+    sig0 = (i32) -> i32
+    sig1 = () -> i32
+    fn0 = colocated u0:1234 sig0
+    fn1 = colocated u0:36 sig0
+    fn2 = %callee sig1
+block0(v0: i32):
+    v1 = call fn0(v0)
+    v2 = call fn2()
+    v3 = call fn1(v1)
+    return v3
+}
+
+; function %caller(i32) -> i32 fast {
+;     sig0 = (i32) -> i32 fast
+;     sig1 = () -> i32 fast
+;     sig2 = () -> i32 fast
+;     fn0 = colocated u0:1234 sig0
+;     fn1 = colocated u0:36 sig0
+;     fn2 = %callee sig1
+;     fn3 = colocated u0:36 sig2
+;     fn4 = colocated u0:42 sig2
+;
+; block0(v0: i32):
+;     v1 = call fn0(v0)
+;     jump block1
+;
+; block1:
+;     v5 = call fn3()
+;     v6 = call fn4()
+;     v7 = iadd v5, v6
+;     jump block2(v7)
+;
+; block2(v4: i32):
+;     v2 -> v4
+;     v3 = call fn1(v1)
+;     return v3
+; }
+

--- a/tests/disas/component-model/inlining-fuzz-bug.wat
+++ b/tests/disas/component-model/inlining-fuzz-bug.wat
@@ -1,0 +1,96 @@
+;;! target = "x86_64"
+;;! test = "optimize"
+;;! filter = "wasm[2]--function"
+;;! flags = "-C inlining=y"
+
+(component
+  (core module $A
+    (func (export "f0") (result i32)
+      (i32.const 100)
+    )
+    (func (export "f1") (result i32)
+      (i32.const 101)
+    )
+  )
+
+  (core module $B
+    (import "a" "f0" (func $f0 (result i32)))
+    (import "a" "f1" (func $f1 (result i32)))
+    (func (export "f2") (result i32)
+      (i32.add (call $f0) (call $f1))
+    )
+  )
+
+  (core module $C
+    (import "b" "f2" (func $f2 (result i32)))
+    (func (export "f3") (result i32)
+      (i32.add (i32.const 100) (call $f2))
+    )
+  )
+
+  (core instance $a (instantiate $A))
+  (core instance $b (instantiate $B (with "a" (instance $a))))
+  (core instance $c (instantiate $C (with "b" (instance $b))))
+
+  (func (export "f") (result u32)
+    (canon lift (core func $c "f3"))
+  )
+)
+
+;; function u0:1(i64 vmctx, i64) -> i32 tail {
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv2 = load.i64 notrap aligned gv1+16
+;;     gv3 = vmctx
+;;     gv4 = vmctx
+;;     gv5 = load.i64 notrap aligned readonly gv4+8
+;;     gv6 = load.i64 notrap aligned gv5+16
+;;     gv7 = vmctx
+;;     gv8 = vmctx
+;;     gv9 = load.i64 notrap aligned readonly gv8+8
+;;     gv10 = load.i64 notrap aligned gv9+16
+;;     gv11 = vmctx
+;;     gv12 = load.i64 notrap aligned readonly gv11+8
+;;     gv13 = load.i64 notrap aligned gv12+16
+;;     sig0 = (i64 vmctx, i64) -> i32 tail
+;;     sig1 = (i64 vmctx, i64) -> i32 tail
+;;     sig2 = (i64 vmctx, i64) -> i32 tail
+;;     fn0 = colocated u0:0 sig0
+;;     fn1 = colocated u0:0 sig1
+;;     fn2 = colocated u0:1 sig2
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64):
+;; @00c3                               jump block2
+;;
+;;                                 block2:
+;;                                     jump block4
+;;
+;;                                 block4:
+;;                                     jump block5
+;;
+;;                                 block5:
+;;                                     jump block6
+;;
+;;                                 block6:
+;;                                     jump block7
+;;
+;;                                 block7:
+;;                                     jump block8
+;;
+;;                                 block8:
+;;                                     jump block9
+;;
+;;                                 block9:
+;;                                     jump block3
+;;
+;;                                 block3:
+;;                                     jump block10
+;;
+;;                                 block10:
+;; @00c6                               jump block1
+;;
+;;                                 block1:
+;;                                     v26 = iconst.i32 301
+;; @00c6                               return v26  ; v26 = 301
+;; }


### PR DESCRIPTION
This was an entity that we forgot to translate from the callee into the caller. Note that we do not use the `EntityMap` offset approach for these entities because `ir::Function` hash-conses them.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
