### PR TITLE
add `task_exit` option to `wasmtime-wit-bindgen`

### DIFF
--- a/crates/component-macro/src/bindgen.rs
+++ b/crates/component-macro/src/bindgen.rs
@@ -261,6 +261,7 @@ mod kw {
     syn::custom_keyword!(trappable);
     syn::custom_keyword!(ignore_wit);
     syn::custom_keyword!(exact);
+    syn::custom_keyword!(task_exit);
 }
 
 enum Opt {
@@ -530,6 +531,9 @@ fn parse_function_config(input: ParseStream<'_>) -> Result<FunctionConfig> {
                 } else if l.peek(kw::exact) {
                     input.parse::<kw::exact>()?;
                     flags |= FunctionFlags::EXACT;
+                } else if l.peek(kw::task_exit) {
+                    input.parse::<kw::task_exit>()?;
+                    flags |= FunctionFlags::TASK_EXIT;
                 } else {
                     return Err(l.error());
                 }

--- a/crates/component-macro/tests/expanded/char_concurrent.rs
+++ b/crates/component-macro/tests/expanded/char_concurrent.rs
@@ -331,7 +331,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.take_char)
                         };
-                        let () = callee.call_concurrent(accessor, (arg0,)).await?.0;
+                        let ((), _) = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
                     }
                     /// A function that returns a character
@@ -349,7 +349,7 @@ pub mod exports {
                                 (char,),
                             >::new_unchecked(self.return_char)
                         };
-                        let (ret0,) = callee.call_concurrent(accessor, ()).await?.0;
+                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                 }

--- a/crates/component-macro/tests/expanded/conventions_concurrent.rs
+++ b/crates/component-macro/tests/expanded/conventions_concurrent.rs
@@ -636,7 +636,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.kebab_case)
                         };
-                        let () = callee.call_concurrent(accessor, ()).await?.0;
+                        let ((), _) = callee.call_concurrent(accessor, ()).await?;
                         Ok(())
                     }
                     pub async fn call_foo<_T, _D>(
@@ -654,7 +654,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.foo)
                         };
-                        let () = callee.call_concurrent(accessor, (arg0,)).await?.0;
+                        let ((), _) = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
                     }
                     pub async fn call_function_with_dashes<_T, _D>(
@@ -671,7 +671,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.function_with_dashes)
                         };
-                        let () = callee.call_concurrent(accessor, ()).await?.0;
+                        let ((), _) = callee.call_concurrent(accessor, ()).await?;
                         Ok(())
                     }
                     pub async fn call_function_with_no_weird_characters<_T, _D>(
@@ -688,7 +688,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.function_with_no_weird_characters)
                         };
-                        let () = callee.call_concurrent(accessor, ()).await?.0;
+                        let ((), _) = callee.call_concurrent(accessor, ()).await?;
                         Ok(())
                     }
                     pub async fn call_apple<_T, _D>(
@@ -705,7 +705,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.apple)
                         };
-                        let () = callee.call_concurrent(accessor, ()).await?.0;
+                        let ((), _) = callee.call_concurrent(accessor, ()).await?;
                         Ok(())
                     }
                     pub async fn call_apple_pear<_T, _D>(
@@ -722,7 +722,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.apple_pear)
                         };
-                        let () = callee.call_concurrent(accessor, ()).await?.0;
+                        let ((), _) = callee.call_concurrent(accessor, ()).await?;
                         Ok(())
                     }
                     pub async fn call_apple_pear_grape<_T, _D>(
@@ -739,7 +739,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.apple_pear_grape)
                         };
-                        let () = callee.call_concurrent(accessor, ()).await?.0;
+                        let ((), _) = callee.call_concurrent(accessor, ()).await?;
                         Ok(())
                     }
                     pub async fn call_a0<_T, _D>(
@@ -756,7 +756,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.a0)
                         };
-                        let () = callee.call_concurrent(accessor, ()).await?.0;
+                        let ((), _) = callee.call_concurrent(accessor, ()).await?;
                         Ok(())
                     }
                     /// Comment out identifiers that collide when mapped to snake_case, for now; see
@@ -778,7 +778,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.is_xml)
                         };
-                        let () = callee.call_concurrent(accessor, ()).await?.0;
+                        let ((), _) = callee.call_concurrent(accessor, ()).await?;
                         Ok(())
                     }
                     pub async fn call_explicit<_T, _D>(
@@ -795,7 +795,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.explicit)
                         };
-                        let () = callee.call_concurrent(accessor, ()).await?.0;
+                        let ((), _) = callee.call_concurrent(accessor, ()).await?;
                         Ok(())
                     }
                     pub async fn call_explicit_kebab<_T, _D>(
@@ -812,7 +812,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.explicit_kebab)
                         };
-                        let () = callee.call_concurrent(accessor, ()).await?.0;
+                        let ((), _) = callee.call_concurrent(accessor, ()).await?;
                         Ok(())
                     }
                     /// Identifiers with the same name as keywords are quoted.
@@ -830,7 +830,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.bool)
                         };
-                        let () = callee.call_concurrent(accessor, ()).await?.0;
+                        let ((), _) = callee.call_concurrent(accessor, ()).await?;
                         Ok(())
                     }
                 }

--- a/crates/component-macro/tests/expanded/flags_concurrent.rs
+++ b/crates/component-macro/tests/expanded/flags_concurrent.rs
@@ -730,7 +730,9 @@ pub mod exports {
                                 (Flag1,),
                             >::new_unchecked(self.roundtrip_flag1)
                         };
