### PR TITLE
[Cranelift] `(x - y) u> x --> y u> x`

### DIFF
--- a/cranelift/codegen/src/opts/icmp.isle
+++ b/cranelift/codegen/src/opts/icmp.isle
@@ -290,3 +290,6 @@
 
 (rule (simplify (eq cty x (bxor (ty_int bty) x y))) (subsume (eq cty y (iconst_u bty 0))))
 (rule (simplify (ne cty x (bxor (ty_int bty) x y))) (subsume (ne cty y (iconst_u bty 0))))
+
+; (x - y) > x == y > x
+(rule (simplify (ugt cty (isub ty x y) x)) (ugt cty y x))

--- a/cranelift/filetests/filetests/egraph/icmp.clif
+++ b/cranelift/filetests/filetests/egraph/icmp.clif
@@ -223,3 +223,18 @@ block0():
 ;     return v3
 ; }
 
+;; (x - y) u> x == y u> x
+function %ugt_isub_x_y_x(i32, i32) -> i8 fast {
+block0(v0: i32, v1: i32):
+    v2 = isub v0, v1
+    v3 = icmp ugt v2, v0
+    return v3
+}
+
+; function %ugt_isub_x_y_x(i32, i32) -> i8 fast {
+; block0(v0: i32, v1: i32):
+;     v4 = icmp ugt v1, v0
+;     return v4
+; }
+
+


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->

This adds an optimization: `(X - Y) u> X --> Y u> X`.
Same proof with crocus is used to verify the correctness. (See my previous PR #11359)