### PR TITLE
Re-enable single-pass regalloc in fuzzing

### DIFF
--- a/crates/fuzzing/src/generators/config.rs
+++ b/crates/fuzzing/src/generators/config.rs
@@ -838,18 +838,14 @@ impl OptLevel {
 #[derive(Arbitrary, Clone, Debug, PartialEq, Eq, Hash)]
 enum RegallocAlgorithm {
     Backtracking,
-    // FIXME(#11544 and #11545): rename back to `SinglePass` and handle below
-    // when those issues are fixed
-    TemporarilyDisabledSinglePass,
+    SinglePass,
 }
 
 impl RegallocAlgorithm {
     fn to_wasmtime(&self) -> wasmtime::RegallocAlgorithm {
         match self {
             RegallocAlgorithm::Backtracking => wasmtime::RegallocAlgorithm::Backtracking,
-            RegallocAlgorithm::TemporarilyDisabledSinglePass => {
-                wasmtime::RegallocAlgorithm::Backtracking
-            }
+            RegallocAlgorithm::SinglePass => wasmtime::RegallocAlgorithm::SinglePass,
         }
     }
 }

--- a/tests/all/stack_overflow.rs
+++ b/tests/all/stack_overflow.rs
@@ -152,8 +152,7 @@ fn big_stack_works_ok(config: &mut Config) -> Result<()> {
     // Disable cranelift optimizations to ensure that this test doesn't take too
     // long in debug mode due to the large size of its code.
     config.cranelift_opt_level(OptLevel::None);
-    // FIXME(#11544) helps make this test case faster
-    // config.cranelift_regalloc_algorithm(RegallocAlgorithm::SinglePass);
+    config.cranelift_regalloc_algorithm(RegallocAlgorithm::SinglePass);
     let engine = Engine::new(config)?;
 
     let mut store = Store::new(&engine, ());


### PR DESCRIPTION
Follow-up to #11712

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
