### PR TITLE
Tune new "much stdout" test for runtime

### DIFF
--- a/tests/all/cli_tests.rs
+++ b/tests/all/cli_tests.rs
@@ -2176,10 +2176,10 @@ start a print 1234
     }
 
     fn run_much_stdout(component: &str, extra_flags: &[&str]) -> Result<()> {
-        let total_write_size = 1 << 19;
+        let total_write_size = 1 << 18;
         let expected = iter::repeat('a').take(total_write_size).collect::<String>();
 
-        for i in 0..15 {
+        for i in 10..15 {
             let string = iter::repeat('a').take(1 << i).collect::<String>();
             let times = (total_write_size >> i).to_string();
             println!("writing {} bytes {times} times", string.len());


### PR DESCRIPTION
On Pulley platforms this test is taking 40+ minutes in CI. Locally it took 2 minutes to complete. After this change it should still roughly test the same thing but takes less than 100ms to complete locally.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
