### PR TITLE
Refactor resetting memory on `MemoryImageSlot` drop

### DIFF
--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -117,6 +117,10 @@ harness = false
 name = "engine_across_forks"
 harness = false
 
+[[test]]
+name = "pooling_alloc_near_oom"
+harness = false
+
 # =============================================================================
 #
 # Features for the Wasmtime crate.

--- a/crates/wasmtime/src/runtime/vm/memory.rs
+++ b/crates/wasmtime/src/runtime/vm/memory.rs
@@ -551,29 +551,6 @@ impl LocalMemory {
 
                     let mut slot =
                         MemoryImageSlot::create(mmap_base, byte_size, alloc.byte_capacity());
-                    // On drop, we will unmap our mmap'd range that this slot
-                    // was mapped on top of, so there is no need for the slot to
-                    // wipe it with an anonymous mapping first.
-                    //
-                    // Note that this code would be incorrect if clear-on-drop
-                    // were enabled. That's because:
-                    //
-                    // * In the struct definition, `memory_image` above is listed
-                    //   after `alloc`.
-                    // * Rust drops fields in the order they're defined, so
-                    //   `memory_image` would be dropped after `alloc`.
-                    // * `alloc` can represent either owned memory (i.e. the mmap is
-                    //   freed on drop) or logically borrowed memory (something else
-                    //   manages the mmap).
-                    // * If `alloc` is borrowed memory, then this isn't an issue.
-                    // * But if `alloc` is owned memory, then it would first drop
-                    //   the mmap, and then `memory_image` would try to remap
-                    //   part of that same memory as part of clear-on-drop.
-                    //
-                    // A lot of this really suggests representing the ownership
-                    // via Rust lifetimes -- that would be a major refactor,
-                    // though.
-                    slot.no_clear_on_drop();
                     slot.instantiate(alloc.byte_size(), Some(image), ty, tunables)?;
                     Some(slot)
                 } else {

--- a/crates/wasmtime/tests/pooling_alloc_near_oom.rs
+++ b/crates/wasmtime/tests/pooling_alloc_near_oom.rs
@@ -1,0 +1,112 @@
+use libtest_mimic::Arguments;
+use wasmtime::Result;
+
+fn main() -> Result<()> {
+    let mut trials = Vec::new();
+
+    #[cfg(unix)]
+    if !cfg!(miri) && !cfg!(asan) {
+        for (name, test) in unix::TESTS {
+            trials.push(libtest_mimic::Trial::test(*name, || {
+                test().map_err(|e| format!("{e:?}").into())
+            }));
+        }
+    }
+    let _ = &mut trials;
+
+    let mut args = Arguments::from_args();
+    // When testing memory exhaustion scenarios just test one at a time
+    args.test_threads = Some(1);
+    libtest_mimic::run(&args, trials).exit()
+}
+
+#[cfg(unix)]
+mod unix {
+    use rustix::mm::*;
+    use std::ffi::c_void;
+    use std::ptr;
+    use wasmtime::*;
+
+    pub const TESTS: &[(&str, fn() -> Result<()>)] = &[("exhausted_vmas", exhausted_vmas)];
+
+    fn exhausted_vmas() -> Result<()> {
+        // Create a small-ish pooling allocator which can hold a number of
+        // instances with memories, but we won't end up using all of them.
+        let mut pooling = PoolingAllocationConfig::new();
+        pooling.total_memories(100);
+        pooling.total_tables(0);
+        pooling.total_stacks(0);
+        let mut config = Config::new();
+        config.allocation_strategy(pooling);
+        let engine = Engine::new(&config)?;
+
+        // Create a module which has a CoW image to try to increase the number
+        // of VMAs in use.
+        let module = Module::new(
+            &engine,
+            r#"(module
+                (memory 1)
+                (data (i32.const 1) "\aa")
+            )"#,
+        )?;
+
+        // Eat up all kernel VMAs we're allowed in this process. This makes a
+        // lot of little tiny mmaps which force usage of a VMA by having a
+        // readable region in the middle of an otherwise unmapped region.
+        let mut vma_hogs = Vec::new();
+        while let Ok(hog) = VmaHog::new() {
+            vma_hogs.push(hog);
+        }
+
+        // Now that our process has reached it's VMA limit, or it's at least
+        // close to it, start allocating some instances. Do this until failure
+        // happens.
+        let mut stores = Vec::new();
+        loop {
+            let mut store = Store::new(&engine, ());
+            if Instance::new(&mut store, &module, &[]).is_ok() {
+                stores.push(store);
+            } else {
+                break;
+            }
+        }
+
+        // At this point if nothing has panicked then the test has passed.
+        // Destructors will clean everything else up.
+
+        Ok(())
+    }
+
+    struct VmaHog {
+        addr: *mut c_void,
+        size: usize,
+    }
+
+    impl VmaHog {
+        fn new() -> Result<VmaHog> {
+            unsafe {
+                let page_size = rustix::param::page_size();
+                let addr = mmap_anonymous(
+                    ptr::null_mut(),
+                    page_size * 3,
+                    ProtFlags::empty(),
+                    MapFlags::PRIVATE,
+                )?;
+                let ret = VmaHog {
+                    addr,
+                    size: page_size * 3,
+                };
+                mprotect(ret.addr.byte_add(page_size), page_size, MprotectFlags::READ)?;
+                Ok(ret)
+            }
+        }
+    }
+
+    impl Drop for VmaHog {
+        fn drop(&mut self) {
+            unsafe {
+                munmap(self.addr, self.size).unwrap();
+            }
+        }
+    }
+}

