### PR TITLE
Cranelift: fix an inliner bug where the last-inlined block was not inserted in the layout

### DIFF
--- a/cranelift/filetests/filetests/inline/unreachable-block.clif
+++ b/cranelift/filetests/filetests/inline/unreachable-block.clif
@@ -44,3 +44,45 @@ block0():
 ;     v1 -> v2
 ;     return v1
 ; }
+
+;; A similar test as above, but with multiple and indirectly unreachable blocks.
+function %f3() -> i32 {
+block0:
+    jump block1
+block1:
+    v0 = iconst.i32 42
+    return v0
+block2:
+    jump block3
+block3:
+    trap user42
+}
+
+; (no functions inlined into %f3)
+
+function %f4() -> i32 {
+    fn0 = %f3() -> i32
+block0:
+    v0 = call fn0()
+    return v0
+}
+
+; function %f4() -> i32 fast {
+;     sig0 = () -> i32 fast
+;     fn0 = %f3 sig0
+;
+; block0:
+;     jump block1
+;
+; block1:
+;     jump block2
+;
+; block2:
+;     v2 = iconst.i32 42
+;     jump block5(v2)  ; v2 = 42
+;
+; block5(v1: i32):
+;     v0 -> v1
+;     return v0
+; }
+


### PR DESCRIPTION


Fixes #11493

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
