### PR TITLE
Disallow loading code on `x86_64-unknown-none`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1225,6 +1225,7 @@ version = "37.0.0"
 dependencies = [
  "anyhow",
  "dlmalloc",
+ "raw-cpuid",
  "wasmtime",
  "wasmtime-wasi-io",
 ]
@@ -2943,6 +2944,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
 dependencies = [
  "rand_core 0.6.3",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6df7ab838ed27997ba19a4664507e6f82b41fe6e20be42929332156e5e85146"
+dependencies = [
+ "bitflags 2.6.0",
 ]
 
 [[package]]

--- a/crates/wasmtime/src/compile/runtime.rs
+++ b/crates/wasmtime/src/compile/runtime.rs
@@ -21,10 +21,6 @@ impl<'a> CodeBuilder<'a> {
         let wasm = self.get_wasm()?;
         let dwarf_package = self.get_dwarf_package();
 
-        self.engine
-            .check_compatible_with_native_host()
-            .context("compilation settings are not compatible with the native host")?;
-
         #[cfg(feature = "cache")]
         {
             let state = (

--- a/crates/wasmtime/src/compile/runtime.rs
+++ b/crates/wasmtime/src/compile/runtime.rs
@@ -21,6 +21,10 @@ impl<'a> CodeBuilder<'a> {
         let wasm = self.get_wasm()?;
         let dwarf_package = self.get_dwarf_package();
 
+        self.engine
+            .check_compatible_with_native_host()
+            .context("compilation settings are not compatible with the native host")?;
+
         #[cfg(feature = "cache")]
         {
             let state = (

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -163,6 +163,7 @@ pub struct Config {
     pub(crate) coredump_on_trap: bool,
     pub(crate) macos_use_mach_ports: bool,
     pub(crate) detect_host_feature: Option<fn(&str) -> Option<bool>>,
+    pub(crate) x86_float_abi_ok: Option<bool>,
 }
 
 /// User-provided configuration for the compiler.
@@ -271,6 +272,7 @@ impl Config {
             detect_host_feature: Some(detect_host_feature),
             #[cfg(not(feature = "std"))]
             detect_host_feature: None,
+            x86_float_abi_ok: None,
         };
         #[cfg(any(feature = "cranelift", feature = "winch"))]
         {
@@ -2700,6 +2702,76 @@ impl Config {
     /// not.
     pub fn gc_support(&mut self, enable: bool) -> &mut Self {
         self.wasm_feature(WasmFeatures::GC_TYPES, enable)
+    }
+
+    /// Explicitly indicate or not whether the host is using a hardware float
+    /// ABI on x86 targets.
+    ///
+    /// This configuration option is only applicable on the
+    /// `x86_64-unknown-none` Rust target and has no affect on other host
+    /// targets. The `x86_64-unknown-none` Rust target does not support hardware
+    /// floats by default and uses a "soft float" implementation and ABI. This
+    /// means that `f32`, for example, is passed in a general-purpose register
+    /// between functions instead of a floating-point register. This does not
+    /// match Cranelift's ABI for `f32` where it's passed in floating-point
+    /// registers.  Cranelift does not have support for a "soft float"
+    /// implementation where all floating-point operations are lowered to
+    /// libcalls.
+    ///
+    /// This means that for the `x86_64-unknown-none` target the ABI between
+    /// Wasmtime's libcalls and the host is incompatible when floats are used.
+    /// This further means that, by default, Wasmtime is unable to load native
+    /// code when compiled to the `x86_64-unknown-none` target. The purpose of
+    /// this option is to explicitly allow loading code and bypass this check.
+    ///
+    /// Setting this configuration option to `true` indicates that either:
+    /// (a) the Rust target is compiled with the hard-float ABI manually via
+    /// `-Zbuild-std` and a custom target JSON configuration, or (b) sufficient
+    /// x86 features have been enabled in the compiler such that float libcalls
+    /// will not be used in Wasmtime. For (a) there is no way in Rust at this
+    /// time to detect whether a hard-float or soft-float ABI is in use on
+    /// stable Rust, so this manual opt-in is required. For (b) the only
+    /// instance where Wasmtime passes a floating-point value in a register
+    /// between the host and compiled wasm code is with libcalls.
+    ///
+    /// Float-based libcalls are only used when the compilation target for a
+    /// wasm module has insufficient target features enabled for native
+    /// support. For example SSE4.1 is required for the `f32.ceil` WebAssembly
+    /// instruction to be compiled to a native instruction. If SSE4.1 is not
+    /// enabled then `f32.ceil` is translated to a "libcall" which is
+    /// implemented on the host. Float-based libcalls can be avoided with
+    /// sufficient target features enabled, for example:
+    ///
+    /// * `self.cranelift_flag_enable("has_sse3")`
+    /// * `self.cranelift_flag_enable("has_ssse3")`
+    /// * `self.cranelift_flag_enable("has_sse41")`
+    /// * `self.cranelift_flag_enable("has_sse42")`
+    /// * `self.cranelift_flag_enable("has_fma")`
+    ///
+    /// Note that when these features are enabled Wasmtime will perform a
+    /// runtime check to determine that the host actually has the feature
+    /// present.
+    ///
+    /// For some more discussion see [#11506].
+    ///
+    /// [#11506]: https://github.com/bytecodealliance/wasmtime/issues/11506
+    ///
+    /// # Safety
+    ///
+    /// This method is not safe because it cannot be detected in Rust right now
+    /// whether the host is compiled with a soft or hard float ABI. Additionally
+    /// if the host is compiled with a soft float ABI disabling this check does
+    /// not ensure that the wasm module in question has zero usage of floats
+    /// in the boundary to the host.
+    ///
+    /// Safely using this method requires one of:
+    ///
+    /// * The host target is compiled to use hardware floats.
+    /// * Wasm modules loaded are compiled with enough x86 Cranelift features
+    ///   enabled to avoid float-related hostcalls.
+    pub unsafe fn x86_float_abi_ok(&mut self, enable: bool) -> &mut Self {
+        self.x86_float_abi_ok = Some(enable);
+        self
     }
 }
 

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -2708,7 +2708,7 @@ impl Config {
     /// ABI on x86 targets.
     ///
     /// This configuration option is only applicable on the
-    /// `x86_64-unknown-none` Rust target and has no affect on other host
+    /// `x86_64-unknown-none` Rust target and has no effect on other host
     /// targets. The `x86_64-unknown-none` Rust target does not support hardware
     /// floats by default and uses a "soft float" implementation and ABI. This
     /// means that `f32`, for example, is passed in a general-purpose register

--- a/examples/min-platform/embedding/Cargo.toml
+++ b/examples/min-platform/embedding/Cargo.toml
@@ -22,6 +22,9 @@ wasmtime-wasi-io = { workspace = true, optional = true }
 # Memory allocator used in this example (not required, however)
 dlmalloc = "0.2.4"
 
+[target.'cfg(target_arch = "x86_64")'.dependencies]
+raw-cpuid = "11.5.0"
+
 [lib]
 crate-type = ['staticlib']
 test = false

--- a/examples/min-platform/embedding/src/lib.rs
+++ b/examples/min-platform/embedding/src/lib.rs
@@ -84,6 +84,9 @@ fn config() -> Config {
         // that the feature is actually supplied at runtime, but a default check
         // isn't possible in no_std. For x86_64 we can use the cpuid instruction
         // bound through an external crate.
+        //
+        // Note that CPU support for these features has existend since 2013
+        // (Haswell) on Intel chips and 2012 (Piledriver) on AMD chips.
         unsafe {
             config.detect_host_feature(move |feature| {
                 let id = raw_cpuid::CpuId::new();

--- a/examples/min-platform/embedding/src/lib.rs
+++ b/examples/min-platform/embedding/src/lib.rs
@@ -4,9 +4,9 @@
 extern crate alloc;
 
 use alloc::string::ToString;
-use anyhow::Result;
+use anyhow::{Result, ensure};
 use core::ptr;
-use wasmtime::{Engine, Instance, Linker, Module, Store};
+use wasmtime::{Config, Engine, Instance, Linker, Module, Store};
 
 mod allocator;
 mod panic;
@@ -29,6 +29,8 @@ pub unsafe extern "C" fn run(
     simple_add_size: usize,
     simple_host_fn_module: *const u8,
     simple_host_fn_size: usize,
+    simple_floats_module: *const u8,
+    simple_floats_size: usize,
 ) -> usize {
     unsafe {
         let buf = core::slice::from_raw_parts_mut(error_buf, error_size);
@@ -36,7 +38,8 @@ pub unsafe extern "C" fn run(
         let simple_add = core::slice::from_raw_parts(simple_add_module, simple_add_size);
         let simple_host_fn =
             core::slice::from_raw_parts(simple_host_fn_module, simple_host_fn_size);
-        match run_result(smoke, simple_add, simple_host_fn) {
+        let simple_floats = core::slice::from_raw_parts(simple_floats_module, simple_floats_size);
+        match run_result(smoke, simple_add, simple_host_fn, simple_floats) {
             Ok(()) => 0,
             Err(e) => {
                 let msg = format!("{e:?}");
@@ -52,15 +55,55 @@ fn run_result(
     smoke_module: &[u8],
     simple_add_module: &[u8],
     simple_host_fn_module: &[u8],
+    simple_floats_module: &[u8],
 ) -> Result<()> {
     smoke(smoke_module)?;
     simple_add(simple_add_module)?;
     simple_host_fn(simple_host_fn_module)?;
+    simple_floats(simple_floats_module)?;
     Ok(())
 }
 
+fn config() -> Config {
+    let mut config = Config::new();
+    let _ = &mut config;
+
+    #[cfg(target_arch = "x86_64")]
+    {
+        // This example runs in a Linux process where it's valid to use
+        // floating point registers. Additionally sufficient x86 features are
+        // enabled during compilation to avoid float-related libcalls. Thus
+        // despite the host being configured for "soft float" it should be
+        // valid to turn this on.
+        unsafe {
+            config.x86_float_abi_ok(true);
+        }
+
+        // To make the float ABI above OK it requires CPU features above
+        // baseline to be enabled. Wasmtime needs to be able to check to ensure
+        // that the feature is actually supplied at runtime, but a default check
+        // isn't possible in no_std. For x86_64 we can use the cpuid instruction
+        // bound through an external crate.
+        unsafe {
+            config.detect_host_feature(move |feature| {
+                let id = raw_cpuid::CpuId::new();
+                match feature {
+                    "sse3" => Some(id.get_feature_info()?.has_sse3()),
+                    "ssse3" => Some(id.get_feature_info()?.has_sse3()),
+                    "sse4.1" => Some(id.get_feature_info()?.has_sse41()),
+                    "sse4.2" => Some(id.get_feature_info()?.has_sse42()),
+                    "fma" => Some(id.get_feature_info()?.has_fma()),
+                    _ => None,
+                }
+            });
+        }
+    }
+
+    config
+}
+
 fn smoke(module: &[u8]) -> Result<()> {
-    let engine = Engine::default();
+    let engine = Engine::new(&config())?;
     let module = match deserialize(&engine, module)? {
         Some(module) => module,
         None => return Ok(()),
@@ -70,7 +113,7 @@ fn smoke(module: &[u8]) -> Result<()> {
 }
 
 fn simple_add(module: &[u8]) -> Result<()> {
-    let engine = Engine::default();
+    let engine = Engine::new(&config())?;
     let module = match deserialize(&engine, module)? {
         Some(module) => module,
         None => return Ok(()),
@@ -78,12 +121,12 @@ fn simple_add(module: &[u8]) -> Result<()> {
     let mut store = Store::new(&engine, ());
     let instance = Linker::new(&engine).instantiate(&mut store, &module)?;
     let func = instance.get_typed_func::<(u32, u32), u32>(&mut store, "add")?;
-    assert_eq!(func.call(&mut store, (2, 3))?, 5);
+    ensure!(func.call(&mut store, (2, 3))? == 5);
     Ok(())
 }
 
 fn simple_host_fn(module: &[u8]) -> Result<()> {
-    let engine = Engine::default();
+    let engine = Engine::new(&config())?;
     let module = match deserialize(&engine, module)? {
         Some(module) => module,
         None => return Ok(()),
@@ -93,7 +136,20 @@ fn simple_host_fn(module: &[u8]) -> Result<()> {
     let mut store = Store::new(&engine, ());
     let instance = linker.instantiate(&mut store, &module)?;
     let func = instance.get_typed_func::<(u32, u32, u32), u32>(&mut store, "add_and_mul")?;
-    assert_eq!(func.call(&mut store, (2, 3, 4))?, 10);
+    ensure!(func.call(&mut store, (2, 3, 4))? == 10);
+    Ok(())
+}
+
+fn simple_floats(module: &[u8]) -> Result<()> {
+    let engine = Engine::new(&config())?;
+    let module = match deserialize(&engine, module)? {
+        Some(module) => module,
+        None => panic!(),
+    };
+    let mut store = Store::new(&engine, ());
+    let instance = Linker::new(&engine).instantiate(&mut store, &module)?;
+    let func = instance.get_typed_func::<(f32, f32), f32>(&mut store, "frob")?;
+    ensure!(func.call(&mut store, (1.4, 3.2))? == 5.);
     Ok(())
 }
 

--- a/examples/min-platform/embedding/src/lib.rs
+++ b/examples/min-platform/embedding/src/lib.rs
@@ -147,7 +147,7 @@ fn simple_floats(module: &[u8]) -> Result<()> {
     let engine = Engine::new(&config())?;
     let module = match deserialize(&engine, module)? {
         Some(module) => module,
-        None => panic!(),
+        None => return Ok(()),
     };
     let mut store = Store::new(&engine, ());
     let instance = Linker::new(&engine).instantiate(&mut store, &module)?;

--- a/examples/min-platform/embedding/src/wasi.rs
+++ b/examples/min-platform/embedding/src/wasi.rs
@@ -33,7 +33,7 @@ use core::future::Future;
 use core::pin::Pin;
 use core::task::{Context, Poll, Waker};
 use wasmtime::component::{Component, Linker, Resource, ResourceTable};
-use wasmtime::{Config, Engine, Store};
+use wasmtime::{Engine, Store};
 use wasmtime_wasi_io::{
     IoView,
     bytes::Bytes,
@@ -78,7 +78,7 @@ fn run(wasi_component: &[u8]) -> Result<String> {
     // interface will poll as Pending while execution is suspended and it is
     // waiting for a Pollable to become Ready. This example provides a very
     // small async executor which is entered below with `block_on`.
-    let mut config = Config::default();
+    let mut config = super::config();
     config.async_support(true);
     // For future: we could consider turning on fuel in the Config to meter
     // how long a wasm guest could execute for.

--- a/examples/min-platform/src/main.rs
+++ b/examples/min-platform/src/main.rs
@@ -79,6 +79,11 @@ fn main() -> Result<()> {
     // For x86_64 targets be sure to enable relevant CPU features to avoid
     // float-related libcalls which is required for the `x86_64-unknown-none`
     // target.
+    //
+    // Note that the embedding will need to check that these features are
+    // actually available at runtime. CPU support for these features has
+    // existend since 2013 (Haswell) on Intel chips and 2012 (Piledriver) on
+    // AMD chips.
     if cfg!(target_arch = "x86_64") {
         unsafe {
             config.cranelift_flag_enable("has_sse3");

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -3278,6 +3278,15 @@ who = "Pat Hickey <phickey@fastly.com>"
 criteria = "safe-to-deploy"
 delta = "1.0.23 -> 1.0.27"
 
+[[audits.raw-cpuid]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+version = "11.5.0"
+notes = """
+Very little `unsafe` usage, what is there is well-documented. Otherwise it's a
+big library but that's more Intel's fault than anyone else's.
+"""
+
 [[audits.regalloc2]]
 who = "Jamey Sharp <jsharp@fastly.com>"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
... And then also add an escape hatch to allow loading code. This commit is the culmination of discussion on #11506 with a proposed resolution for Wasmtime. The resolution being:

* Wasmtime will reject loading code on `x86_64-unknown-none` platforms by default.
* A new `Config::x86_float_abi_ok` escape hatch is added to bypass this check.
* Documentation/errors are updated around `x86_float_abi_ok` to document the situation.
* The `min-platform` example is updated to showcase how this is valid to run in that particular embedding (aka enable more features and sufficiently detect said features).

The basic tl;dr; is that we can't detect in stable Rust what float ABI is being used so therefore we pessimistically assume that `x86_64-unknown-none` is using a soft-float ABI. This is incompatible with libcalls unless they aren't actually called which is only possible when sufficiently many target features are enabled.

The goal of this commit is to be a relatively low-effort way to place a roadblock in the way of "ok ABIs are weird" but at the same time enable getting around the roadblock easily. Additionally the roadblock points to documentation about itself to learn more about what's going on here.

Closes #11506

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
