### PR TITLE
chore: fix typos

### DIFF
--- a/examples/min-platform/embedding/src/wasi.rs
+++ b/examples/min-platform/embedding/src/wasi.rs
@@ -301,7 +301,7 @@ impl InputStream for NeverReadable {
     }
 }
 
-// WriteLog is used implement stdout and stderr. Clonable because wasi:cli
+// WriteLog is used implement stdout and stderr. Cloneable because wasi:cli
 // requires, when calling get_stdout/get_stderr multiple times, to provide
 // distinct resources that point to the same underlying stream. RefCell
 // provides mutation, and VecDeque provides O(1) push_back operation.

--- a/pulley/src/disas.rs
+++ b/pulley/src/disas.rs
@@ -65,7 +65,7 @@ impl<'a> Disassembler<'a> {
         self
     }
 
-    /// Whether to include branche tables in the disassembly.
+    /// Whether to include branch tables in the disassembly.
     ///
     /// True by default.
     pub fn br_tables(&mut self, enable: bool) -> &mut Self {


### PR DESCRIPTION
## Description

This pull request fixes several typos in documentation comments across the codebase:

* Fixed `Clonable` to `Cloneable` in `examples/min-platform/embedding/src/wasi.rs`
* Fixed `branche` to `branch` in `pulley/src/disas.rs`

These changes improve the clarity and professionalism of the documentation.