### PR TITLE
docs: fix typo

### DIFF
--- a/crates/cranelift/src/compiler/component.rs
+++ b/crates/cranelift/src/compiler/component.rs
@@ -772,7 +772,7 @@ impl<'a> TrampolineCompiler<'a> {
         )
     }
 
-    /// Translates an invokation of a host function and interpret the result.
+    /// Translates an invocation of a host function and interpret the result.
     ///
     /// This is intended to be a relatively narrow waist which most intrinsics
     /// go through. The configuration supported here is:

--- a/crates/cranelift/src/func_environ/gc/enabled.rs
+++ b/crates/cranelift/src/func_environ/gc/enabled.rs
@@ -1234,7 +1234,7 @@ pub fn translate_ref_test(
         WasmHeapType::ConcreteCont(_) => {
             // TODO(#10248) GC integration for stack switching
             return Err(wasmtime_environ::WasmError::Unsupported(
-                "Stack switching feature not compatbile with GC, yet".to_string(),
+                "Stack switching feature not compatible with GC, yet".to_string(),
             ));
         }
     };

--- a/crates/wasmtime/src/runtime/vm/mmap.rs
+++ b/crates/wasmtime/src/runtime/vm/mmap.rs
@@ -418,7 +418,7 @@ impl MmapOffset {
     ///
     /// ## Safety
     ///
-    /// The caller must ensure that noone else has a reference to this memory.
+    /// The caller must ensure that no one else has a reference to this memory.
     pub unsafe fn map_image_at(
         &self,
         image_source: &MemoryImageSource,


### PR DESCRIPTION
`invokation` to `invocation`
`compatbile` to `compatible`
`noone` to `no one`