### PR TITLE
Use `mutate` instead of `mutate_with` for `TableOps` test

### DIFF
--- a/crates/fuzzing/src/generators/table_ops.rs
+++ b/crates/fuzzing/src/generators/table_ops.rs
@@ -633,11 +633,10 @@ mod tests {
         let mut unseen_ops: std::collections::HashSet<_> = OP_NAMES.iter().copied().collect();
 
         let mut res = empty_test_ops();
-        let mut generator = TableOpsMutator;
         let mut session = mutatis::Session::new();
 
         'outer: for _ in 0..=1024 {
-            session.mutate_with(&mut generator, &mut res)?;
+            session.mutate(&mut res)?;
             for op in &res.ops {
                 unseen_ops.remove(op.name());
                 if unseen_ops.is_empty() {
@@ -645,6 +644,7 @@ mod tests {
                 }
             }
         }
+
         assert!(unseen_ops.is_empty(), "Failed to generate {unseen_ops:?}");
         Ok(())
     }


### PR DESCRIPTION
We were passing in the default mutator, which is the same thing that `mutate` does, so no need to explicitly do it ourselves.

cc @khagankhan 

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
