### PR TITLE
async: add stream/future producers and blanket impl for `Future`

### DIFF
--- a/crates/wasi-http/src/p3/body.rs
+++ b/crates/wasi-http/src/p3/body.rs
@@ -2,6 +2,7 @@ use crate::p3::bindings::http::types::{ErrorCode, Fields, Trailers};
 use crate::p3::{WasiHttp, WasiHttpCtxView};
 use anyhow::Context as _;
 use bytes::Bytes;
+use core::iter;
 use core::num::NonZeroUsize;
 use core::pin::Pin;
 use core::task::{Context, Poll, ready};
@@ -13,8 +14,8 @@ use std::sync::Arc;
 use tokio::sync::{mpsc, oneshot};
 use tokio_util::sync::PollSender;
 use wasmtime::component::{
-    Access, Destination, EmptyProducer, FutureConsumer, FutureReader, Resource, Source,
-    StreamConsumer, StreamProducer, StreamReader, StreamResult,
+    Access, Destination, FutureConsumer, FutureReader, Resource, Source, StreamConsumer,
+    StreamProducer, StreamReader, StreamResult,
 };
 use wasmtime::{AsContextMut, StoreContextMut};
 
@@ -74,7 +75,7 @@ impl Body {
                 // https://github.com/WebAssembly/wasi-http/issues/176
                 _ = result_tx.send(Box::new(async { Ok(()) }));
                 Ok((
-                    StreamReader::new(instance, &mut store, EmptyProducer::default()),
+                    StreamReader::new(instance, &mut store, iter::empty()),
                     trailers_rx,
                 ))
             }

--- a/crates/wasmtime/src/runtime/component/concurrent.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent.rs
@@ -92,10 +92,9 @@ use wasmtime_environ::component::{
 
 pub use abort::JoinHandle;
 pub use futures_and_streams::{
-    Destination, DirectDestination, DirectSource, EmptyProducer, ErrorContext, FutureConsumer,
-    FutureProducer, FutureReader, GuardedFutureReader, GuardedStreamReader, ReadBuffer,
-    ReadyProducer, Source, StreamConsumer, StreamProducer, StreamReader, StreamResult, VecBuffer,
-    WriteBuffer,
+    Destination, DirectDestination, DirectSource, ErrorContext, FutureConsumer, FutureProducer,
+    FutureReader, GuardedFutureReader, GuardedStreamReader, ReadBuffer, Source, StreamConsumer,
+    StreamProducer, StreamReader, StreamResult, VecBuffer, WriteBuffer,
 };
 pub(crate) use futures_and_streams::{
     ResourcePair, lower_error_context_to_index, lower_future_to_index, lower_stream_to_index,

--- a/crates/wasmtime/src/runtime/component/mod.rs
+++ b/crates/wasmtime/src/runtime/component/mod.rs
@@ -120,9 +120,9 @@ pub use self::component::{Component, ComponentExportIndex};
 #[cfg(feature = "component-model-async")]
 pub use self::concurrent::{
     Access, Accessor, AccessorTask, AsAccessor, Destination, DirectDestination, DirectSource,
-    EmptyProducer, ErrorContext, FutureConsumer, FutureProducer, FutureReader, GuardedFutureReader,
-    GuardedStreamReader, JoinHandle, ReadBuffer, ReadyProducer, Source, StreamConsumer,
-    StreamProducer, StreamReader, StreamResult, VMComponentAsyncStore, VecBuffer, WriteBuffer,
+    ErrorContext, FutureConsumer, FutureProducer, FutureReader, GuardedFutureReader,
+    GuardedStreamReader, JoinHandle, ReadBuffer, Source, StreamConsumer, StreamProducer,
+    StreamReader, StreamResult, VMComponentAsyncStore, VecBuffer, WriteBuffer,
 };
 #[cfg(feature = "component-model-async")]
 pub use self::func::TaskExit;


### PR DESCRIPTION
A few fairly small improvements:
- Introduce a blanket implementation of `FutureProducer` for `Future`, which allows calling `poll_produce` on any `Future`
- Move `StreamEmptyProducer` from `wasmtime_wasi` to `wasmtime` for better reusability and discoverability for embeders