### PR TITLE
fix: accurate leaf detection

### DIFF
--- a/cranelift/codegen/src/ir/function.rs
+++ b/cranelift/codegen/src/ir/function.rs
@@ -320,24 +320,6 @@ impl FunctionStencil {
         })
     }
 
-    /// Returns true if the function is function that doesn't call any other functions. This is not
-    /// to be confused with a "leaf function" in Windows terminology.
-    pub fn is_leaf(&self) -> bool {
-        // Conservative result: if there's at least one function signature referenced in this
-        // function, assume it is not a leaf.
-        let has_signatures = !self.dfg.signatures.is_empty();
-
-        // Under some TLS models, retrieving the address of a TLS variable requires calling a
-        // function. Conservatively assume that any function that references a tls global value
-        // is not a leaf.
-        let has_tls = self.global_values.values().any(|gv| match gv {
-            GlobalValueData::Symbol { tls, .. } => *tls,
-            _ => false,
-        });
-
-        !has_signatures && !has_tls
-    }
-
     /// Replace the `dst` instruction's data with the `src` instruction's data
     /// and then remove `src`.
     ///

--- a/cranelift/codegen/src/isa/aarch64/abi.rs
+++ b/cranelift/codegen/src/isa/aarch64/abi.rs
@@ -1167,6 +1167,7 @@ impl ABIMachineSpec for AArch64MachineDeps {
             stackslots_size,
             outgoing_args_size,
             clobbered_callee_saves: regs,
+            is_leaf,
         }
     }
 

--- a/cranelift/codegen/src/isa/aarch64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/mod.rs
@@ -1000,6 +1000,18 @@ impl MachInst for Inst {
         }
     }
 
+    fn is_call(&self) -> bool {
+        match self {
+            Inst::Call { .. }
+            | Inst::CallInd { .. }
+            | Inst::ReturnCall { .. }
+            | Inst::ReturnCallInd { .. }
+            | Inst::ElfTlsGetAddr { .. }
+            | Inst::MachOTlsGetAddr { .. } => true,
+            _ => false,
+        }
+    }
+
     fn is_term(&self) -> MachTerminator {
         match self {
             &Inst::Rets { .. } => MachTerminator::Ret,

--- a/cranelift/codegen/src/isa/pulley_shared/abi.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/abi.rs
@@ -537,6 +537,7 @@ where
             stackslots_size,
             outgoing_args_size,
             clobbered_callee_saves: regs,
+            is_leaf,
         }
     }
 

--- a/cranelift/codegen/src/isa/pulley_shared/inst/mod.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/inst/mod.rs
@@ -490,6 +490,17 @@ where
         todo!()
     }
 
