### PR TITLE
chore(wasi-io): Set max chunk size for blocking writes to 64kb

### DIFF
--- a/crates/wasi-io/src/impls.rs
+++ b/crates/wasi-io/src/impls.rs
@@ -141,9 +141,9 @@ impl streams::HostOutputStream for ResourceTable {
         stream: Resource<DynOutputStream>,
         bytes: Vec<u8>,
     ) -> StreamResult<()> {
-        if bytes.len() > 4096 {
+        if bytes.len() > 65536 {
             return Err(StreamError::trap(
-                "Buffer too large for blocking-write-and-flush (expected at most 4096)",
+                "Buffer too large for blocking-write-and-flush (expected at most 65536)",
             ));
         }
 
@@ -157,9 +157,9 @@ impl streams::HostOutputStream for ResourceTable {
         stream: Resource<DynOutputStream>,
         len: u64,
     ) -> StreamResult<()> {
-        if len > 4096 {
+        if len > 65536 {
             return Err(StreamError::trap(
-                "Buffer too large for blocking-write-zeroes-and-flush (expected at most 4096)",
+                "Buffer too large for blocking-write-zeroes-and-flush (expected at most 65536)",
             ));
         }
 


### PR DESCRIPTION
While moving vast amounts of data using `wasi:io` streams, we found the existing max chunk size of 4KB adding a lot of overhead. To reduce the number of chunks that one must create, this PR changes the max chunk size from 4KB to 64KB for all blocking write operations.

Here a simple table outlining how many chunks are required based on max chunk size being either 4KB or 64KB:

| File Size | No. of Chunks (4 KB) | No. of Chunks (64 KB)
| -- | -- | -- |
| 16 KB | 4 | 1 |
| 100 KB | 25 | 2 |
| 1 MB | 256 | 16 |
| 10 MB | 2,560 | 160 |
| 100 MB | 25,600 | 1,600 |
| 1 GB | 262,144 | 16,384 |
| 10 GB | 2,621,440 | 163,840 |
| 100 GB | 26,214,400 | 1,638,400 |


I'll leave this in a draft state for now and will collect additional data on performance improvements
