### PR TITLE
chore: remove redundant word in README.md

### DIFF
--- a/.github/actions/github-release/README.md
+++ b/.github/actions/github-release/README.md
@@ -7,7 +7,7 @@ perform github releases but they all tend to have their set of drawbacks.
 Additionally nothing handles deleting releases which we need for our rolling
 `dev` release.
 
-To handle all this this action rolls-its-own implementation using the
+To handle all this action rolls-its-own implementation using the
 actions/toolkit repository and packages published there. These run in a Docker
 container and take various inputs to orchestrate the release from the build.
 


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->

 remove redundant word in .github/actions/github-release/README.md
