### PR TITLE
remove `Trap::AsyncDeadlock`

### DIFF
--- a/crates/environ/src/trap_encoding.rs
+++ b/crates/environ/src/trap_encoding.rs
@@ -103,11 +103,6 @@ pub enum Trap {
     /// compile time.
     DisabledOpcode,
 
-    /// Async event loop deadlocked; i.e. it cannot make further progress given
-    /// that all host tasks have completed and any/all host-owned stream/future
-    /// handles have been dropped.
-    AsyncDeadlock,
-
     /// When the `component-model` feature is enabled this trap represents a
     /// scenario where a component instance tried to call an import or intrinsic
     /// when it wasn't allowed to, e.g. from a post-return function.
@@ -152,7 +147,6 @@ impl Trap {
             UnhandledTag
             ContinuationAlreadyConsumed
             DisabledOpcode
-            AsyncDeadlock
             CannotLeaveComponent
         }
 
@@ -188,7 +182,6 @@ impl fmt::Display for Trap {
             UnhandledTag => "unhandled tag",
             ContinuationAlreadyConsumed => "continuation already consumed",
             DisabledOpcode => "pulley opcode disabled at compile time was executed",
-            AsyncDeadlock => "deadlock detected: event loop cannot make further progress",
             CannotLeaveComponent => "cannot leave component instance",
         };
         write!(f, "wasm trap: {desc}")


### PR DESCRIPTION
Previously, `Instance::run_concurrent` returned this when all guest tasks and background host tasks had completed, and yet the future parameter it was passed still hadn't resolved.  The theory was that this indicated a mistake on the host embedder's part, but it turns out there are scenarios where this is actually what the embedder wanted.

For example, consider a host embedder that implements a pool of worker tasks, each of which runs a loop inside async closure passed to `Instance::run_concurrent`.  In this case, each worker accepts jobs (which involve calling guest functions) from a multiple-producer, multiple-consumer job queue, adding them to a `futures::stream::FuturesUnordered` so they can be run concurrently.  When all the jobs accepted by a given worker have finished, there may be a lull during which no new jobs are yet available.  In that case, the worker _could_ break out of the loop, resolve the future, allow `Instance::run_concurrent` to finish, and wait until the next job arrives before calling `Instance::run_concurrent` again, but that's more awkward (i.e. nested loops, complicated control flow) than just a single loop inside `Instance::run_concurrent` that goes idle now and then.

In short, the closure passed to `Instance::run_concurrent` might experience delays between when a set of guest tasks have completed and when the next set are ready to start, and that's not necessarily a bug.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
