### PR TITLE
Fix minor typos in runtime comments

### DIFF
--- a/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams.rs
@@ -478,7 +478,7 @@ pub trait StreamProducer<D>: Send + 'static {
     ///
     /// If more items are written to `destination` than the reader has immediate
     /// capacity to accept, they will be retained in memory by the caller and
-    /// used to satisify future reads, in which case `poll_produce` will only be
+    /// used to satisfy future reads, in which case `poll_produce` will only be
     /// called again once all those items have been delivered.
     ///
     /// If this function is called with zero capacity
@@ -780,7 +780,7 @@ pub trait StreamConsumer<D>: Send + 'static {
     /// upstream sink, `poll_consume` will be called with `finish` set to true,
     /// and the implementation may either:
     ///
-    /// - Interrupt the forwarding process gracefully.  This may be preferrable
+    /// - Interrupt the forwarding process gracefully.  This may be preferable
     /// if there is an out-of-band channel for communicating to the writer how
     /// many items were forwarded before being interrupted.
     ///

--- a/crates/wasmtime/src/runtime/store.rs
+++ b/crates/wasmtime/src/runtime/store.rs
@@ -1950,7 +1950,7 @@ impl StoreOpaque {
                 }
                 VMStackState::Parent => {
                     // We don't know whether our child is suspended or running, but in
-                    // either case things should be hanlded correctly when traversing
+                    // either case things should be handled correctly when traversing
                     // further along in the chain, nothing required at this point.
                 }
                 VMStackState::Fresh | VMStackState::Returned => {


### PR DESCRIPTION

  - Correct spelling in comments:
    - `crates/wasmtime/src/runtime/component/concurrent/futures_and_streams.rs`: “preferrable” → “preferable”; minor wording cleanup.
    - `crates/wasmtime/src/runtime/store.rs`: “hanlded” → “handled”.
