### PR TITLE
Skip a long test on Miri

### DIFF
--- a/tests/all/gc.rs
+++ b/tests/all/gc.rs
@@ -1531,6 +1531,7 @@ fn owned_rooted() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn owned_rooted_lots_of_root_creation() -> Result<()> {
     let mut config = Config::new();
     config.wasm_function_references(true);


### PR DESCRIPTION
According to a [recent log] this took 30 minutes to execute in Miri so skip the test on Miri.

[recent log]: https://github.com/bytecodealliance/wasmtime/actions/runs/17312769413/job/49149879051

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
