### PR TITLE
docs: fix typos

### DIFF
--- a/crates/wasmtime/src/runtime/types.rs
+++ b/crates/wasmtime/src/runtime/types.rs
@@ -697,7 +697,7 @@ impl RefType {
 ///
 /// The top of the exception types hierarchy is `exn`; the bottom is
 /// `noexn`. At the WebAssembly level, there are no concrete types in
-/// this hierachy. However, internally we do reify a heap type for
+/// this hierarchy. However, internally we do reify a heap type for
 /// each tag, similar to how continuation objects work.
 ///
 /// ```text

--- a/crates/wasmtime/src/runtime/vm/traphandlers/signals.rs
+++ b/crates/wasmtime/src/runtime/vm/traphandlers/signals.rs
@@ -3,7 +3,7 @@
 //! This module is conditionally included in the above `traphandlers` module and
 //! contains support and shared routines for working with signals-based traps.
 //! Each platform will have its own `signals-based-traps` configuration and
-//! thise module serves as a shared entrypoint for initialization entrypoints
+//! this module serves as a shared entrypoint for initialization entrypoints
 //! (`init_traps`) and testing if a trapping opcode is wasm (`test_if_trap`).
 
 use crate::sync::RwLock;


### PR DESCRIPTION
### Description

This PR corrects several minor typos in comments and documentation across the codebase. The changes are non-functional and purely textual to improve clarity and maintain a clean, professional codebase.

### Details

- Corrected misspellings:
  - `hierachy` → `hierarchy`
  - `thise` → `this`

These fixes help enhance readability and eliminate minor distractions during development and code reviews.

### Additional Info

No logic or functionality has been modified. All changes are restricted to comments or non-executable doc annotations.