### PR TITLE
fix panic in `Instance::set_consumer` when write end is already dropped

### DIFF
--- a/crates/misc/component-async-tests/tests/test_all.rs
+++ b/crates/misc/component-async-tests/tests/test_all.rs
@@ -30,7 +30,7 @@ use scenario::round_trip_many::{
     async_round_trip_many_stackful, async_round_trip_many_stackless,
     async_round_trip_many_synchronous, async_round_trip_many_wait,
 };
-use scenario::streams::async_closed_streams;
+use scenario::streams::{async_closed_stream, async_closed_streams};
 use scenario::transmit::{
     async_cancel_callee, async_cancel_caller, async_cancel_transmit, async_intertask_communication,
     async_poll_stackless, async_poll_synchronous, async_readiness, async_synchronous_transmit,

--- a/crates/misc/component-async-tests/wit/test.wit
+++ b/crates/misc/component-async-tests/wit/test.wit
@@ -174,6 +174,10 @@ interface sleep-post-return {
   run: async func(sleep-time-millis: u64);
 }
 
+interface closed-stream {
+  get: func() -> stream<u8>;
+}
+
 world yield-caller {
   import continue;
   import ready;
@@ -337,4 +341,8 @@ world sleep-post-return-caller {
   import sleep;
   import sleep-post-return;
   export sleep-post-return;
+}
+
+world closed-stream-guest {
+  export closed-stream;
 }

--- a/crates/test-programs/src/bin/async_closed_stream.rs
+++ b/crates/test-programs/src/bin/async_closed_stream.rs
@@ -1,0 +1,22 @@
+mod bindings {
+    wit_bindgen::generate!({
+        path: "../misc/component-async-tests/wit",
+        world: "closed-stream-guest",
+    });
+
+    use super::Component;
+    export!(Component);
+}
+
+use {bindings::exports::local::local::closed_stream::Guest, wit_bindgen::StreamReader};
+
+struct Component;
+
+impl Guest for Component {
+    fn get() -> StreamReader<u8> {
+        bindings::wit_stream::new().1
+    }
+}
+
+// Unused function; required since this file is built as a `bin`:
+fn main() {}

--- a/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams.rs
@@ -2108,7 +2108,10 @@ impl Instance {
 
                 state.push_future(Box::pin(future));
             }
-            WriteState::Dropped => unreachable!(),
+            WriteState::Dropped => {
+                let reader = transmit.read_handle;
+                self.host_drop_reader(store.0, reader, kind).unwrap();
+            }
         }
     }
 


### PR DESCRIPTION
In this case, we can drop the whole stream or future immediately since there's nothing left to do with it.

Fixes #11621

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