-                        let (ret0,) = callee.call_concurrent(accessor, (arg0,)).await?.0;
+                        let ((ret0,), _) = callee
+                            .call_concurrent(accessor, (arg0,))
+                            .await?;
                         Ok(ret0)
                     }
                     pub async fn call_roundtrip_flag2<_T, _D>(
@@ -748,7 +750,9 @@ pub mod exports {
                                 (Flag2,),
                             >::new_unchecked(self.roundtrip_flag2)
                         };
-                        let (ret0,) = callee.call_concurrent(accessor, (arg0,)).await?.0;
+                        let ((ret0,), _) = callee
+                            .call_concurrent(accessor, (arg0,))
+                            .await?;
                         Ok(ret0)
                     }
                     pub async fn call_roundtrip_flag4<_T, _D>(
@@ -766,7 +770,9 @@ pub mod exports {
                                 (Flag4,),
                             >::new_unchecked(self.roundtrip_flag4)
                         };
-                        let (ret0,) = callee.call_concurrent(accessor, (arg0,)).await?.0;
+                        let ((ret0,), _) = callee
+                            .call_concurrent(accessor, (arg0,))
+                            .await?;
                         Ok(ret0)
                     }
                     pub async fn call_roundtrip_flag8<_T, _D>(
@@ -784,7 +790,9 @@ pub mod exports {
                                 (Flag8,),
                             >::new_unchecked(self.roundtrip_flag8)
                         };
-                        let (ret0,) = callee.call_concurrent(accessor, (arg0,)).await?.0;
+                        let ((ret0,), _) = callee
+                            .call_concurrent(accessor, (arg0,))
+                            .await?;
                         Ok(ret0)
                     }
                     pub async fn call_roundtrip_flag16<_T, _D>(
@@ -802,7 +810,9 @@ pub mod exports {
                                 (Flag16,),
                             >::new_unchecked(self.roundtrip_flag16)
                         };
-                        let (ret0,) = callee.call_concurrent(accessor, (arg0,)).await?.0;
+                        let ((ret0,), _) = callee
+                            .call_concurrent(accessor, (arg0,))
+                            .await?;
                         Ok(ret0)
                     }
                     pub async fn call_roundtrip_flag32<_T, _D>(
@@ -820,7 +830,9 @@ pub mod exports {
                                 (Flag32,),
                             >::new_unchecked(self.roundtrip_flag32)
                         };
-                        let (ret0,) = callee.call_concurrent(accessor, (arg0,)).await?.0;
+                        let ((ret0,), _) = callee
+                            .call_concurrent(accessor, (arg0,))
+                            .await?;
                         Ok(ret0)
                     }
                     pub async fn call_roundtrip_flag64<_T, _D>(
@@ -838,7 +850,9 @@ pub mod exports {
                                 (Flag64,),
                             >::new_unchecked(self.roundtrip_flag64)
                         };
-                        let (ret0,) = callee.call_concurrent(accessor, (arg0,)).await?.0;
+                        let ((ret0,), _) = callee
+                            .call_concurrent(accessor, (arg0,))
+                            .await?;
                         Ok(ret0)
                     }
                 }

--- a/crates/component-macro/tests/expanded/floats_concurrent.rs
+++ b/crates/component-macro/tests/expanded/floats_concurrent.rs
@@ -373,7 +373,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.f32_param)
                         };
-                        let () = callee.call_concurrent(accessor, (arg0,)).await?.0;
+                        let ((), _) = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
                     }
                     pub async fn call_f64_param<_T, _D>(
@@ -391,7 +391,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.f64_param)
                         };
-                        let () = callee.call_concurrent(accessor, (arg0,)).await?.0;
+                        let ((), _) = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
                     }
                     pub async fn call_f32_result<_T, _D>(
@@ -408,7 +408,7 @@ pub mod exports {
                                 (f32,),
                             >::new_unchecked(self.f32_result)
                         };
-                        let (ret0,) = callee.call_concurrent(accessor, ()).await?.0;
+                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_f64_result<_T, _D>(
@@ -425,7 +425,7 @@ pub mod exports {
                                 (f64,),
                             >::new_unchecked(self.f64_result)
                         };
-                        let (ret0,) = callee.call_concurrent(accessor, ()).await?.0;
+                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                 }

--- a/crates/component-macro/tests/expanded/function-new_concurrent.rs
+++ b/crates/component-macro/tests/expanded/function-new_concurrent.rs
@@ -193,7 +193,7 @@ const _: () = {
             let callee = unsafe {
                 wasmtime::component::TypedFunc::<(), ()>::new_unchecked(self.new)
             };
-            let () = callee.call_concurrent(accessor, ()).await?.0;
+            let ((), _) = callee.call_concurrent(accessor, ()).await?;
             Ok(())
         }
     }

--- a/crates/component-macro/tests/expanded/integers_concurrent.rs
+++ b/crates/component-macro/tests/expanded/integers_concurrent.rs
@@ -710,7 +710,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.a1)
                         };
-                        let () = callee.call_concurrent(accessor, (arg0,)).await?.0;
+                        let ((), _) = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
                     }
                     pub async fn call_a2<_T, _D>(
@@ -728,7 +728,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.a2)
                         };
-                        let () = callee.call_concurrent(accessor, (arg0,)).await?.0;
+                        let ((), _) = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
                     }
                     pub async fn call_a3<_T, _D>(
@@ -746,7 +746,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.a3)
                         };
-                        let () = callee.call_concurrent(accessor, (arg0,)).await?.0;
+                        let ((), _) = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
                     }
                     pub async fn call_a4<_T, _D>(
@@ -764,7 +764,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.a4)
                         };
-                        let () = callee.call_concurrent(accessor, (arg0,)).await?.0;
+                        let ((), _) = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
                     }
                     pub async fn call_a5<_T, _D>(
@@ -782,7 +782,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.a5)
                         };
-                        let () = callee.call_concurrent(accessor, (arg0,)).await?.0;
+                        let ((), _) = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
                     }
                     pub async fn call_a6<_T, _D>(
@@ -800,7 +800,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.a6)
                         };
-                        let () = callee.call_concurrent(accessor, (arg0,)).await?.0;
+                        let ((), _) = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
                     }
                     pub async fn call_a7<_T, _D>(
@@ -818,7 +818,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.a7)
                         };
-                        let () = callee.call_concurrent(accessor, (arg0,)).await?.0;
+                        let ((), _) = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
                     }
                     pub async fn call_a8<_T, _D>(
@@ -836,7 +836,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.a8)
                         };
-                        let () = callee.call_concurrent(accessor, (arg0,)).await?.0;
+                        let ((), _) = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
                     }
                     pub async fn call_a9<_T, _D>(
@@ -861,13 +861,12 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.a9)
                         };
-                        let () = callee
+                        let ((), _) = callee
                             .call_concurrent(
                                 accessor,
                                 (arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7),
                             )
