### PR TITLE
Try to make CI more robust with more retries

### DIFF
--- a/.github/actions/install-rust/action.yml
+++ b/.github/actions/install-rust/action.yml
@@ -17,6 +17,10 @@ runs:
     - name: Install Rust
       shell: bash
       id: select
+      env:
+        # This is an attempt to reduce flakiness and see what happens. If this
+        # lands it worked. Feel free to modify if this becomes flaky again.
+        RUSTUP_USE_RUSTLS: 1
       run: |
         # Determine MSRV as N in `1.N.0` by looking at the `rust-version`
         # located in the root `Cargo.toml`.

--- a/.github/actions/install-rust/action.yml
+++ b/.github/actions/install-rust/action.yml
@@ -37,7 +37,12 @@ runs:
       shell: bash
       run: |
         rustup set profile minimal
-        rustup update "${{ steps.select.outputs.version }}" --no-self-update
+        for attempt in 1 2 3 4 5; do
+          [ "$attempt" = "5" ] && exit 1
+          rustup update "${{ steps.select.outputs.version }}" --no-self-update \
+            && break
+          sleep 5
+        done
         rustup default "${{ steps.select.outputs.version }}"
 
         # Save disk space by avoiding incremental compilation. Also turn down

--- a/.github/actions/install-rust/action.yml
+++ b/.github/actions/install-rust/action.yml
@@ -20,7 +20,7 @@ runs:
       env:
         # This is an attempt to reduce flakiness and see what happens. If this
         # lands it worked. Feel free to modify if this becomes flaky again.
-        RUSTUP_USE_RUSTLS: 1
+        RUSTUP_USE_CURL: 1
       run: |
         # Determine MSRV as N in `1.N.0` by looking at the `rust-version`
         # located in the root `Cargo.toml`.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -91,7 +91,9 @@ jobs:
     - uses: ./.github/actions/install-rust
     - run: |
         set -e
-        curl -L https://github.com/EmbarkStudios/cargo-deny/releases/download/0.18.2/cargo-deny-0.18.2-x86_64-unknown-linux-musl.tar.gz | tar xzf -
+        curl --retry 5 --retry-all-errors -L -o cargo-deny.tar.gz https://github.com/EmbarkStudios/cargo-deny/releases/download/0.18.2/cargo-deny-0.18.2-x86_64-unknown-linux-musl.tar.gz
+        tar xzf cargo-deny.tar.gz
+        rm cargo-deny.tar.gz
         mv cargo-deny-*-x86_64-unknown-linux-musl/cargo-deny cargo-deny
         echo `pwd` >> $GITHUB_PATH
     - run: cargo deny check bans licenses
@@ -263,7 +265,10 @@ jobs:
         toolchain: wasmtime-ci-pinned-nightly
 
     # Build C API documentation
-    - run: curl -L https://github.com/doxygen/doxygen/releases/download/Release_1_9_3/doxygen-1.9.3.linux.bin.tar.gz | tar xzf -
+    - run: |
+        curl --retry 5 --retry-all-errors -o doxygen.tar.gz -L https://github.com/doxygen/doxygen/releases/download/Release_1_9_3/doxygen-1.9.3.linux.bin.tar.gz
+        tar xzf doxygen.tar.gz
+        rm doxygen.tar.gz
     - run: echo "`pwd`/doxygen-1.9.3/bin" >> $GITHUB_PATH
     - run: cmake -S crates/c-api -B target/c-api
     - run: cmake --build target/c-api --target doc
@@ -728,7 +733,9 @@ jobs:
         # way faster at arm emulation than the current version github actions'
         # ubuntu image uses. Disable as much as we can to get it to build
         # quickly.
-        curl https://download.qemu.org/qemu-$QEMU_BUILD_VERSION.tar.xz | tar xJf -
+        curl --retry 5 --retry-all-errors -o qemu.tar.xz https://download.qemu.org/qemu-$QEMU_BUILD_VERSION.tar.xz
+        tar xJf qemu.tar.xz
+        rm qemu.tar.xz
         cd qemu-$QEMU_BUILD_VERSION
         ./configure --target-list=${{ matrix.qemu_target }} --prefix=${{ runner.tool_cache}}/qemu --disable-tools --disable-slirp --disable-fdt --disable-capstone --disable-docs
         ninja -C build install
