### PR TITLE
Add clif instructions tests (`imul_imm`, `get_return_address`) to riscv64 backend.

### DIFF
--- a/cranelift/filetests/filetests/isa/riscv64/amodes-fp.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/amodes-fp.clif
@@ -35,3 +35,33 @@ block0:
 ;   addi sp, sp, 0x10
 ;   ret
 
+function %return_address() -> i64 {
+block0:
+    v0 = get_return_address.i64
+    return v0
+}
+
+; VCode:
+;   addi sp,sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   ld a0,8(fp)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   addi sp,sp,16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   mv s0, sp
+; block1: ; offset 0x10
+;   ld a0, 8(s0)
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/arithmetic.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/arithmetic.clif
@@ -803,3 +803,76 @@ block0(v0: i8):
 ; block0: ; offset 0x0
 ;   addiw a0, a0, -1
 ;   ret
+
+function %imul_i8_const(i8) -> i8 {
+block0(v0: i8):
+    v3 = imul_imm v0, 97
+    return v3
+}
+
+; VCode:
+; block0:
+;   li a3,97
+;   mulw a0,a0,a3
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi a3, zero, 0x61
+;   mulw a0, a0, a3
+;   ret
+
+function %imul_i16_const(i16) -> i16 {
+block0(v0: i16):
+    v3 = imul_imm v0, 97
+    return v3
+}
+
+; VCode:
+; block0:
+;   li a3,97
+;   mulw a0,a0,a3
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi a3, zero, 0x61
+;   mulw a0, a0, a3
+;   ret
+
+function %imul_i32_const(i32) -> i32 {
+block0(v0: i32):
+    v3 = imul_imm v0, 97
+    return v3
+}
+
+; VCode:
+; block0:
+;   li a3,97
+;   mulw a0,a0,a3
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi a3, zero, 0x61
+;   mulw a0, a0, a3
+;   ret
+
+function %imul_i64_const(i64) -> i64 {
+block0(v0: i64):
+    v3 = imul_imm v0, 97
+    return v3
+}
+
+; VCode:
+; block0:
+;   li a3,97
+;   mul a0,a0,a3
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi a3, zero, 0x61
+;   mul a0, a0, a3
+;   ret
+


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
The riscv64 backend seems to be missing tests for some CLIF instructions that are included in other architectures. This PR adds the `imul_imm` and `get_return_address` instructions.