### PR TITLE
Add public accessors of sub-contexts of `WasiCtx`

### DIFF
--- a/crates/wasi/src/ctx.rs
+++ b/crates/wasi/src/ctx.rs
@@ -528,4 +528,29 @@ impl WasiCtx {
     pub fn builder() -> WasiCtxBuilder {
         WasiCtxBuilder::new()
     }
+
+    /// Returns access to the underlying [`WasiRandomCtx`].
+    pub fn random(&mut self) -> &mut WasiRandomCtx {
+        &mut self.random
+    }
+
+    /// Returns access to the underlying [`WasiClocksCtx`].
+    pub fn clocks(&mut self) -> &mut WasiClocksCtx {
+        &mut self.clocks
+    }
+
+    /// Returns access to the underlying [`WasiFilesystemCtx`].
+    pub fn filesystem(&mut self) -> &mut WasiFilesystemCtx {
+        &mut self.filesystem
+    }
+
+    /// Returns access to the underlying [`WasiCliCtx`].
+    pub fn cli(&mut self) -> &mut WasiCliCtx {
+        &mut self.cli
+    }
+
+    /// Returns access to the underlying [`WasiSocketsCtx`].
+    pub fn sockets(&mut self) -> &mut WasiSocketsCtx {
+        &mut self.sockets
+    }
 }


### PR DESCRIPTION
This is intended to assist with embedders who aren't necessarily using `WasiView` for everything.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
