### PR TITLE
Fix a typo in the bounds of `InstancePre::instantiate_async`

### DIFF
--- a/crates/wasmtime/src/runtime/instance.rs
+++ b/crates/wasmtime/src/runtime/instance.rs
@@ -853,8 +853,11 @@ impl<T: 'static> InstancePre<T> {
     #[cfg(feature = "async")]
     pub async fn instantiate_async(
         &self,
-        mut store: impl AsContextMut<Data: Send>,
-    ) -> Result<Instance> {
+        mut store: impl AsContextMut<Data = T>,
+    ) -> Result<Instance>
+    where
+        T: Send,
+    {
         let mut store = store.as_context_mut();
         let imports = pre_instantiate_raw(
             &mut store.0,


### PR DESCRIPTION
The refactoring in #10760 mistakenly switched the input argument to not be constrained with the same `T` as the store of the `InstancePre` itself.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
