### PR TITLE
Renew expiring cargo vet audits

### DIFF
--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -6,7 +6,7 @@ who = "Nick Fitzgerald <fitzgen@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 696 # Nick Fitzgerald (fitzgen)
 start = "2020-01-14"
-end = "2025-07-30"
+end = "2026-08-21"
 notes = "I am an author of this crate."
 
 [[wildcard-audits.bumpalo]]
@@ -14,14 +14,14 @@ who = "Nick Fitzgerald <fitzgen@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 696 # Nick Fitzgerald (fitzgen)
 start = "2019-03-16"
-end = "2025-07-30"
+end = "2026-08-21"
 
 [[wildcard-audits.cranelift]]
 who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
 start = "2021-10-29"
-end = "2025-07-30"
+end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.cranelift-assembler-x64]]
@@ -45,7 +45,15 @@ who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
 start = "2021-10-29"
-end = "2025-07-30"
+end = "2026-08-21"
+notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.cranelift-bitset]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2025-04-21"
+end = "2026-04-21"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.cranelift-codegen]]
@@ -53,7 +61,7 @@ who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
 start = "2021-10-29"
-end = "2025-07-30"
+end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.cranelift-codegen-meta]]
@@ -61,7 +69,7 @@ who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
 start = "2021-10-29"
-end = "2025-07-30"
+end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.cranelift-codegen-shared]]
@@ -69,7 +77,7 @@ who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
 start = "2021-10-29"
-end = "2025-07-30"
+end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.cranelift-control]]
@@ -77,7 +85,7 @@ who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
 start = "2023-05-22"
-end = "2025-07-30"
+end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.cranelift-entity]]
@@ -85,7 +93,7 @@ who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
 start = "2021-10-29"
-end = "2025-07-30"
+end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.cranelift-frontend]]
@@ -93,7 +101,7 @@ who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
 start = "2021-10-29"
-end = "2025-07-30"
+end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.cranelift-interpreter]]
@@ -101,7 +109,7 @@ who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
 start = "2021-10-29"
-end = "2025-07-30"
+end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.cranelift-isle]]
@@ -109,7 +117,7 @@ who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
 start = "2021-12-13"
-end = "2025-07-30"
+end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.cranelift-jit]]
@@ -117,7 +125,7 @@ who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
 start = "2021-10-29"
-end = "2025-07-30"
+end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.cranelift-module]]
@@ -125,7 +133,7 @@ who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
 start = "2021-10-29"
-end = "2025-07-30"
+end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.cranelift-native]]
@@ -133,7 +141,7 @@ who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
 start = "2021-10-29"
-end = "2025-07-30"
+end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.cranelift-object]]
@@ -141,7 +149,7 @@ who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
 start = "2021-10-29"
-end = "2025-07-30"
+end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.cranelift-reader]]
@@ -149,7 +157,7 @@ who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
 start = "2021-10-29"
-end = "2025-07-30"
+end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.cranelift-serde]]
@@ -157,7 +165,7 @@ who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
 start = "2021-10-29"
-end = "2025-07-30"
+end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.cranelift-srcgen]]
@@ -173,7 +181,7 @@ who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
 start = "2021-10-29"
-end = "2025-07-30"
+end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.derive_arbitrary]]
@@ -181,7 +189,7 @@ who = "Nick Fitzgerald <fitzgen@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 696 # Nick Fitzgerald (fitzgen)
 start = "2020-01-14"
-end = "2025-07-30"
+end = "2026-08-21"
 notes = "I am an author of this crate"
 
 [[wildcard-audits.json-from-wast]]
@@ -199,7 +207,7 @@ who = "Nick Fitzgerald <fitzgen@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 696 # Nick Fitzgerald (fitzgen)
 start = "2019-03-16"
-end = "2025-07-30"
+end = "2026-08-21"
 notes = """
 I am the author of this crate.
 """
@@ -209,7 +217,7 @@ who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
 start = "2024-09-20"
-end = "2025-09-25"
+end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.regalloc2]]
@@ -217,7 +225,7 @@ who = "Chris Fallin <chris@cfallin.org>"
 criteria = "safe-to-deploy"
 user-id = 3726 # Chris Fallin (cfallin)
 start = "2021-12-03"
-end = "2025-07-30"
+end = "2026-08-21"
 notes = "We (Bytecode Alliance) are the primary authors of regalloc2 and co-develop it with Cranelift/Wasmtime, with the same code-review, testing/fuzzing, and security standards."
 
 [[wildcard-audits.regalloc2]]
@@ -225,7 +233,7 @@ who = "Trevor Elliott <telliott@fastly.com>"
 criteria = "safe-to-deploy"
 user-id = 187138
 start = "2022-11-29"
