### PR TITLE
Add missing rotates for cranelift

### DIFF
--- a/cranelift/codegen/src/isle_prelude.rs
+++ b/cranelift/codegen/src/isle_prelude.rs
@@ -28,6 +28,42 @@ macro_rules! isle_common_prelude_methods {
         }
 
         #[inline]
+        fn imm64_rotl(&mut self, ty: Type, x: Imm64, k: Imm64) -> Imm64 {
+            let bw: u32 = ty.bits().min(64);
+            let amt: u32 = if bw == 0 { 0 } else { (k.bits() as u32) % bw };
+
+            let xv = x.bits() as u64;
+            let v = match bw {
+                8 => (xv as u8).rotate_left(amt) as u64,
+                16 => (xv as u16).rotate_left(amt) as u64,
+                32 => (xv as u32).rotate_left(amt) as u64,
+                64 => xv.rotate_left(amt),
+                _ => xv,
+            };
+
+            let masked = v & self.ty_mask(ty);
+            Imm64::new(masked as i64)
+        }
+
+        #[inline]
+        fn imm64_rotr(&mut self, ty: Type, x: Imm64, k: Imm64) -> Imm64 {
+            let bw: u32 = ty.bits().min(64);
+            let amt: u32 = if bw == 0 { 0 } else { (k.bits() as u32) % bw };
+
+            let xv = x.bits() as u64;
+            let v = match bw {
+                8 => (xv as u8).rotate_right(amt) as u64,
+                16 => (xv as u16).rotate_right(amt) as u64,
+                32 => (xv as u32).rotate_right(amt) as u64,
+                64 => xv.rotate_right(amt),
+                _ => xv,
+            };
+
+            let masked = v & self.ty_mask(ty);
+            Imm64::new(masked as i64)
+        }
+
+        #[inline]
         fn imm64_sdiv(&mut self, ty: Type, x: Imm64, y: Imm64) -> Option<Imm64> {
             // Sign extend `x` and `y`.
             let shift = u32::checked_sub(64, ty.bits()).unwrap_or(0);

--- a/cranelift/codegen/src/opts/cprop.isle
+++ b/cranelift/codegen/src/opts/cprop.isle
@@ -1,6 +1,18 @@
 ;; Constant propagation.
 
 (rule (simplify
+       (rotl (fits_in_64 ty)
+             (iconst ty kx)
+             (iconst ty kk)))
+      (subsume (iconst ty (imm64_rotl ty kx kk))))
+
+(rule (simplify
+       (rotr (fits_in_64 ty)
+             (iconst ty kx)
+             (iconst ty kk)))
+      (subsume (iconst ty (imm64_rotr ty kx kk))))
+
+(rule (simplify
        (iadd (fits_in_64 ty)
              (iconst ty (u64_from_imm64 k1))
              (iconst ty (u64_from_imm64 k2))))

--- a/cranelift/codegen/src/prelude.isle
+++ b/cranelift/codegen/src/prelude.isle
@@ -96,6 +96,12 @@
 (decl pure imm64_icmp (Type IntCC Imm64 Imm64) Imm64)
 (extern constructor imm64_icmp imm64_icmp)
 
+(decl pure imm64_rotl (Type Imm64 Imm64) Imm64)
+(extern constructor imm64_rotl imm64_rotl)
+
+(decl pure imm64_rotr (Type Imm64 Imm64) Imm64)
+(extern constructor imm64_rotr imm64_rotr)
+
 ;; Each of these extractors tests whether the upper half of the input equals the
 ;; lower half of the input
 (decl u128_replicated_u64 (u64) u128)


### PR DESCRIPTION
This adds the missed rotate optimizations in cranelift mid-end opened in #11722 

```wasm
(module
  (func $main (export "main") (result i32)
    ;; Step 1: (i32.rotl (i32.const 1) (i32.const 1))
    ;; 1 in binary (32-bit) = 0b...0001
    ;; Rotate left by 1 bit = 0b...0010 = 2
    (i32.rotl (i32.const 1) (i32.const 1))

    ;; Step 2: (i32.rotr (i32.const 10) (i32.const 1))
    ;; 10 in binary = 0b...1010
    ;; Rotate right by 1 bit = 0b...0101 = 5
    (i32.rotr (i32.const 10) (i32.const 1))

    ;; Step 3: Add the results
    ;; 2 + 5 = 7
    (i32.add)
  )
)
```

Before PR: 
```
;; Intermediate Representation of function <wasm[0]::function[0]::main>:
function u0:0(i64 vmctx, i64) -> i32 tail {
    gv0 = vmctx
    gv1 = load.i64 notrap aligned readonly gv0+8
    gv2 = load.i64 notrap aligned gv1+16
    stack_limit = gv2

                                block0(v0: i64, v1: i64):
@002d                               jump block1

                                block1:
@0022                               v3 = iconst.i32 1
@0026                               v5 = rotl v3, v3  ; v3 = 1, v3 = 1
@0027                               v6 = iconst.i32 10
@002b                               v8 = rotr v6, v3  ; v6 = 10, v3 = 1
@002c                               v9 = iadd v5, v8
@002d                               return v9
}
```

After PR:
```
;; Intermediate Representation of function <wasm[0]::function[0]::main>:
function u0:0(i64 vmctx, i64) -> i32 tail {
    gv0 = vmctx
    gv1 = load.i64 notrap aligned readonly gv0+8
    gv2 = load.i64 notrap aligned gv1+16
    stack_limit = gv2

                                block0(v0: i64, v1: i64):
@002d                               jump block1

                                block1:
                                    v12 = iconst.i32 7
@002d                               return v12  ; v12 = 7
}
```