### PR TITLE
Fix aliasing tags within a component

### DIFF
--- a/crates/environ/src/component/translate/inline.rs
+++ b/crates/environ/src/component/translate/inline.rs
@@ -203,7 +203,7 @@ struct InlinerFrame<'a> {
     memories: PrimaryMap<MemoryIndex, dfg::CoreExport<EntityIndex>>,
     tables: PrimaryMap<TableIndex, dfg::CoreExport<EntityIndex>>,
     globals: PrimaryMap<GlobalIndex, dfg::CoreExport<EntityIndex>>,
-    tags: PrimaryMap<GlobalIndex, dfg::CoreExport<EntityIndex>>,
+    tags: PrimaryMap<TagIndex, dfg::CoreExport<EntityIndex>>,
     modules: PrimaryMap<ModuleIndex, ModuleDef<'a>>,
 
     // component model index spaces
@@ -1432,7 +1432,7 @@ impl<'a> Inliner<'a> {
                 EntityIndex::Table(i) => frame.tables[i].clone().into(),
                 EntityIndex::Global(i) => frame.globals[i].clone().into(),
                 EntityIndex::Memory(i) => frame.memories[i].clone().into(),
-                EntityIndex::Tag(_) => todo!(), // FIXME: #10252 support for tags in the component model
+                EntityIndex::Tag(i) => frame.tags[i].clone().into(),
             },
         }
     }

--- a/tests/misc_testsuite/component-model/tags.wast
+++ b/tests/misc_testsuite/component-model/tags.wast
@@ -1,0 +1,14 @@
+;;! exceptions = true
+
+(component
+  (core module $a (tag (export "t")))
+  (core module $b (import "a" "t" (tag)))
+
+  (core instance $a (instantiate $a))
+  (core instance (instantiate $b (with "a" (instance $a))))
+  (core instance (instantiate $b
+    (with "a" (instance
+      (export "t" (tag $a "t"))
+    ))
+  ))
+)


### PR DESCRIPTION
This commit fixes an issue where if, during instantiating a component, a tag was aliased from a core module a panic would happen when compiling. This then additionally fixes a typo in the definition of a local `tags` list.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
