### PR TITLE
Minimize lazy allocation of the GC store

### DIFF
--- a/crates/environ/src/compile/module_environ.rs
+++ b/crates/environ/src/compile/module_environ.rs
@@ -360,12 +360,7 @@ impl<'a, 'data> ModuleEnvironment<'a, 'data> {
                 for entry in tables {
                     let wasmparser::Table { ty, init } = entry?;
                     let table = self.convert_table_type(&ty)?;
-                    self.result.module.needs_gc_heap |= match table.ref_type.heap_type.top() {
-                        WasmHeapTopType::Extern | WasmHeapTopType::Exn | WasmHeapTopType::Any => {
-                            true
-                        }
-                        WasmHeapTopType::Func | WasmHeapTopType::Cont => false,
-                    };
+                    self.result.module.needs_gc_heap |= table.ref_type.is_vmgcref_type();
                     self.result.module.tables.push(table);
                     let init = match init {
                         wasmparser::TableInit::RefNull => TableInitialValue::Null {

--- a/crates/environ/src/compile/module_environ.rs
+++ b/crates/environ/src/compile/module_environ.rs
@@ -360,6 +360,12 @@ impl<'a, 'data> ModuleEnvironment<'a, 'data> {
                 for entry in tables {
                     let wasmparser::Table { ty, init } = entry?;
                     let table = self.convert_table_type(&ty)?;
+                    self.result.module.needs_gc_heap |= match table.ref_type.heap_type.top() {
+                        WasmHeapTopType::Extern | WasmHeapTopType::Exn | WasmHeapTopType::Any => {
+                            true
+                        }
+                        WasmHeapTopType::Func | WasmHeapTopType::Cont => false,
+                    };
                     self.result.module.tables.push(table);
                     let init = match init {
                         wasmparser::TableInit::RefNull => TableInitialValue::Null {

--- a/crates/wasmtime/src/runtime/externals/global.rs
+++ b/crates/wasmtime/src/runtime/externals/global.rs
@@ -158,7 +158,7 @@ impl Global {
                         HeapType::NoFunc => Ref::Func(None),
 
                         HeapType::Extern => Ref::Extern(definition.as_gc_ref().map(|r| {
-                            let r = store.unwrap_gc_store_mut().clone_gc_ref(r);
+                            let r = store.clone_gc_ref(r);
                             ExternRef::from_cloned_gc_ref(&mut store, r)
                         })),
 
@@ -180,7 +180,7 @@ impl Global {
                         | HeapType::ConcreteExn(_) => definition
                             .as_gc_ref()
                             .map(|r| {
-                                let r = store.unwrap_gc_store_mut().clone_gc_ref(r);
+                                let r = store.clone_gc_ref(r);
                                 AnyRef::from_cloned_gc_ref(&mut store, r)
                             })
                             .into(),
@@ -236,7 +236,7 @@ impl Global {
                         Some(e) => Some(e.try_gc_ref(&store)?.unchecked_copy()),
                     };
                     let new = new.as_ref();
-                    definition.write_gc_ref(store.unwrap_gc_store_mut(), new);
+                    definition.write_gc_ref(&mut store, new);
                 }
                 Val::AnyRef(a) => {
                     let new = match a {
@@ -244,7 +244,7 @@ impl Global {
                         Some(a) => Some(a.try_gc_ref(&store)?.unchecked_copy()),
                     };
                     let new = new.as_ref();
-                    definition.write_gc_ref(store.unwrap_gc_store_mut(), new);
+                    definition.write_gc_ref(&mut store, new);
                 }
                 Val::ExnRef(e) => {
                     let new = match e {
@@ -252,7 +252,7 @@ impl Global {
                         Some(e) => Some(e.try_gc_ref(&store)?.unchecked_copy()),
                     };
                     let new = new.as_ref();
-                    definition.write_gc_ref(store.unwrap_gc_store_mut(), new);
+                    definition.write_gc_ref(&mut store, new);
                 }
             }
         }

--- a/crates/wasmtime/src/runtime/gc/enabled/anyref.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/anyref.rs
@@ -280,11 +280,7 @@ impl AnyRef {
     // (Not actually memory unsafe since we have indexed GC heaps.)
     pub(crate) fn _from_raw(store: &mut AutoAssertNoGc, raw: u32) -> Option<Rooted<Self>> {
         let gc_ref = VMGcRef::from_raw_u32(raw)?;
-        let gc_ref = if gc_ref.is_i31() {
-            gc_ref.copy_i31()
-        } else {
-            store.unwrap_gc_store_mut().clone_gc_ref(&gc_ref)
-        };
+        let gc_ref = store.clone_gc_ref(&gc_ref);
         Some(Self::from_cloned_gc_ref(store, gc_ref))
     }
 

--- a/crates/wasmtime/src/runtime/gc/enabled/anyref.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/anyref.rs
@@ -340,7 +340,7 @@ impl AnyRef {
         let raw = if gc_ref.is_i31() {
             gc_ref.as_raw_non_zero_u32()
         } else {
-            store.gc_store_mut()?.expose_gc_ref_to_wasm(gc_ref)
+            store.require_gc_store_mut()?.expose_gc_ref_to_wasm(gc_ref)
         };
         Ok(raw.get())
     }
@@ -364,7 +364,7 @@ impl AnyRef {
             return Ok(HeapType::I31);
         }
 
-        let header = store.gc_store()?.header(gc_ref);
+        let header = store.require_gc_store()?.header(gc_ref);
 
         if header.kind().matches(VMGcKind::ExternRef) {
             return Ok(HeapType::Any);
@@ -437,7 +437,11 @@ impl AnyRef {
     pub(crate) fn _is_eqref(&self, store: &StoreOpaque) -> Result<bool> {
         assert!(self.comes_from_same_store(store));
         let gc_ref = self.inner.try_gc_ref(store)?;
-        Ok(gc_ref.is_i31() || store.gc_store()?.kind(gc_ref).matches(VMGcKind::EqRef))
+        Ok(gc_ref.is_i31()
+            || store
+                .require_gc_store()?
+                .kind(gc_ref)
+                .matches(VMGcKind::EqRef))
     }
 
     /// Downcast this `anyref` to an `eqref`.
@@ -558,7 +562,11 @@ impl AnyRef {
 
     pub(crate) fn _is_struct(&self, store: &StoreOpaque) -> Result<bool> {
         let gc_ref = self.inner.try_gc_ref(store)?;
-        Ok(!gc_ref.is_i31() && store.gc_store()?.kind(gc_ref).matches(VMGcKind::StructRef))
+        Ok(!gc_ref.is_i31()
+            && store
+                .require_gc_store()?
+                .kind(gc_ref)
+                .matches(VMGcKind::StructRef))
     }
 
     /// Downcast this `anyref` to a `structref`.
@@ -622,7 +630,11 @@ impl AnyRef {
 
     pub(crate) fn _is_array(&self, store: &StoreOpaque) -> Result<bool> {
         let gc_ref = self.inner.try_gc_ref(store)?;
-        Ok(!gc_ref.is_i31() && store.gc_store()?.kind(gc_ref).matches(VMGcKind::ArrayRef))
+        Ok(!gc_ref.is_i31()
+            && store
+                .require_gc_store()?
+                .kind(gc_ref)
+                .matches(VMGcKind::ArrayRef))
     }
 
     /// Downcast this `anyref` to an `arrayref`.

--- a/crates/wasmtime/src/runtime/gc/enabled/eqref.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/eqref.rs
@@ -198,7 +198,7 @@ impl EqRef {
             return Ok(HeapType::I31);
         }
 
-        let header = store.gc_store()?.header(gc_ref);
+        let header = store.require_gc_store()?.header(gc_ref);
 
         if header.kind().matches(VMGcKind::StructRef) {
             return Ok(HeapType::ConcreteStruct(
@@ -320,7 +320,11 @@ impl EqRef {
 
     pub(crate) fn _is_struct(&self, store: &StoreOpaque) -> Result<bool> {
         let gc_ref = self.inner.try_gc_ref(store)?;
-        Ok(!gc_ref.is_i31() && store.gc_store()?.kind(gc_ref).matches(VMGcKind::StructRef))
+        Ok(!gc_ref.is_i31()
+            && store
+                .require_gc_store()?
+                .kind(gc_ref)
+                .matches(VMGcKind::StructRef))
     }
 
     /// Downcast this `eqref` to a `structref`.
@@ -384,7 +388,11 @@ impl EqRef {
 
     pub(crate) fn _is_array(&self, store: &StoreOpaque) -> Result<bool> {
         let gc_ref = self.inner.try_gc_ref(store)?;
-        Ok(!gc_ref.is_i31() && store.gc_store()?.kind(gc_ref).matches(VMGcKind::ArrayRef))
+        Ok(!gc_ref.is_i31()
+            && store
+                .require_gc_store()?
+                .kind(gc_ref)
+                .matches(VMGcKind::ArrayRef))
     }
 
     /// Downcast this `eqref` to an `arrayref`.

--- a/crates/wasmtime/src/runtime/gc/enabled/exnref.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/exnref.rs
@@ -166,7 +166,7 @@ impl ExnRef {
     // (Not actually memory unsafe since we have indexed GC heaps.)
     pub(crate) fn _from_raw(store: &mut AutoAssertNoGc, raw: u32) -> Option<Rooted<Self>> {
         let gc_ref = VMGcRef::from_raw_u32(raw)?;
-        let gc_ref = store.unwrap_gc_store_mut().clone_gc_ref(&gc_ref);
+        let gc_ref = store.clone_gc_ref(&gc_ref);
         Some(Self::from_cloned_gc_ref(store, gc_ref))
     }
 

--- a/crates/wasmtime/src/runtime/gc/enabled/exnref.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/exnref.rs
@@ -335,7 +335,7 @@ impl ExnRef {
         // Allocate the exn and write each field value into the appropriate
         // offset.
         let exnref = store
-            .gc_store_mut()?
+            .require_gc_store_mut()?
             .alloc_uninit_exn(allocator.type_index(), &allocator.layout())
             .context("unrecoverable error when allocating new `exnref`")?
             .map_err(|n| GcHeapOutOfMemory::new((), n))?;
@@ -361,7 +361,7 @@ impl ExnRef {
         })() {
             Ok(()) => Ok(Rooted::new(&mut store, exnref.into())),
             Err(e) => {
-                store.gc_store_mut()?.dealloc_uninit_exn(exnref);
+                store.require_gc_store_mut()?.dealloc_uninit_exn(exnref);
                 Err(e)
             }
         }
@@ -369,7 +369,7 @@ impl ExnRef {
 
     pub(crate) fn type_index(&self, store: &StoreOpaque) -> Result<VMSharedTypeIndex> {
         let gc_ref = self.inner.try_gc_ref(store)?;
-        let header = store.gc_store()?.header(gc_ref);
+        let header = store.require_gc_store()?.header(gc_ref);
         debug_assert!(header.kind().matches(VMGcKind::ExnRef));
         Ok(header.ty().expect("exnrefs should have concrete types"))
     }
@@ -421,7 +421,7 @@ impl ExnRef {
         let raw = if gc_ref.is_i31() {
             gc_ref.as_raw_non_zero_u32()
         } else {
-            store.gc_store_mut()?.expose_gc_ref_to_wasm(gc_ref)
+            store.require_gc_store_mut()?.expose_gc_ref_to_wasm(gc_ref)
         };
         Ok(raw.get())
     }
@@ -501,7 +501,7 @@ impl ExnRef {
         let store = AutoAssertNoGc::new(store);
 
         let gc_ref = self.inner.try_gc_ref(&store)?;
-        let header = store.gc_store()?.header(gc_ref);
+        let header = store.require_gc_store()?.header(gc_ref);
         debug_assert!(header.kind().matches(VMGcKind::ExnRef));
 
         let index = header.ty().expect("exnrefs should have concrete types");
@@ -554,7 +554,7 @@ impl ExnRef {
     fn header<'a>(&self, store: &'a AutoAssertNoGc<'_>) -> Result<&'a VMGcHeader> {
         assert!(self.comes_from_same_store(&store));
         let gc_ref = self.inner.try_gc_ref(store)?;
-        Ok(store.gc_store()?.header(gc_ref))
+        Ok(store.require_gc_store()?.header(gc_ref))
     }
 
     fn exnref<'a>(&self, store: &'a AutoAssertNoGc<'_>) -> Result<&'a VMExnRef> {

--- a/crates/wasmtime/src/runtime/gc/enabled/externref.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/externref.rs
@@ -229,7 +229,7 @@ impl ExternRef {
         let gc_ref = store
             .retry_after_gc(value, |store, value| {
                 store
-                    .gc_store_mut()?
+                    .require_gc_store_mut()?
                     .alloc_externref(value)
                     .context("unrecoverable error when allocating new `externref`")?
                     .map_err(|(x, n)| GcHeapOutOfMemory::new(x, n).into())
@@ -346,7 +346,7 @@ impl ExternRef {
         let gc_ref = store
             .retry_after_gc_async(value, |store, value| {
                 store
-                    .gc_store_mut()?
+                    .require_gc_store_mut()?
                     .alloc_externref(value)
                     .context("unrecoverable error when allocating new `externref`")?
                     .map_err(|(x, n)| GcHeapOutOfMemory::new(x, n).into())
@@ -481,7 +481,7 @@ impl ExternRef {
     {
         let store = store.into().0;
         let gc_ref = self.inner.try_gc_ref(&store)?;
-        let gc_store = store.gc_store()?;
+        let gc_store = store.require_gc_store()?;
         if let Some(externref) = gc_ref.as_externref(&*gc_store.gc_heap) {
             Ok(Some(gc_store.externref_host_data(externref)))
         } else {
@@ -532,7 +532,7 @@ impl ExternRef {
         // so that we can get the store's GC store. But importantly we cannot
         // trigger a GC while we are working with `gc_ref` here.
         let gc_ref = self.inner.try_gc_ref(store)?.unchecked_copy();
-        let gc_store = store.gc_store_mut()?;
+        let gc_store = store.require_gc_store_mut()?;
         if let Some(externref) = gc_ref.as_externref(&*gc_store.gc_heap) {
             Ok(Some(gc_store.externref_host_data_mut(externref)))
         } else {

--- a/crates/wasmtime/src/runtime/gc/enabled/externref.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/externref.rs
@@ -579,7 +579,7 @@ impl ExternRef {
     // (Not actually memory unsafe since we have indexed GC heaps.)
     pub(crate) fn _from_raw(store: &mut AutoAssertNoGc, raw: u32) -> Option<Rooted<ExternRef>> {
         let gc_ref = VMGcRef::from_raw_u32(raw)?;
-        let gc_ref = store.unwrap_gc_store_mut().clone_gc_ref(&gc_ref);
+        let gc_ref = store.clone_gc_ref(&gc_ref);
         Some(Self::from_cloned_gc_ref(store, gc_ref))
     }
 

--- a/crates/wasmtime/src/runtime/gc/enabled/rooting.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/rooting.rs
@@ -175,7 +175,7 @@ mod sealed {
         /// objects that have been unrooted.
         fn try_clone_gc_ref(&self, store: &mut AutoAssertNoGc<'_>) -> Result<VMGcRef> {
             let gc_ref = self.try_gc_ref(store)?.unchecked_copy();
-            Ok(store.gc_store_mut()?.clone_gc_ref(&gc_ref))
+            Ok(store.require_gc_store_mut()?.clone_gc_ref(&gc_ref))
         }
     }
 }
@@ -263,7 +263,7 @@ impl GcRootIndex {
     /// particular `T: GcRef`.
     pub(crate) fn try_clone_gc_ref(&self, store: &mut AutoAssertNoGc<'_>) -> Result<VMGcRef> {
         let gc_ref = self.try_gc_ref(store)?.unchecked_copy();
-        Ok(store.gc_store_mut()?.clone_gc_ref(&gc_ref))
+        Ok(store.require_gc_store_mut()?.clone_gc_ref(&gc_ref))
     }
 }
 
@@ -1781,7 +1781,7 @@ where
         val_raw: impl Fn(u32) -> ValRaw,
     ) -> Result<()> {
         let gc_ref = self.try_clone_gc_ref(store)?;
-        let raw = store.gc_store_mut()?.expose_gc_ref_to_wasm(gc_ref);
+        let raw = store.require_gc_store_mut()?.expose_gc_ref_to_wasm(gc_ref);
         ptr.write(val_raw(raw.get()));
         Ok(())
     }

--- a/crates/wasmtime/src/runtime/gc/enabled/rooting.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/rooting.rs
@@ -168,14 +168,14 @@ mod sealed {
         /// Panics if this root is not associated with the given store.
         fn clone_gc_ref(&self, store: &mut AutoAssertNoGc<'_>) -> Option<VMGcRef> {
             let gc_ref = self.get_gc_ref(store)?.unchecked_copy();
-            Some(store.unwrap_gc_store_mut().clone_gc_ref(&gc_ref))
+            Some(store.clone_gc_ref(&gc_ref))
         }
 
         /// Same as `clone_gc_ref` but returns an error instead of `None` for
         /// objects that have been unrooted.
         fn try_clone_gc_ref(&self, store: &mut AutoAssertNoGc<'_>) -> Result<VMGcRef> {
             let gc_ref = self.try_gc_ref(store)?.unchecked_copy();
-            Ok(store.require_gc_store_mut()?.clone_gc_ref(&gc_ref))
+            Ok(store.clone_gc_ref(&gc_ref))
         }
     }
 }
@@ -263,14 +263,14 @@ impl GcRootIndex {
     /// particular `T: GcRef`.
     pub(crate) fn try_clone_gc_ref(&self, store: &mut AutoAssertNoGc<'_>) -> Result<VMGcRef> {
         let gc_ref = self.try_gc_ref(store)?.unchecked_copy();
-        Ok(store.require_gc_store_mut()?.clone_gc_ref(&gc_ref))
+        Ok(store.clone_gc_ref(&gc_ref))
     }
 }
 
 /// This is a bit-packed version of
 ///
 /// ```ignore
-/// enema {
+/// enum {
 ///     Lifo(usize),
 ///     Manual(SlabId),
 /// }
@@ -1031,7 +1031,7 @@ impl<T: GcRef> Rooted<T> {
         from_cloned_gc_ref: impl Fn(&mut AutoAssertNoGc<'_>, VMGcRef) -> Self,
     ) -> Option<Self> {
         let gc_ref = VMGcRef::from_raw_u32(raw_gc_ref)?;
-        let gc_ref = store.unwrap_gc_store_mut().clone_gc_ref(&gc_ref);
+        let gc_ref = store.clone_gc_ref(&gc_ref);
         Some(from_cloned_gc_ref(store, gc_ref))
     }
 }
@@ -1795,7 +1795,7 @@ where
     ) -> Self {
         debug_assert_ne!(raw_gc_ref, 0);
         let gc_ref = VMGcRef::from_raw_u32(raw_gc_ref).expect("non-null");
-        let gc_ref = store.unwrap_gc_store_mut().clone_gc_ref(&gc_ref);
+        let gc_ref = store.clone_gc_ref(&gc_ref);
         RootSet::with_lifo_scope(store, |store| {
             let rooted = from_cloned_gc_ref(store, gc_ref);
             rooted
@@ -1829,7 +1829,7 @@ where
         from_cloned_gc_ref: impl Fn(&mut AutoAssertNoGc<'_>, VMGcRef) -> Rooted<T>,
     ) -> Option<Self> {
         let gc_ref = VMGcRef::from_raw_u32(raw_gc_ref)?;
-        let gc_ref = store.unwrap_gc_store_mut().clone_gc_ref(&gc_ref);
+        let gc_ref = store.clone_gc_ref(&gc_ref);
         RootSet::with_lifo_scope(store, |store| {
             let rooted = from_cloned_gc_ref(store, gc_ref);
             Some(

--- a/crates/wasmtime/src/runtime/instance.rs
+++ b/crates/wasmtime/src/runtime/instance.rs
@@ -274,7 +274,7 @@ impl Instance {
 
         // Allocate the GC heap, if necessary.
         if module.env_module().needs_gc_heap {
-            let _ = store.gc_store_mut()?;
+            store.ensure_gc_store()?;
         }
 
         let compiled_module = module.compiled_module();

--- a/crates/wasmtime/src/runtime/store.rs
+++ b/crates/wasmtime/src/runtime/store.rs
@@ -1531,6 +1531,7 @@ impl StoreOpaque {
 
     /// Same as [`Self::require_gc_store`], but mutable.
     #[inline]
+    #[cfg(feature = "gc")]
     pub(crate) fn require_gc_store_mut(&mut self) -> Result<&mut GcStore> {
         match &mut self.gc_store {
             Some(gc_store) => Ok(gc_store),

--- a/crates/wasmtime/src/runtime/store.rs
+++ b/crates/wasmtime/src/runtime/store.rs
@@ -1508,6 +1508,7 @@ impl StoreOpaque {
     /// `GcStore` is sure to have already happened prior, otherwise this may
     /// return a confusing error to embedders which is a bug in Wasmtime.
     #[inline]
+    #[cfg(feature = "gc")]
     pub(crate) fn require_gc_store(&self) -> Result<&GcStore> {
         match &self.gc_store {
             Some(gc_store) => Ok(gc_store),
@@ -1551,7 +1552,6 @@ impl StoreOpaque {
     /// for example, or if `ensure_gc_store` has already been called.
     #[inline]
     #[track_caller]
-    #[cfg(feature = "gc")]
     pub(crate) fn unwrap_gc_store(&self) -> &GcStore {
         self.gc_store
             .as_ref()

--- a/crates/wasmtime/src/runtime/store/gc.rs
+++ b/crates/wasmtime/src/runtime/store/gc.rs
@@ -3,7 +3,6 @@
 use super::*;
 use crate::GcHeapOutOfMemory;
 use crate::runtime::vm::VMGcRef;
-use core::mem::MaybeUninit;
 
 impl StoreOpaque {
     /// Collect garbage, potentially growing the GC heap.
@@ -207,38 +206,6 @@ impl StoreOpaque {
                 }
                 Err(e) => Err(e),
             },
-        }
-    }
-
-    /// Helper function execute a `init_gc_ref` when placing `gc_ref` in `dest`.
-    ///
-    /// This avoids allocating `GcStore` where possible.
-    pub(crate) fn init_gc_ref(
-        &mut self,
-        dest: &mut MaybeUninit<Option<VMGcRef>>,
-        gc_ref: Option<&VMGcRef>,
-    ) {
-        if GcStore::needs_init_barrier(gc_ref) {
-            self.unwrap_gc_store_mut().init_gc_ref(dest, gc_ref)
-        } else {
-            dest.write(gc_ref.map(|r| r.copy_i31()));
-        }
-    }
-
-    /// Helper function execute a write barrier when placing `gc_ref` in `dest`.
-    ///
-    /// This avoids allocating `GcStore` where possible.
-    pub(crate) fn write_gc_ref(&mut self, dest: &mut Option<VMGcRef>, gc_ref: Option<&VMGcRef>) {
-        GcStore::write_gc_ref_optional_store(self.optional_gc_store_mut(), dest, gc_ref)
-    }
-
-    /// Helper function to clone `gc_ref` notably avoiding allocating a
-    /// `GcStore` where possible.
-    pub(crate) fn clone_gc_ref(&mut self, gc_ref: &VMGcRef) -> VMGcRef {
-        if gc_ref.is_i31() {
-            gc_ref.copy_i31()
-        } else {
-            self.unwrap_gc_store_mut().clone_gc_ref(gc_ref)
         }
     }
 }

--- a/crates/wasmtime/src/runtime/store/gc.rs
+++ b/crates/wasmtime/src/runtime/store/gc.rs
@@ -52,7 +52,7 @@ impl StoreOpaque {
                     .get_gc_ref(&scope)
                     .expect("still in scope")
                     .unchecked_copy();
-                Some(scope.gc_store_mut()?.clone_gc_ref(&r))
+                Some(scope.require_gc_store_mut()?.clone_gc_ref(&r))
             }
         };
 
@@ -163,6 +163,7 @@ impl StoreOpaque {
             !self.async_support(),
             "use the `*_async` versions of methods when async is configured"
         );
+        self.ensure_gc_store()?;
         match alloc_func(self, value) {
             Ok(x) => Ok(x),
             Err(e) => match e.downcast::<crate::GcHeapOutOfMemory<T>>() {
@@ -190,6 +191,7 @@ impl StoreOpaque {
     where
         T: Send + Sync + 'static,
     {
+        self.ensure_gc_store()?;
         match alloc_func(self, value) {
             Ok(x) => Ok(x),
             Err(e) => match e.downcast::<crate::GcHeapOutOfMemory<T>>() {
@@ -245,6 +247,7 @@ impl StoreOpaque {
             self.async_support(),
             "you must configure async to use the `*_async` versions of methods"
         );
+        self.ensure_gc_store()?;
         match alloc_func(self, value) {
             Ok(x) => Ok(x),
             Err(e) => match e.downcast::<crate::GcHeapOutOfMemory<T>>() {

--- a/crates/wasmtime/src/runtime/trampoline/global.rs
+++ b/crates/wasmtime/src/runtime/trampoline/global.rs
@@ -52,7 +52,7 @@ pub fn generate_global_export(
                     Some(x) => Some(x.try_gc_ref(&store)?.unchecked_copy()),
                 };
                 let new = new.as_ref();
-                global.write_gc_ref(store.gc_store_mut()?, new);
+                global.write_gc_ref(store.require_gc_store_mut()?, new);
             }
             Val::AnyRef(a) => {
                 let new = match a {
@@ -60,7 +60,7 @@ pub fn generate_global_export(
                     Some(a) => Some(a.try_gc_ref(&store)?.unchecked_copy()),
                 };
                 let new = new.as_ref();
-                global.write_gc_ref(store.gc_store_mut()?, new);
+                global.write_gc_ref(store.require_gc_store_mut()?, new);
             }
             Val::ExnRef(e) => {
                 let new = match e {
@@ -68,7 +68,7 @@ pub fn generate_global_export(
                     Some(e) => Some(e.try_gc_ref(&store)?.unchecked_copy()),
                 };
                 let new = new.as_ref();
-                global.write_gc_ref(store.gc_store_mut()?, new);
+                global.write_gc_ref(store.require_gc_store_mut()?, new);
             }
         }
     }

--- a/crates/wasmtime/src/runtime/trampoline/global.rs
+++ b/crates/wasmtime/src/runtime/trampoline/global.rs
@@ -52,7 +52,7 @@ pub fn generate_global_export(
                     Some(x) => Some(x.try_gc_ref(&store)?.unchecked_copy()),
                 };
                 let new = new.as_ref();
-                global.write_gc_ref(store.require_gc_store_mut()?, new);
+                global.write_gc_ref(&mut store, new);
             }
             Val::AnyRef(a) => {
                 let new = match a {
@@ -60,7 +60,7 @@ pub fn generate_global_export(
                     Some(a) => Some(a.try_gc_ref(&store)?.unchecked_copy()),
                 };
                 let new = new.as_ref();
-                global.write_gc_ref(store.require_gc_store_mut()?, new);
+                global.write_gc_ref(&mut store, new);
             }
             Val::ExnRef(e) => {
                 let new = match e {
@@ -68,7 +68,7 @@ pub fn generate_global_export(
                     Some(e) => Some(e.try_gc_ref(&store)?.unchecked_copy()),
                 };
                 let new = new.as_ref();
-                global.write_gc_ref(store.require_gc_store_mut()?, new);
+                global.write_gc_ref(&mut store, new);
             }
         }
     }

--- a/crates/wasmtime/src/runtime/vm/gc/enabled/exnref.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/enabled/exnref.rs
@@ -179,12 +179,11 @@ impl VMExnRef {
         instance: InstanceId,
         tag: DefinedTagIndex,
     ) -> Result<()> {
+        let store = store.require_gc_store_mut()?;
         store
-            .gc_store_mut()?
             .gc_object_data(&self.0)
             .write_u32(layout.tag_offset, instance.as_u32());
         store
-            .gc_store_mut()?
             .gc_object_data(&self.0)
             .write_u32(layout.tag_offset + 4, tag.as_u32());
         Ok(())
@@ -196,13 +195,10 @@ impl VMExnRef {
         store: &mut AutoAssertNoGc,
         layout: &GcExceptionLayout,
     ) -> Result<(InstanceId, DefinedTagIndex)> {
-        let instance = store
-            .gc_store_mut()?
-            .gc_object_data(&self.0)
-            .read_u32(layout.tag_offset);
+        let store = store.require_gc_store_mut()?;
+        let instance = store.gc_object_data(&self.0).read_u32(layout.tag_offset);
         let instance = InstanceId::from_u32(instance);
         let tag = store
-            .gc_store_mut()?
             .gc_object_data(&self.0)
             .read_u32(layout.tag_offset + 4);
         let tag = DefinedTagIndex::from_u32(tag);

--- a/crates/wasmtime/src/runtime/vm/gc/enabled/structref.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/enabled/structref.rs
@@ -165,7 +165,8 @@ impl VMStructRef {
         debug_assert!(val._matches_ty(&store, &ty.unpack())?);
 
         let offset = layout.fields[field].offset;
-        let data = store.gc_store_mut()?.gc_object_data(self.as_gc_ref());
+        let gcstore = store.require_gc_store_mut()?;
+        let data = gcstore.gc_object_data(self.as_gc_ref());
         match val {
             Val::I32(i) if ty.is_i8() => data.write_i8(offset, truncate_i32_to_i8(i)),
             Val::I32(i) if ty.is_i16() => data.write_i16(offset, truncate_i32_to_i16(i)),
@@ -194,8 +195,9 @@ impl VMStructRef {
                     Some(e) => Some(e.try_gc_ref(store)?.unchecked_copy()),
                     None => None,
                 };
-                store.gc_store_mut()?.write_gc_ref(&mut gc_ref, e.as_ref());
-                let data = store.gc_store_mut()?.gc_object_data(self.as_gc_ref());
+                let store = store.require_gc_store_mut()?;
+                store.write_gc_ref(&mut gc_ref, e.as_ref());
+                let data = store.gc_object_data(self.as_gc_ref());
                 data.write_u32(offset, gc_ref.map_or(0, |r| r.as_raw_u32()));
             }
             Val::AnyRef(a) => {
@@ -205,8 +207,9 @@ impl VMStructRef {
                     Some(a) => Some(a.try_gc_ref(store)?.unchecked_copy()),
                     None => None,
                 };
-                store.gc_store_mut()?.write_gc_ref(&mut gc_ref, a.as_ref());
-                let data = store.gc_store_mut()?.gc_object_data(self.as_gc_ref());
+                let store = store.require_gc_store_mut()?;
+                store.write_gc_ref(&mut gc_ref, a.as_ref());
+                let data = store.gc_object_data(self.as_gc_ref());
                 data.write_u32(offset, gc_ref.map_or(0, |r| r.as_raw_u32()));
             }
             Val::ExnRef(e) => {
@@ -216,16 +219,17 @@ impl VMStructRef {
                     Some(e) => Some(e.try_gc_ref(store)?.unchecked_copy()),
                     None => None,
                 };
-                store.gc_store_mut()?.write_gc_ref(&mut gc_ref, e.as_ref());
-                let data = store.gc_store_mut()?.gc_object_data(self.as_gc_ref());
+                let store = store.require_gc_store_mut()?;
+                store.write_gc_ref(&mut gc_ref, e.as_ref());
+                let data = store.gc_object_data(self.as_gc_ref());
                 data.write_u32(offset, gc_ref.map_or(0, |r| r.as_raw_u32()));
             }
 
             Val::FuncRef(f) => {
                 let f = f.map(|f| SendSyncPtr::new(f.vm_func_ref(store)));
-                let id = unsafe { store.gc_store_mut()?.func_ref_table.intern(f) };
-                store
-                    .gc_store_mut()?
+                let gcstore = store.require_gc_store_mut()?;
+                let id = unsafe { gcstore.func_ref_table.intern(f) };
+                gcstore
                     .gc_object_data(self.as_gc_ref())
                     .write_u32(offset, id.into_raw());
             }
@@ -326,35 +330,19 @@ pub(crate) fn initialize_field_impl(
     offset: u32,
     val: Val,
 ) -> Result<()> {
+    let gcstore = store.require_gc_store_mut()?;
     match val {
-        Val::I32(i) if ty.is_i8() => store
-            .gc_store_mut()?
+        Val::I32(i) if ty.is_i8() => gcstore
             .gc_object_data(gc_ref)
             .write_i8(offset, truncate_i32_to_i8(i)),
-        Val::I32(i) if ty.is_i16() => store
-            .gc_store_mut()?
+        Val::I32(i) if ty.is_i16() => gcstore
             .gc_object_data(gc_ref)
             .write_i16(offset, truncate_i32_to_i16(i)),
-        Val::I32(i) => store
-            .gc_store_mut()?
-            .gc_object_data(gc_ref)
-            .write_i32(offset, i),
-        Val::I64(i) => store
-            .gc_store_mut()?
-            .gc_object_data(gc_ref)
-            .write_i64(offset, i),
-        Val::F32(f) => store
-            .gc_store_mut()?
-            .gc_object_data(gc_ref)
-            .write_u32(offset, f),
-        Val::F64(f) => store
-            .gc_store_mut()?
-            .gc_object_data(gc_ref)
-            .write_u64(offset, f),
-        Val::V128(v) => store
-            .gc_store_mut()?
-            .gc_object_data(gc_ref)
-            .write_v128(offset, v),
+        Val::I32(i) => gcstore.gc_object_data(gc_ref).write_i32(offset, i),
+        Val::I64(i) => gcstore.gc_object_data(gc_ref).write_i64(offset, i),
+        Val::F32(f) => gcstore.gc_object_data(gc_ref).write_u32(offset, f),
+        Val::F64(f) => gcstore.gc_object_data(gc_ref).write_u64(offset, f),
+        Val::V128(v) => gcstore.gc_object_data(gc_ref).write_v128(offset, v),
 
         // NB: We don't need to do a write barrier when initializing a
         // field, because there is nothing being overwritten. Therefore, we
@@ -365,7 +353,7 @@ pub(crate) fn initialize_field_impl(
                 Some(x) => x.try_clone_gc_ref(store)?.as_raw_u32(),
             };
             store
-                .gc_store_mut()?
+                .require_gc_store_mut()?
                 .gc_object_data(gc_ref)
                 .write_u32(offset, x);
         }
@@ -375,7 +363,7 @@ pub(crate) fn initialize_field_impl(
                 Some(x) => x.try_clone_gc_ref(store)?.as_raw_u32(),
             };
             store
-                .gc_store_mut()?
+                .require_gc_store_mut()?
                 .gc_object_data(gc_ref)
                 .write_u32(offset, x);
         }
@@ -385,16 +373,16 @@ pub(crate) fn initialize_field_impl(
                 Some(x) => x.try_clone_gc_ref(store)?.as_raw_u32(),
             };
             store
-                .gc_store_mut()?
+                .require_gc_store_mut()?
                 .gc_object_data(gc_ref)
                 .write_u32(offset, x);
         }
 
         Val::FuncRef(f) => {
             let f = f.map(|f| SendSyncPtr::new(f.vm_func_ref(store)));
-            let id = unsafe { store.gc_store_mut()?.func_ref_table.intern(f) };
-            store
-                .gc_store_mut()?
+            let gcstore = store.require_gc_store_mut()?;
+            let id = unsafe { gcstore.func_ref_table.intern(f) };
+            gcstore
                 .gc_object_data(gc_ref)
                 .write_u32(offset, id.into_raw());
         }

--- a/crates/wasmtime/src/runtime/vm/instance.rs
+++ b/crates/wasmtime/src/runtime/vm/instance.rs
@@ -581,10 +581,7 @@ impl Instance {
                 }
 
                 if self.env_module().needs_gc_heap {
-                    self.as_mut().set_gc_heap(Some(store.gc_store().expect(
-                        "if we need a GC heap, then `Instance::new_raw` should have already \
-                     allocated it for us",
-                    )));
+                    self.as_mut().set_gc_heap(Some(store.unwrap_gc_store()));
                 } else {
                     self.as_mut().set_gc_heap(None);
                 }

--- a/crates/wasmtime/src/runtime/vm/instance/allocator.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator.rs
@@ -612,7 +612,7 @@ fn initialize_tables(
                 let idx = module.table_index(table);
                 match module.tables[idx].ref_type.heap_type.top() {
                     WasmHeapTopType::Extern => {
-                        store.gc_store_mut()?;
+                        store.ensure_gc_store()?;
                         let (gc_store, instance) =
                             store.optional_gc_store_and_instance_mut(context.instance);
                         let gc_store = gc_store.unwrap();
@@ -624,7 +624,7 @@ fn initialize_tables(
                     }
 
                     WasmHeapTopType::Any => {
-                        store.gc_store_mut()?;
+                        store.ensure_gc_store()?;
                         let (gc_store, instance) =
                             store.optional_gc_store_and_instance_mut(context.instance);
                         let gc_store = gc_store.unwrap();
@@ -636,7 +636,7 @@ fn initialize_tables(
                     }
 
                     WasmHeapTopType::Exn => {
-                        store.gc_store_mut()?;
+                        store.ensure_gc_store()?;
                         let (gc_store, instance) =
                             store.optional_gc_store_and_instance_mut(context.instance);
                         let gc_store = gc_store.unwrap();

--- a/crates/wasmtime/src/runtime/vm/instance/allocator.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator.rs
@@ -612,7 +612,6 @@ fn initialize_tables(
                 let idx = module.table_index(table);
                 match module.tables[idx].ref_type.heap_type.top() {
                     WasmHeapTopType::Extern => {
-                        store.ensure_gc_store()?;
                         let (gc_store, instance) =
                             store.optional_gc_store_and_instance_mut(context.instance);
                         let gc_store = gc_store.unwrap();
@@ -624,7 +623,6 @@ fn initialize_tables(
                     }
 
                     WasmHeapTopType::Any => {
-                        store.ensure_gc_store()?;
                         let (gc_store, instance) =
                             store.optional_gc_store_and_instance_mut(context.instance);
                         let gc_store = gc_store.unwrap();
@@ -636,7 +634,6 @@ fn initialize_tables(
                     }
 
                     WasmHeapTopType::Exn => {
-                        store.ensure_gc_store()?;
                         let (gc_store, instance) =
                             store.optional_gc_store_and_instance_mut(context.instance);
                         let gc_store = gc_store.unwrap();

--- a/crates/wasmtime/src/runtime/vm/libcalls.rs
+++ b/crates/wasmtime/src/runtime/vm/libcalls.rs
@@ -533,7 +533,14 @@ unsafe fn grow_gc_heap(
     _instance: Pin<&mut Instance>,
     bytes_needed: u64,
 ) -> Result<()> {
-    let orig_len = u64::try_from(store.gc_store()?.gc_heap.vmmemory().current_length()).unwrap();
+    let orig_len = u64::try_from(
+        store
+            .require_gc_store()?
+            .gc_heap
+            .vmmemory()
+            .current_length(),
+    )
+    .unwrap();
 
     unsafe {
         store
@@ -544,7 +551,14 @@ unsafe fn grow_gc_heap(
 
     // JIT code relies on the memory having grown by `bytes_needed` bytes if
     // this libcall returns successfully, so trap if we didn't grow that much.
-    let new_len = u64::try_from(store.gc_store()?.gc_heap.vmmemory().current_length()).unwrap();
+    let new_len = u64::try_from(
+        store
+            .require_gc_store()?
+            .gc_heap
+            .vmmemory()
+            .current_length(),
+    )
+    .unwrap();
     if orig_len
         .checked_add(bytes_needed)
         .is_none_or(|expected_len| new_len < expected_len)
@@ -626,7 +640,12 @@ unsafe fn intern_func_ref_for_gc_heap(
     let func_ref = func_ref.cast::<VMFuncRef>();
     let func_ref = NonNull::new(func_ref).map(SendSyncPtr::new);
 
-    let func_ref_id = unsafe { store.gc_store_mut()?.func_ref_table.intern(func_ref) };
+    let func_ref_id = unsafe {
+        store
+            .require_gc_store_mut()?
+            .func_ref_table
+            .intern(func_ref)
+    };
     Ok(func_ref_id.into_raw())
 }
 

--- a/crates/wasmtime/src/runtime/vm/vmcontext.rs
+++ b/crates/wasmtime/src/runtime/vm/vmcontext.rs
@@ -560,17 +560,17 @@ impl VMGlobalDefinition {
                 WasmValType::Ref(r) => match r.heap_type.top() {
                     WasmHeapTopType::Extern => {
                         let r = VMGcRef::from_raw_u32(raw.get_externref());
-                        global.init_gc_ref(store.gc_store_mut()?, r.as_ref())
+                        global.init_gc_ref(store.require_gc_store_mut()?, r.as_ref())
                     }
                     WasmHeapTopType::Any => {
                         let r = VMGcRef::from_raw_u32(raw.get_anyref());
-                        global.init_gc_ref(store.gc_store_mut()?, r.as_ref())
+                        global.init_gc_ref(store.require_gc_store_mut()?, r.as_ref())
                     }
                     WasmHeapTopType::Func => *global.as_func_ref_mut() = raw.get_funcref().cast(),
                     WasmHeapTopType::Cont => *global.as_func_ref_mut() = raw.get_funcref().cast(), // TODO(#10248): temporary hack.
                     WasmHeapTopType::Exn => {
                         let r = VMGcRef::from_raw_u32(raw.get_exnref());
-                        global.init_gc_ref(store.gc_store_mut()?, r.as_ref())
+                        global.init_gc_ref(store.require_gc_store_mut()?, r.as_ref())
                     }
                 },
             }
@@ -597,18 +597,18 @@ impl VMGlobalDefinition {
                 WasmValType::V128 => ValRaw::v128(self.get_u128()),
                 WasmValType::Ref(r) => match r.heap_type.top() {
                     WasmHeapTopType::Extern => ValRaw::externref(match self.as_gc_ref() {
-                        Some(r) => store.gc_store_mut()?.clone_gc_ref(r).as_raw_u32(),
+                        Some(r) => store.require_gc_store_mut()?.clone_gc_ref(r).as_raw_u32(),
                         None => 0,
                     }),
                     WasmHeapTopType::Any => ValRaw::anyref({
                         match self.as_gc_ref() {
-                            Some(r) => store.gc_store_mut()?.clone_gc_ref(r).as_raw_u32(),
+                            Some(r) => store.require_gc_store_mut()?.clone_gc_ref(r).as_raw_u32(),
                             None => 0,
                         }
                     }),
                     WasmHeapTopType::Exn => ValRaw::exnref({
                         match self.as_gc_ref() {
-                            Some(r) => store.gc_store_mut()?.clone_gc_ref(r).as_raw_u32(),
+                            Some(r) => store.require_gc_store_mut()?.clone_gc_ref(r).as_raw_u32(),
                             None => 0,
                         }
                     }),

--- a/tests/all/table.rs
+++ b/tests/all/table.rs
@@ -366,3 +366,23 @@ fn host_table_keep_type_registration() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn gc_store_with_table_initializers() -> Result<()> {
+    let mut config = Config::new();
+    config.wasm_gc(true);
+    config.wasm_function_references(true);
+    let engine = Engine::new(&config)?;
+
+    let test = |wat: &str| -> Result<()> {
+        let module = Module::new(&engine, wat)?;
+        Instance::new(&mut Store::new(&engine, ()), &module, &[])?;
+        Ok(())
+    };
+
+    test("(module (table 1 i31ref))")?;
+    test("(module (table 1 i31ref (ref.i31 (i32.const 1))))")?;
+    test("(module (table 1 i31ref (ref.null i31)))")?;
+
+    Ok(())
+}


### PR DESCRIPTION
This commit is an effort to minimize the number of entrypoints which might lazily allocate a GC store. The is currently done through `StoreOpaque::gc_store_mut` but this method is very commonly used meaning that there are many many places to audit for lazily allocating a GC store. The reason that this needs an audit is that lazy allocation is an async operation right now that must be on a fiber and is something I'm looking to fix as part of #11262.

This commit performs a few refactorings to achieve this:

* `gc_store_mut` is renamed to `ensure_gc_store`. This is intended to be an `async` function in the future and clearly demarcates where lazy allocation of a GC store is occurring.

* `require_gc_store{,_mut}` is now added which is a pure accessor of the GC store with no lazy allocation. Most locations previously using `gc_store_mut` are updated to use this instead.

Documentation is added to store methods to clearly indicate which ones are allocating and which ones should only be called in a context where allocation should already have happened.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
