### PR TITLE
docs: fix typos

### DIFF
--- a/docs/examples-deterministic-wasm-execution.md
+++ b/docs/examples-deterministic-wasm-execution.md
@@ -32,7 +32,7 @@ for more details.
 
 The relaxed SIMD proposal gives Wasm programs access to SIMD operations that
 cannot be made to execute both identically and performantly across different
-architectures. The proposal gave up determinism across different achitectures in
+architectures. The proposal gave up determinism across different architectures in
 order to maintain portable performance.
 
 At the cost of worse runtime performance, Wasmtime can deterministically execute

--- a/winch/codegen/src/isa/x64/asm.rs
+++ b/winch/codegen/src/isa/x64/asm.rs
@@ -2022,7 +2022,7 @@ impl Assembler {
         self.emit(Inst::External { inst });
     }
 
-    /// Substract unsigned integers with unsigned saturation.
+    /// Subtract unsigned integers with unsigned saturation.
     pub fn xmm_vpsubus_rrr(&mut self, dst: WritableReg, src1: Reg, src2: Reg, size: OperandSize) {
         let dst: WritableXmm = dst.map(|r| r.into());
         let inst = match size {


### PR DESCRIPTION
### Description

This PR corrects several minor typos in comments and documentation across the codebase. The changes are non-functional and purely textual to improve clarity and maintain a clean, professional codebase.

### Details

- Corrected misspellings:
  - `achitectures` → `architectures`
  - `Substract` → `Subtract`

These fixes help enhance readability and eliminate minor distractions during development and code reviews.

### Additional Info

No logic or functionality has been modified. All changes are restricted to comments or non-executable doc annotations.