### PR TITLE
Cranelift: add get_exception_handler_address.

### DIFF
--- a/cranelift/codegen/meta/src/cdsl/formats.rs
+++ b/cranelift/codegen/meta/src/cdsl/formats.rs
@@ -40,6 +40,8 @@ pub(crate) struct InstructionFormat {
 
     pub num_block_operands: usize,
 
+    pub num_raw_block_operands: usize,
+
     /// Index of the value input operand that is used to infer the controlling type variable. By
     /// default, this is `0`, the first `value` operand. The index is relative to the values only,
     /// ignoring immediate operands.
@@ -52,6 +54,7 @@ pub(crate) struct FormatStructure {
     pub num_value_operands: usize,
     pub has_value_list: bool,
     pub num_block_operands: usize,
+    pub num_raw_block_operands: usize,
     /// Tuples of (Rust field name / Rust type) for each immediate field.
     pub imm_field_names: Vec<(&'static str, &'static str)>,
 }
@@ -65,8 +68,12 @@ impl fmt::Display for InstructionFormat {
             .collect::<Vec<_>>()
             .join(", ");
         fmt.write_fmt(format_args!(
-            "{}(imms=({}), vals={}, blocks={})",
-            self.name, imm_args, self.num_value_operands, self.num_block_operands,
+            "{}(imms=({}), vals={}, blocks={}, raw_blocks={})",
+            self.name,
+            imm_args,
+            self.num_value_operands,
+            self.num_block_operands,
+            self.num_raw_block_operands,
         ))?;
         Ok(())
     }
@@ -79,6 +86,7 @@ impl InstructionFormat {
             num_value_operands: self.num_value_operands,
             has_value_list: self.has_value_list,
             num_block_operands: self.num_block_operands,
+            num_raw_block_operands: self.num_raw_block_operands,
             imm_field_names: self
                 .imm_fields
                 .iter()
@@ -97,6 +105,7 @@ impl InstructionFormatBuilder {
             num_value_operands: 0,
             has_value_list: false,
             num_block_operands: 0,
+            num_raw_block_operands: 0,
             imm_fields: Vec::new(),
             typevar_operand: None,
         })
@@ -114,6 +123,11 @@ impl InstructionFormatBuilder {
 
     pub fn block(mut self) -> Self {
         self.0.num_block_operands += 1;
+        self
+    }
+
+    pub fn raw_block(mut self) -> Self {
+        self.0.num_raw_block_operands += 1;
         self
     }
 

--- a/cranelift/codegen/meta/src/cdsl/instructions.rs
+++ b/cranelift/codegen/meta/src/cdsl/instructions.rs
@@ -288,6 +288,7 @@ fn verify_format(inst_name: &str, operands_in: &[Operand], format: &InstructionF
     // - whether it has a value list or not.
     let mut num_values = 0;
     let mut num_blocks = 0;
+    let mut num_raw_blocks = 0;
     let mut num_immediates = 0;
 
     for operand in operands_in.iter() {
@@ -304,6 +305,8 @@ fn verify_format(inst_name: &str, operands_in: &[Operand], format: &InstructionF
         }
         if operand.kind.is_block() {
             num_blocks += 1;
+        } else if operand.kind.is_raw_block() {
+            num_raw_blocks += 1;
         } else if operand.is_immediate_or_entityref() {
             if let Some(format_field) = format.imm_fields.get(num_immediates) {
                 assert_eq!(
@@ -332,6 +335,13 @@ fn verify_format(inst_name: &str, operands_in: &[Operand], format: &InstructionF
         num_blocks, format.num_block_operands,
         "inst {} doesn't have as many block input operands as its format {} declares; you may need \
         to use a different format.",
+        inst_name, format.name,
+    );
+
+    assert_eq!(
+        num_raw_blocks, format.num_raw_block_operands,
+        "inst {} doesn't have as many raw-block input operands as its format {} declares; you may need \
+         to use a different format.",
         inst_name, format.name,
     );
 

--- a/cranelift/codegen/meta/src/cdsl/operands.rs
+++ b/cranelift/codegen/meta/src/cdsl/operands.rs
@@ -150,6 +150,10 @@ impl OperandKind {
     pub(crate) fn is_block(&self) -> bool {
         self.rust_type == "ir::BlockCall"
     }
+
+    pub(crate) fn is_raw_block(&self) -> bool {
+        self.rust_type == "ir::Block"
+    }
 }
 
 impl From<&TypeVar> for OperandKind {

--- a/cranelift/codegen/meta/src/shared/entities.rs
+++ b/cranelift/codegen/meta/src/shared/entities.rs
@@ -23,6 +23,11 @@ pub(crate) struct EntityRefs {
     /// This is primarily used in control flow instructions.
     pub(crate) block_else: OperandKind,
 
+    /// A reference to a basic block in the same function, without any arguments.
+    /// This is primarily used to refer to block `try_call` terminators to get
+    /// exception metadata (e.g., resume PCs) as first-class values.
+    pub(crate) raw_block: OperandKind,
+
     /// A reference to a stack slot declared in the function preamble.
     pub(crate) stack_slot: OperandKind,
 
@@ -82,6 +87,12 @@ impl EntityRefs {
                 "block_else",
                 "ir::BlockCall",
                 "a basic block in the same function, with its arguments provided.",
+            ),
+
+            raw_block: new(
+                "raw_block",
+                "ir::Block",
+                "a basic block in the same function, with no arguments provided.",
             ),
 
             stack_slot: new("stack_slot", "ir::StackSlot", "A stack slot"),

--- a/cranelift/codegen/meta/src/shared/formats.rs
+++ b/cranelift/codegen/meta/src/shared/formats.rs
@@ -42,6 +42,7 @@ pub(crate) struct Formats {
     pub(crate) unary_ieee32: Rc<InstructionFormat>,
     pub(crate) unary_ieee64: Rc<InstructionFormat>,
     pub(crate) unary_imm: Rc<InstructionFormat>,
+    pub(crate) exception_handler_address: Rc<InstructionFormat>,
 }
 
 impl Formats {
@@ -218,6 +219,11 @@ impl Formats {
                 .value()
                 .value()
                 .imm(&imm.trapcode)
+                .build(),
+
+            exception_handler_address: Builder::new("ExceptionHandlerAddress")
+                .raw_block()
+                .imm(&imm.imm64)
                 .build(),
         }
     }

--- a/cranelift/codegen/meta/src/shared/instructions.rs
+++ b/cranelift/codegen/meta/src/shared/instructions.rs
@@ -1405,6 +1405,38 @@ pub(crate) fn define(
 
     ig.push(
         Inst::new(
+            "get_exception_handler_address",
+            r#"
+        Get the handler PC for the given exceptional edge for an
+        exception return from the given `try_call`-terminated block.
+
+        This instruction provides the PC for the handler resume point,
+        as defined by the exception-handling aspect of the given
+        callee ABI, for a return from the given calling block.  It can
+        be used when the exception unwind mechanism requires manual
+        plumbing for this information which must be set up before the call
+        itself: for example, if the resume address needs to be stored in
+        some context structure for a runtime to resume to on error.
+
+        The given caller block must end in a `try_call` and the given
+        exception-handling block must be one of its exceptional
+        successors in the associated exception-handling table. The
+        returned PC is *only* valid to resume to when the `try_call`
+        is on the stack having called the callee; in other words, when
+        a normal exception unwinder might otherwise resume to that
+        handler.
+        "#,
+            &formats.exception_handler_address,
+        )
+        .operands_in(vec![
+            Operand::new("block", &entities.raw_block),
+            Operand::new("index", &imm.imm64),
+        ])
+        .operands_out(vec![Operand::new("addr", iAddr)]),
+    );
+
+    ig.push(
+        Inst::new(
             "iconst",
             r#"
         Integer constant.

--- a/cranelift/codegen/src/inline.rs
+++ b/cranelift/codegen/src/inline.rs
@@ -946,6 +946,10 @@ impl<'a> ir::instructions::InstructionMapper for InliningInstRemapper<'a> {
         ir::BlockCall::new(inlined_block, args, &mut self.func.dfg.value_lists)
     }
 
+    fn map_block(&mut self, block: ir::Block) -> ir::Block {
+        self.entity_map.inlined_block(block)
+    }
+
     fn map_func_ref(&mut self, func_ref: ir::FuncRef) -> ir::FuncRef {
         self.entity_map.inlined_func_ref(func_ref)
     }

--- a/cranelift/codegen/src/ir/instructions.rs
+++ b/cranelift/codegen/src/ir/instructions.rs
@@ -1061,6 +1061,9 @@ pub trait InstructionMapper {
     /// Map a function over a `BlockCall`.
     fn map_block_call(&mut self, block_call: BlockCall) -> BlockCall;
 
+    /// Map a function over a `Block`.
+    fn map_block(&mut self, block: Block) -> Block;
+
     /// Map a function over a `FuncRef`.
     fn map_func_ref(&mut self, func_ref: FuncRef) -> FuncRef;
 
@@ -1109,6 +1112,10 @@ where
 
     fn map_block_call(&mut self, block_call: BlockCall) -> BlockCall {
         (**self).map_block_call(block_call)
+    }
+
+    fn map_block(&mut self, block: Block) -> Block {
+        (**self).map_block(block)
     }
 
     fn map_func_ref(&mut self, func_ref: FuncRef) -> FuncRef {
@@ -1329,6 +1336,10 @@ mod tests {
                 BlockCall::new(block, [], &mut pool)
             }
 
+            fn map_block(&mut self, block: Block) -> Block {
+                Block::from_u32(block.as_u32() + 1)
+            }
+
             fn map_func_ref(&mut self, func_ref: FuncRef) -> FuncRef {
                 FuncRef::from_u32(func_ref.as_u32() + 1)
             }
@@ -1444,6 +1455,20 @@ mod tests {
                 opcode: Opcode::Jump,
                 destination: BlockCall::new(Block::from_u32(42), [], &mut pool),
             })
+        );
+
+        // Mapping `Block`s.
+        assert_eq!(
+            map(InstructionData::ExceptionHandlerAddress {
+                opcode: Opcode::GetExceptionHandlerAddress,
+                block: Block::from_u32(1),
+                imm: 0.into(),
+            }),
+            InstructionData::ExceptionHandlerAddress {
+                opcode: Opcode::GetExceptionHandlerAddress,
+                block: Block::from_u32(2),
+                imm: 0.into(),
+            },
         );
 
         // Mapping `SigRef`s.

--- a/cranelift/codegen/src/isa/aarch64/inst.isle
+++ b/cranelift/codegen/src/isa/aarch64/inst.isle
@@ -993,10 +993,9 @@
        (DummyUse
         (reg Reg))
 
-       ;; A pseudoinstruction that loads the address of an exception
-       ;; handler target.
-       (ExceptionHandlerAddress (dst WritableReg)
-                                (label MachLabel))
+       ;; A pseudoinstruction that loads the address of a label.
+       (LabelAddress (dst WritableReg)
+                     (label MachLabel))
 
        ;; Emits an inline stack probe loop.
        ;;
@@ -5188,9 +5187,9 @@
             (_ Unit (emit (MInst.FpuLoad128 dst amode flags))))
        dst))
 
-;; Helper for creating an `ExceptionHandlerAddress` instruction.
-(decl a64_exception_handler_address (MachLabel) Reg)
-(rule (a64_exception_handler_address label)
+;; Helper for creating an `LabelAddress` instruction.
+(decl a64_label_address (MachLabel) Reg)
+(rule (a64_label_address label)
       (let ((dst WritableReg (temp_writable_reg $I64))
-            (_ Unit (emit (MInst.ExceptionHandlerAddress dst label))))
+            (_ Unit (emit (MInst.LabelAddress dst label))))
         dst))

--- a/cranelift/codegen/src/isa/aarch64/inst.isle
+++ b/cranelift/codegen/src/isa/aarch64/inst.isle
@@ -993,6 +993,11 @@
        (DummyUse
         (reg Reg))
 
+       ;; A pseudoinstruction that loads the address of an exception
+       ;; handler target.
+       (ExceptionHandlerAddress (dst WritableReg)
+                                (label MachLabel))
+
        ;; Emits an inline stack probe loop.
        ;;
        ;; Note that this is emitted post-regalloc so `start` and `end` can be
@@ -5182,3 +5187,10 @@
       (let ((dst WritableReg (temp_writable_reg $I8X16))
             (_ Unit (emit (MInst.FpuLoad128 dst amode flags))))
        dst))
+
+;; Helper for creating an `ExceptionHandlerAddress` instruction.
+(decl a64_exception_handler_address (MachLabel) Reg)
+(rule (a64_exception_handler_address label)
+      (let ((dst WritableReg (temp_writable_reg $I64))
+            (_ Unit (emit (MInst.ExceptionHandlerAddress dst label))))
+        dst))

--- a/cranelift/codegen/src/isa/aarch64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit.rs
@@ -3535,10 +3535,11 @@ impl MachInstEmit for Inst {
 
             &Inst::DummyUse { .. } => {}
 
-            &Inst::ExceptionHandlerAddress { dst, label } => {
+            &Inst::LabelAddress { dst, label } => {
                 // We emit an ADR only, which is +/- 2MiB range. This
-                // should be sufficient for the small trampolines in
-                // which this is typically used.
+                // should be sufficient for the typical use-case of
+                // this instruction, which is insmall trampolines to
+                // get exception-handler addresses.
                 let inst = Inst::Adr { rd: dst, off: 0 };
                 let offset = sink.cur_offset();
                 inst.emit(sink, emit_info, state);

--- a/cranelift/codegen/src/isa/aarch64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit.rs
@@ -3535,6 +3535,16 @@ impl MachInstEmit for Inst {
 
             &Inst::DummyUse { .. } => {}
 
+            &Inst::ExceptionHandlerAddress { dst, label } => {
+                // We emit an ADR only, which is +/- 2MiB range. This
+                // should be sufficient for the small trampolines in
+                // which this is typically used.
+                let inst = Inst::Adr { rd: dst, off: 0 };
+                let offset = sink.cur_offset();
+                inst.emit(sink, emit_info, state);
+                sink.use_label_at_offset(offset, label, LabelUse::Adr21);
+            }
+
             &Inst::StackProbeLoop { start, end, step } => {
                 assert!(emit_info.0.enable_probestack());
 

--- a/cranelift/codegen/src/isa/aarch64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/mod.rs
@@ -916,6 +916,9 @@ fn aarch64_get_operands(inst: &mut Inst, collector: &mut impl OperandVisitor) {
         Inst::DummyUse { reg } => {
             collector.reg_use(reg);
         }
+        Inst::ExceptionHandlerAddress { dst, .. } => {
+            collector.reg_def(dst);
+        }
         Inst::StackProbeLoop { start, end, .. } => {
             collector.reg_early_def(start);
             collector.reg_use(end);
@@ -2887,6 +2890,10 @@ impl Inst {
                 let reg = pretty_print_reg(reg);
                 format!("dummy_use {reg}")
             }
+            &Inst::ExceptionHandlerAddress { dst, label } => {
+                let dst = pretty_print_reg(dst.to_reg());
+                format!("exception_handler_address {dst}, {label:?}")
+            }
             &Inst::StackProbeLoop { start, end, step } => {
                 let start = pretty_print_reg(start.to_reg());
                 let end = pretty_print_reg(end);
@@ -2983,7 +2990,9 @@ impl MachInstLabelUse for LabelUse {
             LabelUse::Branch14 => (pc_rel_shifted & 0x3fff) << 5,
             LabelUse::Branch19 | LabelUse::Ldr19 => (pc_rel_shifted & 0x7ffff) << 5,
             LabelUse::Branch26 => pc_rel_shifted & 0x3ffffff,
-            LabelUse::Adr21 => (pc_rel_shifted & 0x7ffff) << 5 | (pc_rel_shifted & 0x180000) << 10,
+            // Note: the *low* two bits of offset are put in the
+            // *high* bits (30, 29).
+            LabelUse::Adr21 => (pc_rel_shifted & 0x1ffffc) << 3 | (pc_rel_shifted & 3) << 29,
             LabelUse::PCRel32 => pc_rel_shifted,
         };
         let is_add = match self {

--- a/cranelift/codegen/src/isa/aarch64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/mod.rs
@@ -916,7 +916,7 @@ fn aarch64_get_operands(inst: &mut Inst, collector: &mut impl OperandVisitor) {
         Inst::DummyUse { reg } => {
             collector.reg_use(reg);
         }
-        Inst::ExceptionHandlerAddress { dst, .. } => {
+        Inst::LabelAddress { dst, .. } => {
             collector.reg_def(dst);
         }
         Inst::StackProbeLoop { start, end, .. } => {
@@ -2890,9 +2890,9 @@ impl Inst {
                 let reg = pretty_print_reg(reg);
                 format!("dummy_use {reg}")
             }
-            &Inst::ExceptionHandlerAddress { dst, label } => {
+            &Inst::LabelAddress { dst, label } => {
                 let dst = pretty_print_reg(dst.to_reg());
-                format!("exception_handler_address {dst}, {label:?}")
+                format!("label_address {dst}, {label:?}")
             }
             &Inst::StackProbeLoop { start, end, step } => {
                 let start = pretty_print_reg(start.to_reg());

--- a/cranelift/codegen/src/isa/aarch64/lower.isle
+++ b/cranelift/codegen/src/isa/aarch64/lower.isle
@@ -3238,3 +3238,9 @@
                   (emit_island (targets_jt_space targets))))
             (ridx Reg (put_in_reg_zext32 idx)))
        (br_table_impl jt_size ridx default targets)))
+
+;; Rules for `get_exception_handler_address` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(rule (lower (get_exception_handler_address (u64_from_imm64 idx) block))
+      (let ((succ_label MachLabel (block_exn_successor_label block idx)))
+        (a64_exception_handler_address succ_label)))

--- a/cranelift/codegen/src/isa/aarch64/lower.isle
+++ b/cranelift/codegen/src/isa/aarch64/lower.isle
@@ -3243,4 +3243,4 @@
 
 (rule (lower (get_exception_handler_address (u64_from_imm64 idx) block))
       (let ((succ_label MachLabel (block_exn_successor_label block idx)))
-        (a64_exception_handler_address succ_label)))
+        (a64_label_address succ_label)))

--- a/cranelift/codegen/src/isa/pulley_shared/inst.isle
+++ b/cranelift/codegen/src/isa/pulley_shared/inst.isle
@@ -92,10 +92,9 @@
     ;; Island generation prior to variable-length instructions.
     (EmitIsland (space_needed u32))
 
-    ;; A pseudoinstruction that loads the address of an exception
-    ;; handler target.
-    (ExceptionHandlerAddress (dst WritableXReg)
-                             (label MachLabel))
+    ;; A pseudoinstruction that loads the address of a label.
+    (LabelAddress (dst WritableXReg)
+                  (label MachLabel))
   )
 )
 
@@ -787,9 +786,9 @@
 (rule (sext64 val @ (value_type $I32)) (pulley_sext32 val))
 (rule (sext64 val @ (value_type $I64)) val)
 
-;; Helper for creating an `ExceptionHandlerAddress` instruction.
-(decl pulley_exception_handler_address (MachLabel) Reg)
-(rule (pulley_exception_handler_address label)
+;; Helper for creating an `LabelAddress` instruction.
+(decl pulley_label_address (MachLabel) Reg)
+(rule (pulley_label_address label)
       (let ((dst WritableReg (temp_writable_xreg))
-            (_ Unit (emit (MInst.ExceptionHandlerAddress dst label))))
+            (_ Unit (emit (MInst.LabelAddress dst label))))
         dst))

--- a/cranelift/codegen/src/isa/pulley_shared/inst.isle
+++ b/cranelift/codegen/src/isa/pulley_shared/inst.isle
@@ -91,6 +91,11 @@
 
     ;; Island generation prior to variable-length instructions.
     (EmitIsland (space_needed u32))
+
+    ;; A pseudoinstruction that loads the address of an exception
+    ;; handler target.
+    (ExceptionHandlerAddress (dst WritableXReg)
+                             (label MachLabel))
   )
 )
 
@@ -781,3 +786,10 @@
 (rule (sext64 val @ (value_type $I16)) (pulley_sext16 val))
 (rule (sext64 val @ (value_type $I32)) (pulley_sext32 val))
 (rule (sext64 val @ (value_type $I64)) val)
+
+;; Helper for creating an `ExceptionHandlerAddress` instruction.
+(decl pulley_exception_handler_address (MachLabel) Reg)
+(rule (pulley_exception_handler_address label)
+      (let ((dst WritableReg (temp_writable_xreg))
+            (_ Unit (emit (MInst.ExceptionHandlerAddress dst label))))
+        dst))

--- a/cranelift/codegen/src/isa/pulley_shared/inst/emit.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/inst/emit.rs
@@ -590,6 +590,12 @@ fn pulley_emit<P>(
                 sink.bind_label(label, &mut state.ctrl_plane);
             }
         }
+
+        Inst::ExceptionHandlerAddress { dst, label } => {
+            patch_pc_rel_offset(sink, |sink| enc::xpcadd(sink, dst, 0));
+            let end = sink.cur_offset();
+            sink.use_label_at_offset(end - 4, *label, LabelUse::PcRel);
+        }
     }
 }
 

--- a/cranelift/codegen/src/isa/pulley_shared/inst/emit.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/inst/emit.rs
@@ -591,7 +591,7 @@ fn pulley_emit<P>(
             }
         }
 
-        Inst::ExceptionHandlerAddress { dst, label } => {
+        Inst::LabelAddress { dst, label } => {
             patch_pc_rel_offset(sink, |sink| enc::xpcadd(sink, dst, 0));
             let end = sink.cur_offset();
             sink.use_label_at_offset(end - 4, *label, LabelUse::PcRel);

--- a/cranelift/codegen/src/isa/pulley_shared/inst/mod.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/inst/mod.rs
@@ -332,7 +332,7 @@ fn pulley_get_operands(inst: &mut Inst, collector: &mut impl OperandVisitor) {
 
         Inst::EmitIsland { .. } => {}
 
-        Inst::ExceptionHandlerAddress { dst, label: _ } => {
+        Inst::LabelAddress { dst, label: _ } => {
             collector.reg_def(dst);
         }
     }
@@ -830,9 +830,9 @@ impl Inst {
 
             Inst::EmitIsland { space_needed } => format!("emit_island {space_needed}"),
 
-            Inst::ExceptionHandlerAddress { dst, label } => {
+            Inst::LabelAddress { dst, label } => {
                 let dst = format_reg(dst.to_reg().to_reg());
-                format!("exception_handler_address {dst}, {label:?}")
+                format!("label_address {dst}, {label:?}")
             }
         }
     }

--- a/cranelift/codegen/src/isa/pulley_shared/inst/mod.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/inst/mod.rs
@@ -331,6 +331,10 @@ fn pulley_get_operands(inst: &mut Inst, collector: &mut impl OperandVisitor) {
         Inst::Raw { raw } => generated::get_operands(raw, collector),
 
         Inst::EmitIsland { .. } => {}
+
+        Inst::ExceptionHandlerAddress { dst, label: _ } => {
+            collector.reg_def(dst);
+        }
     }
 }
 
@@ -825,6 +829,11 @@ impl Inst {
             Inst::Raw { raw } => generated::print(raw),
 
             Inst::EmitIsland { space_needed } => format!("emit_island {space_needed}"),
+
+            Inst::ExceptionHandlerAddress { dst, label } => {
+                let dst = format_reg(dst.to_reg().to_reg());
+                format!("exception_handler_address {dst}, {label:?}")
+            }
         }
     }
 }

--- a/cranelift/codegen/src/isa/pulley_shared/lower.isle
+++ b/cranelift/codegen/src/isa/pulley_shared/lower.isle
@@ -1835,4 +1835,4 @@
 
 (rule (lower (get_exception_handler_address (u64_from_imm64 idx) block))
       (let ((succ_label MachLabel (block_exn_successor_label block idx)))
-        (pulley_exception_handler_address succ_label)))
+        (pulley_label_address succ_label)))

--- a/cranelift/codegen/src/isa/pulley_shared/lower.isle
+++ b/cranelift/codegen/src/isa/pulley_shared/lower.isle
@@ -1829,3 +1829,10 @@
 
 (rule (lower (func_addr (func_ref_data _ extname dist)))
       (load_ext_name extname 0 dist))
+
+
+;; Rules for `get_exception_handler_address` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(rule (lower (get_exception_handler_address (u64_from_imm64 idx) block))
+      (let ((succ_label MachLabel (block_exn_successor_label block idx)))
+        (pulley_exception_handler_address succ_label)))

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -254,10 +254,9 @@
        (DummyUse
         (reg Reg))
 
-    ;; A pseudoinstruction that loads the address of an exception
-    ;; handler target.
-    (ExceptionHandlerAddress (dst WritableReg)
-                             (label MachLabel))
+    ;; A pseudoinstruction that loads the address of a label.
+    (LabelAddress (dst WritableReg)
+                  (label MachLabel))
 
     ;; popcnt  if target doesn't support extension B
     ;; use iteration to implement.
@@ -3257,9 +3256,9 @@
   (FloatCompare.One (rv_fge ty a b)))
 
 
-;; Helper for creating an `ExceptionHandlerAddress` instruction.
-(decl rv64_exception_handler_address (MachLabel) Reg)
-(rule (rv64_exception_handler_address label)
+;; Helper for creating an `LabelAddress` instruction.
+(decl rv64_label_address (MachLabel) Reg)
+(rule (rv64_label_address label)
       (let ((dst WritableReg (temp_writable_reg $I64))
-            (_ Unit (emit (MInst.ExceptionHandlerAddress dst label))))
+            (_ Unit (emit (MInst.LabelAddress dst label))))
         dst))

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -254,6 +254,11 @@
        (DummyUse
         (reg Reg))
 
+    ;; A pseudoinstruction that loads the address of an exception
+    ;; handler target.
+    (ExceptionHandlerAddress (dst WritableReg)
+                             (label MachLabel))
+
     ;; popcnt  if target doesn't support extension B
     ;; use iteration to implement.
     (Popcnt
@@ -3250,3 +3255,11 @@
 ;; a >= b
 (rule 1 (fcmp_to_float_compare (FloatCC.GreaterThanOrEqual) ty a b)
   (FloatCompare.One (rv_fge ty a b)))
+
+
+;; Helper for creating an `ExceptionHandlerAddress` instruction.
+(decl rv64_exception_handler_address (MachLabel) Reg)
+(rule (rv64_exception_handler_address label)
+      (let ((dst WritableReg (temp_writable_reg $I64))
+            (_ Unit (emit (MInst.ExceptionHandlerAddress dst label))))
+        dst))

--- a/cranelift/codegen/src/isa/riscv64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/emit.rs
@@ -194,7 +194,7 @@ impl Inst {
             | Inst::TrapIf { .. }
             | Inst::Unwind { .. }
             | Inst::DummyUse { .. }
-            | Inst::ExceptionHandlerAddress { .. }
+            | Inst::LabelAddress { .. }
             | Inst::Popcnt { .. }
             | Inst::Cltz { .. }
             | Inst::Brev8 { .. }
@@ -2107,7 +2107,7 @@ impl Inst {
                 .emit_uncompressed(sink, emit_info, state, start_off);
             }
 
-            &Inst::ExceptionHandlerAddress { dst, label } => {
+            &Inst::LabelAddress { dst, label } => {
                 let offset = sink.cur_offset();
                 Inst::Auipc {
                     rd: dst,

--- a/cranelift/codegen/src/isa/riscv64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/mod.rs
@@ -696,7 +696,7 @@ fn riscv64_get_operands(inst: &mut Inst, collector: &mut impl OperandVisitor) {
             vec_mask_operands(mask, collector);
         }
         Inst::EmitIsland { .. } => {}
-        Inst::ExceptionHandlerAddress { dst, .. } => {
+        Inst::LabelAddress { dst, .. } => {
             collector.reg_def(dst);
         }
     }
@@ -1676,9 +1676,9 @@ impl Inst {
                 format!("emit_island {needed_space}")
             }
 
-            Inst::ExceptionHandlerAddress { dst, label } => {
+            Inst::LabelAddress { dst, label } => {
                 let dst = format_reg(dst.to_reg());
-                format!("exception_handler_address {dst}, {label:?}")
+                format!("label_address {dst}, {label:?}")
             }
         }
     }

--- a/cranelift/codegen/src/isa/riscv64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/mod.rs
@@ -696,6 +696,9 @@ fn riscv64_get_operands(inst: &mut Inst, collector: &mut impl OperandVisitor) {
             vec_mask_operands(mask, collector);
         }
         Inst::EmitIsland { .. } => {}
+        Inst::ExceptionHandlerAddress { dst, .. } => {
+            collector.reg_def(dst);
+        }
     }
 }
 
@@ -1671,6 +1674,11 @@ impl Inst {
             }
             Inst::EmitIsland { needed_space } => {
                 format!("emit_island {needed_space}")
+            }
+
+            Inst::ExceptionHandlerAddress { dst, label } => {
+                let dst = format_reg(dst.to_reg());
+                format!("exception_handler_address {dst}, {label:?}")
             }
         }
     }

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -3131,3 +3131,10 @@
         (x_clip VReg (rv_vnclipu_wi x_pos zero (unmasked) (vstate_mf2 (ty_half_lanes out_ty))))
         (y_clip VReg (rv_vnclipu_wi y_pos zero (unmasked) (vstate_mf2 (ty_half_lanes out_ty)))))
     (rv_vslideup_vvi x_clip y_clip lane_diff (unmasked) out_ty)))
+
+
+;; Rules for `get_exception_handler_address` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(rule (lower (get_exception_handler_address (u64_from_imm64 idx) block))
+      (let ((succ_label MachLabel (block_exn_successor_label block idx)))
+        (rv64_exception_handler_address succ_label)))

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -3137,4 +3137,4 @@
 
 (rule (lower (get_exception_handler_address (u64_from_imm64 idx) block))
       (let ((succ_label MachLabel (block_exn_successor_label block idx)))
-        (rv64_exception_handler_address succ_label)))
+        (rv64_label_address succ_label)))

