### PR TITLE
docs: fix typo

### DIFF
--- a/crates/cranelift/src/func_environ/gc/enabled.rs
+++ b/crates/cranelift/src/func_environ/gc/enabled.rs
@@ -167,7 +167,7 @@ fn read_field_at_addr(
                 WasmHeapTopType::Cont => {
                     // TODO(#10248) GC integration for stack switching
                     return Err(wasmtime_environ::WasmError::Unsupported(
-                        "Stack switching feature not compatbile with GC, yet".to_string(),
+                        "Stack switching feature not compatible with GC, yet".to_string(),
                     ));
                 }
             },

--- a/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams/buffers.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams/buffers.rs
@@ -57,7 +57,7 @@ mod untyped {
             }
         }
 
-        /// Acquires the underyling `WriteBuffer<T>` this was created with.
+        /// Acquires the underlying `WriteBuffer<T>` this was created with.
         ///
         /// # Panics
         ///

--- a/crates/wasmtime/src/runtime/vm/mmap_vec.rs
+++ b/crates/wasmtime/src/runtime/vm/mmap_vec.rs
@@ -145,7 +145,7 @@ impl MmapVec {
         Ok(result)
     }
 
-    /// Return `true` if the `MmapVec` suport virtual memory operations
+    /// Return `true` if the `MmapVec` support virtual memory operations
     ///
     /// In some cases, such as when using externally owned memory, the underlying
     /// platform may support virtual memory but it still may not be legal


### PR DESCRIPTION
compatbile to compatible
underyling to underlying
suport to support