--- a/crates/wasmtime/tests/pooling_alloc_near_oom.rs
+++ b/crates/wasmtime/tests/pooling_alloc_near_oom.rs
@@ -30,6 +30,13 @@ mod unix {
     pub const TESTS: &[(&str, fn() -> Result<()>)] = &[("exhausted_vmas", exhausted_vmas)];
 
     fn exhausted_vmas() -> Result<()> {
+        // Non-Linux environments have different behavior around OOM and
+        // overcommit it seems. For example macOS looks to wedge the CI runner
+        // if it runs this tests. For now only run on Linux.
+        if !cfg!(target_os = "linux") {
+            return Ok(());
+        }
+
         // Create a small-ish pooling allocator which can hold a number of
         // instances with memories, but we won't end up using all of them.
         let mut pooling = PoolingAllocationConfig::new();

--- a/crates/wasmtime/tests/pooling_alloc_near_oom.rs
+++ b/crates/wasmtime/tests/pooling_alloc_near_oom.rs
@@ -5,7 +5,7 @@ fn main() -> Result<()> {
     let mut trials = Vec::new();
 
     #[cfg(unix)]
-    if !cfg!(miri) && !cfg!(asan) {
+    if !cfg!(miri) && !cfg!(asan) && std::env::var("WASMTIME_TEST_NO_HOG_MEMORY").is_err() {
         for (name, test) in unix::TESTS {
             trials.push(libtest_mimic::Trial::test(*name, || {
                 test().map_err(|e| format!("{e:?}").into())

--- a/tests/all/pooling_allocator.rs
+++ b/tests/all/pooling_allocator.rs
@@ -1354,3 +1354,60 @@ fn pagemap_scan_enabled_or_disabled() -> Result<()> {
     }
     Ok(())
 }
+
+// This test instantiates a memory with an image into a slot in the pooling
+// allocator in a way that maps the image into the allocator but fails
+// instantiation. Failure here is injected with `ResourceLimiter`. Afterwards
+// instantiation is allowed to succeed with a memory that has no image, and this
+// asserts that the previous image is indeed not available any more as that
+// would otherwise mean data was leaked between modules.
+#[test]
+fn memory_reset_if_instantiation_fails() -> Result<()> {
+    struct Limiter;
+
+    impl ResourceLimiter for Limiter {
+        fn memory_growing(&mut self, _: usize, _: usize, _: Option<usize>) -> Result<bool> {
+            Ok(false)
+        }
+
+        fn table_growing(&mut self, _: usize, _: usize, _: Option<usize>) -> Result<bool> {
+            Ok(false)
+        }
+    }
+
+    let pool = crate::small_pool_config();
+    let mut config = Config::new();
+    config.allocation_strategy(pool);
+    let engine = Engine::new(&config)?;
+
+    let module_with_image = Module::new(
+        &engine,
+        r#"
+            (module
+                (memory 1)
+                (data (i32.const 0) "\aa")
+            )
+        "#,
+    )?;
+    let module_without_image = Module::new(
+        &engine,
+        r#"
+            (module
+                (memory (export "m") 1)
+            )
+        "#,
+    )?;
+
+    let mut store = Store::new(&engine, Limiter);
+    store.limiter(|s| s);
+    assert!(Instance::new(&mut store, &module_with_image, &[]).is_err());
+    drop(store);
+
+    let mut store = Store::new(&engine, Limiter);
+    let instance = Instance::new(&mut store, &module_without_image, &[])?;
+    let mem = instance.get_memory(&mut store, "m").unwrap();
+    let data = mem.data(&store);
+    assert_eq!(data[0], 0);
+
+    Ok(())
+}


### PR DESCRIPTION
This commit refactors the behavior of dropping a `MemoryImageSlot` to no longer map anonymous memory into the slot. This behavior was implemented previously because if a `MemoryImageSlot` is dropped then the state of the slot is unknown and to prevent any sort of data leakage a reset is performed.

This reset operation, however, is fallible in that it calls `mmap`. Calls to `mmap` can fail due to `ENOMEM`, for example, if the process has reached its VMA limit. This means that if a process is in a near-OOM condition then failing to allocate a memory image could panic the process due to the `unwrap()` in the destructor of `MemoryImageSlot`. The purpose of this commit is to avoid this `unwrap()` and instead move the reset behavior to a location where an error can be propagated.

This commit removes the clear-on-drop behavior of `MemoryImageSlot` slot. This was already disabled everywhere except the pooling allocator. The pooling allocator now maintains an extra bit of state-per-slot where instead of storing `Option<MemoryImageSlot>` it now stores effectively one other variant of "unknown". On reuse of an "unknown" slot the memory is reset back to an anonymous mapping and this is all done in a context where an error can be propagated.

Two tests are added in this commit to confirm all of this behavior:

* The first test is a new test that passes both before and after this commit which performs a failed allocation of a memory slot. A successful allocation is then made to ensure that the previous image is not present and zero memory is present. This test fails before the commit if the clear-on-drop behavior is removed, and it fails with this commit if the clear-on-reusing-unknown behavior is removed. Effectively this test ensures that the clear-on-unknown-state logic is present.

* The second test is a new test that panicked before this commit and passes afterwards. This second test exhausts all VMAs in the current process, or at least most of them, and then tries to allocate some instances with an image. Instance allocation will eventually fail and cause the erroneous path to get executed. This previously unwrapped a `ENOMEM` failure, and now it can be handled gracefully by the embedder.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