--- a/cranelift/codegen/src/isa/s390x/inst.isle
+++ b/cranelift/codegen/src/isa/s390x/inst.isle
@@ -1015,6 +1015,11 @@
       (got Reg)
       (got_offset Reg)
       (symbol BoxSymbolReloc))
+
+    ;; A pseudoinstruction that loads the address of an exception
+    ;; handler target.
+    (ExceptionHandlerAddress (dst WritableReg)
+                             (label MachLabel))
 ))
 
 ;; Primitive types used in instruction formats.
@@ -4928,6 +4933,14 @@
 (decl vec_fcmphes (Type Reg Reg) ProducesFlags)
 (rule (vec_fcmphes (ty_vec128 ty) x y) (vec_float_cmps ty (vecop_float_cmphe ty) x y))
 
+;; Other helpers ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; Helper for creating an `ExceptionHandlerAddress` instruction.
+(decl s390x_exception_handler_address (MachLabel) Reg)
+(rule (s390x_exception_handler_address label)
+      (let ((dst WritableReg (temp_writable_reg $I64))
+            (_ Unit (emit (MInst.ExceptionHandlerAddress dst label))))
+        dst))
 
 ;; Implicit conversions ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/cranelift/codegen/src/isa/s390x/inst.isle
+++ b/cranelift/codegen/src/isa/s390x/inst.isle
@@ -1016,10 +1016,9 @@
       (got_offset Reg)
       (symbol BoxSymbolReloc))
 
