### PR TITLE
Support exceptions with Pulley

### DIFF
--- a/crates/test-util/src/wast.rs
+++ b/crates/test-util/src/wast.rs
@@ -322,11 +322,7 @@ impl Compiler {
             }
 
             Compiler::CraneliftPulley => {
-                config.threads()
-                    || config.legacy_exceptions()
-                    // Pulley doesn't yet support exception unwinding.
-                    || config.exceptions()
-                    || config.stack_switching()
+                config.threads() || config.legacy_exceptions() || config.stack_switching()
             }
         }
     }

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -2083,13 +2083,6 @@ impl Config {
                     unsupported |= WasmFeatures::STACK_SWITCHING;
                 }
 
-                // Pulley also doesn't support exceptions, because we
-                // need to refactor the setjmp/longjmp emulation to
-                // also support resuming into Wasm.
-                if self.compiler_target().is_pulley() {
-                    unsupported |= WasmFeatures::EXCEPTIONS;
-                }
-
                 use target_lexicon::*;
                 match self.compiler_target() {
                     Triple {

--- a/crates/wasmtime/src/runtime/vm/interpreter.rs
+++ b/crates/wasmtime/src/runtime/vm/interpreter.rs
@@ -254,7 +254,7 @@ impl InterpreterRef<'_> {
                 DoneReason::CallIndirectHost { id, resume } => {
                     let state = unsafe { self.call_indirect_host(id) };
 
-                    // After the host as finished take a look at what hostcall
+                    // After the host has finished take a look at what hostcall
                     // was just made. The `raise` hostcall gets special
                     // handling for its non-local transfer of control flow,
                     // notably here we see if it's a longjmp or a resume that

--- a/crates/wasmtime/src/runtime/vm/interpreter.rs
+++ b/crates/wasmtime/src/runtime/vm/interpreter.rs
@@ -1,10 +1,11 @@
 use crate::runtime::vm::vmcontext::VMArrayCallNative;
 use crate::runtime::vm::{
     StoreBox, TrapRegisters, TrapTest, VMContext, VMOpaqueContext, f32x4, f64x2, i8x16, tls,
+    traphandlers,
 };
 use crate::{Engine, ValRaw};
 use core::marker;
-use core::ptr::NonNull;
+use core::ptr::{self, NonNull};
 use pulley_interpreter::interp::{DoneReason, RegType, TrapKind, Val, Vm, XRegVal};
 use pulley_interpreter::{FReg, Reg, XReg};
 use wasmtime_environ::{BuiltinFunctionIndex, HostCall, Trap};
@@ -46,14 +47,27 @@ pub struct Interpreter {
     /// carries a borrow of this type to ensure this isn't dropped
     /// independently, and then this file never overwrites this private field to
     /// otherwise guarantee this.
-    pulley: StoreBox<Vm>,
+    pulley: StoreBox<VmState>,
+}
+
+struct VmState {
+    vm: Vm,
+    raise: Option<Raise>,
+}
+
+enum Raise {
+    Longjmp,
+    ResumeToExceptionHandler(usize),
 }
 
 impl Interpreter {
     /// Creates a new interpreter ready to interpret code.
     pub fn new(engine: &Engine) -> Interpreter {
         let ret = Interpreter {
-            pulley: StoreBox::new(Vm::with_stack(engine.config().max_wasm_stack)),
+            pulley: StoreBox::new(VmState {
+                vm: Vm::with_stack(engine.config().max_wasm_stack),
+                raise: None,
+            }),
         };
         engine.profiler().register_interpreter(&ret);
         ret
@@ -69,7 +83,8 @@ impl Interpreter {
     }
 
     pub fn pulley(&self) -> &Vm {
-        unsafe { self.pulley.get().as_ref() }
+        let state = unsafe { self.pulley.get().as_ref() };
+        &state.vm
     }
 
     /// Get an implementation of `Unwind` used to walk the Pulley stack.
@@ -82,8 +97,8 @@ impl Interpreter {
 /// zero-sized structure when pulley is disabled at compile time.
 #[repr(transparent)]
 pub struct InterpreterRef<'a> {
-    vm: NonNull<Vm>,
-    _phantom: marker::PhantomData<&'a mut Vm>,
+    vm: NonNull<VmState>,
+    _phantom: marker::PhantomData<&'a mut VmState>,
 }
 
 /// An implementation of stack-walking details specifically designed
@@ -151,7 +166,7 @@ struct Setjmp {
 }
 
 impl InterpreterRef<'_> {
-    fn vm(&mut self) -> &mut Vm {
+    fn vm_state(&mut self) -> &mut VmState {
         // SAFETY: This is a bit of a tricky code. The safety here is isolated
         // to this file, but not isolated to just this function call.
         //
@@ -177,6 +192,10 @@ impl InterpreterRef<'_> {
         // calls the interpreter needs to be re-borrowed as the state may have
         // changed as part of the dynamic host call.
         unsafe { self.vm.as_mut() }
+    }
+
+    fn vm(&mut self) -> &mut Vm {
+        &mut self.vm_state().vm
     }
 
     /// Invokes interpreted code.
@@ -208,6 +227,7 @@ impl InterpreterRef<'_> {
         // See more comments in `trap` below about how this isn't actually
         // correct as it's not saving all callee-save state.
         let setjmp = setjmp(vm);
+        traphandlers::set_jmp_buf((&raw const setjmp).cast());
 
         let old_lr = unsafe { vm.call_start(&args) };
 
@@ -228,19 +248,38 @@ impl InterpreterRef<'_> {
                     }
                 }
                 // If the VM wants to call out to the host then dispatch that
-                // here based on `sig`. Once that returns we can resume
+                // here based on `id`. Once that returns we typically resume
                 // execution at `resume`.
-                //
-                // Note that the `raise` libcall is handled specially here since
-                // longjmp/setjmp is handled differently than on the host.
                 DoneReason::CallIndirectHost { id, resume } => {
+                    let state = unsafe { self.call_indirect_host(id) };
+
+                    // After the host as finished take a look at what hostcall
+                    // was just made. The `raise` hostcall gets special
+                    // handling for its non-local transfer of control flow,
+                    // notably here we see if it's a longjmp or a resume that
+                    // just happened. For a longjmp we exit the interpreter loop
+                    // here entirely, and for raise we update to the specified
+                    // bytecode pointer.
+                    //
+                    // Also note that for non-`raise` hostcalls the
+                    // `state.raise` value should always be `None`.
                     if u32::from(id) == HostCall::Builtin(BuiltinFunctionIndex::raise()).index() {
-                        longjmp(vm, setjmp);
-                        break false;
+                        let raise = state.raise.take().unwrap();
+                        match raise {
+                            Raise::Longjmp => {
+                                vm = &mut state.vm;
+                                break false;
+                            }
+                            Raise::ResumeToExceptionHandler(pc) => {
+                                let pc = ptr::with_exposed_provenance_mut(pc);
+                                bytecode = NonNull::new(pc).unwrap();
+                            }
+                        }
                     } else {
-                        vm = unsafe { self.call_indirect_host(id) };
+                        debug_assert!(state.raise.is_none());
                         bytecode = resume;
                     }
+                    vm = &mut state.vm;
                 }
                 // If the VM trapped then process that here and return `false`.
                 DoneReason::Trap { pc, kind } => {
@@ -260,6 +299,11 @@ impl InterpreterRef<'_> {
             assert!(vm.fp() == setjmp.fp);
             assert!(vm.lr() == setjmp.lr);
         }
+
+        // Keep `setjmp` accessible on this stack frame statically as it's
+        // handed out via `set_jmp_buf` above to `CallThreadState`.
+        let _ = &setjmp;
+
         ret
     }
 
@@ -275,7 +319,7 @@ impl InterpreterRef<'_> {
         not(feature = "component-model"),
         expect(unused_macro_rules, reason = "macro-code")
     )]
-    unsafe fn call_indirect_host(&mut self, id: u8) -> &mut Vm {
+    unsafe fn call_indirect_host(&mut self, id: u8) -> &mut VmState {
         let id = u32::from(id);
         let fnptr = self.vm()[XReg::x0].get_ptr();
         let mut arg_reg = 1;
@@ -316,17 +360,18 @@ impl InterpreterRef<'_> {
                 };
                 let _ = arg_reg; // silence last dead arg_reg increment warning
 
-                let vm = self.vm();
+                let state = self.vm_state();
+                let _vm = &mut state.vm;
 
                 // Store the return value, if one is here, in x0.
                 $(
-                    call!(@set $result ret => vm[XReg::x0]);
+                    call!(@set $result ret => _vm[XReg::x0]);
                 )?
                 let _ = ret; // silence warning if no return value
 
                 // Return from the outer `call_indirect_host` host function as
                 // it's been processed.
-                return vm;
+                return state;
             }};
 
             // Conversion from macro-defined types to Rust host types.
