### PR TITLE
docs: update outdated docs on moving GCs not being supported

### DIFF
--- a/cranelift/frontend/src/frontend.rs
+++ b/cranelift/frontend/src/frontend.rs
@@ -420,9 +420,10 @@ impl<'a> FunctionBuilder<'a> {
     /// map metadata.
     ///
     /// All values that are uses of this variable will be spilled to the stack
-    /// before each safepoint and their location on the stack included in stack
-    /// maps. Stack maps allow the garbage collector to identify the on-stack GC
-    /// roots.
+    /// before each safepoint and reloaded afterwards. Stack maps allow the
+    /// garbage collector to identify the on-stack GC roots. Between spilling
+    /// the stack and it being reloading again, the stack can be updated to
+    /// facilitate moving GCs.
     ///
     /// This does not affect any pre-existing uses of the variable.
     ///
@@ -536,10 +537,11 @@ impl<'a> FunctionBuilder<'a> {
     /// Declare that the given value is a GC reference that requires inclusion
     /// in a stack map when it is live across GC safepoints.
     ///
-    /// At the current moment, values that need inclusion in stack maps are
-    /// spilled before safepoints, but they are not reloaded afterwards. This
-    /// means that moving GCs are not yet supported, however the intention is to
-    /// add this support in the near future.
+    /// All values that are uses of this variable will be spilled to the stack
+    /// before each safepoint and reloaded afterwards. Stack maps allow the
+    /// garbage collector to identify the on-stack GC roots. Between spilling
+    /// the stack and it being reloading again, the stack can be updated to
+    /// facilitate moving GCs.
     ///
     /// # Panics
     ///


### PR DESCRIPTION
Updated documentation about moving GCs not being supported, as per [the conversation on Zulip](https://bytecodealliance.zulipchat.com/#narrow/channel/217117-cranelift/topic/Support.20for.20moving.20GCs.20via.20user.20stack.20maps/with/538486092).

I figured the change is relevant to both `declare_value_needs_stack_map`, as well as `declare_var_needs_stack_map`, since they serve a similar purpose.