### PR TITLE
Make const-expr evaluation `async`

### DIFF
--- a/crates/wasmtime/src/runtime/gc/enabled/arrayref.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/arrayref.rs
@@ -353,7 +353,6 @@ impl ArrayRef {
         Self::_new_async(store.as_context_mut().0, allocator, elem, len).await
     }
 
-    #[cfg(feature = "async")]
     pub(crate) async fn _new_async(
         store: &mut StoreOpaque,
         allocator: &ArrayRefPre,
@@ -512,7 +511,6 @@ impl ArrayRef {
         Self::_new_fixed_async(store.as_context_mut().0, allocator, elems).await
     }
 
-    #[cfg(feature = "async")]
     pub(crate) async fn _new_fixed_async(
         store: &mut StoreOpaque,
         allocator: &ArrayRefPre,

--- a/crates/wasmtime/src/runtime/gc/enabled/structref.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/structref.rs
@@ -269,10 +269,6 @@ impl StructRef {
     ///
     /// # Panics
     ///
-    /// Panics if your engine is not configured for async; use
-    /// [`StructRef::new`][crate::StructRef::new] to perform synchronous
-    /// allocation instead.
-    ///
     /// Panics if the allocator, or any of the field values, is not associated
     /// with the given store.
     #[cfg(feature = "async")]
@@ -290,31 +286,12 @@ impl StructRef {
         allocator: &StructRefPre,
         fields: &[Val],
     ) -> Result<Rooted<StructRef>> {
-        assert!(
-            store.async_support(),
-            "use `StructRef::new` with synchronous stores"
-        );
         Self::type_check_fields(store, allocator, fields)?;
         store
             .retry_after_gc_async((), |store, ()| {
                 Self::new_unchecked(store, allocator, fields)
             })
             .await
-    }
-
-    /// Like `Self::new` but caller's must ensure that if the store is
-    /// configured for async, this is only ever called from on a fiber stack.
-    pub(crate) unsafe fn new_maybe_async(
-        store: &mut StoreOpaque,
-        allocator: &StructRefPre,
-        fields: &[Val],
-    ) -> Result<Rooted<StructRef>> {
-        Self::type_check_fields(store, allocator, fields)?;
-        unsafe {
-            store.retry_after_gc_maybe_async((), |store, ()| {
-                Self::new_unchecked(store, allocator, fields)
-            })
-        }
     }
 
     /// Type check the field values before allocating a new struct.

--- a/crates/wasmtime/src/runtime/gc/enabled/structref.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/structref.rs
@@ -280,7 +280,6 @@ impl StructRef {
         Self::_new_async(store.as_context_mut().0, allocator, fields).await
     }
 
-    #[cfg(feature = "async")]
     pub(crate) async fn _new_async(
         store: &mut StoreOpaque,
         allocator: &StructRefPre,

--- a/crates/wasmtime/src/runtime/instance.rs
+++ b/crates/wasmtime/src/runtime/instance.rs
@@ -378,12 +378,15 @@ impl Instance {
             .contains(WasmFeatures::BULK_MEMORY);
 
         if store.async_support() {
+            #[cfg(feature = "async")]
             store.block_on(|store| {
                 let module = compiled_module.module().clone();
                 Box::pin(
                     async move { vm::initialize_instance(store, id, &module, bulk_memory).await },
                 )
             })??;
+            #[cfg(not(feature = "async"))]
+            unreachable!();
         } else {
             vm::assert_ready(vm::initialize_instance(
                 store,

--- a/crates/wasmtime/src/runtime/store/gc.rs
+++ b/crates/wasmtime/src/runtime/store/gc.rs
@@ -197,10 +197,7 @@ impl StoreOpaque {
             },
         }
     }
-}
 
-#[cfg(feature = "async")]
-impl StoreOpaque {
     /// Attempt an allocation, if it fails due to GC OOM, then do a GC and
     /// retry.
     pub(crate) async fn retry_after_gc_async<T, U>(

--- a/crates/wasmtime/src/runtime/vm/instance/allocator.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator.rs
@@ -387,48 +387,28 @@ impl dyn InstanceAllocator + '_ {
         self.increment_core_instance_count()?;
 
         let num_defined_memories = module.num_defined_memories();
+        let mut memories = PrimaryMap::with_capacity(num_defined_memories);
+
         let num_defined_tables = module.num_defined_tables();
+        let mut tables = PrimaryMap::with_capacity(num_defined_tables);
 
-        let mut guard = DeallocateOnDrop {
-            run_deallocate: true,
-            memories: PrimaryMap::with_capacity(num_defined_memories),
-            tables: PrimaryMap::with_capacity(num_defined_tables),
-            allocator: self,
-        };
-
-        self.allocate_memories(&mut request, &mut guard.memories)?;
-        self.allocate_tables(&mut request, &mut guard.tables)?;
-        guard.run_deallocate = false;
-        // SAFETY: memories/tables were just allocated from the store within
-        // `request` and this function's own contract requires that the
-        // imports are valid.
-        return unsafe {
-            Ok(Instance::new(
-                request,
-                mem::take(&mut guard.memories),
-                mem::take(&mut guard.tables),
-                &module.memories,
-            ))
-        };
-
-        struct DeallocateOnDrop<'a> {
-            run_deallocate: bool,
-            memories: PrimaryMap<DefinedMemoryIndex, (MemoryAllocationIndex, Memory)>,
-            tables: PrimaryMap<DefinedTableIndex, (TableAllocationIndex, Table)>,
-            allocator: &'a (dyn InstanceAllocator + 'a),
-        }
-
-        impl Drop for DeallocateOnDrop<'_> {
-            fn drop(&mut self) {
-                if !self.run_deallocate {
-                    return;
-                }
+        match (|| {
+            self.allocate_memories(&mut request, &mut memories)?;
+            self.allocate_tables(&mut request, &mut tables)?;
+            Ok(())
+        })() {
+            // SAFETY: memories/tables were just allocated from the store within
+            // `request` and this function's own contract requires that the
+            // imports are valid.
+            Ok(_) => unsafe { Ok(Instance::new(request, memories, tables, &module.memories)) },
+            Err(e) => {
                 // SAFETY: these were previously allocated by this allocator
                 unsafe {
-                    self.allocator.deallocate_memories(&mut self.memories);
-                    self.allocator.deallocate_tables(&mut self.tables);
+                    self.deallocate_memories(&mut memories);
+                    self.deallocate_tables(&mut tables);
                 }
-                self.allocator.decrement_core_instance_count();
+                self.decrement_core_instance_count();
+                Err(e)
             }
         }
     }
@@ -560,11 +540,9 @@ fn check_table_init_bounds(
 
     for segment in module.table_initialization.segments.iter() {
         let mut context = ConstEvalContext::new(instance);
-        let start = unsafe {
-            const_evaluator
-                .eval(&mut store, &mut context, &segment.offset)
-                .expect("const expression should be valid")
-        };
+        let start = const_evaluator
+            .eval_int(&mut store, &mut context, &segment.offset)
+            .expect("const expression should be valid");
         let start = usize::try_from(start.unwrap_i32().cast_unsigned()).unwrap();
         let end = start.checked_add(usize::try_from(segment.elements.len()).unwrap());
 
@@ -582,7 +560,7 @@ fn check_table_init_bounds(
     Ok(())
 }
 
-fn initialize_tables(
+async fn initialize_tables(
     store: &mut StoreOpaque,
     context: &mut ConstEvalContext,
     const_evaluator: &mut ConstExprEvaluator,
@@ -595,11 +573,10 @@ fn initialize_tables(
             TableInitialValue::Null { precomputed: _ } => {}
 
             TableInitialValue::Expr(expr) => {
-                let init = unsafe {
-                    const_evaluator
-                        .eval(&mut store, context, expr)
-                        .expect("const expression should be valid")
-                };
+                let init = const_evaluator
+                    .eval(&mut store, context, expr)
+                    .await
+                    .expect("const expression should be valid");
                 let idx = module.table_index(table);
                 let id = store.id();
                 let table = store
@@ -619,11 +596,9 @@ fn initialize_tables(
     // iterates over all segments (Segments mode) or leftover
     // segments (FuncTable mode) to initialize.
     for segment in module.table_initialization.segments.iter() {
-        let start = unsafe {
-            const_evaluator
-                .eval(&mut store, context, &segment.offset)
-                .expect("const expression should be valid")
-        };
+        let start = const_evaluator
+            .eval_int(&mut store, context, &segment.offset)
+            .expect("const expression should be valid");
         let start = get_index(
             start,
             store.instance(context.instance).env_module().tables[segment.table_index].idx_type,
@@ -637,7 +612,8 @@ fn initialize_tables(
             start,
             0,
             segment.elements.len(),
-        )?;
+        )
+        .await?;
     }
 
     Ok(())
@@ -658,12 +634,14 @@ fn get_memory_init_start(
     let mut context = ConstEvalContext::new(instance);
     let mut const_evaluator = ConstExprEvaluator::default();
     let mut store = OpaqueRootScope::new(store);
-    unsafe { const_evaluator.eval(&mut store, &mut context, &init.offset) }.map(|v| {
-        get_index(
-            v,
-            store.instance(instance).env_module().memories[init.memory_index].idx_type,
-        )
-    })
+    const_evaluator
+        .eval_int(&mut store, &mut context, &init.offset)
+        .map(|v| {
+            get_index(
+                v,
+                store.instance(instance).env_module().memories[init.memory_index].idx_type,
+            )
+        })
 }
 
 fn check_memory_init_bounds(
@@ -733,7 +711,9 @@ fn initialize_memories(
             expr: &wasmtime_environ::ConstExpr,
         ) -> Option<u64> {
             let mut store = OpaqueRootScope::new(&mut *self.store);
-            let val = unsafe { self.const_evaluator.eval(&mut store, self.context, expr) }
+            let val = self
+                .const_evaluator
+                .eval_int(&mut store, self.context, expr)
                 .expect("const expression should be valid");
             Some(get_index(
                 val,
@@ -803,7 +783,7 @@ fn check_init_bounds(store: &mut StoreOpaque, instance: InstanceId, module: &Mod
     Ok(())
 }
 
-fn initialize_globals(
+async fn initialize_globals(
     store: &mut StoreOpaque,
     context: &mut ConstEvalContext,
     const_evaluator: &mut ConstExprEvaluator,
@@ -817,9 +797,15 @@ fn initialize_globals(
     let mut store = OpaqueRootScope::new(store);
 
     for (index, init) in module.global_initializers.iter() {
-        let val = unsafe {
+        // Attempt a simple, synchronous evaluation before hitting the
+        // general-purpose `.await` point below. This benchmarks ~15% faster in
+        // instantiation vs just falling through to `.await` below.
+        let val = if let Some(val) = const_evaluator.try_simple(init) {
+            val
+        } else {
             const_evaluator
                 .eval(&mut store, context, init)
+                .await
                 .expect("should be a valid const expr")
         };
 
@@ -853,7 +839,7 @@ fn initialize_globals(
     Ok(())
 }
 
-pub fn initialize_instance(
+pub async fn initialize_instance(
     store: &mut StoreOpaque,
     instance: InstanceId,
     module: &Module,
@@ -870,8 +856,8 @@ pub fn initialize_instance(
     let mut context = ConstEvalContext::new(instance);
     let mut const_evaluator = ConstExprEvaluator::default();
 
-    initialize_globals(store, &mut context, &mut const_evaluator, module)?;
-    initialize_tables(store, &mut context, &mut const_evaluator, module)?;
+    initialize_globals(store, &mut context, &mut const_evaluator, module).await?;
+    initialize_tables(store, &mut context, &mut const_evaluator, module).await?;
     initialize_memories(store, &mut context, &mut const_evaluator, &module)?;
 
     Ok(())


### PR DESCRIPTION
This commit is extracted from #11430 to accurately reflect how const-expr evaluation is an async operation due to GC pauses that may happen. The changes in this commit are:

* Const-expr evaluation is, at its core, now an `async` function.
* To leverage this new `async`-ness all internal operations are switched from `*_maybe_async` to `*_async` meaning all the `*_maybe_async` methods can be removed.
* Some libcalls using `*_maybe_async` are switch to using `*_async` plus the `block_on!` utility to help jettison more `*_maybe_async` methods.
* Instance initialization is now an `async` function. This is temporarily handled with `block_on` during instance initialization to avoid propagating the `async`-ness further upwards. This `block_on` will get deleted in future refactorings.
* Const-expr evaluation has been refactored slightly to enable having a fast path in global initialization which skips an `await` point entirely, achieving performance-parity in benchmarks prior to this commit.

This ended up fixing a niche issue with GC where if a wasm execution was suspended during `table.init`, for example, during a const-expr evaluation triggering a GC then if the wasm execution was cancelled it would panic the host. This panic was because the GC operation returned `Result` but it was `unwrap`'d as part of the const-expr evaluation which can fail not only to invalid-ness but also due to "computation is cancelled" traps.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
