### PR TITLE
contributing docs: Add a policy for documentation typo fixes

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -68,6 +68,13 @@ Also, we encourage people to just look around and find things they're
 interested in. This a good time to get involved, as there aren't a lot of
 things set in stone yet.
 
+### Documentation typo fixes
+
+We all make typos, and in comments and documentation, rustc doesn't catch them
+for us. We appreciate recieving PRs to fix them. However, we request that new
+contributors (those who have not had any substantive code PRs merged) only
+submit one PR per week dedicated to fixing typos.
+
 [Rust's issue tags]: https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md#issue-triage
 [E-easy]: https://github.com/bytecodealliance/wasmtime/labels/cranelift%3AE-easy
 [E-rust]: https://github.com/bytecodealliance/wasmtime/labels/cranelift%3AE-rust


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
