### PR TITLE
 Switch vets for wasmtime-publish to wildcard audits 

### DIFF
--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -220,6 +220,29 @@ start = "2024-09-20"
 end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
 
+[[wildcard-audits.pulley-macros]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2025-06-20"
+end = "2026-08-21"
+
+[[wildcard-audits.pulley-macros]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2025-06-20"
+end = "2026-08-21"
+notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.pulley-macros]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2025-06-20"
+end = "2026-08-21"
+notes = "The Bytecode Alliance is the author of this crate."
+
 [[wildcard-audits.regalloc2]]
 who = "Chris Fallin <chris@cfallin.org>"
 criteria = "safe-to-deploy"
@@ -269,6 +292,14 @@ notes = "The Bytecode Alliance is the author of this crate."
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
+start = "2024-02-15"
+end = "2026-08-21"
+notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.wasm-compose]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
 start = "2025-07-28"
 end = "2026-07-28"
 notes = """
@@ -300,6 +331,14 @@ publication of this crate from CI. This repository requires all PRs are reviewed
 by a Bytecode Alliance maintainer and it owned by the Bytecode Alliance itself.
 """
 
+[[wildcard-audits.wasm-encoder]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2024-02-15"
+end = "2026-08-21"
+notes = "The Bytecode Alliance is the author of this crate."
+
 [[wildcard-audits.wasm-metadata]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
@@ -324,6 +363,14 @@ The Bytecode Alliance uses the `wasmtime-publish` crates.io account to automate
 publication of this crate from CI. This repository requires all PRs are reviewed
 by a Bytecode Alliance maintainer and it owned by the Bytecode Alliance itself.
 """
+
+[[wildcard-audits.wasm-metadata]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2024-02-15"
+end = "2026-08-21"
+notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.wasm-mutate]]
 who = "Alex Crichton <alex@alexcrichton.com>"
@@ -358,6 +405,14 @@ I am employed by a member of the Bytecode Alliance and plan to continue doing
 so and will actively maintain this crate over time.
 """
 
+[[wildcard-audits.wasm-wave]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2024-06-19"
+end = "2026-08-21"
+notes = "The Bytecode Alliance is the author of this crate."
+
 [[wildcard-audits.wasmparser]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
@@ -383,6 +438,14 @@ publication of this crate from CI. This repository requires all PRs are reviewed
 by a Bytecode Alliance maintainer and it owned by the Bytecode Alliance itself.
 """
 
+[[wildcard-audits.wasmparser]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2024-02-15"
+end = "2026-08-21"
+notes = "The Bytecode Alliance is the author of this crate."
+
 [[wildcard-audits.wasmprinter]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
@@ -407,6 +470,14 @@ The Bytecode Alliance uses the `wasmtime-publish` crates.io account to automate
 publication of this crate from CI. This repository requires all PRs are reviewed
 by a Bytecode Alliance maintainer and it owned by the Bytecode Alliance itself.
 """
+
+[[wildcard-audits.wasmprinter]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2024-02-15"
+end = "2026-08-21"
+notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.wasmprinter]]
 who = "Nick Fitzgerald <fitzgen@gmail.com>"
@@ -916,6 +987,14 @@ publication of this crate from CI. This repository requires all PRs are reviewed
 by a Bytecode Alliance maintainer and it owned by the Bytecode Alliance itself.
 """
 
+[[wildcard-audits.wast]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2024-02-15"
+end = "2026-08-21"
+notes = "The Bytecode Alliance is the author of this crate."
+
 [[wildcard-audits.wat]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
@@ -940,6 +1019,14 @@ The Bytecode Alliance uses the `wasmtime-publish` crates.io account to automate
 publication of this crate from CI. This repository requires all PRs are reviewed
 by a Bytecode Alliance maintainer and it owned by the Bytecode Alliance itself.
 """
+
+[[wildcard-audits.wat]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2024-02-15"
+end = "2026-08-21"
+notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.wiggle]]
 who = "Bobby Holley <bobbyholley@gmail.com>"
@@ -1132,6 +1219,14 @@ by a Bytecode Alliance maintainer and it owned by the Bytecode Alliance itself.
 """
 
 [[wildcard-audits.wit-component]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2024-02-15"
+end = "2026-08-21"
+notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.wit-component]]
 who = "Nick Fitzgerald <fitzgen@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 696 # Nick Fitzgerald (fitzgen)
@@ -1162,6 +1257,14 @@ The Bytecode Alliance uses the `wasmtime-publish` crates.io account to automate
 publication of this crate from CI. This repository requires all PRs are reviewed
 by a Bytecode Alliance maintainer and it owned by the Bytecode Alliance itself.
 """
+
+[[wildcard-audits.wit-parser]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2024-02-15"
+end = "2026-08-21"
+notes = "The Bytecode Alliance is the author of this crate."
 
 [[audits.addr2line]]
 who = "Alex Crichton <alex@alexcrichton.com>"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -241,7 +241,7 @@ criteria = "safe-to-deploy"
 
 [[exemptions.bitmaps]]
 version = "2.1.0"
-criteria = "safe-to-deploy"
+criteria = "safe-to-run"
 
 [[exemptions.capstone]]
 version = "0.12.0"
@@ -461,7 +461,7 @@ criteria = "safe-to-deploy"
 
 [[exemptions.petgraph]]
 version = "0.6.5"
-criteria = "safe-to-deploy"
+criteria = "safe-to-run"
 
 [[exemptions.ppv-lite86]]
 version = "0.2.16"
@@ -469,10 +469,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.proptest]]
 version = "1.0.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.psm]]
-version = "0.1.18"
 criteria = "safe-to-deploy"
 
 [[exemptions.quick-error]]
@@ -493,7 +489,7 @@ criteria = "safe-to-deploy"
 
 [[exemptions.rand_xoshiro]]
 version = "0.6.0"
-criteria = "safe-to-deploy"
+criteria = "safe-to-run"
 
 [[exemptions.rawpointer]]
 version = "0.2.1"
@@ -545,7 +541,7 @@ criteria = "safe-to-deploy"
 
 [[exemptions.serde_yaml]]
 version = "0.9.34+deprecated"
-criteria = "safe-to-deploy"
+criteria = "safe-to-run"
 
 [[exemptions.shuffling-allocator]]
 version = "1.1.2"
@@ -553,7 +549,7 @@ criteria = "safe-to-deploy"
 
 [[exemptions.sized-chunks]]
 version = "0.6.5"
-criteria = "safe-to-deploy"
+criteria = "safe-to-run"
 
 [[exemptions.smallvec]]
 version = "1.8.0"
@@ -608,18 +604,13 @@ criteria = "safe-to-deploy"
 version = "0.1.28"
 criteria = "safe-to-deploy"
 
-[[exemptions.trait-variant]]
-version = "0.1.2"
-criteria = "safe-to-deploy"
-notes = "This crate is maintained by the `rust-lang` maintainers and is [officially recommended](https://blog.rust-lang.org/2023/12/21/async-fn-rpit-in-traits.html) by the Rust project."
-
 [[exemptions.typenum]]
 version = "1.15.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.unsafe-libyaml]]
 version = "0.2.11"
-criteria = "safe-to-deploy"
+criteria = "safe-to-run"
 
 [[exemptions.untrusted]]
 version = "0.9.0"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -2,423 +2,87 @@
 # cargo-vet imports lock
 
 [[unpublished.cranelift]]
-version = "0.121.0"
-audited_as = "0.120.0"
-
-[[unpublished.cranelift]]
-version = "0.122.0"
-audited_as = "0.120.0"
-
-[[unpublished.cranelift]]
-version = "0.123.0"
-audited_as = "0.121.1"
-
-[[unpublished.cranelift]]
 version = "0.124.0"
-audited_as = "0.122.0"
-
-[[unpublished.cranelift]]
-version = "0.125.0"
 audited_as = "0.123.1"
 
 [[unpublished.cranelift-assembler-x64]]
-version = "0.121.0"
-audited_as = "0.120.0"
-
-[[unpublished.cranelift-assembler-x64]]
-version = "0.122.0"
-audited_as = "0.120.0"
-
-[[unpublished.cranelift-assembler-x64]]
-version = "0.123.0"
-audited_as = "0.121.1"
-
-[[unpublished.cranelift-assembler-x64]]
 version = "0.124.0"
-audited_as = "0.122.0"
-
-[[unpublished.cranelift-assembler-x64]]
-version = "0.125.0"
 audited_as = "0.123.1"
 
 [[unpublished.cranelift-assembler-x64-meta]]
-version = "0.121.0"
-audited_as = "0.120.0"
-
-[[unpublished.cranelift-assembler-x64-meta]]
-version = "0.122.0"
-audited_as = "0.120.0"
-
-[[unpublished.cranelift-assembler-x64-meta]]
-version = "0.123.0"
-audited_as = "0.121.1"
-
-[[unpublished.cranelift-assembler-x64-meta]]
 version = "0.124.0"
-audited_as = "0.122.0"
-
-[[unpublished.cranelift-assembler-x64-meta]]
-version = "0.125.0"
 audited_as = "0.123.1"
 
 [[unpublished.cranelift-bforest]]
-version = "0.121.0"
-audited_as = "0.120.0"
-
-[[unpublished.cranelift-bforest]]
-version = "0.122.0"
-audited_as = "0.120.0"
-
-[[unpublished.cranelift-bforest]]
-version = "0.123.0"
-audited_as = "0.121.1"
-
-[[unpublished.cranelift-bforest]]
 version = "0.124.0"
-audited_as = "0.122.0"
-
-[[unpublished.cranelift-bforest]]
-version = "0.125.0"
 audited_as = "0.123.1"
 
 [[unpublished.cranelift-bitset]]
-version = "0.121.0"
-audited_as = "0.120.0"
-
-[[unpublished.cranelift-bitset]]
-version = "0.122.0"
-audited_as = "0.120.0"
-
-[[unpublished.cranelift-bitset]]
-version = "0.123.0"
-audited_as = "0.121.1"
-
-[[unpublished.cranelift-bitset]]
 version = "0.124.0"
-audited_as = "0.122.0"
-
-[[unpublished.cranelift-bitset]]
-version = "0.125.0"
 audited_as = "0.123.1"
 
 [[unpublished.cranelift-codegen]]
-version = "0.121.0"
-audited_as = "0.120.0"
-
-[[unpublished.cranelift-codegen]]
-version = "0.122.0"
-audited_as = "0.120.0"
-
-[[unpublished.cranelift-codegen]]
-version = "0.123.0"
-audited_as = "0.121.1"
-
-[[unpublished.cranelift-codegen]]
 version = "0.124.0"
-audited_as = "0.122.0"
-
-[[unpublished.cranelift-codegen]]
-version = "0.125.0"
 audited_as = "0.123.1"
 
 [[unpublished.cranelift-codegen-meta]]
-version = "0.121.0"
-audited_as = "0.120.0"
-
-[[unpublished.cranelift-codegen-meta]]
-version = "0.122.0"
-audited_as = "0.120.0"
-
-[[unpublished.cranelift-codegen-meta]]
-version = "0.123.0"
-audited_as = "0.121.1"
-
-[[unpublished.cranelift-codegen-meta]]
 version = "0.124.0"
-audited_as = "0.122.0"
-
-[[unpublished.cranelift-codegen-meta]]
-version = "0.125.0"
 audited_as = "0.123.1"
 
 [[unpublished.cranelift-codegen-shared]]
-version = "0.121.0"
-audited_as = "0.120.0"
-
-[[unpublished.cranelift-codegen-shared]]
-version = "0.122.0"
-audited_as = "0.120.0"
-
-[[unpublished.cranelift-codegen-shared]]
-version = "0.123.0"
-audited_as = "0.121.1"
-
-[[unpublished.cranelift-codegen-shared]]
 version = "0.124.0"
-audited_as = "0.122.0"
-
-[[unpublished.cranelift-codegen-shared]]
-version = "0.125.0"
 audited_as = "0.123.1"
 
 [[unpublished.cranelift-control]]
-version = "0.121.0"
-audited_as = "0.120.0"
-
-[[unpublished.cranelift-control]]
-version = "0.122.0"
-audited_as = "0.120.0"
-
-[[unpublished.cranelift-control]]
-version = "0.123.0"
-audited_as = "0.121.1"
-
-[[unpublished.cranelift-control]]
 version = "0.124.0"
-audited_as = "0.122.0"
-
-[[unpublished.cranelift-control]]
-version = "0.125.0"
 audited_as = "0.123.1"
 
 [[unpublished.cranelift-entity]]
-version = "0.121.0"
-audited_as = "0.120.0"
-
-[[unpublished.cranelift-entity]]
-version = "0.122.0"
-audited_as = "0.120.0"
-
-[[unpublished.cranelift-entity]]
-version = "0.123.0"
-audited_as = "0.121.1"
-
-[[unpublished.cranelift-entity]]
 version = "0.124.0"
-audited_as = "0.122.0"
-
-[[unpublished.cranelift-entity]]
-version = "0.125.0"
 audited_as = "0.123.1"
 
 [[unpublished.cranelift-frontend]]
-version = "0.121.0"
-audited_as = "0.120.0"
-
-[[unpublished.cranelift-frontend]]
-version = "0.122.0"
-audited_as = "0.120.0"
-
-[[unpublished.cranelift-frontend]]
-version = "0.123.0"
-audited_as = "0.121.1"
-
-[[unpublished.cranelift-frontend]]
 version = "0.124.0"
-audited_as = "0.122.0"
-
-[[unpublished.cranelift-frontend]]
-version = "0.125.0"
 audited_as = "0.123.1"
 
 [[unpublished.cranelift-interpreter]]
-version = "0.121.0"
-audited_as = "0.120.0"
-
-[[unpublished.cranelift-interpreter]]
-version = "0.122.0"
-audited_as = "0.120.0"
-
-[[unpublished.cranelift-interpreter]]
-version = "0.123.0"
-audited_as = "0.121.1"
-
-[[unpublished.cranelift-interpreter]]
 version = "0.124.0"
-audited_as = "0.122.0"
-
-[[unpublished.cranelift-interpreter]]
-version = "0.125.0"
 audited_as = "0.123.1"
 
 [[unpublished.cranelift-isle]]
-version = "0.121.0"
-audited_as = "0.120.0"
-
-[[unpublished.cranelift-isle]]
-version = "0.122.0"
-audited_as = "0.120.0"
-
-[[unpublished.cranelift-isle]]
-version = "0.123.0"
-audited_as = "0.121.1"
-
-[[unpublished.cranelift-isle]]
 version = "0.124.0"
-audited_as = "0.122.0"
-
-[[unpublished.cranelift-isle]]
-version = "0.125.0"
 audited_as = "0.123.1"
 
 [[unpublished.cranelift-jit]]
-version = "0.121.0"
-audited_as = "0.120.0"
-
-[[unpublished.cranelift-jit]]
-version = "0.122.0"
-audited_as = "0.120.0"
-
-[[unpublished.cranelift-jit]]
-version = "0.123.0"
-audited_as = "0.121.1"
-
-[[unpublished.cranelift-jit]]
 version = "0.124.0"
-audited_as = "0.122.0"
-
-[[unpublished.cranelift-jit]]
-version = "0.125.0"
 audited_as = "0.123.1"
 
 [[unpublished.cranelift-module]]
-version = "0.121.0"
-audited_as = "0.120.0"
-
-[[unpublished.cranelift-module]]
-version = "0.122.0"
-audited_as = "0.120.0"
-
-[[unpublished.cranelift-module]]
-version = "0.123.0"
-audited_as = "0.121.1"
-
-[[unpublished.cranelift-module]]
 version = "0.124.0"
-audited_as = "0.122.0"
-
-[[unpublished.cranelift-module]]
-version = "0.125.0"
 audited_as = "0.123.1"
 
 [[unpublished.cranelift-native]]
-version = "0.121.0"
-audited_as = "0.120.0"
-
-[[unpublished.cranelift-native]]
-version = "0.122.0"
-audited_as = "0.120.0"
-
-[[unpublished.cranelift-native]]
-version = "0.123.0"
-audited_as = "0.121.1"
-
-[[unpublished.cranelift-native]]
 version = "0.124.0"
-audited_as = "0.122.0"
-
-[[unpublished.cranelift-native]]
-version = "0.125.0"
 audited_as = "0.123.1"
 
 [[unpublished.cranelift-object]]
-version = "0.121.0"
-audited_as = "0.120.0"
-
-[[unpublished.cranelift-object]]
-version = "0.122.0"
-audited_as = "0.120.0"
-
-[[unpublished.cranelift-object]]
-version = "0.123.0"
-audited_as = "0.121.1"
-
-[[unpublished.cranelift-object]]
 version = "0.124.0"
-audited_as = "0.122.0"
-
-[[unpublished.cranelift-object]]
-version = "0.125.0"
 audited_as = "0.123.1"
 
 [[unpublished.cranelift-reader]]
-version = "0.121.0"
-audited_as = "0.120.0"
-
-[[unpublished.cranelift-reader]]
-version = "0.122.0"
-audited_as = "0.120.0"
-
-[[unpublished.cranelift-reader]]
-version = "0.123.0"
-audited_as = "0.121.1"
-
-[[unpublished.cranelift-reader]]
 version = "0.124.0"
-audited_as = "0.122.0"
-
-[[unpublished.cranelift-reader]]
-version = "0.125.0"
 audited_as = "0.123.1"
 
 [[unpublished.cranelift-serde]]
-version = "0.121.0"
-audited_as = "0.120.0"
-
-[[unpublished.cranelift-serde]]
-version = "0.122.0"
-audited_as = "0.120.0"
-
-[[unpublished.cranelift-serde]]
-version = "0.123.0"
-audited_as = "0.121.1"
-
-[[unpublished.cranelift-serde]]
 version = "0.124.0"
-audited_as = "0.122.0"
-
-[[unpublished.cranelift-serde]]
-version = "0.125.0"
 audited_as = "0.123.1"
 
 [[unpublished.cranelift-srcgen]]
-version = "0.121.0"
-audited_as = "0.120.0"
-
-[[unpublished.cranelift-srcgen]]
-version = "0.122.0"
-audited_as = "0.120.0"
-
-[[unpublished.cranelift-srcgen]]
-version = "0.123.0"
-audited_as = "0.121.1"
-
-[[unpublished.cranelift-srcgen]]
 version = "0.124.0"
-audited_as = "0.122.0"
-
-[[unpublished.cranelift-srcgen]]
-version = "0.125.0"
 audited_as = "0.123.1"
-
-[[unpublished.pulley-interpreter]]
-version = "34.0.0"
-audited_as = "33.0.0"
-
-[[unpublished.pulley-interpreter]]
-version = "35.0.0"
-audited_as = "33.0.0"
-
-[[unpublished.pulley-interpreter]]
-version = "36.0.0"
-audited_as = "34.0.1"
 
 [[unpublished.pulley-interpreter]]
 version = "37.0.0"
-audited_as = "35.0.0"
-
-[[unpublished.pulley-interpreter]]
-version = "38.0.0"
 audited_as = "36.0.1"
 
 [[unpublished.pulley-macros]]
@@ -426,671 +90,143 @@ version = "37.0.0"
 audited_as = "36.0.1"
 
 [[unpublished.wasi-common]]
-version = "34.0.0"
-audited_as = "33.0.0"
-
-[[unpublished.wasi-common]]
-version = "35.0.0"
-audited_as = "33.0.0"
-
-[[unpublished.wasi-common]]
-version = "36.0.0"
-audited_as = "34.0.1"
-
-[[unpublished.wasi-common]]
 version = "37.0.0"
-audited_as = "35.0.0"
-
-[[unpublished.wasi-common]]
-version = "38.0.0"
 audited_as = "36.0.1"
 
 [[unpublished.wasmtime]]
-version = "34.0.0"
-audited_as = "33.0.0"
-
-[[unpublished.wasmtime]]
-version = "35.0.0"
-audited_as = "33.0.0"
-
-[[unpublished.wasmtime]]
-version = "36.0.0"
-audited_as = "34.0.1"
-
-[[unpublished.wasmtime]]
 version = "37.0.0"
-audited_as = "35.0.0"
-
-[[unpublished.wasmtime]]
-version = "38.0.0"
 audited_as = "36.0.1"
-
-[[unpublished.wasmtime-asm-macros]]
-version = "34.0.0"
-audited_as = "33.0.0"
-
-[[unpublished.wasmtime-asm-macros]]
-version = "35.0.0"
-audited_as = "33.0.0"
-
-[[unpublished.wasmtime-cache]]
-version = "34.0.0"
-audited_as = "33.0.0"
-
-[[unpublished.wasmtime-cache]]
-version = "35.0.0"
-audited_as = "33.0.0"
-
-[[unpublished.wasmtime-cli]]
-version = "34.0.0"
-audited_as = "33.0.0"
-
-[[unpublished.wasmtime-cli]]
-version = "35.0.0"
-audited_as = "33.0.0"
-
-[[unpublished.wasmtime-cli]]
-version = "36.0.0"
-audited_as = "34.0.1"
 
 [[unpublished.wasmtime-cli]]
 version = "37.0.0"
-audited_as = "35.0.0"
-
-[[unpublished.wasmtime-cli]]
-version = "38.0.0"
 audited_as = "36.0.1"
-
-[[unpublished.wasmtime-cli-flags]]
-version = "34.0.0"
-audited_as = "33.0.0"
-
-[[unpublished.wasmtime-cli-flags]]
-version = "35.0.0"
-audited_as = "33.0.0"
-
-[[unpublished.wasmtime-cli-flags]]
-version = "36.0.0"
-audited_as = "34.0.1"
 
 [[unpublished.wasmtime-cli-flags]]
 version = "37.0.0"
-audited_as = "35.0.0"
-
-[[unpublished.wasmtime-cli-flags]]
-version = "38.0.0"
 audited_as = "36.0.1"
-
-[[unpublished.wasmtime-component-macro]]
-version = "34.0.0"
-audited_as = "33.0.0"
-
-[[unpublished.wasmtime-component-macro]]
-version = "35.0.0"
-audited_as = "33.0.0"
-
-[[unpublished.wasmtime-component-util]]
-version = "34.0.0"
-audited_as = "33.0.0"
-
-[[unpublished.wasmtime-component-util]]
-version = "35.0.0"
-audited_as = "33.0.0"
-
-[[unpublished.wasmtime-cranelift]]
-version = "34.0.0"
-audited_as = "33.0.0"
-
-[[unpublished.wasmtime-cranelift]]
-version = "35.0.0"
-audited_as = "33.0.0"
-
-[[unpublished.wasmtime-environ]]
-version = "34.0.0"
-audited_as = "33.0.0"
-
-[[unpublished.wasmtime-environ]]
-version = "35.0.0"
-audited_as = "33.0.0"
-
-[[unpublished.wasmtime-environ]]
-version = "36.0.0"
-audited_as = "34.0.1"
 
 [[unpublished.wasmtime-environ]]
 version = "37.0.0"
-audited_as = "35.0.0"
-
-[[unpublished.wasmtime-environ]]
-version = "38.0.0"
 audited_as = "36.0.1"
-
-[[unpublished.wasmtime-explorer]]
-version = "34.0.0"
-audited_as = "33.0.0"
-
-[[unpublished.wasmtime-explorer]]
-version = "35.0.0"
-audited_as = "33.0.0"
-
-[[unpublished.wasmtime-fiber]]
-version = "34.0.0"
-audited_as = "33.0.0"
-
-[[unpublished.wasmtime-fiber]]
-version = "35.0.0"
-audited_as = "33.0.0"
-
-[[unpublished.wasmtime-internal-asm-macros]]
-version = "36.0.0"
-audited_as = "35.0.0"
 
 [[unpublished.wasmtime-internal-asm-macros]]
 version = "37.0.0"
-audited_as = "35.0.0"
-
-[[unpublished.wasmtime-internal-asm-macros]]
-version = "38.0.0"
 audited_as = "36.0.1"
 
 [[unpublished.wasmtime-internal-c-api-macros]]
-version = "36.0.0"
-audited_as = "35.0.0"
-
-[[unpublished.wasmtime-internal-c-api-macros]]
 version = "37.0.0"
-audited_as = "35.0.0"
-
-[[unpublished.wasmtime-internal-c-api-macros]]
-version = "38.0.0"
 audited_as = "36.0.1"
 
 [[unpublished.wasmtime-internal-cache]]
-version = "36.0.0"
-audited_as = "35.0.0"
-
-[[unpublished.wasmtime-internal-cache]]
 version = "37.0.0"
-audited_as = "35.0.0"
-
-[[unpublished.wasmtime-internal-cache]]
-version = "38.0.0"
 audited_as = "36.0.1"
 
 [[unpublished.wasmtime-internal-component-macro]]
-version = "36.0.0"
-audited_as = "35.0.0"
-
-[[unpublished.wasmtime-internal-component-macro]]
 version = "37.0.0"
-audited_as = "35.0.0"
-
-[[unpublished.wasmtime-internal-component-macro]]
-version = "38.0.0"
 audited_as = "36.0.1"
 
 [[unpublished.wasmtime-internal-component-util]]
-version = "36.0.0"
-audited_as = "35.0.0"
-
-[[unpublished.wasmtime-internal-component-util]]
 version = "37.0.0"
-audited_as = "35.0.0"
-
-[[unpublished.wasmtime-internal-component-util]]
-version = "38.0.0"
 audited_as = "36.0.1"
 
 [[unpublished.wasmtime-internal-cranelift]]
-version = "36.0.0"
-audited_as = "35.0.0"
-
-[[unpublished.wasmtime-internal-cranelift]]
 version = "37.0.0"
-audited_as = "35.0.0"
-
-[[unpublished.wasmtime-internal-cranelift]]
-version = "38.0.0"
 audited_as = "36.0.1"
 
 [[unpublished.wasmtime-internal-explorer]]
-version = "36.0.0"
-audited_as = "35.0.0"
-
-[[unpublished.wasmtime-internal-explorer]]
 version = "37.0.0"
-audited_as = "35.0.0"
-
-[[unpublished.wasmtime-internal-explorer]]
-version = "38.0.0"
 audited_as = "36.0.1"
 
 [[unpublished.wasmtime-internal-fiber]]
-version = "36.0.0"
-audited_as = "35.0.0"
-
-[[unpublished.wasmtime-internal-fiber]]
 version = "37.0.0"
-audited_as = "35.0.0"
-
-[[unpublished.wasmtime-internal-fiber]]
-version = "38.0.0"
 audited_as = "36.0.1"
 
 [[unpublished.wasmtime-internal-jit-debug]]
-version = "36.0.0"
-audited_as = "35.0.0"
-
-[[unpublished.wasmtime-internal-jit-debug]]
 version = "37.0.0"
-audited_as = "35.0.0"
-
-[[unpublished.wasmtime-internal-jit-debug]]
-version = "38.0.0"
 audited_as = "36.0.1"
 
 [[unpublished.wasmtime-internal-jit-icache-coherence]]
-version = "36.0.0"
-audited_as = "35.0.0"
-
-[[unpublished.wasmtime-internal-jit-icache-coherence]]
 version = "37.0.0"
-audited_as = "35.0.0"
-
-[[unpublished.wasmtime-internal-jit-icache-coherence]]
-version = "38.0.0"
 audited_as = "36.0.1"
 
 [[unpublished.wasmtime-internal-math]]
-version = "36.0.0"
-audited_as = "35.0.0"
-
-[[unpublished.wasmtime-internal-math]]
 version = "37.0.0"
-audited_as = "35.0.0"
-
-[[unpublished.wasmtime-internal-math]]
-version = "38.0.0"
 audited_as = "36.0.1"
 
 [[unpublished.wasmtime-internal-slab]]
-version = "36.0.0"
-audited_as = "35.0.0"
-
-[[unpublished.wasmtime-internal-slab]]
 version = "37.0.0"
-audited_as = "35.0.0"
-
-[[unpublished.wasmtime-internal-slab]]
-version = "38.0.0"
 audited_as = "36.0.1"
 
 [[unpublished.wasmtime-internal-unwinder]]
-version = "36.0.0"
-audited_as = "35.0.0"
-
-[[unpublished.wasmtime-internal-unwinder]]
 version = "37.0.0"
-audited_as = "35.0.0"
-
-[[unpublished.wasmtime-internal-unwinder]]
-version = "38.0.0"
 audited_as = "36.0.1"
 
 [[unpublished.wasmtime-internal-versioned-export-macros]]
-version = "36.0.0"
-audited_as = "35.0.0"
-
-[[unpublished.wasmtime-internal-versioned-export-macros]]
 version = "37.0.0"
-audited_as = "35.0.0"
-
-[[unpublished.wasmtime-internal-versioned-export-macros]]
-version = "38.0.0"
 audited_as = "36.0.1"
 
 [[unpublished.wasmtime-internal-winch]]
-version = "36.0.0"
-audited_as = "35.0.0"
-
-[[unpublished.wasmtime-internal-winch]]
 version = "37.0.0"
-audited_as = "35.0.0"
-
-[[unpublished.wasmtime-internal-winch]]
-version = "38.0.0"
 audited_as = "36.0.1"
 
 [[unpublished.wasmtime-internal-wit-bindgen]]
-version = "36.0.0"
-audited_as = "35.0.0"
-
-[[unpublished.wasmtime-internal-wit-bindgen]]
 version = "37.0.0"
-audited_as = "35.0.0"
-
-[[unpublished.wasmtime-internal-wit-bindgen]]
-version = "38.0.0"
 audited_as = "36.0.1"
 
 [[unpublished.wasmtime-internal-wmemcheck]]
-version = "36.0.0"
-audited_as = "35.0.0"
-
-[[unpublished.wasmtime-internal-wmemcheck]]
 version = "37.0.0"
-audited_as = "35.0.0"
-
-[[unpublished.wasmtime-internal-wmemcheck]]
-version = "38.0.0"
 audited_as = "36.0.1"
-
-[[unpublished.wasmtime-jit-debug]]
-version = "34.0.0"
-audited_as = "33.0.0"
-
-[[unpublished.wasmtime-jit-debug]]
-version = "35.0.0"
-audited_as = "33.0.0"
-
-[[unpublished.wasmtime-jit-icache-coherence]]
-version = "34.0.0"
-audited_as = "33.0.0"
-
-[[unpublished.wasmtime-jit-icache-coherence]]
-version = "35.0.0"
-audited_as = "33.0.0"
-
-[[unpublished.wasmtime-math]]
-version = "34.0.0"
-audited_as = "33.0.0"
-
-[[unpublished.wasmtime-math]]
-version = "35.0.0"
-audited_as = "33.0.0"
-
-[[unpublished.wasmtime-slab]]
-version = "34.0.0"
-audited_as = "33.0.0"
-
-[[unpublished.wasmtime-slab]]
-version = "35.0.0"
-audited_as = "33.0.0"
-
-[[unpublished.wasmtime-wasi]]
-version = "34.0.0"
-audited_as = "33.0.0"
-
-[[unpublished.wasmtime-wasi]]
-version = "35.0.0"
-audited_as = "33.0.0"
-
-[[unpublished.wasmtime-wasi]]
-version = "36.0.0"
-audited_as = "34.0.1"
 
 [[unpublished.wasmtime-wasi]]
 version = "37.0.0"
-audited_as = "35.0.0"
-
-[[unpublished.wasmtime-wasi]]
-version = "38.0.0"
 audited_as = "36.0.1"
 
 [[unpublished.wasmtime-wasi-config]]
-version = "34.0.0"
-audited_as = "33.0.0"
-
-[[unpublished.wasmtime-wasi-config]]
-version = "35.0.0"
-audited_as = "33.0.0"
-
-[[unpublished.wasmtime-wasi-config]]
-version = "36.0.0"
-audited_as = "34.0.1"
-
-[[unpublished.wasmtime-wasi-config]]
 version = "37.0.0"
-audited_as = "35.0.0"
-
-[[unpublished.wasmtime-wasi-config]]
-version = "38.0.0"
 audited_as = "36.0.1"
 
 [[unpublished.wasmtime-wasi-http]]
-version = "34.0.0"
-audited_as = "33.0.0"
-
-[[unpublished.wasmtime-wasi-http]]
-version = "35.0.0"
-audited_as = "33.0.0"
-
-[[unpublished.wasmtime-wasi-http]]
-version = "36.0.0"
-audited_as = "34.0.1"
-
-[[unpublished.wasmtime-wasi-http]]
 version = "37.0.0"
-audited_as = "35.0.0"
-
-[[unpublished.wasmtime-wasi-http]]
-version = "38.0.0"
 audited_as = "36.0.1"
 
 [[unpublished.wasmtime-wasi-io]]
-version = "34.0.0"
-audited_as = "33.0.0"
-
-[[unpublished.wasmtime-wasi-io]]
-version = "35.0.0"
-audited_as = "33.0.0"
-
-[[unpublished.wasmtime-wasi-io]]
-version = "36.0.0"
-audited_as = "34.0.1"
-
-[[unpublished.wasmtime-wasi-io]]
 version = "37.0.0"
-audited_as = "35.0.0"
-
-[[unpublished.wasmtime-wasi-io]]
-version = "38.0.0"
 audited_as = "36.0.1"
 
 [[unpublished.wasmtime-wasi-keyvalue]]
-version = "34.0.0"
-audited_as = "33.0.0"
-
-[[unpublished.wasmtime-wasi-keyvalue]]
-version = "35.0.0"
-audited_as = "33.0.0"
-
-[[unpublished.wasmtime-wasi-keyvalue]]
-version = "36.0.0"
-audited_as = "34.0.1"
-
-[[unpublished.wasmtime-wasi-keyvalue]]
 version = "37.0.0"
-audited_as = "35.0.0"
-
-[[unpublished.wasmtime-wasi-keyvalue]]
-version = "38.0.0"
 audited_as = "36.0.1"
 
 [[unpublished.wasmtime-wasi-nn]]
-version = "34.0.0"
-audited_as = "33.0.0"
-
-[[unpublished.wasmtime-wasi-nn]]
-version = "35.0.0"
-audited_as = "33.0.0"
-
-[[unpublished.wasmtime-wasi-nn]]
-version = "36.0.0"
-audited_as = "34.0.1"
-
-[[unpublished.wasmtime-wasi-nn]]
 version = "37.0.0"
-audited_as = "35.0.0"
-
-[[unpublished.wasmtime-wasi-nn]]
-version = "38.0.0"
 audited_as = "36.0.1"
 
 [[unpublished.wasmtime-wasi-threads]]
-version = "34.0.0"
-audited_as = "33.0.0"
-
-[[unpublished.wasmtime-wasi-threads]]
-version = "35.0.0"
-audited_as = "33.0.0"
-
-[[unpublished.wasmtime-wasi-threads]]
-version = "36.0.0"
-audited_as = "34.0.1"
-
-[[unpublished.wasmtime-wasi-threads]]
 version = "37.0.0"
-audited_as = "35.0.0"
-
-[[unpublished.wasmtime-wasi-threads]]
-version = "38.0.0"
 audited_as = "36.0.1"
 
 [[unpublished.wasmtime-wasi-tls]]
-version = "34.0.0"
-audited_as = "33.0.0"
-
-[[unpublished.wasmtime-wasi-tls]]
-version = "35.0.0"
-audited_as = "33.0.0"
-
-[[unpublished.wasmtime-wasi-tls]]
-version = "36.0.0"
-audited_as = "34.0.1"
-
-[[unpublished.wasmtime-wasi-tls]]
 version = "37.0.0"
-audited_as = "35.0.0"
-
-[[unpublished.wasmtime-wasi-tls]]
-version = "38.0.0"
 audited_as = "36.0.1"
 
 [[unpublished.wasmtime-wasi-tls-nativetls]]
-version = "36.0.0"
-audited_as = "35.0.0"
-
-[[unpublished.wasmtime-wasi-tls-nativetls]]
 version = "37.0.0"
-audited_as = "35.0.0"
-
-[[unpublished.wasmtime-wasi-tls-nativetls]]
-version = "38.0.0"
 audited_as = "36.0.1"
 
 [[unpublished.wasmtime-wast]]
-version = "34.0.0"
-audited_as = "33.0.0"
-
-[[unpublished.wasmtime-wast]]
-version = "35.0.0"
-audited_as = "33.0.0"
-
-[[unpublished.wasmtime-wast]]
-version = "36.0.0"
-audited_as = "34.0.1"
-
-[[unpublished.wasmtime-wast]]
 version = "37.0.0"
-audited_as = "35.0.0"
-
-[[unpublished.wasmtime-wast]]
-version = "38.0.0"
 audited_as = "36.0.1"
 
-[[unpublished.wasmtime-winch]]
-version = "34.0.0"
-audited_as = "33.0.0"
-
-[[unpublished.wasmtime-winch]]
-version = "35.0.0"
-audited_as = "33.0.0"
-
-[[unpublished.wasmtime-wit-bindgen]]
-version = "34.0.0"
-audited_as = "33.0.0"
-
-[[unpublished.wasmtime-wit-bindgen]]
-version = "35.0.0"
-audited_as = "33.0.0"
-
-[[unpublished.wasmtime-wmemcheck]]
-version = "34.0.0"
-audited_as = "33.0.0"
-
-[[unpublished.wasmtime-wmemcheck]]
-version = "35.0.0"
-audited_as = "33.0.0"
-
-[[unpublished.wiggle]]
-version = "34.0.0"
-audited_as = "33.0.0"
-
-[[unpublished.wiggle]]
-version = "35.0.0"
-audited_as = "33.0.0"
-
-[[unpublished.wiggle]]
-version = "36.0.0"
-audited_as = "34.0.1"
-
 [[unpublished.wiggle]]
 version = "37.0.0"
-audited_as = "35.0.0"
-
-[[unpublished.wiggle]]
-version = "38.0.0"
 audited_as = "36.0.1"
 
 [[unpublished.wiggle-generate]]
-version = "34.0.0"
-audited_as = "33.0.0"
-
-[[unpublished.wiggle-generate]]
-version = "35.0.0"
-audited_as = "33.0.0"
-
-[[unpublished.wiggle-generate]]
-version = "36.0.0"
-audited_as = "34.0.1"
-
-[[unpublished.wiggle-generate]]
 version = "37.0.0"
-audited_as = "35.0.0"
-
-[[unpublished.wiggle-generate]]
-version = "38.0.0"
 audited_as = "36.0.1"
 
 [[unpublished.wiggle-macro]]
-version = "34.0.0"
-audited_as = "33.0.0"
-
-[[unpublished.wiggle-macro]]
-version = "35.0.0"
-audited_as = "33.0.0"
-
-[[unpublished.wiggle-macro]]
-version = "36.0.0"
-audited_as = "34.0.1"
-
-[[unpublished.wiggle-macro]]
 version = "37.0.0"
-audited_as = "35.0.0"
-
-[[unpublished.wiggle-macro]]
-version = "38.0.0"
 audited_as = "36.0.1"
 
 [[unpublished.wiggle-test]]
@@ -1098,23 +234,7 @@ version = "0.0.0"
 audited_as = "0.1.0"
 
 [[unpublished.winch-codegen]]
-version = "34.0.0"
-audited_as = "33.0.0"
-
-[[unpublished.winch-codegen]]
-version = "35.0.0"
-audited_as = "33.0.0"
-
-[[unpublished.winch-codegen]]
-version = "36.0.0"
-audited_as = "34.0.1"
-
-[[unpublished.winch-codegen]]
 version = "37.0.0"
-audited_as = "35.0.0"
-
-[[unpublished.winch-codegen]]
-version = "38.0.0"
 audited_as = "36.0.1"
 
 [[publisher.aho-corasick]]
@@ -1320,122 +440,122 @@ user-login = "jrmuizel"
 user-name = "Jeff Muizelaar"
 
 [[publisher.cranelift]]
-version = "0.122.0"
-when = "2025-07-22"
+version = "0.123.1"
+when = "2025-08-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-assembler-x64]]
-version = "0.122.0"
-when = "2025-07-22"
+version = "0.123.1"
+when = "2025-08-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-assembler-x64-meta]]
-version = "0.122.0"
-when = "2025-07-22"
+version = "0.123.1"
+when = "2025-08-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-bforest]]
-version = "0.122.0"
-when = "2025-07-22"
+version = "0.123.1"
+when = "2025-08-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-bitset]]
-version = "0.122.0"
-when = "2025-07-22"
+version = "0.123.1"
+when = "2025-08-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-codegen]]
-version = "0.122.0"
-when = "2025-07-22"
+version = "0.123.1"
+when = "2025-08-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-codegen-meta]]
-version = "0.122.0"
-when = "2025-07-22"
+version = "0.123.1"
+when = "2025-08-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-codegen-shared]]
-version = "0.122.0"
-when = "2025-07-22"
+version = "0.123.1"
+when = "2025-08-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-control]]
-version = "0.122.0"
-when = "2025-07-22"
+version = "0.123.1"
+when = "2025-08-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-entity]]
-version = "0.122.0"
-when = "2025-07-22"
+version = "0.123.1"
+when = "2025-08-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-frontend]]
-version = "0.122.0"
-when = "2025-07-22"
+version = "0.123.1"
+when = "2025-08-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-interpreter]]
-version = "0.122.0"
-when = "2025-07-22"
+version = "0.123.1"
+when = "2025-08-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-isle]]
-version = "0.122.0"
-when = "2025-07-22"
+version = "0.123.1"
+when = "2025-08-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-jit]]
-version = "0.122.0"
-when = "2025-07-22"
+version = "0.123.1"
+when = "2025-08-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-module]]
-version = "0.122.0"
-when = "2025-07-22"
+version = "0.123.1"
+when = "2025-08-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-native]]
-version = "0.122.0"
-when = "2025-07-22"
+version = "0.123.1"
+when = "2025-08-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-object]]
-version = "0.122.0"
-when = "2025-07-22"
+version = "0.123.1"
+when = "2025-08-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-reader]]
-version = "0.122.0"
-when = "2025-07-22"
+version = "0.123.1"
+when = "2025-08-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-serde]]
-version = "0.122.0"
-when = "2025-07-22"
+version = "0.123.1"
+when = "2025-08-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-srcgen]]
-version = "0.122.0"
-when = "2025-07-22"
+version = "0.123.1"
+when = "2025-08-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1649,8 +769,8 @@ user-login = "dtolnay"
 user-name = "David Tolnay"
 
 [[publisher.pulley-interpreter]]
-version = "35.0.0"
-when = "2025-07-22"
+version = "36.0.1"
+when = "2025-08-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1927,8 +1047,8 @@ user-login = "sunfishcode"
 user-name = "Dan Gohman"
 
 [[publisher.wasi-common]]
-version = "33.0.0"
-when = "2025-05-20"
+version = "36.0.1"
+when = "2025-08-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2022,194 +1142,188 @@ user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime]]
-version = "33.0.0"
-when = "2025-05-20"
+version = "36.0.1"
+when = "2025-08-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-cli]]
-version = "33.0.0"
-when = "2025-05-20"
+version = "36.0.1"
+when = "2025-08-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-cli-flags]]
-version = "33.0.0"
-when = "2025-05-20"
+version = "36.0.1"
+when = "2025-08-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-environ]]
-version = "35.0.0"
-when = "2025-07-22"
+version = "36.0.1"
+when = "2025-08-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-internal-asm-macros]]
-version = "35.0.0"
-when = "2025-07-22"
+version = "36.0.1"
+when = "2025-08-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-internal-c-api-macros]]
-version = "35.0.0"
-when = "2025-07-22"
-user-id = 1
-user-login = "alexcrichton"
-user-name = "Alex Crichton"
+version = "36.0.1"
+when = "2025-08-21"
+user-id = 73222
+user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-internal-cache]]
-version = "35.0.0"
-when = "2025-07-22"
-user-id = 1
-user-login = "alexcrichton"
-user-name = "Alex Crichton"
+version = "36.0.1"
+when = "2025-08-21"
+user-id = 73222
+user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-internal-component-macro]]
-version = "35.0.0"
-when = "2025-07-22"
+version = "36.0.1"
+when = "2025-08-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-internal-component-util]]
-version = "35.0.0"
-when = "2025-07-22"
+version = "36.0.1"
+when = "2025-08-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-internal-cranelift]]
-version = "35.0.0"
-when = "2025-07-22"
-user-id = 1
-user-login = "alexcrichton"
-user-name = "Alex Crichton"
+version = "36.0.1"
+when = "2025-08-21"
+user-id = 73222
+user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-internal-explorer]]
-version = "35.0.0"
-when = "2025-07-22"
-user-id = 1
-user-login = "alexcrichton"
-user-name = "Alex Crichton"
+version = "36.0.1"
+when = "2025-08-21"
+user-id = 73222
+user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-internal-fiber]]
-version = "35.0.0"
-when = "2025-07-22"
+version = "36.0.1"
+when = "2025-08-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-internal-jit-debug]]
-version = "35.0.0"
-when = "2025-07-22"
+version = "36.0.1"
+when = "2025-08-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-internal-jit-icache-coherence]]
-version = "35.0.0"
-when = "2025-07-22"
+version = "36.0.1"
+when = "2025-08-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-internal-math]]
-version = "35.0.0"
-when = "2025-07-22"
+version = "36.0.1"
+when = "2025-08-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-internal-slab]]
-version = "35.0.0"
-when = "2025-07-22"
+version = "36.0.1"
+when = "2025-08-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-internal-unwinder]]
-version = "35.0.0"
-when = "2025-07-22"
+version = "36.0.1"
+when = "2025-08-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-internal-versioned-export-macros]]
-version = "35.0.0"
-when = "2025-07-22"
+version = "36.0.1"
+when = "2025-08-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-internal-winch]]
-version = "35.0.0"
-when = "2025-07-22"
-user-id = 1
-user-login = "alexcrichton"
-user-name = "Alex Crichton"
+version = "36.0.1"
+when = "2025-08-21"
+user-id = 73222
+user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-internal-wit-bindgen]]
-version = "35.0.0"
-when = "2025-07-22"
+version = "36.0.1"
+when = "2025-08-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-internal-wmemcheck]]
-version = "35.0.0"
-when = "2025-07-22"
+version = "36.0.1"
+when = "2025-08-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi]]
-version = "35.0.0"
-when = "2025-07-22"
+version = "36.0.1"
+when = "2025-08-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-config]]
-version = "35.0.0"
-when = "2025-07-22"
+version = "36.0.1"
+when = "2025-08-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-http]]
-version = "35.0.0"
-when = "2025-07-22"
+version = "36.0.1"
+when = "2025-08-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-io]]
-version = "35.0.0"
-when = "2025-07-22"
+version = "36.0.1"
+when = "2025-08-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-keyvalue]]
-version = "35.0.0"
-when = "2025-07-22"
+version = "36.0.1"
+when = "2025-08-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-nn]]
-version = "35.0.0"
-when = "2025-07-22"
+version = "36.0.1"
+when = "2025-08-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-threads]]
-version = "35.0.0"
-when = "2025-07-22"
+version = "36.0.1"
+when = "2025-08-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-tls]]
-version = "35.0.0"
-when = "2025-07-22"
+version = "36.0.1"
+when = "2025-08-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-tls-nativetls]]
-version = "35.0.0"
-when = "2025-07-22"
-user-id = 1
-user-login = "alexcrichton"
-user-name = "Alex Crichton"
+version = "36.0.1"
+when = "2025-08-21"
+user-id = 73222
+user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wast]]
-version = "33.0.0"
-when = "2025-05-20"
+version = "36.0.1"
+when = "2025-08-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2233,20 +1347,20 @@ user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
 [[publisher.wiggle]]
