### PR TITLE
Add golden tests for entry trampoline output

### DIFF
--- a/tests/disas/aarch64-entry-trampoline.wat
+++ b/tests/disas/aarch64-entry-trampoline.wat
@@ -1,0 +1,26 @@
+;;! target = "aarch64"
+;;! test = "compile"
+;;! objdump = "--filter array_to_wasm --funcs all"
+
+(module (func (export "")))
+
+;; wasm[0]::array_to_wasm_trampoline[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       ldr     w10, [x0]
+;;       mov     w9, #0x6f63
+;;       movk    w9, #0x6572, lsl #16
+;;       cmp     w10, w9
+;;       cset    x13, eq
+;;       uxtb    w11, w13
+;;       cbz     x11, #0x58
+;;   34: ldr     x12, [x0, #8]
+;;       mov     x13, x29
+;;       str     x13, [x12, #0x38]
+;;       mov     x2, x0
+;;       mov     x3, x1
+;;       bl      #0
+;;   4c: mov     w0, #1
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret
+;;   58: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/pulley-entry-trampoline.wat
+++ b/tests/disas/pulley-entry-trampoline.wat
@@ -1,0 +1,18 @@
+;;! target = "pulley64"
+;;! test = "compile"
+;;! objdump = "--filter array_to_wasm --funcs all"
+
+(module (func (export "")))
+
+;; wasm[0]::array_to_wasm_trampoline[0]:
+;;       push_frame
+;;       xload32le_o32 x6, x0, 0
+;;       br_if_xneq32_i32 x6, 1701998435, 0x25    // target = 0x30
+;;   15: xload64le_o32 x7, x0, 8
+;;       xmov_fp x8
+;;       xstore64le_o32 x7, 56, x8
+;;       call -0x27    // target = 0x0
+;;       xone x0
+;;       pop_frame
+;;       ret
+;;   30: trap

--- a/tests/disas/riscv64-entry-trampoline.wat
+++ b/tests/disas/riscv64-entry-trampoline.wat
@@ -1,0 +1,26 @@
+;;! target = "riscv64"
+;;! test = "compile"
+;;! objdump = "--filter array_to_wasm --funcs all"
+
+(module (func (export "")))
+
+;; wasm[0]::array_to_wasm_trampoline[0]:
+;;       addi    sp, sp, -0x10
+;;       sd      ra, 8(sp)
+;;       sd      s0, 0(sp)
+;;       mv      s0, sp
+;;       lw      a2, 0(a0)
+;;       lui     a3, 0x65727
+;;       addi    a3, a3, -0x9d
+;;       beq     a2, a3, 8
+;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       ld      a3, 8(a0)
+;;       mv      a4, s0
+;;       sd      a4, 0x38(a3)
+;;       auipc   ra, 0
+;;       jalr    ra, ra, -0x50
+;;       addi    a0, zero, 1
+;;       ld      ra, 8(sp)
+;;       ld      s0, 0(sp)
+;;       addi    sp, sp, 0x10
+;;       ret

--- a/tests/disas/s390x-entry-trampoline.wat
+++ b/tests/disas/s390x-entry-trampoline.wat
@@ -1,0 +1,37 @@
+;;! target = "s390x"
+;;! test = "compile"
+;;! objdump = "--filter array_to_wasm --funcs all"
+
+(module (func (export "")))
+
+;; wasm[0]::array_to_wasm_trampoline[0]:
+;;       stmg    %r6, %r15, 0x30(%r15)
+;;       lgr     %r1, %r15
+;;       aghi    %r15, -0xe0
+;;       stg     %r1, 0(%r15)
+;;       std     %f8, 0xa0(%r15)
+;;       std     %f9, 0xa8(%r15)
+;;       std     %f10, 0xb0(%r15)
+;;       std     %f11, 0xb8(%r15)
+;;       std     %f12, 0xc0(%r15)
+;;       std     %f13, 0xc8(%r15)
+;;       std     %f14, 0xd0(%r15)
+;;       std     %f15, 0xd8(%r15)
+;;       l       %r4, 0(%r2)
+;;       clfi    %r4, 0x65726f63
+;;       jgne    0x70
+;;       lg      %r4, 8(%r2)
+;;       lg      %r5, 0(%r15)
+;;       stg     %r5, 0x38(%r4)
+;;       brasl   %r14, 0
+;;       lhi     %r2, 1
+;;       ld      %f8, 0xa0(%r15)
+;;       ld      %f9, 0xa8(%r15)
+;;       ld      %f10, 0xb0(%r15)
+;;       ld      %f11, 0xb8(%r15)
+;;       ld      %f12, 0xc0(%r15)
+;;       ld      %f13, 0xc8(%r15)
+;;       ld      %f14, 0xd0(%r15)
+;;       ld      %f15, 0xd8(%r15)
+;;       lmg     %r6, %r15, 0x110(%r15)
+;;       br      %r14

--- a/tests/disas/x64-entry-trampoline.wat
+++ b/tests/disas/x64-entry-trampoline.wat
@@ -1,0 +1,21 @@
+;;! target = "x86_64"
+;;! test = "compile"
+;;! objdump = "--filter array_to_wasm --funcs all"
+
+(module (func (export "")))
+
+;; wasm[0]::array_to_wasm_trampoline[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movl    (%rdi), %r9d
+;;       cmpl    $0x65726f63, %r9d
+;;       jne     0x37
+;;   1d: movq    8(%rdi), %r11
+;;       movq    %rbp, %rax
+;;       movq    %rax, 0x38(%r11)
+;;       callq   0
+;;       movl    $1, %eax
+;;       movq    %rbp, %rsp
+;;       popq    %rbp
+;;       retq
+;;   37: ud2


### PR DESCRIPTION
This commit adds a set of tests to the `disas` test suite which reflect the generated assembly for entry trampolines to Wasmtime. I plan on making some large-ish changes to these in the near future and I figured it'd be good to have examples in-tree of how these are changing over time.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
