### PR TITLE
feat: add granular tail call detection infrastructure to MachInst

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/abi.rs
+++ b/cranelift/codegen/src/isa/aarch64/abi.rs
@@ -1120,7 +1120,7 @@ impl ABIMachineSpec for AArch64MachineDeps {
         flags: &settings::Flags,
         sig: &Signature,
         regs: &[Writable<RealReg>],
-        is_leaf: bool,
+        function_calls: FunctionCalls,
         incoming_args_size: u32,
         tail_args_size: u32,
         stackslots_size: u32,
@@ -1144,7 +1144,7 @@ impl ABIMachineSpec for AArch64MachineDeps {
 
         // Compute linkage frame size.
         let setup_area_size = if flags.preserve_frame_pointers()
-            || !is_leaf
+            || function_calls != FunctionCalls::None
             // The function arguments that are passed on the stack are addressed
             // relative to the Frame Pointer.
             || incoming_args_size > 0
@@ -1167,7 +1167,7 @@ impl ABIMachineSpec for AArch64MachineDeps {
             stackslots_size,
             outgoing_args_size,
             clobbered_callee_saves: regs,
-            is_leaf,
+            function_calls,
         }
     }
 

--- a/cranelift/codegen/src/isa/aarch64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/mod.rs
@@ -1000,15 +1000,16 @@ impl MachInst for Inst {
         }
     }
 
-    fn is_call(&self) -> bool {
+    fn call_type(&self) -> CallType {
         match self {
             Inst::Call { .. }
             | Inst::CallInd { .. }
-            | Inst::ReturnCall { .. }
-            | Inst::ReturnCallInd { .. }
             | Inst::ElfTlsGetAddr { .. }
-            | Inst::MachOTlsGetAddr { .. } => true,
-            _ => false,
+            | Inst::MachOTlsGetAddr { .. } => CallType::Regular,
+
+            Inst::ReturnCall { .. } | Inst::ReturnCallInd { .. } => CallType::TailCall,
+
+            _ => CallType::None,
         }
     }
 

--- a/cranelift/codegen/src/isa/pulley_shared/abi.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/abi.rs
@@ -495,7 +495,7 @@ where
         flags: &settings::Flags,
         _sig: &Signature,
         regs: &[Writable<RealReg>],
-        is_leaf: bool,
+        function_calls: FunctionCalls,
         incoming_args_size: u32,
         tail_args_size: u32,
         stackslots_size: u32,
@@ -515,7 +515,7 @@ where
 
         // Compute linkage frame size.
         let setup_area_size = if flags.preserve_frame_pointers()
-            || !is_leaf
+            || function_calls != FunctionCalls::None
             // The function arguments that are passed on the stack are addressed
             // relative to the Frame Pointer.
             || incoming_args_size > 0
@@ -537,7 +537,7 @@ where
             stackslots_size,
             outgoing_args_size,
             clobbered_callee_saves: regs,
-            is_leaf,
+            function_calls,
         }
     }
 

--- a/cranelift/codegen/src/isa/pulley_shared/inst/mod.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/inst/mod.rs
@@ -490,14 +490,15 @@ where
         todo!()
     }
 
