### PR TITLE
Allow dead code in `component_api` fuzz target

### DIFF
--- a/fuzz/fuzz_targets/component_api.rs
+++ b/fuzz/fuzz_targets/component_api.rs
@@ -1,4 +1,5 @@
 #![no_main]
+#![allow(dead_code, reason = "fuzz-generation sometimes generates unused types")]
 
 use libfuzzer_sys::{arbitrary, fuzz_target};
 use wasmtime_fuzzing::oracles;


### PR DESCRIPTION
Fuzz-generation might generate dead types, so this avoids build errors where types aren't used. Aims to fix [this build log][log]

[log]: https://github.com/bytecodealliance/wasmtime/actions/runs/17335065094/job/49219595286?pr=11570

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