-    ;; A pseudoinstruction that loads the address of an exception
-    ;; handler target.
-    (ExceptionHandlerAddress (dst WritableReg)
-                             (label MachLabel))
+    ;; A pseudoinstruction that loads the address of a label.
+    (LabelAddress (dst WritableReg)
+                  (label MachLabel))
 ))
 
 ;; Primitive types used in instruction formats.
@@ -4935,11 +4934,11 @@
 
 ;; Other helpers ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;; Helper for creating an `ExceptionHandlerAddress` instruction.
-(decl s390x_exception_handler_address (MachLabel) Reg)
-(rule (s390x_exception_handler_address label)
+;; Helper for creating an `LabelAddress` instruction.
+(decl s390x_label_address (MachLabel) Reg)
+(rule (s390x_label_address label)
       (let ((dst WritableReg (temp_writable_reg $I64))
-            (_ Unit (emit (MInst.ExceptionHandlerAddress dst label))))
+            (_ Unit (emit (MInst.LabelAddress dst label))))
         dst))
 
 ;; Implicit conversions ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/cranelift/codegen/src/isa/s390x/inst/emit.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/emit.rs
@@ -3537,7 +3537,7 @@ impl Inst {
 
             &Inst::DummyUse { .. } => {}
 
-            &Inst::ExceptionHandlerAddress { dst, label } => {
+            &Inst::LabelAddress { dst, label } => {
                 let inst = Inst::LoadAddr {
                     rd: dst,
                     mem: MemArg::Label { target: label },

--- a/cranelift/codegen/src/isa/s390x/inst/emit.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/emit.rs
@@ -3536,6 +3536,14 @@ impl Inst {
             }
 
             &Inst::DummyUse { .. } => {}
+
+            &Inst::ExceptionHandlerAddress { dst, label } => {
+                let inst = Inst::LoadAddr {
+                    rd: dst,
+                    mem: MemArg::Label { target: label },
+                };
+                inst.emit(sink, emit_info, state);
+            }
         }
 
         state.clear_post_insn();

--- a/cranelift/codegen/src/isa/s390x/inst/mod.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/mod.rs
@@ -282,6 +282,8 @@ impl Inst {
             | Inst::VecStoreLaneRev { .. } => InstructionSet::VXRS_EXT2,
 
             Inst::DummyUse { .. } => InstructionSet::Base,
+
+            Inst::ExceptionHandlerAddress { .. } => InstructionSet::Base,
         }
     }
 
@@ -1005,6 +1007,9 @@ fn s390x_get_operands(inst: &mut Inst, collector: &mut DenyReuseVisitor<impl Ope
         Inst::Unwind { .. } => {}
         Inst::DummyUse { reg } => {
             collector.reg_use(reg);
+        }
+        Inst::ExceptionHandlerAddress { dst, .. } => {
+            collector.reg_def(dst);
         }
     }
 }
@@ -3404,6 +3409,10 @@ impl Inst {
             &Inst::DummyUse { reg } => {
                 let reg = pretty_print_reg(reg);
                 format!("dummy_use {reg}")
+            }
+            &Inst::ExceptionHandlerAddress { dst, label } => {
+                let dst = pretty_print_reg(dst.to_reg());
+                format!("exception_handler_address {dst}, {label:?}")
             }
         }
     }

--- a/cranelift/codegen/src/isa/s390x/inst/mod.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/mod.rs
@@ -283,7 +283,7 @@ impl Inst {
 
             Inst::DummyUse { .. } => InstructionSet::Base,
 
-            Inst::ExceptionHandlerAddress { .. } => InstructionSet::Base,
+            Inst::LabelAddress { .. } => InstructionSet::Base,
         }
     }
 
