### PR TITLE
Fix a missing outparam write in the p1 adapter

### DIFF
--- a/crates/wasi-preview1-component-adapter/src/lib.rs
+++ b/crates/wasi-preview1-component-adapter/src/lib.rs
@@ -1406,7 +1406,10 @@ pub unsafe extern "C" fn fd_readdir(
                     match iter.next() {
                         Some(Ok(_)) => {}
                         Some(Err(e)) => return Err(e),
-                        None => return Ok(()),
+                        None => {
+                            *bufused = 0;
+                            return Ok(());
+                        }
                     }
                 }
             }


### PR DESCRIPTION
This fixes an issue found through #11701, notably the "release mode infinite loops" behavior that was seen. The cause was when `fd_readdir` returned after skipping all directory entries it forgot to write the final `*bufused = 0` out-param in the early-exit, unlike the end of the function which already sets this.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
