### PR TITLE
Refactor `InstanceAllocator` trait impl split

### DIFF
--- a/crates/wasmtime/src/runtime/store.rs
+++ b/crates/wasmtime/src/runtime/store.rs
@@ -2505,11 +2505,11 @@ impl Drop for StoreOpaque {
 
             for (id, instance) in self.instances.iter_mut() {
                 log::trace!("store {store_id:?} is deallocating {id:?}");
-                if let StoreInstanceKind::Dummy = instance.kind {
-                    ondemand.deallocate_module(&mut instance.handle);
-                } else {
-                    allocator.deallocate_module(&mut instance.handle);
-                }
+                let allocator = match instance.kind {
+                    StoreInstanceKind::Dummy => &ondemand,
+                    _ => allocator,
+                };
+                allocator.deallocate_module(&mut instance.handle);
             }
 
             #[cfg(feature = "component-model")]

--- a/crates/wasmtime/src/runtime/vm.rs
+++ b/crates/wasmtime/src/runtime/vm.rs
@@ -98,9 +98,9 @@ pub use crate::runtime::vm::export::*;
 pub use crate::runtime::vm::gc::*;
 pub use crate::runtime::vm::imports::Imports;
 pub use crate::runtime::vm::instance::{
-    GcHeapAllocationIndex, Instance, InstanceAllocationRequest, InstanceAllocator,
-    InstanceAllocatorImpl, InstanceHandle, MemoryAllocationIndex, OnDemandInstanceAllocator,
-    StorePtr, TableAllocationIndex, initialize_instance,
+    GcHeapAllocationIndex, Instance, InstanceAllocationRequest, InstanceAllocator, InstanceHandle,
+    MemoryAllocationIndex, OnDemandInstanceAllocator, StorePtr, TableAllocationIndex,
+    initialize_instance,
 };
 #[cfg(feature = "pooling-allocator")]
 pub use crate::runtime::vm::instance::{

--- a/crates/wasmtime/src/runtime/vm/instance/allocator/on_demand.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/on_demand.rs
@@ -1,5 +1,5 @@
 use super::{
-    InstanceAllocationRequest, InstanceAllocatorImpl, MemoryAllocationIndex, TableAllocationIndex,
+    InstanceAllocationRequest, InstanceAllocator, MemoryAllocationIndex, TableAllocationIndex,
 };
 use crate::prelude::*;
 use crate::runtime::vm::CompiledModuleId;
@@ -76,9 +76,9 @@ impl Default for OnDemandInstanceAllocator {
     }
 }
 
-unsafe impl InstanceAllocatorImpl for OnDemandInstanceAllocator {
+unsafe impl InstanceAllocator for OnDemandInstanceAllocator {
     #[cfg(feature = "component-model")]
-    fn validate_component_impl<'a>(
+    fn validate_component<'a>(
         &self,
         _component: &Component,
         _offsets: &VMComponentOffsets<HostPtr>,
@@ -87,12 +87,12 @@ unsafe impl InstanceAllocatorImpl for OnDemandInstanceAllocator {
         Ok(())
     }
 
-    fn validate_module_impl(&self, _module: &Module, _offsets: &VMOffsets<HostPtr>) -> Result<()> {
+    fn validate_module(&self, _module: &Module, _offsets: &VMOffsets<HostPtr>) -> Result<()> {
         Ok(())
     }
 
     #[cfg(feature = "gc")]
-    fn validate_memory_impl(&self, _memory: &wasmtime_environ::Memory) -> Result<()> {
+    fn validate_memory(&self, _memory: &wasmtime_environ::Memory) -> Result<()> {
         Ok(())
     }
 

--- a/crates/wasmtime/src/runtime/vm/instance/allocator/pooling.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/pooling.rs
@@ -44,7 +44,7 @@ use self::decommit_queue::DecommitQueue;
 use self::memory_pool::MemoryPool;
 use self::table_pool::TablePool;
 use super::{
-    InstanceAllocationRequest, InstanceAllocatorImpl, MemoryAllocationIndex, TableAllocationIndex,
+    InstanceAllocationRequest, InstanceAllocator, MemoryAllocationIndex, TableAllocationIndex,
 };
 use crate::Enabled;
 use crate::prelude::*;
@@ -523,9 +523,9 @@ impl PoolingInstanceAllocator {
     }
 }
 
-unsafe impl InstanceAllocatorImpl for PoolingInstanceAllocator {
+unsafe impl InstanceAllocator for PoolingInstanceAllocator {
     #[cfg(feature = "component-model")]
-    fn validate_component_impl<'a>(
+    fn validate_component<'a>(
         &self,
         component: &Component,
         offsets: &VMComponentOffsets<HostPtr>,
@@ -549,7 +549,7 @@ unsafe impl InstanceAllocatorImpl for PoolingInstanceAllocator {
                 InstantiateModule(InstantiateModule::Static(static_module_index, _)) => {
                     let module = get_module(*static_module_index);
                     let offsets = VMOffsets::new(HostPtr, &module);
-                    self.validate_module_impl(module, &offsets)?;
+                    self.validate_module(module, &offsets)?;
                     num_core_instances += 1;
                     num_memories += module.num_defined_memories();
                     num_tables += module.num_defined_tables();
@@ -593,7 +593,7 @@ unsafe impl InstanceAllocatorImpl for PoolingInstanceAllocator {
         Ok(())
     }
 
-    fn validate_module_impl(&self, module: &Module, offsets: &VMOffsets<HostPtr>) -> Result<()> {
+    fn validate_module(&self, module: &Module, offsets: &VMOffsets<HostPtr>) -> Result<()> {
         self.validate_memory_plans(module)
             .context("module memory does not fit in pooling allocator requirements")?;
         self.validate_table_plans(module)
@@ -604,7 +604,7 @@ unsafe impl InstanceAllocatorImpl for PoolingInstanceAllocator {
     }
 
     #[cfg(feature = "gc")]
-    fn validate_memory_impl(&self, memory: &wasmtime_environ::Memory) -> Result<()> {
+    fn validate_memory(&self, memory: &wasmtime_environ::Memory) -> Result<()> {
         self.memories.validate_memory(memory)
     }
 


### PR DESCRIPTION
Prior to this commit Wasmtime had an `InstanceAllocatorImpl` trait with a number of required methods as well as an `InstanceAllocator` trait with a number of provided impls. The `InstanceAllocator` trait is implemented for everything implementing `InstanceAllocatorImpl` to force users to be unable to override the default methods. When adding `async` support internally to Wasmtime these are going to need to be `#[async_trait]`-annotated-traits which adds a cost to `async` functions as a future needs to be heap-allocated.

The goal of this commit is to make this future `async`-ification a bit more optimal. Notably the `InstanceAllocator` trait is removed and replaced with inherent methods on `impl dyn InstanceAllocatorImpl`. After that the previous `InstanceAllocatorImpl` trait was renamed to `InstanceAllocator` meaning that there's just one `InstanceAllocator` trait which has inherent methods which cannot be overridden. A consequence of this is that the inherent methods are also forced to do virtual dispatch unlike before where they would internally use monomorphization to have static dispatch. Given the complexity of instance allocation this is expected to be a negligible cost, however.

The main benefit is that `allocate_module`, `allocate_tables`, and `allocate_memories` all get to be native `async` functions without the cost of `#[async_trait]`. Only allocation of a single table/memory will require an allocation of a future which in profiling helps reduce the cost of instantiation slightly.

Note that `#[async_trait]` is not currently used, this commit is just preparation for its eventual use.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
