### PR TITLE
Pull in new regalloc2 with fastalloc fixes for exceptions, and re-enable and add to testing.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2995,9 +2995,9 @@ dependencies = [
 
 [[package]]
 name = "regalloc2"
-version = "0.12.2"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5216b1837de2149f8bc8e6d5f88a9326b63b8c836ed58ce4a0a29ec736a59734"
+checksum = "68e18e1ef763167dc6718c28a5585e62f907590a21028b8e87be1318f19ef1cb"
 dependencies = [
  "allocator-api2",
  "bumpalo",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -309,7 +309,7 @@ component-async-tests = { path = "crates/misc/component-async-tests" }
 
 # Bytecode Alliance maintained dependencies:
 # ---------------------------
-regalloc2 = "0.12.2"
+regalloc2 = "0.13.1"
 
 # cap-std family:
 target-lexicon = "0.13.0"

--- a/cranelift/codegen/meta/src/shared/settings.rs
+++ b/cranelift/codegen/meta/src/shared/settings.rs
@@ -38,12 +38,10 @@ pub(crate) fn define() -> SettingGroup {
 
             - `backtracking`: A backtracking allocator with range splitting; more expensive
                               but generates better code.
-
-            Note that the `single_pass` option is currently disabled because it does not
-            have adequate support for the kinds of allocations required by exception
-            handling (https://github.com/bytecodealliance/regalloc2/issues/217).
+            - `single_pass`: A single-pass algorithm that yields quick compilation but
+                             results in code with more register spills and moves.
         "#,
-        vec!["backtracking"],
+        vec!["backtracking", "single_pass"],
     );
 
     settings.add_enum(

--- a/cranelift/codegen/src/machinst/compile.rs
+++ b/cranelift/codegen/src/machinst/compile.rs
@@ -66,8 +66,7 @@ pub fn compile<B: LowerBackend + TargetIsa>(
 
         options.algorithm = match b.flags().regalloc_algorithm() {
             RegallocAlgorithm::Backtracking => Algorithm::Ion,
-            // Note: single-pass is currently disabled
-            // (https://github.com/bytecodealliance/regalloc2/issues/217).
+            RegallocAlgorithm::SinglePass => Algorithm::Fastalloc,
         };
 
         regalloc2::run(&vcode, vcode.abi.machine_env(), &options)

--- a/crates/cli-flags/src/lib.rs
+++ b/crates/cli-flags/src/lib.rs
@@ -1134,6 +1134,7 @@ mod tests {
         // Regalloc algorithm
         for (regalloc_value, expected) in [
             ("\"backtracking\"", Some(RegallocAlgorithm::Backtracking)),
+            ("\"single-pass\"", Some(RegallocAlgorithm::SinglePass)),
             ("\"hello\"", None), // should fail
             ("3", None),         // should fail
             ("true", None),      // should fail

--- a/crates/cli-flags/src/opt.rs
+++ b/crates/cli-flags/src/opt.rs
@@ -485,6 +485,7 @@ impl WasmtimeOptionValue for wasmtime::RegallocAlgorithm {
     fn parse(val: Option<&str>) -> Result<Self> {
         match String::parse(val)?.as_str() {
             "backtracking" => Ok(wasmtime::RegallocAlgorithm::Backtracking),
+            "single-pass" => Ok(wasmtime::RegallocAlgorithm::SinglePass),
             other => bail!(
                 "unknown regalloc algorithm`{}`, only backtracking,single-pass accepted",
                 other
@@ -495,6 +496,7 @@ impl WasmtimeOptionValue for wasmtime::RegallocAlgorithm {
     fn display(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             wasmtime::RegallocAlgorithm::Backtracking => f.write_str("backtracking"),
+            wasmtime::RegallocAlgorithm::SinglePass => f.write_str("single-pass"),
             _ => unreachable!(),
         }
     }

--- a/crates/fuzzing/src/generators/config.rs
+++ b/crates/fuzzing/src/generators/config.rs
@@ -840,13 +840,7 @@ impl RegallocAlgorithm {
     fn to_wasmtime(&self) -> wasmtime::RegallocAlgorithm {
         match self {
             RegallocAlgorithm::Backtracking => wasmtime::RegallocAlgorithm::Backtracking,
-            // Note: we have disabled `single_pass` for now because of
-            // its limitations w.r.t. exception handling
-            // (https://github.com/bytecodealliance/regalloc2/issues/217). To
-            // avoid breaking all existing fuzzbugs by changing the
-            // `arbitrary` mappings, we keep the `RegallocAlgorithm`
-            // enum as it is and remap here to `Backtracking`.
-            RegallocAlgorithm::SinglePass => wasmtime::RegallocAlgorithm::Backtracking,
+            RegallocAlgorithm::SinglePass => wasmtime::RegallocAlgorithm::SinglePass,
         }
     }
 }

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -279,9 +279,10 @@ impl Config {
 
             // When running under MIRI try to optimize for compile time of wasm
             // code itself as much as possible. Disable optimizations by
-            // default.
+            // default and use the fastest regalloc available to us.
             if cfg!(miri) {
                 ret.cranelift_opt_level(OptLevel::None);
+                ret.cranelift_regalloc_algorithm(RegallocAlgorithm::SinglePass);
             }
         }
 
@@ -1299,6 +1300,7 @@ impl Config {
     pub fn cranelift_regalloc_algorithm(&mut self, algo: RegallocAlgorithm) -> &mut Self {
         let val = match algo {
             RegallocAlgorithm::Backtracking => "backtracking",
+            RegallocAlgorithm::SinglePass => "single_pass",
         };
         self.compiler_config
             .settings
@@ -2934,6 +2936,16 @@ pub enum RegallocAlgorithm {
     /// results in better register utilization, producing fewer spills
     /// and moves, but can cause super-linear compile runtime.
     Backtracking,
+    /// Generates acceptable code very quickly.
+    ///
+    /// This algorithm performs a single pass through the code,
+    /// guaranteed to work in linear time.  (Note that the rest of
+    /// Cranelift is not necessarily guaranteed to run in linear time,
+    /// however.) It cannot undo earlier decisions, however, and it
+    /// cannot foresee constraints or issues that may occur further
+    /// ahead in the code, so the code may have more spills and moves as
+    /// a result.
+    SinglePass,
 }
 
 /// Select which profiling technique to support.

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -788,8 +788,8 @@ user-login = "dtolnay"
 user-name = "David Tolnay"
 
 [[publisher.regalloc2]]
-version = "0.12.2"
-when = "2025-05-07"
+version = "0.13.1"
+when = "2025-08-25"
 user-id = 3726
 user-login = "cfallin"
 user-name = "Chris Fallin"

--- a/tests/all/cli_tests.rs
+++ b/tests/all/cli_tests.rs
@@ -2239,10 +2239,14 @@ fn config_cli_flag() -> Result<()> {
         br#"
         [optimize]
         opt-level = 2
+        regalloc-algorithm = "single-pass"
         signals-based-traps = false
 
         [codegen]
         collector = "null"
+
+        [debug]
+        debug-info = true
 
         [wasm]
         max-wasm-stack = 65536

--- a/tests/all/stack_overflow.rs
+++ b/tests/all/stack_overflow.rs
@@ -152,6 +152,7 @@ fn big_stack_works_ok(config: &mut Config) -> Result<()> {
     // Disable cranelift optimizations to ensure that this test doesn't take too
     // long in debug mode due to the large size of its code.
     config.cranelift_opt_level(OptLevel::None);
+    config.cranelift_regalloc_algorithm(RegallocAlgorithm::SinglePass);
     let engine = Engine::new(config)?;
 
     let mut store = Store::new(&engine, ());


### PR DESCRIPTION
Thanks to @d-sonuga in bytecodealliance/regalloc2#233, the fastalloc (single-pass) register allocator now supports arbitrary numbers of non-register-constrained defs, which we use on call instructions after #10502. This should be sufficient to resolve the issues that had led us to disable fastalloc temporarily in #10554.

This PR reverts that disabling step; adds Cranelift-with-single-pass as a new compiler strategy (alongside Cranelift, Winch, and Cranelift/Pulley) to all of our wast/spec tests and fuzzing; and pulls in the new RA2.

Adding to our compiler strategy list is perhaps the most controversial thing here, but I believe it's probably appropriate to add the extra dimension here to ensure fastalloc stays working (it's a great feature to have!). Note that this surfaces as a new compiler strategy rather than a separate config dimension (like GC backend is currently) because it applies only to Cranelift, not Winch.