### PR TITLE
fix a memory leak in wasi-nn

### DIFF
--- a/crates/wasi-nn/src/wit.rs
+++ b/crates/wasi-nn/src/wit.rs
@@ -249,11 +249,11 @@ impl generated::inference::HostGraphExecutionContext for WasiNnView<'_> {
         tracing::debug!("compute with {} inputs", inputs.len());
 
         let mut named_tensors = Vec::new();
-        for (name, tensor_resopurce) in inputs.iter() {
-            let tensor = self.table.get(&tensor_resopurce)?;
+        for (name, tensor_resopurce) in inputs.into_iter() {
+            let tensor = self.table.delete(tensor_resopurce)?;
             named_tensors.push(crate::backend::NamedTensor {
-                name: name.clone(),
-                tensor: tensor.clone(),
+                name: name,
+                tensor: tensor,
             });
         }
 

--- a/crates/wasi-nn/src/wit.rs
+++ b/crates/wasi-nn/src/wit.rs
@@ -251,10 +251,7 @@ impl generated::inference::HostGraphExecutionContext for WasiNnView<'_> {
         let mut named_tensors = Vec::new();
         for (name, tensor_resopurce) in inputs.into_iter() {
             let tensor = self.table.delete(tensor_resopurce)?;
-            named_tensors.push(crate::backend::NamedTensor {
-                name,
-                tensor,
-            });
+            named_tensors.push(crate::backend::NamedTensor { name, tensor });
         }
 
         let exec_context = &mut self.table.get_mut(&exec_context)?;

--- a/crates/wasi-nn/src/wit.rs
+++ b/crates/wasi-nn/src/wit.rs
@@ -252,8 +252,8 @@ impl generated::inference::HostGraphExecutionContext for WasiNnView<'_> {
         for (name, tensor_resopurce) in inputs.into_iter() {
             let tensor = self.table.delete(tensor_resopurce)?;
             named_tensors.push(crate::backend::NamedTensor {
-                name: name,
-                tensor: tensor,
+                name,
+                tensor,
             });
         }
 


### PR DESCRIPTION
This PR will fix a memory leak in wasi-nn, which does'nt free the tensor resource whose owenership is transferred. You can find [a discussion](https://bytecodealliance.zulipchat.com/#narrow/channel/217126-wasmtime/topic/memory.20leak.20in.20wasi-nn/with/539706208) in the zulip.
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
