### PR TITLE
Fix C API "min" artifacts

### DIFF
--- a/ci/build-tarballs.sh
+++ b/ci/build-tarballs.sh
@@ -44,6 +44,7 @@ cp LICENSE README.md tmp/$bin_pkgname
 # clashes with the normal builds when the tarballs are unioned together.
 if [[ $build == *-min ]]; then
   min="-min"
+  mkdir tmp/$api_pkgname/min
   cp -r $api_install/include tmp/$api_pkgname/min
   cp -r $api_install/lib tmp/$api_pkgname/min
 else


### PR DESCRIPTION
Fix a bug where the `include` directory wasn't copied over correctly because a `cp -r` command was wrong due to the destination directory not existing. I sure know how to shell.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
