### PR TITLE
Wasmtime: enforce function-body-size implementation limit.

### DIFF
--- a/tests/all/module.rs
+++ b/tests/all/module.rs
@@ -649,3 +649,19 @@ fn deserialize_raw_fails_for_native() {
         );
     }
 }
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn too_large_function_fails() {
+    // Generate a module with a single function body that is too large
+    // to meet the 7_654_321 byte implementation limit.
+    let mut module = "(module (func".to_owned();
+    for _ in 0..8_000_000 {
+        module.push_str(" unreachable");
+    }
+    module.push_str("))");
+
+    let engine = Engine::default();
+    let result = Module::new(&engine, &module);
+    assert!(result.is_err());
+}


### PR DESCRIPTION
In #11682 we see a module with an extremely large single function body (function index 193). This causes a panic in Cranelift as we run out of SSA value numbers: the `ValueDataPacked` bit-packing supports only 2^24 (16M) values per function.

I started down the path of propagating `CodegenError`s everywhere throughout Cranelift to properly bubble up a
`CodegenError::CodeTooLarge`, but that turns out to be an extremely pervasive change: it means not only that we have more Result plumbing, but that (i) Cranelift's public API changes so that all function builder methods return Results, which is a huge change for any existing user; and (ii) ISLE can't generate Rust that propagates Results, so we need to awkwardly set an error flag on a context, return a fake Value, and "catch" it on the other side of the invocation, which is error-prone.

I then considered a size-check on function bodies as they enter Cranelift, but at that point, realized that Wasm already provides for implementation limits for this purpose. The JS embedding spec at https://webassembly.github.io/spec/js-api/index.html#limits specifies that a function body can be at most 7_654_321 bytes (7.65MB). We don't *have* to follow the JS embedding's implementation limits, but there is good reason to expect that producers will try to stay within them, and the reasons that led to those limits in Web engines' compilers equally apply to ours. This PR thus instead enforces the limit directly.

Fixes #11682.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
