### PR TITLE
Get the min-platform example working again

### DIFF
--- a/crates/wasmtime/src/runtime/vm/sys/windows/mmap.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/windows/mmap.rs
@@ -188,6 +188,33 @@ impl Mmap {
         range: Range<usize>,
         enable_branch_protection: bool,
     ) -> Result<()> {
+        let base = self
+            .as_send_sync_ptr()
+            .as_ptr()
+            .wrapping_add(range.start)
+            .cast();
+        let len = range.end - range.start;
+
+        if !cfg!(feature = "std") {
+            bail!(
+                "with the `std` feature disabled at compile time \
+                 there must be a custom implementation of publishing \
+                 code memory, otherwise it's unknown how to do icache \
+                 management"
+            );
+        }
+
+        // Clear the newly allocated code from cache if the processor requires
+        // it
+        //
+        // Do this before marking the memory as R+X, technically we should be
+        // able to do it after but there are some CPU's that have had errata
+        // about doing this with read only memory.
+        #[cfg(feature = "std")]
+        unsafe {
+            wasmtime_jit_icache_coherence::clear_cache(base, len).context("failed cache clear")?;
+        }
+
         let flags = if enable_branch_protection {
             // TODO: We use this check to avoid an unused variable warning,
             // but some of the CFG-related flags might be applicable
@@ -197,12 +224,15 @@ impl Mmap {
         };
         let mut old = 0;
         unsafe {
-            let base = self.as_send_sync_ptr().as_ptr().add(range.start).cast();
-            let result = VirtualProtect(base, range.end - range.start, flags, &mut old);
+            let result = VirtualProtect(base, len, flags, &mut old);
             if result == 0 {
                 bail!(io::Error::last_os_error());
             }
         }
+
+        // Flush any in-flight instructions from the pipeline
+        #[cfg(feature = "std")]
+        wasmtime_jit_icache_coherence::pipeline_flush_mt().context("Failed pipeline flush")?;
         Ok(())
     }
 


### PR DESCRIPTION
A few various changes have happened in the meantime which means that this wasn't actually testing anything on CI. Notably these changes were made:

* Sink icache maintenance into `vm::sys` modules. This is fallout of #11152 where no_std support was added for unix/windows targets. This commit moves the error-on-lack-of-std to the `unix` and `windows` modules, relegating the custom module to figure its own pieces out as necessary. This also feels like a more accurate reflection of how responsibilities should be sliced up.

* The example runner now uses `bail!` to return an error in case something bad happens instead of continuing as usual and pretending nothing bad happened.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
