### PR TITLE
GC: replace ManuallyRooted with OwnedRooted.

### DIFF
--- a/crates/c-api/include/wasmtime/val.h
+++ b/crates/c-api/include/wasmtime/val.h
@@ -45,7 +45,7 @@ typedef struct wasmtime_anyref {
   /// Internal to Wasmtime.
   uint32_t __private2;
   /// Internal to Wasmtime.
-  uintptr_t __private3;
+  void *__private3;
 } wasmtime_anyref_t;
 
 /// \brief Helper function to initialize the `ref` provided to a null anyref
@@ -182,7 +182,7 @@ typedef struct wasmtime_externref {
   /// Internal to Wasmtime.
   uint32_t __private2;
   /// Internal to Wasmtime.
-  uintptr_t __private3;
+  void *__private3;
 } wasmtime_externref_t;
 
 /// \brief Helper function to initialize the `ref` provided to a null externref

--- a/crates/c-api/include/wasmtime/val.h
+++ b/crates/c-api/include/wasmtime/val.h
@@ -32,6 +32,10 @@ extern "C" {
  * Anyref values are required to be explicitly unrooted via
  * #wasmtime_anyref_unroot to enable them to be garbage-collected.
  *
+ * If you do not unroot the value, *even if you free the corresponding
+ * Store*, there will be some memory leaked, because GC roots use a
+ * separate allocation to track liveness.
+ *
  * Null anyref values are represented by this structure and can be tested and
  * created with the `wasmtime_anyref_is_null` and `wasmtime_anyref_set_null`
  * functions.
@@ -218,6 +222,10 @@ static inline bool wasmtime_externref_is_null(const wasmtime_externref_t *ref) {
  * in the future with #wasmtime_externref_unroot. If `false` is returned then
  * the host wasn't able to create more GC values at this time. Performing a GC
  * may free up enough space to try again.
+ *
+ * If you do not unroot the value, *even if you free the corresponding
+ * Store*, there will be some memory leaked, because GC roots use a
+ * separate allocation to track liveness.
  */
 WASM_API_EXTERN bool wasmtime_externref_new(wasmtime_context_t *context,
                                             void *data,
@@ -444,6 +452,10 @@ static inline void __wasmtime_val_assertions() {
  * consume a #wasmtime_val_t do not take ownership, but APIs that return
  * #wasmtime_val_t require that #wasmtime_val_unroot is called to clean up
  * any possible GC roots in the value.
+ *
+ * If you do not unroot the value, *even if you free the corresponding
+ * Store*, there will be some memory leaked, because GC roots use a
+ * separate allocation to track liveness.
  */
 typedef struct wasmtime_val {
   /// Discriminant of which field of #of is valid.

--- a/crates/c-api/include/wasmtime/val.h
+++ b/crates/c-api/include/wasmtime/val.h
@@ -44,6 +44,8 @@ typedef struct wasmtime_anyref {
   uint32_t __private1;
   /// Internal to Wasmtime.
   uint32_t __private2;
+  /// Internal to Wasmtime.
+  uintptr_t __private3;
 } wasmtime_anyref_t;
 
 /// \brief Helper function to initialize the `ref` provided to a null anyref
@@ -179,6 +181,8 @@ typedef struct wasmtime_externref {
   uint32_t __private1;
   /// Internal to Wasmtime.
   uint32_t __private2;
+  /// Internal to Wasmtime.
+  uintptr_t __private3;
 } wasmtime_externref_t;
 
 /// \brief Helper function to initialize the `ref` provided to a null externref
@@ -418,7 +422,8 @@ typedef union wasmtime_val_raw {
 // Assert that the shape of this type is as expected since it needs to match
 // Rust.
 static inline void __wasmtime_val_assertions() {
-  static_assert(sizeof(wasmtime_valunion_t) == 16, "should be 16-bytes large");
+  static_assert(sizeof(wasmtime_valunion_t) == 16 + sizeof(void *),
+                "should be 16 bytes plus a pointer large");
   static_assert(__alignof(wasmtime_valunion_t) == 8,
                 "should be 8-byte aligned");
   static_assert(sizeof(wasmtime_val_raw_t) == 16, "should be 16 bytes large");

--- a/crates/c-api/include/wasmtime/val.h
+++ b/crates/c-api/include/wasmtime/val.h
@@ -422,8 +422,10 @@ typedef union wasmtime_val_raw {
 // Assert that the shape of this type is as expected since it needs to match
 // Rust.
 static inline void __wasmtime_val_assertions() {
-  static_assert(sizeof(wasmtime_valunion_t) == 16 + sizeof(void *),
-                "should be 16 bytes plus a pointer large");
+  static_assert(sizeof(wasmtime_valunion_t) >= 16 &&
+                    sizeof(wasmtime_valunion_t) <= 24,
+                "should be 16 bytes plus a pointer large (plus alignment on "
+                "some platforms)");
   static_assert(__alignof(wasmtime_valunion_t) == 8,
                 "should be 8-byte aligned");
   static_assert(sizeof(wasmtime_val_raw_t) == 16, "should be 16 bytes large");

--- a/crates/c-api/src/ref.rs
+++ b/crates/c-api/src/ref.rs
@@ -196,7 +196,7 @@ macro_rules! ref_wrapper {
             store_id: u64,
             a: u32,
             b: u32,
-            c: usize,
+            c: *const (),
         }
 
         impl $c {
@@ -221,7 +221,7 @@ macro_rules! ref_wrapper {
                     store_id: 0,
                     a: 0,
                     b: 0,
-                    c: 0,
+                    c: core::ptr::null(),
                 };
                 if let Some(rooted) = rooted {
                     let (store_id, a, b, c) = rooted.into_parts_for_c_api();
@@ -233,6 +233,13 @@ macro_rules! ref_wrapper {
                 ret
             }
         }
+
+        // SAFETY: The `*const ()` comes from (and is converted back
+        // into) an `Arc<()>`, and is only accessed as such, so this
+        // type is both Send and Sync. These constraints are necessary
+        // in the async machinery in this crate.
+        unsafe impl Send for $c {}
+        unsafe impl Sync for $c {}
     };
 }
 

--- a/crates/c-api/src/ref.rs
+++ b/crates/c-api/src/ref.rs
@@ -1,6 +1,6 @@
 use crate::{WasmtimeStoreContextMut, abort};
 use std::{mem::MaybeUninit, num::NonZeroU64, os::raw::c_void, ptr};
-use wasmtime::{AnyRef, ExternRef, I31, ManuallyRooted, Ref, RootScope, Val};
+use wasmtime::{AnyRef, ExternRef, I31, OwnedRooted, Ref, RootScope, Val};
 
 /// `*mut wasm_ref_t` is a reference type (`externref` or `funcref`), as seen by
 /// the C API. Because we do not have a uniform representation for `funcref`s
@@ -188,7 +188,7 @@ pub extern "C" fn wasm_foreign_new(_store: &crate::wasm_store_t) -> Box<wasm_for
 /// this is dispatched internally. Null anyref values are represented with a
 /// `store_id` of zero, and otherwise the `rooted` field is valid.
 ///
-/// Note that this relies on the Wasmtime definition of `ManuallyRooted` to have
+/// Note that this relies on the Wasmtime definition of `OwnedRooted` to have
 /// a 64-bit store_id first.
 macro_rules! ref_wrapper {
     ($wasmtime:ident => $c:ident) => {
@@ -196,29 +196,39 @@ macro_rules! ref_wrapper {
             store_id: u64,
             a: u32,
             b: u32,
+            c: usize,
         }
 
         impl $c {
-            pub unsafe fn as_wasmtime(&self) -> Option<ManuallyRooted<$wasmtime>> {
+            pub unsafe fn as_wasmtime(&self) -> Option<OwnedRooted<$wasmtime>> {
                 let store_id = NonZeroU64::new(self.store_id)?;
-                Some(ManuallyRooted::from_raw_parts_for_c_api(
-                    store_id, self.a, self.b,
+                Some(OwnedRooted::from_borrowed_raw_parts_for_c_api(
+                    store_id, self.a, self.b, self.c,
+                ))
+            }
+
+            pub unsafe fn from_wasmtime(self) -> Option<OwnedRooted<$wasmtime>> {
+                let store_id = NonZeroU64::new(self.store_id)?;
+                Some(OwnedRooted::from_owned_raw_parts_for_c_api(
+                    store_id, self.a, self.b, self.c,
                 ))
             }
         }
 
-        impl From<Option<ManuallyRooted<$wasmtime>>> for $c {
-            fn from(rooted: Option<ManuallyRooted<$wasmtime>>) -> $c {
+        impl From<Option<OwnedRooted<$wasmtime>>> for $c {
+            fn from(rooted: Option<OwnedRooted<$wasmtime>>) -> $c {
                 let mut ret = $c {
                     store_id: 0,
                     a: 0,
                     b: 0,
+                    c: 0,
                 };
                 if let Some(rooted) = rooted {
-                    let (store_id, a, b) = rooted.into_parts_for_c_api();
+                    let (store_id, a, b, c) = rooted.into_parts_for_c_api();
                     ret.store_id = store_id.get();
                     ret.a = a;
                     ret.b = b;
+                    ret.c = c;
                 }
                 ret
             }
@@ -231,21 +241,21 @@ ref_wrapper!(ExternRef => wasmtime_externref_t);
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasmtime_anyref_clone(
-    cx: WasmtimeStoreContextMut<'_>,
+    _cx: WasmtimeStoreContextMut<'_>,
     anyref: Option<&wasmtime_anyref_t>,
     out: &mut MaybeUninit<wasmtime_anyref_t>,
 ) {
-    let anyref = anyref.and_then(|a| a.as_wasmtime()).map(|a| a.clone(cx));
+    let anyref = anyref.and_then(|a| a.as_wasmtime());
     crate::initialize(out, anyref.into());
 }
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasmtime_anyref_unroot(
-    cx: WasmtimeStoreContextMut<'_>,
+    _cx: WasmtimeStoreContextMut<'_>,
     val: Option<&mut MaybeUninit<wasmtime_anyref_t>>,
 ) {
-    if let Some(val) = val.and_then(|v| v.assume_init_read().as_wasmtime()) {
-        val.unroot(cx);
+    if let Some(val) = val.and_then(|v| v.assume_init_read().from_wasmtime()) {
+        drop(val);
     }
 }
 
@@ -266,8 +276,8 @@ pub unsafe extern "C" fn wasmtime_anyref_from_raw(
     val: &mut MaybeUninit<wasmtime_anyref_t>,
 ) {
     let mut scope = RootScope::new(cx);
-    let anyref = AnyRef::from_raw(&mut scope, raw)
-        .map(|a| a.to_manually_rooted(&mut scope).expect("in scope"));
+    let anyref =
+        AnyRef::from_raw(&mut scope, raw).map(|a| a.to_owned_rooted(&mut scope).expect("in scope"));
     crate::initialize(val, anyref.into());
 }
 
@@ -279,7 +289,7 @@ pub extern "C" fn wasmtime_anyref_from_i31(
 ) {
     let mut scope = RootScope::new(cx);
     let anyref = AnyRef::from_i31(&mut scope, I31::wrapping_u32(val));
-    let anyref = anyref.to_manually_rooted(&mut scope).expect("in scope");
+    let anyref = anyref.to_owned_rooted(&mut scope).expect("in scope");
     crate::initialize(out, Some(anyref).into())
 }
 
@@ -290,10 +300,10 @@ pub unsafe extern "C" fn wasmtime_anyref_i31_get_u(
     dst: &mut MaybeUninit<u32>,
 ) -> bool {
     match anyref.and_then(|a| a.as_wasmtime()) {
-        Some(anyref) if anyref.is_i31(&cx).expect("ManuallyRooted always in scope") => {
+        Some(anyref) if anyref.is_i31(&cx).expect("OwnedRooted always in scope") => {
             let val = anyref
                 .unwrap_i31(&cx)
-                .expect("ManuallyRooted always in scope")
+                .expect("OwnedRooted always in scope")
                 .get_u32();
             crate::initialize(dst, val);
             true
@@ -309,10 +319,10 @@ pub unsafe extern "C" fn wasmtime_anyref_i31_get_s(
     dst: &mut MaybeUninit<i32>,
 ) -> bool {
     match anyref.and_then(|a| a.as_wasmtime()) {
-        Some(anyref) if anyref.is_i31(&cx).expect("ManuallyRooted always in scope") => {
+        Some(anyref) if anyref.is_i31(&cx).expect("OwnedRooted always in scope") => {
             let val = anyref
                 .unwrap_i31(&cx)
-                .expect("ManuallyRooted always in scope")
+                .expect("OwnedRooted always in scope")
                 .get_i32();
             crate::initialize(dst, val);
             true
@@ -333,7 +343,7 @@ pub extern "C" fn wasmtime_externref_new(
         Ok(e) => e,
         Err(_) => return false,
     };
-    let e = e.to_manually_rooted(&mut scope).expect("in scope");
+    let e = e.to_owned_rooted(&mut scope).expect("in scope");
     crate::initialize(out, Some(e).into());
     true
 }
@@ -354,21 +364,21 @@ pub unsafe extern "C" fn wasmtime_externref_data(
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasmtime_externref_clone(
-    cx: WasmtimeStoreContextMut<'_>,
+    _cx: WasmtimeStoreContextMut<'_>,
     externref: Option<&wasmtime_externref_t>,
     out: &mut MaybeUninit<wasmtime_externref_t>,
 ) {
-    let externref = externref.and_then(|e| e.as_wasmtime()).map(|e| e.clone(cx));
+    let externref = externref.and_then(|e| e.as_wasmtime());
     crate::initialize(out, externref.into());
 }
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasmtime_externref_unroot(
-    cx: WasmtimeStoreContextMut<'_>,
+    _cx: WasmtimeStoreContextMut<'_>,
     val: Option<&mut MaybeUninit<wasmtime_externref_t>>,
 ) {
-    if let Some(val) = val.and_then(|v| v.assume_init_read().as_wasmtime()) {
-        val.unroot(cx);
+    if let Some(val) = val.and_then(|v| v.assume_init_read().from_wasmtime()) {
+        drop(val);
     }
 }
 
@@ -390,6 +400,6 @@ pub unsafe extern "C" fn wasmtime_externref_from_raw(
 ) {
     let mut scope = RootScope::new(cx);
     let rooted = ExternRef::from_raw(&mut scope, raw)
-        .map(|e| e.to_manually_rooted(&mut scope).expect("in scope"));
+        .map(|e| e.to_owned_rooted(&mut scope).expect("in scope"));
     crate::initialize(val, rooted.into());
 }

--- a/crates/c-api/src/val.rs
+++ b/crates/c-api/src/val.rs
@@ -152,7 +152,8 @@ pub union wasmtime_val_union {
 }
 
 const _: () = {
-    assert!(std::mem::size_of::<wasmtime_val_union>() == 16);
+    // This is forced to 24 or 20 bytes by `anyref` and `externref`.
+    assert!(std::mem::size_of::<wasmtime_val_union>() == 16 + std::mem::size_of::<usize>());
     assert!(std::mem::align_of::<wasmtime_val_union>() == std::mem::align_of::<u64>());
 };
 
@@ -235,15 +236,13 @@ impl wasmtime_val_t {
             Val::AnyRef(a) => wasmtime_val_t {
                 kind: crate::WASMTIME_ANYREF,
                 of: wasmtime_val_union {
-                    anyref: ManuallyDrop::new(a.and_then(|a| a.to_manually_rooted(cx).ok()).into()),
+                    anyref: ManuallyDrop::new(a.and_then(|a| a.to_owned_rooted(cx).ok()).into()),
                 },
             },
             Val::ExternRef(e) => wasmtime_val_t {
                 kind: crate::WASMTIME_EXTERNREF,
                 of: wasmtime_val_union {
-                    externref: ManuallyDrop::new(
-                        e.and_then(|e| e.to_manually_rooted(cx).ok()).into(),
-                    ),
+                    externref: ManuallyDrop::new(e.and_then(|e| e.to_owned_rooted(cx).ok()).into()),
                 },
             },
             Val::FuncRef(func) => wasmtime_val_t {
@@ -298,19 +297,19 @@ impl wasmtime_val_t {
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasmtime_val_unroot(
-    cx: WasmtimeStoreContextMut<'_>,
+    _cx: WasmtimeStoreContextMut<'_>,
     val: &mut MaybeUninit<wasmtime_val_t>,
 ) {
     let val = val.assume_init_read();
     match val.kind {
         crate::WASMTIME_ANYREF => {
             if let Some(val) = ManuallyDrop::into_inner(val.of.anyref).as_wasmtime() {
-                val.unroot(cx);
+                drop(val);
             }
         }
         crate::WASMTIME_EXTERNREF => {
             if let Some(val) = ManuallyDrop::into_inner(val.of.externref).as_wasmtime() {
-                val.unroot(cx);
+                drop(val);
             }
         }
         _ => {}

--- a/crates/c-api/src/val.rs
+++ b/crates/c-api/src/val.rs
@@ -153,7 +153,7 @@ pub union wasmtime_val_union {
 
 const _: () = {
     // This is forced to 24 or 20 bytes by `anyref` and `externref`.
-    assert!(std::mem::size_of::<wasmtime_val_union>() == 16 + std::mem::size_of::<usize>());
+    assert!(std::mem::size_of::<wasmtime_val_union>() <= 24);
     assert!(std::mem::align_of::<wasmtime_val_union>() == std::mem::align_of::<u64>());
 };
 

--- a/crates/wasmtime/src/runtime/func.rs
+++ b/crates/wasmtime/src/runtime/func.rs
@@ -589,7 +589,7 @@ impl Func {
     /// | `Option<NoneRef>`                 | `nullref` aka `(ref null none)`           |
     /// | `NoneRef`                         | `(ref none)`                              |
     ///
-    /// Note that anywhere a `Rooted<T>` appears, a `ManuallyRooted<T>` may also
+    /// Note that anywhere a `Rooted<T>` appears, a `OwnedRooted<T>` may also
     /// be used.
     ///
     /// Any of the Rust types can be returned from the closure as well, in
@@ -1346,7 +1346,7 @@ impl Func {
     /// | `v128`                                    | `V128` on `x86-64` and `aarch64` only |
     ///
     /// (Note that this mapping is the same as that of [`Func::wrap`], and that
-    /// anywhere a `Rooted<T>` appears, a `ManuallyRooted<T>` may also appear).
+    /// anywhere a `Rooted<T>` appears, a `OwnedRooted<T>` may also appear).
     ///
     /// Note that once the [`TypedFunc`] return value is acquired you'll use either
     /// [`TypedFunc::call`] or [`TypedFunc::call_async`] as necessary to actually invoke

--- a/crates/wasmtime/src/runtime/gc.rs
+++ b/crates/wasmtime/src/runtime/gc.rs
@@ -28,7 +28,7 @@ impl<T> GcRef for T where T: GcRefImpl {}
 /// A trait implemented for GC references that are guaranteed to be rooted:
 ///
 /// * [`Rooted<T>`][crate::Rooted]
-/// * [`ManuallyRooted<T>`][crate::ManuallyRooted]
+/// * [`OwnedRooted<T>`][crate::OwnedRooted]
 ///
 /// You can use this to abstract over the different kinds of rooted GC
 /// references. Note that `Deref<Target = T>` is a supertrait for

--- a/crates/wasmtime/src/runtime/gc/disabled/anyref.rs
+++ b/crates/wasmtime/src/runtime/gc/disabled/anyref.rs
@@ -1,6 +1,6 @@
 use crate::runtime::vm::VMGcRef;
 use crate::{
-    ArrayRef, AsContext, AsContextMut, EqRef, GcRefImpl, HeapType, I31, ManuallyRooted, Result,
+    ArrayRef, AsContext, AsContextMut, EqRef, GcRefImpl, HeapType, I31, OwnedRooted, Result,
     Rooted, StructRef,
     store::{AutoAssertNoGc, StoreOpaque},
 };
@@ -16,9 +16,9 @@ impl From<Rooted<EqRef>> for Rooted<AnyRef> {
     }
 }
 
-impl From<ManuallyRooted<EqRef>> for ManuallyRooted<AnyRef> {
+impl From<OwnedRooted<EqRef>> for OwnedRooted<AnyRef> {
     #[inline]
-    fn from(s: ManuallyRooted<EqRef>) -> Self {
+    fn from(s: OwnedRooted<EqRef>) -> Self {
         match s.inner {}
     }
 }
@@ -30,9 +30,9 @@ impl From<Rooted<StructRef>> for Rooted<AnyRef> {
     }
 }
 
-impl From<ManuallyRooted<StructRef>> for ManuallyRooted<AnyRef> {
+impl From<OwnedRooted<StructRef>> for OwnedRooted<AnyRef> {
     #[inline]
-    fn from(s: ManuallyRooted<StructRef>) -> Self {
+    fn from(s: OwnedRooted<StructRef>) -> Self {
         match s.inner {}
     }
 }
@@ -44,9 +44,9 @@ impl From<Rooted<ArrayRef>> for Rooted<AnyRef> {
     }
 }
 
-impl From<ManuallyRooted<ArrayRef>> for ManuallyRooted<AnyRef> {
+impl From<OwnedRooted<ArrayRef>> for OwnedRooted<AnyRef> {
     #[inline]
-    fn from(s: ManuallyRooted<ArrayRef>) -> Self {
+    fn from(s: OwnedRooted<ArrayRef>) -> Self {
         match s.inner {}
     }
 }

--- a/crates/wasmtime/src/runtime/gc/disabled/eqref.rs
+++ b/crates/wasmtime/src/runtime/gc/disabled/eqref.rs
@@ -1,5 +1,5 @@
 use crate::{
-    ArrayRef, AsContext, GcRefImpl, HeapType, I31, ManuallyRooted, Result, Rooted, StructRef,
+    ArrayRef, AsContext, GcRefImpl, HeapType, I31, OwnedRooted, Result, Rooted, StructRef,
     store::StoreOpaque,
 };
 
@@ -14,9 +14,9 @@ impl From<Rooted<StructRef>> for Rooted<EqRef> {
     }
 }
 
-impl From<ManuallyRooted<StructRef>> for ManuallyRooted<EqRef> {
+impl From<OwnedRooted<StructRef>> for OwnedRooted<EqRef> {
     #[inline]
-    fn from(s: ManuallyRooted<StructRef>) -> Self {
+    fn from(s: OwnedRooted<StructRef>) -> Self {
         match s.inner {}
     }
 }
@@ -28,9 +28,9 @@ impl From<Rooted<ArrayRef>> for Rooted<EqRef> {
     }
 }
 
-impl From<ManuallyRooted<ArrayRef>> for ManuallyRooted<EqRef> {
+impl From<OwnedRooted<ArrayRef>> for OwnedRooted<EqRef> {
     #[inline]
-    fn from(s: ManuallyRooted<ArrayRef>) -> Self {
+    fn from(s: OwnedRooted<ArrayRef>) -> Self {
         match s.inner {}
     }
 }

--- a/crates/wasmtime/src/runtime/gc/disabled/rooting.rs
+++ b/crates/wasmtime/src/runtime/gc/disabled/rooting.rs
@@ -99,7 +99,7 @@ impl<T: GcRef> Rooted<T> {
         match self.inner {}
     }
 
-    pub fn to_manually_rooted(&self, _store: impl AsContextMut) -> Result<ManuallyRooted<T>> {
+    pub fn to_owned_rooted(&self, _store: impl AsContextMut) -> Result<OwnedRooted<T>> {
         match self.inner {}
     }
 
@@ -157,7 +157,7 @@ where
 
 /// This type has been disabled because the `gc` cargo feature was not enabled
 /// at compile time.
-pub struct ManuallyRooted<T>
+pub struct OwnedRooted<T>
 where
     T: GcRef,
 {
@@ -165,13 +165,13 @@ where
     _phantom: marker::PhantomData<T>,
 }
 
-impl<T: GcRef> Debug for ManuallyRooted<T> {
+impl<T: GcRef> Debug for OwnedRooted<T> {
     fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.inner {}
     }
 }
 
-impl<T: GcRef> Deref for ManuallyRooted<T> {
+impl<T: GcRef> Deref for OwnedRooted<T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
@@ -179,15 +179,11 @@ impl<T: GcRef> Deref for ManuallyRooted<T> {
     }
 }
 
-impl<T> ManuallyRooted<T>
+impl<T> OwnedRooted<T>
 where
     T: GcRef,
 {
     pub fn clone(&self, _store: impl AsContextMut) -> Self {
-        match self.inner {}
-    }
-
-    pub fn unroot(self, _store: impl AsContextMut) {
         match self.inner {}
     }
 
@@ -200,7 +196,7 @@ where
     }
 }
 
-impl<T: GcRef> RootedGcRefImpl<T> for ManuallyRooted<T> {
+impl<T: GcRef> RootedGcRefImpl<T> for OwnedRooted<T> {
     fn assert_unreachable<U>(&self) -> U {
         match self.inner {}
     }

--- a/crates/wasmtime/src/runtime/gc/enabled/anyref.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/anyref.rs
@@ -5,7 +5,7 @@ use crate::prelude::*;
 use crate::runtime::vm::VMGcRef;
 use crate::{
     ArrayRef, ArrayType, AsContext, AsContextMut, EqRef, GcRefImpl, GcRootIndex, HeapType, I31,
-    ManuallyRooted, RefType, Result, Rooted, StructRef, StructType, ValRaw, ValType, WasmTy,
+    OwnedRooted, RefType, Result, Rooted, StructRef, StructType, ValRaw, ValType, WasmTy,
     store::{AutoAssertNoGc, StoreOpaque},
 };
 use core::mem;
@@ -23,7 +23,7 @@ use wasmtime_environ::VMGcKind;
 /// `0x12345678` into a reference, pretend it is a valid `anyref`, and trick the
 /// host into dereferencing it and segfaulting or worse.
 ///
-/// Note that you can also use `Rooted<AnyRef>` and `ManuallyRooted<AnyRef>` as
+/// Note that you can also use `Rooted<AnyRef>` and `OwnedRooted<AnyRef>` as
 /// a type parameter with [`Func::typed`][crate::Func::typed]- and
 /// [`Func::wrap`][crate::Func::wrap]-style APIs.
 ///
@@ -103,9 +103,9 @@ impl From<Rooted<EqRef>> for Rooted<AnyRef> {
     }
 }
 
-impl From<ManuallyRooted<EqRef>> for ManuallyRooted<AnyRef> {
+impl From<OwnedRooted<EqRef>> for OwnedRooted<AnyRef> {
     #[inline]
-    fn from(e: ManuallyRooted<EqRef>) -> Self {
+    fn from(e: OwnedRooted<EqRef>) -> Self {
         e.to_anyref()
     }
 }
@@ -117,9 +117,9 @@ impl From<Rooted<StructRef>> for Rooted<AnyRef> {
     }
 }
 
-impl From<ManuallyRooted<StructRef>> for ManuallyRooted<AnyRef> {
+impl From<OwnedRooted<StructRef>> for OwnedRooted<AnyRef> {
     #[inline]
-    fn from(s: ManuallyRooted<StructRef>) -> Self {
+    fn from(s: OwnedRooted<StructRef>) -> Self {
         s.to_anyref()
     }
 }
@@ -131,9 +131,9 @@ impl From<Rooted<ArrayRef>> for Rooted<AnyRef> {
     }
 }
 
-impl From<ManuallyRooted<ArrayRef>> for ManuallyRooted<AnyRef> {
+impl From<OwnedRooted<ArrayRef>> for OwnedRooted<AnyRef> {
     #[inline]
-    fn from(s: ManuallyRooted<ArrayRef>) -> Self {
+    fn from(s: OwnedRooted<ArrayRef>) -> Self {
         s.to_anyref()
     }
 }
@@ -754,7 +754,7 @@ unsafe impl WasmTy for Option<Rooted<AnyRef>> {
     }
 }
 
-unsafe impl WasmTy for ManuallyRooted<AnyRef> {
+unsafe impl WasmTy for OwnedRooted<AnyRef> {
     #[inline]
     fn valtype() -> ValType {
         ValType::Ref(RefType::new(false, HeapType::Any))
@@ -784,7 +784,7 @@ unsafe impl WasmTy for ManuallyRooted<AnyRef> {
     }
 }
 
-unsafe impl WasmTy for Option<ManuallyRooted<AnyRef>> {
+unsafe impl WasmTy for Option<OwnedRooted<AnyRef>> {
     #[inline]
     fn valtype() -> ValType {
         ValType::ANYREF
@@ -821,11 +821,11 @@ unsafe impl WasmTy for Option<ManuallyRooted<AnyRef>> {
     }
 
     fn store(self, store: &mut AutoAssertNoGc<'_>, ptr: &mut MaybeUninit<ValRaw>) -> Result<()> {
-        <ManuallyRooted<AnyRef>>::wasm_ty_option_store(self, store, ptr, ValRaw::anyref)
+        <OwnedRooted<AnyRef>>::wasm_ty_option_store(self, store, ptr, ValRaw::anyref)
     }
 
     unsafe fn load(store: &mut AutoAssertNoGc<'_>, ptr: &ValRaw) -> Self {
-        <ManuallyRooted<AnyRef>>::wasm_ty_option_load(
+        <OwnedRooted<AnyRef>>::wasm_ty_option_load(
             store,
             ptr.get_anyref(),
             AnyRef::from_cloned_gc_ref,

--- a/crates/wasmtime/src/runtime/gc/enabled/exnref.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/exnref.rs
@@ -4,7 +4,7 @@ use crate::runtime::vm::{VMGcRef, VMStore};
 use crate::store::{StoreId, StoreResourceLimiter};
 use crate::vm::{self, VMExnRef, VMGcHeader};
 use crate::{
-    AsContext, AsContextMut, GcRefImpl, GcRootIndex, HeapType, ManuallyRooted, RefType, Result,
+    AsContext, AsContextMut, GcRefImpl, GcRootIndex, HeapType, OwnedRooted, RefType, Result,
     Rooted, Val, ValRaw, ValType, WasmTy,
     store::{AutoAssertNoGc, StoreOpaque},
 };
@@ -101,7 +101,7 @@ impl ExnRefPre {
 /// thrown exception in WebAssembly with a `catch_ref` clause of a
 /// `try_table`, or by allocating via the host API.
 ///
-/// Note that you can also use `Rooted<ExnRef>` and `ManuallyRooted<ExnRef>` as
+/// Note that you can also use `Rooted<ExnRef>` and `OwnedRooted<ExnRef>` as
 /// a type parameter with [`Func::typed`][crate::Func::typed]- and
 /// [`Func::wrap`][crate::Func::wrap]-style APIs.
 #[derive(Debug)]
@@ -695,7 +695,7 @@ unsafe impl WasmTy for Option<Rooted<ExnRef>> {
     }
 }
 
-unsafe impl WasmTy for ManuallyRooted<ExnRef> {
+unsafe impl WasmTy for OwnedRooted<ExnRef> {
     #[inline]
     fn valtype() -> ValType {
         ValType::Ref(RefType::new(false, HeapType::Exn))
@@ -725,7 +725,7 @@ unsafe impl WasmTy for ManuallyRooted<ExnRef> {
     }
 }
 
-unsafe impl WasmTy for Option<ManuallyRooted<ExnRef>> {
+unsafe impl WasmTy for Option<OwnedRooted<ExnRef>> {
     #[inline]
     fn valtype() -> ValType {
         ValType::EXNREF
@@ -762,11 +762,11 @@ unsafe impl WasmTy for Option<ManuallyRooted<ExnRef>> {
     }
 
     fn store(self, store: &mut AutoAssertNoGc<'_>, ptr: &mut MaybeUninit<ValRaw>) -> Result<()> {
-        <ManuallyRooted<ExnRef>>::wasm_ty_option_store(self, store, ptr, ValRaw::anyref)
+        <OwnedRooted<ExnRef>>::wasm_ty_option_store(self, store, ptr, ValRaw::anyref)
     }
 
     unsafe fn load(store: &mut AutoAssertNoGc<'_>, ptr: &ValRaw) -> Self {
-        <ManuallyRooted<ExnRef>>::wasm_ty_option_load(
+        <OwnedRooted<ExnRef>>::wasm_ty_option_load(
             store,
             ptr.get_anyref(),
             ExnRef::from_cloned_gc_ref,

--- a/crates/wasmtime/src/runtime/gc/enabled/externref.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/externref.rs
@@ -4,7 +4,7 @@ use super::{AnyRef, RootedGcRefImpl};
 use crate::prelude::*;
 use crate::runtime::vm::{self, VMGcRef, VMStore};
 use crate::{
-    AsContextMut, GcHeapOutOfMemory, GcRefImpl, GcRootIndex, HeapType, ManuallyRooted, RefType,
+    AsContextMut, GcHeapOutOfMemory, GcRefImpl, GcRootIndex, HeapType, OwnedRooted, RefType,
     Result, Rooted, StoreContext, StoreContextMut, ValRaw, ValType, WasmTy,
     store::{AutoAssertNoGc, StoreOpaque, StoreResourceLimiter},
 };
@@ -31,7 +31,7 @@ use core::mem::MaybeUninit;
 /// the host into dereferencing it and segfaulting or worse.
 ///
 /// Note that you can also use `Rooted<ExternRef>` and
-/// `ManuallyRooted<ExternRef>` as a type parameter with
+/// `OwnedRooted<ExternRef>` as a type parameter with
 /// [`Func::typed`][crate::Func::typed]- and
 /// [`Func::wrap`][crate::Func::wrap]-style APIs.
 ///
@@ -140,10 +140,10 @@ impl ExternRef {
     ///
     /// The resulting value is automatically unrooted when the given `context`'s
     /// scope is exited. If you need to hold the reference past the `context`'s
-    /// scope, convert the result into a
-    /// [`ManuallyRooted<T>`][crate::ManuallyRooted]. See the documentation for
+    /// scope, convert the result into an
+    /// [`OwnedRooted<T>`][crate::OwnedRooted]. See the documentation for
     /// [`Rooted<T>`][crate::Rooted] and
-    /// [`ManuallyRooted<T>`][crate::ManuallyRooted] for more details.
+    /// [`OwnedRooted<T>`][crate::OwnedRooted] for more details.
     ///
     /// # Automatic Garbage Collection
     ///
@@ -223,10 +223,10 @@ impl ExternRef {
     ///
     /// The resulting value is automatically unrooted when the given `context`'s
     /// scope is exited. If you need to hold the reference past the `context`'s
-    /// scope, convert the result into a
-    /// [`ManuallyRooted<T>`][crate::ManuallyRooted]. See the documentation for
+    /// scope, convert the result into an
+    /// [`OwnedRooted<T>`][crate::OwnedRooted]. See the documentation for
     /// [`Rooted<T>`][crate::Rooted] and
-    /// [`ManuallyRooted<T>`][crate::ManuallyRooted] for more details.
+    /// [`OwnedRooted<T>`][crate::OwnedRooted] for more details.
     ///
     /// # Automatic Garbage Collection
     ///
@@ -646,7 +646,7 @@ unsafe impl WasmTy for Option<Rooted<ExternRef>> {
     }
 }
 
-unsafe impl WasmTy for ManuallyRooted<ExternRef> {
+unsafe impl WasmTy for OwnedRooted<ExternRef> {
     #[inline]
     fn valtype() -> ValType {
         ValType::Ref(RefType::new(false, HeapType::Extern))
@@ -676,7 +676,7 @@ unsafe impl WasmTy for ManuallyRooted<ExternRef> {
     }
 }
 
-unsafe impl WasmTy for Option<ManuallyRooted<ExternRef>> {
+unsafe impl WasmTy for Option<OwnedRooted<ExternRef>> {
     #[inline]
     fn valtype() -> ValType {
         ValType::EXTERNREF
@@ -699,11 +699,11 @@ unsafe impl WasmTy for Option<ManuallyRooted<ExternRef>> {
     }
 
     fn store(self, store: &mut AutoAssertNoGc<'_>, ptr: &mut MaybeUninit<ValRaw>) -> Result<()> {
-        <ManuallyRooted<ExternRef>>::wasm_ty_option_store(self, store, ptr, ValRaw::externref)
+        <OwnedRooted<ExternRef>>::wasm_ty_option_store(self, store, ptr, ValRaw::externref)
     }
 
     unsafe fn load(store: &mut AutoAssertNoGc<'_>, ptr: &ValRaw) -> Self {
-        <ManuallyRooted<ExternRef>>::wasm_ty_option_load(
+        <OwnedRooted<ExternRef>>::wasm_ty_option_load(
             store,
             ptr.get_externref(),
             ExternRef::from_cloned_gc_ref,

--- a/crates/wasmtime/src/runtime/gc/enabled/rooting.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/rooting.rs
@@ -1862,6 +1862,6 @@ mod tests {
         // Try to keep tabs on the size of these things. Don't want them growing
         // unintentionally.
         assert_eq!(std::mem::size_of::<Rooted<ExternRef>>(), 16);
-        assert_eq!(std::mem::size_of::<OwnedRooted<ExternRef>>(), 24);
+        assert!(std::mem::size_of::<OwnedRooted<ExternRef>>() <= 24);
     }
 }

--- a/crates/wasmtime/src/runtime/gc/enabled/rooting.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/rooting.rs
@@ -704,14 +704,12 @@ impl RootSet {
             }
         });
 
-        if !eager {
-            let post_trim_len = self.liveness_flags.len();
-            let high_water_mark = core::cmp::max(
-                DEFAULT_HIGH_WATER,
-                post_trim_len.saturating_mul(GROWTH_FACTOR),
-            );
-            self.liveness_trim_high_water = Some(NonZeroUsize::new(high_water_mark).unwrap());
-        }
+        let post_trim_len = self.liveness_flags.len();
+        let high_water_mark = core::cmp::max(
+            DEFAULT_HIGH_WATER,
+            post_trim_len.saturating_mul(GROWTH_FACTOR),
+        );
+        self.liveness_trim_high_water = Some(NonZeroUsize::new(high_water_mark).unwrap());
     }
 }
 

--- a/crates/wasmtime/src/runtime/gc/enabled/rooting.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/rooting.rs
@@ -1478,9 +1478,19 @@ const _: () = {
     use crate::{AnyRef, ExternRef};
 
     // NB: these match the C API which should also be updated if this changes.
-    assert!(mem::size_of::<OwnedRooted<AnyRef>>() == 16 + mem::size_of::<usize>());
+    //
+    // The size is really "16 + pointer + alignment", which is either
+    // 20 bytes on some 32-bit platforms or 24 bytes on other 32-bit
+    // platforms (e.g., riscv32, which adds an extra 4 bytes of
+    // padding) and 64-bit platforms.
+    assert!(
+        mem::size_of::<OwnedRooted<AnyRef>>() >= 16 && mem::size_of::<OwnedRooted<AnyRef>>() <= 24
+    );
     assert!(mem::align_of::<OwnedRooted<AnyRef>>() == mem::align_of::<u64>());
-    assert!(mem::size_of::<OwnedRooted<ExternRef>>() == 16 + mem::size_of::<usize>());
+    assert!(
+        mem::size_of::<OwnedRooted<ExternRef>>() >= 16
+            && mem::size_of::<OwnedRooted<ExternRef>>() <= 24
+    );
     assert!(mem::align_of::<OwnedRooted<ExternRef>>() == mem::align_of::<u64>());
 };
 

--- a/crates/wasmtime/src/runtime/gc/enabled/rooting.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/rooting.rs
@@ -706,7 +706,7 @@ impl RootSet {
 
         if !eager {
             let post_trim_len = self.liveness_flags.len();
-            let high_water_mark = std::cmp::max(
+            let high_water_mark = core::cmp::max(
                 DEFAULT_HIGH_WATER,
                 post_trim_len.saturating_mul(GROWTH_FACTOR),
             );

--- a/crates/wasmtime/src/runtime/gc/enabled/rooting.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/rooting.rs
@@ -1782,12 +1782,12 @@ where
     }
 
     #[doc(hidden)]
-    pub fn into_parts_for_c_api(self) -> (NonZeroU64, u32, u32, usize) {
+    pub fn into_parts_for_c_api(self) -> (NonZeroU64, u32, u32, *const ()) {
         (
             self.inner.store_id.as_raw(),
             self.inner.generation,
             self.inner.index.0,
-            Arc::into_raw(self.liveness_flag).addr(),
+            Arc::into_raw(self.liveness_flag),
         )
     }
 
@@ -1796,14 +1796,14 @@ where
         a: NonZeroU64,
         b: u32,
         c: u32,
-        d: usize,
+        d: *const (),
     ) -> OwnedRooted<T> {
         // We are given a *borrow* of the Arc. This is a little
         // sketchy because `Arc::from_raw()` takes *ownership* of the
         // passed-in pointer, so we need to clone then forget that
         // original.
         let liveness_flag = {
-            let original = unsafe { Arc::from_raw(d as *const ()) };
+            let original = unsafe { Arc::from_raw(d) };
             let clone = original.clone();
             core::mem::forget(original);
             clone
@@ -1824,9 +1824,9 @@ where
         a: NonZeroU64,
         b: u32,
         c: u32,
-        d: usize,
+        d: *const (),
     ) -> OwnedRooted<T> {
-        let liveness_flag = unsafe { Arc::from_raw(d as *const ()) };
+        let liveness_flag = unsafe { Arc::from_raw(d) };
         OwnedRooted {
             inner: GcRootIndex {
                 store_id: StoreId::from_raw(a),

--- a/tests/all/func.rs
+++ b/tests/all/func.rs
@@ -401,18 +401,18 @@ fn func_constructors() {
         loop {}
     });
     Func::wrap(&mut store, || -> Option<Rooted<ExternRef>> { None });
-    Func::wrap(&mut store, || -> ManuallyRooted<ExternRef> {
+    Func::wrap(&mut store, || -> OwnedRooted<ExternRef> {
         loop {}
     });
-    Func::wrap(&mut store, || -> Option<ManuallyRooted<ExternRef>> { None });
+    Func::wrap(&mut store, || -> Option<OwnedRooted<ExternRef>> { None });
     Func::wrap(&mut store, || -> Rooted<AnyRef> {
         loop {}
     });
     Func::wrap(&mut store, || -> Option<Rooted<AnyRef>> { None });
-    Func::wrap(&mut store, || -> ManuallyRooted<AnyRef> {
+    Func::wrap(&mut store, || -> OwnedRooted<AnyRef> {
         loop {}
     });
-    Func::wrap(&mut store, || -> Option<ManuallyRooted<AnyRef>> { None });
+    Func::wrap(&mut store, || -> Option<OwnedRooted<AnyRef>> { None });
     Func::wrap(&mut store, || -> I31 {
         loop {}
     });
@@ -455,23 +455,22 @@ fn func_constructors() {
     Func::wrap(&mut store, || -> Result<Option<Rooted<ExternRef>>> {
         loop {}
     });
-    Func::wrap(&mut store, || -> Result<ManuallyRooted<ExternRef>> {
+    Func::wrap(&mut store, || -> Result<OwnedRooted<ExternRef>> {
         loop {}
     });
-    Func::wrap(
-        &mut store,
-        || -> Result<Option<ManuallyRooted<ExternRef>>> { loop {} },
-    );
+    Func::wrap(&mut store, || -> Result<Option<OwnedRooted<ExternRef>>> {
+        loop {}
+    });
     Func::wrap(&mut store, || -> Result<Rooted<AnyRef>> {
         loop {}
     });
     Func::wrap(&mut store, || -> Result<Option<Rooted<AnyRef>>> {
         loop {}
     });
-    Func::wrap(&mut store, || -> Result<ManuallyRooted<AnyRef>> {
+    Func::wrap(&mut store, || -> Result<OwnedRooted<AnyRef>> {
         loop {}
     });
-    Func::wrap(&mut store, || -> Result<Option<ManuallyRooted<AnyRef>>> {
+    Func::wrap(&mut store, || -> Result<Option<OwnedRooted<AnyRef>>> {
         loop {}
     });
     Func::wrap(&mut store, || -> Result<I31> {
@@ -601,9 +600,9 @@ fn signatures_match() {
          _: i64,
          _: i32,
          _: Option<Rooted<ExternRef>>,
-         _: Option<ManuallyRooted<ExternRef>>,
+         _: Option<OwnedRooted<ExternRef>>,
          _: Option<Rooted<AnyRef>>,
-         _: Option<ManuallyRooted<AnyRef>>,
+         _: Option<OwnedRooted<AnyRef>>,
          _: Option<Func>|
          -> f64 { loop {} },
     );
@@ -698,10 +697,10 @@ fn import_works() -> Result<()> {
              d: f32,
              e: f64,
              f: Option<Rooted<ExternRef>>,
-             g: Option<ManuallyRooted<ExternRef>>,
+             g: Option<OwnedRooted<ExternRef>>,
              h: Option<Func>,
              i: Option<Rooted<AnyRef>>,
-             j: Option<ManuallyRooted<AnyRef>>,
+             j: Option<OwnedRooted<AnyRef>>,
              k: Option<I31>|
              -> Result<()> {
                 assert_eq!(a, 100);
@@ -820,15 +819,15 @@ fn get_from_wrapper() {
         loop {}
     });
     assert!(f.typed::<(), Option<Rooted<ExternRef>>>(&store).is_ok());
-    let f = Func::wrap(&mut store, || -> ManuallyRooted<ExternRef> {
+    let f = Func::wrap(&mut store, || -> OwnedRooted<ExternRef> {
         loop {}
     });
-    assert!(f.typed::<(), ManuallyRooted<ExternRef>>(&store).is_ok());
-    let f = Func::wrap(&mut store, || -> Option<ManuallyRooted<ExternRef>> {
+    assert!(f.typed::<(), OwnedRooted<ExternRef>>(&store).is_ok());
+    let f = Func::wrap(&mut store, || -> Option<OwnedRooted<ExternRef>> {
         loop {}
     });
     assert!(
-        f.typed::<(), Option<ManuallyRooted<ExternRef>>>(&store)
+        f.typed::<(), Option<OwnedRooted<ExternRef>>>(&store)
             .is_ok()
     );
     let f = Func::wrap(&mut store, || -> Rooted<AnyRef> {
@@ -839,17 +838,14 @@ fn get_from_wrapper() {
         loop {}
     });
     assert!(f.typed::<(), Option<Rooted<AnyRef>>>(&store).is_ok());
-    let f = Func::wrap(&mut store, || -> ManuallyRooted<AnyRef> {
+    let f = Func::wrap(&mut store, || -> OwnedRooted<AnyRef> {
         loop {}
     });
-    assert!(f.typed::<(), ManuallyRooted<AnyRef>>(&store).is_ok());
-    let f = Func::wrap(&mut store, || -> Option<ManuallyRooted<AnyRef>> {
+    assert!(f.typed::<(), OwnedRooted<AnyRef>>(&store).is_ok());
+    let f = Func::wrap(&mut store, || -> Option<OwnedRooted<AnyRef>> {
         loop {}
     });
-    assert!(
-        f.typed::<(), Option<ManuallyRooted<AnyRef>>>(&store)
-            .is_ok()
-    );
+    assert!(f.typed::<(), Option<OwnedRooted<AnyRef>>>(&store).is_ok());
     let f = Func::wrap(&mut store, || -> I31 {
         loop {}
     });
@@ -882,24 +878,21 @@ fn get_from_wrapper() {
     assert!(f.typed::<Rooted<ExternRef>, ()>(&store).is_ok());
     let f = Func::wrap(&mut store, |_: Option<Rooted<ExternRef>>| {});
     assert!(f.typed::<Option<Rooted<ExternRef>>, ()>(&store).is_ok());
-    let f = Func::wrap(&mut store, |_: ManuallyRooted<ExternRef>| {});
-    assert!(f.typed::<ManuallyRooted<ExternRef>, ()>(&store).is_ok());
-    let f = Func::wrap(&mut store, |_: Option<ManuallyRooted<ExternRef>>| {});
+    let f = Func::wrap(&mut store, |_: OwnedRooted<ExternRef>| {});
+    assert!(f.typed::<OwnedRooted<ExternRef>, ()>(&store).is_ok());
+    let f = Func::wrap(&mut store, |_: Option<OwnedRooted<ExternRef>>| {});
     assert!(
-        f.typed::<Option<ManuallyRooted<ExternRef>>, ()>(&store)
+        f.typed::<Option<OwnedRooted<ExternRef>>, ()>(&store)
             .is_ok()
     );
     let f = Func::wrap(&mut store, |_: Rooted<AnyRef>| {});
     assert!(f.typed::<Rooted<AnyRef>, ()>(&store).is_ok());
     let f = Func::wrap(&mut store, |_: Option<Rooted<AnyRef>>| {});
     assert!(f.typed::<Option<Rooted<AnyRef>>, ()>(&store).is_ok());
-    let f = Func::wrap(&mut store, |_: ManuallyRooted<AnyRef>| {});
-    assert!(f.typed::<ManuallyRooted<AnyRef>, ()>(&store).is_ok());
-    let f = Func::wrap(&mut store, |_: Option<ManuallyRooted<AnyRef>>| {});
-    assert!(
-        f.typed::<Option<ManuallyRooted<AnyRef>>, ()>(&store)
-            .is_ok()
-    );
+    let f = Func::wrap(&mut store, |_: OwnedRooted<AnyRef>| {});
+    assert!(f.typed::<OwnedRooted<AnyRef>, ()>(&store).is_ok());
+    let f = Func::wrap(&mut store, |_: Option<OwnedRooted<AnyRef>>| {});
+    assert!(f.typed::<Option<OwnedRooted<AnyRef>>, ()>(&store).is_ok());
     let f = Func::wrap(&mut store, |_: I31| {});
     assert!(f.typed::<I31, ()>(&store).is_ok());
     let f = Func::wrap(&mut store, |_: Option<I31>| {});


### PR DESCRIPTION
This implements the ideas from #11445: it replaces `ManuallyRooted`, which requires an explicit unroot action with a mut borrow of the store (making it impossible to implement in a standard `Drop` impl), with `OwnedRooted`, which holds an `Arc` only to a small auxiliary memory allocation (an `Arc<()>`) and uses this externalized "liveness flag" to allow for a `Store`-less drop. These liveness flags are scanned during a "trim" pass, which happens both when new owned roots are created, and just before a GC.

This should greatly increase safety for host-side users of GC: it provides a way to have a handle whose ownership works like any other Rust value, alive until dropped. It is still not quite as efficient as LIFO-scoped handles (by analogy, for the same reason that individually-freed RAII types are not as efficient as arena allocation), so those remain for efficiency-minded users that have a clear picture of reference lifetimes.

At some later time we may wish to use `OwnedRooted` exclusively in our public APIs rather than `Rooted`, and we may wish to rename `Rooted` to `ScopedRooted`, but I haven't done either of those things yet.

I opted to *replace* `ManuallyRooted` rather than add a third kind of root, after discussion with fitzgen. One implication of this is that the C API's `anyref` and `externref` types are now 24 or 20 bytes rather than 16 (because of the `Arc` pointer), and correspondingly the Val union grew to that size. I *believe* this is an acceptable tradeoff, but I'm happy to put `ManuallyRooted` back if not.

Fixes #11445.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
