### PR TITLE
Put each component in its own store in wast testing

### DIFF
--- a/crates/fuzzing/src/generators/config.rs
+++ b/crates/fuzzing/src/generators/config.rs
@@ -459,7 +459,12 @@ impl Config {
     /// Configures a store based on this configuration.
     pub fn configure_store(&self, store: &mut Store<StoreLimits>) {
         store.limiter(|s| s as &mut dyn wasmtime::ResourceLimiter);
+        self.configure_store_epoch_and_fuel(store);
+    }
 
+    /// Configures everything unrelated to `T` in a store, such as epochs and
+    /// fuel.
+    pub fn configure_store_epoch_and_fuel<T>(&self, store: &mut Store<T>) {
         // Configure the store to never abort by default, that is it'll have
         // max fuel or otherwise trap on an epoch change but the epoch won't
         // ever change.

--- a/crates/fuzzing/src/oracles.rs
+++ b/crates/fuzzing/src/oracles.rs
@@ -758,7 +758,10 @@ pub fn wast_test(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<()> {
     } else {
         wasmtime_wast::Async::Yes
     };
-    let mut wast_context = WastContext::new(fuzz_config.to_store(), async_);
+    let engine = Engine::new(&fuzz_config.to_wasmtime()).unwrap();
+    let mut wast_context = WastContext::new(&engine, async_, move |store| {
+        fuzz_config.configure_store_epoch_and_fuel(store);
+    });
     wast_context
         .register_spectest(&wasmtime_wast::SpectestConfig {
             use_shared_memory: true,

--- a/tests/wast.rs
+++ b/tests/wast.rs
@@ -1,9 +1,7 @@
 use anyhow::{Context, bail};
 use libtest_mimic::{Arguments, FormatSetting, Trial};
 use std::sync::{Condvar, LazyLock, Mutex};
-use wasmtime::{
-    Config, Enabled, Engine, InstanceAllocationStrategy, PoolingAllocationConfig, Store,
-};
+use wasmtime::{Config, Enabled, Engine, InstanceAllocationStrategy, PoolingAllocationConfig};
 use wasmtime_test_util::wast::{Collector, Compiler, WastConfig, WastTest, limits};
 use wasmtime_wast::{Async, SpectestConfig, WastContext};
 
@@ -249,8 +247,7 @@ fn run_wast(test: &WastTest, config: WastConfig) -> anyhow::Result<()> {
 
     for (engine, desc) in engines {
         let result = engine.and_then(|engine| {
-            let store = Store::new(&engine, ());
-            let mut wast_context = WastContext::new(store, Async::Yes);
+            let mut wast_context = WastContext::new(&engine, Async::Yes, |_store| {});
             wast_context.generate_dwarf(true);
             wast_context.register_spectest(&SpectestConfig {
                 use_shared_memory: true,


### PR DESCRIPTION
This commit refactors the `wasmtime-wast` crate to place each component in its own store. This is in contrast to core wasm testing where all instances get placed in the same store. The reason for this is that components, in particular async state, is only fully defined so long as a trap doesn't happen and once a trap happens it's expected the entire store is torn down. This removes the need for the store to keep track of exactly which instance all async tasks are associated with to ensure that once any of them trap only the precise set of tasks necessary are torn down. Instead Wasmtime can rely on embedders throwing away `Store<T>` entirely.

The refactoring here provides a hook in `WastContext` to configure the store but otherwise a new store is manufactured for all component instances. Core wasm is unaffected. Tests are also unaffected as same-store behavior isn't actually required by any tests.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
