### PR TITLE
Make some WASI types public

### DIFF
--- a/crates/wasi/src/cli.rs
+++ b/crates/wasi/src/cli.rs
@@ -20,7 +20,7 @@ pub use self::locked_async::{AsyncStdinStream, AsyncStdoutStream};
 #[doc(no_inline)]
 pub use tokio::io::{Stderr, Stdin, Stdout, stderr, stdin, stdout};
 
-pub(crate) struct WasiCli;
+pub struct WasiCli;
 
 impl HasData for WasiCli {
     type Data<'a> = WasiCliCtxView<'a>;

--- a/crates/wasi/src/clocks.rs
+++ b/crates/wasi/src/clocks.rs
@@ -3,7 +3,7 @@ use cap_std::{AmbientAuthority, ambient_authority};
 use cap_time_ext::{MonotonicClockExt as _, SystemClockExt as _};
 use wasmtime::component::{HasData, ResourceTable};
 
-pub(crate) struct WasiClocks;
+pub struct WasiClocks;
 
 impl HasData for WasiClocks {
     type Data<'a> = WasiClocksCtxView<'a>;

--- a/crates/wasi/src/filesystem.rs
+++ b/crates/wasi/src/filesystem.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use tracing::debug;
 use wasmtime::component::{HasData, Resource, ResourceTable};
 
-pub(crate) struct WasiFilesystem;
+pub struct WasiFilesystem;
 
 impl HasData for WasiFilesystem {
     type Data<'a> = WasiFilesystemCtxView<'a>;

--- a/crates/wasi/src/random.rs
+++ b/crates/wasi/src/random.rs
@@ -1,7 +1,7 @@
 use cap_rand::{Rng as _, RngCore, SeedableRng as _};
 use wasmtime::component::HasData;
 
-pub(crate) struct WasiRandom;
+pub struct WasiRandom;
 
 impl HasData for WasiRandom {
     type Data<'a> = &'a mut WasiRandomCtx;

--- a/crates/wasi/src/sockets/mod.rs
+++ b/crates/wasi/src/sockets/mod.rs
@@ -14,7 +14,7 @@ pub(crate) use tcp::NonInheritedOptions;
 pub use tcp::TcpSocket;
 pub use udp::UdpSocket;
 
-pub(crate) struct WasiSockets;
+pub struct WasiSockets;
 
 impl HasData for WasiSockets {
     type Data<'a> = WasiSocketsCtxView<'a>;


### PR DESCRIPTION
If these are private it's impossible to implement a version of `add_to_linker()` that only pulls in some of this WASI implementation (e.g if you want to provide a custom implementation of some parts of it).

See #8963