### PR TITLE
pulley: Implement support for `symbol_value`

### DIFF
--- a/cranelift/codegen/src/binemit/mod.rs
+++ b/cranelift/codegen/src/binemit/mod.rs
@@ -125,6 +125,9 @@ pub enum Reloc {
     /// s390x TLS GDCall - marker to enable optimization of TLS calls
     S390xTlsGdCall,
 
+    /// Pulley - a relocation which is a pc-relative offset.
+    PulleyPcRel,
+
     /// Pulley - call a host function indirectly where the embedder resolving
     /// this relocation needs to fill the 8-bit immediate that's part of the
     /// `call_indirect_host` opcode (an opaque identifier used by the host).
@@ -164,6 +167,7 @@ impl fmt::Display for Reloc {
             Self::Aarch64AddAbsLo12Nc => write!(f, "Aarch64AddAbsLo12Nc"),
             Self::S390xTlsGd64 => write!(f, "TlsGd64"),
             Self::S390xTlsGdCall => write!(f, "TlsGdCall"),
+            Self::PulleyPcRel => write!(f, "PulleyPcRel"),
             Self::PulleyCallIndirectHost => write!(f, "PulleyCallIndirectHost"),
         }
     }

--- a/cranelift/codegen/src/isa/pulley_shared/inst.isle
+++ b/cranelift/codegen/src/isa/pulley_shared/inst.isle
@@ -42,9 +42,8 @@
       (reg XReg))
 
     ;; Load an external symbol's address into a register.
-    (LoadExtName (dst WritableXReg)
-                 (name BoxExternalName)
-                 (offset i64))
+    (LoadExtNameNear (dst WritableXReg) (name BoxExternalName) (offset i64))
+    (LoadExtNameFar (dst WritableXReg) (name BoxExternalName) (offset i64))
 
     ;; A direct call to a known callee.
     (Call (info BoxCallInfo))
@@ -154,6 +153,7 @@
 (convert RawInst MInst raw_inst_to_inst)
 
 (type U6 (primitive U6))
+(type PcRelOffset (primitive PcRelOffset))
 (type BoxCallInfo (primitive BoxCallInfo))
 (type BoxCallIndInfo (primitive BoxCallIndInfo))
 (type BoxReturnCallInfo (primitive BoxReturnCallInfo))
@@ -688,6 +688,27 @@
 (decl gen_br_table (XReg MachLabel BoxVecMachLabel) Unit)
 (rule (gen_br_table idx default labels)
       (emit (MInst.BrTable idx default labels)))
+
+;; Helper for creating `MInst.LoadExtNameNear` instructions.
+(decl load_ext_name_near (BoxExternalName i64) XReg)
+(rule (load_ext_name_near name offset)
+      (let ((dst WritableXReg (temp_writable_xreg))
+            (_ Unit (emit (MInst.LoadExtNameNear dst name offset))))
+        dst))
+
+;; Helper for creating `MInst.LoadExtNameFar` instructions.
+(decl load_ext_name_far (BoxExternalName i64) XReg)
+(rule (load_ext_name_far name offset)
+      (let ((dst WritableXReg (temp_writable_xreg))
+            (_ Unit (emit (MInst.LoadExtNameFar dst name offset))))
+        dst))
+
+;; Helper for creating `MInst.LoadExtName*` instructions.
+(decl load_ext_name (BoxExternalName i64 RelocDistance) XReg)
+(rule 1 (load_ext_name name offset (RelocDistance.Near))
+  (load_ext_name_near name offset))
+(rule 0 (load_ext_name name offset (RelocDistance.Far))
+  (load_ext_name_far name offset))
 
 ;;;; Helpers for Emitting Calls ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/cranelift/codegen/src/isa/pulley_shared/inst/args.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/inst/args.rs