-                            .await?
-                            .0;
+                            .await?;
                         Ok(())
                     }
                     pub async fn call_r1<_T, _D>(
@@ -884,7 +883,7 @@ pub mod exports {
                                 (u8,),
                             >::new_unchecked(self.r1)
                         };
-                        let (ret0,) = callee.call_concurrent(accessor, ()).await?.0;
+                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_r2<_T, _D>(
@@ -901,7 +900,7 @@ pub mod exports {
                                 (i8,),
                             >::new_unchecked(self.r2)
                         };
-                        let (ret0,) = callee.call_concurrent(accessor, ()).await?.0;
+                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_r3<_T, _D>(
@@ -918,7 +917,7 @@ pub mod exports {
                                 (u16,),
                             >::new_unchecked(self.r3)
                         };
-                        let (ret0,) = callee.call_concurrent(accessor, ()).await?.0;
+                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_r4<_T, _D>(
@@ -935,7 +934,7 @@ pub mod exports {
                                 (i16,),
                             >::new_unchecked(self.r4)
                         };
-                        let (ret0,) = callee.call_concurrent(accessor, ()).await?.0;
+                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_r5<_T, _D>(
@@ -952,7 +951,7 @@ pub mod exports {
                                 (u32,),
                             >::new_unchecked(self.r5)
                         };
-                        let (ret0,) = callee.call_concurrent(accessor, ()).await?.0;
+                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_r6<_T, _D>(
@@ -969,7 +968,7 @@ pub mod exports {
                                 (i32,),
                             >::new_unchecked(self.r6)
                         };
-                        let (ret0,) = callee.call_concurrent(accessor, ()).await?.0;
+                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_r7<_T, _D>(
@@ -986,7 +985,7 @@ pub mod exports {
                                 (u64,),
                             >::new_unchecked(self.r7)
                         };
-                        let (ret0,) = callee.call_concurrent(accessor, ()).await?.0;
+                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_r8<_T, _D>(
@@ -1003,7 +1002,7 @@ pub mod exports {
                                 (i64,),
                             >::new_unchecked(self.r8)
                         };
-                        let (ret0,) = callee.call_concurrent(accessor, ()).await?.0;
+                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_pair_ret<_T, _D>(
@@ -1020,7 +1019,7 @@ pub mod exports {
                                 ((i64, u8),),
                             >::new_unchecked(self.pair_ret)
                         };
-                        let (ret0,) = callee.call_concurrent(accessor, ()).await?.0;
+                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                 }

--- a/crates/component-macro/tests/expanded/lists_concurrent.rs
+++ b/crates/component-macro/tests/expanded/lists_concurrent.rs
@@ -1526,7 +1526,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.list_u8_param)
                         };
-                        let () = callee.call_concurrent(accessor, (arg0,)).await?.0;
+                        let ((), _) = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
                     }
                     pub async fn call_list_u16_param<_T, _D>(
@@ -1544,7 +1544,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.list_u16_param)
                         };
-                        let () = callee.call_concurrent(accessor, (arg0,)).await?.0;
+                        let ((), _) = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
                     }
                     pub async fn call_list_u32_param<_T, _D>(
@@ -1562,7 +1562,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.list_u32_param)
                         };
-                        let () = callee.call_concurrent(accessor, (arg0,)).await?.0;
+                        let ((), _) = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
                     }
                     pub async fn call_list_u64_param<_T, _D>(
@@ -1580,7 +1580,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.list_u64_param)
                         };
-                        let () = callee.call_concurrent(accessor, (arg0,)).await?.0;
+                        let ((), _) = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
                     }
                     pub async fn call_list_s8_param<_T, _D>(
@@ -1598,7 +1598,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.list_s8_param)
                         };
-                        let () = callee.call_concurrent(accessor, (arg0,)).await?.0;
+                        let ((), _) = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
                     }
                     pub async fn call_list_s16_param<_T, _D>(
@@ -1616,7 +1616,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.list_s16_param)
                         };
-                        let () = callee.call_concurrent(accessor, (arg0,)).await?.0;
+                        let ((), _) = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
                     }
                     pub async fn call_list_s32_param<_T, _D>(
@@ -1634,7 +1634,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.list_s32_param)
                         };
-                        let () = callee.call_concurrent(accessor, (arg0,)).await?.0;
+                        let ((), _) = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
                     }
                     pub async fn call_list_s64_param<_T, _D>(
@@ -1652,7 +1652,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.list_s64_param)
                         };
-                        let () = callee.call_concurrent(accessor, (arg0,)).await?.0;
+                        let ((), _) = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
                     }
                     pub async fn call_list_f32_param<_T, _D>(
@@ -1670,7 +1670,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.list_f32_param)
                         };
-                        let () = callee.call_concurrent(accessor, (arg0,)).await?.0;
+                        let ((), _) = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
                     }
                     pub async fn call_list_f64_param<_T, _D>(
@@ -1688,7 +1688,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.list_f64_param)
                         };
