### PR TITLE
Simplify Miri-compatible sleep in tests

### DIFF
--- a/tests/all/pulley.rs
+++ b/tests/all/pulley.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use std::ptr::NonNull;
+use std::thread;
 use wasmtime::component::{self, Component};
 use wasmtime::{
     Caller, Config, Engine, Func, FuncType, Instance, Module, Store, Trap, Val, ValType,
@@ -411,47 +412,12 @@ fn pulley_provenance_test_components() -> Result<()> {
 }
 
 async fn sleep(duration: std::time::Duration) {
-    // TODO: We should be able to use `tokio::time::sleep` here, but as of this
-    // writing the miri-compatible version of `wasmtime-fiber` uses threads
-    // behind the scenes, which means thread-local storage is not preserved when
-    // we switch fibers, and that confuses Tokio.  If we ever fix that we can
-    // stop using our own, special version of `sleep` and switch back to the
-    // Tokio version.
-
-    use std::{
-        future,
-        sync::{
-            Arc, Mutex,
-            atomic::{AtomicU32, Ordering::SeqCst},
-        },
-        task::Poll,
-        thread,
-    };
-
-    let state = Arc::new(AtomicU32::new(0));
-    let waker = Arc::new(Mutex::new(None));
-    future::poll_fn(move |cx| match state.load(SeqCst) {
-        0 => {
-            state.store(1, SeqCst);
-            let state = state.clone();
-            *waker.lock().unwrap() = Some(cx.waker().clone());
-            let waker = waker.clone();
-            thread::spawn(move || {
-                thread::sleep(duration);
-                state.store(2, SeqCst);
-                let waker = waker.lock().unwrap().clone().unwrap();
-                waker.wake();
-            });
-            Poll::Pending
-        }
-        1 => {
-            *waker.lock().unwrap() = Some(cx.waker().clone());
-            Poll::Pending
-        }
-        2 => Poll::Ready(()),
-        _ => unreachable!(),
-    })
-    .await;
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    thread::spawn(move || {
+        thread::sleep(duration);
+        tx.send(()).unwrap();
+    });
+    rx.await.unwrap()
 }
 
 #[tokio::test]


### PR DESCRIPTION
This test occasionally gets stuck infinitely on CI and I think it's due to a race with the manual state management so this commit simplifies the sleep implementation to use more standard primitives.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