@@ -872,7 +879,7 @@ jobs:
     - run: |
         rustup target add wasm32-wasip1 wasm32-unknown-unknown
         cd /tmp
-        curl -OL https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-25/wasi-sdk-25.0-x86_64-linux.tar.gz
+        curl --retry 5 --retry-all-errors -OL https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-25/wasi-sdk-25.0-x86_64-linux.tar.gz
         tar -xzf wasi-sdk-25.0-x86_64-linux.tar.gz
         mv wasi-sdk-25.0-x86_64-linux wasi-sdk
     - run: |
@@ -903,7 +910,9 @@ jobs:
 
     - name: Install wasm-tools
       run: |
-        curl -L https://github.com/bytecodealliance/wasm-tools/releases/download/wasm-tools-1.0.27/wasm-tools-1.0.27-x86_64-linux.tar.gz | tar xfz -
+        curl --retry 5 --retry-all-errors -o wasm-tools.tar.gz -L https://github.com/bytecodealliance/wasm-tools/releases/download/wasm-tools-1.0.27/wasm-tools-1.0.27-x86_64-linux.tar.gz
+        tar xfz wasm-tools.tar.gz
+        rm wasm-tools.tar.gz
         echo `pwd`/wasm-tools-1.0.27-x86_64-linux >> $GITHUB_PATH
 
     - run: ./ci/build-wasi-preview1-component-adapter.sh
@@ -1005,7 +1014,10 @@ jobs:
     - uses: ./.github/actions/install-rust
     - run: |
         cd ${{ runner.tool_cache }}
-        curl -L https://github.com/mozilla/sccache/releases/download/0.2.13/sccache-0.2.13-x86_64-unknown-linux-musl.tar.gz | tar xzf -
+        curl --retry 5 --retry-all-errors -L -o sccache.tar.gz \
+          https://github.com/mozilla/sccache/releases/download/0.2.13/sccache-0.2.13-x86_64-unknown-linux-musl.tar.gz
+        tar xzf sccache.tar.gz
+        rm sccache.tar.gz
         echo "`pwd`/sccache-0.2.13-x86_64-unknown-linux-musl" >> $GITHUB_PATH
         echo RUSTC_WRAPPER=sccache >> $GITHUB_ENV
     - run: rustc scripts/publish.rs

--- a/ci/docker/aarch64-linux/Dockerfile
+++ b/ci/docker/aarch64-linux/Dockerfile
@@ -5,7 +5,10 @@ RUN git config --global --add safe.directory '*'
 
 # The CMake in Ubuntu 16.04 was a bit too old for us to use so download one from
 # CMake's own releases and use that instead.
-RUN curl -L https://github.com/Kitware/CMake/releases/download/v3.29.3/cmake-3.29.3-linux-x86_64.tar.gz | tar xzf -
+RUN curl --retry 5 -L -o cmake.tar.gz \
+    https://github.com/Kitware/CMake/releases/download/v3.29.3/cmake-3.29.3-linux-x86_64.tar.gz && \
+  tar xf cmake.tar.gz && \
+  rm cmake.tar.gz
 ENV PATH=$PATH:/cmake-3.29.3-linux-x86_64/bin
 
 ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc

--- a/ci/docker/armv7-linux/Dockerfile
+++ b/ci/docker/armv7-linux/Dockerfile
@@ -5,7 +5,10 @@ RUN git config --global --add safe.directory '*'
 
 # The CMake in Ubuntu 16.04 was a bit too old for us to use so download one from
 # CMake's own releases and use that instead.
-RUN curl -L https://github.com/Kitware/CMake/releases/download/v3.29.3/cmake-3.29.3-linux-x86_64.tar.gz | tar xzf -
+RUN curl --retry 5 -L -o cmake.tar.gz \
+    https://github.com/Kitware/CMake/releases/download/v3.29.3/cmake-3.29.3-linux-x86_64.tar.gz && \
+  tar xf cmake.tar.gz && \
+  rm cmake.tar.gz
 ENV PATH=$PATH:/cmake-3.29.3-linux-x86_64/bin
 
 ENV CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER=arm-linux-gnueabihf-gcc

