### PR TITLE
WASI preview 0,1 set_rights API returns ENOTSUP

### DIFF
--- a/crates/wasi-common/src/snapshots/preview_1.rs
+++ b/crates/wasi-common/src/snapshots/preview_1.rs
@@ -246,10 +246,10 @@ impl wasi_snapshot_preview1::WasiSnapshotPreview1 for WasiCtx {
         let fd = u32::from(fd);
         if table.is::<FileEntry>(fd) {
             let _file_entry: Arc<FileEntry> = table.get(fd)?;
-            Ok(())
+            Err(Error::not_supported())
         } else if table.is::<DirEntry>(fd) {
             let _dir_entry: Arc<DirEntry> = table.get(fd)?;
-            Ok(())
+            Err(Error::not_supported())
         } else {
             Err(Error::badf())
         }

--- a/crates/wasi-preview1-component-adapter/src/lib.rs
+++ b/crates/wasi-preview1-component-adapter/src/lib.rs
@@ -952,7 +952,7 @@ pub unsafe extern "C" fn fd_fdstat_set_rights(
     State::with(|state| {
         let ds = state.descriptors();
         match ds.get(fd)? {
-            Descriptor::Streams(..) => Ok(()),
+            Descriptor::Streams(..) => Err(wasi::ERRNO_NOTSUP),
             Descriptor::Closed(..) | Descriptor::Bad => Err(wasi::ERRNO_BADF),
         }
     })

--- a/crates/wasi/src/p1.rs
+++ b/crates/wasi/src/p1.rs
@@ -1537,7 +1537,7 @@ impl wasi_snapshot_preview1::WasiSnapshotPreview1 for WasiP1Ctx {
         _fs_rights_inheriting: types::Rights,
     ) -> Result<(), types::Error> {
         self.get_fd(fd)?;
-        Ok(())
+        Err(types::Errno::Notsup.into())
     }
 
     /// Return the attributes of an open file.


### PR DESCRIPTION
Instead of silently succeeding, return an error.

See https://github.com/WebAssembly/wasi-testsuite/issues/101#issuecomment-3219290417.