### PR TITLE
Resolve `unsafe_op_in_unsafe_fn` in `wasmtime` crate

### DIFF
--- a/crates/wasmtime/src/engine.rs
+++ b/crates/wasmtime/src/engine.rs
@@ -845,7 +845,9 @@ impl Engine {
         memory: NonNull<[u8]>,
         expected: ObjectKind,
     ) -> Result<Arc<crate::CodeMemory>> {
-        self.load_code(crate::runtime::vm::MmapVec::from_raw(memory)?, expected)
+        // SAFETY: the contract of this function is the same as that of
+        // `from_raw`.
+        unsafe { self.load_code(crate::runtime::vm::MmapVec::from_raw(memory)?, expected) }
     }
 
     /// Like `load_code_bytes`, but creates a mmap from a file on disk.
@@ -925,8 +927,11 @@ impl Engine {
         assert_eq!(Arc::weak_count(&self.inner), 0);
         assert_eq!(Arc::strong_count(&self.inner), 1);
 
+        // SAFETY: the contract of this function is the same as `deinit_traps`.
         #[cfg(not(miri))]
-        crate::runtime::vm::deinit_traps();
+        unsafe {
+            crate::runtime::vm::deinit_traps();
+        }
     }
 }
 

--- a/crates/wasmtime/src/runtime.rs
+++ b/crates/wasmtime/src/runtime.rs
@@ -25,10 +25,6 @@
 // explanation of why truncation shouldn't be happening at runtime. This
 // situation should be pretty rare though.
 #![warn(clippy::cast_possible_truncation)]
-#![warn(
-    unsafe_op_in_unsafe_fn,
-    reason = "opt-in until the crate opts-in as a whole -- #11180"
-)]
 
 #[macro_use]
 pub(crate) mod func;


### PR DESCRIPTION
Just a few unsafe blocks remained

Closes #11180

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
