### PR TITLE
Make `GcRuntime::take_memory` a safe method

### DIFF
--- a/crates/wasmtime/src/runtime/store/gc.rs
+++ b/crates/wasmtime/src/runtime/store/gc.rs
@@ -82,7 +82,7 @@ impl StoreOpaque {
 
         // Take the GC heap's underlying memory out of the GC heap, attempt to
         // grow it, then replace it.
-        let mut memory = unsafe { self.unwrap_gc_store_mut().gc_heap.take_memory() };
+        let mut memory = self.unwrap_gc_store_mut().gc_heap.take_memory();
         let mut delta_bytes_grown = 0;
         let grow_result: Result<()> = (|| {
             let page_size = self.engine().tunables().gc_heap_memory_type().page_size();

--- a/crates/wasmtime/src/runtime/vm/gc/enabled/drc.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/enabled/drc.rs
@@ -935,7 +935,7 @@ unsafe impl GcHeap for DrcHeap {
         ptr.cast()
     }
 
-    unsafe fn take_memory(&mut self) -> crate::vm::Memory {
+    fn take_memory(&mut self) -> crate::vm::Memory {
         debug_assert!(self.is_attached());
         self.vmmemory.take();
         self.memory.take().unwrap()

--- a/crates/wasmtime/src/runtime/vm/gc/enabled/null.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/enabled/null.rs
@@ -219,7 +219,7 @@ unsafe impl GcHeap for NullHeap {
         self.no_gc_count -= 1;
     }
 
-    unsafe fn take_memory(&mut self) -> crate::vm::Memory {
+    fn take_memory(&mut self) -> crate::vm::Memory {
         debug_assert!(self.is_attached());
         self.memory.take().unwrap()
     }

--- a/crates/wasmtime/src/runtime/vm/gc/gc_runtime.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/gc_runtime.rs
@@ -423,10 +423,11 @@ pub unsafe trait GcHeap: 'static + Send + Sync {
 
     /// Take the underlying memory storage out of this GC heap.
     ///
-    /// # Safety
+    /// # Panics
     ///
-    /// You may not use this GC heap again until after you replace the memory.
-    unsafe fn take_memory(&mut self) -> crate::vm::Memory;
+    /// If this GC heap is used while the memory is taken then a panic will
+    /// occur. This will also panic if the memory is already taken.
+    fn take_memory(&mut self) -> crate::vm::Memory;
 
     /// Replace this GC heap's underlying memory storage.
     ///


### PR DESCRIPTION
This cannot be an `unsafe` method as it's not possible to provide the guarantee that the memory is placed back in the store (e.g. `forget`-ing futures). Instead make the method more strict and say that panics will happen if `replace_memory` isn't called. Existing implementations should already adhere to this.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
