### PR TITLE
pulley: Fix big-endian results in a spillslot

### DIFF
--- a/cranelift/codegen/src/machinst/abi.rs
+++ b/cranelift/codegen/src/machinst/abi.rs
@@ -2477,11 +2477,14 @@ impl<T> CallInfo<T> {
                         // returns), we use the integer temp register in
                         // steps.
                         let parts = (ty.bytes() + M::word_bytes() - 1) / M::word_bytes();
+                        let one_part_load_ty =
+                            Type::int_with_byte_size(M::word_bytes().min(ty.bytes()) as u16)
+                                .unwrap();
                         for part in 0..parts {
                             emit(M::gen_load_stack(
                                 amode.offset_by(part * M::word_bytes()),
                                 temp,
-                                M::word_type(),
+                                one_part_load_ty,
                             ));
                             emit(M::gen_store_stack(
                                 StackAMode::Slot(

--- a/crates/test-util/src/wast.rs
+++ b/crates/test-util/src/wast.rs
@@ -293,7 +293,13 @@ impl Compiler {
     /// `Config::compiler_panicking_wasm_features`.
     pub fn should_fail(&self, config: &TestConfig) -> bool {
         match self {
-            Compiler::CraneliftNative => config.legacy_exceptions(),
+            Compiler::CraneliftNative => {
+                // FIXME(#11602) temporarily disabled
+                if cfg!(target_arch = "s390x") && config.exceptions() {
+                    return true;
+                }
+                config.legacy_exceptions()
+            }
 
             Compiler::Winch => {
                 let unsupported_base = config.gc()

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -2087,6 +2087,11 @@ impl Config {
                     unsupported |= WasmFeatures::STACK_SWITCHING;
                 }
 
+                // FIXME(#11602) temporarily disabled
+                if self.compiler_target().architecture == target_lexicon::Architecture::S390x {
+                    unsupported |= WasmFeatures::EXCEPTIONS;
+                }
+
                 use target_lexicon::*;
                 match self.compiler_target() {
                     Triple {

--- a/tests/misc_testsuite/many-results-with-exceptions.wast
+++ b/tests/misc_testsuite/many-results-with-exceptions.wast
@@ -1,5 +1,24 @@
+;;! exceptions = true
+
 (module
   (func (export "f")
+    (result
+      i32 i32 i32 i32
+      i32 i32 i32 i32
+      i32 i32 i32 i32
+      i32 i32 i32 i32
+      i32
+    )
+
+    (block $h
+      (try_table (catch_all $h)
+        call $f_callee
+        return
+      )
+    )
+    unreachable
+  )
+  (func $f_callee
     (result
       i32 i32 i32 i32
       i32 i32 i32 i32
@@ -28,6 +47,48 @@
   )
 
   (func (export "f2")
+    (param
+      i32 i32 i32 i32
+      i32 i32 i32 i32
+      i32 i32 i32 i32
+      i32 i32 i32 i32
+      i32
+    )
+    (result
+      i32 i32 i32 i32
+      i32 i32 i32 i32
+      i32 i32 i32 i32
+      i32 i32 i32 i32
+      i32
+    )
+
+    (block $h
+      (try_table (catch_all $h)
+        local.get 0
+        local.get 1
+        local.get 2
+        local.get 3
+        local.get 4
+        local.get 5
+        local.get 6
+        local.get 7
+        local.get 8
+        local.get 9
+        local.get 10
+        local.get 11
+        local.get 12
+        local.get 13
+        local.get 14
+        local.get 15
+        local.get 16
+
+        call $f2_callee
+        return
+      )
+    )
+    unreachable
+  )
+  (func $f2_callee
     (param
       i32 i32 i32 i32
       i32 i32 i32 i32


### PR DESCRIPTION
This commit fixes an issue for Pulley on big-endian targets where if a call's result was mapped to a spillslot it was loaded with a too-wide load when moving from the return location to the storage location. This only affects the shared `CallInfo::emit_retval_loads` implementation which is unused on s390x. All other targets, with the exception of big-endian Pulley targets, using this are little-endian where the width won't matter since slots are always integer-register-in-size.

The fix here is to perform a load with the exact type of the return value as opposed to a full machine word width. This fixes the big-endian behavior for Pulley and fixes the attached test cases which reproduce the issue. I've also expanded some of the many-results tests to also have many parameters to try to exercise more parts of the ABI pipeline too.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
