### PR TITLE
Exceptions: global.get from external or table init: null exnref is not an anyref.

### DIFF
--- a/crates/wasmtime/src/runtime/externals/global.rs
+++ b/crates/wasmtime/src/runtime/externals/global.rs
@@ -1,8 +1,8 @@
 use crate::prelude::*;
 use crate::runtime::vm::{self, VMGlobalDefinition, VMGlobalKind, VMOpaqueContext};
 use crate::{
-    AnyRef, AsContext, AsContextMut, ExternRef, Func, GlobalType, HeapType, Mutability, Ref,
-    RootedGcRefImpl, Val, ValType,
+    AnyRef, AsContext, AsContextMut, ExnRef, ExternRef, Func, GlobalType, HeapType, Mutability,
+    Ref, RootedGcRefImpl, Val, ValType,
     store::{AutoAssertNoGc, InstanceId, StoreId, StoreInstanceId, StoreOpaque},
     trampoline::generate_global_export,
 };
@@ -172,15 +172,21 @@ impl Global {
 
                         HeapType::NoExtern => Ref::Extern(None),
 
+                        HeapType::Exn | HeapType::ConcreteExn(_) => definition
+                            .as_gc_ref()
+                            .map(|r| {
+                                let r = store.clone_gc_ref(r);
+                                ExnRef::from_cloned_gc_ref(store, r)
+                            })
+                            .into(),
+
                         HeapType::Any
                         | HeapType::Eq
                         | HeapType::I31
                         | HeapType::Struct
                         | HeapType::ConcreteStruct(_)
                         | HeapType::Array
-                        | HeapType::ConcreteArray(_)
-                        | HeapType::Exn
-                        | HeapType::ConcreteExn(_) => definition
+                        | HeapType::ConcreteArray(_) => definition
                             .as_gc_ref()
                             .map(|r| {
                                 let r = store.clone_gc_ref(r);

--- a/tests/misc_testsuite/issue11561.wast
+++ b/tests/misc_testsuite/issue11561.wast
@@ -1,0 +1,8 @@
+;;! exceptions = true
+;;! gc = true
+
+(module
+  (table $t 10 exnref)
+  (global $g exnref (ref.null exn))
+  (elem (table $t) (i32.const 0) exnref (global.get $g))
+)

--- a/tests/misc_testsuite/issue11563.wat
+++ b/tests/misc_testsuite/issue11563.wat
@@ -1,0 +1,10 @@
+;;! gc = yes
+;;! exceptions = yes
+;;! function-references = yes
+
+(module $m
+  (global (export "") exnref (ref.null exn))) 
+
+(module
+  (import "m" "" (global exnref))
+  (table 1 exnref (global.get 0)))


### PR DESCRIPTION
Previously, the `Global::get()` implementation lumped exnref types in with other anyrefs and wrapped the raw GC ref in an anyref type. This isn't appropriate for exnrefs as they are not anyrefs.

Found via OSS-Fuzz.

Fixes #11561.
Fixes #11563.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
