### PR TITLE
Fix a verifier error generated during optimizations

### DIFF
--- a/cranelift/codegen/src/opts/selects.isle
+++ b/cranelift/codegen/src/opts/selects.isle
@@ -96,5 +96,5 @@
 (rule (simplify
         (iadd ty (select ty c (iconst_u ty x) (iconst_u ty y)) (iconst_u ty z)))
         (select ty c
-            (iconst ty (imm64 (u64_add x z)))
-            (iconst ty (imm64 (u64_add y z)))))
+            (iconst ty (imm64_masked ty (u64_add x z)))
+            (iconst ty (imm64_masked ty (u64_add y z)))))

--- a/cranelift/filetests/filetests/egraph/selects.clif
+++ b/cranelift/filetests/filetests/egraph/selects.clif
@@ -21,3 +21,23 @@ block0(v0: i8):
 ;     return v8
 ; }
 
+
+;; (iadd ty (select ty c x y) z) -> (select ty c (x + z) (y + z))
+function %simplify_iadd_select_const_i32_big_constants(i8) -> i8 fast {
+block0(v0: i8):
+    v1 = iconst.i8 100
+    v2 = iconst.i8 200
+    v3 = select v0, v1, v2
+    v4 = iconst.i8 200
+    v5 = iadd v3, v4
+    return v5
+}
+
+; function %simplify_iadd_select_const_i32_big_constants(i8) -> i8 fast {
+; block0(v0: i8):
+;     v6 = iconst.i8 44
+;     v7 = iconst.i8 -112
+;     v8 = select v0, v6, v7  ; v6 = 44, v7 = -112
+;     return v8
+; }
+


### PR DESCRIPTION
This commit fixes an accidental regression from #11526 detected on OSS-Fuzz. The `imm64` constants created needed to be masked off to the type width to avoid having the upper bits set.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
