### PR TITLE
Fix the QEMU command in the cross-compilation documentation.

### DIFF
--- a/docs/contributing-cross-compiling.md
+++ b/docs/contributing-cross-compiling.md
@@ -62,15 +62,15 @@ if none already exists).
 ```toml
 [target.aarch64-unknown-linux-gnu]
 linker = "aarch64-linux-gnu-gcc"
-runner = "qemu-aarch64 -L /usr/aarch64-linux-gnu -E LD_LIBRARY_PATH=/usr/aarch64-linux-gnu/lib -E WASMTIME_TEST_NO_HOG_MEMORY=1"
+runner = "env QEMU_LD_PREFIX=/usr/aarch64-linux-gnu WASMTIME_TEST_NO_HOG_MEMORY=1 qemu-aarch64"
 
 [target.riscv64gc-unknown-linux-gnu]
 linker = "riscv64-linux-gnu-gcc"
-runner = "qemu-riscv64 -L /usr/riscv64-linux-gnu -E LD_LIBRARY_PATH=/usr/riscv64-linux-gnu/lib -E WASMTIME_TEST_NO_HOG_MEMORY=1"
+runner = "env QEMU_LD_PREFIX=/usr/riscv64-linux-gnu WASMTIME_TEST_NO_HOG_MEMORY=1 qemu-riscv64"
 
 [target.s390x-unknown-linux-gnu]
 linker = "s390x-linux-gnu-gcc"
-runner = "qemu-s390x -L /usr/s390x-linux-gnu -E LD_LIBRARY_PATH=/usr/s390x-linux-gnu/lib -E WASMTIME_TEST_NO_HOG_MEMORY=1"
+runner = "env QEMU_LD_PREFIX=/usr/s390x-linux-gnu WASMTIME_TEST_NO_HOG_MEMORY=1 qemu-s390x"
 ```
 
 ## Cross-Compile Tests and Run Them!


### PR DESCRIPTION
cargo test command of cross compilation target causes the following error in the many tests because the setting `runner = "qemu-aarch64 -L /usr/aarch64-linux-gnu -E LD_LIBRARY_PATH=/usr/aarch64-linux-gnu/lib -E WASMTIME_TEST_NO_HOG_MEMORY=1"` of .cargo/config.toml cannot pass environment variables to the qemu-user executed by binfmt.

```shell
# aarch64
aarch64-binfmt-P: Could not open '/lib/ld-linux-aarch64.so.1': No such file or directory
```

This PR fixes the error by specifying `env QEMU_LD_PREFIX=...`  to the .cargo/config.toml.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
