### PR TITLE
Add PoolingAllocatorMetrics

### DIFF
--- a/crates/wasmtime/src/engine.rs
+++ b/crates/wasmtime/src/engine.rs
@@ -720,6 +720,13 @@ impl Engine {
         crate::runtime::vm::tls_eager_initialize();
     }
 
+    /// Returns a [`PoolingAllocatorMetrics`] if this engine was configured with
+    /// [`InstanceAllocationStrategy::Pooling`].
+    #[cfg(feature = "pooling-allocator")]
+    pub fn pooling_allocator_metrics(&self) -> Option<crate::vm::PoolingAllocatorMetrics> {
+        crate::runtime::vm::PoolingAllocatorMetrics::new(self)
+    }
+
     pub(crate) fn allocator(&self) -> &dyn crate::runtime::vm::InstanceAllocator {
         self.inner.allocator.as_ref()
     }

--- a/crates/wasmtime/src/runtime.rs
+++ b/crates/wasmtime/src/runtime.rs
@@ -99,7 +99,7 @@ pub use values::*;
 pub(crate) use uninhabited::*;
 
 #[cfg(feature = "pooling-allocator")]
-pub use vm::PoolConcurrencyLimitError;
+pub use vm::{PoolConcurrencyLimitError, PoolingAllocatorMetrics};
 
 #[cfg(feature = "profiling")]
 mod profiling;

--- a/crates/wasmtime/src/runtime/vm.rs
+++ b/crates/wasmtime/src/runtime/vm.rs
@@ -105,7 +105,7 @@ pub use crate::runtime::vm::instance::{
 };
 #[cfg(feature = "pooling-allocator")]
 pub use crate::runtime::vm::instance::{
-    InstanceLimits, PoolConcurrencyLimitError, PoolingInstanceAllocator,
+    InstanceLimits, PoolConcurrencyLimitError, PoolingAllocatorMetrics, PoolingInstanceAllocator,
     PoolingInstanceAllocatorConfig,
 };
 pub use crate::runtime::vm::interpreter::*;

--- a/crates/wasmtime/src/runtime/vm/instance/allocator.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator.rs
@@ -30,7 +30,7 @@ pub use self::on_demand::OnDemandInstanceAllocator;
 mod pooling;
 #[cfg(feature = "pooling-allocator")]
 pub use self::pooling::{
-    InstanceLimits, PoolConcurrencyLimitError, PoolingInstanceAllocator,
+    InstanceLimits, PoolConcurrencyLimitError, PoolingAllocatorMetrics, PoolingInstanceAllocator,
     PoolingInstanceAllocatorConfig,
 };
 
@@ -286,6 +286,12 @@ pub unsafe trait InstanceAllocator: Send + Sync {
 
     /// Allow access to memory regions protected by any protection key.
     fn allow_all_pkeys(&self);
+
+    /// Returns `Some(&PoolingInstanceAllocator)` if this is one.
+    #[cfg(feature = "pooling-allocator")]
+    fn as_pooling(&self) -> Option<&PoolingInstanceAllocator> {
+        None
+    }
 }
 
 impl dyn InstanceAllocator + '_ {

--- a/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/metrics.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/metrics.rs
@@ -1,0 +1,115 @@
+use core::sync::atomic::Ordering;
+
+use crate::{Engine, vm::PoolingInstanceAllocator};
+
+/// `PoolingAllocatorMetrics` provides access to runtime metrics of a pooling
+/// allocator configured with [`crate::InstanceAllocationStrategy::Pooling`].
+///
+/// This is a cheap cloneable handle which can be obtained with
+/// [`Engine::pooling_allocator_metrics`].
+#[derive(Clone)]
+pub struct PoolingAllocatorMetrics {
+    engine: Engine,
+}
+
+impl PoolingAllocatorMetrics {
+    pub(crate) fn new(engine: &Engine) -> Option<Self> {
+        engine.allocator().as_pooling().map(|_| Self {
+            engine: engine.clone(),
+        })
+    }
+
+    /// Returns the number of core (module) instances currently allocated.
+    pub fn core_instances(&self) -> u64 {
+        self.allocator().live_core_instances.load(Ordering::Relaxed)
+    }
+
+    /// Returns the number of component instances currently allocated.
+    pub fn component_instances(&self) -> u64 {
+        self.allocator()
+            .live_component_instances
+            .load(Ordering::Relaxed)
+    }
+
+    /// Returns the number of WebAssembly memories currently allocated.
+    pub fn memories(&self) -> usize {
+        self.allocator().live_memories.load(Ordering::Relaxed)
+    }
+
+    /// Returns the number of WebAssembly tables currently allocated.
+    pub fn tables(&self) -> usize {
+        self.allocator().live_tables.load(Ordering::Relaxed)
+    }
+
+    fn allocator(&self) -> &PoolingInstanceAllocator {
+        self.engine
+            .allocator()
+            .as_pooling()
+            .expect("engine should have pooling allocator")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        Config, InstanceAllocationStrategy, Store,
+        component::{Component, Linker},
+    };
+
+    use super::*;
+
+    // A component with 1 core instance, 1 memory, 1 table
+    const TEST_COMPONENT: &[u8] = b"
+        (component
+            (core module $m
+                (memory 1)
+                (table 1 funcref)
+            )
+            (core instance (instantiate (module $m)))
+        )
+    ";
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn smoke_test() {
+        // Start with nothing
+        let engine =
+            Engine::new(&Config::new().allocation_strategy(InstanceAllocationStrategy::pooling()))
+                .unwrap();
+        let metrics = engine.pooling_allocator_metrics().unwrap();
+
+        assert_eq!(metrics.core_instances(), 0);
+        assert_eq!(metrics.component_instances(), 0);
+        assert_eq!(metrics.memories(), 0);
+        assert_eq!(metrics.tables(), 0);
+
+        // Instantiate one of each
+        let mut store = Store::new(&engine, ());
+        let component = Component::new(&engine, TEST_COMPONENT).unwrap();
+        let linker = Linker::new(&engine);
+        let instance = linker.instantiate(&mut store, &component).unwrap();
+
+        assert_eq!(metrics.core_instances(), 1);
+        assert_eq!(metrics.component_instances(), 1);
+        assert_eq!(metrics.memories(), 1);
+        assert_eq!(metrics.tables(), 1);
+
+        // Back to nothing
+        let _ = (instance, store);
+
+        assert_eq!(metrics.core_instances(), 0);
+        assert_eq!(metrics.component_instances(), 0);
+        assert_eq!(metrics.memories(), 0);
+        assert_eq!(metrics.tables(), 0);
+    }
+
+    #[test]
+    fn test_non_pooling_allocator() {
+        let engine =
+            Engine::new(&Config::new().allocation_strategy(InstanceAllocationStrategy::OnDemand))
+                .unwrap();
+
+        let maybe_metrics = engine.pooling_allocator_metrics();
+        assert!(maybe_metrics.is_none());
+    }
+}


### PR DESCRIPTION
This exposes some basic runtime metrics derived from the internal state of a `PoolingInstanceAllocator`.

Two new atomics were added to PoolingInstanceAllocator: `live_memories` and `live_tables`. While these counts could be derived from existing state it would require acquiring mutexes on some inner state.

Fixes https://github.com/bytecodealliance/wasmtime/issues/11449
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
