### PR TITLE
Enable the `clippy::multiple_bound_locations` lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -216,6 +216,7 @@ unnecessary_cast = 'warn'
 allow_attributes_without_reason = 'warn'
 from_over_into = 'warn'
 redundant_field_names = 'warn'
+multiple_bound_locations = 'warn'
 
 [workspace.dependencies]
 # Public crates related to Wasmtime.

--- a/cranelift/entity/src/set.rs
+++ b/cranelift/entity/src/set.rs
@@ -23,9 +23,9 @@ where
     unused: PhantomData<K>,
 }
 
-impl<K: fmt::Debug> fmt::Debug for EntitySet<K>
+impl<K> fmt::Debug for EntitySet<K>
 where
-    K: EntityRef,
+    K: fmt::Debug + EntityRef,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_set().entries(self.keys()).finish()

--- a/crates/wasmtime/src/runtime/component/concurrent.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent.rs
@@ -2500,7 +2500,7 @@ impl Instance {
     /// it an `&Accessor<T>`.
     ///
     /// See the `Accessor` documentation for details.
-    pub(crate) fn wrap_call<T: 'static, F, R>(
+    pub(crate) fn wrap_call<T, F, R>(
         self,
         store: StoreContextMut<T>,
         closure: F,

--- a/crates/wasmtime/src/runtime/component/func/host.rs
+++ b/crates/wasmtime/src/runtime/component/func/host.rs
@@ -40,7 +40,7 @@ enum HostResult<T> {
 }
 
 impl HostFunc {
-    fn from_canonical<T: 'static, F, P, R>(func: F) -> Arc<HostFunc>
+    fn from_canonical<T, F, P, R>(func: F) -> Arc<HostFunc>
     where
         F: Fn(StoreContextMut<'_, T>, Instance, P) -> HostResult<R> + Send + Sync + 'static,
         P: ComponentNamedList + Lift + 'static,
@@ -55,8 +55,9 @@ impl HostFunc {
         })
     }
 
-    pub(crate) fn from_closure<T: 'static, F, P, R>(func: F) -> Arc<HostFunc>
+    pub(crate) fn from_closure<T, F, P, R>(func: F) -> Arc<HostFunc>
     where
+        T: 'static,
         F: Fn(StoreContextMut<T>, P) -> Result<R> + Send + Sync + 'static,
         P: ComponentNamedList + Lift + 'static,
         R: ComponentNamedList + Lower + 'static,
@@ -67,7 +68,7 @@ impl HostFunc {
     }
 
     #[cfg(feature = "component-model-async")]
-    pub(crate) fn from_concurrent<T: 'static, F, P, R>(func: F) -> Arc<HostFunc>
+    pub(crate) fn from_concurrent<T, F, P, R>(func: F) -> Arc<HostFunc>
     where
         T: 'static,
         F: Fn(&Accessor<T>, P) -> Pin<Box<dyn Future<Output = Result<R>> + Send + '_>>
@@ -86,7 +87,7 @@ impl HostFunc {
         })
     }
 
-    extern "C" fn entrypoint<T: 'static, F, P, R>(
+    extern "C" fn entrypoint<T, F, P, R>(
         cx: NonNull<VMOpaqueContext>,
         data: NonNull<u8>,
         ty: u32,
@@ -115,7 +116,7 @@ impl HostFunc {
         }
     }
 
-    fn new_dynamic_canonical<T: 'static, F>(func: F) -> Arc<HostFunc>
+    fn new_dynamic_canonical<T, F>(func: F) -> Arc<HostFunc>
     where
         F: Fn(
                 StoreContextMut<'_, T>,
@@ -152,7 +153,7 @@ impl HostFunc {
     }
 
     #[cfg(feature = "component-model-async")]
-    pub(crate) fn new_dynamic_concurrent<T: 'static, F>(func: F) -> Arc<HostFunc>
+    pub(crate) fn new_dynamic_concurrent<T, F>(func: F) -> Arc<HostFunc>
     where
         T: 'static,
         F: for<'a> Fn(
@@ -922,7 +923,7 @@ pub(crate) fn validate_inbounds_dynamic(
     Ok(ptr)
 }
 
-extern "C" fn dynamic_entrypoint<T: 'static, F>(
+extern "C" fn dynamic_entrypoint<T, F>(
     cx: NonNull<VMOpaqueContext>,
     data: NonNull<u8>,
     ty: u32,


### PR DESCRIPTION
This opts-in to a new Clippy lint which is intended to help clean up historical refactorings to ensure that bounds on type parameters are either in the type parameter declaration or in a `where` clause, but not both.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