@@ -1008,7 +1008,7 @@ fn s390x_get_operands(inst: &mut Inst, collector: &mut DenyReuseVisitor<impl Ope
         Inst::DummyUse { reg } => {
             collector.reg_use(reg);
         }
-        Inst::ExceptionHandlerAddress { dst, .. } => {
+        Inst::LabelAddress { dst, .. } => {
             collector.reg_def(dst);
         }
     }
@@ -3410,9 +3410,9 @@ impl Inst {
                 let reg = pretty_print_reg(reg);
                 format!("dummy_use {reg}")
             }
-            &Inst::ExceptionHandlerAddress { dst, label } => {
+            &Inst::LabelAddress { dst, label } => {
                 let dst = pretty_print_reg(dst.to_reg());
-                format!("exception_handler_address {dst}, {label:?}")
+                format!("label_address {dst}, {label:?}")
             }
         }
     }

--- a/cranelift/codegen/src/isa/s390x/lower.isle
+++ b/cranelift/codegen/src/isa/s390x/lower.isle
@@ -4072,4 +4072,4 @@
 
 (rule (lower (get_exception_handler_address (u64_from_imm64 idx) block))
       (let ((succ_label MachLabel (block_exn_successor_label block idx)))
-        (s390x_exception_handler_address succ_label)))
+        (s390x_label_address succ_label)))

--- a/cranelift/codegen/src/isa/s390x/lower.isle
+++ b/cranelift/codegen/src/isa/s390x/lower.isle
@@ -4067,3 +4067,9 @@
 
 (rule (lower (get_return_address))
       (load64 (memarg_return_address_offset)))
+
+;; Rules for `get_exception_handler_address` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(rule (lower (get_exception_handler_address (u64_from_imm64 idx) block))
+      (let ((succ_label MachLabel (block_exn_successor_label block idx)))
+        (s390x_exception_handler_address succ_label)))

--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -316,6 +316,11 @@
        ;; A pseudoinstruction that just keeps a value alive.
        (DummyUse (reg Reg))
 
+       ;; A pseudoinstruction that loads the address of an exception
+       ;; handler target.
+       (ExceptionHandlerAddress (dst WritableGpr)
+                                (label MachLabel))
+
        ;; An instruction assembled outside of cranelift-codegen.
        (External (inst AssemblerInst))))
 
@@ -3882,6 +3887,14 @@
       (let ((dst WritableGpr (temp_writable_gpr))
             (tmp WritableGpr (temp_writable_gpr))
             (_ Unit (emit (MInst.CoffTlsGetAddr name dst tmp))))
+        dst))
+
+;;;; Exception Handler Addresses ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(decl x64_exception_handler_address (MachLabel) Gpr)
+(rule (x64_exception_handler_address label)
+      (let ((dst WritableGpr (temp_writable_gpr))
+            (_ Unit (emit (MInst.ExceptionHandlerAddress dst label))))
         dst))
 
 ;;;; Automatic conversions ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -316,10 +316,9 @@
        ;; A pseudoinstruction that just keeps a value alive.
        (DummyUse (reg Reg))
 
-       ;; A pseudoinstruction that loads the address of an exception
-       ;; handler target.
-       (ExceptionHandlerAddress (dst WritableGpr)
-                                (label MachLabel))
+       ;; A pseudoinstruction that loads the address of a label.
+       (LabelAddress (dst WritableGpr)
+                     (label MachLabel))
 
        ;; An instruction assembled outside of cranelift-codegen.
        (External (inst AssemblerInst))))
@@ -3889,12 +3888,12 @@
             (_ Unit (emit (MInst.CoffTlsGetAddr name dst tmp))))
         dst))
 
-;;;; Exception Handler Addresses ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;; Label Addresses ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(decl x64_exception_handler_address (MachLabel) Gpr)
-(rule (x64_exception_handler_address label)
+(decl x64_label_address (MachLabel) Gpr)
+(rule (x64_label_address label)
       (let ((dst WritableGpr (temp_writable_gpr))
-            (_ Unit (emit (MInst.ExceptionHandlerAddress dst label))))
+            (_ Unit (emit (MInst.LabelAddress dst label))))
         dst))
 
 ;;;; Automatic conversions ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/cranelift/codegen/src/isa/x64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit.rs
@@ -1810,7 +1810,7 @@ pub(crate) fn emit(
             // Nothing.
         }
 
