### PR TITLE
disable simplification splat + iconst -> vconst for 64 bit vectors

### DIFF
--- a/cranelift/codegen/src/opts/cprop.isle
+++ b/cranelift/codegen/src/opts/cprop.isle
@@ -201,17 +201,17 @@
 
 ;; A splat of a constant can become a direct `vconst` with the appropriate bit
 ;; pattern.
-(rule (simplify (splat dst (iconst $I8 n)))
+(rule (simplify (splat (ty_vec128 dst) (iconst $I8 n)))
       (vconst dst (splat8 (u64_uextend_imm64 $I8 n))))
-(rule (simplify (splat dst (iconst $I16 n)))
+(rule (simplify (splat (ty_vec128 dst) (iconst $I16 n)))
       (vconst dst (splat16 (u64_uextend_imm64 $I16 n))))
-(rule (simplify (splat dst (iconst $I32 n)))
+(rule (simplify (splat (ty_vec128 dst) (iconst $I32 n)))
       (vconst dst (splat32 (u64_uextend_imm64 $I32 n))))
-(rule (simplify (splat dst (iconst $I64 n)))
+(rule (simplify (splat (ty_vec128 dst) (iconst $I64 n)))
       (vconst dst (splat64 (u64_uextend_imm64 $I64 n))))
-(rule (simplify (splat dst (f32const _ (u32_from_ieee32 n))))
+(rule (simplify (splat (ty_vec128 dst) (f32const _ (u32_from_ieee32 n))))
       (vconst dst (splat32 n)))
-(rule (simplify (splat dst (f64const _ (u64_from_ieee64 n))))
+(rule (simplify (splat (ty_vec128 dst) (f64const _ (u64_from_ieee64 n))))
       (vconst dst (splat64 n)))
 
 (decl splat8 (u64) Constant)

--- a/cranelift/filetests/filetests/egraph/cprop-splat.clif
+++ b/cranelift/filetests/filetests/egraph/cprop-splat.clif
@@ -167,3 +167,58 @@ block0:
 ;     return v3  ; v3 = const0
 ; }
 
+function %i8x8() -> i8x8 {
+block0:
+    v1 = iconst.i8 0
+    v2 = splat.i8x8 v1
+    return v2
+}
+
+; function %i8x8() -> i8x8 fast {
+; block0:
+;     v1 = iconst.i8 0
+;     v2 = splat.i8x8 v1  ; v1 = 0
+;     return v2
+; }
+
+function %i16x4() -> i16x4 {
+block0:
+    v1 = iconst.i16 0
+    v2 = splat.i16x4 v1
+    return v2
+}
+
+; function %i16x4() -> i16x4 fast {
+; block0:
+;     v1 = iconst.i16 0
+;     v2 = splat.i16x4 v1  ; v1 = 0
+;     return v2
+; }
+
+function %i32x2() -> i32x2 {
+block0:
+    v1 = iconst.i32 0
+    v2 = splat.i32x2 v1
+    return v2
+}
+
+; function %i32x2() -> i32x2 fast {
+; block0:
+;     v1 = iconst.i32 0
+;     v2 = splat.i32x2 v1  ; v1 = 0
+;     return v2
+; }
+
+function %f32x2() -> f32x2 {
+block0:
+    v1 = f32const 0.0
+    v2 = splat.f32x2 v1
+    return v2
+}
+
+; function %f32x2() -> f32x2 fast {
+; block0:
+;     v1 = f32const 0.0
+;     v2 = splat.f32x2 v1  ; v1 = 0.0
+;     return v2
+; }


### PR DESCRIPTION
The following clif file produces a verification error during compilation with optimization enabled (not target dependent) :

`clif-util compile --target aarch64 --set opt_level=speed bug.clif`

```
function %i16x4() -> i16x4 {
block0:
    v1 = iconst.i16 0
    v2 = splat.i16x4 v1
    return v2
}
```

```
Error: function %i16x4() -> i16x4 fast {
    const0 = 0x00000000000000000000000000000000

block0:
    v3 = vconst.i16x4 const0
;   ^~~~~~~~~~~~~~~~~~~~~~~~
; error: inst3: The instruction expects const0 to have a size of 8 bytes but it has 16

    return v3  ; v3 = const0
}

; 1 verifier error detected (see above). Compilation aborted.
```

The constant is incorrectly simplified as a 128-bit constant, producing a validation error.

This PR restricts this simplification only for 128-bit vectors and add some regression tests.