### PR TITLE
[36.0.0] Shrink C API release artifacts 

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,6 +1,6 @@
 ## 36.0.1
 
-Released 2025-08-20.
+Released 2025-08-21.
 
 ### Added
 
@@ -8,6 +8,12 @@ Released 2025-08-20.
   `wasmtime_wasi::WasiCtx` to account for refactorings that happened in this
   release.
   [#11473](https://github.com/bytecodealliance/wasmtime/pull/11473)
+
+### Changed
+
+* Release artifacts for the C API are now smaller than the previous release to
+  assist with redistribution as-is.
+  [#11483](https://github.com/bytecodealliance/wasmtime/pull/11483)
 
 --------------------------------------------------------------------------------
 

--- a/ci/build-release-artifacts.sh
+++ b/ci/build-release-artifacts.sh
@@ -71,6 +71,21 @@ fi
 
 cargo build --release $flags --target $target -p wasmtime-cli $bin_flags --features run
 
+# Shrink the size of `*.a` artifacts without spending too much extra time in CI.
+# See #11476 for some more context. Here Windows builds achieve this with 1 CGU
+# which results in modest size gains, and other platforms use LTO to achieve
+# much more significant size gains. The reason the platforms are different is
+# that CI is extremely slow on Windows, almost 2x slower, so this is an attempt
+# to keep CI cycle time under control.
+case $build in
+  *-mingw* | *-windows*)
+    export CARGO_PROFILE_RELEASE_CODEGEN_UNITS=1
+    ;;
+  *)
+    export CARGO_PROFILE_RELEASE_LTO=true
+    ;;
+esac
+
 mkdir -p target/c-api-build
 cd target/c-api-build
 cmake \


### PR DESCRIPTION
Backport of #11483 plus updating the release notes for a tomorrow-release.