### PR TITLE
Return `true` from `yield` intrinsic if `EVENT_CANCELLED` is pending

### DIFF
--- a/crates/misc/component-async-tests/tests/scenario/yield_.rs
+++ b/crates/misc/component-async-tests/tests/scenario/yield_.rs
@@ -10,6 +10,14 @@ use super::util::test_run;
 )]
 pub fn async_yield_caller() {}
 
+// No-op function; we only test this by composing it in
+// `async_yield_callee_synchronous` and `async_yield_callee_stackful`
+#[allow(
+    dead_code,
+    reason = "here only to make the `assert_test_exists` macro happy"
+)]
+pub fn async_yield_caller_cancel() {}
+
 #[tokio::test]
 pub async fn async_yield_callee_synchronous() -> Result<()> {
     test_run(&[
@@ -23,6 +31,24 @@ pub async fn async_yield_callee_synchronous() -> Result<()> {
 pub async fn async_yield_callee_stackless() -> Result<()> {
     test_run(&[
         test_programs_artifacts::ASYNC_YIELD_CALLER_COMPONENT,
+        test_programs_artifacts::ASYNC_YIELD_CALLEE_STACKLESS_COMPONENT,
+    ])
+    .await
+}
+
+#[tokio::test]
+pub async fn async_yield_callee_cancel_synchronous() -> Result<()> {
+    test_run(&[
+        test_programs_artifacts::ASYNC_YIELD_CALLER_CANCEL_COMPONENT,
+        test_programs_artifacts::ASYNC_YIELD_CALLEE_SYNCHRONOUS_COMPONENT,
+    ])
+    .await
+}
+
+#[tokio::test]
+pub async fn async_yield_callee_cancel_stackless() -> Result<()> {
+    test_run(&[
+        test_programs_artifacts::ASYNC_YIELD_CALLER_CANCEL_COMPONENT,
         test_programs_artifacts::ASYNC_YIELD_CALLEE_STACKLESS_COMPONENT,
     ])
     .await

--- a/crates/misc/component-async-tests/tests/test_all.rs
+++ b/crates/misc/component-async-tests/tests/test_all.rs
@@ -35,4 +35,5 @@ use scenario::transmit::{
 use scenario::unit_stream::{async_unit_stream_callee, async_unit_stream_caller};
 use scenario::yield_::{
     async_yield_callee_stackless, async_yield_callee_synchronous, async_yield_caller,
+    async_yield_caller_cancel,
 };

--- a/crates/test-programs/src/bin/async_yield_callee_stackless.rs
+++ b/crates/test-programs/src/bin/async_yield_callee_stackless.rs
@@ -9,7 +9,7 @@ mod bindings {
 
 use {
     bindings::local::local::continue_,
-    test_programs::async_::{CALLBACK_CODE_EXIT, CALLBACK_CODE_YIELD, EVENT_NONE},
+    test_programs::async_::{CALLBACK_CODE_EXIT, CALLBACK_CODE_YIELD, EVENT_CANCELLED, EVENT_NONE},
 };
 
 #[cfg(target_arch = "wasm32")]
@@ -30,9 +30,9 @@ unsafe extern "C" fn export_run() -> u32 {
 
 #[unsafe(export_name = "[callback][async-lift]local:local/run#[async]run")]
 unsafe extern "C" fn callback_run(event0: u32, _event1: u32, _event2: u32) -> u32 {
-    assert_eq!(event0, EVENT_NONE);
+    assert!(event0 == EVENT_NONE || event0 == EVENT_CANCELLED);
 
-    if continue_::get_continue() {
+    if continue_::get_continue() && event0 == EVENT_NONE {
         CALLBACK_CODE_YIELD
     } else {
         task_return_run();

--- a/crates/test-programs/src/bin/async_yield_callee_synchronous.rs
+++ b/crates/test-programs/src/bin/async_yield_callee_synchronous.rs
@@ -18,9 +18,7 @@ struct Component;
 
 impl Guest for Component {
     fn run() {
-        while continue_::get_continue() {
-            assert!(async_support::yield_blocking());
-        }
+        while continue_::get_continue() && async_support::yield_blocking() {}
     }
 }
 

--- a/crates/test-programs/src/bin/async_yield_caller_cancel.rs
+++ b/crates/test-programs/src/bin/async_yield_caller_cancel.rs
@@ -1,0 +1,57 @@
+mod bindings {
+    wit_bindgen::generate!({
+        path: "../misc/component-async-tests/wit",
+        world: "yield-caller",
+    });
+
+    use super::Component;
+    export!(Component);
+}
+
+use {
+    bindings::{
+        exports::local::local::run::Guest,
+        local::local::{continue_, ready},
+    },
+    test_programs::async_::{STATUS_RETURNED, STATUS_STARTED, subtask_cancel},
+};
+
+#[cfg(target_arch = "wasm32")]
+#[link(wasm_import_module = "local:local/run")]
+unsafe extern "C" {
+    #[link_name = "[async-lower][async]run"]
+    fn run() -> u32;
+}
+#[cfg(not(target_arch = "wasm32"))]
+unsafe extern "C" fn run() -> u32 {
+    unreachable!()
+}
+
+struct Component;
+
+impl Guest for Component {
+    async fn run() {
+        ready::set_ready(true);
+        continue_::set_continue(true);
+
+        unsafe {
+            let status = run();
+            let waitable = status >> 4;
+            let status = status & 0xF;
+            assert_eq!(status, STATUS_STARTED);
+
+            // Here we assume the following:
+            //
+            // - Wasmtime will deliver a cancel event to the callee before returning
+            // from `subtask_cancel`.
+            //
+            // - The callee will immediately return as soon as it receives the
+            // event.
+            let status = subtask_cancel(waitable);
+            assert_eq!(status, STATUS_RETURNED);
+        }
+    }
+}
+
+// Unused function; required since this file is built as a `bin`:
+fn main() {}


### PR DESCRIPTION
Fixes #11191

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
