### PR TITLE
make `wasmtime_wasi_http::p3::WasiHttp` public

### DIFF
--- a/crates/wasi-http/src/p3/mod.rs
+++ b/crates/wasi-http/src/p3/mod.rs
@@ -42,7 +42,8 @@ pub(crate) type HeaderError = TrappableError<types::HeaderError>;
 pub(crate) type RequestOptionsResult<T> = Result<T, RequestOptionsError>;
 pub(crate) type RequestOptionsError = TrappableError<types::RequestOptionsError>;
 
-pub(crate) struct WasiHttp;
+/// The type for which this crate implements the `wasi:http` interfaces.
+pub struct WasiHttp;
 
 impl HasData for WasiHttp {
     type Data<'a> = WasiHttpCtxView<'a>;


### PR DESCRIPTION
This gives the embedder the flexibility to call
`wasmtime_wasi_http::p3::bindings::http::{handler,types}::add_to_linker::<_, WasiHttp>(linker, getter)`, where `getter` is a custom function.  That's useful in the scenario where implementing `WasiHttpView` for the `T` in `Linker<T>` is difficult or impossible given that `T` might be defined in a different crate.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
