### PR TITLE
Update to wasm-tools 239

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -625,7 +625,7 @@ dependencies = [
  "test-programs-artifacts",
  "tokio",
  "wasm-compose",
- "wasmparser 0.238.1",
+ "wasmparser 0.239.0",
  "wasmtime",
  "wasmtime-wasi",
 ]
@@ -2166,14 +2166,14 @@ dependencies = [
 
 [[package]]
 name = "json-from-wast"
-version = "0.238.1"
+version = "0.239.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02235cfca0a8e390adc798ef7e68d1a18b015be3dcf248be0f6b0aabf3b32c05"
+checksum = "10e0969e6cddea32e749f84d2422e042699c3dbc24f33b3f089859db7d75185b"
 dependencies = [
  "anyhow",
  "serde",
  "serde_derive",
- "wast 238.0.1",
+ "wast 239.0.0",
 ]
 
 [[package]]
@@ -4070,7 +4070,7 @@ name = "verify-component-adapter"
 version = "38.0.0"
 dependencies = [
  "anyhow",
- "wasmparser 0.238.1",
+ "wasmparser 0.239.0",
  "wat",
 ]
 
@@ -4241,9 +4241,9 @@ checksum = "6ee99da9c5ba11bd675621338ef6fa52296b76b83305e9b6e5c77d4c286d6d49"
 
 [[package]]
 name = "wasm-compose"
-version = "0.238.1"
+version = "0.239.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37eea07d4044aecf66f6be21dc7868247ae4d01bb43d67763f172555d5080b9f"
+checksum = "d0ec5bc51a265c73434ede0659536ac9af486eebf0397ff073bfb19093421cd8"
 dependencies = [
  "anyhow",
  "heck 0.4.1",
@@ -4256,51 +4256,51 @@ dependencies = [
  "serde_yaml",
  "smallvec",
  "wasm-encoder",
- "wasmparser 0.238.1",
+ "wasmparser 0.239.0",
  "wat",
 ]
 
 [[package]]
 name = "wasm-encoder"
-version = "0.238.1"
+version = "0.239.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d50d48c31c615f77679b61c607b8151378a5d03159616bf3d17e8e2005afdaf5"
+checksum = "5be00faa2b4950c76fe618c409d2c3ea5a3c9422013e079482d78544bb2d184c"
 dependencies = [
  "leb128fmt",
- "wasmparser 0.238.1",
+ "wasmparser 0.239.0",
 ]
 
 [[package]]
 name = "wasm-metadata"
-version = "0.238.1"
+version = "0.239.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00094573b000c92134f2ef0f8afa4f6f892de37e78442988c946243a8c44364e"
+checksum = "20b3ec880a9ac69ccd92fbdbcf46ee833071cf09f82bb005b2327c7ae6025ae2"
 dependencies = [
  "anyhow",
  "indexmap 2.7.0",
  "wasm-encoder",
- "wasmparser 0.238.1",
+ "wasmparser 0.239.0",
 ]
 
 [[package]]
 name = "wasm-mutate"
-version = "0.238.1"
+version = "0.239.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7894373ad16a61ebee8a46a33818ddc6f602e81031d8fff757435a608a4c6f2"
+checksum = "27725e1c0a17d26b106d3f1f33b7d9734f0303973a0d61aeda548a421e6ee121"
 dependencies = [
  "egg",
  "log",
  "rand 0.9.2",
  "thiserror 2.0.12",
  "wasm-encoder",
- "wasmparser 0.238.1",
+ "wasmparser 0.239.0",
 ]
 
 [[package]]
 name = "wasm-smith"
-version = "0.238.1"
+version = "0.239.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6060ccc4d18a6187c45855c3b66b8ca9198d2ad13867897c6252cc3f1c6da2f9"
+checksum = "740315856034a7417b7d291bdfe0d7ff34a6b08541fa10af47d7a00c694cac1e"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -4321,9 +4321,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-wave"
-version = "0.238.1"
+version = "0.239.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b23704f090f52f6d64f3064e203a39026aa8fc64042494f7885f7fe30cf69224"
+checksum = "eb21d7c71e0571ca78cc756606094d8d973116b7eaba8d40a23e7c4859061920"
 dependencies = [
  "indexmap 2.7.0",
  "logos",
@@ -4387,9 +4387,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.238.1"
+version = "0.239.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fa99c8328024423875ae4a55345cfde8f0371327fb2d0f33b0f52a06fc44408"
+checksum = "8c9d90bb93e764f6beabf1d02028c70a2156a6583e63ac4218dd07ef733368b0"
 dependencies = [
  "bitflags 2.6.0",
  "hashbrown 0.15.2",
@@ -4400,13 +4400,13 @@ dependencies = [
 
 [[package]]
 name = "wasmprinter"
-version = "0.238.1"
+version = "0.239.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd2d53749ac5922bdc60ef3288adc7b45990fb079331d977b25dd7e83c75c810"
+checksum = "b3981f3d51f39f24f5fc90f93049a90f08dbbca8deba602cd46bb8ca67a94718"
 dependencies = [
  "anyhow",
  "termcolor",
- "wasmparser 0.238.1",
+ "wasmparser 0.239.0",
 ]
 
 [[package]]
@@ -4453,7 +4453,7 @@ dependencies = [
  "tokio",
  "wasm-encoder",
  "wasm-wave",
- "wasmparser 0.238.1",
+ "wasmparser 0.239.0",
  "wasmtime-environ",
  "wasmtime-internal-asm-macros",
  "wasmtime-internal-cache",
@@ -4563,7 +4563,7 @@ dependencies = [
  "walkdir",
  "wasi-common",
  "wasm-encoder",
- "wasmparser 0.238.1",
+ "wasmparser 0.239.0",
  "wasmtime",
  "wasmtime-cli-flags",
  "wasmtime-environ",
@@ -4582,7 +4582,7 @@ dependencies = [
  "wasmtime-wasi-threads",
  "wasmtime-wasi-tls",
  "wasmtime-wast",
- "wast 238.0.1",
+ "wast 239.0.0",
  "wat",
  "windows-sys 0.60.2",
  "wit-component",
@@ -4625,7 +4625,7 @@ dependencies = [
  "smallvec",
  "target-lexicon",
  "wasm-encoder",
- "wasmparser 0.238.1",
+ "wasmparser 0.239.0",
  "wasmprinter",
  "wasmtime-internal-component-util",
  "wat",
@@ -4638,7 +4638,7 @@ dependencies = [
  "arbitrary",
  "env_logger 0.11.5",
  "libfuzzer-sys",
- "wasmparser 0.238.1",
+ "wasmparser 0.239.0",
  "wasmprinter",
  "wasmtime-environ",
  "wasmtime-test-util",
@@ -4671,7 +4671,7 @@ dependencies = [
  "rand 0.9.2",
  "smallvec",
  "target-lexicon",
- "wasmparser 0.238.1",
+ "wasmparser 0.239.0",
  "wasmtime",
  "wasmtime-fuzzing",
  "wasmtime-test-util",
@@ -4700,7 +4700,7 @@ dependencies = [
  "wasm-smith",
  "wasm-spec-interpreter",
  "wasmi",
- "wasmparser 0.238.1",
+ "wasmparser 0.239.0",
  "wasmprinter",
  "wasmtime",
  "wasmtime-cli-flags",
@@ -4788,7 +4788,7 @@ dependencies = [
  "smallvec",
  "target-lexicon",
  "thiserror 2.0.12",
- "wasmparser 0.238.1",
+ "wasmparser 0.239.0",
  "wasmtime-environ",
  "wasmtime-internal-math",
  "wasmtime-internal-unwinder",
@@ -4886,7 +4886,7 @@ dependencies = [
  "log",
  "object 0.37.3",
  "target-lexicon",
- "wasmparser 0.238.1",
+ "wasmparser 0.239.0",
  "wasmtime-environ",
  "wasmtime-internal-cranelift",
  "winch-codegen",
@@ -5109,9 +5109,9 @@ dependencies = [
  "object 0.37.3",
  "serde_json",
  "tokio",
- "wasmparser 0.238.1",
+ "wasmparser 0.239.0",
  "wasmtime",
- "wast 238.0.1",
+ "wast 239.0.0",
 ]
 
 [[package]]
@@ -5125,9 +5125,9 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "238.0.1"
+version = "239.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0a564e7eab2abb8920c1302b90eb2c98a15efbbe30fc060d4e2d88483aa23fe"
+checksum = "9139176fe8a2590e0fb174cdcaf373b224cb93c3dde08e4297c1361d2ba1ea5d"
 dependencies = [
  "bumpalo",
  "gimli 0.31.1",
@@ -5139,11 +5139,11 @@ dependencies = [
 
 [[package]]
 name = "wat"
-version = "1.238.1"
+version = "1.239.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eb84e6ac2997025f80482266fdc9f60fa28ba791b674bfd33855e77fe867631"
+checksum = "3e1c941927d34709f255558166f8901a2005f8ab4a9650432e9281b7cc6f3b75"
 dependencies = [
- "wast 238.0.1",
+ "wast 239.0.0",
 ]
 
 [[package]]
@@ -5273,7 +5273,7 @@ dependencies = [
  "smallvec",
  "target-lexicon",
  "thiserror 2.0.12",
- "wasmparser 0.238.1",
+ "wasmparser 0.239.0",
  "wasmtime-environ",
  "wasmtime-internal-cranelift",
  "wasmtime-internal-math",
@@ -5504,9 +5504,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.45.1"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c573471f125075647d03df72e026074b7203790d41351cd6edc96f46bcccd36"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 dependencies = [
  "bitflags 2.6.0",
  "futures",
@@ -5516,9 +5516,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-core"
-version = "0.45.1"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0467b3f0420b5d42f8b5538d21d9f416e7c8dea38d04642c7203eb5de331fd8f"
+checksum = "cabd629f94da277abc739c71353397046401518efb2c707669f805205f0b9890"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -5545,9 +5545,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-rust"
-version = "0.45.1"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f089b7beb50fdcf0b9dc68be920843d743c00cbbd5ef1fa21c727f9b5089dac5"
+checksum = "9a4232e841089fa5f3c4fc732a92e1c74e1a3958db3b12f1de5934da2027f1f4"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -5561,9 +5561,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-rust-macro"
-version = "0.45.1"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb386c24660f5803b1056efe4fca83490460c6c5ff48114cea2979946629b09"
+checksum = "1e0d4698c2913d8d9c2b220d116409c3f51a7aa8d7765151b886918367179ee9"
 dependencies = [
  "anyhow",
  "prettyplease",
@@ -5576,9 +5576,9 @@ dependencies = [
 
 [[package]]
 name = "wit-component"
-version = "0.238.1"
+version = "0.239.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d31c985f541330d1a809547043ad19dd58739a2f83c7f116aeabcab86aed597"
+checksum = "88a866b19dba2c94d706ec58c92a4c62ab63e482b4c935d2a085ac94caecb136"
 dependencies = [
  "anyhow",
  "bitflags 2.6.0",
@@ -5589,15 +5589,15 @@ dependencies = [
  "serde_json",
  "wasm-encoder",
  "wasm-metadata",
- "wasmparser 0.238.1",
+ "wasmparser 0.239.0",
  "wit-parser",
 ]
 
 [[package]]
 name = "wit-parser"
-version = "0.238.1"
+version = "0.239.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1eea12c964ed423ed14745e51aac2f1e28e5572ca012b0503bdcf65ffee3b44c"
+checksum = "55c92c939d667b7bf0c6bf2d1f67196529758f99a2a45a3355cc56964fd5315d"
 dependencies = [
  "anyhow",
  "id-arena",
@@ -5608,7 +5608,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-xid",
- "wasmparser 0.238.1",
+ "wasmparser 0.239.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -325,22 +325,22 @@ io-lifetimes = { version = "2.0.3", default-features = false }
 io-extras = "0.18.1"
 rustix = "1.0.3"
 # wit-bindgen:
-wit-bindgen = { version = "0.45.1", default-features = false }
-wit-bindgen-rust-macro = { version = "0.45.1", default-features = false }
+wit-bindgen = { version = "0.46.0", default-features = false }
+wit-bindgen-rust-macro = { version = "0.46.0", default-features = false }
 
 # wasm-tools family:
-wasmparser = { version = "0.238.1", default-features = false, features = ['simd'] }
-wat = "1.238.1"
-wast = "238.0.1"
-wasmprinter = "0.238.1"
-wasm-encoder = "0.238.1"
-wasm-smith = "0.238.1"
-wasm-mutate = "0.238.1"
-wit-parser = "0.238.1"
-wit-component = "0.238.1"
-wasm-wave = "0.238.1"
-wasm-compose = "0.238.1"
-json-from-wast = "0.238.1"
+wasmparser = { version = "0.239.0", default-features = false, features = ['simd'] }
+wat = "1.239.0"
+wast = "239.0.0"
+wasmprinter = "0.239.0"
+wasm-encoder = "0.239.0"
+wasm-smith = "0.239.0"
+wasm-mutate = "0.239.0"
+wit-parser = "0.239.0"
+wit-component = "0.239.0"
+wasm-wave = "0.239.0"
+wasm-compose = "0.239.0"
+json-from-wast = "0.239.0"
 
 # Non-Bytecode Alliance maintained dependencies:
 # --------------------------

--- a/crates/cranelift/src/compiler/component.rs
+++ b/crates/cranelift/src/compiler/component.rs
@@ -311,13 +311,17 @@ impl<'a> TrampolineCompiler<'a> {
                     },
                 );
             }
-            Trampoline::Yield { async_ } => {
+            Trampoline::ThreadYield { cancellable } => {
                 self.translate_libcall(
-                    host::yield_,
+                    host::thread_yield,
                     TrapSentinel::NegativeOne,
                     WasmArgs::InRegisters,
                     |me, params| {
-                        params.push(me.builder.ins().iconst(ir::types::I8, i64::from(*async_)));
+                        params.push(
+                            me.builder
+                                .ins()
+                                .iconst(ir::types::I8, i64::from(*cancellable)),
+                        );
                     },
                 );
             }

--- a/crates/environ/src/component.rs
+++ b/crates/environ/src/component.rs
@@ -114,7 +114,7 @@ macro_rules! foreach_builtin_component_function {
             #[cfg(feature = "component-model-async")]
             waitable_join(vmctx: vmctx, caller_instance: u32, set: u32, waitable: u32) -> bool;
             #[cfg(feature = "component-model-async")]
-            yield_(vmctx: vmctx, async_: u8) -> u32;
+            thread_yield(vmctx: vmctx, cancellable: u8) -> u32;
             #[cfg(feature = "component-model-async")]
             subtask_drop(vmctx: vmctx, caller_instance: u32, task_id: u32) -> bool;
             #[cfg(feature = "component-model-async")]

--- a/crates/environ/src/component/dfg.rs
+++ b/crates/environ/src/component/dfg.rs
@@ -344,8 +344,8 @@ pub enum Trampoline {
     WaitableJoin {
         instance: RuntimeComponentInstanceIndex,
     },
-    Yield {
-        async_: bool,
+    ThreadYield {
+        cancellable: bool,
     },
     SubtaskDrop {
         instance: RuntimeComponentInstanceIndex,
@@ -470,6 +470,7 @@ pub struct CanonicalOptions {
     pub callback: Option<CallbackId>,
     pub post_return: Option<PostReturnId>,
     pub async_: bool,
+    pub cancellable: bool,
     pub core_type: ModuleInternedTypeIndex,
     pub data_model: CanonicalOptionsDataModel,
 }
@@ -764,6 +765,7 @@ impl LinearizeDfg<'_> {
             callback,
             post_return,
             async_: options.async_,
+            cancellable: options.cancellable,
             core_type: options.core_type,
             data_model,
         };
@@ -880,7 +882,9 @@ impl LinearizeDfg<'_> {
             Trampoline::WaitableJoin { instance } => info::Trampoline::WaitableJoin {
                 instance: *instance,
             },
-            Trampoline::Yield { async_ } => info::Trampoline::Yield { async_: *async_ },
+            Trampoline::ThreadYield { cancellable } => info::Trampoline::ThreadYield {
+                cancellable: *cancellable,
+            },
             Trampoline::SubtaskDrop { instance } => info::Trampoline::SubtaskDrop {
                 instance: *instance,
             },

--- a/crates/environ/src/component/info.rs
+++ b/crates/environ/src/component/info.rs
@@ -521,6 +521,10 @@ pub struct CanonicalOptions {
     /// Whether to use the async ABI for lifting or lowering.
     pub async_: bool,
 
+    /// Whether or not this function can consume a task cancellation
+    /// notification.
+    pub cancellable: bool,
+
     /// The core function type that is being lifted from / lowered to.
     pub core_type: ModuleInternedTypeIndex,
 
@@ -783,11 +787,11 @@ pub enum Trampoline {
         instance: RuntimeComponentInstanceIndex,
     },
 
-    /// A `yield` intrinsic, which yields control to the host so that other
+    /// A `thread.yield` intrinsic, which yields control to the host so that other
     /// tasks are able to make progress, if any.
-    Yield {
+    ThreadYield {
         /// If `true`, indicates the caller instance maybe reentered.
-        async_: bool,
+        cancellable: bool,
     },
 
     /// A `subtask.drop` intrinsic to drop a specified task which has completed.
@@ -1069,7 +1073,7 @@ impl Trampoline {
             WaitableSetPoll { .. } => format!("waitable-set-poll"),
             WaitableSetDrop { .. } => format!("waitable-set-drop"),
             WaitableJoin { .. } => format!("waitable-join"),
-            Yield { .. } => format!("yield"),
+            ThreadYield { .. } => format!("thread-yield"),
             SubtaskDrop { .. } => format!("subtask-drop"),
             SubtaskCancel { .. } => format!("subtask-cancel"),
             StreamNew { .. } => format!("stream-new"),

--- a/crates/environ/src/component/translate/adapt.rs
+++ b/crates/environ/src/component/translate/adapt.rs
@@ -174,6 +174,9 @@ pub struct AdapterOptions {
     pub post_return: Option<dfg::CoreDef>,
     /// Whether to use the async ABI for lifting or lowering.
     pub async_: bool,
+    /// Whether or not this intrinsic can consume a task cancellation
+    /// notification.
+    pub cancellable: bool,
     /// The core function type that is being lifted from / lowered to.
     pub core_type: ModuleInternedTypeIndex,
     /// The data model used by this adapter: linear memory or GC objects.

--- a/crates/environ/src/component/translate/inline.rs
+++ b/crates/environ/src/component/translate/inline.rs
@@ -752,11 +752,13 @@ impl<'a> Inliner<'a> {
                 ));
                 frame.funcs.push((*func, dfg::CoreDef::Trampoline(index)));
             }
-            Yield { func, async_ } => {
-                let index = self
-                    .result
-                    .trampolines
-                    .push((*func, dfg::Trampoline::Yield { async_: *async_ }));
+            ThreadYield { func, cancellable } => {
+                let index = self.result.trampolines.push((
+                    *func,
+                    dfg::Trampoline::ThreadYield {
+                        cancellable: *cancellable,
+                    },
+                ));
                 frame.funcs.push((*func, dfg::CoreDef::Trampoline(index)));
             }
             SubtaskDrop { func } => {
@@ -1410,6 +1412,7 @@ impl<'a> Inliner<'a> {
             callback,
             post_return,
             async_: options.async_,
+            cancellable: options.cancellable,
             core_type: options.core_type,
             data_model,
         }
@@ -1441,6 +1444,7 @@ impl<'a> Inliner<'a> {
             callback,
             post_return,
             async_: options.async_,
+            cancellable: options.cancellable,
             core_type: options.core_type,
             data_model,
         })

--- a/crates/environ/src/fact.rs
+++ b/crates/environ/src/fact.rs
@@ -322,7 +322,9 @@ impl<'a> Module<'a> {
             async_,
             core_type,
             data_model,
+            cancellable,
         } = options;
+        assert!(!cancellable);
 
         let flags = self.import_global(
             "flags",

--- a/crates/test-programs/src/bin/async_backpressure_callee.rs
+++ b/crates/test-programs/src/bin/async_backpressure_callee.rs
@@ -20,6 +20,7 @@ impl Run for Component {
 
 impl Backpressure for Component {
     fn set_backpressure(enabled: bool) {
+        #[expect(deprecated, reason = "will replace with backpressure.inc/dec soon")]
         wit_bindgen::backpressure_set(enabled);
     }
 }

--- a/crates/test-programs/src/bin/async_cancel_callee.rs
+++ b/crates/test-programs/src/bin/async_cancel_callee.rs
@@ -80,6 +80,7 @@ enum State {
 
 #[unsafe(export_name = "local:local/backpressure#set-backpressure")]
 unsafe extern "C" fn export_set_backpressure(enabled: bool) {
+    #[expect(deprecated, reason = "will replace with backpressure.inc/dec soon")]
     wit_bindgen::backpressure_set(enabled);
 }
 

--- a/crates/wasmtime/src/runtime/component/concurrent.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent.rs
@@ -2688,14 +2688,14 @@ impl Instance {
         payload: u32,
     ) -> Result<u32> {
         let opts = self.concurrent_state_mut(store).options(options);
-        let async_ = opts.async_;
+        let cancellable = opts.cancellable;
         let caller_instance = opts.instance;
         let rep =
             self.id().get_mut(store).guest_tables().0[caller_instance].waitable_set_rep(set)?;
 
         self.waitable_check(
             store,
-            async_,
+            cancellable,
             WaitableCheck::Wait(WaitableCheckParams {
                 set: TableId::new(rep),
                 options,
@@ -2713,14 +2713,14 @@ impl Instance {
         payload: u32,
     ) -> Result<u32> {
         let opts = self.concurrent_state_mut(store).options(options);
-        let async_ = opts.async_;
+        let cancellable = opts.cancellable;
         let caller_instance = opts.instance;
         let rep =
             self.id().get_mut(store).guest_tables().0[caller_instance].waitable_set_rep(set)?;
 
         self.waitable_check(
             store,
-            async_,
+            cancellable,
             WaitableCheck::Poll(WaitableCheckParams {
                 set: TableId::new(rep),
                 options,
@@ -2729,9 +2729,9 @@ impl Instance {
         )
     }
 
-    /// Implements the `yield` intrinsic.
-    pub(crate) fn yield_(self, store: &mut dyn VMStore, async_: bool) -> Result<bool> {
-        self.waitable_check(store, async_, WaitableCheck::Yield)
+    /// Implements the `thread.yield` intrinsic.
+    pub(crate) fn thread_yield(self, store: &mut dyn VMStore, cancellable: bool) -> Result<bool> {
+        self.waitable_check(store, cancellable, WaitableCheck::Yield)
             .map(|_| {
                 let state = self.concurrent_state_mut(store);
                 let task = state.guest_task.unwrap();
@@ -2749,12 +2749,13 @@ impl Instance {
     fn waitable_check(
         self,
         store: &mut dyn VMStore,
-        async_: bool,
+        cancellable: bool,
         check: WaitableCheck,
     ) -> Result<u32> {
-        if async_ {
+        if cancellable {
             bail!(
-                "todo: async `waitable-set.wait`, `waitable-set.poll`, and `yield` not yet implemented"
+                "todo: cancellable `waitable-set.wait`, `waitable-set.poll`, \
+                 and `yield` not yet implemented"
             );
         }
 

--- a/crates/wasmtime/src/runtime/vm/component/libcalls.rs
+++ b/crates/wasmtime/src/runtime/vm/component/libcalls.rs
@@ -758,8 +758,8 @@ fn waitable_join(
 }
 
 #[cfg(feature = "component-model-async")]
-fn yield_(store: &mut dyn VMStore, instance: Instance, async_: u8) -> Result<bool> {
-    instance.yield_(store, async_ != 0)
+fn thread_yield(store: &mut dyn VMStore, instance: Instance, cancellable: u8) -> Result<bool> {
+    instance.thread_yield(store, cancellable != 0)
 }
 
 #[cfg(feature = "component-model-async")]

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -2690,6 +2690,12 @@ criteria = "safe-to-run"
 delta = "0.237.0 -> 0.238.1"
 notes = "The Bytecode Alliance is the author of this crate"
 
+[[audits.json-from-wast]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.238.1 -> 0.239.0"
+notes = "The Bytecode Alliance is the author of this crate"
+
 [[audits.leb128]]
 who = "Nick Fitzgerald <fitzgen@gmail.com>"
 criteria = "safe-to-deploy"
@@ -3935,6 +3941,12 @@ criteria = "safe-to-run"
 delta = "0.237.0 -> 0.238.1"
 notes = "The Bytecode Alliance is the author of this crate"
 
+[[audits.wasm-compose]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.238.1 -> 0.239.0"
+notes = "The Bytecode Alliance is the author of this crate"
+
 [[audits.wasm-coredump-builder]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
@@ -4073,6 +4085,12 @@ criteria = "safe-to-run"
 delta = "0.237.0 -> 0.238.1"
 notes = "The Bytecode Alliance is the author of this crate"
 
+[[audits.wasm-encoder]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.238.1 -> 0.239.0"
+notes = "The Bytecode Alliance is the author of this crate"
+
 [[audits.wasm-metadata]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
@@ -4089,6 +4107,12 @@ notes = "The Bytecode Alliance is the author of this crate"
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-run"
 delta = "0.237.0 -> 0.238.1"
+notes = "The Bytecode Alliance is the author of this crate"
+
+[[audits.wasm-metadata]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.238.1 -> 0.239.0"
 notes = "The Bytecode Alliance is the author of this crate"
 
 [[audits.wasm-mutate]]
@@ -4265,6 +4289,12 @@ criteria = "safe-to-run"
 delta = "0.237.0 -> 0.238.1"
 notes = "The Bytecode Alliance is the author of this crate"
 
+[[audits.wasm-wave]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.238.1 -> 0.239.0"
+notes = "The Bytecode Alliance is the author of this crate"
+
 [[audits.wasmi]]
 who = "Robin Freyler <robin.freyler@gmail.com>"
 criteria = "safe-to-run"
@@ -4409,6 +4439,12 @@ criteria = "safe-to-run"
 delta = "0.237.0 -> 0.238.1"
 notes = "The Bytecode Alliance is the author of this crate"
 
+[[audits.wasmparser]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.238.1 -> 0.239.0"
+notes = "The Bytecode Alliance is the author of this crate"
+
 [[audits.wasmparser-nostd]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-run"
@@ -4522,6 +4558,12 @@ criteria = "safe-to-run"
 delta = "0.237.0 -> 0.238.1"
 notes = "The Bytecode Alliance is the author of this crate"
 
+[[audits.wasmprinter]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.238.1 -> 0.239.0"
+notes = "The Bytecode Alliance is the author of this crate"
+
 [[audits.wast]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
@@ -4618,6 +4660,12 @@ criteria = "safe-to-run"
 delta = "237.0.0 -> 238.0.1"
 notes = "The Bytecode Alliance is the author of this crate"
 
+[[audits.wast]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "238.0.1 -> 239.0.0"
+notes = "The Bytecode Alliance is the author of this crate"
+
 [[audits.wat]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
@@ -4702,6 +4750,12 @@ criteria = "safe-to-run"
 delta = "1.237.0 -> 1.238.1"
 notes = "The Bytecode Alliance is the author of this crate"
 
+[[audits.wat]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "1.238.1 -> 1.239.0"
+notes = "The Bytecode Alliance is the author of this crate"
+
 [[audits.webpki-roots]]
 who = "Pat Hickey <phickey@fastly.com>"
 criteria = "safe-to-deploy"
@@ -4759,6 +4813,12 @@ criteria = "safe-to-deploy"
 delta = "0.45.0 -> 0.45.1"
 notes = "The Bytecode Alliance is the author of this crate"
 
+[[audits.wit-bindgen]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.45.1 -> 0.46.0"
+notes = "The Bytecode Alliance is the author of this crate"
+
 [[audits.wit-bindgen-core]]
 who = "Joel Dice <joel.dice@gmail.com>"
 criteria = "safe-to-run"
@@ -4774,6 +4834,12 @@ notes = "The Bytecode Alliance is the author of this crate"
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
 delta = "0.45.0 -> 0.45.1"
+notes = "The Bytecode Alliance is the author of this crate"
+
+[[audits.wit-bindgen-core]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.45.1 -> 0.46.0"
 notes = "The Bytecode Alliance is the author of this crate"
 
 [[audits.wit-bindgen-rt]]
@@ -4798,6 +4864,12 @@ criteria = "safe-to-deploy"
 delta = "0.45.0 -> 0.45.1"
 notes = "The Bytecode Alliance is the author of this crate"
 
+[[audits.wit-bindgen-rust]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.45.1 -> 0.46.0"
+notes = "The Bytecode Alliance is the author of this crate"
+
 [[audits.wit-bindgen-rust-macro]]
 who = "Joel Dice <joel.dice@gmail.com>"
 criteria = "safe-to-run"
@@ -4813,6 +4885,12 @@ notes = "The Bytecode Alliance is the author of this crate"
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
 delta = "0.45.0 -> 0.45.1"
+notes = "The Bytecode Alliance is the author of this crate"
+
+[[audits.wit-bindgen-rust-macro]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.45.1 -> 0.46.0"
 notes = "The Bytecode Alliance is the author of this crate"
 
 [[audits.wit-component]]
@@ -4831,6 +4909,12 @@ notes = "The Bytecode Alliance is the author of this crate"
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-run"
 delta = "0.237.0 -> 0.238.1"
+notes = "The Bytecode Alliance is the author of this crate"
+
+[[audits.wit-component]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.238.1 -> 0.239.0"
 notes = "The Bytecode Alliance is the author of this crate"
 
 [[audits.wit-parser]]
@@ -4897,6 +4981,12 @@ notes = "The Bytecode Alliance is the author of this crate"
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-run"
 delta = "0.237.0 -> 0.238.1"
+notes = "The Bytecode Alliance is the author of this crate"
+
+[[audits.wit-parser]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.238.1 -> 0.239.0"
 notes = "The Bytecode Alliance is the author of this crate"
 
 [[audits.xattr]]

--- a/tests/misc_testsuite/component-model-async/task-builtins.wast
+++ b/tests/misc_testsuite/component-model-async/task-builtins.wast
@@ -26,7 +26,7 @@
   (core module $m
     (import "" "waitable-set.wait" (func $waitable-set-wait (param i32 i32) (result i32)))
   )
-  (core func $waitable-set-wait (canon waitable-set.wait async (memory $libc "memory")))
+  (core func $waitable-set-wait (canon waitable-set.wait cancellable (memory $libc "memory")))
   (core instance $i (instantiate $m (with "" (instance (export "waitable-set.wait" (func $waitable-set-wait))))))
 )
 
@@ -37,7 +37,7 @@
   (core module $m
     (import "" "waitable-set.poll" (func $waitable-set-poll (param i32 i32) (result i32)))
   )
-  (core func $waitable-set-poll (canon waitable-set.poll async (memory $libc "memory")))
+  (core func $waitable-set-poll (canon waitable-set.poll cancellable (memory $libc "memory")))
   (core instance $i (instantiate $m (with "" (instance (export "waitable-set.poll" (func $waitable-set-poll))))))
 )
 
@@ -46,7 +46,7 @@
   (core module $m
     (import "" "yield" (func $yield (result i32)))
   )
-  (core func $yield (canon yield async))
+  (core func $yield (canon thread.yield cancellable))
   (core instance $i (instantiate $m (with "" (instance (export "yield" (func $yield))))))
 )
 


### PR DESCRIPTION
Changes include:

* `async` option on some CM intrinsics renamed to `cancellable`
* New `backpressure.{inc,dec}` intrinsics
* New component-model-threading-related intrinsics

New features aren't yet implemented, they're left for future PRs.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
