### PR TITLE
[Cranelift] folds comparison over bitwise-not operands

### DIFF
--- a/cranelift/codegen/src/opts/icmp.isle
+++ b/cranelift/codegen/src/opts/icmp.isle
@@ -298,3 +298,5 @@
 ;; (x < y) ? x : y != x == x > y, for both signed and unsigned.
 (rule (simplify (ne cty (select ty (slt cty x y) x y) x)) (sgt cty x y))
 (rule (simplify (ne cty (select ty (ult cty x y) x y) x)) (ugt cty x y))
+
+(rule (simplify (ult cty (bnot ty x) (bnot ty y))) (ugt cty x y))

--- a/cranelift/codegen/src/opts/icmp.isle
+++ b/cranelift/codegen/src/opts/icmp.isle
@@ -300,3 +300,5 @@
 (rule (simplify (ne cty (select ty (ult cty x y) x y) x)) (ugt cty x y))
 
 (rule (simplify (ult cty (bnot ty x) (bnot ty y))) (ugt cty x y))
+(rule (simplify (slt cty (bnot ty x) (bnot ty y))) (sgt cty x y))
+

--- a/cranelift/filetests/filetests/egraph/icmp-new.clif
+++ b/cranelift/filetests/filetests/egraph/icmp-new.clif
@@ -1,0 +1,18 @@
+test optimize precise-output
+set opt_level=speed
+target x86_64
+
+function %test1(i8, i8) -> i8 {
+block0(v0: i8, v2: i8):
+    v1 = bnot v0
+    v3 = bnot v2
+    v4 = icmp ult v1, v3
+    return v4
+}
+
+; function %test1(i8, i8) -> i8 fast {
+; block0(v0: i8, v2: i8):
+;     v5 = icmp ugt v0, v2
+;     return v5
+; }
+

--- a/cranelift/filetests/filetests/egraph/icmp-new.clif
+++ b/cranelift/filetests/filetests/egraph/icmp-new.clif
@@ -16,3 +16,17 @@ block0(v0: i8, v2: i8):
 ;     return v5
 ; }
 
+function %test1(i8, i8) -> i8 {
+block0(v0: i8, v2: i8):
+    v1 = bnot v0
+    v3 = bnot v2
+    v4 = icmp slt v1, v3
+    return v4
+}
+
+; function %test1(i8, i8) -> i8 fast {
+; block0(v0: i8, v2: i8):
+;     v5 = icmp sgt v0, v2
+;     return v5
+; }
+


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->

This adds the following rules
`~X < ~Y` --> `X > Y` for both signed and unsigned.
