### PR TITLE
Fix no_std builds on supported targets

### DIFF
--- a/crates/wasmtime/build.rs
+++ b/crates/wasmtime/build.rs
@@ -9,7 +9,11 @@ fn main() {
     let unix = cfg("unix");
     let windows = cfg("windows");
     let miri = cfg("miri");
-    let supported_os = unix || windows;
+
+    // A boolean indicating whether there's a `sys` module for this platform.
+    // This is true for `unix` or `windows`, but both of those require the `std`
+    // feature to also be active so check that too.
+    let supported_os = (unix || windows) && cfg!(feature = "std");
 
     // Determine if the current host architecture is supported by Cranelift
     // meaning that we might be executing native code.


### PR DESCRIPTION
This commit fixes a conditional in Wasmtime's build script from accidentally considering Unix and Windows targets as being a supported OS with all the bells and whistles. This is only true if the `std` feature is also active. When `std` is disabled the `custom` implementation of OS primitives is used instead meaning that it shouldn't be automatically assumed signals/virtual memory are available.

Resolves a build issue found [on Zulip].

[on Zulip]: https://bytecodealliance.zulipchat.com/#narrow/channel/217126-wasmtime/topic/.E2.9C.94.20pulley32.20on.20x86_64-unknown-linux-gnu

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
