### PR TITLE
[Cranelift] `(C ? X : Y) + Z --> (C ? X + Z : Y + Z)`

### DIFF
--- a/cranelift/codegen/src/opts/selects.isle
+++ b/cranelift/codegen/src/opts/selects.isle
@@ -91,3 +91,10 @@
 (rule (simplify (select ty (sge _ x (iconst_u ty 0)) x (ineg ty x))) (subsume (iabs ty x)))
 (rule (simplify (select ty (sle _ x (iconst_u ty 0)) (ineg ty x) x)) (subsume (iabs ty x)))
 (rule (simplify (select ty (slt _ x (iconst_u ty 0)) (ineg ty x) x)) (subsume (iabs ty x)))
+
+;; fold add-select to select-add
+(rule (simplify
+        (iadd ty (select ty c (iconst_u ty x) (iconst_u ty y)) (iconst_u ty z)))
+        (select ty c
+            (iconst ty (imm64 (u64_add x z)))
+            (iconst ty (imm64 (u64_add y z)))))

--- a/cranelift/filetests/filetests/egraph/selects.clif
+++ b/cranelift/filetests/filetests/egraph/selects.clif
@@ -1,0 +1,23 @@
+test optimize precise-output
+set opt_level=speed
+target x86_64
+
+;; (iadd ty (select ty c x y) z) -> (select ty c (x + z) (y + z))
+function %simplify_iadd_select_const_i32(i8) -> i32 fast {
+block0(v0: i8):
+    v1 = iconst.i32 5
+    v2 = iconst.i32 10
+    v3 = select v0, v1, v2
+    v4 = iconst.i32 3
+    v5 = iadd v3, v4
+    return v5
+}
+
+; function %simplify_iadd_select_const_i32(i8) -> i32 fast {
+; block0(v0: i8):
+;     v6 = iconst.i32 8
+;     v7 = iconst.i32 13
+;     v8 = select v0, v6, v7  ; v6 = 8, v7 = 13
+;     return v8
+; }
+

--- a/cranelift/filetests/filetests/runtests/select.clif
+++ b/cranelift/filetests/filetests/runtests/select.clif
@@ -400,3 +400,16 @@ block0(v0: i64, v1: i64, v2: i64):
 ; run: %select_icmp64_uge_imm(7, 42, 35) == 42
 ; run: %select_icmp64_uge_imm(0, 42, 35) == 35
 ; run: %select_icmp64_uge_imm(-1, 42, 35) == 42
+
+function %simplify_iadd_select_const_i32(i8) -> i32 fast {
+block0(v0: i8):
+    v1 = iconst.i32 5
+    v2 = iconst.i32 10
+    v3 = select v0, v1, v2
+    v4 = iconst.i32 3
+    v5 = iadd v3, v4
+    return v5
+}
+
+; run: %simplify_iadd_select_const_i32(0) == 13
+; run: %simplify_iadd_select_const_i32(1) == 8


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->

This adds a new optimization `(C ? X : Y) + Z --> (C ? X + Z : Y +Z)`.
Same proof with crocus is used to verify the correctness. (See my previous PR https://github.com/bytecodealliance/wasmtime/pull/11359)
