### PR TITLE
Shrink C API release artifacts

### DIFF
--- a/ci/build-release-artifacts.sh
+++ b/ci/build-release-artifacts.sh
@@ -77,6 +77,21 @@ cargo build --release $flags --target $target -p wasmtime-cli $bin_flags --featu
 # a different project that wants to unwind.
 export RUSTFLAGS="$RUSTFLAGS -C force-unwind-tables"
 
+# Shrink the size of `*.a` artifacts without spending too much extra time in CI.
+# See #11476 for some more context. Here Windows builds achieve this with 1 CGU
+# which results in modest size gains, and other platforms use LTO to achieve
+# much more significant size gains. The reason the platforms are different is
+# that CI is extremely slow on Windows, almost 2x slower, so this is an attempt
+# to keep CI cycle time under control.
+case $build in
+  *-mingw* | *-windows*)
+    export CARGO_PROFILE_RELEASE_CODEGEN_UNITS=1
+    ;;
+  *)
+    export CARGO_PROFILE_RELEASE_LTO=true
+    ;;
+esac
+
 mkdir -p target/c-api-build
 cd target/c-api-build
 cmake \


### PR DESCRIPTION
This is needed to currently shrink our `*.a` artifacts under 100M in size which is required downstream in the wasmtime-go embedding. Some testing in #11475 of using full LTO or only building Linux/macOS with 1 CGU shows that this'll likely increase cycle time by ~1 minute. Windows builders are already the slowest release build builders and this is adding 1 minute using 1 CGU vs 2-3 extra minutes for full LTO. Linux/macOS are switched to using full LTO which the CI builders currently have plenty of time for.

This shaves 50M off the C API artifacts for Linux which buys a good amount of headroom for future changes.

Closes #11476

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
