### PR TITLE
 Support store-access in `bindgen!` generated imports 

### DIFF
--- a/crates/component-macro/tests/codegen.rs
+++ b/crates/component-macro/tests/codegen.rs
@@ -30,6 +30,12 @@ macro_rules! gentest {
                     }
                 });
             }
+            mod imports_with_store {
+                wasmtime::component::bindgen!({
+                    path: $path,
+                    imports: { default: store },
+                });
+            }
         }
     };
 }

--- a/crates/component-macro/tests/expanded/char_concurrent.rs
+++ b/crates/component-macro/tests/expanded/char_concurrent.rs
@@ -193,12 +193,12 @@ pub mod foo {
             use wasmtime::component::__internal::{anyhow, Box};
             pub trait HostWithStore: wasmtime::component::HasData + Send {
                 /// A function that accepts a character
-                fn take_char<T: 'static>(
+                fn take_char<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: char,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
                 /// A function that returns a character
-                fn return_char<T: 'static>(
+                fn return_char<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = char> + Send;
             }
@@ -218,9 +218,8 @@ pub mod foo {
                     "take-char",
                     move |caller: &wasmtime::component::Accessor<T>, (arg0,): (char,)| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::take_char(accessor, arg0)
-                                .await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::take_char(host, arg0).await;
                             Ok(r)
                         })
                     },
@@ -229,8 +228,8 @@ pub mod foo {
                     "return-char",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::return_char(accessor).await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::return_char(host).await;
                             Ok((r,))
                         })
                     },

--- a/crates/component-macro/tests/expanded/conventions_concurrent.rs
+++ b/crates/component-macro/tests/expanded/conventions_concurrent.rs
@@ -226,29 +226,29 @@ pub mod foo {
                 );
             };
             pub trait HostWithStore: wasmtime::component::HasData + Send {
-                fn kebab_case<T: 'static>(
+                fn kebab_case<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn foo<T: 'static>(
+                fn foo<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: LudicrousSpeed,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn function_with_dashes<T: 'static>(
+                fn function_with_dashes<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn function_with_no_weird_characters<T: 'static>(
+                fn function_with_no_weird_characters<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn apple<T: 'static>(
+                fn apple<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn apple_pear<T: 'static>(
+                fn apple_pear<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn apple_pear_grape<T: 'static>(
+                fn apple_pear_grape<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn a0<T: 'static>(
+                fn a0<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
                 /// Comment out identifiers that collide when mapped to snake_case, for now; see
@@ -256,17 +256,17 @@ pub mod foo {
                 /// APPLE: func()
                 /// APPLE-pear-GRAPE: func()
                 /// apple-PEAR-grape: func()
-                fn is_xml<T: 'static>(
+                fn is_xml<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn explicit<T: 'static>(
+                fn explicit<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn explicit_kebab<T: 'static>(
+                fn explicit_kebab<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
                 /// Identifiers with the same name as keywords are quoted.
-                fn bool<T: 'static>(
+                fn bool<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
             }
@@ -286,8 +286,8 @@ pub mod foo {
                     "kebab-case",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::kebab_case(accessor).await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::kebab_case(host).await;
                             Ok(r)
                         })
                     },
@@ -299,8 +299,8 @@ pub mod foo {
                         (arg0,): (LudicrousSpeed,)|
                     {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::foo(accessor, arg0).await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::foo(host, arg0).await;
                             Ok(r)
                         })
                     },
@@ -309,8 +309,8 @@ pub mod foo {
                     "function-with-dashes",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::function_with_dashes(accessor)
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::function_with_dashes(host)
                                 .await;
                             Ok(r)
                         })
@@ -320,9 +320,9 @@ pub mod foo {
                     "function-with-no-weird-characters",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
+                            let host = &caller.with_getter(host_getter);
                             let r = <D as HostWithStore>::function_with_no_weird_characters(
-                                    accessor,
+                                    host,
                                 )
                                 .await;
                             Ok(r)
@@ -333,8 +333,8 @@ pub mod foo {
                     "apple",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::apple(accessor).await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::apple(host).await;
                             Ok(r)
                         })
                     },
@@ -343,8 +343,8 @@ pub mod foo {
                     "apple-pear",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::apple_pear(accessor).await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::apple_pear(host).await;
                             Ok(r)
                         })
                     },
@@ -353,9 +353,8 @@ pub mod foo {
                     "apple-pear-grape",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::apple_pear_grape(accessor)
-                                .await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::apple_pear_grape(host).await;
                             Ok(r)
                         })
                     },
@@ -364,8 +363,8 @@ pub mod foo {
                     "a0",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::a0(accessor).await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::a0(host).await;
                             Ok(r)
                         })
                     },
@@ -374,8 +373,8 @@ pub mod foo {
                     "is-XML",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::is_xml(accessor).await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::is_xml(host).await;
                             Ok(r)
                         })
                     },
@@ -384,8 +383,8 @@ pub mod foo {
                     "explicit",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::explicit(accessor).await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::explicit(host).await;
                             Ok(r)
                         })
                     },
@@ -394,8 +393,8 @@ pub mod foo {
                     "explicit-kebab",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::explicit_kebab(accessor).await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::explicit_kebab(host).await;
                             Ok(r)
                         })
                     },
@@ -404,8 +403,8 @@ pub mod foo {
                     "bool",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::bool(accessor).await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::bool(host).await;
                             Ok(r)
                         })
                     },

--- a/crates/component-macro/tests/expanded/dead-code_concurrent.rs
+++ b/crates/component-macro/tests/expanded/dead-code_concurrent.rs
@@ -208,7 +208,7 @@ pub mod a {
                 );
             };
             pub trait HostWithStore: wasmtime::component::HasData + Send {
-                fn f<T: 'static>(
+                fn f<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = LiveType> + Send;
             }
@@ -228,8 +228,8 @@ pub mod a {
                     "f",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::f(accessor).await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::f(host).await;
                             Ok((r,))
                         })
                     },

--- a/crates/component-macro/tests/expanded/direct-import_concurrent.rs
+++ b/crates/component-macro/tests/expanded/direct-import_concurrent.rs
@@ -99,7 +99,7 @@ pub struct FooIndices {}
 /// [`Linker`]: wasmtime::component::Linker
 pub struct Foo {}
 pub trait FooImportsWithStore: wasmtime::component::HasData + Send {
-    fn foo<T: 'static>(
+    fn foo<T>(
         accessor: &wasmtime::component::Accessor<T, Self>,
     ) -> impl ::core::future::Future<Output = ()> + Send;
 }
@@ -184,8 +184,8 @@ const _: () = {
                     "foo",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as FooImportsWithStore>::foo(accessor).await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as FooImportsWithStore>::foo(host).await;
                             Ok(r)
                         })
                     },

--- a/crates/component-macro/tests/expanded/flags_concurrent.rs
+++ b/crates/component-macro/tests/expanded/flags_concurrent.rs
@@ -306,31 +306,31 @@ pub mod foo {
                 assert!(4 == < Flag64 as wasmtime::component::ComponentType >::ALIGN32);
             };
             pub trait HostWithStore: wasmtime::component::HasData + Send {
-                fn roundtrip_flag1<T: 'static>(
+                fn roundtrip_flag1<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: Flag1,
                 ) -> impl ::core::future::Future<Output = Flag1> + Send;
-                fn roundtrip_flag2<T: 'static>(
+                fn roundtrip_flag2<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: Flag2,
                 ) -> impl ::core::future::Future<Output = Flag2> + Send;
-                fn roundtrip_flag4<T: 'static>(
+                fn roundtrip_flag4<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: Flag4,
                 ) -> impl ::core::future::Future<Output = Flag4> + Send;
-                fn roundtrip_flag8<T: 'static>(
+                fn roundtrip_flag8<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: Flag8,
                 ) -> impl ::core::future::Future<Output = Flag8> + Send;
-                fn roundtrip_flag16<T: 'static>(
+                fn roundtrip_flag16<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: Flag16,
                 ) -> impl ::core::future::Future<Output = Flag16> + Send;
-                fn roundtrip_flag32<T: 'static>(
+                fn roundtrip_flag32<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: Flag32,
                 ) -> impl ::core::future::Future<Output = Flag32> + Send;
-                fn roundtrip_flag64<T: 'static>(
+                fn roundtrip_flag64<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: Flag64,
                 ) -> impl ::core::future::Future<Output = Flag64> + Send;
@@ -351,8 +351,8 @@ pub mod foo {
                     "roundtrip-flag1",
                     move |caller: &wasmtime::component::Accessor<T>, (arg0,): (Flag1,)| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::roundtrip_flag1(accessor, arg0)
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::roundtrip_flag1(host, arg0)
                                 .await;
                             Ok((r,))
                         })
@@ -362,8 +362,8 @@ pub mod foo {
                     "roundtrip-flag2",
                     move |caller: &wasmtime::component::Accessor<T>, (arg0,): (Flag2,)| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::roundtrip_flag2(accessor, arg0)
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::roundtrip_flag2(host, arg0)
                                 .await;
                             Ok((r,))
                         })
@@ -373,8 +373,8 @@ pub mod foo {
                     "roundtrip-flag4",
                     move |caller: &wasmtime::component::Accessor<T>, (arg0,): (Flag4,)| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::roundtrip_flag4(accessor, arg0)
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::roundtrip_flag4(host, arg0)
                                 .await;
                             Ok((r,))
                         })
@@ -384,8 +384,8 @@ pub mod foo {
                     "roundtrip-flag8",
                     move |caller: &wasmtime::component::Accessor<T>, (arg0,): (Flag8,)| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::roundtrip_flag8(accessor, arg0)
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::roundtrip_flag8(host, arg0)
                                 .await;
                             Ok((r,))
                         })
@@ -395,11 +395,8 @@ pub mod foo {
                     "roundtrip-flag16",
                     move |caller: &wasmtime::component::Accessor<T>, (arg0,): (Flag16,)| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::roundtrip_flag16(
-                                    accessor,
-                                    arg0,
-                                )
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::roundtrip_flag16(host, arg0)
                                 .await;
                             Ok((r,))
                         })
@@ -409,11 +406,8 @@ pub mod foo {
                     "roundtrip-flag32",
                     move |caller: &wasmtime::component::Accessor<T>, (arg0,): (Flag32,)| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::roundtrip_flag32(
-                                    accessor,
-                                    arg0,
-                                )
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::roundtrip_flag32(host, arg0)
                                 .await;
                             Ok((r,))
                         })
@@ -423,11 +417,8 @@ pub mod foo {
                     "roundtrip-flag64",
                     move |caller: &wasmtime::component::Accessor<T>, (arg0,): (Flag64,)| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::roundtrip_flag64(
-                                    accessor,
-                                    arg0,
-                                )
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::roundtrip_flag64(host, arg0)
                                 .await;
                             Ok((r,))
                         })

