### PR TITLE
Improve garbage collection of DWARF for dead code

### DIFF
--- a/crates/cranelift/src/debug/transform/address_transform.rs
+++ b/crates/cranelift/src/debug/transform/address_transform.rs
@@ -552,8 +552,10 @@ impl AddressTransform {
     }
 
     fn translate_raw(&self, addr: u64) -> Option<(usize, GeneratedAddress)> {
-        if addr == 0 {
-            // It's normally 0 for debug info without the linked code.
+        const TOMBSTONE: u64 = u32::MAX as u64;
+        if addr == 0 || addr == TOMBSTONE {
+            // Addresses for unlinked code may be left as 0 or replaced
+            // with -1, depending on the linker used.
             return None;
         }
         if let Some(func) = self.find_func(addr) {

--- a/crates/cranelift/src/debug/transform/unit.rs
+++ b/crates/cranelift/src/debug/transform/unit.rs
@@ -245,15 +245,6 @@ fn replace_pointer_type(
     Ok(wrapper_die_id)
 }
 
-fn is_dead_code(entry: &DebuggingInformationEntry<Reader<'_>>) -> bool {
-    const TOMBSTONE: u64 = u32::MAX as u64;
-
-    match entry.attr_value(gimli::DW_AT_low_pc) {
-        Ok(Some(AttributeValue::Addr(addr))) => addr == TOMBSTONE,
-        _ => false,
-    }
-}
-
 pub(crate) fn clone_unit(
     compilation: &mut Compilation<'_>,
     module: StaticModuleIndex,
@@ -387,7 +378,6 @@ pub(crate) fn clone_unit(
         if !context
             .reachable
             .contains(&entry.offset().to_unit_section_offset(&unit))
-            || is_dead_code(&entry)
         {
             // entry is not reachable: discarding all its info.
             // Here B = C so `depth` is 0. A is the previous node so `cached` =


### PR DESCRIPTION
Checking for the tombstone address during the reachability calculation allows more DWARF entries to be marked as unreachable, and there was already code to handle this for addresses left as 0.