### PR TITLE
wasip3: Add a test cancelling TCP reads

### DIFF
--- a/crates/test-programs/src/bin/p3_sockets_tcp_streams.rs
+++ b/crates/test-programs/src/bin/p3_sockets_tcp_streams.rs
@@ -1,8 +1,11 @@
 use futures::join;
+use std::pin::pin;
+use std::task::{Context, Poll, Waker};
 use test_programs::p3::wasi::sockets::types::{
     IpAddress, IpAddressFamily, IpSocketAddress, TcpSocket,
 };
 use test_programs::p3::wit_stream;
+use wit_bindgen::StreamResult;
 
 struct Component;
 
@@ -109,6 +112,82 @@ async fn test_tcp_shutdown_should_not_lose_data(family: IpAddressFamily) {
     .await;
 }
 
+/// Model a situation where there's a continuous stream of data coming into the
+/// guest from one side and the other side is reading in chunks but also
+/// cancelling reads occasionally. Should receive the complete stream of data
+/// into the result.
+async fn test_tcp_read_cancellation(family: IpAddressFamily) {
+    // Send 2M of data in 256-byte chunks.
+    const CHUNKS: usize = (2 << 20) / 256;
+    let mut data = [0; 256];
+    for (i, slot) in data.iter_mut().enumerate() {
+        *slot = i as u8;
+    }
+
+    setup(family, |server, client| async move {
+        // Minimize the local send buffer:
+        client.set_send_buffer_size(1024).unwrap();
+
+        let (mut client_tx, client_rx) = wit_stream::new();
+        join!(
+            async {
+                client.send(client_rx).await.unwrap();
+            },
+            async {
+                for i in 0..CHUNKS {
+                    println!("write {i}");
+                    let ret = client_tx.write_all(data.to_vec()).await;
+                    assert!(ret.is_empty());
+                }
+                drop(client_tx);
+            },
+            async {
+                let mut buf = Vec::with_capacity(1024);
+                let (mut server_rx, server_fut) = server.receive();
+                let mut i = 0_usize;
+                let mut consecutive_zero_length_reads = 0;
+                loop {
+                    assert!(buf.is_empty());
+                    let (status, b) = {
+                        let mut fut = pin!(server_rx.read(buf));
+                        let mut cx = Context::from_waker(Waker::noop());
+                        match fut.as_mut().poll(&mut cx) {
+                            Poll::Ready(pair) => pair,
+                            Poll::Pending => fut.cancel(),
+                        }
+                    };
+                    buf = b;
+                    match status {
+                        StreamResult::Complete(n) => {
+                            eprintln!("read {n}");
+                            assert_eq!(buf.len(), n);
+                            for slot in buf.iter_mut() {
+                                assert_eq!(*slot, i as u8);
+                                i = i.wrapping_add(1);
+                            }
+                            buf.truncate(0);
+                            // consecutive_zero_length_reads = 0;
+                        }
+                        StreamResult::Dropped => break,
+                        StreamResult::Cancelled => {
+                            eprintln!("wait {consecutive_zero_length_reads}");
+                            assert!(consecutive_zero_length_reads < 10);
+                            consecutive_zero_length_reads += 1;
+                            server_rx.read(Vec::new()).await;
+                        }
+                    }
+                }
+                assert_eq!(i, CHUNKS * 256);
+                server_fut.await.unwrap();
+            },
+        );
+    })
+    .await;
+    if true {
+        panic!();
+    }
+}
+
 impl test_programs::p3::exports::wasi::cli::run::Guest for Component {
     async fn run() -> Result<(), ()> {
         test_tcp_input_stream_should_be_closed_by_remote_shutdown(IpAddressFamily::Ipv4).await;
@@ -122,6 +201,8 @@ impl test_programs::p3::exports::wasi::cli::run::Guest for Component {
 
         test_tcp_shutdown_should_not_lose_data(IpAddressFamily::Ipv4).await;
         test_tcp_shutdown_should_not_lose_data(IpAddressFamily::Ipv6).await;
+
+        test_tcp_read_cancellation(IpAddressFamily::Ipv4).await;
         Ok(())
     }
 }


### PR DESCRIPTION
This commit adds a test where a stream of data is being sent over TCP and the read side reads as much as it can and then cancels any read that shows up pending. It then waits for readiness via a 0-length read and retries again. The test is intended to assert that the number of consecutive zero-length reads reported is capped at some small number (e.g. this shouldn't infinite loop).

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
