### PR TITLE
Make core wasm libcalls sound

### DIFF
--- a/crates/wasmtime/src/runtime/func.rs
+++ b/crates/wasmtime/src/runtime/func.rs
@@ -2403,7 +2403,7 @@ impl HostContext {
         unsafe {
             vm::Instance::enter_host_from_wasm(caller_vmctx, |store, instance| {
                 let store = store.unchecked_context_mut();
-                Caller::with(store, instance.id(), run)
+                Caller::with(store, instance, run)
             })
         }
     }

--- a/crates/wasmtime/src/runtime/trampoline/func.rs
+++ b/crates/wasmtime/src/runtime/trampoline/func.rs
@@ -42,7 +42,6 @@ where
     // unsafe operations are commented below.
     unsafe {
         Instance::enter_host_from_wasm(caller_vmctx, |store, instance| {
-            let instance = instance.id();
             // SAFETY: this function itself requires that the `vmctx` is valid to
             // use here.
             let state = {

--- a/crates/wasmtime/src/runtime/vm/debug_builtins.rs
+++ b/crates/wasmtime/src/runtime/vm/debug_builtins.rs
@@ -18,7 +18,8 @@ pub unsafe extern "C" fn resolve_vmctx_memory_ptr(p: *const u32) -> *const u8 {
             VMCTX_AND_MEMORY.0 != NonNull::dangling(),
             "must call `__vmctx->set()` before resolving Wasm pointers"
         );
-        Instance::enter_host_from_wasm(VMCTX_AND_MEMORY.0, |_store, handle| {
+        Instance::enter_host_from_wasm(VMCTX_AND_MEMORY.0, |store, instance| {
+            let handle = store.instance_mut(instance);
             assert!(
                 VMCTX_AND_MEMORY.1 < handle.env_module().memories.len(),
                 "memory index for debugger is out of bounds"

--- a/crates/wasmtime/src/runtime/vm/libcalls.rs
+++ b/crates/wasmtime/src/runtime/vm/libcalls.rs
@@ -1308,7 +1308,8 @@ unsafe impl HostResultHasUnwindSentinel for NextEpoch {
 
 // Hook for validating malloc using wmemcheck_state.
 #[cfg(feature = "wmemcheck")]
-fn check_malloc(_store: &mut dyn VMStore, instance: InstanceId, addr: u32, len: u32) -> Result<()> {
+fn check_malloc(store: &mut dyn VMStore, instance: InstanceId, addr: u32, len: u32) -> Result<()> {
+    let instance = store.instance_mut(instance);
     if let Some(wmemcheck_state) = instance.wmemcheck_state_mut() {
         let result = wmemcheck_state.malloc(addr as usize, len as usize);
         wmemcheck_state.memcheck_on();
@@ -1330,7 +1331,8 @@ fn check_malloc(_store: &mut dyn VMStore, instance: InstanceId, addr: u32, len: 
 
 // Hook for validating free using wmemcheck_state.
 #[cfg(feature = "wmemcheck")]
-fn check_free(_store: &mut dyn VMStore, instance: InstanceId, addr: u32) -> Result<()> {
+fn check_free(store: &mut dyn VMStore, instance: InstanceId, addr: u32) -> Result<()> {
+    let instance = store.instance_mut(instance);
     if let Some(wmemcheck_state) = instance.wmemcheck_state_mut() {
         let result = wmemcheck_state.free(addr as usize);
         wmemcheck_state.memcheck_on();
@@ -1350,12 +1352,13 @@ fn check_free(_store: &mut dyn VMStore, instance: InstanceId, addr: u32) -> Resu
 // Hook for validating load using wmemcheck_state.
 #[cfg(feature = "wmemcheck")]
 fn check_load(
-    _store: &mut dyn VMStore,
+    store: &mut dyn VMStore,
     instance: InstanceId,
     num_bytes: u32,
     addr: u32,
     offset: u32,
 ) -> Result<()> {
+    let instance = store.instance_mut(instance);
     if let Some(wmemcheck_state) = instance.wmemcheck_state_mut() {
         let result = wmemcheck_state.read(addr as usize + offset as usize, num_bytes as usize);
         match result {
@@ -1377,12 +1380,13 @@ fn check_load(
 // Hook for validating store using wmemcheck_state.
 #[cfg(feature = "wmemcheck")]
 fn check_store(
-    _store: &mut dyn VMStore,
+    store: &mut dyn VMStore,
     instance: InstanceId,
     num_bytes: u32,
     addr: u32,
     offset: u32,
 ) -> Result<()> {
+    let instance = store.instance_mut(instance);
     if let Some(wmemcheck_state) = instance.wmemcheck_state_mut() {
         let result = wmemcheck_state.write(addr as usize + offset as usize, num_bytes as usize);
         match result {
@@ -1403,7 +1407,8 @@ fn check_store(
 
 // Hook for turning wmemcheck load/store validation off when entering a malloc function.
 #[cfg(feature = "wmemcheck")]
-fn malloc_start(_store: &mut dyn VMStore, instance: InstanceId) {
+fn malloc_start(store: &mut dyn VMStore, instance: InstanceId) {
+    let instance = store.instance_mut(instance);
     if let Some(wmemcheck_state) = instance.wmemcheck_state_mut() {
         wmemcheck_state.memcheck_off();
     }
@@ -1411,7 +1416,8 @@ fn malloc_start(_store: &mut dyn VMStore, instance: InstanceId) {
 
 // Hook for turning wmemcheck load/store validation off when entering a free function.
 #[cfg(feature = "wmemcheck")]
-fn free_start(_store: &mut dyn VMStore, instance: InstanceId) {
+fn free_start(store: &mut dyn VMStore, instance: InstanceId) {
+    let instance = store.instance_mut(instance);
     if let Some(wmemcheck_state) = instance.wmemcheck_state_mut() {
         wmemcheck_state.memcheck_off();
     }
@@ -1430,7 +1436,8 @@ fn update_stack_pointer(_store: &mut dyn VMStore, _instance: InstanceId, _value:
 
 // Hook updating wmemcheck_state memory state vector every time memory.grow is called.
 #[cfg(feature = "wmemcheck")]
-fn update_mem_size(_store: &mut dyn VMStore, instance: InstanceId, num_pages: u32) {
+fn update_mem_size(store: &mut dyn VMStore, instance: InstanceId, num_pages: u32) {
+    let instance = store.instance_mut(instance);
     if let Some(wmemcheck_state) = instance.wmemcheck_state_mut() {
         const KIB: usize = 1024;
         let num_bytes = num_pages as usize * 64 * KIB;

--- a/crates/wasmtime/src/runtime/vm/stack_switching.rs
+++ b/crates/wasmtime/src/runtime/vm/stack_switching.rs
@@ -302,11 +302,12 @@ unsafe impl Sync for VMContRef {}
 #[inline(always)]
 pub fn cont_new(
     store: &mut dyn crate::vm::VMStore,
-    instance: core::pin::Pin<&mut crate::vm::Instance>,
+    instance: crate::store::InstanceId,
     func: *mut u8,
     param_count: u32,
     result_count: u32,
 ) -> anyhow::Result<*mut VMContRef> {
+    let instance = store.instance_mut(instance);
     let caller_vmctx = instance.vmctx();
 
     let stack_size = store.engine().config().async_stack_size;


### PR DESCRIPTION
This commit updates the signature of core wasm libcalls to look more like component libcalls where the instance argument is just an id, not an actual pointer. This is required to make them sound because otherwise it's possible to, in safe Rust, acquire two mutable pointers to the same instance. Implementing this change is made possible by the many many previous refactors to how all of these internals work. All that was required here was changing type signatures and minor updates to the order of operations inside of libcalls.

Closes #11178

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
