### PR TITLE
[36.0.x]: Add public accessors of sub-contexts of `WasiCtx`

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,16 @@
+## 36.0.1
+
+Released 2025-08-20.
+
+### Added
+
+* Accessors for internal WASI-related contexts are added to
+  `wasmtime_wasi::WasiCtx` to account for refactorings that happened in this
+  release.
+  [#11473](https://github.com/bytecodealliance/wasmtime/pull/11473)
+
+--------------------------------------------------------------------------------
+
 ## 36.0.0
 
 Released 2025-08-20.

--- a/crates/wasi/src/ctx.rs
+++ b/crates/wasi/src/ctx.rs
@@ -533,4 +533,24 @@ impl WasiCtx {
     pub fn builder() -> WasiCtxBuilder {
         WasiCtxBuilder::new()
     }
+
+    /// Returns access to the underlying [`WasiRandomCtx`].
+    pub fn random(&mut self) -> &mut WasiRandomCtx {
+        &mut self.random
+    }
+
+    /// Returns access to the underlying [`WasiClocksCtx`].
+    pub fn clocks(&mut self) -> &mut WasiClocksCtx {
+        &mut self.clocks
+    }
+
+    /// Returns access to the underlying [`WasiCliCtx`].
+    pub fn cli(&mut self) -> &mut WasiCliCtx {
+        &mut self.cli
+    }
+
+    /// Returns access to the underlying [`WasiSocketsCtx`].
+    pub fn sockets(&mut self) -> &mut WasiSocketsCtx {
+        &mut self.sockets
+    }
 }


### PR DESCRIPTION
Backport of https://github.com/bytecodealliance/wasmtime/pull/11473 to the 36.0.x release branch which I plan to do a 36.0.1 point release for later today.