### PR TITLE
wasmtime: drop wasi-common as a dev-dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4483,7 +4483,6 @@ dependencies = [
  "smallvec",
  "target-lexicon",
  "tempfile",
- "wasi-common",
  "wasm-encoder 0.236.0",
  "wasm-wave",
  "wasmparser 0.236.0",

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -100,7 +100,6 @@ env_logger = { workspace = true }
 proptest = { workspace = true }
 rand = { workspace = true }
 tempfile = { workspace = true }
-wasi-common = { path = "../wasi-common", default-features = true }
 libtest-mimic = { workspace = true }
 cranelift-native = { workspace = true }
 wasmtime-test-util = { workspace = true }


### PR DESCRIPTION
This was no longer needed, and was adding build time to testing wasmtime (rebuilt every time wasmtime changes, because it depends on wasmtime) for no reason.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