--- a/crates/component-macro/tests/expanded/floats_concurrent.rs
+++ b/crates/component-macro/tests/expanded/floats_concurrent.rs
@@ -194,18 +194,18 @@ pub mod foo {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::{anyhow, Box};
             pub trait HostWithStore: wasmtime::component::HasData + Send {
-                fn f32_param<T: 'static>(
+                fn f32_param<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: f32,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn f64_param<T: 'static>(
+                fn f64_param<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: f64,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn f32_result<T: 'static>(
+                fn f32_result<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = f32> + Send;
-                fn f64_result<T: 'static>(
+                fn f64_result<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = f64> + Send;
             }
@@ -225,9 +225,8 @@ pub mod foo {
                     "f32-param",
                     move |caller: &wasmtime::component::Accessor<T>, (arg0,): (f32,)| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::f32_param(accessor, arg0)
-                                .await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::f32_param(host, arg0).await;
                             Ok(r)
                         })
                     },
@@ -236,9 +235,8 @@ pub mod foo {
                     "f64-param",
                     move |caller: &wasmtime::component::Accessor<T>, (arg0,): (f64,)| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::f64_param(accessor, arg0)
-                                .await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::f64_param(host, arg0).await;
                             Ok(r)
                         })
                     },
@@ -247,8 +245,8 @@ pub mod foo {
                     "f32-result",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::f32_result(accessor).await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::f32_result(host).await;
                             Ok((r,))
                         })
                     },
@@ -257,8 +255,8 @@ pub mod foo {
                     "f64-result",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::f64_result(accessor).await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::f64_result(host).await;
                             Ok((r,))
                         })
                     },

--- a/crates/component-macro/tests/expanded/host-world_concurrent.rs
+++ b/crates/component-macro/tests/expanded/host-world_concurrent.rs
@@ -99,7 +99,7 @@ pub struct Host_Indices {}
 /// [`Linker`]: wasmtime::component::Linker
 pub struct Host_ {}
 pub trait Host_ImportsWithStore: wasmtime::component::HasData + Send {
-    fn foo<T: 'static>(
+    fn foo<T>(
         accessor: &wasmtime::component::Accessor<T, Self>,
     ) -> impl ::core::future::Future<Output = ()> + Send;
 }
@@ -184,8 +184,8 @@ const _: () = {
                     "foo",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as Host_ImportsWithStore>::foo(accessor).await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as Host_ImportsWithStore>::foo(host).await;
                             Ok(r)
                         })
                     },

--- a/crates/component-macro/tests/expanded/integers_concurrent.rs
+++ b/crates/component-macro/tests/expanded/integers_concurrent.rs
@@ -194,39 +194,39 @@ pub mod foo {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::{anyhow, Box};
             pub trait HostWithStore: wasmtime::component::HasData + Send {
-                fn a1<T: 'static>(
+                fn a1<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: u8,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn a2<T: 'static>(
+                fn a2<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: i8,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn a3<T: 'static>(
+                fn a3<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: u16,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn a4<T: 'static>(
+                fn a4<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: i16,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn a5<T: 'static>(
+                fn a5<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: u32,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn a6<T: 'static>(
+                fn a6<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: i32,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn a7<T: 'static>(
+                fn a7<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: u64,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn a8<T: 'static>(
+                fn a8<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: i64,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn a9<T: 'static>(
+                fn a9<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     p1: u8,
                     p2: i8,
@@ -237,31 +237,31 @@ pub mod foo {
                     p7: u64,
                     p8: i64,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn r1<T: 'static>(
+                fn r1<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = u8> + Send;
-                fn r2<T: 'static>(
+                fn r2<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = i8> + Send;
-                fn r3<T: 'static>(
+                fn r3<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = u16> + Send;
-                fn r4<T: 'static>(
+                fn r4<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = i16> + Send;
-                fn r5<T: 'static>(
+                fn r5<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = u32> + Send;
-                fn r6<T: 'static>(
+                fn r6<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = i32> + Send;
-                fn r7<T: 'static>(
+                fn r7<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = u64> + Send;
-                fn r8<T: 'static>(
+                fn r8<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = i64> + Send;
-                fn pair_ret<T: 'static>(
+                fn pair_ret<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = (i64, u8)> + Send;
             }
@@ -281,8 +281,8 @@ pub mod foo {
                     "a1",
                     move |caller: &wasmtime::component::Accessor<T>, (arg0,): (u8,)| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::a1(accessor, arg0).await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::a1(host, arg0).await;
                             Ok(r)
                         })
                     },
@@ -291,8 +291,8 @@ pub mod foo {
                     "a2",
                     move |caller: &wasmtime::component::Accessor<T>, (arg0,): (i8,)| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::a2(accessor, arg0).await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::a2(host, arg0).await;
                             Ok(r)
                         })
                     },
@@ -301,8 +301,8 @@ pub mod foo {
                     "a3",
                     move |caller: &wasmtime::component::Accessor<T>, (arg0,): (u16,)| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::a3(accessor, arg0).await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::a3(host, arg0).await;
                             Ok(r)
                         })
                     },
@@ -311,8 +311,8 @@ pub mod foo {
                     "a4",
                     move |caller: &wasmtime::component::Accessor<T>, (arg0,): (i16,)| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::a4(accessor, arg0).await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::a4(host, arg0).await;
                             Ok(r)
                         })
                     },
@@ -321,8 +321,8 @@ pub mod foo {
                     "a5",
                     move |caller: &wasmtime::component::Accessor<T>, (arg0,): (u32,)| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::a5(accessor, arg0).await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::a5(host, arg0).await;
                             Ok(r)
                         })
                     },
@@ -331,8 +331,8 @@ pub mod foo {
                     "a6",
                     move |caller: &wasmtime::component::Accessor<T>, (arg0,): (i32,)| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::a6(accessor, arg0).await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::a6(host, arg0).await;
                             Ok(r)
                         })
                     },
@@ -341,8 +341,8 @@ pub mod foo {
                     "a7",
                     move |caller: &wasmtime::component::Accessor<T>, (arg0,): (u64,)| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::a7(accessor, arg0).await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::a7(host, arg0).await;
                             Ok(r)
                         })
                     },
@@ -351,8 +351,8 @@ pub mod foo {
                     "a8",
                     move |caller: &wasmtime::component::Accessor<T>, (arg0,): (i64,)| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::a8(accessor, arg0).await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::a8(host, arg0).await;
                             Ok(r)
                         })
                     },
@@ -373,9 +373,9 @@ pub mod foo {
                         ): (u8, i8, u16, i16, u32, i32, u64, i64)|
                     {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
+                            let host = &caller.with_getter(host_getter);
                             let r = <D as HostWithStore>::a9(
-                                    accessor,
+                                    host,
                                     arg0,
                                     arg1,
                                     arg2,
@@ -394,8 +394,8 @@ pub mod foo {
                     "r1",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::r1(accessor).await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::r1(host).await;
                             Ok((r,))
                         })
                     },
@@ -404,8 +404,8 @@ pub mod foo {
                     "r2",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::r2(accessor).await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::r2(host).await;
                             Ok((r,))
                         })
                     },
@@ -414,8 +414,8 @@ pub mod foo {
                     "r3",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::r3(accessor).await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::r3(host).await;
                             Ok((r,))
                         })
                     },
@@ -424,8 +424,8 @@ pub mod foo {
                     "r4",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::r4(accessor).await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::r4(host).await;
                             Ok((r,))
                         })
                     },
@@ -434,8 +434,8 @@ pub mod foo {
                     "r5",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::r5(accessor).await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::r5(host).await;
                             Ok((r,))
                         })
                     },
@@ -444,8 +444,8 @@ pub mod foo {
                     "r6",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::r6(accessor).await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::r6(host).await;
                             Ok((r,))
                         })
                     },
@@ -454,8 +454,8 @@ pub mod foo {
                     "r7",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::r7(accessor).await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::r7(host).await;
                             Ok((r,))
                         })
                     },
@@ -464,8 +464,8 @@ pub mod foo {
                     "r8",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::r8(accessor).await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::r8(host).await;
                             Ok((r,))
                         })
                     },
@@ -474,8 +474,8 @@ pub mod foo {
                     "pair-ret",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::pair_ret(accessor).await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::pair_ret(host).await;
                             Ok((r,))
                         })
                     },

--- a/crates/component-macro/tests/expanded/lists_concurrent.rs
+++ b/crates/component-macro/tests/expanded/lists_concurrent.rs
@@ -372,116 +372,116 @@ pub mod foo {
                 );
             };
             pub trait HostWithStore: wasmtime::component::HasData + Send {
-                fn list_u8_param<T: 'static>(
+                fn list_u8_param<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: wasmtime::component::__internal::Vec<u8>,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn list_u16_param<T: 'static>(
+                fn list_u16_param<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: wasmtime::component::__internal::Vec<u16>,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn list_u32_param<T: 'static>(
+                fn list_u32_param<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: wasmtime::component::__internal::Vec<u32>,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn list_u64_param<T: 'static>(
+                fn list_u64_param<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: wasmtime::component::__internal::Vec<u64>,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn list_s8_param<T: 'static>(
+                fn list_s8_param<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: wasmtime::component::__internal::Vec<i8>,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn list_s16_param<T: 'static>(
+                fn list_s16_param<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: wasmtime::component::__internal::Vec<i16>,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn list_s32_param<T: 'static>(
+                fn list_s32_param<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: wasmtime::component::__internal::Vec<i32>,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn list_s64_param<T: 'static>(
+                fn list_s64_param<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: wasmtime::component::__internal::Vec<i64>,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn list_f32_param<T: 'static>(
+                fn list_f32_param<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: wasmtime::component::__internal::Vec<f32>,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn list_f64_param<T: 'static>(
+                fn list_f64_param<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: wasmtime::component::__internal::Vec<f64>,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn list_u8_ret<T: 'static>(
+                fn list_u8_ret<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<
                     Output = wasmtime::component::__internal::Vec<u8>,
                 > + Send;
-                fn list_u16_ret<T: 'static>(
+                fn list_u16_ret<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<
                     Output = wasmtime::component::__internal::Vec<u16>,
                 > + Send;
-                fn list_u32_ret<T: 'static>(
+                fn list_u32_ret<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<
                     Output = wasmtime::component::__internal::Vec<u32>,
                 > + Send;
-                fn list_u64_ret<T: 'static>(
+                fn list_u64_ret<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<
                     Output = wasmtime::component::__internal::Vec<u64>,
                 > + Send;
-                fn list_s8_ret<T: 'static>(
+                fn list_s8_ret<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<
                     Output = wasmtime::component::__internal::Vec<i8>,
                 > + Send;
-                fn list_s16_ret<T: 'static>(
+                fn list_s16_ret<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<
                     Output = wasmtime::component::__internal::Vec<i16>,
                 > + Send;
-                fn list_s32_ret<T: 'static>(
+                fn list_s32_ret<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<
                     Output = wasmtime::component::__internal::Vec<i32>,
                 > + Send;
-                fn list_s64_ret<T: 'static>(
+                fn list_s64_ret<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<
                     Output = wasmtime::component::__internal::Vec<i64>,
                 > + Send;
-                fn list_f32_ret<T: 'static>(
+                fn list_f32_ret<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<
                     Output = wasmtime::component::__internal::Vec<f32>,
                 > + Send;
-                fn list_f64_ret<T: 'static>(
+                fn list_f64_ret<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<
                     Output = wasmtime::component::__internal::Vec<f64>,
                 > + Send;
-                fn tuple_list<T: 'static>(
+                fn tuple_list<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: wasmtime::component::__internal::Vec<(u8, i8)>,
                 ) -> impl ::core::future::Future<
                     Output = wasmtime::component::__internal::Vec<(i64, u32)>,
                 > + Send;
