### PR TITLE
wasip3: Port the `preview1_file_write` test to WASIp3

### DIFF
--- a/crates/test-programs/src/bin/p3_file_write.rs
+++ b/crates/test-programs/src/bin/p3_file_write.rs
@@ -110,7 +110,7 @@ async fn test_file_long_write(dir: &Descriptor, filename: &str) {
         async {
             let err = file.write_via_stream(rx, 0).await.unwrap_err();
             assert!(
-                matches!(err, ErrorCode::Access | ErrorCode::BadDescriptor),
+                matches!(err, ErrorCode::Access | ErrorCode::BadDescriptor | ErrorCode::NotPermitted),
                 "bad error {err:?}",
             );
         },

--- a/crates/test-programs/src/bin/p3_file_write.rs
+++ b/crates/test-programs/src/bin/p3_file_write.rs
@@ -1,0 +1,123 @@
+use futures::join;
+use test_programs::p3::wasi::filesystem::types::{
+    Descriptor, DescriptorFlags, ErrorCode, OpenFlags, PathFlags,
+};
+use test_programs::p3::{wasi, wit_stream};
+
+struct Component;
+
+test_programs::p3::export!(Component);
+
+impl test_programs::p3::exports::wasi::cli::run::Guest for Component {
+    async fn run() -> Result<(), ()> {
+        let preopens = wasi::filesystem::preopens::get_directories();
+        let (dir, _) = &preopens[0];
+
+        test_file_long_write(dir, "long_write.txt").await;
+        Ok(())
+    }
+}
+
+fn main() {
+    unreachable!()
+}
+
+async fn test_file_long_write(dir: &Descriptor, filename: &str) {
+    let mut content = Vec::new();
+    // 16 byte string, 4096 times, is 64k
+    for n in 0..4096 {
+        let chunk = format!("123456789 {n:05} ");
+        assert_eq!(chunk.as_str().as_bytes().len(), 16);
+        content.extend_from_slice(chunk.as_str().as_bytes());
+    }
+
+    // Write to the file
+    let file = dir
+        .open_at(
+            PathFlags::empty(),
+            filename.to_string(),
+            OpenFlags::CREATE,
+            DescriptorFlags::WRITE,
+        )
+        .await
+        .expect("creating a file for writing");
+    let (mut tx, rx) = wit_stream::new();
+    join! {
+        async {
+            file.write_via_stream(rx, 0).await.unwrap();
+        },
+        async {
+            let result = tx.write_all(content.clone()).await;
+            drop(tx);
+            assert!(result.is_empty());
+        },
+    };
+
+    // The file should be of the appropriate size via `stat` now.
+    let stat = file.stat().await.unwrap();
+    assert_eq!(
+        stat.size,
+        content.len() as u64,
+        "file should be size of content",
+    );
+
+    drop(file);
+
+    // Make sure the file can be read at various offsets.
+    let file = dir
+        .open_at(
+            PathFlags::empty(),
+            filename.to_string(),
+            OpenFlags::empty(),
+            DescriptorFlags::READ,
+        )
+        .await
+        .expect("creating a file for reading");
+
+    let (read_contents, result) = file.read_via_stream(0);
+    let read_contents = read_contents.collect().await;
+    result.await.unwrap();
+    assert!(read_contents == content);
+
+    let (read_contents, result) = file.read_via_stream((content.len() as u64) - 100);
+    let read_contents = read_contents.collect().await;
+    result.await.unwrap();
+    assert!(read_contents == &content[content.len() - 100..]);
+    drop(file);
+
+    // Writing to a read-only handle should be an error.
+    let filename = "test-zero-write-fails.txt";
+    dir.open_at(
+        PathFlags::empty(),
+        filename.to_string(),
+        OpenFlags::CREATE,
+        DescriptorFlags::WRITE,
+    )
+    .await
+    .expect("creating a file for writing");
+    let file = dir
+        .open_at(
+            PathFlags::empty(),
+            filename.to_string(),
+            OpenFlags::empty(),
+            DescriptorFlags::READ,
+        )
+        .await
+        .expect("creating a file for writing");
+
+    let (mut tx, rx) = wit_stream::new();
+    join! {
+        async {
+            let err = file.write_via_stream(rx, 0).await.unwrap_err();
+            assert!(
+                matches!(err, ErrorCode::Access | ErrorCode::BadDescriptor),
+                "bad error {err:?}",
+            );
+        },
+        async {
+            let result = tx.write_all(b"x".to_vec()).await;
+            drop(tx);
+            assert_eq!(result.len(), 1);
+        },
+    };
+}

--- a/crates/wasi/tests/all/p3/mod.rs
+++ b/crates/wasi/tests/all/p3/mod.rs
@@ -142,3 +142,13 @@ async fn p3_readdir() -> anyhow::Result<()> {
 async fn p3_readdir_blocking() -> anyhow::Result<()> {
     run_allow_blocking_current_thread(P3_READDIR_COMPONENT, true).await
 }
+
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
+async fn p3_file_write() -> anyhow::Result<()> {
+    run(P3_FILE_WRITE_COMPONENT).await
+}
+
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
+async fn p3_file_write_blocking() -> anyhow::Result<()> {
+    run_allow_blocking_current_thread(P3_FILE_WRITE_COMPONENT, true).await
+}


### PR DESCRIPTION
Porting more tests to the new world.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
