### PR TITLE
wasip3: Update std{out,err} implementation

### DIFF
--- a/crates/test-programs/src/bin/cli_p1_much_stdout.rs
+++ b/crates/test-programs/src/bin/cli_p1_much_stdout.rs
@@ -1,0 +1,18 @@
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let string_to_write = args.next().unwrap();
+    let times_to_write = args.next().unwrap().parse::<u32>().unwrap();
+
+    let bytes = string_to_write.as_bytes();
+    for _ in 0..times_to_write {
+        let mut remaining = bytes;
+        while !remaining.is_empty() {
+            let iovec = wasip1::Ciovec {
+                buf: remaining.as_ptr(),
+                buf_len: remaining.len(),
+            };
+            let amt = unsafe { wasip1::fd_write(1, &[iovec]).unwrap() };
+            remaining = &remaining[amt..];
+        }
+    }
+}

--- a/crates/test-programs/src/bin/cli_p2_much_stdout.rs
+++ b/crates/test-programs/src/bin/cli_p2_much_stdout.rs
@@ -1,0 +1,13 @@
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let string_to_write = args.next().unwrap();
+    let times_to_write = args.next().unwrap().parse::<u32>().unwrap();
+
+    let bytes = string_to_write.as_bytes();
+    let stdout = wasip2::cli::stdout::get_stdout();
+    for _ in 0..times_to_write {
+        for chunk in bytes.chunks(4096) {
+            stdout.blocking_write_and_flush(chunk).unwrap();
+        }
+    }
+}

--- a/crates/test-programs/src/bin/cli_p3_much_stdout.rs
+++ b/crates/test-programs/src/bin/cli_p3_much_stdout.rs
@@ -1,0 +1,26 @@
+use test_programs::p3::{wasi, wit_stream};
+
+struct Component;
+
+test_programs::p3::export!(Component);
+
+impl test_programs::p3::exports::wasi::cli::run::Guest for Component {
+    async fn run() -> Result<(), ()> {
+        let mut args = std::env::args().skip(1);
+        let string_to_write = args.next().unwrap();
+        let times_to_write = args.next().unwrap().parse::<u32>().unwrap();
+
+        let bytes = string_to_write.as_bytes();
+        let (mut tx, rx) = wit_stream::new();
+        wasi::cli::stdout::set_stdout(rx);
+        for _ in 0..times_to_write {
+            let result = tx.write_all(bytes.to_vec()).await;
+            assert!(result.is_empty());
+        }
+        Ok(())
+    }
+}
+
+fn main() {
+    unreachable!();
+}

--- a/tests/all/cli_tests.rs
+++ b/tests/all/cli_tests.rs
@@ -1108,6 +1108,7 @@ mod test_programs {
     use http_body_util::BodyExt;
     use hyper::header::HeaderValue;
     use std::io::{BufRead, BufReader, Read, Write};
+    use std::iter;
     use std::net::SocketAddr;
     use std::process::{Child, Command, Stdio};
     use test_programs_artifacts::*;
@@ -2172,6 +2173,52 @@ start a print 1234
         ])?;
         assert_eq!(output, "\"hello?\"\n");
         Ok(())
+    }
+
+    fn run_much_stdout(component: &str, extra_flags: &[&str]) -> Result<()> {
+        let total_write_size = 1 << 19;
+        let expected = iter::repeat('a').take(total_write_size).collect::<String>();
+
+        for i in 0..16 {
+            let string = iter::repeat('a').take(1 << i).collect::<String>();
+            let times = (total_write_size >> i).to_string();
+            println!("writing {} bytes {times} times", string.len());
+
+            let mut args = Vec::new();
+            args.push("run");
+            args.extend_from_slice(extra_flags);
+            args.push(component);
+            args.push(&string);
+            args.push(&times);
+            let output = run_wasmtime(&args)?;
+            println!(
+                "expected {} bytes, got {} bytes",
+                expected.len(),
+                output.len()
+            );
+            assert!(output == expected);
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn cli_p1_much_stdout() -> Result<()> {
+        run_much_stdout(CLI_P1_MUCH_STDOUT_COMPONENT, &[])
+    }
+
+    #[test]
+    fn cli_p2_much_stdout() -> Result<()> {
+        run_much_stdout(CLI_P2_MUCH_STDOUT_COMPONENT, &[])
+    }
+
+    #[test]
+    #[cfg_attr(not(feature = "component-model-async"), ignore)]
+    fn cli_p3_much_stdout() -> Result<()> {
+        run_much_stdout(
+            CLI_P3_MUCH_STDOUT_COMPONENT,
+            &["-Wcomponent-model-async", "-Sp3"],
+        )
     }
 }
 

--- a/tests/all/cli_tests.rs
+++ b/tests/all/cli_tests.rs
@@ -2179,7 +2179,7 @@ start a print 1234
         let total_write_size = 1 << 19;
         let expected = iter::repeat('a').take(total_write_size).collect::<String>();
 
-        for i in 0..16 {
+        for i in 0..15 {
             let string = iter::repeat('a').take(1 << i).collect::<String>();
             let times = (total_write_size >> i).to_string();
             println!("writing {} bytes {times} times", string.len());


### PR DESCRIPTION
Match the WASIp2 stdio implementation and "lie" about stdio actually being async. Instead of using Tokio's primitives use the `std::io` primitives which will block the current program while the output is produced. This matches WASIp2 semantics and we always have the option of making this more async in the future (or even have it as a runtime flag). This avoids the need to call `poll_flush` in stdio unconditionally in the `wasi:cli` implementation which didn't feel quite right.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
