### PR TITLE
Manually register-allocate in inline asm

### DIFF
--- a/crates/unwinder/src/arch/aarch64.rs
+++ b/crates/unwinder/src/arch/aarch64.rs
@@ -57,14 +57,14 @@ pub unsafe fn resume_to_exception_handler(
 ) -> ! {
     unsafe {
         core::arch::asm!(
-            "mov sp, {}",
-            "mov fp, {}",
-            "br {}",
-            in(reg) sp,
-            in(reg) fp,
-            in(reg) pc,
+            "mov sp, x2",
+            "mov fp, x3",
+            "br x4",
             in("x0") payload1,
             in("x1") payload2,
+            in("x2") sp,
+            in("x3") fp,
+            in("x4") pc,
             options(nostack, nomem, noreturn),
         );
     }

--- a/crates/unwinder/src/arch/riscv64.rs
+++ b/crates/unwinder/src/arch/riscv64.rs
@@ -26,14 +26,14 @@ pub unsafe fn resume_to_exception_handler(
 ) -> ! {
     unsafe {
         core::arch::asm!(
-            "mv sp, {}",
-            "mv fp, {}",
-            "jr {}",
-            in(reg) sp,
-            in(reg) fp,
-            in(reg) pc,
+            "mv sp, a2",
+            "mv fp, a3",
+            "jr a4",
             in("a0") payload1,
             in("a1") payload2,
+            in("a2") sp,
+            in("a3") fp,
+            in("a4") pc,
             options(nostack, nomem, noreturn),
         );
     }

--- a/crates/unwinder/src/arch/x86.rs
+++ b/crates/unwinder/src/arch/x86.rs
@@ -29,14 +29,14 @@ pub unsafe fn resume_to_exception_handler(
 ) -> ! {
     unsafe {
         core::arch::asm!(
-            "mov rsp, {}",
-            "mov rbp, {}",
-            "jmp {}",
-            in(reg) sp,
-            in(reg) fp,
-            in(reg) pc,
+            "mov rsp, rcx",
+            "mov rbp, rsi",
+            "jmp rdi",
             in("rax") payload1,
             in("rdx") payload2,
+            in("rcx") sp,
+            in("rsi") fp,
+            in("rdi") pc,
             options(nostack, nomem, noreturn),
         );
     }


### PR DESCRIPTION
This commit fixes a mistake with our inline assembly for resumption of an exception on various platforms. This was detected during the development of #11592 for riscv64 but I believe this affects other platforms too. The basic issue is that our inline assembly blocks are all clobbering the frame pointer because that's what wasm uses but we have no constraint against preventing any input to these inline assembly blocks from being allocated into the frame pointer. This means that if the destination to jump to is allocated to the frame pointer register then we'll jump to wasm's old frame pointer, no the actual destination, because the frame pointer register is clobbered before jumping. An example of this for riscv64 is on [godbolt] where the `s0` register, the frame pointer on riscv64, is clobbered and then jumped to.

The fix in this PR is to manually allocate all registers. All input operands are allocated to explicit registers rather than letting the compiler pick which register they're in. This ensures no overlap with the frame pointer and fixes the test in question. Note that s390x isn't updated here as it doesn't have a frame pointer.

[godbolt]: https://godbolt.org/z/E9vWb9coq

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
