### PR TITLE
update fxprof-processed-profile to 0.8.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1559,24 +1559,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "fxhash"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
 name = "fxprof-processed-profile"
-version = "0.6.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27d12c0aed7f1e24276a241aadc4cb8ea9f83000f34bc062b7cc2d51e3b0fabd"
+checksum = "25234f20a3ec0a962a61770cfe39ecf03cb529a6e474ad8cff025ed497eda557"
 dependencies = [
  "bitflags 2.6.0",
  "debugid",
- "fxhash",
+ "rustc-hash",
  "serde",
+ "serde_derive",
  "serde_json",
 ]
 

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -53,7 +53,7 @@ object = { workspace = true, features = ['unaligned'] }
 async-trait = { workspace = true, optional = true }
 encoding_rs = { version = "0.8.31", optional = true }
 bumpalo = "3.11.0"
-fxprof-processed-profile = { version = "0.6.0", optional = true }
+fxprof-processed-profile = { version = "0.8.1", optional = true }
 gimli = { workspace = true, optional = true }
 addr2line = { workspace = true, optional = true }
 semver = { workspace = true, optional = true }

--- a/crates/wasmtime/src/runtime/profiling.rs
+++ b/crates/wasmtime/src/runtime/profiling.rs
@@ -7,8 +7,9 @@ use crate::{AsContext, CallHook, Module};
 use core::cmp::Ordering;
 use fxprof_processed_profile::debugid::DebugId;
 use fxprof_processed_profile::{
-    CategoryHandle, Frame, FrameFlags, FrameInfo, LibraryInfo, MarkerLocation, MarkerSchema,
-    MarkerTiming, Profile, ProfilerMarker, ReferenceTimestamp, Symbol, SymbolTable, Timestamp,
+    CategoryHandle, Frame, FrameFlags, FrameInfo, LibraryInfo, MarkerLocations, MarkerTiming,
+    Profile, ReferenceTimestamp, StaticSchemaMarker, StaticSchemaMarkerField, StringHandle, Symbol,
+    SymbolTable, Timestamp,
 };
 use std::ops::Range;
 use std::sync::Arc;
@@ -189,8 +190,11 @@ impl GuestProfiler {
         );
         let backtrace = Backtrace::new(store.as_context().0);
         let frames = lookup_frames(&self.modules, &backtrace);
+        let stack = self
+            .profile
+            .intern_stack_frames(self.thread, frames.into_iter());
         self.profile
-            .add_sample(self.thread, now, frames, delta.into(), 1);
+            .add_sample(self.thread, now, stack, delta.into(), 1);
     }
 
     /// Add a marker for transitions between guest and host to the profile.
@@ -206,21 +210,19 @@ impl GuestProfiler {
             CallHook::CallingHost => {
                 let backtrace = Backtrace::new(store.as_context().0);
                 let frames = lookup_frames(&self.modules, &backtrace);
-                self.profile.add_marker_with_stack(
+                let marker = self.profile.add_marker(
                     self.thread,
-                    "hostcall",
-                    CallMarker,
                     MarkerTiming::IntervalStart(now),
-                    frames,
+                    CallMarker,
                 );
+                let stack = self
+                    .profile
+                    .intern_stack_frames(self.thread, frames.into_iter());
+                self.profile.set_marker_stack(self.thread, marker, stack);
             }
             CallHook::ReturningFromHost => {
-                self.profile.add_marker(
-                    self.thread,
-                    "hostcall",
-                    CallMarker,
-                    MarkerTiming::IntervalEnd(now),
-                );
+                self.profile
+                    .add_marker(self.thread, MarkerTiming::IntervalEnd(now), CallMarker);
             }
         }
     }
@@ -314,25 +316,22 @@ fn lookup_frames<'a>(
 
 struct CallMarker;
 
-impl ProfilerMarker for CallMarker {
-    const MARKER_TYPE_NAME: &'static str = "hostcall";
+impl StaticSchemaMarker for CallMarker {
+    const UNIQUE_MARKER_TYPE_NAME: &'static str = "hostcall";
+    const FIELDS: &'static [StaticSchemaMarkerField] = &[];
+    const LOCATIONS: MarkerLocations = MarkerLocations::MARKER_CHART
+        .union(MarkerLocations::MARKER_TABLE.union(MarkerLocations::TIMELINE_OVERVIEW));
 
-    fn schema() -> MarkerSchema {
-        MarkerSchema {
-            type_name: Self::MARKER_TYPE_NAME,
-            locations: vec![
-                MarkerLocation::MarkerChart,
-                MarkerLocation::MarkerTable,
-                MarkerLocation::TimelineOverview,
-            ],
-            chart_label: None,
-            tooltip_label: None,
-            table_label: None,
-            fields: vec![],
-        }
+    fn name(&self, _profile: &mut Profile) -> StringHandle {
+        unreachable!()
     }
-
-    fn json_marker_data(&self) -> serde_json::Value {
-        serde_json::json!({ "type": Self::MARKER_TYPE_NAME })
+    fn category(&self, _profile: &mut Profile) -> CategoryHandle {
+        CategoryHandle::OTHER
+    }
+    fn string_field_value(&self, _field_index: u32) -> StringHandle {
+        unreachable!("no fields")
+    }
+    fn number_field_value(&self, _field_index: u32) -> f64 {
+        unreachable!("no fields")
     }
 }

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -2321,6 +2321,11 @@ serialization support. All logic is trivial: either unit conversion, or
 hash-consing to support de-duplication required by the format.
 """
 
+[[audits.fxprof-processed-profile]]
+who = "Pat Hickey <p.hickey@f5.com>"
+criteria = "safe-to-deploy"
+delta = "0.6.0 -> 0.8.1"
+
 [[audits.gimli]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
in order to drop the fxhash dependency. Closes #11633

prtest:full

I took a guess at the updates required for changes to the fxprof-processed-profile api. I don't actually know enough about the profiling code to know if that exact path has test coverage.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
