### PR TITLE
s390x: Fix epilog for some tail-call ABI routines

### DIFF
--- a/cranelift/codegen/src/isa/s390x/abi.rs
+++ b/cranelift/codegen/src/isa/s390x/abi.rs
@@ -1100,8 +1100,8 @@ impl S390xMachineDeps {
 fn is_reg_saved_in_prologue(call_conv: isa::CallConv, r: RealReg) -> bool {
     match (call_conv, r.class()) {
         (isa::CallConv::Tail, RegClass::Int) => {
-            // r8 - r15 inclusive are callee-saves.
-            r.hw_enc() >= 8 && r.hw_enc() <= 15
+            // r8 - r14 inclusive are callee-saves.
+            r.hw_enc() >= 8 && r.hw_enc() <= 14
         }
         (_, RegClass::Int) => {
             // r6 - r15 inclusive are callee-saves.

--- a/crates/test-util/src/wast.rs
+++ b/crates/test-util/src/wast.rs
@@ -326,13 +326,7 @@ impl Compiler {
     /// `Config::compiler_panicking_wasm_features`.
     pub fn should_fail(&self, config: &TestConfig) -> bool {
         match self {
-            Compiler::CraneliftNative => {
-                // FIXME(#11602) temporarily disabled
-                if cfg!(target_arch = "s390x") && config.exceptions() {
-                    return true;
-                }
-                config.legacy_exceptions()
-            }
+            Compiler::CraneliftNative => config.legacy_exceptions(),
 
             Compiler::Winch => {
                 if config.gc()

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -2096,11 +2096,6 @@ impl Config {
                     unsupported |= WasmFeatures::STACK_SWITCHING;
                 }
 
-                // FIXME(#11602) temporarily disabled
-                if self.compiler_target().architecture == target_lexicon::Architecture::S390x {
-                    unsupported |= WasmFeatures::EXCEPTIONS;
-                }
-
                 use target_lexicon::*;
                 match self.compiler_target() {
                     Triple {


### PR DESCRIPTION
When using the tail-call ABI and the callee needs to pop a non-zero amount of bytes, the stack pointer may never be implicitly restored via the LOAD MULTIPLE instruction in the epilog, but will always be manually updated.

In some rare cases involving exception handling, the epilog for such functions incorrectly did include the stack pointer in the LOAD MULTIPLE list.  It turns out that the
is_reg_saved_in_prologue routine did not handle the stack pointer correctly.

Note that this only makes any difference for functions where cranelift common code includes the stack pointer in the list of clobbered registers passed to compute_frame_layout, which normally never happens as modifications to the stack pointer should be invisible to common code register tracking ...

Fixes: https://github.com/bytecodealliance/wasmtime/issues/11602

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
