### PR TITLE
Make Wasmtime's `FuncKey` one-to-one with Cranelift's `ir::UserExternalName`

### DIFF
--- a/cranelift/codegen/src/inline.rs
+++ b/cranelift/codegen/src/inline.rs
@@ -445,7 +445,7 @@ fn inline_one(
     // terminator, so do a quick pass over the inlined blocks and remove any
     // empty blocks from the caller's layout.
     for block in entity_map.iter_inlined_blocks(func) {
-        if func.layout.first_inst(block).is_none() {
+        if func.layout.is_block_inserted(block) && func.layout.first_inst(block).is_none() {
             func.layout.remove_block(block);
         }
     }

--- a/crates/cranelift/src/compiler.rs
+++ b/crates/cranelift/src/compiler.rs
@@ -30,10 +30,10 @@ use std::sync::{Arc, Mutex};
 use wasmparser::{FuncValidatorAllocations, FunctionBody};
 use wasmtime_environ::{
     AddressMapSection, BuiltinFunctionIndex, CacheStore, CompileError, CompiledFunctionBody,
-    DefinedFuncIndex, FlagValue, FuncIndex, FunctionBodyData, FunctionLoc, HostCall,
-    InliningCompiler, ModuleTranslation, ModuleTypesBuilder, PtrSize, RelocationTarget,
-    StackMapSection, StaticModuleIndex, TrapEncodingBuilder, TrapSentinel, TripleExt, Tunables,
-    VMOffsets, WasmFuncType, WasmValType,
+    DefinedFuncIndex, FlagValue, FuncKey, FunctionBodyData, FunctionLoc, HostCall,
+    InliningCompiler, ModuleTranslation, ModuleTypesBuilder, PtrSize, StackMapSection,
+    StaticModuleIndex, TrapEncodingBuilder, TrapSentinel, TripleExt, Tunables, VMOffsets,
+    WasmFuncType, WasmValType,
 };
 
 #[cfg(feature = "component-model")]
@@ -176,12 +176,13 @@ impl Compiler {
                 .params
                 .insert(0, ir::AbiParam::new(self.isa.pointer_type()));
             let new_sig = builder.func.import_signature(new_signature);
-            let name = ir::ExternalName::User(builder.func.declare_imported_user_function(
-                ir::UserExternalName {
-                    namespace: crate::NS_PULLEY_HOSTCALL,
-                    index: hostcall.into().index(),
-                },
-            ));
+            let key = FuncKey::PulleyHostCall(hostcall.into());
+            let (namespace, index) = key.into_raw_parts();
+            let name = ir::ExternalName::User(
+                builder
+                    .func
+                    .declare_imported_user_function(ir::UserExternalName { namespace, index }),
+            );
             let func = builder.func.import_function(ir::ExtFuncData {
                 name,
                 signature: new_sig,
@@ -206,14 +207,18 @@ impl wasmtime_environ::Compiler for Compiler {
     fn compile_function(
         &self,
         translation: &ModuleTranslation<'_>,
-        func_index: DefinedFuncIndex,
+        key: FuncKey,
         input: FunctionBodyData<'_>,
         types: &ModuleTypesBuilder,
         symbol: &str,
     ) -> Result<CompiledFunctionBody, CompileError> {
         let isa = &*self.isa;
         let module = &translation.module;
-        let func_index = module.func_index(func_index);
+
+        let (module_index, def_func_index) = key.unwrap_defined_wasm_function();
+        debug_assert_eq!(translation.module_index, module_index);
+
+        let func_index = module.func_index(def_func_index);
         let sig = translation.module.functions[func_index]
             .signature
             .unwrap_module_type_index();
@@ -223,10 +228,8 @@ impl wasmtime_environ::Compiler for Compiler {
 
         let context = &mut compiler.cx.codegen_context;
         context.func.signature = wasm_call_signature(isa, wasm_func_ty, &self.tunables);
-        context.func.name = UserFuncName::User(UserExternalName {
-            namespace: crate::NS_WASM_FUNC,
-            index: func_index.as_u32(),
-        });
+        let (namespace, index) = key.into_raw_parts();
+        context.func.name = UserFuncName::User(UserExternalName { namespace, index });
 
         if self.tunables.generate_native_debuginfo {
             context.func.collect_debug_info();
@@ -320,9 +323,12 @@ impl wasmtime_environ::Compiler for Compiler {
         &self,
         translation: &ModuleTranslation<'_>,
         types: &ModuleTypesBuilder,
-        def_func_index: DefinedFuncIndex,
+        key: FuncKey,
         _symbol: &str,
     ) -> Result<CompiledFunctionBody, CompileError> {
+        let (module_index, def_func_index) = key.unwrap_array_to_wasm_trampoline();
+        debug_assert_eq!(translation.module_index, module_index);
+
         let func_index = translation.module.func_index(def_func_index);
         let sig = translation.module.functions[func_index]
             .signature
@@ -369,7 +375,8 @@ impl wasmtime_environ::Compiler for Compiler {
         );
 
         // Then call the Wasm function with those arguments.
-        let call = declare_and_call(&mut builder, wasm_call_sig, func_index.as_u32(), &args);
+        let callee_key = FuncKey::DefinedWasmFunction(module_index, def_func_index);
+        let call = declare_and_call(&mut builder, wasm_call_sig, callee_key, &args);
         let results = builder.func.dfg.inst_results(call).to_vec();
 
         // Then store the results back into the array.
@@ -398,6 +405,7 @@ impl wasmtime_environ::Compiler for Compiler {
     fn compile_wasm_to_array_trampoline(
         &self,
         wasm_func_ty: &WasmFuncType,
+        _key: FuncKey,
         _symbol: &str,
     ) -> Result<CompiledFunctionBody, CompileError> {
         let isa = &*self.isa;
@@ -473,7 +481,7 @@ impl wasmtime_environ::Compiler for Compiler {
         &self,
         obj: &mut Object<'static>,
         funcs: &[(String, Box<dyn Any + Send + Sync>)],
-        resolve_reloc: &dyn Fn(usize, RelocationTarget) -> usize,
+        resolve_reloc: &dyn Fn(usize, FuncKey) -> usize,
     ) -> Result<Vec<(SymbolId, FunctionLoc)>> {
         let mut builder =
             ModuleTextBuilder::new(obj, self, self.isa.text_section_builder(funcs.len()));
@@ -613,15 +621,16 @@ impl wasmtime_environ::Compiler for Compiler {
 
     fn compile_wasm_to_builtin(
         &self,
-        index: BuiltinFunctionIndex,
+        key: FuncKey,
         _symbol: &str,
     ) -> Result<CompiledFunctionBody, CompileError> {
         let isa = &*self.isa;
         let ptr_size = isa.pointer_bytes();
         let pointer_type = isa.pointer_type();
         let sigs = BuiltinFunctionSignatures::new(self);
-        let wasm_sig = sigs.wasm_signature(index);
-        let host_sig = sigs.host_signature(index);
+        let builtin_func_index = key.unwrap_wasm_to_builtin_trampoline();
+        let wasm_sig = sigs.wasm_signature(builtin_func_index);
+        let host_sig = sigs.host_signature(builtin_func_index);
 
         let mut compiler = self.function_compiler();
         let func = ir::Function::with_name_signature(Default::default(), wasm_sig.clone());
@@ -643,7 +652,7 @@ impl wasmtime_environ::Compiler for Compiler {
         // Now it's time to delegate to the actual builtin. Forward all our own
         // arguments to the libcall itself.
         let args = builder.block_params(block0).to_vec();
-        let call = self.call_builtin(&mut builder, vmctx, &args, index, host_sig);
+        let call = self.call_builtin(&mut builder, vmctx, &args, builtin_func_index, host_sig);
         let results = builder.func.dfg.inst_results(call).to_vec();
 
         // Libcalls do not explicitly `longjmp` for example but instead return a
@@ -652,7 +661,7 @@ impl wasmtime_environ::Compiler for Compiler {
         // value and raise a trap as appropriate. With the `results` above check
         // what `index` is and for each libcall that has a trapping return value
         // process it here.
-        match index.trap_sentinel() {
+        match builtin_func_index.trap_sentinel() {
             Some(TrapSentinel::Falsy) => {
                 self.raise_if_host_trapped(&mut builder, vmctx, results[0]);
             }
@@ -693,7 +702,7 @@ impl wasmtime_environ::Compiler for Compiler {
     fn compiled_function_relocation_targets<'a>(
         &'a self,
         func: &'a dyn Any,
-    ) -> Box<dyn Iterator<Item = RelocationTarget> + 'a> {
+    ) -> Box<dyn Iterator<Item = FuncKey> + 'a> {
         let func = func.downcast_ref::<CompiledFunction>().unwrap();
         Box::new(func.relocations().map(|r| r.reloc_target))
     }
@@ -703,7 +712,7 @@ impl InliningCompiler for Compiler {
     fn calls(
         &self,
         func_body: &CompiledFunctionBody,
-        calls: &mut wasmtime_environ::prelude::IndexSet<FuncIndex>,
+        calls: &mut wasmtime_environ::prelude::IndexSet<FuncKey>,
     ) -> Result<()> {
         let cx = func_body
             .code
@@ -716,8 +725,8 @@ impl InliningCompiler for Compiler {
             func.params
                 .user_named_funcs()
                 .values()
-                .filter(|name| name.namespace == crate::NS_WASM_FUNC)
-                .map(|name| FuncIndex::from_u32(name.index)),
+                .map(|name| FuncKey::from_raw_parts(name.namespace, name.index))
+                .filter(|key| matches!(key, FuncKey::DefinedWasmFunction(_, _))),
         );
         Ok(())
     }
@@ -737,7 +746,7 @@ impl InliningCompiler for Compiler {
     fn inline<'a>(
         &self,
         func_body: &mut CompiledFunctionBody,
-        get_callee: &'a mut dyn FnMut(FuncIndex) -> Option<&'a CompiledFunctionBody>,
+        get_callee: &'a mut dyn FnMut(FuncKey) -> Option<&'a CompiledFunctionBody>,
     ) -> Result<()> {
         let code = func_body
             .code
@@ -748,7 +757,7 @@ impl InliningCompiler for Compiler {
         cx.codegen_context.inline(Inliner(get_callee))?;
         return Ok(());
 
-        struct Inliner<'a>(&'a mut dyn FnMut(FuncIndex) -> Option<&'a CompiledFunctionBody>);
+        struct Inliner<'a>(&'a mut dyn FnMut(FuncKey) -> Option<&'a CompiledFunctionBody>);
 
         impl cranelift_codegen::inline::Inline for Inliner<'_> {
             fn inline(
@@ -767,22 +776,21 @@ impl InliningCompiler for Compiler {
                     | ir::ExternalName::KnownSymbol(_) => return InlineCommand::KeepCall,
                 };
                 let callee = &caller.params.user_named_funcs()[callee];
-                let callee = if callee.namespace == crate::NS_WASM_FUNC {
-                    FuncIndex::from_u32(callee.index)
-                } else {
-                    return InlineCommand::KeepCall;
-                };
-                match (self.0)(callee) {
-                    None => InlineCommand::KeepCall,
-                    Some(func_body) => {
-                        let cx = func_body
-                            .code
-                            .downcast_ref::<Option<CompilerContext>>()
-                            .unwrap();
-                        InlineCommand::Inline(Cow::Borrowed(
-                            &cx.as_ref().unwrap().codegen_context.func,
-                        ))
-                    }
+                let callee = FuncKey::from_raw_parts(callee.namespace, callee.index);
+                match callee {
+                    FuncKey::DefinedWasmFunction(_, _) => match (self.0)(callee) {
+                        None => InlineCommand::KeepCall,
+                        Some(func_body) => {
+                            let cx = func_body
+                                .code
+                                .downcast_ref::<Option<CompilerContext>>()
+                                .unwrap();
+                            InlineCommand::Inline(Cow::Borrowed(
+                                &cx.as_ref().unwrap().codegen_context.func,
+                            ))
+                        }
+                    },
+                    _ => InlineCommand::KeepCall,
                 }
             }
         }
@@ -1256,15 +1264,15 @@ fn clif_to_env_stack_maps(
 fn declare_and_call(
     builder: &mut FunctionBuilder,
     signature: ir::Signature,
-    func_index: u32,
+    callee_key: FuncKey,
     args: &[ir::Value],
 ) -> ir::Inst {
-    let name = ir::ExternalName::User(builder.func.declare_imported_user_function(
-        ir::UserExternalName {
-            namespace: crate::NS_WASM_FUNC,
-            index: func_index,
-        },
-    ));
+    let (namespace, index) = callee_key.into_raw_parts();
+    let name = ir::ExternalName::User(
+        builder
+            .func
+            .declare_imported_user_function(ir::UserExternalName { namespace, index }),
+    );
     let signature = builder.func.import_signature(signature);
     let callee = builder.func.dfg.ext_funcs.push(ir::ExtFuncData {
         name,

--- a/crates/cranelift/src/compiler/component.rs
+++ b/crates/cranelift/src/compiler/component.rs
@@ -9,12 +9,12 @@ use cranelift_codegen::ir::condcodes::IntCC;
 use cranelift_codegen::ir::{self, InstBuilder, MemFlags, Value};
 use cranelift_codegen::isa::{CallConv, TargetIsa};
 use cranelift_frontend::FunctionBuilder;
-use wasmtime_environ::fact::PREPARE_CALL_FIXED_PARAMS;
 use wasmtime_environ::{CompiledFunctionBody, component::*};
 use wasmtime_environ::{
     EntityRef, HostCall, ModuleInternedTypeIndex, PtrSize, TrapSentinel, Tunables, WasmFuncType,
     WasmValType,
 };
+use wasmtime_environ::{FuncKey, fact::PREPARE_CALL_FIXED_PARAMS};
 
 struct TrampolineCompiler<'a> {
     compiler: &'a Compiler,
@@ -1281,7 +1281,7 @@ impl ComponentCompiler for Compiler {
         &self,
         component: &ComponentTranslation,
         types: &ComponentTypesBuilder,
-        index: TrampolineIndex,
+        key: FuncKey,
         tunables: &Tunables,
         _symbol: &str,
     ) -> Result<AllCallFunc<CompiledFunctionBody>> {
@@ -1292,7 +1292,7 @@ impl ComponentCompiler for Compiler {
                 &mut compiler,
                 &component.component,
                 types,
-                index,
+                key.unwrap_component_trampoline(),
                 abi,
                 tunables,
             );
@@ -1325,7 +1325,7 @@ impl ComponentCompiler for Compiler {
                 );
             }
 
-            c.translate(&component.trampolines[index]);
+            c.translate(&component.trampolines[key.unwrap_component_trampoline()]);
             c.builder.finalize();
             compiler.cx.abi = Some(abi);
 

--- a/crates/cranelift/src/debug/transform/mod.rs
+++ b/crates/cranelift/src/debug/transform/mod.rs
@@ -121,16 +121,20 @@ fn read_dwarf_package_from_bytes<'data>(
     let mut validator = wasmparser::Validator::new();
     let parser = wasmparser::Parser::new(0);
     let mut types = wasmtime_environ::ModuleTypesBuilder::new(&validator);
-    let translation =
-        match wasmtime_environ::ModuleEnvironment::new(tunables, &mut validator, &mut types)
-            .translate(parser, dwp_bytes)
-        {
-            Ok(translation) => translation,
-            Err(e) => {
-                log::warn!("failed to parse wasm dwarf package: {e:?}");
-                return None;
-            }
-        };
+    let translation = match wasmtime_environ::ModuleEnvironment::new(
+        tunables,
+        &mut validator,
+        &mut types,
+        StaticModuleIndex::from_u32(0),
+    )
+    .translate(parser, dwp_bytes)
+    {
+        Ok(translation) => translation,
+        Err(e) => {
+            log::warn!("failed to parse wasm dwarf package: {e:?}");
+            return None;
+        }
+    };
 
     match load_dwp(translation, buffer) {
         Ok(package) => Some(package),

--- a/crates/environ/src/compile/key.rs
+++ b/crates/environ/src/compile/key.rs
@@ -1,0 +1,220 @@
+//! TODO FITZGEN
+
+#[cfg(feature = "component-model")]
+use crate::component;
+use crate::{
+    BuiltinFunctionIndex, DefinedFuncIndex, HostCall, ModuleInternedTypeIndex, StaticModuleIndex,
+};
+
+/// A sortable, comparable function key for compilation output, call graph
+/// edges, and relocations.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum FuncKey {
+    /// A Wasm-defined function.
+    DefinedWasmFunction(StaticModuleIndex, DefinedFuncIndex),
+
+    /// A trampoline from an array-caller to the given Wasm-callee.
+    ArrayToWasmTrampoline(StaticModuleIndex, DefinedFuncIndex),
+
+    /// A trampoline from a Wasm-caller to an array-callee of the given type.
+    WasmToArrayTrampoline(ModuleInternedTypeIndex),
+
+    /// A trampoline from a Wasm-caller to the given builtin.
+    WasmToBuiltinTrampoline(BuiltinFunctionIndex),
+
+    /// A Pulley-specific host call.
+    PulleyHostCall(HostCall),
+
+    /// A Wasm-caller to component builtin trampoline.
+    #[cfg(feature = "component-model")]
+    ComponentTrampoline(component::TrampolineIndex),
+
+    /// A Wasm-caller to array-callee `resource.drop` trampoline.
+    #[cfg(feature = "component-model")]
+    ResourceDropTrampoline,
+}
+
+impl FuncKey {
+    const KIND_BITS: u32 = 3;
+    const KIND_OFFSET: u32 = 32 - Self::KIND_BITS;
+    const KIND_MASK: u32 = ((1 << Self::KIND_BITS) - 1) << Self::KIND_OFFSET;
+    const MODULE_MASK: u32 = !Self::KIND_MASK;
+
+    const fn new_kind(kind: u32) -> u32 {
+        assert!(kind < (1 << Self::KIND_BITS));
+        kind << Self::KIND_OFFSET
+    }
+
+    const DEFINED_WASM_FUNCTION_KIND: u32 = Self::new_kind(0);
+    const ARRAY_TO_WASM_TRAMPOLINE_KIND: u32 = Self::new_kind(1);
+    const WASM_TO_ARRAY_TRAMPOLINE_KIND: u32 = Self::new_kind(2);
+    const WASM_TO_BUILTIN_TRAMPOLINE_KIND: u32 = Self::new_kind(3);
+    const PULLEY_HOST_CALL_KIND: u32 = Self::new_kind(4);
+
+    #[cfg(feature = "component-model")]
+    const COMPONENT_TRAMPOLINE_KIND: u32 = Self::new_kind(5);
+    #[cfg(feature = "component-model")]
+    const RESOURCE_DROP_TRAMPOLINE_KIND: u32 = Self::new_kind(6);
+
+    /// Get the raw, underlying representation of this compilation key.
+    ///
+    /// The resulting values should only be used for (eventually) calling
+    /// `CompileKey::from_raw_parts`.
+    //
+    // NB: We use two `u32`s to exactly match
+    // `cranelift_codegen::ir::UserExternalName` and ensure that we can map
+    // one-to-one between that and `FuncKey`.
+    pub fn into_raw_parts(self) -> (u32, u32) {
+        match self {
+            FuncKey::DefinedWasmFunction(module, def_func) => {
+                assert_eq!(module.as_u32() & Self::KIND_MASK, 0);
+                let namespace = Self::DEFINED_WASM_FUNCTION_KIND | module.as_u32();
+                let index = def_func.as_u32();
+                (namespace, index)
+            }
+            FuncKey::ArrayToWasmTrampoline(module, def_func) => {
+                assert_eq!(module.as_u32() & Self::KIND_MASK, 0);
+                let namespace = Self::ARRAY_TO_WASM_TRAMPOLINE_KIND | module.as_u32();
+                let index = def_func.as_u32();
+                (namespace, index)
+            }
+            FuncKey::WasmToArrayTrampoline(ty) => {
+                let namespace = Self::WASM_TO_ARRAY_TRAMPOLINE_KIND;
+                let index = ty.as_u32();
+                (namespace, index)
+            }
+            FuncKey::WasmToBuiltinTrampoline(builtin) => {
+                let namespace = Self::WASM_TO_BUILTIN_TRAMPOLINE_KIND;
+                let index = builtin.index();
+                (namespace, index)
+            }
+            FuncKey::PulleyHostCall(host_call) => {
+                let namespace = Self::PULLEY_HOST_CALL_KIND;
+                let index = host_call.index();
+                (namespace, index)
+            }
+
+            #[cfg(feature = "component-model")]
+            FuncKey::ComponentTrampoline(trampoline) => {
+                let namespace = Self::COMPONENT_TRAMPOLINE_KIND;
+                let index = trampoline.as_u32();
+                (namespace, index)
+            }
+            #[cfg(feature = "component-model")]
+            FuncKey::ResourceDropTrampoline => {
+                let namespace = Self::RESOURCE_DROP_TRAMPOLINE_KIND;
+                let index = 0;
+                (namespace, index)
+            }
+        }
+    }
+
+    /// Create a compilation key from its raw, underlying representation.
+    ///
+    /// Should only be given the results of a previous call to
+    /// `CompileKey::into_raw_parts`.
+    pub fn from_raw_parts(a: u32, b: u32) -> Self {
+        match a & Self::KIND_MASK {
+            Self::DEFINED_WASM_FUNCTION_KIND => {
+                let module = StaticModuleIndex::from_u32(a & Self::MODULE_MASK);
+                let def_func = DefinedFuncIndex::from_u32(b);
+                Self::DefinedWasmFunction(module, def_func)
+            }
+            Self::ARRAY_TO_WASM_TRAMPOLINE_KIND => {
+                let module = StaticModuleIndex::from_u32(a & Self::MODULE_MASK);
+                let def_func = DefinedFuncIndex::from_u32(b);
+                Self::ArrayToWasmTrampoline(module, def_func)
+            }
+            Self::WASM_TO_ARRAY_TRAMPOLINE_KIND => {
+                assert_eq!(a & Self::MODULE_MASK, 0);
+                let ty = ModuleInternedTypeIndex::from_u32(b);
+                Self::WasmToArrayTrampoline(ty)
+            }
+            Self::WASM_TO_BUILTIN_TRAMPOLINE_KIND => {
+                assert_eq!(a & Self::MODULE_MASK, 0);
+                let builtin = BuiltinFunctionIndex::from_u32(b);
+                Self::WasmToBuiltinTrampoline(builtin)
+            }
+            Self::PULLEY_HOST_CALL_KIND => {
+                assert_eq!(a & Self::MODULE_MASK, 0);
+                let host_call = HostCall::from_index(b);
+                Self::PulleyHostCall(host_call)
+            }
+
+            #[cfg(feature = "component-model")]
+            Self::COMPONENT_TRAMPOLINE_KIND => {
+                assert_eq!(a & Self::MODULE_MASK, 0);
+                let trampoline = component::TrampolineIndex::from_u32(b);
+                Self::ComponentTrampoline(trampoline)
+            }
+            #[cfg(feature = "component-model")]
+            Self::RESOURCE_DROP_TRAMPOLINE_KIND => {
+                assert_eq!(a & Self::MODULE_MASK, 0);
+                assert_eq!(b, 0);
+                Self::ResourceDropTrampoline
+            }
+
+            k => panic!(
+                "bad raw parts given to `FuncKey::from_raw_parts` call: ({a}, {b}), kind would be {k}"
+            ),
+        }
+    }
+
+    /// Unwrap a `FuncKey::DefinedWasmFunction` or else panic.
+    pub fn unwrap_defined_wasm_function(self) -> (StaticModuleIndex, DefinedFuncIndex) {
+        match self {
+            Self::DefinedWasmFunction(module, def_func) => (module, def_func),
+            _ => panic!("`FuncKey::unwrap_defined_wasm_function` called on {self:?}"),
+        }
+    }
+
+    /// Unwrap a `FuncKey::ArrayToWasmTrampoline` or else panic.
+    pub fn unwrap_array_to_wasm_trampoline(self) -> (StaticModuleIndex, DefinedFuncIndex) {
+        match self {
+            Self::ArrayToWasmTrampoline(module, def_func) => (module, def_func),
+            _ => panic!("`FuncKey::unwrap_array_to_wasm_trampoline` called on {self:?}"),
+        }
+    }
+
+    /// Unwrap a `FuncKey::WasmToArrayTrampoline` or else panic.
+    pub fn unwrap_wasm_to_array_trampoline(self) -> ModuleInternedTypeIndex {
+        match self {
+            Self::WasmToArrayTrampoline(ty) => ty,
+            _ => panic!("`FuncKey::unwrap_wasm_to_array_trampoline` called on {self:?}"),
+        }
+    }
+
+    /// Unwrap a `FuncKey::WasmToBuiltinTrampoline` or else panic.
+    pub fn unwrap_wasm_to_builtin_trampoline(self) -> BuiltinFunctionIndex {
+        match self {
+            Self::WasmToBuiltinTrampoline(builtin) => builtin,
+            _ => panic!("`FuncKey::unwrap_wasm_to_builtin_trampoline` called on {self:?}"),
+        }
+    }
+
+    /// Unwrap a `FuncKey::PulleyHostCall` or else panic.
+    pub fn unwrap_pulley_host_call(self) -> HostCall {
+        match self {
+            Self::PulleyHostCall(host_call) => host_call,
+            _ => panic!("`FuncKey::unwrap_pulley_host_call` called on {self:?}"),
+        }
+    }
+
+    /// Unwrap a `FuncKey::ComponentTrampoline` or else panic.
+    #[cfg(feature = "component-model")]
+    pub fn unwrap_component_trampoline(self) -> component::TrampolineIndex {
+        match self {
+            Self::ComponentTrampoline(trampoline) => trampoline,
+            _ => panic!("`FuncKey::unwrap_component_trampoline` called on {self:?}"),
+        }
+    }
+
+    /// Unwrap a `FuncKey::ResourceDropTrampoline` or else panic.
+    #[cfg(feature = "component-model")]
+    pub fn unwrap_resource_drop_trampoline(self) {
+        match self {
+            Self::ResourceDropTrampoline => {}
+            _ => panic!("`FuncKey::unwrap_resource_drop_trampoline` called on {self:?}"),
+        }
+    }
+}

--- a/crates/environ/src/component/compiler.rs
+++ b/crates/environ/src/component/compiler.rs
@@ -1,5 +1,5 @@
-use crate::component::{AllCallFunc, ComponentTranslation, ComponentTypesBuilder, TrampolineIndex};
-use crate::{CompiledFunctionBody, Tunables};
+use crate::component::{AllCallFunc, ComponentTranslation, ComponentTypesBuilder};
+use crate::{FuncKey, CompiledFunctionBody, Tunables};
 use anyhow::Result;
 
 /// Compilation support necessary for components.
@@ -14,7 +14,7 @@ pub trait ComponentCompiler: Send + Sync {
         &self,
         component: &ComponentTranslation,
         types: &ComponentTypesBuilder,
-        trampoline: TrampolineIndex,
+        key: FuncKey,
         tunables: &Tunables,
         symbol: &str,
     ) -> Result<AllCallFunc<CompiledFunctionBody>>;

--- a/crates/environ/src/component/translate.rs
+++ b/crates/environ/src/component/translate.rs
@@ -1082,10 +1082,12 @@ impl<'a, 'data> Translator<'a, 'data> {
             } => {
                 let index = self.validator.types(0).unwrap().module_count();
                 self.validator.module_section(&unchecked_range)?;
+                let static_module_index = self.static_modules.next_key();
                 let translation = ModuleEnvironment::new(
                     self.tunables,
                     self.validator,
                     self.types.module_types_builder(),
+                    static_module_index,
                 )
                 .translate(
                     parser,
@@ -1101,12 +1103,13 @@ impl<'a, 'data> Translator<'a, 'data> {
                             .context("wasm component contains an invalid module section")
                         })?,
                 )?;
-                let static_idx = self.static_modules.push(translation);
+                let static_module_index2 = self.static_modules.push(translation);
+                assert_eq!(static_module_index, static_module_index2);
                 let types = self.validator.types(0).unwrap();
                 let ty = types.module_at(index);
                 self.result
                     .initializers
-                    .push(LocalInitializer::ModuleStatic(static_idx, ty));
+                    .push(LocalInitializer::ModuleStatic(static_module_index, ty));
                 return Ok(Action::Skip(unchecked_range.end - unchecked_range.start));
             }
 

--- a/crates/environ/src/component/translate/adapt.rs
+++ b/crates/environ/src/component/translate/adapt.rs
@@ -231,10 +231,12 @@ impl<'data> Translator<'_, 'data> {
             // likely to use that if anything is actually indirected through
             // memory.
             self.validator.reset();
+            let static_module_index = self.static_modules.next_key();
             let translation = ModuleEnvironment::new(
                 self.tunables,
                 &mut self.validator,
                 self.types.module_types_builder(),
+                static_module_index,
             )
             .translate(Parser::new(0), wasm)
             .expect("invalid adapter module generated");
@@ -260,8 +262,9 @@ impl<'data> Translator<'_, 'data> {
                 .zip(translation.module.imports())
                 .map(|(arg, (_, _, ty))| fact_import_to_core_def(component, arg, ty))
                 .collect::<Vec<_>>();
-            let static_index = self.static_modules.push(translation);
-            let id = component.adapter_modules.push((static_index, args));
+            let static_module_index2 = self.static_modules.push(translation);
+            assert_eq!(static_module_index, static_module_index2);
+            let id = component.adapter_modules.push((static_module_index, args));
             assert_eq!(id, module_id);
         }
     }

--- a/crates/environ/src/hostcall.rs
+++ b/crates/environ/src/hostcall.rs
@@ -8,6 +8,7 @@ use crate::component::ComponentBuiltinFunctionIndex;
 /// This type is intended to be serialized into a 32-bit index (or smaller) and
 /// is used by Pulley for example to identify how transitions from the guest to
 /// the host are performed.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum HostCall {
     /// An "array call" is being done which means that the wasm is calling the
     /// host using the array calling convention (e.g. `VMArrayCallNative`).
@@ -42,6 +43,34 @@ impl HostCall {
             #[cfg(feature = "component-model")]
             HostCall::ComponentBuiltin(i) => 2 + BuiltinFunctionIndex::len() + i.index(),
         }
+    }
+
+    /// Create a `HostCall` from the result of an earlier call to
+    /// `HostCall::index`.
+    pub fn from_index(index: u32) -> Self {
+        let host_call = match index {
+            0 => Self::ArrayCall,
+            _ if index < 1 + BuiltinFunctionIndex::len() => {
+                Self::Builtin(BuiltinFunctionIndex::from_u32(index - 1))
+            }
+            #[cfg(feature = "component-model")]
+            _ if index == 1 + BuiltinFunctionIndex::len() => Self::ComponentLowerImport,
+            #[cfg(feature = "component-model")]
+            _ if index < 2 + BuiltinFunctionIndex::len() + ComponentBuiltinFunctionIndex::len() => {
+                Self::ComponentBuiltin(ComponentBuiltinFunctionIndex::from_u32(
+                    index - 2 - BuiltinFunctionIndex::len(),
+                ))
+            }
+            _ => panic!(
+                "bad host call index: {index}\n\
+                 BuiltinFunctionIndex::len() = {}\n\
+                 ComponentBuiltinFunctionIndex::len() = {}",
+                BuiltinFunctionIndex::len(),
+                ComponentBuiltinFunctionIndex::len()
+            ),
+        };
+        debug_assert_eq!(index, host_call.index());
+        host_call
     }
 }
 

--- a/crates/environ/src/module_artifacts.rs
+++ b/crates/environ/src/module_artifacts.rs
@@ -9,7 +9,7 @@ use core::str;
 use serde_derive::{Deserialize, Serialize};
 
 /// Secondary in-memory results of function compilation.
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct CompiledFunctionInfo {
     /// Where this function was found in the original wasm file.
     pub start_srcloc: FilePos,

--- a/crates/wasmtime/src/compile.rs
+++ b/crates/wasmtime/src/compile.rs
@@ -29,24 +29,19 @@ use crate::prelude::*;
 use std::{
     any::Any,
     borrow::Cow,
-    collections::{BTreeMap, BTreeSet, btree_map},
+    collections::{BTreeMap, BTreeSet},
     mem,
     ops::Range,
 };
 
 use call_graph::CallGraph;
-use wasmtime_environ::CompiledFunctionBody;
-use wasmtime_environ::FuncIndex;
-use wasmtime_environ::InliningCompiler;
-use wasmtime_environ::IntraModuleInlining;
-use wasmtime_environ::Tunables;
 #[cfg(feature = "component-model")]
 use wasmtime_environ::component::Translator;
 use wasmtime_environ::{
-    BuiltinFunctionIndex, CompiledFunctionInfo, CompiledModuleInfo, Compiler, DefinedFuncIndex,
-    FilePos, FinishedObject, FunctionBodyData, ModuleEnvironment, ModuleInternedTypeIndex,
-    ModuleTranslation, ModuleTypes, ModuleTypesBuilder, ObjectKind, PrimaryMap, RelocationTarget,
-    StaticModuleIndex,
+    BuiltinFunctionIndex, CompiledFunctionBody, CompiledFunctionInfo, CompiledModuleInfo, Compiler,
+    DefinedFuncIndex, FilePos, FinishedObject, FuncKey, FunctionBodyData, FunctionLoc,
+    InliningCompiler, IntraModuleInlining, ModuleEnvironment, ModuleTranslation, ModuleTypes,
+    ModuleTypesBuilder, ObjectKind, PrimaryMap, SecondaryMap, StaticModuleIndex, Tunables,
 };
 
 mod call_graph;
@@ -87,9 +82,14 @@ pub(crate) fn build_artifacts<T: FinishedObject>(
     let mut validator = wasmparser::Validator::new_with_features(engine.features());
     parser.set_features(*validator.features());
     let mut types = ModuleTypesBuilder::new(&validator);
-    let mut translation = ModuleEnvironment::new(tunables, &mut validator, &mut types)
-        .translate(parser, wasm)
-        .context("failed to parse WebAssembly module")?;
+    let mut translation = ModuleEnvironment::new(
+        tunables,
+        &mut validator,
+        &mut types,
+        StaticModuleIndex::from_u32(0),
+    )
+    .translate(parser, wasm)
+    .context("failed to parse WebAssembly module")?;
     let functions = mem::take(&mut translation.function_body_inputs);
 
     let compile_inputs = CompileInputs::for_module(&types, &translation, functions);
@@ -200,8 +200,7 @@ pub(crate) fn build_component_artifacts<T: FinishedObject>(
     let info = CompiledComponentInfo {
         component: component.component,
         trampolines: compilation_artifacts.trampolines,
-        resource_drop_wasm_to_array_trampoline: compilation_artifacts
-            .resource_drop_wasm_to_array_trampoline,
+        resource_drop_wasm_to_array_trampoline: compilation_artifacts.resource_drop_trampoline,
     };
     let artifacts = ComponentArtifacts {
         info,
@@ -216,145 +215,6 @@ pub(crate) fn build_component_artifacts<T: FinishedObject>(
 }
 
 type CompileInput<'a> = Box<dyn FnOnce(&dyn Compiler) -> Result<CompileOutput<'a>> + Send + 'a>;
-
-/// A sortable, comparable key for a compilation output.
-///
-/// Two `u32`s to align with `cranelift_codegen::ir::UserExternalName`.
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-struct CompileKey {
-    // The namespace field is bitpacked like:
-    //
-    //     [ kind:i3 module:i29 ]
-    namespace: u32,
-
-    index: u32,
-}
-
-#[repr(u32)]
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-enum CompileKind {
-    WasmFunction = CompileKey::new_kind(0),
-    ArrayToWasmTrampoline = CompileKey::new_kind(1),
-    WasmToArrayTrampoline = CompileKey::new_kind(2),
-    WasmToBuiltinTrampoline = CompileKey::new_kind(3),
-
-    #[cfg(feature = "component-model")]
-    Trampoline = CompileKey::new_kind(4),
-    #[cfg(feature = "component-model")]
-    ResourceDropWasmToArrayTrampoline = CompileKey::new_kind(5),
-}
-
-impl From<CompileKind> for u32 {
-    fn from(kind: CompileKind) -> Self {
-        kind as u32
-    }
-}
-
-impl core::fmt::Debug for CompileKey {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CompileKey")
-            .field("kind", &self.kind())
-            .field("module", &self.module())
-            .field("index", &self.index)
-            .finish()
-    }
-}
-
-impl CompileKey {
-    const KIND_BITS: u32 = 3;
-    const KIND_OFFSET: u32 = 32 - Self::KIND_BITS;
-    const KIND_MASK: u32 = ((1 << Self::KIND_BITS) - 1) << Self::KIND_OFFSET;
-
-    const fn new_kind(kind: u32) -> u32 {
-        assert!(kind < (1 << Self::KIND_BITS));
-        kind << Self::KIND_OFFSET
-    }
-
-    fn kind(&self) -> CompileKind {
-        let k = self.namespace & Self::KIND_MASK;
-        if k == u32::from(CompileKind::WasmFunction) {
-            return CompileKind::WasmFunction;
-        }
-        if k == u32::from(CompileKind::ArrayToWasmTrampoline) {
-            return CompileKind::ArrayToWasmTrampoline;
-        }
-        if k == u32::from(CompileKind::WasmToArrayTrampoline) {
-            return CompileKind::WasmToArrayTrampoline;
-        }
-        if k == u32::from(CompileKind::WasmToBuiltinTrampoline) {
-            return CompileKind::WasmToBuiltinTrampoline;
-        }
-
-        #[cfg(feature = "component-model")]
-        {
-            if k == u32::from(CompileKind::Trampoline) {
-                return CompileKind::Trampoline;
-            }
-            if k == u32::from(CompileKind::ResourceDropWasmToArrayTrampoline) {
-                return CompileKind::ResourceDropWasmToArrayTrampoline;
-            }
-        }
-
-        unreachable!()
-    }
-
-    fn module(&self) -> StaticModuleIndex {
-        StaticModuleIndex::from_u32(self.namespace & !Self::KIND_MASK)
-    }
-
-    fn defined_func_index(&self) -> DefinedFuncIndex {
-        DefinedFuncIndex::from_u32(self.index)
-    }
-
-    // NB: more kinds in the other `impl` block.
-
-    fn wasm_function(module: StaticModuleIndex, index: DefinedFuncIndex) -> Self {
-        debug_assert_eq!(module.as_u32() & Self::KIND_MASK, 0);
-        Self {
-            namespace: u32::from(CompileKind::WasmFunction) | module.as_u32(),
-            index: index.as_u32(),
-        }
-    }
-
-    fn array_to_wasm_trampoline(module: StaticModuleIndex, index: DefinedFuncIndex) -> Self {
-        debug_assert_eq!(module.as_u32() & Self::KIND_MASK, 0);
-        Self {
-            namespace: u32::from(CompileKind::ArrayToWasmTrampoline) | module.as_u32(),
-            index: index.as_u32(),
-        }
-    }
-
-    fn wasm_to_array_trampoline(index: ModuleInternedTypeIndex) -> Self {
-        Self {
-            namespace: CompileKind::WasmToArrayTrampoline.into(),
-            index: index.as_u32(),
-        }
-    }
-
-    fn wasm_to_builtin_trampoline(index: BuiltinFunctionIndex) -> Self {
-        Self {
-            namespace: CompileKind::WasmToBuiltinTrampoline.into(),
-            index: index.index(),
-        }
-    }
-}
-
-#[cfg(feature = "component-model")]
-impl CompileKey {
-    fn trampoline(index: wasmtime_environ::component::TrampolineIndex) -> Self {
-        Self {
-            namespace: CompileKind::Trampoline.into(),
-            index: index.as_u32(),
-        }
-    }
-
-    fn resource_drop_wasm_to_array_trampoline() -> Self {
-        Self {
-            namespace: CompileKind::ResourceDropWasmToArrayTrampoline.into(),
-            index: 0,
-        }
-    }
-}
 
 #[derive(Clone, Copy)]
 enum CompiledFunction<T> {
@@ -405,11 +265,15 @@ impl<T> From<wasmtime_environ::component::AllCallFunc<T>> for CompiledFunction<T
 }
 
 struct CompileOutput<'a> {
-    key: CompileKey,
+    key: FuncKey,
     symbol: String,
     function: CompiledFunction<CompiledFunctionBody>,
     start_srcloc: FilePos,
+
+    // Only present when `self.key` is a `FuncKey::DefinedWasmFunction(..)`.
     translation: Option<&'a ModuleTranslation<'a>>,
+
+    // Only present when `self.key` is a `FuncKey::DefinedWasmFunction(..)`.
     func_body: Option<wasmparser::FunctionBody<'a>>,
 }
 
@@ -475,12 +339,13 @@ impl<'a> CompileInputs<'a> {
 
         for (idx, trampoline) in component.trampolines.iter() {
             ret.push_input(move |compiler| {
+                let key = FuncKey::ComponentTrampoline(idx);
                 let symbol = trampoline.symbol_name();
                 Ok(CompileOutput {
-                    key: CompileKey::trampoline(idx),
+                    key,
                     function: compiler
                         .component_compiler()
-                        .compile_trampoline(component, types, idx, tunables, &symbol)
+                        .compile_trampoline(component, types, key, tunables, &symbol)
                         .with_context(|| format!("failed to compile {symbol}"))?
                         .into(),
                     symbol,
@@ -500,12 +365,13 @@ impl<'a> CompileInputs<'a> {
         if component.component.num_resources > 0 {
             if let Some(sig) = types.find_resource_drop_signature() {
                 ret.push_input(move |compiler| {
+                    let key = FuncKey::ResourceDropTrampoline;
                     let symbol = "resource_drop_trampoline".to_string();
                     let function = compiler
-                        .compile_wasm_to_array_trampoline(types[sig].unwrap_func(), &symbol)
+                        .compile_wasm_to_array_trampoline(types[sig].unwrap_func(), key, &symbol)
                         .with_context(|| format!("failed to compile `{symbol}`"))?;
                     Ok(CompileOutput {
-                        key: CompileKey::resource_drop_wasm_to_array_trampoline(),
+                        key,
                         function: CompiledFunction::Function(function),
                         symbol,
                         start_srcloc: FilePos::default(),
@@ -563,6 +429,7 @@ impl<'a> CompileInputs<'a> {
         for (module, translation, functions) in translations {
             for (def_func_index, func_body_data) in functions {
                 self.push_input(move |compiler| {
+                    let key = FuncKey::DefinedWasmFunction(module, def_func_index);
                     let func_index = translation.module.func_index(def_func_index);
                     let symbol = match translation
                         .debuginfo
@@ -587,17 +454,11 @@ impl<'a> CompileInputs<'a> {
                     let offset = data.original_position();
                     let start_srcloc = FilePos::new(u32::try_from(offset).unwrap());
                     let function = compiler
-                        .compile_function(
-                            translation,
-                            def_func_index,
-                            func_body_data,
-                            types,
-                            &symbol,
-                        )
+                        .compile_function(translation, key, func_body_data, types, &symbol)
                         .with_context(|| format!("failed to compile: {symbol}"))?;
 
                     Ok(CompileOutput {
-                        key: CompileKey::wasm_function(module, def_func_index),
+                        key,
                         symbol,
                         function: CompiledFunction::Function(function),
                         start_srcloc,
@@ -609,6 +470,7 @@ impl<'a> CompileInputs<'a> {
                 let func_index = translation.module.func_index(def_func_index);
                 if translation.module.functions[func_index].is_escaping() {
                     self.push_input(move |compiler| {
+                        let key = FuncKey::ArrayToWasmTrampoline(module, def_func_index);
                         let func_index = translation.module.func_index(def_func_index);
                         let symbol = format!(
                             "wasm[{}]::array_to_wasm_trampoline[{}]",
@@ -616,15 +478,10 @@ impl<'a> CompileInputs<'a> {
                             func_index.as_u32()
                         );
                         let trampoline = compiler
-                            .compile_array_to_wasm_trampoline(
-                                translation,
-                                types,
-                                def_func_index,
-                                &symbol,
-                            )
+                            .compile_array_to_wasm_trampoline(translation, types, key, &symbol)
                             .with_context(|| format!("failed to compile: {symbol}"))?;
                         Ok(CompileOutput {
-                            key: CompileKey::array_to_wasm_trampoline(module, def_func_index),
+                            key,
                             symbol,
                             function: CompiledFunction::Function(trampoline),
                             start_srcloc: FilePos::default(),
@@ -644,15 +501,16 @@ impl<'a> CompileInputs<'a> {
             }
             let trampoline_func_ty = types[trampoline_type_index].unwrap_func();
             self.push_input(move |compiler| {
+                let key = FuncKey::WasmToArrayTrampoline(trampoline_type_index);
                 let symbol = format!(
                     "signatures[{}]::wasm_to_array_trampoline",
                     trampoline_type_index.as_u32()
                 );
                 let trampoline = compiler
-                    .compile_wasm_to_array_trampoline(trampoline_func_ty, &symbol)
+                    .compile_wasm_to_array_trampoline(trampoline_func_ty, key, &symbol)
                     .with_context(|| format!("failed to compile: {symbol}"))?;
                 Ok(CompileOutput {
-                    key: CompileKey::wasm_to_array_trampoline(trampoline_type_index),
+                    key,
                     function: CompiledFunction::Function(trampoline),
                     symbol,
                     start_srcloc: FilePos::default(),
@@ -731,9 +589,9 @@ the use case.
         compile_required_builtins(engine, &mut raw_outputs)?;
 
         // Bucket the outputs by kind.
-        let mut outputs: BTreeMap<CompileKind, Vec<CompileOutput>> = BTreeMap::new();
+        let mut outputs: BTreeMap<FuncKey, CompileOutput> = BTreeMap::new();
         for output in raw_outputs {
-            outputs.entry(output.key.kind()).or_default().push(output);
+            outputs.insert(output.key, output);
         }
 
         Ok(UnlinkedCompileOutputs { outputs })
@@ -761,12 +619,9 @@ the use case.
         fn wasm_functions<'a>(
             outputs: &'a PrimaryMap<OutputIndex, Option<CompileOutput<'_>>>,
         ) -> impl Iterator<Item = OutputIndex> + 'a {
-            outputs.iter().filter_map(|(i, o)| {
-                if o.as_ref()?.key.kind() == CompileKind::WasmFunction {
-                    Some(i)
-                } else {
-                    None
-                }
+            outputs.iter().filter_map(|(i, o)| match o.as_ref()?.key {
+                FuncKey::DefinedWasmFunction(..) => Some(i),
+                _ => None,
             })
         }
 
@@ -780,11 +635,15 @@ the use case.
         // module. This map enables that translation.
         let pair_to_output: HashMap<(StaticModuleIndex, DefinedFuncIndex), OutputIndex> = outputs
             .iter()
-            .filter(|(_, output)| output.as_ref().unwrap().key.kind() == CompileKind::WasmFunction)
+            .filter(|(_, output)| {
+                matches!(
+                    output.as_ref().unwrap().key,
+                    FuncKey::DefinedWasmFunction(..)
+                )
+            })
             .map(|(output_index, output)| {
                 let output = output.as_ref().unwrap();
-                let module_index = output.key.module();
-                let defined_func_index = output.key.defined_func_index();
+                let (module_index, defined_func_index) = output.key.unwrap_defined_wasm_function();
                 ((module_index, defined_func_index), output_index)
             })
             .collect();
@@ -795,14 +654,14 @@ the use case.
         // trampolines being in their own stack frame when we save the entry and
         // exit SP, FP, and PC for backtraces in trampolines.
         let call_graph = CallGraph::<OutputIndex>::new(wasm_functions(&outputs), {
-            let mut func_indices = IndexSet::default();
+            let mut compile_keys = IndexSet::default();
             let outputs = &outputs;
             let pair_to_output = &pair_to_output;
             move |output_index, calls| {
                 debug_assert!(calls.is_empty());
 
                 let output = outputs[output_index].as_ref().unwrap();
-                debug_assert_eq!(output.key.kind(), CompileKind::WasmFunction);
+                debug_assert!(matches!(output.key, FuncKey::DefinedWasmFunction(..)));
 
                 let func = match &output.function {
                     CompiledFunction::Function(f) => f,
@@ -812,31 +671,17 @@ the use case.
                     }
                 };
 
-                // Get this function's call graph edges as `FuncIndex`es.
-                func_indices.clear();
-                inlining_compiler.calls(func, &mut func_indices)?;
+                // Get this function's call graph edges as `CompileKey`s.
+                compile_keys.clear();
+                inlining_compiler.calls(func, &mut compile_keys)?;
 
                 // Translate each of those to (module, defined-function-index)
                 // pairs and then finally to output indices, which is what we
                 // actually need.
-                let caller_module = output.key.module();
-                let translation = output
-                    .translation
-                    .expect("all wasm functions have translations");
-                calls.extend(func_indices.iter().copied().filter_map(|callee_func| {
-                    if let Some(callee_def_func) =
-                        translation.module.defined_func_index(callee_func)
-                    {
-                        // Call to a function in the same module.
-                        Some(pair_to_output[&(caller_module, callee_def_func)])
-                    } else if let Some(pair) = translation.known_imported_functions[callee_func] {
-                        // Call to a statically-known imported function.
-                        Some(pair_to_output[&pair])
+                calls.extend(compile_keys.iter().copied().filter_map(|key| {
+                    if let FuncKey::DefinedWasmFunction(module, def_func) = key {
+                        Some(pair_to_output[&(module, def_func)])
                     } else {
-                        // Call to an unknown imported function or perhaps to
-                        // multiple different functions in different
-                        // instantiations. Can't inline these calls, so don't
-                        // add them to the call graph.
                         None
                     }
                 }));
@@ -868,12 +713,12 @@ the use case.
             engine.run_maybe_parallel_mut(
                 &mut layer_outputs,
                 |output: &mut CompileOutput<'_>| {
-                    debug_assert_eq!(output.key.kind(), CompileKind::WasmFunction);
                     log::trace!("processing inlining for {:?}", output.key);
+                    debug_assert!(matches!(output.key, FuncKey::DefinedWasmFunction(..)));
 
                     let caller_translation = output.translation.unwrap();
-                    let caller_module = output.key.module();
-                    let caller_def_func = output.key.defined_func_index();
+                    let (caller_module, caller_def_func) =
+                        output.key.unwrap_defined_wasm_function();
                     let caller_needs_gc_heap = caller_translation.module.needs_gc_heap;
 
                     let caller = output
@@ -883,39 +728,30 @@ the use case.
 
                     let mut caller_size = inlining_compiler.size(caller);
 
-                    inlining_compiler.inline(caller, &mut |callee: FuncIndex| {
-                        let (callee_module, callee_def_func, callee_needs_gc_heap) =
-                            if let Some(def_func) =
-                                caller_translation.module.defined_func_index(callee)
-                            {
-                                (caller_module, def_func, Some(caller_needs_gc_heap))
-                            } else {
-                                let (def_module, def_func) = caller_translation
-                                    .known_imported_functions[callee]
-                                    .unwrap_or_else(|| {
-                                        panic!(
-                                            "a direct call to an imported function must have a \
-                                             statically-known definition, but direct call to imported \
-                                             function {callee:?} has no statically-known definition",
-                                        )
-                                    });
-                                (def_module, def_func, None)
-                            };
-
+                    inlining_compiler.inline(caller, &mut |callee_key: FuncKey| {
+                        let (callee_module, callee_def_func) =
+                            callee_key.unwrap_defined_wasm_function();
                         let callee_output_index: OutputIndex =
                             pair_to_output[&(callee_module, callee_def_func)];
-                        let callee_output = outputs[callee_output_index].as_ref()?;
-                        let callee_needs_gc_heap = callee_needs_gc_heap.unwrap_or_else(|| {
-                            callee_output.translation.unwrap().module.needs_gc_heap
-                        });
 
-                        debug_assert_eq!(callee_output.key.kind(), CompileKind::WasmFunction);
+                        // NB: If the callee is not inside `outputs`, then it is
+                        // in the same `Strata` layer as the caller (and
+                        // therefore is in the same strongly-connected component
+                        // as the caller, and they mutually recursive). In this
+                        // case, we do not do any inlining; communicate this
+                        // command via `?`-propagation.
+                        let callee_output = outputs[callee_output_index].as_ref()?;
+
+                        debug_assert_eq!(callee_output.key, callee_key);
+
                         let callee = callee_output
                             .function
                             .as_function()
                             .expect("wasm functions are not all-call functions");
-
                         let callee_size = inlining_compiler.size(callee);
+
+                        let callee_needs_gc_heap =
+                            callee_output.translation.unwrap().module.needs_gc_heap;
 
                         if Self::should_inline(InlineHeuristicParams {
                             tunables: engine.tunables(),
@@ -1078,15 +914,16 @@ fn compile_required_builtins(engine: &Engine, raw_outputs: &mut Vec<CompileOutpu
 
     let compile_builtin = |builtin: BuiltinFunctionIndex| {
         Box::new(move |compiler: &dyn Compiler| {
+            let key = FuncKey::WasmToBuiltinTrampoline(builtin);
             let symbol = format!("wasmtime_builtin_{}", builtin.name());
             let mut trampoline = compiler
-                .compile_wasm_to_builtin(builtin, &symbol)
+                .compile_wasm_to_builtin(key, &symbol)
                 .with_context(|| format!("failed to compile `{symbol}`"))?;
             if let Some(compiler) = compiler.inlining_compiler() {
                 compiler.finish_compiling(&mut trampoline, None, &symbol)?;
             }
             Ok(CompileOutput {
-                key: CompileKey::wasm_to_builtin_trampoline(builtin),
+                key,
                 function: CompiledFunction::Function(trampoline),
                 symbol,
                 start_srcloc: FilePos::default(),
@@ -1103,13 +940,10 @@ fn compile_required_builtins(engine: &Engine, raw_outputs: &mut Vec<CompileOutpu
             CompiledFunction::AllCallFunc(_) => continue,
         };
         for reloc in compiler.compiled_function_relocation_targets(&*f.code) {
-            match reloc {
-                RelocationTarget::Builtin(i) => {
-                    if builtins.insert(i) {
-                        new_inputs.push(compile_builtin(i));
-                    }
+            if let FuncKey::WasmToBuiltinTrampoline(builtin) = reloc {
+                if builtins.insert(builtin) {
+                    new_inputs.push(compile_builtin(builtin));
                 }
-                _ => {}
             }
         }
     }
@@ -1120,7 +954,7 @@ fn compile_required_builtins(engine: &Engine, raw_outputs: &mut Vec<CompileOutpu
 #[derive(Default)]
 struct UnlinkedCompileOutputs<'a> {
     // A map from kind to `CompileOutput`.
-    outputs: BTreeMap<CompileKind, Vec<CompileOutput<'a>>>,
+    outputs: BTreeMap<FuncKey, CompileOutput<'a>>,
 }
 
 impl UnlinkedCompileOutputs<'_> {
@@ -1136,7 +970,7 @@ impl UnlinkedCompileOutputs<'_> {
         let mut indices = FunctionIndices::default();
         let mut needs_gc_heap = false;
 
-        for output in self.outputs.into_iter().flat_map(|(_kind, outs)| outs) {
+        for output in self.outputs.into_values() {
             let index = match output.function {
                 CompiledFunction::Function(f) => {
                     needs_gc_heap |= f.needs_gc_heap;
@@ -1164,22 +998,18 @@ impl UnlinkedCompileOutputs<'_> {
                 }
             };
 
-            if output.key.kind() == CompileKind::WasmFunction
-                || output.key.kind() == CompileKind::ArrayToWasmTrampoline
+            if let FuncKey::DefinedWasmFunction(module, _)
+            | FuncKey::ArrayToWasmTrampoline(module, _) = output.key
             {
                 indices
                     .compiled_func_index_to_module
-                    .insert(index.unwrap_function(), output.key.module());
+                    .insert(index.unwrap_function(), module);
                 indices
                     .start_srclocs
                     .insert(output.key, output.start_srcloc);
             }
 
-            indices
-                .indices
-                .entry(output.key.kind())
-                .or_default()
-                .insert(output.key, index);
+            indices.indices.insert(output.key, index);
         }
 
         PreLinkOutput {
@@ -1209,17 +1039,17 @@ struct FunctionIndices {
     compiled_func_index_to_module: HashMap<usize, StaticModuleIndex>,
 
     // A map of wasm functions and where they're located in the original file.
-    start_srclocs: HashMap<CompileKey, FilePos>,
+    start_srclocs: HashMap<FuncKey, FilePos>,
 
-    // The index of each compiled function, bucketed by compile key kind.
-    indices: BTreeMap<CompileKind, BTreeMap<CompileKey, CompiledFunction<usize>>>,
+    // The index of each compiled function.
+    indices: BTreeMap<FuncKey, CompiledFunction<usize>>,
 }
 
 impl FunctionIndices {
     /// Link the compiled functions together, resolving relocations, and append
     /// them to the given ELF file.
     fn link_and_append_code<'a>(
-        mut self,
+        self,
         types: &ModuleTypesBuilder,
         mut obj: object::write::Object<'static>,
         engine: &'a Engine,
@@ -1237,36 +1067,13 @@ impl FunctionIndices {
         let symbol_ids_and_locs = compiler.append_code(
             &mut obj,
             &compiled_funcs,
-            &|caller_index: usize, callee: RelocationTarget| match callee {
-                RelocationTarget::Wasm(callee_index) => {
-                    let caller_module = self
-                        .compiled_func_index_to_module
-                        .get(&caller_index)
-                        .copied()
-                        .expect("should only reloc inside wasm function callers");
-                    let key = if let Some(def_func_index) = translations[caller_module]
-                        .module
-                        .defined_func_index(callee_index)
-                    {
-                        CompileKey::wasm_function(caller_module, def_func_index)
-                    } else {
-                        let (def_module, def_func_index) = translations[caller_module]
-                            .known_imported_functions[callee_index]
-                            .expect(
-                                "a direct call to an imported function must have a \
-                                 statically-known import",
-                            );
-                        CompileKey::wasm_function(def_module, def_func_index)
-                    };
-                    self.indices[&CompileKind::WasmFunction][&key].unwrap_function()
-                }
-                RelocationTarget::Builtin(builtin) => self.indices
-                    [&CompileKind::WasmToBuiltinTrampoline]
-                    [&CompileKey::wasm_to_builtin_trampoline(builtin)]
-                    .unwrap_function(),
-                RelocationTarget::PulleyHostcall(_) => {
-                    unreachable!("relocation is resolved at runtime, not compile time");
-                }
+            &|_caller_index: usize, callee: FuncKey| {
+                self.indices
+                    .get(&callee)
+                    .and_then(|f| f.as_function().copied())
+                    .unwrap_or_else(|| {
+                        panic!("cannot resolve relocation! no index for callee {callee:?}")
+                    })
             },
         )?;
 
@@ -1276,106 +1083,122 @@ impl FunctionIndices {
                 &mut obj,
                 &translations,
                 &|module, func| {
-                    let bucket = &self.indices[&CompileKind::WasmFunction];
-                    let i = bucket[&CompileKey::wasm_function(module, func)].unwrap_function();
-                    (symbol_ids_and_locs[i].0, &*compiled_funcs[i].1)
+                    let i =
+                        self.indices[&FuncKey::DefinedWasmFunction(module, func)].unwrap_function();
+                    let (symbol, _) = symbol_ids_and_locs[i];
+                    let (_, compiled_func) = &compiled_funcs[i];
+                    (symbol, compiled_func)
                 },
                 dwarf_package_bytes,
                 tunables,
             )?;
         }
 
-        let mut obj = wasmtime_environ::ObjectBuilder::new(obj, tunables);
-        let mut artifacts = Artifacts::default();
+        // TODO FITZGEN
+        let mut def_funcs = SecondaryMap::<
+            StaticModuleIndex,
+            PrimaryMap<DefinedFuncIndex, CompiledFunctionInfo>,
+        >::new();
 
-        // Remove this as it's not needed by anything below and we'll debug
-        // assert `self.indices` is empty, so this is acknowledgement that this
-        // is a pure runtime implementation detail and not needed in any
-        // metadata generated below.
-        self.indices.remove(&CompileKind::WasmToBuiltinTrampoline);
+        #[cfg(feature = "component-model")]
+        let mut trampolines = PrimaryMap::<
+            wasmtime_environ::component::TrampolineIndex,
+            wasmtime_environ::component::AllCallFunc<FunctionLoc>,
+        >::new();
 
-        // Finally, build our binary artifacts that map things like `FuncIndex`
-        // to a function location and all of that using the indices we saved
-        // earlier and the function locations we just received after appending
-        // the code.
+        #[cfg(feature = "component-model")]
+        let mut resource_drop_trampoline = None;
 
-        let mut wasm_functions = self
-            .indices
-            .remove(&CompileKind::WasmFunction)
-            .unwrap_or_default()
-            .into_iter()
-            .peekable();
+        for (key, index) in &self.indices {
+            match *key {
+                FuncKey::DefinedWasmFunction(module, def_func) => {
+                    let index = index.unwrap_function();
+                    let (_, wasm_func_loc) = symbol_ids_and_locs[index];
+                    let start_srcloc = self.start_srclocs[key];
 
-        fn wasm_functions_for_module(
-            wasm_functions: &mut std::iter::Peekable<
-                btree_map::IntoIter<CompileKey, CompiledFunction<usize>>,
-            >,
-            module: StaticModuleIndex,
-        ) -> impl Iterator<Item = (CompileKey, CompiledFunction<usize>)> + '_ {
-            std::iter::from_fn(move || {
-                let (key, _) = wasm_functions.peek()?;
-                if key.module() == module {
-                    wasm_functions.next()
-                } else {
-                    None
+                    let array_to_wasm_trampoline = self
+                        .indices
+                        .get(&FuncKey::ArrayToWasmTrampoline(module, def_func))
+                        .map(|index| {
+                            let index = index.unwrap_function();
+                            let (_, loc) = symbol_ids_and_locs[index];
+                            loc
+                        });
+
+                    debug_assert!(def_funcs[module].get(def_func).is_none());
+                    let def_func2 = def_funcs[module].push(CompiledFunctionInfo {
+                        start_srcloc,
+                        wasm_func_loc,
+                        array_to_wasm_trampoline,
+                    });
+                    debug_assert_eq!(def_func, def_func2);
                 }
-            })
+
+                FuncKey::ArrayToWasmTrampoline(module, def_func) => {
+                    // These are handled by the `DefinedWasmFunction` arm above.
+                    debug_assert!(def_funcs[module].get(def_func).is_some());
+                }
+
+                FuncKey::WasmToArrayTrampoline(_) => {
+                    // These are handled in `modules` creation below.
+                }
+
+                FuncKey::WasmToBuiltinTrampoline(_) => {
+                    // Nothing we need to do for these: they are only called by
+                    // Wasm functions, and we never create `funcref`s containing
+                    // them, so we don't need to keep any metadata for them or
+                    // anything like that.
+                }
+
+                FuncKey::PulleyHostCall(_) => {
+                    unreachable!("we don't compile any artifacts for Pulley host calls")
+                }
+
+                #[cfg(feature = "component-model")]
+                FuncKey::ComponentTrampoline(trampoline) => {
+                    let index = index.unwrap_all_call_func();
+                    let loc = index.map(|i| {
+                        let (_, loc) = symbol_ids_and_locs[i];
+                        loc
+                    });
+                    debug_assert!(trampolines.get(trampoline).is_none());
+                    let trampoline2 = trampolines.push(loc);
+                    debug_assert_eq!(trampoline, trampoline2);
+                }
+
+                #[cfg(feature = "component-model")]
+                FuncKey::ResourceDropTrampoline => {
+                    let index = index.unwrap_function();
+                    let (_, loc) = symbol_ids_and_locs[index];
+                    resource_drop_trampoline = Some(loc);
+                }
+            }
         }
 
-        let mut array_to_wasm_trampolines = self
-            .indices
-            .remove(&CompileKind::ArrayToWasmTrampoline)
-            .unwrap_or_default();
-
-        // NB: unlike the above maps this is not emptied out during iteration
-        // since each module may reach into different portions of this map.
-        let wasm_to_array_trampolines = self
-            .indices
-            .remove(&CompileKind::WasmToArrayTrampoline)
-            .unwrap_or_default();
-
-        artifacts.modules = translations
+        let mut obj = wasmtime_environ::ObjectBuilder::new(obj, tunables);
+        let modules = translations
             .into_iter()
             .map(|(module, mut translation)| {
-                // If configured attempt to use static memory initialization which
-                // can either at runtime be implemented as a single memcpy to
-                // initialize memory or otherwise enabling virtual-memory-tricks
-                // such as mmap'ing from a file to get copy-on-write.
+                let def_funcs = mem::take(&mut def_funcs[module]);
+
+                // If configured attempt to use static memory initialization
+                // which can either at runtime be implemented as a single memcpy
+                // to initialize memory or otherwise enabling
+                // virtual-memory-tricks such as mmap'ing from a file to get
+                // copy-on-write.
                 if engine.tunables().memory_init_cow {
                     let align = compiler.page_size_align();
                     let max_always_allowed = engine.config().memory_guaranteed_dense_image_size;
                     translation.try_static_init(align, max_always_allowed);
                 }
 
-                // Attempt to convert table initializer segments to
-                // FuncTable representation where possible, to enable
-                // table lazy init.
+                // Attempt to convert table initializer segments to FuncTable
+                // representation where possible, to enable table lazy init.
                 if engine.tunables().table_lazy_init {
                     translation.try_func_table_init();
                 }
 
-                let funcs: PrimaryMap<DefinedFuncIndex, CompiledFunctionInfo> =
-                    wasm_functions_for_module(&mut wasm_functions, module)
-                        .map(|(key, wasm_func_index)| {
-                            let wasm_func_index = wasm_func_index.unwrap_function();
-                            let wasm_func_loc = symbol_ids_and_locs[wasm_func_index].1;
-                            let start_srcloc = self.start_srclocs.remove(&key).unwrap();
-
-                            let array_to_wasm_trampoline = array_to_wasm_trampolines
-                                .remove(&CompileKey::array_to_wasm_trampoline(
-                                    key.module(),
-                                    DefinedFuncIndex::from_u32(key.index),
-                                ))
-                                .map(|x| symbol_ids_and_locs[x.unwrap_function()].1);
-
-                            CompiledFunctionInfo {
-                                start_srcloc,
-                                wasm_func_loc,
-                                array_to_wasm_trampoline,
-                            }
-                        })
-                        .collect();
-
+                // Gather this module's trampolines.
                 let unique_and_sorted_trampoline_sigs = translation
                     .module
                     .types
@@ -1385,43 +1208,25 @@ impl FunctionIndices {
                     .map(|idx| types.trampoline_type(idx))
                     .collect::<BTreeSet<_>>();
                 let wasm_to_array_trampolines = unique_and_sorted_trampoline_sigs
-                    .iter()
-                    .map(|idx| {
-                        let trampoline = types.trampoline_type(*idx);
-                        let key = CompileKey::wasm_to_array_trampoline(trampoline);
-                        let compiled = wasm_to_array_trampolines[&key];
-                        (*idx, symbol_ids_and_locs[compiled.unwrap_function()].1)
+                    .into_iter()
+                    .map(|ty| {
+                        debug_assert_eq!(ty, types.trampoline_type(ty));
+                        let key = FuncKey::WasmToArrayTrampoline(ty);
+                        let index = self.indices[&key].unwrap_function();
+                        let (_, loc) = symbol_ids_and_locs[index];
+                        (ty, loc)
                     })
                     .collect();
 
-                obj.append(translation, funcs, wasm_to_array_trampolines)
+                obj.append(translation, def_funcs, wasm_to_array_trampolines)
             })
             .collect::<Result<PrimaryMap<_, _>>>()?;
 
-        #[cfg(feature = "component-model")]
-        {
-            artifacts.trampolines = self
-                .indices
-                .remove(&CompileKind::Trampoline)
-                .unwrap_or_default()
-                .into_iter()
-                .map(|(_id, x)| x.unwrap_all_call_func().map(|i| symbol_ids_and_locs[i].1))
-                .collect();
-            let map = self
-                .indices
-                .remove(&CompileKind::ResourceDropWasmToArrayTrampoline)
-                .unwrap_or_default();
-            assert!(map.len() <= 1);
-            artifacts.resource_drop_wasm_to_array_trampoline = map
-                .into_iter()
-                .next()
-                .map(|(_id, x)| symbol_ids_and_locs[x.unwrap_function()].1);
-        }
-
-        debug_assert!(
-            self.indices.is_empty(),
-            "Should have processed all compile outputs"
-        );
+        let artifacts = Artifacts {
+            modules,
+            trampolines,
+            resource_drop_trampoline,
+        };
 
         Ok((obj, artifacts))
     }
@@ -1438,7 +1243,7 @@ struct Artifacts {
         wasmtime_environ::component::AllCallFunc<wasmtime_environ::FunctionLoc>,
     >,
     #[cfg(feature = "component-model")]
-    resource_drop_wasm_to_array_trampoline: Option<wasmtime_environ::FunctionLoc>,
+    resource_drop_trampoline: Option<wasmtime_environ::FunctionLoc>,
 }
 
 impl Artifacts {

--- a/tests/disas/call-indirect.wat
+++ b/tests/disas/call-indirect.wat
@@ -16,7 +16,7 @@
 ;;     gv5 = load.i64 notrap aligned gv3+56
 ;;     sig0 = (i64 vmctx, i64, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
-;;     fn0 = colocated u1:9 sig1
+;;     fn0 = colocated u1610612736:9 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):

--- a/tests/disas/component-model/direct-adapter-calls-inlining.wat
+++ b/tests/disas/component-model/direct-adapter-calls-inlining.wat
@@ -54,7 +54,7 @@
   (export "g" (func $b "g"))
 )
 
-;; function u0:1(i64 vmctx, i64) -> i32 tail {
+;; function u1:0(i64 vmctx, i64) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+16
@@ -70,7 +70,7 @@
 ;;     gv12 = load.i64 notrap aligned gv11+16
 ;;     sig0 = (i64 vmctx, i64, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64, i32) -> i32 tail
-;;     fn0 = colocated u0:0 sig0
+;;     fn0 = colocated u2:0 sig0
 ;;     fn1 = colocated u0:0 sig1
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/component-model/direct-adapter-calls.wat
+++ b/tests/disas/component-model/direct-adapter-calls.wat
@@ -72,13 +72,13 @@
 ;; @003b                               return v5
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64) -> i32 tail {
+;; function u1:0(i64 vmctx, i64) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i64, i32) -> i32 tail
-;;     fn0 = colocated u0:0 sig0
+;;     fn0 = colocated u2:0 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
@@ -91,7 +91,7 @@
 ;; @00f0                               return v6
 ;; }
 ;;
-;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
+;; function u2:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+16

--- a/tests/disas/component-model/enum.wat
+++ b/tests/disas/component-model/enum.wat
@@ -31,7 +31,7 @@
                   (with "f" (func $i1 "f"))))
 )
 
-;; function u0:1(i64 vmctx, i64) -> i32 tail {
+;; function u2:0(i64 vmctx, i64) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+16

--- a/tests/disas/component-model/exported-module-makes-adapters-indirect.wat
+++ b/tests/disas/component-model/exported-module-makes-adapters-indirect.wat
@@ -58,7 +58,7 @@
   (export "module" (core module $b "module"))
 )
 
-;; function u0:1(i64 vmctx, i64) -> i32 tail {
+;; function u1:0(i64 vmctx, i64) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+16

--- a/tests/disas/component-model/inlining-bug.wat
+++ b/tests/disas/component-model/inlining-bug.wat
@@ -5,26 +5,23 @@
 
 (component
   (core module $A
-    (func (export "f0") (result i32)
-      (i32.const 100)
-    )
-    (func (export "f1") (result i32)
-      (i32.const 101)
-    )
+    (func (export "f0") (result i32) (i32.const 0))
+    (func (export "f1") (result i32) (call $not-inlined) (i32.const 1))
+    (func $not-inlined )
   )
 
   (core module $B
     (import "a" "f0" (func $f0 (result i32)))
     (import "a" "f1" (func $f1 (result i32)))
     (func (export "f2") (result i32)
-      (i32.add (call $f0) (call $f1))
+      (call $f1)
     )
   )
 
   (core module $C
     (import "b" "f2" (func $f2 (result i32)))
     (func (export "f3") (result i32)
-      (i32.add (i32.const 100) (call $f2))
+      (call $f2)
     )
   )
 
@@ -54,24 +51,19 @@
 ;;     gv13 = load.i64 notrap aligned gv12+16
 ;;     sig0 = (i64 vmctx, i64) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64) -> i32 tail
+;;     sig2 = (i64 vmctx, i64) tail
 ;;     fn0 = colocated u1:0 sig0
-;;     fn1 = colocated u0:0 sig1
-;;     fn2 = colocated u0:1 sig1
+;;     fn1 = colocated u0:1 sig1
+;;     fn2 = colocated u0:2 sig2
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @00c3                               jump block2
+;; @00d4                               jump block2
 ;;
 ;;                                 block2:
 ;;                                     jump block4
 ;;
 ;;                                 block4:
-;;                                     jump block5
-;;
-;;                                 block5:
-;;                                     jump block6
-;;
-;;                                 block6:
 ;;                                     jump block7
 ;;
 ;;                                 block7:
@@ -81,15 +73,21 @@
 ;;                                     jump block9
 ;;
 ;;                                 block9:
+;;                                     jump block5
+;;
+;;                                 block5:
+;;                                     jump block6
+;;
+;;                                 block6:
 ;;                                     jump block3
 ;;
 ;;                                 block3:
 ;;                                     jump block10
 ;;
 ;;                                 block10:
-;; @00c6                               jump block1
+;; @00d6                               jump block1
 ;;
 ;;                                 block1:
-;;                                     v26 = iconst.i32 301
-;; @00c6                               return v26  ; v26 = 301
+;;                                     v11 = iconst.i32 1
+;; @00d6                               return v11  ; v11 = 1
 ;; }

--- a/tests/disas/component-model/multiple-instantiations-makes-adapters-indirect.wat
+++ b/tests/disas/component-model/multiple-instantiations-makes-adapters-indirect.wat
@@ -64,7 +64,7 @@
   (export "module" (core module $b "module"))
 )
 
-;; function u0:1(i64 vmctx, i64) -> i32 tail {
+;; function u1:0(i64 vmctx, i64) -> i32 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+16

--- a/tests/disas/duplicate-function-types.wat
+++ b/tests/disas/duplicate-function-types.wat
@@ -26,7 +26,7 @@
 ;;     gv6 = load.i64 notrap aligned gv4+8
 ;;     sig0 = (i64 vmctx, i64) -> i32 tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
-;;     fn0 = colocated u1:9 sig1
+;;     fn0 = colocated u1610612736:9 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/epoch-interruption.wat
+++ b/tests/disas/epoch-interruption.wat
@@ -11,7 +11,7 @@
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
 ;;     sig0 = (i64 vmctx) -> i64 tail
-;;     fn0 = colocated u1:16 sig0
+;;     fn0 = colocated u1610612736:16 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):

--- a/tests/disas/gc/drc/array-new-fixed-of-gc-refs.wat
+++ b/tests/disas/gc/drc/array-new-fixed-of-gc-refs.wat
@@ -21,7 +21,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+24
 ;;     gv6 = load.i64 notrap aligned gv4+32
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
-;;     fn0 = colocated u1:27 sig0
+;;     fn0 = colocated u1610612736:27 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):

--- a/tests/disas/gc/drc/array-new-fixed.wat
+++ b/tests/disas/gc/drc/array-new-fixed.wat
@@ -17,7 +17,7 @@
 ;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+24
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
-;;     fn0 = colocated u1:27 sig0
+;;     fn0 = colocated u1610612736:27 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64):

--- a/tests/disas/gc/drc/array-new.wat
+++ b/tests/disas/gc/drc/array-new.wat
@@ -17,7 +17,7 @@
 ;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+24
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
-;;     fn0 = colocated u1:27 sig0
+;;     fn0 = colocated u1610612736:27 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):

--- a/tests/disas/gc/drc/br-on-cast-fail.wat
+++ b/tests/disas/gc/drc/br-on-cast-fail.wat
@@ -16,7 +16,7 @@
     return
   )
 )
-;; function u0:2(i64 vmctx, i64, i32) tail {
+;; function u0:0(i64 vmctx, i64, i32) tail {
 ;;     ss0 = explicit_slot 4, align = 4
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
@@ -27,7 +27,7 @@
 ;;     gv6 = load.i64 notrap aligned gv4+32
 ;;     sig0 = (i64 vmctx, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64) tail
-;;     fn0 = colocated u1:35 sig0
+;;     fn0 = colocated u1610612736:35 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/drc/br-on-cast.wat
+++ b/tests/disas/gc/drc/br-on-cast.wat
@@ -16,7 +16,7 @@
     return
   )
 )
-;; function u0:2(i64 vmctx, i64, i32) tail {
+;; function u0:0(i64 vmctx, i64, i32) tail {
 ;;     ss0 = explicit_slot 4, align = 4
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
@@ -27,7 +27,7 @@
 ;;     gv6 = load.i64 notrap aligned gv4+32
 ;;     sig0 = (i64 vmctx, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64) tail
-;;     fn0 = colocated u1:35 sig0
+;;     fn0 = colocated u1610612736:35 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/drc/call-indirect-and-subtyping.wat
+++ b/tests/disas/gc/drc/call-indirect-and-subtyping.wat
@@ -16,7 +16,7 @@
     (call_indirect (type $t1) (local.get 0))
   )
 )
-;; function u0:2(i64 vmctx, i64, i32) tail {
+;; function u0:0(i64 vmctx, i64, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+16
@@ -25,8 +25,8 @@
 ;;     sig0 = (i64 vmctx, i64) tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
 ;;     sig2 = (i64 vmctx, i32, i32) -> i32 tail
-;;     fn0 = colocated u1:9 sig1
-;;     fn1 = colocated u1:35 sig2
+;;     fn0 = colocated u1610612736:9 sig1
+;;     fn1 = colocated u1610612736:35 sig2
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/drc/externref-globals.wat
+++ b/tests/disas/gc/drc/externref-globals.wat
@@ -78,7 +78,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+24
 ;;     gv6 = load.i64 notrap aligned gv4+32
 ;;     sig0 = (i64 vmctx, i32) tail
-;;     fn0 = colocated u1:25 sig0
+;;     fn0 = colocated u1610612736:25 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/drc/funcref-in-gc-heap-get.wat
+++ b/tests/disas/gc/drc/funcref-in-gc-heap-get.wat
@@ -18,7 +18,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+24
 ;;     gv6 = load.i64 notrap aligned gv4+32
 ;;     sig0 = (i64 vmctx, i32, i32) -> i64 tail
-;;     fn0 = colocated u1:29 sig0
+;;     fn0 = colocated u1610612736:29 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/drc/funcref-in-gc-heap-new.wat
+++ b/tests/disas/gc/drc/funcref-in-gc-heap-new.wat
@@ -19,8 +19,8 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+24
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64) -> i64 tail
-;;     fn0 = colocated u1:27 sig0
-;;     fn1 = colocated u1:28 sig1
+;;     fn0 = colocated u1610612736:27 sig0
+;;     fn1 = colocated u1610612736:28 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):

--- a/tests/disas/gc/drc/funcref-in-gc-heap-set.wat
+++ b/tests/disas/gc/drc/funcref-in-gc-heap-set.wat
@@ -18,7 +18,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+24
 ;;     gv6 = load.i64 notrap aligned gv4+32
 ;;     sig0 = (i64 vmctx, i64) -> i64 tail
-;;     fn0 = colocated u1:28 sig0
+;;     fn0 = colocated u1610612736:28 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i64):

--- a/tests/disas/gc/drc/ref-cast.wat
+++ b/tests/disas/gc/drc/ref-cast.wat
@@ -18,7 +18,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+24
 ;;     gv6 = load.i64 notrap aligned gv4+32
 ;;     sig0 = (i64 vmctx, i32, i32) -> i32 tail
-;;     fn0 = colocated u1:35 sig0
+;;     fn0 = colocated u1610612736:35 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/drc/ref-test-concrete-func-type.wat
+++ b/tests/disas/gc/drc/ref-test-concrete-func-type.wat
@@ -14,7 +14,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i32, i32) -> i32 tail
-;;     fn0 = colocated u1:35 sig0
+;;     fn0 = colocated u1610612736:35 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):

--- a/tests/disas/gc/drc/ref-test-concrete-type.wat
+++ b/tests/disas/gc/drc/ref-test-concrete-type.wat
@@ -17,7 +17,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+24
 ;;     gv6 = load.i64 notrap aligned gv4+32
 ;;     sig0 = (i64 vmctx, i32, i32) -> i32 tail
-;;     fn0 = colocated u1:35 sig0
+;;     fn0 = colocated u1610612736:35 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/drc/struct-new-default.wat
+++ b/tests/disas/gc/drc/struct-new-default.wat
@@ -20,7 +20,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+24
 ;;     gv6 = load.i64 notrap aligned gv4+32
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
-;;     fn0 = colocated u1:27 sig0
+;;     fn0 = colocated u1610612736:27 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):

--- a/tests/disas/gc/drc/struct-new.wat
+++ b/tests/disas/gc/drc/struct-new.wat
@@ -21,7 +21,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+24
 ;;     gv6 = load.i64 notrap aligned gv4+32
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
-;;     fn0 = colocated u1:27 sig0
+;;     fn0 = colocated u1610612736:27 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: f32, v3: i32, v4: i32):

--- a/tests/disas/gc/drc/struct-set.wat
+++ b/tests/disas/gc/drc/struct-set.wat
@@ -78,7 +78,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+24
 ;;     gv6 = load.i64 notrap aligned gv4+32
 ;;     sig0 = (i64 vmctx, i32) tail
-;;     fn0 = colocated u1:25 sig0
+;;     fn0 = colocated u1610612736:25 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):

--- a/tests/disas/gc/null/array-new-fixed-of-gc-refs.wat
+++ b/tests/disas/gc/null/array-new-fixed-of-gc-refs.wat
@@ -21,7 +21,7 @@
 ;;     gv5 = load.i64 notrap aligned gv4+32
 ;;     gv6 = load.i64 notrap aligned readonly can_move gv4+24
 ;;     sig0 = (i64 vmctx, i64) -> i8 tail
-;;     fn0 = colocated u1:26 sig0
+;;     fn0 = colocated u1610612736:26 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):

--- a/tests/disas/gc/null/array-new-fixed.wat
+++ b/tests/disas/gc/null/array-new-fixed.wat
@@ -18,7 +18,7 @@
 ;;     gv5 = load.i64 notrap aligned gv4+32
 ;;     gv6 = load.i64 notrap aligned readonly can_move gv4+24
 ;;     sig0 = (i64 vmctx, i64) -> i8 tail
-;;     fn0 = colocated u1:26 sig0
+;;     fn0 = colocated u1610612736:26 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64):

--- a/tests/disas/gc/null/array-new.wat
+++ b/tests/disas/gc/null/array-new.wat
@@ -18,7 +18,7 @@
 ;;     gv5 = load.i64 notrap aligned gv4+32
 ;;     gv6 = load.i64 notrap aligned readonly can_move gv4+24
 ;;     sig0 = (i64 vmctx, i64) -> i8 tail
-;;     fn0 = colocated u1:26 sig0
+;;     fn0 = colocated u1610612736:26 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):

--- a/tests/disas/gc/null/br-on-cast-fail.wat
+++ b/tests/disas/gc/null/br-on-cast-fail.wat
@@ -16,7 +16,7 @@
     return
   )
 )
-;; function u0:2(i64 vmctx, i64, i32) tail {
+;; function u0:0(i64 vmctx, i64, i32) tail {
 ;;     ss0 = explicit_slot 4, align = 4
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
@@ -27,7 +27,7 @@
 ;;     gv6 = load.i64 notrap aligned gv4+32
 ;;     sig0 = (i64 vmctx, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64) tail
-;;     fn0 = colocated u1:35 sig0
+;;     fn0 = colocated u1610612736:35 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/null/br-on-cast.wat
+++ b/tests/disas/gc/null/br-on-cast.wat
@@ -16,7 +16,7 @@
     return
   )
 )
-;; function u0:2(i64 vmctx, i64, i32) tail {
+;; function u0:0(i64 vmctx, i64, i32) tail {
 ;;     ss0 = explicit_slot 4, align = 4
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
@@ -27,7 +27,7 @@
 ;;     gv6 = load.i64 notrap aligned gv4+32
 ;;     sig0 = (i64 vmctx, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64) tail
-;;     fn0 = colocated u1:35 sig0
+;;     fn0 = colocated u1610612736:35 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/null/call-indirect-and-subtyping.wat
+++ b/tests/disas/gc/null/call-indirect-and-subtyping.wat
@@ -16,7 +16,7 @@
     (call_indirect (type $t1) (local.get 0))
   )
 )
-;; function u0:2(i64 vmctx, i64, i32) tail {
+;; function u0:0(i64 vmctx, i64, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+16
@@ -25,8 +25,8 @@
 ;;     sig0 = (i64 vmctx, i64) tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
 ;;     sig2 = (i64 vmctx, i32, i32) -> i32 tail
-;;     fn0 = colocated u1:9 sig1
-;;     fn1 = colocated u1:35 sig2
+;;     fn0 = colocated u1610612736:9 sig1
+;;     fn1 = colocated u1610612736:35 sig2
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/null/funcref-in-gc-heap-get.wat
+++ b/tests/disas/gc/null/funcref-in-gc-heap-get.wat
@@ -18,7 +18,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+24
 ;;     gv6 = load.i64 notrap aligned gv4+32
 ;;     sig0 = (i64 vmctx, i32, i32) -> i64 tail
-;;     fn0 = colocated u1:29 sig0
+;;     fn0 = colocated u1610612736:29 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/null/funcref-in-gc-heap-new.wat
+++ b/tests/disas/gc/null/funcref-in-gc-heap-new.wat
@@ -19,8 +19,8 @@
 ;;     gv6 = load.i64 notrap aligned readonly can_move gv4+24
 ;;     sig0 = (i64 vmctx, i64) -> i8 tail
 ;;     sig1 = (i64 vmctx, i64) -> i64 tail
-;;     fn0 = colocated u1:26 sig0
-;;     fn1 = colocated u1:28 sig1
+;;     fn0 = colocated u1610612736:26 sig0
+;;     fn1 = colocated u1610612736:28 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):

--- a/tests/disas/gc/null/funcref-in-gc-heap-set.wat
+++ b/tests/disas/gc/null/funcref-in-gc-heap-set.wat
@@ -18,7 +18,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+24
 ;;     gv6 = load.i64 notrap aligned gv4+32
 ;;     sig0 = (i64 vmctx, i64) -> i64 tail
-;;     fn0 = colocated u1:28 sig0
+;;     fn0 = colocated u1610612736:28 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i64):

--- a/tests/disas/gc/null/ref-cast.wat
+++ b/tests/disas/gc/null/ref-cast.wat
@@ -18,7 +18,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+24
 ;;     gv6 = load.i64 notrap aligned gv4+32
 ;;     sig0 = (i64 vmctx, i32, i32) -> i32 tail
-;;     fn0 = colocated u1:35 sig0
+;;     fn0 = colocated u1610612736:35 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/null/ref-test-concrete-func-type.wat
+++ b/tests/disas/gc/null/ref-test-concrete-func-type.wat
@@ -14,7 +14,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i32, i32) -> i32 tail
-;;     fn0 = colocated u1:35 sig0
+;;     fn0 = colocated u1610612736:35 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):

--- a/tests/disas/gc/null/ref-test-concrete-type.wat
+++ b/tests/disas/gc/null/ref-test-concrete-type.wat
@@ -17,7 +17,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+24
 ;;     gv6 = load.i64 notrap aligned gv4+32
 ;;     sig0 = (i64 vmctx, i32, i32) -> i32 tail
-;;     fn0 = colocated u1:35 sig0
+;;     fn0 = colocated u1610612736:35 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/null/struct-new-default.wat
+++ b/tests/disas/gc/null/struct-new-default.wat
@@ -20,7 +20,7 @@
 ;;     gv5 = load.i64 notrap aligned gv4+32
 ;;     gv6 = load.i64 notrap aligned readonly can_move gv4+24
 ;;     sig0 = (i64 vmctx, i64) -> i8 tail
-;;     fn0 = colocated u1:26 sig0
+;;     fn0 = colocated u1610612736:26 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):

--- a/tests/disas/gc/null/struct-new.wat
+++ b/tests/disas/gc/null/struct-new.wat
@@ -21,7 +21,7 @@
 ;;     gv5 = load.i64 notrap aligned gv4+32
 ;;     gv6 = load.i64 notrap aligned readonly can_move gv4+24
 ;;     sig0 = (i64 vmctx, i64) -> i8 tail
-;;     fn0 = colocated u1:26 sig0
+;;     fn0 = colocated u1610612736:26 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: f32, v3: i32, v4: i32):

--- a/tests/disas/gc/struct-new-default.wat
+++ b/tests/disas/gc/struct-new-default.wat
@@ -21,7 +21,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+24
 ;;     gv6 = load.i64 notrap aligned gv4+32
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
-;;     fn0 = colocated u1:27 sig0
+;;     fn0 = colocated u1610612736:27 sig0
 ;;     const0 = 0x00000000000000000000000000000000
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/gc/struct-new.wat
+++ b/tests/disas/gc/struct-new.wat
@@ -21,7 +21,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+24
 ;;     gv6 = load.i64 notrap aligned gv4+32
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
-;;     fn0 = colocated u1:27 sig0
+;;     fn0 = colocated u1610612736:27 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: f32, v3: i32, v4: i32):

--- a/tests/disas/icall-loop.wat
+++ b/tests/disas/icall-loop.wat
@@ -30,7 +30,7 @@
 ;;     gv4 = load.i64 notrap aligned readonly can_move gv3+48
 ;;     sig0 = (i64 vmctx, i64) -> i32 tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
-;;     fn0 = colocated u1:9 sig1
+;;     fn0 = colocated u1610612736:9 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -78,7 +78,7 @@
 ;;     gv4 = load.i64 notrap aligned readonly can_move gv3+48
 ;;     sig0 = (i64 vmctx, i64) -> i32 tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
-;;     fn0 = colocated u1:9 sig1
+;;     fn0 = colocated u1610612736:9 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):

--- a/tests/disas/icall-simd.wat
+++ b/tests/disas/icall-simd.wat
@@ -16,7 +16,7 @@
 ;;     gv4 = load.i64 notrap aligned readonly can_move gv3+48
 ;;     sig0 = (i64 vmctx, i64, i8x16) -> i8x16 tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
-;;     fn0 = colocated u1:9 sig1
+;;     fn0 = colocated u1610612736:9 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i8x16):

--- a/tests/disas/icall.wat
+++ b/tests/disas/icall.wat
@@ -16,7 +16,7 @@
 ;;     gv4 = load.i64 notrap aligned readonly can_move gv3+48
 ;;     sig0 = (i64 vmctx, i64, f32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
-;;     fn0 = colocated u1:9 sig1
+;;     fn0 = colocated u1610612736:9 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: f32):

--- a/tests/disas/indirect-call-no-caching.wat
+++ b/tests/disas/indirect-call-no-caching.wat
@@ -70,7 +70,7 @@
 ;;     gv4 = load.i64 notrap aligned readonly can_move gv3+48
 ;;     sig0 = (i64 vmctx, i64) -> i32 tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
-;;     fn0 = colocated u1:9 sig1
+;;     fn0 = colocated u1610612736:9 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/memory-min-max-same.wat
+++ b/tests/disas/memory-min-max-same.wat
@@ -33,7 +33,7 @@
     )
   )
 )
-;; function u0:1(i64 vmctx, i64, i32) tail {
+;; function u0:0(i64 vmctx, i64, i32) tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+16

--- a/tests/disas/passive-data.wat
+++ b/tests/disas/passive-data.wat
@@ -21,7 +21,7 @@
 ;;     gv4 = load.i64 notrap aligned gv3+64
 ;;     gv5 = load.i64 notrap aligned readonly can_move checked gv3+56
 ;;     sig0 = (i64 vmctx, i32, i32, i64, i32, i32) -> i8 tail
-;;     fn0 = colocated u1:6 sig0
+;;     fn0 = colocated u1610612736:6 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
@@ -41,7 +41,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i32) tail
-;;     fn0 = colocated u1:8 sig0
+;;     fn0 = colocated u1610612736:8 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):

--- a/tests/disas/readonly-funcrefs.wat
+++ b/tests/disas/readonly-funcrefs.wat
@@ -39,7 +39,7 @@
 ;;     gv4 = load.i64 notrap aligned readonly can_move gv3+48
 ;;     sig0 = (i64 vmctx, i64) tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
-;;     fn0 = colocated u1:9 sig1
+;;     fn0 = colocated u1610612736:9 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/ref-func-0.wat
+++ b/tests/disas/ref-func-0.wat
@@ -13,7 +13,7 @@
   (global (export "funcref-imported") funcref (ref.func $imported))
   (global (export "funcref-local") funcref (ref.func $local)))
 
-;; function u0:1(i64 vmctx, i64) -> i32, i32, i64, i64 tail {
+;; function u0:0(i64 vmctx, i64) -> i32, i32, i64, i64 tail {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+16

--- a/tests/disas/table-copy.wat
+++ b/tests/disas/table-copy.wat
@@ -68,7 +68,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i32, i32, i64, i64, i64) -> i8 tail
-;;     fn0 = colocated u1:1 sig0
+;;     fn0 = colocated u1610612736:1 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
@@ -90,7 +90,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i32, i32, i64, i64, i64) -> i8 tail
-;;     fn0 = colocated u1:1 sig0
+;;     fn0 = colocated u1610612736:1 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):

--- a/tests/disas/table-set-fixed-size.wat
+++ b/tests/disas/table-set-fixed-size.wat
@@ -26,7 +26,7 @@
 ;;     gv6 = load.i64 notrap aligned readonly can_move gv5+24
 ;;     gv7 = load.i64 notrap aligned gv5+32
 ;;     sig0 = (i64 vmctx, i32) tail
-;;     fn0 = colocated u1:25 sig0
+;;     fn0 = colocated u1610612736:25 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -123,7 +123,7 @@
 ;;     gv6 = load.i64 notrap aligned readonly can_move gv5+24
 ;;     gv7 = load.i64 notrap aligned gv5+32
 ;;     sig0 = (i64 vmctx, i32) tail
-;;     fn0 = colocated u1:25 sig0
+;;     fn0 = colocated u1610612736:25 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):

--- a/tests/disas/table-set.wat
+++ b/tests/disas/table-set.wat
@@ -27,7 +27,7 @@
 ;;     gv7 = load.i64 notrap aligned readonly can_move gv6+24
 ;;     gv8 = load.i64 notrap aligned gv6+32
 ;;     sig0 = (i64 vmctx, i32) tail
-;;     fn0 = colocated u1:25 sig0
+;;     fn0 = colocated u1610612736:25 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -126,7 +126,7 @@
 ;;     gv7 = load.i64 notrap aligned readonly can_move gv6+24
 ;;     gv8 = load.i64 notrap aligned gv6+32
 ;;     sig0 = (i64 vmctx, i32) tail
-;;     fn0 = colocated u1:25 sig0
+;;     fn0 = colocated u1610612736:25 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):

--- a/tests/disas/typed-funcrefs.wat
+++ b/tests/disas/typed-funcrefs.wat
@@ -134,7 +134,7 @@
 ;;     gv4 = load.i64 notrap aligned readonly can_move gv3+48
 ;;     sig0 = (i64 vmctx, i32, i64) -> i64 tail
 ;;     sig1 = (i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail
-;;     fn0 = colocated u1:9 sig0
+;;     fn0 = colocated u1610612736:9 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
@@ -188,7 +188,7 @@
 ;;     gv4 = load.i64 notrap aligned readonly can_move gv3+48
 ;;     sig0 = (i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
-;;     fn0 = colocated u1:9 sig1
+;;     fn0 = colocated u1610612736:9 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):

--- a/tests/disas/winch/x64/table/init_copy_drop.wat
+++ b/tests/disas/winch/x64/table/init_copy_drop.wat
@@ -142,11 +142,11 @@
 ;;       movl    $7, %ecx
 ;;       movl    $0, %r8d
 ;;       movl    $4, %r9d
-;;       callq   0x8a7
+;;       callq   0x905
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $1, %esi
-;;       callq   0x905
+;;       callq   0x963
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
@@ -154,11 +154,11 @@
 ;;       movl    $0xf, %ecx
 ;;       movl    $1, %r8d
 ;;       movl    $3, %r9d
-;;       callq   0x8a7
+;;       callq   0x905
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $3, %esi
-;;       callq   0x905
+;;       callq   0x963
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
@@ -166,7 +166,7 @@
 ;;       movl    $0x14, %ecx
 ;;       movl    $0xf, %r8d
 ;;       movl    $5, %r9d
-;;       callq   0x943
+;;       callq   0x8a7
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
@@ -174,7 +174,7 @@
 ;;       movl    $0x15, %ecx
 ;;       movl    $0x1d, %r8d
 ;;       movl    $1, %r9d
-;;       callq   0x943
+;;       callq   0x8a7
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
@@ -182,7 +182,7 @@
 ;;       movl    $0x18, %ecx
 ;;       movl    $0xa, %r8d
 ;;       movl    $1, %r9d
-;;       callq   0x943
+;;       callq   0x8a7
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
@@ -190,7 +190,7 @@
 ;;       movl    $0xd, %ecx
 ;;       movl    $0xb, %r8d
 ;;       movl    $4, %r9d
-;;       callq   0x943
+;;       callq   0x8a7
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
@@ -198,7 +198,7 @@
 ;;       movl    $0x13, %ecx
 ;;       movl    $0x14, %r8d
 ;;       movl    $5, %r9d
-;;       callq   0x943
+;;       callq   0x8a7
 ;;       movq    8(%rsp), %r14
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp

--- a/tests/disas/x64-simd-round-without-sse41.wat
+++ b/tests/disas/x64-simd-round-without-sse41.wat
@@ -17,7 +17,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, f32) -> f32 tail
-;;     fn0 = colocated u1:38 sig0
+;;     fn0 = colocated u1610612736:38 sig0
 ;;     const0 = 0x00000000000000000000000000000000
 ;;     stack_limit = gv2
 ;;
@@ -49,7 +49,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, f32) -> f32 tail
-;;     fn0 = colocated u1:40 sig0
+;;     fn0 = colocated u1610612736:40 sig0
 ;;     const0 = 0x00000000000000000000000000000000
 ;;     stack_limit = gv2
 ;;
@@ -81,7 +81,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, f32) -> f32 tail
-;;     fn0 = colocated u1:42 sig0
+;;     fn0 = colocated u1610612736:42 sig0
 ;;     const0 = 0x00000000000000000000000000000000
 ;;     stack_limit = gv2
 ;;
@@ -113,7 +113,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, f32) -> f32 tail
-;;     fn0 = colocated u1:44 sig0
+;;     fn0 = colocated u1610612736:44 sig0
 ;;     const0 = 0x00000000000000000000000000000000
 ;;     stack_limit = gv2
 ;;
@@ -145,7 +145,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, f64) -> f64 tail
-;;     fn0 = colocated u1:39 sig0
+;;     fn0 = colocated u1610612736:39 sig0
 ;;     const0 = 0x00000000000000000000000000000000
 ;;     stack_limit = gv2
 ;;
@@ -171,7 +171,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, f64) -> f64 tail
-;;     fn0 = colocated u1:41 sig0
+;;     fn0 = colocated u1610612736:41 sig0
 ;;     const0 = 0x00000000000000000000000000000000
 ;;     stack_limit = gv2
 ;;
@@ -197,7 +197,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, f64) -> f64 tail
-;;     fn0 = colocated u1:43 sig0
+;;     fn0 = colocated u1610612736:43 sig0
 ;;     const0 = 0x00000000000000000000000000000000
 ;;     stack_limit = gv2
 ;;
@@ -223,7 +223,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+16
 ;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, f64) -> f64 tail
-;;     fn0 = colocated u1:45 sig0
+;;     fn0 = colocated u1610612736:45 sig0
 ;;     const0 = 0x00000000000000000000000000000000
 ;;     stack_limit = gv2
 ;;


### PR DESCRIPTION
`FuncKey`, which used to be called `CompileKey`, is now one-to-one with `cranelift_codegen::ir::UserExternalName`, and is used for not just identifying compilation objects but also relocations and call-graph edges. This allows us to determine the `StaticModuleIndex` and `DefinedFuncIndex` pair for any `cranelift_codegen::ir::FuncRef`, regardless of inlining depth, which fixes some fuzz bugs on OSS-Fuzz.

This continues pushing on the idea that Wasmtime's compilation orchestration and linking should be relatively agnostic to the kinds of things it is actually compiling and linking, allowing us to tweak, add, and remove new kinds of `FuncKey`s more easily. Adding a new `FuncKey` should not require modifying relocation resolution, for example, just a little bit of code to run the associated compilation and optionally some code to extract metadata into our final artifacts for querying at runtime. Everything in between should Just Continue Working. We still aren't all the way there yet, but this does bring us a little bit closer.

Finally, in Cranelift's inlining pass, this adds a check that a block is inserted in the layout before attempting to remove it from the layout, which would otherwise cause panics. This was triggered by multi-level inlining and now-unreachable blocks in the inner callees.

I'll note that this does update basically all of the disas tests, or at least nearly all of them that make function calls. This is because the namespace/index numbering pair changed slightly to align with `FuncKey`, but that should pretty much be the only changes.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
