### PR TITLE
Refactor exception objects to share more implementation with structs.

### DIFF
--- a/crates/environ/src/compile/module_environ.rs
+++ b/crates/environ/src/compile/module_environ.rs
@@ -354,7 +354,13 @@ impl<'a, 'data> ModuleEnvironment<'a, 'data> {
                         TypeRef::Tag(ty) => {
                             let index = TypeIndex::from_u32(ty.func_type_idx);
                             let signature = self.result.module.types[index];
-                            let tag = Tag { signature };
+                            let exception = self.types.define_exception_type_for_tag(
+                                signature.unwrap_module_type_index(),
+                            );
+                            let tag = Tag {
+                                signature,
+                                exception: EngineOrModuleTypeIndex::Module(exception),
+                            };
                             self.result.module.num_imported_tags += 1;
                             EntityType::Tag(tag)
                         }
@@ -426,7 +432,10 @@ impl<'a, 'data> ModuleEnvironment<'a, 'data> {
                     let sigindex = entry?.func_type_idx;
                     let ty = TypeIndex::from_u32(sigindex);
                     let interned_index = self.result.module.types[ty];
-                    self.result.module.push_tag(interned_index);
+                    let exception = self
+                        .types
+                        .define_exception_type_for_tag(interned_index.unwrap_module_type_index());
+                    self.result.module.push_tag(interned_index, exception);
                 }
             }
 

--- a/crates/environ/src/gc/drc.rs
+++ b/crates/environ/src/gc/drc.rs
@@ -11,6 +11,9 @@ pub const HEADER_ALIGN: u32 = 8;
 /// The offset of the length field in a `VMDrcArrayHeader`.
 pub const ARRAY_LENGTH_OFFSET: u32 = HEADER_SIZE;
 
+/// The offset of the tag fields in an exception header.
+pub const EXCEPTION_TAG_OFFSET: u32 = HEADER_SIZE;
+
 /// The bit within a `VMDrcHeader`'s reserved bits that is the mark
 /// bit. Collectively, this bit in all the heap's objects' headers implements
 /// the precise-stack-roots set.
@@ -29,6 +32,10 @@ impl GcTypeLayouts for DrcTypeLayouts {
         ARRAY_LENGTH_OFFSET
     }
 
+    fn exception_tag_offset(&self) -> u32 {
+        EXCEPTION_TAG_OFFSET
+    }
+
     fn array_layout(&self, ty: &WasmArrayType) -> GcArrayLayout {
         common_array_layout(ty, HEADER_SIZE, HEADER_ALIGN, ARRAY_LENGTH_OFFSET)
     }
@@ -37,7 +44,7 @@ impl GcTypeLayouts for DrcTypeLayouts {
         common_struct_layout(ty, HEADER_SIZE, HEADER_ALIGN)
     }
 
-    fn exn_layout(&self, ty: &WasmExnType) -> GcExceptionLayout {
+    fn exn_layout(&self, ty: &WasmExnType) -> GcStructLayout {
         common_exn_layout(ty, HEADER_SIZE, HEADER_ALIGN)
     }
 }

--- a/crates/environ/src/gc/null.rs
+++ b/crates/environ/src/gc/null.rs
@@ -11,6 +11,9 @@ pub const HEADER_ALIGN: u32 = 8;
 /// The offset of the length field in a `VMNullArrayHeader`.
 pub const ARRAY_LENGTH_OFFSET: u32 = HEADER_SIZE;
 
+/// The offset of the tag fields in an exception header.
+pub const EXCEPTION_TAG_OFFSET: u32 = HEADER_SIZE;
+
 /// The layout of Wasm GC objects in the null collector.
 #[derive(Default)]
 pub struct NullTypeLayouts;
