### PR TITLE
docs: fix typo 

### DIFF
--- a/crates/environ/src/component/translate/adapt.rs
+++ b/crates/environ/src/component/translate/adapt.rs
@@ -244,7 +244,7 @@ impl<'data> Translator<'_, 'data> {
             // Record, for each adapter in this adapter module, the module that
             // the adapter was placed within as well as the function index of
             // the adapter in the wasm module generated. Note that adapters are
-            // paritioned in-order so we're guaranteed to push the adapters
+            // partitioned in-order so we're guaranteed to push the adapters
             // in-order here as well. (with an assert to double-check)
             for (adapter, name) in adapter_module.adapters.iter().zip(&names) {
                 let index = translation.module.exports[name];

--- a/examples/min-platform/embedding/src/wasi.rs
+++ b/examples/min-platform/embedding/src/wasi.rs
@@ -43,7 +43,7 @@ use wasmtime_wasi_io::{
 
 /// Unlike super::run, its nice to provide some sort of output showing what the
 /// wasi program did while it executed, so this function reports in out_buf
-/// what stdout/stderr prints occured on success (returns 0), or the error
+/// what stdout/stderr prints occurred on success (returns 0), or the error
 /// message on failure (returns != 0).
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn run_wasi(

--- a/winch/codegen/src/codegen/mod.rs
+++ b/winch/codegen/src/codegen/mod.rs
@@ -850,7 +850,7 @@ where
                         // Similar to the dynamic heap case, even though the
                         // offset and access size are bound through the heap
                         // type, when added they can overflow, resulting in
-                        // an erroneous comparison, therfore we rely on the
+                        // an erroneous comparison, therefore we rely on the
                         // target pointer size.
                         ptr_size,
                     )?;


### PR DESCRIPTION
paritioned to partitioned
occured to occurred
therfore to therefore
