### PR TITLE
Fuzzing: ignore thrown exceptions during instantiation.

### DIFF
--- a/crates/fuzzing/src/oracles.rs
+++ b/crates/fuzzing/src/oracles.rs
@@ -417,6 +417,8 @@ fn unwrap_instance(
         || e.is::<wasmtime::PoolConcurrencyLimitError>()
         // And GC heap OOMs.
         || e.is::<wasmtime::GcHeapOutOfMemory<()>>()
+        // And thrown exceptions.
+        || e.is::<wasmtime::ThrownException>()
     {
         return None;
     }


### PR DESCRIPTION
This updates the instantiation logic to ignore inputs that throw an exception during instantiation, just as it does for other kinds of errors such as traps currently.

Fixes #11551.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