-                fn string_list_arg<T: 'static>(
+                fn string_list_arg<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     a: wasmtime::component::__internal::Vec<
                         wasmtime::component::__internal::String,
                     >,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn string_list_ret<T: 'static>(
+                fn string_list_ret<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<
                     Output = wasmtime::component::__internal::Vec<
                         wasmtime::component::__internal::String,
                     >,
                 > + Send;
-                fn tuple_string_list<T: 'static>(
+                fn tuple_string_list<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: wasmtime::component::__internal::Vec<
                         (u8, wasmtime::component::__internal::String),
@@ -491,7 +491,7 @@ pub mod foo {
                         (wasmtime::component::__internal::String, u8),
                     >,
                 > + Send;
-                fn string_list<T: 'static>(
+                fn string_list<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: wasmtime::component::__internal::Vec<
                         wasmtime::component::__internal::String,
@@ -501,25 +501,25 @@ pub mod foo {
                         wasmtime::component::__internal::String,
                     >,
                 > + Send;
-                fn record_list<T: 'static>(
+                fn record_list<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: wasmtime::component::__internal::Vec<SomeRecord>,
                 ) -> impl ::core::future::Future<
                     Output = wasmtime::component::__internal::Vec<OtherRecord>,
                 > + Send;
-                fn record_list_reverse<T: 'static>(
+                fn record_list_reverse<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: wasmtime::component::__internal::Vec<OtherRecord>,
                 ) -> impl ::core::future::Future<
                     Output = wasmtime::component::__internal::Vec<SomeRecord>,
                 > + Send;
-                fn variant_list<T: 'static>(
+                fn variant_list<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: wasmtime::component::__internal::Vec<SomeVariant>,
                 ) -> impl ::core::future::Future<
                     Output = wasmtime::component::__internal::Vec<OtherVariant>,
                 > + Send;
-                fn load_store_everything<T: 'static>(
+                fn load_store_everything<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     a: LoadStoreAllSizes,
                 ) -> impl ::core::future::Future<Output = LoadStoreAllSizes> + Send;
@@ -543,8 +543,8 @@ pub mod foo {
                         (arg0,): (wasmtime::component::__internal::Vec<u8>,)|
                     {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::list_u8_param(accessor, arg0)
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::list_u8_param(host, arg0)
                                 .await;
                             Ok(r)
                         })
@@ -557,8 +557,8 @@ pub mod foo {
                         (arg0,): (wasmtime::component::__internal::Vec<u16>,)|
                     {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::list_u16_param(accessor, arg0)
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::list_u16_param(host, arg0)
                                 .await;
                             Ok(r)
                         })
@@ -571,8 +571,8 @@ pub mod foo {
                         (arg0,): (wasmtime::component::__internal::Vec<u32>,)|
                     {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::list_u32_param(accessor, arg0)
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::list_u32_param(host, arg0)
                                 .await;
                             Ok(r)
                         })
@@ -585,8 +585,8 @@ pub mod foo {
                         (arg0,): (wasmtime::component::__internal::Vec<u64>,)|
                     {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::list_u64_param(accessor, arg0)
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::list_u64_param(host, arg0)
                                 .await;
                             Ok(r)
                         })
@@ -599,8 +599,8 @@ pub mod foo {
                         (arg0,): (wasmtime::component::__internal::Vec<i8>,)|
                     {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::list_s8_param(accessor, arg0)
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::list_s8_param(host, arg0)
                                 .await;
                             Ok(r)
                         })
@@ -613,8 +613,8 @@ pub mod foo {
                         (arg0,): (wasmtime::component::__internal::Vec<i16>,)|
                     {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::list_s16_param(accessor, arg0)
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::list_s16_param(host, arg0)
                                 .await;
                             Ok(r)
                         })
@@ -627,8 +627,8 @@ pub mod foo {
                         (arg0,): (wasmtime::component::__internal::Vec<i32>,)|
                     {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::list_s32_param(accessor, arg0)
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::list_s32_param(host, arg0)
                                 .await;
                             Ok(r)
                         })
@@ -641,8 +641,8 @@ pub mod foo {
                         (arg0,): (wasmtime::component::__internal::Vec<i64>,)|
                     {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::list_s64_param(accessor, arg0)
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::list_s64_param(host, arg0)
                                 .await;
                             Ok(r)
                         })
@@ -655,8 +655,8 @@ pub mod foo {
                         (arg0,): (wasmtime::component::__internal::Vec<f32>,)|
                     {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::list_f32_param(accessor, arg0)
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::list_f32_param(host, arg0)
                                 .await;
                             Ok(r)
                         })
@@ -669,8 +669,8 @@ pub mod foo {
                         (arg0,): (wasmtime::component::__internal::Vec<f64>,)|
                     {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::list_f64_param(accessor, arg0)
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::list_f64_param(host, arg0)
                                 .await;
                             Ok(r)
                         })
@@ -680,8 +680,8 @@ pub mod foo {
                     "list-u8-ret",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::list_u8_ret(accessor).await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::list_u8_ret(host).await;
                             Ok((r,))
                         })
                     },
@@ -690,8 +690,8 @@ pub mod foo {
                     "list-u16-ret",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::list_u16_ret(accessor).await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::list_u16_ret(host).await;
                             Ok((r,))
                         })
                     },
@@ -700,8 +700,8 @@ pub mod foo {
                     "list-u32-ret",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::list_u32_ret(accessor).await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::list_u32_ret(host).await;
                             Ok((r,))
                         })
                     },
@@ -710,8 +710,8 @@ pub mod foo {
                     "list-u64-ret",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::list_u64_ret(accessor).await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::list_u64_ret(host).await;
                             Ok((r,))
                         })
                     },
@@ -720,8 +720,8 @@ pub mod foo {
                     "list-s8-ret",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::list_s8_ret(accessor).await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::list_s8_ret(host).await;
                             Ok((r,))
                         })
                     },
@@ -730,8 +730,8 @@ pub mod foo {
                     "list-s16-ret",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::list_s16_ret(accessor).await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::list_s16_ret(host).await;
                             Ok((r,))
                         })
                     },
@@ -740,8 +740,8 @@ pub mod foo {
                     "list-s32-ret",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::list_s32_ret(accessor).await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::list_s32_ret(host).await;
                             Ok((r,))
                         })
                     },
@@ -750,8 +750,8 @@ pub mod foo {
                     "list-s64-ret",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::list_s64_ret(accessor).await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::list_s64_ret(host).await;
                             Ok((r,))
                         })
                     },
@@ -760,8 +760,8 @@ pub mod foo {
                     "list-f32-ret",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::list_f32_ret(accessor).await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::list_f32_ret(host).await;
                             Ok((r,))
                         })
                     },
@@ -770,8 +770,8 @@ pub mod foo {
                     "list-f64-ret",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::list_f64_ret(accessor).await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::list_f64_ret(host).await;
                             Ok((r,))
                         })
                     },
@@ -783,9 +783,8 @@ pub mod foo {
                         (arg0,): (wasmtime::component::__internal::Vec<(u8, i8)>,)|
                     {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::tuple_list(accessor, arg0)
-                                .await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::tuple_list(host, arg0).await;
                             Ok((r,))
                         })
                     },
@@ -803,8 +802,8 @@ pub mod foo {
                         )|
                     {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::string_list_arg(accessor, arg0)
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::string_list_arg(host, arg0)
                                 .await;
                             Ok(r)
                         })
@@ -814,9 +813,8 @@ pub mod foo {
                     "string-list-ret",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::string_list_ret(accessor)
-                                .await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::string_list_ret(host).await;
                             Ok((r,))
                         })
                     },
@@ -834,11 +832,8 @@ pub mod foo {
                         )|
                     {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::tuple_string_list(
-                                    accessor,
-                                    arg0,
-                                )
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::tuple_string_list(host, arg0)
                                 .await;
                             Ok((r,))
                         })
@@ -857,9 +852,8 @@ pub mod foo {
                         )|
                     {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::string_list(accessor, arg0)
-                                .await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::string_list(host, arg0).await;
                             Ok((r,))
                         })
                     },
@@ -871,9 +865,8 @@ pub mod foo {
                         (arg0,): (wasmtime::component::__internal::Vec<SomeRecord>,)|
                     {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::record_list(accessor, arg0)
-                                .await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::record_list(host, arg0).await;
                             Ok((r,))
                         })
                     },
@@ -885,11 +878,8 @@ pub mod foo {
                         (arg0,): (wasmtime::component::__internal::Vec<OtherRecord>,)|
                     {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::record_list_reverse(
-                                    accessor,
-                                    arg0,
-                                )
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::record_list_reverse(host, arg0)
                                 .await;
                             Ok((r,))
                         })
@@ -902,9 +892,8 @@ pub mod foo {
                         (arg0,): (wasmtime::component::__internal::Vec<SomeVariant>,)|
                     {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::variant_list(accessor, arg0)
-                                .await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::variant_list(host, arg0).await;
                             Ok((r,))
                         })
                     },
