### PR TITLE
Exceptions: add basic support for fuzzing.

### DIFF
--- a/crates/fuzzing/src/generators/config.rs
+++ b/crates/fuzzing/src/generators/config.rs
@@ -662,6 +662,7 @@ impl WasmtimeConfig {
                 config.config.gc_enabled = false;
                 config.config.tail_call_enabled = false;
                 config.config.reference_types_enabled = false;
+                config.config.exceptions_enabled = false;
                 config.function_references_enabled = false;
 
                 // Winch's SIMD implementations require AVX and AVX2.

--- a/crates/fuzzing/src/generators/module.rs
+++ b/crates/fuzzing/src/generators/module.rs
@@ -48,7 +48,7 @@ impl<'a> Arbitrary<'a> for ModuleConfig {
         let _ = config.tail_call_enabled;
         let _ = config.extended_const_enabled;
         let _ = config.gc_enabled;
-        config.exceptions_enabled = false;
+        let _ = config.exceptions_enabled;
         config.custom_page_sizes_enabled = u.arbitrary()?;
         config.wide_arithmetic_enabled = u.arbitrary()?;
         config.memory64_enabled = u.ratio(1, 20)?;

--- a/crates/fuzzing/src/generators/value.rs
+++ b/crates/fuzzing/src/generators/value.rs
@@ -272,6 +272,7 @@ impl PartialEq for DiffValue {
             (Self::FuncRef { null: a }, Self::FuncRef { null: b }) => a == b,
             (Self::ExternRef { null: a }, Self::ExternRef { null: b }) => a == b,
             (Self::AnyRef { null: a }, Self::AnyRef { null: b }) => a == b,
+            (Self::ExnRef { null: a }, Self::ExnRef { null: b }) => a == b,
             _ => false,
         }
     }

--- a/crates/fuzzing/src/oracles.rs
+++ b/crates/fuzzing/src/oracles.rs
@@ -1417,7 +1417,8 @@ mod tests {
             | WasmFeatures::GC
             | WasmFeatures::GC_TYPES
             | WasmFeatures::CUSTOM_PAGE_SIZES
-            | WasmFeatures::EXTENDED_CONST;
+            | WasmFeatures::EXTENDED_CONST
+            | WasmFeatures::EXCEPTIONS;
 
         // All other features that wasmparser supports, which is presumably a
         // superset of the features that wasm-smith supports, are listed here as

--- a/crates/fuzzing/src/oracles/diff_spec.rs
+++ b/crates/fuzzing/src/oracles/diff_spec.rs
@@ -28,6 +28,7 @@ impl SpecInterpreter {
         config.custom_page_sizes_enabled = false;
         config.wide_arithmetic_enabled = false;
         config.extended_const_enabled = false;
+        config.exceptions_enabled = false;
 
         Self
     }


### PR DESCRIPTION
This pulls in Alex's patch from [here](https://github.com/bytecodealliance/wasmtime/issues/11505#issue-3343508228) as the first commit, and an update to `DiffValue` comparison to support exnrefs as the second commit.

I've fuzzed locally with `differential` and (i) found the exnref comparison that led to the second commit, so I know that this is doing "something", and (ii) hit a segfault in V8 on a divide-by-zero, so that's a thing but I think not my thing.

Fixes #11485.