### PR TITLE
Exceptions: support creating a `Ref::null` for an exception type.

### DIFF
--- a/crates/wasmtime/src/runtime/values.rs
+++ b/crates/wasmtime/src/runtime/values.rs
@@ -837,6 +837,7 @@ impl Ref {
             HeapType::Any => Ref::Any(None),
             HeapType::Extern => Ref::Extern(None),
             HeapType::Func => Ref::Func(None),
+            HeapType::Exn => Ref::Exn(None),
             ty => unreachable!("not a heap type: {ty:?}"),
         }
     }


### PR DESCRIPTION
Missed adding this case to the match arms. Found via OSS-Fuzz.

Fixes #11529.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
