### PR TITLE
[36.0.0] Fix a typo in the bounds of `InstancePre::instantiate_async`

### DIFF
--- a/crates/wasmtime/src/runtime/instance.rs
+++ b/crates/wasmtime/src/runtime/instance.rs
@@ -853,8 +853,11 @@ impl<T: 'static> InstancePre<T> {
     #[cfg(feature = "async")]
     pub async fn instantiate_async(
         &self,
-        mut store: impl AsContextMut<Data: Send>,
-    ) -> Result<Instance> {
+        mut store: impl AsContextMut<Data = T>,
+    ) -> Result<Instance>
+    where
+        T: Send,
+    {
         let mut store = store.as_context_mut();
         let imports = pre_instantiate_raw(
             &mut store.0,


### PR DESCRIPTION
Backport of #11451