### PR TITLE
change `Network::check_socket_addr` back to `pub`

### DIFF
--- a/crates/wasi/src/p2/network.rs
+++ b/crates/wasi/src/p2/network.rs
@@ -60,7 +60,7 @@ pub struct Network {
 }
 
 impl Network {
-    pub(crate) async fn check_socket_addr(
+    pub async fn check_socket_addr(
         &self,
         addr: SocketAddr,
         reason: SocketAddrUse,


### PR DESCRIPTION
https://github.com/bytecodealliance/wasmtime/pull/11379 changed it from `pub` to `pub(crate)`, which breaks external users of that function.  Since the `Network` type itself is `pub` and not very useful without any `pub` fields or functions, I'm switching it back.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