@@ -450,6 +495,54 @@ impl InterpreterRef<'_> {
         fn unreachable<T, U>(_: U) -> T {
             unreachable!()
         }
+    }
+
+    /// Executes a `longjmp` from the `raise` hostcall.
+    ///
+    /// Assume that `jmp_buf` is a `Setjmp` and executes a Pulley-defined
+    /// longjmp as a result.
+    ///
+    /// # Safety
+    ///
+    /// Requires that `jmp_buf` is valid, it's a `Setjmp`, and it's valid to
+    /// jump to.
+    pub unsafe fn longjmp(mut self, jmp_buf: *const u8) {
+        unsafe {
+            longjmp(self.vm(), *jmp_buf.cast::<Setjmp>());
+        }
+        let state = self.vm_state();
+        debug_assert!(state.raise.is_none());
+        self.vm_state().raise = Some(Raise::Longjmp);
+    }
+
+    /// Configures Pulley to be able to resume to the specified exception
+    /// handler.
+    ///
+    /// This is executed from a `raise` hostcall when an exception is being
+    /// raised.
+    ///
+    /// # Safety
+    ///
+    /// Requires that all the parameters here are valid and will leave Pulley
+    /// in a valid state for executing.
+    pub unsafe fn resume_to_exception_handler(
+        mut self,
+        pc: usize,
+        sp: usize,
+        fp: usize,
+        payload1: usize,
+        payload2: usize,
+    ) {
+        unsafe {
+            let vm = self.vm();
+            vm[XReg::x0].set_u64(payload1 as u64);
+            vm[XReg::x1].set_u64(payload2 as u64);
+            vm[XReg::sp].set_ptr(ptr::with_exposed_provenance_mut::<u8>(sp));
+            vm.set_fp(ptr::with_exposed_provenance_mut(fp));
+        }
+        let state = self.vm_state();
+        debug_assert!(state.raise.is_none());
+        self.vm_state().raise = Some(Raise::ResumeToExceptionHandler(pc));
     }
 }
 

