### PR TITLE
[Cranelift] `(x | y) ^ (x & y) --> (x ^ y)`

### DIFF
--- a/cranelift/codegen/src/opts/bitops.isle
+++ b/cranelift/codegen/src/opts/bitops.isle
@@ -189,3 +189,5 @@
           (iconst_u ty 0xff00))
         (ushr ty x (iconst_u ty 56))))))
   (bswap ty x))
+
+(rule (simplify (bxor ty (bor ty x y) (band ty x y))) (bxor ty x y))

--- a/cranelift/filetests/filetests/egraph/bitops.clif
+++ b/cranelift/filetests/filetests/egraph/bitops.clif
@@ -412,3 +412,33 @@ block0(v0: i8, v1: i8):
     ; check: v5 = bor v0, v1
     ; check: return v5
 }
+
+function %test_bxor_bor_band_i64(i64, i64) -> i64 {
+block0(v0: i64, v1: i64):
+    v2 = bor v0, v1
+    v3 = band v0, v1
+    v4 = bxor v2, v3
+    return v4
+    ; check: v5 = bxor v0, v1
+    ; check: return v5
+}
+
+function %test_bxor_bor_band_i32(i32, i32) -> i32 {
+block0(v0: i32, v1: i32):
+    v2 = bor v0, v1
+    v3 = band v0, v1
+    v4 = bxor v2, v3
+    return v4
+    ; check: v5 = bxor v0, v1
+    ; check: return v5
+}
+
+function %test_bxor_bor_band_i16(i16, i16) -> i16 {
+block0(v0: i16, v1: i16):
+    v2 = bor v0, v1
+    v3 = band v0, v1
+    v4 = bxor v2, v3
+    return v4
+    ; check: v5 = bxor v0, v1
+    ; check: return v5
+}


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->

This adds an optimization `(x | y) ^ (x & y) --> (x ^ y)`.
Same proof with crocus is used to verify the correctness. (See my previous PR https://github.com/bytecodealliance/wasmtime/pull/11359)
