### PR TITLE
Change how wasm features/gc support work in `Config`

### DIFF
--- a/crates/cli-flags/src/lib.rs
+++ b/crates/cli-flags/src/lib.rs
@@ -403,6 +403,8 @@ wasmtime_option_group! {
         pub exceptions: Option<bool>,
         /// DEPRECATED: Configure support for the legacy exceptions proposal.
         pub legacy_exceptions: Option<bool>,
+        /// Whether or not any GC infrastructure in Wasmtime is enabled or not.
+        pub gc_support: Option<bool>,
     }
 
     enum Wasm {
@@ -988,6 +990,10 @@ impl CommonOptions {
             ["cranelift" : self.wasm.wmemcheck]
             enable => config.wmemcheck(enable),
             true => err,
+        }
+
+        if let Some(enable) = self.wasm.gc_support {
+            config.gc_support(enable);
         }
 
         Ok(config)


### PR DESCRIPTION
This commit aims to address #11450 in complementary but somewhat orthogonal ways. First a new `Config::gc_support` option is added which is hooked up to the CLI as `-Wgc-support`. This option controls the wasmparser-internal `GC_TYPES` feature. Its default value, like before, is `cfg!(feature = "gc")` and additionally enabling it requires the `gc` crate feature to be enabled.

This commit then additionally updates how wasm features are processed during validating a deserialized module to only require enabled features to be enabled in the host. Previously modules that disabled a feature but the feature was enabled in the host would fail to deserialize. All WebAssembly proposals are additive, however, so it's always ok to disable a feature and then load it into a module that enables the wasm proposal.

Closes #11450

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
