### PR TITLE
Don't unwrap results of const-eval

### DIFF
--- a/crates/wasmtime/src/runtime/vm/instance.rs
+++ b/crates/wasmtime/src/runtime/vm/instance.rs
@@ -888,7 +888,7 @@ impl Instance {
         dst: u64,
         src: u64,
         len: u64,
-    ) -> Result<(), Trap> {
+    ) -> Result<()> {
         let mut storage = None;
         let elements = store
             .instance(instance)
@@ -918,7 +918,7 @@ impl Instance {
         dst: u64,
         src: u64,
         len: u64,
-    ) -> Result<(), Trap> {
+    ) -> Result<()> {
         // https://webassembly.github.io/bulk-memory-operations/core/exec/instructions.html#exec-table-init
 
         let store_id = store.id();
@@ -967,8 +967,7 @@ impl Instance {
                 for (i, expr) in positions.zip(exprs) {
                     let element = const_evaluator
                         .eval(&mut store, limiter.as_deref_mut(), &mut context, expr)
-                        .await
-                        .expect("const expr should be valid");
+                        .await?;
                     table.set_(&mut store, i, element.ref_().unwrap()).unwrap();
                 }
             }

--- a/crates/wasmtime/src/runtime/vm/instance/allocator.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator.rs
@@ -535,8 +535,7 @@ async fn initialize_tables(
             TableInitialValue::Expr(expr) => {
                 let init = const_evaluator
                     .eval(&mut store, limiter.as_deref_mut(), context, expr)
-                    .await
-                    .expect("const expression should be valid");
+                    .await?;
                 let idx = module.table_index(table);
                 let id = store.id();
                 let table = store
@@ -767,8 +766,7 @@ async fn initialize_globals(
         } else {
             const_evaluator
                 .eval(&mut store, limiter.as_deref_mut(), context, init)
-                .await
-                .expect("should be a valid const expr")
+                .await?
         };
 
         let id = store.id();

--- a/crates/wasmtime/src/runtime/vm/libcalls.rs
+++ b/crates/wasmtime/src/runtime/vm/libcalls.rs
@@ -987,8 +987,7 @@ fn array_new_elem(
                 for x in xs.iter() {
                     let val = *const_evaluator
                         .eval(&mut store, limiter.as_mut(), &mut const_context, x)
-                        .await
-                        .expect("const expr should be valid");
+                        .await?;
                     vals.push(val);
                 }
             }
@@ -1083,8 +1082,7 @@ fn array_init_elem(
                 {
                     let val = *const_evaluator
                         .eval(&mut store, limiter.as_mut(), &mut const_context, x)
-                        .await
-                        .expect("const expr should be valid");
+                        .await?;
                     vals.push(val);
                 }
                 vals


### PR DESCRIPTION
While all const expressions executed at runtime are valid they can still fail due to GC OOM or failure to allocate more GC memory. As a result all `unwrap()` on `eval(...)` is removed in favor of propagating upwards the result.

Closes #11469

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
