### PR TITLE
[Cranelift] `(x | (x | y)) --> (x | y)`

### DIFF
--- a/cranelift/codegen/src/opts/bitops.isle
+++ b/cranelift/codegen/src/opts/bitops.isle
@@ -191,3 +191,9 @@
   (bswap ty x))
 
 (rule (simplify (bxor ty (bor ty x y) (band ty x y))) (bxor ty x y))
+
+
+(rule (simplify (bor ty (bor ty x y) x)) (bor ty x y))
+(rule (simplify (bor ty (bor ty x y) y)) (bor ty x y))
+(rule (simplify (bor ty x (bor ty x y))) (bor ty x y))
+(rule (simplify (bor ty y (bor ty x y))) (bor ty x y))

--- a/cranelift/filetests/filetests/egraph/fold-bitops.clif
+++ b/cranelift/filetests/filetests/egraph/fold-bitops.clif
@@ -1,0 +1,60 @@
+test optimize precise-output
+set opt_level=speed
+target x86_64
+
+;; (rule (simplify (bor ty x (bor ty x y))) (bor ty x y))
+function %simplify_bor_xxy(i32, i32) -> i32 {
+block0(v0: i32, v1: i32):
+    v2 = bor v0, v1
+    v3 = bor v0, v2
+    return v3
+}
+
+; function %simplify_bor_xxy(i32, i32) -> i32 fast {
+; block0(v0: i32, v1: i32):
+;     v2 = bor v0, v1
+;     return v2
+; }
+
+;; (rule (simplify (bor ty y (bor ty x y))) (bor ty x y))
+function %simplify_bor_yxy(i32, i32) -> i32 {
+block0(v0: i32, v1: i32):
+    v3 = bor v0, v1
+    v4 = bor v1, v3
+    return v4
+}
+
+; function %simplify_bor_yxy(i32, i32) -> i32 fast {
+; block0(v0: i32, v1: i32):
+;     v3 = bor v0, v1
+;     return v3
+; }
+
+;; (rule (simplify (bor ty (bor ty x y) x)) (bor ty x y))
+function %simplify_bor_xyx(i32, i32) -> i32 {
+block0(v0: i32, v1: i32):
+    v2 = bor v0, v1
+    v3 = bor v2, v0
+    return v3
+}
+
+; function %simplify_bor_xyx(i32, i32) -> i32 fast {
+; block0(v0: i32, v1: i32):
+;     v2 = bor v0, v1
+;     return v2
+; }
+
+;; (rule (simplify (bor ty (bor ty x y) y)) (bor ty x y))
+function %simplify_bor_xyy(i32, i32) -> i32 {
+block0(v0: i32, v1: i32):
+    v2 = bor v0, v1
+    v3 = bor v2, v1
+    return v3
+}
+
+; function %simplify_bor_xyy(i32, i32) -> i32 fast {
+; block0(v0: i32, v1: i32):
+;     v2 = bor v0, v1
+;     return v2
+; }
+

--- a/cranelift/filetests/filetests/runtests/fold-bitops.clif
+++ b/cranelift/filetests/filetests/runtests/fold-bitops.clif
@@ -1,0 +1,66 @@
+test interpret
+test run
+set opt_level=none
+target aarch64
+target s390x
+target riscv64
+target riscv64 has_c has_zcb
+target s390x has_mie3
+target x86_64
+target pulley32
+target pulley32be
+target pulley64
+target pulley64be
+
+set opt_level=speed
+target aarch64
+target s390x
+target riscv64
+target riscv64 has_c has_zcb
+target s390x has_mie3
+target x86_64
+target pulley32
+target pulley32be
+target pulley64
+target pulley64be
+
+
+function %simplify_bor_xxy(i32, i32) -> i32 {
+block0(v0: i32, v1: i32):
+    v2 = bor v0, v1
+    v3 = bor v0, v2
+    return v3
+}
+
+; run: %simplify_bor_xxy(1, 2) == 3
+; run: %simplify_bor_xxy(54, 9) == 63
+
+function %simplify_bor_yxy(i32, i32) -> i32 {
+block0(v0: i32, v1: i32):
+    v3 = bor v0, v1
+    v4 = bor v1, v3
+    return v4
+}
+
+; run: %simplify_bor_yxy(1, 2) == 3
+; run: %simplify_bor_yxy(54, 9) == 63
+
+function %simplify_bor_xyx(i32, i32) -> i32 {
+block0(v0: i32, v1: i32):
+    v2 = bor v0, v1
+    v3 = bor v2, v0
+    return v3
+}
+
+; run: %simplify_bor_xyx(1, 2) == 3
+; run: %simplify_bor_xyx(54, 9) == 63
+
+function %simplify_bor_xyy(i32, i32) -> i32 {
+block0(v0: i32, v1: i32):
+    v2 = bor v0, v1
+    v3 = bor v2, v1
+    return v3
+}
+
+; run: %simplify_bor_xyy(1, 2) == 3
+; run: %simplify_bor_xyy(54, 9) == 63


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->

This obvious one was missing!
Proved with crocus, with the same specification of #11359 