-    fn is_call(&self) -> bool {
+    fn call_type(&self) -> CallType {
         match &self.inst {
-            Inst::Call { .. }
-            | Inst::IndirectCall { .. }
-            | Inst::IndirectCallHost { .. }
-            | Inst::ReturnCall { .. }
-            | Inst::ReturnIndirectCall { .. } => true,
-            _ => false,
+            Inst::Call { .. } | Inst::IndirectCall { .. } | Inst::IndirectCallHost { .. } => {
+                CallType::Regular
+            }
+
+            Inst::ReturnCall { .. } | Inst::ReturnIndirectCall { .. } => CallType::TailCall,
+
+            _ => CallType::None,
         }
     }
 

--- a/cranelift/codegen/src/isa/riscv64/abi.rs
+++ b/cranelift/codegen/src/isa/riscv64/abi.rs
@@ -628,7 +628,7 @@ impl ABIMachineSpec for Riscv64MachineDeps {
         flags: &settings::Flags,
         _sig: &Signature,
         regs: &[Writable<RealReg>],
-        is_leaf: bool,
+        function_calls: FunctionCalls,
         incoming_args_size: u32,
         tail_args_size: u32,
         stackslots_size: u32,
@@ -648,7 +648,7 @@ impl ABIMachineSpec for Riscv64MachineDeps {
 
         // Compute linkage frame size.
         let setup_area_size = if flags.preserve_frame_pointers()
-            || !is_leaf
+            || function_calls != FunctionCalls::None
             // The function arguments that are passed on the stack are addressed
             // relative to the Frame Pointer.
             || incoming_args_size > 0
@@ -671,7 +671,7 @@ impl ABIMachineSpec for Riscv64MachineDeps {
             stackslots_size,
             outgoing_args_size,
             clobbered_callee_saves: regs,
-            is_leaf,
+            function_calls,
         }
     }
 

--- a/cranelift/codegen/src/isa/riscv64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/mod.rs
@@ -758,14 +758,15 @@ impl MachInst for Inst {
         }
     }
 
-    fn is_call(&self) -> bool {
+    fn call_type(&self) -> CallType {
         match self {
-            Inst::Call { .. }
-            | Inst::CallInd { .. }
-            | Inst::ReturnCall { .. }
-            | Inst::ReturnCallInd { .. }
-            | Inst::ElfTlsGetAddr { .. } => true,
-            _ => false,
+            Inst::Call { .. } | Inst::CallInd { .. } | Inst::ElfTlsGetAddr { .. } => {
+                CallType::Regular
+            }
+
+            Inst::ReturnCall { .. } | Inst::ReturnCallInd { .. } => CallType::TailCall,
+
+            _ => CallType::None,
         }
     }
 

--- a/cranelift/codegen/src/isa/s390x/abi.rs
+++ b/cranelift/codegen/src/isa/s390x/abi.rs
@@ -896,7 +896,7 @@ impl ABIMachineSpec for S390xMachineDeps {
         flags: &settings::Flags,
         _sig: &Signature,
         regs: &[Writable<RealReg>],
-        is_leaf: bool,
+        function_calls: FunctionCalls,
         incoming_args_size: u32,
         tail_args_size: u32,
         stackslots_size: u32,
@@ -975,7 +975,7 @@ impl ABIMachineSpec for S390xMachineDeps {
             stackslots_size,
             outgoing_args_size,
             clobbered_callee_saves: regs,
-            is_leaf,
+            function_calls,
         }
     }
 

--- a/cranelift/codegen/src/isa/s390x/inst/mod.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/mod.rs
@@ -1122,10 +1122,13 @@ impl MachInst for Inst {
         }
     }
 
-    fn is_call(&self) -> bool {
+    fn call_type(&self) -> CallType {
         match self {
-            Inst::Call { .. } | Inst::ReturnCall { .. } | Inst::ElfTlsGetOffset { .. } => true,
-            _ => false,
+            Inst::Call { .. } | Inst::ElfTlsGetOffset { .. } => CallType::Regular,
+
+            Inst::ReturnCall { .. } => CallType::TailCall,
+
+            _ => CallType::None,
         }
     }
 

--- a/cranelift/codegen/src/isa/x64/abi.rs
+++ b/cranelift/codegen/src/isa/x64/abi.rs
@@ -900,7 +900,7 @@ impl ABIMachineSpec for X64ABIMachineSpec {
         flags: &settings::Flags,
         _sig: &Signature,
         regs: &[Writable<RealReg>],
-        is_leaf: bool,
+        function_calls: FunctionCalls,
         incoming_args_size: u32,
         tail_args_size: u32,
         stackslots_size: u32,
@@ -947,7 +947,7 @@ impl ABIMachineSpec for X64ABIMachineSpec {
             stackslots_size,
             outgoing_args_size,
             clobbered_callee_saves: regs,
-            is_leaf,
+            function_calls,
         }
     }
 

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -1281,15 +1281,16 @@ impl MachInst for Inst {
         }
     }
 
-    fn is_call(&self) -> bool {
+    fn call_type(&self) -> CallType {
         match self {
             Inst::CallKnown { .. }
             | Inst::CallUnknown { .. }
-            | Inst::ReturnCallKnown { .. }
-            | Inst::ReturnCallUnknown { .. }
             | Inst::ElfTlsGetAddr { .. }
-            | Inst::MachOTlsGetAddr { .. } => true,
-            _ => false,
+            | Inst::MachOTlsGetAddr { .. } => CallType::Regular,
+
+            Inst::ReturnCallKnown { .. } | Inst::ReturnCallUnknown { .. } => CallType::TailCall,
+
+            _ => CallType::None,
         }
     }
 

--- a/cranelift/codegen/src/machinst/abi.rs
+++ b/cranelift/codegen/src/machinst/abi.rs
@@ -490,7 +490,7 @@ pub trait ABIMachineSpec {
         flags: &settings::Flags,
         sig: &Signature,
         regs: &[Writable<RealReg>],
-        is_leaf: bool,
+        function_calls: FunctionCalls,
         incoming_args_size: u32,
         tail_args_size: u32,
         stackslots_size: u32,
@@ -1079,8 +1079,8 @@ pub struct FrameLayout {
     /// restored by gen_clobber_save and gen_clobber_restore.
     pub clobbered_callee_saves: Vec<Writable<RealReg>>,
 
-    /// Whether this function is a leaf function (makes no calls).
-    pub is_leaf: bool,
+    /// The function's call pattern classification.
+    pub function_calls: FunctionCalls,
 }
 
 impl FrameLayout {
@@ -2173,7 +2173,7 @@ impl<M: ABIMachineSpec> Callee<M> {
         sigs: &SigSet,
         spillslots: usize,
         clobbered: Vec<Writable<RealReg>>,
-        is_leaf: bool,
+        function_calls: FunctionCalls,
     ) {
         let bytes = M::word_bytes();
         let total_stacksize = self.stackslots_size + bytes * spillslots as u32;
@@ -2184,7 +2184,7 @@ impl<M: ABIMachineSpec> Callee<M> {
             &self.flags,
             self.signature(),
             &clobbered,
-            is_leaf,
+            function_calls,
             self.stack_args_size(sigs),
             self.tail_args_size,
             self.stackslots_size,
@@ -2221,7 +2221,7 @@ impl<M: ABIMachineSpec> Callee<M> {
             + frame_layout.clobber_size
             + frame_layout.fixed_frame_storage_size
             + frame_layout.outgoing_args_size
-            + if frame_layout.is_leaf {
+            + if frame_layout.function_calls == FunctionCalls::None {
                 0
             } else {
                 frame_layout.setup_area_size
@@ -2229,7 +2229,7 @@ impl<M: ABIMachineSpec> Callee<M> {
 
         // Leaf functions with zero stack don't need a stack check if one's
         // specified, otherwise always insert the stack check.
-        if total_stacksize > 0 || !frame_layout.is_leaf {
+        if total_stacksize > 0 || frame_layout.function_calls != FunctionCalls::None {
             if let Some((reg, stack_limit_load)) = &self.stack_limit {
                 insts.extend(stack_limit_load.clone());
                 self.insert_stack_check(*reg, total_stacksize, &mut insts);

--- a/cranelift/codegen/src/machinst/mod.rs
+++ b/cranelift/codegen/src/machinst/mod.rs
@@ -291,21 +291,15 @@ pub enum CallType {
 /// - `None`: No calls at all (can use simplified calling conventions)
 /// - `TailOnly`: Only tail calls (may skip frame setup in some cases)
 /// - `Regular`: Has regular calls (requires full calling convention support)
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) enum FunctionCalls {
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum FunctionCalls {
     /// Function makes no calls at all.
+    #[default]
     None,
     /// Function only makes tail calls (no regular calls).
     TailOnly,
     /// Function makes at least one regular call (may also have tail calls).
     Regular,
-}
-
-impl FunctionCalls {
-    /// Convert to boolean leaf classification.
-    pub fn is_leaf(self) -> bool {
-        matches!(self, FunctionCalls::None)
-    }
 }
 
 /// Describes a block terminator (not call) in the VCode.
@@ -605,16 +599,4 @@ pub trait TextSectionBuilder {
     /// Completes this text section, filling out any final details, and returns
     /// the bytes of the text section.
     fn finish(&mut self, ctrl_plane: &mut ControlPlane) -> Vec<u8>;
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_function_calls_is_leaf() {
-        assert!(FunctionCalls::None.is_leaf());
-        assert!(!FunctionCalls::TailOnly.is_leaf());
-        assert!(!FunctionCalls::Regular.is_leaf());
-    }
 }

--- a/cranelift/codegen/src/machinst/mod.rs
+++ b/cranelift/codegen/src/machinst/mod.rs
@@ -302,6 +302,26 @@ pub enum FunctionCalls {
     Regular,
 }
 
+impl FunctionCalls {
+    /// Update the function classification based on a new call instruction.
+    ///
+    /// This method implements the merge logic for accumulating call patterns:
+    /// - Any regular call makes the function Regular
+    /// - Tail calls upgrade None to TailOnly
+    /// - Regular always stays Regular
+    pub fn update(&mut self, call_type: CallType) {
+        *self = match (*self, call_type) {
+            // No call instruction - state unchanged
+            (current, CallType::None) => current,
+            // Regular call always results in Regular classification
+            (_, CallType::Regular) => FunctionCalls::Regular,
+            // Tail call: None becomes TailOnly, others unchanged
+            (FunctionCalls::None, CallType::TailCall) => FunctionCalls::TailOnly,
+            (current, CallType::TailCall) => current,
+        };
+    }
+}
+
 /// Describes a block terminator (not call) in the VCode.
 ///
 /// Actual targets are not included: the single-source-of-truth for

--- a/cranelift/codegen/src/machinst/vcode.rs
+++ b/cranelift/codegen/src/machinst/vcode.rs
@@ -673,7 +673,7 @@ impl<I: VCodeInst> VCode<I> {
         self.insts.len()
     }
 
-    fn compute_clobbers_and_function_type(
+    fn compute_clobbers_and_function_calls(
         &self,
         regalloc: &regalloc2::Output,
     ) -> (Vec<Writable<RealReg>>, FunctionCalls) {
@@ -736,13 +736,13 @@ impl<I: VCodeInst> VCode<I> {
             .map(|preg| Writable::from_reg(RealReg::from(preg)))
             .collect();
 
-        let function_type = match (has_regular_calls, has_tail_calls) {
+        let function_calls = match (has_regular_calls, has_tail_calls) {
             (true, _) => FunctionCalls::Regular,
             (false, true) => FunctionCalls::TailOnly,
             (false, false) => FunctionCalls::None,
         };
 
-        (clobbered_regs, function_type)
+        (clobbered_regs, function_calls)
     }
 
     /// Emit the instructions to a `MachBuffer`, containing fixed-up
@@ -796,12 +796,12 @@ impl<I: VCodeInst> VCode<I> {
         // mutate `VCode`. The info it usually carries prior to
         // setting clobbers is fairly minimal so this should be
         // relatively cheap.
-        let (clobbers, function_type) = self.compute_clobbers_and_function_type(regalloc);
+        let (clobbers, function_calls) = self.compute_clobbers_and_function_calls(regalloc);
         self.abi.compute_frame_layout(
             &self.sigs,
             regalloc.num_spillslots,
             clobbers,
-            function_type.is_leaf(),
+            function_calls,
         );
 
         // Emit blocks.


### PR DESCRIPTION
This PR introduces granular call instruction classification in Cranelift's machine instruction layer, enabling more precise function type analysis and potential optimization opportunities.

#### Changes
  - Added `CallType` enum to distinguish between regular calls, tail calls, and non-calls
  - Introduced `FunctionType` enum for enhanced function classification (`Leaf`, `TailCallOnly`, `NonLeaf`)
  - Replaced boolean `is_call()` with more descriptive `call_type()` method in MachInst trait
   - Updated all ISA backends (AArch64, x64, RISC-V 64, s390x, Pulley) to implement `call_type()` methodAdds core infrastructure for distinguishing between regular calls and tail calls at the instruction level.