--- a/crates/wasmtime/src/runtime/vm/interpreter_disabled.rs
+++ b/crates/wasmtime/src/runtime/vm/interpreter_disabled.rs
@@ -5,7 +5,7 @@
 //! having these structures plumbed around.
 
 use crate::runtime::Uninhabited;
-use crate::runtime::vm::{VMContext, VMOpaqueContext};
+use crate::runtime::vm::{VMContext, VMOpaqueContext, traphandlers};
 use crate::{Engine, ValRaw};
 use core::marker;
 use core::mem;
@@ -49,6 +49,24 @@ impl InterpreterRef<'_> {
         _caller: NonNull<VMContext>,
         _args_and_results: NonNull<[ValRaw]>,
     ) -> bool {
+        match self.empty {}
+    }
+
+    pub(crate) unsafe fn longjmp(self, jmp_buf: *const u8) {
+        // just consider this function used
+        traphandlers::set_jmp_buf(jmp_buf);
+        match self.empty {}
+    }
+
+    #[cfg(feature = "gc")]
+    pub(crate) unsafe fn resume_to_exception_handler(
+        self,
+        _pc: usize,
+        _sp: usize,
+        _fp: usize,
+        _payload1: usize,
+        _payload2: usize,
+    ) {
         match self.empty {}
     }
 }

--- a/crates/wasmtime/src/runtime/vm/libcalls.rs
+++ b/crates/wasmtime/src/runtime/vm/libcalls.rs
@@ -1665,18 +1665,7 @@ fn raise(store: &mut dyn VMStore, _instance: Pin<&mut Instance>) {
     // SAFETY: this is only called from compiled wasm so we know that wasm has
     // already been entered. It's a dynamic safety precondition that the trap
     // information has already been arranged to be present.
-    #[cfg(has_host_compiler_backend)]
-    unsafe {
-        crate::runtime::vm::traphandlers::raise_preexisting_trap(store)
-    }
-
-    // When Cranelift isn't in use then this is an unused libcall for Pulley, so
-    // just insert a stub to catch bugs if it's accidentally called.
-    #[cfg(not(has_host_compiler_backend))]
-    {
-        let _ = store;
-        unreachable!()
-    }
+    unsafe { crate::runtime::vm::traphandlers::raise_preexisting_trap(store) }
 }
 
 // Builtins for continuations. These are thin wrappers around the