@@ -289,103 +289,103 @@ impl Cond {
     ///
     /// Note that the offset encoded to jump by is filled in as 0 and it's
     /// assumed `MachBuffer` will come back and clean it up.
-    pub fn encode(&self, sink: &mut impl Extend<u8>) {
+    pub fn encode(&self, sink: &mut impl Extend<u8>, rel: i32) {
         match *self {
-            Cond::If32 { reg } => encode::br_if32(sink, reg, 0),
-            Cond::IfNot32 { reg } => encode::br_if_not32(sink, reg, 0),
-            Cond::IfXeq32 { src1, src2 } => encode::br_if_xeq32(sink, src1, src2, 0),
-            Cond::IfXneq32 { src1, src2 } => encode::br_if_xneq32(sink, src1, src2, 0),
-            Cond::IfXslt32 { src1, src2 } => encode::br_if_xslt32(sink, src1, src2, 0),
-            Cond::IfXslteq32 { src1, src2 } => encode::br_if_xslteq32(sink, src1, src2, 0),
-            Cond::IfXult32 { src1, src2 } => encode::br_if_xult32(sink, src1, src2, 0),
-            Cond::IfXulteq32 { src1, src2 } => encode::br_if_xulteq32(sink, src1, src2, 0),
-            Cond::IfXeq64 { src1, src2 } => encode::br_if_xeq64(sink, src1, src2, 0),
-            Cond::IfXneq64 { src1, src2 } => encode::br_if_xneq64(sink, src1, src2, 0),
-            Cond::IfXslt64 { src1, src2 } => encode::br_if_xslt64(sink, src1, src2, 0),
-            Cond::IfXslteq64 { src1, src2 } => encode::br_if_xslteq64(sink, src1, src2, 0),
-            Cond::IfXult64 { src1, src2 } => encode::br_if_xult64(sink, src1, src2, 0),
-            Cond::IfXulteq64 { src1, src2 } => encode::br_if_xulteq64(sink, src1, src2, 0),
+            Cond::If32 { reg } => encode::br_if32(sink, reg, rel),
+            Cond::IfNot32 { reg } => encode::br_if_not32(sink, reg, rel),
+            Cond::IfXeq32 { src1, src2 } => encode::br_if_xeq32(sink, src1, src2, rel),
+            Cond::IfXneq32 { src1, src2 } => encode::br_if_xneq32(sink, src1, src2, rel),
+            Cond::IfXslt32 { src1, src2 } => encode::br_if_xslt32(sink, src1, src2, rel),
+            Cond::IfXslteq32 { src1, src2 } => encode::br_if_xslteq32(sink, src1, src2, rel),
+            Cond::IfXult32 { src1, src2 } => encode::br_if_xult32(sink, src1, src2, rel),
+            Cond::IfXulteq32 { src1, src2 } => encode::br_if_xulteq32(sink, src1, src2, rel),
+            Cond::IfXeq64 { src1, src2 } => encode::br_if_xeq64(sink, src1, src2, rel),
+            Cond::IfXneq64 { src1, src2 } => encode::br_if_xneq64(sink, src1, src2, rel),
+            Cond::IfXslt64 { src1, src2 } => encode::br_if_xslt64(sink, src1, src2, rel),
+            Cond::IfXslteq64 { src1, src2 } => encode::br_if_xslteq64(sink, src1, src2, rel),
+            Cond::IfXult64 { src1, src2 } => encode::br_if_xult64(sink, src1, src2, rel),
+            Cond::IfXulteq64 { src1, src2 } => encode::br_if_xulteq64(sink, src1, src2, rel),
 
             Cond::IfXeq32I32 { src1, src2 } => match i8::try_from(src2) {
-                Ok(src2) => encode::br_if_xeq32_i8(sink, src1, src2, 0),
-                Err(_) => encode::br_if_xeq32_i32(sink, src1, src2, 0),
+                Ok(src2) => encode::br_if_xeq32_i8(sink, src1, src2, rel),
+                Err(_) => encode::br_if_xeq32_i32(sink, src1, src2, rel),
             },
             Cond::IfXneq32I32 { src1, src2 } => match i8::try_from(src2) {
-                Ok(src2) => encode::br_if_xneq32_i8(sink, src1, src2, 0),
-                Err(_) => encode::br_if_xneq32_i32(sink, src1, src2, 0),
+                Ok(src2) => encode::br_if_xneq32_i8(sink, src1, src2, rel),
+                Err(_) => encode::br_if_xneq32_i32(sink, src1, src2, rel),
             },
             Cond::IfXslt32I32 { src1, src2 } => match i8::try_from(src2) {
-                Ok(src2) => encode::br_if_xslt32_i8(sink, src1, src2, 0),
-                Err(_) => encode::br_if_xslt32_i32(sink, src1, src2, 0),
+                Ok(src2) => encode::br_if_xslt32_i8(sink, src1, src2, rel),
+                Err(_) => encode::br_if_xslt32_i32(sink, src1, src2, rel),
             },
             Cond::IfXslteq32I32 { src1, src2 } => match i8::try_from(src2) {
-                Ok(src2) => encode::br_if_xslteq32_i8(sink, src1, src2, 0),
-                Err(_) => encode::br_if_xslteq32_i32(sink, src1, src2, 0),
+                Ok(src2) => encode::br_if_xslteq32_i8(sink, src1, src2, rel),
+                Err(_) => encode::br_if_xslteq32_i32(sink, src1, src2, rel),
             },
             Cond::IfXsgt32I32 { src1, src2 } => match i8::try_from(src2) {
-                Ok(src2) => encode::br_if_xsgt32_i8(sink, src1, src2, 0),
-                Err(_) => encode::br_if_xsgt32_i32(sink, src1, src2, 0),
+                Ok(src2) => encode::br_if_xsgt32_i8(sink, src1, src2, rel),
+                Err(_) => encode::br_if_xsgt32_i32(sink, src1, src2, rel),
             },
             Cond::IfXsgteq32I32 { src1, src2 } => match i8::try_from(src2) {
-                Ok(src2) => encode::br_if_xsgteq32_i8(sink, src1, src2, 0),
-                Err(_) => encode::br_if_xsgteq32_i32(sink, src1, src2, 0),
+                Ok(src2) => encode::br_if_xsgteq32_i8(sink, src1, src2, rel),
+                Err(_) => encode::br_if_xsgteq32_i32(sink, src1, src2, rel),
             },
             Cond::IfXult32I32 { src1, src2 } => match u8::try_from(src2) {
-                Ok(src2) => encode::br_if_xult32_u8(sink, src1, src2, 0),
-                Err(_) => encode::br_if_xult32_u32(sink, src1, src2, 0),
+                Ok(src2) => encode::br_if_xult32_u8(sink, src1, src2, rel),
+                Err(_) => encode::br_if_xult32_u32(sink, src1, src2, rel),
             },
             Cond::IfXulteq32I32 { src1, src2 } => match u8::try_from(src2) {
-                Ok(src2) => encode::br_if_xulteq32_u8(sink, src1, src2, 0),
-                Err(_) => encode::br_if_xulteq32_u32(sink, src1, src2, 0),
+                Ok(src2) => encode::br_if_xulteq32_u8(sink, src1, src2, rel),
+                Err(_) => encode::br_if_xulteq32_u32(sink, src1, src2, rel),
             },
             Cond::IfXugt32I32 { src1, src2 } => match u8::try_from(src2) {
-                Ok(src2) => encode::br_if_xugt32_u8(sink, src1, src2, 0),
-                Err(_) => encode::br_if_xugt32_u32(sink, src1, src2, 0),
+                Ok(src2) => encode::br_if_xugt32_u8(sink, src1, src2, rel),
+                Err(_) => encode::br_if_xugt32_u32(sink, src1, src2, rel),
             },
             Cond::IfXugteq32I32 { src1, src2 } => match u8::try_from(src2) {
-                Ok(src2) => encode::br_if_xugteq32_u8(sink, src1, src2, 0),
-                Err(_) => encode::br_if_xugteq32_u32(sink, src1, src2, 0),
+                Ok(src2) => encode::br_if_xugteq32_u8(sink, src1, src2, rel),
+                Err(_) => encode::br_if_xugteq32_u32(sink, src1, src2, rel),
             },
 
             Cond::IfXeq64I32 { src1, src2 } => match i8::try_from(src2) {
-                Ok(src2) => encode::br_if_xeq64_i8(sink, src1, src2, 0),
-                Err(_) => encode::br_if_xeq64_i32(sink, src1, src2, 0),
+                Ok(src2) => encode::br_if_xeq64_i8(sink, src1, src2, rel),
+                Err(_) => encode::br_if_xeq64_i32(sink, src1, src2, rel),
             },
             Cond::IfXneq64I32 { src1, src2 } => match i8::try_from(src2) {
-                Ok(src2) => encode::br_if_xneq64_i8(sink, src1, src2, 0),
-                Err(_) => encode::br_if_xneq64_i32(sink, src1, src2, 0),
+                Ok(src2) => encode::br_if_xneq64_i8(sink, src1, src2, rel),
+                Err(_) => encode::br_if_xneq64_i32(sink, src1, src2, rel),
             },
             Cond::IfXslt64I32 { src1, src2 } => match i8::try_from(src2) {
-                Ok(src2) => encode::br_if_xslt64_i8(sink, src1, src2, 0),
-                Err(_) => encode::br_if_xslt64_i32(sink, src1, src2, 0),
+                Ok(src2) => encode::br_if_xslt64_i8(sink, src1, src2, rel),
+                Err(_) => encode::br_if_xslt64_i32(sink, src1, src2, rel),
             },
             Cond::IfXslteq64I32 { src1, src2 } => match i8::try_from(src2) {
-                Ok(src2) => encode::br_if_xslteq64_i8(sink, src1, src2, 0),
-                Err(_) => encode::br_if_xslteq64_i32(sink, src1, src2, 0),
+                Ok(src2) => encode::br_if_xslteq64_i8(sink, src1, src2, rel),
+                Err(_) => encode::br_if_xslteq64_i32(sink, src1, src2, rel),
             },
             Cond::IfXsgt64I32 { src1, src2 } => match i8::try_from(src2) {
-                Ok(src2) => encode::br_if_xsgt64_i8(sink, src1, src2, 0),
-                Err(_) => encode::br_if_xsgt64_i32(sink, src1, src2, 0),
+                Ok(src2) => encode::br_if_xsgt64_i8(sink, src1, src2, rel),
+                Err(_) => encode::br_if_xsgt64_i32(sink, src1, src2, rel),
             },
             Cond::IfXsgteq64I32 { src1, src2 } => match i8::try_from(src2) {
-                Ok(src2) => encode::br_if_xsgteq64_i8(sink, src1, src2, 0),
-                Err(_) => encode::br_if_xsgteq64_i32(sink, src1, src2, 0),
+                Ok(src2) => encode::br_if_xsgteq64_i8(sink, src1, src2, rel),
+                Err(_) => encode::br_if_xsgteq64_i32(sink, src1, src2, rel),
             },
             Cond::IfXult64I32 { src1, src2 } => match u8::try_from(src2) {
-                Ok(src2) => encode::br_if_xult64_u8(sink, src1, src2, 0),
-                Err(_) => encode::br_if_xult64_u32(sink, src1, src2, 0),
+                Ok(src2) => encode::br_if_xult64_u8(sink, src1, src2, rel),
+                Err(_) => encode::br_if_xult64_u32(sink, src1, src2, rel),
             },
             Cond::IfXulteq64I32 { src1, src2 } => match u8::try_from(src2) {
-                Ok(src2) => encode::br_if_xulteq64_u8(sink, src1, src2, 0),
-                Err(_) => encode::br_if_xulteq64_u32(sink, src1, src2, 0),
+                Ok(src2) => encode::br_if_xulteq64_u8(sink, src1, src2, rel),
+                Err(_) => encode::br_if_xulteq64_u32(sink, src1, src2, rel),
             },
             Cond::IfXugt64I32 { src1, src2 } => match u8::try_from(src2) {
-                Ok(src2) => encode::br_if_xugt64_u8(sink, src1, src2, 0),
-                Err(_) => encode::br_if_xugt64_u32(sink, src1, src2, 0),
+                Ok(src2) => encode::br_if_xugt64_u8(sink, src1, src2, rel),
+                Err(_) => encode::br_if_xugt64_u32(sink, src1, src2, rel),
             },
             Cond::IfXugteq64I32 { src1, src2 } => match u8::try_from(src2) {
-                Ok(src2) => encode::br_if_xugteq64_u8(sink, src1, src2, 0),
-                Err(_) => encode::br_if_xugteq64_u32(sink, src1, src2, 0),
+                Ok(src2) => encode::br_if_xugteq64_u8(sink, src1, src2, rel),
+                Err(_) => encode::br_if_xugteq64_u32(sink, src1, src2, rel),
             },
         }
     }

--- a/cranelift/codegen/src/isa/pulley_shared/inst/emit.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/inst/emit.rs
@@ -145,11 +145,28 @@ fn pulley_emit<P>(
 
         Inst::GetSpecial { dst, reg } => enc::xmov(sink, dst, reg),
 
-        Inst::LoadExtName { .. } => todo!(),
+        Inst::LoadExtNameNear { dst, name, offset } => {
+            patch_pc_rel_offset(sink, |sink| enc::xpcadd(sink, dst, 0));
+            let end = sink.cur_offset();
+            sink.add_reloc_at_offset(end - 4, Reloc::PulleyPcRel, &**name, *offset);
+        }
+
+        Inst::LoadExtNameFar { dst, name, offset } => {
+            let size = match P::pointer_width() {
+                PointerWidth::PointerWidth32 => {
+                    enc::xconst32(sink, dst, 0);
+                    4
+                }
+                PointerWidth::PointerWidth64 => {
+                    enc::xconst64(sink, dst, 0);
+                    8
+                }
+            };
+            let end = sink.cur_offset();
+            sink.add_reloc_at_offset(end - size, Reloc::Abs8, &**name, *offset);
+        }
 
         Inst::Call { info } => {
-            let offset = sink.cur_offset();
-
             // If arguments happen to already be in the right register for the
             // ABI then remove them from this list. Otherwise emit the
             // appropriate `Call` instruction depending on how many arguments we
@@ -159,25 +176,16 @@ fn pulley_emit<P>(
             while !args.is_empty() && args.last().copied() == XReg::new(x_reg(args.len() - 1)) {
                 args = &args[..args.len() - 1];
             }
-            match args {
+            patch_pc_rel_offset(sink, |sink| match args {
                 [] => enc::call(sink, 0),
                 [x0] => enc::call1(sink, x0, 0),
                 [x0, x1] => enc::call2(sink, x0, x1, 0),
                 [x0, x1, x2] => enc::call3(sink, x0, x1, x2, 0),
                 [x0, x1, x2, x3] => enc::call4(sink, x0, x1, x2, x3, 0),
                 _ => unreachable!(),
-            }
+            });
             let end = sink.cur_offset();
-            sink.add_reloc_at_offset(
-                end - 4,
-                // TODO: is it actually okay to reuse this reloc here?
-                Reloc::X86CallPCRel4,
-                &info.dest.name,
-                // This addend adjusts for the difference between the start of
-                // the instruction and the beginning of the immediate offset
-                // field which is always the final 4 bytes of the instruction.
-                -i64::from(end - offset - 4),
-            );
+            sink.add_reloc_at_offset(end - 4, Reloc::PulleyPcRel, &info.dest.name, 0);
             if let Some(s) = state.take_stack_map() {
                 let offset = sink.cur_offset();
                 sink.push_user_stack_map(state, offset, s);
@@ -267,8 +275,8 @@ fn pulley_emit<P>(
             // Emit an unconditional jump which is quite similar to `Inst::Call`
             // except that a `jump` opcode is used instead of a `call` opcode.
             sink.put1(pulley_interpreter::Opcode::Jump as u8);
-            sink.add_reloc(Reloc::X86CallPCRel4, &info.dest, -1);
-            sink.put4(0);
+            sink.add_reloc(Reloc::PulleyPcRel, &info.dest, 0);
+            sink.put4(1);
 
             // Islands were manually handled in
             // `emit_return_call_common_sequence`.
@@ -310,9 +318,9 @@ fn pulley_emit<P>(
         }
 
         Inst::Jump { label } => {
-            sink.use_label_at_offset(*start_offset + 1, *label, LabelUse::Jump(1));
+            sink.use_label_at_offset(*start_offset + 1, *label, LabelUse::PcRel);
             sink.add_uncond_branch(*start_offset, *start_offset + 5, *label);
-            enc::jump(sink, 0x00000000);
+            patch_pc_rel_offset(sink, |sink| enc::jump(sink, 0));
         }
 
         Inst::BrIf {
@@ -324,9 +332,12 @@ fn pulley_emit<P>(
             // their trailing 4 bytes as the relative offset which is what we're
             // going to target here within the `MachBuffer`.
             let mut inverted = SmallVec::<[u8; 16]>::new();
-            cond.invert().encode(&mut inverted);
+            cond.invert().encode(&mut inverted, 0);
             let len = inverted.len() as u32;
-            debug_assert!(len > 4);
+            inverted.clear();
+            cond.invert()
+                .encode(&mut inverted, i32::try_from(len - 4).unwrap());
+            assert!(len > 4);
 
             // Use the `taken` label 4 bytes before the end of the instruction
             // we're about to emit as that's the base of `PcRelOffset`. Note
@@ -334,9 +345,9 @@ fn pulley_emit<P>(
             // instruction to the start of the relative offset, hence `len - 4`
             // as the factor to adjust by.
             let taken_end = *start_offset + len;
-            sink.use_label_at_offset(taken_end - 4, *taken, LabelUse::Jump(len - 4));
+            sink.use_label_at_offset(taken_end - 4, *taken, LabelUse::PcRel);
             sink.add_cond_branch(*start_offset, taken_end, *taken, &inverted);
-            cond.encode(sink);
+            patch_pc_rel_offset(sink, |sink| cond.encode(sink, 0));
             debug_assert_eq!(sink.cur_offset(), taken_end);
 
             // For the not-taken branch use an unconditional jump to the
@@ -344,9 +355,9 @@ fn pulley_emit<P>(
             // long where the final 4 bytes are the offset to jump by.
             let not_taken_start = taken_end + 1;
             let not_taken_end = not_taken_start + 4;
-            sink.use_label_at_offset(not_taken_start, *not_taken, LabelUse::Jump(1));
+            sink.use_label_at_offset(not_taken_start, *not_taken, LabelUse::PcRel);
             sink.add_uncond_branch(taken_end, not_taken_end, *not_taken);
-            enc::jump(sink, 0x00000000);
+            patch_pc_rel_offset(sink, |sink| enc::jump(sink, 0));
             assert_eq!(sink.cur_offset(), not_taken_end);
         }
 
@@ -555,11 +566,11 @@ fn pulley_emit<P>(
             enc::br_table32(sink, *idx, amt);
             for target in targets.iter() {
                 let offset = sink.cur_offset();
-                sink.use_label_at_offset(offset, *target, LabelUse::Jump(0));
+                sink.use_label_at_offset(offset, *target, LabelUse::PcRel);
                 sink.put4(0);
             }
             let offset = sink.cur_offset();
-            sink.use_label_at_offset(offset, *default, LabelUse::Jump(0));
+            sink.use_label_at_offset(offset, *default, LabelUse::PcRel);
             sink.put4(0);
 
             // We manually handled `emit_island` above when dealing with
@@ -655,4 +666,28 @@ fn return_call_emit_impl<T, P>(
             inst.emit(sink, emit_info, state);
         }
     }
+}
+
+/// Invokes `f` with `sink` and assumes that a single instruction is emitted
+/// which ends with a Pulley `PcRelOffset`.
+///
+/// The offset at that location is patched to include the size of the
+/// instruction before the relative offset since relocations will be applied to
+/// the address of the offset and added to the contents at the offset. The
+/// Pulley interpreter, however, will calculate the offset from the start of the
+/// instruction, so this extra offset is required.
+fn patch_pc_rel_offset<P>(
+    sink: &mut MachBuffer<InstAndKind<P>>,
+    f: impl FnOnce(&mut MachBuffer<InstAndKind<P>>),
+) where
+    P: PulleyTargetKind,
+{
+    let patch = sink.start_patchable();
+    let start = sink.cur_offset();
+    f(sink);
+    let end = sink.cur_offset();
+    let region = sink.end_patchable(patch).patch(sink);
+    let chunk = region.last_chunk_mut::<4>().unwrap();
+    assert_eq!(*chunk, [0, 0, 0, 0]);
+    *chunk = (end - start - 4).to_le_bytes();
 }

--- a/cranelift/codegen/src/isa/pulley_shared/inst/mod.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/inst/mod.rs
@@ -144,11 +144,7 @@ fn pulley_get_operands(inst: &mut Inst, collector: &mut impl OperandVisitor) {
             assert!(reg.is_special());
         }
 
-        Inst::LoadExtName {
-            dst,
-            name: _,
-            offset: _,
-        } => {
+        Inst::LoadExtNameNear { dst, .. } | Inst::LoadExtNameFar { dst, .. } => {
             collector.reg_def(dst);
         }
 
@@ -669,9 +665,14 @@ impl Inst {
                 format!("xmov {dst}, {reg}")
             }
 
-            Inst::LoadExtName { dst, name, offset } => {
+            Inst::LoadExtNameNear { dst, name, offset } => {
                 let dst = format_reg(*dst.to_reg());
-                format!("{dst} = load_ext_name {name:?}, {offset}")
+                format!("{dst} = load_ext_name_near {name:?}, {offset}")
+            }
+
+            Inst::LoadExtNameFar { dst, name, offset } => {
+                let dst = format_reg(*dst.to_reg());
+                format!("{dst} = load_ext_name_far {name:?}, {offset}")
             }
 
             Inst::Call { info } => {
@@ -820,9 +821,11 @@ impl Inst {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum LabelUse {
     /// A PC-relative `jump`/`call`/etc... instruction with an `i32` relative
-    /// target. The payload value is an addend that describes the positive
-    /// offset from the start of the instruction to the offset being relocated.
-    Jump(u32),
+    /// target.
+    ///
+    /// The relative distance to the destination is added to the 4 bytes at the
+    /// label site.
+    PcRel,
 }
 
 impl MachInstLabelUse for LabelUse {
@@ -833,21 +836,21 @@ impl MachInstLabelUse for LabelUse {
     /// Maximum PC-relative range (positive), inclusive.
     fn max_pos_range(self) -> CodeOffset {
         match self {
-            Self::Jump(_) => 0x7fff_ffff,
+            Self::PcRel => 0x7fff_ffff,
         }
     }
 
     /// Maximum PC-relative range (negative).
     fn max_neg_range(self) -> CodeOffset {
         match self {
-            Self::Jump(_) => 0x8000_0000,
+            Self::PcRel => 0x8000_0000,
         }
     }
 
     /// Size of window into code needed to do the patch.
     fn patch_size(self) -> CodeOffset {
         match self {
-            Self::Jump(_) => 4,
+            Self::PcRel => 4,
         }
     }
 
@@ -858,13 +861,17 @@ impl MachInstLabelUse for LabelUse {
         debug_assert!(use_relative >= -(self.max_neg_range() as i64));
         let pc_rel = i32::try_from(use_relative).unwrap() as u32;
         match self {
-            Self::Jump(addend) => {
-                let value = pc_rel.wrapping_add(addend);
+            Self::PcRel => {
+                let buf: &mut [u8; 4] = buffer.try_into().unwrap();
+                let addend = u32::from_le_bytes(*buf);
                 trace!(
-                    "patching label use @ {use_offset:#x} to label {label_offset:#x} via \
-                     PC-relative offset {pc_rel:#x}"
+                    "patching label use @ {use_offset:#x} \
+                     to label {label_offset:#x} via \
+                     PC-relative offset {pc_rel:#x} \
+                     adding in {addend:#x}"
                 );
-                buffer.copy_from_slice(&value.to_le_bytes()[..]);
+                let value = pc_rel.wrapping_add(addend);
+                *buf = value.to_le_bytes();
             }
         }
     }
@@ -872,14 +879,14 @@ impl MachInstLabelUse for LabelUse {
     /// Is a veneer supported for this label reference type?
     fn supports_veneer(self) -> bool {
         match self {
-            Self::Jump(_) => false,
+            Self::PcRel => false,
         }
     }
 
     /// How large is the veneer, if supported?
     fn veneer_size(self) -> CodeOffset {
         match self {
-            Self::Jump(_) => 0,
+            Self::PcRel => 0,
         }
     }
 
@@ -895,19 +902,13 @@ impl MachInstLabelUse for LabelUse {
         _veneer_offset: CodeOffset,
     ) -> (CodeOffset, LabelUse) {
         match self {
-            Self::Jump(_) => panic!("veneer not supported for {self:?}"),
+            Self::PcRel => panic!("veneer not supported for {self:?}"),
         }
     }
 
     fn from_reloc(reloc: Reloc, addend: Addend) -> Option<LabelUse> {
-        match reloc {
-            Reloc::X86CallPCRel4 if addend < 0 => {
-                // We are always relocating some offset that is within an
-                // instruction, but pulley adds the offset relative to the PC
-                // pointing to the *start* of the instruction. Therefore, adjust
-                // back to the beginning of the instruction.
-                Some(LabelUse::Jump(i32::try_from(-addend).unwrap() as u32))
-            }
+        match (reloc, addend) {
+            (Reloc::PulleyPcRel, 0) => Some(LabelUse::PcRel),
             _ => None,
         }
     }

--- a/cranelift/codegen/src/isa/pulley_shared/lower.isle
+++ b/cranelift/codegen/src/isa/pulley_shared/lower.isle
@@ -211,6 +211,14 @@
             (info BoxReturnCallInfo (gen_return_call_info abi name uses)))
         (side_effect (return_call_impl info))))
 
+;; Direct call to a pulley function.
+(rule (lower (return_call (func_ref_data sig_ref name dist) args))
+      (let ((abi Sig (abi_sig sig_ref))
+            (uses CallArgList (gen_return_call_args abi args))
+            (target Reg (load_ext_name name 0 dist))
+            (info BoxReturnCallIndInfo (gen_return_call_ind_info abi target uses)))
+        (side_effect (return_indirect_call_impl info))))
+
 ;; Indirect call (assumed to be pulley->pulley).
 (rule (lower (return_call_indirect sig_ref ptr args))
       (let ((abi Sig (abi_sig sig_ref))
@@ -1811,3 +1819,13 @@
 
 (rule (lower (has_type $F32X4 (fma a b c))) (pulley_vfma32x4 a b c))
 (rule (lower (has_type $F64X2 (fma a b c))) (pulley_vfma64x2 a b c))
+
+;; Rules for `symbol_value` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(rule (lower (symbol_value (symbol_value_data extname dist offset)))
+  (load_ext_name extname offset dist))
+
+;; Rules for `func_addr` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(rule (lower (func_addr (func_ref_data _ extname dist)))
+      (load_ext_name extname 0 dist))

--- a/cranelift/codegen/src/isa/pulley_shared/lower/isle.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/lower/isle.rs
@@ -35,6 +35,7 @@ type BoxReturnCallInfo = Box<ReturnCallInfo<ExternalName>>;
 type BoxReturnCallIndInfo = Box<ReturnCallInfo<XReg>>;
 type BoxExternalName = Box<ExternalName>;
 type UpperXRegSet = pulley_interpreter::UpperRegSet<pulley_interpreter::XReg>;
+type PcRelOffset = pulley_interpreter::PcRelOffset;
 
 #[expect(
     unused_imports,

--- a/cranelift/filetests/filetests/isa/pulley32/call.clif
+++ b/cranelift/filetests/filetests/isa/pulley32/call.clif
@@ -24,7 +24,7 @@ block0:
 ; Disassembled:
 ; push_frame
 ; xzero x2
-; call1 x2, 0x0    // target = 0x3
+; call1 x2, 0x2    // target = 0x5
 ; xone x0
 ; pop_frame
 ; ret
@@ -51,7 +51,7 @@ block0:
 ; Disassembled:
 ; push_frame
 ; xzero x2
-; call1 x2, 0x0    // target = 0x3
+; call1 x2, 0x2    // target = 0x5
 ; xone x0
 ; pop_frame
 ; ret
@@ -85,7 +85,7 @@ block0:
 ; xone x4
 ; xconst8 x5, 2
 ; xconst8 x6, 3
-; call4 x3, x4, x5, x6, 0x0    // target = 0xb
+; call4 x3, x4, x5, x6, 0x5    // target = 0x10
 ; pop_frame
 ; ret
 
@@ -112,7 +112,7 @@ block0:
 ;
 ; Disassembled:
 ; push_frame
-; call 0x0    // target = 0x1
+; call 0x1    // target = 0x2
 ; xadd64 x4, x0, x2
 ; xadd64 x3, x1, x3
 ; xadd64 x0, x4, x3
@@ -173,7 +173,7 @@ block0:
 ; xmov x11, x14
 ; xmov x12, x14
 ; xmov x13, x14
-; call4 x14, x14, x14, x14, 0x0    // target = 0x56
+; call4 x14, x14, x14, x14, 0x5    // target = 0x5b
 ; pop_frame_restore 64, 
 ; ret
 
@@ -247,7 +247,7 @@ block0:
 ; Disassembled:
 ; push_frame_save 112, x16, x17, x18, x19, x26, x27, x28, x29
 ; xmov x12, sp
-; call1 x12, 0x0    // target = 0x8
+; call1 x12, 0x2    // target = 0xa
 ; xload64le_o32 x27, sp, 0
 ; xload64le_o32 x19, sp, 8
 ; xload64le_o32 x29, sp, 16

--- a/cranelift/filetests/filetests/isa/pulley32/exceptions.clif
+++ b/cranelift/filetests/filetests/isa/pulley32/exceptions.clif
@@ -15,7 +15,7 @@ function %f0(i32) -> i32, f32, f64 {
 
     block2(v6: i32):
         v8 = iadd_imm.i32 v6, 1
-        v9 = f32const 0x0.0        
+        v9 = f32const 0x0.0
         return v8, v9, v2
 }
 
@@ -41,7 +41,7 @@ function %f0(i32) -> i32, f32, f64 {
 ; push_frame_save 144, x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0
 ; fconst64 f1, 4607182418800017408
 ; fstore64le_o32 sp, 0, f1
-; call 0x0    // target = 0x1a
+; call 0x1    // target = 0x1b
 ; xone x0
 ; fload64le_o32 f1, sp, 0
 ; pop_frame_restore 144, x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0
@@ -66,7 +66,7 @@ function %f2(i32, i32) -> i32, f32, f64 {
 
     block2(v7: i32):
         v8 = iadd_imm.i32 v7, 1
-        v9 = f32const 0x0.0        
+        v9 = f32const 0x0.0
         return v8, v9, v2
 }
 
@@ -117,7 +117,7 @@ function %f4(i32, i32) -> i32, f32, f64 {
 
     block2(v6: i32):
         v8 = iadd_imm.i32 v6, 1
-        v9 = f32const 0x0.0        
+        v9 = f32const 0x0.0
         return v8, v9, v2
 
     block3:
@@ -163,7 +163,7 @@ function %f4(i32, i32) -> i32, f32, f64 {
 ; fconst64 f1, 4607182418800017408
 ; xload64le_o32 x2, sp, 0
 ; fstore64le_o32 sp, 16, f1
-; call1 x2, 0x0    // target = 0x2f
+; call1 x2, 0x2    // target = 0x31
 ; jump 0x27    // target = 0x5c
 ; xmov x3, x0
 ; fload64le_o32 f1, sp, 16

--- a/cranelift/filetests/filetests/isa/pulley32/extend.clif
+++ b/cranelift/filetests/filetests/isa/pulley32/extend.clif
@@ -19,7 +19,7 @@ block0(v0: i8):
 ; Disassembled:
 ; push_frame
 ; zext8 x2, x0
-; call1 x2, 0x0    // target = 0x4
+; call1 x2, 0x2    // target = 0x6
 ; pop_frame
 ; ret
 
@@ -41,7 +41,7 @@ block0(v0: i16):
 ; Disassembled:
 ; push_frame
 ; zext16 x2, x0
-; call1 x2, 0x0    // target = 0x4
+; call1 x2, 0x2    // target = 0x6
 ; pop_frame
 ; ret
 
@@ -61,7 +61,7 @@ block0(v0: i32):
 ;
 ; Disassembled:
 ; push_frame
-; call 0x0    // target = 0x1
+; call 0x1    // target = 0x2
 ; pop_frame
 ; ret
 
@@ -81,7 +81,7 @@ block0(v0: i64):
 ;
 ; Disassembled:
 ; push_frame
-; call 0x0    // target = 0x1
+; call 0x1    // target = 0x2
 ; pop_frame
 ; ret
 
@@ -103,7 +103,7 @@ block0(v0: i8):
 ; Disassembled:
 ; push_frame
 ; sext8 x2, x0
-; call1 x2, 0x0    // target = 0x4
+; call1 x2, 0x2    // target = 0x6
 ; pop_frame
 ; ret
 
@@ -125,7 +125,7 @@ block0(v0: i16):
 ; Disassembled:
 ; push_frame
 ; sext16 x2, x0
-; call1 x2, 0x0    // target = 0x4
+; call1 x2, 0x2    // target = 0x6
 ; pop_frame
 ; ret
 
@@ -145,7 +145,7 @@ block0(v0: i32):
 ;
 ; Disassembled:
 ; push_frame
-; call 0x0    // target = 0x1
+; call 0x1    // target = 0x2
 ; pop_frame
 ; ret
 
@@ -165,7 +165,7 @@ block0(v0: i64):
 ;
 ; Disassembled:
 ; push_frame
-; call 0x0    // target = 0x1
+; call 0x1    // target = 0x2
 ; pop_frame
 ; ret
 

--- a/cranelift/filetests/filetests/isa/pulley32/symbols.clif
+++ b/cranelift/filetests/filetests/isa/pulley32/symbols.clif
@@ -1,0 +1,147 @@
+test compile precise-output
+target pulley32
+
+function %func_addr() -> i32 {
+    fn0 = %func0(i32) -> i32
+
+block0:
+    v0 = func_addr.i32 fn0
+    return v0
+}
+
+; VCode:
+;   push_frame
+; block0:
+;   x0 = load_ext_name_far TestCase(%func0), 0
+;   pop_frame
+;   ret
+;
+; Disassembled:
+; push_frame
+; xconst32 x0, 0
+; pop_frame
+; ret
+
+function %colocated_func_addr() -> i32 {
+    fn0 = colocated %func0(i32) -> i32
+
+block0:
+    v0 = func_addr.i32 fn0
+    return v0
+}
+
+; VCode:
+;   push_frame
+; block0:
+;   x0 = load_ext_name_near TestCase(%func0), 0
+;   pop_frame
+;   ret
+;
+; Disassembled:
+; push_frame
+; xpcadd x0, 0x4    // target = 0x5
+; pop_frame
+; ret
+
+function %symbol_value() -> i32 {
+    gv0 = symbol %global0
+
+block0:
+    v0 = symbol_value.i32 gv0
+    return v0
+}
+
+; VCode:
+; block0:
+;   x0 = load_ext_name_far TestCase(%global0), 0
+;   ret
+;
+; Disassembled:
+; xconst32 x0, 0
+; ret
+
+function %symbol_value_plus_offset() -> i32 {
+    gv0 = symbol %global0+123
+
+block0:
+    v0 = symbol_value.i32 gv0
+    return v0
+}
+
+; VCode:
+; block0:
+;   x0 = load_ext_name_far TestCase(%global0), 123
+;   ret
+;
+; Disassembled:
+; xconst32 x0, 0
+; ret
+
+function %symbol_value_minus_offset() -> i32 {
+    gv0 = symbol %global0-123
+
+block0:
+    v0 = symbol_value.i32 gv0
+    return v0
+}
+
+; VCode:
+; block0:
+;   x0 = load_ext_name_far TestCase(%global0), -123
+;   ret
+;
+; Disassembled:
+; xconst32 x0, 0
+; ret
+
+function %colocated_symbol_value() -> i32 {
+    gv0 = symbol colocated %global0
+
+block0:
+    v0 = symbol_value.i32 gv0
+    return v0
+}
+
+; VCode:
+; block0:
+;   x0 = load_ext_name_near TestCase(%global0), 0
+;   ret
+;
+; Disassembled:
+; xpcadd x0, 0x4    // target = 0x4
+; ret
+
+function %colocated_symbol_value_plus_offset() -> i32 {
+    gv0 = symbol colocated %global0+123
+
+block0:
+    v0 = symbol_value.i32 gv0
+    return v0
+}
+
+; VCode:
+; block0:
+;   x0 = load_ext_name_near TestCase(%global0), 123
+;   ret
+;
+; Disassembled:
+; xpcadd x0, 0x4    // target = 0x4
+; ret
+
+function %colocated_symbol_value_minus_offset() -> i32 {
+    gv0 = symbol colocated %global0-123
+
+block0:
+    v0 = symbol_value.i32 gv0
+    return v0
+}
+
+; VCode:
+; block0:
+;   x0 = load_ext_name_near TestCase(%global0), -123
+;   ret
+;
+; Disassembled:
+; xpcadd x0, 0x4    // target = 0x4
+; ret
+

--- a/cranelift/filetests/filetests/isa/pulley64/call.clif
+++ b/cranelift/filetests/filetests/isa/pulley64/call.clif
@@ -24,7 +24,7 @@ block0:
 ; Disassembled:
 ; push_frame
 ; xzero x2
-; call1 x2, 0x0    // target = 0x3
+; call1 x2, 0x2    // target = 0x5
 ; xone x0
 ; pop_frame
 ; ret
@@ -51,7 +51,7 @@ block0:
 ; Disassembled:
 ; push_frame
 ; xzero x2
-; call1 x2, 0x0    // target = 0x3
+; call1 x2, 0x2    // target = 0x5
 ; xone x0
 ; pop_frame
 ; ret
@@ -85,7 +85,7 @@ block0:
 ; xone x4
 ; xconst8 x5, 2
 ; xconst8 x6, 3
-; call4 x3, x4, x5, x6, 0x0    // target = 0xb
+; call4 x3, x4, x5, x6, 0x5    // target = 0x10
 ; pop_frame
 ; ret
 
@@ -112,7 +112,7 @@ block0:
 ;
 ; Disassembled:
 ; push_frame
-; call 0x0    // target = 0x1
+; call 0x1    // target = 0x2
 ; xadd64 x4, x0, x2
 ; xadd64 x3, x1, x3
 ; xadd64 x0, x4, x3
@@ -173,7 +173,7 @@ block0:
 ; xmov x11, x14
 ; xmov x12, x14
 ; xmov x13, x14
-; call4 x14, x14, x14, x14, 0x0    // target = 0x56
+; call4 x14, x14, x14, x14, 0x5    // target = 0x5b
 ; pop_frame_restore 64, 
 ; ret
 
@@ -247,7 +247,7 @@ block0:
 ; Disassembled:
 ; push_frame_save 112, x16, x17, x18, x19, x26, x27, x28, x29
 ; xmov x12, sp
-; call1 x12, 0x0    // target = 0x8
+; call1 x12, 0x2    // target = 0xa
 ; xload64le_o32 x27, sp, 0
 ; xload64le_o32 x19, sp, 8
 ; xload64le_o32 x29, sp, 16
@@ -367,7 +367,7 @@ block0:
 ; xmov x11, x14
 ; xmov x12, x14
 ; xmov x13, x14
-; call4 x14, x14, x14, x14, 0x0    // target = 0x64
+; call4 x14, x14, x14, x14, 0x5    // target = 0x69
 ; pop_frame_restore 80, 
 ; ret
 
@@ -400,7 +400,7 @@ block0(v0: i32):
 ; stack_alloc32 1000016
 ; xstore64le_o32 sp, 1000008, x20
 ; xmov x20, x0
-; call 0x0    // target = 0x10
+; call 0x1    // target = 0x11
 ; xmov x5, x20
 ; xadd32 x0, x5, x0
 ; xload64le_o32 x20, sp, 1000008

--- a/cranelift/filetests/filetests/isa/pulley64/exceptions.clif
+++ b/cranelift/filetests/filetests/isa/pulley64/exceptions.clif
@@ -16,7 +16,7 @@ function %f0(i32) -> i32, f32, f64 {
     block2(v6: i64):
         v7 = ireduce.i32 v6
         v8 = iadd_imm.i32 v7, 1
-        v9 = f32const 0x0.0        
+        v9 = f32const 0x0.0
         return v8, v9, v2
 }
 
@@ -42,7 +42,7 @@ function %f0(i32) -> i32, f32, f64 {
 ; push_frame_save 144, x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0
 ; fconst64 f1, 4607182418800017408
 ; fstore64le_o32 sp, 0, f1
-; call 0x0    // target = 0x1a
+; call 0x1    // target = 0x1b
 ; xone x0
 ; fload64le_o32 f1, sp, 0
 ; pop_frame_restore 144, x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0
@@ -68,7 +68,7 @@ function %f2(i32, i64) -> i32, f32, f64 {
     block2(v6: i64):
         v7 = ireduce.i32 v6
         v8 = iadd_imm.i32 v7, 1
-        v9 = f32const 0x0.0        
+        v9 = f32const 0x0.0
         return v8, v9, v2
 }
 
@@ -120,7 +120,7 @@ function %f4(i64, i32) -> i32, f32, f64 {
     block2(v6: i64):
         v7 = ireduce.i32 v6
         v8 = iadd_imm.i32 v7, 1
-        v9 = f32const 0x0.0        
+        v9 = f32const 0x0.0
         return v8, v9, v2
 
     block3:

--- a/cranelift/filetests/filetests/isa/pulley64/extend.clif
+++ b/cranelift/filetests/filetests/isa/pulley64/extend.clif
@@ -19,7 +19,7 @@ block0(v0: i8):
 ; Disassembled:
 ; push_frame
 ; zext8 x2, x0
-; call1 x2, 0x0    // target = 0x4
+; call1 x2, 0x2    // target = 0x6
 ; pop_frame
 ; ret
 
@@ -41,7 +41,7 @@ block0(v0: i16):
 ; Disassembled:
 ; push_frame
 ; zext16 x2, x0
-; call1 x2, 0x0    // target = 0x4
+; call1 x2, 0x2    // target = 0x6
 ; pop_frame
 ; ret
 
@@ -63,7 +63,7 @@ block0(v0: i32):
 ; Disassembled:
 ; push_frame
 ; zext32 x2, x0
-; call1 x2, 0x0    // target = 0x4
+; call1 x2, 0x2    // target = 0x6
 ; pop_frame
 ; ret
 
@@ -83,7 +83,7 @@ block0(v0: i64):
 ;
 ; Disassembled:
 ; push_frame
-; call 0x0    // target = 0x1
+; call 0x1    // target = 0x2
 ; pop_frame
 ; ret
 
@@ -105,7 +105,7 @@ block0(v0: i8):
 ; Disassembled:
 ; push_frame
 ; sext8 x2, x0
-; call1 x2, 0x0    // target = 0x4
+; call1 x2, 0x2    // target = 0x6
 ; pop_frame
 ; ret
 
@@ -127,7 +127,7 @@ block0(v0: i16):
 ; Disassembled:
 ; push_frame
 ; sext16 x2, x0
-; call1 x2, 0x0    // target = 0x4
+; call1 x2, 0x2    // target = 0x6
 ; pop_frame
 ; ret
 
@@ -149,7 +149,7 @@ block0(v0: i32):
 ; Disassembled:
 ; push_frame
 ; sext32 x2, x0
-; call1 x2, 0x0    // target = 0x4
+; call1 x2, 0x2    // target = 0x6
 ; pop_frame
 ; ret
 
@@ -169,7 +169,7 @@ block0(v0: i64):
 ;
 ; Disassembled:
 ; push_frame
-; call 0x0    // target = 0x1
+; call 0x1    // target = 0x2
 ; pop_frame
 ; ret
 

--- a/cranelift/filetests/filetests/isa/pulley64/symbols.clif
+++ b/cranelift/filetests/filetests/isa/pulley64/symbols.clif
@@ -1,0 +1,147 @@
+test compile precise-output
+target pulley64
+
+function %func_addr() -> i64 {
+    fn0 = %func0(i64) -> i64
+
+block0:
+    v0 = func_addr.i64 fn0
+    return v0
+}
+
+; VCode:
+;   push_frame
+; block0:
+;   x0 = load_ext_name_far TestCase(%func0), 0
+;   pop_frame
+;   ret
+;
+; Disassembled:
+; push_frame
+; xconst64 x0, 0
+; pop_frame
+; ret
+
+function %colocated_func_addr() -> i64 {
+    fn0 = colocated %func0(i64) -> i64
+
+block0:
+    v0 = func_addr.i64 fn0
+    return v0
+}
+
+; VCode:
+;   push_frame
+; block0:
+;   x0 = load_ext_name_near TestCase(%func0), 0
+;   pop_frame
+;   ret
+;
+; Disassembled:
+; push_frame
+; xpcadd x0, 0x4    // target = 0x5
+; pop_frame
+; ret
+
+function %symbol_value() -> i64 {
+    gv0 = symbol %global0
+
+block0:
+    v0 = symbol_value.i64 gv0
+    return v0
+}
+
+; VCode:
+; block0:
+;   x0 = load_ext_name_far TestCase(%global0), 0
+;   ret
+;
+; Disassembled:
+; xconst64 x0, 0
+; ret
+
+function %symbol_value_plus_offset() -> i64 {
+    gv0 = symbol %global0+123
+
+block0:
+    v0 = symbol_value.i64 gv0
+    return v0
+}
+
+; VCode:
+; block0:
+;   x0 = load_ext_name_far TestCase(%global0), 123
+;   ret
+;
+; Disassembled:
+; xconst64 x0, 0
+; ret
+
+function %symbol_value_minus_offset() -> i64 {
+    gv0 = symbol %global0-123
+
+block0:
+    v0 = symbol_value.i64 gv0
+    return v0
+}
+
+; VCode:
+; block0:
+;   x0 = load_ext_name_far TestCase(%global0), -123
+;   ret
+;
+; Disassembled:
+; xconst64 x0, 0
+; ret
+
+function %colocated_symbol_value() -> i64 {
+    gv0 = symbol colocated %global0
+
+block0:
+    v0 = symbol_value.i64 gv0
+    return v0
+}
+
+; VCode:
+; block0:
+;   x0 = load_ext_name_near TestCase(%global0), 0
+;   ret
+;
+; Disassembled:
+; xpcadd x0, 0x4    // target = 0x4
+; ret
+
+function %colocated_symbol_value_plus_offset() -> i64 {
+    gv0 = symbol colocated %global0+123
+
+block0:
+    v0 = symbol_value.i64 gv0
+    return v0
+}
+
+; VCode:
+; block0:
+;   x0 = load_ext_name_near TestCase(%global0), 123
+;   ret
+;
+; Disassembled:
+; xpcadd x0, 0x4    // target = 0x4
+; ret
+
+function %colocated_symbol_value_minus_offset() -> i64 {
+    gv0 = symbol colocated %global0-123
+
+block0:
+    v0 = symbol_value.i64 gv0
+    return v0
+}
+
+; VCode:
+; block0:
+;   x0 = load_ext_name_near TestCase(%global0), -123
+;   ret
+;
+; Disassembled:
+; xpcadd x0, 0x4    // target = 0x4
+; ret
+

--- a/cranelift/filetests/filetests/runtests/call_indirect.clif
+++ b/cranelift/filetests/filetests/runtests/call_indirect.clif
@@ -7,6 +7,10 @@ target aarch64 has_pauth sign_return_address
 target s390x
 target riscv64
 target riscv64 has_c has_zcb
+target pulley32
+target pulley32be
+target pulley64
+target pulley64be
 
 
 function %callee_indirect(i64) -> i64 {

--- a/cranelift/filetests/filetests/runtests/return-call-indirect.clif
+++ b/cranelift/filetests/filetests/runtests/return-call-indirect.clif
@@ -10,6 +10,10 @@ target aarch64 has_pauth sign_return_address
 target riscv64
 target riscv64 has_c has_zcb
 target s390x
+target pulley32
+target pulley32be
+target pulley64
+target pulley64be
 
 ;;;; Test passing `i64`s ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/cranelift/filetests/filetests/runtests/return-call-loop.clif
+++ b/cranelift/filetests/filetests/runtests/return-call-loop.clif
@@ -7,6 +7,10 @@ target aarch64 has_pauth sign_return_address
 target riscv64
 target riscv64 has_c has_zcb
 target s390x
+target pulley32
+target pulley32be
+target pulley64
+target pulley64be
 
 ;;;; Tail-Recursive Loop ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -39,7 +43,7 @@ block4(v6: i64):
     return_call fn0(v4, v6)
 }
 
-; run: %loop(1_000_000, 0) == 1
+; run: %loop(100_000, 0) == 1
 
 ;;;; Tail-Recursive Loop With Stack Arguments ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -72,7 +76,7 @@ block4(v30: i64):
     return_call fn0(v28, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v30)
 }
 
-; run: %loop_stack_args(1_000_000, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0) == 1
+; run: %loop_stack_args(100_000, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0) == 1
 
 ;;;; Mutually-Recursive Loop With Different #s of Stack Arguments ;;;;;;;;;;;;;;
 
@@ -113,7 +117,7 @@ block0(v0: i64, v1: i64):
     return_call fn0(v2, v1, v3, v3, v3, v3, v3, v3, v3, v3, v3, v3, v3, v3, v3, v3, v3, v3, v3, v3, v3, v3, v3, v3, v3, v3)
 }
 
-; run: %mutual_loop_2(1_000_000, 0) == 1
+; run: %mutual_loop_2(100_000, 0) == 1
 
 ;;;; Indirect Return-Call Loop ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -141,4 +145,4 @@ block0(v0: i64):
     return_call fn0(v1)
 }
 
-; run: %indirect_main(1_000_000) == 42
+; run: %indirect_main(100_000) == 42

--- a/cranelift/jit/src/compiled_blob.rs
+++ b/cranelift/jit/src/compiled_blob.rs
@@ -150,7 +150,16 @@ impl CompiledBlob {
                         modify_inst32(jalr_addr, |jalr| (jalr & 0xFFFFF) | (lo12 << 20));
                     }
                 }
-                _ => unimplemented!(),
+                Reloc::PulleyPcRel => {
+                    let base = get_address(name);
+                    let what = unsafe { base.offset(isize::try_from(addend).unwrap()) };
+                    let pcrel = i32::try_from((what as isize) - (at as isize)).unwrap();
+                    let at = at as *mut i32;
+                    unsafe {
+                        at.write_unaligned(at.read_unaligned().wrapping_add(pcrel));
+                    }
+                }
+                other => unimplemented!("unimplemented reloc {other:?}"),
             }
         }
     }

--- a/pulley/src/imms.rs
+++ b/pulley/src/imms.rs
@@ -32,6 +32,12 @@ impl From<PcRelOffset> for i32 {
     }
 }
 
+impl fmt::Display for PcRelOffset {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        i32::from(*self).fmt(f)
+    }
+}
+
 /// A 6-byte unsigned integer.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct U6(u8);

--- a/pulley/src/lib.rs
+++ b/pulley/src/lib.rs
@@ -646,6 +646,10 @@ macro_rules! for_each_extended_op {
             /// assembled into the final object that Wasmtime will interpret.
             call_indirect_host = CallIndirectHost { id: u8 };
 
+            /// Adds `offset` to the pc of this instruction and stores it in
+            /// `dst`.
+            xpcadd = Xpcadd { dst: XReg, offset: PcRelOffset };
+
             /// Gets the special "fp" register and moves it into `dst`.
             xmov_fp = XmovFp { dst: XReg };
 


### PR DESCRIPTION
This commit fills out the Pulley lowerings of the `symbol_value` and `func_addr` CLIF instructions. Additionally handling of relocations on Pulley is improved to be more "formal" as opposed to just blindly using an x64 relocation and assuming it works out. The intention here is to make Pulley behave more similarly to other platforms in all these respects while also enabling usage of Wasmtime to eventually use `symbol_addr` to calculate an address relative to the current PC (similar to x64).

This includes Cranelift golden tests as well as more filetests being run, but the actual integration into Wasmtime will be deferred to a future commit.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
