### PR TITLE
Skip some tests with ASAN

### DIFF
--- a/tests/all/code_too_large.rs
+++ b/tests/all/code_too_large.rs
@@ -5,6 +5,11 @@ use wasmtime::*;
 
 #[test]
 fn code_too_large_without_panic() -> Result<()> {
+    // This takes 1m+ in ASAN and isn't too useful to test in ASAN.
+    if cfg!(asan) {
+        return Ok(());
+    }
+
     const N: usize = 80000;
 
     // Build a module with a function whose body will allocate too many

--- a/tests/all/stack_overflow.rs
+++ b/tests/all/stack_overflow.rs
@@ -122,6 +122,11 @@ fn host_always_has_some_stack() -> Result<()> {
 
 #[wasmtime_test]
 fn big_stack_works_ok(config: &mut Config) -> Result<()> {
+    // This test takes 1m+ in ASAN and isn't too useful, so prune it.
+    if cfg!(asan) {
+        return Ok(());
+    }
+
     const N: usize = 10000;
 
     // Build a module with a function that uses a very large amount of stack space,

--- a/tests/disas.rs
+++ b/tests/disas.rs
@@ -54,7 +54,7 @@ use wasmtime::{Engine, OptLevel, Strategy};
 use wasmtime_cli_flags::CommonOptions;
 
 fn main() -> Result<()> {
-    if cfg!(miri) {
+    if cfg!(miri) || cfg!(asan) {
         return Ok(());
     }
 

--- a/tests/wast.rs
+++ b/tests/wast.rs
@@ -48,6 +48,12 @@ fn main() {
     ];
     compilers.retain(|c| c.supports_host());
 
+    // Only test one compiler in ASAN since we're mostly interested in testing
+    // runtime code, not compiler-generated code.
+    if cfg!(asan) {
+        compilers.truncate(1);
+    }
+
     // Run each wast test in a few interesting configuration combinations, but
     // leave the full combinatorial matrix and such to fuzz testing which
     // configures many more settings than those configured here.
@@ -68,6 +74,12 @@ fn main() {
                     collector,
                 },
             );
+        }
+
+        // Don't do extra tests in ASAN as it takes awhile and is unlikely to
+        // reap much benefit.
+        if cfg!(asan) {
+            continue;
         }
 
         let compiler = compilers[0];


### PR DESCRIPTION
ASAN is the longest builder right now and many of the slow tests aren't really buying much such as:

* `disas` - no `unsafe` code
* `wast` - no need to test all permutations of compilers/collectors and instead one should suffice
* `all` - various tests taking 1m+ were flagged to ignore under ASAN as it's not necessarily important to run 100% of tests under ASAN.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