--- a/crates/wasmtime/src/runtime/vm/traphandlers.rs
+++ b/crates/wasmtime/src/runtime/vm/traphandlers.rs
@@ -446,7 +446,7 @@ where
 
     let result = CallThreadState::new(store.0, old_state).with(|cx| match store.0.executor() {
         // In interpreted mode directly invoke the host closure since we won't
-        // be using host-based `etjmp`/`longjmp` as that's not going to save
+        // be using host-based `setjmp`/`longjmp` as that's not going to save
         // the context we want.
         ExecutorRef::Interpreter(r) => {
             cx.jmp_buf

--- a/crates/wasmtime/src/runtime/vm/traphandlers.rs
+++ b/crates/wasmtime/src/runtime/vm/traphandlers.rs
@@ -946,8 +946,6 @@ impl CallThreadState {
                 ExecutorRef::Interpreter(r) => {
                     r.resume_to_exception_handler(pc, sp, fp, payload1, payload2)
                 }
-
-                // TODO
                 #[cfg(has_host_compiler_backend)]
                 ExecutorRef::Native => {
                     wasmtime_unwinder::resume_to_exception_handler(pc, sp, fp, payload1, payload2)

--- a/crates/wasmtime/src/runtime/vm/traphandlers.rs
+++ b/crates/wasmtime/src/runtime/vm/traphandlers.rs
@@ -932,6 +932,7 @@ impl CallThreadState {
         }
     }
 
+    #[cfg(feature = "gc")]
     unsafe fn resume_to_exception_handler(
         &self,
         executor: ExecutorRef<'_>,

--- a/docs/stability-tiers.md
+++ b/docs/stability-tiers.md
@@ -334,7 +334,7 @@ emitting Pulley bytecode.
 | [`gc`]                                  | ✅        | ❌     |
 | [`wide-arithmetic`]                     | ✅        | ❌     |
 | [`custom-page-sizes`]                   | ✅        | ❌     |
-| [`exception-handling`]                  | 🚧        | ❌     |
+| [`exception-handling`]                  | ✅        | ❌     |
 | [`stack-switching`]                     | ❌        | ❌     |
 
 [^a]: Winch supports some features of the [`reference-types`] proposal such as

--- a/tests/all/exceptions.rs
+++ b/tests/all/exceptions.rs
@@ -2,6 +2,7 @@ use wasmtime::*;
 use wasmtime_test_macros::wasmtime_test;
 
 #[wasmtime_test(wasm_features(exceptions))]
+#[cfg_attr(miri, ignore)]
 fn basic_throw(config: &mut Config) -> Result<()> {
     let engine = Engine::new(config)?;
     let mut store = Store::new(&engine, ());
@@ -37,6 +38,7 @@ fn basic_throw(config: &mut Config) -> Result<()> {
 }
 
 #[wasmtime_test(wasm_features(exceptions))]
+#[cfg_attr(miri, ignore)]
 fn dynamic_tags(config: &mut Config) -> Result<()> {
     let engine = Engine::new(config)?;
     let mut store = Store::new(&engine, ());
@@ -96,6 +98,7 @@ fn dynamic_tags(config: &mut Config) -> Result<()> {
 }
 
 #[wasmtime_test(wasm_features(exceptions))]
+#[cfg_attr(miri, ignore)]
 fn exception_escape_to_host(config: &mut Config) -> Result<()> {
     let engine = Engine::new(config)?;
     let mut store = Store::new(&engine, ());
@@ -128,6 +131,7 @@ fn exception_escape_to_host(config: &mut Config) -> Result<()> {
 }
 
 #[wasmtime_test(wasm_features(exceptions))]
+#[cfg_attr(miri, ignore)]
 fn exception_from_host(config: &mut Config) -> Result<()> {
     let engine = Engine::new(config)?;
     let mut store = Store::new(&engine, ());


### PR DESCRIPTION
This implements Chris's suggestion to avoid special-casing the `raise` libcall and instead let it fully execute for Pulley. The switch of whether to do a native longjmp or a Pulley longjmp is done based on the interpreter state of Wasmtime's configured executor.

Closes #11486


<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