-version = "33.0.0"
-when = "2025-05-20"
+version = "36.0.1"
+when = "2025-08-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wiggle-generate]]
-version = "35.0.0"
-when = "2025-07-22"
+version = "36.0.1"
+when = "2025-08-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wiggle-macro]]
-version = "35.0.0"
-when = "2025-07-22"
+version = "36.0.1"
+when = "2025-08-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2265,8 +1379,8 @@ user-login = "BurntSushi"
 user-name = "Andrew Gallant"
 
 [[publisher.winch-codegen]]
-version = "33.0.0"
-when = "2025-05-20"
+version = "36.0.1"
+when = "2025-08-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -422,19 +422,7 @@ version = "38.0.0"
 audited_as = "36.0.1"
 
 [[unpublished.pulley-macros]]
-version = "35.0.0"
-audited_as = "34.0.0"
-
-[[unpublished.pulley-macros]]
-version = "36.0.0"
-audited_as = "34.0.1"
-
-[[unpublished.pulley-macros]]
 version = "37.0.0"
-audited_as = "35.0.0"
-
-[[unpublished.pulley-macros]]
-version = "38.0.0"
 audited_as = "36.0.1"
 
 [[unpublished.wasi-common]]
@@ -1667,8 +1655,8 @@ user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.pulley-macros]]
-version = "35.0.0"
-when = "2025-07-22"
+version = "36.0.1"
+when = "2025-08-21"
 user-id = 73222
 user-login = "wasmtime-publish"
 


### PR DESCRIPTION
This is the same as https://github.com/bytecodealliance/wasmtime/pull/8586 but updating some more tables. Effectively
wildcard audits are usable by other organizations, but trusted authors
aren't, so switch over crates maintained and published by us.