-                        let () = callee.call_concurrent(accessor, (arg0,)).await?.0;
+                        let ((), _) = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
                     }
                     pub async fn call_list_u8_ret<_T, _D>(
@@ -1705,7 +1705,7 @@ pub mod exports {
                                 (wasmtime::component::__internal::Vec<u8>,),
                             >::new_unchecked(self.list_u8_ret)
                         };
-                        let (ret0,) = callee.call_concurrent(accessor, ()).await?.0;
+                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_list_u16_ret<_T, _D>(
@@ -1722,7 +1722,7 @@ pub mod exports {
                                 (wasmtime::component::__internal::Vec<u16>,),
                             >::new_unchecked(self.list_u16_ret)
                         };
-                        let (ret0,) = callee.call_concurrent(accessor, ()).await?.0;
+                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_list_u32_ret<_T, _D>(
@@ -1739,7 +1739,7 @@ pub mod exports {
                                 (wasmtime::component::__internal::Vec<u32>,),
                             >::new_unchecked(self.list_u32_ret)
                         };
-                        let (ret0,) = callee.call_concurrent(accessor, ()).await?.0;
+                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_list_u64_ret<_T, _D>(
@@ -1756,7 +1756,7 @@ pub mod exports {
                                 (wasmtime::component::__internal::Vec<u64>,),
                             >::new_unchecked(self.list_u64_ret)
                         };
-                        let (ret0,) = callee.call_concurrent(accessor, ()).await?.0;
+                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_list_s8_ret<_T, _D>(
@@ -1773,7 +1773,7 @@ pub mod exports {
                                 (wasmtime::component::__internal::Vec<i8>,),
                             >::new_unchecked(self.list_s8_ret)
                         };
-                        let (ret0,) = callee.call_concurrent(accessor, ()).await?.0;
+                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_list_s16_ret<_T, _D>(
@@ -1790,7 +1790,7 @@ pub mod exports {
                                 (wasmtime::component::__internal::Vec<i16>,),
                             >::new_unchecked(self.list_s16_ret)
                         };
-                        let (ret0,) = callee.call_concurrent(accessor, ()).await?.0;
+                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_list_s32_ret<_T, _D>(
@@ -1807,7 +1807,7 @@ pub mod exports {
                                 (wasmtime::component::__internal::Vec<i32>,),
                             >::new_unchecked(self.list_s32_ret)
                         };
-                        let (ret0,) = callee.call_concurrent(accessor, ()).await?.0;
+                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_list_s64_ret<_T, _D>(
@@ -1824,7 +1824,7 @@ pub mod exports {
                                 (wasmtime::component::__internal::Vec<i64>,),
                             >::new_unchecked(self.list_s64_ret)
                         };
-                        let (ret0,) = callee.call_concurrent(accessor, ()).await?.0;
+                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_list_f32_ret<_T, _D>(
@@ -1841,7 +1841,7 @@ pub mod exports {
                                 (wasmtime::component::__internal::Vec<f32>,),
                             >::new_unchecked(self.list_f32_ret)
                         };
-                        let (ret0,) = callee.call_concurrent(accessor, ()).await?.0;
+                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_list_f64_ret<_T, _D>(
@@ -1858,7 +1858,7 @@ pub mod exports {
                                 (wasmtime::component::__internal::Vec<f64>,),
                             >::new_unchecked(self.list_f64_ret)
                         };
-                        let (ret0,) = callee.call_concurrent(accessor, ()).await?.0;
+                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_tuple_list<_T, _D>(
@@ -1878,7 +1878,9 @@ pub mod exports {
                                 (wasmtime::component::__internal::Vec<(i64, u32)>,),
                             >::new_unchecked(self.tuple_list)
                         };
-                        let (ret0,) = callee.call_concurrent(accessor, (arg0,)).await?.0;
+                        let ((ret0,), _) = callee
+                            .call_concurrent(accessor, (arg0,))
+                            .await?;
                         Ok(ret0)
                     }
                     pub async fn call_string_list_arg<_T, _D>(
@@ -1902,7 +1904,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.string_list_arg)
                         };
-                        let () = callee.call_concurrent(accessor, (arg0,)).await?.0;
+                        let ((), _) = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
                     }
                     pub async fn call_string_list_ret<_T, _D>(
@@ -1927,7 +1929,7 @@ pub mod exports {
                                 ),
                             >::new_unchecked(self.string_list_ret)
                         };
-                        let (ret0,) = callee.call_concurrent(accessor, ()).await?.0;
+                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_tuple_string_list<_T, _D>(
@@ -1959,7 +1961,9 @@ pub mod exports {
                                 ),
                             >::new_unchecked(self.tuple_string_list)
                         };
-                        let (ret0,) = callee.call_concurrent(accessor, (arg0,)).await?.0;
+                        let ((ret0,), _) = callee
+                            .call_concurrent(accessor, (arg0,))
+                            .await?;
                         Ok(ret0)
                     }
                     pub async fn call_string_list<_T, _D>(
@@ -1991,7 +1995,9 @@ pub mod exports {
                                 ),
                             >::new_unchecked(self.string_list)
                         };
-                        let (ret0,) = callee.call_concurrent(accessor, (arg0,)).await?.0;
+                        let ((ret0,), _) = callee
+                            .call_concurrent(accessor, (arg0,))
+                            .await?;
                         Ok(ret0)
                     }
                     pub async fn call_record_list<_T, _D>(
@@ -2011,7 +2017,9 @@ pub mod exports {
                                 (wasmtime::component::__internal::Vec<OtherRecord>,),
                             >::new_unchecked(self.record_list)
                         };
-                        let (ret0,) = callee.call_concurrent(accessor, (arg0,)).await?.0;
+                        let ((ret0,), _) = callee
+                            .call_concurrent(accessor, (arg0,))
+                            .await?;
                         Ok(ret0)
                     }
                     pub async fn call_record_list_reverse<_T, _D>(
@@ -2031,7 +2039,9 @@ pub mod exports {
                                 (wasmtime::component::__internal::Vec<SomeRecord>,),
                             >::new_unchecked(self.record_list_reverse)
                         };
-                        let (ret0,) = callee.call_concurrent(accessor, (arg0,)).await?.0;
+                        let ((ret0,), _) = callee
+                            .call_concurrent(accessor, (arg0,))
+                            .await?;
                         Ok(ret0)
                     }
                     pub async fn call_variant_list<_T, _D>(
@@ -2051,7 +2061,9 @@ pub mod exports {
                                 (wasmtime::component::__internal::Vec<OtherVariant>,),
                             >::new_unchecked(self.variant_list)
                         };
-                        let (ret0,) = callee.call_concurrent(accessor, (arg0,)).await?.0;
+                        let ((ret0,), _) = callee
+                            .call_concurrent(accessor, (arg0,))
+                            .await?;
                         Ok(ret0)
                     }
                     pub async fn call_load_store_everything<_T, _D>(
@@ -2069,7 +2081,9 @@ pub mod exports {
                                 (LoadStoreAllSizes,),
                             >::new_unchecked(self.load_store_everything)
                         };
-                        let (ret0,) = callee.call_concurrent(accessor, (arg0,)).await?.0;
+                        let ((ret0,), _) = callee
+                            .call_concurrent(accessor, (arg0,))
+                            .await?;
                         Ok(ret0)
                     }
                 }

--- a/crates/component-macro/tests/expanded/many-arguments_concurrent.rs
+++ b/crates/component-macro/tests/expanded/many-arguments_concurrent.rs
@@ -623,7 +623,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.many_args)
                         };
-                        let () = callee
+                        let ((), _) = callee
                             .call_concurrent(
                                 accessor,
                                 (
@@ -645,8 +645,7 @@ pub mod exports {
                                     arg15,
                                 ),
                             )
-                            .await?
-                            .0;
+                            .await?;
                         Ok(())
                     }
                     pub async fn call_big_argument<_T, _D>(
@@ -664,7 +663,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.big_argument)
                         };
-                        let () = callee.call_concurrent(accessor, (arg0,)).await?.0;
+                        let ((), _) = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
                     }
                 }

