### PR TITLE
Implement backpressure.{inc,dec} 

### DIFF
--- a/crates/cranelift/src/compiler/component.rs
+++ b/crates/cranelift/src/compiler/component.rs
@@ -240,6 +240,28 @@ impl<'a> TrampolineCompiler<'a> {
                     },
                 );
             }
+            Trampoline::BackpressureInc { instance } => {
+                self.translate_libcall(
+                    host::backpressure_modify,
+                    TrapSentinel::Falsy,
+                    WasmArgs::InRegisters,
+                    |me, params| {
+                        params.push(me.index_value(*instance));
+                        params.push(me.builder.ins().iconst(ir::types::I8, 1));
+                    },
+                );
+            }
+            Trampoline::BackpressureDec { instance } => {
+                self.translate_libcall(
+                    host::backpressure_modify,
+                    TrapSentinel::Falsy,
+                    WasmArgs::InRegisters,
+                    |me, params| {
+                        params.push(me.index_value(*instance));
+                        params.push(me.builder.ins().iconst(ir::types::I8, 0));
+                    },
+                );
+            }
             Trampoline::TaskReturn { results, options } => {
                 self.translate_libcall(
                     host::task_return,

--- a/crates/environ/src/component.rs
+++ b/crates/environ/src/component.rs
@@ -100,6 +100,8 @@ macro_rules! foreach_builtin_component_function {
             #[cfg(feature = "component-model-async")]
             backpressure_set(vmctx: vmctx, caller_instance: u32, enabled: u32) -> bool;
             #[cfg(feature = "component-model-async")]
+            backpressure_modify(vmctx: vmctx, caller_instance: u32, increment: u8) -> bool;
+            #[cfg(feature = "component-model-async")]
             task_return(vmctx: vmctx, ty: u32, options: u32, storage: ptr_u8, storage_len: size) -> bool;
             #[cfg(feature = "component-model-async")]
             task_cancel(vmctx: vmctx, caller_instance: u32) -> bool;

--- a/crates/environ/src/component/dfg.rs
+++ b/crates/environ/src/component/dfg.rs
@@ -322,6 +322,12 @@ pub enum Trampoline {
     BackpressureSet {
         instance: RuntimeComponentInstanceIndex,
     },
+    BackpressureInc {
+        instance: RuntimeComponentInstanceIndex,
+    },
+    BackpressureDec {
+        instance: RuntimeComponentInstanceIndex,
+    },
     TaskReturn {
         results: TypeTupleIndex,
         options: OptionsId,
@@ -858,6 +864,12 @@ impl LinearizeDfg<'_> {
             Trampoline::ResourceDrop(ty) => info::Trampoline::ResourceDrop(*ty),
             Trampoline::ResourceRep(ty) => info::Trampoline::ResourceRep(*ty),
             Trampoline::BackpressureSet { instance } => info::Trampoline::BackpressureSet {
+                instance: *instance,
+            },
+            Trampoline::BackpressureInc { instance } => info::Trampoline::BackpressureInc {
+                instance: *instance,
+            },
+            Trampoline::BackpressureDec { instance } => info::Trampoline::BackpressureDec {
                 instance: *instance,
             },
             Trampoline::TaskReturn { results, options } => info::Trampoline::TaskReturn {

--- a/crates/environ/src/component/info.rs
+++ b/crates/environ/src/component/info.rs
@@ -734,6 +734,18 @@ pub enum Trampoline {
         instance: RuntimeComponentInstanceIndex,
     },
 
+    /// A `backpressure.inc` intrinsic.
+    BackpressureInc {
+        /// The specific component instance which is calling the intrinsic.
+        instance: RuntimeComponentInstanceIndex,
+    },
+
+    /// A `backpressure.dec` intrinsic.
+    BackpressureDec {
+        /// The specific component instance which is calling the intrinsic.
+        instance: RuntimeComponentInstanceIndex,
+    },
+
     /// A `task.return` intrinsic, which returns a result to the caller of a
     /// lifted export function.  This allows the callee to continue executing
     /// after returning a result.
@@ -1066,6 +1078,8 @@ impl Trampoline {
             ResourceRep(i) => format!("component-resource-rep[{}]", i.as_u32()),
             ResourceDrop(i) => format!("component-resource-drop[{}]", i.as_u32()),
             BackpressureSet { .. } => format!("backpressure-set"),
+            BackpressureInc { .. } => format!("backpressure-inc"),
+            BackpressureDec { .. } => format!("backpressure-dec"),
             TaskReturn { .. } => format!("task-return"),
             TaskCancel { .. } => format!("task-cancel"),
             WaitableSetNew { .. } => format!("waitable-set-new"),

--- a/crates/environ/src/component/translate.rs
+++ b/crates/environ/src/component/translate.rs
@@ -193,6 +193,12 @@ enum LocalInitializer<'data> {
     BackpressureSet {
         func: ModuleInternedTypeIndex,
     },
+    BackpressureInc {
+        func: ModuleInternedTypeIndex,
+    },
+    BackpressureDec {
+        func: ModuleInternedTypeIndex,
+    },
     TaskReturn {
         result: Option<ComponentValType>,
         options: LocalCanonicalOptions,
@@ -814,6 +820,17 @@ impl<'a, 'data> Translator<'a, 'data> {
                             core_func_index += 1;
                             LocalInitializer::BackpressureSet { func: core_type }
                         }
+                        wasmparser::CanonicalFunction::BackpressureInc => {
+                            let core_type = self.core_func_signature(core_func_index)?;
+                            core_func_index += 1;
+                            LocalInitializer::BackpressureInc { func: core_type }
+                        }
+                        wasmparser::CanonicalFunction::BackpressureDec => {
+                            let core_type = self.core_func_signature(core_func_index)?;
+                            core_func_index += 1;
+                            LocalInitializer::BackpressureDec { func: core_type }
+                        }
+
                         wasmparser::CanonicalFunction::TaskReturn { result, options } => {
                             let result = result.map(|ty| match ty {
                                 wasmparser::ComponentValType::Primitive(ty) => {
@@ -1071,13 +1088,6 @@ impl<'a, 'data> Translator<'a, 'data> {
                             let func = self.core_func_signature(core_func_index)?;
                             core_func_index += 1;
                             LocalInitializer::ContextSet { i, func }
-                        }
-
-                        wasmparser::CanonicalFunction::BackpressureInc => {
-                            bail!("unimplemented `backpressure.inc`");
-                        }
-                        wasmparser::CanonicalFunction::BackpressureDec => {
-                            bail!("unimplemented `backpressure.dec`");
                         }
 
                         wasmparser::CanonicalFunction::ThreadIndex => {

--- a/crates/environ/src/component/translate/inline.rs
+++ b/crates/environ/src/component/translate/inline.rs
@@ -681,6 +681,24 @@ impl<'a> Inliner<'a> {
                 ));
                 frame.funcs.push((*func, dfg::CoreDef::Trampoline(index)));
             }
+            BackpressureInc { func } => {
+                let index = self.result.trampolines.push((
+                    *func,
+                    dfg::Trampoline::BackpressureInc {
+                        instance: frame.instance,
+                    },
+                ));
+                frame.funcs.push((*func, dfg::CoreDef::Trampoline(index)));
+            }
+            BackpressureDec { func } => {
+                let index = self.result.trampolines.push((
+                    *func,
+                    dfg::Trampoline::BackpressureDec {
+                        instance: frame.instance,
+                    },
+                ));
+                frame.funcs.push((*func, dfg::CoreDef::Trampoline(index)));
+            }
             TaskReturn { result, options } => {
                 let results = result
                     .iter()

--- a/crates/misc/component-async-tests/wit/test.wit
+++ b/crates/misc/component-async-tests/wit/test.wit
@@ -58,6 +58,8 @@ interface run {
 
 interface backpressure {
   set-backpressure: func(enabled: bool);
+  inc-backpressure: func();
+  dec-backpressure: func();
 }
 
 interface transmit {

--- a/crates/test-programs/src/bin/async_backpressure_callee.rs
+++ b/crates/test-programs/src/bin/async_backpressure_callee.rs
@@ -23,6 +23,12 @@ impl Backpressure for Component {
         #[expect(deprecated, reason = "will replace with backpressure.inc/dec soon")]
         wit_bindgen::backpressure_set(enabled);
     }
+    fn inc_backpressure() {
+        wit_bindgen::backpressure_inc();
+    }
+    fn dec_backpressure() {
+        wit_bindgen::backpressure_dec();
+    }
 }
 
 // Unused function; required since this file is built as a `bin`:

--- a/crates/test-programs/src/bin/async_backpressure_caller.rs
+++ b/crates/test-programs/src/bin/async_backpressure_caller.rs
@@ -25,35 +25,48 @@ struct Component;
 
 impl Guest for Component {
     async fn run() {
-        backpressure::set_backpressure(true);
-
-        let mut a = Some(Box::pin(run::run()));
-        let mut b = Some(Box::pin(run::run()));
-        let mut c = Some(Box::pin(run::run()));
-
-        let mut backpressure_is_set = true;
-        future::poll_fn(move |cx| {
-            let a_ready = is_ready(cx, &mut a);
-            let b_ready = is_ready(cx, &mut b);
-            let c_ready = is_ready(cx, &mut c);
-
-            if backpressure_is_set {
-                assert!(!a_ready);
-                assert!(!b_ready);
-                assert!(!c_ready);
-
-                backpressure::set_backpressure(false);
-                backpressure_is_set = false;
-
-                Poll::Pending
-            } else if a_ready && b_ready && c_ready {
-                Poll::Ready(())
-            } else {
-                Poll::Pending
-            }
-        })
-        .await
+        test(
+            || backpressure::set_backpressure(true),
+            || backpressure::set_backpressure(false),
+        )
+        .await;
+        test(
+            || backpressure::inc_backpressure(),
+            || backpressure::dec_backpressure(),
+        )
+        .await;
     }
+}
+
+async fn test(enable: impl Fn(), disable: impl Fn()) {
+    enable();
+
+    let mut a = Some(Box::pin(run::run()));
+    let mut b = Some(Box::pin(run::run()));
+    let mut c = Some(Box::pin(run::run()));
+
+    let mut backpressure_is_set = true;
+    future::poll_fn(move |cx| {
+        let a_ready = is_ready(cx, &mut a);
+        let b_ready = is_ready(cx, &mut b);
+        let c_ready = is_ready(cx, &mut c);
+
+        if backpressure_is_set {
+            assert!(!a_ready);
+            assert!(!b_ready);
+            assert!(!c_ready);
+
+            disable();
+            backpressure_is_set = false;
+
+            Poll::Pending
+        } else if a_ready && b_ready && c_ready {
+            Poll::Ready(())
+        } else {
+            Poll::Pending
+        }
+    })
+    .await
 }
 
 fn is_ready(cx: &mut Context, fut: &mut Option<Pin<Box<impl Future<Output = ()>>>>) -> bool {

--- a/crates/test-programs/src/bin/async_cancel_callee.rs
+++ b/crates/test-programs/src/bin/async_cancel_callee.rs
@@ -84,6 +84,16 @@ unsafe extern "C" fn export_set_backpressure(enabled: bool) {
     wit_bindgen::backpressure_set(enabled);
 }
 
+#[unsafe(export_name = "local:local/backpressure#inc-backpressure")]
+unsafe extern "C" fn export_inc_backpressure() {
+    wit_bindgen::backpressure_inc();
+}
+
+#[unsafe(export_name = "local:local/backpressure#dec-backpressure")]
+unsafe extern "C" fn export_dec_backpressure() {
+    wit_bindgen::backpressure_dec();
+}
+
 #[unsafe(export_name = "local:local/sleep#[async]sleep-millis")]
 unsafe extern "C" fn export_sleep_sleep_millis(time_in_millis: u64) {
     unsafe {

--- a/crates/test-programs/src/bin/async_cancel_caller.rs
+++ b/crates/test-programs/src/bin/async_cancel_caller.rs
@@ -26,11 +26,17 @@ unsafe extern "C" fn task_return_run() {
 #[cfg(target_arch = "wasm32")]
 #[link(wasm_import_module = "local:local/backpressure")]
 unsafe extern "C" {
-    #[link_name = "set-backpressure"]
-    fn set_backpressure(_: bool);
+    #[link_name = "inc-backpressure"]
+    fn inc_backpressure();
+    #[link_name = "dec-backpressure"]
+    fn dec_backpressure();
 }
 #[cfg(not(target_arch = "wasm32"))]
-unsafe fn set_backpressure(_: bool) {
+unsafe fn inc_backpressure() {
+    unreachable!()
+}
+#[cfg(not(target_arch = "wasm32"))]
+unsafe fn dec_backpressure() {
     unreachable!()
 }
 
@@ -137,7 +143,7 @@ unsafe extern "C" fn callback_run(event0: u32, event1: u32, event2: u32) -> u32 
                 // with backpressure enabled.  Cancelling should not block since
                 // the call will not even have started.
 
-                set_backpressure(true);
+                inc_backpressure();
 
                 let params = Box::into_raw(Box::new(SleepParams {
                     time_in_millis: 60 * 60 * 1000,
@@ -171,7 +177,7 @@ unsafe extern "C" fn callback_run(event0: u32, event1: u32, event2: u32) -> u32 
                 // backpressure disabled.  Cancelling should not block since we
                 // specified zero cancel delay to the callee.
 
-                set_backpressure(false);
+                dec_backpressure();
 
                 let status = sleep_with_options::sleep_millis(params.cast());
 

--- a/crates/wasmtime/src/runtime/vm/component/libcalls.rs
+++ b/crates/wasmtime/src/runtime/vm/component/libcalls.rs
@@ -664,9 +664,28 @@ fn backpressure_set(
     caller_instance: u32,
     enabled: u32,
 ) -> Result<()> {
-    instance.concurrent_state_mut(store).backpressure_set(
+    instance.concurrent_state_mut(store).backpressure_modify(
         RuntimeComponentInstanceIndex::from_u32(caller_instance),
-        enabled,
+        |_| Some(if enabled != 0 { 1 } else { 0 }),
+    )
+}
+
+#[cfg(feature = "component-model-async")]
+fn backpressure_modify(
+    store: &mut dyn VMStore,
+    instance: Instance,
+    caller_instance: u32,
+    increment: u8,
+) -> Result<()> {
+    instance.concurrent_state_mut(store).backpressure_modify(
+        RuntimeComponentInstanceIndex::from_u32(caller_instance),
+        |old| {
+            if increment != 0 {
+                old.checked_add(1)
+            } else {
+                old.checked_sub(1)
+            }
+        },
     )
 }
 

--- a/tests/misc_testsuite/component-model-async/backpressure-deadlock.wast
+++ b/tests/misc_testsuite/component-model-async/backpressure-deadlock.wast
@@ -15,20 +15,20 @@
 (component
 
   (component $A
-    (core func $backpressure.set (canon backpressure.set))
+    (core func $backpressure.inc (canon backpressure.inc))
     (core module $m
-      (import "" "backpressure.set" (func $backpressure.set (param i32)))
+      (import "" "backpressure.inc" (func $backpressure.inc))
 
       (func (export "f") (result i32) unreachable)
       (func (export "callback") (param i32 i32 i32) (result i32) unreachable)
 
       (func (export "turn-on-backpressure")
-        (call $backpressure.set (i32.const 1)))
+        (call $backpressure.inc))
     )
 
     (core instance $i (instantiate $m
       (with "" (instance
-        (export "backpressure.set" (func $backpressure.set))
+        (export "backpressure.inc" (func $backpressure.inc))
       ))
     ))
 

--- a/tests/misc_testsuite/component-model-async/backpressure-overflow.wast
+++ b/tests/misc_testsuite/component-model-async/backpressure-overflow.wast
@@ -1,0 +1,43 @@
+;;! component_model_async = true
+
+(component definition $A
+  (core func $inc (canon backpressure.inc))
+  (core func $dec (canon backpressure.dec))
+  (core module $m
+    (import "" "inc" (func $inc))
+    (import "" "dec" (func $dec))
+    (func (export "run") (param $inc i32) (param $dec i32)
+      loop $l
+        call $inc
+        (local.tee $inc (i32.sub (local.get $inc) (i32.const 1)))
+        if br $l end
+      end
+
+      loop $l
+        call $dec
+        (local.tee $dec (i32.sub (local.get $dec) (i32.const 1)))
+        if br $l end
+      end)
+  )
+  (core instance $i (instantiate $m
+    (with "" (instance
+      (export "inc" (func $inc))
+      (export "dec" (func $dec))
+    ))
+  ))
+  (func (export "run") (param "incs" u32) (param "decs" u32)
+    (canon lift (core func $i "run")))
+)
+
+(component instance $a1 $A)
+(assert_trap (invoke "run" (u32.const 0) (u32.const 1)) "backpressure counter overflow")
+
+(component instance $a2 $A)
+(assert_trap (invoke "run" (u32.const 1) (u32.const 2)) "backpressure counter overflow")
+
+(component instance $a3 $A)
+(assert_trap (invoke "run" (u32.const 65536) (u32.const 0)) "backpressure counter overflow")
+
+(component instance $a4 $A)
+(assert_return (invoke "run" (u32.const 65535) (u32.const 65535)))
+(assert_trap (invoke "run" (u32.const 0) (u32.const 1)) "backpressure counter overflow")

--- a/tests/misc_testsuite/component-model-async/task-builtins.wast
+++ b/tests/misc_testsuite/component-model-async/task-builtins.wast
@@ -10,6 +10,24 @@
   (core instance $i (instantiate $m (with "" (instance (export "backpressure.set" (func $backpressure-set))))))
 )
 
+;; backpressure.inc
+(component
+  (core module $m
+    (import "" "backpressure.inc" (func $backpressure-inc))
+  )
+  (core func $backpressure-inc (canon backpressure.inc))
+  (core instance $i (instantiate $m (with "" (instance (export "backpressure.inc" (func $backpressure-inc))))))
+)
+
+;; backpressure.dec
+(component
+  (core module $m
+    (import "" "backpressure.dec" (func $backpressure-dec))
+  )
+  (core func $backpressure-dec (canon backpressure.dec))
+  (core instance $i (instantiate $m (with "" (instance (export "backpressure.dec" (func $backpressure-dec))))))
+)
+
 ;; task.return
 (component
   (core module $m


### PR DESCRIPTION
Added to the async specification in https://github.com/WebAssembly/component-model/pull/560
these are minor adaptations to the preexisting `backpressure.set`
intrinsic and are intended to replace it. The `backpressure.set`
intrinsic will remain until tooling propagates to understand
`backpressure.{inc,dec}`.