-end = "2025-07-30"
+end = "2026-08-21"
 notes = """
 This is a Bytecode Alliance authored crate maintained in the `regalloc2`
 repository of which I'm one of the maintainers and publishers for. I am employed
@@ -238,7 +246,7 @@ who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
 start = "2021-10-29"
-end = "2025-07-30"
+end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.wasi-common]]
@@ -246,7 +254,7 @@ who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
 start = "2021-10-29"
-end = "2025-07-30"
+end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.wasi-tokio]]
@@ -254,7 +262,7 @@ who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
 start = "2021-10-29"
-end = "2025-07-30"
+end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.wasm-compose]]
@@ -272,7 +280,7 @@ who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
 user-id = 1 # Alex Crichton (alexcrichton)
 start = "2020-12-11"
-end = "2025-07-30"
+end = "2026-08-21"
 notes = """
 This is a Bytecode Alliance authored crate maintained in the `wasm-tools`
 repository of which I'm one of the primary maintainers and publishers for.
@@ -297,7 +305,7 @@ who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
 user-id = 1 # Alex Crichton (alexcrichton)
 start = "2020-12-11"
-end = "2025-07-30"
+end = "2026-08-21"
 notes = """
 This is a Bytecode Alliance authored crate maintained in the `wasm-tools`
 repository of which I'm one of the primary maintainers and publishers for.
@@ -322,7 +330,7 @@ who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
 user-id = 1 # Alex Crichton (alexcrichton)
 start = "2022-01-05"
-end = "2025-07-30"
+end = "2026-08-21"
 notes = """
 This is a Bytecode Alliance authored crate maintained in the `wasm-tools`
 repository of which I'm one of the primary maintainers and publishers for.
@@ -335,14 +343,14 @@ who = "Nick Fitzgerald <fitzgen@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 696 # Nick Fitzgerald (fitzgen)
 start = "2022-02-17"