--- a/crates/component-macro/tests/expanded/multiversion_concurrent.rs
+++ b/crates/component-macro/tests/expanded/multiversion_concurrent.rs
@@ -348,7 +348,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.x)
                         };
-                        let () = callee.call_concurrent(accessor, ()).await?.0;
+                        let ((), _) = callee.call_concurrent(accessor, ()).await?;
                         Ok(())
                     }
                 }
@@ -430,7 +430,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.x)
                         };
-                        let () = callee.call_concurrent(accessor, ()).await?.0;
+                        let ((), _) = callee.call_concurrent(accessor, ()).await?;
                         Ok(())
                     }
                 }

--- a/crates/component-macro/tests/expanded/records_concurrent.rs
+++ b/crates/component-macro/tests/expanded/records_concurrent.rs
@@ -910,7 +910,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.tuple_arg)
                         };
-                        let () = callee.call_concurrent(accessor, (arg0,)).await?.0;
+                        let ((), _) = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
                     }
                     pub async fn call_tuple_result<_T, _D>(
@@ -927,7 +927,7 @@ pub mod exports {
                                 ((char, u32),),
                             >::new_unchecked(self.tuple_result)
                         };
-                        let (ret0,) = callee.call_concurrent(accessor, ()).await?.0;
+                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_empty_arg<_T, _D>(
@@ -945,7 +945,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.empty_arg)
                         };
-                        let () = callee.call_concurrent(accessor, (arg0,)).await?.0;
+                        let ((), _) = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
                     }
                     pub async fn call_empty_result<_T, _D>(
@@ -962,7 +962,7 @@ pub mod exports {
                                 (Empty,),
                             >::new_unchecked(self.empty_result)
                         };
-                        let (ret0,) = callee.call_concurrent(accessor, ()).await?.0;
+                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_scalar_arg<_T, _D>(
@@ -980,7 +980,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.scalar_arg)
                         };
-                        let () = callee.call_concurrent(accessor, (arg0,)).await?.0;
+                        let ((), _) = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
                     }
                     pub async fn call_scalar_result<_T, _D>(
@@ -997,7 +997,7 @@ pub mod exports {
                                 (Scalars,),
                             >::new_unchecked(self.scalar_result)
                         };
-                        let (ret0,) = callee.call_concurrent(accessor, ()).await?.0;
+                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_flags_arg<_T, _D>(
@@ -1015,7 +1015,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.flags_arg)
                         };
-                        let () = callee.call_concurrent(accessor, (arg0,)).await?.0;
+                        let ((), _) = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
                     }
                     pub async fn call_flags_result<_T, _D>(
@@ -1032,7 +1032,7 @@ pub mod exports {
                                 (ReallyFlags,),
                             >::new_unchecked(self.flags_result)
                         };
-                        let (ret0,) = callee.call_concurrent(accessor, ()).await?.0;
+                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_aggregate_arg<_T, _D>(
@@ -1050,7 +1050,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.aggregate_arg)
                         };
-                        let () = callee.call_concurrent(accessor, (arg0,)).await?.0;
+                        let ((), _) = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
                     }
                     pub async fn call_aggregate_result<_T, _D>(
@@ -1067,7 +1067,7 @@ pub mod exports {
                                 (Aggregates,),
                             >::new_unchecked(self.aggregate_result)
                         };
-                        let (ret0,) = callee.call_concurrent(accessor, ()).await?.0;
+                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_typedef_inout<_T, _D>(
@@ -1085,7 +1085,9 @@ pub mod exports {
                                 (i32,),
                             >::new_unchecked(self.typedef_inout)
                         };
-                        let (ret0,) = callee.call_concurrent(accessor, (arg0,)).await?.0;
+                        let ((ret0,), _) = callee
+                            .call_concurrent(accessor, (arg0,))
+                            .await?;
                         Ok(ret0)
                     }
                 }

--- a/crates/component-macro/tests/expanded/resources-export_concurrent.rs
+++ b/crates/component-macro/tests/expanded/resources-export_concurrent.rs
@@ -399,7 +399,7 @@ pub mod exports {
                                 (wasmtime::component::ResourceAny,),
                             >::new_unchecked(self.funcs.constructor_a_constructor)
                         };
-                        let (ret0,) = callee.call_concurrent(accessor, ()).await?.0;
+                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_static_a<_T, _D>(
@@ -416,7 +416,7 @@ pub mod exports {
                                 (u32,),
                             >::new_unchecked(self.funcs.static_a_static_a)
                         };
-                        let (ret0,) = callee.call_concurrent(accessor, ()).await?.0;
+                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_method_a<_T, _D>(
@@ -434,7 +434,9 @@ pub mod exports {
                                 (u32,),
                             >::new_unchecked(self.funcs.method_a_method_a)
                         };
-                        let (ret0,) = callee.call_concurrent(accessor, (arg0,)).await?.0;
+                        let ((ret0,), _) = callee
+                            .call_concurrent(accessor, (arg0,))
+                            .await?;
                         Ok(ret0)
                     }
                 }
@@ -557,7 +559,9 @@ pub mod exports {
                                 (wasmtime::component::ResourceAny,),
                             >::new_unchecked(self.funcs.constructor_a_constructor)
                         };
-                        let (ret0,) = callee.call_concurrent(accessor, (arg0,)).await?.0;
+                        let ((ret0,), _) = callee
+                            .call_concurrent(accessor, (arg0,))
+                            .await?;
                         Ok(ret0)
                     }
                     pub async fn call_static_a<_T, _D>(
@@ -574,7 +578,7 @@ pub mod exports {
                                 (wasmtime::component::Resource<Y>,),
                             >::new_unchecked(self.funcs.static_a_static_a)
                         };
-                        let (ret0,) = callee.call_concurrent(accessor, ()).await?.0;
+                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_method_a<_T, _D>(
@@ -596,10 +600,9 @@ pub mod exports {
                                 (wasmtime::component::Resource<Y>,),
                             >::new_unchecked(self.funcs.method_a_method_a)
                         };
-                        let (ret0,) = callee
+                        let ((ret0,), _) = callee
                             .call_concurrent(accessor, (arg0, arg1))
-                            .await?
-                            .0;
+                            .await?;
                         Ok(ret0)
                     }
                 }
@@ -693,7 +696,7 @@ pub mod exports {
                                 (wasmtime::component::ResourceAny,),
                             >::new_unchecked(self.funcs.constructor_a_constructor)
                         };
