### PR TITLE
Enable clippy in CI for WASIp3 bits

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -447,7 +447,7 @@ jobs:
     - uses: ./.github/actions/install-rust
 
     - run: rustup component add clippy
-    - run: cargo clippy --workspace --all-targets
+    - run: cargo clippy --workspace --all-targets --features p3,component-model-async
 
   # Similar to `micro_checks` but where we need to install some more state
   # (e.g. Android NDK) and we haven't factored support for those things out into

--- a/crates/wasi/src/p3/filesystem/host.rs
+++ b/crates/wasi/src/p3/filesystem/host.rs
@@ -573,8 +573,8 @@ impl types::HostDescriptorWithStore for WasiFilesystem {
     ) -> wasmtime::Result<bool> {
         let (fd, other) = store.with(|mut store| {
             let table = store.get().table;
-            let fd = get_descriptor(table, &fd).map(|fd| fd.clone())?;
-            let other = get_descriptor(table, &other).map(|other| other.clone())?;
+            let fd = get_descriptor(table, &fd)?.clone();
+            let other = get_descriptor(table, &other)?.clone();
             anyhow::Ok((fd, other))
         })?;
         fd.is_same_object(&other).await

--- a/crates/wasi/src/p3/sockets/host/types/tcp.rs
+++ b/crates/wasi/src/p3/sockets/host/types/tcp.rs
@@ -169,15 +169,14 @@ impl HostTcpSocketWithStore for WasiSockets {
         if !is_addr_allowed(store, remote_address, SocketAddrUse::TcpConnect).await {
             return Err(ErrorCode::AccessDenied.into());
         }
-        let addr = remote_address.into();
         let sock = store.with(|mut view| -> SocketResult<_> {
             let socket = get_socket_mut(view.get().table, &socket)?;
-            Ok(socket.start_connect(&addr)?)
+            Ok(socket.start_connect(&remote_address)?)
         })?;
 
         // FIXME: handle possible cancellation of the outer `connect`
         // https://github.com/bytecodealliance/wasmtime/pull/11291#discussion_r2223917986
-        let res = sock.connect(addr).await;
+        let res = sock.connect(remote_address).await;
         store.with(|mut view| -> SocketResult<_> {
             let socket = get_socket_mut(view.get().table, &socket)?;
             socket.finish_connect(res)?;

--- a/crates/wasi/src/sockets/udp.rs
+++ b/crates/wasi/src/sockets/udp.rs
@@ -213,7 +213,7 @@ impl UdpSocket {
         let socket = match self.udp_state {
             UdpState::Default | UdpState::BindStarted => Err(ErrorCode::InvalidState),
             UdpState::Bound => Ok(Mode::RecvFrom(Arc::clone(&self.socket))),
-            UdpState::Connected(addr) => Ok(Mode::Recv(Arc::clone(&self.socket), addr.into())),
+            UdpState::Connected(addr) => Ok(Mode::Recv(Arc::clone(&self.socket), addr)),
         };
         async move {
             let socket = socket?;


### PR DESCRIPTION
Much of these are off-by-default at compile time currently so opt-in to auditing them.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
