### PR TITLE
Use assembler encodings, simplify pretty-printing

### DIFF
--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -5,7 +5,7 @@ pub use emit_state::EmitState;
 use crate::binemit::{Addend, CodeOffset, Reloc};
 use crate::ir::{ExternalName, LibCall, TrapCode, Type, types};
 use crate::isa::x64::abi::X64ABIMachineSpec;
-use crate::isa::x64::inst::regs::{pretty_print_reg, show_ireg_sized};
+use crate::isa::x64::inst::regs::pretty_print_reg;
 use crate::isa::x64::settings as x64_settings;
 use crate::isa::{CallConv, FunctionAlignment};
 use crate::{CodegenError, CodegenResult, settings};
@@ -522,7 +522,7 @@ impl PrettyPrint for Inst {
 
             Inst::MovFromPReg { src, dst } => {
                 let src: Reg = (*src).into();
-                let src = regs::show_ireg_sized(src, 8);
+                let src = pretty_print_reg(src, 8);
                 let dst = pretty_print_reg(dst.to_reg().to_reg(), 8);
                 let op = ljustify("movq".to_string());
                 format!("{op} {src}, {dst}")
@@ -531,7 +531,7 @@ impl PrettyPrint for Inst {
             Inst::MovToPReg { src, dst } => {
                 let src = pretty_print_reg(src.to_reg(), 8);
                 let dst: Reg = (*dst).into();
-                let dst = regs::show_ireg_sized(dst, 8);
+                let dst = pretty_print_reg(dst, 8);
                 let op = ljustify("movq".to_string());
                 format!("{op} {src}, {dst}")
             }
@@ -606,7 +606,7 @@ impl PrettyPrint for Inst {
                 let tmp = pretty_print_reg(tmp.to_reg().to_reg(), 8);
                 let mut s = format!("return_call_known {dest:?} ({new_stack_arg_size}) tmp={tmp}");
                 for ret in uses {
-                    let preg = regs::show_reg(ret.preg);
+                    let preg = pretty_print_reg(ret.preg, 8);
                     let vreg = pretty_print_reg(ret.vreg, 8);
                     write!(&mut s, " {vreg}={preg}").unwrap();
                 }
@@ -625,7 +625,7 @@ impl PrettyPrint for Inst {
                 let mut s =
                     format!("return_call_unknown {callee} ({new_stack_arg_size}) tmp={tmp}");
                 for ret in uses {
-                    let preg = regs::show_reg(ret.preg);
+                    let preg = pretty_print_reg(ret.preg, 8);
                     let vreg = pretty_print_reg(ret.vreg, 8);
                     write!(&mut s, " {vreg}={preg}").unwrap();
                 }
@@ -635,7 +635,7 @@ impl PrettyPrint for Inst {
             Inst::Args { args } => {
                 let mut s = "args".to_string();
                 for arg in args {
-                    let preg = regs::show_reg(arg.preg);
+                    let preg = pretty_print_reg(arg.preg, 8);
                     let def = pretty_print_reg(arg.vreg.to_reg(), 8);
                     write!(&mut s, " {def}={preg}").unwrap();
                 }
@@ -645,7 +645,7 @@ impl PrettyPrint for Inst {
             Inst::Rets { rets } => {
                 let mut s = "rets".to_string();
                 for ret in rets {
-                    let preg = regs::show_reg(ret.preg);
+                    let preg = pretty_print_reg(ret.preg, 8);
                     let vreg = pretty_print_reg(ret.vreg, 8);
                     write!(&mut s, " {vreg}={preg}").unwrap();
                 }
@@ -808,7 +808,7 @@ impl PrettyPrint for Inst {
 
                 let mut s = format!("{dst} = coff_tls_get_addr {symbol:?}");
                 if tmp.is_virtual() {
-                    let tmp = show_ireg_sized(tmp, 8);
+                    let tmp = pretty_print_reg(tmp, 8);
                     write!(&mut s, ", {tmp}").unwrap();
                 };
 
@@ -1162,7 +1162,7 @@ fn x64_get_operands(inst: &mut Inst, collector: &mut impl OperandVisitor) {
             // Windows) use different TLS strategies.
             let mut clobbers =
                 X64ABIMachineSpec::get_regs_clobbered_by_call(CallConv::SystemV, false);
-            clobbers.remove(regs::gpr_preg(regs::ENC_RAX));
+            clobbers.remove(regs::gpr_preg(asm::gpr::enc::RAX));
             collector.reg_clobbers(clobbers);
         }
 

--- a/cranelift/codegen/src/isa/x64/inst/regs.rs
+++ b/cranelift/codegen/src/isa/x64/inst/regs.rs
@@ -5,29 +5,11 @@
 //!
 //! Note also that we make use of pinned VRegs to refer to PRegs.
 
-use crate::machinst::{RealReg, Reg};
+use crate::machinst::Reg;
 use alloc::string::ToString;
+use cranelift_assembler_x64::{gpr, xmm};
 use regalloc2::{PReg, RegClass, VReg};
 use std::string::String;
-
-// Hardware encodings (note the special rax, rcx, rdx, rbx order).
-
-pub const ENC_RAX: u8 = 0;
-pub const ENC_RCX: u8 = 1;
-pub const ENC_RDX: u8 = 2;
-pub const ENC_RBX: u8 = 3;
-pub const ENC_RSP: u8 = 4;
-pub const ENC_RBP: u8 = 5;
-pub const ENC_RSI: u8 = 6;
-pub const ENC_RDI: u8 = 7;
-pub const ENC_R8: u8 = 8;
-pub const ENC_R9: u8 = 9;
-pub const ENC_R10: u8 = 10;
-pub const ENC_R11: u8 = 11;
-pub const ENC_R12: u8 = 12;
-pub const ENC_R13: u8 = 13;
-pub const ENC_R14: u8 = 14;
-pub const ENC_R15: u8 = 15;
 
 // Constructors for Regs.
 
@@ -39,55 +21,53 @@ pub(crate) const fn gpr_preg(enc: u8) -> PReg {
     PReg::new(enc as usize, RegClass::Int)
 }
 
-pub(crate) const fn rsi() -> Reg {
-    gpr(ENC_RSI)
-}
-pub(crate) const fn rdi() -> Reg {
-    gpr(ENC_RDI)
-}
 pub(crate) const fn rax() -> Reg {
-    gpr(ENC_RAX)
+    gpr(gpr::enc::RAX)
 }
 pub(crate) const fn rcx() -> Reg {
-    gpr(ENC_RCX)
+    gpr(gpr::enc::RCX)
 }
 pub(crate) const fn rdx() -> Reg {
-    gpr(ENC_RDX)
-}
-pub(crate) const fn r8() -> Reg {
-    gpr(ENC_R8)
-}
-pub(crate) const fn r9() -> Reg {
-    gpr(ENC_R9)
-}
-pub(crate) const fn r10() -> Reg {
-    gpr(ENC_R10)
-}
-pub(crate) const fn r11() -> Reg {
-    gpr(ENC_R11)
-}
-pub(crate) const fn r12() -> Reg {
-    gpr(ENC_R12)
-}
-pub(crate) const fn r13() -> Reg {
-    gpr(ENC_R13)
-}
-pub(crate) const fn r14() -> Reg {
-    gpr(ENC_R14)
+    gpr(gpr::enc::RDX)
 }
 pub(crate) const fn rbx() -> Reg {
-    gpr(ENC_RBX)
+    gpr(gpr::enc::RBX)
 }
-
-pub(crate) const fn r15() -> Reg {
-    gpr(ENC_R15)
-}
-
 pub(crate) const fn rsp() -> Reg {
-    gpr(ENC_RSP)
+    gpr(gpr::enc::RSP)
 }
 pub(crate) const fn rbp() -> Reg {
-    gpr(ENC_RBP)
+    gpr(gpr::enc::RBP)
+}
+pub(crate) const fn rsi() -> Reg {
+    gpr(gpr::enc::RSI)
+}
+pub(crate) const fn rdi() -> Reg {
+    gpr(gpr::enc::RDI)
+}
+pub(crate) const fn r8() -> Reg {
+    gpr(gpr::enc::R8)
+}
+pub(crate) const fn r9() -> Reg {
+    gpr(gpr::enc::R9)
+}
+pub(crate) const fn r10() -> Reg {
+    gpr(gpr::enc::R10)
+}
+pub(crate) const fn r11() -> Reg {
+    gpr(gpr::enc::R11)
+}
+pub(crate) const fn r12() -> Reg {
+    gpr(gpr::enc::R12)
+}
+pub(crate) const fn r13() -> Reg {
+    gpr(gpr::enc::R13)
+}
+pub(crate) const fn r14() -> Reg {
+    gpr(gpr::enc::R14)
+}
+pub(crate) const fn r15() -> Reg {
+    gpr(gpr::enc::R15)
 }
 
 /// The pinned register on this architecture.
@@ -107,160 +87,52 @@ pub(crate) const fn fpr_preg(enc: u8) -> PReg {
 }
 
 pub(crate) const fn xmm0() -> Reg {
-    fpr(0)
+    fpr(xmm::enc::XMM0)
 }
 pub(crate) const fn xmm1() -> Reg {
-    fpr(1)
+    fpr(xmm::enc::XMM1)
 }
 pub(crate) const fn xmm2() -> Reg {
-    fpr(2)
+    fpr(xmm::enc::XMM2)
 }
 pub(crate) const fn xmm3() -> Reg {
-    fpr(3)
+    fpr(xmm::enc::XMM3)
 }
 pub(crate) const fn xmm4() -> Reg {
-    fpr(4)
+    fpr(xmm::enc::XMM4)
 }
 pub(crate) const fn xmm5() -> Reg {
-    fpr(5)
+    fpr(xmm::enc::XMM5)
 }
 pub(crate) const fn xmm6() -> Reg {
-    fpr(6)
+    fpr(xmm::enc::XMM6)
 }
 pub(crate) const fn xmm7() -> Reg {
-    fpr(7)
+    fpr(xmm::enc::XMM7)
 }
 pub(crate) const fn xmm8() -> Reg {
-    fpr(8)
+    fpr(xmm::enc::XMM8)
 }
 pub(crate) const fn xmm9() -> Reg {
-    fpr(9)
+    fpr(xmm::enc::XMM9)
 }
 pub(crate) const fn xmm10() -> Reg {
-    fpr(10)
+    fpr(xmm::enc::XMM10)
 }
 pub(crate) const fn xmm11() -> Reg {
-    fpr(11)
+    fpr(xmm::enc::XMM11)
 }
 pub(crate) const fn xmm12() -> Reg {
-    fpr(12)
+    fpr(xmm::enc::XMM12)
 }
 pub(crate) const fn xmm13() -> Reg {
-    fpr(13)
+    fpr(xmm::enc::XMM13)
 }
 pub(crate) const fn xmm14() -> Reg {
-    fpr(14)
+    fpr(xmm::enc::XMM14)
 }
 pub(crate) const fn xmm15() -> Reg {
-    fpr(15)
-}
-
-/// Give the name of a RealReg.
-pub fn realreg_name(reg: RealReg) -> &'static str {
-    let preg = PReg::from(reg);
-    match preg.class() {
-        RegClass::Int => match preg.hw_enc() as u8 {
-            ENC_RAX => "%rax",
-            ENC_RBX => "%rbx",
-            ENC_RCX => "%rcx",
-            ENC_RDX => "%rdx",
-            ENC_RSI => "%rsi",
-            ENC_RDI => "%rdi",
-            ENC_RBP => "%rbp",
-            ENC_RSP => "%rsp",
-            ENC_R8 => "%r8",
-            ENC_R9 => "%r9",
-            ENC_R10 => "%r10",
-            ENC_R11 => "%r11",
-            ENC_R12 => "%r12",
-            ENC_R13 => "%r13",
-            ENC_R14 => "%r14",
-            ENC_R15 => "%r15",
-            _ => panic!("Invalid PReg: {preg:?}"),
-        },
-        RegClass::Float => match preg.hw_enc() {
-            0 => "%xmm0",
-            1 => "%xmm1",
-            2 => "%xmm2",
-            3 => "%xmm3",
-            4 => "%xmm4",
-            5 => "%xmm5",
-            6 => "%xmm6",
-            7 => "%xmm7",
-            8 => "%xmm8",
-            9 => "%xmm9",
-            10 => "%xmm10",
-            11 => "%xmm11",
-            12 => "%xmm12",
-            13 => "%xmm13",
-            14 => "%xmm14",
-            15 => "%xmm15",
-            _ => panic!("Invalid PReg: {preg:?}"),
-        },
-        RegClass::Vector => unreachable!(),
-    }
-}
-
-pub fn show_reg(reg: Reg) -> String {
-    if let Some(rreg) = reg.to_real_reg() {
-        realreg_name(rreg).to_string()
-    } else {
-        format!("%{reg:?}")
-    }
-}
-
-/// If `ireg` denotes an I64-classed reg, make a best-effort attempt to show its name at some
-/// smaller size (4, 2 or 1 bytes).
-pub fn show_ireg_sized(reg: Reg, size: u8) -> String {
-    let mut s = show_reg(reg);
-
-    if reg.class() != RegClass::Int || size == 8 {
-        // We can't do any better.
-        return s;
-    }
-
-    if reg.is_real() {
-        // Change (eg) "rax" into "eax", "ax" or "al" as appropriate.  This is something one could
-        // describe diplomatically as "a kludge", but it's only debug code.
-        let remapper = match s.as_str() {
-            "%rax" => Some(["%eax", "%ax", "%al"]),
-            "%rbx" => Some(["%ebx", "%bx", "%bl"]),
-            "%rcx" => Some(["%ecx", "%cx", "%cl"]),
-            "%rdx" => Some(["%edx", "%dx", "%dl"]),
-            "%rsi" => Some(["%esi", "%si", "%sil"]),
-            "%rdi" => Some(["%edi", "%di", "%dil"]),
-            "%rbp" => Some(["%ebp", "%bp", "%bpl"]),
-            "%rsp" => Some(["%esp", "%sp", "%spl"]),
-            "%r8" => Some(["%r8d", "%r8w", "%r8b"]),
-            "%r9" => Some(["%r9d", "%r9w", "%r9b"]),
-            "%r10" => Some(["%r10d", "%r10w", "%r10b"]),
-            "%r11" => Some(["%r11d", "%r11w", "%r11b"]),
-            "%r12" => Some(["%r12d", "%r12w", "%r12b"]),
-            "%r13" => Some(["%r13d", "%r13w", "%r13b"]),
-            "%r14" => Some(["%r14d", "%r14w", "%r14b"]),
-            "%r15" => Some(["%r15d", "%r15w", "%r15b"]),
-            _ => None,
-        };
-        if let Some(smaller_names) = remapper {
-            match size {
-                4 => s = smaller_names[0].into(),
-                2 => s = smaller_names[1].into(),
-                1 => s = smaller_names[2].into(),
-                _ => panic!("show_ireg_sized: real"),
-            }
-        }
-    } else {
-        // Add a "l", "w" or "b" suffix to RegClass::I64 vregs used at narrower widths.
-        let suffix = match size {
-            4 => "l",
-            2 => "w",
-            1 => "b",
-            _ => panic!("show_ireg_sized: virtual"),
-        };
-        s = s + suffix;
-    }
-
-    s
+    fpr(xmm::enc::XMM15)
 }
 
 // N.B.: this is not an `impl PrettyPrint for Reg` because it is
@@ -271,5 +143,34 @@ pub fn show_ireg_sized(reg: Reg, size: u8) -> String {
 // may have multiple backends; but we can pretty-print one as part of
 // an x64 Inst or x64 RegMemImm.)
 pub fn pretty_print_reg(reg: Reg, size: u8) -> String {
-    show_ireg_sized(reg, size)
+    if let Some(rreg) = reg.to_real_reg() {
+        let enc = rreg.hw_enc();
+        let name = match rreg.class() {
+            RegClass::Int => {
+                let size = match size {
+                    8 => gpr::Size::Quadword,
+                    4 => gpr::Size::Doubleword,
+                    2 => gpr::Size::Word,
+                    1 => gpr::Size::Byte,
+                    _ => unreachable!("invalid size"),
+                };
+                gpr::enc::to_string(enc, size)
+            }
+            RegClass::Float => xmm::enc::to_string(enc),
+            RegClass::Vector => unreachable!(),
+        };
+        name.to_string()
+    } else {
+        let mut name = format!("%{reg:?}");
+        // Add size suffixes to GPR virtual registers at narrower widths.
+        if reg.class() == RegClass::Int && size != 8 {
+            name.push_str(match size {
+                4 => "l",
+                2 => "w",
+                1 => "b",
+                _ => unreachable!("invalid size"),
+            });
+        }
+        name
+    }
 }


### PR DESCRIPTION
While exploring the possibility of extending the set of x86 registers available to Cranelift, I noticed some opportunities for improvement:
- this change uses on the assembler's `enc` modules for the "hardware encoding source of truth" instead of an older implementation in `cranelift-codegen` and/or raw integers.
- this change uses the assembler's pretty printing instead of multiple implementations in `cranelift-codegen`

With this in place, it should be more clear where to implement new registers.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
