### PR TITLE
asm: add `num_registers_available()`

### DIFF
--- a/cranelift/assembler-x64/meta/src/generate/inst.rs
+++ b/cranelift/assembler-x64/meta/src/generate/inst.rs
@@ -68,6 +68,8 @@ impl dsl::Inst {
             self.generate_is_available_function(f);
             f.empty_line();
             self.generate_features_function(f);
+            f.empty_line();
+            self.generate_num_registers_function(f);
         });
     }
 
@@ -241,6 +243,19 @@ impl dsl::Inst {
         fmtln!(f, "#[must_use]");
         f.add_block("pub fn features(&self) -> &'static Features", |f| {
             self.features.generate_constructor_expr(f);
+        });
+    }
+
+    /// `fn num_registers_available(&self) -> usize { ... }`
+    fn generate_num_registers_function(&self, f: &mut Formatter) {
+        fmtln!(f, "#[must_use]");
+        f.add_block("pub fn num_registers_available(&self) -> usize", |f| {
+            use dsl::Encoding::*;
+            let n = match self.encoding {
+                Rex(_) | Vex(_) => 16,
+                Evex(_) => 32,
+            };
+            fmtln!(f, "{n}")
         });
     }
 


### PR DESCRIPTION
This change adds a way to inspect how many registers an instruction can address. We assume for now that legacy instructions can always emit the REX prefix and thus access 16 registers; thus, the only encoding that allows access to 32 registers is EVEX.

This also refactors some of the top-level generation logic to be less verbose.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
