### PR TITLE
Reexport pulley/all-arch through the C API

### DIFF
--- a/crates/c-api/Cargo.toml
+++ b/crates/c-api/Cargo.toml
@@ -60,5 +60,7 @@ debug-builtins = ['wasmtime/debug-builtins']
 wat = ['dep:wat', 'wasmtime/wat']
 pooling-allocator = ["wasmtime/pooling-allocator"]
 component-model = ["wasmtime/component-model"]
+pulley = ["wasmtime/pulley"]
+all-arch = ["wasmtime/all-arch"]
 # ... if you add a line above this be sure to change the other locations
 # marked WASMTIME_FEATURE_LIST

--- a/crates/c-api/artifact/Cargo.toml
+++ b/crates/c-api/artifact/Cargo.toml
@@ -41,6 +41,8 @@ default = [
   'debug-builtins',
   'pooling-allocator',
   'component-model',
+  'pulley',
+  # 'all-arch', # intentionally off-by-default
   # ... if you add a line above this be sure to change the other locations
   # marked WASMTIME_FEATURE_LIST
 ]
@@ -64,5 +66,7 @@ winch = ["wasmtime-c-api/winch"]
 debug-builtins = ["wasmtime-c-api/debug-builtins"]
 pooling-allocator = ["wasmtime-c-api/pooling-allocator"]
 component-model = ["wasmtime-c-api/component-model"]
+pulley = ["wasmtime-c-api/pulley"]
+all-arch = ["wasmtime-c-api/all-arch"]
 # ... if you add a line above this be sure to read the comment at the end of
 # `default`

--- a/crates/c-api/build.rs
+++ b/crates/c-api/build.rs
@@ -23,6 +23,8 @@ const FEATURES: &[&str] = &[
     "WAT",
     "POOLING_ALLOCATOR",
     "COMPONENT_MODEL",
+    "PULLEY",
+    "ALL_ARCH",
 ];
 // ... if you add a line above this be sure to change the other locations
 // marked WASMTIME_FEATURE_LIST

--- a/crates/c-api/cmake/features.cmake
+++ b/crates/c-api/cmake/features.cmake
@@ -46,5 +46,7 @@ feature(winch ON)
 feature(debug-builtins ON)
 feature(pooling-allocator ON)
 feature(component-model ON)
+feature(pulley ON)
+feature(all-arch OFF)
 # ... if you add a line above this be sure to change the other locations
 # marked WASMTIME_FEATURE_LIST

--- a/crates/c-api/include/wasmtime/conf.h.in
+++ b/crates/c-api/include/wasmtime/conf.h.in
@@ -28,6 +28,8 @@
 #cmakedefine WASMTIME_FEATURE_DEBUG_BUILTINS
 #cmakedefine WASMTIME_FEATURE_POOLING_ALLOCATOR
 #cmakedefine WASMTIME_FEATURE_COMPONENT_MODEL
+#cmakedefine WASMTIME_FEATURE_PULLEY
+#cmakedefine WASMTIME_FEATURE_ALL_ARCH
 // ... if you add a line above this be sure to change the other locations
 // marked WASMTIME_FEATURE_LIST
 


### PR DESCRIPTION
This commit adds a few more features from the Wasmtime crate to the C API for pulley and the all-arch option for Cranelift to support compiling for multiple architectures.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
