### PR TITLE
refactor(wasi): use `WasiFilesystemCtx`

### DIFF
--- a/crates/wasi/src/filesystem.rs
+++ b/crates/wasi/src/filesystem.rs
@@ -1,3 +1,27 @@
+use crate::p2::filesystem::Dir;
+use wasmtime::component::{HasData, ResourceTable};
+
+pub(crate) struct WasiFilesystem;
+
+impl HasData for WasiFilesystem {
+    type Data<'a> = WasiFilesystemCtxView<'a>;
+}
+
+#[derive(Clone, Default)]
+pub struct WasiFilesystemCtx {
+    pub allow_blocking_current_thread: bool,
+    pub preopens: Vec<(Dir, String)>,
+}
+
+pub struct WasiFilesystemCtxView<'a> {
+    pub ctx: &'a mut WasiFilesystemCtx,
+    pub table: &'a mut ResourceTable,
+}
+
+pub trait WasiFilesystemView: Send {
+    fn filesystem(&mut self) -> WasiFilesystemCtxView<'_>;
+}
+
 bitflags::bitflags! {
     #[derive(Copy, Clone, Debug, PartialEq, Eq)]
     pub struct FilePerms: usize {

--- a/crates/wasi/src/p2/host/filesystem.rs
+++ b/crates/wasi/src/p2/host/filesystem.rs
@@ -1,3 +1,4 @@
+use crate::filesystem::WasiFilesystemCtxView;
 use crate::p2::bindings::clocks::wall_clock;
 use crate::p2::bindings::filesystem::preopens;
 use crate::p2::bindings::filesystem::types::{
@@ -6,7 +7,7 @@ use crate::p2::bindings::filesystem::types::{
 use crate::p2::filesystem::{
     Descriptor, Dir, File, FileInputStream, FileOutputStream, ReaddirIterator,
 };
-use crate::p2::{FsError, FsResult, WasiCtxView};
+use crate::p2::{FsError, FsResult};
 use crate::{DirPerms, FilePerms, OpenMode};
 use anyhow::Context;
 use wasmtime::component::Resource;
@@ -14,7 +15,7 @@ use wasmtime_wasi_io::streams::{DynInputStream, DynOutputStream};
 
 mod sync;
 
-impl preopens::Host for WasiCtxView<'_> {
+impl preopens::Host for WasiFilesystemCtxView<'_> {
     fn get_directories(
         &mut self,
     ) -> Result<Vec<(Resource<types::Descriptor>, String)>, anyhow::Error> {
@@ -30,7 +31,7 @@ impl preopens::Host for WasiCtxView<'_> {
     }
 }
 
-impl types::Host for WasiCtxView<'_> {
+impl types::Host for WasiFilesystemCtxView<'_> {
     fn convert_error_code(&mut self, err: FsError) -> anyhow::Result<ErrorCode> {
         err.downcast()
     }
@@ -51,7 +52,7 @@ impl types::Host for WasiCtxView<'_> {
     }
 }
 
-impl HostDescriptor for WasiCtxView<'_> {
+impl HostDescriptor for WasiFilesystemCtxView<'_> {
     async fn advise(
         &mut self,
         fd: Resource<types::Descriptor>,
@@ -823,7 +824,7 @@ impl HostDescriptor for WasiCtxView<'_> {
     }
 }
 
-impl HostDirectoryEntryStream for WasiCtxView<'_> {
+impl HostDirectoryEntryStream for WasiFilesystemCtxView<'_> {
     async fn read_directory_entry(
         &mut self,
         stream: Resource<types::DirectoryEntryStream>,

--- a/crates/wasi/src/p2/host/filesystem/sync.rs
+++ b/crates/wasi/src/p2/host/filesystem/sync.rs
@@ -1,11 +1,12 @@
+use crate::filesystem::WasiFilesystemCtxView;
 use crate::p2::bindings::filesystem::types as async_filesystem;
 use crate::p2::bindings::sync::filesystem::types as sync_filesystem;
 use crate::p2::bindings::sync::io::streams;
-use crate::p2::{FsError, FsResult, WasiCtxView};
+use crate::p2::{FsError, FsResult};
 use crate::runtime::in_tokio;
 use wasmtime::component::Resource;
 
-impl sync_filesystem::Host for WasiCtxView<'_> {
+impl sync_filesystem::Host for WasiFilesystemCtxView<'_> {
     fn convert_error_code(&mut self, err: FsError) -> anyhow::Result<sync_filesystem::ErrorCode> {
         Ok(async_filesystem::Host::convert_error_code(self, err)?.into())
     }
@@ -18,7 +19,7 @@ impl sync_filesystem::Host for WasiCtxView<'_> {
     }
 }
 
-impl sync_filesystem::HostDescriptor for WasiCtxView<'_> {
+impl sync_filesystem::HostDescriptor for WasiFilesystemCtxView<'_> {
     fn advise(
         &mut self,
         fd: Resource<sync_filesystem::Descriptor>,
@@ -302,7 +303,7 @@ impl sync_filesystem::HostDescriptor for WasiCtxView<'_> {
     }
 }
 