@@ -18,6 +21,10 @@ pub struct NullTypeLayouts;
 impl GcTypeLayouts for NullTypeLayouts {
     fn array_length_field_offset(&self) -> u32 {
         ARRAY_LENGTH_OFFSET
+    }
+
+    fn exception_tag_offset(&self) -> u32 {
+        EXCEPTION_TAG_OFFSET
     }
 
     fn array_layout(&self, ty: &WasmArrayType) -> GcArrayLayout {
@@ -28,7 +35,7 @@ impl GcTypeLayouts for NullTypeLayouts {
         common_struct_layout(ty, HEADER_SIZE, HEADER_ALIGN)
     }
 
-    fn exn_layout(&self, ty: &WasmExnType) -> GcExceptionLayout {
+    fn exn_layout(&self, ty: &WasmExnType) -> GcStructLayout {
         common_exn_layout(ty, HEADER_SIZE, HEADER_ALIGN)
     }
 }

--- a/crates/environ/src/module.rs
+++ b/crates/environ/src/module.rs
@@ -561,9 +561,17 @@ impl Module {
     }
 
     /// Appends a new tag to this module with the given type information.
-    pub fn push_tag(&mut self, signature: impl Into<EngineOrModuleTypeIndex>) -> TagIndex {
+    pub fn push_tag(
+        &mut self,
+        signature: impl Into<EngineOrModuleTypeIndex>,
+        exception: impl Into<EngineOrModuleTypeIndex>,
+    ) -> TagIndex {
         let signature = signature.into();
-        self.tags.push(Tag { signature })
+        let exception = exception.into();
+        self.tags.push(Tag {
+            signature,
+            exception,
+        })
     }
 
     /// Appends a new function to this module with the given type information,

--- a/crates/environ/src/types.rs
+++ b/crates/environ/src/types.rs
@@ -2238,6 +2238,8 @@ impl From<wasmparser::MemoryType> for Memory {
 pub struct Tag {
     /// The tag signature type.
     pub signature: EngineOrModuleTypeIndex,
+    /// The corresponding exception type.
+    pub exception: EngineOrModuleTypeIndex,
 }
 
 impl TypeTrace for Tag {
@@ -2245,14 +2247,18 @@ impl TypeTrace for Tag {
     where
         F: FnMut(EngineOrModuleTypeIndex) -> Result<(), E>,
     {
-        func(self.signature)
+        func(self.signature)?;
+        func(self.exception)?;
+        Ok(())
     }
 
     fn trace_mut<F, E>(&mut self, func: &mut F) -> Result<(), E>
     where
         F: FnMut(&mut EngineOrModuleTypeIndex) -> Result<(), E>,
     {
-        func(&mut self.signature)
+        func(&mut self.signature)?;
+        func(&mut self.exception)?;
+        Ok(())
     }
 }
 

--- a/crates/wasmtime/src/runtime/gc/enabled/arrayref.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/arrayref.rs
@@ -741,7 +741,6 @@ impl ArrayRef {
         match layout {
             GcLayout::Array(a) => Ok(a),
             GcLayout::Struct(_) => unreachable!(),
-            GcLayout::Exception(_) => unreachable!(),
         }
     }
 

--- a/crates/wasmtime/src/runtime/gc/enabled/structref.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/structref.rs
@@ -549,7 +549,6 @@ impl StructRef {
         match layout {
             GcLayout::Struct(s) => Ok(s),
             GcLayout::Array(_) => unreachable!(),
-            GcLayout::Exception(_) => unreachable!(),
         }
     }
 

--- a/crates/wasmtime/src/runtime/trampoline/tag.rs
+++ b/crates/wasmtime/src/runtime/trampoline/tag.rs
@@ -1,3 +1,4 @@
+use crate::ExnType;
 use crate::TagType;
 use crate::prelude::*;
 use crate::runtime::vm::{Imports, ModuleRuntimeInfo, OnDemandInstanceAllocator};
@@ -10,14 +11,20 @@ use wasmtime_environ::{EntityIndex, Module, TypeTrace};
 pub fn create_tag(store: &mut StoreOpaque, ty: &TagType) -> Result<InstanceId> {
     let mut module = Module::new();
     let func_ty = ty.ty().clone().into_registered_type();
+    let exn_ty = ExnType::from_tag_type(ty)?.registered_type().clone();
 
     debug_assert!(
         func_ty.is_canonicalized_for_runtime_usage(),
         "should be canonicalized for runtime usage: {func_ty:?}",
     );
+    debug_assert!(
+        exn_ty.is_canonicalized_for_runtime_usage(),
+        "should be canonicalized for runtime usage: {exn_ty:?}",
+    );
 
     let tag_id = module.tags.push(Tag {
         signature: EngineOrModuleTypeIndex::Engine(func_ty.index()),
+        exception: EngineOrModuleTypeIndex::Engine(exn_ty.index()),
     });
 
     module

--- a/crates/wasmtime/src/runtime/vm/gc/disabled.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/disabled.rs
@@ -1,5 +1,7 @@
 //! Dummy GC types for when the `gc` cargo feature is disabled.
 
+use super::VMGcRef;
+
 pub enum VMExternRef {}
 
 pub enum VMStructRef {}
@@ -11,6 +13,28 @@ pub enum VMExnRef {}
 pub struct VMGcObjectData {
     _inner: VMStructRef,
     _phantom: core::marker::PhantomData<[u8]>,
+}
+
+impl VMGcRef {
+    pub fn into_structref_unchecked(self) -> VMStructRef {
+        unreachable!()
+    }
+
+    pub fn into_exnref_unchecked(self) -> VMExnRef {
+        unreachable!()
+    }
+}
+
+impl From<VMStructRef> for VMGcRef {
+    fn from(s: VMStructRef) -> VMGcRef {
+        match s {}
+    }
+}
+
+impl From<VMExnRef> for VMGcRef {
+    fn from(e: VMExnRef) -> VMGcRef {
+        match e {}
+    }
 }
 
 impl<'a> From<&'a [u8]> for &'a VMGcObjectData {

--- a/crates/wasmtime/src/runtime/vm/gc/enabled/drc.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/enabled/drc.rs
@@ -44,8 +44,8 @@
 //! Examination of Deferred Reference Counting and Cycle Detection* by Quinane:
 //! <https://openresearch-repository.anu.edu.au/bitstream/1885/42030/2/hon-thesis.pdf>
 
+use super::VMArrayRef;
 use super::free_list::FreeList;
-use super::{VMArrayRef, VMExnRef, VMStructRef};
 use crate::hash_map::HashMap;
 use crate::hash_set::HashSet;
 use crate::runtime::vm::{
@@ -64,8 +64,7 @@ use core::{
 };
 use wasmtime_environ::drc::{ARRAY_LENGTH_OFFSET, DrcTypeLayouts};
 use wasmtime_environ::{
-    GcArrayLayout, GcExceptionLayout, GcLayout, GcStructLayout, GcTypeLayouts, VMGcKind,
-    VMSharedTypeIndex,
+    GcArrayLayout, GcLayout, GcStructLayout, GcTypeLayouts, VMGcKind, VMSharedTypeIndex,
 };
 
 #[expect(clippy::cast_possible_truncation, reason = "known to not overflow")]
@@ -292,13 +291,6 @@ impl DrcHeap {
             }
             GcLayout::Struct(l) => TraceInfo::Struct {
                 gc_ref_offsets: l
-                    .fields
-                    .iter()
-                    .filter_map(|f| if f.is_gc_ref { Some(f.offset) } else { None })
-                    .collect(),
-            },
-            GcLayout::Exception(e) => TraceInfo::Struct {
-                gc_ref_offsets: e
                     .fields
                     .iter()
                     .filter_map(|f| if f.is_gc_ref { Some(f.offset) } else { None })
@@ -846,24 +838,27 @@ unsafe impl GcHeap for DrcHeap {
         Ok(Ok(gc_ref))
     }
 
-    fn alloc_uninit_struct(
+    fn alloc_uninit_struct_or_exn(
         &mut self,
         ty: VMSharedTypeIndex,
         layout: &GcStructLayout,
-    ) -> Result<Result<VMStructRef, u64>> {
-        let gc_ref = match self.alloc_raw(
-            VMGcHeader::from_kind_and_index(VMGcKind::StructRef, ty),
-            layout.layout(),
-        )? {
-            Err(n) => return Ok(Err(n)),
-            Ok(gc_ref) => gc_ref,
+    ) -> Result<Result<VMGcRef, u64>> {
+        let kind = if layout.is_exception {
+            VMGcKind::ExnRef
+        } else {
+            VMGcKind::StructRef
         };
+        let gc_ref =
+            match self.alloc_raw(VMGcHeader::from_kind_and_index(kind, ty), layout.layout())? {
+                Err(n) => return Ok(Err(n)),
+                Ok(gc_ref) => gc_ref,
+            };
 
-        Ok(Ok(gc_ref.into_structref_unchecked()))
+        Ok(Ok(gc_ref))
     }
 
-    fn dealloc_uninit_struct(&mut self, structref: VMStructRef) {
-        self.dealloc(structref.into());
+    fn dealloc_uninit_struct_or_exn(&mut self, gcref: VMGcRef) {
+        self.dealloc(gcref);
     }
 
     fn alloc_uninit_array(
@@ -894,26 +889,6 @@ unsafe impl GcHeap for DrcHeap {
         debug_assert!(arrayref.as_gc_ref().is_typed::<VMDrcArrayHeader>(self));
         self.index::<VMDrcArrayHeader>(arrayref.as_gc_ref().as_typed_unchecked())
             .length
-    }
-
-    fn alloc_uninit_exn(
-        &mut self,
-        ty: VMSharedTypeIndex,
-        layout: &GcExceptionLayout,
-    ) -> Result<Result<VMExnRef, u64>> {
-        let gc_ref = match self.alloc_raw(
-            VMGcHeader::from_kind_and_index(VMGcKind::ExnRef, ty),
-            layout.layout(),
-        )? {
-            Err(n) => return Ok(Err(n)),
-            Ok(gc_ref) => gc_ref,
-        };
-
-        Ok(Ok(gc_ref.into_exnref_unchecked()))
-    }
-
-    fn dealloc_uninit_exn(&mut self, exnref: VMExnRef) {
-        self.dealloc(exnref.into());
     }
 
     fn gc<'a>(

--- a/crates/wasmtime/src/runtime/vm/gc/enabled/null.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/enabled/null.rs
@@ -17,7 +17,7 @@ use crate::{
 use core::ptr::NonNull;
 use core::{alloc::Layout, any::Any, num::NonZeroU32};
 use wasmtime_environ::{
-    GcArrayLayout, GcExceptionLayout, GcStructLayout, GcTypeLayouts, VMGcKind, VMSharedTypeIndex,
+    GcArrayLayout, GcStructLayout, GcTypeLayouts, VMGcKind, VMSharedTypeIndex,
     null::NullTypeLayouts,
 };
 
@@ -286,19 +286,20 @@ unsafe impl GcHeap for NullHeap {
         self.alloc(header, layout)
     }
 
-    fn alloc_uninit_struct(
+    fn alloc_uninit_struct_or_exn(
         &mut self,
         ty: VMSharedTypeIndex,
         layout: &GcStructLayout,
-    ) -> Result<Result<VMStructRef, u64>> {
-        self.alloc(
-            VMGcHeader::from_kind_and_index(VMGcKind::StructRef, ty),
-            layout.layout(),
-        )
-        .map(|r| r.map(|r| r.into_structref_unchecked()))
+    ) -> Result<Result<VMGcRef, u64>> {
+        let kind = if layout.is_exception {
+            VMGcKind::ExnRef
+        } else {
+            VMGcKind::StructRef
+        };
+        self.alloc(VMGcHeader::from_kind_and_index(kind, ty), layout.layout())
     }
 
-    fn dealloc_uninit_struct(&mut self, _struct_ref: VMStructRef) {}
+    fn dealloc_uninit_struct_or_exn(&mut self, _struct_ref: VMGcRef) {}
 
     fn alloc_uninit_array(
         &mut self,
@@ -325,20 +326,6 @@ unsafe impl GcHeap for NullHeap {
         let arrayref = VMNullArrayHeader::typed_ref(self, arrayref);
         self.index(arrayref).length
     }
-
-    fn alloc_uninit_exn(
-        &mut self,
-        ty: VMSharedTypeIndex,
-        layout: &GcExceptionLayout,
-    ) -> Result<Result<VMExnRef, u64>> {
-        self.alloc(
-            VMGcHeader::from_kind_and_index(VMGcKind::ExnRef, ty),
-            layout.layout(),
-        )
-        .map(|r| r.map(|r| r.into_exnref_unchecked()))
-    }
-
-    fn dealloc_uninit_exn(&mut self, _exnref: VMExnRef) {}
 
     fn gc<'a>(
         &'a mut self,

--- a/crates/wasmtime/src/runtime/vm/gc/gc_runtime.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/gc_runtime.rs
@@ -3,17 +3,13 @@
 use crate::prelude::*;
 use crate::runtime::vm::{
     ExternRefHostDataId, ExternRefHostDataTable, GcHeapObject, SendSyncPtr, TypedGcRef, VMArrayRef,
-    VMExternRef, VMGcHeader, VMGcObjectData, VMGcRef, VMStructRef,
+    VMExternRef, VMGcHeader, VMGcObjectData, VMGcRef,
 };
 use crate::vm::VMMemoryDefinition;
 use core::ptr::NonNull;
 use core::slice;
 use core::{alloc::Layout, any::Any, marker, mem, ops::Range, ptr};
-use wasmtime_environ::{
-    GcArrayLayout, GcExceptionLayout, GcStructLayout, GcTypeLayouts, VMSharedTypeIndex,
-};
-
-use super::VMExnRef;
+use wasmtime_environ::{GcArrayLayout, GcStructLayout, GcTypeLayouts, VMSharedTypeIndex};
 
 /// Trait for integrating a garbage collector with the runtime.
 ///
@@ -293,19 +289,19 @@ pub unsafe trait GcHeap: 'static + Send + Sync {
     ///   collection. This could be because, for example, the requested
     ///   allocation is larger than this collector's implementation limit for
     ///   object size.
-    fn alloc_uninit_struct(
+    fn alloc_uninit_struct_or_exn(
         &mut self,
         ty: VMSharedTypeIndex,
         layout: &GcStructLayout,
-    ) -> Result<Result<VMStructRef, u64>>;
+    ) -> Result<Result<VMGcRef, u64>>;
 
-    /// Deallocate an uninitialized, GC-managed struct.
+    /// Deallocate an uninitialized, GC-managed struct or exception.
     ///
     /// This is useful for if initialization of the struct's fields fails, so
     /// that the struct's allocation can be eagerly reclaimed, and so that the
     /// collector doesn't attempt to treat any of the uninitialized fields as
     /// valid GC references, or something like that.
-    fn dealloc_uninit_struct(&mut self, structref: VMStructRef);
+    fn dealloc_uninit_struct_or_exn(&mut self, structref: VMGcRef);
 
     /// * `Ok(Ok(_))`: The allocation was successful.
     ///
@@ -341,46 +337,6 @@ pub unsafe trait GcHeap: 'static + Send + Sync {
     /// do so is memory safe, but may result in general failures such as panics
     /// or incorrect results.
     fn array_len(&self, arrayref: &VMArrayRef) -> u32;
-
-    /// Allocate a GC-managed exception object of the given type and
-    /// layout, with the given tag.
-    ///
-    /// The exception object's fields are left uninitialized. It is
-    /// the caller's responsibility to initialize them before exposing
-    /// the object to Wasm or triggering a GC.
-    ///
-    /// The `ty` and `layout` must match, and the tag's function type
-    /// must have a matching signature to the exception layout's.
-    ///
-    /// Failure to do either of the above is memory safe, but may result in
-    /// general failures such as panics or incorrect results.
-    ///
-    /// Return values:
-    ///
-    /// * `Ok(Ok(_))`: The allocation was successful.
-    ///
-    /// * `Ok(Err(n))`: There is currently not enough available space for this
-    ///   allocation of size `n`. The caller should either grow the heap or run
-    ///   a collection to reclaim space, and then try allocating again.
-    ///
-    /// * `Err(_)`: The collector cannot satisfy this allocation request, and
-    ///   would not be able to even after the caller were to trigger a
-    ///   collection. This could be because, for example, the requested
-    ///   allocation is larger than this collector's implementation limit for
-    ///   object size.
-    fn alloc_uninit_exn(
-        &mut self,
-        ty: VMSharedTypeIndex,
-        layout: &GcExceptionLayout,
-    ) -> Result<Result<VMExnRef, u64>>;
-
-    /// Deallocate an uninitialized, GC-managed exception object.
-    ///
-    /// This is useful for if initialization of the struct's fields fails, so
-    /// that the struct's allocation can be eagerly reclaimed, and so that the
-    /// collector doesn't attempt to treat any of the uninitialized fields as
-    /// valid GC references, or something like that.
-    fn dealloc_uninit_exn(&mut self, exnref: VMExnRef);
 
     ////////////////////////////////////////////////////////////////////////////
     // Garbage Collection Methods


### PR DESCRIPTION
This PR updates the implementation of Wasm exception objects to share more layout-computation code with structs, except for a single fixed tag slot. The former is simply a nice refactor, and the latter is in preparation for full exception support, which will require accessing an exception's tag without knowing its layout dynamically at runtime.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