-                        let (ret0,) = callee.call_concurrent(accessor, ()).await?.0;
+                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                 }
@@ -789,7 +792,9 @@ pub mod exports {
                                 (wasmtime::component::ResourceAny,),
                             >::new_unchecked(self.funcs.constructor_b_constructor)
                         };
-                        let (ret0,) = callee.call_concurrent(accessor, (arg0,)).await?.0;
+                        let ((ret0,), _) = callee
+                            .call_concurrent(accessor, (arg0,))
+                            .await?;
                         Ok(ret0)
                     }
                 }

--- a/crates/component-macro/tests/expanded/resources-import_concurrent.rs
+++ b/crates/component-macro/tests/expanded/resources-import_concurrent.rs
@@ -369,7 +369,7 @@ const _: () = {
                     (wasmtime::component::Resource<WorldResource>,),
                 >::new_unchecked(self.some_world_func2)
             };
-            let (ret0,) = callee.call_concurrent(accessor, ()).await?.0;
+            let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
             Ok(ret0)
         }
         pub fn foo_foo_uses_resource_transitively(
@@ -1182,7 +1182,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.handle)
                         };
-                        let () = callee.call_concurrent(accessor, (arg0,)).await?.0;
+                        let ((), _) = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
                     }
                 }

--- a/crates/component-macro/tests/expanded/share-types_concurrent.rs
+++ b/crates/component-macro/tests/expanded/share-types_concurrent.rs
@@ -385,7 +385,7 @@ pub mod exports {
                         (Response,),
                     >::new_unchecked(self.handle_request)
                 };
-                let (ret0,) = callee.call_concurrent(accessor, (arg0,)).await?.0;
+                let ((ret0,), _) = callee.call_concurrent(accessor, (arg0,)).await?;
                 Ok(ret0)
             }
         }

--- a/crates/component-macro/tests/expanded/simple-functions_concurrent.rs
+++ b/crates/component-macro/tests/expanded/simple-functions_concurrent.rs
@@ -421,7 +421,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.f1)
                         };
-                        let () = callee.call_concurrent(accessor, ()).await?.0;
+                        let ((), _) = callee.call_concurrent(accessor, ()).await?;
                         Ok(())
                     }
                     pub async fn call_f2<_T, _D>(
@@ -439,7 +439,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.f2)
                         };
-                        let () = callee.call_concurrent(accessor, (arg0,)).await?.0;
+                        let ((), _) = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
                     }
                     pub async fn call_f3<_T, _D>(
@@ -458,7 +458,9 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.f3)
                         };
-                        let () = callee.call_concurrent(accessor, (arg0, arg1)).await?.0;
+                        let ((), _) = callee
+                            .call_concurrent(accessor, (arg0, arg1))
+                            .await?;
                         Ok(())
                     }
                     pub async fn call_f4<_T, _D>(
@@ -475,7 +477,7 @@ pub mod exports {
                                 (u32,),
                             >::new_unchecked(self.f4)
                         };
-                        let (ret0,) = callee.call_concurrent(accessor, ()).await?.0;
+                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_f5<_T, _D>(
@@ -492,7 +494,7 @@ pub mod exports {
                                 ((u32, u32),),
                             >::new_unchecked(self.f5)
                         };
-                        let (ret0,) = callee.call_concurrent(accessor, ()).await?.0;
+                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_f6<_T, _D>(
@@ -512,10 +514,9 @@ pub mod exports {
                                 ((u32, u32, u32),),
                             >::new_unchecked(self.f6)
                         };
-                        let (ret0,) = callee
+                        let ((ret0,), _) = callee
                             .call_concurrent(accessor, (arg0, arg1, arg2))
-                            .await?
-                            .0;
+                            .await?;
                         Ok(ret0)
                     }
                 }

--- a/crates/component-macro/tests/expanded/simple-lists_concurrent.rs
+++ b/crates/component-macro/tests/expanded/simple-lists_concurrent.rs
@@ -431,7 +431,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.simple_list1)
                         };
-                        let () = callee.call_concurrent(accessor, (arg0,)).await?.0;
+                        let ((), _) = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
                     }
                     pub async fn call_simple_list2<_T, _D>(
@@ -448,7 +448,7 @@ pub mod exports {
                                 (wasmtime::component::__internal::Vec<u32>,),
                             >::new_unchecked(self.simple_list2)
                         };
-                        let (ret0,) = callee.call_concurrent(accessor, ()).await?.0;
+                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_simple_list3<_T, _D>(
@@ -480,10 +480,9 @@ pub mod exports {
                                 ),
                             >::new_unchecked(self.simple_list3)
                         };
-                        let (ret0,) = callee
+                        let ((ret0,), _) = callee
                             .call_concurrent(accessor, (arg0, arg1))
-                            .await?
-                            .0;
+                            .await?;
                         Ok(ret0)
                     }
                     pub async fn call_simple_list4<_T, _D>(
@@ -515,7 +514,9 @@ pub mod exports {
                                 ),
                             >::new_unchecked(self.simple_list4)
                         };
-                        let (ret0,) = callee.call_concurrent(accessor, (arg0,)).await?.0;
+                        let ((ret0,), _) = callee
+                            .call_concurrent(accessor, (arg0,))
+                            .await?;
                         Ok(ret0)
                     }
                 }

--- a/crates/component-macro/tests/expanded/small-anonymous_concurrent.rs
+++ b/crates/component-macro/tests/expanded/small-anonymous_concurrent.rs
@@ -419,7 +419,7 @@ pub mod exports {
                                 ),
                             >::new_unchecked(self.option_test)
                         };
-                        let (ret0,) = callee.call_concurrent(accessor, ()).await?.0;
+                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                 }

--- a/crates/component-macro/tests/expanded/smoke-default_concurrent.rs
+++ b/crates/component-macro/tests/expanded/smoke-default_concurrent.rs
@@ -193,7 +193,7 @@ const _: () = {
             let callee = unsafe {
                 wasmtime::component::TypedFunc::<(), ()>::new_unchecked(self.y)
             };
-            let () = callee.call_concurrent(accessor, ()).await?.0;
+            let ((), _) = callee.call_concurrent(accessor, ()).await?;
             Ok(())
         }
     }

