### PR TITLE
Check fuel on GC-related branching instructions

### DIFF
--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -419,6 +419,10 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
             | Operator::Br { .. }
             | Operator::BrIf { .. }
             | Operator::BrTable { .. }
+            | Operator::BrOnNull { .. }
+            | Operator::BrOnNonNull { .. }
+            | Operator::BrOnCast { .. }
+            | Operator::BrOnCastFail { .. }
 
             // Exiting a scope means that we need to update the fuel
             // consumption because there are multiple ways to exit a scope and


### PR DESCRIPTION
Previously GC instructions didn't check for fuel meaning that an infinite loop with a GC-related branch instruction would never terminate.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
