### PR TITLE
Consume fuel in `array.new_default`

### DIFF
--- a/crates/cranelift/src/func_environ/gc/enabled.rs
+++ b/crates/cranelift/src/func_environ/gc/enabled.rs
@@ -607,6 +607,7 @@ fn emit_array_fill_impl(
     builder.switch_to_block(loop_header_block);
     builder.append_block_param(loop_header_block, pointer_ty);
     log::trace!("emit_array_fill_impl: loop header");
+    func_env.translate_loop_header(builder)?;
     let elem_addr = builder.block_params(loop_header_block)[0];
     let done = builder.ins().icmp(IntCC::Equal, elem_addr, fill_end);
     builder

--- a/tests/all/fuel.rs
+++ b/tests/all/fuel.rs
@@ -171,6 +171,20 @@ fn iloop(config: &mut Config) -> Result<()> {
             )
         "#,
     )?;
+    iloop_aborts(
+        &config,
+        r#"
+            (module
+                (type $a (array i8))
+                (start 0)
+                (func
+                    i32.const 0x400_0000
+                    array.new_default $a
+                    drop
+                )
+            )
+        "#,
+    )?;
 
     fn iloop_aborts(config: &Config, wat: &str) -> Result<()> {
         let engine = Engine::new(&config)?;


### PR DESCRIPTION
This commit updates the Cranelift-generated loop for `array.new_default` to contain fuel/epoch checks. This ensures that large arrays have an opportunity to context-switch away or otherwise interrupt the program to prevent excessively long-running executions.

cc #11427 (does not solve it though)

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
