### PR TITLE
Delete `StoreOpaque::traitobj_mut`

### DIFF
--- a/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams.rs
@@ -680,11 +680,7 @@ impl<T> FutureReader<T> {
         // `self` should never be used again, but leave an invalid handle there just in case.
         let id = mem::replace(&mut self.id, TableId::new(0));
         self.instance
-            .host_drop_reader(
-                store.as_context_mut().0.traitobj_mut(),
-                id,
-                TransmitKind::Future,
-            )
+            .host_drop_reader(store.as_context_mut().0, id, TransmitKind::Future)
             .unwrap();
     }
 
@@ -1252,11 +1248,7 @@ impl<T> StreamReader<T> {
         // `self` should never be used again, but leave an invalid handle there just in case.
         let id = mem::replace(&mut self.id, TableId::new(0));
         self.instance
-            .host_drop_reader(
-                store.as_context_mut().0.traitobj_mut(),
-                id,
-                TransmitKind::Stream,
-            )
+            .host_drop_reader(store.as_context_mut().0, id, TransmitKind::Stream)
             .unwrap()
     }
 
@@ -2047,7 +2039,7 @@ impl Instance {
 
             WriteState::HostReady { accept, post_write } => {
                 accept(
-                    store.0.traitobj_mut(),
+                    store.0,
                     self,
                     Reader::Host {
                         accept: Box::new(|input, count| {
@@ -2863,7 +2855,7 @@ impl Instance {
                 }
 
                 let code = accept(
-                    store.0.traitobj_mut(),
+                    store.0,
                     self,
                     Reader::Guest {
                         options: &options,

--- a/crates/wasmtime/src/runtime/component/func/host.rs
+++ b/crates/wasmtime/src/runtime/component/func/host.rs
@@ -344,7 +344,7 @@ where
             HostResult::Done(result) => result?,
             #[cfg(feature = "component-model-async")]
             HostResult::Future(future) => {
-                instance.poll_and_block(store.0.traitobj_mut(), future, caller_instance)?
+                instance.poll_and_block(store.0, future, caller_instance)?
             }
         };
 
@@ -829,8 +829,7 @@ where
             params_and_results,
             result_start,
         );
-        let result_vals =
-            instance.poll_and_block(store.0.traitobj_mut(), future, caller_instance)?;
+        let result_vals = instance.poll_and_block(store.0, future, caller_instance)?;
         let result_vals = &result_vals[result_start..];
 
         unsafe {

--- a/crates/wasmtime/src/runtime/component/linker.rs
+++ b/crates/wasmtime/src/runtime/component/linker.rs
@@ -837,7 +837,7 @@ impl<T: 'static> LinkerInstance<'_, T> {
                         );
                         let mut future = std::pin::pin!(dtor(accessor, param));
                         std::future::poll_fn(|cx| {
-                            crate::component::concurrent::tls::set(store.0.traitobj_mut(), || {
+                            crate::component::concurrent::tls::set(store.0, || {
                                 future.as_mut().poll(cx)
                             })
                         })

--- a/crates/wasmtime/src/runtime/component/store.rs
+++ b/crates/wasmtime/src/runtime/component/store.rs
@@ -1,3 +1,4 @@
+use crate::runtime::vm::VMStore;
 use crate::runtime::vm::component::{ComponentInstance, OwnedComponentInstance};
 use crate::store::{StoreData, StoreId, StoreOpaque};
 #[cfg(feature = "component-model-async")]
@@ -32,7 +33,7 @@ impl ComponentStoreData {
     }
 
     #[cfg(feature = "component-model-async")]
-    pub(crate) fn drop_fibers_and_futures(store: &mut StoreOpaque) {
+    pub(crate) fn drop_fibers_and_futures(store: &mut dyn VMStore) {
         let mut fibers = Vec::new();
         let mut futures = Vec::new();
         for (_, instance) in store.store_data_mut().components.instances.iter_mut() {
@@ -50,7 +51,7 @@ impl ComponentStoreData {
             fiber.dispose(store);
         }
 
-        crate::component::concurrent::tls::set(store.traitobj_mut(), move || drop(futures));
+        crate::component::concurrent::tls::set(store, move || drop(futures));
     }
 }
 

--- a/crates/wasmtime/src/runtime/fiber.rs
+++ b/crates/wasmtime/src/runtime/fiber.rs
@@ -112,11 +112,17 @@ impl AsyncState {
     }
 }
 
-trait AsStoreOpaque {
+pub(crate) trait AsStoreOpaque {
     fn as_store_opaque(&mut self) -> &mut StoreOpaque;
 }
 
 impl AsStoreOpaque for StoreOpaque {
+    fn as_store_opaque(&mut self) -> &mut StoreOpaque {
+        self
+    }
+}
+
+impl AsStoreOpaque for dyn VMStore {
     fn as_store_opaque(&mut self) -> &mut StoreOpaque {
         self
     }
@@ -772,15 +778,19 @@ fn resume_fiber<'a>(
 }
 
 /// Create a new `StoreFiber` which runs the specified closure.
-pub(crate) fn make_fiber<'a>(
-    store: &mut dyn VMStore,
-    fun: impl FnOnce(&mut dyn VMStore) -> Result<()> + Send + Sync + 'a,
-) -> Result<StoreFiber<'a>> {
-    let engine = store.engine().clone();
+pub(crate) fn make_fiber<'a, S>(
+    store: &mut S,
+    fun: impl FnOnce(&mut S) -> Result<()> + Send + Sync + 'a,
+) -> Result<StoreFiber<'a>>
+where
+    S: AsStoreOpaque + ?Sized + 'a,
+{
+    let opaque = store.as_store_opaque();
+    let engine = opaque.engine().clone();
     let executor = Executor::new(&engine);
-    let id = store.store_opaque().id();
-    let stack = store.store_opaque_mut().allocate_fiber_stack()?;
-    let track_pkey_context_switch = store.has_pkey();
+    let id = opaque.id();
+    let stack = opaque.allocate_fiber_stack()?;
+    let track_pkey_context_switch = opaque.has_pkey();
     let store = &raw mut *store;
     let fiber = Fiber::new(stack, move |result: WasmtimeResume, suspend| {
         let future_cx = match result {
@@ -799,17 +809,22 @@ pub(crate) fn make_fiber<'a>(
         // the fiber is running and `future_cx` and `suspend` are both in scope.
         // Note that these pointers are removed when this function returns as
         // that's when they fall out of scope.
-        let async_state = store_ref.store_opaque_mut().fiber_async_state_mut();
+        let async_state = store_ref.as_store_opaque().fiber_async_state_mut();
         assert!(async_state.current_suspend.is_none());
         assert!(async_state.current_future_cx.is_none());
         async_state.current_suspend = Some(NonNull::from(suspend));
         async_state.current_future_cx = Some(future_cx);
 
-        struct ResetCurrentPointersToNull<'a>(&'a mut dyn VMStore);
+        struct ResetCurrentPointersToNull<'a, S>(&'a mut S)
+        where
+            S: AsStoreOpaque + ?Sized;
 
-        impl Drop for ResetCurrentPointersToNull<'_> {
+        impl<S> Drop for ResetCurrentPointersToNull<'_, S>
+        where
+            S: AsStoreOpaque + ?Sized,
+        {
             fn drop(&mut self) {
-                let state = self.0.fiber_async_state_mut();
+                let state = self.0.as_store_opaque().fiber_async_state_mut();
 
                 // Double-check that the current suspension isn't null (it
                 // should be what's in this closure). Note though that we
@@ -845,23 +860,28 @@ pub(crate) fn make_fiber<'a>(
 
 /// Run the specified function on a newly-created fiber and `.await` its
 /// completion.
-pub(crate) async fn on_fiber<R: Send + Sync>(
-    store: &mut StoreOpaque,
-    func: impl FnOnce(&mut StoreOpaque) -> R + Send + Sync,
-) -> Result<R> {
-    let config = store.engine().config();
-    debug_assert!(store.async_support());
+pub(crate) async fn on_fiber<S, R>(
+    store: &mut S,
+    func: impl FnOnce(&mut S) -> R + Send + Sync,
+) -> Result<R>
+where
+    S: AsStoreOpaque + ?Sized,
+    R: Send + Sync,
+{
+    let opaque = store.as_store_opaque();
+    let config = opaque.engine().config();
+    debug_assert!(opaque.async_support());
     debug_assert!(config.async_stack_size > 0);
 
     let mut result = None;
-    let fiber = make_fiber(store.traitobj_mut(), |store| {
+    let fiber = make_fiber(store, |store| {
         result = Some(func(store));
         Ok(())
     })?;
 
     {
         let fiber = FiberFuture {
-            store,
+            store: store.as_store_opaque(),
             fiber: Some(fiber),
             #[cfg(feature = "component-model-async")]
             on_release: OnRelease::ReturnPending,

--- a/crates/wasmtime/src/runtime/store.rs
+++ b/crates/wasmtime/src/runtime/store.rs
@@ -669,7 +669,7 @@ impl<T> Store<T> {
         // in their `Drop::drop` implementations, in which case they'll need to
         // be called from with in the context of a `tls::set` closure.
         #[cfg(feature = "component-model-async")]
-        ComponentStoreData::drop_fibers_and_futures(&mut self.inner);
+        ComponentStoreData::drop_fibers_and_futures(&mut **self.inner);
 
         // Ensure all fiber stacks, even cached ones, are all flushed out to the
         // instance allocator.
@@ -1871,11 +1871,6 @@ impl StoreOpaque {
     #[inline]
     pub fn traitobj(&self) -> NonNull<dyn vm::VMStore> {
         self.traitobj.as_raw().unwrap()
-    }
-
-    #[inline]
-    pub fn traitobj_mut(&mut self) -> &mut dyn vm::VMStore {
-        unsafe { self.traitobj().as_mut() }
     }
 
     /// Takes the cached `Vec<Val>` stored internally across hostcalls to get

--- a/crates/wasmtime/src/runtime/store/async_.rs
+++ b/crates/wasmtime/src/runtime/store/async_.rs
@@ -2,8 +2,8 @@
 use crate::CallHook;
 use crate::fiber::{self};
 use crate::prelude::*;
-use crate::store::{ResourceLimiterInner, StoreInner, StoreOpaque, StoreToken};
-use crate::{AsContextMut, Store, StoreContextMut, UpdateDeadline};
+use crate::store::{ResourceLimiterInner, StoreInner, StoreOpaque};
+use crate::{Store, StoreContextMut, UpdateDeadline};
 
 /// An object that can take callbacks when the runtime enters or exits hostcalls.
 #[cfg(feature = "call-hook")]
@@ -281,9 +281,6 @@ impl<T> StoreContextMut<'_, T> {
     where
         T: Send + 'static,
     {
-        let token = StoreToken::new(self.as_context_mut());
-        self.0
-            .on_fiber(|opaque| func(&mut token.as_context_mut(opaque.traitobj_mut())))
-            .await
+        fiber::on_fiber(self.0, |me| func(&mut StoreContextMut(me))).await
     }
 }


### PR DESCRIPTION
This was a fundamentally unsound function because it is widening a mutable borrow to encompass more than it originally contained. Removal of its usage falls into a few buckets here:

* Many instances of `store.0.traitobj_mut()` were starting from a `&mut StoreInner<T>`, going to `&mut StoreOpaque`, then going back to `&mut dyn VMStore`. These are replaced with `store.0` as `&mut StoreInner<T>` directly coerces into `&mut dyn VMStore`.

* Some fiber-related helpers were updated to take any store-opaque-thing which encapsulates the ability to start/resume a borrow with a part of the store, but you only get that part of the store during the fiber itself. This means there's no widening necessary.

* Some methods previously taking `&mut StoreOpaque` are now appropriately widened to `&mut dyn VMStore`.

This all enables full deletion of this function which prevents accidentally ever tripping over its unsound-ness.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