--- a/crates/component-macro/tests/expanded/smoke-export_concurrent.rs
+++ b/crates/component-macro/tests/expanded/smoke-export_concurrent.rs
@@ -242,7 +242,7 @@ pub mod exports {
                 let callee = unsafe {
                     wasmtime::component::TypedFunc::<(), ()>::new_unchecked(self.y)
                 };
-                let () = callee.call_concurrent(accessor, ()).await?.0;
+                let ((), _) = callee.call_concurrent(accessor, ()).await?;
                 Ok(())
             }
         }

--- a/crates/component-macro/tests/expanded/strings_concurrent.rs
+++ b/crates/component-macro/tests/expanded/strings_concurrent.rs
@@ -367,7 +367,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.a)
                         };
-                        let () = callee.call_concurrent(accessor, (arg0,)).await?.0;
+                        let ((), _) = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
                     }
                     pub async fn call_b<_T, _D>(
@@ -384,7 +384,7 @@ pub mod exports {
                                 (wasmtime::component::__internal::String,),
                             >::new_unchecked(self.b)
                         };
-                        let (ret0,) = callee.call_concurrent(accessor, ()).await?.0;
+                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_c<_T, _D>(
@@ -406,10 +406,9 @@ pub mod exports {
                                 (wasmtime::component::__internal::String,),
                             >::new_unchecked(self.c)
                         };
-                        let (ret0,) = callee
+                        let ((ret0,), _) = callee
                             .call_concurrent(accessor, (arg0, arg1))
-                            .await?
-                            .0;
+                            .await?;
                         Ok(ret0)
                     }
                 }

--- a/crates/component-macro/tests/expanded/variants_concurrent.rs
+++ b/crates/component-macro/tests/expanded/variants_concurrent.rs
@@ -1538,7 +1538,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.e1_arg)
                         };
-                        let () = callee.call_concurrent(accessor, (arg0,)).await?.0;
+                        let ((), _) = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
                     }
                     pub async fn call_e1_result<_T, _D>(
@@ -1555,7 +1555,7 @@ pub mod exports {
                                 (E1,),
                             >::new_unchecked(self.e1_result)
                         };
-                        let (ret0,) = callee.call_concurrent(accessor, ()).await?.0;
+                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_v1_arg<_T, _D>(
@@ -1573,7 +1573,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.v1_arg)
                         };
-                        let () = callee.call_concurrent(accessor, (arg0,)).await?.0;
+                        let ((), _) = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
                     }
                     pub async fn call_v1_result<_T, _D>(
@@ -1590,7 +1590,7 @@ pub mod exports {
                                 (V1,),
                             >::new_unchecked(self.v1_result)
                         };
-                        let (ret0,) = callee.call_concurrent(accessor, ()).await?.0;
+                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_bool_arg<_T, _D>(
@@ -1608,7 +1608,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.bool_arg)
                         };
-                        let () = callee.call_concurrent(accessor, (arg0,)).await?.0;
+                        let ((), _) = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
                     }
                     pub async fn call_bool_result<_T, _D>(
@@ -1625,7 +1625,7 @@ pub mod exports {
                                 (bool,),
                             >::new_unchecked(self.bool_result)
                         };
-                        let (ret0,) = callee.call_concurrent(accessor, ()).await?.0;
+                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_option_arg<_T, _D>(
@@ -1655,13 +1655,12 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.option_arg)
                         };
-                        let () = callee
+                        let ((), _) = callee
                             .call_concurrent(
                                 accessor,
                                 (arg0, arg1, arg2, arg3, arg4, arg5),
                             )
-                            .await?
-                            .0;
+                            .await?;
                         Ok(())
                     }
                     pub async fn call_option_result<_T, _D>(
@@ -1696,7 +1695,7 @@ pub mod exports {
                                 ),
                             >::new_unchecked(self.option_result)
                         };
-                        let (ret0,) = callee.call_concurrent(accessor, ()).await?.0;
+                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_casts<_T, _D>(
@@ -1721,13 +1720,12 @@ pub mod exports {
                                 ((Casts1, Casts2, Casts3, Casts4, Casts5, Casts6),),
                             >::new_unchecked(self.casts)
                         };
-                        let (ret0,) = callee
+                        let ((ret0,), _) = callee
                             .call_concurrent(
                                 accessor,
                                 (arg0, arg1, arg2, arg3, arg4, arg5),
                             )
-                            .await?
-                            .0;
+                            .await?;
                         Ok(ret0)
                     }
                     pub async fn call_result_arg<_T, _D>(
@@ -1763,13 +1761,12 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.result_arg)
                         };
-                        let () = callee
+                        let ((), _) = callee
                             .call_concurrent(
                                 accessor,
                                 (arg0, arg1, arg2, arg3, arg4, arg5),
                             )
-                            .await?
-                            .0;
+                            .await?;
                         Ok(())
                     }
                     pub async fn call_result_result<_T, _D>(
@@ -1810,7 +1807,7 @@ pub mod exports {
                                 ),
                             >::new_unchecked(self.result_result)
                         };