@@ -916,9 +905,9 @@ pub mod foo {
                         (arg0,): (LoadStoreAllSizes,)|
                     {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
+                            let host = &caller.with_getter(host_getter);
                             let r = <D as HostWithStore>::load_store_everything(
-                                    accessor,
+                                    host,
                                     arg0,
                                 )
                                 .await;

--- a/crates/component-macro/tests/expanded/many-arguments_concurrent.rs
+++ b/crates/component-macro/tests/expanded/many-arguments_concurrent.rs
@@ -275,7 +275,7 @@ pub mod foo {
                 );
             };
             pub trait HostWithStore: wasmtime::component::HasData + Send {
-                fn many_args<T: 'static>(
+                fn many_args<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     a1: u64,
                     a2: u64,
@@ -294,7 +294,7 @@ pub mod foo {
                     a15: u64,
                     a16: u64,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn big_argument<T: 'static>(
+                fn big_argument<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: BigStruct,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
@@ -352,9 +352,9 @@ pub mod foo {
                         )|
                     {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
+                            let host = &caller.with_getter(host_getter);
                             let r = <D as HostWithStore>::many_args(
-                                    accessor,
+                                    host,
                                     arg0,
                                     arg1,
                                     arg2,
@@ -384,9 +384,8 @@ pub mod foo {
                         (arg0,): (BigStruct,)|
                     {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::big_argument(accessor, arg0)
-                                .await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::big_argument(host, arg0).await;
                             Ok(r)
                         })
                     },

--- a/crates/component-macro/tests/expanded/multiversion_concurrent.rs
+++ b/crates/component-macro/tests/expanded/multiversion_concurrent.rs
@@ -203,7 +203,7 @@ pub mod my {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::{anyhow, Box};
             pub trait HostWithStore: wasmtime::component::HasData + Send {
-                fn x<T: 'static>(
+                fn x<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
             }
@@ -223,8 +223,8 @@ pub mod my {
                     "x",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::x(accessor).await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::x(host).await;
                             Ok(r)
                         })
                     },
@@ -239,7 +239,7 @@ pub mod my {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::{anyhow, Box};
             pub trait HostWithStore: wasmtime::component::HasData + Send {
-                fn x<T: 'static>(
+                fn x<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
             }
@@ -259,8 +259,8 @@ pub mod my {
                     "x",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::x(accessor).await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::x(host).await;
                             Ok(r)
                         })
                     },

--- a/crates/component-macro/tests/expanded/records_concurrent.rs
+++ b/crates/component-macro/tests/expanded/records_concurrent.rs
@@ -349,42 +349,42 @@ pub mod foo {
                 );
             };
             pub trait HostWithStore: wasmtime::component::HasData + Send {
-                fn tuple_arg<T: 'static>(
+                fn tuple_arg<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: (char, u32),
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn tuple_result<T: 'static>(
+                fn tuple_result<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = (char, u32)> + Send;
-                fn empty_arg<T: 'static>(
+                fn empty_arg<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: Empty,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn empty_result<T: 'static>(
+                fn empty_result<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = Empty> + Send;
-                fn scalar_arg<T: 'static>(
+                fn scalar_arg<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: Scalars,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn scalar_result<T: 'static>(
+                fn scalar_result<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = Scalars> + Send;
-                fn flags_arg<T: 'static>(
+                fn flags_arg<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: ReallyFlags,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn flags_result<T: 'static>(
+                fn flags_result<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = ReallyFlags> + Send;
-                fn aggregate_arg<T: 'static>(
+                fn aggregate_arg<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: Aggregates,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn aggregate_result<T: 'static>(
+                fn aggregate_result<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = Aggregates> + Send;
-                fn typedef_inout<T: 'static>(
+                fn typedef_inout<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     e: TupleTypedef2,
                 ) -> impl ::core::future::Future<Output = i32> + Send;
@@ -408,9 +408,8 @@ pub mod foo {
                         (arg0,): ((char, u32),)|
                     {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::tuple_arg(accessor, arg0)
-                                .await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::tuple_arg(host, arg0).await;
                             Ok(r)
                         })
                     },
@@ -419,8 +418,8 @@ pub mod foo {
                     "tuple-result",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::tuple_result(accessor).await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::tuple_result(host).await;
                             Ok((r,))
                         })
                     },
@@ -429,9 +428,8 @@ pub mod foo {
                     "empty-arg",
                     move |caller: &wasmtime::component::Accessor<T>, (arg0,): (Empty,)| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::empty_arg(accessor, arg0)
-                                .await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::empty_arg(host, arg0).await;
                             Ok(r)
                         })
                     },
@@ -440,8 +438,8 @@ pub mod foo {
                     "empty-result",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::empty_result(accessor).await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::empty_result(host).await;
                             Ok((r,))
                         })
                     },
@@ -453,9 +451,8 @@ pub mod foo {
                         (arg0,): (Scalars,)|
                     {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::scalar_arg(accessor, arg0)
-                                .await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::scalar_arg(host, arg0).await;
                             Ok(r)
                         })
                     },
@@ -464,8 +461,8 @@ pub mod foo {
                     "scalar-result",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::scalar_result(accessor).await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::scalar_result(host).await;
                             Ok((r,))
                         })
                     },
@@ -477,9 +474,8 @@ pub mod foo {
                         (arg0,): (ReallyFlags,)|
                     {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::flags_arg(accessor, arg0)
-                                .await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::flags_arg(host, arg0).await;
                             Ok(r)
                         })
                     },
@@ -488,8 +484,8 @@ pub mod foo {
                     "flags-result",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::flags_result(accessor).await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::flags_result(host).await;
                             Ok((r,))
                         })
                     },
@@ -501,8 +497,8 @@ pub mod foo {
                         (arg0,): (Aggregates,)|
                     {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::aggregate_arg(accessor, arg0)
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::aggregate_arg(host, arg0)
                                 .await;
                             Ok(r)
                         })
@@ -512,9 +508,8 @@ pub mod foo {
                     "aggregate-result",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::aggregate_result(accessor)
-                                .await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::aggregate_result(host).await;
                             Ok((r,))
                         })
                     },
@@ -526,8 +521,8 @@ pub mod foo {
                         (arg0,): (TupleTypedef2,)|
                     {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::typedef_inout(accessor, arg0)
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::typedef_inout(host, arg0)
                                 .await;
                             Ok((r,))
                         })

--- a/crates/component-macro/tests/expanded/rename_concurrent.rs
+++ b/crates/component-macro/tests/expanded/rename_concurrent.rs
@@ -218,7 +218,7 @@ pub mod foo {
                 assert!(4 == < Thing as wasmtime::component::ComponentType >::ALIGN32);
             };
             pub trait HostWithStore: wasmtime::component::HasData + Send {
-                fn foo<T: 'static>(
+                fn foo<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = Thing> + Send;
             }
@@ -238,8 +238,8 @@ pub mod foo {
                     "foo",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::foo(accessor).await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::foo(host).await;
                             Ok((r,))
                         })
                     },

--- a/crates/component-macro/tests/expanded/resources-export.rs
+++ b/crates/component-macro/tests/expanded/resources-export.rs
@@ -277,10 +277,8 @@ pub mod foo {
                     "y",
                     wasmtime::component::ResourceType::host::<Y>(),
                     move |mut store, rep| -> wasmtime::Result<()> {
-                        HostY::drop(
-                            &mut host_getter(store.data_mut()),
-                            wasmtime::component::Resource::new_own(rep),
-                        )
+                        let resource = wasmtime::component::Resource::new_own(rep);
+                        HostY::drop(&mut host_getter(store.data_mut()), resource)
                     },
                 )?;
                 Ok(())

