### PR TITLE
Refactor `AbortHandle`, renamed to `JoinHandle`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4483,6 +4483,7 @@ dependencies = [
  "smallvec",
  "target-lexicon",
  "tempfile",
+ "tokio",
  "wasm-encoder 0.236.0",
  "wasm-wave",
  "wasmparser 0.236.0",

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -103,6 +103,7 @@ tempfile = { workspace = true }
 libtest-mimic = { workspace = true }
 cranelift-native = { workspace = true }
 wasmtime-test-util = { workspace = true }
+tokio = { workspace = true, features = ["macros", "sync"] }
 
 [build-dependencies]
 cc = { workspace = true, optional = true }

--- a/crates/wasmtime/src/runtime/component/concurrent/abort.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent/abort.rs
@@ -8,6 +8,10 @@ use std::task::{Context, Poll, Waker};
 /// This represents a handle to a running task which can be cancelled with
 /// [`JoinHandle::abort`]. The final result and drop of the task can be
 /// determined by `await`-ing this handle.
+///
+/// Note that dropping this handle does not affect the running task it's
+/// connected to. A manual invocation of [`JoinHandle::abort`] is required to
+/// affect the task.
 pub struct JoinHandle {
     state: Arc<Mutex<JoinState>>,
 }

--- a/crates/wasmtime/src/runtime/component/concurrent/abort.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent/abort.rs
@@ -1,71 +1,278 @@
-use std::future;
-use std::pin::pin;
+use std::mem::{self, ManuallyDrop};
+use std::pin::Pin;
 use std::sync::{Arc, Mutex};
 use std::task::{Context, Poll, Waker};
 
-/// Handle to a task which may be used to abort it.
+/// Handle to a task which may be used to join on the result of executing it.
 ///
 /// This represents a handle to a running task which can be cancelled with
-/// [`AbortHandle::abort`].
-pub struct AbortHandle {
-    state: Arc<Mutex<AbortState>>,
+/// [`JoinHandle::abort`]. The final result and drop of the task can be
+/// determined by `await`-ing this handle.
+pub struct JoinHandle {
+    state: Arc<Mutex<JoinState>>,
 }
 
-#[derive(Default)]
-struct AbortState {
-    aborted: bool,
-    waker: Option<Waker>,
+enum JoinState {
+    /// The task this is connected to is still running and has not completed or
+    /// been dropped.
+    Running {
+        /// The waker that the running task has registered which is signaled
+        /// upon abort.
+        waiting_for_abort_signal: Option<Waker>,
+
+        /// The waker that the `JoinHandle` has registered to await
+        /// destruction of the running task itself.
+        waiting_for_abort_to_complete: Option<Waker>,
+    },
+
+    /// An abort as been requested through an `JoinHandle`. The task specified
+    /// here is used for `Future for JoinHandle`.
+    AbortRequested {
+        waiting_for_abort_to_complete: Option<Waker>,
+    },
+
+    /// The running task has completed, so no need to abort it and nothing else
+    /// needs to wait.
+    Complete,
 }
 
-impl AbortHandle {
+impl JoinHandle {
     /// Abort the task.
     ///
     /// This flags the connected task should abort in the near future, but note
     /// that if this is called while the future is being polled then that call
     /// will still complete.
+    ///
+    /// Note that this `JoinHandle` is itself a `Future` and can be used to
+    /// await the result and destruction of the task that this is associated
+    /// with.
     pub fn abort(&self) {
-        let waker = {
-            let mut state = self.state.lock().unwrap();
-            state.aborted = true;
-            state.waker.take()
-        };
-        if let Some(waker) = waker {
-            waker.wake();
-        }
-    }
-
-    fn is_aborted(&self, cx: &mut Context<'_>) -> bool {
         let mut state = self.state.lock().unwrap();
-        if state.aborted {
-            return true;
+
+        match &mut *state {
+            // If this task is still running, then fall through to below to
+            // transition it into the `AbortRequested` state. If present the
+            // waker for the running task is notified to indicate that an abort
+            // signal has been received.
+            JoinState::Running {
+                waiting_for_abort_signal,
+                waiting_for_abort_to_complete,
+            } => {
+                if let Some(task) = waiting_for_abort_signal.take() {
+                    task.wake();
+                }
+
+                *state = JoinState::AbortRequested {
+                    waiting_for_abort_to_complete: waiting_for_abort_to_complete.take(),
+                };
+            }
+
+            // If this task has already been aborted or has completed, nothing
+            // is left to do.
+            JoinState::AbortRequested { .. } | JoinState::Complete => {}
         }
-        state.waker = Some(cx.waker().clone());
-        false
     }
 
     /// Wraps the `future` provided in a new future which is "abortable" where
-    /// if the returned `AbortHandle` is flagged then the future will resolve
+    /// if the returned `JoinHandle` is flagged then the future will resolve
     /// ASAP with `None` and drop the provided `future`.
-    pub(crate) fn run<F>(future: F) -> (AbortHandle, impl Future<Output = Option<F::Output>>)
+    pub(crate) fn run<F>(future: F) -> (JoinHandle, impl Future<Output = Option<F::Output>>)
     where
         F: Future,
     {
-        let handle = AbortHandle {
-            state: Default::default(),
+        let handle = JoinHandle {
+            state: Arc::new(Mutex::new(JoinState::Running {
+                waiting_for_abort_signal: None,
+                waiting_for_abort_to_complete: None,
+            })),
         };
-        let handle2 = AbortHandle {
+        let future = JoinHandleFuture {
+            future: ManuallyDrop::new(future),
             state: handle.state.clone(),
         };
-        let future = async move {
-            let mut future = pin!(future);
-            future::poll_fn(|cx| {
-                if handle2.is_aborted(cx) {
+        (handle, future)
+    }
+}
+
+impl Future for JoinHandle {
+    type Output = ();
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let mut state = self.state.lock().unwrap();
+        match &mut *state {
+            // If this task is running or still only has requested an abort,
+            // wait further for the task to get dropped.
+            JoinState::Running {
+                waiting_for_abort_to_complete,
+                ..
+            }
+            | JoinState::AbortRequested {
+                waiting_for_abort_to_complete,
+            } => {
+                *waiting_for_abort_to_complete = Some(cx.waker().clone());
+                Poll::Pending
+            }
+
+            // The task is dropped, done!
+            JoinState::Complete => Poll::Ready(()),
+        }
+    }
+}
+
+struct JoinHandleFuture<F> {
+    future: ManuallyDrop<F>,
+    state: Arc<Mutex<JoinState>>,
+}
+
+impl<F> Future for JoinHandleFuture<F>
+where
+    F: Future,
+{
+    type Output = Option<F::Output>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        // SAFETY: this is a pin-projection from `Self` to the state and `Pin`
+        // of the internal future. This is the exclusive access of these fields
+        // apart from the destructor and should be safe.
+        let (state, future) = unsafe {
+            let me = self.get_unchecked_mut();
+            (&me.state, Pin::new_unchecked(&mut *me.future))
+        };
+
+        // First, before polling the future, check to see if we've been
+        // aborted. If not register our task as awaiting such an abort.
+        {
+            let mut state = state.lock().unwrap();
+            match &mut *state {
+                JoinState::Running {
+                    waiting_for_abort_signal,
+                    ..
+                } => {
+                    *waiting_for_abort_signal = Some(cx.waker().clone());
+                }
+                JoinState::AbortRequested { .. } | JoinState::Complete => {
                     return Poll::Ready(None);
                 }
-                future.as_mut().poll(cx).map(Some)
-            })
-            .await
+            }
+        }
+
+        future.poll(cx).map(Some)
+    }
+}
+
+impl<F> Drop for JoinHandleFuture<F> {
+    fn drop(&mut self) {
+        // SAFETY: this is the exclusive owner of this future and it's safe to
+        // drop here during the owning destructor.
+        //
+        // Note that this explicitly happens before notifying the abort handle
+        // that the task completed so that when the notification goes through
+        // it's guaranteed that the future has been destroyed.
+        unsafe {
+            ManuallyDrop::drop(&mut self.future);
+        }
+
+        // After the future dropped see if there was a task awaiting its
+        // destruction. Simultaneously flag this state as complete.
+        let prev = mem::replace(&mut *self.state.lock().unwrap(), JoinState::Complete);
+        let task = match prev {
+            JoinState::Running {
+                waiting_for_abort_to_complete,
+                ..
+            }
+            | JoinState::AbortRequested {
+                waiting_for_abort_to_complete,
+            } => waiting_for_abort_to_complete,
+            JoinState::Complete => None,
         };
-        (handle, future)
+        if let Some(task) = task {
+            task.wake();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::JoinHandle;
+    use std::pin::{Pin, pin};
+    use std::task::{Context, Poll, Waker};
+    use tokio::sync::oneshot;
+
+    fn is_ready<F>(future: Pin<&mut F>) -> bool
+    where
+        F: Future,
+    {
+        match future.poll(&mut Context::from_waker(Waker::noop())) {
+            Poll::Ready(_) => true,
+            Poll::Pending => false,
+        }
+    }
+
+    #[tokio::test]
+    async fn abort_in_progress() {
+        let (tx, rx) = oneshot::channel::<()>();
+        let (mut handle, future) = JoinHandle::run(rx);
+        let mut handle = Pin::new(&mut handle);
+        {
+            let mut future = pin!(future);
+            assert!(!is_ready(future.as_mut()));
+            assert!(!is_ready(handle.as_mut()));
+            handle.abort();
+            assert!(is_ready(future.as_mut()));
+            assert!(!is_ready(handle.as_mut()));
+            assert!(!tx.is_closed());
+        }
+        assert!(is_ready(handle.as_mut()));
+        assert!(tx.is_closed());
+    }
+
+    #[tokio::test]
+    async fn abort_complete() {
+        let (tx, rx) = oneshot::channel::<()>();
+        let (mut handle, future) = JoinHandle::run(rx);
+        let mut handle = Pin::new(&mut handle);
+        tx.send(()).unwrap();
+        assert!(!is_ready(handle.as_mut()));
+        {
+            let mut future = pin!(future);
+            assert!(is_ready(future.as_mut()));
+            assert!(!is_ready(handle.as_mut()));
+        }
+        assert!(is_ready(handle.as_mut()));
+        handle.abort();
+        assert!(is_ready(handle.as_mut()));
+    }
+
+    #[tokio::test]
+    async fn abort_dropped() {
+        let (tx, rx) = oneshot::channel::<()>();
+        let (mut handle, future) = JoinHandle::run(rx);
+        let mut handle = Pin::new(&mut handle);
+        drop(future);
+        assert!(is_ready(handle.as_mut()));
+        handle.abort();
+        assert!(is_ready(handle.as_mut()));
+        assert!(tx.is_closed());
+    }
+
+    #[tokio::test]
+    async fn await_completion() {
+        let (tx, rx) = oneshot::channel::<()>();
+        tx.send(()).unwrap();
+        let (handle, future) = JoinHandle::run(rx);
+        let task = tokio::task::spawn(future);
+        handle.await;
+        task.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn await_abort() {
+        let (tx, rx) = oneshot::channel::<()>();
+        tx.send(()).unwrap();
+        let (handle, future) = JoinHandle::run(rx);
+        handle.abort();
+        let task = tokio::task::spawn(future);
+        handle.await;
+        task.await.unwrap();
     }
 }

--- a/crates/wasmtime/src/runtime/component/mod.rs
+++ b/crates/wasmtime/src/runtime/component/mod.rs
@@ -119,10 +119,9 @@ mod values;
 pub use self::component::{Component, ComponentExportIndex};
 #[cfg(feature = "component-model-async")]
 pub use self::concurrent::{
-    AbortHandle, Access, Accessor, AccessorTask, AsAccessor, ErrorContext, FutureReader,
-    FutureWriter, GuardedFutureReader, GuardedFutureWriter, GuardedStreamReader,
-    GuardedStreamWriter, ReadBuffer, StreamReader, StreamWriter, VMComponentAsyncStore, VecBuffer,
-    WriteBuffer,
+    Access, Accessor, AccessorTask, AsAccessor, ErrorContext, FutureReader, FutureWriter,
+    GuardedFutureReader, GuardedFutureWriter, GuardedStreamReader, GuardedStreamWriter, JoinHandle,
+    ReadBuffer, StreamReader, StreamWriter, VMComponentAsyncStore, VecBuffer, WriteBuffer,
 };
 pub use self::func::{
     ComponentNamedList, ComponentType, Func, Lift, Lower, TypedFunc, WasmList, WasmStr,


### PR DESCRIPTION
This commit is inspired by recent discussions about providing more guarantees around dropping WASI resources. This commit renames `wasmtime::component::AbortHandle` to `wasmtime::component::JoinHandle` and additionally implements `Future for JoinHandle` to know when the associated task's future has been dropped. The renaming is intended to more closely align with `tokio::task::JoinHandle` where `tokio::task::AbortHandle` is notably different and doesn't have a `Future` implementation. The `Future` implementation helps embedders know exactly when a value has been dropped and synchronize on that.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