-        Inst::ExceptionHandlerAddress { dst, label } => {
+        Inst::LabelAddress { dst, label } => {
             // Emit an LEA with a LabelUse given this label.
             asm::inst::leaq_rm::new(*dst, Amode::rip_relative(*label)).emit(sink, info, state);
         }

--- a/cranelift/codegen/src/isa/x64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit.rs
@@ -1810,6 +1810,11 @@ pub(crate) fn emit(
             // Nothing.
         }
 
+        Inst::ExceptionHandlerAddress { dst, label } => {
+            // Emit an LEA with a LabelUse given this label.
+            asm::inst::leaq_rm::new(*dst, Amode::rip_relative(*label)).emit(sink, info, state);
+        }
+
         Inst::External { inst } => {
             let frame = state.frame_layout();
             emit_maybe_shrink(

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -106,7 +106,7 @@ impl Inst {
             | Inst::CoffTlsGetAddr { .. }
             | Inst::Unwind { .. }
             | Inst::DummyUse { .. }
-            | Inst::ExceptionHandlerAddress { .. } => true,
+            | Inst::LabelAddress { .. } => true,
 
             Inst::Atomic128RmwSeq { .. } | Inst::Atomic128XchgSeq { .. } => emit_info.cmpxchg16b(),
 
@@ -823,9 +823,9 @@ impl PrettyPrint for Inst {
                 format!("dummy_use {reg}")
             }
 
-            Inst::ExceptionHandlerAddress { dst, label } => {
+            Inst::LabelAddress { dst, label } => {
                 let dst = pretty_print_reg(dst.to_reg().to_reg(), 8);
-                format!("exception_handler_address {dst}, {label:?}")
+                format!("label_address {dst}, {label:?}")
             }
 
             Inst::External { inst } => {
@@ -1189,7 +1189,7 @@ fn x64_get_operands(inst: &mut Inst, collector: &mut impl OperandVisitor) {
             collector.reg_use(reg);
         }
 
-        Inst::ExceptionHandlerAddress { dst, .. } => {
+        Inst::LabelAddress { dst, .. } => {
             collector.reg_def(dst);
         }
 

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -105,7 +105,8 @@ impl Inst {
             | Inst::MachOTlsGetAddr { .. }
             | Inst::CoffTlsGetAddr { .. }
             | Inst::Unwind { .. }
-            | Inst::DummyUse { .. } => true,
+            | Inst::DummyUse { .. }
+            | Inst::ExceptionHandlerAddress { .. } => true,
 
             Inst::Atomic128RmwSeq { .. } | Inst::Atomic128XchgSeq { .. } => emit_info.cmpxchg16b(),
 
@@ -822,6 +823,11 @@ impl PrettyPrint for Inst {
                 format!("dummy_use {reg}")
             }
 
+            Inst::ExceptionHandlerAddress { dst, label } => {
+                let dst = pretty_print_reg(dst.to_reg().to_reg(), 8);
+                format!("exception_handler_address {dst}, {label:?}")
+            }
+
             Inst::External { inst } => {
                 format!("{inst}")
             }
@@ -1181,6 +1187,10 @@ fn x64_get_operands(inst: &mut Inst, collector: &mut impl OperandVisitor) {
 
         Inst::DummyUse { reg } => {
             collector.reg_use(reg);
+        }
+
+        Inst::ExceptionHandlerAddress { dst, .. } => {
+            collector.reg_def(dst);
         }
 
         Inst::External { inst } => {

--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -5049,6 +5049,12 @@
         ;; SHUFPS xmm_y, xmm_xmp, 0x88
         (x64_shufps dst zeros 0x88)))
 
+;; Rules for `get_exception_handler_address` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(rule (lower (get_exception_handler_address (u64_from_imm64 idx) block))
+      (let ((succ_label MachLabel (block_exn_successor_label block idx)))
+        (x64_exception_handler_address succ_label)))
+
 ;; Rules for `nop` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (nop))

--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -5053,7 +5053,7 @@
 
 (rule (lower (get_exception_handler_address (u64_from_imm64 idx) block))
       (let ((succ_label MachLabel (block_exn_successor_label block idx)))
-        (x64_exception_handler_address succ_label)))
+        (x64_label_address succ_label)))
 
 ;; Rules for `nop` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/cranelift/codegen/src/isa/x64/pcc.rs
+++ b/cranelift/codegen/src/isa/x64/pcc.rs
@@ -209,7 +209,7 @@ pub(crate) fn check(
 
         Inst::StackSwitchBasic { .. } => Err(PccError::UnimplementedInst),
 
-        Inst::ExceptionHandlerAddress { .. } => Err(PccError::UnimplementedInst),
+        Inst::LabelAddress { .. } => Err(PccError::UnimplementedInst),
 
         Inst::External { .. } => Ok(()), // TODO: unsure what to do about this!
     }

--- a/cranelift/codegen/src/isa/x64/pcc.rs
+++ b/cranelift/codegen/src/isa/x64/pcc.rs
@@ -209,6 +209,8 @@ pub(crate) fn check(
 
         Inst::StackSwitchBasic { .. } => Err(PccError::UnimplementedInst),
 
+        Inst::ExceptionHandlerAddress { .. } => Err(PccError::UnimplementedInst),
+
         Inst::External { .. } => Ok(()), // TODO: unsure what to do about this!
     }
 }

--- a/cranelift/codegen/src/machinst/isle.rs
+++ b/cranelift/codegen/src/machinst/isle.rs
@@ -754,6 +754,14 @@ macro_rules! isle_lower_prelude_methods {
         fn value_is_unused(&mut self, val: Value) -> bool {
             self.lower_ctx.value_is_unused(val)
         }
+
+        fn block_exn_successor_label(&mut self, block: &Block, exn_succ: u64) -> MachLabel {
+            // The first N successors are the exceptional edges, and
+            // the normal return is last; so the `exn_succ`'th
+            // exceptional edge is just the `exn_succ`'th edge overall.
+            let succ = usize::try_from(exn_succ).unwrap();
+            self.lower_ctx.block_successor_label(*block, succ)
+        }
     };
 }
 

--- a/cranelift/codegen/src/machinst/lower.rs
+++ b/cranelift/codegen/src/machinst/lower.rs
@@ -1201,6 +1201,20 @@ impl<'func, I: VCodeInst> Lower<'func, I> {
             _ => false,
         }
     }
+
+    pub fn block_successor_label(&self, block: Block, succ: usize) -> MachLabel {
+        trace!("block_successor_label: block {block} succ {succ}");
+        let lowered = self
+            .vcode
+            .block_order()
+            .lowered_index_for_block(block)
+            .expect("Unreachable block");
+        trace!(" -> lowered block {lowered:?}");
+        let (_, succs) = self.vcode.block_order().succ_indices(lowered);
+        trace!(" -> succs {succs:?}");
+        let succ_block = *succs.get(succ).expect("Successor index out of range");
+        MachLabel::from_block(succ_block)
+    }
 }
 
 /// Pre-analysis: compute `value_ir_uses`. See comment on

--- a/cranelift/codegen/src/prelude_lower.isle
+++ b/cranelift/codegen/src/prelude_lower.isle
@@ -381,6 +381,10 @@
 (decl sge (Value Value) Value)
 (extractor (sge x y) (icmp (IntCC.SignedGreaterThanOrEqual) x y))
 
+;; Get the MachLabel for a particular CLIF block's indexed exception-handling successor.
+(decl block_exn_successor_label (Block u64) MachLabel)
+(extern constructor block_exn_successor_label block_exn_successor_label)
+
 ;; Instruction creation helpers ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Emit an instruction.

--- a/cranelift/codegen/src/verifier/mod.rs
+++ b/cranelift/codegen/src/verifier/mod.rs
@@ -2010,6 +2010,10 @@ impl<'a> Verifier<'a> {
         };
 
         let etd = &self.func.dfg.exception_tables[et];
+        // The exception table's out-edges consist of all exceptional
+        // edges first, followed by the normal return last. For N
+        // out-edges, there are N-1 exception handlers that can be
+        // selected.
         let num_exceptional_edges = etd.all_branches().len() - 1;
         if index >= num_exceptional_edges {
             return errors.fatal((

--- a/cranelift/codegen/src/verifier/mod.rs
+++ b/cranelift/codegen/src/verifier/mod.rs
@@ -729,6 +729,11 @@ impl<'a> Verifier<'a> {
                 self.verify_constant_size(inst, opcode, constant_handle, errors)?;
             }
 
+            ExceptionHandlerAddress { block, imm, .. } => {
+                self.verify_block(inst, block, errors)?;
+                self.verify_try_call_handler_index(inst, block, imm.into(), errors)?;
+            }
+
             // Exhaustive list so we can't forget to add new formats
             AtomicCas { .. }
             | AtomicRmw { .. }
@@ -1970,6 +1975,50 @@ impl<'a> Verifier<'a> {
         }
 
         if errors.has_error() { Err(()) } else { Ok(()) }
+    }
+
+    fn verify_try_call_handler_index(
+        &self,
+        inst: Inst,
+        block: Block,
+        index_imm: i64,
+        errors: &mut VerifierErrors,
+    ) -> VerifierStepResult {
+        if index_imm < 0 {
+            return errors.fatal((
+                inst,
+                format!("exception handler index {index_imm} cannot be negative"),
+            ));
+        }
+        let Ok(index) = usize::try_from(index_imm) else {
+            return errors.fatal((
+                inst,
+                format!("exception handler index {index_imm} is out-of-range"),
+            ));
+        };
+        let Some(terminator) = self.func.layout.last_inst(block) else {
+            return errors.fatal((
+                inst,
+                format!("referenced block {block} does not have a terminator"),
+            ));
+        };
+        let Some(et) = self.func.dfg.insts[terminator].exception_table() else {
+            return errors.fatal((
+                inst,
+                format!("referenced block {block} does not end in a try_call"),
+            ));
+        };
+
+        let etd = &self.func.dfg.exception_tables[et];
+        let num_exceptional_edges = etd.all_branches().len() - 1;
+        if index >= num_exceptional_edges {
+            return errors.fatal((
+                inst,
+                format!("exception handler index {index_imm} is out-of-range"),
+            ));
+        }
+
+        Ok(())
     }
 
     pub fn run(&self, errors: &mut VerifierErrors) -> VerifierStepResult {

--- a/cranelift/codegen/src/write.rs
+++ b/cranelift/codegen/src/write.rs
@@ -537,6 +537,7 @@ pub fn write_operands(w: &mut dyn Write, dfg: &DataFlowGraph, inst: Inst) -> fmt
         } => write!(w, "{} {}, {}{}", flags, args[0], args[1], offset),
         Trap { code, .. } => write!(w, " {code}"),
         CondTrap { arg, code, .. } => write!(w, " {arg}, {code}"),
+        ExceptionHandlerAddress { block, imm, .. } => write!(w, " {block}, {imm}"),
     }?;
 
     let mut sep = "  ; ";

--- a/cranelift/filetests/filetests/isa/aarch64/exception-handler-address.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/exception-handler-address.clif
@@ -1,0 +1,311 @@
+test compile precise-output
+target aarch64
+
+;; Index 0 on get_exception_handler_address selects index 0 in the
+;; exceptional edges, i.e., the one to `block3`. Note the lowering
+;; order reverses block3/block4 when reading the `label_address` inst;
+;; compare to the exception table.
+function %f0() -> i64 {
+    sig0 = () tail
+    fn0 = %g() tail
+
+    block0:
+        v1 = get_exception_handler_address.i64 block1, 0
+        jump block1
+
+    block1:
+        try_call fn0(), sig0, block2(), [ context v1, tag0: block3(exn1), default: block4() ]
+
+    block2:
+        return v1
+
+    block3(v2: i64):
+        return v2
+
+    block4:
+        return v1
+}
+
+; VCode:
+;   stp fp, lr, [sp, #-16]!
+;   mov fp, sp
+;   stp x27, x28, [sp, #-16]!
+;   stp x25, x26, [sp, #-16]!
+;   stp x23, x24, [sp, #-16]!
+;   stp x21, x22, [sp, #-16]!
+;   stp x19, x20, [sp, #-16]!
+;   stp d14, d15, [sp, #-16]!
+;   stp d12, d13, [sp, #-16]!
+;   stp d10, d11, [sp, #-16]!
+;   stp d8, d9, [sp, #-16]!
+;   sub sp, sp, #16
+; block0:
+;   label_address x4, MachLabel(4)
+;   str x4, [sp]
+;   b label1
+; block1:
+;   load_ext_name_far x5, TestCase(%g)+0
+;   blr x5; b MachLabel(2); catch [context stack0, tag0: MachLabel(4), default: MachLabel(3)]
+; block2:
+;   ldr x0, [sp]
+;   add sp, sp, #16
+;   ldp d8, d9, [sp], #16
+;   ldp d10, d11, [sp], #16
+;   ldp d12, d13, [sp], #16
+;   ldp d14, d15, [sp], #16
+;   ldp x19, x20, [sp], #16
+;   ldp x21, x22, [sp], #16
+;   ldp x23, x24, [sp], #16
+;   ldp x25, x26, [sp], #16
+;   ldp x27, x28, [sp], #16
+;   ldp fp, lr, [sp], #16
+;   ret
+; block3:
+;   ldr x0, [sp]
+;   add sp, sp, #16
+;   ldp d8, d9, [sp], #16
+;   ldp d10, d11, [sp], #16
+;   ldp d12, d13, [sp], #16
+;   ldp d14, d15, [sp], #16
+;   ldp x19, x20, [sp], #16
+;   ldp x21, x22, [sp], #16
+;   ldp x23, x24, [sp], #16
+;   ldp x25, x26, [sp], #16
+;   ldp x27, x28, [sp], #16
+;   ldp fp, lr, [sp], #16
+;   ret
+; block4:
+;   mov x0, x1
+;   add sp, sp, #16
+;   ldp d8, d9, [sp], #16
+;   ldp d10, d11, [sp], #16
+;   ldp d12, d13, [sp], #16
+;   ldp d14, d15, [sp], #16
+;   ldp x19, x20, [sp], #16
+;   ldp x21, x22, [sp], #16
+;   ldp x23, x24, [sp], #16
+;   ldp x25, x26, [sp], #16
+;   ldp x27, x28, [sp], #16
+;   ldp fp, lr, [sp], #16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   stp x27, x28, [sp, #-0x10]!
+;   stp x25, x26, [sp, #-0x10]!
+;   stp x23, x24, [sp, #-0x10]!
+;   stp x21, x22, [sp, #-0x10]!
+;   stp x19, x20, [sp, #-0x10]!
+;   stp d14, d15, [sp, #-0x10]!
+;   stp d12, d13, [sp, #-0x10]!
+;   stp d10, d11, [sp, #-0x10]!
+;   stp d8, d9, [sp, #-0x10]!
+;   sub sp, sp, #0x10
+; block1: ; offset 0x30
+;   adr x4, #0xb4
+;   stur x4, [sp]
+; block2: ; offset 0x38
+;   ldr x5, #0x40
+;   b #0x48
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %g 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   blr x5
+; block3: ; offset 0x4c
+;   ldur x0, [sp]
+;   add sp, sp, #0x10
+;   ldp d8, d9, [sp], #0x10
+;   ldp d10, d11, [sp], #0x10
+;   ldp d12, d13, [sp], #0x10
+;   ldp d14, d15, [sp], #0x10
+;   ldp x19, x20, [sp], #0x10
+;   ldp x21, x22, [sp], #0x10
+;   ldp x23, x24, [sp], #0x10
+;   ldp x25, x26, [sp], #0x10
+;   ldp x27, x28, [sp], #0x10
+;   ldp x29, x30, [sp], #0x10
+;   ret
+; block4: ; offset 0x80
+;   ldur x0, [sp]
+;   add sp, sp, #0x10
+;   ldp d8, d9, [sp], #0x10
+;   ldp d10, d11, [sp], #0x10
+;   ldp d12, d13, [sp], #0x10
+;   ldp d14, d15, [sp], #0x10
+;   ldp x19, x20, [sp], #0x10
+;   ldp x21, x22, [sp], #0x10
+;   ldp x23, x24, [sp], #0x10
+;   ldp x25, x26, [sp], #0x10
+;   ldp x27, x28, [sp], #0x10
+;   ldp x29, x30, [sp], #0x10
+;   ret
+; block5: ; offset 0xb4
+;   mov x0, x1
+;   add sp, sp, #0x10
+;   ldp d8, d9, [sp], #0x10
+;   ldp d10, d11, [sp], #0x10
+;   ldp d12, d13, [sp], #0x10
+;   ldp d14, d15, [sp], #0x10
+;   ldp x19, x20, [sp], #0x10
+;   ldp x21, x22, [sp], #0x10
+;   ldp x23, x24, [sp], #0x10
+;   ldp x25, x26, [sp], #0x10
+;   ldp x27, x28, [sp], #0x10
+;   ldp x29, x30, [sp], #0x10
+;   ret
+
+;; Index 1 on get_exception_handler_address selects index 1 in the
+;; exceptional edges, i.e., the one to `block4`. Note the lowering
+;; order reverses block3/block4 when reading the `label_address` inst;
+;; compare to the exception table.
+function %f0() -> i64 {
+    sig0 = () tail
+    fn0 = %g() tail
+
+    block0:
+        v1 = get_exception_handler_address.i64 block1, 1
+        jump block1
+
+    block1:
+        try_call fn0(), sig0, block2(), [ context v1, tag0: block3(exn1), default: block4() ]
+
+    block2:
+        return v1
+
+    block3(v2: i64):
+        return v2
+
+    block4:
+        return v1
+}
+
+; VCode:
+;   stp fp, lr, [sp, #-16]!
+;   mov fp, sp
+;   stp x27, x28, [sp, #-16]!
+;   stp x25, x26, [sp, #-16]!
+;   stp x23, x24, [sp, #-16]!
+;   stp x21, x22, [sp, #-16]!
+;   stp x19, x20, [sp, #-16]!
+;   stp d14, d15, [sp, #-16]!
+;   stp d12, d13, [sp, #-16]!
+;   stp d10, d11, [sp, #-16]!
+;   stp d8, d9, [sp, #-16]!
+;   sub sp, sp, #16
+; block0:
+;   label_address x4, MachLabel(3)
+;   str x4, [sp]
+;   b label1
+; block1:
+;   load_ext_name_far x5, TestCase(%g)+0
+;   blr x5; b MachLabel(2); catch [context stack0, tag0: MachLabel(4), default: MachLabel(3)]
+; block2:
+;   ldr x0, [sp]
+;   add sp, sp, #16
+;   ldp d8, d9, [sp], #16
+;   ldp d10, d11, [sp], #16
+;   ldp d12, d13, [sp], #16
+;   ldp d14, d15, [sp], #16
+;   ldp x19, x20, [sp], #16
+;   ldp x21, x22, [sp], #16
+;   ldp x23, x24, [sp], #16
+;   ldp x25, x26, [sp], #16
+;   ldp x27, x28, [sp], #16
+;   ldp fp, lr, [sp], #16
+;   ret
+; block3:
+;   ldr x0, [sp]
+;   add sp, sp, #16
+;   ldp d8, d9, [sp], #16
+;   ldp d10, d11, [sp], #16
+;   ldp d12, d13, [sp], #16
+;   ldp d14, d15, [sp], #16
+;   ldp x19, x20, [sp], #16
+;   ldp x21, x22, [sp], #16
+;   ldp x23, x24, [sp], #16
+;   ldp x25, x26, [sp], #16
+;   ldp x27, x28, [sp], #16
+;   ldp fp, lr, [sp], #16
+;   ret
+; block4:
+;   mov x0, x1
+;   add sp, sp, #16
+;   ldp d8, d9, [sp], #16
+;   ldp d10, d11, [sp], #16
+;   ldp d12, d13, [sp], #16
+;   ldp d14, d15, [sp], #16
+;   ldp x19, x20, [sp], #16
+;   ldp x21, x22, [sp], #16
+;   ldp x23, x24, [sp], #16
+;   ldp x25, x26, [sp], #16
+;   ldp x27, x28, [sp], #16
+;   ldp fp, lr, [sp], #16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   stp x27, x28, [sp, #-0x10]!
+;   stp x25, x26, [sp, #-0x10]!
+;   stp x23, x24, [sp, #-0x10]!
+;   stp x21, x22, [sp, #-0x10]!
+;   stp x19, x20, [sp, #-0x10]!
+;   stp d14, d15, [sp, #-0x10]!
+;   stp d12, d13, [sp, #-0x10]!
+;   stp d10, d11, [sp, #-0x10]!
+;   stp d8, d9, [sp, #-0x10]!
+;   sub sp, sp, #0x10
+; block1: ; offset 0x30
+;   adr x4, #0x80
+;   stur x4, [sp]
+; block2: ; offset 0x38
+;   ldr x5, #0x40
+;   b #0x48
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %g 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   blr x5
+; block3: ; offset 0x4c
+;   ldur x0, [sp]
+;   add sp, sp, #0x10
+;   ldp d8, d9, [sp], #0x10
+;   ldp d10, d11, [sp], #0x10
+;   ldp d12, d13, [sp], #0x10
+;   ldp d14, d15, [sp], #0x10
+;   ldp x19, x20, [sp], #0x10
+;   ldp x21, x22, [sp], #0x10
+;   ldp x23, x24, [sp], #0x10
+;   ldp x25, x26, [sp], #0x10
+;   ldp x27, x28, [sp], #0x10
+;   ldp x29, x30, [sp], #0x10
+;   ret
+; block4: ; offset 0x80
+;   ldur x0, [sp]
+;   add sp, sp, #0x10
+;   ldp d8, d9, [sp], #0x10
+;   ldp d10, d11, [sp], #0x10
+;   ldp d12, d13, [sp], #0x10
+;   ldp d14, d15, [sp], #0x10
+;   ldp x19, x20, [sp], #0x10
+;   ldp x21, x22, [sp], #0x10
+;   ldp x23, x24, [sp], #0x10
+;   ldp x25, x26, [sp], #0x10
+;   ldp x27, x28, [sp], #0x10
+;   ldp x29, x30, [sp], #0x10
+;   ret
+; block5: ; offset 0xb4
+;   mov x0, x1
+;   add sp, sp, #0x10
+;   ldp d8, d9, [sp], #0x10
+;   ldp d10, d11, [sp], #0x10
+;   ldp d12, d13, [sp], #0x10
+;   ldp d14, d15, [sp], #0x10
+;   ldp x19, x20, [sp], #0x10
+;   ldp x21, x22, [sp], #0x10
+;   ldp x23, x24, [sp], #0x10
+;   ldp x25, x26, [sp], #0x10
+;   ldp x27, x28, [sp], #0x10
+;   ldp x29, x30, [sp], #0x10
+;   ret
+

--- a/cranelift/filetests/filetests/isa/aarch64/exceptions.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/exceptions.clif
@@ -397,3 +397,122 @@ function %f4(i64, i32) -> i32, f32, f64 {
 ;   ldp x29, x30, [sp], #0x10
 ;   ret
 
+function %f5() -> i64 {
+    sig0 = () tail
+    fn0 = %g() tail
+
+    block0:
+        v1 = get_exception_handler_address.i64 block1, 0
+        jump block1
+
+    block1:
+        try_call fn0(), sig0, block2(), [ default: block3() ]
+
+    block2:
+        return v1
+
+    block3:
+        return v1
+}
+
+; VCode:
+;   stp fp, lr, [sp, #-16]!
+;   mov fp, sp
+;   stp x27, x28, [sp, #-16]!
+;   stp x25, x26, [sp, #-16]!
+;   stp x23, x24, [sp, #-16]!
+;   stp x21, x22, [sp, #-16]!
+;   stp x19, x20, [sp, #-16]!
+;   stp d14, d15, [sp, #-16]!
+;   stp d12, d13, [sp, #-16]!
+;   stp d10, d11, [sp, #-16]!
+;   stp d8, d9, [sp, #-16]!
+;   sub sp, sp, #16
+; block0:
+;   exception_handler_address x0, MachLabel(3)
+;   str x0, [sp]
+;   b label1
+; block1:
+;   load_ext_name_far x4, TestCase(%g)+0
+;   blr x4; b MachLabel(2); catch [default: MachLabel(3)]
+; block2:
+;   ldr x0, [sp]
+;   add sp, sp, #16
+;   ldp d8, d9, [sp], #16
+;   ldp d10, d11, [sp], #16
+;   ldp d12, d13, [sp], #16
+;   ldp d14, d15, [sp], #16
+;   ldp x19, x20, [sp], #16
+;   ldp x21, x22, [sp], #16
+;   ldp x23, x24, [sp], #16
+;   ldp x25, x26, [sp], #16
+;   ldp x27, x28, [sp], #16
+;   ldp fp, lr, [sp], #16
+;   ret
+; block3:
+;   ldr x0, [sp]
+;   add sp, sp, #16
+;   ldp d8, d9, [sp], #16
+;   ldp d10, d11, [sp], #16
+;   ldp d12, d13, [sp], #16
+;   ldp d14, d15, [sp], #16
+;   ldp x19, x20, [sp], #16
+;   ldp x21, x22, [sp], #16
+;   ldp x23, x24, [sp], #16
+;   ldp x25, x26, [sp], #16
+;   ldp x27, x28, [sp], #16
+;   ldp fp, lr, [sp], #16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   stp x27, x28, [sp, #-0x10]!
+;   stp x25, x26, [sp, #-0x10]!
+;   stp x23, x24, [sp, #-0x10]!
+;   stp x21, x22, [sp, #-0x10]!
+;   stp x19, x20, [sp, #-0x10]!
+;   stp d14, d15, [sp, #-0x10]!
+;   stp d12, d13, [sp, #-0x10]!
+;   stp d10, d11, [sp, #-0x10]!
+;   stp d8, d9, [sp, #-0x10]!
+;   sub sp, sp, #0x10
+; block1: ; offset 0x30
+;   adr x0, #0x80
+;   stur x0, [sp]
+; block2: ; offset 0x38
+;   ldr x4, #0x40
+;   b #0x48
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %g 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   blr x4
+; block3: ; offset 0x4c
+;   ldur x0, [sp]
+;   add sp, sp, #0x10
+;   ldp d8, d9, [sp], #0x10
+;   ldp d10, d11, [sp], #0x10
+;   ldp d12, d13, [sp], #0x10
+;   ldp d14, d15, [sp], #0x10
+;   ldp x19, x20, [sp], #0x10
+;   ldp x21, x22, [sp], #0x10
+;   ldp x23, x24, [sp], #0x10
+;   ldp x25, x26, [sp], #0x10
+;   ldp x27, x28, [sp], #0x10
+;   ldp x29, x30, [sp], #0x10
+;   ret
+; block4: ; offset 0x80
+;   ldur x0, [sp]
+;   add sp, sp, #0x10
+;   ldp d8, d9, [sp], #0x10
+;   ldp d10, d11, [sp], #0x10
+;   ldp d12, d13, [sp], #0x10
+;   ldp d14, d15, [sp], #0x10
+;   ldp x19, x20, [sp], #0x10
+;   ldp x21, x22, [sp], #0x10
+;   ldp x23, x24, [sp], #0x10
+;   ldp x25, x26, [sp], #0x10
+;   ldp x27, x28, [sp], #0x10
+;   ldp x29, x30, [sp], #0x10
+;   ret
+

--- a/cranelift/filetests/filetests/isa/aarch64/exceptions.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/exceptions.clif
@@ -429,7 +429,7 @@ function %f5() -> i64 {
 ;   stp d8, d9, [sp, #-16]!
 ;   sub sp, sp, #16
 ; block0:
-;   exception_handler_address x0, MachLabel(3)
+;   label_address x0, MachLabel(3)
 ;   str x0, [sp]
 ;   b label1
 ; block1:

--- a/cranelift/filetests/filetests/isa/pulley32/exceptions.clif
+++ b/cranelift/filetests/filetests/isa/pulley32/exceptions.clif
@@ -203,7 +203,7 @@ function %f5() -> i32 {
 ; VCode:
 ;   push_frame_save 144, {x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0}
 ; block0:
-;   exception_handler_address x0, MachLabel(3)
+;   label_address x0, MachLabel(3)
 ;   xstore64 Slot(0), x0 // flags =  notrap aligned
 ;   jump label1
 ; block1:

--- a/cranelift/filetests/filetests/isa/pulley32/exceptions.clif
+++ b/cranelift/filetests/filetests/isa/pulley32/exceptions.clif
@@ -182,3 +182,50 @@ function %f4(i32, i32) -> i32, f32, f64 {
 ; pop_frame_restore 160, x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0
 ; ret
 
+function %f5() -> i32 {
+    sig0 = () tail
+    fn0 = %g() tail
+
+    block0:
+        v1 = get_exception_handler_address.i32 block1, 0
+        jump block1
+
+    block1:
+        try_call fn0(), sig0, block2(), [ default: block3() ]
+
+    block2:
+        return v1
+
+    block3:
+        return v1
+}
+
+; VCode:
+;   push_frame_save 144, {x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0}
+; block0:
+;   exception_handler_address x0, MachLabel(3)
+;   xstore64 Slot(0), x0 // flags =  notrap aligned
+;   jump label1
+; block1:
+;   indirect_call_host CallInfo { dest: TestCase(%g), uses: [], defs: [CallRetPair { vreg: Writable { reg: p0i }, location: Reg(p0i, types::I32) }, CallRetPair { vreg: Writable { reg: p1i }, location: Reg(p1i, types::I32) }], clobbers: PRegSet { bits: [4294967292, 4294967295, 4294967295, 0] }, callee_conv: Tail, caller_conv: Fast, callee_pop_size: 0, try_call_info: Some(TryCallInfo { continuation: MachLabel(2), exception_handlers: [Default(MachLabel(3))] }) }; jump MachLabel(2); catch [default: MachLabel(3)]
+; block2:
+;   x0 = xload64 Slot(0) // flags = notrap aligned
+;   pop_frame_restore 144, {x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0}
+;   ret
+; block3:
+;   x0 = xload64 Slot(0) // flags = notrap aligned
+;   pop_frame_restore 144, {x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0}
+;   ret
+;
+; Disassembled:
+; push_frame_save 144, x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0
+; xpcadd x0, 0x20    // target = 0x25
+; xstore64le_o32 sp, 0, x0
+; call_indirect_host 0
+; xload64le_o32 x0, sp, 0
+; pop_frame_restore 144, x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0
+; ret
+; xload64le_o32 x0, sp, 0
+; pop_frame_restore 144, x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0
+; ret
+

--- a/cranelift/filetests/filetests/isa/pulley64/exceptions.clif
+++ b/cranelift/filetests/filetests/isa/pulley64/exceptions.clif
@@ -205,7 +205,7 @@ function %f5() -> i64 {
 ; VCode:
 ;   push_frame_save 144, {x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0}
 ; block0:
-;   exception_handler_address x0, MachLabel(3)
+;   label_address x0, MachLabel(3)
 ;   xstore64 Slot(0), x0 // flags =  notrap aligned
 ;   jump label1
 ; block1:

--- a/cranelift/filetests/filetests/isa/pulley64/exceptions.clif
+++ b/cranelift/filetests/filetests/isa/pulley64/exceptions.clif
@@ -184,3 +184,50 @@ function %f4(i64, i32) -> i32, f32, f64 {
 ; pop_frame_restore 160, x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0
 ; ret
 
+function %f5() -> i64 {
+    sig0 = () tail
+    fn0 = %g() tail
+
+    block0:
+        v1 = get_exception_handler_address.i64 block1, 0
+        jump block1
+
+    block1:
+        try_call fn0(), sig0, block2(), [ default: block3() ]
+
+    block2:
+        return v1
+
+    block3:
+        return v1
+}
+
+; VCode:
+;   push_frame_save 144, {x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0}
+; block0:
+;   exception_handler_address x0, MachLabel(3)
+;   xstore64 Slot(0), x0 // flags =  notrap aligned
+;   jump label1
+; block1:
+;   indirect_call_host CallInfo { dest: TestCase(%g), uses: [], defs: [CallRetPair { vreg: Writable { reg: p0i }, location: Reg(p0i, types::I64) }, CallRetPair { vreg: Writable { reg: p1i }, location: Reg(p1i, types::I64) }], clobbers: PRegSet { bits: [4294967292, 4294967295, 4294967295, 0] }, callee_conv: Tail, caller_conv: Fast, callee_pop_size: 0, try_call_info: Some(TryCallInfo { continuation: MachLabel(2), exception_handlers: [Default(MachLabel(3))] }) }; jump MachLabel(2); catch [default: MachLabel(3)]
+; block2:
+;   x0 = xload64 Slot(0) // flags = notrap aligned
+;   pop_frame_restore 144, {x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0}
+;   ret
+; block3:
+;   x0 = xload64 Slot(0) // flags = notrap aligned
+;   pop_frame_restore 144, {x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0}
+;   ret
+;
+; Disassembled:
+; push_frame_save 144, x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0
+; xpcadd x0, 0x20    // target = 0x25
+; xstore64le_o32 sp, 0, x0
+; call_indirect_host 0
+; xload64le_o32 x0, sp, 0
+; pop_frame_restore 144, x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0
+; ret
+; xload64le_o32 x0, sp, 0
+; pop_frame_restore 144, x16, x17, x18, x19, x20, x21, x22, x23, x24, x25, x26, x27, x28, x29, sp, spilltmp0
+; ret
+

--- a/cranelift/filetests/filetests/isa/riscv64/exceptions.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/exceptions.clif
@@ -744,7 +744,7 @@ function %f5() -> i64 {
 ;   fsd fs10,32(sp)
 ;   fsd fs11,24(sp)
 ; block0:
-;   exception_handler_address a0, MachLabel(3)
+;   label_address a0, MachLabel(3)
 ;   sd a0,0(slot)
 ;   j label1
 ; block1:

--- a/cranelift/filetests/filetests/isa/riscv64/exceptions.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/exceptions.clif
@@ -696,3 +696,220 @@ function %f4(i64, i32) -> i32, f32, f64 {
 ;   addi sp, sp, 0x10
 ;   ret
 
+function %f5() -> i64 {
+    sig0 = () tail
+    fn0 = %g() tail
+
+    block0:
+        v1 = get_exception_handler_address.i64 block1, 0
+        jump block1
+
+    block1:
+        try_call fn0(), sig0, block2(), [ default: block3() ]
+
+    block2:
+        return v1
+
+    block3:
+        return v1
+}
+
+; VCode:
+;   addi sp,sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+;   addi sp,sp,-208
+;   sd fp,200(sp)
+;   sd s1,192(sp)
+;   sd s2,184(sp)
+;   sd s3,176(sp)
+;   sd s4,168(sp)
+;   sd s5,160(sp)
+;   sd s6,152(sp)
+;   sd s7,144(sp)
+;   sd s8,136(sp)
+;   sd s9,128(sp)
+;   sd s10,120(sp)
+;   sd s11,112(sp)
+;   fsd fs0,104(sp)
+;   fsd fs2,96(sp)
+;   fsd fs3,88(sp)
+;   fsd fs4,80(sp)
+;   fsd fs5,72(sp)
+;   fsd fs6,64(sp)
+;   fsd fs7,56(sp)
+;   fsd fs8,48(sp)
+;   fsd fs9,40(sp)
+;   fsd fs10,32(sp)
+;   fsd fs11,24(sp)
+; block0:
+;   exception_handler_address a0, MachLabel(3)
+;   sd a0,0(slot)
+;   j label1
+; block1:
+;   load_ext_name_far a4,%g+0
+;   callind a4; j MachLabel(2); catch [default: MachLabel(3)]
+; block2:
+;   ld a0,0(slot)
+;   ld fp,200(sp)
+;   ld s1,192(sp)
+;   ld s2,184(sp)
+;   ld s3,176(sp)
+;   ld s4,168(sp)
+;   ld s5,160(sp)
+;   ld s6,152(sp)
+;   ld s7,144(sp)
+;   ld s8,136(sp)
+;   ld s9,128(sp)
+;   ld s10,120(sp)
+;   ld s11,112(sp)
+;   fld fs0,104(sp)
+;   fld fs2,96(sp)
+;   fld fs3,88(sp)
+;   fld fs4,80(sp)
+;   fld fs5,72(sp)
+;   fld fs6,64(sp)
+;   fld fs7,56(sp)
+;   fld fs8,48(sp)
+;   fld fs9,40(sp)
+;   fld fs10,32(sp)
+;   fld fs11,24(sp)
+;   addi sp,sp,208
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   addi sp,sp,16
+;   ret
+; block3:
+;   ld a0,0(slot)
+;   ld fp,200(sp)
+;   ld s1,192(sp)
+;   ld s2,184(sp)
+;   ld s3,176(sp)
+;   ld s4,168(sp)
+;   ld s5,160(sp)
+;   ld s6,152(sp)
+;   ld s7,144(sp)
+;   ld s8,136(sp)
+;   ld s9,128(sp)
+;   ld s10,120(sp)
+;   ld s11,112(sp)
+;   fld fs0,104(sp)
+;   fld fs2,96(sp)
+;   fld fs3,88(sp)
+;   fld fs4,80(sp)
+;   fld fs5,72(sp)
+;   fld fs6,64(sp)
+;   fld fs7,56(sp)
+;   fld fs8,48(sp)
+;   fld fs9,40(sp)
+;   fld fs10,32(sp)
+;   fld fs11,24(sp)
+;   addi sp,sp,208
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   addi sp,sp,16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   mv s0, sp
+;   addi sp, sp, -0xd0
+;   sd s0, 0xc8(sp)
+;   sd s1, 0xc0(sp)
+;   sd s2, 0xb8(sp)
+;   sd s3, 0xb0(sp)
+;   sd s4, 0xa8(sp)
+;   sd s5, 0xa0(sp)
+;   sd s6, 0x98(sp)
+;   sd s7, 0x90(sp)
+;   sd s8, 0x88(sp)
+;   sd s9, 0x80(sp)
+;   sd s10, 0x78(sp)
+;   sd s11, 0x70(sp)
+;   fsd fs0, 0x68(sp)
+;   fsd fs2, 0x60(sp)
+;   fsd fs3, 0x58(sp)
+;   fsd fs4, 0x50(sp)
+;   fsd fs5, 0x48(sp)
+;   fsd fs6, 0x40(sp)
+;   fsd fs7, 0x38(sp)
+;   fsd fs8, 0x30(sp)
+;   fsd fs9, 0x28(sp)
+;   fsd fs10, 0x20(sp)
+;   fsd fs11, 0x18(sp)
+; block1: ; offset 0x70
+;   auipc a0, 0
+;   addi a0, a0, 0x98
+;   sd a0, 0(sp)
+; block2: ; offset 0x7c
+;   auipc a4, 0
+;   ld a4, 0xc(a4)
+;   j 0xc
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %g 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   jalr a4
+; block3: ; offset 0x94
+;   ld a0, 0(sp)
+;   ld s0, 0xc8(sp)
+;   ld s1, 0xc0(sp)
+;   ld s2, 0xb8(sp)
+;   ld s3, 0xb0(sp)
+;   ld s4, 0xa8(sp)
+;   ld s5, 0xa0(sp)
+;   ld s6, 0x98(sp)
+;   ld s7, 0x90(sp)
+;   ld s8, 0x88(sp)
+;   ld s9, 0x80(sp)
+;   ld s10, 0x78(sp)
+;   ld s11, 0x70(sp)
+;   fld fs0, 0x68(sp)
+;   fld fs2, 0x60(sp)
+;   fld fs3, 0x58(sp)
+;   fld fs4, 0x50(sp)
+;   fld fs5, 0x48(sp)
+;   fld fs6, 0x40(sp)
+;   fld fs7, 0x38(sp)
+;   fld fs8, 0x30(sp)
+;   fld fs9, 0x28(sp)
+;   fld fs10, 0x20(sp)
+;   fld fs11, 0x18(sp)
+;   addi sp, sp, 0xd0
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+; block4: ; offset 0x108
+;   ld a0, 0(sp)
+;   ld s0, 0xc8(sp)
+;   ld s1, 0xc0(sp)
+;   ld s2, 0xb8(sp)
+;   ld s3, 0xb0(sp)
+;   ld s4, 0xa8(sp)
+;   ld s5, 0xa0(sp)
+;   ld s6, 0x98(sp)
+;   ld s7, 0x90(sp)
+;   ld s8, 0x88(sp)
+;   ld s9, 0x80(sp)
+;   ld s10, 0x78(sp)
+;   ld s11, 0x70(sp)
+;   fld fs0, 0x68(sp)
+;   fld fs2, 0x60(sp)
+;   fld fs3, 0x58(sp)
+;   fld fs4, 0x50(sp)
+;   fld fs5, 0x48(sp)
+;   fld fs6, 0x40(sp)
+;   fld fs7, 0x38(sp)
+;   fld fs8, 0x30(sp)
+;   fld fs9, 0x28(sp)
+;   fld fs10, 0x20(sp)
+;   fld fs11, 0x18(sp)
+;   addi sp, sp, 0xd0
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+

--- a/cranelift/filetests/filetests/isa/s390x/exceptions.clif
+++ b/cranelift/filetests/filetests/isa/s390x/exceptions.clif
@@ -396,3 +396,112 @@ function %f4(i64, i32) -> i32, f32, f64 {
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
 
+function %f5() -> i64 {
+    sig0 = () tail
+    fn0 = %g() tail
+
+    block0:
+        v1 = get_exception_handler_address.i64 block1, 0
+        jump block1
+
+    block1:
+        try_call fn0(), sig0, block2(), [ default: block3() ]
+
+    block2:
+        return v1
+
+    block3:
+        return v1
+}
+
+; VCode:
+;   stmg %r6, %r15, 48(%r15)
+;   aghi %r15, -232
+;   std %f8, 168(%r15)
+;   std %f9, 176(%r15)
+;   std %f10, 184(%r15)
+;   std %f11, 192(%r15)
+;   std %f12, 200(%r15)
+;   std %f13, 208(%r15)
+;   std %f14, 216(%r15)
+;   std %f15, 224(%r15)
+; block0:
+;   exception_handler_address %r2, MachLabel(3)
+;   stg %r2, 160(%r15)
+;   jg label1
+; block1:
+;   bras %r1, 12 ; data %g + 0 ; lg %r2, 0(%r1)
+;   basr %r14, %r2; jg MachLabel(2); catch [default: MachLabel(3)]
+; block2:
+;   lg %r2, 160(%r15)
+;   ld %f8, 168(%r15)
+;   ld %f9, 176(%r15)
+;   ld %f10, 184(%r15)
+;   ld %f11, 192(%r15)
+;   ld %f12, 200(%r15)
+;   ld %f13, 208(%r15)
+;   ld %f14, 216(%r15)
+;   ld %f15, 224(%r15)
+;   lmg %r6, %r15, 280(%r15)
+;   br %r14
+; block3:
+;   lg %r2, 160(%r15)
+;   ld %f8, 168(%r15)
+;   ld %f9, 176(%r15)
+;   ld %f10, 184(%r15)
+;   ld %f11, 192(%r15)
+;   ld %f12, 200(%r15)
+;   ld %f13, 208(%r15)
+;   ld %f14, 216(%r15)
+;   ld %f15, 224(%r15)
+;   lmg %r6, %r15, 280(%r15)
+;   br %r14
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   stmg %r6, %r15, 0x30(%r15)
+;   aghi %r15, -0xe8
+;   std %f8, 0xa8(%r15)
+;   std %f9, 0xb0(%r15)
+;   std %f10, 0xb8(%r15)
+;   std %f11, 0xc0(%r15)
+;   std %f12, 0xc8(%r15)
+;   std %f13, 0xd0(%r15)
+;   std %f14, 0xd8(%r15)
+;   std %f15, 0xe0(%r15)
+; block1: ; offset 0x2a
+;   larl %r2, 0x78
+;   stg %r2, 0xa0(%r15)
+; block2: ; offset 0x36
+;   bras %r1, 0x42
+;   .byte 0x00, 0x00 ; reloc_external Abs8 %g 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   lg %r2, 0(%r1)
+;   basr %r14, %r2
+; block3: ; offset 0x4a
+;   lg %r2, 0xa0(%r15)
+;   ld %f8, 0xa8(%r15)
+;   ld %f9, 0xb0(%r15)
+;   ld %f10, 0xb8(%r15)
+;   ld %f11, 0xc0(%r15)
+;   ld %f12, 0xc8(%r15)
+;   ld %f13, 0xd0(%r15)
+;   ld %f14, 0xd8(%r15)
+;   ld %f15, 0xe0(%r15)
+;   lmg %r6, %r15, 0x118(%r15)
+;   br %r14
+; block4: ; offset 0x78
+;   lg %r2, 0xa0(%r15)
+;   ld %f8, 0xa8(%r15)
+;   ld %f9, 0xb0(%r15)
+;   ld %f10, 0xb8(%r15)
+;   ld %f11, 0xc0(%r15)
+;   ld %f12, 0xc8(%r15)
+;   ld %f13, 0xd0(%r15)
+;   ld %f14, 0xd8(%r15)
+;   ld %f15, 0xe0(%r15)
+;   lmg %r6, %r15, 0x118(%r15)
+;   br %r14
+

--- a/cranelift/filetests/filetests/isa/s390x/exceptions.clif
+++ b/cranelift/filetests/filetests/isa/s390x/exceptions.clif
@@ -426,7 +426,7 @@ function %f5() -> i64 {
 ;   std %f14, 216(%r15)
 ;   std %f15, 224(%r15)
 ; block0:
-;   exception_handler_address %r2, MachLabel(3)
+;   label_address %r2, MachLabel(3)
 ;   stg %r2, 160(%r15)
 ;   jg label1
 ; block1:

--- a/cranelift/filetests/filetests/isa/x64/exceptions.clif
+++ b/cranelift/filetests/filetests/isa/x64/exceptions.clif
@@ -568,7 +568,7 @@ function %f5() -> i64 {
 ;   movq %r14, 0x28(%rsp)
 ;   movq %r15, 0x30(%rsp)
 ; block0:
-;   exception_handler_address %rax, MachLabel(3)
+;   label_address %rax, MachLabel(3)
 ;   movq %rax, <offset:1>+(%rsp)
 ;   jmp     label1
 ; block1:

--- a/cranelift/filetests/filetests/isa/x64/exceptions.clif
+++ b/cranelift/filetests/filetests/isa/x64/exceptions.clif
@@ -539,3 +539,100 @@ function %f4(i64, i32) -> i32, f32, f64 {
 ;   popq %rbp
 ;   retq
 
+
+function %f5() -> i64 {
+    sig0 = () tail
+    fn0 = %g() tail
+
+    block0:
+        v1 = get_exception_handler_address.i64 block1, 0
+        jump block1
+
+    block1:
+        try_call fn0(), sig0, block2(), [ default: block3() ]
+
+    block2:
+        return v1
+
+    block3:
+        return v1
+}
+
+; VCode:
+;   pushq %rbp
+;   movq %rsp, %rbp
+;   subq $0x40, %rsp
+;   movq %rbx, 0x10(%rsp)
+;   movq %r12, 0x18(%rsp)
+;   movq %r13, 0x20(%rsp)
+;   movq %r14, 0x28(%rsp)
+;   movq %r15, 0x30(%rsp)
+; block0:
+;   exception_handler_address %rax, MachLabel(3)
+;   movq %rax, <offset:1>+(%rsp)
+;   jmp     label1
+; block1:
+;   load_ext_name %g+0, %rdx
+;   call    *%rdx; jmp MachLabel(2); catch [default: MachLabel(3)]
+; block2:
+;   movq <offset:1>+(%rsp), %rax
+;   movq 0x10(%rsp), %rbx
+;   movq 0x18(%rsp), %r12
+;   movq 0x20(%rsp), %r13
+;   movq 0x28(%rsp), %r14
+;   movq 0x30(%rsp), %r15
+;   addq $0x40, %rsp
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+; block3:
+;   movq <offset:1>+(%rsp), %rax
+;   movq 0x10(%rsp), %rbx
+;   movq 0x18(%rsp), %r12
+;   movq 0x20(%rsp), %r13
+;   movq 0x28(%rsp), %r14
+;   movq 0x30(%rsp), %r15
+;   addq $0x40, %rsp
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+;   subq $0x40, %rsp
+;   movq %rbx, 0x10(%rsp)
+;   movq %r12, 0x18(%rsp)
+;   movq %r13, 0x20(%rsp)
+;   movq %r14, 0x28(%rsp)
+;   movq %r15, 0x30(%rsp)
+; block1: ; offset 0x21
+;   leaq 0x36(%rip), %rax
+;   movq %rax, (%rsp)
+; block2: ; offset 0x2c
+;   movabsq $0, %rdx ; reloc_external Abs8 %g 0
+;   callq *%rdx
+; block3: ; offset 0x38
+;   movq (%rsp), %rax
+;   movq 0x10(%rsp), %rbx
+;   movq 0x18(%rsp), %r12
+;   movq 0x20(%rsp), %r13
+;   movq 0x28(%rsp), %r14
+;   movq 0x30(%rsp), %r15
+;   addq $0x40, %rsp
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+; block4: ; offset 0x5e
+;   movq (%rsp), %rax
+;   movq 0x10(%rsp), %rbx
+;   movq 0x18(%rsp), %r12
+;   movq 0x20(%rsp), %r13
+;   movq 0x28(%rsp), %r14
+;   movq 0x30(%rsp), %r15
+;   addq $0x40, %rsp
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+

--- a/cranelift/filetests/filetests/verifier/exceptions.clif
+++ b/cranelift/filetests/filetests/verifier/exceptions.clif
@@ -285,3 +285,23 @@ function %f8() -> i64 {
     block3:
         return v1
 }
+
+
+;; invalid block terminator on `get_exception_handler_address`
+function %f9() -> i64 {
+    sig0 = () tail
+    fn0 = %g() tail
+
+    block0:
+        v1 = get_exception_handler_address.i64 block1, 0 ; error: exception handler index 0 is out-of-range
+        jump block1
+
+    block1:
+        try_call fn0(), sig0, block2(), []
+
+    block2:
+        return v1
+
+    block3:
+        return v1
+}

--- a/cranelift/filetests/filetests/verifier/exceptions.clif
+++ b/cranelift/filetests/filetests/verifier/exceptions.clif
@@ -209,3 +209,79 @@ function %f5() {
     block2(v1: i64, v2: i64):
         return
 }
+
+;; invalid successor index on `get_exception_handler_address`
+function %f6() -> i64 {
+    sig0 = () tail
+    fn0 = %g() tail
+
+    block0:
+        v1 = get_exception_handler_address.i64 block1, 1 ; error: exception handler index 1 is out-of-range
+        jump block1
+
+    block1:
+        try_call fn0(), sig0, block2(), [ default: block3() ]
+
+    block2:
+        return v1
+
+    block3:
+        return v1
+}
+
+;; invalid successor index on `get_exception_handler_address`
+function %f7() -> i64 {
+    sig0 = () tail
+    fn0 = %g() tail
+
+    block0:
+        v1 = get_exception_handler_address.i64 block1, -1 ; error: exception handler index -1 cannot be negative
+        jump block1
+
+    block1:
+        try_call fn0(), sig0, block2(), [ default: block3() ]
+
+    block2:
+        return v1
+
+    block3:
+        return v1
+}
+
+;; invalid block on `get_exception_handler_address`
+function %f8() -> i64 {
+    sig0 = () tail
+    fn0 = %g() tail
+
+    block0:
+        v1 = get_exception_handler_address.i64 block17, 0 ; error: invalid block reference block17
+        jump block1
+
+    block1:
+        try_call fn0(), sig0, block2(), [ default: block3() ]
+
+    block2:
+        return v1
+
+    block3:
+        return v1
+}
+
+;; invalid block terminator on `get_exception_handler_address`
+function %f8() -> i64 {
+    sig0 = () tail
+    fn0 = %g() tail
+
+    block0:
+        v1 = get_exception_handler_address.i64 block2, 0 ; error: referenced block block2 does not end in a try_call
+        jump block1
+
+    block1:
+        try_call fn0(), sig0, block2(), [ default: block3() ]
+
+    block2:
+        return v1
+
+    block3:
+        return v1
+}

--- a/cranelift/fuzzgen/src/function_generator.rs
+++ b/cranelift/fuzzgen/src/function_generator.rs
@@ -1104,6 +1104,7 @@ fn inserter_for_format(fmt: InstructionFormat) -> OpcodeInserter {
         InstructionFormat::UnaryIeee32 => insert_const,
         InstructionFormat::UnaryIeee64 => insert_const,
         InstructionFormat::UnaryImm => insert_const,
+        InstructionFormat::ExceptionHandlerAddress => insert_const,
 
         InstructionFormat::BranchTable
         | InstructionFormat::Brif

--- a/cranelift/interpreter/src/step.rs
+++ b/cranelift/interpreter/src/step.rs
@@ -1319,6 +1319,8 @@ where
 
         Opcode::TryCall => unimplemented!("TryCall"),
         Opcode::TryCallIndirect => unimplemented!("TryCallIndirect"),
+
+        Opcode::GetExceptionHandlerAddress => unimplemented!("GetExceptionHandlerAddress"),
     })
 }
 

--- a/cranelift/reader/src/parser.rs
+++ b/cranelift/reader/src/parser.rs
@@ -3347,6 +3347,12 @@ impl<'a> Parser<'a> {
                     code,
                 }
             }
+            InstructionFormat::ExceptionHandlerAddress => {
+                let block = self.match_block("expected block")?;
+                self.match_token(Token::Comma, "expected ',' between operands")?;
+                let imm = self.match_imm64("expected immediate handler index")?;
+                InstructionData::ExceptionHandlerAddress { opcode, block, imm }
+            }
         };
         Ok(idata)
     }


### PR DESCRIPTION
This is designed to enable applications such as #11592 that use alternative unwinding mechanisms that may not necessarily want to walk a stack and look up exception tables. The idea is that whenever it would be valid to resume to an exception handler that is active on the stack, we can provide the same PC as a first-class runtime value that would be found in the exception table for the given handler edge. A "custom" resume step can then use this PC as a resume-point as long as it follows the relevant exception ABI (i.e.: restore SP, FP, any other saved registers that the exception ABI specifies, and provide appropriate payload value(s)).

Handlers are associated with edges out of `try_call`s (or `try_call_indirect`s); and edges specifically, not blocks, because there could be multiple out-edges to one block. The instruction thus takes the block that contains the try-call and an immediate that indexes its exceptional edges.

This CLIF instruction required a bit of infrastructure to (i) allow naming raw blocks, not just block calls, as instruction arguments, and (ii) allow getting the MachLabel for any other lowered block during lowering. But given that, the lowerings themselves are straightforward uses of MachBuffer labels to fix-up PC-relative address-loading instructions (e.g., `LEA` or `ADR` or `AUIPC`+`ADDI`).

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
