### PR TITLE
docs: fix typos

### DIFF
--- a/crates/wit-bindgen/src/config.rs
+++ b/crates/wit-bindgen/src/config.rs
@@ -124,7 +124,7 @@ impl FunctionConfig {
                 rule.used = true;
                 *base |= rule.flags;
 
-                // only the first fule is used.
+                // only the first rule is used.
                 return true;
             }
 

--- a/winch/codegen/src/isa/aarch64/masm.rs
+++ b/winch/codegen/src/isa/aarch64/masm.rs
@@ -1069,7 +1069,7 @@ impl Masm for MacroAssembler {
         match &(lhs, rhs) {
             (rlhs, RegImm::Reg(rrhs)) => {
                 // If the comparison kind is zero or not zero and both operands
-                // are the same register, emit a ands instruction. Else we emit
+                // are the same register, emit an ands instruction. Else we emit
                 // a normal comparison.
                 if (kind == Eq || kind == Ne) && (rlhs == rrhs) {
                     self.asm.ands_rr(*rlhs, *rrhs, size);


### PR DESCRIPTION
### Description

This PR corrects several minor typos in comments and documentation across the codebase. The changes are non-functional and purely textual to improve clarity and maintain a clean, professional codebase.

### Details

- Corrected misspellings:
  - `fule` → `rule`
  - `a` → `an`

These fixes help enhance readability and eliminate minor distractions during development and code reviews.