### PR TITLE
docs: fix typo

### DIFF
--- a/crates/wasmtime/src/compile.rs
+++ b/crates/wasmtime/src/compile.rs
@@ -538,7 +538,7 @@ ignore this test in Miri with:
 
 If this is not a mistake then try to edit the `pulley_provenance_test` test
 which runs Cranelift outside of Miri. If you still feel this is a mistake then
-please open an issue or a topic on Zulip to talk about how best to accomodate
+please open an issue or a topic on Zulip to talk about how best to accommodate
 the use case.
 "
             );
@@ -629,7 +629,7 @@ the use case.
         // its index in our unlinked outputs.
         //
         // We will generally just be working with `OutputIndex`es, but
-        // occassionally we must translate from these pairs back to our index
+        // occasionally we must translate from these pairs back to our index
         // space, for example when we know that one module's function import is
         // always satisfied with a particular function defined in a particular
         // module. This map enables that translation.

--- a/pulley/src/interp.rs
+++ b/pulley/src/interp.rs
@@ -93,7 +93,7 @@ impl Vm {
         }
     }
 
-    /// Peforms the initial part of [`Vm::call`] in setting up the `args`
+    /// Performs the initial part of [`Vm::call`] in setting up the `args`
     /// provided in registers according to Pulley's ABI.
     ///
     /// # Return
@@ -103,7 +103,7 @@ impl Vm {
     ///
     /// # Unsafety
     ///
-    /// All the same unsafety as `call` and additiionally, you must
+    /// All the same unsafety as `call` and additionally, you must
     /// invoke `call_run` and then `call_end` after calling `call_start`.
     /// If you don't want to wrangle these invocations, use `call` instead
     /// of `call_{start,run,end}`.


### PR DESCRIPTION
accomodate to accommodate
occassionally to occasionally
Peforms to Performs
additiionally to additionally
