### PR TITLE
Cranelift: update to regalloc2 0.13.2.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2997,9 +2997,9 @@ dependencies = [
 
 [[package]]
 name = "regalloc2"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68e18e1ef763167dc6718c28a5585e62f907590a21028b8e87be1318f19ef1cb"
+checksum = "efd8138ce7c3d7c13be4f61893154b5d711bd798d2d7be3ecb8dcc7e7a06ca98"
 dependencies = [
  "allocator-api2",
  "bumpalo",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -308,7 +308,7 @@ component-async-tests = { path = "crates/misc/component-async-tests" }
 
 # Bytecode Alliance maintained dependencies:
 # ---------------------------
-regalloc2 = "0.13.1"
+regalloc2 = "0.13.2"
 
 # cap-std family:
 target-lexicon = "0.13.0"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1020,8 +1020,8 @@ user-login = "dtolnay"
 user-name = "David Tolnay"
 
 [[publisher.regalloc2]]
-version = "0.13.1"
-when = "2025-08-25"
+version = "0.13.2"
+when = "2025-09-18"
 user-id = 3726
 user-login = "cfallin"
 user-name = "Chris Fallin"


### PR DESCRIPTION
Pulls in fix for fastalloc from bytecodealliance/regalloc2#240 (thanks!).

Fixes #11544.
Fixes #11545.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
