### PR TITLE
Enable component-model-async in release artifacts

### DIFF
--- a/ci/build-release-artifacts.sh
+++ b/ci/build-release-artifacts.sh
@@ -60,7 +60,7 @@ if [[ "$build" = *-min ]]; then
 else
   # For release builds the CLI is built a bit more feature-ful than the Cargo
   # defaults to provide artifacts that can do as much as possible.
-  bin_flags="--features all-arch,component-model"
+  bin_flags="--features all-arch,component-model,component-model-async"
 fi
 
 if [[ "$target" = "x86_64-pc-windows-msvc" ]]; then


### PR DESCRIPTION
Don't enable it by default in the crates just yet, but it should be suitable to enable it in release artifacts for testing. I'm mostly interested in updating `wit-bindgen` to use binaries from this repository instead of wasip3-prototyping to run async tests.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
