### PR TITLE
Use `async fn` internally within Wasmtime 

### DIFF
--- a/crates/component-macro/src/bindgen.rs
+++ b/crates/component-macro/src/bindgen.rs
@@ -140,7 +140,6 @@ impl Parse for Config {
                     }
                     Opt::Stringify(val) => opts.stringify = val,
                     Opt::SkipMutForwardingImpls(val) => opts.skip_mut_forwarding_impls = val,
-                    Opt::RequireStoreDataSend(val) => opts.require_store_data_send = val,
                     Opt::WasmtimeCrate(f) => {
                         opts.wasmtime_crate = Some(f.into_token_stream().to_string())
                     }
@@ -280,7 +279,6 @@ mod kw {
     syn::custom_keyword!(additional_derives);
     syn::custom_keyword!(stringify);
     syn::custom_keyword!(skip_mut_forwarding_impls);
-    syn::custom_keyword!(require_store_data_send);
     syn::custom_keyword!(wasmtime_crate);
     syn::custom_keyword!(include_generated_code_from_file);
     syn::custom_keyword!(debug);
@@ -303,7 +301,6 @@ enum Opt {
     AdditionalDerives(Vec<syn::Path>),
     Stringify(bool),
     SkipMutForwardingImpls(bool),
-    RequireStoreDataSend(bool),
     WasmtimeCrate(syn::Path),
     IncludeGeneratedCodeFromFile(bool),
     Debug(bool),
@@ -419,12 +416,6 @@ impl Parse for Opt {
             input.parse::<kw::skip_mut_forwarding_impls>()?;
             input.parse::<Token![:]>()?;
             Ok(Opt::SkipMutForwardingImpls(
-                input.parse::<syn::LitBool>()?.value,
-            ))
-        } else if l.peek(kw::require_store_data_send) {
-            input.parse::<kw::require_store_data_send>()?;
-            input.parse::<Token![:]>()?;
-            Ok(Opt::RequireStoreDataSend(
                 input.parse::<syn::LitBool>()?.value,
             ))
         } else if l.peek(kw::wasmtime_crate) {

--- a/crates/component-macro/src/component.rs
+++ b/crates/component-macro/src/component.rs
@@ -723,7 +723,7 @@ impl Expander for LowerExpander {
         let expanded = quote! {
             unsafe impl #impl_generics #wt::component::Lower for #name #ty_generics #where_clause {
                 #[inline]
-                fn linear_lower_to_flat<T>(
+                fn linear_lower_to_flat<T: Send>(
                     &self,
                     cx: &mut #internal::LowerContext<'_, T>,
                     ty: #internal::InterfaceType,
@@ -735,7 +735,7 @@ impl Expander for LowerExpander {
                 }
 
                 #[inline]
-                fn linear_lower_to_memory<T>(
+                fn linear_lower_to_memory<T: Send>(
                     &self,
                     cx: &mut #internal::LowerContext<'_, T>,
                     ty: #internal::InterfaceType,
@@ -821,7 +821,7 @@ impl Expander for LowerExpander {
         let expanded = quote! {
             unsafe impl #impl_generics #wt::component::Lower for #name #ty_generics #where_clause {
                 #[inline]
-                fn linear_lower_to_flat<T>(
+                fn linear_lower_to_flat<T: Send>(
                     &self,
                     cx: &mut #internal::LowerContext<'_, T>,
                     ty: #internal::InterfaceType,
@@ -834,7 +834,7 @@ impl Expander for LowerExpander {
                 }
 
                 #[inline]
-                fn linear_lower_to_memory<T>(
+                fn linear_lower_to_memory<T: Send>(
                     &self,
                     cx: &mut #internal::LowerContext<'_, T>,
                     ty: #internal::InterfaceType,
@@ -878,7 +878,7 @@ impl Expander for LowerExpander {
         let expanded = quote! {
             unsafe impl #wt::component::Lower for #name {
                 #[inline]
-                fn linear_lower_to_flat<T>(
+                fn linear_lower_to_flat<T: Send>(
                     &self,
                     cx: &mut #internal::LowerContext<'_, T>,
                     ty: #internal::InterfaceType,
@@ -891,7 +891,7 @@ impl Expander for LowerExpander {
                 }
 
                 #[inline]
-                fn linear_lower_to_memory<T>(
+                fn linear_lower_to_memory<T: Send>(
                     &self,
                     cx: &mut #internal::LowerContext<'_, T>,
                     ty: #internal::InterfaceType,
@@ -1467,7 +1467,7 @@ pub fn expand_flags(flags: &Flags) -> Result<TokenStream> {
         #component_type_impl
 
         unsafe impl #wt::component::Lower for #name {
-            fn linear_lower_to_flat<T>(
+            fn linear_lower_to_flat<T: Send>(
                 &self,
                 cx: &mut #internal::LowerContext<'_, T>,
                 _ty: #internal::InterfaceType,
@@ -1483,7 +1483,7 @@ pub fn expand_flags(flags: &Flags) -> Result<TokenStream> {
                 Ok(())
             }
 
-            fn linear_lower_to_memory<T>(
+            fn linear_lower_to_memory<T: Send>(
                 &self,
                 cx: &mut #internal::LowerContext<'_, T>,
                 _ty: #internal::InterfaceType,

--- a/crates/component-macro/tests/codegen.rs
+++ b/crates/component-macro/tests/codegen.rs
@@ -628,7 +628,6 @@ mod with_and_mixing_async {
             with: {
                 "my:inline/foo": super::with_async::my::inline::foo,
             },
-            require_store_data_send: true,
         });
     }
 
@@ -656,7 +655,6 @@ mod with_and_mixing_async {
                 "my:inline/foo": super::with_async::my::inline::foo,
                 "my:inline/bar": super::without_async::my::inline::bar,
             },
-            require_store_data_send: true,
         });
     }
 }

--- a/crates/fuzzing/src/oracles/dummy.rs
+++ b/crates/fuzzing/src/oracles/dummy.rs
@@ -4,7 +4,7 @@ use anyhow::Context;
 use wasmtime::*;
 
 /// Create a set of dummy functions/globals/etc for the given imports.
-pub fn dummy_linker<T>(store: &mut Store<T>, module: &Module) -> Result<Linker<T>> {
+pub fn dummy_linker<T: Send>(store: &mut Store<T>, module: &Module) -> Result<Linker<T>> {
     let mut linker = Linker::new(store.engine());
     linker.allow_shadowing(true);
     for import in module.imports() {

--- a/crates/misc/component-async-tests/src/resource_stream.rs
+++ b/crates/misc/component-async-tests/src/resource_stream.rs
@@ -34,7 +34,7 @@ impl bindings::local::local::resource_stream::HostX for Ctx {
 }
 
 impl bindings::local::local::resource_stream::HostWithStore for Ctx {
-    async fn foo<T: 'static>(
+    async fn foo<T: Send>(
         accessor: &Accessor<T, Self>,
         count: u32,
     ) -> wasmtime::Result<StreamReader<Resource<ResourceStreamX>>> {
@@ -44,7 +44,7 @@ impl bindings::local::local::resource_stream::HostWithStore for Ctx {
             count: u32,
         }
 
-        impl<T> AccessorTask<T, Ctx, Result<()>> for Task {
+        impl<T: Send + 'static> AccessorTask<T, Ctx, Result<()>> for Task {
             async fn run(self, accessor: &Accessor<T, Ctx>) -> Result<()> {
                 let mut tx = GuardedStreamWriter::new(accessor, self.tx);
                 for _ in 0..self.count {

--- a/crates/misc/component-async-tests/src/round_trip.rs
+++ b/crates/misc/component-async-tests/src/round_trip.rs
@@ -18,7 +18,7 @@ pub mod non_concurrent_export_bindings {
 }
 
 impl bindings::local::local::baz::HostWithStore for Ctx {
-    async fn foo<T>(_: &Accessor<T, Self>, s: String) -> String {
+    async fn foo<T: Send>(_: &Accessor<T, Self>, s: String) -> String {
         crate::util::sleep(Duration::from_millis(10)).await;
         format!("{s} - entered host - exited host")
     }

--- a/crates/misc/component-async-tests/src/round_trip_direct.rs
+++ b/crates/misc/component-async-tests/src/round_trip_direct.rs
@@ -10,7 +10,7 @@ pub mod bindings {
 }
 
 impl bindings::RoundTripDirectImportsWithStore for Ctx {
-    async fn foo<T>(_: &Accessor<T, Self>, s: String) -> String {
+    async fn foo<T: Send>(_: &Accessor<T, Self>, s: String) -> String {
         crate::util::sleep(Duration::from_millis(10)).await;
         format!("{s} - entered host - exited host")
     }

--- a/crates/misc/component-async-tests/src/round_trip_many.rs
+++ b/crates/misc/component-async-tests/src/round_trip_many.rs
@@ -23,7 +23,7 @@ pub mod non_concurrent_export_bindings {
 use bindings::local::local::many::Stuff;
 
 impl bindings::local::local::many::HostWithStore for Ctx {
-    async fn foo<T>(
+    async fn foo<T: Send>(
         _: &Accessor<T, Self>,
         a: String,
         b: u32,

--- a/crates/misc/component-async-tests/src/sleep.rs
+++ b/crates/misc/component-async-tests/src/sleep.rs
@@ -8,7 +8,7 @@ wasmtime::component::bindgen!({
 });
 
 impl local::local::sleep::HostWithStore for Ctx {
-    async fn sleep_millis<T>(_: &Accessor<T, Self>, time_in_millis: u64) {
+    async fn sleep_millis<T: Send>(_: &Accessor<T, Self>, time_in_millis: u64) {
         crate::util::sleep(Duration::from_millis(time_in_millis)).await;
     }
 }

--- a/crates/misc/component-async-tests/src/yield_host.rs
+++ b/crates/misc/component-async-tests/src/yield_host.rs
@@ -37,7 +37,7 @@ impl bindings::local::local::ready::Host for Ctx {
 }
 
 impl bindings::local::local::ready::HostWithStore for Ctx {
-    async fn when_ready<T>(accessor: &Accessor<T, Self>) {
+    async fn when_ready<T: Send>(accessor: &Accessor<T, Self>) {
         let wakers = accessor.with(|mut view| view.get().wakers.clone());
         future::poll_fn(move |cx| {
             let mut wakers = wakers.lock().unwrap();

--- a/crates/test-util/src/component.rs
+++ b/crates/test-util/src/component.rs
@@ -97,7 +97,7 @@ macro_rules! forward_impls {
         }
 
         unsafe impl Lower for $a {
-            fn linear_lower_to_flat<U>(
+            fn linear_lower_to_flat<U: Send>(
                 &self,
                 cx: &mut LowerContext<'_, U>,
                 ty: InterfaceType,
@@ -106,7 +106,7 @@ macro_rules! forward_impls {
                 <$b as Lower>::linear_lower_to_flat(&self.0, cx, ty, dst)
             }
 
-            fn linear_lower_to_memory<U>(&self, cx: &mut LowerContext<'_, U>, ty: InterfaceType, offset: usize) -> Result<()> {
+            fn linear_lower_to_memory<U: Send>(&self, cx: &mut LowerContext<'_, U>, ty: InterfaceType, offset: usize) -> Result<()> {
                 <$b as Lower>::linear_lower_to_memory(&self.0, cx, ty, offset)
             }
         }

--- a/crates/wasi-common/src/lib.rs
+++ b/crates/wasi-common/src/lib.rs
@@ -117,7 +117,7 @@ macro_rules! define_wasi {
         where U: Send
                 + crate::snapshots::preview_0::wasi_unstable::WasiUnstable
                 + crate::snapshots::preview_1::wasi_snapshot_preview1::WasiSnapshotPreview1,
-              T: 'static,
+              T: Send + 'static,
             $($bounds)*
     {
         snapshots::preview_1::add_wasi_snapshot_preview1_to_linker(linker, get_cx)?;

--- a/crates/wasi-config/src/lib.rs
+++ b/crates/wasi-config/src/lib.rs
@@ -140,7 +140,7 @@ impl generated::Host for WasiConfig<'_> {
 }
 
 /// Add all the `wasi-config` world's interfaces to a [`wasmtime::component::Linker`].
-pub fn add_to_linker<T: 'static>(
+pub fn add_to_linker<T: Send + 'static>(
     l: &mut wasmtime::component::Linker<T>,
     f: fn(&mut T) -> WasiConfig<'_>,
 ) -> Result<()> {

--- a/crates/wasi-http/src/bindings.rs
+++ b/crates/wasi-http/src/bindings.rs
@@ -10,7 +10,6 @@ mod generated {
         world: "wasi:http/proxy",
         imports: { default: tracing | trappable },
         exports: { default: async },
-        require_store_data_send: true,
         with: {
             // Upstream package dependencies
             "wasi:io": wasmtime_wasi::p2::bindings::io,
@@ -57,7 +56,6 @@ pub mod sync {
                 // order to have in_tokio
                 "wasi:io": wasmtime_wasi::p2::bindings::sync::io,
             },
-            require_store_data_send: true,
         });
     }
 

--- a/crates/wasi-http/src/lib.rs
+++ b/crates/wasi-http/src/lib.rs
@@ -302,7 +302,7 @@ pub fn add_only_http_to_linker_async<T>(
     l: &mut wasmtime::component::Linker<T>,
 ) -> anyhow::Result<()>
 where
-    T: WasiHttpView + 'static,
+    T: WasiHttpView + Send + 'static,
 {
     let options = crate::bindings::LinkOptions::default(); // FIXME: Thread through to the CLI options.
     crate::bindings::http::outgoing_handler::add_to_linker::<_, WasiHttp<T>>(l, |x| {
@@ -376,7 +376,7 @@ where
 /// example to avoid re-adding the same interfaces twice.
 pub fn add_only_http_to_linker_sync<T>(l: &mut Linker<T>) -> anyhow::Result<()>
 where
-    T: WasiHttpView + 'static,
+    T: WasiHttpView + Send + 'static,
 {
     let options = crate::bindings::LinkOptions::default(); // FIXME: Thread through to the CLI options.
     crate::bindings::sync::http::outgoing_handler::add_to_linker::<_, WasiHttp<T>>(l, |x| {

--- a/crates/wasi-nn/src/wit.rs
+++ b/crates/wasi-nn/src/wit.rs
@@ -149,7 +149,7 @@ pub use generated_::Ml as ML;
 
 /// Add the WIT-based version of the `wasi-nn` API to a
 /// [`wasmtime::component::Linker`].
-pub fn add_to_linker<T: 'static>(
+pub fn add_to_linker<T: Send + 'static>(
     l: &mut wasmtime::component::Linker<T>,
     f: fn(&mut T) -> WasiNnView<'_>,
 ) -> anyhow::Result<()> {

--- a/crates/wasi-tls/src/bindings.rs
+++ b/crates/wasi-tls/src/bindings.rs
@@ -12,7 +12,6 @@ mod generated {
             "wasi:tls/types/future-client-streams": crate::HostFutureClientStreams,
         },
         imports: { default: trappable },
-        require_store_data_send: true,
     });
 }
 

--- a/crates/wasi/src/p2/bindings.rs
+++ b/crates/wasi/src/p2/bindings.rs
@@ -109,9 +109,6 @@
 ///     with: {
 ///         "wasi": wasmtime_wasi::p2::bindings::sync,
 ///     },
-///     // This is required for bindings using `wasmtime-wasi` and it otherwise
-///     // isn't the default for non-async bindings.
-///     require_store_data_send: true,
 /// });
 ///
 /// struct MyState {
@@ -184,7 +181,6 @@ pub mod sync {
                 "wasi:io/streams/output-stream": wasmtime_wasi_io::streams::DynOutputStream,
 
             },
-            require_store_data_send: true,
         });
     }
     pub use self::generated::exports;

--- a/crates/wasi/src/p3/cli/host.rs
+++ b/crates/wasi/src/p3/cli/host.rs
@@ -22,6 +22,7 @@ struct InputTask<T> {
 
 impl<T, U, V> AccessorTask<T, U, wasmtime::Result<()>> for InputTask<V>
 where
+    T: Send + 'static,
     U: HasData,
     V: AsyncRead + Send + Sync + Unpin + 'static,
 {
@@ -52,6 +53,7 @@ struct OutputTask<T> {
 
 impl<T, U, V> AccessorTask<T, U, wasmtime::Result<()>> for OutputTask<V>
 where
+    T: Send + 'static,
     U: HasData,
     V: AsyncWrite + Send + Sync + Unpin + 'static,
 {
@@ -139,7 +141,7 @@ impl terminal_stderr::Host for WasiCliCtxView<'_> {
 }
 
 impl stdin::HostWithStore for WasiCli {
-    async fn get_stdin<U>(store: &Accessor<U, Self>) -> wasmtime::Result<StreamReader<u8>> {
+    async fn get_stdin<U: Send>(store: &Accessor<U, Self>) -> wasmtime::Result<StreamReader<u8>> {
         store.with(|mut view| {
             let instance = view.instance();
             let (tx, rx) = instance
@@ -158,7 +160,7 @@ impl stdin::HostWithStore for WasiCli {
 impl stdin::Host for WasiCliCtxView<'_> {}
 
 impl stdout::HostWithStore for WasiCli {
-    async fn set_stdout<U>(
+    async fn set_stdout<U: Send>(
         store: &Accessor<U, Self>,
         data: StreamReader<u8>,
     ) -> wasmtime::Result<()> {
@@ -176,7 +178,7 @@ impl stdout::HostWithStore for WasiCli {
 impl stdout::Host for WasiCliCtxView<'_> {}
 
 impl stderr::HostWithStore for WasiCli {
-    async fn set_stderr<U>(
+    async fn set_stderr<U: Send>(
         store: &Accessor<U, Self>,
         data: StreamReader<u8>,
     ) -> wasmtime::Result<()> {

--- a/crates/wasi/src/p3/clocks/host.rs
+++ b/crates/wasi/src/p3/clocks/host.rs
@@ -24,7 +24,7 @@ impl wall_clock::Host for WasiClocksCtxView<'_> {
 }
 
 impl monotonic_clock::HostWithStore for WasiClocks {
-    async fn wait_until<U>(
+    async fn wait_until<U: Send>(
         store: &Accessor<U, Self>,
         when: monotonic_clock::Instant,
     ) -> wasmtime::Result<()> {
@@ -35,7 +35,7 @@ impl monotonic_clock::HostWithStore for WasiClocks {
         Ok(())
     }
 
-    async fn wait_for<U>(
+    async fn wait_for<U: Send>(
         _store: &Accessor<U, Self>,
         duration: monotonic_clock::Duration,
     ) -> wasmtime::Result<()> {

--- a/crates/wasi/src/p3/sockets/host/ip_name_lookup.rs
+++ b/crates/wasi/src/p3/sockets/host/ip_name_lookup.rs
@@ -8,7 +8,7 @@ use crate::sockets::WasiSocketsCtxView;
 use crate::sockets::util::{from_ipv4_addr, from_ipv6_addr, parse_host};
 
 impl HostWithStore for WasiSockets {
-    async fn resolve_addresses<U>(
+    async fn resolve_addresses<U: Send>(
         store: &Accessor<U, Self>,
         name: String,
     ) -> wasmtime::Result<Result<Vec<types::IpAddress>, ErrorCode>> {

--- a/crates/wasi/src/p3/sockets/host/types/mod.rs
+++ b/crates/wasi/src/p3/sockets/host/types/mod.rs
@@ -13,11 +13,11 @@ impl Host for WasiSocketsCtxView<'_> {
     }
 }
 
-fn get_socket_addr_check<T>(store: &Accessor<T, WasiSockets>) -> SocketAddrCheck {
+fn get_socket_addr_check<T: Send>(store: &Accessor<T, WasiSockets>) -> SocketAddrCheck {
     store.with(|mut view| view.get().ctx.socket_addr_check.clone())
 }
 
-async fn is_addr_allowed<T>(
+async fn is_addr_allowed<T: Send>(
     store: &Accessor<T, WasiSockets>,
     addr: SocketAddr,
     reason: SocketAddrUse,

--- a/crates/wasi/src/p3/sockets/host/types/tcp.rs
+++ b/crates/wasi/src/p3/sockets/host/types/tcp.rs
@@ -49,7 +49,10 @@ struct ListenTask {
     options: NonInheritedOptions,
 }
 
-impl<T> AccessorTask<T, WasiSockets, wasmtime::Result<()>> for ListenTask {
+impl<T> AccessorTask<T, WasiSockets, wasmtime::Result<()>> for ListenTask
+where
+    T: Send + 'static,
+{
     async fn run(self, store: &Accessor<T, WasiSockets>) -> wasmtime::Result<()> {
         let mut tx = GuardedStreamWriter::new(store, self.tx);
         while !tx.is_closed() {
@@ -93,7 +96,10 @@ struct ReceiveTask {
     result_tx: FutureWriter<Result<(), ErrorCode>>,
 }
 
-impl<T> AccessorTask<T, WasiSockets, wasmtime::Result<()>> for ReceiveTask {
+impl<T> AccessorTask<T, WasiSockets, wasmtime::Result<()>> for ReceiveTask
+where
+    T: Send + 'static,
+{
     async fn run(self, store: &Accessor<T, WasiSockets>) -> wasmtime::Result<()> {
         let mut buf = BytesMut::with_capacity(DEFAULT_BUFFER_CAPACITY);
         let mut data_tx = GuardedStreamWriter::new(store, self.data_tx);
@@ -143,7 +149,7 @@ impl<T> AccessorTask<T, WasiSockets, wasmtime::Result<()>> for ReceiveTask {
 }
 
 impl HostTcpSocketWithStore for WasiSockets {
-    async fn bind<T>(
+    async fn bind<T: Send>(
         store: &Accessor<T, Self>,
         socket: Resource<TcpSocket>,
         local_address: IpSocketAddress,
@@ -160,7 +166,7 @@ impl HostTcpSocketWithStore for WasiSockets {
         })
     }
 
-    async fn connect<T>(
+    async fn connect<T: Send>(
         store: &Accessor<T, Self>,
         socket: Resource<TcpSocket>,
         remote_address: IpSocketAddress,
@@ -184,7 +190,7 @@ impl HostTcpSocketWithStore for WasiSockets {
         })
     }
 
-    async fn listen<T: 'static>(
+    async fn listen<T: Send>(
         store: &Accessor<T, Self>,
         socket: Resource<TcpSocket>,
     ) -> SocketResult<StreamReader<Resource<TcpSocket>>> {
@@ -211,7 +217,7 @@ impl HostTcpSocketWithStore for WasiSockets {
         })
     }
 
-    async fn send<T: 'static>(
+    async fn send<T: Send>(
         store: &Accessor<T, Self>,
         socket: Resource<TcpSocket>,
         mut data: StreamReader<u8>,
@@ -249,7 +255,7 @@ impl HostTcpSocketWithStore for WasiSockets {
         result
     }
 
-    async fn receive<T: 'static>(
+    async fn receive<T: Send>(
         store: &Accessor<T, Self>,
         socket: Resource<TcpSocket>,
     ) -> wasmtime::Result<(StreamReader<u8>, FutureReader<Result<(), ErrorCode>>)> {

--- a/crates/wasi/src/p3/sockets/host/types/udp.rs
+++ b/crates/wasi/src/p3/sockets/host/types/udp.rs
@@ -30,7 +30,7 @@ fn get_socket_mut<'a>(
 }
 
 impl HostUdpSocketWithStore for WasiSockets {
-    async fn bind<T>(
+    async fn bind<T: Send>(
         store: &Accessor<T, Self>,
         socket: Resource<UdpSocket>,
         local_address: IpSocketAddress,
@@ -47,7 +47,7 @@ impl HostUdpSocketWithStore for WasiSockets {
         })
     }
 
-    async fn connect<T>(
+    async fn connect<T: Send>(
         store: &Accessor<T, Self>,
         socket: Resource<UdpSocket>,
         remote_address: IpSocketAddress,
@@ -63,7 +63,7 @@ impl HostUdpSocketWithStore for WasiSockets {
         })
     }
 
-    async fn send<T>(
+    async fn send<T: Send>(
         store: &Accessor<T, Self>,
         socket: Resource<UdpSocket>,
         data: Vec<u8>,
@@ -91,7 +91,7 @@ impl HostUdpSocketWithStore for WasiSockets {
         }
     }
 
-    async fn receive<T>(
+    async fn receive<T: Send>(
         store: &Accessor<T, Self>,
         socket: Resource<UdpSocket>,
     ) -> SocketResult<(Vec<u8>, IpSocketAddress)> {

--- a/crates/wasi/tests/all/p2/api.rs
+++ b/crates/wasi/tests/all/p2/api.rs
@@ -133,7 +133,6 @@ wasmtime::component::bindgen!({
     world: "test-reactor",
     imports: { default: async },
     exports: { default: async },
-    require_store_data_send: true,
     with: { "wasi": wasmtime_wasi::p2::bindings },
     ownership: Borrowing {
         duplicate_if_necessary: false

--- a/crates/wasi/tests/all/store.rs
+++ b/crates/wasi/tests/all/store.rs
@@ -18,7 +18,7 @@ fn prepare_workspace(exe_name: &str) -> Result<TempDir> {
     Ok(tempdir)
 }
 
-impl<T> Ctx<T> {
+impl<T: Send> Ctx<T> {
     pub fn new(
         engine: &Engine,
         name: &str,

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -261,6 +261,7 @@ runtime = [
   "dep:windows-sys",
   "pulley-interpreter/interp",
   "dep:wasmtime-unwinder",
+  "dep:async-trait",
 ]
 
 # Enable support for garbage collection-related things.

--- a/crates/wasmtime/src/runtime.rs
+++ b/crates/wasmtime/src/runtime.rs
@@ -132,7 +132,7 @@ fn _assertions_runtime() {
     _assert_send_and_sync::<InstancePre<()>>();
     _assert_send_and_sync::<InstancePre<*mut u8>>();
     _assert_send_and_sync::<Linker<()>>();
-    _assert_send_and_sync::<Linker<*mut u8>>();
+    _assert_send_and_sync::<Linker<vm::SendSyncPtr<u8>>>();
     _assert_send_and_sync::<Module>();
     _assert_send_and_sync::<Store<()>>();
     _assert_send_and_sync::<StoreContext<'_, ()>>();

--- a/crates/wasmtime/src/runtime/component/concurrent_disabled.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent_disabled.rs
@@ -32,7 +32,7 @@ impl Instance {
     }
 }
 
-pub(crate) fn lower_future_to_index<U>(
+pub(crate) fn lower_future_to_index<U: Send>(
     _rep: u32,
     _cx: &mut LowerContext<'_, U>,
     _ty: InterfaceType,
@@ -40,7 +40,7 @@ pub(crate) fn lower_future_to_index<U>(
     should_have_failed_validation("use of `future`")
 }
 
-pub(crate) fn lower_stream_to_index<U>(
+pub(crate) fn lower_stream_to_index<U: Send>(
     _rep: u32,
     _cx: &mut LowerContext<'_, U>,
     _ty: InterfaceType,
@@ -48,7 +48,7 @@ pub(crate) fn lower_stream_to_index<U>(
     should_have_failed_validation("use of `stream`")
 }
 
-pub(crate) fn lower_error_context_to_index<U>(
+pub(crate) fn lower_error_context_to_index<U: Send>(
     _rep: u32,
     _cx: &mut LowerContext<'_, U>,
     _ty: InterfaceType,

--- a/crates/wasmtime/src/runtime/component/func.rs
+++ b/crates/wasmtime/src/runtime/component/func.rs
@@ -298,7 +298,7 @@ impl Func {
         }
     }
 
-    fn check_params_results<T>(
+    fn check_params_results<T: Send>(
         &self,
         store: StoreContextMut<T>,
         params: &[Val],
@@ -544,6 +544,7 @@ impl Func {
         lift: impl FnOnce(&mut LiftContext<'_>, InterfaceType, &LowerReturn) -> Result<Return>,
     ) -> Result<Return>
     where
+        T: Send,
         LowerParams: Copy,
         LowerReturn: Copy,
     {
@@ -763,7 +764,7 @@ impl Func {
         Ok(())
     }
 
-    fn lower_args<T>(
+    fn lower_args<T: Send>(
         cx: &mut LowerContext<'_, T>,
         params: &[Val],
         params_ty: InterfaceType,
@@ -785,7 +786,7 @@ impl Func {
         }
     }
 
-    fn store_args<T>(
+    fn store_args<T: Send>(
         cx: &mut LowerContext<'_, T>,
         params_ty: &TypeTuple,
         args: &[Val],
@@ -869,7 +870,7 @@ impl Func {
     /// The `lower` closure provided should perform the actual lowering and
     /// return the result of the lowering operation which is then returned from
     /// this function as well.
-    fn with_lower_context<T>(
+    fn with_lower_context<T: Send>(
         self,
         mut store: StoreContextMut<T>,
         may_enter: bool,

--- a/crates/wasmtime/src/runtime/component/func/options.rs
+++ b/crates/wasmtime/src/runtime/component/func/options.rs
@@ -100,7 +100,7 @@ impl Options {
         }
     }
 
-    fn realloc<'a, T>(
+    fn realloc<'a, T: Send>(
         &self,
         store: &'a mut StoreContextMut<'_, T>,
         realloc_ty: &FuncType,
@@ -208,7 +208,7 @@ impl Options {
 /// contextual information necessary related to the context in which the
 /// lowering is happening.
 #[doc(hidden)]
-pub struct LowerContext<'a, T: 'static> {
+pub struct LowerContext<'a, T: Send + 'static> {
     /// Lowering may involve invoking memory allocation functions so part of the
     /// context here is carrying access to the entire store that wasm is
     /// executing within. This store serves as proof-of-ability to actually
@@ -236,7 +236,7 @@ pub struct LowerContext<'a, T: 'static> {
 }
 
 #[doc(hidden)]
-impl<'a, T: 'static> LowerContext<'a, T> {
+impl<'a, T: Send + 'static> LowerContext<'a, T> {
     /// Creates a new lowering context from the specified parameters.
     pub fn new(
         store: StoreContextMut<'a, T>,

--- a/crates/wasmtime/src/runtime/component/instance.rs
+++ b/crates/wasmtime/src/runtime/component/instance.rs
@@ -357,7 +357,10 @@ impl Instance {
     }
 
     /// Returns the [`InstancePre`] that was used to create this instance.
-    pub fn instance_pre<T>(&self, store: impl AsContext<Data = T>) -> InstancePre<T> {
+    pub fn instance_pre<S>(&self, store: S) -> InstancePre<S::Data>
+    where
+        S: AsContext,
+    {
         // This indexing operation asserts the Store owns the Instance.
         // Therefore, the InstancePre<T> must match the Store<T>.
         let data = self.id().get(store.as_context().0);
@@ -634,7 +637,7 @@ impl<'a> Instantiator<'a> {
         }
     }
 
-    fn run<T>(&mut self, store: &mut StoreContextMut<'_, T>) -> Result<()> {
+    fn run<T: Send>(&mut self, store: &mut StoreContextMut<'_, T>) -> Result<()> {
         let env_component = self.component.env_component();
 
         // Before all initializers are processed configure all destructors for
@@ -942,7 +945,7 @@ impl<T: 'static> Clone for InstancePre<T> {
     }
 }
 
-impl<T: 'static> InstancePre<T> {
+impl<T: Send + 'static> InstancePre<T> {
     /// This function is `unsafe` since there's no guarantee that the
     /// `RuntimeImport` items provided are guaranteed to work with the `T` of
     /// the store.

--- a/crates/wasmtime/src/runtime/component/linker.rs
+++ b/crates/wasmtime/src/runtime/component/linker.rs
@@ -109,7 +109,7 @@ pub(crate) enum Definition {
     Resource(ResourceType, Arc<crate::func::HostFunc>),
 }
 
-impl<T: 'static> Linker<T> {
+impl<T: Send + 'static> Linker<T> {
     /// Creates a new linker for the [`Engine`] specified with no items defined
     /// within it.
     pub fn new(engine: &Engine) -> Linker<T> {
@@ -319,7 +319,7 @@ impl<T: 'static> Linker<T> {
         use wasmtime_environ::component::ComponentTypes;
         use wasmtime_environ::component::TypeDef;
         // Recursively stub out all imports of the component with a function that traps.
-        fn stub_item<T>(
+        fn stub_item<T: Send>(
             linker: &mut LinkerInstance<T>,
             item_name: &str,
             item_def: &TypeDef,
@@ -379,7 +379,7 @@ impl<T: 'static> Linker<T> {
     }
 }
 
-impl<T: 'static> LinkerInstance<'_, T> {
+impl<T: Send + 'static> LinkerInstance<'_, T> {
     fn as_mut(&mut self) -> LinkerInstance<'_, T> {
         LinkerInstance {
             engine: self.engine,

--- a/crates/wasmtime/src/runtime/component/values.rs
+++ b/crates/wasmtime/src/runtime/component/values.rs
@@ -349,7 +349,7 @@ impl Val {
     }
 
     /// Serialize this value as core Wasm stack values.
-    pub(crate) fn lower<T>(
+    pub(crate) fn lower<T: Send>(
         &self,
         cx: &mut LowerContext<'_, T>,
         ty: InterfaceType,
@@ -507,7 +507,7 @@ impl Val {
     }
 
     /// Serialize this value to the heap at the specified memory location.
-    pub(crate) fn store<T>(
+    pub(crate) fn store<T: Send>(
         &self,
         cx: &mut LowerContext<'_, T>,
         ty: InterfaceType,
@@ -882,7 +882,7 @@ impl GenericVariant<'_> {
         })
     }
 
-    fn lower<T>(
+    fn lower<T: Send>(
         &self,
         cx: &mut LowerContext<'_, T>,
         dst: &mut IterMut<'_, MaybeUninit<ValRaw>>,
@@ -906,7 +906,7 @@ impl GenericVariant<'_> {
         Ok(())
     }
 
-    fn store<T>(&self, cx: &mut LowerContext<'_, T>, offset: usize) -> Result<()> {
+    fn store<T: Send>(&self, cx: &mut LowerContext<'_, T>, offset: usize) -> Result<()> {
         match self.info.size {
             DiscriminantSize::Size1 => u8::try_from(self.discriminant)
                 .unwrap()
@@ -1028,7 +1028,7 @@ fn lift_variant(
 }
 
 /// Lower a list with the specified element type and values.
-fn lower_list<T>(
+fn lower_list<T: Send>(
     cx: &mut LowerContext<'_, T>,
     element_type: InterfaceType,
     items: &[Val],

--- a/crates/wasmtime/src/runtime/coredump.rs
+++ b/crates/wasmtime/src/runtime/coredump.rs
@@ -103,7 +103,11 @@ impl WasmCoreDump {
         self._serialize(store, name)
     }
 
-    fn _serialize<T: 'static>(&self, mut store: StoreContextMut<'_, T>, name: &str) -> Vec<u8> {
+    fn _serialize<T: Send + 'static>(
+        &self,
+        mut store: StoreContextMut<'_, T>,
+        name: &str,
+    ) -> Vec<u8> {
         let mut core_dump = wasm_encoder::Module::new();
 
         core_dump.section(&wasm_encoder::CoreDumpSection::new(name));

--- a/crates/wasmtime/src/runtime/externals/table.rs
+++ b/crates/wasmtime/src/runtime/externals/table.rs
@@ -1,6 +1,6 @@
 use crate::prelude::*;
 use crate::runtime::RootedGcRefImpl;
-use crate::runtime::vm::{self as runtime, GcStore, TableElementType, VMFuncRef, VMGcRef};
+use crate::runtime::vm::{self, GcStore, TableElementType, VMFuncRef, VMGcRef};
 use crate::store::{AutoAssertNoGc, StoreInstanceId, StoreOpaque};
 use crate::trampoline::generate_table_export;
 use crate::{
@@ -92,7 +92,8 @@ impl Table {
     /// # }
     /// ```
     pub fn new(mut store: impl AsContextMut, ty: TableType, init: Ref) -> Result<Table> {
-        Table::_new(store.as_context_mut().0, ty, init)
+        vm::one_poll(Table::_new(store.as_context_mut().0, ty, init))
+            .expect("must use `new_async` when async resource limiters are in use")
     }
 
     /// Async variant of [`Table::new`]. You must use this variant with
@@ -109,18 +110,12 @@ impl Table {
         ty: TableType,
         init: Ref,
     ) -> Result<Table> {
-        let mut store = store.as_context_mut();
-        assert!(
-            store.0.async_support(),
-            "cannot use `new_async` without enabling async support on the config"
-        );
-        store
-            .on_fiber(|store| Table::_new(store.0, ty, init))
-            .await?
+        let store = store.as_context_mut();
+        Table::_new(store.0, ty, init).await
     }
 
-    fn _new(store: &mut StoreOpaque, ty: TableType, init: Ref) -> Result<Table> {
-        let table = generate_table_export(store, &ty)?;
+    async fn _new(store: &mut StoreOpaque, ty: TableType, init: Ref) -> Result<Table> {
+        let table = generate_table_export(store, &ty).await?;
         table._fill(store, 0, init, ty.minimum())?;
         Ok(table)
     }
@@ -139,7 +134,7 @@ impl Table {
         TableType::from_wasmtime_table(store.engine(), self.wasmtime_ty(store))
     }
 
-    /// Returns the `runtime::Table` within `store` as well as the optional
+    /// Returns the `vm::Table` within `store` as well as the optional
     /// `GcStore` in use within `store`.
     ///
     /// # Panics
@@ -149,7 +144,7 @@ impl Table {
         &self,
         store: &'a mut StoreOpaque,
         lazy_init_range: impl IntoIterator<Item = u64>,
-    ) -> (&'a mut runtime::Table, Option<&'a mut GcStore>) {
+    ) -> (&'a mut vm::Table, Option<&'a mut GcStore>) {
         self.instance.assert_belongs_to(store.id());
         let (store, instance) = store.optional_gc_store_and_instance_mut(self.instance.instance());
 
@@ -281,43 +276,8 @@ impl Table {
     /// When using an async resource limiter, use [`Table::grow_async`]
     /// instead.
     pub fn grow(&self, mut store: impl AsContextMut, delta: u64, init: Ref) -> Result<u64> {
-        let store = store.as_context_mut().0;
-        let ty = self.ty(&store);
-        let (table, _gc_store) = self.wasmtime_table(store, iter::empty());
-        // FIXME(#11179) shouldn't need to subvert the borrow checker
-        let table: *mut _ = table;
-        unsafe {
-            let result = match element_type(&ty) {
-                TableElementType::Func => {
-                    let element = init.into_table_func(store, ty.element())?;
-                    (*table).grow_func(store, delta, element)?
-                }
-                TableElementType::GcRef => {
-                    // FIXME: `grow_gc_ref` shouldn't require the whole store
-                    // and should require `AutoAssertNoGc`. For now though we
-                    // know that table growth doesn't trigger GC so it should be
-                    // ok to create a copy of the GC reference even though it's
-                    // not tracked anywhere.
-                    let element = init
-                        .into_table_gc_ref(&mut AutoAssertNoGc::new(store), ty.element())?
-                        .map(|r| r.unchecked_copy());
-                    (*table).grow_gc_ref(store, delta, element.as_ref())?
-                }
-                // TODO(#10248) Required to support stack switching in the
-                // embedder API.
-                TableElementType::Cont => bail!("unimplemented table for cont"),
-            };
-            match result {
-                Some(size) => {
-                    let vm = (*table).vmtable();
-                    store[self.instance].table_ptr(self.index).write(vm);
-                    // unwrap here should be ok because the runtime should always guarantee
-                    // that we can fit the table size in a 64-bit integer.
-                    Ok(u64::try_from(size).unwrap())
-                }
-                None => bail!("failed to grow table by `{}`", delta),
-            }
-        }
+        vm::one_poll(self.grow_(store.as_context_mut().0, delta, init))
+            .expect("must use `grow_async` when async resource limiters are in use")
     }
 
     /// Async variant of [`Table::grow`]. Required when using a
@@ -334,14 +294,46 @@ impl Table {
         delta: u64,
         init: Ref,
     ) -> Result<u64> {
-        let mut store = store.as_context_mut();
-        assert!(
-            store.0.async_support(),
-            "cannot use `grow_async` without enabling async support on the config"
-        );
-        store
-            .on_fiber(|store| self.grow(store, delta, init))
-            .await?
+        self.grow_(store.as_context_mut().0, delta, init).await
+    }
+
+    async fn grow_(&self, store: &mut dyn vm::VMStore, delta: u64, init: Ref) -> Result<u64> {
+        let ty = self._ty(store);
+        let (table, _gc_store) = self.wasmtime_table(store, iter::empty());
+        // FIXME(#11179) shouldn't need to subvert the borrow checker
+        let table: *mut _ = table;
+        unsafe {
+            let result = match element_type(&ty) {
+                TableElementType::Func => {
+                    let element = init.into_table_func(store, ty.element())?.map(|e| e.into());
+                    (*table).grow_func(store, delta, element).await?
+                }
+                TableElementType::GcRef => {
+                    // FIXME: `grow_gc_ref` shouldn't require the whole store
+                    // and should require `AutoAssertNoGc`. For now though we
+                    // know that table growth doesn't trigger GC so it should be
+                    // ok to create a copy of the GC reference even though it's
+                    // not tracked anywhere.
+                    let element = init
+                        .into_table_gc_ref(&mut AutoAssertNoGc::new(store), ty.element())?
+                        .map(|r| r.unchecked_copy());
+                    (*table).grow_gc_ref(store, delta, element.as_ref()).await?
+                }
+                // TODO(#10248) Required to support stack switching in the
+                // embedder API.
+                TableElementType::Cont => bail!("unimplemented table for cont"),
+            };
+            match result {
+                Some(size) => {
+                    let vm = (*table).vmtable();
+                    store[self.instance].table_ptr(self.index).write(vm);
+                    // unwrap here should be ok because the runtime should always guarantee
+                    // that we can fit the table size in a 64-bit integer.
+                    Ok(u64::try_from(size).unwrap())
+                }
+                None => bail!("failed to grow table by `{}`", delta),
+            }
+        }
     }
 
     /// Copy `len` elements from `src_table[src_index..]` into
@@ -516,11 +508,7 @@ impl Table {
     }
 
     #[cfg(feature = "gc")]
-    pub(crate) fn trace_roots(
-        &self,
-        store: &mut StoreOpaque,
-        gc_roots_list: &mut crate::runtime::vm::GcRootsList,
-    ) {
+    pub(crate) fn trace_roots(&self, store: &mut StoreOpaque, gc_roots_list: &mut vm::GcRootsList) {
         if !self
             ._ty(store)
             .element()
@@ -549,9 +537,9 @@ impl Table {
         &module.tables[index]
     }
 
-    pub(crate) fn vmimport(&self, store: &StoreOpaque) -> crate::runtime::vm::VMTableImport {
+    pub(crate) fn vmimport(&self, store: &StoreOpaque) -> vm::VMTableImport {
         let instance = &store[self.instance];
-        crate::runtime::vm::VMTableImport {
+        vm::VMTableImport {
             from: instance.table_ptr(self.index).into(),
             vmctx: instance.vmctx().into(),
             index: self.index,

--- a/crates/wasmtime/src/runtime/fiber.rs
+++ b/crates/wasmtime/src/runtime/fiber.rs
@@ -122,7 +122,7 @@ impl AsStoreOpaque for StoreOpaque {
     }
 }
 
-impl<T: 'static> AsStoreOpaque for StoreInner<T> {
+impl<T: Send + 'static> AsStoreOpaque for StoreInner<T> {
     fn as_store_opaque(&mut self) -> &mut StoreOpaque {
         self
     }
@@ -331,7 +331,7 @@ impl<'a, 'b> BlockingContext<'a, 'b> {
     }
 }
 
-impl<T> StoreContextMut<'_, T> {
+impl<T: Send> StoreContextMut<'_, T> {
     /// Blocks on the future computed by `f`.
     ///
     /// # Panics
@@ -358,7 +358,7 @@ impl<T> StoreContextMut<'_, T> {
     }
 }
 
-impl<T> crate::store::StoreInner<T> {
+impl<T: Send> crate::store::StoreInner<T> {
     /// Blocks on the future computed by `f`.
     ///
     /// # Panics

--- a/crates/wasmtime/src/runtime/func.rs
+++ b/crates/wasmtime/src/runtime/func.rs
@@ -2228,7 +2228,7 @@ impl<T: Send> Caller<'_, T> {
     ///
     /// Same as [`Store::gc_async`](crate::Store::gc_async).
     #[cfg(all(feature = "async", feature = "gc"))]
-    pub async fn gc_async(&mut self, why: Option<&crate::GcHeapOutOfMemory<()>>) -> Result<()>
+    pub async fn gc_async(&mut self, why: Option<&crate::GcHeapOutOfMemory<()>>)
     where
         T: Send + 'static,
     {

--- a/crates/wasmtime/src/runtime/func/typed.rs
+++ b/crates/wasmtime/src/runtime/func/typed.rs
@@ -152,7 +152,7 @@ where
     ///
     /// `func` must be of the given type, and it additionally must be a valid
     /// store-owned pointer within the `store` provided.
-    pub(crate) unsafe fn call_raw<T>(
+    pub(crate) unsafe fn call_raw<T: Send>(
         store: &mut StoreContextMut<'_, T>,
         ty: &FuncType,
         func: ptr::NonNull<VMFuncRef>,

--- a/crates/wasmtime/src/runtime/gc/disabled/arrayref.rs
+++ b/crates/wasmtime/src/runtime/gc/disabled/arrayref.rs
@@ -30,7 +30,7 @@ impl ArrayRef {
         match *self {}
     }
 
-    pub fn elems<'a, T: 'static>(
+    pub fn elems<'a, T: Send + 'static>(
         &self,
         _store: impl Into<StoreContextMut<'a, T>>,
     ) -> Result<impl ExactSizeIterator<Item = Val> + 'a + '_> {

--- a/crates/wasmtime/src/runtime/gc/disabled/exnref.rs
+++ b/crates/wasmtime/src/runtime/gc/disabled/exnref.rs
@@ -60,7 +60,7 @@ impl ExnRef {
         match *self {}
     }
 
-    pub fn fields<'a, T: 'static>(
+    pub fn fields<'a, T: Send + 'static>(
         &self,
         _store: impl Into<StoreContextMut<'a, T>>,
     ) -> Result<impl ExactSizeIterator<Item = Val> + 'a + '_> {

--- a/crates/wasmtime/src/runtime/gc/disabled/externref.rs
+++ b/crates/wasmtime/src/runtime/gc/disabled/externref.rs
@@ -18,7 +18,7 @@ impl ExternRef {
         unreachable!()
     }
 
-    pub fn data<'a, T: 'static>(
+    pub fn data<'a, T: Send + 'static>(
         &self,
         _store: impl Into<StoreContext<'a, T>>,
     ) -> Result<&'a (dyn Any + Send + Sync)>
@@ -28,13 +28,10 @@ impl ExternRef {
         match *self {}
     }
 
-    pub fn data_mut<'a, T: 'static>(
+    pub fn data_mut<'a, T: Send + 'static>(
         &self,
         _store: impl Into<StoreContextMut<'a, T>>,
-    ) -> Result<&'a mut (dyn Any + Send + Sync)>
-    where
-        T: 'a,
-    {
+    ) -> Result<&'a mut (dyn Any + Send + Sync)> {
         match *self {}
     }
 

--- a/crates/wasmtime/src/runtime/gc/disabled/structref.rs
+++ b/crates/wasmtime/src/runtime/gc/disabled/structref.rs
@@ -26,7 +26,7 @@ impl StructRef {
         match *self {}
     }
 
-    pub fn fields<'a, T: 'static>(
+    pub fn fields<'a, T: Send + 'static>(
         &self,
         _store: impl Into<StoreContextMut<'a, T>>,
     ) -> Result<impl ExactSizeIterator<Item = Val> + 'a + '_> {

--- a/crates/wasmtime/src/runtime/gc/enabled/arrayref.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/arrayref.rs
@@ -652,7 +652,7 @@ impl ArrayRef {
     /// # Panics
     ///
     /// Panics if this reference is associated with a different store.
-    pub fn elems<'a, T: 'static>(
+    pub fn elems<'a, T: Send + 'static>(
         &'a self,
         store: impl Into<StoreContextMut<'a, T>>,
     ) -> Result<impl ExactSizeIterator<Item = Val> + 'a> {

--- a/crates/wasmtime/src/runtime/gc/enabled/exnref.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/exnref.rs
@@ -486,7 +486,7 @@ impl ExnRef {
     /// # Panics
     ///
     /// Panics if this reference is associated with a different store.
-    pub fn fields<'a, T: 'static>(
+    pub fn fields<'a, T: Send + 'static>(
         &'a self,
         store: impl Into<StoreContextMut<'a, T>>,
     ) -> Result<impl ExactSizeIterator<Item = Val> + 'a> {

--- a/crates/wasmtime/src/runtime/gc/enabled/exnref.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/exnref.rs
@@ -2,7 +2,7 @@
 
 use crate::runtime::vm::VMGcRef;
 use crate::store::StoreId;
-use crate::vm::{VMExnRef, VMGcHeader};
+use crate::vm::{self, VMExnRef, VMGcHeader};
 use crate::{
     AsContext, AsContextMut, GcRefImpl, GcRootIndex, HeapType, ManuallyRooted, RefType, Result,
     Rooted, Val, ValRaw, ValType, WasmTy,
@@ -205,23 +205,23 @@ impl ExnRef {
         tag: &Tag,
         fields: &[Val],
     ) -> Result<Rooted<ExnRef>> {
-        Self::_new(store.as_context_mut().0, allocator, tag, fields)
+        let store = store.as_context_mut().0;
+        assert!(!store.async_support());
+        vm::assert_ready(Self::_new(store, allocator, tag, fields))
     }
 
-    pub(crate) fn _new(
+    pub(crate) async fn _new(
         store: &mut StoreOpaque,
         allocator: &ExnRefPre,
         tag: &Tag,
         fields: &[Val],
     ) -> Result<Rooted<ExnRef>> {
-        assert!(
-            !store.async_support(),
-            "use `ExnRef::new_async` with asynchronous stores"
-        );
         Self::type_check_tag_and_fields(store, allocator, tag, fields)?;
-        store.retry_after_gc((), |store, ()| {
-            Self::new_unchecked(store, allocator, tag, fields)
-        })
+        store
+            .retry_after_gc((), |store, ()| {
+                Self::new_unchecked(store, allocator, tag, fields)
+            })
+            .await
     }
 
     /// Asynchronously allocate a new exception object and get a
@@ -259,26 +259,7 @@ impl ExnRef {
         tag: &Tag,
         fields: &[Val],
     ) -> Result<Rooted<ExnRef>> {
-        Self::_new_async(store.as_context_mut().0, allocator, tag, fields).await
-    }
-
-    #[cfg(feature = "async")]
-    pub(crate) async fn _new_async(
-        store: &mut StoreOpaque,
-        allocator: &ExnRefPre,
-        tag: &Tag,
-        fields: &[Val],
-    ) -> Result<Rooted<ExnRef>> {
-        assert!(
-            store.async_support(),
-            "use `ExnRef::new` with synchronous stores"
-        );
-        Self::type_check_tag_and_fields(store, allocator, tag, fields)?;
-        store
-            .retry_after_gc_async((), |store, ()| {
-                Self::new_unchecked(store, allocator, tag, fields)
-            })
-            .await
+        Self::_new(store.as_context_mut().0, allocator, tag, fields).await
     }
 
     /// Type check the tag instance and field values before allocating

--- a/crates/wasmtime/src/runtime/gc/enabled/externref.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/externref.rs
@@ -479,7 +479,7 @@ impl ExternRef {
         store: impl Into<StoreContext<'a, T>>,
     ) -> Result<Option<&'a (dyn Any + Send + Sync)>>
     where
-        T: 'static,
+        T: Send + 'static,
     {
         let store = store.into().0;
         let gc_ref = self.inner.try_gc_ref(&store)?;
@@ -530,7 +530,7 @@ impl ExternRef {
         store: impl Into<StoreContextMut<'a, T>>,
     ) -> Result<Option<&'a mut (dyn Any + Send + Sync)>>
     where
-        T: 'static,
+        T: Send + 'static,
     {
         let store = store.into().0;
         // NB: need to do an unchecked copy to release the borrow on the store

--- a/crates/wasmtime/src/runtime/gc/enabled/externref.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/externref.rs
@@ -2,7 +2,7 @@
 
 use super::{AnyRef, RootedGcRefImpl};
 use crate::prelude::*;
-use crate::runtime::vm::VMGcRef;
+use crate::runtime::vm::{self, VMGcRef};
 use crate::{
     AsContextMut, GcHeapOutOfMemory, GcRefImpl, GcRootIndex, HeapType, ManuallyRooted, RefType,
     Result, Rooted, StoreContext, StoreContextMut, ValRaw, ValType, WasmTy,
@@ -215,10 +215,11 @@ impl ExternRef {
         T: 'static + Any + Send + Sync,
     {
         let ctx = context.as_context_mut().0;
-        Self::_new(ctx, value)
+        assert!(!ctx.async_support());
+        vm::assert_ready(Self::_new(ctx, value))
     }
 
-    pub(crate) fn _new<T>(store: &mut StoreOpaque, value: T) -> Result<Rooted<ExternRef>>
+    pub(crate) async fn _new<T>(store: &mut StoreOpaque, value: T) -> Result<Rooted<ExternRef>>
     where
         T: 'static + Any + Send + Sync,
     {
@@ -234,6 +235,7 @@ impl ExternRef {
                     .context("unrecoverable error when allocating new `externref`")?
                     .map_err(|(x, n)| GcHeapOutOfMemory::new(x, n).into())
             })
+            .await
             // Translate the `GcHeapOutOfMemory`'s inner value from the boxed
             // trait object into `T`.
             .map_err(
@@ -316,53 +318,13 @@ impl ExternRef {
     /// # Ok(())
     /// # }
     /// ```
-    ///
-    /// # Panics
-    ///
-    /// Panics if the `context` is not configured for async; use
-    /// [`ExternRef::new`][crate::ExternRef::new] to perform synchronous
-    /// allocation instead.
     #[cfg(feature = "async")]
     pub async fn new_async<T>(mut context: impl AsContextMut, value: T) -> Result<Rooted<ExternRef>>
     where
         T: 'static + Any + Send + Sync,
     {
         let ctx = context.as_context_mut().0;
-        Self::_new_async(ctx, value).await
-    }
-
-    #[cfg(feature = "async")]
-    pub(crate) async fn _new_async<T>(
-        store: &mut StoreOpaque,
-        value: T,
-    ) -> Result<Rooted<ExternRef>>
-    where
-        T: 'static + Any + Send + Sync,
-    {
-        // Allocate the box once, regardless how many gc-and-retry attempts we
-        // make.
-        let value: Box<dyn Any + Send + Sync> = Box::new(value);
-
-        let gc_ref = store
-            .retry_after_gc_async(value, |store, value| {
-                store
-                    .require_gc_store_mut()?
-                    .alloc_externref(value)
-                    .context("unrecoverable error when allocating new `externref`")?
-                    .map_err(|(x, n)| GcHeapOutOfMemory::new(x, n).into())
-            })
-            .await
-            // Translate the `GcHeapOutOfMemory`'s inner value from the boxed
-            // trait object into `T`.
-            .map_err(
-                |e| match e.downcast::<GcHeapOutOfMemory<Box<dyn Any + Send + Sync>>>() {
-                    Ok(oom) => oom.map_inner(|x| *x.downcast::<T>().unwrap()).into(),
-                    Err(e) => e,
-                },
-            )?;
-
-        let mut ctx = AutoAssertNoGc::new(store);
-        Ok(Self::from_cloned_gc_ref(&mut ctx, gc_ref.into()))
+        Self::_new(ctx, value).await
     }
 
     /// Convert an `anyref` into an `externref`.

--- a/crates/wasmtime/src/runtime/gc/enabled/structref.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/structref.rs
@@ -2,7 +2,7 @@
 
 use crate::runtime::vm::VMGcRef;
 use crate::store::StoreId;
-use crate::vm::{VMGcHeader, VMStructRef};
+use crate::vm::{self, VMGcHeader, VMStructRef};
 use crate::{AnyRef, FieldType};
 use crate::{
     AsContext, AsContextMut, EqRef, GcHeapOutOfMemory, GcRefImpl, GcRootIndex, HeapType,
@@ -231,22 +231,22 @@ impl StructRef {
         allocator: &StructRefPre,
         fields: &[Val],
     ) -> Result<Rooted<StructRef>> {
-        Self::_new(store.as_context_mut().0, allocator, fields)
+        let store = store.as_context_mut().0;
+        assert!(!store.async_support());
+        vm::assert_ready(Self::_new(store, allocator, fields))
     }
 
-    pub(crate) fn _new(
+    pub(crate) async fn _new(
         store: &mut StoreOpaque,
         allocator: &StructRefPre,
         fields: &[Val],
     ) -> Result<Rooted<StructRef>> {
-        assert!(
-            !store.async_support(),
-            "use `StructRef::new_async` with asynchronous stores"
-        );
         Self::type_check_fields(store, allocator, fields)?;
-        store.retry_after_gc((), |store, ()| {
-            Self::new_unchecked(store, allocator, fields)
-        })
+        store
+            .retry_after_gc((), |store, ()| {
+                Self::new_unchecked(store, allocator, fields)
+            })
+            .await
     }
 
     /// Asynchronously allocate a new `struct` and get a reference to it.
@@ -281,40 +281,7 @@ impl StructRef {
         allocator: &StructRefPre,
         fields: &[Val],
     ) -> Result<Rooted<StructRef>> {
-        Self::_new_async(store.as_context_mut().0, allocator, fields).await
-    }
-
-    #[cfg(feature = "async")]
-    pub(crate) async fn _new_async(
-        store: &mut StoreOpaque,
-        allocator: &StructRefPre,
-        fields: &[Val],
-    ) -> Result<Rooted<StructRef>> {
-        assert!(
-            store.async_support(),
-            "use `StructRef::new` with synchronous stores"
-        );
-        Self::type_check_fields(store, allocator, fields)?;
-        store
-            .retry_after_gc_async((), |store, ()| {
-                Self::new_unchecked(store, allocator, fields)
-            })
-            .await
-    }
-
-    /// Like `Self::new` but caller's must ensure that if the store is
-    /// configured for async, this is only ever called from on a fiber stack.
-    pub(crate) unsafe fn new_maybe_async(
-        store: &mut StoreOpaque,
-        allocator: &StructRefPre,
-        fields: &[Val],
-    ) -> Result<Rooted<StructRef>> {
-        Self::type_check_fields(store, allocator, fields)?;
-        unsafe {
-            store.retry_after_gc_maybe_async((), |store, ()| {
-                Self::new_unchecked(store, allocator, fields)
-            })
-        }
+        Self::_new(store.as_context_mut().0, allocator, fields).await
     }
 
     /// Type check the field values before allocating a new struct.

--- a/crates/wasmtime/src/runtime/gc/enabled/structref.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/structref.rs
@@ -460,7 +460,7 @@ impl StructRef {
     /// # Panics
     ///
     /// Panics if this reference is associated with a different store.
-    pub fn fields<'a, T: 'static>(
+    pub fn fields<'a, T: Send + 'static>(
         &'a self,
         store: impl Into<StoreContextMut<'a, T>>,
     ) -> Result<impl ExactSizeIterator<Item = Val> + 'a> {

--- a/crates/wasmtime/src/runtime/instance.rs
+++ b/crates/wasmtime/src/runtime/instance.rs
@@ -188,7 +188,7 @@ impl Instance {
     /// Internal function to create an instance and run the start function.
     ///
     /// This function's unsafety is the same as `Instance::new_raw`.
-    pub(crate) unsafe fn new_started<T>(
+    pub(crate) unsafe fn new_started<T: Send>(
         store: &mut StoreContextMut<'_, T>,
         module: &Module,
         imports: Imports<'_>,
@@ -207,7 +207,7 @@ impl Instance {
     ///
     /// ONLY CALL THIS IF YOU HAVE ALREADY CHECKED FOR ASYNCNESS AND HANDLED
     /// THE FIBER NONSENSE
-    pub(crate) unsafe fn new_started_impl<T>(
+    pub(crate) unsafe fn new_started_impl<T: Send>(
         store: &mut StoreContextMut<'_, T>,
         module: &Module,
         imports: Imports<'_>,
@@ -337,7 +337,11 @@ impl Instance {
         }
     }
 
-    fn start_raw<T>(&self, store: &mut StoreContextMut<'_, T>, start: FuncIndex) -> Result<()> {
+    fn start_raw<T: Send>(
+        &self,
+        store: &mut StoreContextMut<'_, T>,
+        start: FuncIndex,
+    ) -> Result<()> {
         // If a start function is present, invoke it. Make sure we use all the
         // trap-handling configuration in `store` as well.
         let store_id = store.0.id();
@@ -356,7 +360,10 @@ impl Instance {
     }
 
     /// Get this instance's module.
-    pub fn module<'a, T: 'static>(&self, store: impl Into<StoreContext<'a, T>>) -> &'a Module {
+    pub fn module<'a, T: Send + 'static>(
+        &self,
+        store: impl Into<StoreContext<'a, T>>,
+    ) -> &'a Module {
         self._module(store.into().0)
     }
 
@@ -369,7 +376,7 @@ impl Instance {
     /// # Panics
     ///
     /// Panics if `store` does not own this instance.
-    pub fn exports<'a, T: 'static>(
+    pub fn exports<'a, T: Send + 'static>(
         &'a self,
         store: impl Into<StoreContextMut<'a, T>>,
     ) -> impl ExactSizeIterator<Item = Export<'a>> + 'a {
@@ -760,7 +767,7 @@ impl<T> Clone for InstancePre<T> {
     }
 }
 
-impl<T: 'static> InstancePre<T> {
+impl<T: Send + 'static> InstancePre<T> {
     /// Creates a new `InstancePre` which type-checks the `items` provided and
     /// on success is ready to instantiate a new instance.
     ///

--- a/crates/wasmtime/src/runtime/instance.rs
+++ b/crates/wasmtime/src/runtime/instance.rs
@@ -113,11 +113,19 @@ impl Instance {
         imports: &[Extern],
     ) -> Result<Instance> {
         let mut store = store.as_context_mut();
+        assert!(
+            !store.0.async_support(),
+            "must use async instantiation when async support is enabled",
+        );
         let imports = Instance::typecheck_externs(store.0, module, imports)?;
-        // Note that the unsafety here should be satisfied by the call to
-        // `typecheck_externs` above which satisfies the condition that all
+        // SAFETY: Note that the unsafety here should be satisfied by the call
+        // to `typecheck_externs` above which satisfies the condition that all
         // the imports are valid for this module.
-        unsafe { Instance::new_started(&mut store, module, imports.as_ref()) }
+        //
+        // Also note that `vm::assert_ready` should be valid here as
+        // `async_support` is disabled so it shouldn't be possible for anything
+        // to have introduce an await point.
+        unsafe { vm::assert_ready(Instance::new_started(&mut store, module, imports.as_ref())) }
     }
 
     /// Same as [`Instance::new`], except for usage in [asynchronous stores].
@@ -146,7 +154,7 @@ impl Instance {
         let mut store = store.as_context_mut();
         let imports = Instance::typecheck_externs(store.0, module, imports)?;
         // See `new` for notes on this unsafety
-        unsafe { Instance::new_started_async(&mut store, module, imports.as_ref()).await }
+        unsafe { Instance::new_started(&mut store, module, imports.as_ref()).await }
     }
 
     fn typecheck_externs(
@@ -186,65 +194,27 @@ impl Instance {
     }
 
     /// Internal function to create an instance and run the start function.
-    ///
-    /// This function's unsafety is the same as `Instance::new_raw`.
-    pub(crate) unsafe fn new_started<T: Send>(
-        store: &mut StoreContextMut<'_, T>,
-        module: &Module,
-        imports: Imports<'_>,
-    ) -> Result<Instance> {
-        assert!(
-            !store.0.async_support(),
-            "must use async instantiation when async support is enabled",
-        );
-
-        // SAFETY: the safety contract of `new_started_impl` is the same as this
-        // function.
-        unsafe { Self::new_started_impl(store, module, imports) }
-    }
-
-    /// Internal function to create an instance and run the start function.
-    ///
-    /// ONLY CALL THIS IF YOU HAVE ALREADY CHECKED FOR ASYNCNESS AND HANDLED
-    /// THE FIBER NONSENSE
-    pub(crate) unsafe fn new_started_impl<T: Send>(
+    pub(crate) async unsafe fn new_started<T: Send>(
         store: &mut StoreContextMut<'_, T>,
         module: &Module,
         imports: Imports<'_>,
     ) -> Result<Instance> {
         // SAFETY: the safety contract of `new_raw` is the same as this
         // function.
-        let (instance, start) = unsafe { Instance::new_raw(store.0, module, imports)? };
+        let (instance, start) = unsafe { Instance::new_raw(store.0, module, imports).await? };
         if let Some(start) = start {
-            instance.start_raw(store, start)?;
+            if store.0.async_support() {
+                #[cfg(feature = "async")]
+                store
+                    .on_fiber(|store| instance.start_raw(store, start))
+                    .await??;
+                #[cfg(not(feature = "async"))]
+                unreachable!();
+            } else {
+                instance.start_raw(store, start)?;
+            }
         }
         Ok(instance)
-    }
-
-    /// Internal function to create an instance and run the start function.
-    ///
-    /// This function's unsafety is the same as `Instance::new_raw`.
-    #[cfg(feature = "async")]
-    async unsafe fn new_started_async<T>(
-        store: &mut StoreContextMut<'_, T>,
-        module: &Module,
-        imports: Imports<'_>,
-    ) -> Result<Instance>
-    where
-        T: Send + 'static,
-    {
-        assert!(
-            store.0.async_support(),
-            "must use sync instantiation when async support is disabled",
-        );
-
-        store
-            .on_fiber(|store| {
-                // SAFETY: the unsafe contract of `new_started_impl` is the same
-                // as this function.
-                unsafe { Self::new_started_impl(store, module, imports) }
-            })
-            .await?
     }
 
     /// Internal function to create an instance which doesn't have its `start`
@@ -262,7 +232,7 @@ impl Instance {
     /// This method is unsafe because it does not type-check the `imports`
     /// provided. The `imports` provided must be suitable for the module
     /// provided as well.
-    unsafe fn new_raw(
+    async unsafe fn new_raw(
         store: &mut StoreOpaque,
         module: &Module,
         imports: Imports<'_>,
@@ -274,7 +244,7 @@ impl Instance {
 
         // Allocate the GC heap, if necessary.
         if module.env_module().needs_gc_heap {
-            store.ensure_gc_store()?;
+            store.ensure_gc_store().await?;
         }
 
         let compiled_module = module.compiled_module();
@@ -290,11 +260,13 @@ impl Instance {
         // SAFETY: this module, by construction, was already validated within
         // the store.
         let id = unsafe {
-            store.allocate_instance(
-                AllocateInstanceKind::Module(module_id),
-                &ModuleRuntimeInfo::Module(module.clone()),
-                imports,
-            )?
+            store
+                .allocate_instance(
+                    AllocateInstanceKind::Module(module_id),
+                    &ModuleRuntimeInfo::Module(module.clone()),
+                    imports,
+                )
+                .await?
         };
 
         // Additionally, before we start doing fallible instantiation, we
@@ -326,7 +298,7 @@ impl Instance {
             .features()
             .contains(WasmFeatures::BULK_MEMORY);
 
-        vm::initialize_instance(store, id, compiled_module.module(), bulk_memory)?;
+        vm::initialize_instance(store, id, compiled_module.module(), bulk_memory).await?;
 
         Ok((instance, compiled_module.module().start_func))
     }
@@ -833,6 +805,10 @@ impl<T: Send + 'static> InstancePre<T> {
     /// [`Engine`] than the [`InstancePre`] originally came from.
     pub fn instantiate(&self, mut store: impl AsContextMut<Data = T>) -> Result<Instance> {
         let mut store = store.as_context_mut();
+        assert!(
+            !store.0.async_support(),
+            "must use async instantiation when async support is enabled",
+        );
         let imports = pre_instantiate_raw(
             &mut store.0,
             &self.module,
@@ -841,10 +817,20 @@ impl<T: Send + 'static> InstancePre<T> {
             &self.func_refs,
         )?;
 
-        // This unsafety should be handled by the type-checking performed by the
-        // constructor of `InstancePre` to assert that all the imports we're passing
-        // in match the module we're instantiating.
-        unsafe { Instance::new_started(&mut store, &self.module, imports.as_ref()) }
+        // SAFETY: This unsafety should be handled by the type-checking
+        // performed by the constructor of `InstancePre` to assert that all the
+        // imports we're passing in match the module we're instantiating.
+        //
+        // Also note that `vm::assert_ready` should be valid here as
+        // `async_support` is disabled so it shouldn't be possible for anything
+        // to have introduce an await point.
+        unsafe {
+            vm::assert_ready(Instance::new_started(
+                &mut store,
+                &self.module,
+                imports.as_ref(),
+            ))
+        }
     }
 
     /// Creates a new instance, running the start function asynchronously
@@ -874,7 +860,7 @@ impl<T: Send + 'static> InstancePre<T> {
         // This unsafety should be handled by the type-checking performed by the
         // constructor of `InstancePre` to assert that all the imports we're passing
         // in match the module we're instantiating.
-        unsafe { Instance::new_started_async(&mut store, &self.module, imports.as_ref()).await }
+        unsafe { Instance::new_started(&mut store, &self.module, imports.as_ref()).await }
     }
 }
 

--- a/crates/wasmtime/src/runtime/memory.rs
+++ b/crates/wasmtime/src/runtime/memory.rs
@@ -372,7 +372,7 @@ impl Memory {
     /// # Panics
     ///
     /// Panics if this memory doesn't belong to `store`.
-    pub fn data<'a, T: 'static>(&self, store: impl Into<StoreContext<'a, T>>) -> &'a [u8] {
+    pub fn data<'a, T: Send + 'static>(&self, store: impl Into<StoreContext<'a, T>>) -> &'a [u8] {
         unsafe {
             let store = store.into();
             let definition = store[self.instance].memory(self.index);
@@ -389,7 +389,7 @@ impl Memory {
     /// # Panics
     ///
     /// Panics if this memory doesn't belong to `store`.
-    pub fn data_mut<'a, T: 'static>(
+    pub fn data_mut<'a, T: Send + 'static>(
         &self,
         store: impl Into<StoreContextMut<'a, T>>,
     ) -> &'a mut [u8] {
@@ -413,7 +413,7 @@ impl Memory {
     /// # Panics
     ///
     /// Panics if this memory doesn't belong to `store`.
-    pub fn data_and_store_mut<'a, T: 'static>(
+    pub fn data_and_store_mut<'a, T: Send + 'static>(
         &self,
         store: impl Into<StoreContextMut<'a, T>>,
     ) -> (&'a mut [u8], &'a mut T) {

--- a/crates/wasmtime/src/runtime/store/async_.rs
+++ b/crates/wasmtime/src/runtime/store/async_.rs
@@ -8,13 +8,13 @@ use crate::{AsContextMut, Store, StoreContextMut, UpdateDeadline};
 /// An object that can take callbacks when the runtime enters or exits hostcalls.
 #[cfg(feature = "call-hook")]
 #[async_trait::async_trait]
-pub trait CallHookHandler<T>: Send {
+pub trait CallHookHandler<T: Send>: Send {
     /// A callback to run when wasmtime is about to enter a host call, or when about to
     /// exit the hostcall.
     async fn handle_call_event(&self, t: StoreContextMut<'_, T>, ch: CallHook) -> Result<()>;
 }
 
-impl<T> Store<T> {
+impl<T: Send> Store<T> {
     /// Configures the [`ResourceLimiterAsync`](crate::ResourceLimiterAsync)
     /// used to limit resource creation within this [`Store`].
     ///
@@ -125,7 +125,7 @@ impl<T> Store<T> {
     }
 }
 
-impl<'a, T> StoreContextMut<'a, T> {
+impl<'a, T: Send> StoreContextMut<'a, T> {
     /// Perform garbage collection of `ExternRef`s.
     ///
     /// Same as [`Store::gc`].
@@ -150,7 +150,7 @@ impl<'a, T> StoreContextMut<'a, T> {
     }
 }
 
-impl<T> StoreInner<T> {
+impl<T: Send> StoreInner<T> {
     #[cfg(target_has_atomic = "64")]
     fn epoch_deadline_async_yield_and_update(&mut self, delta: u64) {
         assert!(
@@ -272,7 +272,7 @@ impl StoreOpaque {
     }
 }
 
-impl<T> StoreContextMut<'_, T> {
+impl<T: Send> StoreContextMut<'_, T> {
     /// Executes a synchronous computation `func` asynchronously on a new fiber.
     pub(crate) async fn on_fiber<R: Send + Sync>(
         &mut self,

--- a/crates/wasmtime/src/runtime/store/context.rs
+++ b/crates/wasmtime/src/runtime/store/context.rs
@@ -8,7 +8,7 @@ use crate::store::{Store, StoreInner};
 // representation of this `struct` is a pointer for now. If the representation
 // changes then the C API will need to be updated
 #[repr(transparent)]
-pub struct StoreContext<'a, T: 'static>(pub(crate) &'a StoreInner<T>);
+pub struct StoreContext<'a, T: Send + 'static>(pub(crate) &'a StoreInner<T>);
 
 /// A temporary handle to a [`&mut Store<T>`][`Store`].
 ///
@@ -16,7 +16,7 @@ pub struct StoreContext<'a, T: 'static>(pub(crate) &'a StoreInner<T>);
 /// methods if desired.  For more information, see [`Store`].
 // NB the repr(transparent) here is for the same reason as above.
 #[repr(transparent)]
-pub struct StoreContextMut<'a, T: 'static>(pub(crate) &'a mut StoreInner<T>);
+pub struct StoreContextMut<'a, T: Send + 'static>(pub(crate) &'a mut StoreInner<T>);
 
 /// A trait used to get shared access to a [`Store`] in Wasmtime.
 ///
@@ -33,7 +33,7 @@ pub struct StoreContextMut<'a, T: 'static>(pub(crate) &'a mut StoreInner<T>);
 pub trait AsContext {
     /// The host information associated with the [`Store`], aka the `T` in
     /// [`Store<T>`].
-    type Data: 'static;
+    type Data: Send + 'static;
 
     /// Returns the store context that this type provides access to.
     fn as_context(&self) -> StoreContext<'_, Self::Data>;
@@ -100,7 +100,7 @@ pub trait AsContextMut: AsContext {
     fn as_context_mut(&mut self) -> StoreContextMut<'_, Self::Data>;
 }
 
-impl<T: 'static> AsContext for Store<T> {
+impl<T: Send + 'static> AsContext for Store<T> {
     type Data = T;
 
     #[inline]
@@ -109,14 +109,14 @@ impl<T: 'static> AsContext for Store<T> {
     }
 }
 
-impl<T: 'static> AsContextMut for Store<T> {
+impl<T: Send + 'static> AsContextMut for Store<T> {
     #[inline]
     fn as_context_mut(&mut self) -> StoreContextMut<'_, T> {
         StoreContextMut(&mut self.inner)
     }
 }
 
-impl<T: 'static> AsContext for StoreContext<'_, T> {
+impl<T: Send + 'static> AsContext for StoreContext<'_, T> {
     type Data = T;
 
     #[inline]
@@ -125,7 +125,7 @@ impl<T: 'static> AsContext for StoreContext<'_, T> {
     }
 }
 
-impl<T: 'static> AsContext for StoreContextMut<'_, T> {
+impl<T: Send + 'static> AsContext for StoreContextMut<'_, T> {
     type Data = T;
 
     #[inline]
@@ -134,14 +134,14 @@ impl<T: 'static> AsContext for StoreContextMut<'_, T> {
     }
 }
 
-impl<T: 'static> AsContextMut for StoreContextMut<'_, T> {
+impl<T: Send + 'static> AsContextMut for StoreContextMut<'_, T> {
     #[inline]
     fn as_context_mut(&mut self) -> StoreContextMut<'_, T> {
         StoreContextMut(&mut *self.0)
     }
 }
 
-impl<'a, T: 'static> From<StoreContextMut<'a, T>> for StoreContext<'a, T> {
+impl<'a, T: Send + 'static> From<StoreContextMut<'a, T>> for StoreContext<'a, T> {
     #[inline]
     fn from(store: StoreContextMut<'a, T>) -> StoreContext<'a, T> {
         StoreContext(store.0)
@@ -150,7 +150,7 @@ impl<'a, T: 'static> From<StoreContextMut<'a, T>> for StoreContext<'a, T> {
 
 // Implementations for internal consumers, but these aren't public types so
 // they're not publicly accessible for crate consumers.
-impl<T: 'static> AsContext for &'_ StoreInner<T> {
+impl<T: Send + 'static> AsContext for &'_ StoreInner<T> {
     type Data = T;
 
     #[inline]
@@ -159,7 +159,7 @@ impl<T: 'static> AsContext for &'_ StoreInner<T> {
     }
 }
 
-impl<T: 'static> AsContext for &'_ mut StoreInner<T> {
+impl<T: Send + 'static> AsContext for &'_ mut StoreInner<T> {
     type Data = T;
 
     #[inline]
@@ -168,7 +168,7 @@ impl<T: 'static> AsContext for &'_ mut StoreInner<T> {
     }
 }
 
-impl<T: 'static> AsContextMut for &'_ mut StoreInner<T> {
+impl<T: Send + 'static> AsContextMut for &'_ mut StoreInner<T> {
     #[inline]
     fn as_context_mut(&mut self) -> StoreContextMut<'_, T> {
         StoreContextMut(&mut **self)

--- a/crates/wasmtime/src/runtime/store/data.rs
+++ b/crates/wasmtime/src/runtime/store/data.rs
@@ -57,7 +57,7 @@ where
 }
 
 // forward StoreContext => StoreOpaque
-impl<I, T> Index<I> for StoreContext<'_, T>
+impl<I, T: Send> Index<I> for StoreContext<'_, T>
 where
     StoreOpaque: Index<I>,
 {
@@ -70,7 +70,7 @@ where
 }
 
 // forward StoreContextMut => StoreOpaque
-impl<I, T> Index<I> for StoreContextMut<'_, T>
+impl<I, T: Send> Index<I> for StoreContextMut<'_, T>
 where
     StoreOpaque: Index<I>,
 {
@@ -82,7 +82,7 @@ where
     }
 }
 
-impl<I, T> IndexMut<I> for StoreContextMut<'_, T>
+impl<I, T: Send> IndexMut<I> for StoreContextMut<'_, T>
 where
     StoreOpaque: IndexMut<I>,
 {

--- a/crates/wasmtime/src/runtime/store/gc.rs
+++ b/crates/wasmtime/src/runtime/store/gc.rs
@@ -1,19 +1,10 @@
 //! GC-related methods for stores.
 
 use super::*;
-use crate::GcHeapOutOfMemory;
 use crate::runtime::vm::VMGcRef;
+use core::mem::ManuallyDrop;
 
 impl StoreOpaque {
-    /// Collect garbage, potentially growing the GC heap.
-    pub(crate) fn gc(&mut self, why: Option<&GcHeapOutOfMemory<()>>) {
-        assert!(!self.async_support());
-        unsafe {
-            self.maybe_async_gc(None, why.map(|oom| oom.bytes_needed()))
-                .expect("infallible when not async");
-        }
-    }
-
     /// Attempt to grow the GC heap by `bytes_needed` or, if that fails, perform
     /// a garbage collection.
     ///
@@ -24,26 +15,16 @@ impl StoreOpaque {
     /// heap could fail, and then performing a collection could succeed but
     /// might not free up enough space. Therefore, callers should not assume
     /// that a retried allocation will always succeed.
-    ///
-    /// # Safety
-    ///
-    /// When async is enabled, it is the caller's responsibility to ensure that
-    /// this is called on a fiber stack.
-    pub(crate) unsafe fn maybe_async_gc(
+    pub(crate) async fn gc(
         &mut self,
         root: Option<VMGcRef>,
         bytes_needed: Option<u64>,
-    ) -> Result<Option<VMGcRef>> {
+    ) -> Option<VMGcRef> {
         let mut scope = crate::OpaqueRootScope::new(self);
         let store_id = scope.id();
         let root = root.map(|r| scope.gc_roots_mut().push_lifo_root(store_id, r));
 
-        if scope.async_support() {
-            #[cfg(feature = "async")]
-            scope.block_on(|scope| Box::pin(scope.grow_or_collect_gc_heap_async(bytes_needed)))?;
-        } else {
-            scope.grow_or_collect_gc_heap(bytes_needed);
-        }
+        scope.grow_or_collect_gc_heap(bytes_needed).await;
 
         let root = match root {
             None => None,
@@ -56,186 +37,126 @@ impl StoreOpaque {
             }
         };
 
-        Ok(root)
+        root
     }
 
-    fn grow_or_collect_gc_heap(&mut self, bytes_needed: Option<u64>) {
-        assert!(!self.async_support());
+    async fn grow_or_collect_gc_heap(&mut self, bytes_needed: Option<u64>) {
         if let Some(n) = bytes_needed {
-            if unsafe { self.maybe_async_grow_gc_heap(n).is_ok() } {
+            if self.grow_gc_heap(n).await.is_ok() {
                 return;
             }
         }
-        self.do_gc();
+        self.do_gc().await;
     }
 
     /// Attempt to grow the GC heap by `bytes_needed` bytes.
     ///
     /// Returns an error if growing the GC heap fails.
-    ///
-    /// # Safety
-    ///
-    /// When async is enabled, it is the caller's responsibility to ensure that
-    /// this is called on a fiber stack.
-    unsafe fn maybe_async_grow_gc_heap(&mut self, bytes_needed: u64) -> Result<()> {
+    async fn grow_gc_heap(&mut self, bytes_needed: u64) -> Result<()> {
         log::trace!("Attempting to grow the GC heap by {bytes_needed} bytes");
         assert!(bytes_needed > 0);
 
         // Take the GC heap's underlying memory out of the GC heap, attempt to
         // grow it, then replace it.
-        let mut memory = self.unwrap_gc_store_mut().gc_heap.take_memory();
-        let mut delta_bytes_grown = 0;
-        let grow_result: Result<()> = (|| {
-            let page_size = self.engine().tunables().gc_heap_memory_type().page_size();
+        let mut heap = TakenGcHeap::new(self);
 
-            let current_size_in_bytes = u64::try_from(memory.byte_size()).unwrap();
-            let current_size_in_pages = current_size_in_bytes / page_size;
+        let page_size = heap
+            .store
+            .engine()
+            .tunables()
+            .gc_heap_memory_type()
+            .page_size();
 
-            // Aim to double the heap size, amortizing the cost of growth.
-            let doubled_size_in_pages = current_size_in_pages.saturating_mul(2);
-            assert!(doubled_size_in_pages >= current_size_in_pages);
-            let delta_pages_for_doubling = doubled_size_in_pages - current_size_in_pages;
+        let current_size_in_bytes = u64::try_from(heap.memory.byte_size()).unwrap();
+        let current_size_in_pages = current_size_in_bytes / page_size;
 
-            // When doubling our size, saturate at the maximum memory size in pages.
-            //
-            // TODO: we should consult the instance allocator for its configured
-            // maximum memory size, if any, rather than assuming the index
-            // type's maximum size.
-            let max_size_in_bytes = 1 << 32;
-            let max_size_in_pages = max_size_in_bytes / page_size;
-            let delta_to_max_size_in_pages = max_size_in_pages - current_size_in_pages;
-            let delta_pages_for_alloc = delta_pages_for_doubling.min(delta_to_max_size_in_pages);
+        // Aim to double the heap size, amortizing the cost of growth.
+        let doubled_size_in_pages = current_size_in_pages.saturating_mul(2);
+        assert!(doubled_size_in_pages >= current_size_in_pages);
+        let delta_pages_for_doubling = doubled_size_in_pages - current_size_in_pages;
 
-            // But always make sure we are attempting to grow at least as many pages
-            // as needed by the requested allocation. This must happen *after* the
-            // max-size saturation, so that if we are at the max already, we do not
-            // succeed in growing by zero delta pages, and then return successfully
-            // to our caller, who would be assuming that there is now capacity for
-            // their allocation.
-            let pages_needed = bytes_needed.div_ceil(page_size);
-            assert!(pages_needed > 0);
-            let delta_pages_for_alloc = delta_pages_for_alloc.max(pages_needed);
-            assert!(delta_pages_for_alloc > 0);
+        // When doubling our size, saturate at the maximum memory size in pages.
+        //
+        // TODO: we should consult the instance allocator for its configured
+        // maximum memory size, if any, rather than assuming the index
+        // type's maximum size.
+        let max_size_in_bytes = 1 << 32;
+        let max_size_in_pages = max_size_in_bytes / page_size;
+        let delta_to_max_size_in_pages = max_size_in_pages - current_size_in_pages;
+        let delta_pages_for_alloc = delta_pages_for_doubling.min(delta_to_max_size_in_pages);
 
-            // Safety: we pair growing the GC heap with updating its associated
-            // `VMMemoryDefinition` in the `VMStoreContext` immediately
-            // afterwards.
-            unsafe {
-                memory
-                    .grow(delta_pages_for_alloc, Some(self.traitobj().as_mut()))?
-                    .ok_or_else(|| anyhow!("failed to grow GC heap"))?;
-            }
-            self.vm_store_context.gc_heap = memory.vmmemory();
+        // But always make sure we are attempting to grow at least as many pages
+        // as needed by the requested allocation. This must happen *after* the
+        // max-size saturation, so that if we are at the max already, we do not
+        // succeed in growing by zero delta pages, and then return successfully
+        // to our caller, who would be assuming that there is now capacity for
+        // their allocation.
+        let pages_needed = bytes_needed.div_ceil(page_size);
+        assert!(pages_needed > 0);
+        let delta_pages_for_alloc = delta_pages_for_alloc.max(pages_needed);
+        assert!(delta_pages_for_alloc > 0);
 
-            let new_size_in_bytes = u64::try_from(memory.byte_size()).unwrap();
-            assert!(new_size_in_bytes > current_size_in_bytes);
-            delta_bytes_grown = new_size_in_bytes - current_size_in_bytes;
-            let delta_bytes_for_alloc = delta_pages_for_alloc.checked_mul(page_size).unwrap();
-            assert!(
-                delta_bytes_grown >= delta_bytes_for_alloc,
-                "{delta_bytes_grown} should be greater than or equal to {delta_bytes_for_alloc}"
-            );
-            Ok(())
-        })();
+        // FIXME(#11409): this is not sound
+        let vmstore = unsafe { heap.store.traitobj().as_mut() };
 
-        // Regardless whether growing succeeded or failed, place the memory back
-        // inside the GC heap.
+        // Safety: we pair growing the GC heap with updating its associated
+        // `VMMemoryDefinition` in the `VMStoreContext` immediately
+        // afterwards.
         unsafe {
-            self.unwrap_gc_store_mut()
-                .gc_heap
-                .replace_memory(memory, delta_bytes_grown);
+            heap.memory
+                .grow(delta_pages_for_alloc, Some(vmstore))
+                .await?
+                .ok_or_else(|| anyhow!("failed to grow GC heap"))?;
         }
+        heap.store.vm_store_context.gc_heap = heap.memory.vmmemory();
 
-        grow_result
-    }
-
-    /// Attempt an allocation, if it fails due to GC OOM, then do a GC and
-    /// retry.
-    pub(crate) fn retry_after_gc<T, U>(
-        &mut self,
-        value: T,
-        alloc_func: impl Fn(&mut Self, T) -> Result<U>,
-    ) -> Result<U>
-    where
-        T: Send + Sync + 'static,
-    {
+        let new_size_in_bytes = u64::try_from(heap.memory.byte_size()).unwrap();
+        assert!(new_size_in_bytes > current_size_in_bytes);
+        heap.delta_bytes_grown = new_size_in_bytes - current_size_in_bytes;
+        let delta_bytes_for_alloc = delta_pages_for_alloc.checked_mul(page_size).unwrap();
         assert!(
-            !self.async_support(),
-            "use the `*_async` versions of methods when async is configured"
+            heap.delta_bytes_grown >= delta_bytes_for_alloc,
+            "{} should be greater than or equal to {delta_bytes_for_alloc}",
+            heap.delta_bytes_grown,
         );
-        self.ensure_gc_store()?;
-        match alloc_func(self, value) {
-            Ok(x) => Ok(x),
-            Err(e) => match e.downcast::<crate::GcHeapOutOfMemory<T>>() {
-                Ok(oom) => {
-                    let (value, oom) = oom.take_inner();
-                    self.gc(Some(&oom));
-                    alloc_func(self, value)
-                }
-                Err(e) => Err(e),
-            },
+        return Ok(());
+
+        struct TakenGcHeap<'a> {
+            store: &'a mut StoreOpaque,
+            memory: ManuallyDrop<vm::Memory>,
+            delta_bytes_grown: u64,
         }
-    }
 
-    /// Like `retry_after_gc` but async yielding (if necessary) is transparent.
-    ///
-    /// # Safety
-    ///
-    /// When async is enabled, it is the caller's responsibility to ensure that
-    /// this is called on a fiber stack.
-    pub(crate) unsafe fn retry_after_gc_maybe_async<T, U>(
-        &mut self,
-        value: T,
-        alloc_func: impl Fn(&mut Self, T) -> Result<U>,
-    ) -> Result<U>
-    where
-        T: Send + Sync + 'static,
-    {
-        self.ensure_gc_store()?;
-        match alloc_func(self, value) {
-            Ok(x) => Ok(x),
-            Err(e) => match e.downcast::<crate::GcHeapOutOfMemory<T>>() {
-                Ok(oom) => {
-                    let (value, oom) = oom.take_inner();
-                    // SAFETY: it's the caller's responsibility to ensure that
-                    // this is on a fiber stack if necessary.
-                    unsafe {
-                        self.maybe_async_gc(None, Some(oom.bytes_needed()))?;
-                    }
-                    alloc_func(self, value)
+        impl<'a> TakenGcHeap<'a> {
+            fn new(store: &'a mut StoreOpaque) -> TakenGcHeap<'a> {
+                TakenGcHeap {
+                    memory: ManuallyDrop::new(store.unwrap_gc_store_mut().gc_heap.take_memory()),
+                    store,
+                    delta_bytes_grown: 0,
                 }
-                Err(e) => Err(e),
-            },
-        }
-    }
-}
-
-#[cfg(feature = "async")]
-impl StoreOpaque {
-    /// Asynchronously collect garbage, potentially growing the GC heap.
-    pub(crate) async fn gc_async(&mut self, why: Option<&GcHeapOutOfMemory<()>>) -> Result<()> {
-        assert!(self.async_support());
-        self.on_fiber(|store| unsafe {
-            store.maybe_async_gc(None, why.map(|oom| oom.bytes_needed()))
-        })
-        .await??;
-        Ok(())
-    }
-
-    async fn grow_or_collect_gc_heap_async(&mut self, bytes_needed: Option<u64>) {
-        assert!(self.async_support());
-        if let Some(bytes_needed) = bytes_needed {
-            if unsafe { self.maybe_async_grow_gc_heap(bytes_needed).is_ok() } {
-                return;
             }
         }
 
-        self.do_gc_async().await;
+        impl Drop for TakenGcHeap<'_> {
+            fn drop(&mut self) {
+                // SAFETY: this `Drop` guard ensures that this has exclusive
+                // ownership of fields and is thus safe to take `self.memory`.
+                // Additionally for `replace_memory` the memory was previously
+                // taken when this was created so it should be safe to place
+                // back inside the GC heap.
+                unsafe {
+                    self.store.unwrap_gc_store_mut().gc_heap.replace_memory(
+                        ManuallyDrop::take(&mut self.memory),
+                        self.delta_bytes_grown,
+                    );
+                }
+            }
+        }
     }
 
     /// Attempt an allocation, if it fails due to GC OOM, then do a GC and
     /// retry.
-    pub(crate) async fn retry_after_gc_async<T, U>(
+    pub(crate) async fn retry_after_gc<T, U>(
         &mut self,
         value: T,
         alloc_func: impl Fn(&mut Self, T) -> Result<U>,
@@ -243,17 +164,13 @@ impl StoreOpaque {
     where
         T: Send + Sync + 'static,
     {
-        assert!(
-            self.async_support(),
-            "you must configure async to use the `*_async` versions of methods"
-        );
-        self.ensure_gc_store()?;
+        self.ensure_gc_store().await?;
         match alloc_func(self, value) {
             Ok(x) => Ok(x),
             Err(e) => match e.downcast::<crate::GcHeapOutOfMemory<T>>() {
                 Ok(oom) => {
                     let (value, oom) = oom.take_inner();
-                    self.gc_async(Some(&oom)).await?;
+                    self.gc(None, Some(oom.bytes_needed())).await;
                     alloc_func(self, value)
                 }
                 Err(e) => Err(e),

--- a/crates/wasmtime/src/runtime/store/token.rs
+++ b/crates/wasmtime/src/runtime/store/token.rs
@@ -24,7 +24,7 @@ impl<T> Clone for StoreToken<T> {
 
 impl<T> Copy for StoreToken<T> {}
 
-impl<T: 'static> StoreToken<T> {
+impl<T: Send + 'static> StoreToken<T> {
     /// Create a new `StoreToken`, witnessing that this store has data type
     /// parameter `T`.
     pub fn new(store: StoreContextMut<T>) -> Self {

--- a/crates/wasmtime/src/runtime/trampoline.rs
+++ b/crates/wasmtime/src/runtime/trampoline.rs
@@ -19,21 +19,21 @@ use crate::store::StoreOpaque;
 use crate::{MemoryType, TableType, TagType};
 use wasmtime_environ::{MemoryIndex, TableIndex, TagIndex};
 
-pub fn generate_memory_export(
+pub async fn generate_memory_export(
     store: &mut StoreOpaque,
     m: &MemoryType,
     preallocation: Option<&SharedMemory>,
 ) -> Result<crate::Memory> {
     let id = store.id();
-    let instance = create_memory(store, m, preallocation)?;
+    let instance = create_memory(store, m, preallocation).await?;
     Ok(store
         .instance_mut(instance)
         .get_exported_memory(id, MemoryIndex::from_u32(0)))
 }
 
-pub fn generate_table_export(store: &mut StoreOpaque, t: &TableType) -> Result<crate::Table> {
+pub async fn generate_table_export(store: &mut StoreOpaque, t: &TableType) -> Result<crate::Table> {
     let id = store.id();
-    let instance = create_table(store, t)?;
+    let instance = create_table(store, t).await?;
     Ok(store
         .instance_mut(instance)
         .get_exported_table(id, TableIndex::from_u32(0)))

--- a/crates/wasmtime/src/runtime/trampoline/table.rs
+++ b/crates/wasmtime/src/runtime/trampoline/table.rs
@@ -5,7 +5,7 @@ use crate::store::{AllocateInstanceKind, InstanceId, StoreOpaque};
 use alloc::sync::Arc;
 use wasmtime_environ::{EntityIndex, Module, TypeTrace};
 
-pub fn create_table(store: &mut StoreOpaque, table: &TableType) -> Result<InstanceId> {
+pub async fn create_table(store: &mut StoreOpaque, table: &TableType) -> Result<InstanceId> {
     let mut module = Module::new();
 
     let wasmtime_table = *table.wasmtime_table();
@@ -29,15 +29,17 @@ pub fn create_table(store: &mut StoreOpaque, table: &TableType) -> Result<Instan
         let allocator =
             OnDemandInstanceAllocator::new(store.engine().config().mem_creator.clone(), 0, false);
         let module = Arc::new(module);
-        store.allocate_instance(
-            AllocateInstanceKind::Dummy {
-                allocator: &allocator,
-            },
-            &ModuleRuntimeInfo::bare_with_registered_type(
-                module,
-                table.element().clone().into_registered_type(),
-            ),
-            imports,
-        )
+        store
+            .allocate_instance(
+                AllocateInstanceKind::Dummy {
+                    allocator: &allocator,
+                },
+                &ModuleRuntimeInfo::bare_with_registered_type(
+                    module,
+                    table.element().clone().into_registered_type(),
+                ),
+                imports,
+            )
+            .await
     }
 }

--- a/crates/wasmtime/src/runtime/unix.rs
+++ b/crates/wasmtime/src/runtime/unix.rs
@@ -29,7 +29,7 @@ pub trait StoreExt {
             + Sync;
 }
 
-impl<T> StoreExt for Store<T> {
+impl<T: Send> StoreExt for Store<T> {
     #[cfg(has_native_signals)]
     unsafe fn set_signal_handler<H>(&mut self, handler: H)
     where

--- a/crates/wasmtime/src/runtime/vm.rs
+++ b/crates/wasmtime/src/runtime/vm.rs
@@ -274,7 +274,7 @@ impl dyn VMStore + '_ {
     ///
     /// This method is not safe as there's no static guarantee that `T` is
     /// correct for this store.
-    pub(crate) unsafe fn unchecked_context_mut<T>(&mut self) -> StoreContextMut<'_, T> {
+    pub(crate) unsafe fn unchecked_context_mut<T: Send>(&mut self) -> StoreContextMut<'_, T> {
         unsafe { StoreContextMut(&mut *(self as *mut dyn VMStore as *mut StoreInner<T>)) }
     }
 }

--- a/crates/wasmtime/src/runtime/vm/component.rs
+++ b/crates/wasmtime/src/runtime/vm/component.rs
@@ -811,7 +811,7 @@ impl ComponentInstance {
     ///
     /// This function places no bounds on `T` so it's up to the caller to match
     /// that up appropriately with the store that this instance resides within.
-    pub unsafe fn instance_pre<T>(&self) -> InstancePre<T> {
+    pub unsafe fn instance_pre<T: Send>(&self) -> InstancePre<T> {
         // SAFETY: The `T` part of `new_unchecked` is forwarded as a contract of
         // this function, and otherwise the validity of the components of the
         // InstancePre should be guaranteed as it's what we were built with

--- a/crates/wasmtime/src/runtime/vm/const_expr.rs
+++ b/crates/wasmtime/src/runtime/vm/const_expr.rs
@@ -1,6 +1,7 @@
 //! Evaluating const expressions.
 
 use crate::prelude::*;
+use crate::runtime::vm;
 use crate::store::{AutoAssertNoGc, InstanceId, StoreOpaque};
 #[cfg(feature = "gc")]
 use crate::{
@@ -60,7 +61,7 @@ impl ConstEvalContext {
 
     /// Safety: field values must be of the correct types.
     #[cfg(feature = "gc")]
-    unsafe fn struct_new(
+    async fn struct_new(
         &mut self,
         store: &mut StoreOpaque,
         shared_ty: VMSharedTypeIndex,
@@ -68,12 +69,12 @@ impl ConstEvalContext {
     ) -> Result<Val> {
         let struct_ty = StructType::from_shared_type_index(store.engine(), shared_ty);
         let allocator = StructRefPre::_new(store, struct_ty);
-        let struct_ref = unsafe { StructRef::new_maybe_async(store, &allocator, &fields)? };
+        let struct_ref = StructRef::_new(store, &allocator, &fields).await?;
         Ok(Val::AnyRef(Some(struct_ref.into())))
     }
 
     #[cfg(feature = "gc")]
-    fn struct_new_default(
+    async fn struct_new_default(
         &mut self,
         store: &mut StoreOpaque,
         shared_ty: VMSharedTypeIndex,
@@ -121,11 +122,25 @@ impl ConstEvalContext {
             })
             .collect::<smallvec::SmallVec<[_; 8]>>();
 
-        unsafe { self.struct_new(store, shared_ty, &fields) }
+        self.struct_new(store, shared_ty, &fields).await
     }
 }
 
 impl ConstExprEvaluator {
+    /// Same as [`Self::eval`], except only suitable for when `Val`
+    /// represents an integer result.
+    pub fn eval_int(
+        &mut self,
+        store: &mut StoreOpaque,
+        context: &mut ConstEvalContext,
+        expr: &ConstExpr,
+    ) -> Result<&Val> {
+        // Note that `assert_ready` here should be valid as production of an
+        // integer cannot involve GC meaning that async operations aren't used.
+        let mut scope = OpaqueRootScope::new(store);
+        vm::assert_ready(self.eval(&mut scope, context, expr))
+    }
+
     /// Evaluate the given const expression in the given context.
     ///
     ///
@@ -135,19 +150,10 @@ impl ConstExprEvaluator {
     /// and itself trigger a GC meaning that all references must be rooted,
     /// hence the external requirement of a rooting scope.
     ///
-    /// # Unsafety
+    /// # Panics
     ///
-    /// When async is enabled, this may only be executed on a fiber stack.
-    ///
-    /// The given const expression must be valid within the given context,
-    /// e.g. the const expression must be well-typed and the context must return
-    /// global values of the expected types. This evaluator operates directly on
-    /// untyped `ValRaw`s and does not and cannot check that its operands are of
-    /// the correct type.
-    ///
-    /// If given async store, then this must be called from on an async fiber
-    /// stack.
-    pub unsafe fn eval(
+    /// This function will panic if `expr` is an invalid constant expression.
+    pub async fn eval(
         &mut self,
         store: &mut OpaqueRootScope<&mut StoreOpaque>,
         context: &mut ConstEvalContext,
@@ -162,22 +168,19 @@ impl ConstExprEvaluator {
             [ConstOp::F64Const(f)] => self.return_one(Val::F64(*f)),
 
             // Fall back to the interpreter loop for all other expressions.
-            //
-            // SAFETY: this function has the same contract as `eval_loop`.
-            other => unsafe { self.eval_loop(store, context, other) },
+            other => self.eval_loop(store, context, other).await,
         }
     }
 
+    #[inline]
     fn return_one(&mut self, val: Val) -> Result<&Val> {
         self.stack.clear();
         self.stack.push(val);
         Ok(&self.stack[0])
     }
 
-    /// # Safety
-    ///
-    /// See [`Self::eval`].
-    unsafe fn eval_loop(
+    #[cold]
+    async fn eval_loop(
         &mut self,
         store: &mut OpaqueRootScope<&mut StoreOpaque>,
         context: &mut ConstEvalContext,
@@ -267,9 +270,9 @@ impl ConstExprEvaluator {
                     }
 
                     let start = self.stack.len() - len;
-                    let s = unsafe {
-                        context.struct_new(store, interned_type_index, &self.stack[start..])?
-                    };
+                    let s = context
+                        .struct_new(store, interned_type_index, &self.stack[start..])
+                        .await?;
                     self.stack.truncate(start);
                     self.stack.push(s);
                 }
@@ -279,7 +282,8 @@ impl ConstExprEvaluator {
                     let ty = store.instance(context.instance).env_module().types
                         [*struct_type_index]
                         .unwrap_engine_type_index();
-                    self.stack.push(context.struct_new_default(store, ty)?);
+                    self.stack
+                        .push(context.struct_new_default(store, ty).await?);
                 }
 
                 #[cfg(feature = "gc")]
@@ -293,7 +297,7 @@ impl ConstExprEvaluator {
                     let elem = self.pop()?;
 
                     let pre = ArrayRefPre::_new(store, ty);
-                    let array = unsafe { ArrayRef::new_maybe_async(store, &pre, &elem, len)? };
+                    let array = ArrayRef::_new(store, &pre, &elem, len).await?;
 
                     self.stack.push(Val::AnyRef(Some(array.into())));
                 }
@@ -310,7 +314,7 @@ impl ConstExprEvaluator {
                         .expect("type should have a default value");
 
                     let pre = ArrayRefPre::_new(store, ty);
-                    let array = unsafe { ArrayRef::new_maybe_async(store, &pre, &elem, len)? };
+                    let array = ArrayRef::_new(store, &pre, &elem, len).await?;
 
                     self.stack.push(Val::AnyRef(Some(array.into())));
                 }
@@ -340,7 +344,7 @@ impl ConstExprEvaluator {
                         .collect::<smallvec::SmallVec<[_; 8]>>();
 
                     let pre = ArrayRefPre::_new(store, ty);
-                    let array = unsafe { ArrayRef::new_fixed_maybe_async(store, &pre, &elems)? };
+                    let array = ArrayRef::_new_fixed(store, &pre, &elems).await?;
 
                     self.stack.push(Val::AnyRef(Some(array.into())));
                 }

--- a/crates/wasmtime/src/runtime/vm/gc.rs
+++ b/crates/wasmtime/src/runtime/vm/gc.rs
@@ -70,16 +70,9 @@ impl GcStore {
     }
 
     /// Perform garbage collection within this heap.
-    pub fn gc(&mut self, roots: GcRootsIter<'_>) {
-        let mut collection = self.gc_heap.gc(roots, &mut self.host_data_table);
-        collection.collect();
-    }
-
-    /// Asynchronously perform garbage collection within this heap.
-    #[cfg(feature = "async")]
-    pub async fn gc_async(&mut self, roots: GcRootsIter<'_>) {
+    pub async fn gc(&mut self, async_yield: bool, roots: GcRootsIter<'_>) {
         let collection = self.gc_heap.gc(roots, &mut self.host_data_table);
-        collect_async(collection).await;
+        collect_async(collection, async_yield).await;
     }
 
     /// Get the kind of the given GC reference.

--- a/crates/wasmtime/src/runtime/vm/gc/gc_runtime.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/gc_runtime.rs
@@ -789,11 +789,17 @@ pub enum GcProgress {
 
 /// Asynchronously run the given garbage collection process to completion,
 /// cooperatively yielding back to the event loop after each increment of work.
-#[cfg(feature = "async")]
-pub async fn collect_async<'a>(mut collection: Box<dyn GarbageCollection<'a> + 'a>) {
+pub async fn collect_async<'a>(
+    mut collection: Box<dyn GarbageCollection<'a> + 'a>,
+    async_yield: bool,
+) {
     loop {
         match collection.collect_increment() {
-            GcProgress::Continue => crate::runtime::vm::Yield::new().await,
+            GcProgress::Continue => {
+                if async_yield {
+                    crate::runtime::vm::Yield::new().await
+                }
+            }
             GcProgress::Complete => return,
         }
     }
@@ -808,7 +814,7 @@ mod collect_async_tests {
         fn _assert_send_sync<T: Send + Sync>(_: T) {}
 
         fn _foo<'a>(collection: Box<dyn GarbageCollection<'a>>) {
-            _assert_send_sync(collect_async(collection));
+            _assert_send_sync(collect_async(collection, true));
         }
     }
 }

--- a/crates/wasmtime/src/runtime/vm/instance/allocator/on_demand.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/on_demand.rs
@@ -76,6 +76,7 @@ impl Default for OnDemandInstanceAllocator {
     }
 }
 
+#[async_trait::async_trait]
 unsafe impl InstanceAllocatorImpl for OnDemandInstanceAllocator {
     #[cfg(feature = "component-model")]
     fn validate_component_impl<'a>(
@@ -110,9 +111,9 @@ unsafe impl InstanceAllocatorImpl for OnDemandInstanceAllocator {
 
     fn decrement_core_instance_count(&self) {}
 
-    fn allocate_memory(
+    async fn allocate_memory(
         &self,
-        request: &mut InstanceAllocationRequest,
+        request: &mut InstanceAllocationRequest<'_>,
         ty: &wasmtime_environ::Memory,
         tunables: &Tunables,
         memory_index: Option<DefinedMemoryIndex>,
@@ -140,7 +141,8 @@ unsafe impl InstanceAllocatorImpl for OnDemandInstanceAllocator {
                     .expect("if module has memory plans, store is not empty")
             },
             image,
-        )?;
+        )
+        .await?;
         Ok((allocation_index, memory))
     }
 
@@ -154,9 +156,9 @@ unsafe impl InstanceAllocatorImpl for OnDemandInstanceAllocator {
         // Normal destructors do all the necessary clean up.
     }
 
-    fn allocate_table(
+    async fn allocate_table(
         &self,
-        request: &mut InstanceAllocationRequest,
+        request: &mut InstanceAllocationRequest<'_>,
         ty: &wasmtime_environ::Table,
         tunables: &Tunables,
         _table_index: DefinedTableIndex,
@@ -167,7 +169,8 @@ unsafe impl InstanceAllocatorImpl for OnDemandInstanceAllocator {
                 .store
                 .get()
                 .expect("if module has table plans, store is not empty")
-        })?;
+        })
+        .await?;
         Ok((allocation_index, table))
     }
 

--- a/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/table_pool.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/table_pool.rs
@@ -130,9 +130,9 @@ impl TablePool {
     }
 
     /// Allocate a single table for the given instance allocation request.
-    pub fn allocate(
+    pub async fn allocate(
         &self,
-        request: &mut InstanceAllocationRequest,
+        request: &mut InstanceAllocationRequest<'_>,
         ty: &wasmtime_environ::Table,
         tunables: &Tunables,
     ) -> Result<(TableAllocationIndex, Table)> {
@@ -143,29 +143,45 @@ impl TablePool {
             .ok_or_else(|| {
                 super::PoolConcurrencyLimitError::new(self.max_total_tables, "tables")
             })?;
+        let mut guard = DeallocateIndexGuard {
+            pool: self,
+            allocation_index,
+            active: true,
+        };
 
-        match (|| {
-            let base = self.get(allocation_index);
-            let data_size = self.data_size(crate::vm::table::wasm_to_table_type(ty.ref_type));
-            unsafe {
-                commit_pages(base, data_size)?;
-            }
+        let base = self.get(allocation_index);
+        let data_size = self.data_size(crate::vm::table::wasm_to_table_type(ty.ref_type));
+        unsafe {
+            commit_pages(base, data_size)?;
+        }
 
-            let ptr =
-                NonNull::new(std::ptr::slice_from_raw_parts_mut(base.cast(), data_size)).unwrap();
-            unsafe {
-                Table::new_static(
-                    ty,
-                    tunables,
-                    SendSyncPtr::new(ptr),
-                    &mut *request.store.get().unwrap(),
-                )
-            }
-        })() {
-            Ok(table) => Ok((allocation_index, table)),
-            Err(e) => {
-                self.index_allocator.free(SlotId(allocation_index.0));
-                Err(e)
+        let ptr = NonNull::new(std::ptr::slice_from_raw_parts_mut(base.cast(), data_size)).unwrap();
+        let table = unsafe {
+            Table::new_static(
+                ty,
+                tunables,
+                SendSyncPtr::new(ptr),
+                &mut *request.store.get().unwrap(),
+            )
+            .await?
+        };
+        guard.active = false;
+        return Ok((allocation_index, table));
+
+        struct DeallocateIndexGuard<'a> {
+            pool: &'a TablePool,
+            allocation_index: TableAllocationIndex,
+            active: bool,
+        }
+
+        impl Drop for DeallocateIndexGuard<'_> {
+            fn drop(&mut self) {
+                if !self.active {
+                    return;
+                }
+                self.pool
+                    .index_allocator
+                    .free(SlotId(self.allocation_index.0));
             }
         }
     }

--- a/crates/wasmtime/src/runtime/vm/memory/shared_memory_disabled.rs
+++ b/crates/wasmtime/src/runtime/vm/memory/shared_memory_disabled.rs
@@ -1,6 +1,6 @@
 use crate::prelude::*;
 use crate::runtime::vm::memory::LocalMemory;
-use crate::runtime::vm::{VMMemoryDefinition, VMStore, WaitResult};
+use crate::runtime::vm::{VMMemoryDefinition, WaitResult};
 use core::ops::Range;
 use core::ptr::NonNull;
 use core::time::Duration;
@@ -26,11 +26,7 @@ impl SharedMemory {
         match *self {}
     }
 
-    pub fn grow(
-        &self,
-        _delta_pages: u64,
-        _store: Option<&mut dyn VMStore>,
-    ) -> Result<Option<(usize, usize)>> {
+    pub fn grow(&self, _delta_pages: u64) -> Result<Option<(usize, usize)>> {
         match *self {}
     }
 

--- a/crates/wasmtime/src/runtime/vm/traphandlers.rs
+++ b/crates/wasmtime/src/runtime/vm/traphandlers.rs
@@ -378,7 +378,7 @@ impl From<wasmtime_environ::Trap> for TrapReason {
 ///
 /// This function is unsafe because during the execution of `closure` it may be
 /// longjmp'd over and none of its destructors on the stack may be run.
-pub unsafe fn catch_traps<T, F>(
+pub unsafe fn catch_traps<T: Send, F>(
     store: &mut StoreContextMut<'_, T>,
     old_state: &mut EntryStoreContext,
     mut closure: F,

--- a/crates/wasmtime/src/runtime/windows.rs
+++ b/crates/wasmtime/src/runtime/windows.rs
@@ -28,7 +28,7 @@ pub trait StoreExt {
         H: 'static + Fn(*mut EXCEPTION_POINTERS) -> bool + Send + Sync;
 }
 
-impl<T> StoreExt for Store<T> {
+impl<T: Send> StoreExt for Store<T> {
     #[cfg(has_native_signals)]
     unsafe fn set_signal_handler<H>(&mut self, handler: H)
     where

--- a/crates/wast/src/core.rs
+++ b/crates/wast/src/core.rs
@@ -5,7 +5,7 @@ use std::fmt::{Display, LowerHex};
 use wasmtime::{Store, Val};
 
 /// Translate from a `script::Value` to a `RuntimeValue`.
-pub fn val<T>(ctx: &mut WastContext<T>, v: &CoreConst) -> Result<Val> {
+pub fn val<T: Send>(ctx: &mut WastContext<T>, v: &CoreConst) -> Result<Val> {
     use CoreConst::*;
 
     Ok(match v {
@@ -64,7 +64,7 @@ fn extract_lane_as_i64(bytes: u128, lane: usize) -> i64 {
     (bytes >> (lane * 64)) as i64
 }
 
-pub fn match_val<T>(store: &mut Store<T>, actual: &Val, expected: &CoreConst) -> Result<()> {
+pub fn match_val<T: Send>(store: &mut Store<T>, actual: &Val, expected: &CoreConst) -> Result<()> {
     match (actual, expected) {
         (_, CoreConst::Either { values }) => {
             for expected in values {

--- a/crates/wast/src/spectest.rs
+++ b/crates/wast/src/spectest.rs
@@ -10,7 +10,7 @@ pub struct SpectestConfig {
 
 /// Return an instance implementing the "spectest" interface used in the
 /// spec testsuite.
-pub fn link_spectest<T>(
+pub fn link_spectest<T: Send>(
     linker: &mut Linker<T>,
     store: &mut Store<T>,
     config: &SpectestConfig,
@@ -88,7 +88,7 @@ pub fn link_spectest<T>(
 }
 
 #[cfg(feature = "component-model")]
-pub fn link_component_spectest<T>(linker: &mut component::Linker<T>) -> Result<()> {
+pub fn link_component_spectest<T: Send>(linker: &mut component::Linker<T>) -> Result<()> {
     use std::sync::Arc;
     use std::sync::atomic::{AtomicU32, Ordering::SeqCst};
     use wasmtime::component::{Resource, ResourceType};

--- a/crates/wast/src/wast.rs
+++ b/crates/wast/src/wast.rs
@@ -15,7 +15,7 @@ use wast::parser::{self, ParseBuffer};
 
 /// The wast test script language allows modules to be defined and actions
 /// to be performed on them.
-pub struct WastContext<T: 'static> {
+pub struct WastContext<T: Send + 'static> {
     /// Wast files have a concept of a "current" module, which is the most
     /// recently defined.
     current: Option<InstanceKind>,

--- a/crates/wiggle/generate/src/wasmtime.rs
+++ b/crates/wiggle/generate/src/wasmtime.rs
@@ -14,7 +14,7 @@ pub fn link_module(
     let module_ident = names::module(&module.name);
 
     let send_bound = if settings.async_.contains_async(module) {
-        quote! { + Send, T: Send }
+        quote! { + Send }
     } else {
         quote! {}
     };
@@ -58,7 +58,7 @@ pub fn link_module(
             get_cx: impl Fn(&mut T) -> #u + Send + Sync + Copy + 'static,
         ) -> wiggle::anyhow::Result<()>
             where
-                T: 'static,
+                T: Send + 'static,
                 U: #ctx_bound #send_bound
         {
             #(#bodies)*

--- a/examples/min-platform/embedding/src/wasi.rs
+++ b/examples/min-platform/embedding/src/wasi.rs
@@ -154,7 +154,6 @@ wasmtime::component::bindgen!({
     world: "wasi:cli/command",
     imports: { default: trappable },
     exports: { default: async },
-    require_store_data_send: true,
     // Important: tell bindgen that anywhere it encounters the wasi:io
     // package, refer to the bindings generated in the wasmtime_wasi_io crate.
     // This way, all uses of the streams and pollable in the bindings in this

--- a/tests/all/component_model/bindgen.rs
+++ b/tests/all/component_model/bindgen.rs
@@ -12,7 +12,6 @@ mod results;
 
 mod no_imports {
     use super::*;
-    use std::rc::Rc;
 
     wasmtime::component::bindgen!({
         inline: "
@@ -55,11 +54,6 @@ mod no_imports {
         no_imports.call_bar(&mut store)?;
         no_imports.foo().call_foo(&mut store)?;
 
-        let linker = Linker::new(&engine);
-        let mut non_send_store = Store::new(&engine, Rc::new(()));
-        let no_imports = NoImports::instantiate(&mut non_send_store, &component, &linker)?;
-        no_imports.call_bar(&mut non_send_store)?;
-        no_imports.foo().call_foo(&mut non_send_store)?;
         Ok(())
     }
 }
@@ -276,7 +270,7 @@ mod one_import_concurrent {
         }
 
         impl foo::HostWithStore for MyImports {
-            async fn foo<T>(accessor: &Accessor<T, Self>) {
+            async fn foo<T: Send>(accessor: &Accessor<T, Self>) {
                 accessor.with(|mut view| view.get().hit = true);
             }
         }

--- a/tests/all/epoch_interruption.rs
+++ b/tests/all/epoch_interruption.rs
@@ -13,7 +13,7 @@ fn build_engine(config: &mut Config) -> Result<Arc<Engine>> {
     Ok(Arc::new(Engine::new(&config)?))
 }
 
-fn make_env<T: 'static>(engine: &Engine) -> Linker<T> {
+fn make_env<T: Send + 'static>(engine: &Engine) -> Linker<T> {
     let mut linker = Linker::new(engine);
     let engine = engine.clone();
 

--- a/tests/all/pooling_allocator.rs
+++ b/tests/all/pooling_allocator.rs
@@ -938,6 +938,9 @@ async fn total_stacks_limit() -> Result<()> {
             (func (export "run")
                 call $yield
             )
+
+            (func $start)
+            (start $start)
         )
     "#,
     )?;


### PR DESCRIPTION
This commit is an initial step towards resolving https://github.com/bytecodealliance/wasmtime/issues/11262 by having async
functions internally Wasmtime actually be `async` instead of requiring
the use of fibers. This is expected to have a number of benefits:

* The Rust compiler can be used to verify a future is `Send` instead of
  "please audit the whole codebase's stack-local variables".

* Raw pointer workarounds during table/memory growth will no longer be
  required since the arguments can properly be a split borrow to data in
  the store (eventually leading to unblocking https://github.com/bytecodealliance/wasmtime/issues/11178).

* Less duplication inside of Wasmtime and clearer implementations
  internally. For example GC bits prior to this PR has duplicated
  sync/async entrypoints (sometimes a few layers deep) which eventually
  bottomed out in `*_maybe_async` bits which were `unsafe` and require
  fiber bits to be setup. All of that is now gone with the `async`
  functions being the "source of truth" and sync functions just call
  them.

* Fibers are not required for operations such as a GC, growing memory,
  etc.

The general idea is that the source of truth for the implementation of
Wasmtime internals are all `async` functions. These functions are
callable from synchronous functions in the API with a documented panic
condition about avoiding them when `Config::async_support` is disabled.
When `async_support` is disabled it's known internally there should
never be an `.await` point meaning that we can poll the future of the
async version and assert that it's ready.

This commit is not the full realization of plumbing `async` everywhere
internally in Wasmtime. Instead all this does is plumb the async-ness of
`ResourceLimiterAsync` and that's it, aka memory and table growth are
now properly async. It turns out though that these limiters are
extremely deep within Wasmtime and thus necessitated many changes to get
this all working. In the end this ended up covering some of the trickier
parts of dealing with async and propagating that throughout the runtime.

Most changes in this commit are intended to be straightforward, but a
summary is:

* Many more functions are `async` and `.await` their internals.

* Some instances of run-a-closure-and-catch-the-error are now replaced
  with type-with-`Drop` as that's the equivalent in the async world.

* Internal traits in Wasmtime are now `#[async_trait]` to be object
  safe. This has a performance impact detailed more below.

* `vm::assert_ready` is used in synchronous contexts to assert that the
  async version is done immediately. This is intended to always be
  accompanied with an assert about `async_support` nearby.

* `vm::one_poll` is used test if an asynchronous computation is ready
  yet and is used in a few locations where a synchronous public API says
  it'll work in `async_support` mode but fails with an async resource limiter.

* GC and other internals were simplified where `async` functions are now
  the "guts" and sync functions are thin veneers over these `async` functions.

* An example of new async functions are that lazy GC store allocation
  and instance allocation are both async functions now.

* In a small number of locations a conditional check of
  `store.async_support()` is done. For example during GC if
  `async_support` is enabled arbitrary yield points are injected. For
  libcalls if it's enabled `block_on` is used or otherwise it's asserted
  to complete synchronously.

* Previously `unsafe` functions dealing requiring external fiber
  handling are now all safe and `async`.

* Libcalls have a `block_on!` helper macro which should be itself a
  function-taking-async-closure but requires future Rust features to
  make it a function.

A consequence of this refactoring is that instantiation is now slower
than before. For example from our `instantiation.rs` benchmark:

```
sequential/pooling/spidermonkey.wasm
                        time:   [2.6674 µs 2.6691 µs 2.6718 µs]
                        change: [+20.975% +21.039% +21.111%] (p = 0.00 < 0.05)
                        Performance has regressed.
```

Other benchmarks I've been looking at locally in `instantiation.rs` have
pretty wild swings from either a performance improvement in this PR of
10% to a regression of 20%. This benchmark in particular though, also
one of the more interesting ones, is consistently 20% slower with this
commit. Attempting to bottom out this performance difference it looks
like it's largely "just async state machines vs not" where nothing else
really jumps out in the profile to me. In terms of absolute numbers the
time-to-instantiate is still in the single-digit-microsecond range with
`madvise` being the dominant function.