--- a/crates/component-macro/tests/expanded/resources-export_concurrent.rs
+++ b/crates/component-macro/tests/expanded/resources-export_concurrent.rs
@@ -238,7 +238,7 @@ pub mod foo {
             use wasmtime::component::__internal::{anyhow, Box};
             pub enum Y {}
             pub trait HostYWithStore: wasmtime::component::HasData {
-                fn drop<T: 'static>(
+                fn drop<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     rep: wasmtime::component::Resource<Y>,
                 ) -> impl ::core::future::Future<Output = wasmtime::Result<()>> + Send
@@ -330,7 +330,7 @@ pub mod exports {
                                 .ok_or_else(|| {
                                     anyhow::anyhow!(
                                         "instance export `foo:foo/simple-export` does \
-                  not have export `{name}`"
+                not have export `{name}`"
                                     )
                                 })
                         };
@@ -484,7 +484,7 @@ pub mod exports {
                                 .ok_or_else(|| {
                                     anyhow::anyhow!(
                                         "instance export `foo:foo/export-using-import` does \
-                  not have export `{name}`"
+                not have export `{name}`"
                                     )
                                 })
                         };
@@ -643,7 +643,7 @@ pub mod exports {
                                 .ok_or_else(|| {
                                     anyhow::anyhow!(
                                         "instance export `foo:foo/export-using-export1` does \
-                  not have export `{name}`"
+                not have export `{name}`"
                                     )
                                 })
                         };
@@ -738,7 +738,7 @@ pub mod exports {
                                 .ok_or_else(|| {
                                     anyhow::anyhow!(
                                         "instance export `foo:foo/export-using-export2` does \
-                  not have export `{name}`"
+                not have export `{name}`"
                                     )
                                 })
                         };

--- a/crates/component-macro/tests/expanded/resources-import.rs
+++ b/crates/component-macro/tests/expanded/resources-import.rs
@@ -271,9 +271,10 @@ const _: () = {
                     "world-resource",
                     wasmtime::component::ResourceType::host::<WorldResource>(),
                     move |mut store, rep| -> wasmtime::Result<()> {
+                        let resource = wasmtime::component::Resource::new_own(rep);
                         HostWorldResource::drop(
                             &mut host_getter(store.data_mut()),
-                            wasmtime::component::Resource::new_own(rep),
+                            resource,
                         )
                     },
                 )?;
@@ -679,20 +680,16 @@ pub mod foo {
                     "bar",
                     wasmtime::component::ResourceType::host::<Bar>(),
                     move |mut store, rep| -> wasmtime::Result<()> {
-                        HostBar::drop(
-                            &mut host_getter(store.data_mut()),
-                            wasmtime::component::Resource::new_own(rep),
-                        )
+                        let resource = wasmtime::component::Resource::new_own(rep);
+                        HostBar::drop(&mut host_getter(store.data_mut()), resource)
                     },
                 )?;
                 inst.resource(
                     "fallible",
                     wasmtime::component::ResourceType::host::<Fallible>(),
                     move |mut store, rep| -> wasmtime::Result<()> {
-                        HostFallible::drop(
-                            &mut host_getter(store.data_mut()),
-                            wasmtime::component::Resource::new_own(rep),
-                        )
+                        let resource = wasmtime::component::Resource::new_own(rep);
+                        HostFallible::drop(&mut host_getter(store.data_mut()), resource)
                     },
                 )?;
                 inst.func_wrap(
@@ -981,10 +978,8 @@ pub mod foo {
                     "a",
                     wasmtime::component::ResourceType::host::<A>(),
                     move |mut store, rep| -> wasmtime::Result<()> {
-                        HostA::drop(
-                            &mut host_getter(store.data_mut()),
-                            wasmtime::component::Resource::new_own(rep),
-                        )
+                        let resource = wasmtime::component::Resource::new_own(rep);
+                        HostA::drop(&mut host_getter(store.data_mut()), resource)
                     },
                 )?;
                 Ok(())
@@ -1125,10 +1120,8 @@ pub mod foo {
                     "foo",
                     wasmtime::component::ResourceType::host::<Foo>(),
                     move |mut store, rep| -> wasmtime::Result<()> {
-                        HostFoo::drop(
-                            &mut host_getter(store.data_mut()),
-                            wasmtime::component::Resource::new_own(rep),
-                        )
+                        let resource = wasmtime::component::Resource::new_own(rep);
+                        HostFoo::drop(&mut host_getter(store.data_mut()), resource)
                     },
                 )?;
                 Ok(())

--- a/crates/component-macro/tests/expanded/resources-import_concurrent.rs
+++ b/crates/component-macro/tests/expanded/resources-import_concurrent.rs
@@ -1,21 +1,21 @@
 pub enum WorldResource {}
 pub trait HostWorldResourceWithStore: wasmtime::component::HasData + Send {
-    fn drop<T: 'static>(
+    fn drop<T>(
         accessor: &wasmtime::component::Accessor<T, Self>,
         rep: wasmtime::component::Resource<WorldResource>,
     ) -> impl ::core::future::Future<Output = wasmtime::Result<()>> + Send
     where
         Self: Sized;
-    fn new<T: 'static>(
+    fn new<T>(
         accessor: &wasmtime::component::Accessor<T, Self>,
     ) -> impl ::core::future::Future<
         Output = wasmtime::component::Resource<WorldResource>,
     > + Send;
-    fn foo<T: 'static>(
+    fn foo<T>(
         accessor: &wasmtime::component::Accessor<T, Self>,
         self_: wasmtime::component::Resource<WorldResource>,
     ) -> impl ::core::future::Future<Output = ()> + Send;
-    fn static_foo<T: 'static>(
+    fn static_foo<T>(
         accessor: &wasmtime::component::Accessor<T, Self>,
     ) -> impl ::core::future::Future<Output = ()> + Send;
 }
@@ -128,7 +128,7 @@ pub struct TheWorld {
     some_world_func2: wasmtime::component::Func,
 }
 pub trait TheWorldImportsWithStore: wasmtime::component::HasData + HostWorldResourceWithStore + Send {
-    fn some_world_func<T: 'static>(
+    fn some_world_func<T>(
         accessor: &wasmtime::component::Accessor<T, Self>,
     ) -> impl ::core::future::Future<
         Output = wasmtime::component::Resource<WorldResource>,
@@ -273,9 +273,9 @@ const _: () = {
                     "some-world-func",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
+                            let host = &caller.with_getter(host_getter);
                             let r = <D as TheWorldImportsWithStore>::some_world_func(
-                                    accessor,
+                                    host,
                                 )
                                 .await;
                             Ok((r,))
@@ -287,9 +287,8 @@ const _: () = {
                     "[constructor]world-resource",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWorldResourceWithStore>::new(accessor)
-                                .await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWorldResourceWithStore>::new(host).await;
                             Ok((r,))
                         })
                     },
@@ -302,11 +301,8 @@ const _: () = {
                         (arg0,): (wasmtime::component::Resource<WorldResource>,)|
                     {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWorldResourceWithStore>::foo(
-                                    accessor,
-                                    arg0,
-                                )
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWorldResourceWithStore>::foo(host, arg0)
                                 .await;
                             Ok(r)
                         })
@@ -317,10 +313,8 @@ const _: () = {
                     "[static]world-resource.static-foo",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWorldResourceWithStore>::static_foo(
-                                    accessor,
-                                )
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWorldResourceWithStore>::static_foo(host)
                                 .await;
                             Ok(r)
                         })
@@ -393,21 +387,21 @@ pub mod foo {
             use wasmtime::component::__internal::{anyhow, Box};
             pub enum Bar {}
             pub trait HostBarWithStore: wasmtime::component::HasData + Send {
-                fn drop<T: 'static>(
+                fn drop<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     rep: wasmtime::component::Resource<Bar>,
                 ) -> impl ::core::future::Future<Output = wasmtime::Result<()>> + Send
                 where
                     Self: Sized;
-                fn new<T: 'static>(
+                fn new<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<
                     Output = wasmtime::component::Resource<Bar>,
                 > + Send;
-                fn static_a<T: 'static>(
+                fn static_a<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = u32> + Send;
-                fn method_a<T: 'static>(
+                fn method_a<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     self_: wasmtime::component::Resource<Bar>,
                 ) -> impl ::core::future::Future<Output = u32> + Send;
@@ -471,13 +465,13 @@ pub mod foo {
             };
             pub enum Fallible {}
             pub trait HostFallibleWithStore: wasmtime::component::HasData + Send {
-                fn drop<T: 'static>(
+                fn drop<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     rep: wasmtime::component::Resource<Fallible>,
                 ) -> impl ::core::future::Future<Output = wasmtime::Result<()>> + Send
                 where
                     Self: Sized;
-                fn new<T: 'static>(
+                fn new<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<
                     Output = Result<
@@ -489,89 +483,89 @@ pub mod foo {
             pub trait HostFallible: Send {}
             impl<_T: HostFallible + ?Sized + Send> HostFallible for &mut _T {}
             pub trait HostWithStore: wasmtime::component::HasData + HostBarWithStore + HostFallibleWithStore + Send {
-                fn bar_own_arg<T: 'static>(
+                fn bar_own_arg<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: wasmtime::component::Resource<Bar>,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn bar_borrow_arg<T: 'static>(
+                fn bar_borrow_arg<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: wasmtime::component::Resource<Bar>,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn bar_result<T: 'static>(
+                fn bar_result<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<
                     Output = wasmtime::component::Resource<Bar>,
                 > + Send;
-                fn tuple_own_arg<T: 'static>(
+                fn tuple_own_arg<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: (wasmtime::component::Resource<Bar>, u32),
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn tuple_borrow_arg<T: 'static>(
+                fn tuple_borrow_arg<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: (wasmtime::component::Resource<Bar>, u32),
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn tuple_result<T: 'static>(
+                fn tuple_result<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<
                     Output = (wasmtime::component::Resource<Bar>, u32),
                 > + Send;
-                fn option_own_arg<T: 'static>(
+                fn option_own_arg<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: Option<wasmtime::component::Resource<Bar>>,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn option_borrow_arg<T: 'static>(
+                fn option_borrow_arg<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: Option<wasmtime::component::Resource<Bar>>,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn option_result<T: 'static>(
+                fn option_result<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<
                     Output = Option<wasmtime::component::Resource<Bar>>,
                 > + Send;
-                fn result_own_arg<T: 'static>(
+                fn result_own_arg<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: Result<wasmtime::component::Resource<Bar>, ()>,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn result_borrow_arg<T: 'static>(
+                fn result_borrow_arg<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: Result<wasmtime::component::Resource<Bar>, ()>,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn result_result<T: 'static>(
+                fn result_result<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<
                     Output = Result<wasmtime::component::Resource<Bar>, ()>,
                 > + Send;
-                fn list_own_arg<T: 'static>(
+                fn list_own_arg<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: wasmtime::component::__internal::Vec<
                         wasmtime::component::Resource<Bar>,
                     >,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn list_borrow_arg<T: 'static>(
+                fn list_borrow_arg<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: wasmtime::component::__internal::Vec<
                         wasmtime::component::Resource<Bar>,
                     >,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn list_result<T: 'static>(
+                fn list_result<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<
                     Output = wasmtime::component::__internal::Vec<
                         wasmtime::component::Resource<Bar>,
                     >,
                 > + Send;
-                fn record_own_arg<T: 'static>(
+                fn record_own_arg<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: NestedOwn,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn record_borrow_arg<T: 'static>(
+                fn record_borrow_arg<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: NestedBorrow,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn record_result<T: 'static>(
+                fn record_result<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = NestedOwn> + Send;
-                fn func_with_handle_typedef<T: 'static>(
+                fn func_with_handle_typedef<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: SomeHandle,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
@@ -620,8 +614,8 @@ pub mod foo {
                     "[constructor]bar",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostBarWithStore>::new(accessor).await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostBarWithStore>::new(host).await;
                             Ok((r,))
                         })
                     },
@@ -630,8 +624,8 @@ pub mod foo {
                     "[static]bar.static-a",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostBarWithStore>::static_a(accessor).await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostBarWithStore>::static_a(host).await;
                             Ok((r,))
                         })
                     },
@@ -643,9 +637,8 @@ pub mod foo {
                         (arg0,): (wasmtime::component::Resource<Bar>,)|
                     {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostBarWithStore>::method_a(accessor, arg0)
-                                .await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostBarWithStore>::method_a(host, arg0).await;
                             Ok((r,))
                         })
                     },
@@ -657,9 +650,8 @@ pub mod foo {
                         (arg0,): (wasmtime::component::Resource<Bar>,)|
                     {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::bar_own_arg(accessor, arg0)
-                                .await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::bar_own_arg(host, arg0).await;
                             Ok(r)
                         })
                     },
@@ -671,8 +663,8 @@ pub mod foo {
                         (arg0,): (wasmtime::component::Resource<Bar>,)|
                     {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::bar_borrow_arg(accessor, arg0)
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::bar_borrow_arg(host, arg0)
                                 .await;
                             Ok(r)
                         })
@@ -682,8 +674,8 @@ pub mod foo {
                     "bar-result",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::bar_result(accessor).await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::bar_result(host).await;
                             Ok((r,))
                         })
                     },
@@ -695,8 +687,8 @@ pub mod foo {
                         (arg0,): ((wasmtime::component::Resource<Bar>, u32),)|
                     {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::tuple_own_arg(accessor, arg0)
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::tuple_own_arg(host, arg0)
                                 .await;
                             Ok(r)
                         })
@@ -709,11 +701,8 @@ pub mod foo {
                         (arg0,): ((wasmtime::component::Resource<Bar>, u32),)|
                     {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::tuple_borrow_arg(
-                                    accessor,
-                                    arg0,
-                                )
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::tuple_borrow_arg(host, arg0)
                                 .await;
                             Ok(r)
                         })
@@ -723,8 +712,8 @@ pub mod foo {
                     "tuple-result",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::tuple_result(accessor).await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::tuple_result(host).await;
                             Ok((r,))
                         })
                     },
@@ -736,8 +725,8 @@ pub mod foo {
                         (arg0,): (Option<wasmtime::component::Resource<Bar>>,)|
                     {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::option_own_arg(accessor, arg0)
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::option_own_arg(host, arg0)
                                 .await;
                             Ok(r)
                         })
@@ -750,11 +739,8 @@ pub mod foo {
                         (arg0,): (Option<wasmtime::component::Resource<Bar>>,)|
                     {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::option_borrow_arg(
-                                    accessor,
-                                    arg0,
-                                )
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::option_borrow_arg(host, arg0)
                                 .await;
                             Ok(r)
                         })
@@ -764,8 +750,8 @@ pub mod foo {
                     "option-result",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::option_result(accessor).await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::option_result(host).await;
                             Ok((r,))
                         })
                     },
@@ -777,8 +763,8 @@ pub mod foo {
                         (arg0,): (Result<wasmtime::component::Resource<Bar>, ()>,)|
                     {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::result_own_arg(accessor, arg0)
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::result_own_arg(host, arg0)
                                 .await;
                             Ok(r)
                         })
@@ -791,11 +777,8 @@ pub mod foo {
                         (arg0,): (Result<wasmtime::component::Resource<Bar>, ()>,)|
                     {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::result_borrow_arg(
-                                    accessor,
-                                    arg0,
-                                )
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::result_borrow_arg(host, arg0)
                                 .await;
                             Ok(r)
                         })
@@ -805,8 +788,8 @@ pub mod foo {
                     "result-result",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::result_result(accessor).await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::result_result(host).await;
                             Ok((r,))
                         })
                     },
@@ -824,9 +807,8 @@ pub mod foo {
                         )|
                     {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::list_own_arg(accessor, arg0)
-                                .await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::list_own_arg(host, arg0).await;
                             Ok(r)
                         })
                     },
@@ -844,8 +826,8 @@ pub mod foo {
                         )|
                     {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::list_borrow_arg(accessor, arg0)
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::list_borrow_arg(host, arg0)
                                 .await;
                             Ok(r)
                         })
@@ -855,8 +837,8 @@ pub mod foo {
                     "list-result",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::list_result(accessor).await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::list_result(host).await;
                             Ok((r,))
                         })
                     },
@@ -868,8 +850,8 @@ pub mod foo {
                         (arg0,): (NestedOwn,)|
                     {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::record_own_arg(accessor, arg0)
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::record_own_arg(host, arg0)
                                 .await;
                             Ok(r)
                         })
