### PR TITLE
wasip3: Refactor file in/out streams

### DIFF
--- a/crates/wasi/tests/all/p3/mod.rs
+++ b/crates/wasi/tests/all/p3/mod.rs
@@ -64,6 +64,11 @@ async fn p3_filesystem_file_read_write() -> anyhow::Result<()> {
 }
 
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
+async fn p3_filesystem_file_read_write_blocking() -> anyhow::Result<()> {
+    run_allow_blocking_current_thread(P3_FILESYSTEM_FILE_READ_WRITE_COMPONENT, true).await
+}
+
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn p3_random_imports() -> anyhow::Result<()> {
     run(P3_RANDOM_IMPORTS_COMPONENT).await
 }


### PR DESCRIPTION
* Deduplicate write/append streams
* Deduplicate poll-the-task and spawn-the-task-then-poll
* Explicitly ignore the `finish` flag

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
