### PR TITLE
pulley: Flag all float registers as caller-saved

### DIFF
--- a/cranelift/codegen/src/isa/pulley_shared/abi.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/abi.rs
@@ -745,24 +745,7 @@ const DEFAULT_CALLEE_SAVES: PRegSet = PRegSet::empty()
     .with(px_reg(29))
     .with(px_reg(30))
     .with(px_reg(31))
-    // Float registers.
-    .with(pf_reg(16))
-    .with(pf_reg(17))
-    .with(pf_reg(18))
-    .with(pf_reg(19))
-    .with(pf_reg(20))
-    .with(pf_reg(21))
-    .with(pf_reg(22))
-    .with(pf_reg(23))
-    .with(pf_reg(24))
-    .with(pf_reg(25))
-    .with(pf_reg(26))
-    .with(pf_reg(27))
-    .with(pf_reg(28))
-    .with(pf_reg(29))
-    .with(pf_reg(30))
-    .with(pf_reg(31))
-    // Note: no vector registers are callee-saved.
+    // Note: no float/vector registers are callee-saved.
 ;
 
 fn compute_clobber_size(clobbers: &[Writable<RealReg>]) -> u32 {
@@ -799,7 +782,7 @@ const DEFAULT_CLOBBERS: PRegSet = PRegSet::empty()
     .with(px_reg(13))
     .with(px_reg(14))
     .with(px_reg(15))
-    // Float registers: the first 16 get clobbered.
+    // All float registers get clobbered.
     .with(pf_reg(0))
     .with(pf_reg(1))
     .with(pf_reg(2))
@@ -816,6 +799,22 @@ const DEFAULT_CLOBBERS: PRegSet = PRegSet::empty()
     .with(pf_reg(13))
     .with(pf_reg(14))
     .with(pf_reg(15))
+    .with(pf_reg(16))
+    .with(pf_reg(17))
+    .with(pf_reg(18))
+    .with(pf_reg(19))
+    .with(pf_reg(20))
+    .with(pf_reg(21))
+    .with(pf_reg(22))
+    .with(pf_reg(23))
+    .with(pf_reg(24))
+    .with(pf_reg(25))
+    .with(pf_reg(26))
+    .with(pf_reg(27))
+    .with(pf_reg(28))
+    .with(pf_reg(29))
+    .with(pf_reg(30))
+    .with(pf_reg(31))
     // All vector registers get clobbered.
     .with(pv_reg(0))
     .with(pv_reg(1))
@@ -955,7 +954,7 @@ fn create_reg_environment() -> MachineEnv {
 
     let preferred_regs_by_class: [Vec<PReg>; 3] = {
         let x_registers: Vec<PReg> = (0..16).map(|x| px_reg(x)).collect();
-        let f_registers: Vec<PReg> = (0..16).map(|x| pf_reg(x)).collect();
+        let f_registers: Vec<PReg> = (0..32).map(|x| pf_reg(x)).collect();
         let v_registers: Vec<PReg> = (0..32).map(|x| pv_reg(x)).collect();
         [x_registers, f_registers, v_registers]
     };
@@ -964,7 +963,7 @@ fn create_reg_environment() -> MachineEnv {
         let x_registers: Vec<PReg> = (16..XReg::SPECIAL_START)
             .map(|x| px_reg(x.into()))
             .collect();
-        let f_registers: Vec<PReg> = (16..32).map(|x| pf_reg(x)).collect();
+        let f_registers: Vec<PReg> = vec![];
         let v_registers: Vec<PReg> = vec![];
         [x_registers, f_registers, v_registers]
     };

--- a/cranelift/filetests/filetests/isa/pulley32/call.clif
+++ b/cranelift/filetests/filetests/isa/pulley32/call.clif
@@ -16,7 +16,7 @@ block0:
 ;   push_frame
 ; block0:
 ;   xzero x2
-;   call CallInfo { dest: PulleyCall { name: TestCase(%g), args: [XReg(p2i)] }, uses: [], defs: [CallRetPair { vreg: Writable { reg: p0i }, location: Reg(p0i, types::I64) }], clobbers: PRegSet { bits: [65534, 65535, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0, try_call_info: None }
+;   call CallInfo { dest: PulleyCall { name: TestCase(%g), args: [XReg(p2i)] }, uses: [], defs: [CallRetPair { vreg: Writable { reg: p0i }, location: Reg(p0i, types::I64) }], clobbers: PRegSet { bits: [65534, 4294967295, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0, try_call_info: None }
 ;   xone x0
 ;   pop_frame
 ;   ret
@@ -43,7 +43,7 @@ block0:
 ;   push_frame
 ; block0:
 ;   xzero x2
-;   call CallInfo { dest: PulleyCall { name: TestCase(%g), args: [XReg(p2i)] }, uses: [], defs: [CallRetPair { vreg: Writable { reg: p0i }, location: Reg(p0i, types::I32) }], clobbers: PRegSet { bits: [65534, 65535, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0, try_call_info: None }
+;   call CallInfo { dest: PulleyCall { name: TestCase(%g), args: [XReg(p2i)] }, uses: [], defs: [CallRetPair { vreg: Writable { reg: p0i }, location: Reg(p0i, types::I32) }], clobbers: PRegSet { bits: [65534, 4294967295, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0, try_call_info: None }
 ;   xone x0
 ;   pop_frame
 ;   ret
@@ -75,7 +75,7 @@ block0:
 ;   xone x4
 ;   xconst8 x5, 2
 ;   xconst8 x6, 3
-;   call CallInfo { dest: PulleyCall { name: TestCase(%g), args: [XReg(p3i), XReg(p4i), XReg(p5i), XReg(p6i)] }, uses: [], defs: [], clobbers: PRegSet { bits: [65535, 65535, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0, try_call_info: None }
+;   call CallInfo { dest: PulleyCall { name: TestCase(%g), args: [XReg(p3i), XReg(p4i), XReg(p5i), XReg(p6i)] }, uses: [], defs: [], clobbers: PRegSet { bits: [65535, 4294967295, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0, try_call_info: None }
 ;   pop_frame
 ;   ret
 ;
@@ -103,7 +103,7 @@ block0:
 ; VCode:
 ;   push_frame
 ; block0:
-;   call CallInfo { dest: PulleyCall { name: TestCase(%g), args: [] }, uses: [], defs: [CallRetPair { vreg: Writable { reg: p0i }, location: Reg(p0i, types::I64) }, CallRetPair { vreg: Writable { reg: p1i }, location: Reg(p1i, types::I64) }, CallRetPair { vreg: Writable { reg: p2i }, location: Reg(p2i, types::I64) }, CallRetPair { vreg: Writable { reg: p3i }, location: Reg(p3i, types::I64) }], clobbers: PRegSet { bits: [65520, 65535, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0, try_call_info: None }
+;   call CallInfo { dest: PulleyCall { name: TestCase(%g), args: [] }, uses: [], defs: [CallRetPair { vreg: Writable { reg: p0i }, location: Reg(p0i, types::I64) }, CallRetPair { vreg: Writable { reg: p1i }, location: Reg(p1i, types::I64) }, CallRetPair { vreg: Writable { reg: p2i }, location: Reg(p2i, types::I64) }, CallRetPair { vreg: Writable { reg: p3i }, location: Reg(p3i, types::I64) }], clobbers: PRegSet { bits: [65520, 4294967295, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0, try_call_info: None }
 ;   xadd64 x4, x0, x2
 ;   xadd64 x3, x1, x3
 ;   xadd64 x0, x4, x3
@@ -149,7 +149,7 @@ block0:
 ;   xmov x11, x14
 ;   xmov x12, x14
 ;   xmov x13, x14
-;   call CallInfo { dest: PulleyCall { name: TestCase(%g), args: [XReg(p14i), XReg(p14i), XReg(p14i), XReg(p14i)] }, uses: [CallArgPair { vreg: p4i, preg: p4i }, CallArgPair { vreg: p5i, preg: p5i }, CallArgPair { vreg: p6i, preg: p6i }, CallArgPair { vreg: p7i, preg: p7i }, CallArgPair { vreg: p8i, preg: p8i }, CallArgPair { vreg: p9i, preg: p9i }, CallArgPair { vreg: p10i, preg: p10i }, CallArgPair { vreg: p11i, preg: p11i }, CallArgPair { vreg: p12i, preg: p12i }, CallArgPair { vreg: p13i, preg: p13i }, CallArgPair { vreg: p14i, preg: p14i }], defs: [], clobbers: PRegSet { bits: [65535, 65535, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0, try_call_info: None }
+;   call CallInfo { dest: PulleyCall { name: TestCase(%g), args: [XReg(p14i), XReg(p14i), XReg(p14i), XReg(p14i)] }, uses: [CallArgPair { vreg: p4i, preg: p4i }, CallArgPair { vreg: p5i, preg: p5i }, CallArgPair { vreg: p6i, preg: p6i }, CallArgPair { vreg: p7i, preg: p7i }, CallArgPair { vreg: p8i, preg: p8i }, CallArgPair { vreg: p9i, preg: p9i }, CallArgPair { vreg: p10i, preg: p10i }, CallArgPair { vreg: p11i, preg: p11i }, CallArgPair { vreg: p12i, preg: p12i }, CallArgPair { vreg: p13i, preg: p13i }, CallArgPair { vreg: p14i, preg: p14i }], defs: [], clobbers: PRegSet { bits: [65535, 4294967295, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0, try_call_info: None }
 ;   pop_frame_restore 64, {}
 ;   ret
 ;
@@ -217,7 +217,7 @@ block0:
 ;   push_frame_save 112, {x16, x17, x18, x19, x26, x27, x28, x29}
 ; block0:
 ;   x12 = load_addr OutgoingArg(0)
-;   call CallInfo { dest: PulleyCall { name: TestCase(%g), args: [XReg(p12i)] }, uses: [], defs: [CallRetPair { vreg: Writable { reg: p0i }, location: Reg(p0i, types::I64) }, CallRetPair { vreg: Writable { reg: p1i }, location: Reg(p1i, types::I64) }, CallRetPair { vreg: Writable { reg: p2i }, location: Reg(p2i, types::I64) }, CallRetPair { vreg: Writable { reg: p3i }, location: Reg(p3i, types::I64) }, CallRetPair { vreg: Writable { reg: p4i }, location: Reg(p4i, types::I64) }, CallRetPair { vreg: Writable { reg: p5i }, location: Reg(p5i, types::I64) }, CallRetPair { vreg: Writable { reg: p6i }, location: Reg(p6i, types::I64) }, CallRetPair { vreg: Writable { reg: p7i }, location: Reg(p7i, types::I64) }, CallRetPair { vreg: Writable { reg: p8i }, location: Reg(p8i, types::I64) }, CallRetPair { vreg: Writable { reg: p9i }, location: Reg(p9i, types::I64) }, CallRetPair { vreg: Writable { reg: p10i }, location: Reg(p10i, types::I64) }, CallRetPair { vreg: Writable { reg: p11i }, location: Reg(p11i, types::I64) }, CallRetPair { vreg: Writable { reg: p12i }, location: Reg(p12i, types::I64) }, CallRetPair { vreg: Writable { reg: p13i }, location: Reg(p13i, types::I64) }, CallRetPair { vreg: Writable { reg: p14i }, location: Reg(p14i, types::I64) }, CallRetPair { vreg: Writable { reg: p27i }, location: Stack(OutgoingArg(0), types::I64) }, CallRetPair { vreg: Writable { reg: p19i }, location: Stack(OutgoingArg(8), types::I64) }, CallRetPair { vreg: Writable { reg: p29i }, location: Stack(OutgoingArg(16), types::I64) }, CallRetPair { vreg: Writable { reg: p16i }, location: Stack(OutgoingArg(24), types::I64) }, CallRetPair { vreg: Writable { reg: p17i }, location: Stack(OutgoingArg(32), types::I64) }, CallRetPair { vreg: Writable { reg: p18i }, location: Stack(OutgoingArg(40), types::I64) }], clobbers: PRegSet { bits: [32768, 65535, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0, try_call_info: None }
+;   call CallInfo { dest: PulleyCall { name: TestCase(%g), args: [XReg(p12i)] }, uses: [], defs: [CallRetPair { vreg: Writable { reg: p0i }, location: Reg(p0i, types::I64) }, CallRetPair { vreg: Writable { reg: p1i }, location: Reg(p1i, types::I64) }, CallRetPair { vreg: Writable { reg: p2i }, location: Reg(p2i, types::I64) }, CallRetPair { vreg: Writable { reg: p3i }, location: Reg(p3i, types::I64) }, CallRetPair { vreg: Writable { reg: p4i }, location: Reg(p4i, types::I64) }, CallRetPair { vreg: Writable { reg: p5i }, location: Reg(p5i, types::I64) }, CallRetPair { vreg: Writable { reg: p6i }, location: Reg(p6i, types::I64) }, CallRetPair { vreg: Writable { reg: p7i }, location: Reg(p7i, types::I64) }, CallRetPair { vreg: Writable { reg: p8i }, location: Reg(p8i, types::I64) }, CallRetPair { vreg: Writable { reg: p9i }, location: Reg(p9i, types::I64) }, CallRetPair { vreg: Writable { reg: p10i }, location: Reg(p10i, types::I64) }, CallRetPair { vreg: Writable { reg: p11i }, location: Reg(p11i, types::I64) }, CallRetPair { vreg: Writable { reg: p12i }, location: Reg(p12i, types::I64) }, CallRetPair { vreg: Writable { reg: p13i }, location: Reg(p13i, types::I64) }, CallRetPair { vreg: Writable { reg: p14i }, location: Reg(p14i, types::I64) }, CallRetPair { vreg: Writable { reg: p27i }, location: Stack(OutgoingArg(0), types::I64) }, CallRetPair { vreg: Writable { reg: p19i }, location: Stack(OutgoingArg(8), types::I64) }, CallRetPair { vreg: Writable { reg: p29i }, location: Stack(OutgoingArg(16), types::I64) }, CallRetPair { vreg: Writable { reg: p16i }, location: Stack(OutgoingArg(24), types::I64) }, CallRetPair { vreg: Writable { reg: p17i }, location: Stack(OutgoingArg(32), types::I64) }, CallRetPair { vreg: Writable { reg: p18i }, location: Stack(OutgoingArg(40), types::I64) }], clobbers: PRegSet { bits: [32768, 4294967295, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0, try_call_info: None }
 ;   xadd64 x26, x0, x1
 ;   xadd64 x28, x2, x3
 ;   xadd64 x2, x4, x5
@@ -291,7 +291,7 @@ block0(v0: i32):
 ; VCode:
 ;   push_frame
 ; block0:
-;   indirect_call x0, CallInfo { dest: XReg(p0i), uses: [], defs: [CallRetPair { vreg: Writable { reg: p0i }, location: Reg(p0i, types::I64) }], clobbers: PRegSet { bits: [65534, 65535, 4294967295, 0] }, callee_conv: Tail, caller_conv: Fast, callee_pop_size: 0, try_call_info: None }
+;   indirect_call x0, CallInfo { dest: XReg(p0i), uses: [], defs: [CallRetPair { vreg: Writable { reg: p0i }, location: Reg(p0i, types::I64) }], clobbers: PRegSet { bits: [65534, 4294967295, 4294967295, 0] }, callee_conv: Tail, caller_conv: Fast, callee_pop_size: 0, try_call_info: None }
 ;   pop_frame
 ;   ret
 ;

--- a/cranelift/filetests/filetests/isa/pulley32/exceptions.clif
+++ b/cranelift/filetests/filetests/isa/pulley32/exceptions.clif
@@ -20,23 +20,7 @@ function %f0(i32) -> i32, f32, f64 {
 }
 
 ; VCode:
-;   push_frame_save 272, {x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0}
-;   fstore64 sp+136, f16 // flags =  notrap aligned
-;   fstore64 sp+128, f17 // flags =  notrap aligned
-;   fstore64 sp+120, f18 // flags =  notrap aligned
-;   fstore64 sp+112, f19 // flags =  notrap aligned
-;   fstore64 sp+104, f20 // flags =  notrap aligned
-;   fstore64 sp+96, f21 // flags =  notrap aligned
-;   fstore64 sp+88, f22 // flags =  notrap aligned
-;   fstore64 sp+80, f23 // flags =  notrap aligned
-;   fstore64 sp+72, f24 // flags =  notrap aligned
-;   fstore64 sp+64, f25 // flags =  notrap aligned
-;   fstore64 sp+56, f26 // flags =  notrap aligned
-;   fstore64 sp+48, f27 // flags =  notrap aligned
-;   fstore64 sp+40, f28 // flags =  notrap aligned
-;   fstore64 sp+32, f29 // flags =  notrap aligned
-;   fstore64 sp+24, f30 // flags =  notrap aligned
-;   fstore64 sp+16, f31 // flags =  notrap aligned
+;   push_frame_save 144, {x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0}
 ; block0:
 ;   fconst64 f1, 4607182418800017408
 ;   fstore64 Slot(0), f1 // flags =  notrap aligned
@@ -44,108 +28,28 @@ function %f0(i32) -> i32, f32, f64 {
 ; block1:
 ;   xone x0
 ;   f1 = fload64 Slot(0) // flags = notrap aligned
-;   f16 = fload64 sp+136 // flags = notrap aligned
-;   f17 = fload64 sp+128 // flags = notrap aligned
-;   f18 = fload64 sp+120 // flags = notrap aligned
-;   f19 = fload64 sp+112 // flags = notrap aligned
-;   f20 = fload64 sp+104 // flags = notrap aligned
-;   f21 = fload64 sp+96 // flags = notrap aligned
-;   f22 = fload64 sp+88 // flags = notrap aligned
-;   f23 = fload64 sp+80 // flags = notrap aligned
-;   f24 = fload64 sp+72 // flags = notrap aligned
-;   f25 = fload64 sp+64 // flags = notrap aligned
-;   f26 = fload64 sp+56 // flags = notrap aligned
-;   f27 = fload64 sp+48 // flags = notrap aligned
-;   f28 = fload64 sp+40 // flags = notrap aligned
-;   f29 = fload64 sp+32 // flags = notrap aligned
-;   f30 = fload64 sp+24 // flags = notrap aligned
-;   f31 = fload64 sp+16 // flags = notrap aligned
-;   pop_frame_restore 272, {x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0}
+;   pop_frame_restore 144, {x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0}
 ;   ret
 ; block2:
 ;   f1 = fload64 Slot(0) // flags = notrap aligned
 ;   xadd32_u8 x0, x0, 1
 ;   fconst32 f0, 0
-;   f16 = fload64 sp+136 // flags = notrap aligned
-;   f17 = fload64 sp+128 // flags = notrap aligned
-;   f18 = fload64 sp+120 // flags = notrap aligned
-;   f19 = fload64 sp+112 // flags = notrap aligned
-;   f20 = fload64 sp+104 // flags = notrap aligned
-;   f21 = fload64 sp+96 // flags = notrap aligned
-;   f22 = fload64 sp+88 // flags = notrap aligned
-;   f23 = fload64 sp+80 // flags = notrap aligned
-;   f24 = fload64 sp+72 // flags = notrap aligned
-;   f25 = fload64 sp+64 // flags = notrap aligned
-;   f26 = fload64 sp+56 // flags = notrap aligned
-;   f27 = fload64 sp+48 // flags = notrap aligned
-;   f28 = fload64 sp+40 // flags = notrap aligned
-;   f29 = fload64 sp+32 // flags = notrap aligned
-;   f30 = fload64 sp+24 // flags = notrap aligned
-;   f31 = fload64 sp+16 // flags = notrap aligned
-;   pop_frame_restore 272, {x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0}
+;   pop_frame_restore 144, {x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0}
 ;   ret
 ;
 ; Disassembled:
-; push_frame_save 272, x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0
-; fstore64le_o32 sp, 136, f16
-; fstore64le_o32 sp, 128, f17
-; fstore64le_o32 sp, 120, f18
-; fstore64le_o32 sp, 112, f19
-; fstore64le_o32 sp, 104, f20
-; fstore64le_o32 sp, 96, f21
-; fstore64le_o32 sp, 88, f22
-; fstore64le_o32 sp, 80, f23
-; fstore64le_o32 sp, 72, f24
-; fstore64le_o32 sp, 64, f25
-; fstore64le_o32 sp, 56, f26
-; fstore64le_o32 sp, 48, f27
-; fstore64le_o32 sp, 40, f28
-; fstore64le_o32 sp, 32, f29
-; fstore64le_o32 sp, 24, f30
-; fstore64le_o32 sp, 16, f31
+; push_frame_save 144, x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0
 ; fconst64 f1, 4607182418800017408
 ; fstore64le_o32 sp, 0, f1
-; call 0x0    // target = 0xaa
+; call 0x0    // target = 0x1a
 ; xone x0
 ; fload64le_o32 f1, sp, 0
-; fload64le_o32 f16, sp, 136
-; fload64le_o32 f17, sp, 128
-; fload64le_o32 f18, sp, 120
-; fload64le_o32 f19, sp, 112
-; fload64le_o32 f20, sp, 104
-; fload64le_o32 f21, sp, 96
-; fload64le_o32 f22, sp, 88
-; fload64le_o32 f23, sp, 80
-; fload64le_o32 f24, sp, 72
-; fload64le_o32 f25, sp, 64
-; fload64le_o32 f26, sp, 56
-; fload64le_o32 f27, sp, 48
-; fload64le_o32 f28, sp, 40
-; fload64le_o32 f29, sp, 32
-; fload64le_o32 f30, sp, 24
-; fload64le_o32 f31, sp, 16
-; pop_frame_restore 272, x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0
+; pop_frame_restore 144, x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0
 ; ret
 ; fload64le_o32 f1, sp, 0
 ; xadd32_u8 x0, x0, 1
 ; fconst32 f0, 0
-; fload64le_o32 f16, sp, 136
-; fload64le_o32 f17, sp, 128
-; fload64le_o32 f18, sp, 120
-; fload64le_o32 f19, sp, 112
-; fload64le_o32 f20, sp, 104
-; fload64le_o32 f21, sp, 96
-; fload64le_o32 f22, sp, 88
-; fload64le_o32 f23, sp, 80
-; fload64le_o32 f24, sp, 72
-; fload64le_o32 f25, sp, 64
-; fload64le_o32 f26, sp, 56
-; fload64le_o32 f27, sp, 48
-; fload64le_o32 f28, sp, 40
-; fload64le_o32 f29, sp, 32
-; fload64le_o32 f30, sp, 24
-; fload64le_o32 f31, sp, 16
-; pop_frame_restore 272, x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0
+; pop_frame_restore 144, x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0
 ; ret
 
 function %f2(i32, i32) -> i32, f32, f64 {
@@ -167,23 +71,7 @@ function %f2(i32, i32) -> i32, f32, f64 {
 }
 
 ; VCode:
-;   push_frame_save 272, {x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0}
-;   fstore64 sp+136, f16 // flags =  notrap aligned
-;   fstore64 sp+128, f17 // flags =  notrap aligned
-;   fstore64 sp+120, f18 // flags =  notrap aligned
-;   fstore64 sp+112, f19 // flags =  notrap aligned
-;   fstore64 sp+104, f20 // flags =  notrap aligned
-;   fstore64 sp+96, f21 // flags =  notrap aligned
-;   fstore64 sp+88, f22 // flags =  notrap aligned
-;   fstore64 sp+80, f23 // flags =  notrap aligned
-;   fstore64 sp+72, f24 // flags =  notrap aligned
-;   fstore64 sp+64, f25 // flags =  notrap aligned
-;   fstore64 sp+56, f26 // flags =  notrap aligned
-;   fstore64 sp+48, f27 // flags =  notrap aligned
-;   fstore64 sp+40, f28 // flags =  notrap aligned
-;   fstore64 sp+32, f29 // flags =  notrap aligned
-;   fstore64 sp+24, f30 // flags =  notrap aligned
-;   fstore64 sp+16, f31 // flags =  notrap aligned
+;   push_frame_save 144, {x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0}
 ; block0:
 ;   fconst64 f1, 4607182418800017408
 ;   fstore64 Slot(0), f1 // flags =  notrap aligned
@@ -191,108 +79,28 @@ function %f2(i32, i32) -> i32, f32, f64 {
 ; block1:
 ;   xone x0
 ;   f1 = fload64 Slot(0) // flags = notrap aligned
-;   f16 = fload64 sp+136 // flags = notrap aligned
-;   f17 = fload64 sp+128 // flags = notrap aligned
-;   f18 = fload64 sp+120 // flags = notrap aligned
-;   f19 = fload64 sp+112 // flags = notrap aligned
-;   f20 = fload64 sp+104 // flags = notrap aligned
-;   f21 = fload64 sp+96 // flags = notrap aligned
-;   f22 = fload64 sp+88 // flags = notrap aligned
-;   f23 = fload64 sp+80 // flags = notrap aligned
-;   f24 = fload64 sp+72 // flags = notrap aligned
-;   f25 = fload64 sp+64 // flags = notrap aligned
-;   f26 = fload64 sp+56 // flags = notrap aligned
-;   f27 = fload64 sp+48 // flags = notrap aligned
-;   f28 = fload64 sp+40 // flags = notrap aligned
-;   f29 = fload64 sp+32 // flags = notrap aligned
-;   f30 = fload64 sp+24 // flags = notrap aligned
-;   f31 = fload64 sp+16 // flags = notrap aligned
-;   pop_frame_restore 272, {x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0}
+;   pop_frame_restore 144, {x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0}
 ;   ret
 ; block2:
 ;   f1 = fload64 Slot(0) // flags = notrap aligned
 ;   xadd32_u8 x0, x0, 1
 ;   fconst32 f0, 0
-;   f16 = fload64 sp+136 // flags = notrap aligned
-;   f17 = fload64 sp+128 // flags = notrap aligned
-;   f18 = fload64 sp+120 // flags = notrap aligned
-;   f19 = fload64 sp+112 // flags = notrap aligned
-;   f20 = fload64 sp+104 // flags = notrap aligned
-;   f21 = fload64 sp+96 // flags = notrap aligned
-;   f22 = fload64 sp+88 // flags = notrap aligned
-;   f23 = fload64 sp+80 // flags = notrap aligned
-;   f24 = fload64 sp+72 // flags = notrap aligned
-;   f25 = fload64 sp+64 // flags = notrap aligned
-;   f26 = fload64 sp+56 // flags = notrap aligned
-;   f27 = fload64 sp+48 // flags = notrap aligned
-;   f28 = fload64 sp+40 // flags = notrap aligned
-;   f29 = fload64 sp+32 // flags = notrap aligned
-;   f30 = fload64 sp+24 // flags = notrap aligned
-;   f31 = fload64 sp+16 // flags = notrap aligned
-;   pop_frame_restore 272, {x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0}
+;   pop_frame_restore 144, {x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0}
 ;   ret
 ;
 ; Disassembled:
-; push_frame_save 272, x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0
-; fstore64le_o32 sp, 136, f16
-; fstore64le_o32 sp, 128, f17
-; fstore64le_o32 sp, 120, f18
-; fstore64le_o32 sp, 112, f19
-; fstore64le_o32 sp, 104, f20
-; fstore64le_o32 sp, 96, f21
-; fstore64le_o32 sp, 88, f22
-; fstore64le_o32 sp, 80, f23
-; fstore64le_o32 sp, 72, f24
-; fstore64le_o32 sp, 64, f25
-; fstore64le_o32 sp, 56, f26
-; fstore64le_o32 sp, 48, f27
-; fstore64le_o32 sp, 40, f28
-; fstore64le_o32 sp, 32, f29
-; fstore64le_o32 sp, 24, f30
-; fstore64le_o32 sp, 16, f31
+; push_frame_save 144, x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0
 ; fconst64 f1, 4607182418800017408
 ; fstore64le_o32 sp, 0, f1
 ; call_indirect x1
 ; xone x0
 ; fload64le_o32 f1, sp, 0
-; fload64le_o32 f16, sp, 136
-; fload64le_o32 f17, sp, 128
-; fload64le_o32 f18, sp, 120
-; fload64le_o32 f19, sp, 112
-; fload64le_o32 f20, sp, 104
-; fload64le_o32 f21, sp, 96
-; fload64le_o32 f22, sp, 88
-; fload64le_o32 f23, sp, 80
-; fload64le_o32 f24, sp, 72
-; fload64le_o32 f25, sp, 64
-; fload64le_o32 f26, sp, 56
-; fload64le_o32 f27, sp, 48
-; fload64le_o32 f28, sp, 40
-; fload64le_o32 f29, sp, 32
-; fload64le_o32 f30, sp, 24
-; fload64le_o32 f31, sp, 16
-; pop_frame_restore 272, x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0
+; pop_frame_restore 144, x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0
 ; ret
 ; fload64le_o32 f1, sp, 0
 ; xadd32_u8 x0, x0, 1
 ; fconst32 f0, 0
-; fload64le_o32 f16, sp, 136
-; fload64le_o32 f17, sp, 128
-; fload64le_o32 f18, sp, 120
-; fload64le_o32 f19, sp, 112
-; fload64le_o32 f20, sp, 104
-; fload64le_o32 f21, sp, 96
-; fload64le_o32 f22, sp, 88
-; fload64le_o32 f23, sp, 80
-; fload64le_o32 f24, sp, 72
-; fload64le_o32 f25, sp, 64
-; fload64le_o32 f26, sp, 56
-; fload64le_o32 f27, sp, 48
-; fload64le_o32 f28, sp, 40
-; fload64le_o32 f29, sp, 32
-; fload64le_o32 f30, sp, 24
-; fload64le_o32 f31, sp, 16
-; pop_frame_restore 272, x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0
+; pop_frame_restore 144, x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0
 ; ret
 
 function %f4(i32, i32) -> i32, f32, f64 {
@@ -317,23 +125,7 @@ function %f4(i32, i32) -> i32, f32, f64 {
 }
 
 ; VCode:
-;   push_frame_save 288, {x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0}
-;   fstore64 sp+152, f16 // flags =  notrap aligned
-;   fstore64 sp+144, f17 // flags =  notrap aligned
-;   fstore64 sp+136, f18 // flags =  notrap aligned
-;   fstore64 sp+128, f19 // flags =  notrap aligned
-;   fstore64 sp+120, f20 // flags =  notrap aligned
-;   fstore64 sp+112, f21 // flags =  notrap aligned
-;   fstore64 sp+104, f22 // flags =  notrap aligned
-;   fstore64 sp+96, f23 // flags =  notrap aligned
-;   fstore64 sp+88, f24 // flags =  notrap aligned
-;   fstore64 sp+80, f25 // flags =  notrap aligned
-;   fstore64 sp+72, f26 // flags =  notrap aligned
-;   fstore64 sp+64, f27 // flags =  notrap aligned
-;   fstore64 sp+56, f28 // flags =  notrap aligned
-;   fstore64 sp+48, f29 // flags =  notrap aligned
-;   fstore64 sp+40, f30 // flags =  notrap aligned
-;   fstore64 sp+32, f31 // flags =  notrap aligned
+;   push_frame_save 160, {x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0}
 ; block0:
 ;   xstore64 Slot(0), x1 // flags =  notrap aligned
 ;   xstore64 Slot(8), x0 // flags =  notrap aligned
@@ -352,23 +144,7 @@ function %f4(i32, i32) -> i32, f32, f64 {
 ; block3:
 ;   xone x0
 ;   f1 = fload64 Slot(16) // flags = notrap aligned
-;   f16 = fload64 sp+152 // flags = notrap aligned
-;   f17 = fload64 sp+144 // flags = notrap aligned
-;   f18 = fload64 sp+136 // flags = notrap aligned
-;   f19 = fload64 sp+128 // flags = notrap aligned
-;   f20 = fload64 sp+120 // flags = notrap aligned
-;   f21 = fload64 sp+112 // flags = notrap aligned
-;   f22 = fload64 sp+104 // flags = notrap aligned
-;   f23 = fload64 sp+96 // flags = notrap aligned
-;   f24 = fload64 sp+88 // flags = notrap aligned
-;   f25 = fload64 sp+80 // flags = notrap aligned
-;   f26 = fload64 sp+72 // flags = notrap aligned
-;   f27 = fload64 sp+64 // flags = notrap aligned
-;   f28 = fload64 sp+56 // flags = notrap aligned
-;   f29 = fload64 sp+48 // flags = notrap aligned
-;   f30 = fload64 sp+40 // flags = notrap aligned
-;   f31 = fload64 sp+32 // flags = notrap aligned
-;   pop_frame_restore 288, {x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0}
+;   pop_frame_restore 160, {x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0}
 ;   ret
 ; block4:
 ;   f1 = fload64 Slot(16) // flags = notrap aligned
@@ -377,96 +153,32 @@ function %f4(i32, i32) -> i32, f32, f64 {
 ; block5:
 ;   xadd32_u8 x0, x3, 1
 ;   fconst32 f0, 0
-;   f16 = fload64 sp+152 // flags = notrap aligned
-;   f17 = fload64 sp+144 // flags = notrap aligned
-;   f18 = fload64 sp+136 // flags = notrap aligned
-;   f19 = fload64 sp+128 // flags = notrap aligned
-;   f20 = fload64 sp+120 // flags = notrap aligned
-;   f21 = fload64 sp+112 // flags = notrap aligned
-;   f22 = fload64 sp+104 // flags = notrap aligned
-;   f23 = fload64 sp+96 // flags = notrap aligned
-;   f24 = fload64 sp+88 // flags = notrap aligned
-;   f25 = fload64 sp+80 // flags = notrap aligned
-;   f26 = fload64 sp+72 // flags = notrap aligned
-;   f27 = fload64 sp+64 // flags = notrap aligned
-;   f28 = fload64 sp+56 // flags = notrap aligned
-;   f29 = fload64 sp+48 // flags = notrap aligned
-;   f30 = fload64 sp+40 // flags = notrap aligned
-;   f31 = fload64 sp+32 // flags = notrap aligned
-;   pop_frame_restore 288, {x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0}
+;   pop_frame_restore 160, {x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0}
 ;   ret
 ;
 ; Disassembled:
-; push_frame_save 288, x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0
-; fstore64le_o32 sp, 152, f16
-; fstore64le_o32 sp, 144, f17
-; fstore64le_o32 sp, 136, f18
-; fstore64le_o32 sp, 128, f19
-; fstore64le_o32 sp, 120, f20
-; fstore64le_o32 sp, 112, f21
-; fstore64le_o32 sp, 104, f22
-; fstore64le_o32 sp, 96, f23
-; fstore64le_o32 sp, 88, f24
-; fstore64le_o32 sp, 80, f25
-; fstore64le_o32 sp, 72, f26
-; fstore64le_o32 sp, 64, f27
-; fstore64le_o32 sp, 56, f28
-; fstore64le_o32 sp, 48, f29
-; fstore64le_o32 sp, 40, f30
-; fstore64le_o32 sp, 32, f31
+; push_frame_save 160, x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0
 ; xstore64le_o32 sp, 0, x1
 ; xstore64le_o32 sp, 8, x0
 ; fconst64 f1, 4607182418800017408
 ; xload64le_o32 x2, sp, 0
 ; fstore64le_o32 sp, 16, f1
-; call1 x2, 0x0    // target = 0xbf
-; jump 0x27    // target = 0xec
+; call1 x2, 0x0    // target = 0x2f
+; jump 0x27    // target = 0x5c
 ; xmov x3, x0
 ; fload64le_o32 f1, sp, 16
-; jump 0xc7    // target = 0x19d
+; jump 0x37    // target = 0x7d
 ; xmov x3, x0
 ; fload64le_o32 f1, sp, 16
-; jump 0xb6    // target = 0x19d
+; jump 0x26    // target = 0x7d
 ; xone x0
 ; fload64le_o32 f1, sp, 16
-; fload64le_o32 f16, sp, 152
-; fload64le_o32 f17, sp, 144
-; fload64le_o32 f18, sp, 136
-; fload64le_o32 f19, sp, 128
-; fload64le_o32 f20, sp, 120
-; fload64le_o32 f21, sp, 112
-; fload64le_o32 f22, sp, 104
-; fload64le_o32 f23, sp, 96
-; fload64le_o32 f24, sp, 88
-; fload64le_o32 f25, sp, 80
-; fload64le_o32 f26, sp, 72
-; fload64le_o32 f27, sp, 64
-; fload64le_o32 f28, sp, 56
-; fload64le_o32 f29, sp, 48
-; fload64le_o32 f30, sp, 40
-; fload64le_o32 f31, sp, 32
-; pop_frame_restore 288, x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0
+; pop_frame_restore 160, x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0
 ; ret
 ; fload64le_o32 f1, sp, 16
 ; xload64le_o32 x3, sp, 8
 ; xadd32_u8 x0, x3, 1
 ; fconst32 f0, 0
-; fload64le_o32 f16, sp, 152
-; fload64le_o32 f17, sp, 144
-; fload64le_o32 f18, sp, 136
-; fload64le_o32 f19, sp, 128
-; fload64le_o32 f20, sp, 120
-; fload64le_o32 f21, sp, 112
-; fload64le_o32 f22, sp, 104
-; fload64le_o32 f23, sp, 96
-; fload64le_o32 f24, sp, 88
-; fload64le_o32 f25, sp, 80
-; fload64le_o32 f26, sp, 72
-; fload64le_o32 f27, sp, 64
-; fload64le_o32 f28, sp, 56
-; fload64le_o32 f29, sp, 48
-; fload64le_o32 f30, sp, 40
-; fload64le_o32 f31, sp, 32
-; pop_frame_restore 288, x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0
+; pop_frame_restore 160, x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0
 ; ret
 

--- a/cranelift/filetests/filetests/isa/pulley32/extend.clif
+++ b/cranelift/filetests/filetests/isa/pulley32/extend.clif
@@ -12,7 +12,7 @@ block0(v0: i8):
 ;   push_frame
 ; block0:
 ;   zext8 x2, x0
-;   call CallInfo { dest: PulleyCall { name: TestCase(%g), args: [XReg(p2i)] }, uses: [], defs: [], clobbers: PRegSet { bits: [65535, 65535, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0, try_call_info: None }
+;   call CallInfo { dest: PulleyCall { name: TestCase(%g), args: [XReg(p2i)] }, uses: [], defs: [], clobbers: PRegSet { bits: [65535, 4294967295, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0, try_call_info: None }
 ;   pop_frame
 ;   ret
 ;
@@ -34,7 +34,7 @@ block0(v0: i16):
 ;   push_frame
 ; block0:
 ;   zext16 x2, x0
-;   call CallInfo { dest: PulleyCall { name: TestCase(%g), args: [XReg(p2i)] }, uses: [], defs: [], clobbers: PRegSet { bits: [65535, 65535, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0, try_call_info: None }
+;   call CallInfo { dest: PulleyCall { name: TestCase(%g), args: [XReg(p2i)] }, uses: [], defs: [], clobbers: PRegSet { bits: [65535, 4294967295, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0, try_call_info: None }
 ;   pop_frame
 ;   ret
 ;
@@ -55,7 +55,7 @@ block0(v0: i32):
 ; VCode:
 ;   push_frame
 ; block0:
-;   call CallInfo { dest: PulleyCall { name: TestCase(%g), args: [XReg(p0i)] }, uses: [], defs: [], clobbers: PRegSet { bits: [65535, 65535, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0, try_call_info: None }
+;   call CallInfo { dest: PulleyCall { name: TestCase(%g), args: [XReg(p0i)] }, uses: [], defs: [], clobbers: PRegSet { bits: [65535, 4294967295, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0, try_call_info: None }
 ;   pop_frame
 ;   ret
 ;
@@ -75,7 +75,7 @@ block0(v0: i64):
 ; VCode:
 ;   push_frame
 ; block0:
-;   call CallInfo { dest: PulleyCall { name: TestCase(%g), args: [XReg(p0i)] }, uses: [], defs: [], clobbers: PRegSet { bits: [65535, 65535, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0, try_call_info: None }
+;   call CallInfo { dest: PulleyCall { name: TestCase(%g), args: [XReg(p0i)] }, uses: [], defs: [], clobbers: PRegSet { bits: [65535, 4294967295, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0, try_call_info: None }
 ;   pop_frame
 ;   ret
 ;
@@ -96,7 +96,7 @@ block0(v0: i8):
 ;   push_frame
 ; block0:
 ;   sext8 x2, x0
-;   call CallInfo { dest: PulleyCall { name: TestCase(%g), args: [XReg(p2i)] }, uses: [], defs: [], clobbers: PRegSet { bits: [65535, 65535, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0, try_call_info: None }
+;   call CallInfo { dest: PulleyCall { name: TestCase(%g), args: [XReg(p2i)] }, uses: [], defs: [], clobbers: PRegSet { bits: [65535, 4294967295, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0, try_call_info: None }
 ;   pop_frame
 ;   ret
 ;
@@ -118,7 +118,7 @@ block0(v0: i16):
 ;   push_frame
 ; block0:
 ;   sext16 x2, x0
-;   call CallInfo { dest: PulleyCall { name: TestCase(%g), args: [XReg(p2i)] }, uses: [], defs: [], clobbers: PRegSet { bits: [65535, 65535, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0, try_call_info: None }
+;   call CallInfo { dest: PulleyCall { name: TestCase(%g), args: [XReg(p2i)] }, uses: [], defs: [], clobbers: PRegSet { bits: [65535, 4294967295, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0, try_call_info: None }
 ;   pop_frame
 ;   ret
 ;
@@ -139,7 +139,7 @@ block0(v0: i32):
 ; VCode:
 ;   push_frame
 ; block0:
-;   call CallInfo { dest: PulleyCall { name: TestCase(%g), args: [XReg(p0i)] }, uses: [], defs: [], clobbers: PRegSet { bits: [65535, 65535, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0, try_call_info: None }
+;   call CallInfo { dest: PulleyCall { name: TestCase(%g), args: [XReg(p0i)] }, uses: [], defs: [], clobbers: PRegSet { bits: [65535, 4294967295, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0, try_call_info: None }
 ;   pop_frame
 ;   ret
 ;
@@ -159,7 +159,7 @@ block0(v0: i64):
 ; VCode:
 ;   push_frame
 ; block0:
-;   call CallInfo { dest: PulleyCall { name: TestCase(%g), args: [XReg(p0i)] }, uses: [], defs: [], clobbers: PRegSet { bits: [65535, 65535, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0, try_call_info: None }
+;   call CallInfo { dest: PulleyCall { name: TestCase(%g), args: [XReg(p0i)] }, uses: [], defs: [], clobbers: PRegSet { bits: [65535, 4294967295, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0, try_call_info: None }
 ;   pop_frame
 ;   ret
 ;

--- a/cranelift/filetests/filetests/isa/pulley64/call.clif
+++ b/cranelift/filetests/filetests/isa/pulley64/call.clif
@@ -16,7 +16,7 @@ block0:
 ;   push_frame
 ; block0:
 ;   xzero x2
-;   call CallInfo { dest: PulleyCall { name: TestCase(%g), args: [XReg(p2i)] }, uses: [], defs: [CallRetPair { vreg: Writable { reg: p0i }, location: Reg(p0i, types::I64) }], clobbers: PRegSet { bits: [65534, 65535, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0, try_call_info: None }
+;   call CallInfo { dest: PulleyCall { name: TestCase(%g), args: [XReg(p2i)] }, uses: [], defs: [CallRetPair { vreg: Writable { reg: p0i }, location: Reg(p0i, types::I64) }], clobbers: PRegSet { bits: [65534, 4294967295, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0, try_call_info: None }
 ;   xone x0
 ;   pop_frame
 ;   ret
@@ -43,7 +43,7 @@ block0:
 ;   push_frame
 ; block0:
 ;   xzero x2
-;   call CallInfo { dest: PulleyCall { name: TestCase(%g), args: [XReg(p2i)] }, uses: [], defs: [CallRetPair { vreg: Writable { reg: p0i }, location: Reg(p0i, types::I32) }], clobbers: PRegSet { bits: [65534, 65535, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0, try_call_info: None }
+;   call CallInfo { dest: PulleyCall { name: TestCase(%g), args: [XReg(p2i)] }, uses: [], defs: [CallRetPair { vreg: Writable { reg: p0i }, location: Reg(p0i, types::I32) }], clobbers: PRegSet { bits: [65534, 4294967295, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0, try_call_info: None }
 ;   xone x0
 ;   pop_frame
 ;   ret
@@ -75,7 +75,7 @@ block0:
 ;   xone x4
 ;   xconst8 x5, 2
 ;   xconst8 x6, 3
-;   call CallInfo { dest: PulleyCall { name: TestCase(%g), args: [XReg(p3i), XReg(p4i), XReg(p5i), XReg(p6i)] }, uses: [], defs: [], clobbers: PRegSet { bits: [65535, 65535, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0, try_call_info: None }
+;   call CallInfo { dest: PulleyCall { name: TestCase(%g), args: [XReg(p3i), XReg(p4i), XReg(p5i), XReg(p6i)] }, uses: [], defs: [], clobbers: PRegSet { bits: [65535, 4294967295, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0, try_call_info: None }
 ;   pop_frame
 ;   ret
 ;
@@ -103,7 +103,7 @@ block0:
 ; VCode:
 ;   push_frame
 ; block0:
-;   call CallInfo { dest: PulleyCall { name: TestCase(%g), args: [] }, uses: [], defs: [CallRetPair { vreg: Writable { reg: p0i }, location: Reg(p0i, types::I64) }, CallRetPair { vreg: Writable { reg: p1i }, location: Reg(p1i, types::I64) }, CallRetPair { vreg: Writable { reg: p2i }, location: Reg(p2i, types::I64) }, CallRetPair { vreg: Writable { reg: p3i }, location: Reg(p3i, types::I64) }], clobbers: PRegSet { bits: [65520, 65535, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0, try_call_info: None }
+;   call CallInfo { dest: PulleyCall { name: TestCase(%g), args: [] }, uses: [], defs: [CallRetPair { vreg: Writable { reg: p0i }, location: Reg(p0i, types::I64) }, CallRetPair { vreg: Writable { reg: p1i }, location: Reg(p1i, types::I64) }, CallRetPair { vreg: Writable { reg: p2i }, location: Reg(p2i, types::I64) }, CallRetPair { vreg: Writable { reg: p3i }, location: Reg(p3i, types::I64) }], clobbers: PRegSet { bits: [65520, 4294967295, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0, try_call_info: None }
 ;   xadd64 x4, x0, x2
 ;   xadd64 x3, x1, x3
 ;   xadd64 x0, x4, x3
@@ -149,7 +149,7 @@ block0:
 ;   xmov x11, x14
 ;   xmov x12, x14
 ;   xmov x13, x14
-;   call CallInfo { dest: PulleyCall { name: TestCase(%g), args: [XReg(p14i), XReg(p14i), XReg(p14i), XReg(p14i)] }, uses: [CallArgPair { vreg: p4i, preg: p4i }, CallArgPair { vreg: p5i, preg: p5i }, CallArgPair { vreg: p6i, preg: p6i }, CallArgPair { vreg: p7i, preg: p7i }, CallArgPair { vreg: p8i, preg: p8i }, CallArgPair { vreg: p9i, preg: p9i }, CallArgPair { vreg: p10i, preg: p10i }, CallArgPair { vreg: p11i, preg: p11i }, CallArgPair { vreg: p12i, preg: p12i }, CallArgPair { vreg: p13i, preg: p13i }, CallArgPair { vreg: p14i, preg: p14i }], defs: [], clobbers: PRegSet { bits: [65535, 65535, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0, try_call_info: None }
+;   call CallInfo { dest: PulleyCall { name: TestCase(%g), args: [XReg(p14i), XReg(p14i), XReg(p14i), XReg(p14i)] }, uses: [CallArgPair { vreg: p4i, preg: p4i }, CallArgPair { vreg: p5i, preg: p5i }, CallArgPair { vreg: p6i, preg: p6i }, CallArgPair { vreg: p7i, preg: p7i }, CallArgPair { vreg: p8i, preg: p8i }, CallArgPair { vreg: p9i, preg: p9i }, CallArgPair { vreg: p10i, preg: p10i }, CallArgPair { vreg: p11i, preg: p11i }, CallArgPair { vreg: p12i, preg: p12i }, CallArgPair { vreg: p13i, preg: p13i }, CallArgPair { vreg: p14i, preg: p14i }], defs: [], clobbers: PRegSet { bits: [65535, 4294967295, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0, try_call_info: None }
 ;   pop_frame_restore 64, {}
 ;   ret
 ;
@@ -217,7 +217,7 @@ block0:
 ;   push_frame_save 112, {x16, x17, x18, x19, x26, x27, x28, x29}
 ; block0:
 ;   x12 = load_addr OutgoingArg(0)
-;   call CallInfo { dest: PulleyCall { name: TestCase(%g), args: [XReg(p12i)] }, uses: [], defs: [CallRetPair { vreg: Writable { reg: p0i }, location: Reg(p0i, types::I64) }, CallRetPair { vreg: Writable { reg: p1i }, location: Reg(p1i, types::I64) }, CallRetPair { vreg: Writable { reg: p2i }, location: Reg(p2i, types::I64) }, CallRetPair { vreg: Writable { reg: p3i }, location: Reg(p3i, types::I64) }, CallRetPair { vreg: Writable { reg: p4i }, location: Reg(p4i, types::I64) }, CallRetPair { vreg: Writable { reg: p5i }, location: Reg(p5i, types::I64) }, CallRetPair { vreg: Writable { reg: p6i }, location: Reg(p6i, types::I64) }, CallRetPair { vreg: Writable { reg: p7i }, location: Reg(p7i, types::I64) }, CallRetPair { vreg: Writable { reg: p8i }, location: Reg(p8i, types::I64) }, CallRetPair { vreg: Writable { reg: p9i }, location: Reg(p9i, types::I64) }, CallRetPair { vreg: Writable { reg: p10i }, location: Reg(p10i, types::I64) }, CallRetPair { vreg: Writable { reg: p11i }, location: Reg(p11i, types::I64) }, CallRetPair { vreg: Writable { reg: p12i }, location: Reg(p12i, types::I64) }, CallRetPair { vreg: Writable { reg: p13i }, location: Reg(p13i, types::I64) }, CallRetPair { vreg: Writable { reg: p14i }, location: Reg(p14i, types::I64) }, CallRetPair { vreg: Writable { reg: p27i }, location: Stack(OutgoingArg(0), types::I64) }, CallRetPair { vreg: Writable { reg: p19i }, location: Stack(OutgoingArg(8), types::I64) }, CallRetPair { vreg: Writable { reg: p29i }, location: Stack(OutgoingArg(16), types::I64) }, CallRetPair { vreg: Writable { reg: p16i }, location: Stack(OutgoingArg(24), types::I64) }, CallRetPair { vreg: Writable { reg: p17i }, location: Stack(OutgoingArg(32), types::I64) }, CallRetPair { vreg: Writable { reg: p18i }, location: Stack(OutgoingArg(40), types::I64) }], clobbers: PRegSet { bits: [32768, 65535, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0, try_call_info: None }
+;   call CallInfo { dest: PulleyCall { name: TestCase(%g), args: [XReg(p12i)] }, uses: [], defs: [CallRetPair { vreg: Writable { reg: p0i }, location: Reg(p0i, types::I64) }, CallRetPair { vreg: Writable { reg: p1i }, location: Reg(p1i, types::I64) }, CallRetPair { vreg: Writable { reg: p2i }, location: Reg(p2i, types::I64) }, CallRetPair { vreg: Writable { reg: p3i }, location: Reg(p3i, types::I64) }, CallRetPair { vreg: Writable { reg: p4i }, location: Reg(p4i, types::I64) }, CallRetPair { vreg: Writable { reg: p5i }, location: Reg(p5i, types::I64) }, CallRetPair { vreg: Writable { reg: p6i }, location: Reg(p6i, types::I64) }, CallRetPair { vreg: Writable { reg: p7i }, location: Reg(p7i, types::I64) }, CallRetPair { vreg: Writable { reg: p8i }, location: Reg(p8i, types::I64) }, CallRetPair { vreg: Writable { reg: p9i }, location: Reg(p9i, types::I64) }, CallRetPair { vreg: Writable { reg: p10i }, location: Reg(p10i, types::I64) }, CallRetPair { vreg: Writable { reg: p11i }, location: Reg(p11i, types::I64) }, CallRetPair { vreg: Writable { reg: p12i }, location: Reg(p12i, types::I64) }, CallRetPair { vreg: Writable { reg: p13i }, location: Reg(p13i, types::I64) }, CallRetPair { vreg: Writable { reg: p14i }, location: Reg(p14i, types::I64) }, CallRetPair { vreg: Writable { reg: p27i }, location: Stack(OutgoingArg(0), types::I64) }, CallRetPair { vreg: Writable { reg: p19i }, location: Stack(OutgoingArg(8), types::I64) }, CallRetPair { vreg: Writable { reg: p29i }, location: Stack(OutgoingArg(16), types::I64) }, CallRetPair { vreg: Writable { reg: p16i }, location: Stack(OutgoingArg(24), types::I64) }, CallRetPair { vreg: Writable { reg: p17i }, location: Stack(OutgoingArg(32), types::I64) }, CallRetPair { vreg: Writable { reg: p18i }, location: Stack(OutgoingArg(40), types::I64) }], clobbers: PRegSet { bits: [32768, 4294967295, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0, try_call_info: None }
 ;   xadd64 x26, x0, x1
 ;   xadd64 x28, x2, x3
 ;   xadd64 x2, x4, x5
@@ -291,7 +291,7 @@ block0(v0: i64):
 ; VCode:
 ;   push_frame
 ; block0:
-;   indirect_call x0, CallInfo { dest: XReg(p0i), uses: [], defs: [CallRetPair { vreg: Writable { reg: p0i }, location: Reg(p0i, types::I64) }], clobbers: PRegSet { bits: [65534, 65535, 4294967295, 0] }, callee_conv: Tail, caller_conv: Fast, callee_pop_size: 0, try_call_info: None }
+;   indirect_call x0, CallInfo { dest: XReg(p0i), uses: [], defs: [CallRetPair { vreg: Writable { reg: p0i }, location: Reg(p0i, types::I64) }], clobbers: PRegSet { bits: [65534, 4294967295, 4294967295, 0] }, callee_conv: Tail, caller_conv: Fast, callee_pop_size: 0, try_call_info: None }
 ;   pop_frame
 ;   ret
 ;
@@ -341,7 +341,7 @@ block0:
 ;   xmov x11, x14
 ;   xmov x12, x14
 ;   xmov x13, x14
-;   call CallInfo { dest: PulleyCall { name: TestCase(%g), args: [XReg(p14i), XReg(p14i), XReg(p14i), XReg(p14i)] }, uses: [CallArgPair { vreg: p4i, preg: p4i }, CallArgPair { vreg: p5i, preg: p5i }, CallArgPair { vreg: p6i, preg: p6i }, CallArgPair { vreg: p7i, preg: p7i }, CallArgPair { vreg: p8i, preg: p8i }, CallArgPair { vreg: p9i, preg: p9i }, CallArgPair { vreg: p10i, preg: p10i }, CallArgPair { vreg: p11i, preg: p11i }, CallArgPair { vreg: p12i, preg: p12i }, CallArgPair { vreg: p13i, preg: p13i }, CallArgPair { vreg: p14i, preg: p14i }], defs: [], clobbers: PRegSet { bits: [65535, 65535, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0, try_call_info: None }
+;   call CallInfo { dest: PulleyCall { name: TestCase(%g), args: [XReg(p14i), XReg(p14i), XReg(p14i), XReg(p14i)] }, uses: [CallArgPair { vreg: p4i, preg: p4i }, CallArgPair { vreg: p5i, preg: p5i }, CallArgPair { vreg: p6i, preg: p6i }, CallArgPair { vreg: p7i, preg: p7i }, CallArgPair { vreg: p8i, preg: p8i }, CallArgPair { vreg: p9i, preg: p9i }, CallArgPair { vreg: p10i, preg: p10i }, CallArgPair { vreg: p11i, preg: p11i }, CallArgPair { vreg: p12i, preg: p12i }, CallArgPair { vreg: p13i, preg: p13i }, CallArgPair { vreg: p14i, preg: p14i }], defs: [], clobbers: PRegSet { bits: [65535, 4294967295, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0, try_call_info: None }
 ;   pop_frame_restore 80, {}
 ;   ret
 ;
@@ -387,7 +387,7 @@ block0(v0: i32):
 ;   xstore64 sp+1000008, x20 // flags =  notrap aligned
 ; block0:
 ;   xmov x20, x0
-;   call CallInfo { dest: PulleyCall { name: TestCase(%g), args: [] }, uses: [], defs: [CallRetPair { vreg: Writable { reg: p0i }, location: Reg(p0i, types::I32) }], clobbers: PRegSet { bits: [65534, 65535, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0, try_call_info: None }
+;   call CallInfo { dest: PulleyCall { name: TestCase(%g), args: [] }, uses: [], defs: [CallRetPair { vreg: Writable { reg: p0i }, location: Reg(p0i, types::I32) }], clobbers: PRegSet { bits: [65534, 4294967295, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0, try_call_info: None }
 ;   xmov x5, x20
 ;   xadd32 x0, x5, x0
 ;   x20 = xload64 sp+1000008 // flags = notrap aligned

--- a/cranelift/filetests/filetests/isa/pulley64/call_indirect_host.clif
+++ b/cranelift/filetests/filetests/isa/pulley64/call_indirect_host.clif
@@ -11,7 +11,7 @@ block0:
 ; VCode:
 ;   push_frame
 ; block0:
-;   indirect_call_host CallInfo { dest: User(userextname0), uses: [], defs: [], clobbers: PRegSet { bits: [65535, 65535, 4294967295, 0] }, callee_conv: SystemV, caller_conv: Fast, callee_pop_size: 0, try_call_info: None }
+;   indirect_call_host CallInfo { dest: User(userextname0), uses: [], defs: [], clobbers: PRegSet { bits: [65535, 4294967295, 4294967295, 0] }, callee_conv: SystemV, caller_conv: Fast, callee_pop_size: 0, try_call_info: None }
 ;   pop_frame
 ;   ret
 ;

--- a/cranelift/filetests/filetests/isa/pulley64/exceptions.clif
+++ b/cranelift/filetests/filetests/isa/pulley64/exceptions.clif
@@ -21,23 +21,7 @@ function %f0(i32) -> i32, f32, f64 {
 }
 
 ; VCode:
-;   push_frame_save 272, {x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0}
-;   fstore64 sp+136, f16 // flags =  notrap aligned
-;   fstore64 sp+128, f17 // flags =  notrap aligned
-;   fstore64 sp+120, f18 // flags =  notrap aligned
-;   fstore64 sp+112, f19 // flags =  notrap aligned
-;   fstore64 sp+104, f20 // flags =  notrap aligned
-;   fstore64 sp+96, f21 // flags =  notrap aligned
-;   fstore64 sp+88, f22 // flags =  notrap aligned
-;   fstore64 sp+80, f23 // flags =  notrap aligned
-;   fstore64 sp+72, f24 // flags =  notrap aligned
-;   fstore64 sp+64, f25 // flags =  notrap aligned
-;   fstore64 sp+56, f26 // flags =  notrap aligned
-;   fstore64 sp+48, f27 // flags =  notrap aligned
-;   fstore64 sp+40, f28 // flags =  notrap aligned
-;   fstore64 sp+32, f29 // flags =  notrap aligned
-;   fstore64 sp+24, f30 // flags =  notrap aligned
-;   fstore64 sp+16, f31 // flags =  notrap aligned
+;   push_frame_save 144, {x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0}
 ; block0:
 ;   fconst64 f1, 4607182418800017408
 ;   fstore64 Slot(0), f1 // flags =  notrap aligned
@@ -45,108 +29,28 @@ function %f0(i32) -> i32, f32, f64 {
 ; block1:
 ;   xone x0
 ;   f1 = fload64 Slot(0) // flags = notrap aligned
-;   f16 = fload64 sp+136 // flags = notrap aligned
-;   f17 = fload64 sp+128 // flags = notrap aligned
-;   f18 = fload64 sp+120 // flags = notrap aligned
-;   f19 = fload64 sp+112 // flags = notrap aligned
-;   f20 = fload64 sp+104 // flags = notrap aligned
-;   f21 = fload64 sp+96 // flags = notrap aligned
-;   f22 = fload64 sp+88 // flags = notrap aligned
-;   f23 = fload64 sp+80 // flags = notrap aligned
-;   f24 = fload64 sp+72 // flags = notrap aligned
-;   f25 = fload64 sp+64 // flags = notrap aligned
-;   f26 = fload64 sp+56 // flags = notrap aligned
-;   f27 = fload64 sp+48 // flags = notrap aligned
-;   f28 = fload64 sp+40 // flags = notrap aligned
-;   f29 = fload64 sp+32 // flags = notrap aligned
-;   f30 = fload64 sp+24 // flags = notrap aligned
-;   f31 = fload64 sp+16 // flags = notrap aligned
-;   pop_frame_restore 272, {x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0}
+;   pop_frame_restore 144, {x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0}
 ;   ret
 ; block2:
 ;   f1 = fload64 Slot(0) // flags = notrap aligned
 ;   xadd32_u8 x0, x0, 1
 ;   fconst32 f0, 0
-;   f16 = fload64 sp+136 // flags = notrap aligned
-;   f17 = fload64 sp+128 // flags = notrap aligned
-;   f18 = fload64 sp+120 // flags = notrap aligned
-;   f19 = fload64 sp+112 // flags = notrap aligned
-;   f20 = fload64 sp+104 // flags = notrap aligned
-;   f21 = fload64 sp+96 // flags = notrap aligned
-;   f22 = fload64 sp+88 // flags = notrap aligned
-;   f23 = fload64 sp+80 // flags = notrap aligned
-;   f24 = fload64 sp+72 // flags = notrap aligned
-;   f25 = fload64 sp+64 // flags = notrap aligned
-;   f26 = fload64 sp+56 // flags = notrap aligned
-;   f27 = fload64 sp+48 // flags = notrap aligned
-;   f28 = fload64 sp+40 // flags = notrap aligned
-;   f29 = fload64 sp+32 // flags = notrap aligned
-;   f30 = fload64 sp+24 // flags = notrap aligned
-;   f31 = fload64 sp+16 // flags = notrap aligned
-;   pop_frame_restore 272, {x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0}
+;   pop_frame_restore 144, {x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0}
 ;   ret
 ;
 ; Disassembled:
-; push_frame_save 272, x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0
-; fstore64le_o32 sp, 136, f16
-; fstore64le_o32 sp, 128, f17
-; fstore64le_o32 sp, 120, f18
-; fstore64le_o32 sp, 112, f19
-; fstore64le_o32 sp, 104, f20
-; fstore64le_o32 sp, 96, f21
-; fstore64le_o32 sp, 88, f22
-; fstore64le_o32 sp, 80, f23
-; fstore64le_o32 sp, 72, f24
-; fstore64le_o32 sp, 64, f25
-; fstore64le_o32 sp, 56, f26
-; fstore64le_o32 sp, 48, f27
-; fstore64le_o32 sp, 40, f28
-; fstore64le_o32 sp, 32, f29
-; fstore64le_o32 sp, 24, f30
-; fstore64le_o32 sp, 16, f31
+; push_frame_save 144, x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0
 ; fconst64 f1, 4607182418800017408
 ; fstore64le_o32 sp, 0, f1
-; call 0x0    // target = 0xaa
+; call 0x0    // target = 0x1a
 ; xone x0
 ; fload64le_o32 f1, sp, 0
-; fload64le_o32 f16, sp, 136
-; fload64le_o32 f17, sp, 128
-; fload64le_o32 f18, sp, 120
-; fload64le_o32 f19, sp, 112
-; fload64le_o32 f20, sp, 104
-; fload64le_o32 f21, sp, 96
-; fload64le_o32 f22, sp, 88
-; fload64le_o32 f23, sp, 80
-; fload64le_o32 f24, sp, 72
-; fload64le_o32 f25, sp, 64
-; fload64le_o32 f26, sp, 56
-; fload64le_o32 f27, sp, 48
-; fload64le_o32 f28, sp, 40
-; fload64le_o32 f29, sp, 32
-; fload64le_o32 f30, sp, 24
-; fload64le_o32 f31, sp, 16
-; pop_frame_restore 272, x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0
+; pop_frame_restore 144, x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0
 ; ret
 ; fload64le_o32 f1, sp, 0
 ; xadd32_u8 x0, x0, 1
 ; fconst32 f0, 0
-; fload64le_o32 f16, sp, 136
-; fload64le_o32 f17, sp, 128
-; fload64le_o32 f18, sp, 120
-; fload64le_o32 f19, sp, 112
-; fload64le_o32 f20, sp, 104
-; fload64le_o32 f21, sp, 96
-; fload64le_o32 f22, sp, 88
-; fload64le_o32 f23, sp, 80
-; fload64le_o32 f24, sp, 72
-; fload64le_o32 f25, sp, 64
-; fload64le_o32 f26, sp, 56
-; fload64le_o32 f27, sp, 48
-; fload64le_o32 f28, sp, 40
-; fload64le_o32 f29, sp, 32
-; fload64le_o32 f30, sp, 24
-; fload64le_o32 f31, sp, 16
-; pop_frame_restore 272, x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0
+; pop_frame_restore 144, x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0
 ; ret
 
 function %f2(i32, i64) -> i32, f32, f64 {
@@ -169,23 +73,7 @@ function %f2(i32, i64) -> i32, f32, f64 {
 }
 
 ; VCode:
-;   push_frame_save 272, {x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0}
-;   fstore64 sp+136, f16 // flags =  notrap aligned
-;   fstore64 sp+128, f17 // flags =  notrap aligned
-;   fstore64 sp+120, f18 // flags =  notrap aligned
-;   fstore64 sp+112, f19 // flags =  notrap aligned
-;   fstore64 sp+104, f20 // flags =  notrap aligned
-;   fstore64 sp+96, f21 // flags =  notrap aligned
-;   fstore64 sp+88, f22 // flags =  notrap aligned
-;   fstore64 sp+80, f23 // flags =  notrap aligned
-;   fstore64 sp+72, f24 // flags =  notrap aligned
-;   fstore64 sp+64, f25 // flags =  notrap aligned
-;   fstore64 sp+56, f26 // flags =  notrap aligned
-;   fstore64 sp+48, f27 // flags =  notrap aligned
-;   fstore64 sp+40, f28 // flags =  notrap aligned
-;   fstore64 sp+32, f29 // flags =  notrap aligned
-;   fstore64 sp+24, f30 // flags =  notrap aligned
-;   fstore64 sp+16, f31 // flags =  notrap aligned
+;   push_frame_save 144, {x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0}
 ; block0:
 ;   fconst64 f1, 4607182418800017408
 ;   fstore64 Slot(0), f1 // flags =  notrap aligned
@@ -193,108 +81,28 @@ function %f2(i32, i64) -> i32, f32, f64 {
 ; block1:
 ;   xone x0
 ;   f1 = fload64 Slot(0) // flags = notrap aligned
-;   f16 = fload64 sp+136 // flags = notrap aligned
-;   f17 = fload64 sp+128 // flags = notrap aligned
-;   f18 = fload64 sp+120 // flags = notrap aligned
-;   f19 = fload64 sp+112 // flags = notrap aligned
-;   f20 = fload64 sp+104 // flags = notrap aligned
-;   f21 = fload64 sp+96 // flags = notrap aligned
-;   f22 = fload64 sp+88 // flags = notrap aligned
-;   f23 = fload64 sp+80 // flags = notrap aligned
-;   f24 = fload64 sp+72 // flags = notrap aligned
-;   f25 = fload64 sp+64 // flags = notrap aligned
-;   f26 = fload64 sp+56 // flags = notrap aligned
-;   f27 = fload64 sp+48 // flags = notrap aligned
-;   f28 = fload64 sp+40 // flags = notrap aligned
-;   f29 = fload64 sp+32 // flags = notrap aligned
-;   f30 = fload64 sp+24 // flags = notrap aligned
-;   f31 = fload64 sp+16 // flags = notrap aligned
-;   pop_frame_restore 272, {x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0}
+;   pop_frame_restore 144, {x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0}
 ;   ret
 ; block2:
 ;   f1 = fload64 Slot(0) // flags = notrap aligned
 ;   xadd32_u8 x0, x0, 1
 ;   fconst32 f0, 0
-;   f16 = fload64 sp+136 // flags = notrap aligned
-;   f17 = fload64 sp+128 // flags = notrap aligned
-;   f18 = fload64 sp+120 // flags = notrap aligned
-;   f19 = fload64 sp+112 // flags = notrap aligned
-;   f20 = fload64 sp+104 // flags = notrap aligned
-;   f21 = fload64 sp+96 // flags = notrap aligned
-;   f22 = fload64 sp+88 // flags = notrap aligned
-;   f23 = fload64 sp+80 // flags = notrap aligned
-;   f24 = fload64 sp+72 // flags = notrap aligned
-;   f25 = fload64 sp+64 // flags = notrap aligned
-;   f26 = fload64 sp+56 // flags = notrap aligned
-;   f27 = fload64 sp+48 // flags = notrap aligned
-;   f28 = fload64 sp+40 // flags = notrap aligned
-;   f29 = fload64 sp+32 // flags = notrap aligned
-;   f30 = fload64 sp+24 // flags = notrap aligned
-;   f31 = fload64 sp+16 // flags = notrap aligned
-;   pop_frame_restore 272, {x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0}
+;   pop_frame_restore 144, {x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0}
 ;   ret
 ;
 ; Disassembled:
-; push_frame_save 272, x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0
-; fstore64le_o32 sp, 136, f16
-; fstore64le_o32 sp, 128, f17
-; fstore64le_o32 sp, 120, f18
-; fstore64le_o32 sp, 112, f19
-; fstore64le_o32 sp, 104, f20
-; fstore64le_o32 sp, 96, f21
-; fstore64le_o32 sp, 88, f22
-; fstore64le_o32 sp, 80, f23
-; fstore64le_o32 sp, 72, f24
-; fstore64le_o32 sp, 64, f25
-; fstore64le_o32 sp, 56, f26
-; fstore64le_o32 sp, 48, f27
-; fstore64le_o32 sp, 40, f28
-; fstore64le_o32 sp, 32, f29
-; fstore64le_o32 sp, 24, f30
-; fstore64le_o32 sp, 16, f31
+; push_frame_save 144, x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0
 ; fconst64 f1, 4607182418800017408
 ; fstore64le_o32 sp, 0, f1
 ; call_indirect x1
 ; xone x0
 ; fload64le_o32 f1, sp, 0
-; fload64le_o32 f16, sp, 136
-; fload64le_o32 f17, sp, 128
-; fload64le_o32 f18, sp, 120
-; fload64le_o32 f19, sp, 112
-; fload64le_o32 f20, sp, 104
-; fload64le_o32 f21, sp, 96
-; fload64le_o32 f22, sp, 88
-; fload64le_o32 f23, sp, 80
-; fload64le_o32 f24, sp, 72
-; fload64le_o32 f25, sp, 64
-; fload64le_o32 f26, sp, 56
-; fload64le_o32 f27, sp, 48
-; fload64le_o32 f28, sp, 40
-; fload64le_o32 f29, sp, 32
-; fload64le_o32 f30, sp, 24
-; fload64le_o32 f31, sp, 16
-; pop_frame_restore 272, x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0
+; pop_frame_restore 144, x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0
 ; ret
 ; fload64le_o32 f1, sp, 0
 ; xadd32_u8 x0, x0, 1
 ; fconst32 f0, 0
-; fload64le_o32 f16, sp, 136
-; fload64le_o32 f17, sp, 128
-; fload64le_o32 f18, sp, 120
-; fload64le_o32 f19, sp, 112
-; fload64le_o32 f20, sp, 104
-; fload64le_o32 f21, sp, 96
-; fload64le_o32 f22, sp, 88
-; fload64le_o32 f23, sp, 80
-; fload64le_o32 f24, sp, 72
-; fload64le_o32 f25, sp, 64
-; fload64le_o32 f26, sp, 56
-; fload64le_o32 f27, sp, 48
-; fload64le_o32 f28, sp, 40
-; fload64le_o32 f29, sp, 32
-; fload64le_o32 f30, sp, 24
-; fload64le_o32 f31, sp, 16
-; pop_frame_restore 272, x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0
+; pop_frame_restore 144, x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0
 ; ret
 
 function %f4(i64, i32) -> i32, f32, f64 {
@@ -320,23 +128,7 @@ function %f4(i64, i32) -> i32, f32, f64 {
 }
 
 ; VCode:
-;   push_frame_save 288, {x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0}
-;   fstore64 sp+152, f16 // flags =  notrap aligned
-;   fstore64 sp+144, f17 // flags =  notrap aligned
-;   fstore64 sp+136, f18 // flags =  notrap aligned
-;   fstore64 sp+128, f19 // flags =  notrap aligned
-;   fstore64 sp+120, f20 // flags =  notrap aligned
-;   fstore64 sp+112, f21 // flags =  notrap aligned
-;   fstore64 sp+104, f22 // flags =  notrap aligned
-;   fstore64 sp+96, f23 // flags =  notrap aligned
-;   fstore64 sp+88, f24 // flags =  notrap aligned
-;   fstore64 sp+80, f25 // flags =  notrap aligned
-;   fstore64 sp+72, f26 // flags =  notrap aligned
-;   fstore64 sp+64, f27 // flags =  notrap aligned
-;   fstore64 sp+56, f28 // flags =  notrap aligned
-;   fstore64 sp+48, f29 // flags =  notrap aligned
-;   fstore64 sp+40, f30 // flags =  notrap aligned
-;   fstore64 sp+32, f31 // flags =  notrap aligned
+;   push_frame_save 160, {x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0}
 ; block0:
 ;   xstore64 Slot(8), x0 // flags =  notrap aligned
 ;   fconst64 f1, 4607182418800017408
@@ -355,23 +147,7 @@ function %f4(i64, i32) -> i32, f32, f64 {
 ; block3:
 ;   xone x0
 ;   f1 = fload64 Slot(16) // flags = notrap aligned
-;   f16 = fload64 sp+152 // flags = notrap aligned
-;   f17 = fload64 sp+144 // flags = notrap aligned
-;   f18 = fload64 sp+136 // flags = notrap aligned
-;   f19 = fload64 sp+128 // flags = notrap aligned
-;   f20 = fload64 sp+120 // flags = notrap aligned
-;   f21 = fload64 sp+112 // flags = notrap aligned
-;   f22 = fload64 sp+104 // flags = notrap aligned
-;   f23 = fload64 sp+96 // flags = notrap aligned
-;   f24 = fload64 sp+88 // flags = notrap aligned
-;   f25 = fload64 sp+80 // flags = notrap aligned
-;   f26 = fload64 sp+72 // flags = notrap aligned
-;   f27 = fload64 sp+64 // flags = notrap aligned
-;   f28 = fload64 sp+56 // flags = notrap aligned
-;   f29 = fload64 sp+48 // flags = notrap aligned
-;   f30 = fload64 sp+40 // flags = notrap aligned
-;   f31 = fload64 sp+32 // flags = notrap aligned
-;   pop_frame_restore 288, {x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0}
+;   pop_frame_restore 160, {x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0}
 ;   ret
 ; block4:
 ;   f1 = fload64 Slot(16) // flags = notrap aligned
@@ -380,43 +156,11 @@ function %f4(i64, i32) -> i32, f32, f64 {
 ; block5:
 ;   xadd32_u8 x0, x2, 1
 ;   fconst32 f0, 0
-;   f16 = fload64 sp+152 // flags = notrap aligned
-;   f17 = fload64 sp+144 // flags = notrap aligned
-;   f18 = fload64 sp+136 // flags = notrap aligned
-;   f19 = fload64 sp+128 // flags = notrap aligned
-;   f20 = fload64 sp+120 // flags = notrap aligned
-;   f21 = fload64 sp+112 // flags = notrap aligned
-;   f22 = fload64 sp+104 // flags = notrap aligned
-;   f23 = fload64 sp+96 // flags = notrap aligned
-;   f24 = fload64 sp+88 // flags = notrap aligned
-;   f25 = fload64 sp+80 // flags = notrap aligned
-;   f26 = fload64 sp+72 // flags = notrap aligned
-;   f27 = fload64 sp+64 // flags = notrap aligned
-;   f28 = fload64 sp+56 // flags = notrap aligned
-;   f29 = fload64 sp+48 // flags = notrap aligned
-;   f30 = fload64 sp+40 // flags = notrap aligned
-;   f31 = fload64 sp+32 // flags = notrap aligned
-;   pop_frame_restore 288, {x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0}
+;   pop_frame_restore 160, {x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0}
 ;   ret
 ;
 ; Disassembled:
-; push_frame_save 288, x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0
-; fstore64le_o32 sp, 152, f16
-; fstore64le_o32 sp, 144, f17
-; fstore64le_o32 sp, 136, f18
-; fstore64le_o32 sp, 128, f19
-; fstore64le_o32 sp, 120, f20
-; fstore64le_o32 sp, 112, f21
-; fstore64le_o32 sp, 104, f22
-; fstore64le_o32 sp, 96, f23
-; fstore64le_o32 sp, 88, f24
-; fstore64le_o32 sp, 80, f25
-; fstore64le_o32 sp, 72, f26
-; fstore64le_o32 sp, 64, f27
-; fstore64le_o32 sp, 56, f28
-; fstore64le_o32 sp, 48, f29
-; fstore64le_o32 sp, 40, f30
-; fstore64le_o32 sp, 32, f31
+; push_frame_save 160, x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0
 ; xstore64le_o32 sp, 8, x0
 ; fconst64 f1, 4607182418800017408
 ; xmov x0, x1
@@ -425,50 +169,18 @@ function %f4(i64, i32) -> i32, f32, f64 {
 ; call_indirect_host 0
 ; xmov x2, x0
 ; fload64le_o32 f1, sp, 16
-; jump 0xc7    // target = 0x192
+; jump 0x37    // target = 0x72
 ; xmov x2, x0
 ; fload64le_o32 f1, sp, 16
-; jump 0xb6    // target = 0x192
+; jump 0x26    // target = 0x72
 ; xone x0
 ; fload64le_o32 f1, sp, 16
-; fload64le_o32 f16, sp, 152
-; fload64le_o32 f17, sp, 144
-; fload64le_o32 f18, sp, 136
-; fload64le_o32 f19, sp, 128
-; fload64le_o32 f20, sp, 120
-; fload64le_o32 f21, sp, 112
-; fload64le_o32 f22, sp, 104
-; fload64le_o32 f23, sp, 96
-; fload64le_o32 f24, sp, 88
-; fload64le_o32 f25, sp, 80
-; fload64le_o32 f26, sp, 72
-; fload64le_o32 f27, sp, 64
-; fload64le_o32 f28, sp, 56
-; fload64le_o32 f29, sp, 48
-; fload64le_o32 f30, sp, 40
-; fload64le_o32 f31, sp, 32
-; pop_frame_restore 288, x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0
+; pop_frame_restore 160, x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0
 ; ret
 ; fload64le_o32 f1, sp, 16
 ; xload64le_o32 x2, sp, 8
 ; xadd32_u8 x0, x2, 1
 ; fconst32 f0, 0
-; fload64le_o32 f16, sp, 152
-; fload64le_o32 f17, sp, 144
-; fload64le_o32 f18, sp, 136
-; fload64le_o32 f19, sp, 128
-; fload64le_o32 f20, sp, 120
-; fload64le_o32 f21, sp, 112
-; fload64le_o32 f22, sp, 104
-; fload64le_o32 f23, sp, 96
-; fload64le_o32 f24, sp, 88
-; fload64le_o32 f25, sp, 80
-; fload64le_o32 f26, sp, 72
-; fload64le_o32 f27, sp, 64
-; fload64le_o32 f28, sp, 56
-; fload64le_o32 f29, sp, 48
-; fload64le_o32 f30, sp, 40
-; fload64le_o32 f31, sp, 32
-; pop_frame_restore 288, x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0
+; pop_frame_restore 160, x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0
 ; ret
 

--- a/cranelift/filetests/filetests/isa/pulley64/extend.clif
+++ b/cranelift/filetests/filetests/isa/pulley64/extend.clif
@@ -12,7 +12,7 @@ block0(v0: i8):
 ;   push_frame
 ; block0:
 ;   zext8 x2, x0
-;   call CallInfo { dest: PulleyCall { name: TestCase(%g), args: [XReg(p2i)] }, uses: [], defs: [], clobbers: PRegSet { bits: [65535, 65535, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0, try_call_info: None }
+;   call CallInfo { dest: PulleyCall { name: TestCase(%g), args: [XReg(p2i)] }, uses: [], defs: [], clobbers: PRegSet { bits: [65535, 4294967295, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0, try_call_info: None }
 ;   pop_frame
 ;   ret
 ;
@@ -34,7 +34,7 @@ block0(v0: i16):
 ;   push_frame
 ; block0:
 ;   zext16 x2, x0
-;   call CallInfo { dest: PulleyCall { name: TestCase(%g), args: [XReg(p2i)] }, uses: [], defs: [], clobbers: PRegSet { bits: [65535, 65535, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0, try_call_info: None }
+;   call CallInfo { dest: PulleyCall { name: TestCase(%g), args: [XReg(p2i)] }, uses: [], defs: [], clobbers: PRegSet { bits: [65535, 4294967295, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0, try_call_info: None }
 ;   pop_frame
 ;   ret
 ;
@@ -56,7 +56,7 @@ block0(v0: i32):
 ;   push_frame
 ; block0:
 ;   zext32 x2, x0
-;   call CallInfo { dest: PulleyCall { name: TestCase(%g), args: [XReg(p2i)] }, uses: [], defs: [], clobbers: PRegSet { bits: [65535, 65535, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0, try_call_info: None }
+;   call CallInfo { dest: PulleyCall { name: TestCase(%g), args: [XReg(p2i)] }, uses: [], defs: [], clobbers: PRegSet { bits: [65535, 4294967295, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0, try_call_info: None }
 ;   pop_frame
 ;   ret
 ;
@@ -77,7 +77,7 @@ block0(v0: i64):
 ; VCode:
 ;   push_frame
 ; block0:
-;   call CallInfo { dest: PulleyCall { name: TestCase(%g), args: [XReg(p0i)] }, uses: [], defs: [], clobbers: PRegSet { bits: [65535, 65535, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0, try_call_info: None }
+;   call CallInfo { dest: PulleyCall { name: TestCase(%g), args: [XReg(p0i)] }, uses: [], defs: [], clobbers: PRegSet { bits: [65535, 4294967295, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0, try_call_info: None }
 ;   pop_frame
 ;   ret
 ;
@@ -98,7 +98,7 @@ block0(v0: i8):
 ;   push_frame
 ; block0:
 ;   sext8 x2, x0
-;   call CallInfo { dest: PulleyCall { name: TestCase(%g), args: [XReg(p2i)] }, uses: [], defs: [], clobbers: PRegSet { bits: [65535, 65535, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0, try_call_info: None }
+;   call CallInfo { dest: PulleyCall { name: TestCase(%g), args: [XReg(p2i)] }, uses: [], defs: [], clobbers: PRegSet { bits: [65535, 4294967295, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0, try_call_info: None }
 ;   pop_frame
 ;   ret
 ;
@@ -120,7 +120,7 @@ block0(v0: i16):
 ;   push_frame
 ; block0:
 ;   sext16 x2, x0
-;   call CallInfo { dest: PulleyCall { name: TestCase(%g), args: [XReg(p2i)] }, uses: [], defs: [], clobbers: PRegSet { bits: [65535, 65535, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0, try_call_info: None }
+;   call CallInfo { dest: PulleyCall { name: TestCase(%g), args: [XReg(p2i)] }, uses: [], defs: [], clobbers: PRegSet { bits: [65535, 4294967295, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0, try_call_info: None }
 ;   pop_frame
 ;   ret
 ;
@@ -142,7 +142,7 @@ block0(v0: i32):
 ;   push_frame
 ; block0:
 ;   sext32 x2, x0
-;   call CallInfo { dest: PulleyCall { name: TestCase(%g), args: [XReg(p2i)] }, uses: [], defs: [], clobbers: PRegSet { bits: [65535, 65535, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0, try_call_info: None }
+;   call CallInfo { dest: PulleyCall { name: TestCase(%g), args: [XReg(p2i)] }, uses: [], defs: [], clobbers: PRegSet { bits: [65535, 4294967295, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0, try_call_info: None }
 ;   pop_frame
 ;   ret
 ;
@@ -163,7 +163,7 @@ block0(v0: i64):
 ; VCode:
 ;   push_frame
 ; block0:
-;   call CallInfo { dest: PulleyCall { name: TestCase(%g), args: [XReg(p0i)] }, uses: [], defs: [], clobbers: PRegSet { bits: [65535, 65535, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0, try_call_info: None }
+;   call CallInfo { dest: PulleyCall { name: TestCase(%g), args: [XReg(p0i)] }, uses: [], defs: [], clobbers: PRegSet { bits: [65535, 4294967295, 4294967295, 0] }, callee_conv: Fast, caller_conv: Fast, callee_pop_size: 0, try_call_info: None }
 ;   pop_frame
 ;   ret
 ;


### PR DESCRIPTION
This commit updates the ABI used by Pulley to consider all float register as caller-saved instead of the previous classification which was a split half/half. This change means that when exceptions are used, for example, only the upper X registers need to be saved instead of the upper F registers as well. This mirrors the x64 ABI for example which clobbers all float registers on SystemV variants.

The motivation for this commit is to shrink the generated bytecode for exception-using functions. Clobbering all X registers has special support in the `push_frame_save` and `pop_frame_restore` opcodes where the registers to save are a bitmask. With floats a separate instruction-per-register is needed. While it's possible to add a macro opcode to handle floats as well it was easier to update the ABI to match x64. Basically I figure that if the ABI is good enough for x64 it's probably fine for Pulley which already doesn't have great float performance (all float ops are "extended opcodes").

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