@@ -882,11 +864,8 @@ pub mod foo {
                         (arg0,): (NestedBorrow,)|
                     {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::record_borrow_arg(
-                                    accessor,
-                                    arg0,
-                                )
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::record_borrow_arg(host, arg0)
                                 .await;
                             Ok(r)
                         })
@@ -896,8 +875,8 @@ pub mod foo {
                     "record-result",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::record_result(accessor).await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::record_result(host).await;
                             Ok((r,))
                         })
                     },
@@ -909,9 +888,9 @@ pub mod foo {
                         (arg0,): (SomeHandle,)|
                     {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
+                            let host = &caller.with_getter(host_getter);
                             let r = <D as HostWithStore>::func_with_handle_typedef(
-                                    accessor,
+                                    host,
                                     arg0,
                                 )
                                 .await;
@@ -923,8 +902,8 @@ pub mod foo {
                     "[constructor]fallible",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostFallibleWithStore>::new(accessor).await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostFallibleWithStore>::new(host).await;
                             Ok((r,))
                         })
                     },
@@ -938,7 +917,7 @@ pub mod foo {
             use wasmtime::component::__internal::{anyhow, Box};
             pub enum A {}
             pub trait HostAWithStore: wasmtime::component::HasData {
-                fn drop<T: 'static>(
+                fn drop<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     rep: wasmtime::component::Resource<A>,
                 ) -> impl ::core::future::Future<Output = wasmtime::Result<()>> + Send
@@ -1037,7 +1016,7 @@ pub mod foo {
             use wasmtime::component::__internal::{anyhow, Box};
             pub type A = super::super::super::foo::foo::long_use_chain3::A;
             pub trait HostWithStore: wasmtime::component::HasData + Send {
-                fn foo<T: 'static>(
+                fn foo<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<
                     Output = wasmtime::component::Resource<A>,
@@ -1059,8 +1038,8 @@ pub mod foo {
                     "foo",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::foo(accessor).await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::foo(host).await;
                             Ok((r,))
                         })
                     },
@@ -1074,7 +1053,7 @@ pub mod foo {
             use wasmtime::component::__internal::{anyhow, Box};
             pub enum Foo {}
             pub trait HostFooWithStore: wasmtime::component::HasData {
-                fn drop<T: 'static>(
+                fn drop<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     rep: wasmtime::component::Resource<Foo>,
                 ) -> impl ::core::future::Future<Output = wasmtime::Result<()>> + Send
@@ -1160,7 +1139,7 @@ pub mod exports {
                                 .ok_or_else(|| {
                                     anyhow::anyhow!(
                                         "instance export `foo:foo/uses-resource-transitively` does \
-                    not have export `{name}`"
+                not have export `{name}`"
                                     )
                                 })
                         };

--- a/crates/component-macro/tests/expanded/share-types_concurrent.rs
+++ b/crates/component-macro/tests/expanded/share-types_concurrent.rs
@@ -267,7 +267,7 @@ pub mod http_fetch {
         assert!(4 == < Response as wasmtime::component::ComponentType >::ALIGN32);
     };
     pub trait HostWithStore: wasmtime::component::HasData + Send {
-        fn fetch_request<T: 'static>(
+        fn fetch_request<T>(
             accessor: &wasmtime::component::Accessor<T, Self>,
             request: Request,
         ) -> impl ::core::future::Future<Output = Response> + Send;
@@ -288,8 +288,8 @@ pub mod http_fetch {
             "fetch-request",
             move |caller: &wasmtime::component::Accessor<T>, (arg0,): (Request,)| {
                 wasmtime::component::__internal::Box::pin(async move {
-                    let accessor = &caller.with_getter(host_getter);
-                    let r = <D as HostWithStore>::fetch_request(accessor, arg0).await;
+                    let host = &caller.with_getter(host_getter);
+                    let r = <D as HostWithStore>::fetch_request(host, arg0).await;
                     Ok((r,))
                 })
             },

--- a/crates/component-macro/tests/expanded/simple-functions_concurrent.rs
+++ b/crates/component-macro/tests/expanded/simple-functions_concurrent.rs
@@ -194,25 +194,25 @@ pub mod foo {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::{anyhow, Box};
             pub trait HostWithStore: wasmtime::component::HasData + Send {
-                fn f1<T: 'static>(
+                fn f1<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn f2<T: 'static>(
+                fn f2<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     a: u32,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn f3<T: 'static>(
+                fn f3<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     a: u32,
                     b: u32,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn f4<T: 'static>(
+                fn f4<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = u32> + Send;
-                fn f5<T: 'static>(
+                fn f5<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = (u32, u32)> + Send;
-                fn f6<T: 'static>(
+                fn f6<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     a: u32,
                     b: u32,
@@ -235,8 +235,8 @@ pub mod foo {
                     "f1",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::f1(accessor).await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::f1(host).await;
                             Ok(r)
                         })
                     },
@@ -245,8 +245,8 @@ pub mod foo {
                     "f2",
                     move |caller: &wasmtime::component::Accessor<T>, (arg0,): (u32,)| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::f2(accessor, arg0).await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::f2(host, arg0).await;
                             Ok(r)
                         })
                     },
@@ -258,8 +258,8 @@ pub mod foo {
                         (arg0, arg1): (u32, u32)|
                     {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::f3(accessor, arg0, arg1).await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::f3(host, arg0, arg1).await;
                             Ok(r)
                         })
                     },
@@ -268,8 +268,8 @@ pub mod foo {
                     "f4",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::f4(accessor).await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::f4(host).await;
                             Ok((r,))
                         })
                     },
@@ -278,8 +278,8 @@ pub mod foo {
                     "f5",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::f5(accessor).await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::f5(host).await;
                             Ok((r,))
                         })
                     },
@@ -291,8 +291,8 @@ pub mod foo {
                         (arg0, arg1, arg2): (u32, u32, u32)|
                     {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::f6(accessor, arg0, arg1, arg2)
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::f6(host, arg0, arg1, arg2)
                                 .await;
                             Ok((r,))
                         })

--- a/crates/component-macro/tests/expanded/simple-lists_concurrent.rs
+++ b/crates/component-macro/tests/expanded/simple-lists_concurrent.rs
@@ -194,16 +194,16 @@ pub mod foo {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::{anyhow, Box};
             pub trait HostWithStore: wasmtime::component::HasData + Send {
-                fn simple_list1<T: 'static>(
+                fn simple_list1<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     l: wasmtime::component::__internal::Vec<u32>,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn simple_list2<T: 'static>(
+                fn simple_list2<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<
                     Output = wasmtime::component::__internal::Vec<u32>,
                 > + Send;
-                fn simple_list3<T: 'static>(
+                fn simple_list3<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     a: wasmtime::component::__internal::Vec<u32>,
                     b: wasmtime::component::__internal::Vec<u32>,
@@ -213,7 +213,7 @@ pub mod foo {
                         wasmtime::component::__internal::Vec<u32>,
                     ),
                 > + Send;
-                fn simple_list4<T: 'static>(
+                fn simple_list4<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     l: wasmtime::component::__internal::Vec<
                         wasmtime::component::__internal::Vec<u32>,
@@ -243,9 +243,8 @@ pub mod foo {
                         (arg0,): (wasmtime::component::__internal::Vec<u32>,)|
                     {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::simple_list1(accessor, arg0)
-                                .await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::simple_list1(host, arg0).await;
                             Ok(r)
                         })
                     },
@@ -254,8 +253,8 @@ pub mod foo {
                     "simple-list2",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::simple_list2(accessor).await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::simple_list2(host).await;
                             Ok((r,))
                         })
                     },
@@ -273,12 +272,8 @@ pub mod foo {
                         )|
                     {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::simple_list3(
-                                    accessor,
-                                    arg0,
-                                    arg1,
-                                )
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::simple_list3(host, arg0, arg1)
                                 .await;
                             Ok((r,))
                         })
@@ -297,9 +292,8 @@ pub mod foo {
                         )|
                     {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::simple_list4(accessor, arg0)
-                                .await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::simple_list4(host, arg0).await;
                             Ok((r,))
                         })
                     },

--- a/crates/component-macro/tests/expanded/simple-wasi_concurrent.rs
+++ b/crates/component-macro/tests/expanded/simple-wasi_concurrent.rs
@@ -248,10 +248,10 @@ pub mod foo {
                 assert!(1 == < Errno as wasmtime::component::ComponentType >::ALIGN32);
             };
             pub trait HostWithStore: wasmtime::component::HasData + Send {
-                fn create_directory_at<T: 'static>(
+                fn create_directory_at<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = Result<(), Errno>> + Send;
-                fn stat<T: 'static>(
+                fn stat<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<
                     Output = Result<DescriptorStat, Errno>,
@@ -273,8 +273,8 @@ pub mod foo {
                     "create-directory-at",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::create_directory_at(accessor)
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::create_directory_at(host)
                                 .await;
                             Ok((r,))
                         })
@@ -284,8 +284,8 @@ pub mod foo {
                     "stat",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::stat(accessor).await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::stat(host).await;
                             Ok((r,))
                         })
                     },

--- a/crates/component-macro/tests/expanded/small-anonymous_concurrent.rs
+++ b/crates/component-macro/tests/expanded/small-anonymous_concurrent.rs
@@ -237,7 +237,7 @@ pub mod foo {
                 assert!(1 == < Error as wasmtime::component::ComponentType >::ALIGN32);
             };
             pub trait HostWithStore: wasmtime::component::HasData + Send {
-                fn option_test<T: 'static>(
+                fn option_test<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<
                     Output = Result<
@@ -262,8 +262,8 @@ pub mod foo {
                     "option-test",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::option_test(accessor).await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::option_test(host).await;
                             Ok((r,))
                         })
                     },

--- a/crates/component-macro/tests/expanded/smoke_concurrent.rs
+++ b/crates/component-macro/tests/expanded/smoke_concurrent.rs
@@ -181,7 +181,7 @@ pub mod imports {
     #[allow(unused_imports)]
     use wasmtime::component::__internal::{anyhow, Box};
     pub trait HostWithStore: wasmtime::component::HasData + Send {
-        fn y<T: 'static>(
+        fn y<T>(
             accessor: &wasmtime::component::Accessor<T, Self>,
         ) -> impl ::core::future::Future<Output = ()> + Send;
     }
@@ -201,8 +201,8 @@ pub mod imports {
             "y",
             move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                 wasmtime::component::__internal::Box::pin(async move {
-                    let accessor = &caller.with_getter(host_getter);
-                    let r = <D as HostWithStore>::y(accessor).await;
+                    let host = &caller.with_getter(host_getter);
+                    let r = <D as HostWithStore>::y(host).await;
                     Ok(r)
                 })
             },

--- a/crates/component-macro/tests/expanded/strings_concurrent.rs
+++ b/crates/component-macro/tests/expanded/strings_concurrent.rs
@@ -194,16 +194,16 @@ pub mod foo {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::{anyhow, Box};
             pub trait HostWithStore: wasmtime::component::HasData + Send {
-                fn a<T: 'static>(
+                fn a<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: wasmtime::component::__internal::String,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn b<T: 'static>(
+                fn b<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<
                     Output = wasmtime::component::__internal::String,
                 > + Send;
-                fn c<T: 'static>(
+                fn c<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     a: wasmtime::component::__internal::String,
                     b: wasmtime::component::__internal::String,
@@ -230,8 +230,8 @@ pub mod foo {
                         (arg0,): (wasmtime::component::__internal::String,)|
                     {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::a(accessor, arg0).await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::a(host, arg0).await;
                             Ok(r)
                         })
                     },
@@ -240,8 +240,8 @@ pub mod foo {
                     "b",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::b(accessor).await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::b(host).await;
                             Ok((r,))
                         })
                     },
