### PR TITLE
Use `wasip{1,2}` crates, not `wasi`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1310,7 +1310,7 @@ dependencies = [
 name = "example-component-wasm"
 version = "0.0.0"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.46.0",
 ]
 
 [[package]]
@@ -1321,7 +1321,7 @@ version = "0.0.0"
 name = "example-resource-component-wasm"
 version = "0.1.0"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.46.0",
 ]
 
 [[package]]
@@ -3632,10 +3632,10 @@ dependencies = [
  "once_cell",
  "sha2",
  "url",
- "wasi 0.11.0+wasi-snapshot-preview1",
- "wasi 0.14.0+wasi-0.2.3",
  "wasi-nn",
- "wit-bindgen",
+ "wasip1",
+ "wasip2",
+ "wit-bindgen 0.46.0",
 ]
 
 [[package]]
@@ -4121,16 +4121,7 @@ version = "0.13.3+wasi-0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
 dependencies = [
- "wit-bindgen-rt 0.33.0",
-]
-
-[[package]]
-name = "wasi"
-version = "0.14.0+wasi-0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3d67b0bdfec72b9fbaba698033291c327ef19ce3b34efbdcd7dc402a53850d9"
-dependencies = [
- "wit-bindgen-rt 0.37.0",
+ "wit-bindgen-rt",
 ]
 
 [[package]]
@@ -4182,6 +4173,21 @@ dependencies = [
  "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-encoder",
  "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wasip1"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e26842486624357dbeb8f0381cf1fb42f022291fd787d4a816768fec8cc760"
+
+[[package]]
+name = "wasip2"
+version = "1.0.0+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03fa2761397e5bd52002cd7e73110c71af2109aca4e521a9f40473fe685b0a24"
+dependencies = [
+ "wit-bindgen 0.45.1",
 ]
 
 [[package]]
@@ -5504,6 +5510,15 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
+version = "0.45.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c573471f125075647d03df72e026074b7203790d41351cd6edc96f46bcccd36"
+dependencies = [
+ "bitflags 2.6.0",
+]
+
+[[package]]
+name = "wit-bindgen"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
@@ -5530,15 +5545,6 @@ name = "wit-bindgen-rt"
 version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
-dependencies = [
- "bitflags 2.6.0",
-]
-
-[[package]]
-name = "wit-bindgen-rt"
-version = "0.37.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc801b991c56492f87ab3086e786468f75c285a4d73017ab0ebc2fa1aed5d82c"
 dependencies = [
  "bitflags 2.6.0",
 ]

--- a/crates/test-programs/Cargo.toml
+++ b/crates/test-programs/Cargo.toml
@@ -19,7 +19,7 @@ futures = { workspace = true, default-features = false, features = ['alloc'] }
 url = { workspace = true }
 sha2 = "0.10.2"
 base64 = { workspace = true }
-wasip1 = { version = "0.11.0", package = 'wasi' }
-wasip2 = { version = "0.14.0", package = 'wasi' }
+wasip1 = "1.0.0"
+wasip2 = "1.0.0"
 once_cell = "1.19.0"
 flate2 = "1.0.28"

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -264,6 +264,16 @@ by a member of the Bytecode Alliance and plan to continue doing so and will
 actively maintain this crate over time.
 """
 
+[[wildcard-audits.wasi]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+user-id = 1 # Alex Crichton (alexcrichton)
+start = "2025-08-10"
+end = "2026-08-21"
+notes = """
+This is a Bytecode Alliance authored crate.
+"""
+
 [[wildcard-audits.wasi-cap-std-sync]]
 who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
@@ -287,6 +297,36 @@ user-id = 73222 # wasmtime-publish
 start = "2021-10-29"
 end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.wasip1]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+user-id = 1 # Alex Crichton (alexcrichton)
+start = "2025-08-10"
+end = "2026-08-21"
+notes = """
+This is a Bytecode Alliance authored crate.
+"""
+
+[[wildcard-audits.wasip2]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+user-id = 1 # Alex Crichton (alexcrichton)
+start = "2025-08-10"
+end = "2026-08-21"
+notes = """
+This is a Bytecode Alliance authored crate.
+"""
+
+[[wildcard-audits.wasip3]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+user-id = 1 # Alex Crichton (alexcrichton)
+start = "2025-09-10"
+end = "2026-08-21"
+notes = """
+This is a Bytecode Alliance authored crate.
+"""
 
 [[wildcard-audits.wasm-compose]]
 who = "Alex Crichton <alex@alexcrichton.com>"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1284,6 +1284,20 @@ when = "2025-08-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasip1]]
+version = "1.0.0"
+when = "2025-09-09"
+user-id = 1
+user-login = "alexcrichton"
+user-name = "Alex Crichton"
+
+[[publisher.wasip2]]
+version = "1.0.0+wasi-0.2.4"
+when = "2025-09-09"
+user-id = 1
+user-login = "alexcrichton"
+user-name = "Alex Crichton"
+
 [[publisher.wasm-bindgen]]
 version = "0.2.97"
 when = "2024-11-30"


### PR DESCRIPTION
These are the new structure for how the `wasi-rs` repository is managed.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
