### PR TITLE
[Cranelift] `(x & y) & x --> x & y`

### DIFF
--- a/cranelift/codegen/src/opts/bitops.isle
+++ b/cranelift/codegen/src/opts/bitops.isle
@@ -197,3 +197,8 @@
 (rule (simplify (bor ty (bor ty x y) y)) (bor ty x y))
 (rule (simplify (bor ty x (bor ty x y))) (bor ty x y))
 (rule (simplify (bor ty y (bor ty x y))) (bor ty x y))
+
+(rule (simplify (band ty (band ty x y) x)) (band ty x y))
+(rule (simplify (band ty (band ty x y) y)) (band ty x y))
+(rule (simplify (band ty x (band ty x y))) (band ty x y))
+(rule (simplify (band ty y (band ty x y))) (band ty x y))

--- a/cranelift/filetests/filetests/egraph/bitops.clif
+++ b/cranelift/filetests/filetests/egraph/bitops.clif
@@ -442,3 +442,43 @@ block0(v0: i16, v1: i16):
     ; check: v5 = bxor v0, v1
     ; check: return v5
 }
+
+;; (x & y) & x == x & y
+;; (x & y) & y == x & y
+;; x & (x & y) == x & y
+;; y & (x & y) == x & y
+function %test_and_and1(i32, i32) -> i32 {
+block0(v0: i32, v1: i32):
+    v2 = band v0, v1
+    v3 = band v2, v0
+    return v3
+    ; check: v2 = band v0, v1
+    ; check: return v2
+}
+
+function %test_and_and2(i32, i32) -> i32 {
+block0(v0: i32, v1: i32):
+    v2 = band v0, v1
+    v3 = band v0, v2
+    return v3
+    ; check: v2 = band v0, v1
+    ; check: return v2
+}
+
+function %test_and_and3(i32, i32) -> i32 {
+block0(v0: i32, v1: i32):
+    v2 = band v1, v0
+    v3 = band v0, v2
+    return v3
+    ; check: v2 = band v1, v0
+    ; check: return v2
+}
+
+function %test_and_and4(i32, i32) -> i32 {
+block0(v0: i32, v1: i32):
+    v2 = band v1, v0
+    v3 = band v2, v0
+    return v3
+    ; check: v2 = band v1, v0
+    ; check: return v2
+}

--- a/cranelift/filetests/filetests/runtests/bitops.clif
+++ b/cranelift/filetests/filetests/runtests/bitops.clif
@@ -126,3 +126,41 @@ block0(v0: i64, v1: i64):
 ; run: %test_bxor_bor_band_i64(1, 0) == 1
 ; run: %test_bxor_bor_band_i64(1, 1) == 0
 ; run: %test_bxor_bor_band_i64(7879, 7879) == 0
+
+
+function %test_and_and1(i32, i32) -> i32 {
+block0(v0: i32, v1: i32):
+    v2 = band v0, v1
+    v3 = band v2, v0
+    return v3
+}
+
+; run: %test_and_and1(4, 3) == 0
+
+function %test_and_and2(i32, i32) -> i32 {
+block0(v0: i32, v1: i32):
+    v2 = band v0, v1
+    v3 = band v0, v2
+    return v3
+}
+
+; run: %test_and_and2(4, 3) == 0
+
+function %test_and_and3(i32, i32) -> i32 {
+block0(v0: i32, v1: i32):
+    v2 = band v1, v0
+    v3 = band v0, v2
+    return v3
+}
+
+; run: %test_and_and3(4, 3) == 0
+
+function %test_and_and4(i32, i32) -> i32 {
+block0(v0: i32, v1: i32):
+    v2 = band v1, v0
+    v3 = band v2, v0
+    return v3
+}
+
+; run: %test_and_and4(4, 3) == 0
+


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->

This folds consecutive bitwise-and instructions into a single instruction.
