### PR TITLE
Exceptions: handle `try_table` in unreachable code properly.

### DIFF
--- a/crates/cranelift/src/translate/code_translator.rs
+++ b/crates/cranelift/src/translate/code_translator.rs
@@ -3098,7 +3098,9 @@ fn translate_unreachable_operator(
                 blockty,
             );
         }
-        Operator::Loop { blockty: _ } | Operator::Block { blockty: _ } => {
+        Operator::Loop { blockty: _ }
+        | Operator::Block { blockty: _ }
+        | Operator::TryTable { try_table: _ } => {
             stack.push_block(ir::Block::reserved_value(), 0, 0);
         }
         Operator::Else => {

--- a/tests/disas/try-table-unreachable.wat
+++ b/tests/disas/try-table-unreachable.wat
@@ -1,0 +1,12 @@
+;;! target = "x86_64"
+;;! test = "compile"
+;;! flags = ["-Wexceptions=yes"]
+
+(module
+  (func
+    (unreachable)
+    (try_table)))
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       ud2


### PR DESCRIPTION
Our Wasm-to-CLIF translator has a separate match-over-opcodes for unreachable code that mostly does nothing, but needs to push entries onto the control stack so that `end`-opcode processing works properly and tracks the bytecode's nesting (which is important because after an `end` we might re-enter reachable code).

Previously, `try_table` was not handled here -- it fell into the catchall case that did nothing -- so a `try_table` in unreachable code (most trivially, `(unreachable) (try_table)` in any block) would result in a panic. This PR fixes that by updating `try_table` handling to work like `block` and `loop` in unreachable contexts.

Fixes #11505.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