+    fn is_call(&self) -> bool {
+        match &self.inst {
+            Inst::Call { .. }
+            | Inst::IndirectCall { .. }
+            | Inst::IndirectCallHost { .. }
+            | Inst::ReturnCall { .. }
+            | Inst::ReturnIndirectCall { .. } => true,
+            _ => false,
+        }
+    }
+
     fn gen_move(to_reg: Writable<Reg>, from_reg: Reg, ty: Type) -> Self {
         match ty {
             ir::types::I8 | ir::types::I16 | ir::types::I32 | ir::types::I64 => RawInst::Xmov {

--- a/cranelift/codegen/src/isa/riscv64/abi.rs
+++ b/cranelift/codegen/src/isa/riscv64/abi.rs
@@ -671,6 +671,7 @@ impl ABIMachineSpec for Riscv64MachineDeps {
             stackslots_size,
             outgoing_args_size,
             clobbered_callee_saves: regs,
+            is_leaf,
         }
     }
 

--- a/cranelift/codegen/src/isa/riscv64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/mod.rs
@@ -756,6 +756,17 @@ impl MachInst for Inst {
         }
     }
 
+    fn is_call(&self) -> bool {
+        match self {
+            Inst::Call { .. }
+            | Inst::CallInd { .. }
+            | Inst::ReturnCall { .. }
+            | Inst::ReturnCallInd { .. }
+            | Inst::ElfTlsGetAddr { .. } => true,
+            _ => false,
+        }
+    }
+
     fn is_term(&self) -> MachTerminator {
         match self {
             &Inst::Jal { .. } => MachTerminator::Branch,

--- a/cranelift/codegen/src/isa/s390x/abi.rs
+++ b/cranelift/codegen/src/isa/s390x/abi.rs
@@ -896,7 +896,7 @@ impl ABIMachineSpec for S390xMachineDeps {
         flags: &settings::Flags,
         _sig: &Signature,
         regs: &[Writable<RealReg>],
-        _is_leaf: bool,
+        is_leaf: bool,
         incoming_args_size: u32,
         tail_args_size: u32,
         stackslots_size: u32,
@@ -975,6 +975,7 @@ impl ABIMachineSpec for S390xMachineDeps {
             stackslots_size,
             outgoing_args_size,
             clobbered_callee_saves: regs,
+            is_leaf,
         }
     }
 

--- a/cranelift/codegen/src/isa/s390x/inst/mod.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/mod.rs
@@ -1122,6 +1122,13 @@ impl MachInst for Inst {
         }
     }
 
+    fn is_call(&self) -> bool {
+        match self {
+            Inst::Call { .. } | Inst::ReturnCall { .. } | Inst::ElfTlsGetOffset { .. } => true,
+            _ => false,
+        }
+    }
+
     fn gen_move(to_reg: Writable<Reg>, from_reg: Reg, ty: Type) -> Inst {
         assert!(ty.bits() <= 128);
         if ty.bits() <= 32 {

--- a/cranelift/codegen/src/isa/x64/abi.rs
+++ b/cranelift/codegen/src/isa/x64/abi.rs
@@ -900,7 +900,7 @@ impl ABIMachineSpec for X64ABIMachineSpec {
         flags: &settings::Flags,
         _sig: &Signature,
         regs: &[Writable<RealReg>],
-        _is_leaf: bool,
+        is_leaf: bool,
         incoming_args_size: u32,
         tail_args_size: u32,
         stackslots_size: u32,
@@ -947,6 +947,7 @@ impl ABIMachineSpec for X64ABIMachineSpec {
             stackslots_size,
             outgoing_args_size,
             clobbered_callee_saves: regs,
+            is_leaf,
         }
     }
 

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -1281,6 +1281,18 @@ impl MachInst for Inst {
         }
     }
 
+    fn is_call(&self) -> bool {
+        match self {
+            Inst::CallKnown { .. }
+            | Inst::CallUnknown { .. }
+            | Inst::ReturnCallKnown { .. }
+            | Inst::ReturnCallUnknown { .. }
+            | Inst::ElfTlsGetAddr { .. }
+            | Inst::MachOTlsGetAddr { .. } => true,
+            _ => false,
+        }
+    }
+
     fn is_term(&self) -> MachTerminator {
         match self {
             // Interesting cases.

--- a/cranelift/codegen/src/machinst/mod.rs
+++ b/cranelift/codegen/src/machinst/mod.rs
@@ -109,6 +109,10 @@ pub trait MachInst: Clone + Debug {
     /// Is this an "args" pseudoinst?
     fn is_args(&self) -> bool;
 
+    /// Is this a call instruction (including indirect calls and tail calls)?
+    /// This is used to determine if a function is truly a leaf function.
+    fn is_call(&self) -> bool;
+
     /// Should this instruction's clobber-list be included in the
     /// clobber-set?
     fn is_included_in_clobbers(&self) -> bool;

--- a/cranelift/filetests/filetests/isa/aarch64/leaf_function_detection.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/leaf_function_detection.clif
@@ -1,0 +1,185 @@
+;; Test leaf function detection across different function types.
+;; This test verifies that the is_leaf detection works correctly for:
+;; - True leaf functions (no calls)
+;; - Non-leaf functions (with calls, call_indirect)
+
+test compile precise-output
+set unwind_info=false
+set preserve_frame_pointers=false
+target aarch64
+
+;; Test 1: Simple leaf function - just arithmetic operations
+function %simple_leaf(i32) -> i32 {
+block0(v0: i32):
+    v1 = iconst.i32 10
+    v2 = imul v0, v1
+    return v2
+}
+
+; VCode:
+; block0:
+;   movz w3, #10
+;   madd w0, w0, w3, wzr
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   mov w3, #0xa
+;   mul w0, w0, w3
+;   ret
+
+;; Test 2: Leaf function with multiple basic blocks and control flow
+function %leaf_with_branches(i32) -> i32 {
+block0(v0: i32):
+    v1 = iconst.i32 0
+    v2 = icmp sgt v0, v1
+    brif v2, block1, block2
+
+block1:
+    v3 = iconst.i32 2
+    v4 = imul v0, v3
+    jump block3(v4)
+
+block2:
+    v5 = isub v1, v0
+    jump block3(v5)
+
+block3(v6: i32):
+    return v6
+}
+
+; VCode:
+; block0:
+;   movz w6, #0
+;   subs wzr, w0, #0
+;   b.gt label2 ; b label1
+; block1:
+;   sub w0, w6, w0
+;   b label3
+; block2:
+;   movz w9, #2
+;   madd w0, w0, w9, wzr
+;   b label3
+; block3:
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   mov w6, #0
+;   cmp w0, #0
+;   b.gt #0x14
+; block1: ; offset 0xc
+;   sub w0, w6, w0
+;   b #0x1c
+; block2: ; offset 0x14
+;   mov w9, #2
+;   mul w0, w0, w9
+; block3: ; offset 0x1c
+;   ret
+
+;; Test 3: Non-leaf function with direct call
+function %non_leaf_with_call(i32) -> i32 {
+    sig0 = (i32) -> i32
+    fn0 = colocated %simple_leaf sig0
+
+block0(v0: i32):
+    v1 = call fn0(v0)
+    return v1
+}
+
+; VCode:
+;   stp fp, lr, [sp, #-16]!
+;   mov fp, sp
+; block0:
+;   bl 0
+;   ldp fp, lr, [sp], #16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+; block1: ; offset 0x8
+;   bl #8 ; reloc_external Call %simple_leaf 0
+;   ldp x29, x30, [sp], #0x10
+;   ret
+
+;; Test 4: Non-leaf function with indirect call
+function %non_leaf_with_call_indirect(i32, i64) -> i32 {
+    sig0 = (i32) -> i32
+
+block0(v0: i32, v1: i64):
+    v2 = call_indirect sig0, v1(v0)
+    return v2
+}
+
+; VCode:
+;   stp fp, lr, [sp, #-16]!
+;   mov fp, sp
+; block0:
+;   blr x1
+;   ldp fp, lr, [sp], #16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+; block1: ; offset 0x8
+;   blr x1
+;   ldp x29, x30, [sp], #0x10
+;   ret
+
+;; Test 5: Leaf function with memory operations (should still be leaf)
+function %leaf_with_memory(i32, i64) -> i32 {
+block0(v0: i32, v1: i64):
+    store v0, v1
+    v2 = load.i32 v1
+    v3 = iconst.i32 1
+    v4 = iadd v2, v3
+    return v4
+}
+
+; VCode:
+; block0:
+;   str w0, [x1]
+;   ldr w5, [x1]
+;   add w0, w5, #1
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   str w0, [x1] ; trap: heap_oob
+;   ldr w5, [x1] ; trap: heap_oob
+;   add w0, w5, #1
+;   ret
+
+;; Test 6: Leaf function that looks like it might call but doesn't
+function %leaf_no_actual_calls(i32) -> i32 {
+block0(v0: i32):
+    v1 = iconst.i32 42
+    v2 = imul v0, v1
+    v3 = iconst.i32 7
+    v4 = udiv v2, v3
+    v5 = iconst.i32 3
+    v6 = band v4, v5
+    return v6
+}
+
+; VCode:
+; block0:
+;   movz w6, #42
+;   madd w6, w0, w6, wzr
+;   movz w5, #7
+;   udiv w7, w6, w5
+;   and w0, w7, #3
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   mov w6, #0x2a
+;   mul w6, w0, w6
+;   mov w5, #7
+;   udiv w7, w6, w5
+;   and w0, w7, #3
+;   ret

--- a/cranelift/filetests/filetests/isa/aarch64/symbol-value-pic.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/symbol-value-pic.clif
@@ -12,21 +12,14 @@ block0:
 }
 
 ; VCode:
-;   stp fp, lr, [sp, #-16]!
-;   mov fp, sp
 ; block0:
 ;   load_ext_name_got x0, TestCase(%func0)
-;   ldp fp, lr, [sp], #16
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   stp x29, x30, [sp, #-0x10]!
-;   mov x29, sp
-; block1: ; offset 0x8
 ;   adrp x0, #0 ; reloc_external Aarch64AdrGotPage21 %func0 0
 ;   ldr x0, [x0] ; reloc_external Aarch64AdrGotLo12Nc %func0 0
-;   ldp x29, x30, [sp], #0x10
 ;   ret
 
 function %colocated_func_addr() -> i64 {
@@ -38,21 +31,14 @@ block0:
 }
 
 ; VCode:
-;   stp fp, lr, [sp, #-16]!
-;   mov fp, sp
 ; block0:
 ;   load_ext_name_got x0, TestCase(%func0)
-;   ldp fp, lr, [sp], #16
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   stp x29, x30, [sp, #-0x10]!
-;   mov x29, sp
-; block1: ; offset 0x8
 ;   adrp x0, #0 ; reloc_external Aarch64AdrGotPage21 %func0 0
 ;   ldr x0, [x0] ; reloc_external Aarch64AdrGotLo12Nc %func0 0
-;   ldp x29, x30, [sp], #0x10
 ;   ret
 
 function %symbol_value() -> i64 {

--- a/cranelift/filetests/filetests/isa/aarch64/symbol-value.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/symbol-value.clif
@@ -11,23 +11,16 @@ block0:
 }
 
 ; VCode:
-;   stp fp, lr, [sp, #-16]!
-;   mov fp, sp
 ; block0:
 ;   load_ext_name_far x0, TestCase(%func0)+0
-;   ldp fp, lr, [sp], #16
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   stp x29, x30, [sp, #-0x10]!
-;   mov x29, sp
-; block1: ; offset 0x8
-;   ldr x0, #0x10
-;   b #0x18
+;   ldr x0, #8
+;   b #0x10
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %func0 0
 ;   .byte 0x00, 0x00, 0x00, 0x00
-;   ldp x29, x30, [sp], #0x10
 ;   ret
 
 function %colocated_func_addr() -> i64 {
@@ -39,21 +32,14 @@ block0:
 }
 
 ; VCode:
-;   stp fp, lr, [sp, #-16]!
-;   mov fp, sp
 ; block0:
 ;   load_ext_name_near x0, TestCase(%func0)+0
-;   ldp fp, lr, [sp], #16
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   stp x29, x30, [sp, #-0x10]!
-;   mov x29, sp
-; block1: ; offset 0x8
 ;   adrp x0, #0 ; reloc_external Aarch64AdrPrelPgHi21 %func0 0
 ;   add x0, x0, #0 ; reloc_external Aarch64AddAbsLo12Nc %func0 0
-;   ldp x29, x30, [sp], #0x10
 ;   ret
 
 function %symbol_value() -> i64 {

--- a/cranelift/filetests/filetests/isa/pulley32/symbols.clif
+++ b/cranelift/filetests/filetests/isa/pulley32/symbols.clif
@@ -10,16 +10,12 @@ block0:
 }
 
 ; VCode:
-;   push_frame
 ; block0:
 ;   x0 = load_ext_name_far TestCase(%func0), 0
-;   pop_frame
 ;   ret
 ;
 ; Disassembled:
-; push_frame
 ; xconst32 x0, 0
-; pop_frame
 ; ret
 
 function %colocated_func_addr() -> i32 {
@@ -31,16 +27,12 @@ block0:
 }
 
 ; VCode:
-;   push_frame
 ; block0:
 ;   x0 = load_ext_name_near TestCase(%func0), 0
-;   pop_frame
 ;   ret
 ;
 ; Disassembled:
-; push_frame
-; xpcadd x0, 0x4    // target = 0x5
-; pop_frame
+; xpcadd x0, 0x4    // target = 0x4
 ; ret
 
 function %symbol_value() -> i32 {

--- a/cranelift/filetests/filetests/isa/pulley64/symbols.clif
+++ b/cranelift/filetests/filetests/isa/pulley64/symbols.clif
@@ -10,16 +10,12 @@ block0:
 }
 
 ; VCode:
-;   push_frame
 ; block0:
 ;   x0 = load_ext_name_far TestCase(%func0), 0
-;   pop_frame
 ;   ret
 ;
 ; Disassembled:
-; push_frame
 ; xconst64 x0, 0
-; pop_frame
 ; ret
 
 function %colocated_func_addr() -> i64 {
@@ -31,16 +27,12 @@ block0:
 }
 
 ; VCode:
-;   push_frame
 ; block0:
 ;   x0 = load_ext_name_near TestCase(%func0), 0
-;   pop_frame
 ;   ret
 ;
 ; Disassembled:
-; push_frame
-; xpcadd x0, 0x4    // target = 0x5
-; pop_frame
+; xpcadd x0, 0x4    // target = 0x4
 ; ret
 
 function %symbol_value() -> i64 {

--- a/cranelift/filetests/filetests/isa/riscv64/leaf_function_detection.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/leaf_function_detection.clif
@@ -1,0 +1,202 @@
+;; Test leaf function detection across different function types.
+;; This test verifies that the is_leaf detection works correctly for:
+;; - True leaf functions (no calls)
+;; - Non-leaf functions (with calls, call_indirect)
+
+test compile precise-output
+set unwind_info=false
+set preserve_frame_pointers=false
+target riscv64
+
+;; Test 1: Simple leaf function - just arithmetic operations
+function %simple_leaf(i32) -> i32 {
+block0(v0: i32):
+    v1 = iconst.i32 10
+    v2 = imul v0, v1
+    return v2
+}
+
+; VCode:
+; block0:
+;   li a3,10
+;   mulw a0,a0,a3
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi a3, zero, 0xa
+;   mulw a0, a0, a3
+;   ret
+
+;; Test 2: Leaf function with multiple basic blocks and control flow
+function %leaf_with_branches(i32) -> i32 {
+block0(v0: i32):
+    v1 = iconst.i32 0
+    v2 = icmp sgt v0, v1
+    brif v2, block1, block2
+
+block1:
+    v3 = iconst.i32 2
+    v4 = imul v0, v3
+    jump block3(v4)
+
+block2:
+    v5 = isub v1, v0
+    jump block3(v5)
+
+block3(v6: i32):
+    return v6
+}
+
+; VCode:
+; block0:
+;   li a1,0
+;   sext.w a2,a0
+;   bgt a2,zero,taken(label2),not_taken(label1)
+; block1:
+;   subw a0,a1,a0
+;   j label3
+; block2:
+;   li a3,2
+;   mulw a0,a0,a3
+;   j label3
+; block3:
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   mv a1, zero
+;   sext.w a2, a0
+;   bgtz a2, 0xc
+; block1: ; offset 0xc
+;   subw a0, a1, a0
+;   j 0xc
+; block2: ; offset 0x14
+;   addi a3, zero, 2
+;   mulw a0, a0, a3
+; block3: ; offset 0x1c
+;   ret
+
+;; Test 3: Non-leaf function with direct call
+function %non_leaf_with_call(i32) -> i32 {
+    sig0 = (i32) -> i32
+    fn0 = colocated %simple_leaf sig0
+
+block0(v0: i32):
+    v1 = call fn0(v0)
+    return v1
+}
+
+; VCode:
+;   addi sp,sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   call %simple_leaf
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   addi sp,sp,16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   mv s0, sp
+; block1: ; offset 0x10
+;   auipc ra, 0 ; reloc_external RiscvCallPlt %simple_leaf 0
+;   jalr ra
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+;; Test 4: Non-leaf function with indirect call
+function %non_leaf_with_call_indirect(i32, i64) -> i32 {
+    sig0 = (i32) -> i32
+
+block0(v0: i32, v1: i64):
+    v2 = call_indirect sig0, v1(v0)
+    return v2
+}
+
+; VCode:
+;   addi sp,sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   callind a1
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   addi sp,sp,16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   mv s0, sp
+; block1: ; offset 0x10
+;   jalr a1
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+;; Test 5: Leaf function with memory operations (should still be leaf)
+function %leaf_with_memory(i32, i64) -> i32 {
+block0(v0: i32, v1: i64):
+    store v0, v1
+    v2 = load.i32 v1
+    v3 = iconst.i32 1
+    v4 = iadd v2, v3
+    return v4
+}
+
+; VCode:
+; block0:
+;   sw a0,0(a1)
+;   lw a5,0(a1)
+;   addiw a0,a5,1
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   sw a0, 0(a1) ; trap: heap_oob
+;   lw a5, 0(a1) ; trap: heap_oob
+;   addiw a0, a5, 1
+;   ret
+
+;; Test 6: Leaf function that looks like it might call but doesn't
+function %leaf_no_actual_calls(i32) -> i32 {
+block0(v0: i32):
+    v1 = iconst.i32 42
+    v2 = imul v0, v1
+    v3 = iconst.i32 7
+    v4 = udiv v2, v3
+    v5 = iconst.i32 3
+    v6 = band v4, v5
+    return v6
+}
+
+; VCode:
+; block0:
+;   li a1,42
+;   mulw a0,a0,a1
+;   li a1,7
+;   divuw a0,a0,a1
+;   andi a0,a0,3
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi a1, zero, 0x2a
+;   mulw a0, a0, a1
+;   addi a1, zero, 7
+;   divuw a0, a0, a1
+;   andi a0, a0, 3
+;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/symbol-value.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/symbol-value.clif
@@ -11,32 +11,17 @@ block0:
 }
 
 ; VCode:
-;   addi sp,sp,-16
-;   sd ra,8(sp)
-;   sd fp,0(sp)
-;   mv fp,sp
 ; block0:
 ;   load_ext_name_far a0,%func0+0
-;   ld ra,8(sp)
-;   ld fp,0(sp)
-;   addi sp,sp,16
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   addi sp, sp, -0x10
-;   sd ra, 8(sp)
-;   sd s0, 0(sp)
-;   mv s0, sp
-; block1: ; offset 0x10
 ;   auipc a0, 0
 ;   ld a0, 0xc(a0)
 ;   j 0xc
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %func0 0
 ;   .byte 0x00, 0x00, 0x00, 0x00
-;   ld ra, 8(sp)
-;   ld s0, 0(sp)
-;   addi sp, sp, 0x10
 ;   ret
 
 function %colocated_func_addr() -> i64 {
@@ -48,29 +33,14 @@ block0:
 }
 
 ; VCode:
-;   addi sp,sp,-16
-;   sd ra,8(sp)
-;   sd fp,0(sp)
-;   mv fp,sp
 ; block0:
 ;   load_ext_name_near a0,%func0+0
-;   ld ra,8(sp)
-;   ld fp,0(sp)
-;   addi sp,sp,16
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   addi sp, sp, -0x10
-;   sd ra, 8(sp)
-;   sd s0, 0(sp)
-;   mv s0, sp
-; block1: ; offset 0x10
 ;   auipc a0, 0 ; reloc_external RiscvPCRelHi20 %func0 0
-;   mv a0, a0 ; reloc_external RiscvPCRelLo12I func+16 0
-;   ld ra, 8(sp)
-;   ld s0, 0(sp)
-;   addi sp, sp, 0x10
+;   mv a0, a0 ; reloc_external RiscvPCRelLo12I func+0 0
 ;   ret
 
 function %symbol_value() -> i64 {

--- a/cranelift/filetests/filetests/isa/s390x/leaf_function_detection.clif
+++ b/cranelift/filetests/filetests/isa/s390x/leaf_function_detection.clif
@@ -1,0 +1,185 @@
+;; Test leaf function detection across different function types.
+;; This test verifies that the is_leaf detection works correctly for:
+;; - True leaf functions (no calls)
+;; - Non-leaf functions (with calls, call_indirect)
+
+test compile precise-output
+set unwind_info=false
+set preserve_frame_pointers=false
+target s390x
+
+;; Test 1: Simple leaf function - just arithmetic operations
+function %simple_leaf(i32) -> i32 {
+block0(v0: i32):
+    v1 = iconst.i32 10
+    v2 = imul v0, v1
+    return v2
+}
+
+; VCode:
+; block0:
+;   mhi %r2, 10
+;   br %r14
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   mhi %r2, 0xa
+;   br %r14
+
+;; Test 2: Leaf function with multiple basic blocks and control flow
+function %leaf_with_branches(i32) -> i32 {
+block0(v0: i32):
+    v1 = iconst.i32 0
+    v2 = icmp sgt v0, v1
+    brif v2, block1, block2
+
+block1:
+    v3 = iconst.i32 2
+    v4 = imul v0, v3
+    jump block3(v4)
+
+block2:
+    v5 = isub v1, v0
+    jump block3(v5)
+
+block3(v6: i32):
+    return v6
+}
+
+; VCode:
+; block0:
+;   lhi %r3, 0
+;   chi %r2, 0
+;   jgh label2 ; jg label1
+; block1:
+;   srk %r2, %r3, %r2
+;   jg label3
+; block2:
+;   mhi %r2, 2
+;   jg label3
+; block3:
+;   br %r14
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   lhi %r3, 0
+;   chi %r2, 0
+;   jgh 0x18
+; block1: ; offset 0xe
+;   srk %r2, %r3, %r2
+;   jg 0x1c
+; block2: ; offset 0x18
+;   mhi %r2, 2
+; block3: ; offset 0x1c
+;   br %r14
+
+;; Test 3: Non-leaf function with direct call
+function %non_leaf_with_call(i32) -> i32 {
+    sig0 = (i32) -> i32
+    fn0 = colocated %simple_leaf sig0
+
+block0(v0: i32):
+    v1 = call fn0(v0)
+    return v1
+}
+
+; VCode:
+;   stmg %r14, %r15, 112(%r15)
+;   aghi %r15, -160
+; block0:
+;   brasl %r14, %simple_leaf
+;   lmg %r14, %r15, 272(%r15)
+;   br %r14
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   stmg %r14, %r15, 0x70(%r15)
+;   aghi %r15, -0xa0
+; block1: ; offset 0xa
+;   brasl %r14, 0xa ; reloc_external PLTRel32Dbl %simple_leaf 2
+;   lmg %r14, %r15, 0x110(%r15)
+;   br %r14
+
+;; Test 4: Non-leaf function with indirect call
+function %non_leaf_with_call_indirect(i32, i64) -> i32 {
+    sig0 = (i32) -> i32
+
+block0(v0: i32, v1: i64):
+    v2 = call_indirect sig0, v1(v0)
+    return v2
+}
+
+; VCode:
+;   stmg %r14, %r15, 112(%r15)
+;   aghi %r15, -160
+; block0:
+;   basr %r14, %r3
+;   lmg %r14, %r15, 272(%r15)
+;   br %r14
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   stmg %r14, %r15, 0x70(%r15)
+;   aghi %r15, -0xa0
+; block1: ; offset 0xa
+;   basr %r14, %r3
+;   lmg %r14, %r15, 0x110(%r15)
+;   br %r14
+
+;; Test 5: Leaf function with memory operations (should still be leaf)
+function %leaf_with_memory(i32, i64) -> i32 {
+block0(v0: i32, v1: i64):
+    store v0, v1
+    v2 = load.i32 v1
+    v3 = iconst.i32 1
+    v4 = iadd v2, v3
+    return v4
+}
+
+; VCode:
+; block0:
+;   st %r2, 0(%r3)
+;   lhi %r2, 1
+;   a %r2, 0(%r3)
+;   br %r14
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   st %r2, 0(%r3) ; trap: heap_oob
+;   lhi %r2, 1
+;   a %r2, 0(%r3) ; trap: heap_oob
+;   br %r14
+
+;; Test 6: Leaf function that looks like it might call but doesn't
+function %leaf_no_actual_calls(i32) -> i32 {
+block0(v0: i32):
+    v1 = iconst.i32 42
+    v2 = imul v0, v1
+    v3 = iconst.i32 7
+    v4 = udiv v2, v3
+    v5 = iconst.i32 3
+    v6 = band v4, v5
+    return v6
+}
+
+; VCode:
+; block0:
+;   lgr %r3, %r2
+;   mhi %r3, 42
+;   lhi %r2, 0
+;   lhi %r4, 7
+;   dlr %r2, %r4
+;   lgr %r2, %r3
+;   nilf %r2, 3
+;   br %r14
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   lgr %r3, %r2
+;   mhi %r3, 0x2a
+;   lhi %r2, 0
+;   lhi %r4, 7
+;   dlr %r2, %r4 ; trap: int_divz
+;   lgr %r2, %r3
+;   nilf %r2, 3
+;   br %r14

--- a/cranelift/filetests/filetests/isa/x64/leaf_function_detection.clif
+++ b/cranelift/filetests/filetests/isa/x64/leaf_function_detection.clif
@@ -1,0 +1,227 @@
+;; Test leaf function detection across different function types.
+;; This test verifies that the is_leaf detection works correctly for:
+;; - True leaf functions (no calls)
+;; - Non-leaf functions (with calls, call_indirect)
+;;
+;; NOTE: This test is included for completeness with respect to other ISAs,
+;; but x64 does not yet implement the leaf-function optimization, so frame
+;; setup is still present in the generated code below.
+
+test compile precise-output
+set unwind_info=false
+set preserve_frame_pointers=false
+target x86_64
+
+;; Test 1: Simple leaf function - just arithmetic operations
+function %simple_leaf(i32) -> i32 {
+block0(v0: i32):
+    v1 = iconst.i32 10
+    v2 = imul v0, v1
+    return v2
+}
+
+; VCode:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0:
+;   imull $0xa, %edi, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   imull $0xa, %edi, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+;; Test 2: Leaf function with multiple basic blocks and control flow
+function %leaf_with_branches(i32) -> i32 {
+block0(v0: i32):
+    v1 = iconst.i32 0
+    v2 = icmp sgt v0, v1
+    brif v2, block1, block2
+
+block1:
+    v3 = iconst.i32 2
+    v4 = imul v0, v3
+    jump block3(v4)
+
+block2:
+    v5 = isub v1, v0
+    jump block3(v5)
+
+block3(v6: i32):
+    return v6
+}
+
+; VCode:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0:
+;   uninit  %rax
+;   xorl %eax, %eax
+;   testl %edi, %edi
+;   jnle    label2; j label1
+; block1:
+;   subl %edi, %eax
+;   jmp     label3
+; block2:
+;   imull $0x2, %edi, %eax
+;   jmp     label3
+; block3:
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   xorl %eax, %eax
+;   testl %edi, %edi
+;   jg 0x15
+; block2: ; offset 0xe
+;   subl %edi, %eax
+;   jmp 0x18
+; block3: ; offset 0x15
+;   imull $2, %edi, %eax
+; block4: ; offset 0x18
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+;; Test 3: Non-leaf function with direct call
+function %non_leaf_with_call(i32) -> i32 {
+    sig0 = (i32) -> i32
+    fn0 = colocated %simple_leaf sig0
+
+block0(v0: i32):
+    v1 = call fn0(v0)
+    return v1
+}
+
+; VCode:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0:
+;   call    TestCase(%simple_leaf)
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   callq 9 ; reloc_external CallPCRel4 %simple_leaf -4
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+;; Test 4: Non-leaf function with indirect call
+function %non_leaf_with_call_indirect(i32, i64) -> i32 {
+    sig0 = (i32) -> i32
+
+block0(v0: i32, v1: i64):
+    v2 = call_indirect sig0, v1(v0)
+    return v2
+}
+
+; VCode:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0:
+;   call    *%rsi
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   callq *%rsi
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+;; Test 5: Leaf function with memory operations (should still be leaf)
+function %leaf_with_memory(i32, i64) -> i32 {
+block0(v0: i32, v1: i64):
+    store v0, v1
+    v2 = load.i32 v1
+    v3 = iconst.i32 1
+    v4 = iadd v2, v3
+    return v4
+}
+
+; VCode:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0:
+;   movl %edi, (%rsi)
+;   movl $0x1, %eax
+;   addl (%rsi), %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movl %edi, (%rsi) ; trap: heap_oob
+;   movl $1, %eax
+;   addl (%rsi), %eax ; trap: heap_oob
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+;; Test 6: Leaf function that looks like it might call but doesn't
+function %leaf_no_actual_calls(i32) -> i32 {
+block0(v0: i32):
+    v1 = iconst.i32 42
+    v2 = imul v0, v1
+    v3 = iconst.i32 7
+    v4 = udiv v2, v3
+    v5 = iconst.i32 3
+    v6 = band v4, v5
+    return v6
+}
+
+; VCode:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0:
+;   imull $0x2a, %edi, %eax
+;   movl $0x7, %r11d
+;   uninit  %rdx
+;   xorq %rdx, %rdx
+;   divl %r11d ;; implicit: %eax, %edx, trap=254
+;   andl $0x3, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   imull $0x2a, %edi, %eax
+;   movl $7, %r11d
+;   xorq %rdx, %rdx
+;   divl %r11d ; trap: int_divz
+;   andl $3, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq


### PR DESCRIPTION
  ## Problem

  The previous leaf function detection in `FunctionStencil::is_leaf()` was overly conservative. It would incorrectly mark functions as non-leaf if they:
  - Had any function signatures defined (even if unused)
  - Referenced any TLS global values (even without calling)

  ## Solution

  This PR implements accurate leaf function detection by analyzing the actual generated machine code during the VCode register allocation phase. The new approach:

  1. **Adds `is_call()` method to `MachInst` trait** - Each architecture implementation now identifies its call instructions (including indirect calls and tail calls)

  2. **Detects calls during register allocation** - The `compute_clobbers()` method in VCode now tracks whether any actual call instructions exist

  3. **Removes the conservative `is_leaf()` method** - The old method that made assumptions based on IR-level information is replaced

Fixes #11573