-                        let (ret0,) = callee.call_concurrent(accessor, ()).await?.0;
+                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_return_result_sugar<_T, _D>(
@@ -1827,7 +1824,7 @@ pub mod exports {
                                 (Result<i32, MyErrno>,),
                             >::new_unchecked(self.return_result_sugar)
                         };
-                        let (ret0,) = callee.call_concurrent(accessor, ()).await?.0;
+                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_return_result_sugar2<_T, _D>(
@@ -1844,7 +1841,7 @@ pub mod exports {
                                 (Result<(), MyErrno>,),
                             >::new_unchecked(self.return_result_sugar2)
                         };
-                        let (ret0,) = callee.call_concurrent(accessor, ()).await?.0;
+                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_return_result_sugar3<_T, _D>(
@@ -1861,7 +1858,7 @@ pub mod exports {
                                 (Result<MyErrno, MyErrno>,),
                             >::new_unchecked(self.return_result_sugar3)
                         };
-                        let (ret0,) = callee.call_concurrent(accessor, ()).await?.0;
+                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_return_result_sugar4<_T, _D>(
@@ -1878,7 +1875,7 @@ pub mod exports {
                                 (Result<(i32, u32), MyErrno>,),
                             >::new_unchecked(self.return_result_sugar4)
                         };
-                        let (ret0,) = callee.call_concurrent(accessor, ()).await?.0;
+                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_return_option_sugar<_T, _D>(
@@ -1895,7 +1892,7 @@ pub mod exports {
                                 (Option<i32>,),
                             >::new_unchecked(self.return_option_sugar)
                         };
-                        let (ret0,) = callee.call_concurrent(accessor, ()).await?.0;
+                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_return_option_sugar2<_T, _D>(
@@ -1912,7 +1909,7 @@ pub mod exports {
                                 (Option<MyErrno>,),
                             >::new_unchecked(self.return_option_sugar2)
                         };
-                        let (ret0,) = callee.call_concurrent(accessor, ()).await?.0;
+                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_result_simple<_T, _D>(
@@ -1929,7 +1926,7 @@ pub mod exports {
                                 (Result<u32, i32>,),
                             >::new_unchecked(self.result_simple)
                         };
-                        let (ret0,) = callee.call_concurrent(accessor, ()).await?.0;
+                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_is_clone_arg<_T, _D>(
@@ -1947,7 +1944,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.is_clone_arg)
                         };
-                        let () = callee.call_concurrent(accessor, (arg0,)).await?.0;
+                        let ((), _) = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
                     }
                     pub async fn call_is_clone_return<_T, _D>(
@@ -1964,7 +1961,7 @@ pub mod exports {
                                 (IsClone,),
                             >::new_unchecked(self.is_clone_return)
                         };
-                        let (ret0,) = callee.call_concurrent(accessor, ()).await?.0;
+                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                 }

--- a/crates/component-macro/tests/expanded/worlds-with-types_concurrent.rs
+++ b/crates/component-macro/tests/expanded/worlds-with-types_concurrent.rs
@@ -232,7 +232,7 @@ const _: () = {
             let callee = unsafe {
                 wasmtime::component::TypedFunc::<(), ((T, U, R),)>::new_unchecked(self.f)
             };
-            let (ret0,) = callee.call_concurrent(accessor, ()).await?.0;
+            let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
             Ok(ret0)
         }
     }

--- a/crates/misc/component-async-tests/tests/scenario/post_return.rs
+++ b/crates/misc/component-async-tests/tests/scenario/post_return.rs
@@ -1,11 +1,19 @@
 use super::util::test_run;
 use crate::scenario::util::{config, make_component};
-use anyhow::{Result, anyhow};
+use anyhow::Result;
 use component_async_tests::{Ctx, sleep};
 use std::sync::{Arc, Mutex};
 use wasmtime::component::{Linker, ResourceTable};
 use wasmtime::{Engine, Store};
 use wasmtime_wasi::WasiCtxBuilder;
+
+mod sleep_post_return {
+    wasmtime::component::bindgen!({
+        path: "wit",
+        world: "sleep-post-return-callee",
+        exports: { default: task_exit },
+    });
+}
 
 // No-op function; we only test this by composing it in `async_post_return_caller`
 #[allow(
@@ -59,21 +67,16 @@ async fn test_sleep_post_return(components: &[&str]) -> Result<()> {
     );
 
     let instance = linker.instantiate_async(&mut store, &component).await?;
-    // TODO: Update the following to use generated bindings once
-    // `wasmtime-wit-bindgen` has an option to expose the `TaskExit` return
-    // value from `[Typed]Func::call_concurrent`.
-    let sleep_post_return_instance = instance
-        .get_export_index(&mut store, None, "local:local/sleep-post-return")
-        .ok_or_else(|| anyhow!("can't find `local:local/sleep-post-return` in instance"))?;
-    let run_function = instance
-        .get_export_index(&mut store, Some(&sleep_post_return_instance), "[async]run")
-        .ok_or_else(|| anyhow!("can't find `[async]run` in instance"))?;
-    let run_function = instance.get_typed_func::<(u64,), ()>(&mut store, run_function)?;
+    let guest = sleep_post_return::SleepPostReturnCallee::new(&mut store, &instance)?;
     instance
         .run_concurrent(&mut store, async |accessor| {
             // This function should return immediately, then sleep the specified
             // number of milliseconds after returning, and then finally exit.
-            let exit = run_function.call_concurrent(accessor, (100,)).await?.1;
+            let exit = guest
+                .local_local_sleep_post_return()
+                .call_run(accessor, 100)
+                .await?
+                .1;
             // The function has returned, now we wait for it (and any subtasks
             // it may have spawned) to exit.
             exit.block(accessor).await;

--- a/crates/wasmtime/src/runtime/component/mod.rs
+++ b/crates/wasmtime/src/runtime/component/mod.rs
@@ -124,6 +124,8 @@ pub use self::concurrent::{
     GuardedStreamReader, JoinHandle, ReadBuffer, Source, StreamConsumer, StreamProducer,
     StreamReader, StreamResult, VMComponentAsyncStore, VecBuffer, WriteBuffer,
 };
+#[cfg(feature = "component-model-async")]
+pub use self::func::TaskExit;
 pub use self::func::{
     ComponentNamedList, ComponentType, Func, Lift, Lower, TypedFunc, WasmList, WasmStr,
 };
@@ -364,8 +366,20 @@ pub(crate) use self::store::ComponentStoreData;
 ///         default: async | trappable,
 ///     },
 ///
-///     // Same as `imports` above, but applies to exported functions.
-///     exports: { /* ... */ },
+///     // Mostly the same as `imports` above, but applies to exported functions.
+///     //
+///     // The one difference here is that, whereas the `task_exit` flag has no
+///     // effect for `imports`, it changes how bindings are generated for
+///     // exported functions as described below.
+///     exports: {
+///         /* ... */
+///
+///         // The `task_exit` flag indicates that the generated binding for
+///         // this function should return a tuple of the result produced by the
+///         // callee and a `TaskExit` future which will resolve when the task
+///         // (and any transitively created subtasks) have exited.
+///         "my:local/api/[async]does-stuff-after-returning": task_exit,
+///     },
 ///
 ///     // This can be used to translate WIT return values of the form
 ///     // `result<T, error-type>` into `Result<T, RustErrorType>` in Rust.

--- a/crates/wit-bindgen/src/config.rs
+++ b/crates/wit-bindgen/src/config.rs
@@ -12,6 +12,7 @@ bitflags::bitflags! {
         const VERBOSE_TRACING = 1 << 4;
         const IGNORE_WIT = 1 << 5;
         const EXACT = 1 << 6;
+        const TASK_EXIT = 1 << 7;
     }
 }
 


### PR DESCRIPTION
This builds on #11662 by optionally exposing the `TaskExit` return value from `[Typed]Func::call_concurrent` in the bindings generated for exported functions.

Note that the first commit is shared with #11662.

Fixes #11600

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