--- a/ci/docker/i686-linux/Dockerfile
+++ b/ci/docker/i686-linux/Dockerfile
@@ -4,7 +4,7 @@ RUN dnf install -y git gcc make cmake git unzip glibc-devel.i686
 RUN git config --global --add safe.directory '*'
 
 WORKDIR /usr/local/bin
-RUN curl -LO https://github.com/ninja-build/ninja/releases/download/v1.12.1/ninja-linux.zip
+RUN curl --retry-connrefused --retry 5 -LO https://github.com/ninja-build/ninja/releases/download/v1.12.1/ninja-linux.zip
 RUN unzip ./ninja-linux
 WORKDIR /
 

--- a/ci/docker/s390x-linux/Dockerfile
+++ b/ci/docker/s390x-linux/Dockerfile
@@ -5,7 +5,10 @@ RUN git config --global --add safe.directory '*'
 
 # The CMake in Ubuntu 16.04 was a bit too old for us to use so download one from
 # CMake's own releases and use that instead.
-RUN curl -L https://github.com/Kitware/CMake/releases/download/v3.29.3/cmake-3.29.3-linux-x86_64.tar.gz | tar xzf -
+RUN curl --retry 5 -L -o cmake.tar.gz \
+    https://github.com/Kitware/CMake/releases/download/v3.29.3/cmake-3.29.3-linux-x86_64.tar.gz && \
+  tar xf cmake.tar.gz && \
+  rm cmake.tar.gz
 ENV PATH=$PATH:/cmake-3.29.3-linux-x86_64/bin
 
 ENV CARGO_TARGET_S390X_UNKNOWN_LINUX_GNU_LINKER=s390x-linux-gnu-gcc

--- a/ci/docker/x86_64-linux/Dockerfile
+++ b/ci/docker/x86_64-linux/Dockerfile
@@ -4,6 +4,6 @@ RUN dnf install -y git gcc make cmake git unzip
 RUN git config --global --add safe.directory '*'
 
 WORKDIR /usr/local/bin
-RUN curl -LO https://github.com/ninja-build/ninja/releases/download/v1.12.1/ninja-linux.zip
+RUN curl --retry-connrefused --retry 5 -LO https://github.com/ninja-build/ninja/releases/download/v1.12.1/ninja-linux.zip
 RUN unzip ./ninja-linux
 WORKDIR /

--- a/ci/vendor-wit.sh
+++ b/ci/vendor-wit.sh
@@ -25,8 +25,9 @@ make_vendor() {
 
     if [[ ! -d $cached_extracted_dir ]]; then
       mkdir -p $cached_extracted_dir
-      curl -sL https://github.com/WebAssembly/wasi-$repo/archive/$tag.tar.gz | \
-        tar xzf - --strip-components=1 -C $cached_extracted_dir
+      curl --retry 5 --retry-all-errors -sLO https://github.com/WebAssembly/wasi-$repo/archive/$tag.tar.gz
+      tar xzf $tag.tar.gz --strip-components=1 -C $cached_extracted_dir
+      rm $tag.tar.gz
       rm -rf $cached_extracted_dir/${subdir:-"wit"}/deps*
     fi
 
@@ -91,5 +92,5 @@ rm -rf $cache_dir
 # slightly different than above.
 repo=https://raw.githubusercontent.com/WebAssembly/wasi-nn
 revision=0.2.0-rc-2024-10-28
-curl -L $repo/$revision/wasi-nn.witx -o crates/wasi-nn/witx/wasi-nn.witx
-curl -L $repo/$revision/wit/wasi-nn.wit -o crates/wasi-nn/wit/wasi-nn.wit
+curl --retry 5 --retry-all-errors -L $repo/$revision/wasi-nn.witx -o crates/wasi-nn/witx/wasi-nn.witx
+curl --retry 5 --retry-all-errors -L $repo/$revision/wit/wasi-nn.wit -o crates/wasi-nn/wit/wasi-nn.wit


### PR DESCRIPTION
Try adding `--retry` to a bunch of `curl` commands to see if we can make CI a bit more robust in the face of flaky network failures.


<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
