### PR TITLE
Update how C API headers are installed

### DIFF
--- a/crates/c-api/CMakeLists.txt
+++ b/crates/c-api/CMakeLists.txt
@@ -109,7 +109,7 @@ set(WASMTIME_HEADER_DST ${CMAKE_BINARY_DIR}/include)
 include(cmake/install-headers.cmake)
 
 include(GNUInstallDirs)
-install(SCRIPT ${CMAKE_CURRENT_SOURCE_DIR}/cmake/install-headers.cmake)
+install(DIRECTORY "${WASMTIME_HEADER_DST}/" TYPE INCLUDE)
 install(FILES ${WASMTIME_SHARED_FILES} ${WASMTIME_STATIC_FILES}
         DESTINATION ${CMAKE_INSTALL_LIBDIR})
 


### PR DESCRIPTION
Currently a script is used which means that at install-time a `*.cmake` script is run. While I thought this inherited CMake configuration options turns out it doesn't so the installed headers don't actually reflect the configured features at build time. This commit changes this to install from the headers-in-the-build-directory which indeed do reflect features.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
