### PR TITLE
make `Destination::as_direct` work for both host and guest readers

### DIFF
--- a/crates/misc/component-async-tests/src/util.rs
+++ b/crates/misc/component-async-tests/src/util.rs
@@ -53,7 +53,7 @@ impl<D, T: Send + Sync + Lower + 'static, S: Stream<Item = T> + Send + 'static> 
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
         _: StoreContextMut<D>,
-        destination: &'a mut Destination<'a, Self::Item, Self::Buffer>,
+        mut destination: Destination<'a, Self::Item, Self::Buffer>,
         finish: bool,
     ) -> Poll<Result<StreamResult>> {
         // SAFETY: This is a standard pin-projection, and we never move
@@ -94,7 +94,7 @@ impl<D, T: Lift + 'static, S: Sink<T, Error: std::error::Error + Send + Sync> + 
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
         store: StoreContextMut<D>,
-        source: &mut Source<Self::Item>,
+        mut source: Source<Self::Item>,
         finish: bool,
     ) -> Poll<Result<StreamResult>> {
         // SAFETY: This is a standard pin-projection, and we never move

--- a/crates/wasi/src/p3/cli/host.rs
+++ b/crates/wasi/src/p3/cli/host.rs
@@ -12,11 +12,11 @@ use core::pin::Pin;
 use core::task::{Context, Poll};
 use std::io::Cursor;
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
-use wasmtime::StoreContextMut;
 use wasmtime::component::{
     Accessor, Destination, Resource, Source, StreamConsumer, StreamProducer, StreamReader,
     StreamResult,
 };
+use wasmtime::{AsContextMut as _, StoreContextMut};
 
 struct InputStreamProducer {
     rx: Pin<Box<dyn AsyncRead + Send + Sync>>,
@@ -29,53 +29,31 @@ impl<D> StreamProducer<D> for InputStreamProducer {
     fn poll_produce<'a>(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-        store: StoreContextMut<'a, D>,
-        dst: &'a mut Destination<'a, Self::Item, Self::Buffer>,
+        mut store: StoreContextMut<'a, D>,
+        dst: Destination<'a, Self::Item, Self::Buffer>,
         finish: bool,
     ) -> Poll<wasmtime::Result<StreamResult>> {
-        if let Some(mut dst) = dst.as_direct_destination(store) {
-            if !dst.remaining().is_empty() {
-                let mut buf = ReadBuf::new(dst.remaining());
-                match self.rx.as_mut().poll_read(cx, &mut buf) {
-                    Poll::Ready(Ok(())) if buf.filled().is_empty() => {
-                        return Poll::Ready(Ok(StreamResult::Dropped));
-                    }
-                    Poll::Ready(Ok(())) => {
-                        let n = buf.filled().len();
-                        dst.mark_written(n);
-                        return Poll::Ready(Ok(StreamResult::Completed));
-                    }
-                    Poll::Ready(Err(..)) => {
-                        // TODO: Report the error to the guest
-                        return Poll::Ready(Ok(StreamResult::Dropped));
-                    }
-                    Poll::Pending if finish => return Poll::Ready(Ok(StreamResult::Cancelled)),
-                    Poll::Pending => return Poll::Pending,
+        if let Some(0) = dst.remaining(store.as_context_mut()) {
+            Poll::Ready(Ok(StreamResult::Completed))
+        } else {
+            let mut dst = dst.as_direct(store, DEFAULT_BUFFER_CAPACITY);
+            let mut buf = ReadBuf::new(dst.remaining());
+            match self.rx.as_mut().poll_read(cx, &mut buf) {
+                Poll::Ready(Ok(())) if buf.filled().is_empty() => {
+                    Poll::Ready(Ok(StreamResult::Dropped))
                 }
+                Poll::Ready(Ok(())) => {
+                    let n = buf.filled().len();
+                    dst.mark_written(n);
+                    Poll::Ready(Ok(StreamResult::Completed))
+                }
+                Poll::Ready(Err(..)) => {
+                    // TODO: Report the error to the guest
+                    Poll::Ready(Ok(StreamResult::Dropped))
+                }
+                Poll::Pending if finish => Poll::Ready(Ok(StreamResult::Cancelled)),
+                Poll::Pending => Poll::Pending,
             }
-        }
-        let mut buf = dst.take_buffer().into_inner();
-        buf.clear();
-        buf.reserve(DEFAULT_BUFFER_CAPACITY);
-        let mut rbuf = ReadBuf::uninit(buf.spare_capacity_mut());
-        match self.rx.as_mut().poll_read(cx, &mut rbuf) {
-            Poll::Ready(Ok(())) if rbuf.filled().is_empty() => {
-                Poll::Ready(Ok(StreamResult::Dropped))
-            }
-            Poll::Ready(Ok(())) => {
-                let n = rbuf.filled().len();
-                // SAFETY: `ReadyBuf::filled` promised us `count` bytes have
-                // been initialized.
-                unsafe { buf.set_len(n) };
-                dst.set_buffer(Cursor::new(buf));
-                Poll::Ready(Ok(StreamResult::Completed))
-            }
-            Poll::Ready(Err(..)) => {
-                // TODO: Report the error to the guest
-                Poll::Ready(Ok(StreamResult::Dropped))
-            }
-            Poll::Pending if finish => Poll::Ready(Ok(StreamResult::Cancelled)),
-            Poll::Pending => Poll::Pending,
         }
     }
 }
@@ -91,10 +69,10 @@ impl<D> StreamConsumer<D> for OutputStreamConsumer {
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
         store: StoreContextMut<D>,
-        src: &mut Source<Self::Item>,
+        src: Source<Self::Item>,
         finish: bool,
     ) -> Poll<wasmtime::Result<StreamResult>> {
-        let mut src = src.as_direct_source(store);
+        let mut src = src.as_direct(store);
         let buf = src.remaining();
         match self.tx.as_mut().poll_write(cx, buf) {
             Poll::Ready(Ok(n)) if buf.is_empty() => {

--- a/crates/wasi/src/p3/mod.rs
+++ b/crates/wasi/src/p3/mod.rs
@@ -46,7 +46,7 @@ impl<T: Send + Sync + 'static, D> StreamProducer<D> for StreamEmptyProducer<T> {
         self: Pin<&mut Self>,
         _: &mut Context<'_>,
         _: StoreContextMut<'a, D>,
-        _: &'a mut Destination<'a, Self::Item, Self::Buffer>,
+        _: Destination<'a, Self::Item, Self::Buffer>,
         _: bool,
     ) -> Poll<wasmtime::Result<StreamResult>> {
         Poll::Ready(Ok(StreamResult::Dropped))

--- a/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams/buffers.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams/buffers.rs
@@ -214,6 +214,54 @@ impl<T: Send + Sync + 'static> ReadBuffer<T> for Option<T> {
     }
 }
 
+/// A `WriteBuffer` implementation, backed by a `Vec<u8>`, a position, and a limit.
+pub struct SliceBuffer {
+    buffer: Vec<u8>,
+    offset: usize,
+    limit: usize,
+}
+
+impl SliceBuffer {
+    pub fn new(buffer: Vec<u8>, offset: usize, limit: usize) -> Self {
+        assert!(limit <= buffer.len());
+        Self {
+            buffer,
+            offset,
+            limit,
+        }
+    }
+
+    pub fn into_parts(self) -> (Vec<u8>, usize, usize) {
+        (self.buffer, self.offset, self.limit)
+    }
+}
+
+// SAFETY: the `take` implementation below guarantees that the `fun` closure is
+// provided with fully initialized items due to all elements in the slice being
+// initialized.
+unsafe impl WriteBuffer<u8> for SliceBuffer {
+    fn remaining(&self) -> &[u8] {
+        &self.buffer[self.offset..self.limit]
+    }
+
+    fn skip(&mut self, count: usize) {
+        assert!(self.offset + count <= self.limit);
+        self.offset += count;
+    }
+
+    fn take(&mut self, count: usize, fun: &mut dyn FnMut(&[MaybeUninit<u8>])) {
+        assert!(count <= self.remaining().len());
+        self.offset += count;
+        // SAFETY: Transmuting from `&[u8]` to `&[MaybeUninit<u8>]` should
+        // always be sound.
+        fun(unsafe {
+            mem::transmute::<&[u8], &[MaybeUninit<u8>]>(
+                &self.buffer[self.offset - count..self.limit],
+            )
+        });
+    }
+}
+
 /// A `WriteBuffer` implementation, backed by a `Vec`.
 pub struct VecBuffer<T> {
     buffer: Vec<MaybeUninit<T>>,
@@ -282,7 +330,7 @@ unsafe impl<T: Send + Sync + 'static> WriteBuffer<T> for VecBuffer<T> {
         // ensure that if `fun` panics that the items are still considered
         // transferred.
         self.offset += count;
-        fun(&mut self.buffer[self.offset - count..]);
+        fun(&self.buffer[self.offset - count..]);
     }
 }
 


### PR DESCRIPTION
In order to reduce code duplication (and code paths to test) in `wasmtime-wasi` and custom host embeddings, I've made `Destination::as_direct` (formerly known as `as_direct_destination`) work for host readers as well as guest ones.  In the process, I noticed and fixed a couple of related issues:

- I had forgotten to implement or test host reader support in `DirectSource` :facepalm:
- The code to support host-to-host pipes failed to account for partial reads

I've also simplified the `StreamConsumer` and `StreamProducer` APIs slightly by having them take their `Source` and `Destination` parameters by value rather than by reference, respectively.

Note that, per https://github.com/WebAssembly/component-model/issues/561, I've tweaked the documentation for `StreamProducer` to indicate that implementations might reasonably opt to "pretend" they're ready without buffering any items when handling zero-length reads given that buffering has its own hazards.  Likewise, I've updated the `wasi-filesystem` and `wasi-cli` implementations to "pretend" instead of buffering.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