@@ -259,8 +259,8 @@ pub mod foo {
                         )|
                     {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::c(accessor, arg0, arg1).await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::c(host, arg0, arg1).await;
                             Ok((r,))
                         })
                     },

--- a/crates/component-macro/tests/expanded/unstable-features.rs
+++ b/crates/component-macro/tests/expanded/unstable-features.rs
@@ -291,10 +291,8 @@ const _: () = {
                             "baz",
                             wasmtime::component::ResourceType::host::<Baz>(),
                             move |mut store, rep| -> wasmtime::Result<()> {
-                                HostBaz::drop(
-                                    &mut host_getter(store.data_mut()),
-                                    wasmtime::component::Resource::new_own(rep),
-                                )
+                                let resource = wasmtime::component::Resource::new_own(rep);
+                                HostBaz::drop(&mut host_getter(store.data_mut()), resource)
                             },
                         )?;
                 }
@@ -448,10 +446,8 @@ pub mod foo {
                             "bar",
                             wasmtime::component::ResourceType::host::<Bar>(),
                             move |mut store, rep| -> wasmtime::Result<()> {
-                                HostBar::drop(
-                                    &mut host_getter(store.data_mut()),
-                                    wasmtime::component::Resource::new_own(rep),
-                                )
+                                let resource = wasmtime::component::Resource::new_own(rep);
+                                HostBar::drop(&mut host_getter(store.data_mut()), resource)
                             },
                         )?;
                     }

--- a/crates/component-macro/tests/expanded/unstable-features_concurrent.rs
+++ b/crates/component-macro/tests/expanded/unstable-features_concurrent.rs
@@ -80,13 +80,13 @@ impl core::convert::From<&LinkOptions> for foo::foo::the_interface::LinkOptions 
 }
 pub enum Baz {}
 pub trait HostBazWithStore: wasmtime::component::HasData + Send {
-    fn drop<T: 'static>(
+    fn drop<T>(
         accessor: &wasmtime::component::Accessor<T, Self>,
         rep: wasmtime::component::Resource<Baz>,
     ) -> impl ::core::future::Future<Output = wasmtime::Result<()>> + Send
     where
         Self: Sized;
-    fn foo<T: 'static>(
+    fn foo<T>(
         accessor: &wasmtime::component::Accessor<T, Self>,
         self_: wasmtime::component::Resource<Baz>,
     ) -> impl ::core::future::Future<Output = ()> + Send;
@@ -194,7 +194,7 @@ pub struct TheWorldIndices {}
 /// [`Linker`]: wasmtime::component::Linker
 pub struct TheWorld {}
 pub trait TheWorldImportsWithStore: wasmtime::component::HasData + HostBazWithStore + Send {
-    fn foo<T: 'static>(
+    fn foo<T>(
         accessor: &wasmtime::component::Accessor<T, Self>,
     ) -> impl ::core::future::Future<Output = ()> + Send;
 }
@@ -299,9 +299,8 @@ const _: () = {
                             "foo",
                             move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                                 wasmtime::component::__internal::Box::pin(async move {
-                                    let accessor = &caller.with_getter(host_getter);
-                                    let r = <D as TheWorldImportsWithStore>::foo(accessor)
-                                        .await;
+                                    let host = &caller.with_getter(host_getter);
+                                    let r = <D as TheWorldImportsWithStore>::foo(host).await;
                                     Ok(r)
                                 })
                             },
@@ -316,8 +315,8 @@ const _: () = {
                                 (arg0,): (wasmtime::component::Resource<Baz>,)|
                             {
                                 wasmtime::component::__internal::Box::pin(async move {
-                                    let accessor = &caller.with_getter(host_getter);
-                                    let r = <D as HostBazWithStore>::foo(accessor, arg0).await;
+                                    let host = &caller.with_getter(host_getter);
+                                    let r = <D as HostBazWithStore>::foo(host, arg0).await;
                                     Ok(r)
                                 })
                             },
@@ -396,13 +395,13 @@ pub mod foo {
             }
             pub enum Bar {}
             pub trait HostBarWithStore: wasmtime::component::HasData + Send {
-                fn drop<T: 'static>(
+                fn drop<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     rep: wasmtime::component::Resource<Bar>,
                 ) -> impl ::core::future::Future<Output = wasmtime::Result<()>> + Send
                 where
                     Self: Sized;
-                fn foo<T: 'static>(
+                fn foo<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     self_: wasmtime::component::Resource<Bar>,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
@@ -410,7 +409,7 @@ pub mod foo {
             pub trait HostBar: Send {}
             impl<_T: HostBar + ?Sized + Send> HostBar for &mut _T {}
             pub trait HostWithStore: wasmtime::component::HasData + HostBarWithStore + Send {
-                fn foo<T: 'static>(
+                fn foo<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
             }
@@ -449,8 +448,8 @@ pub mod foo {
                             "foo",
                             move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                                 wasmtime::component::__internal::Box::pin(async move {
-                                    let accessor = &caller.with_getter(host_getter);
-                                    let r = <D as HostWithStore>::foo(accessor).await;
+                                    let host = &caller.with_getter(host_getter);
+                                    let r = <D as HostWithStore>::foo(host).await;
                                     Ok(r)
                                 })
                             },
@@ -464,8 +463,8 @@ pub mod foo {
                                 (arg0,): (wasmtime::component::Resource<Bar>,)|
                             {
                                 wasmtime::component::__internal::Box::pin(async move {
-                                    let accessor = &caller.with_getter(host_getter);
-                                    let r = <D as HostBarWithStore>::foo(accessor, arg0).await;
+                                    let host = &caller.with_getter(host_getter);
+                                    let r = <D as HostBarWithStore>::foo(host, arg0).await;
                                     Ok(r)
                                 })
                             },

--- a/crates/component-macro/tests/expanded/unversioned-foo_concurrent.rs
+++ b/crates/component-macro/tests/expanded/unversioned-foo_concurrent.rs
@@ -211,7 +211,7 @@ pub mod foo {
                 assert!(4 == < Error as wasmtime::component::ComponentType >::ALIGN32);
             };
             pub trait HostWithStore: wasmtime::component::HasData + Send {
-                fn g<T: 'static>(
+                fn g<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = Result<(), Error>> + Send;
             }
@@ -231,8 +231,8 @@ pub mod foo {
                     "g",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::g(accessor).await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::g(host).await;
                             Ok((r,))
                         })
                     },

--- a/crates/component-macro/tests/expanded/use-paths_concurrent.rs
+++ b/crates/component-macro/tests/expanded/use-paths_concurrent.rs
@@ -205,7 +205,7 @@ pub mod foo {
                 assert!(1 == < Foo as wasmtime::component::ComponentType >::ALIGN32);
             };
             pub trait HostWithStore: wasmtime::component::HasData + Send {
-                fn a<T: 'static>(
+                fn a<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = Foo> + Send;
             }
@@ -225,8 +225,8 @@ pub mod foo {
                     "a",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::a(accessor).await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::a(host).await;
                             Ok((r,))
                         })
                     },
@@ -244,7 +244,7 @@ pub mod foo {
                 assert!(1 == < Foo as wasmtime::component::ComponentType >::ALIGN32);
             };
             pub trait HostWithStore: wasmtime::component::HasData + Send {
-                fn a<T: 'static>(
+                fn a<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = Foo> + Send;
             }
@@ -264,8 +264,8 @@ pub mod foo {
                     "a",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::a(accessor).await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::a(host).await;
                             Ok((r,))
                         })
                     },
@@ -283,7 +283,7 @@ pub mod foo {
                 assert!(1 == < Foo as wasmtime::component::ComponentType >::ALIGN32);
             };
             pub trait HostWithStore: wasmtime::component::HasData + Send {
-                fn a<T: 'static>(
+                fn a<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = Foo> + Send;
             }
@@ -303,8 +303,8 @@ pub mod foo {
                     "a",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::a(accessor).await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::a(host).await;
                             Ok((r,))
                         })
                     },
@@ -324,7 +324,7 @@ pub mod d {
         assert!(1 == < Foo as wasmtime::component::ComponentType >::ALIGN32);
     };
     pub trait HostWithStore: wasmtime::component::HasData + Send {
-        fn b<T: 'static>(
+        fn b<T>(
             accessor: &wasmtime::component::Accessor<T, Self>,
         ) -> impl ::core::future::Future<Output = Foo> + Send;
     }
@@ -344,8 +344,8 @@ pub mod d {
             "b",
             move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                 wasmtime::component::__internal::Box::pin(async move {
-                    let accessor = &caller.with_getter(host_getter);
-                    let r = <D as HostWithStore>::b(accessor).await;
+                    let host = &caller.with_getter(host_getter);
+                    let r = <D as HostWithStore>::b(host).await;
                     Ok((r,))
                 })
             },

