### PR TITLE
Tweak the `declare_builtin_index` macro

### DIFF
--- a/crates/environ/src/builtin.rs
+++ b/crates/environ/src/builtin.rs
@@ -247,8 +247,11 @@ macro_rules! foreach_builtin_function {
 /// `ComponentBuiltinFunctionIndex` using the iterator macro, e.g.
 /// `foreach_builtin_function`, as the way to generate accessor methods.
 macro_rules! declare_builtin_index {
-    ($index_name:ident, $iter:ident) => {
-        /// An index type for builtin functions.
+    (
+        $(#[$attr:meta])*
+        pub struct $index_name:ident : $for_each_builtin:ident ;
+    ) => {
+        $(#[$attr])*
         #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
         pub struct $index_name(u32);
 
@@ -264,7 +267,7 @@ macro_rules! declare_builtin_index {
                 self.0
             }
 
-            $iter!(declare_builtin_index_constructors);
+            $for_each_builtin!(declare_builtin_index_constructors);
         }
     };
 }
@@ -332,7 +335,10 @@ macro_rules! declare_builtin_index_constructors {
 }
 
 // Define `struct BuiltinFunctionIndex`
-declare_builtin_index!(BuiltinFunctionIndex, foreach_builtin_function);
+declare_builtin_index! {
+    /// An index type for builtin functions.
+    pub struct BuiltinFunctionIndex : foreach_builtin_function;
+}
 
 /// Return value of [`BuiltinFunctionIndex::trap_sentinel`].
 pub enum TrapSentinel {

--- a/crates/environ/src/component.rs
+++ b/crates/environ/src/component.rs
@@ -205,7 +205,7 @@ macro_rules! foreach_builtin_component_function {
 }
 
 // Define `struct ComponentBuiltinFunctionIndex`
-declare_builtin_index!(
-    ComponentBuiltinFunctionIndex,
-    foreach_builtin_component_function
-);
+declare_builtin_index! {
+    /// An index type for component builtin functions.
+    pub struct ComponentBuiltinFunctionIndex: foreach_builtin_component_function;
+}


### PR DESCRIPTION
This allows for specifying custom meta attributes (additionaly derives, docs, etc). This functionality is not yet used now, but will be in future commits.

Also makes the macro syntax more similar to a regular struct definition, which allows for easier `grep`-ability.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
