### PR TITLE
Package up exception handler state

### DIFF
--- a/cranelift/filetests/src/function_runner.rs
+++ b/cranelift/filetests/src/function_runner.rs
@@ -675,17 +675,15 @@ extern "C-unwind" fn __cranelift_throw(
             })
     };
     unsafe {
-        match wasmtime_unwinder::compute_throw_action(
+        match wasmtime_unwinder::Handler::find(
             &unwind_host,
             frame_handler,
             exit_pc,
             exit_fp,
             entry_fp,
         ) {
-            wasmtime_unwinder::ThrowAction::Handler { pc, sp, fp } => {
-                wasmtime_unwinder::resume_to_exception_handler(pc, sp, fp, payload1, payload2);
-            }
-            wasmtime_unwinder::ThrowAction::None => {
+            Some(handler) => handler.resume(payload1, payload2),
+            None => {
                 panic!("Expected a handler to exit for throw of tag {tag} at pc {exit_pc:x}");
             }
         }

--- a/crates/unwinder/src/arch/mod.rs
+++ b/crates/unwinder/src/arch/mod.rs
@@ -40,56 +40,56 @@ cfg_if::cfg_if! {
         /// the frame is later popped.
         pub use imp::get_stack_pointer;
 
-        /// Resume execution at the given PC, SP, and FP, with the given
-        /// payload values, according to the tail-call ABI's exception
-        /// scheme. Note that this scheme does not restore any other
-        /// registers, so the given state is all that we need.
-        ///
-        /// # Safety
-        ///
-        /// This method requires:
-        ///
-        /// - the `sp` and `fp` to correspond to an active stack frame
-        ///   (above the current function), in code using Cranelift's
-        ///   `tail` calling convention.
-        ///
-        /// - The `pc` to correspond to a `try_call` handler
-        ///   destination, as emitted in Cranelift metadata, or
-        ///   otherwise a target that is expecting the tail-call ABI's
-        ///   exception ABI.
-        ///
-        /// - The Rust frames between the unwind destination and this
-        ///   frame to be unwind-safe: that is, they cannot have `Drop`
-        ///   handlers for which safety requires that they run.
-        pub unsafe fn resume_to_exception_handler(
-            pc: usize,
-            sp: usize,
-            fp: usize,
-            payload1: usize,
-            payload2: usize,
-        ) -> ! {
-            // Without this ASAN seems to nondeterministically trigger an
-            // internal assertion when running tests with threads. Not entirely
-            // clear what's going on here but it seems related to the fact that
-            // there's Rust code on the stack which is never cleaned up due to
-            // the jump out of `imp::resume_to_exception_handler`.
-            //
-            // This function is documented as something that should be called to
-            // clean up the entire thread's shadow memory and stack which isn't
-            // exactly what we want but this at least seems to resolve ASAN
-            // issues for now. Probably a heavy hammer but better than false
-            // positives I suppose...
-            #[cfg(asan)]
-            {
-                unsafe extern "C" {
-                    fn __asan_handle_no_return();
+        impl crate::Handler {
+            /// Resume execution at the given PC, SP, and FP, with the given
+            /// payload values, according to the tail-call ABI's exception
+            /// scheme. Note that this scheme does not restore any other
+            /// registers, so the given state is all that we need.
+            ///
+            /// # Safety
+            ///
+            /// This method requires:
+            ///
+            /// - the `sp` and `fp` to correspond to an active stack frame
+            ///   (above the current function), in code using Cranelift's
+            ///   `tail` calling convention.
+            ///
+            /// - The `pc` to correspond to a `try_call` handler
+            ///   destination, as emitted in Cranelift metadata, or
+            ///   otherwise a target that is expecting the tail-call ABI's
+            ///   exception ABI.
+            ///
+            /// - The Rust frames between the unwind destination and this
+            ///   frame to be unwind-safe: that is, they cannot have `Drop`
+            ///   handlers for which safety requires that they run.
+            pub unsafe fn resume(
+                &self,
+                payload1: usize,
+                payload2: usize,
+            ) -> ! {
+                // Without this ASAN seems to nondeterministically trigger an
+                // internal assertion when running tests with threads. Not entirely
+                // clear what's going on here but it seems related to the fact that
+                // there's Rust code on the stack which is never cleaned up due to
+                // the jump out of `imp::resume_to_exception_handler`.
+                //
+                // This function is documented as something that should be called to
+                // clean up the entire thread's shadow memory and stack which isn't
+                // exactly what we want but this at least seems to resolve ASAN
+                // issues for now. Probably a heavy hammer but better than false
+                // positives I suppose...
+                #[cfg(asan)]
+                {
+                    unsafe extern "C" {
+                        fn __asan_handle_no_return();
+                    }
+                    unsafe {
+                        __asan_handle_no_return();
+                    }
                 }
                 unsafe {
-                    __asan_handle_no_return();
+                    imp::resume_to_exception_handler(self.pc, self.sp, self.fp, payload1, payload2)
                 }
-            }
-            unsafe {
-                imp::resume_to_exception_handler(pc, sp, fp, payload1, payload2)
             }
         }
 
@@ -101,21 +101,20 @@ cfg_if::cfg_if! {
         /// - Requires that `fp` is a valid frame-pointer value for an
         ///   active stack frame (above the current function), in code
         ///   using Cranelift's `tail` calling convention.
-        pub use imp::get_next_older_pc_from_fp;
-
+        use imp::get_next_older_pc_from_fp;
 
         /// The offset of the saved old-FP value in a frame, from the
         /// location pointed to by a given FP.
-        pub const NEXT_OLDER_FP_FROM_FP_OFFSET: usize = imp::NEXT_OLDER_FP_FROM_FP_OFFSET;
+        const NEXT_OLDER_FP_FROM_FP_OFFSET: usize = imp::NEXT_OLDER_FP_FROM_FP_OFFSET;
 
         /// The offset of the next older SP value, from the value of a
         /// given FP.
-        pub const NEXT_OLDER_SP_FROM_FP_OFFSET: usize = imp::NEXT_OLDER_SP_FROM_FP_OFFSET;
+        const NEXT_OLDER_SP_FROM_FP_OFFSET: usize = imp::NEXT_OLDER_SP_FROM_FP_OFFSET;
 
         /// Assert that the given `fp` is aligned as expected by the
         /// host platform's implementation of the Cranelift tail-call
         /// ABI.
-        pub use imp::assert_fp_is_aligned;
+        use imp::assert_fp_is_aligned;
 
         /// If we have the above host-specific implementations, we can
         /// implement `Unwind`.

--- a/crates/wasmtime/src/runtime/vm/interpreter.rs
+++ b/crates/wasmtime/src/runtime/vm/interpreter.rs
@@ -9,6 +9,7 @@ use core::ptr::NonNull;
 use pulley_interpreter::interp::{DoneReason, RegType, TrapKind, Val, Vm, XRegVal};
 use pulley_interpreter::{FReg, Reg, XReg};
 use wasmtime_environ::{BuiltinFunctionIndex, HostCall, Trap};
+use wasmtime_unwinder::Handler;
 use wasmtime_unwinder::Unwind;
 
 /// Interpreter state stored within a `Store<T>`.
@@ -530,9 +531,7 @@ impl InterpreterRef<'_> {
     #[cfg(feature = "gc")]
     pub(crate) unsafe fn resume_to_exception_handler(
         mut self,
-        pc: usize,
-        sp: usize,
-        fp: usize,
+        handler: &Handler,
         payload1: usize,
         payload2: usize,
     ) {
@@ -540,12 +539,12 @@ impl InterpreterRef<'_> {
             let vm = self.vm();
             vm[XReg::x0].set_u64(payload1 as u64);
             vm[XReg::x1].set_u64(payload2 as u64);
-            vm[XReg::sp].set_ptr(core::ptr::with_exposed_provenance_mut::<u8>(sp));
-            vm.set_fp(core::ptr::with_exposed_provenance_mut(fp));
+            vm[XReg::sp].set_ptr(core::ptr::with_exposed_provenance_mut::<u8>(handler.sp));
+            vm.set_fp(core::ptr::with_exposed_provenance_mut(handler.fp));
         }
         let state = self.vm_state();
         debug_assert!(state.raise.is_none());
-        self.vm_state().raise = Some(Raise::ResumeToExceptionHandler(pc));
+        self.vm_state().raise = Some(Raise::ResumeToExceptionHandler(handler.pc));
     }
 }
 

--- a/crates/wasmtime/src/runtime/vm/interpreter.rs
+++ b/crates/wasmtime/src/runtime/vm/interpreter.rs
@@ -9,6 +9,7 @@ use core::ptr::NonNull;
 use pulley_interpreter::interp::{DoneReason, RegType, TrapKind, Val, Vm, XRegVal};
 use pulley_interpreter::{FReg, Reg, XReg};
 use wasmtime_environ::{BuiltinFunctionIndex, HostCall, Trap};
+#[cfg(feature = "gc")]
 use wasmtime_unwinder::Handler;
 use wasmtime_unwinder::Unwind;
 

--- a/crates/wasmtime/src/runtime/vm/interpreter_disabled.rs
+++ b/crates/wasmtime/src/runtime/vm/interpreter_disabled.rs
@@ -61,9 +61,7 @@ impl InterpreterRef<'_> {
     #[cfg(feature = "gc")]
     pub(crate) unsafe fn resume_to_exception_handler(
         self,
-        _pc: usize,
-        _sp: usize,
-        _fp: usize,
+        _handler: &wasmtime_unwinder::Handler,
         _payload1: usize,
         _payload2: usize,
     ) {

--- a/crates/wasmtime/src/runtime/vm/traphandlers.rs
+++ b/crates/wasmtime/src/runtime/vm/traphandlers.rs
@@ -26,6 +26,7 @@ use crate::{StoreContextMut, WasmBacktrace};
 use core::cell::Cell;
 use core::num::NonZeroU32;
 use core::ptr::{self, NonNull};
+#[cfg(feature = "gc")]
 use wasmtime_unwinder::Handler;
 
 pub use self::backtrace::Backtrace;


### PR DESCRIPTION
This commit is a minor refactoring of the `wasmtime-unwinder` crate to use a `Handler` structure as a "package" for the pc/fp/sp triple that's required to resume to an exception handler. Freestanding functions are now associated methods/functions of `Handler` such as finding a frame on the stack and resuming to a handler.

This doesn't actually change any behavior, just moving some things around to prepare for a future refactoring.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