--- a/crates/component-macro/tests/expanded/variants_concurrent.rs
+++ b/crates/component-macro/tests/expanded/variants_concurrent.rs
@@ -466,28 +466,28 @@ pub mod foo {
                 assert!(4 == < IsClone as wasmtime::component::ComponentType >::ALIGN32);
             };
             pub trait HostWithStore: wasmtime::component::HasData + Send {
-                fn e1_arg<T: 'static>(
+                fn e1_arg<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: E1,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn e1_result<T: 'static>(
+                fn e1_result<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = E1> + Send;
-                fn v1_arg<T: 'static>(
+                fn v1_arg<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: V1,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn v1_result<T: 'static>(
+                fn v1_result<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = V1> + Send;
-                fn bool_arg<T: 'static>(
+                fn bool_arg<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     x: bool,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn bool_result<T: 'static>(
+                fn bool_result<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = bool> + Send;
-                fn option_arg<T: 'static>(
+                fn option_arg<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     a: Option<bool>,
                     b: Option<()>,
@@ -496,7 +496,7 @@ pub mod foo {
                     e: Option<f32>,
                     g: Option<Option<bool>>,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn option_result<T: 'static>(
+                fn option_result<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<
                     Output = (
@@ -508,7 +508,7 @@ pub mod foo {
                         Option<Option<bool>>,
                     ),
                 > + Send;
-                fn casts<T: 'static>(
+                fn casts<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     a: Casts1,
                     b: Casts2,
@@ -519,7 +519,7 @@ pub mod foo {
                 ) -> impl ::core::future::Future<
                     Output = (Casts1, Casts2, Casts3, Casts4, Casts5, Casts6),
                 > + Send;
-                fn result_arg<T: 'static>(
+                fn result_arg<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     a: Result<(), ()>,
                     b: Result<(), E1>,
@@ -531,7 +531,7 @@ pub mod foo {
                         wasmtime::component::__internal::Vec<u8>,
                     >,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn result_result<T: 'static>(
+                fn result_result<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<
                     Output = (
@@ -546,36 +546,36 @@ pub mod foo {
                         >,
                     ),
                 > + Send;
-                fn return_result_sugar<T: 'static>(
+                fn return_result_sugar<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = Result<i32, MyErrno>> + Send;
-                fn return_result_sugar2<T: 'static>(
+                fn return_result_sugar2<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = Result<(), MyErrno>> + Send;
-                fn return_result_sugar3<T: 'static>(
+                fn return_result_sugar3<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<
                     Output = Result<MyErrno, MyErrno>,
                 > + Send;
-                fn return_result_sugar4<T: 'static>(
+                fn return_result_sugar4<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<
                     Output = Result<(i32, u32), MyErrno>,
                 > + Send;
-                fn return_option_sugar<T: 'static>(
+                fn return_option_sugar<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = Option<i32>> + Send;
-                fn return_option_sugar2<T: 'static>(
+                fn return_option_sugar2<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = Option<MyErrno>> + Send;
-                fn result_simple<T: 'static>(
+                fn result_simple<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = Result<u32, i32>> + Send;
-                fn is_clone_arg<T: 'static>(
+                fn is_clone_arg<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                     a: IsClone,
                 ) -> impl ::core::future::Future<Output = ()> + Send;
-                fn is_clone_return<T: 'static>(
+                fn is_clone_return<T>(
                     accessor: &wasmtime::component::Accessor<T, Self>,
                 ) -> impl ::core::future::Future<Output = IsClone> + Send;
             }
@@ -595,8 +595,8 @@ pub mod foo {
                     "e1-arg",
                     move |caller: &wasmtime::component::Accessor<T>, (arg0,): (E1,)| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::e1_arg(accessor, arg0).await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::e1_arg(host, arg0).await;
                             Ok(r)
                         })
                     },
@@ -605,8 +605,8 @@ pub mod foo {
                     "e1-result",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::e1_result(accessor).await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::e1_result(host).await;
                             Ok((r,))
                         })
                     },
@@ -615,8 +615,8 @@ pub mod foo {
                     "v1-arg",
                     move |caller: &wasmtime::component::Accessor<T>, (arg0,): (V1,)| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::v1_arg(accessor, arg0).await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::v1_arg(host, arg0).await;
                             Ok(r)
                         })
                     },
@@ -625,8 +625,8 @@ pub mod foo {
                     "v1-result",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::v1_result(accessor).await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::v1_result(host).await;
                             Ok((r,))
                         })
                     },
@@ -635,8 +635,8 @@ pub mod foo {
                     "bool-arg",
                     move |caller: &wasmtime::component::Accessor<T>, (arg0,): (bool,)| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::bool_arg(accessor, arg0).await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::bool_arg(host, arg0).await;
                             Ok(r)
                         })
                     },
@@ -645,8 +645,8 @@ pub mod foo {
                     "bool-result",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::bool_result(accessor).await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::bool_result(host).await;
                             Ok((r,))
                         })
                     },
@@ -672,9 +672,9 @@ pub mod foo {
                         )|
                     {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
+                            let host = &caller.with_getter(host_getter);
                             let r = <D as HostWithStore>::option_arg(
-                                    accessor,
+                                    host,
                                     arg0,
                                     arg1,
                                     arg2,
@@ -691,8 +691,8 @@ pub mod foo {
                     "option-result",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::option_result(accessor).await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::option_result(host).await;
                             Ok((r,))
                         })
                     },
@@ -711,9 +711,9 @@ pub mod foo {
                         ): (Casts1, Casts2, Casts3, Casts4, Casts5, Casts6)|
                     {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
+                            let host = &caller.with_getter(host_getter);
                             let r = <D as HostWithStore>::casts(
-                                    accessor,
+                                    host,
                                     arg0,
                                     arg1,
                                     arg2,
@@ -750,9 +750,9 @@ pub mod foo {
                         )|
                     {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
+                            let host = &caller.with_getter(host_getter);
                             let r = <D as HostWithStore>::result_arg(
-                                    accessor,
+                                    host,
                                     arg0,
                                     arg1,
                                     arg2,
@@ -769,8 +769,8 @@ pub mod foo {
                     "result-result",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::result_result(accessor).await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::result_result(host).await;
                             Ok((r,))
                         })
                     },
@@ -779,8 +779,8 @@ pub mod foo {
                     "return-result-sugar",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::return_result_sugar(accessor)
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::return_result_sugar(host)
                                 .await;
                             Ok((r,))
                         })
@@ -790,8 +790,8 @@ pub mod foo {
                     "return-result-sugar2",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::return_result_sugar2(accessor)
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::return_result_sugar2(host)
                                 .await;
                             Ok((r,))
                         })
@@ -801,8 +801,8 @@ pub mod foo {
                     "return-result-sugar3",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::return_result_sugar3(accessor)
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::return_result_sugar3(host)
                                 .await;
                             Ok((r,))
                         })
@@ -812,8 +812,8 @@ pub mod foo {
                     "return-result-sugar4",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::return_result_sugar4(accessor)
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::return_result_sugar4(host)
                                 .await;
                             Ok((r,))
                         })
@@ -823,8 +823,8 @@ pub mod foo {
                     "return-option-sugar",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::return_option_sugar(accessor)
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::return_option_sugar(host)
                                 .await;
                             Ok((r,))
                         })
@@ -834,8 +834,8 @@ pub mod foo {
                     "return-option-sugar2",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::return_option_sugar2(accessor)
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::return_option_sugar2(host)
                                 .await;
                             Ok((r,))
                         })
@@ -845,8 +845,8 @@ pub mod foo {
                     "result-simple",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::result_simple(accessor).await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::result_simple(host).await;
                             Ok((r,))
                         })
                     },
@@ -858,9 +858,8 @@ pub mod foo {
                         (arg0,): (IsClone,)|
                     {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::is_clone_arg(accessor, arg0)
-                                .await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::is_clone_arg(host, arg0).await;
                             Ok(r)
                         })
                     },
@@ -869,9 +868,8 @@ pub mod foo {
                     "is-clone-return",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
                         wasmtime::component::__internal::Box::pin(async move {
-                            let accessor = &caller.with_getter(host_getter);
-                            let r = <D as HostWithStore>::is_clone_return(accessor)
-                                .await;
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::is_clone_return(host).await;
                             Ok((r,))
                         })
                     },

--- a/crates/environ/src/compile/mod.rs
+++ b/crates/environ/src/compile/mod.rs
@@ -180,7 +180,7 @@ pub struct CompiledFunctionBody {
 ///
 /// The diagram below depicts typical usage of this trait:
 ///
-/// ```ignore
+/// ```text
 ///                     +------+
 ///                     | Wasm |
 ///                     +------+

--- a/crates/wasmtime/src/compile/stratify.rs
+++ b/crates/wasmtime/src/compile/stratify.rs
@@ -8,7 +8,7 @@
 //!
 //! For example, when given the following tree-like call graph:
 //!
-//! ```ignore
+//! ```text
 //! +---+   +---+   +---+
 //! | a |-->| b |-->| c |
 //! +---+   +---+   +---+
@@ -28,7 +28,7 @@
 //!
 //! then stratification will produce these layers:
 //!
-//! ```ignore
+//! ```text
 //! [
 //!     {c, d, f, g},
 //!     {b, e},

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -2048,7 +2048,7 @@ impl Config {
     /// This may result in faster execution at runtime, but adds additional
     /// compilation time. Inlining may also enlarge the size of compiled
     /// artifacts (for example, the size of the result of
-    /// [`Engine::precompile_component`]).
+    /// [`Engine::precompile_component`](crate::Engine::precompile_component)).
     ///
     /// Inlining is not supported by all of Wasmtime's compilation strategies;
     /// currently, it only Cranelift supports it. This setting will be ignored

--- a/crates/wasmtime/src/engine.rs
+++ b/crates/wasmtime/src/engine.rs
@@ -735,8 +735,9 @@ impl Engine {
         crate::runtime::vm::tls_eager_initialize();
     }
 
-    /// Returns a [`PoolingAllocatorMetrics`] if this engine was configured with
-    /// [`InstanceAllocationStrategy::Pooling`].
+    /// Returns a [`PoolingAllocatorMetrics`](crate::PoolingAllocatorMetrics) if
+    /// this engine was configured with
+    /// [`InstanceAllocationStrategy::Pooling`](crate::InstanceAllocationStrategy::Pooling).
     #[cfg(feature = "pooling-allocator")]
     pub fn pooling_allocator_metrics(&self) -> Option<crate::vm::PoolingAllocatorMetrics> {
         crate::runtime::vm::PoolingAllocatorMetrics::new(self)

--- a/crates/wasmtime/src/runtime/component/bindgen_examples/_8_store_in_imports.rs
+++ b/crates/wasmtime/src/runtime/component/bindgen_examples/_8_store_in_imports.rs
@@ -1,0 +1,23 @@
+bindgen!({
+    inline: r#"
+        package example:store-in-imports;
+
+        world my-world {
+            import sync-with-store: func();
+            import async-with-store: async func();
+
+            import sync-without-store: func();
+            import async-without-store: func();
+
+            export run: async func();
+        }
+    "#,
+
+    imports: {
+        "sync-with-store": store,
+        // note that this isn't required because WIT-level `async` functions
+        // always have access to the store.
+        // "async-with-store": store,
+        "async-without-store": async,
+    },
+});

--- a/crates/wasmtime/src/runtime/component/linker.rs
+++ b/crates/wasmtime/src/runtime/component/linker.rs
@@ -515,9 +515,9 @@ impl<T: 'static> LinkerInstance<'_, T> {
     ///
     /// The closure `f` is provided an [`Accessor`] which can be used to acquire
     /// temporary, blocking, access to a [`StoreContextMut`] (through
-    /// [`Access`]). This models how a store is not available to `f` across
-    /// `await` points but it is temporarily available while actively being
-    /// polled.
+    /// [`Access`](crate::component::Access]). This models how a store is not
+    /// available to `f` across `await` points but it is temporarily available
+    /// while actively being polled.
     ///
     /// # Blocking / Async Behavior
     ///


### PR DESCRIPTION
This commit adds support to accessing the store in `bindgen!`-generated
import functions in traits. Since the inception of `bindgen!` this has
never been possible and access to the store requires manually working
with `Linker`, for example. This is not easy to do because it requires
surgically editing code or working around what bindings generation parts
you do want.

The implementation here is a small step away from what
component-model-async has already implemented for async functions.
Effectively it's a small extension of the `*WithStore` traits to also
have synchronous functions with `Access` parameters instead of `async`
functions with an `Accessor` parameter.

This is something we're going to want for the WASIp3 implementation
where I've noticed some resource destructors are going to want access to
the store to close out streams and such and this'll provide the bindings
necessary for that.

Closes https://github.com/bytecodealliance/wasmtime/issues/11590