-end = "2025-07-30"
+end = "2026-08-21"
 
 [[wildcard-audits.wasm-smith]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
 user-id = 1 # Alex Crichton (alexcrichton)
 start = "2020-09-03"
-end = "2025-07-30"
+end = "2026-08-21"
 notes = """
 This is a Bytecode Alliance authored crate maintained in the `wasm-tools`
 repository of which I'm one of the primary maintainers and publishers for.
@@ -355,7 +363,7 @@ who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
 user-id = 1 # Alex Crichton (alexcrichton)
 start = "2020-07-13"
-end = "2025-07-30"
+end = "2026-08-21"
 notes = """
 This is a Bytecode Alliance authored crate maintained in the `wasm-tools`
 repository of which I'm one of the primary maintainers and publishers for.
@@ -380,7 +388,7 @@ who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
 user-id = 1 # Alex Crichton (alexcrichton)
 start = "2019-11-18"
-end = "2025-07-30"
+end = "2026-08-21"
 notes = """
 This is a Bytecode Alliance authored crate maintained in the `wasm-tools`
 repository of which I'm one of the primary maintainers and publishers for.
@@ -405,14 +413,14 @@ who = "Nick Fitzgerald <fitzgen@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 696 # Nick Fitzgerald (fitzgen)
 start = "2021-04-28"
-end = "2025-07-30"
+end = "2026-08-21"
 
 [[wildcard-audits.wasmtime]]
 who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
 start = "2021-10-29"
-end = "2025-07-30"
+end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.wasmtime-asm-macros]]
@@ -420,7 +428,7 @@ who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
 start = "2022-08-22"
-end = "2025-07-30"
+end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.wasmtime-c-api-impl]]
@@ -444,7 +452,7 @@ who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
 start = "2021-10-29"
-end = "2025-07-30"
+end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.wasmtime-cli]]
@@ -452,7 +460,7 @@ who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
 start = "2021-10-29"
-end = "2025-07-30"
+end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.wasmtime-cli-flags]]
@@ -460,7 +468,7 @@ who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
 start = "2022-05-20"
-end = "2025-07-30"
+end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.wasmtime-component-macro]]
@@ -468,7 +476,7 @@ who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
 start = "2022-07-20"
-end = "2025-07-30"
+end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.wasmtime-component-util]]
@@ -476,7 +484,7 @@ who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
 start = "2022-08-22"
-end = "2025-07-30"
+end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.wasmtime-cranelift]]
@@ -484,7 +492,7 @@ who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
 start = "2021-10-29"
-end = "2025-07-30"
+end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.wasmtime-cranelift-shared]]
@@ -492,7 +500,7 @@ who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
 start = "2023-04-20"
-end = "2025-07-30"
+end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.wasmtime-environ]]
@@ -500,7 +508,7 @@ who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
 start = "2021-10-29"
-end = "2025-07-30"
+end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.wasmtime-explorer]]
@@ -508,7 +516,7 @@ who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
 start = "2023-04-20"
-end = "2025-07-30"
+end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.wasmtime-fiber]]
@@ -516,7 +524,7 @@ who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
 start = "2021-10-29"
-end = "2025-07-30"
+end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.wasmtime-internal-asm-macros]]
@@ -700,7 +708,7 @@ who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
 start = "2021-10-29"
-end = "2025-07-30"
+end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.wasmtime-jit-debug]]
@@ -708,7 +716,7 @@ who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
 start = "2022-03-07"
-end = "2025-07-30"
+end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.wasmtime-jit-icache-coherence]]
@@ -716,7 +724,7 @@ who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
 start = "2022-11-21"
-end = "2025-07-30"
+end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.wasmtime-math]]
@@ -732,7 +740,7 @@ who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
 start = "2021-10-29"
-end = "2025-07-30"
+end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.wasmtime-slab]]
@@ -752,7 +760,7 @@ who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
 start = "2021-10-29"
-end = "2025-07-30"
+end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.wasmtime-wasi]]
@@ -760,7 +768,7 @@ who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
 start = "2021-10-29"
-end = "2025-07-30"
+end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.wasmtime-wasi-config]]
@@ -768,7 +776,7 @@ who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
 start = "2021-10-29"
-end = "2025-07-30"
+end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.wasmtime-wasi-crypto]]
@@ -776,7 +784,7 @@ who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
 start = "2021-10-29"
-end = "2025-07-30"
+end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.wasmtime-wasi-http]]
@@ -784,7 +792,7 @@ who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
 start = "2023-05-22"
-end = "2025-07-30"
+end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.wasmtime-wasi-io]]
@@ -800,7 +808,7 @@ who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
 start = "2021-10-29"
-end = "2025-07-30"
+end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.wasmtime-wasi-nn]]
@@ -808,7 +816,7 @@ who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
 start = "2021-10-29"
-end = "2025-07-30"
+end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.wasmtime-wasi-runtime-config]]
@@ -816,7 +824,7 @@ who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
 start = "2021-10-29"
-end = "2025-07-30"
+end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.wasmtime-wasi-threads]]
@@ -824,7 +832,7 @@ who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
 start = "2023-03-20"
-end = "2025-07-30"
+end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.wasmtime-wasi-tls]]
@@ -856,7 +864,7 @@ who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
 start = "2021-10-29"
-end = "2025-07-30"
+end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.wasmtime-winch]]
@@ -864,7 +872,7 @@ who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
 start = "2022-11-21"
-end = "2025-07-30"
+end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.wasmtime-wit-bindgen]]
@@ -872,7 +880,7 @@ who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
 start = "2023-01-20"
-end = "2025-07-30"
+end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.wasmtime-wmemcheck]]
@@ -880,7 +888,7 @@ who = "Pat Hickey <pat@moreproductive.org>"
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
 start = "2022-11-27"
-end = "2025-07-30"
+end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.wast]]
@@ -888,7 +896,7 @@ who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
 user-id = 1 # Alex Crichton (alexcrichton)
 start = "2019-10-16"
-end = "2025-07-30"
+end = "2026-08-21"
 notes = """
 This is a Bytecode Alliance authored crate maintained in the `wasm-tools`
 repository of which I'm one of the primary maintainers and publishers for.
@@ -913,7 +921,7 @@ who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
 user-id = 1 # Alex Crichton (alexcrichton)
 start = "2019-10-18"
-end = "2025-07-30"
+end = "2026-08-21"
 notes = """
 This is a Bytecode Alliance authored crate maintained in the `wasm-tools`
 repository of which I'm one of the primary maintainers and publishers for.
@@ -938,7 +946,7 @@ who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
 start = "2021-10-29"
-end = "2025-07-30"
+end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.wiggle-generate]]
@@ -946,7 +954,7 @@ who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
 start = "2021-10-29"
-end = "2025-07-30"
+end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.wiggle-macro]]
@@ -954,7 +962,7 @@ who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
 start = "2021-10-29"
-end = "2025-07-30"
+end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.wiggle-test]]
@@ -970,7 +978,7 @@ who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
 start = "2022-11-21"
-end = "2025-07-30"
+end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.wit-bindgen]]
@@ -978,7 +986,7 @@ who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
 user-id = 1 # Alex Crichton (alexcrichton)
 start = "2020-12-11"
-end = "2025-07-30"
+end = "2026-08-21"
 notes = """
 This is a Bytecode Alliance authored crate maintained in the `wit-bindgen`
 repository of which I'm one of the primary maintainers and publishers for.
@@ -1003,7 +1011,7 @@ who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
 user-id = 1 # Alex Crichton (alexcrichton)
 start = "2020-12-11"
-end = "2025-07-30"
+end = "2026-08-21"
 notes = """
 This is a Bytecode Alliance authored crate maintained in the `wit-bindgen`
 repository of which I'm one of the primary maintainers and publishers for.
@@ -1040,7 +1048,7 @@ who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
 user-id = 1 # Alex Crichton (alexcrichton)
 start = "2020-12-11"
-end = "2025-07-30"
+end = "2026-08-21"
 notes = """
 This is a Bytecode Alliance authored crate maintained in the `wit-bindgen`
 repository of which I'm one of the primary maintainers and publishers for.
@@ -1065,7 +1073,7 @@ who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
 user-id = 1 # Alex Crichton (alexcrichton)
 start = "2020-12-11"
-end = "2025-07-30"
+end = "2026-08-21"
 notes = """
 This is a Bytecode Alliance authored crate maintained in the `wit-bindgen`
 repository of which I'm one of the primary maintainers and publishers for.
@@ -1078,7 +1086,7 @@ who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
 user-id = 1 # Alex Crichton (alexcrichton)
 start = "2020-12-11"
-end = "2025-07-30"
+end = "2026-08-21"
 notes = """
 This is a Bytecode Alliance authored crate maintained in the `wit-bindgen`
 repository of which I'm one of the primary maintainers and publishers for.
@@ -1103,7 +1111,7 @@ who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
 user-id = 1 # Alex Crichton (alexcrichton)
 start = "2020-12-11"
-end = "2025-07-30"
+end = "2026-08-21"
 notes = """
 This is a Bytecode Alliance authored crate maintained in the `wasm-tools`
 repository of which I'm one of the primary maintainers and publishers for.
@@ -1128,14 +1136,14 @@ who = "Nick Fitzgerald <fitzgen@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 696 # Nick Fitzgerald (fitzgen)
 start = "2019-03-16"
-end = "2025-07-30"
+end = "2026-08-21"
 
 [[wildcard-audits.wit-parser]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
 user-id = 1 # Alex Crichton (alexcrichton)
 start = "2019-12-02"
-end = "2025-07-30"
+end = "2026-08-21"
 notes = """
 This is a Bytecode Alliance authored crate maintained in the `wasm-tools`
 repository of which I'm one of the primary maintainers and publishers for.

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -17,6 +17,10 @@ audited_as = "0.121.1"
 version = "0.124.0"
 audited_as = "0.122.0"
 
+[[unpublished.cranelift]]
+version = "0.125.0"
+audited_as = "0.123.1"
+
 [[unpublished.cranelift-assembler-x64]]
 version = "0.121.0"
 audited_as = "0.120.0"
@@ -32,6 +36,10 @@ audited_as = "0.121.1"
 [[unpublished.cranelift-assembler-x64]]
 version = "0.124.0"
 audited_as = "0.122.0"
+
+[[unpublished.cranelift-assembler-x64]]
+version = "0.125.0"
+audited_as = "0.123.1"
 
 [[unpublished.cranelift-assembler-x64-meta]]
 version = "0.121.0"
@@ -49,6 +57,10 @@ audited_as = "0.121.1"
 version = "0.124.0"
 audited_as = "0.122.0"
 
+[[unpublished.cranelift-assembler-x64-meta]]
+version = "0.125.0"
+audited_as = "0.123.1"
+
 [[unpublished.cranelift-bforest]]
 version = "0.121.0"
 audited_as = "0.120.0"
@@ -64,6 +76,10 @@ audited_as = "0.121.1"
 [[unpublished.cranelift-bforest]]
 version = "0.124.0"
 audited_as = "0.122.0"
+
+[[unpublished.cranelift-bforest]]
+version = "0.125.0"
+audited_as = "0.123.1"
 
 [[unpublished.cranelift-bitset]]
 version = "0.121.0"
@@ -81,6 +97,10 @@ audited_as = "0.121.1"
 version = "0.124.0"
 audited_as = "0.122.0"
 
+[[unpublished.cranelift-bitset]]
+version = "0.125.0"
+audited_as = "0.123.1"
+
 [[unpublished.cranelift-codegen]]
 version = "0.121.0"
 audited_as = "0.120.0"
@@ -96,6 +116,10 @@ audited_as = "0.121.1"
 [[unpublished.cranelift-codegen]]
 version = "0.124.0"
 audited_as = "0.122.0"
+
+[[unpublished.cranelift-codegen]]
+version = "0.125.0"
+audited_as = "0.123.1"
 
 [[unpublished.cranelift-codegen-meta]]
 version = "0.121.0"
@@ -113,6 +137,10 @@ audited_as = "0.121.1"
 version = "0.124.0"
 audited_as = "0.122.0"
 
+[[unpublished.cranelift-codegen-meta]]
+version = "0.125.0"
+audited_as = "0.123.1"
+
 [[unpublished.cranelift-codegen-shared]]
 version = "0.121.0"
 audited_as = "0.120.0"
@@ -128,6 +156,10 @@ audited_as = "0.121.1"
 [[unpublished.cranelift-codegen-shared]]
 version = "0.124.0"
 audited_as = "0.122.0"
+
+[[unpublished.cranelift-codegen-shared]]
+version = "0.125.0"
+audited_as = "0.123.1"
 
 [[unpublished.cranelift-control]]
 version = "0.121.0"
@@ -145,6 +177,10 @@ audited_as = "0.121.1"
 version = "0.124.0"
 audited_as = "0.122.0"
 
+[[unpublished.cranelift-control]]
+version = "0.125.0"
+audited_as = "0.123.1"
+
 [[unpublished.cranelift-entity]]
 version = "0.121.0"
 audited_as = "0.120.0"
@@ -160,6 +196,10 @@ audited_as = "0.121.1"
 [[unpublished.cranelift-entity]]
 version = "0.124.0"
 audited_as = "0.122.0"
+
+[[unpublished.cranelift-entity]]
+version = "0.125.0"
+audited_as = "0.123.1"
 
 [[unpublished.cranelift-frontend]]
 version = "0.121.0"
@@ -177,6 +217,10 @@ audited_as = "0.121.1"
 version = "0.124.0"
 audited_as = "0.122.0"
 
+[[unpublished.cranelift-frontend]]
+version = "0.125.0"
+audited_as = "0.123.1"
+
 [[unpublished.cranelift-interpreter]]
 version = "0.121.0"
 audited_as = "0.120.0"
@@ -192,6 +236,10 @@ audited_as = "0.121.1"
 [[unpublished.cranelift-interpreter]]
 version = "0.124.0"
 audited_as = "0.122.0"
+
+[[unpublished.cranelift-interpreter]]
+version = "0.125.0"
+audited_as = "0.123.1"
 
 [[unpublished.cranelift-isle]]
 version = "0.121.0"
@@ -209,6 +257,10 @@ audited_as = "0.121.1"
 version = "0.124.0"
 audited_as = "0.122.0"
 
+[[unpublished.cranelift-isle]]
+version = "0.125.0"
+audited_as = "0.123.1"
+
 [[unpublished.cranelift-jit]]
 version = "0.121.0"
 audited_as = "0.120.0"
@@ -224,6 +276,10 @@ audited_as = "0.121.1"
 [[unpublished.cranelift-jit]]
 version = "0.124.0"
 audited_as = "0.122.0"
+
+[[unpublished.cranelift-jit]]
+version = "0.125.0"
+audited_as = "0.123.1"
 
 [[unpublished.cranelift-module]]
 version = "0.121.0"
@@ -241,6 +297,10 @@ audited_as = "0.121.1"
 version = "0.124.0"
 audited_as = "0.122.0"
 
+[[unpublished.cranelift-module]]
+version = "0.125.0"
+audited_as = "0.123.1"
+
 [[unpublished.cranelift-native]]
 version = "0.121.0"
 audited_as = "0.120.0"
@@ -256,6 +316,10 @@ audited_as = "0.121.1"
 [[unpublished.cranelift-native]]
 version = "0.124.0"
 audited_as = "0.122.0"
+
+[[unpublished.cranelift-native]]
+version = "0.125.0"
+audited_as = "0.123.1"
 
 [[unpublished.cranelift-object]]
 version = "0.121.0"
@@ -273,6 +337,10 @@ audited_as = "0.121.1"
 version = "0.124.0"
 audited_as = "0.122.0"
 
+[[unpublished.cranelift-object]]
+version = "0.125.0"
+audited_as = "0.123.1"
+
 [[unpublished.cranelift-reader]]
 version = "0.121.0"
 audited_as = "0.120.0"
@@ -289,6 +357,10 @@ audited_as = "0.121.1"
 version = "0.124.0"
 audited_as = "0.122.0"
 
+[[unpublished.cranelift-reader]]
+version = "0.125.0"
+audited_as = "0.123.1"
+
 [[unpublished.cranelift-serde]]
 version = "0.121.0"
 audited_as = "0.120.0"
@@ -305,6 +377,10 @@ audited_as = "0.121.1"
 version = "0.124.0"
 audited_as = "0.122.0"
 
+[[unpublished.cranelift-serde]]
+version = "0.125.0"
+audited_as = "0.123.1"
+
 [[unpublished.cranelift-srcgen]]
 version = "0.121.0"
 audited_as = "0.120.0"
@@ -320,6 +396,10 @@ audited_as = "0.121.1"
 [[unpublished.cranelift-srcgen]]
 version = "0.124.0"
 audited_as = "0.122.0"
+
+[[unpublished.cranelift-srcgen]]
+version = "0.125.0"
+audited_as = "0.123.1"
 
 [[unpublished.pulley-interpreter]]
 version = "34.0.0"
@@ -336,6 +416,10 @@ audited_as = "34.0.1"
 [[unpublished.pulley-interpreter]]
 version = "37.0.0"
 audited_as = "35.0.0"
+
+[[unpublished.pulley-interpreter]]
+version = "38.0.0"
+audited_as = "36.0.1"
 
 [[unpublished.pulley-macros]]
 version = "35.0.0"
@@ -349,6 +433,10 @@ audited_as = "34.0.1"
 version = "37.0.0"
 audited_as = "35.0.0"
 
+[[unpublished.pulley-macros]]
+version = "38.0.0"
+audited_as = "36.0.1"
+
 [[unpublished.wasi-common]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -365,6 +453,10 @@ audited_as = "34.0.1"
 version = "37.0.0"
 audited_as = "35.0.0"
 
+[[unpublished.wasi-common]]
+version = "38.0.0"
+audited_as = "36.0.1"
+
 [[unpublished.wasmtime]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -380,6 +472,10 @@ audited_as = "34.0.1"
 [[unpublished.wasmtime]]
 version = "37.0.0"
 audited_as = "35.0.0"
+
+[[unpublished.wasmtime]]
+version = "38.0.0"
+audited_as = "36.0.1"
 
 [[unpublished.wasmtime-asm-macros]]
 version = "34.0.0"
@@ -413,6 +509,10 @@ audited_as = "34.0.1"
 version = "37.0.0"
 audited_as = "35.0.0"
 
+[[unpublished.wasmtime-cli]]
+version = "38.0.0"
+audited_as = "36.0.1"
+
 [[unpublished.wasmtime-cli-flags]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -428,6 +528,10 @@ audited_as = "34.0.1"
 [[unpublished.wasmtime-cli-flags]]
 version = "37.0.0"
 audited_as = "35.0.0"
+
+[[unpublished.wasmtime-cli-flags]]
+version = "38.0.0"
+audited_as = "36.0.1"
 
 [[unpublished.wasmtime-component-macro]]
 version = "34.0.0"
@@ -469,6 +573,10 @@ audited_as = "34.0.1"
 version = "37.0.0"
 audited_as = "35.0.0"
 
+[[unpublished.wasmtime-environ]]
+version = "38.0.0"
+audited_as = "36.0.1"
+
 [[unpublished.wasmtime-explorer]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -493,6 +601,10 @@ audited_as = "35.0.0"
 version = "37.0.0"
 audited_as = "35.0.0"
 
+[[unpublished.wasmtime-internal-asm-macros]]
+version = "38.0.0"
+audited_as = "36.0.1"
+
 [[unpublished.wasmtime-internal-c-api-macros]]
 version = "36.0.0"
 audited_as = "35.0.0"
@@ -500,6 +612,10 @@ audited_as = "35.0.0"
 [[unpublished.wasmtime-internal-c-api-macros]]
 version = "37.0.0"
 audited_as = "35.0.0"
+
+[[unpublished.wasmtime-internal-c-api-macros]]
+version = "38.0.0"
+audited_as = "36.0.1"
 
 [[unpublished.wasmtime-internal-cache]]
 version = "36.0.0"
@@ -509,6 +625,10 @@ audited_as = "35.0.0"
 version = "37.0.0"
 audited_as = "35.0.0"
 
+[[unpublished.wasmtime-internal-cache]]
+version = "38.0.0"
+audited_as = "36.0.1"
+
 [[unpublished.wasmtime-internal-component-macro]]
 version = "36.0.0"
 audited_as = "35.0.0"
@@ -516,6 +636,10 @@ audited_as = "35.0.0"
 [[unpublished.wasmtime-internal-component-macro]]
 version = "37.0.0"
 audited_as = "35.0.0"
+
+[[unpublished.wasmtime-internal-component-macro]]
+version = "38.0.0"
+audited_as = "36.0.1"
 
 [[unpublished.wasmtime-internal-component-util]]
 version = "36.0.0"
@@ -525,6 +649,10 @@ audited_as = "35.0.0"
 version = "37.0.0"
 audited_as = "35.0.0"
 
+[[unpublished.wasmtime-internal-component-util]]
+version = "38.0.0"
+audited_as = "36.0.1"
+
 [[unpublished.wasmtime-internal-cranelift]]
 version = "36.0.0"
 audited_as = "35.0.0"
@@ -532,6 +660,10 @@ audited_as = "35.0.0"
 [[unpublished.wasmtime-internal-cranelift]]
 version = "37.0.0"
 audited_as = "35.0.0"
+
+[[unpublished.wasmtime-internal-cranelift]]
+version = "38.0.0"
+audited_as = "36.0.1"
 
 [[unpublished.wasmtime-internal-explorer]]
 version = "36.0.0"
@@ -541,6 +673,10 @@ audited_as = "35.0.0"
 version = "37.0.0"
 audited_as = "35.0.0"
 
+[[unpublished.wasmtime-internal-explorer]]
+version = "38.0.0"
+audited_as = "36.0.1"
+
 [[unpublished.wasmtime-internal-fiber]]
 version = "36.0.0"
 audited_as = "35.0.0"
@@ -548,6 +684,10 @@ audited_as = "35.0.0"
 [[unpublished.wasmtime-internal-fiber]]
 version = "37.0.0"
 audited_as = "35.0.0"
+
+[[unpublished.wasmtime-internal-fiber]]
+version = "38.0.0"
+audited_as = "36.0.1"
 
 [[unpublished.wasmtime-internal-jit-debug]]
 version = "36.0.0"
@@ -557,6 +697,10 @@ audited_as = "35.0.0"
 version = "37.0.0"
 audited_as = "35.0.0"
 
+[[unpublished.wasmtime-internal-jit-debug]]
+version = "38.0.0"
+audited_as = "36.0.1"
+
 [[unpublished.wasmtime-internal-jit-icache-coherence]]
 version = "36.0.0"
 audited_as = "35.0.0"
@@ -564,6 +708,10 @@ audited_as = "35.0.0"
 [[unpublished.wasmtime-internal-jit-icache-coherence]]
 version = "37.0.0"
 audited_as = "35.0.0"
+
+[[unpublished.wasmtime-internal-jit-icache-coherence]]
+version = "38.0.0"
+audited_as = "36.0.1"
 
 [[unpublished.wasmtime-internal-math]]
 version = "36.0.0"
@@ -573,6 +721,10 @@ audited_as = "35.0.0"
 version = "37.0.0"
 audited_as = "35.0.0"
 
+[[unpublished.wasmtime-internal-math]]
+version = "38.0.0"
+audited_as = "36.0.1"
+
 [[unpublished.wasmtime-internal-slab]]
 version = "36.0.0"
 audited_as = "35.0.0"
@@ -580,6 +732,10 @@ audited_as = "35.0.0"
 [[unpublished.wasmtime-internal-slab]]
 version = "37.0.0"
 audited_as = "35.0.0"
+
+[[unpublished.wasmtime-internal-slab]]
+version = "38.0.0"
+audited_as = "36.0.1"
 
 [[unpublished.wasmtime-internal-unwinder]]
 version = "36.0.0"
@@ -589,6 +745,10 @@ audited_as = "35.0.0"
 version = "37.0.0"
 audited_as = "35.0.0"
 
+[[unpublished.wasmtime-internal-unwinder]]
+version = "38.0.0"
+audited_as = "36.0.1"
+
 [[unpublished.wasmtime-internal-versioned-export-macros]]
 version = "36.0.0"
 audited_as = "35.0.0"
@@ -596,6 +756,10 @@ audited_as = "35.0.0"
 [[unpublished.wasmtime-internal-versioned-export-macros]]
 version = "37.0.0"
 audited_as = "35.0.0"
+
+[[unpublished.wasmtime-internal-versioned-export-macros]]
+version = "38.0.0"
+audited_as = "36.0.1"
 
 [[unpublished.wasmtime-internal-winch]]
 version = "36.0.0"
@@ -605,6 +769,10 @@ audited_as = "35.0.0"
 version = "37.0.0"
 audited_as = "35.0.0"
 
+[[unpublished.wasmtime-internal-winch]]
+version = "38.0.0"
+audited_as = "36.0.1"
+
 [[unpublished.wasmtime-internal-wit-bindgen]]
 version = "36.0.0"
 audited_as = "35.0.0"
@@ -613,6 +781,10 @@ audited_as = "35.0.0"
 version = "37.0.0"
 audited_as = "35.0.0"
 
+[[unpublished.wasmtime-internal-wit-bindgen]]
+version = "38.0.0"
+audited_as = "36.0.1"
+
 [[unpublished.wasmtime-internal-wmemcheck]]
 version = "36.0.0"
 audited_as = "35.0.0"
@@ -620,6 +792,10 @@ audited_as = "35.0.0"
 [[unpublished.wasmtime-internal-wmemcheck]]
 version = "37.0.0"
 audited_as = "35.0.0"
+
+[[unpublished.wasmtime-internal-wmemcheck]]
+version = "38.0.0"
+audited_as = "36.0.1"
 
 [[unpublished.wasmtime-jit-debug]]
 version = "34.0.0"
@@ -669,6 +845,10 @@ audited_as = "34.0.1"
 version = "37.0.0"
 audited_as = "35.0.0"
 
+[[unpublished.wasmtime-wasi]]
+version = "38.0.0"
+audited_as = "36.0.1"
+
 [[unpublished.wasmtime-wasi-config]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -684,6 +864,10 @@ audited_as = "34.0.1"
 [[unpublished.wasmtime-wasi-config]]
 version = "37.0.0"
 audited_as = "35.0.0"
+
+[[unpublished.wasmtime-wasi-config]]
+version = "38.0.0"
+audited_as = "36.0.1"
 
 [[unpublished.wasmtime-wasi-http]]
 version = "34.0.0"
@@ -701,6 +885,10 @@ audited_as = "34.0.1"
 version = "37.0.0"
 audited_as = "35.0.0"
 
+[[unpublished.wasmtime-wasi-http]]
+version = "38.0.0"
+audited_as = "36.0.1"
+
 [[unpublished.wasmtime-wasi-io]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -716,6 +904,10 @@ audited_as = "34.0.1"
 [[unpublished.wasmtime-wasi-io]]
 version = "37.0.0"
 audited_as = "35.0.0"
+
+[[unpublished.wasmtime-wasi-io]]
+version = "38.0.0"
+audited_as = "36.0.1"
 
 [[unpublished.wasmtime-wasi-keyvalue]]
 version = "34.0.0"
@@ -733,6 +925,10 @@ audited_as = "34.0.1"
 version = "37.0.0"
 audited_as = "35.0.0"
 
+[[unpublished.wasmtime-wasi-keyvalue]]
+version = "38.0.0"
+audited_as = "36.0.1"
+
 [[unpublished.wasmtime-wasi-nn]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -749,6 +945,10 @@ audited_as = "34.0.1"
 version = "37.0.0"
 audited_as = "35.0.0"
 
+[[unpublished.wasmtime-wasi-nn]]
+version = "38.0.0"
+audited_as = "36.0.1"
+
 [[unpublished.wasmtime-wasi-threads]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -765,6 +965,10 @@ audited_as = "34.0.1"
 version = "37.0.0"
 audited_as = "35.0.0"
 
+[[unpublished.wasmtime-wasi-threads]]
+version = "38.0.0"
+audited_as = "36.0.1"
+
 [[unpublished.wasmtime-wasi-tls]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -780,6 +984,10 @@ audited_as = "34.0.1"
 [[unpublished.wasmtime-wasi-tls]]
 version = "37.0.0"
 audited_as = "35.0.0"
+
+[[unpublished.wasmtime-wasi-tls]]
+version = "38.0.0"
+audited_as = "36.0.1"
 
 [[unpublished.wasmtime-wasi-tls-nativetls]]
 version = "36.0.0"
@@ -789,6 +997,10 @@ audited_as = "35.0.0"
 version = "37.0.0"
 audited_as = "35.0.0"
 
+[[unpublished.wasmtime-wasi-tls-nativetls]]
+version = "38.0.0"
+audited_as = "36.0.1"
+
 [[unpublished.wasmtime-wast]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -804,6 +1016,10 @@ audited_as = "34.0.1"
 [[unpublished.wasmtime-wast]]
 version = "37.0.0"
 audited_as = "35.0.0"
+
+[[unpublished.wasmtime-wast]]
+version = "38.0.0"
+audited_as = "36.0.1"
 
 [[unpublished.wasmtime-winch]]
 version = "34.0.0"
@@ -845,6 +1061,10 @@ audited_as = "34.0.1"
 version = "37.0.0"
 audited_as = "35.0.0"
 
+[[unpublished.wiggle]]
+version = "38.0.0"
+audited_as = "36.0.1"
+
 [[unpublished.wiggle-generate]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -861,6 +1081,10 @@ audited_as = "34.0.1"
 version = "37.0.0"
 audited_as = "35.0.0"
 
+[[unpublished.wiggle-generate]]
+version = "38.0.0"
+audited_as = "36.0.1"
+
 [[unpublished.wiggle-macro]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -876,6 +1100,10 @@ audited_as = "34.0.1"
 [[unpublished.wiggle-macro]]
 version = "37.0.0"
 audited_as = "35.0.0"
+
+[[unpublished.wiggle-macro]]
+version = "38.0.0"
+audited_as = "36.0.1"
 
 [[unpublished.wiggle-test]]
 version = "0.0.0"
@@ -896,6 +1124,10 @@ audited_as = "34.0.1"
 [[unpublished.winch-codegen]]
 version = "37.0.0"
 audited_as = "35.0.0"
+
+[[unpublished.winch-codegen]]
+version = "38.0.0"
+audited_as = "36.0.1"
 
 [[publisher.aho-corasick]]
 version = "1.0.2"


### PR DESCRIPTION
This is otherwise causing CI to fail, so this is the result of running `cargo vet renew --expiring` to update our expiry date on wildcard audits.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
