### PR TITLE
Make `ReaddirIterator` public

### DIFF
--- a/crates/wasi/src/p2/mod.rs
+++ b/crates/wasi/src/p2/mod.rs
@@ -241,7 +241,7 @@ mod tcp;
 mod udp;
 mod write_stream;
 
-pub use self::filesystem::{FsError, FsResult};
+pub use self::filesystem::{FsError, FsResult, ReaddirIterator};
 pub use self::network::{Network, SocketError, SocketResult};
 pub use self::stdio::IsATTY;
 pub(crate) use tcp::P2TcpStreamingState;


### PR DESCRIPTION
This is required because it is used in the generated `wasmtime_wasi::p2::bindings::async_io::wasi::filesystem::types::HostDescriptor` trait for `read_directory()`. Since the type is currently private, third parties can't implement custom versions of that trait even if they don't actually use the `ReaddirIterator` from wasmtime.

See #8963 