### PR TITLE
Disable `SinglePass` regalloc when fuzzing

### DIFF
--- a/crates/fuzzing/src/generators/config.rs
+++ b/crates/fuzzing/src/generators/config.rs
@@ -833,14 +833,18 @@ impl OptLevel {
 #[derive(Arbitrary, Clone, Debug, PartialEq, Eq, Hash)]
 enum RegallocAlgorithm {
     Backtracking,
-    SinglePass,
+    // FIXME(#11544 and #11545): rename back to `SinglePass` and handle below
+    // when those issues are fixed
+    TemporarilyDisabledSinglePass,
 }
 
 impl RegallocAlgorithm {
     fn to_wasmtime(&self) -> wasmtime::RegallocAlgorithm {
         match self {
             RegallocAlgorithm::Backtracking => wasmtime::RegallocAlgorithm::Backtracking,
-            RegallocAlgorithm::SinglePass => wasmtime::RegallocAlgorithm::SinglePass,
+            RegallocAlgorithm::TemporarilyDisabledSinglePass => {
+                wasmtime::RegallocAlgorithm::Backtracking
+            }
         }
     }
 }


### PR DESCRIPTION
OSS-Fuzz found #11544 and #11545 overnight so disable fuzzing for now until those are fixed to avoid hindering too much progress while fuzzing.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
