### PR TITLE
Continuation trapping semantics

### DIFF
--- a/crates/cranelift/src/alias_region.rs
+++ b/crates/cranelift/src/alias_region.rs
@@ -1393,6 +1393,42 @@ where
         )
     }
 
+    /// Load the `VMStoreContext::last_wasm_entry_sp` field.
+    pub fn vmstore_context_last_wasm_entry_sp(
+        &mut self,
+        cursor: &mut FuncCursor<'_>,
+        vmstore_ctx: ir::Value,
+    ) -> ir::Value {
+        self.vmstore_context_load(
+            cursor,
+            self.pointer_type,
+            ir::MemFlagsData::trusted(),
+            vmstore_ctx,
+            self.offsets
+                .get_ptr_size()
+                .vmstore_context_last_wasm_entry_sp()
+                .into(),
+        )
+    }
+
+    /// Load the `VMStoreContext::last_wasm_entry_trap_handler` field.
+    pub fn vmstore_context_last_wasm_entry_trap_handler(
+        &mut self,
+        cursor: &mut FuncCursor<'_>,
+        vmstore_ctx: ir::Value,
+    ) -> ir::Value {
+        self.vmstore_context_load(
+            cursor,
+            self.pointer_type,
+            ir::MemFlagsData::trusted(),
+            vmstore_ctx,
+            self.offsets
+                .get_ptr_size()
+                .vmstore_context_last_wasm_entry_trap_handler()
+                .into(),
+        )
+    }
+
     /// Store the `VMStoreContext::last_wasm_entry_fp` field.
     pub fn store_vmstore_context_last_wasm_entry_fp(
         &mut self,

--- a/crates/cranelift/src/alias_region.rs
+++ b/crates/cranelift/src/alias_region.rs
@@ -2663,6 +2663,79 @@ impl<Offsets> AliasRegions<Offsets>
 where
     Offsets: GetPtrSize,
 {
+    /// Load `VMStackLimits::stack_limit`.
+    pub fn stack_limit(
+        &mut self,
+        cursor: &mut FuncCursor<'_>,
+        stack_limits: ir::Value,
+    ) -> ir::Value {
+        let offset = self.offsets.get_ptr_size().vmstack_limits_stack_limit();
+        let region = self.vmcontref_region(cursor.func);
+        cursor.ins().load(
+            self.pointer_type,
+            ir::MemFlagsData::trusted().with_alias_region(Some(region)),
+            stack_limits,
+            i32::from(offset),
+        )
+    }
+
+    /// Load `VMStackLimits::last_wasm_entry_fp`.
+    pub fn last_wasm_entry_fp(
+        &mut self,
+        cursor: &mut FuncCursor<'_>,
+        stack_limits: ir::Value,
+    ) -> ir::Value {
+        let offset = self
+            .offsets
+            .get_ptr_size()
+            .vmstack_limits_last_wasm_entry_fp();
+        let region = self.vmcontref_region(cursor.func);
+        cursor.ins().load(
+            self.pointer_type,
+            ir::MemFlagsData::trusted().with_alias_region(Some(region)),
+            stack_limits,
+            i32::from(offset),
+        )
+    }
+
+    /// Load `VMStackLimits::last_wasm_entry_sp`.
+    pub fn last_wasm_entry_sp(
+        &mut self,
+        cursor: &mut FuncCursor<'_>,
+        stack_limits: ir::Value,
+    ) -> ir::Value {
+        let offset = self
+            .offsets
+            .get_ptr_size()
+            .vmstack_limits_last_wasm_entry_sp();
+        let region = self.vmcontref_region(cursor.func);
+        cursor.ins().load(
+            self.pointer_type,
+            ir::MemFlagsData::trusted().with_alias_region(Some(region)),
+            stack_limits,
+            i32::from(offset),
+        )
+    }
+
+    /// Load `VMStackLimits::last_wasm_entry_trap_handler`.
+    pub fn last_wasm_entry_trap_handler(
+        &mut self,
+        cursor: &mut FuncCursor<'_>,
+        stack_limits: ir::Value,
+    ) -> ir::Value {
+        let offset = self
+            .offsets
+            .get_ptr_size()
+            .vmstack_limits_last_wasm_entry_trap_handler();
+        let region = self.vmcontref_region(cursor.func);
+        cursor.ins().load(
+            self.pointer_type,
+            ir::MemFlagsData::trusted().with_alias_region(Some(region)),
+            stack_limits,
+            i32::from(offset),
+        )
+    }
+
     /// Region for a continuation-reference object and its inline
     /// sub-structures.
     ///

--- a/crates/cranelift/src/func_environ/stack_switching/control_effect.rs
+++ b/crates/cranelift/src/func_environ/stack_switching/control_effect.rs
@@ -58,6 +58,15 @@ impl ControlEffect {
         Self(val)
     }
 
+    pub fn is_trap(self, builder: &mut FunctionBuilder) -> ir::Value {
+        let signal = self.signal(builder);
+        builder.ins().icmp_imm_u(
+            ir::condcodes::IntCC::Equal,
+            signal,
+            i64::from(wasmtime_environ::CONTROL_EFFECT_TRAP_DISCRIMINANT),
+        )
+    }
+
     /// Returns the payload of the `Suspend` variant
     pub fn handler_index(self, builder: &mut FunctionBuilder) -> ir::Value {
         builder.ins().ireduce(I32, self.0)

--- a/crates/cranelift/src/func_environ/stack_switching/instructions.rs
+++ b/crates/cranelift/src/func_environ/stack_switching/instructions.rs
@@ -783,64 +783,39 @@ pub(crate) mod stack_switching_helpers {
         ) {
             let stack_limits_ptr = self.get_stack_limits_ptr(env, builder);
 
-            let pointer_type = env.pointer_type();
-            let stack_limit_offset = env.offsets.ptr.vmstack_limits_stack_limit();
-            let last_wasm_entry_fp_offset = env.offsets.ptr.vmstack_limits_last_wasm_entry_fp();
-            let last_wasm_entry_sp_offset = env.offsets.ptr.vmstack_limits_last_wasm_entry_sp();
-            let last_wasm_entry_trap_handler_offset = env
-                .offsets
-                .ptr
-                .vmstack_limits_last_wasm_entry_trap_handler();
-
             // The load side reads this continuation's inline `VMStackLimits`
             // (the `VMContRef` region); the store side targets the
             // `VMStoreContext`.
-            let vmcontref_region = env.alias_regions.vmcontref_region(builder.func);
-            let our_memflags =
-                ir::MemFlagsData::trusted().with_alias_region(Some(vmcontref_region));
-
-            let stack_limit = builder.ins().load(
-                pointer_type,
-                our_memflags,
-                stack_limits_ptr,
-                i32::from(stack_limit_offset),
-            );
+            let stack_limit = env
+                .alias_regions
+                .stack_limit(&mut builder.cursor(), stack_limits_ptr);
             env.alias_regions.store_vmstore_context_stack_limit(
                 &mut builder.cursor(),
                 vmruntime_limits_ptr,
                 stack_limit,
             );
 
-            let last_wasm_entry_fp = builder.ins().load(
-                pointer_type,
-                our_memflags,
-                stack_limits_ptr,
-                i32::from(last_wasm_entry_fp_offset),
-            );
+            let last_wasm_entry_fp = env
+                .alias_regions
+                .last_wasm_entry_fp(&mut builder.cursor(), stack_limits_ptr);
             env.alias_regions.store_vmstore_context_last_wasm_entry_fp(
                 &mut builder.cursor(),
                 vmruntime_limits_ptr,
                 last_wasm_entry_fp,
             );
 
-            let last_wasm_entry_sp = builder.ins().load(
-                pointer_type,
-                our_memflags,
-                stack_limits_ptr,
-                i32::from(last_wasm_entry_sp_offset),
-            );
+            let last_wasm_entry_sp = env
+                .alias_regions
+                .last_wasm_entry_sp(&mut builder.cursor(), stack_limits_ptr);
             env.alias_regions.store_vmstore_context_last_wasm_entry_sp(
                 &mut builder.cursor(),
                 vmruntime_limits_ptr,
                 last_wasm_entry_sp,
             );
 
-            let last_wasm_entry_trap_handler = builder.ins().load(
-                pointer_type,
-                our_memflags,
-                stack_limits_ptr,
-                i32::from(last_wasm_entry_trap_handler_offset),
-            );
+            let last_wasm_entry_trap_handler = env
+                .alias_regions
+                .last_wasm_entry_trap_handler(&mut builder.cursor(), stack_limits_ptr);
             env.alias_regions
                 .store_vmstore_context_last_wasm_entry_trap_handler(
                     &mut builder.cursor(),

--- a/crates/cranelift/src/func_environ/stack_switching/instructions.rs
+++ b/crates/cranelift/src/func_environ/stack_switching/instructions.rs
@@ -707,6 +707,15 @@ pub(crate) mod stack_switching_helpers {
             self.set_state_no_payload(env, builder, discriminant);
         }
 
+        pub fn set_state_trapped<'a>(
+            &self,
+            env: &mut crate::func_environ::FuncEnvironment<'a>,
+            builder: &mut FunctionBuilder,
+        ) {
+            let discriminant = wasmtime_environ::STACK_STATE_TRAPPED_DISCRIMINANT;
+            self.set_state_no_payload(env, builder, discriminant);
+        }
+
         /// Checks whether the `VMStackState` reflects that the stack has ever been
         /// active (instead of just having been allocated, but never resumed).
         pub fn was_invoked<'a>(
@@ -764,9 +773,8 @@ pub(crate) mod stack_switching_helpers {
             builder.ins().store(memflags, value, self.address, offset);
         }
 
-        /// Sets `last_wasm_entry_sp` and `stack_limit` fields in
-        /// `VMRuntimelimits` using the values from the `VMStackLimits` of this
-        /// object.
+        /// Restores the stack limit and Wasm entry handler fields in
+        /// `VMStoreContext` from this object's `VMStackLimits`.
         pub fn write_limits_to_vmcontext<'a>(
             &self,
             env: &mut crate::func_environ::FuncEnvironment<'a>,
@@ -778,6 +786,11 @@ pub(crate) mod stack_switching_helpers {
             let pointer_type = env.pointer_type();
             let stack_limit_offset = env.offsets.ptr.vmstack_limits_stack_limit();
             let last_wasm_entry_fp_offset = env.offsets.ptr.vmstack_limits_last_wasm_entry_fp();
+            let last_wasm_entry_sp_offset = env.offsets.ptr.vmstack_limits_last_wasm_entry_sp();
+            let last_wasm_entry_trap_handler_offset = env
+                .offsets
+                .ptr
+                .vmstack_limits_last_wasm_entry_trap_handler();
 
             // The load side reads this continuation's inline `VMStackLimits`
             // (the `VMContRef` region); the store side targets the
@@ -809,11 +822,35 @@ pub(crate) mod stack_switching_helpers {
                 vmruntime_limits_ptr,
                 last_wasm_entry_fp,
             );
+
+            let last_wasm_entry_sp = builder.ins().load(
+                pointer_type,
+                our_memflags,
+                stack_limits_ptr,
+                i32::from(last_wasm_entry_sp_offset),
+            );
+            env.alias_regions.store_vmstore_context_last_wasm_entry_sp(
+                &mut builder.cursor(),
+                vmruntime_limits_ptr,
+                last_wasm_entry_sp,
+            );
+
+            let last_wasm_entry_trap_handler = builder.ins().load(
+                pointer_type,
+                our_memflags,
+                stack_limits_ptr,
+                i32::from(last_wasm_entry_trap_handler_offset),
+            );
+            env.alias_regions
+                .store_vmstore_context_last_wasm_entry_trap_handler(
+                    &mut builder.cursor(),
+                    vmruntime_limits_ptr,
+                    last_wasm_entry_trap_handler,
+                );
         }
 
-        /// Overwrites the `last_wasm_entry_fp` field of the `VMStackLimits`
-        /// object in the `VMStackLimits` of this object by loading the
-        /// corresponding field from the `VMStoreContext`.
+        /// Saves the Wasm entry handler fields from `VMStoreContext` into this
+        /// object's `VMStackLimits`.
         ///
         /// If `load_stack_limit` is true, we do the same for the `stack_limit`
         /// field.
@@ -826,21 +863,45 @@ pub(crate) mod stack_switching_helpers {
         ) {
             let stack_limits_ptr = self.get_stack_limits_ptr(env, builder);
 
-            // The load side reads the `VMStoreContext`...
+            // Loads read the `VMStoreContext`; stores write this
+            // continuation's inline `VMStackLimits`.
             let last_wasm_entry_fp = env
                 .alias_regions
                 .vmstore_context_last_wasm_entry_fp(&mut builder.cursor(), vmruntime_limits_ptr);
+            let last_wasm_entry_sp = env
+                .alias_regions
+                .vmstore_context_last_wasm_entry_sp(&mut builder.cursor(), vmruntime_limits_ptr);
+            let last_wasm_entry_trap_handler = env
+                .alias_regions
+                .vmstore_context_last_wasm_entry_trap_handler(
+                    &mut builder.cursor(),
+                    vmruntime_limits_ptr,
+                );
 
-            // ...and store to this continuation's inline `VMStackLimits`.
             let vmcontref_region = env.alias_regions.vmcontref_region(builder.func);
             let our_memflags =
                 ir::MemFlagsData::trusted().with_alias_region(Some(vmcontref_region));
-            let last_wasm_entry_fp_offset = env.offsets.ptr.vmstack_limits_last_wasm_entry_fp();
             builder.ins().store(
                 our_memflags,
                 last_wasm_entry_fp,
                 stack_limits_ptr,
-                i32::from(last_wasm_entry_fp_offset),
+                i32::from(env.offsets.ptr.vmstack_limits_last_wasm_entry_fp()),
+            );
+            builder.ins().store(
+                our_memflags,
+                last_wasm_entry_sp,
+                stack_limits_ptr,
+                i32::from(env.offsets.ptr.vmstack_limits_last_wasm_entry_sp()),
+            );
+            builder.ins().store(
+                our_memflags,
+                last_wasm_entry_trap_handler,
+                stack_limits_ptr,
+                i32::from(
+                    env.offsets
+                        .ptr
+                        .vmstack_limits_last_wasm_entry_trap_handler(),
+                ),
             );
 
             if load_stack_limit {
@@ -1299,18 +1360,17 @@ pub(crate) fn translate_resume<'a>(
     //              |
     //              |
     //        resume_block
-    //         /           \
-    //        /             \
-    //        |             |
-    //  return_block        |
-    //                suspend block
-    //                      |
-    //                dispatch block
+    //       /      |      \
+    //      /       |       \
+    // return    suspend    trap
+    //  block     block     block
+    //              |
+    //       dispatch block
     //
     // * resume_block handles continuation arguments and performs
     //   actual stack switch. On ordinary return from resume, it jumps
-    //   to the `return_block`, whereas on suspension it jumps to the
-    //   `suspend_block`.
+    //   to the `return_block`; on suspension it jumps to the
+    //   `suspend_block`; and on a terminal trap it jumps to `trap_block`.
     // * suspend_block is used on suspension, jumps onward to
     //   `dispatch_block`.
     // * dispatch_block uses a jump table to dispatch to actual
@@ -1325,6 +1385,8 @@ pub(crate) fn translate_resume<'a>(
     let resume_block = builder.create_block();
     let return_block = builder.create_block();
     let suspend_block = builder.create_block();
+    let trap_block = builder.create_block();
+    let nontrap_block = builder.create_block();
     let dispatch_block = builder.create_block();
 
     let vmctx = env.vmctx_val(&mut builder.cursor());
@@ -1385,14 +1447,14 @@ pub(crate) fn translate_resume<'a>(
         // We mark `resume_contref` as the currently running one
         vmctx_set_active_continuation(env, builder, vmctx, resume_contref);
 
-        // Note that the resume_contref libcall a few lines further below
-        // manipulates the stack limits as follows:
-        // 1. Copy stack_limit, last_wasm_entry_sp and last_wasm_exit* values from
-        // VMRuntimeLimits into the currently active continuation (i.e., the
-        // one that will become the parent of the to-be-resumed one)
+        // The code below manipulates the per-stack runtime state as follows:
         //
-        // 2. Copy `stack_limit` and `last_wasm_entry_sp` in the
-        // `VMStackLimits` of `resume_contref` into the `VMRuntimeLimits`.
+        // 1. Copy the stack limit and Wasm entry handler from
+        // `VMStoreContext` into the currently active stack (i.e., the
+        // one that will become the parent of the to-be-resumed one).
+        //
+        // 2. Copy the corresponding fields from the resumed
+        // continuation into `VMStoreContext`.
         //
         // See the comment on `wasmtime_environ::VMStackChain` for a
         // description of the invariants that we maintain for the various stack
@@ -1484,12 +1546,17 @@ pub(crate) fn translate_resume<'a>(
         handler_list.clear(env, builder, true);
         parent_csi.set_first_switch_handler_index(env, builder, zero);
 
-        // Extract the result and signal bit.
+        // First distinguish terminal traps from ordinary returns and
+        // suspensions.
         let result = ControlEffect::from_u64(result);
-        let signal = result.signal(builder);
+        let is_trap = result.is_trap(builder);
+        builder
+            .ins()
+            .brif(is_trap, trap_block, &[], nontrap_block, &[]);
 
-        // Jump to the return block if the result signal is 0, otherwise jump to
-        // the suspend block.
+        builder.switch_to_block(nontrap_block);
+        builder.seal_block(nontrap_block);
+        let signal = result.signal(builder);
         builder
             .ins()
             .brif(signal, suspend_block, &[], return_block, &[]);
@@ -1501,6 +1568,40 @@ pub(crate) fn translate_resume<'a>(
             new_stack_chain,
         )
     };
+
+    // A Wasm trap terminates the child continuation. The user code
+    // cannot handle this trap, thus we restore the parent stack's
+    // entry handler and retrap there. Its array trampoline will
+    // return the failure through `fiber_start`, propagating the
+    // terminal control effect until the nearest host/engine frame
+    // delimiting this Wasm invocation is reached.
+    {
+        builder.switch_to_block(trap_block);
+        builder.seal_block(trap_block);
+        builder.set_cold_block(trap_block);
+
+        let trapped_continuation = new_stack_chain.unchecked_get_continuation();
+        let trapped_continuation = helpers::VMContRef::new(trapped_continuation);
+        let trapped_csi = trapped_continuation.common_stack_information(env, builder);
+        trapped_csi.set_state_trapped(env, builder);
+
+        let parent_csi = original_stack_chain.get_common_stack_information(env, builder);
+        parent_csi.write_limits_to_vmcontext(env, builder, vm_runtime_limits_ptr);
+
+        let args = trapped_continuation.args(env, builder);
+        args.clear(env, builder, true);
+        let values = trapped_continuation.values(env, builder);
+        values.clear(env, builder, true);
+
+        let raise = env.builtin_functions.raise(&mut builder.func);
+        builder.ins().call(raise, &[vmctx]);
+        // We do not anticipate the call to `raise`
+        // returning. However, viewed through cranelift's lens it is
+        // not a block terminating instruction, therefore we insert a
+        // trap to make the current block structurally complete and
+        // catch any unexpected returns from `raise`.
+        builder.ins().trap(crate::TRAP_INTERNAL_ASSERT);
+    }
 
     // The suspend block: Only used when we suspended, not for returns.
     // Here we extract the index of the handler to use.

--- a/crates/environ/src/stack_switching.rs
+++ b/crates/environ/src/stack_switching.rs
@@ -26,6 +26,9 @@ pub const STACK_STATE_SUSPENDED_DISCRIMINANT: u32 = 3;
 /// Discriminant of variant `Returned` in
 /// `runtime::vm::VMStackState`.
 pub const STACK_STATE_RETURNED_DISCRIMINANT: u32 = 4;
+/// Discriminant of variant `Trapped` in
+/// `runtime::vm::VMStackState`.
+pub const STACK_STATE_TRAPPED_DISCRIMINANT: u32 = 5;
 
 /// Discriminant of variant `Return` in
 /// `runtime::vm::ControlEffect`.
@@ -39,3 +42,6 @@ pub const CONTROL_EFFECT_SUSPEND_DISCRIMINANT: u32 = 2;
 /// Discriminant of variant `Switch` in
 /// `runtime::vm::ControlEffect`.
 pub const CONTROL_EFFECT_SWITCH_DISCRIMINANT: u32 = 3;
+/// Discriminant of variant `Trap` in
+/// `runtime::vm::ControlEffect`.
+pub const CONTROL_EFFECT_TRAP_DISCRIMINANT: u32 = 4;

--- a/crates/environ/src/vmoffsets.rs
+++ b/crates/environ/src/vmoffsets.rs
@@ -379,6 +379,16 @@ pub trait PtrSize {
         self.size()
     }
 
+    /// Return the offset of `VMStackLimits::last_wasm_entry_sp`.
+    fn vmstack_limits_last_wasm_entry_sp(&self) -> u8 {
+        self.vmstack_limits_last_wasm_entry_fp() + self.size()
+    }
+
+    /// Return the offset of `VMStackLimits::last_wasm_entry_trap_handler`.
+    fn vmstack_limits_last_wasm_entry_trap_handler(&self) -> u8 {
+        self.vmstack_limits_last_wasm_entry_sp() + self.size()
+    }
+
     // Offsets within `VMHostArray`
 
     /// Return the offset of `VMHostArray::length`.
@@ -410,7 +420,7 @@ pub trait PtrSize {
 
     /// Return the offset of `VMCommonStackInformation::state`.
     fn vmcommon_stack_information_state(&self) -> u8 {
-        2 * self.size()
+        4 * self.size()
     }
 
     /// Return the offset of `VMCommonStackInformation::handlers`.

--- a/crates/wasmtime/src/runtime/func.rs
+++ b/crates/wasmtime/src/runtime/func.rs
@@ -1587,7 +1587,8 @@ impl EntryStoreContext {
         unsafe {
             let vm_store_context = store.0.vm_store_context();
             let new_stack_chain = VMStackChain::InitialStack(initial_stack_information);
-            *vm_store_context.stack_chain.get() = new_stack_chain;
+            let stack_chain =
+                mem::replace(&mut *vm_store_context.stack_chain.get(), new_stack_chain);
 
             Self {
                 stack_limit,
@@ -1600,7 +1601,7 @@ impl EntryStoreContext {
                 last_wasm_entry_trap_handler: *(*vm_store_context)
                     .last_wasm_entry_trap_handler
                     .get(),
-                stack_chain: (*(*vm_store_context).stack_chain.get()).clone(),
+                stack_chain,
                 vm_store_context,
             }
         }

--- a/crates/wasmtime/src/runtime/store/gc.rs
+++ b/crates/wasmtime/src/runtime/store/gc.rs
@@ -823,8 +823,8 @@ impl StoreOpaque {
                     // either case things should be handled correctly when traversing
                     // further along in the chain, nothing required at this point.
                 }
-                VMStackState::Fresh | VMStackState::Returned => {
-                    // Fresh/Returned continuations have no gc values on their stack.
+                VMStackState::Fresh | VMStackState::Returned | VMStackState::Trapped => {
+                    // Fresh/terminal continuations have no live GC values on their stack.
                 }
             }
         }

--- a/crates/wasmtime/src/runtime/vm/stack_switching.rs
+++ b/crates/wasmtime/src/runtime/vm/stack_switching.rs
@@ -410,7 +410,7 @@ pub fn cont_new(
 /// executing themselves, but are an ancestor of the currently executing
 /// stack), we have the following: All the fields in the stack's
 /// `VMStackLimits` are valid, describing the stack's stack limit, and
-/// pointers where executing for that stack entered and exited WASM.
+/// pointers where executing for that stack entered and exited Wasm.
 ///
 /// Suspended continuations: For suspended continuations (including their
 /// ancestors), we have the following. Note that the initial stack can never

--- a/crates/wasmtime/src/runtime/vm/stack_switching.rs
+++ b/crates/wasmtime/src/runtime/vm/stack_switching.rs
@@ -7,6 +7,16 @@ use core::{marker::PhantomPinned, ptr::NonNull};
 
 pub use stack::*;
 
+// This constant is used to signal that a trap occurred inside a child
+// continuation. Morally, it should be part of
+// `wasmtime_cranelift::stack_switching::control_effect`, but that
+// would require increasing the dependency surface considerably just
+// for a constant, thus we define it here so that it can be referenced
+// by the assembly stubs.
+#[allow(dead_code, reason = "Only referenced by assembly stubs")]
+pub const CONTROL_EFFECT_TRAP_ENCODING: u64 =
+    (wasmtime_environ::CONTROL_EFFECT_TRAP_DISCRIMINANT as u64) << 32;
+
 /// A continuation object is a handle to a continuation reference
 /// (i.e. an actual stack). A continuation object only be consumed
 /// once. The linearity is checked dynamically in the generated code
@@ -76,6 +86,10 @@ pub struct VMStackLimits {
     pub stack_limit: usize,
     /// Saved version of `last_wasm_entry_fp` field of `VMStoreContext`
     pub last_wasm_entry_fp: usize,
+    /// Saved version of `last_wasm_entry_sp` field of `VMStoreContext`
+    pub last_wasm_entry_sp: usize,
+    /// Saved version of `last_wasm_entry_trap_handler` field of `VMStoreContext`
+    pub last_wasm_entry_trap_handler: usize,
 }
 
 /// This type represents "common" information that we need to save both for the
@@ -539,6 +553,9 @@ pub enum VMStackState {
     /// Note that there is no guarantee that a VMContRef will ever
     /// reach this status, as it may stay suspended until being dropped.
     Returned = wasmtime_environ::STACK_STATE_RETURNED_DISCRIMINANT,
+    /// The function originally passed to `cont.new` terminated with a trap.
+    /// This is a terminal state and the continuation cannot be resumed.
+    Trapped = wasmtime_environ::STACK_STATE_TRAPPED_DISCRIMINANT,
 }
 
 #[cfg(test)]
@@ -567,6 +584,14 @@ mod tests {
         assert_eq!(
             offset_of!(VMStackLimits, last_wasm_entry_fp),
             usize::from(offsets.ptr.vmstack_limits_last_wasm_entry_fp())
+        );
+        assert_eq!(
+            offset_of!(VMStackLimits, last_wasm_entry_sp),
+            usize::from(offsets.ptr.vmstack_limits_last_wasm_entry_sp())
+        );
+        assert_eq!(
+            offset_of!(VMStackLimits, last_wasm_entry_trap_handler),
+            usize::from(offsets.ptr.vmstack_limits_last_wasm_entry_trap_handler())
         );
     }
 

--- a/crates/wasmtime/src/runtime/vm/stack_switching/stack/unix.rs
+++ b/crates/wasmtime/src/runtime/vm/stack_switching/stack/unix.rs
@@ -326,7 +326,7 @@ unsafe extern "C" fn fiber_start(
     caller_vmctx: *mut VMContext,
     args: *mut VMHostArray<ValRaw>,
     return_value_count: u32,
-) {
+) -> bool {
     unsafe {
         let func_ref = NonNull::new(func_ref).unwrap();
         let caller_vmxtx = NonNull::new_unchecked(caller_vmctx);
@@ -349,17 +349,18 @@ unsafe extern "C" fn fiber_start(
         // underlying `Store`, it's fine to be slightly sloppy about the exact
         // value we set.
         //
-        // TODO(dhil): we are ignoring the boolean return value
-        // here... we probably shouldn't.
-        VMFuncRef::array_call(func_ref, None, caller_vmxtx, params_and_returns);
+        let succeeded = VMFuncRef::array_call(func_ref, None, caller_vmxtx, params_and_returns);
 
-        // The array call trampoline should have just written
-        // `return_value_count` values to the `args` buffer. Let's reflect that
-        // in its length field, to make various bounds checks happy.
-        args.length = return_value_count;
+        if succeeded {
+            // The array call trampoline should have just written
+            // `return_value_count` values to the `args` buffer. Let's reflect
+            // that in its length field, to make various bounds checks happy.
+            args.length = return_value_count;
+        }
 
         // Note that after this function returns, wasmtime_continuation_start
         // will switch back to the parent stack.
+        succeeded
     }
 }
 

--- a/crates/wasmtime/src/runtime/vm/stack_switching/stack/unix/x86_64.rs
+++ b/crates/wasmtime/src/runtime/vm/stack_switching/stack/unix/x86_64.rs
@@ -63,6 +63,16 @@ pub(crate) unsafe extern "C" fn wasmtime_continuation_start() {
         // control context!
         call {fiber_start}
 
+        // A failed array call means that the continuation trapped. Preserve
+        // this information as the control effect sent to the parent stack.
+        test al, al
+        jz 2f
+        xor edi, edi
+        jmp 3f
+    2:
+        mov rdi, {trap_control_effect}
+    3:
+
         // Return to the parent continuation.
         // RBP is callee-saved (no matter if it's used as a frame pointe or
         // not), so its value is still TOS - 0x10.
@@ -72,20 +82,17 @@ pub(crate) unsafe extern "C" fn wasmtime_continuation_start() {
         mov rsp, -0x08[rbp]
         mov rbp,      [rbp]
 
-        // The stack_switch instruction uses register RDI for the payload.
-        // Here, the payload indicates that we are returning (value 0).
-        // See the test case below to keep this in sync with
-        // ControlEffect::return_()
-        mov rdi, 0
-
         jmp rsi
         ",
         fiber_start = sym super::fiber_start,
+        trap_control_effect = const (
+            crate::vm::CONTROL_EFFECT_TRAP_ENCODING
+        ),
     );
 }
 
 #[test]
-fn test_return_payload() {
-    // The following assumption is baked into `wasmtime_continuation_start`.
+fn test_control_effect_payloads() {
+    // These assumptions are baked into `wasmtime_continuation_start`.
     assert_eq!(wasmtime_environ::CONTROL_EFFECT_RETURN_DISCRIMINANT, 0);
 }

--- a/crates/wasmtime/src/runtime/vm/traphandlers.rs
+++ b/crates/wasmtime/src/runtime/vm/traphandlers.rs
@@ -24,7 +24,6 @@ pub use self::signals::*;
 use crate::ThrownException;
 use crate::runtime::module::lookup_code;
 use crate::runtime::store::{ExecutorRef, StoreOpaque};
-use crate::runtime::vm::stack_switching::VMStackChain;
 use crate::runtime::vm::sys::traphandlers;
 use crate::runtime::vm::{InterpreterRef, VMContext, VMStore, VMStoreContext, f32x4, f64x2, i8x16};
 use crate::{EntryStoreContext, prelude::*};
@@ -913,28 +912,7 @@ impl CallThreadState {
     }
 
     pub(crate) fn entry_trap_handler(&self) -> Handler {
-        unsafe {
-            fn running_on_continuation(stack_chain: *const VMStackChain) -> bool {
-                unsafe { matches!(*stack_chain, VMStackChain::Continuation(_)) }
-            }
-            let vm_store_context = self.vm_store_context.get().as_ref();
-            let vm_stack_chain = vm_store_context.stack_chain.get();
-            // The effects of trapping should not be delimited by the
-            // continuation stack segment we are running on, but
-            // rather the initial continuation stack segment, i.e. the
-            // toplevel part of the program. Therefore we must
-            // retrieve the entry fp of the initial stack.
-            let fp = if running_on_continuation(vm_stack_chain) {
-                let initial_stack_limits =
-                    (*vm_stack_chain).clone().into_stack_limits_iter().last();
-                (*initial_stack_limits.unwrap_or_else(|| panic!("Attempting to find the stack limits of the initial stacks from within a suspended continuation."))).last_wasm_entry_fp
-            } else {
-                *vm_store_context.last_wasm_entry_fp.get()
-            };
-            let sp = *vm_store_context.last_wasm_entry_sp.get();
-            let pc = *vm_store_context.last_wasm_entry_trap_handler.get();
-            Handler { pc, sp, fp }
-        }
+        unsafe { entry_trap_handler(self.vm_store_context.get().as_ref()) }
     }
 
     unsafe fn resume_to_exception_handler(

--- a/crates/wasmtime/src/runtime/vm/traphandlers.rs
+++ b/crates/wasmtime/src/runtime/vm/traphandlers.rs
@@ -24,6 +24,7 @@ pub use self::signals::*;
 use crate::ThrownException;
 use crate::runtime::module::lookup_code;
 use crate::runtime::store::{ExecutorRef, StoreOpaque};
+use crate::runtime::vm::stack_switching::VMStackChain;
 use crate::runtime::vm::sys::traphandlers;
 use crate::runtime::vm::{InterpreterRef, VMContext, VMStore, VMStoreContext, f32x4, f64x2, i8x16};
 use crate::{EntryStoreContext, prelude::*};
@@ -912,7 +913,33 @@ impl CallThreadState {
     }
 
     pub(crate) fn entry_trap_handler(&self) -> Handler {
-        unsafe { entry_trap_handler(self.vm_store_context.get().as_ref()) }
+        unsafe {
+            fn running_on_continuation(stack_chain: *const VMStackChain) -> bool {
+                unsafe {
+                    match *stack_chain {
+                        VMStackChain::Continuation(_) => true,
+                        _ => false,
+                    }
+                }
+            }
+            let vm_store_context = self.vm_store_context.get().as_ref();
+            let vm_stack_chain = vm_store_context.stack_chain.get();
+            // The effects of trapping should not be delimited by the
+            // continuation stack segment we are running on, but
+            // rather the initial continuation stack segment, i.e. the
+            // toplevel part of the program. Therefore we must
+            // retrieve the entry fp of the initial stack.
+            let fp = if running_on_continuation(vm_stack_chain) {
+                let initial_stack_limits =
+                    (*vm_stack_chain).clone().into_stack_limits_iter().last();
+                (*initial_stack_limits.unwrap_or_else(|| panic!("Attempting to find the stack limits of the initial stacks from within a suspended continuation."))).last_wasm_entry_fp
+            } else {
+                *vm_store_context.last_wasm_entry_fp.get()
+            };
+            let sp = *vm_store_context.last_wasm_entry_sp.get();
+            let pc = *vm_store_context.last_wasm_entry_trap_handler.get();
+            Handler { pc, sp, fp }
+        }
     }
 
     unsafe fn resume_to_exception_handler(

--- a/crates/wasmtime/src/runtime/vm/traphandlers.rs
+++ b/crates/wasmtime/src/runtime/vm/traphandlers.rs
@@ -915,12 +915,7 @@ impl CallThreadState {
     pub(crate) fn entry_trap_handler(&self) -> Handler {
         unsafe {
             fn running_on_continuation(stack_chain: *const VMStackChain) -> bool {
-                unsafe {
-                    match *stack_chain {
-                        VMStackChain::Continuation(_) => true,
-                        _ => false,
-                    }
-                }
+                unsafe { matches!(*stack_chain, VMStackChain::Continuation(_)) }
             }
             let vm_store_context = self.vm_store_context.get().as_ref();
             let vm_stack_chain = vm_store_context.stack_chain.get();

--- a/tests/all/continuation_traps.rs
+++ b/tests/all/continuation_traps.rs
@@ -80,7 +80,12 @@ fn host_trap() -> Result<()> {
     bail!("intentional host trap")
 }
 
+// TODO(dhil): Enable ASAN. ASAN produces a false positive here,
+// because ASAN thinks the thread is on the default stack. We need to
+// instrument the stack switching runtime to inform ASAN about the
+// switching of stacks.
 #[test]
+#[cfg_attr(any(asan, miri), ignore)]
 fn traps_cross_continuation_stacks_and_host_frames() -> Result<()> {
     let mut config = Config::new();
     config.wasm_stack_switching(true);
@@ -134,7 +139,9 @@ struct CatchState {
     error: Option<Error>,
 }
 
+// TODO(dhil): Enable ASAN.
 #[test]
+#[cfg_attr(any(asan, miri), ignore)]
 fn parent_frames_resume_after_host_catches_trap() -> Result<()> {
     let mut config = Config::new();
     config.wasm_stack_switching(true);

--- a/tests/all/continuation_traps.rs
+++ b/tests/all/continuation_traps.rs
@@ -1,0 +1,200 @@
+use wasmtime::*;
+
+const MODULE: &str = r#"
+    (module
+        (import "host" "reenter" (func $host-reenter))
+        (import "host" "trap" (func $host-trap))
+
+        (type $ft (func))
+        (type $ct (cont $ft))
+
+        (global $stacks-left (mut i32) (i32.const 0))
+        (global $frames-left (mut i32) (i32.const 0))
+        (global $frames-per-stack (mut i32) (i32.const 0))
+        (global $trap-in-host (mut i32) (i32.const 0))
+        (global $g (export "g") (mut i32) (i32.const 0))
+
+        (func $increment
+            (global.set $g
+                (i32.add (global.get $g) (i32.const 1))))
+
+        (func $continue (export "continue")
+            (if (i32.gt_u (global.get $frames-left) (i32.const 0))
+                (then
+                    (global.set $frames-left
+                        (i32.sub (global.get $frames-left) (i32.const 1)))
+                    (call $host-reenter))
+                (else
+                    (if (i32.gt_u (global.get $stacks-left) (i32.const 0))
+                        (then
+                            ;; Install a new child stack.
+                            (global.set $stacks-left
+                                (i32.sub (global.get $stacks-left) (i32.const 1)))
+                            (global.set $frames-left (global.get $frames-per-stack))
+                            (resume $ct (cont.new $ct (ref.func $continue))))
+                        (else
+                            ;; Call either the host provided trap, or the native Wasm trapping instruction `unreachable`.
+                            (if (global.get $trap-in-host)
+                                (then (call $host-trap))
+                                (else unreachable))))))
+
+            ;; No frame, on any stack, may resume after the terminal trap.
+            (call $increment))
+
+        (func (export "run")
+            (param $stacks i32)
+            (param $frames-per-stack-arg i32)
+            (param $trap-in-host-arg i32)
+            (global.set $stacks-left (local.get $stacks))
+            (global.set $frames-left (local.get $frames-per-stack-arg))
+            (global.set $frames-per-stack (local.get $frames-per-stack-arg))
+            (global.set $trap-in-host (local.get $trap-in-host-arg))
+            (call $continue))
+
+        (elem declare func $continue)
+    )
+"#;
+
+fn increment_global<T>(caller: &mut Caller<'_, T>) -> Result<()> {
+    let g = caller.get_export("g").unwrap().into_global().unwrap();
+    let value = g.get(&mut *caller).unwrap_i32();
+    g.set(caller, Val::I32(value + 1))
+}
+
+fn assert_expected_trap(error: &Error, trap_in_host: bool, stacks: i32, frames_per_stack: i32) {
+    if trap_in_host {
+        assert!(
+            format!("{error:#}").contains("intentional host trap"),
+            "unexpected error for stacks={stacks}, frames_per_stack={frames_per_stack}: {error:#}"
+        );
+    } else {
+        assert_eq!(
+            error.downcast_ref::<Trap>(),
+            Some(&Trap::UnreachableCodeReached),
+            "unexpected error for stacks={stacks}, frames_per_stack={frames_per_stack}: {error:#}"
+        );
+    }
+}
+
+fn host_trap() -> Result<()> {
+    bail!("intentional host trap")
+}
+
+#[test]
+fn traps_cross_continuation_stacks_and_host_frames() -> Result<()> {
+    let mut config = Config::new();
+    config.wasm_stack_switching(true);
+    let engine = Engine::new(&config)?;
+    let module = Module::new(&engine, MODULE)?;
+
+    // Exercise short continuation chains with different numbers of alternating
+    // Wasm and host frames on each stack. Test both a Wasm trap and a host trap
+    // as the youngest frame.
+    for stacks in 0..=10 {
+        for frames_per_stack in 0..=10 {
+            for trap_in_host in [false, true] {
+                let mut store = Store::new(&engine, ());
+                let reenter = Func::wrap(&mut store, |mut caller: Caller<'_, ()>| -> Result<()> {
+                    let continue_ = caller
+                        .get_export("continue")
+                        .unwrap()
+                        .into_func()
+                        .unwrap()
+                        .typed::<(), ()>(&caller)?;
+                    continue_.call(&mut caller, ())?;
+
+                    // This must not execute: the recursive call always traps.
+                    increment_global(&mut caller)
+                });
+                let host_trap = Func::wrap(&mut store, host_trap);
+                let instance =
+                    Instance::new(&mut store, &module, &[reenter.into(), host_trap.into()])?;
+
+                let run = instance.get_typed_func::<(i32, i32, i32), ()>(&mut store, "run")?;
+                let error = run
+                    .call(
+                        &mut store,
+                        (stacks, frames_per_stack, i32::from(trap_in_host)),
+                    )
+                    .unwrap_err();
+
+                assert_expected_trap(&error, trap_in_host, stacks, frames_per_stack);
+
+                let g = instance.get_global(&mut store, "g").unwrap();
+                assert_eq!(g.get(&mut store).unwrap_i32(), 0);
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[derive(Default)]
+struct CatchState {
+    error: Option<Error>,
+}
+
+#[test]
+fn parent_frames_resume_after_host_catches_trap() -> Result<()> {
+    let mut config = Config::new();
+    config.wasm_stack_switching(true);
+    let engine = Engine::new(&config)?;
+    let module = Module::new(&engine, MODULE)?;
+
+    for stacks in 0..=10 {
+        // At least one host re-entry is needed to catch the terminal trap.
+        for frames_per_stack in 1..=10 {
+            for trap_in_host in [false, true] {
+                let mut store = Store::new(&engine, CatchState::default());
+                let reenter = Func::wrap(
+                    &mut store,
+                    |mut caller: Caller<'_, CatchState>| -> Result<()> {
+                        let continue_ = caller
+                            .get_export("continue")
+                            .unwrap()
+                            .into_func()
+                            .unwrap()
+                            .typed::<(), ()>(&caller)?;
+
+                        if let Err(error) = continue_.call(&mut caller, ()) {
+                            let previous = caller.data_mut().error.replace(error);
+                            assert!(previous.is_none(), "more than one host frame caught a trap");
+                        }
+
+                        increment_global(&mut caller)
+                    },
+                );
+                let host_trap = Func::wrap(&mut store, host_trap);
+                let instance =
+                    Instance::new(&mut store, &module, &[reenter.into(), host_trap.into()])?;
+
+                let run = instance.get_typed_func::<(i32, i32, i32), ()>(&mut store, "run")?;
+                run.call(
+                    &mut store,
+                    (stacks, frames_per_stack, i32::from(trap_in_host)),
+                )?;
+
+                let error = store
+                    .data()
+                    .error
+                    .as_ref()
+                    .expect("a host frame should have caught the terminal trap");
+                assert_expected_trap(error, trap_in_host, stacks, frames_per_stack);
+
+                // `stacks` counts child stacks, so there are `stacks + 1`
+                // stacks in total. Each has `frames_per_stack` host frames and
+                // `frames_per_stack + 1` Wasm frames. All frames except the
+                // terminal trapping Wasm frame return and increment `g`.
+                let expected = (stacks + 1) * (2 * frames_per_stack + 1) - 1;
+                let g = instance.get_global(&mut store, "g").unwrap();
+                assert_eq!(
+                    g.get(&mut store).unwrap_i32(),
+                    expected,
+                    "wrong count for stacks={stacks}, frames_per_stack={frames_per_stack}"
+                );
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/tests/all/main.rs
+++ b/tests/all/main.rs
@@ -8,6 +8,8 @@ mod call_hook;
 mod cli_tests;
 mod compile_time_builtins;
 mod component_model;
+#[cfg(all(feature = "stack-switching", unix, target_arch = "x86_64"))]
+mod continuation_traps;
 mod coredump;
 mod custom_code_memory;
 mod debug;

--- a/tests/disas/stack-switching/resume-suspend-data-passing.wat
+++ b/tests/disas/stack-switching/resume-suspend-data-passing.wat
@@ -52,11 +52,11 @@
 ;;                                 block0(v0: i64, v1: i64):
 ;; @003c                               v3 = iconst.i32 10
 ;; @0044                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0044                               v31 = iconst.i64 120
+;; @0044                               v31 = iconst.i64 136
 ;; @0044                               v34 = stack_addr.i64 ss0
-;; @0044                               v40 = iconst.i64 16
+;; @0044                               v40 = iconst.i64 32
 ;; @0044                               v37 = iconst.i64 0
-;; @0044                               v49 = iconst.i64 80
+;; @0044                               v49 = iconst.i64 96
 ;; @0044                               v52 = iconst.i64 -24
 ;;                                     v68 = iconst.i64 0x0002_0000_0000
 ;; @0040                               jump block2(v3)  ; v3 = 10
@@ -65,7 +65,7 @@
 ;; @0044                               v8 = load.i64 notrap aligned region2 v7+88
 ;; @0044                               v9 = load.i64 notrap aligned region2 v7+96
 ;; @0044                               v12 = iconst.i64 1
-;; @0044                               v16 = iconst.i64 24
+;; @0044                               v16 = iconst.i64 40
 ;; @003a                               v2 = iconst.i32 0
 ;; @0044                               jump block4(v8, v9, v4)
 ;;
@@ -76,12 +76,12 @@
 ;; @0044                               jump block5
 ;;
 ;;                                 block5:
-;; @0044                               v14 = load.i64 notrap aligned region3 v11+48
-;; @0044                               v15 = load.i64 notrap aligned region3 v11+56
-;;                                     v73 = iconst.i64 24
-;;                                     v74 = iadd v15, v73  ; v73 = 24
+;; @0044                               v14 = load.i64 notrap aligned region3 v11+64
+;; @0044                               v15 = load.i64 notrap aligned region3 v11+72
+;;                                     v73 = iconst.i64 40
+;;                                     v74 = iadd v15, v73  ; v73 = 40
 ;; @0044                               v18 = load.i64 notrap aligned region3 v74+8
-;; @0044                               v19 = load.i32 notrap aligned region3 v15+40
+;; @0044                               v19 = load.i32 notrap aligned region3 v15+56
 ;;                                     v75 = iconst.i32 0
 ;;                                     v65 = iconst.i32 3
 ;; @0044                               v5 = iconst.i64 48
@@ -106,23 +106,23 @@
 ;; @0044                               brif v79, block8, block6(v81)
 ;;
 ;;                                 block8:
-;; @0044                               store.i64 notrap aligned region3 v11, v9+64
+;; @0044                               store.i64 notrap aligned region3 v11, v9+80
 ;;                                     v82 = iconst.i32 1
-;;                                     v83 = iconst.i64 120
-;;                                     v84 = iadd.i64 v9, v83  ; v83 = 120
+;;                                     v83 = iconst.i64 136
+;;                                     v84 = iadd.i64 v9, v83  ; v83 = 136
 ;; @0044                               store notrap aligned region3 v82, v84+4  ; v82 = 1
 ;; @0044                               store.i64 notrap aligned region3 v34, v84+8
 ;; @0044                               store.i32 notrap aligned region4 v4, v34
 ;; @0044                               store notrap aligned region3 v82, v84  ; v82 = 1
 ;;                                     v85 = iconst.i32 3
-;;                                     v86 = iconst.i64 16
-;;                                     v87 = iadd.i64 v9, v86  ; v86 = 16
+;;                                     v86 = iconst.i64 32
+;;                                     v87 = iadd.i64 v9, v86  ; v86 = 32
 ;; @0044                               store notrap aligned region3 v85, v87  ; v85 = 3
 ;;                                     v88 = iconst.i64 0
-;; @0044                               store notrap aligned region3 v88, v11+48  ; v88 = 0
-;; @0044                               store notrap aligned region3 v88, v11+56  ; v88 = 0
-;;                                     v89 = iconst.i64 80
-;;                                     v90 = iadd.i64 v11, v89  ; v89 = 80
+;; @0044                               store notrap aligned region3 v88, v11+64  ; v88 = 0
+;; @0044                               store notrap aligned region3 v88, v11+72  ; v88 = 0
+;;                                     v89 = iconst.i64 96
+;;                                     v90 = iadd.i64 v11, v89  ; v89 = 96
 ;; @0044                               v51 = load.i64 notrap aligned region3 v90
 ;;                                     v91 = iconst.i64 -24
 ;;                                     v92 = iadd v51, v91  ; v91 = -24
@@ -155,14 +155,18 @@
 ;;     region2 = 1073741824 "VMContRef+0x0"
 ;;     region3 = 67108952 "VMStoreContext+0x58"
 ;;     region4 = 67108936 "VMStoreContext+0x48"
-;;     region5 = 1140850688 "ContinuationStackMemory+0x0"
+;;     region5 = 67108928 "VMStoreContext+0x40"
+;;     region6 = 67108944 "VMStoreContext+0x50"
+;;     region7 = 1140850688 "ContinuationStackMemory+0x0"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i32) -> i64 tail
 ;;     sig1 = (i64 vmctx, i64, i32, i32) -> i64 tail
+;;     sig2 = (i64 vmctx) tail
 ;;     fn0 = colocated u805306368:6 sig0
 ;;     fn1 = colocated u805306368:42 sig1
+;;     fn2 = colocated u805306368:41 sig2
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
@@ -170,27 +174,27 @@
 ;; @0056                               v3 = call fn0(v0, v2)  ; v2 = 0
 ;; @0058                               trapz v3, user16
 ;; @0058                               v6 = call fn1(v0, v3, v2, v2)  ; v2 = 0, v2 = 0
-;; @0058                               v7 = load.i64 notrap aligned region2 v6+72
+;; @0058                               v7 = load.i64 notrap aligned region2 v6+88
 ;; @0058                               v9 = uextend.i128 v7
 ;; @0058                               v10 = iconst.i64 64
-;;                                     v115 = ishl v9, v10  ; v10 = 64
+;;                                     v150 = ishl v9, v10  ; v10 = 64
 ;; @0058                               v8 = uextend.i128 v6
-;; @0058                               v13 = bor v115, v8
+;; @0058                               v13 = bor v150, v8
 ;; @0062                               v22 = iconst.i64 1
 ;; @0062                               v25 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0062                               v28 = iconst.i64 0
 ;; @0062                               v29 = iconst.i64 2
 ;; @0062                               v33 = iconst.i32 1
-;; @0062                               v34 = iconst.i64 16
+;; @0062                               v34 = iconst.i64 32
 ;; @0062                               v36 = iconst.i32 2
-;; @0062                               v48 = iconst.i64 24
-;; @0062                               v51 = stack_addr.i64 ss0
-;; @0062                               v52 = iconst.i64 48
-;; @0062                               v53 = iadd v0, v52  ; v52 = 48
-;; @0062                               v60 = iconst.i64 80
-;; @0062                               v63 = iconst.i64 -24
-;;                                     v119 = iconst.i64 0x0001_0000_0000
-;; @0062                               v58 = iconst.i64 32
+;; @0062                               v52 = iconst.i64 40
+;; @0062                               v55 = stack_addr.i64 ss0
+;; @0062                               v56 = iconst.i64 48
+;; @0062                               v57 = iadd v0, v56  ; v56 = 48
+;; @0062                               v64 = iconst.i64 96
+;; @0062                               v67 = iconst.i64 -24
+;;                                     v154 = iconst.i64 0x0001_0000_0000
+;; @0062                               v82 = iconst.i64 4
 ;; @005c                               jump block2(v13)
 ;;
 ;;                                 block2(v14: i128):
@@ -199,119 +203,171 @@
 ;;                                 block5:
 ;; @0062                               v15 = ireduce.i64 v14
 ;; @0062                               trapz v15, user16
-;; @0062                               v20 = load.i64 notrap aligned region2 v15+72
-;;                                     v122 = iconst.i64 64
-;;                                     v123 = ushr.i128 v14, v122  ; v122 = 64
-;; @0062                               v19 = ireduce.i64 v123
+;; @0062                               v20 = load.i64 notrap aligned region2 v15+88
+;;                                     v157 = iconst.i64 64
+;;                                     v158 = ushr.i128 v14, v157  ; v157 = 64
+;; @0062                               v19 = ireduce.i64 v158
 ;; @0062                               v21 = icmp eq v20, v19
 ;; @0062                               trapz v21, user23
-;;                                     v124 = iconst.i64 1
-;;                                     v125 = iadd v20, v124  ; v124 = 1
-;; @0062                               store notrap aligned region2 v125, v15+72
-;; @0062                               v24 = load.i64 notrap aligned region2 v15+64
+;;                                     v159 = iconst.i64 1
+;;                                     v160 = iadd v20, v159  ; v159 = 1
+;; @0062                               store notrap aligned region2 v160, v15+88
+;; @0062                               v24 = load.i64 notrap aligned region2 v15+80
 ;; @0062                               v26 = load.i64 notrap aligned region3 v25+88
 ;; @0062                               v27 = load.i64 notrap aligned region3 v25+96
-;; @0062                               store notrap aligned region2 v26, v24+48
-;; @0062                               store notrap aligned region2 v27, v24+56
-;;                                     v126 = iconst.i64 0
-;; @0062                               store notrap aligned region2 v126, v15+64  ; v126 = 0
-;;                                     v127 = iconst.i64 2
-;; @0062                               store notrap aligned region3 v127, v25+88  ; v127 = 2
+;; @0062                               store notrap aligned region2 v26, v24+64
+;; @0062                               store notrap aligned region2 v27, v24+72
+;;                                     v161 = iconst.i64 0
+;; @0062                               store notrap aligned region2 v161, v15+80  ; v161 = 0
+;;                                     v162 = iconst.i64 2
+;; @0062                               store notrap aligned region3 v162, v25+88  ; v162 = 2
 ;; @0062                               store notrap aligned region3 v15, v25+96
-;;                                     v128 = iconst.i32 1
-;;                                     v129 = iconst.i64 16
-;;                                     v130 = iadd v15, v129  ; v129 = 16
-;; @0062                               store notrap aligned region2 v128, v130  ; v128 = 1
-;;                                     v131 = iconst.i32 2
-;;                                     v132 = iadd v27, v129  ; v129 = 16
-;; @0062                               store notrap aligned region2 v131, v132  ; v131 = 2
+;;                                     v163 = iconst.i32 1
+;;                                     v164 = iconst.i64 32
+;;                                     v165 = iadd v15, v164  ; v164 = 32
+;; @0062                               store notrap aligned region2 v163, v165  ; v163 = 1
+;;                                     v166 = iconst.i32 2
+;;                                     v167 = iadd v27, v164  ; v164 = 32
+;; @0062                               store notrap aligned region2 v166, v167  ; v166 = 2
 ;; @0062                               v42 = load.i64 notrap aligned region4 v25+72
+;; @0062                               v43 = load.i64 notrap aligned region5 v25+64
+;; @0062                               v44 = load.i64 notrap aligned region6 v25+80
 ;; @0062                               store notrap aligned region2 v42, v27+8
-;; @0062                               v43 = load.i64 notrap aligned region1 v25+24
-;; @0062                               store notrap aligned region2 v43, v27
-;; @0062                               v46 = load.i64 notrap aligned region2 v15
-;; @0062                               store notrap aligned region1 v46, v25+24
-;; @0062                               v47 = load.i64 notrap aligned region2 v15+8
-;; @0062                               store notrap aligned region4 v47, v25+72
-;;                                     v133 = iconst.i64 24
-;;                                     v134 = iadd v27, v133  ; v133 = 24
-;; @0062                               store notrap aligned region2 v128, v134+4  ; v128 = 1
-;; @0062                               store.i64 notrap aligned region2 v51, v134+8
-;;                                     v135 = iadd.i64 v0, v52  ; v52 = 48
-;; @0062                               store notrap aligned region5 v135, v51
-;; @0062                               store notrap aligned region2 v128, v134  ; v128 = 1
-;; @0062                               store notrap aligned region2 v128, v27+40  ; v128 = 1
-;;                                     v136 = iconst.i64 80
-;;                                     v137 = iadd v24, v136  ; v136 = 80
-;; @0062                               v62 = load.i64 notrap aligned region2 v137
-;;                                     v138 = iconst.i64 -24
-;;                                     v139 = iadd v62, v138  ; v138 = -24
-;;                                     v140 = iconst.i64 0x0001_0000_0000
-;; @0062                               v65 = stack_switch v139, v139, v140  ; v140 = 0x0001_0000_0000
-;; @0062                               v67 = load.i64 notrap aligned region3 v25+88
-;; @0062                               v68 = load.i64 notrap aligned region3 v25+96
+;; @0062                               store notrap aligned region2 v43, v27+16
+;; @0062                               store notrap aligned region2 v44, v27+24
+;; @0062                               v45 = load.i64 notrap aligned region1 v25+24
+;; @0062                               store notrap aligned region2 v45, v27
+;; @0062                               v48 = load.i64 notrap aligned region2 v15
+;; @0062                               store notrap aligned region1 v48, v25+24
+;; @0062                               v49 = load.i64 notrap aligned region2 v15+8
+;; @0062                               store notrap aligned region4 v49, v25+72
+;; @0062                               v50 = load.i64 notrap aligned region2 v15+16
+;; @0062                               store notrap aligned region5 v50, v25+64
+;; @0062                               v51 = load.i64 notrap aligned region2 v15+24
+;; @0062                               store notrap aligned region6 v51, v25+80
+;;                                     v168 = iconst.i64 40
+;;                                     v169 = iadd v27, v168  ; v168 = 40
+;; @0062                               store notrap aligned region2 v163, v169+4  ; v163 = 1
+;; @0062                               store.i64 notrap aligned region2 v55, v169+8
+;;                                     v170 = iadd.i64 v0, v56  ; v56 = 48
+;; @0062                               store notrap aligned region7 v170, v55
+;; @0062                               store notrap aligned region2 v163, v169  ; v163 = 1
+;; @0062                               store notrap aligned region2 v163, v27+56  ; v163 = 1
+;;                                     v171 = iconst.i64 96
+;;                                     v172 = iadd v24, v171  ; v171 = 96
+;; @0062                               v66 = load.i64 notrap aligned region2 v172
+;;                                     v173 = iconst.i64 -24
+;;                                     v174 = iadd v66, v173  ; v173 = -24
+;;                                     v175 = iconst.i64 0x0001_0000_0000
+;; @0062                               v69 = stack_switch v174, v174, v175  ; v175 = 0x0001_0000_0000
+;; @0062                               v71 = load.i64 notrap aligned region3 v25+88
+;; @0062                               v72 = load.i64 notrap aligned region3 v25+96
 ;; @0062                               store notrap aligned region3 v26, v25+88
 ;; @0062                               store notrap aligned region3 v27, v25+96
-;; @0062                               store notrap aligned region2 v128, v132  ; v128 = 1
-;;                                     v141 = iconst.i32 0
-;; @0062                               store notrap aligned region2 v141, v134  ; v141 = 0
-;; @0062                               store notrap aligned region2 v141, v134+4  ; v141 = 0
-;; @0062                               store notrap aligned region2 v126, v134+8  ; v126 = 0
-;; @0062                               store notrap aligned region2 v126, v27+40  ; v126 = 0
-;;                                     v142 = iconst.i64 32
-;;                                     v143 = ushr v65, v142  ; v142 = 32
-;; @0062                               brif v143, block7, block6
+;; @0062                               store notrap aligned region2 v163, v167  ; v163 = 1
+;;                                     v176 = iconst.i32 0
+;; @0062                               store notrap aligned region2 v176, v169  ; v176 = 0
+;; @0062                               store notrap aligned region2 v176, v169+4  ; v176 = 0
+;; @0062                               store notrap aligned region2 v161, v169+8  ; v161 = 0
+;; @0062                               store notrap aligned region2 v161, v27+56  ; v161 = 0
+;;                                     v177 = ushr v69, v164  ; v164 = 32
+;;                                     v178 = iconst.i64 4
+;;                                     v179 = icmp eq v177, v178  ; v178 = 4
+;; @0062                               brif v179, block8, block9
+;;
+;;                                 block9:
+;; @0062                               brif.i64 v177, block7, block6
+;;
+;;                                 block8 cold:
+;; @0062                               v88 = iconst.i32 5
+;;                                     v187 = iconst.i64 32
+;;                                     v188 = iadd.i64 v72, v187  ; v187 = 32
+;; @0062                               store notrap aligned region2 v88, v188  ; v88 = 5
+;; @0062                               v93 = load.i64 notrap aligned region2 v27
+;; @0062                               store notrap aligned region1 v93, v25+24
+;; @0062                               v94 = load.i64 notrap aligned region2 v27+8
+;; @0062                               store notrap aligned region4 v94, v25+72
+;; @0062                               v95 = load.i64 notrap aligned region2 v27+16
+;; @0062                               store notrap aligned region5 v95, v25+64
+;; @0062                               v96 = load.i64 notrap aligned region2 v27+24
+;; @0062                               store notrap aligned region6 v96, v25+80
+;;                                     v189 = iconst.i32 0
+;;                                     v190 = iconst.i64 120
+;;                                     v191 = iadd.i64 v72, v190  ; v190 = 120
+;; @0062                               store notrap aligned region2 v189, v191  ; v189 = 0
+;; @0062                               store notrap aligned region2 v189, v191+4  ; v189 = 0
+;;                                     v192 = iconst.i64 0
+;; @0062                               store notrap aligned region2 v192, v191+8  ; v192 = 0
+;;                                     v193 = iconst.i64 136
+;;                                     v194 = iadd.i64 v72, v193  ; v193 = 136
+;; @0062                               store notrap aligned region2 v189, v194  ; v189 = 0
+;; @0062                               store notrap aligned region2 v189, v194+4  ; v189 = 0
+;; @0062                               store notrap aligned region2 v192, v194+8  ; v192 = 0
+;; @0062                               call fn2(v0)
+;; @0062                               trap user1
 ;;
 ;;                                 block7:
-;; @0062                               v82 = load.i64 notrap aligned region4 v25+72
-;; @0062                               store notrap aligned region2 v82, v68+8
-;; @0062                               v85 = load.i64 notrap aligned region2 v27
-;; @0062                               store notrap aligned region1 v85, v25+24
-;; @0062                               v86 = load.i64 notrap aligned region2 v27+8
-;; @0062                               store notrap aligned region4 v86, v25+72
-;; @0062                               v88 = load.i64 notrap aligned region2 v68+72
-;; @0062                               jump block8
+;; @0062                               v111 = load.i64 notrap aligned region4 v25+72
+;; @0062                               v112 = load.i64 notrap aligned region5 v25+64
+;; @0062                               v113 = load.i64 notrap aligned region6 v25+80
+;; @0062                               store notrap aligned region2 v111, v72+8
+;; @0062                               store notrap aligned region2 v112, v72+16
+;; @0062                               store notrap aligned region2 v113, v72+24
+;; @0062                               v116 = load.i64 notrap aligned region2 v27
+;; @0062                               store notrap aligned region1 v116, v25+24
+;; @0062                               v117 = load.i64 notrap aligned region2 v27+8
+;; @0062                               store notrap aligned region4 v117, v25+72
+;; @0062                               v118 = load.i64 notrap aligned region2 v27+16
+;; @0062                               store notrap aligned region5 v118, v25+64
+;; @0062                               v119 = load.i64 notrap aligned region2 v27+24
+;; @0062                               store notrap aligned region6 v119, v25+80
+;; @0062                               v121 = load.i64 notrap aligned region2 v72+88
+;; @0062                               jump block10
 ;;
-;;                                 block9 cold:
+;;                                 block11 cold:
 ;; @0062                               trap user12
 ;;
-;;                                 block10:
-;; @0062                               v95 = iconst.i64 120
-;; @0062                               v96 = iadd.i64 v68, v95  ; v95 = 120
-;; @0062                               v97 = load.i64 notrap aligned region2 v96+8
-;; @0062                               v98 = load.i32 notrap aligned region5 v97
-;;                                     v148 = iconst.i32 0
-;; @0062                               store notrap aligned region2 v148, v96  ; v148 = 0
+;;                                 block12:
+;; @0062                               v128 = iconst.i64 136
+;; @0062                               v129 = iadd.i64 v72, v128  ; v128 = 136
+;; @0062                               v130 = load.i64 notrap aligned region2 v129+8
+;; @0062                               v131 = load.i32 notrap aligned region7 v130
+;;                                     v184 = iconst.i32 0
+;; @0062                               store notrap aligned region2 v184, v129  ; v184 = 0
 ;; @0062                               jump block4
 ;;
-;;                                 block8:
-;; @0062                               v87 = ireduce.i32 v65
-;; @0062                               br_table v87, block9, [block10]
+;;                                 block10:
+;; @0062                               v120 = ireduce.i32 v69
+;; @0062                               br_table v120, block11, [block12]
 ;;
 ;;                                 block6:
-;; @0062                               v102 = load.i64 notrap aligned region2 v27
-;; @0062                               store notrap aligned region1 v102, v25+24
-;; @0062                               v103 = load.i64 notrap aligned region2 v27+8
-;; @0062                               store notrap aligned region4 v103, v25+72
-;; @0062                               v106 = iconst.i32 4
-;;                                     v144 = iconst.i64 16
-;;                                     v145 = iadd.i64 v68, v144  ; v144 = 16
-;; @0062                               store notrap aligned region2 v106, v145  ; v106 = 4
-;; @0062                               v109 = iconst.i64 104
-;; @0062                               v110 = iadd.i64 v68, v109  ; v109 = 104
-;; @0062                               v111 = load.i64 notrap aligned region2 v110+8
-;;                                     v146 = iconst.i32 0
-;; @0062                               store notrap aligned region2 v146, v110  ; v146 = 0
-;; @0062                               store notrap aligned region2 v146, v110+4  ; v146 = 0
-;;                                     v147 = iconst.i64 0
-;; @0062                               store notrap aligned region2 v147, v110+8  ; v147 = 0
+;; @0062                               v135 = load.i64 notrap aligned region2 v27
+;; @0062                               store notrap aligned region1 v135, v25+24
+;; @0062                               v136 = load.i64 notrap aligned region2 v27+8
+;; @0062                               store notrap aligned region4 v136, v25+72
+;; @0062                               v137 = load.i64 notrap aligned region2 v27+16
+;; @0062                               store notrap aligned region5 v137, v25+64
+;; @0062                               v138 = load.i64 notrap aligned region2 v27+24
+;; @0062                               store notrap aligned region6 v138, v25+80
+;; @0062                               v141 = iconst.i32 4
+;;                                     v180 = iconst.i64 32
+;;                                     v181 = iadd.i64 v72, v180  ; v180 = 32
+;; @0062                               store notrap aligned region2 v141, v181  ; v141 = 4
+;; @0062                               v144 = iconst.i64 120
+;; @0062                               v145 = iadd.i64 v72, v144  ; v144 = 120
+;; @0062                               v146 = load.i64 notrap aligned region2 v145+8
+;;                                     v182 = iconst.i32 0
+;; @0062                               store notrap aligned region2 v182, v145  ; v182 = 0
+;; @0062                               store notrap aligned region2 v182, v145+4  ; v182 = 0
+;;                                     v183 = iconst.i64 0
+;; @0062                               store notrap aligned region2 v183, v145+8  ; v183 = 0
 ;; @0068                               return
 ;;
 ;;                                 block4:
-;; @0062                               v90 = uextend.i128 v88
-;;                                     v149 = iconst.i64 64
-;;                                     v150 = ishl v90, v149  ; v149 = 64
-;; @0062                               v89 = uextend.i128 v68
-;; @0062                               v94 = bor v150, v89
-;; @006d                               jump block2(v94)
+;; @0062                               v123 = uextend.i128 v121
+;;                                     v185 = iconst.i64 64
+;;                                     v186 = ishl v123, v185  ; v185 = 64
+;; @0062                               v122 = uextend.i128 v72
+;; @0062                               v127 = bor v186, v122
+;; @006d                               jump block2(v127)
 ;; }

--- a/tests/disas/stack-switching/resume-suspend.wat
+++ b/tests/disas/stack-switching/resume-suspend.wat
@@ -38,7 +38,7 @@
 ;; @003b                               v5 = load.i64 notrap aligned region2 v4+88
 ;; @003b                               v6 = load.i64 notrap aligned region2 v4+96
 ;; @003b                               v9 = iconst.i64 1
-;; @003b                               v13 = iconst.i64 24
+;; @003b                               v13 = iconst.i64 40
 ;; @003b                               v17 = iconst.i32 0
 ;; @003b                               jump block2(v5, v6)
 ;;
@@ -49,12 +49,12 @@
 ;; @003b                               jump block3
 ;;
 ;;                                 block3:
-;; @003b                               v11 = load.i64 notrap aligned region3 v8+48
-;; @003b                               v12 = load.i64 notrap aligned region3 v8+56
-;;                                     v62 = iconst.i64 24
-;;                                     v63 = iadd v12, v62  ; v62 = 24
+;; @003b                               v11 = load.i64 notrap aligned region3 v8+64
+;; @003b                               v12 = load.i64 notrap aligned region3 v8+72
+;;                                     v62 = iconst.i64 40
+;;                                     v63 = iadd v12, v62  ; v62 = 40
 ;; @003b                               v15 = load.i64 notrap aligned region3 v63+8
-;; @003b                               v16 = load.i32 notrap aligned region3 v12+40
+;; @003b                               v16 = load.i32 notrap aligned region3 v12+56
 ;;                                     v64 = iconst.i32 0
 ;;                                     v54 = iconst.i32 3
 ;; @003b                               v2 = iconst.i64 48
@@ -79,16 +79,16 @@
 ;; @003b                               brif v68, block6, block4(v70)
 ;;
 ;;                                 block6:
-;; @003b                               store.i64 notrap aligned region3 v8, v6+64
+;; @003b                               store.i64 notrap aligned region3 v8, v6+80
 ;;                                     v71 = iconst.i32 3
-;; @003b                               v33 = iconst.i64 16
-;; @003b                               v34 = iadd.i64 v6, v33  ; v33 = 16
+;; @003b                               v33 = iconst.i64 32
+;; @003b                               v34 = iadd.i64 v6, v33  ; v33 = 32
 ;; @003b                               store notrap aligned region3 v71, v34  ; v71 = 3
 ;; @003b                               v30 = iconst.i64 0
-;; @003b                               store notrap aligned region3 v30, v8+48  ; v30 = 0
-;; @003b                               store notrap aligned region3 v30, v8+56  ; v30 = 0
-;; @003b                               v42 = iconst.i64 80
-;; @003b                               v43 = iadd.i64 v8, v42  ; v42 = 80
+;; @003b                               store notrap aligned region3 v30, v8+64  ; v30 = 0
+;; @003b                               store notrap aligned region3 v30, v8+72  ; v30 = 0
+;; @003b                               v42 = iconst.i64 96
+;; @003b                               v43 = iadd.i64 v8, v42  ; v42 = 96
 ;; @003b                               v44 = load.i64 notrap aligned region3 v43
 ;; @003b                               v45 = iconst.i64 -24
 ;; @003b                               v46 = iadd v44, v45  ; v45 = -24
@@ -96,8 +96,8 @@
 ;;                                     v57 = iconst.i64 0x0002_0000_0000
 ;;                                     v58 = bor v40, v57  ; v57 = 0x0002_0000_0000
 ;; @003b                               v47 = stack_switch v46, v46, v58
-;; @003b                               v28 = iconst.i64 120
-;; @003b                               v29 = iadd.i64 v6, v28  ; v28 = 120
+;; @003b                               v28 = iconst.i64 136
+;; @003b                               v29 = iadd.i64 v6, v28  ; v28 = 136
 ;; @003b                               v50 = load.i64 notrap aligned region3 v29+8
 ;;                                     v72 = iconst.i32 0
 ;; @003b                               store notrap aligned region3 v72, v29  ; v72 = 0
@@ -116,14 +116,18 @@
 ;;     region2 = 1073741824 "VMContRef+0x0"
 ;;     region3 = 67108952 "VMStoreContext+0x58"
 ;;     region4 = 67108936 "VMStoreContext+0x48"
-;;     region5 = 1140850688 "ContinuationStackMemory+0x0"
+;;     region5 = 67108928 "VMStoreContext+0x40"
+;;     region6 = 67108944 "VMStoreContext+0x50"
+;;     region7 = 1140850688 "ContinuationStackMemory+0x0"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i32) -> i64 tail
 ;;     sig1 = (i64 vmctx, i64, i32, i32) -> i64 tail
+;;     sig2 = (i64 vmctx) tail
 ;;     fn0 = colocated u805306368:6 sig0
 ;;     fn1 = colocated u805306368:42 sig1
+;;     fn2 = colocated u805306368:41 sig2
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
@@ -131,137 +135,189 @@
 ;; @0043                               v10 = call fn0(v0, v9)  ; v9 = 0
 ;; @0045                               trapz v10, user16
 ;; @0045                               v13 = call fn1(v0, v10, v9, v9)  ; v9 = 0, v9 = 0
-;; @0045                               v14 = load.i64 notrap aligned region2 v13+72
+;; @0045                               v14 = load.i64 notrap aligned region2 v13+88
 ;; @004e                               jump block3
 ;;
 ;;                                 block3:
 ;; @0045                               v16 = uextend.i128 v14
 ;; @0040                               v5 = iconst.i64 64
-;;                                     v130 = ishl v16, v5  ; v5 = 64
-;;                                     v132 = ireduce.i64 v130
-;;                                     v134 = bor v132, v13
-;; @004e                               trapz v134, user16
-;; @004e                               v26 = load.i64 notrap aligned region2 v134+72
+;;                                     v165 = ishl v16, v5  ; v5 = 64
+;;                                     v167 = ireduce.i64 v165
+;;                                     v169 = bor v167, v13
+;; @004e                               trapz v169, user16
+;; @004e                               v26 = load.i64 notrap aligned region2 v169+88
 ;; @0045                               v15 = uextend.i128 v13
-;; @0045                               v20 = bor v130, v15
-;;                                     v136 = ushr v20, v5  ; v5 = 64
-;; @004e                               v25 = ireduce.i64 v136
+;; @0045                               v20 = bor v165, v15
+;;                                     v171 = ushr v20, v5  ; v5 = 64
+;; @004e                               v25 = ireduce.i64 v171
 ;; @004e                               v27 = icmp eq v26, v25
 ;; @004e                               trapz v27, user23
 ;; @004e                               v28 = iconst.i64 1
 ;; @004e                               v29 = iadd v26, v28  ; v28 = 1
-;; @004e                               store notrap aligned region2 v29, v134+72
-;; @004e                               v30 = load.i64 notrap aligned region2 v134+64
+;; @004e                               store notrap aligned region2 v29, v169+88
+;; @004e                               v30 = load.i64 notrap aligned region2 v169+80
 ;; @004e                               v31 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @004e                               v32 = load.i64 notrap aligned region3 v31+88
 ;; @004e                               v33 = load.i64 notrap aligned region3 v31+96
-;; @004e                               store notrap aligned region2 v32, v30+48
-;; @004e                               store notrap aligned region2 v33, v30+56
+;; @004e                               store notrap aligned region2 v32, v30+64
+;; @004e                               store notrap aligned region2 v33, v30+72
 ;; @0040                               v2 = iconst.i64 0
-;; @004e                               store notrap aligned region2 v2, v134+64  ; v2 = 0
+;; @004e                               store notrap aligned region2 v2, v169+80  ; v2 = 0
 ;; @004e                               v35 = iconst.i64 2
 ;; @004e                               store notrap aligned region3 v35, v31+88  ; v35 = 2
-;; @004e                               store notrap aligned region3 v134, v31+96
+;; @004e                               store notrap aligned region3 v169, v31+96
 ;; @004e                               v39 = iconst.i32 1
-;; @004e                               v40 = iconst.i64 16
-;; @004e                               v41 = iadd v134, v40  ; v40 = 16
+;; @004e                               v40 = iconst.i64 32
+;; @004e                               v41 = iadd v169, v40  ; v40 = 32
 ;; @004e                               store notrap aligned region2 v39, v41  ; v39 = 1
 ;; @004e                               v42 = iconst.i32 2
-;; @004e                               v44 = iadd v33, v40  ; v40 = 16
+;; @004e                               v44 = iadd v33, v40  ; v40 = 32
 ;; @004e                               store notrap aligned region2 v42, v44  ; v42 = 2
 ;; @004e                               v48 = load.i64 notrap aligned region4 v31+72
+;; @004e                               v49 = load.i64 notrap aligned region5 v31+64
+;; @004e                               v50 = load.i64 notrap aligned region6 v31+80
 ;; @004e                               store notrap aligned region2 v48, v33+8
-;; @004e                               v49 = load.i64 notrap aligned region1 v31+24
-;; @004e                               store notrap aligned region2 v49, v33
-;; @004e                               v52 = load.i64 notrap aligned region2 v134
-;; @004e                               store notrap aligned region1 v52, v31+24
-;; @004e                               v53 = load.i64 notrap aligned region2 v134+8
-;; @004e                               store notrap aligned region4 v53, v31+72
-;; @004e                               v54 = iconst.i64 24
-;; @004e                               v55 = iadd v33, v54  ; v54 = 24
-;; @004e                               store notrap aligned region2 v39, v55+4  ; v39 = 1
-;; @004e                               v57 = stack_addr.i64 ss0
-;; @004e                               store notrap aligned region2 v57, v55+8
-;; @004e                               v58 = iconst.i64 48
-;; @004e                               v59 = iadd.i64 v0, v58  ; v58 = 48
-;; @004e                               store notrap aligned region5 v59, v57
-;; @004e                               store notrap aligned region2 v39, v55  ; v39 = 1
-;; @004e                               store notrap aligned region2 v39, v33+40  ; v39 = 1
-;; @004e                               v66 = iconst.i64 80
-;; @004e                               v67 = iadd v30, v66  ; v66 = 80
-;; @004e                               v68 = load.i64 notrap aligned region2 v67
-;; @004e                               v69 = iconst.i64 -24
-;; @004e                               v70 = iadd v68, v69  ; v69 = -24
-;;                                     v138 = iconst.i64 0x0001_0000_0000
-;; @004e                               v71 = stack_switch v70, v70, v138  ; v138 = 0x0001_0000_0000
-;; @004e                               v73 = load.i64 notrap aligned region3 v31+88
-;; @004e                               v74 = load.i64 notrap aligned region3 v31+96
+;; @004e                               store notrap aligned region2 v49, v33+16
+;; @004e                               store notrap aligned region2 v50, v33+24
+;; @004e                               v51 = load.i64 notrap aligned region1 v31+24
+;; @004e                               store notrap aligned region2 v51, v33
+;; @004e                               v54 = load.i64 notrap aligned region2 v169
+;; @004e                               store notrap aligned region1 v54, v31+24
+;; @004e                               v55 = load.i64 notrap aligned region2 v169+8
+;; @004e                               store notrap aligned region4 v55, v31+72
+;; @004e                               v56 = load.i64 notrap aligned region2 v169+16
+;; @004e                               store notrap aligned region5 v56, v31+64
+;; @004e                               v57 = load.i64 notrap aligned region2 v169+24
+;; @004e                               store notrap aligned region6 v57, v31+80
+;; @004e                               v58 = iconst.i64 40
+;; @004e                               v59 = iadd v33, v58  ; v58 = 40
+;; @004e                               store notrap aligned region2 v39, v59+4  ; v39 = 1
+;; @004e                               v61 = stack_addr.i64 ss0
+;; @004e                               store notrap aligned region2 v61, v59+8
+;; @004e                               v62 = iconst.i64 48
+;; @004e                               v63 = iadd.i64 v0, v62  ; v62 = 48
+;; @004e                               store notrap aligned region7 v63, v61
+;; @004e                               store notrap aligned region2 v39, v59  ; v39 = 1
+;; @004e                               store notrap aligned region2 v39, v33+56  ; v39 = 1
+;; @004e                               v70 = iconst.i64 96
+;; @004e                               v71 = iadd v30, v70  ; v70 = 96
+;; @004e                               v72 = load.i64 notrap aligned region2 v71
+;; @004e                               v73 = iconst.i64 -24
+;; @004e                               v74 = iadd v72, v73  ; v73 = -24
+;;                                     v173 = iconst.i64 0x0001_0000_0000
+;; @004e                               v75 = stack_switch v74, v74, v173  ; v173 = 0x0001_0000_0000
+;; @004e                               v77 = load.i64 notrap aligned region3 v31+88
+;; @004e                               v78 = load.i64 notrap aligned region3 v31+96
 ;; @004e                               store notrap aligned region3 v32, v31+88
 ;; @004e                               store notrap aligned region3 v33, v31+96
 ;; @004e                               store notrap aligned region2 v39, v44  ; v39 = 1
-;;                                     v141 = iconst.i32 0
-;; @004e                               store notrap aligned region2 v141, v55  ; v141 = 0
-;; @004e                               store notrap aligned region2 v141, v55+4  ; v141 = 0
-;; @004e                               store notrap aligned region2 v2, v55+8  ; v2 = 0
-;; @004e                               store notrap aligned region2 v2, v33+40  ; v2 = 0
-;; @004e                               v64 = iconst.i64 32
-;; @004e                               v83 = ushr v71, v64  ; v64 = 32
-;; @004e                               brif v83, block5, block4
+;;                                     v176 = iconst.i32 0
+;; @004e                               store notrap aligned region2 v176, v59  ; v176 = 0
+;; @004e                               store notrap aligned region2 v176, v59+4  ; v176 = 0
+;; @004e                               store notrap aligned region2 v2, v59+8  ; v2 = 0
+;; @004e                               store notrap aligned region2 v2, v33+56  ; v2 = 0
+;; @004e                               v87 = ushr v75, v40  ; v40 = 32
+;; @004e                               v88 = iconst.i64 4
+;; @004e                               v89 = icmp eq v87, v88  ; v88 = 4
+;; @004e                               brif v89, block6, block7
+;;
+;;                                 block7:
+;; @004e                               brif.i64 v87, block5, block4
+;;
+;;                                 block6 cold:
+;; @004e                               v94 = iconst.i32 5
+;;                                     v187 = iconst.i64 32
+;;                                     v188 = iadd.i64 v78, v187  ; v187 = 32
+;; @004e                               store notrap aligned region2 v94, v188  ; v94 = 5
+;; @004e                               v99 = load.i64 notrap aligned region2 v33
+;; @004e                               store notrap aligned region1 v99, v31+24
+;; @004e                               v100 = load.i64 notrap aligned region2 v33+8
+;; @004e                               store notrap aligned region4 v100, v31+72
+;; @004e                               v101 = load.i64 notrap aligned region2 v33+16
+;; @004e                               store notrap aligned region5 v101, v31+64
+;; @004e                               v102 = load.i64 notrap aligned region2 v33+24
+;; @004e                               store notrap aligned region6 v102, v31+80
+;;                                     v189 = iconst.i32 0
+;;                                     v190 = iconst.i64 120
+;;                                     v191 = iadd.i64 v78, v190  ; v190 = 120
+;; @004e                               store notrap aligned region2 v189, v191  ; v189 = 0
+;; @004e                               store notrap aligned region2 v189, v191+4  ; v189 = 0
+;;                                     v192 = iconst.i64 0
+;; @004e                               store notrap aligned region2 v192, v191+8  ; v192 = 0
+;;                                     v193 = iconst.i64 136
+;;                                     v194 = iadd.i64 v78, v193  ; v193 = 136
+;; @004e                               store notrap aligned region2 v189, v194  ; v189 = 0
+;; @004e                               store notrap aligned region2 v189, v194+4  ; v189 = 0
+;; @004e                               store notrap aligned region2 v192, v194+8  ; v192 = 0
+;; @004e                               call fn2(v0)
+;; @004e                               trap user1
 ;;
 ;;                                 block5:
-;; @004e                               v88 = load.i64 notrap aligned region4 v31+72
-;; @004e                               store notrap aligned region2 v88, v74+8
-;; @004e                               v91 = load.i64 notrap aligned region2 v33
-;; @004e                               store notrap aligned region1 v91, v31+24
-;; @004e                               v92 = load.i64 notrap aligned region2 v33+8
-;; @004e                               store notrap aligned region4 v92, v31+72
-;; @004e                               v94 = load.i64 notrap aligned region2 v74+72
-;; @004e                               jump block6
+;; @004e                               v117 = load.i64 notrap aligned region4 v31+72
+;; @004e                               v118 = load.i64 notrap aligned region5 v31+64
+;; @004e                               v119 = load.i64 notrap aligned region6 v31+80
+;; @004e                               store notrap aligned region2 v117, v78+8
+;; @004e                               store notrap aligned region2 v118, v78+16
+;; @004e                               store notrap aligned region2 v119, v78+24
+;; @004e                               v122 = load.i64 notrap aligned region2 v33
+;; @004e                               store notrap aligned region1 v122, v31+24
+;; @004e                               v123 = load.i64 notrap aligned region2 v33+8
+;; @004e                               store notrap aligned region4 v123, v31+72
+;; @004e                               v124 = load.i64 notrap aligned region2 v33+16
+;; @004e                               store notrap aligned region5 v124, v31+64
+;; @004e                               v125 = load.i64 notrap aligned region2 v33+24
+;; @004e                               store notrap aligned region6 v125, v31+80
+;; @004e                               v127 = load.i64 notrap aligned region2 v78+88
+;; @004e                               jump block8
 ;;
-;;                                 block7 cold:
+;;                                 block9 cold:
 ;; @004e                               trap user12
 ;;
-;;                                 block8:
-;; @004e                               v101 = iconst.i64 120
-;; @004e                               v102 = iadd.i64 v74, v101  ; v101 = 120
-;; @004e                               v103 = load.i64 notrap aligned region2 v102+8
-;;                                     v149 = iconst.i32 0
-;; @004e                               store notrap aligned region2 v149, v102  ; v149 = 0
-;; @004e                               v96 = uextend.i128 v94
-;;                                     v150 = iconst.i64 64
-;;                                     v151 = ishl v96, v150  ; v150 = 64
-;; @004e                               v95 = uextend.i128 v74
-;; @004e                               v100 = bor v151, v95
-;; @004e                               jump block2(v100)
+;;                                 block10:
+;; @004e                               v134 = iconst.i64 136
+;; @004e                               v135 = iadd.i64 v78, v134  ; v134 = 136
+;; @004e                               v136 = load.i64 notrap aligned region2 v135+8
+;;                                     v184 = iconst.i32 0
+;; @004e                               store notrap aligned region2 v184, v135  ; v184 = 0
+;; @004e                               v129 = uextend.i128 v127
+;;                                     v185 = iconst.i64 64
+;;                                     v186 = ishl v129, v185  ; v185 = 64
+;; @004e                               v128 = uextend.i128 v78
+;; @004e                               v133 = bor v186, v128
+;; @004e                               jump block2(v133)
 ;;
-;;                                 block6:
-;; @004e                               v93 = ireduce.i32 v71
-;; @004e                               br_table v93, block7, [block8]
+;;                                 block8:
+;; @004e                               v126 = ireduce.i32 v75
+;; @004e                               br_table v126, block9, [block10]
 ;;
 ;;                                 block4:
-;; @004e                               v107 = load.i64 notrap aligned region2 v33
-;; @004e                               store notrap aligned region1 v107, v31+24
-;; @004e                               v108 = load.i64 notrap aligned region2 v33+8
-;; @004e                               store notrap aligned region4 v108, v31+72
-;; @004e                               v111 = iconst.i32 4
-;;                                     v142 = iconst.i64 16
-;;                                     v143 = iadd.i64 v74, v142  ; v142 = 16
-;; @004e                               store notrap aligned region2 v111, v143  ; v111 = 4
-;; @004e                               v114 = iconst.i64 104
-;; @004e                               v115 = iadd.i64 v74, v114  ; v114 = 104
-;; @004e                               v116 = load.i64 notrap aligned region2 v115+8
-;;                                     v144 = iconst.i32 0
-;; @004e                               store notrap aligned region2 v144, v115  ; v144 = 0
-;; @004e                               store notrap aligned region2 v144, v115+4  ; v144 = 0
-;;                                     v145 = iconst.i64 0
-;; @004e                               store notrap aligned region2 v145, v115+8  ; v145 = 0
-;;                                     v146 = uextend.i128 v145  ; v145 = 0
-;;                                     v147 = iconst.i64 64
-;;                                     v148 = ishl v146, v147  ; v147 = 64
-;; @0040                               v8 = bor v148, v146
+;; @004e                               v140 = load.i64 notrap aligned region2 v33
+;; @004e                               store notrap aligned region1 v140, v31+24
+;; @004e                               v141 = load.i64 notrap aligned region2 v33+8
+;; @004e                               store notrap aligned region4 v141, v31+72
+;; @004e                               v142 = load.i64 notrap aligned region2 v33+16
+;; @004e                               store notrap aligned region5 v142, v31+64
+;; @004e                               v143 = load.i64 notrap aligned region2 v33+24
+;; @004e                               store notrap aligned region6 v143, v31+80
+;; @004e                               v146 = iconst.i32 4
+;;                                     v177 = iconst.i64 32
+;;                                     v178 = iadd.i64 v78, v177  ; v177 = 32
+;; @004e                               store notrap aligned region2 v146, v178  ; v146 = 4
+;; @004e                               v149 = iconst.i64 120
+;; @004e                               v150 = iadd.i64 v78, v149  ; v149 = 120
+;; @004e                               v151 = load.i64 notrap aligned region2 v150+8
+;;                                     v179 = iconst.i32 0
+;; @004e                               store notrap aligned region2 v179, v150  ; v179 = 0
+;; @004e                               store notrap aligned region2 v179, v150+4  ; v179 = 0
+;;                                     v180 = iconst.i64 0
+;; @004e                               store notrap aligned region2 v180, v150+8  ; v180 = 0
+;;                                     v181 = uextend.i128 v180  ; v180 = 0
+;;                                     v182 = iconst.i64 64
+;;                                     v183 = ishl v181, v182  ; v182 = 64
+;; @0040                               v8 = bor v183, v181
 ;; @0056                               jump block2(v8)
 ;;
-;;                                 block2(v127: i128):
+;;                                 block2(v162: i128):
 ;; @0058                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/stack-switching/symmetric-switch.wat
+++ b/tests/disas/stack-switching/symmetric-switch.wat
@@ -33,7 +33,9 @@
 ;;     region3 = 67108952 "VMStoreContext+0x58"
 ;;     region4 = 1140850688 "ContinuationStackMemory+0x0"
 ;;     region5 = 67108936 "VMStoreContext+0x48"
-;;     region6 = 1543503872 "Stack(ss0)"
+;;     region6 = 67108928 "VMStoreContext+0x40"
+;;     region7 = 67108944 "VMStoreContext+0x50"
+;;     region8 = 1543503872 "Stack(ss0)"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -50,7 +52,7 @@
 ;; @003c                               v4 = iconst.i32 1
 ;; @003c                               v5 = iconst.i32 0
 ;; @003c                               v6 = call fn1(v0, v3, v4, v5)  ; v4 = 1, v5 = 0
-;; @003c                               v7 = load.i64 notrap aligned region2 v6+72
+;; @003c                               v7 = load.i64 notrap aligned region2 v6+88
 ;; @003c                               v8 = uextend.i128 v6
 ;; @003c                               v9 = uextend.i128 v7
 ;; @003c                               v10 = iconst.i64 64
@@ -63,12 +65,12 @@
 ;; @003e                               v17 = ushr v13, v16
 ;; @003e                               v18 = ireduce.i64 v17
 ;; @003e                               trapz v14, user16
-;; @003e                               v19 = load.i64 notrap aligned region2 v14+72
+;; @003e                               v19 = load.i64 notrap aligned region2 v14+88
 ;; @003e                               v20 = icmp eq v19, v18
 ;; @003e                               trapz v20, user23
 ;; @003e                               v21 = iconst.i64 1
 ;; @003e                               v22 = iadd v19, v21  ; v21 = 1
-;; @003e                               store notrap aligned region2 v22, v14+72
+;; @003e                               store notrap aligned region2 v22, v14+88
 ;; @003e                               v23 = iconst.i64 48
 ;; @003e                               v24 = iadd v0, v23  ; v23 = 48
 ;; @003e                               v25 = load.i64 notrap aligned readonly can_move region0 v0+8
@@ -82,12 +84,12 @@
 ;; @003e                               brif v31, block7, block3
 ;;
 ;;                                 block3:
-;; @003e                               v32 = load.i64 notrap aligned region2 v29+48
-;; @003e                               v33 = load.i64 notrap aligned region2 v29+56
-;; @003e                               v34 = iconst.i64 24
-;; @003e                               v35 = iadd v33, v34  ; v34 = 24
+;; @003e                               v32 = load.i64 notrap aligned region2 v29+64
+;; @003e                               v33 = load.i64 notrap aligned region2 v29+72
+;; @003e                               v34 = iconst.i64 40
+;; @003e                               v35 = iadd v33, v34  ; v34 = 40
 ;; @003e                               v36 = load.i64 notrap aligned region2 v35+8
-;; @003e                               v37 = load.i32 notrap aligned region2 v33+40
+;; @003e                               v37 = load.i32 notrap aligned region2 v33+56
 ;; @003e                               v38 = load.i32 notrap aligned region2 v35
 ;; @003e                               jump block4(v37)
 ;;
@@ -110,125 +112,133 @@
 ;; @003e                               trap user22
 ;;
 ;;                                 block6:
-;; @003e                               store.i64 notrap aligned region2 v29, v27+64
-;; @003e                               v49 = iconst.i64 120
-;; @003e                               v50 = iadd.i64 v27, v49  ; v49 = 120
+;; @003e                               store.i64 notrap aligned region2 v29, v27+80
+;; @003e                               v49 = iconst.i64 136
+;; @003e                               v50 = iadd.i64 v27, v49  ; v49 = 136
 ;; @003e                               v51 = iconst.i64 0
 ;; @003e                               v52 = iadd.i64 v27, v51  ; v51 = 0
 ;; @003e                               v53 = iconst.i32 3
-;; @003e                               v54 = iconst.i64 16
-;; @003e                               v55 = iadd v52, v54  ; v54 = 16
+;; @003e                               v54 = iconst.i64 32
+;; @003e                               v55 = iadd v52, v54  ; v54 = 32
 ;; @003e                               store notrap aligned region2 v53, v55  ; v53 = 3
 ;; @003e                               v56 = iconst.i64 0
 ;; @003e                               v57 = iconst.i64 0
-;; @003e                               store notrap aligned region2 v56, v29+48  ; v56 = 0
-;; @003e                               store notrap aligned region2 v57, v29+56  ; v57 = 0
+;; @003e                               store notrap aligned region2 v56, v29+64  ; v56 = 0
+;; @003e                               store notrap aligned region2 v57, v29+72  ; v57 = 0
 ;; @003e                               v58 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @003e                               v59 = iconst.i64 0
 ;; @003e                               v60 = iadd v52, v59  ; v59 = 0
 ;; @003e                               v61 = load.i64 notrap aligned region5 v58+72
+;; @003e                               v62 = load.i64 notrap aligned region6 v58+64
+;; @003e                               v63 = load.i64 notrap aligned region7 v58+80
 ;; @003e                               store notrap aligned region2 v61, v60+8
-;; @003e                               v62 = load.i64 notrap aligned region2 v27+72
-;; @003e                               v63 = uextend.i128 v27
-;; @003e                               v64 = uextend.i128 v62
-;; @003e                               v65 = iconst.i64 64
-;; @003e                               v66 = uextend.i128 v65  ; v65 = 64
-;; @003e                               v67 = ishl v64, v66
-;; @003e                               v68 = bor v67, v63
-;; @003e                               v70 = iconst.i64 0
-;; @003e                               v71 = iadd.i64 v14, v70  ; v70 = 0
-;; @003e                               v72 = iconst.i64 16
-;; @003e                               v73 = iadd v71, v72  ; v72 = 16
-;; @003e                               v74 = load.i32 notrap aligned region2 v73
-;; @003e                               v75 = iconst.i32 0
-;; @003e                               v76 = icmp ne v74, v75  ; v75 = 0
-;; @003e                               brif v76, block9, block8
+;; @003e                               store notrap aligned region2 v62, v60+16
+;; @003e                               store notrap aligned region2 v63, v60+24
+;; @003e                               v64 = load.i64 notrap aligned region2 v27+88
+;; @003e                               v65 = uextend.i128 v27
+;; @003e                               v66 = uextend.i128 v64
+;; @003e                               v67 = iconst.i64 64
+;; @003e                               v68 = uextend.i128 v67  ; v67 = 64
+;; @003e                               v69 = ishl v66, v68
+;; @003e                               v70 = bor v69, v65
+;; @003e                               v72 = iconst.i64 0
+;; @003e                               v73 = iadd.i64 v14, v72  ; v72 = 0
+;; @003e                               v74 = iconst.i64 32
+;; @003e                               v75 = iadd v73, v74  ; v74 = 32
+;; @003e                               v76 = load.i32 notrap aligned region2 v75
+;; @003e                               v77 = iconst.i32 0
+;; @003e                               v78 = icmp ne v76, v77  ; v77 = 0
+;; @003e                               brif v78, block9, block8
 ;;
 ;;                                 block8:
-;; @003e                               v77 = iconst.i64 104
-;; @003e                               v78 = iadd.i64 v14, v77  ; v77 = 104
-;; @003e                               v79 = load.i64 notrap aligned region2 v78+8
-;; @003e                               v80 = load.i32 notrap aligned region2 v78
-;; @003e                               v81 = iconst.i32 1
-;; @003e                               v82 = iadd v80, v81  ; v81 = 1
-;; @003e                               store notrap aligned region2 v82, v78
-;; @003e                               v83 = uextend.i64 v80
-;; @003e                               v84 = iconst.i64 16
-;; @003e                               v85 = imul v83, v84  ; v84 = 16
-;; @003e                               v86 = iadd v79, v85
-;; @003e                               jump block10(v86)
+;; @003e                               v79 = iconst.i64 120
+;; @003e                               v80 = iadd.i64 v14, v79  ; v79 = 120
+;; @003e                               v81 = load.i64 notrap aligned region2 v80+8
+;; @003e                               v82 = load.i32 notrap aligned region2 v80
+;; @003e                               v83 = iconst.i32 1
+;; @003e                               v84 = iadd v82, v83  ; v83 = 1
+;; @003e                               store notrap aligned region2 v84, v80
+;; @003e                               v85 = uextend.i64 v82
+;; @003e                               v86 = iconst.i64 16
+;; @003e                               v87 = imul v85, v86  ; v86 = 16
+;; @003e                               v88 = iadd v81, v87
+;; @003e                               jump block10(v88)
 ;;
 ;;                                 block9:
-;; @003e                               v87 = iconst.i64 120
-;; @003e                               v88 = iadd.i64 v14, v87  ; v87 = 120
-;; @003e                               v89 = load.i64 notrap aligned region2 v88+8
-;; @003e                               v90 = load.i32 notrap aligned region2 v88
-;; @003e                               v91 = iconst.i32 1
-;; @003e                               v92 = iadd v90, v91  ; v91 = 1
-;; @003e                               store notrap aligned region2 v92, v88
-;; @003e                               v93 = uextend.i64 v90
-;; @003e                               v94 = iconst.i64 16
-;; @003e                               v95 = imul v93, v94  ; v94 = 16
-;; @003e                               v96 = iadd v89, v95
-;; @003e                               jump block10(v96)
+;; @003e                               v89 = iconst.i64 136
+;; @003e                               v90 = iadd.i64 v14, v89  ; v89 = 136
+;; @003e                               v91 = load.i64 notrap aligned region2 v90+8
+;; @003e                               v92 = load.i32 notrap aligned region2 v90
+;; @003e                               v93 = iconst.i32 1
+;; @003e                               v94 = iadd v92, v93  ; v93 = 1
+;; @003e                               store notrap aligned region2 v94, v90
+;; @003e                               v95 = uextend.i64 v92
+;; @003e                               v96 = iconst.i64 16
+;; @003e                               v97 = imul v95, v96  ; v96 = 16
+;; @003e                               v98 = iadd v91, v97
+;; @003e                               jump block10(v98)
 ;;
-;;                                 block10(v69: i64):
-;; @003e                               store.i128 notrap aligned region4 v68, v69
-;; @003e                               v97 = iconst.i64 0
-;; @003e                               v98 = iadd.i64 v14, v97  ; v97 = 0
-;; @003e                               v99 = iconst.i32 1
-;; @003e                               v100 = iconst.i64 16
-;; @003e                               v101 = iadd v98, v100  ; v100 = 16
-;; @003e                               store notrap aligned region2 v99, v101  ; v99 = 1
-;; @003e                               v102 = load.i64 notrap aligned region2 v14+64
-;; @003e                               store.i64 notrap aligned region2 v32, v102+48
-;; @003e                               store.i64 notrap aligned region2 v33, v102+56
-;; @003e                               v103 = iconst.i64 2
-;; @003e                               v104 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @003e                               store notrap aligned region3 v103, v104+88  ; v103 = 2
-;; @003e                               store.i64 notrap aligned region3 v14, v104+96
-;; @003e                               v105 = iconst.i64 0
-;; @003e                               v106 = iadd v98, v105  ; v105 = 0
-;; @003e                               v107 = load.i64 notrap aligned region2 v106
-;; @003e                               store notrap aligned region1 v107, v58+24
-;; @003e                               v108 = load.i64 notrap aligned region2 v106+8
-;; @003e                               store notrap aligned region5 v108, v58+72
-;; @003e                               v109 = iconst.i64 80
-;; @003e                               v110 = iadd.i64 v29, v109  ; v109 = 80
-;; @003e                               v111 = load.i64 notrap aligned region2 v110
-;; @003e                               v112 = iconst.i64 -24
-;; @003e                               v113 = iadd v111, v112  ; v112 = -24
-;; @003e                               v114 = iconst.i64 80
-;; @003e                               v115 = iadd v102, v114  ; v114 = 80
-;; @003e                               v116 = load.i64 notrap aligned region2 v115
-;; @003e                               v117 = iconst.i64 -24
-;; @003e                               v118 = iadd v116, v117  ; v117 = -24
-;; @003e                               v119 = stack_addr.i64 ss0
-;; @003e                               v120 = load.i64 notrap aligned region4 v118
-;; @003e                               store notrap aligned region6 v120, v119
-;; @003e                               v121 = load.i64 notrap aligned region4 v113
-;; @003e                               store notrap aligned region4 v121, v118
-;; @003e                               v122 = load.i64 notrap aligned region4 v118+8
-;; @003e                               store notrap aligned region6 v122, v119+8
-;; @003e                               v123 = load.i64 notrap aligned region4 v113+8
-;; @003e                               store notrap aligned region4 v123, v118+8
-;; @003e                               v124 = load.i64 notrap aligned region4 v118+16
-;; @003e                               store notrap aligned region6 v124, v119+16
-;; @003e                               v125 = load.i64 notrap aligned region4 v113+16
-;; @003e                               store notrap aligned region4 v125, v118+16
-;; @003e                               v126 = iconst.i64 3
-;; @003e                               v127 = iconst.i64 32
-;; @003e                               v128 = ishl v126, v127  ; v126 = 3, v127 = 32
-;; @003e                               v129 = stack_switch v113, v119, v128
-;; @003e                               v130 = iconst.i64 120
-;; @003e                               v131 = iadd.i64 v27, v130  ; v130 = 120
-;; @003e                               v132 = load.i64 notrap aligned region2 v131+8
-;; @003e                               v133 = iconst.i32 0
-;; @003e                               store notrap aligned region2 v133, v131  ; v133 = 0
-;; @003e                               v134 = iconst.i32 0
-;; @003e                               store notrap aligned region2 v134, v131+4  ; v134 = 0
-;; @003e                               v135 = iconst.i64 0
-;; @003e                               store notrap aligned region2 v135, v131+8  ; v135 = 0
+;;                                 block10(v71: i64):
+;; @003e                               store.i128 notrap aligned region4 v70, v71
+;; @003e                               v99 = iconst.i64 0
+;; @003e                               v100 = iadd.i64 v14, v99  ; v99 = 0
+;; @003e                               v101 = iconst.i32 1
+;; @003e                               v102 = iconst.i64 32
+;; @003e                               v103 = iadd v100, v102  ; v102 = 32
+;; @003e                               store notrap aligned region2 v101, v103  ; v101 = 1
+;; @003e                               v104 = load.i64 notrap aligned region2 v14+80
+;; @003e                               store.i64 notrap aligned region2 v32, v104+64
+;; @003e                               store.i64 notrap aligned region2 v33, v104+72
+;; @003e                               v105 = iconst.i64 2
+;; @003e                               v106 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @003e                               store notrap aligned region3 v105, v106+88  ; v105 = 2
+;; @003e                               store.i64 notrap aligned region3 v14, v106+96
+;; @003e                               v107 = iconst.i64 0
+;; @003e                               v108 = iadd v100, v107  ; v107 = 0
+;; @003e                               v109 = load.i64 notrap aligned region2 v108
+;; @003e                               store notrap aligned region1 v109, v58+24
+;; @003e                               v110 = load.i64 notrap aligned region2 v108+8
+;; @003e                               store notrap aligned region5 v110, v58+72
+;; @003e                               v111 = load.i64 notrap aligned region2 v108+16
+;; @003e                               store notrap aligned region6 v111, v58+64
+;; @003e                               v112 = load.i64 notrap aligned region2 v108+24
+;; @003e                               store notrap aligned region7 v112, v58+80
+;; @003e                               v113 = iconst.i64 96
+;; @003e                               v114 = iadd.i64 v29, v113  ; v113 = 96
+;; @003e                               v115 = load.i64 notrap aligned region2 v114
+;; @003e                               v116 = iconst.i64 -24
+;; @003e                               v117 = iadd v115, v116  ; v116 = -24
+;; @003e                               v118 = iconst.i64 96
+;; @003e                               v119 = iadd v104, v118  ; v118 = 96
+;; @003e                               v120 = load.i64 notrap aligned region2 v119
+;; @003e                               v121 = iconst.i64 -24
+;; @003e                               v122 = iadd v120, v121  ; v121 = -24
+;; @003e                               v123 = stack_addr.i64 ss0
+;; @003e                               v124 = load.i64 notrap aligned region4 v122
+;; @003e                               store notrap aligned region8 v124, v123
+;; @003e                               v125 = load.i64 notrap aligned region4 v117
+;; @003e                               store notrap aligned region4 v125, v122
+;; @003e                               v126 = load.i64 notrap aligned region4 v122+8
+;; @003e                               store notrap aligned region8 v126, v123+8
+;; @003e                               v127 = load.i64 notrap aligned region4 v117+8
+;; @003e                               store notrap aligned region4 v127, v122+8
+;; @003e                               v128 = load.i64 notrap aligned region4 v122+16
+;; @003e                               store notrap aligned region8 v128, v123+16
+;; @003e                               v129 = load.i64 notrap aligned region4 v117+16
+;; @003e                               store notrap aligned region4 v129, v122+16
+;; @003e                               v130 = iconst.i64 3
+;; @003e                               v131 = iconst.i64 32
+;; @003e                               v132 = ishl v130, v131  ; v130 = 3, v131 = 32
+;; @003e                               v133 = stack_switch v117, v123, v132
+;; @003e                               v134 = iconst.i64 136
+;; @003e                               v135 = iadd.i64 v27, v134  ; v134 = 136
+;; @003e                               v136 = load.i64 notrap aligned region2 v135+8
+;; @003e                               v137 = iconst.i32 0
+;; @003e                               store notrap aligned region2 v137, v135  ; v137 = 0
+;; @003e                               v138 = iconst.i32 0
+;; @003e                               store notrap aligned region2 v138, v135+4  ; v138 = 0
+;; @003e                               v139 = iconst.i64 0
+;; @003e                               store notrap aligned region2 v139, v135+8  ; v139 = 0
 ;; @0041                               jump block1
 ;;
 ;;                                 block1:
@@ -257,14 +267,18 @@
 ;;     region2 = 1073741824 "VMContRef+0x0"
 ;;     region3 = 67108952 "VMStoreContext+0x58"
 ;;     region4 = 67108936 "VMStoreContext+0x48"
-;;     region5 = 1140850688 "ContinuationStackMemory+0x0"
+;;     region5 = 67108928 "VMStoreContext+0x40"
+;;     region6 = 67108944 "VMStoreContext+0x50"
+;;     region7 = 1140850688 "ContinuationStackMemory+0x0"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i32) -> i64 tail
 ;;     sig1 = (i64 vmctx, i64, i32, i32) -> i64 tail
+;;     sig2 = (i64 vmctx) tail
 ;;     fn0 = colocated u805306368:6 sig0
 ;;     fn1 = colocated u805306368:42 sig1
+;;     fn2 = colocated u805306368:41 sig2
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
@@ -274,7 +288,7 @@
 ;; @0049                               v4 = iconst.i32 0
 ;; @0049                               v5 = iconst.i32 0
 ;; @0049                               v6 = call fn1(v0, v3, v4, v5)  ; v4 = 0, v5 = 0
-;; @0049                               v7 = load.i64 notrap aligned region2 v6+72
+;; @0049                               v7 = load.i64 notrap aligned region2 v6+88
 ;; @0049                               v8 = uextend.i128 v6
 ;; @0049                               v9 = uextend.i128 v7
 ;; @0049                               v10 = iconst.i64 64
@@ -290,20 +304,20 @@
 ;; @004b                               v17 = ushr.i128 v13, v16
 ;; @004b                               v18 = ireduce.i64 v17
 ;; @004b                               trapz v14, user16
-;; @004b                               v19 = load.i64 notrap aligned region2 v14+72
+;; @004b                               v19 = load.i64 notrap aligned region2 v14+88
 ;; @004b                               v20 = icmp eq v19, v18
 ;; @004b                               trapz v20, user23
 ;; @004b                               v21 = iconst.i64 1
 ;; @004b                               v22 = iadd v19, v21  ; v21 = 1
-;; @004b                               store notrap aligned region2 v22, v14+72
-;; @004b                               v23 = load.i64 notrap aligned region2 v14+64
+;; @004b                               store notrap aligned region2 v22, v14+88
+;; @004b                               v23 = load.i64 notrap aligned region2 v14+80
 ;; @004b                               v24 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @004b                               v25 = load.i64 notrap aligned region3 v24+88
 ;; @004b                               v26 = load.i64 notrap aligned region3 v24+96
-;; @004b                               store notrap aligned region2 v25, v23+48
-;; @004b                               store notrap aligned region2 v26, v23+56
+;; @004b                               store notrap aligned region2 v25, v23+64
+;; @004b                               store notrap aligned region2 v26, v23+72
 ;; @004b                               v27 = iconst.i64 0
-;; @004b                               store notrap aligned region2 v27, v14+64  ; v27 = 0
+;; @004b                               store notrap aligned region2 v27, v14+80  ; v27 = 0
 ;; @004b                               v28 = iconst.i64 2
 ;; @004b                               v29 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @004b                               store notrap aligned region3 v28, v29+88  ; v28 = 2
@@ -311,121 +325,184 @@
 ;; @004b                               v30 = iconst.i64 0
 ;; @004b                               v31 = iadd v14, v30  ; v30 = 0
 ;; @004b                               v32 = iconst.i32 1
-;; @004b                               v33 = iconst.i64 16
-;; @004b                               v34 = iadd v31, v33  ; v33 = 16
+;; @004b                               v33 = iconst.i64 32
+;; @004b                               v34 = iadd v31, v33  ; v33 = 32
 ;; @004b                               store notrap aligned region2 v32, v34  ; v32 = 1
 ;; @004b                               v35 = iconst.i32 2
-;; @004b                               v36 = iconst.i64 16
-;; @004b                               v37 = iadd v26, v36  ; v36 = 16
+;; @004b                               v36 = iconst.i64 32
+;; @004b                               v37 = iadd v26, v36  ; v36 = 32
 ;; @004b                               store notrap aligned region2 v35, v37  ; v35 = 2
 ;; @004b                               v38 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @004b                               v39 = iconst.i64 0
 ;; @004b                               v40 = iadd v26, v39  ; v39 = 0
 ;; @004b                               v41 = load.i64 notrap aligned region4 v38+72
+;; @004b                               v42 = load.i64 notrap aligned region5 v38+64
+;; @004b                               v43 = load.i64 notrap aligned region6 v38+80
 ;; @004b                               store notrap aligned region2 v41, v40+8
-;; @004b                               v42 = load.i64 notrap aligned region1 v38+24
-;; @004b                               store notrap aligned region2 v42, v40
-;; @004b                               v43 = iconst.i64 0
-;; @004b                               v44 = iadd v31, v43  ; v43 = 0
-;; @004b                               v45 = load.i64 notrap aligned region2 v44
-;; @004b                               store notrap aligned region1 v45, v38+24
-;; @004b                               v46 = load.i64 notrap aligned region2 v44+8
-;; @004b                               store notrap aligned region4 v46, v38+72
-;; @004b                               v47 = iconst.i64 24
-;; @004b                               v48 = iadd v26, v47  ; v47 = 24
-;; @004b                               v49 = iconst.i32 1
-;; @004b                               v50 = stack_addr.i64 ss0
-;; @004b                               store notrap aligned region2 v49, v48+4  ; v49 = 1
-;; @004b                               store notrap aligned region2 v50, v48+8
-;; @004b                               v51 = iconst.i64 48
-;; @004b                               v52 = iadd.i64 v0, v51  ; v51 = 48
+;; @004b                               store notrap aligned region2 v42, v40+16
+;; @004b                               store notrap aligned region2 v43, v40+24
+;; @004b                               v44 = load.i64 notrap aligned region1 v38+24
+;; @004b                               store notrap aligned region2 v44, v40
+;; @004b                               v45 = iconst.i64 0
+;; @004b                               v46 = iadd v31, v45  ; v45 = 0
+;; @004b                               v47 = load.i64 notrap aligned region2 v46
+;; @004b                               store notrap aligned region1 v47, v38+24
+;; @004b                               v48 = load.i64 notrap aligned region2 v46+8
+;; @004b                               store notrap aligned region4 v48, v38+72
+;; @004b                               v49 = load.i64 notrap aligned region2 v46+16
+;; @004b                               store notrap aligned region5 v49, v38+64
+;; @004b                               v50 = load.i64 notrap aligned region2 v46+24
+;; @004b                               store notrap aligned region6 v50, v38+80
+;; @004b                               v51 = iconst.i64 40
+;; @004b                               v52 = iadd v26, v51  ; v51 = 40
 ;; @004b                               v53 = iconst.i32 1
-;; @004b                               v54 = load.i64 notrap aligned region2 v48+8
-;; @004b                               store notrap aligned region5 v52, v54
-;; @004b                               store notrap aligned region2 v53, v48  ; v53 = 1
-;; @004b                               v55 = iconst.i32 0
-;; @004b                               store notrap aligned region2 v55, v26+40  ; v55 = 0
-;; @004b                               v56 = iconst.i64 1
-;; @004b                               v57 = iconst.i64 32
-;; @004b                               v58 = ishl v56, v57  ; v56 = 1, v57 = 32
-;; @004b                               v59 = iconst.i64 80
-;; @004b                               v60 = iadd v23, v59  ; v59 = 80
-;; @004b                               v61 = load.i64 notrap aligned region2 v60
-;; @004b                               v62 = iconst.i64 -24
-;; @004b                               v63 = iadd v61, v62  ; v62 = -24
-;; @004b                               v64 = stack_switch v63, v63, v58
-;; @004b                               v65 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @004b                               v66 = load.i64 notrap aligned region3 v65+88
-;; @004b                               v67 = load.i64 notrap aligned region3 v65+96
-;; @004b                               v68 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @004b                               store notrap aligned region3 v25, v68+88
-;; @004b                               store notrap aligned region3 v26, v68+96
-;; @004b                               v69 = iconst.i32 1
-;; @004b                               v70 = iconst.i64 16
-;; @004b                               v71 = iadd v26, v70  ; v70 = 16
-;; @004b                               store notrap aligned region2 v69, v71  ; v69 = 1
-;; @004b                               v72 = iconst.i32 0
-;; @004b                               store notrap aligned region2 v72, v48  ; v72 = 0
-;; @004b                               v73 = iconst.i32 0
-;; @004b                               store notrap aligned region2 v73, v48+4  ; v73 = 0
-;; @004b                               v74 = iconst.i64 0
-;; @004b                               store notrap aligned region2 v74, v48+8  ; v74 = 0
-;; @004b                               store notrap aligned region2 v27, v26+40  ; v27 = 0
-;; @004b                               v75 = iconst.i64 32
-;; @004b                               v76 = ushr v64, v75  ; v75 = 32
-;; @004b                               brif v76, block4, block3
+;; @004b                               v54 = stack_addr.i64 ss0
+;; @004b                               store notrap aligned region2 v53, v52+4  ; v53 = 1
+;; @004b                               store notrap aligned region2 v54, v52+8
+;; @004b                               v55 = iconst.i64 48
+;; @004b                               v56 = iadd.i64 v0, v55  ; v55 = 48
+;; @004b                               v57 = iconst.i32 1
+;; @004b                               v58 = load.i64 notrap aligned region2 v52+8
+;; @004b                               store notrap aligned region7 v56, v58
+;; @004b                               store notrap aligned region2 v57, v52  ; v57 = 1
+;; @004b                               v59 = iconst.i32 0
+;; @004b                               store notrap aligned region2 v59, v26+56  ; v59 = 0
+;; @004b                               v60 = iconst.i64 1
+;; @004b                               v61 = iconst.i64 32
+;; @004b                               v62 = ishl v60, v61  ; v60 = 1, v61 = 32
+;; @004b                               v63 = iconst.i64 96
+;; @004b                               v64 = iadd v23, v63  ; v63 = 96
+;; @004b                               v65 = load.i64 notrap aligned region2 v64
+;; @004b                               v66 = iconst.i64 -24
+;; @004b                               v67 = iadd v65, v66  ; v66 = -24
+;; @004b                               v68 = stack_switch v67, v67, v62
+;; @004b                               v69 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @004b                               v70 = load.i64 notrap aligned region3 v69+88
+;; @004b                               v71 = load.i64 notrap aligned region3 v69+96
+;; @004b                               v72 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @004b                               store notrap aligned region3 v25, v72+88
+;; @004b                               store notrap aligned region3 v26, v72+96
+;; @004b                               v73 = iconst.i32 1
+;; @004b                               v74 = iconst.i64 32
+;; @004b                               v75 = iadd v26, v74  ; v74 = 32
+;; @004b                               store notrap aligned region2 v73, v75  ; v73 = 1
+;; @004b                               v76 = iconst.i32 0
+;; @004b                               store notrap aligned region2 v76, v52  ; v76 = 0
+;; @004b                               v77 = iconst.i32 0
+;; @004b                               store notrap aligned region2 v77, v52+4  ; v77 = 0
+;; @004b                               v78 = iconst.i64 0
+;; @004b                               store notrap aligned region2 v78, v52+8  ; v78 = 0
+;; @004b                               store notrap aligned region2 v27, v26+56  ; v27 = 0
+;; @004b                               v79 = iconst.i64 32
+;; @004b                               v80 = ushr v68, v79  ; v79 = 32
+;; @004b                               v81 = iconst.i64 4
+;; @004b                               v82 = icmp eq v80, v81  ; v81 = 4
+;; @004b                               brif v82, block5, block6
+;;
+;;                                 block6:
+;; @004b                               v83 = iconst.i64 32
+;; @004b                               v84 = ushr.i64 v68, v83  ; v83 = 32
+;; @004b                               brif v84, block4, block3
+;;
+;;                                 block5 cold:
+;; @004b                               v85 = iconst.i64 0
+;; @004b                               v86 = iadd.i64 v71, v85  ; v85 = 0
+;; @004b                               v87 = iconst.i32 5
+;; @004b                               v88 = iconst.i64 32
+;; @004b                               v89 = iadd v86, v88  ; v88 = 32
+;; @004b                               store notrap aligned region2 v87, v89  ; v87 = 5
+;; @004b                               v90 = iconst.i64 0
+;; @004b                               v91 = iadd.i64 v26, v90  ; v90 = 0
+;; @004b                               v92 = load.i64 notrap aligned region2 v91
+;; @004b                               store notrap aligned region1 v92, v38+24
+;; @004b                               v93 = load.i64 notrap aligned region2 v91+8
+;; @004b                               store notrap aligned region4 v93, v38+72
+;; @004b                               v94 = load.i64 notrap aligned region2 v91+16
+;; @004b                               store notrap aligned region5 v94, v38+64
+;; @004b                               v95 = load.i64 notrap aligned region2 v91+24
+;; @004b                               store notrap aligned region6 v95, v38+80
+;; @004b                               v96 = iconst.i64 120
+;; @004b                               v97 = iadd.i64 v71, v96  ; v96 = 120
+;; @004b                               v98 = iconst.i32 0
+;; @004b                               store notrap aligned region2 v98, v97  ; v98 = 0
+;; @004b                               v99 = iconst.i32 0
+;; @004b                               store notrap aligned region2 v99, v97+4  ; v99 = 0
+;; @004b                               v100 = iconst.i64 0
+;; @004b                               store notrap aligned region2 v100, v97+8  ; v100 = 0
+;; @004b                               v101 = iconst.i64 136
+;; @004b                               v102 = iadd.i64 v71, v101  ; v101 = 136
+;; @004b                               v103 = iconst.i32 0
+;; @004b                               store notrap aligned region2 v103, v102  ; v103 = 0
+;; @004b                               v104 = iconst.i32 0
+;; @004b                               store notrap aligned region2 v104, v102+4  ; v104 = 0
+;; @004b                               v105 = iconst.i64 0
+;; @004b                               store notrap aligned region2 v105, v102+8  ; v105 = 0
+;; @004b                               call fn2(v0)
+;; @004b                               trap user1
 ;;
 ;;                                 block4:
-;; @004b                               v77 = iconst.i64 0
-;; @004b                               v78 = iadd.i64 v67, v77  ; v77 = 0
-;; @004b                               v79 = iconst.i64 0
-;; @004b                               v80 = iadd v78, v79  ; v79 = 0
-;; @004b                               v81 = load.i64 notrap aligned region4 v38+72
-;; @004b                               store notrap aligned region2 v81, v80+8
-;; @004b                               v82 = iconst.i64 0
-;; @004b                               v83 = iadd.i64 v26, v82  ; v82 = 0
-;; @004b                               v84 = load.i64 notrap aligned region2 v83
-;; @004b                               store notrap aligned region1 v84, v38+24
-;; @004b                               v85 = load.i64 notrap aligned region2 v83+8
-;; @004b                               store notrap aligned region4 v85, v38+72
-;; @004b                               v86 = ireduce.i32 v64
-;; @004b                               v87 = load.i64 notrap aligned region2 v67+72
-;; @004b                               v88 = uextend.i128 v67
-;; @004b                               v89 = uextend.i128 v87
-;; @004b                               v90 = iconst.i64 64
-;; @004b                               v91 = uextend.i128 v90  ; v90 = 64
-;; @004b                               v92 = ishl v89, v91
-;; @004b                               v93 = bor v92, v88
-;; @004b                               jump block5
+;; @004b                               v106 = iconst.i64 0
+;; @004b                               v107 = iadd.i64 v71, v106  ; v106 = 0
+;; @004b                               v108 = iconst.i64 0
+;; @004b                               v109 = iadd v107, v108  ; v108 = 0
+;; @004b                               v110 = load.i64 notrap aligned region4 v38+72
+;; @004b                               v111 = load.i64 notrap aligned region5 v38+64
+;; @004b                               v112 = load.i64 notrap aligned region6 v38+80
+;; @004b                               store notrap aligned region2 v110, v109+8
+;; @004b                               store notrap aligned region2 v111, v109+16
+;; @004b                               store notrap aligned region2 v112, v109+24
+;; @004b                               v113 = iconst.i64 0
+;; @004b                               v114 = iadd.i64 v26, v113  ; v113 = 0
+;; @004b                               v115 = load.i64 notrap aligned region2 v114
+;; @004b                               store notrap aligned region1 v115, v38+24
+;; @004b                               v116 = load.i64 notrap aligned region2 v114+8
+;; @004b                               store notrap aligned region4 v116, v38+72
+;; @004b                               v117 = load.i64 notrap aligned region2 v114+16
+;; @004b                               store notrap aligned region5 v117, v38+64
+;; @004b                               v118 = load.i64 notrap aligned region2 v114+24
+;; @004b                               store notrap aligned region6 v118, v38+80
+;; @004b                               v119 = ireduce.i32 v68
+;; @004b                               v120 = load.i64 notrap aligned region2 v71+88
+;; @004b                               v121 = uextend.i128 v71
+;; @004b                               v122 = uextend.i128 v120
+;; @004b                               v123 = iconst.i64 64
+;; @004b                               v124 = uextend.i128 v123  ; v123 = 64
+;; @004b                               v125 = ishl v122, v124
+;; @004b                               v126 = bor v125, v121
+;; @004b                               jump block7
 ;;
-;;                                 block6 cold:
+;;                                 block8 cold:
 ;; @004b                               trap user12
 ;;
-;;                                 block5:
-;; @004b                               br_table v86, block6, []
+;;                                 block7:
+;; @004b                               br_table v119, block8, []
 ;;
 ;;                                 block3:
-;; @004b                               v94 = iconst.i64 0
-;; @004b                               v95 = iadd.i64 v26, v94  ; v94 = 0
-;; @004b                               v96 = load.i64 notrap aligned region2 v95
-;; @004b                               store notrap aligned region1 v96, v38+24
-;; @004b                               v97 = load.i64 notrap aligned region2 v95+8
-;; @004b                               store notrap aligned region4 v97, v38+72
-;; @004b                               v98 = iconst.i64 0
-;; @004b                               v99 = iadd.i64 v67, v98  ; v98 = 0
-;; @004b                               v100 = iconst.i32 4
-;; @004b                               v101 = iconst.i64 16
-;; @004b                               v102 = iadd v99, v101  ; v101 = 16
-;; @004b                               store notrap aligned region2 v100, v102  ; v100 = 4
-;; @004b                               v103 = iconst.i64 104
-;; @004b                               v104 = iadd.i64 v67, v103  ; v103 = 104
-;; @004b                               v105 = load.i64 notrap aligned region2 v104+8
-;; @004b                               v106 = iconst.i32 0
-;; @004b                               store notrap aligned region2 v106, v104  ; v106 = 0
-;; @004b                               v107 = iconst.i32 0
-;; @004b                               store notrap aligned region2 v107, v104+4  ; v107 = 0
-;; @004b                               v108 = iconst.i64 0
-;; @004b                               store notrap aligned region2 v108, v104+8  ; v108 = 0
+;; @004b                               v127 = iconst.i64 0
+;; @004b                               v128 = iadd.i64 v26, v127  ; v127 = 0
+;; @004b                               v129 = load.i64 notrap aligned region2 v128
+;; @004b                               store notrap aligned region1 v129, v38+24
+;; @004b                               v130 = load.i64 notrap aligned region2 v128+8
+;; @004b                               store notrap aligned region4 v130, v38+72
+;; @004b                               v131 = load.i64 notrap aligned region2 v128+16
+;; @004b                               store notrap aligned region5 v131, v38+64
+;; @004b                               v132 = load.i64 notrap aligned region2 v128+24
+;; @004b                               store notrap aligned region6 v132, v38+80
+;; @004b                               v133 = iconst.i64 0
+;; @004b                               v134 = iadd.i64 v71, v133  ; v133 = 0
+;; @004b                               v135 = iconst.i32 4
+;; @004b                               v136 = iconst.i64 32
+;; @004b                               v137 = iadd v134, v136  ; v136 = 32
+;; @004b                               store notrap aligned region2 v135, v137  ; v135 = 4
+;; @004b                               v138 = iconst.i64 120
+;; @004b                               v139 = iadd.i64 v71, v138  ; v138 = 120
+;; @004b                               v140 = load.i64 notrap aligned region2 v139+8
+;; @004b                               v141 = iconst.i32 0
+;; @004b                               store notrap aligned region2 v141, v139  ; v141 = 0
+;; @004b                               v142 = iconst.i32 0
+;; @004b                               store notrap aligned region2 v142, v139+4  ; v142 = 0
+;; @004b                               v143 = iconst.i64 0
+;; @004b                               store notrap aligned region2 v143, v139+8  ; v143 = 0
 ;; @0050                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/misc_testsuite/stack-switching/trap.wast
+++ b/tests/misc_testsuite/stack-switching/trap.wast
@@ -1,0 +1,17 @@
+;;! stack_switching = true
+;;! reference_types = true
+;;! bulk_memory = true
+
+(module
+  (type $ft (func))
+  (type $ct (cont $ft))
+
+  (func $fn
+    (unreachable))
+
+  (func $run_fn (export "run_fn")
+    (resume $ct (cont.new $ct (ref.func $fn))))
+
+  (elem declare func $fn)
+)
+(assert_trap (invoke "run_fn") "unreachable")


### PR DESCRIPTION
This patch fixes a problem with traps on continuations, which would otherwise allow a Wasm program to continue running after invoking a trapping instruction. Currently, a fresh trap handler is installed per continuation stack, meaning that the effects of a trap is delimited by the stack segment on which the trap occurred -- whereas it really ought to be delimited by the top-level of the program (i.e. the part just before host/engine frames).