-impl sync_filesystem::HostDirectoryEntryStream for WasiCtxView<'_> {
+impl sync_filesystem::HostDirectoryEntryStream for WasiFilesystemCtxView<'_> {
     fn read_directory_entry(
         &mut self,
         stream: Resource<sync_filesystem::DirectoryEntryStream>,

--- a/crates/wasi/src/p2/mod.rs
+++ b/crates/wasi/src/p2/mod.rs
@@ -221,11 +221,12 @@
 //! [async]: https://docs.rs/wasmtime/latest/wasmtime/struct.Config.html#method.async_support
 //! [`ResourceTable`]: wasmtime::component::ResourceTable
 
-use crate::cli::{WasiCli, WasiCliView};
-use crate::clocks::{WasiClocks, WasiClocksView};
+use crate::WasiView;
+use crate::cli::{WasiCli, WasiCliView as _};
+use crate::clocks::{WasiClocks, WasiClocksView as _};
+use crate::filesystem::{WasiFilesystem, WasiFilesystemView as _};
 use crate::random::WasiRandom;
-use crate::sockets::{WasiSockets, WasiSocketsView};
-use crate::{WasiCtxView, WasiView};
+use crate::sockets::{WasiSockets, WasiSocketsView as _};
 use wasmtime::component::{HasData, Linker, ResourceTable};
 
 pub mod bindings;
@@ -323,7 +324,7 @@ pub fn add_to_linker_with_options_async<T: WasiView>(
     add_nonblocking_to_linker(linker, options)?;
 
     let l = linker;
-    bindings::filesystem::types::add_to_linker::<T, HasWasi>(l, T::ctx)?;
+    bindings::filesystem::types::add_to_linker::<T, WasiFilesystem>(l, T::filesystem)?;
     bindings::sockets::tcp::add_to_linker::<T, WasiSockets>(l, T::sockets)?;
     bindings::sockets::udp::add_to_linker::<T, WasiSockets>(l, T::sockets)?;
     Ok(())
@@ -343,7 +344,7 @@ where
     let l = linker;
     clocks::wall_clock::add_to_linker::<T, WasiClocks>(l, T::clocks)?;
     clocks::monotonic_clock::add_to_linker::<T, WasiClocks>(l, T::clocks)?;
-    filesystem::preopens::add_to_linker::<T, HasWasi>(l, T::ctx)?;
+    filesystem::preopens::add_to_linker::<T, WasiFilesystem>(l, T::filesystem)?;
     random::random::add_to_linker::<T, WasiRandom>(l, |t| &mut t.ctx().ctx.random)?;
     random::insecure::add_to_linker::<T, WasiRandom>(l, |t| &mut t.ctx().ctx.random)?;
     random::insecure_seed::add_to_linker::<T, WasiRandom>(l, |t| &mut t.ctx().ctx.random)?;
@@ -467,7 +468,7 @@ pub fn add_to_linker_with_options_sync<T: WasiView>(
     add_sync_wasi_io(linker)?;
 
     let l = linker;
-    bindings::sync::filesystem::types::add_to_linker::<T, HasWasi>(l, T::ctx)?;
+    bindings::sync::filesystem::types::add_to_linker::<T, WasiFilesystem>(l, T::filesystem)?;
     bindings::sync::sockets::tcp::add_to_linker::<T, WasiSockets>(l, T::sockets)?;
     bindings::sync::sockets::udp::add_to_linker::<T, WasiSockets>(l, T::sockets)?;
     Ok(())
@@ -489,12 +490,6 @@ struct HasIo;
 
 impl HasData for HasIo {
     type Data<'a> = &'a mut ResourceTable;
-}
-
-struct HasWasi;
-
-impl HasData for HasWasi {
-    type Data<'a> = WasiCtxView<'a>;
 }
 
 // FIXME: it's a bit unfortunate that this can't use

--- a/crates/wasi/src/view.rs
+++ b/crates/wasi/src/view.rs
@@ -48,11 +48,11 @@ pub struct WasiCtxView<'a> {
     pub table: &'a mut ResourceTable,
 }
 
-impl<T: WasiView> crate::sockets::WasiSocketsView for T {
-    fn sockets(&mut self) -> crate::sockets::WasiSocketsCtxView<'_> {
+impl<T: WasiView> crate::cli::WasiCliView for T {
+    fn cli(&mut self) -> crate::cli::WasiCliCtxView<'_> {
         let WasiCtxView { ctx, table } = self.ctx();
-        crate::sockets::WasiSocketsCtxView {
-            ctx: &mut ctx.sockets,
+        crate::cli::WasiCliCtxView {
+            ctx: &mut ctx.cli,
             table,
         }
     }
@@ -68,17 +68,27 @@ impl<T: WasiView> crate::clocks::WasiClocksView for T {
     }
 }
 
+impl<T: WasiView> crate::filesystem::WasiFilesystemView for T {
+    fn filesystem(&mut self) -> crate::filesystem::WasiFilesystemCtxView<'_> {
+        let WasiCtxView { ctx, table } = self.ctx();
+        crate::filesystem::WasiFilesystemCtxView {
+            ctx: &mut ctx.filesystem,
+            table,
+        }
+    }
+}
+
 impl<T: WasiView> crate::random::WasiRandomView for T {
     fn random(&mut self) -> &mut crate::random::WasiRandomCtx {
         &mut self.ctx().ctx.random
     }
 }
 
-impl<T: WasiView> crate::cli::WasiCliView for T {
-    fn cli(&mut self) -> crate::cli::WasiCliCtxView<'_> {
+impl<T: WasiView> crate::sockets::WasiSocketsView for T {
+    fn sockets(&mut self) -> crate::sockets::WasiSocketsCtxView<'_> {
         let WasiCtxView { ctx, table } = self.ctx();
-        crate::cli::WasiCliCtxView {
-            ctx: &mut ctx.cli,
+        crate::sockets::WasiSocketsCtxView {
+            ctx: &mut ctx.sockets,
             table,
         }
     }


### PR DESCRIPTION
This is a continuation of the PR series based on https://github.com/bytecodealliance/wasmtime/pull/11362 initially started by @alexcrichton 

Note, that since this is the last proposal, which was not converted to the new machinery, `HasWasi` struct is now redundant and removed in this PR