### PR TITLE
Don't break cwasm ABIs in patch releases by default

### DIFF
--- a/crates/wasmtime/src/engine/serialization.rs
+++ b/crates/wasmtime/src/engine/serialization.rs
@@ -97,7 +97,7 @@ pub fn check_compatible(engine: &Engine, mmap: &[u8], expected: ObjectKind) -> R
     match &engine.config().module_version {
         ModuleVersionStrategy::WasmtimeVersion => {
             let version = core::str::from_utf8(version)?;
-            if version != env!("CARGO_PKG_VERSION") {
+            if version != env!("CARGO_PKG_VERSION_MAJOR") {
                 bail!(
                     "Module was compiled with incompatible Wasmtime version '{}'",
                     version
@@ -128,7 +128,7 @@ pub fn append_compiler_info(engine: &Engine, obj: &mut Object<'_>, metadata: &Me
     let mut data = Vec::new();
     data.push(VERSION);
     let version = match &engine.config().module_version {
-        ModuleVersionStrategy::WasmtimeVersion => env!("CARGO_PKG_VERSION"),
+        ModuleVersionStrategy::WasmtimeVersion => env!("CARGO_PKG_VERSION_MAJOR"),
         ModuleVersionStrategy::Custom(c) => c,
         ModuleVersionStrategy::None => "",
     };

--- a/docs/contributing-release-process.md
+++ b/docs/contributing-release-process.md
@@ -85,6 +85,17 @@ of criteria. It's done on an as-needed basis. Two requirements, however are:
   Wasmtime will not release a patch release until all versions have been
   equally patched to ensure that releases remain consistent.
 
+* Patch releases must not contain API-breaking changes in public crates. The
+  list of `PUBLIC_CRATES` in `scripts/publish.rs` is the list of crates to worry
+  about in terms of breaking changes.
+
+* Wasm-level ABI-breaking changes are by default not allowed in patch releases.
+  Users are expected to, for example, be able to load `*.cwasm` artifacts from
+  before the patch release is made. If an ABI-breaking change is necessary then
+  be sure to update `crates/wasmtime/src/engine/serialization.rs` and the
+  `WasmtimeVersion` matching strategy to modify the string to ensure older
+  artifacts cannot be loaded.
+
 Making a patch release is somewhat more manual than a major version, but like
 before there's automation to help guide the process as well and take care of
 more mundane bits.


### PR DESCRIPTION
This commit is an update to our cwasm-version-matching logic to take #11685 into account. To me it feels reasonable to expect that patch releases of Wasmtime by default do not affect the ABI of `*.cwasm` artifacts and thus we should allow by default loading previous versions. This can help embedders avoid recompiles and can additionally assist in more quickly deploying security updates as recompilation is unnecessary.

The concrete change in this commit is that instead of baking in `CARGO_PKG_VERSION` into the cwasm artifact instead `CARGO_PKG_VERSION_MAJOR` is baked in. This means that the patch release is "forgotten" and won't be compared.

This commit also updates documentation for patch releases to indicate that this should be double-checked on patch releases. Furthermore we can always update the string ourselves manually (e.g. to include a ".2" at the end or something like that) if an ABI break is actually needed. This mostly just changes the default of patch releases by default don't break ABI but we still can if we really need to for a particular issue.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
