### PR TITLE
Cranelift: use SP-offset amodes for `stack_addr`+load/store.

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/inst.isle
+++ b/cranelift/codegen/src/isa/aarch64/inst.isle
@@ -3899,6 +3899,11 @@
         (if-let new_offset (i32_checked_add x offset))
         (amode_no_more_iconst ty y new_offset))
 
+(rule 3
+      (amode ty (stack_addr slot offset1) offset2)
+      (AMode.SlotOffset
+       (abi_stackslot_offset_into_slot_region slot offset1 offset2)))
+
 (decl amode_no_more_iconst (Type Value i32) AMode)
 ;; Base case: move the `offset` into a register and add it to `val` via the
 ;; amode

--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -403,6 +403,15 @@
 (decl amode_to_synthetic_amode (Amode) SyntheticAmode)
 (extern constructor amode_to_synthetic_amode amode_to_synthetic_amode)
 
+(decl synthetic_amode_slot (i32) SyntheticAmode)
+(extern constructor synthetic_amode_slot synthetic_amode_slot)
+
+;; Helper for loads/stores to/from stackslots.
+(decl stackslot_amode (StackSlot Offset32 Offset32) SyntheticAmode)
+(rule (stackslot_amode slot offset1 offset2)
+      (let ((slot_offset i32 (abi_stackslot_offset_into_slot_region slot offset1 offset2)))
+        (synthetic_amode_slot slot_offset)))
+
 ;; An `Amode` represents a possible addressing mode that can be used
 ;; in instructions. These denote a 64-bit value only.
 (type Amode (enum
@@ -494,11 +503,15 @@
       (provide (= result (concat flags (bvadd val (sign_ext 64 offset)))))
       (require
             (= (widthof val) 64)))
-(decl to_amode (MemFlags Value Offset32) Amode)
+(decl to_amode (MemFlags Value Offset32) SyntheticAmode)
 (rule 0 (to_amode flags base offset)
         (amode_imm_reg flags base offset))
 (rule 1 (to_amode flags (iadd x y) offset)
         (to_amode_add flags x y offset))
+
+(rule 2
+      (to_amode flags (stack_addr slot offset1) offset2)
+      (stackslot_amode slot offset1 offset2))
 
 ;; Same as `to_amode`, except that the base address is computed via the addition
 ;; of the two `Value` arguments provided.
@@ -572,7 +585,7 @@
 
 ;; Offsetting an Amode. Used when we need to do consecutive
 ;; loads/stores to adjacent addresses.
-(decl amode_offset (Amode i32) Amode)
+(decl amode_offset (SyntheticAmode i32) SyntheticAmode)
 (extern constructor amode_offset amode_offset)
 
 ;; Return a zero offset as an `Offset32`.
@@ -1368,7 +1381,7 @@
 (rule 0 (x64_load (multi_lane _bits _lanes) addr _ext_kind)
       (x64_movdqu_load addr))
 
-(decl x64_mov (Amode) Reg)
+(decl x64_mov (SyntheticAmode) Reg)
 (spec (x64_mov addr)
       (provide (= result (conv_to 64 (load_effect (extract 79 64 addr) 64 (extract 63 0 addr))))))
 (rule (x64_mov addr) (x64_movq_rm addr))
@@ -2701,25 +2714,25 @@
 (decl x64_pextrb (Xmm u8) Gpr)
 (rule (x64_pextrb src lane) (x64_pextrb_a_or_avx src lane))
 
-(decl x64_pextrb_store (Amode Xmm u8) SideEffectNoResult)
+(decl x64_pextrb_store (SyntheticAmode Xmm u8) SideEffectNoResult)
 (rule (x64_pextrb_store addr src lane) (x64_pextrb_a_mem_or_avx addr src lane))
 
 (decl x64_pextrw (Xmm u8) Gpr)
 (rule (x64_pextrw src lane) (x64_pextrw_a_or_avx src lane))
 
-(decl x64_pextrw_store (Amode Xmm u8) SideEffectNoResult)
+(decl x64_pextrw_store (SyntheticAmode Xmm u8) SideEffectNoResult)
 (rule (x64_pextrw_store addr src lane) (x64_pextrw_b_mem_or_avx addr src lane))
 
 (decl x64_pextrd (Xmm u8) Gpr)
 (rule (x64_pextrd src lane) (x64_pextrd_a_or_avx src lane))
 
-(decl x64_pextrd_store (Amode Xmm u8) SideEffectNoResult)
+(decl x64_pextrd_store (SyntheticAmode Xmm u8) SideEffectNoResult)
 (rule (x64_pextrd_store addr src lane) (x64_pextrd_a_mem_or_avx addr src lane))
 
 (decl x64_pextrq (Xmm u8) Gpr)
 (rule (x64_pextrq src lane) (x64_pextrq_a_or_avx src lane))
 
-(decl x64_pextrq_store (Amode Xmm u8) SideEffectNoResult)
+(decl x64_pextrq_store (SyntheticAmode Xmm u8) SideEffectNoResult)
 (rule (x64_pextrq_store addr src lane) (x64_pextrq_a_mem_or_avx addr src lane))
 
 ;; Helper for creating `pmovmskb` instructions.
@@ -3181,7 +3194,7 @@
           )
           (x64_por low_gt_and_high_eq high_halves_gt)))
 
-(decl x64_add_mem (Type Amode Value) SideEffectNoResult)
+(decl x64_add_mem (Type SyntheticAmode Value) SideEffectNoResult)
 (spec (x64_add_mem ty addr val)
       (provide (= result (store_effect
                         (extract 79 64 addr)
@@ -3207,7 +3220,7 @@
 (rule 2 (x64_add_mem $I32 addr (i8_from_iconst val)) (x64_addl_mi_sxb_mem addr val))
 (rule 2 (x64_add_mem $I64 addr (i8_from_iconst val)) (x64_addq_mi_sxb_mem addr val))
 
-(decl x64_sub_mem (Type Amode Value) SideEffectNoResult)
+(decl x64_sub_mem (Type SyntheticAmode Value) SideEffectNoResult)
 
 ;; `sub mem, reg`
 (rule 0 (x64_sub_mem $I8 addr val) (x64_subb_mr_mem addr val))
@@ -3223,7 +3236,7 @@
 (rule 2 (x64_sub_mem $I32 addr (i8_from_iconst val)) (x64_subl_mi_sxb_mem addr val))
 (rule 2 (x64_sub_mem $I64 addr (i8_from_iconst val)) (x64_subq_mi_sxb_mem addr val))
 
-(decl x64_and_mem (Type Amode Value) SideEffectNoResult)
+(decl x64_and_mem (Type SyntheticAmode Value) SideEffectNoResult)
 
 ;; `and mem, imm`
 (rule (x64_and_mem $I8 addr val) (x64_andb_mr_mem addr val))
@@ -3241,7 +3254,7 @@
 (rule 2 (x64_and_mem $I32 addr (i8_from_iconst val)) (x64_andl_mi_sxb_mem addr val))
 (rule 2 (x64_and_mem $I64 addr (i8_from_iconst val)) (x64_andq_mi_sxb_mem addr val))
 
-(decl x64_or_mem (Type Amode Value) SideEffectNoResult)
+(decl x64_or_mem (Type SyntheticAmode Value) SideEffectNoResult)
 
 ;; `or mem, reg`
 (rule 0 (x64_or_mem $I8 addr val) (x64_orb_mr_mem addr val))
@@ -3259,7 +3272,7 @@
 (rule 2 (x64_or_mem $I32 addr (i8_from_iconst val)) (x64_orl_mi_sxb_mem addr val))
 (rule 2 (x64_or_mem $I64 addr (i8_from_iconst val)) (x64_orq_mi_sxb_mem addr val))
 
-(decl x64_xor_mem (Type Amode Value) SideEffectNoResult)
+(decl x64_xor_mem (Type SyntheticAmode Value) SideEffectNoResult)
 
 ;; `xor mem, reg`
 (rule 0 (x64_xor_mem $I8 addr val) (x64_xorb_mr_mem addr val))
@@ -3644,31 +3657,31 @@
 (rule (x64_xchg $I32 addr operand) (x64_xchgl_rm operand addr))
 (rule (x64_xchg $I64 addr operand) (x64_xchgq_rm operand addr))
 
-(decl x64_lock_add (OperandSize Amode Gpr) SideEffectNoResult)
+(decl x64_lock_add (OperandSize SyntheticAmode Gpr) SideEffectNoResult)
 (rule (x64_lock_add (OperandSize.Size8) addr reg)   (x64_lock_addb_mr_mem addr reg))
 (rule (x64_lock_add (OperandSize.Size16) addr reg)  (x64_lock_addw_mr_mem addr reg))
 (rule (x64_lock_add (OperandSize.Size32) addr reg)  (x64_lock_addl_mr_mem addr reg))
 (rule (x64_lock_add (OperandSize.Size64) addr reg)  (x64_lock_addq_mr_mem addr reg))
 
-(decl x64_lock_sub (OperandSize Amode Gpr) SideEffectNoResult)
+(decl x64_lock_sub (OperandSize SyntheticAmode Gpr) SideEffectNoResult)
 (rule (x64_lock_sub (OperandSize.Size8) addr reg)   (x64_lock_subb_mr_mem addr reg))
 (rule (x64_lock_sub (OperandSize.Size16) addr reg)  (x64_lock_subw_mr_mem addr reg))
 (rule (x64_lock_sub (OperandSize.Size32) addr reg)  (x64_lock_subl_mr_mem addr reg))
 (rule (x64_lock_sub (OperandSize.Size64) addr reg)  (x64_lock_subq_mr_mem addr reg))
 
-(decl x64_lock_and (OperandSize Amode Gpr) SideEffectNoResult)
+(decl x64_lock_and (OperandSize SyntheticAmode Gpr) SideEffectNoResult)
 (rule (x64_lock_and (OperandSize.Size8) addr reg)   (x64_lock_andb_mr_mem addr reg))
 (rule (x64_lock_and (OperandSize.Size16) addr reg)  (x64_lock_andw_mr_mem addr reg))
 (rule (x64_lock_and (OperandSize.Size32) addr reg)  (x64_lock_andl_mr_mem addr reg))
 (rule (x64_lock_and (OperandSize.Size64) addr reg)  (x64_lock_andq_mr_mem addr reg))
 
-(decl x64_lock_or (OperandSize Amode Gpr) SideEffectNoResult)
+(decl x64_lock_or (OperandSize SyntheticAmode Gpr) SideEffectNoResult)
 (rule (x64_lock_or (OperandSize.Size8) addr reg)   (x64_lock_orb_mr_mem addr reg))
 (rule (x64_lock_or (OperandSize.Size16) addr reg)  (x64_lock_orw_mr_mem addr reg))
 (rule (x64_lock_or (OperandSize.Size32) addr reg)  (x64_lock_orl_mr_mem addr reg))
 (rule (x64_lock_or (OperandSize.Size64) addr reg)  (x64_lock_orq_mr_mem addr reg))
 
-(decl x64_lock_xor (OperandSize Amode Gpr) SideEffectNoResult)
+(decl x64_lock_xor (OperandSize SyntheticAmode Gpr) SideEffectNoResult)
 (rule (x64_lock_xor (OperandSize.Size8) addr reg)   (x64_lock_xorb_mr_mem addr reg))
 (rule (x64_lock_xor (OperandSize.Size16) addr reg)  (x64_lock_xorw_mr_mem addr reg))
 (rule (x64_lock_xor (OperandSize.Size32) addr reg)  (x64_lock_xorl_mr_mem addr reg))

--- a/cranelift/codegen/src/isa/x64/inst/args.rs
+++ b/cranelift/codegen/src/isa/x64/inst/args.rs
@@ -573,6 +573,21 @@ impl SyntheticAmode {
             | SyntheticAmode::ConstantOffset { .. } => true,
         }
     }
+
+    /// Offset the synthetic amode by a fixed offset.
+    pub(crate) fn offset(&self, offset: i32) -> Self {
+        let mut ret = self.clone();
+        match &mut ret {
+            SyntheticAmode::Real(amode) => *amode = amode.offset(offset),
+            SyntheticAmode::SlotOffset { simm32 } => *simm32 += offset,
+            // `amode_offset` is used only in i128.load/store which
+            // takes a synthetic amode from `to_amode`; `to_amode` can
+            // only produce Real or SlotOffset amodes, never
+            // IncomingArg or ConstantOffset.
+            _ => panic!("Cannot offset SyntheticAmode: {self:?}"),
+        }
+        ret
+    }
 }
 
 impl From<Amode> for SyntheticAmode {

--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -3056,8 +3056,8 @@
 ;; We can load an I128 by doing two 64-bit loads.
 (rule -3 (lower (has_type $I128
                        (load (little_or_native_endian flags) address offset)))
-      (let ((addr_lo Amode (to_amode flags address offset))
-            (addr_hi Amode (amode_offset addr_lo 8))
+      (let ((addr_lo SyntheticAmode (to_amode flags address offset))
+            (addr_hi SyntheticAmode (amode_offset addr_lo 8))
             (value_lo Reg (x64_mov addr_lo))
             (value_hi Reg (x64_mov addr_hi)))
         (value_regs value_lo value_hi)))
@@ -3187,8 +3187,8 @@
       (let ((value_reg ValueRegs value)
             (value_lo Gpr (value_regs_get_gpr value_reg 0))
             (value_hi Gpr (value_regs_get_gpr value_reg 1))
-            (addr_lo Amode (to_amode flags address offset))
-            (addr_hi Amode (amode_offset addr_lo 8)))
+            (addr_lo SyntheticAmode (to_amode flags address offset))
+            (addr_hi SyntheticAmode (amode_offset addr_lo 8)))
       (side_effect
        (side_effect_concat
         (x64_movrm $I64 addr_lo value_lo)

--- a/cranelift/codegen/src/isa/x64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/x64/lower/isle.rs
@@ -410,6 +410,11 @@ impl Context for IsleContext<'_, '_, MInst, X64Backend> {
     }
 
     #[inline]
+    fn synthetic_amode_slot(&mut self, offset: i32) -> SyntheticAmode {
+        SyntheticAmode::SlotOffset { simm32: offset }
+    }
+
+    #[inline]
     fn const_to_synthetic_amode(&mut self, c: VCodeConstant) -> SyntheticAmode {
         SyntheticAmode::ConstantOffset(c)
     }
@@ -633,7 +638,7 @@ impl Context for IsleContext<'_, '_, MInst, X64Backend> {
     }
 
     #[inline]
-    fn amode_offset(&mut self, addr: &Amode, offset: i32) -> Amode {
+    fn amode_offset(&mut self, addr: &SyntheticAmode, offset: i32) -> SyntheticAmode {
         addr.offset(offset)
     }
 

--- a/cranelift/codegen/src/machinst/abi.rs
+++ b/cranelift/codegen/src/machinst/abi.rs
@@ -2139,6 +2139,11 @@ impl<M: ABIMachineSpec> Callee<M> {
         }
     }
 
+    /// Get the raw offset of a sized stackslot in the slot region.
+    pub fn sized_stackslot_offset(&self, slot: StackSlot) -> u32 {
+        self.sized_stackslots[slot]
+    }
+
     /// Produce an instruction that computes a sized stackslot address.
     pub fn sized_stackslot_addr(
         &self,

--- a/cranelift/codegen/src/machinst/isle.rs
+++ b/cranelift/codegen/src/machinst/isle.rs
@@ -507,6 +507,22 @@ macro_rules! isle_lower_prelude_methods {
                 .into()
         }
 
+        fn abi_stackslot_offset_into_slot_region(
+            &mut self,
+            stack_slot: StackSlot,
+            offset1: Offset32,
+            offset2: Offset32,
+        ) -> i32 {
+            let offset1 = i32::from(offset1);
+            let offset2 = i32::from(offset2);
+            i32::try_from(self.lower_ctx.abi().sized_stackslot_offset(stack_slot))
+                .expect("Stack slot region cannot be larger than 2GiB")
+                .checked_add(offset1)
+                .expect("Stack slot region cannot be larger than 2GiB")
+                .checked_add(offset2)
+                .expect("Stack slot region cannot be larger than 2GiB")
+        }
+
         fn abi_dynamic_stackslot_addr(
             &mut self,
             dst: WritableReg,

--- a/cranelift/codegen/src/prelude_lower.isle
+++ b/cranelift/codegen/src/prelude_lower.isle
@@ -1119,6 +1119,10 @@
 (decl abi_stackslot_addr (WritableReg StackSlot Offset32) MInst)
 (extern constructor abi_stackslot_addr abi_stackslot_addr)
 
+;; StackSlot raw offset into slot region
+(decl abi_stackslot_offset_into_slot_region (StackSlot Offset32 Offset32) i32)
+(extern constructor abi_stackslot_offset_into_slot_region abi_stackslot_offset_into_slot_region)
+
 ;; DynamicStackSlot addr
 (decl abi_dynamic_stackslot_addr (WritableReg DynamicStackSlot) MInst)
 (extern constructor abi_dynamic_stackslot_addr abi_dynamic_stackslot_addr)

--- a/cranelift/filetests/filetests/isa/aarch64/dynamic-slot.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/dynamic-slot.clif
@@ -16,9 +16,8 @@ block0:
 ;   mov fp, sp
 ;   sub sp, sp, #16
 ; block0:
-;   movz x1, #1
-;   mov x2, sp
-;   str x1, [x2]
+;   movz x0, #1
+;   str x0, [sp]
 ;   add sp, sp, #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
@@ -29,9 +28,8 @@ block0:
 ;   mov x29, sp
 ;   sub sp, sp, #0x10
 ; block1: ; offset 0xc
-;   mov x1, #1
-;   mov x2, sp
-;   str x1, [x2]
+;   mov x0, #1
+;   stur x0, [sp]
 ;   add sp, sp, #0x10
 ;   ldp x29, x30, [sp], #0x10
 ;   ret
@@ -51,9 +49,8 @@ block0:
 ;   mov fp, sp
 ;   sub sp, sp, #16
 ; block0:
-;   movz x1, #1
-;   mov x2, sp
-;   str x1, [x2]
+;   movz x0, #1
+;   str x0, [sp]
 ;   add sp, sp, #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
@@ -64,9 +61,8 @@ block0:
 ;   mov x29, sp
 ;   sub sp, sp, #0x10
 ; block1: ; offset 0xc
-;   mov x1, #1
-;   mov x2, sp
-;   str x1, [x2]
+;   mov x0, #1
+;   stur x0, [sp]
 ;   add sp, sp, #0x10
 ;   ldp x29, x30, [sp], #0x10
 ;   ret

--- a/cranelift/filetests/filetests/isa/aarch64/stack.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/stack.clif
@@ -82,8 +82,7 @@ block0:
 ;   mov fp, sp
 ;   sub sp, sp, #16
 ; block0:
-;   mov x1, sp
-;   ldr x0, [x1]
+;   ldr x0, [sp]
 ;   add sp, sp, #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
@@ -94,8 +93,7 @@ block0:
 ;   mov x29, sp
 ;   sub sp, sp, #0x10
 ; block1: ; offset 0xc
-;   mov x1, sp
-;   ldr x0, [x1]
+;   ldur x0, [sp]
 ;   add sp, sp, #0x10
 ;   ldp x29, x30, [sp], #0x10
 ;   ret
@@ -116,8 +114,7 @@ block0:
 ;   movk w16, w16, #1, LSL #16
 ;   sub sp, sp, x16, UXTX
 ; block0:
-;   mov x1, sp
-;   ldr x0, [x1]
+;   ldr x0, [sp]
 ;   movz w16, #34480
 ;   movk w16, w16, #1, LSL #16
 ;   add sp, sp, x16, UXTX
@@ -132,8 +129,7 @@ block0:
 ;   movk w16, #1, lsl #16
 ;   sub sp, sp, x16
 ; block1: ; offset 0x14
-;   mov x1, sp
-;   ldr x0, [x1]
+;   ldur x0, [sp]
 ;   mov w16, #0x86b0
 ;   movk w16, #1, lsl #16
 ;   add sp, sp, x16
@@ -153,8 +149,7 @@ block0(v0: i64):
 ;   mov fp, sp
 ;   sub sp, sp, #16
 ; block0:
-;   mov x2, sp
-;   str x0, [x2]
+;   str x0, [sp]
 ;   add sp, sp, #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
@@ -165,8 +160,7 @@ block0(v0: i64):
 ;   mov x29, sp
 ;   sub sp, sp, #0x10
 ; block1: ; offset 0xc
-;   mov x2, sp
-;   str x0, [x2]
+;   stur x0, [sp]
 ;   add sp, sp, #0x10
 ;   ldp x29, x30, [sp], #0x10
 ;   ret
@@ -187,8 +181,7 @@ block0(v0: i64):
 ;   movk w16, w16, #1, LSL #16
 ;   sub sp, sp, x16, UXTX
 ; block0:
-;   mov x2, sp
-;   str x0, [x2]
+;   str x0, [sp]
 ;   movz w16, #34480
 ;   movk w16, w16, #1, LSL #16
 ;   add sp, sp, x16, UXTX
@@ -203,8 +196,7 @@ block0(v0: i64):
 ;   movk w16, #1, lsl #16
 ;   sub sp, sp, x16
 ; block1: ; offset 0x14
-;   mov x2, sp
-;   str x0, [x2]
+;   stur x0, [sp]
 ;   mov w16, #0x86b0
 ;   movk w16, #1, lsl #16
 ;   add sp, sp, x16

--- a/cranelift/filetests/filetests/isa/aarch64/stackslot.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/stackslot.clif
@@ -1,0 +1,60 @@
+test compile precise-output
+set enable_multi_ret_implicit_sret
+target aarch64
+
+function %f1(i32, i64, f32, f64, i8x16) -> i32, i64, f32, f64, i8x16 {
+  ss0 = explicit_slot 40
+
+block0(v0: i32, v1: i64, v2: f32, v3: f64, v4: i8x16):
+  stack_store v0, ss0+0
+  stack_store v1, ss0+4
+  stack_store v2, ss0+12
+  stack_store v3, ss0+16
+  stack_store v4, ss0+24
+  v5 = stack_load.i32 ss0+0
+  v6 = stack_load.i64 ss0+4
+  v7 = stack_load.f32 ss0+12
+  v8 = stack_load.f64 ss0+16
+  v9 = stack_load.i8x16 ss0+24
+  return v5, v6, v7, v8, v9
+}
+
+; VCode:
+;   stp fp, lr, [sp, #-16]!
+;   mov fp, sp
+;   sub sp, sp, #48
+; block0:
+;   str w0, [sp]
+;   str x1, [sp, #4]
+;   str s0, [sp, #12]
+;   str d1, [sp, #16]
+;   str q2, [sp, #24]
+;   ldr w0, [sp]
+;   ldr x1, [sp, #4]
+;   ldr s0, [sp, #12]
+;   ldr d1, [sp, #16]
+;   ldr q2, [sp, #24]
+;   add sp, sp, #48
+;   ldp fp, lr, [sp], #16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   sub sp, sp, #0x30
+; block1: ; offset 0xc
+;   stur w0, [sp]
+;   stur x1, [sp, #4]
+;   stur s0, [sp, #0xc]
+;   stur d1, [sp, #0x10]
+;   stur q2, [sp, #0x18]
+;   ldur w0, [sp]
+;   ldur x1, [sp, #4]
+;   ldur s0, [sp, #0xc]
+;   ldur d1, [sp, #0x10]
+;   ldur q2, [sp, #0x18]
+;   add sp, sp, #0x30
+;   ldp x29, x30, [sp], #0x10
+;   ret
+

--- a/cranelift/filetests/filetests/isa/aarch64/user_stack_maps.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/user_stack_maps.clif
@@ -34,39 +34,33 @@ block0:
 ; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
-;   str x28, [sp, #-16]!
-;   stp x19, x21, [sp, #-16]!
+;   str x24, [sp, #-16]!
+;   stp x22, x23, [sp, #-16]!
 ;   sub sp, sp, #16
 ; block0:
-;   movz w19, #0
-;   movz w28, #1
-;   movz w21, #2
-;   mov x8, sp
-;   str w19, [x8]
-;   add x9, sp, #4
-;   str w28, [x9]
-;   add x10, sp, #8
-;   str w21, [x10]
-;   mov x0, x19
+;   movz w24, #0
+;   movz w22, #1
+;   movz w23, #2
+;   str w24, [sp]
+;   str w22, [sp, #4]
+;   str w23, [sp, #8]
+;   mov x0, x24
 ;   bl 0
 ;   ; UserStackMap { by_type: [(types::I32, CompoundBitSet {0, 4, 8})], sp_to_sized_stack_slots: None }
-;   mov x12, sp
-;   str w28, [x12]
-;   add x13, sp, #4
-;   str w21, [x13]
-;   mov x0, x19
+;   str w22, [sp]
+;   str w23, [sp, #4]
+;   mov x0, x24
 ;   bl 0
 ;   ; UserStackMap { by_type: [(types::I32, CompoundBitSet {0, 4})], sp_to_sized_stack_slots: None }
-;   mov x15, sp
-;   str w21, [x15]
-;   mov x0, x28
+;   str w23, [sp]
+;   mov x0, x22
 ;   bl 0
 ;   ; UserStackMap { by_type: [(types::I32, CompoundBitSet {0})], sp_to_sized_stack_slots: None }
-;   mov x0, x21
+;   mov x0, x23
 ;   bl 0
 ;   add sp, sp, #16
-;   ldp x19, x21, [sp], #16
-;   ldr x28, [sp], #16
+;   ldp x22, x23, [sp], #16
+;   ldr x24, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
 ;
@@ -74,36 +68,30 @@ block0:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
-;   str x28, [sp, #-0x10]!
-;   stp x19, x21, [sp, #-0x10]!
+;   str x24, [sp, #-0x10]!
+;   stp x22, x23, [sp, #-0x10]!
 ;   sub sp, sp, #0x10
 ; block1: ; offset 0x14
-;   mov w19, #0
-;   mov w28, #1
-;   mov w21, #2
-;   mov x8, sp
-;   str w19, [x8]
-;   add x9, sp, #4
-;   str w28, [x9]
-;   add x10, sp, #8
-;   str w21, [x10]
-;   mov x0, x19
-;   bl #0x3c ; reloc_external Call u0:0 0
-;   mov x12, sp
-;   str w28, [x12]
-;   add x13, sp, #4
-;   str w21, [x13]
-;   mov x0, x19
+;   mov w24, #0
+;   mov w22, #1
+;   mov w23, #2
+;   stur w24, [sp]
+;   stur w22, [sp, #4]
+;   stur w23, [sp, #8]
+;   mov x0, x24
+;   bl #0x30 ; reloc_external Call u0:0 0
+;   stur w22, [sp]
+;   stur w23, [sp, #4]
+;   mov x0, x24
+;   bl #0x40 ; reloc_external Call u0:0 0
+;   stur w23, [sp]
+;   mov x0, x22
+;   bl #0x4c ; reloc_external Call u0:0 0
+;   mov x0, x23
 ;   bl #0x54 ; reloc_external Call u0:0 0
-;   mov x15, sp
-;   str w21, [x15]
-;   mov x0, x28
-;   bl #0x64 ; reloc_external Call u0:0 0
-;   mov x0, x21
-;   bl #0x6c ; reloc_external Call u0:0 0
 ;   add sp, sp, #0x10
-;   ldp x19, x21, [sp], #0x10
-;   ldr x28, [sp], #0x10
+;   ldp x22, x23, [sp], #0x10
+;   ldr x24, [sp], #0x10
 ;   ldp x29, x30, [sp], #0x10
 ;   ret
 
@@ -130,39 +118,33 @@ block0(v0: i8, v1: i16, v2: i32, v3: i64, v4: f32, v5: f64):
 ; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
-;   stp x23, x26, [sp, #-16]!
-;   stp x19, x21, [sp, #-16]!
+;   stp x24, x27, [sp, #-16]!
+;   stp x19, x23, [sp, #-16]!
 ;   sub sp, sp, #128
 ; block0:
-;   mov x12, sp
-;   strb w0, [x12]
-;   mov x21, x0
-;   add x13, sp, #8
-;   strh w1, [x13]
-;   mov x26, x1
-;   add x14, sp, #16
-;   str w2, [x14]
-;   mov x23, x2
-;   add x15, sp, #20
-;   str s0, [x15]
+;   strb w0, [sp]
+;   mov x23, x0
+;   strh w1, [sp, #8]
+;   mov x19, x1
+;   str w2, [sp, #16]
+;   mov x27, x2
+;   str s0, [sp, #20]
 ;   str q0, [sp, #96]
-;   add x0, sp, #24
-;   str x3, [x0]
-;   mov x19, x3
-;   add x1, sp, #32
-;   str d1, [x1]
+;   str x3, [sp, #24]
+;   mov x24, x3
+;   str d1, [sp, #32]
 ;   str q1, [sp, #112]
 ;   bl 0
 ;   ; UserStackMap { by_type: [(types::I8, CompoundBitSet {0}), (types::I16, CompoundBitSet {8}), (types::I32, CompoundBitSet {16}), (types::F32, CompoundBitSet {20}), (types::I64, CompoundBitSet {24}), (types::F64, CompoundBitSet {32})], sp_to_sized_stack_slots: None }
-;   mov x0, x21
-;   mov x1, x26
-;   mov x2, x23
-;   mov x3, x19
+;   mov x0, x23
+;   mov x1, x19
+;   mov x2, x27
+;   mov x3, x24
 ;   ldr q0, [sp, #96]
 ;   ldr q1, [sp, #112]
 ;   add sp, sp, #128
-;   ldp x19, x21, [sp], #16
-;   ldp x23, x26, [sp], #16
+;   ldp x19, x23, [sp], #16
+;   ldp x24, x27, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
 ;
@@ -170,38 +152,32 @@ block0(v0: i8, v1: i16, v2: i32, v3: i64, v4: f32, v5: f64):
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
-;   stp x23, x26, [sp, #-0x10]!
-;   stp x19, x21, [sp, #-0x10]!
+;   stp x24, x27, [sp, #-0x10]!
+;   stp x19, x23, [sp, #-0x10]!
 ;   sub sp, sp, #0x80
 ; block1: ; offset 0x14
-;   mov x12, sp
-;   strb w0, [x12]
-;   mov x21, x0
-;   add x13, sp, #8
-;   strh w1, [x13]
-;   mov x26, x1
-;   add x14, sp, #0x10
-;   str w2, [x14]
-;   mov x23, x2
-;   add x15, sp, #0x14
-;   str s0, [x15]
+;   sturb w0, [sp]
+;   mov x23, x0
+;   sturh w1, [sp, #8]
+;   mov x19, x1
+;   stur w2, [sp, #0x10]
+;   mov x27, x2
+;   stur s0, [sp, #0x14]
 ;   stur q0, [sp, #0x60]
-;   add x0, sp, #0x18
-;   str x3, [x0]
-;   mov x19, x3
-;   add x1, sp, #0x20
-;   str d1, [x1]
+;   stur x3, [sp, #0x18]
+;   mov x24, x3
+;   stur d1, [sp, #0x20]
 ;   stur q1, [sp, #0x70]
-;   bl #0x5c ; reloc_external Call u0:0 0
-;   mov x0, x21
-;   mov x1, x26
-;   mov x2, x23
-;   mov x3, x19
+;   bl #0x44 ; reloc_external Call u0:0 0
+;   mov x0, x23
+;   mov x1, x19
+;   mov x2, x27
+;   mov x3, x24
 ;   ldur q0, [sp, #0x60]
 ;   ldur q1, [sp, #0x70]
 ;   add sp, sp, #0x80
-;   ldp x19, x21, [sp], #0x10
-;   ldp x23, x26, [sp], #0x10
+;   ldp x19, x23, [sp], #0x10
+;   ldp x24, x27, [sp], #0x10
 ;   ldp x29, x30, [sp], #0x10
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/x64/fmsub-inst.clif
+++ b/cranelift/filetests/filetests/isa/x64/fmsub-inst.clif
@@ -458,7 +458,7 @@ block0(v0: f64, v1: f64, v2: f64):
 ;   subq $0x10, %rsp
 ; block0:
 ;   leaq <offset:1>+(%rsp), %r8
-;   vmovsd %xmm2, (%r8)
+;   vmovsd %xmm2, <offset:1>+(%rsp)
 ;   vfnmsub213sd (%r8), %xmm1, %xmm0
 ;   addq $0x10, %rsp
 ;   movq %rbp, %rsp
@@ -472,7 +472,7 @@ block0(v0: f64, v1: f64, v2: f64):
 ;   subq $0x10, %rsp
 ; block1: ; offset 0x8
 ;   leaq (%rsp), %r8
-;   vmovsd %xmm2, (%r8) ; trap: heap_oob
+;   vmovsd %xmm2, (%rsp)
 ;   vfnmsub213sd (%r8), %xmm1, %xmm0 ; trap: heap_oob
 ;   addq $0x10, %rsp
 ;   movq %rbp, %rsp
@@ -496,7 +496,7 @@ block0(v0: f64, v1: f64, v2: f64):
 ;   subq $0x10, %rsp
 ; block0:
 ;   leaq <offset:1>+(%rsp), %r8
-;   vmovsd %xmm2, (%r8)
+;   vmovsd %xmm2, <offset:1>+(%rsp)
 ;   vfmsub213sd (%r8), %xmm1, %xmm0
 ;   addq $0x10, %rsp
 ;   movq %rbp, %rsp
@@ -510,7 +510,7 @@ block0(v0: f64, v1: f64, v2: f64):
 ;   subq $0x10, %rsp
 ; block1: ; offset 0x8
 ;   leaq (%rsp), %r8
-;   vmovsd %xmm2, (%r8) ; trap: heap_oob
+;   vmovsd %xmm2, (%rsp)
 ;   vfmsub213sd (%r8), %xmm1, %xmm0 ; trap: heap_oob
 ;   addq $0x10, %rsp
 ;   movq %rbp, %rsp
@@ -534,7 +534,7 @@ block0(v0: f32, v1: f32, v2: f32):
 ;   subq $0x10, %rsp
 ; block0:
 ;   leaq <offset:1>+(%rsp), %r8
-;   vmovss %xmm1, (%r8)
+;   vmovss %xmm1, <offset:1>+(%rsp)
 ;   vfmsub132ss (%r8), %xmm2, %xmm0
 ;   addq $0x10, %rsp
 ;   movq %rbp, %rsp
@@ -548,7 +548,7 @@ block0(v0: f32, v1: f32, v2: f32):
 ;   subq $0x10, %rsp
 ; block1: ; offset 0x8
 ;   leaq (%rsp), %r8
-;   vmovss %xmm1, (%r8) ; trap: heap_oob
+;   vmovss %xmm1, (%rsp)
 ;   vfmsub132ss (%r8), %xmm2, %xmm0 ; trap: heap_oob
 ;   addq $0x10, %rsp
 ;   movq %rbp, %rsp
@@ -574,7 +574,7 @@ block0(v0: f32, v1: f32, v2: f32):
 ;   subq $0x10, %rsp
 ; block0:
 ;   leaq <offset:1>+(%rsp), %r8
-;   vmovss %xmm1, (%r8)
+;   vmovss %xmm1, <offset:1>+(%rsp)
 ;   vfnmsub132ss (%r8), %xmm2, %xmm0
 ;   addq $0x10, %rsp
 ;   movq %rbp, %rsp
@@ -588,7 +588,7 @@ block0(v0: f32, v1: f32, v2: f32):
 ;   subq $0x10, %rsp
 ; block1: ; offset 0x8
 ;   leaq (%rsp), %r8
-;   vmovss %xmm1, (%r8) ; trap: heap_oob
+;   vmovss %xmm1, (%rsp)
 ;   vfnmsub132ss (%r8), %xmm2, %xmm0 ; trap: heap_oob
 ;   addq $0x10, %rsp
 ;   movq %rbp, %rsp
@@ -620,7 +620,7 @@ block0(v0: f32, v1: f32, v2: f32):
 ;   movl $0x80000000, %r9d
 ;   vmovd %r9d, %xmm3
 ;   vxorps %xmm3, %xmm1, %xmm3
-;   vmovss %xmm3, (%r11)
+;   vmovss %xmm3, <offset:1>+(%rsp)
 ;   vfmsub132ss (%r11), %xmm2, %xmm0
 ;   addq $0x10, %rsp
 ;   movq %rbp, %rsp
@@ -637,7 +637,7 @@ block0(v0: f32, v1: f32, v2: f32):
 ;   movl $0x80000000, %r9d
 ;   vmovd %r9d, %xmm3
 ;   vxorps %xmm3, %xmm1, %xmm3
-;   vmovss %xmm3, (%r11) ; trap: heap_oob
+;   vmovss %xmm3, (%rsp)
 ;   vfmsub132ss (%r11), %xmm2, %xmm0 ; trap: heap_oob
 ;   addq $0x10, %rsp
 ;   movq %rbp, %rsp
@@ -661,7 +661,7 @@ block0(v0: f32x4, v1: f32x4, v2: f32x4):
 ;   subq $0x10, %rsp
 ; block0:
 ;   leaq <offset:1>+(%rsp), %r8
-;   vmovups %xmm0, (%r8)
+;   vmovups %xmm0, <offset:1>+(%rsp)
 ;   movdqa %xmm1, %xmm0
 ;   vfmsub132ps (%r8), %xmm2, %xmm0
 ;   addq $0x10, %rsp
@@ -676,7 +676,7 @@ block0(v0: f32x4, v1: f32x4, v2: f32x4):
 ;   subq $0x10, %rsp
 ; block1: ; offset 0x8
 ;   leaq (%rsp), %r8
-;   vmovups %xmm0, (%r8) ; trap: heap_oob
+;   vmovups %xmm0, (%rsp)
 ;   movdqa %xmm1, %xmm0
 ;   vfmsub132ps (%r8), %xmm2, %xmm0 ; trap: heap_oob
 ;   addq $0x10, %rsp

--- a/cranelift/filetests/filetests/isa/x64/fpromote-demote-avx.clif
+++ b/cranelift/filetests/filetests/isa/x64/fpromote-demote-avx.clif
@@ -46,7 +46,7 @@ block0(v1: i64, v2: f32):
 ;   subq $0x10, %rsp
 ; block0:
 ;   leaq <offset:1>+(%rsp), %r8
-;   vmovss %xmm0, (%r8)
+;   vmovss %xmm0, <offset:1>+(%rsp)
 ;   uninit  %xmm4
 ;   vxorpd %xmm4, %xmm4, %xmm6
 ;   vcvtss2sd (%r8), %xmm6, %xmm0
@@ -62,7 +62,7 @@ block0(v1: i64, v2: f32):
 ;   subq $0x10, %rsp
 ; block1: ; offset 0x8
 ;   leaq (%rsp), %r8
-;   vmovss %xmm0, (%r8) ; trap: heap_oob
+;   vmovss %xmm0, (%rsp)
 ;   vxorpd %xmm4, %xmm4, %xmm6
 ;   vcvtss2sd (%r8), %xmm6, %xmm0 ; trap: heap_oob
 ;   addq $0x10, %rsp
@@ -115,7 +115,7 @@ block0(v1: i64, v2: f64):
 ;   subq $0x10, %rsp
 ; block0:
 ;   leaq <offset:1>+(%rsp), %r8
-;   vmovsd %xmm0, (%r8)
+;   vmovsd %xmm0, <offset:1>+(%rsp)
 ;   uninit  %xmm4
 ;   vxorps %xmm4, %xmm4, %xmm6
 ;   vcvtsd2ss (%r8), %xmm6, %xmm0
@@ -131,7 +131,7 @@ block0(v1: i64, v2: f64):
 ;   subq $0x10, %rsp
 ; block1: ; offset 0x8
 ;   leaq (%rsp), %r8
-;   vmovsd %xmm0, (%r8) ; trap: heap_oob
+;   vmovsd %xmm0, (%rsp)
 ;   vxorps %xmm4, %xmm4, %xmm6
 ;   vcvtsd2ss (%r8), %xmm6, %xmm0 ; trap: heap_oob
 ;   addq $0x10, %rsp

--- a/cranelift/filetests/filetests/isa/x64/fpromote-demote.clif
+++ b/cranelift/filetests/filetests/isa/x64/fpromote-demote.clif
@@ -50,7 +50,7 @@ block0(v1: i64, v2: f32):
 ;   subq $0x10, %rsp
 ; block0:
 ;   leaq <offset:1>+(%rsp), %r8
-;   movss %xmm0, (%r8)
+;   movss %xmm0, <offset:1>+(%rsp)
 ;   uninit  %xmm0
 ;   xorpd %xmm0, %xmm0
 ;   cvtss2sd (%r8), %xmm0
@@ -66,7 +66,7 @@ block0(v1: i64, v2: f32):
 ;   subq $0x10, %rsp
 ; block1: ; offset 0x8
 ;   leaq (%rsp), %r8
-;   movss %xmm0, (%r8) ; trap: heap_oob
+;   movss %xmm0, (%rsp)
 ;   xorpd %xmm0, %xmm0
 ;   cvtss2sd (%r8), %xmm0 ; trap: heap_oob
 ;   addq $0x10, %rsp
@@ -123,7 +123,7 @@ block0(v1: i64, v2: f64):
 ;   subq $0x10, %rsp
 ; block0:
 ;   leaq <offset:1>+(%rsp), %r8
-;   movsd %xmm0, (%r8)
+;   movsd %xmm0, <offset:1>+(%rsp)
 ;   uninit  %xmm0
 ;   xorps %xmm0, %xmm0
 ;   cvtsd2ss (%r8), %xmm0
@@ -139,7 +139,7 @@ block0(v1: i64, v2: f64):
 ;   subq $0x10, %rsp
 ; block1: ; offset 0x8
 ;   leaq (%rsp), %r8
-;   movsd %xmm0, (%r8) ; trap: heap_oob
+;   movsd %xmm0, (%rsp)
 ;   xorps %xmm0, %xmm0
 ;   cvtsd2ss (%r8), %xmm0 ; trap: heap_oob
 ;   addq $0x10, %rsp

--- a/cranelift/filetests/filetests/isa/x64/stackslot.clif
+++ b/cranelift/filetests/filetests/isa/x64/stackslot.clif
@@ -60,3 +60,63 @@ block0(v0: i64):
 ;   retq
 ;   ud2 ; trap: stk_ovf
 
+function %f1(i32, i64, f32, f64, i8x16) -> i32, i64, f32, f64, i8x16 {
+  ss0 = explicit_slot 40
+
+block0(v0: i32, v1: i64, v2: f32, v3: f64, v4: i8x16):
+  stack_store v0, ss0+0
+  stack_store v1, ss0+4
+  stack_store v2, ss0+12
+  stack_store v3, ss0+16
+  stack_store v4, ss0+24
+  v5 = stack_load.i32 ss0+0
+  v6 = stack_load.i64 ss0+4
+  v7 = stack_load.f32 ss0+12
+  v8 = stack_load.f64 ss0+16
+  v9 = stack_load.i8x16 ss0+24
+  return v5, v6, v7, v8, v9
+}
+
+; VCode:
+;   pushq %rbp
+;   movq %rsp, %rbp
+;   subq $0x30, %rsp
+; block0:
+;   movl %esi, <offset:1>+(%rsp)
+;   movq %rdx, <offset:1>+4(%rsp)
+;   movss %xmm0, <offset:1>+0xc(%rsp)
+;   movsd %xmm1, <offset:1>+0x10(%rsp)
+;   movdqu %xmm2, <offset:1>+0x18(%rsp)
+;   movl <offset:1>+(%rsp), %eax
+;   movq <offset:1>+4(%rsp), %rdx
+;   movss <offset:1>+0xc(%rsp), %xmm0
+;   movsd <offset:1>+0x10(%rsp), %xmm1
+;   movdqu <offset:1>+0x18(%rsp), %xmm2
+;   movdqu %xmm2, (%rdi)
+;   addq $0x30, %rsp
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+;   subq $0x30, %rsp
+; block1: ; offset 0x8
+;   movl %esi, (%rsp)
+;   movq %rdx, 4(%rsp)
+;   movss %xmm0, 0xc(%rsp)
+;   movsd %xmm1, 0x10(%rsp)
+;   movdqu %xmm2, 0x18(%rsp)
+;   movl (%rsp), %eax
+;   movq 4(%rsp), %rdx
+;   movss 0xc(%rsp), %xmm0
+;   movsd 0x10(%rsp), %xmm1
+;   movdqu 0x18(%rsp), %xmm2
+;   movdqu %xmm2, (%rdi)
+;   addq $0x30, %rsp
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+

--- a/cranelift/filetests/filetests/isa/x64/user_stack_maps.clif
+++ b/cranelift/filetests/filetests/isa/x64/user_stack_maps.clif
@@ -42,31 +42,24 @@ block0:
 ; block0:
 ;   uninit  %rdi
 ;   xorl %edi, %edi
-;   movq %rdi, %r14
-;   movl $0x1, %r15d
-;   movl $0x2, %ebx
-;   leaq <offset:1>+(%rsp), %rsi
-;   movl $0x0, (%rsi)
-;   leaq <offset:1>+4(%rsp), %rdi
-;   movl $0x1, (%rdi)
-;   leaq <offset:1>+8(%rsp), %rax
-;   movl $0x2, (%rax)
-;   movq %r14, %rdi
+;   movq %rdi, %rbx
+;   movl $0x1, %r14d
+;   movl $0x2, %r15d
+;   movl $0x0, <offset:1>+(%rsp)
+;   movl $0x1, <offset:1>+4(%rsp)
+;   movl $0x2, <offset:1>+8(%rsp)
 ;   call    User(userextname0)
 ;   ; UserStackMap { by_type: [(types::I32, CompoundBitSet {0, 4, 8})], sp_to_sized_stack_slots: None }
-;   leaq <offset:1>+(%rsp), %rdx
-;   movl $0x1, (%rdx)
-;   leaq <offset:1>+4(%rsp), %r8
-;   movl $0x2, (%r8)
-;   movq %r14, %rdi
+;   movl $0x1, <offset:1>+(%rsp)
+;   movl $0x2, <offset:1>+4(%rsp)
+;   movq %rbx, %rdi
 ;   call    User(userextname0)
 ;   ; UserStackMap { by_type: [(types::I32, CompoundBitSet {0, 4})], sp_to_sized_stack_slots: None }
-;   leaq <offset:1>+(%rsp), %r10
-;   movl $0x2, (%r10)
-;   movq %r15, %rdi
+;   movl $0x2, <offset:1>+(%rsp)
+;   movq %r14, %rdi
 ;   call    User(userextname0)
 ;   ; UserStackMap { by_type: [(types::I32, CompoundBitSet {0})], sp_to_sized_stack_slots: None }
-;   movq %rbx, %rdi
+;   movq %r15, %rdi
 ;   call    User(userextname0)
 ;   movq 0x10(%rsp), %rbx
 ;   movq 0x18(%rsp), %r14
@@ -86,29 +79,22 @@ block0:
 ;   movq %r15, 0x20(%rsp)
 ; block1: ; offset 0x17
 ;   xorl %edi, %edi
-;   movq %rdi, %r14
-;   movl $1, %r15d
-;   movl $2, %ebx
-;   leaq (%rsp), %rsi
-;   movl $0, (%rsi)
-;   leaq 4(%rsp), %rdi
-;   movl $1, (%rdi)
-;   leaq 8(%rsp), %rax
-;   movl $2, (%rax)
-;   movq %r14, %rdi
-;   callq 0x4f ; reloc_external CallPCRel4 u0:0 -4
-;   leaq (%rsp), %rdx
-;   movl $1, (%rdx)
-;   leaq 4(%rsp), %r8
-;   movl $2, (%r8)
-;   movq %r14, %rdi
-;   callq 0x6d ; reloc_external CallPCRel4 u0:0 -4
-;   leaq (%rsp), %r10
-;   movl $2, (%r10)
-;   movq %r15, %rdi
-;   callq 0x80 ; reloc_external CallPCRel4 u0:0 -4
+;   movq %rdi, %rbx
+;   movl $1, %r14d
+;   movl $2, %r15d
+;   movl $0, (%rsp)
+;   movl $1, 4(%rsp)
+;   movl $2, 8(%rsp)
+;   callq 0x44 ; reloc_external CallPCRel4 u0:0 -4
+;   movl $1, (%rsp)
+;   movl $2, 4(%rsp)
 ;   movq %rbx, %rdi
-;   callq 0x88 ; reloc_external CallPCRel4 u0:0 -4
+;   callq 0x5b ; reloc_external CallPCRel4 u0:0 -4
+;   movl $2, (%rsp)
+;   movq %r14, %rdi
+;   callq 0x6a ; reloc_external CallPCRel4 u0:0 -4
+;   movq %r15, %rdi
+;   callq 0x72 ; reloc_external CallPCRel4 u0:0 -4
 ;   movq 0x10(%rsp), %rbx
 ;   movq 0x18(%rsp), %r14
 ;   movq 0x20(%rsp), %r15
@@ -147,34 +133,28 @@ block0(v0: i8, v1: i16, v2: i32, v3: i64, v4: f32, v5: f64):
 ;   movq %r14, 0x98(%rsp)
 ;   movq %r15, 0xa0(%rsp)
 ; block0:
-;   movq %rdi, %r13
-;   leaq <offset:1>+(%rsp), %r9
-;   movb %sil, (%r9)
-;   movq %rsi, %r15
-;   leaq <offset:1>+8(%rsp), %r9
-;   movw %dx, (%r9)
-;   movq %rdx, %r12
-;   leaq <offset:1>+0x10(%rsp), %r9
-;   movl %ecx, (%r9)
-;   movq %rcx, %rbx
-;   leaq <offset:1>+0x14(%rsp), %r10
-;   movss %xmm0, (%r10)
+;   movq %rdi, %r12
+;   movb %sil, <offset:1>+(%rsp)
+;   movq %rsi, %r14
+;   movw %dx, <offset:1>+8(%rsp)
+;   movq %rdx, %rbx
+;   movl %ecx, <offset:1>+0x10(%rsp)
+;   movq %rcx, %r15
+;   movss %xmm0, <offset:1>+0x14(%rsp)
 ;   movdqu %xmm0, <offset:1>+0x60(%rsp)
-;   leaq <offset:1>+0x18(%rsp), %r11
-;   movq %r8, (%r11)
-;   movq %r8, %r14
-;   leaq <offset:1>+0x20(%rsp), %rsi
-;   movsd %xmm1, (%rsi)
+;   movq %r8, <offset:1>+0x18(%rsp)
+;   movq %r8, %r13
+;   movsd %xmm1, <offset:1>+0x20(%rsp)
 ;   movdqu %xmm1, <offset:1>+0x70(%rsp)
 ;   call    User(userextname0)
 ;   ; UserStackMap { by_type: [(types::I8, CompoundBitSet {0}), (types::I16, CompoundBitSet {8}), (types::I32, CompoundBitSet {16}), (types::F32, CompoundBitSet {20}), (types::I64, CompoundBitSet {24}), (types::F64, CompoundBitSet {32})], sp_to_sized_stack_slots: None }
-;   movq %rbx, %rcx
-;   movq %r13, %rdi
+;   movq %r15, %rcx
+;   movq %r12, %rdi
 ;   movl %ecx, (%rdi)
-;   movq %r14, %r8
+;   movq %r13, %r8
 ;   movq %r8, 8(%rdi)
-;   movq %r15, %rax
-;   movq %r12, %rdx
+;   movq %r14, %rax
+;   movq %rbx, %rdx
 ;   movdqu <offset:1>+0x60(%rsp), %xmm0
 ;   movdqu <offset:1>+0x70(%rsp), %xmm1
 ;   movq 0x80(%rsp), %rbx
@@ -198,33 +178,27 @@ block0(v0: i8, v1: i16, v2: i32, v3: i64, v4: f32, v5: f64):
 ;   movq %r14, 0x98(%rsp)
 ;   movq %r15, 0xa0(%rsp)
 ; block1: ; offset 0x33
-;   movq %rdi, %r13
-;   leaq (%rsp), %r9
-;   movb %sil, (%r9)
-;   movq %rsi, %r15
-;   leaq 8(%rsp), %r9
-;   movw %dx, (%r9)
-;   movq %rdx, %r12
-;   leaq 0x10(%rsp), %r9
-;   movl %ecx, (%r9)
-;   movq %rcx, %rbx
-;   leaq 0x14(%rsp), %r10
-;   movss %xmm0, (%r10)
+;   movq %rdi, %r12
+;   movb %sil, (%rsp)
+;   movq %rsi, %r14
+;   movw %dx, 8(%rsp)
+;   movq %rdx, %rbx
+;   movl %ecx, 0x10(%rsp)
+;   movq %rcx, %r15
+;   movss %xmm0, 0x14(%rsp)
 ;   movdqu %xmm0, 0x60(%rsp)
-;   leaq 0x18(%rsp), %r11
-;   movq %r8, (%r11)
-;   movq %r8, %r14
-;   leaq 0x20(%rsp), %rsi
-;   movsd %xmm1, (%rsi)
+;   movq %r8, 0x18(%rsp)
+;   movq %r8, %r13
+;   movsd %xmm1, 0x20(%rsp)
 ;   movdqu %xmm1, 0x70(%rsp)
-;   callq 0x86 ; reloc_external CallPCRel4 u0:0 -4
-;   movq %rbx, %rcx
-;   movq %r13, %rdi
+;   callq 0x71 ; reloc_external CallPCRel4 u0:0 -4
+;   movq %r15, %rcx
+;   movq %r12, %rdi
 ;   movl %ecx, (%rdi)
-;   movq %r14, %r8
+;   movq %r13, %r8
 ;   movq %r8, 8(%rdi)
-;   movq %r15, %rax
-;   movq %r12, %rdx
+;   movq %r14, %rax
+;   movq %rbx, %rdx
 ;   movdqu 0x60(%rsp), %xmm0
 ;   movdqu 0x70(%rsp), %xmm1
 ;   movq 0x80(%rsp), %rbx

--- a/tests/disas/exceptions.wat
+++ b/tests/disas/exceptions.wat
@@ -33,14 +33,14 @@
 ;;       movq    %rdi, %r12
 ;;       movq    %rcx, %r13
 ;;       movq    %rdx, %r15
-;;       callq   0x3c2
+;;       callq   0x3b2
 ;;       movq    %rax, %r14
 ;;       movl    $0x4000000, %esi
 ;;       movl    $3, %edx
 ;;       movl    $0x30, %ecx
 ;;       movl    $8, %r8d
 ;;       movq    %r12, %rdi
-;;       callq   0x35f
+;;       callq   0x34f
 ;;       movq    8(%r12), %r8
 ;;       movq    0x18(%r8), %r8
 ;;       movl    %eax, %r9d
@@ -54,7 +54,7 @@
 ;;       movq    %rax, %rsi
 ;;       movq    %r12, %rdi
 ;;       movq    %r12, (%rsp)
-;;       callq   0x3ee
+;;       callq   0x3de
 ;;       ud2
 ;;       ud2
 ;;

--- a/tests/disas/gc/struct-new-stack-map.wat
+++ b/tests/disas/gc/struct-new-stack-map.wat
@@ -16,52 +16,47 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r10
 ;;       movq    0x10(%r10), %r10
-;;       addq    $0x50, %r10
+;;       addq    $0x40, %r10
 ;;       cmpq    %rsp, %r10
-;;       ja      0xc7
-;;   19: subq    $0x40, %rsp
-;;       movq    %r12, 0x20(%rsp)
-;;       movq    %r13, 0x28(%rsp)
-;;       movq    %r14, 0x30(%rsp)
-;;       movq    %rdx, %r12
+;;       ja      0xb5
+;;   19: subq    $0x30, %rsp
+;;       movq    %r13, 0x20(%rsp)
+;;       movq    %r14, 0x28(%rsp)
+;;       movq    %rdx, %r14
 ;;       movdqu  %xmm0, 8(%rsp)
-;;       leaq    (%rsp), %r14
-;;       movl    %ecx, (%r14)
+;;       movl    %ecx, (%rsp)
 ;;       movl    $0xb0000000, %esi
 ;;       xorl    %edx, %edx
 ;;       movl    $0x28, %ecx
 ;;       movl    $8, %r8d
 ;;       movq    %rdi, %r13
-;;       callq   0x14b
-;;       movq    8(%r13), %r8
-;;       ╰─╼ stack_map: frame_size=64, frame_offsets=[0]
-;;       movq    0x18(%r8), %r8
-;;       movq    %rax, %r10
-;;       movl    %r10d, %r9d
+;;       callq   0x12f
+;;       movq    8(%r13), %rdx
+;;       ╰─╼ stack_map: frame_size=48, frame_offsets=[0]
+;;       movq    0x18(%rdx), %rdx
+;;       movl    %eax, %r8d
 ;;       movdqu  8(%rsp), %xmm0
-;;       movss   %xmm0, 0x18(%r8, %r9)
-;;       movq    %r12, %rdx
-;;       movb    %dl, 0x1c(%r8, %r9)
-;;       movl    (%r14), %r11d
-;;       movq    %r11, %rdx
-;;       andl    $1, %edx
-;;       testl   %r11d, %r11d
-;;       sete    %sil
-;;       movzbl  %sil, %esi
-;;       orl     %esi, %edx
-;;       testl   %edx, %edx
-;;       jne     0xa4
-;;   97: movl    %r11d, %ecx
-;;       leaq    (%r8, %rcx), %rax
-;;       addq    $1, 8(%r8, %rcx)
-;;       movl    (%r14), %edx
-;;       movl    %edx, 0x20(%r8, %r9)
-;;       movq    %r10, %rax
-;;       movq    0x20(%rsp), %r12
-;;       movq    0x28(%rsp), %r13
-;;       movq    0x30(%rsp), %r14
-;;       addq    $0x40, %rsp
+;;       movss   %xmm0, 0x18(%rdx, %r8)
+;;       movq    %r14, %r9
+;;       movb    %r9b, 0x1c(%rdx, %r8)
+;;       movl    (%rsp), %r9d
+;;       movq    %r9, %rcx
+;;       andl    $1, %ecx
+;;       testl   %r9d, %r9d
+;;       sete    %r10b
+;;       movzbl  %r10b, %r10d
+;;       orl     %r10d, %ecx
+;;       testl   %ecx, %ecx
+;;       jne     0x9a
+;;   8d: movl    %r9d, %edi
+;;       leaq    (%rdx, %rdi), %rcx
+;;       addq    $1, 8(%rdx, %rdi)
+;;       movl    (%rsp), %ecx
+;;       movl    %ecx, 0x20(%rdx, %r8)
+;;       movq    0x20(%rsp), %r13
+;;       movq    0x28(%rsp), %r14
+;;       addq    $0x30, %rsp
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   c7: ud2
+;;   b5: ud2

--- a/tests/disas/trunc.wat
+++ b/tests/disas/trunc.wat
@@ -24,7 +24,7 @@
 ;;       jne     0x101
 ;;   39: movq    %r14, %rdi
 ;;       movdqu  (%rsp), %xmm0
-;;       callq   0x253
+;;       callq   0x245
 ;;       movabsq $13830554455654793216, %rax
 ;;       movq    %rax, %xmm6
 ;;       ucomisd %xmm0, %xmm6
@@ -55,27 +55,27 @@
 ;;       retq
 ;;   d3: movl    $6, %esi
 ;;   d8: movq    %r14, %rdi
-;;   db: callq   0x27f
+;;   db: callq   0x271
 ;;   e0: movq    %r14, %rdi
-;;   e3: callq   0x2af
+;;   e3: callq   0x2a1
 ;;   e8: ud2
 ;;   ea: movl    $6, %esi
 ;;   ef: movq    %r14, %rdi
-;;   f2: callq   0x27f
+;;   f2: callq   0x271
 ;;   f7: movq    %r14, %rdi
-;;   fa: callq   0x2af
+;;   fa: callq   0x2a1
 ;;   ff: ud2
 ;;  101: movl    $8, %esi
 ;;  106: movq    %r14, %rdi
-;;  109: callq   0x27f
+;;  109: callq   0x271
 ;;  10e: movq    %r14, %rdi
-;;  111: callq   0x2af
+;;  111: callq   0x2a1
 ;;  116: ud2
 ;;  118: xorl    %esi, %esi
 ;;  11a: movq    %r14, %rdi
-;;  11d: callq   0x27f
+;;  11d: callq   0x271
 ;;  122: movq    %r14, %rdi
-;;  125: callq   0x2af
+;;  125: callq   0x2a1
 ;;  12a: ud2
 ;;  12c: ud2
 ;;  12e: ud2

--- a/tests/disas/trunc32.wat
+++ b/tests/disas/trunc32.wat
@@ -26,7 +26,7 @@
 ;;       jp      0xf6
 ;;       jne     0xf6
 ;;   46: movq    %r12, %rdi
-;;       callq   0x252
+;;       callq   0x243
 ;;       movabsq $13830554455654793216, %r8
 ;;       movq    %r8, %xmm1
 ;;       ucomisd %xmm0, %xmm1
@@ -56,27 +56,27 @@
 ;;       retq
 ;;   c8: movl    $6, %esi
 ;;   cd: movq    %r12, %rdi
-;;   d0: callq   0x27e
+;;   d0: callq   0x26f
 ;;   d5: movq    %r12, %rdi
-;;   d8: callq   0x2ae
+;;   d8: callq   0x29f
 ;;   dd: ud2
 ;;   df: movl    $6, %esi
 ;;   e4: movq    %r12, %rdi
-;;   e7: callq   0x27e
+;;   e7: callq   0x26f
 ;;   ec: movq    %r12, %rdi
-;;   ef: callq   0x2ae
+;;   ef: callq   0x29f
 ;;   f4: ud2
 ;;   f6: movl    $8, %esi
 ;;   fb: movq    %r12, %rdi
-;;   fe: callq   0x27e
+;;   fe: callq   0x26f
 ;;  103: movq    %r12, %rdi
-;;  106: callq   0x2ae
+;;  106: callq   0x29f
 ;;  10b: ud2
 ;;  10d: xorl    %esi, %esi
 ;;  10f: movq    %r12, %rdi
-;;  112: callq   0x27e
+;;  112: callq   0x26f
 ;;  117: movq    %r12, %rdi
-;;  11a: callq   0x2ae
+;;  11a: callq   0x29f
 ;;  11f: ud2
 ;;  121: ud2
 ;;  123: ud2

--- a/tests/disas/winch/x64/atomic/notify/notify.wat
+++ b/tests/disas/winch/x64/atomic/notify/notify.wat
@@ -27,7 +27,7 @@
 ;;       movl    $0, %esi
 ;;       movq    8(%rsp), %rdx
 ;;       movl    4(%rsp), %ecx
-;;       callq   0x177
+;;       callq   0x175
 ;;       addq    $4, %rsp
 ;;       addq    $0xc, %rsp
 ;;       movq    8(%rsp), %r14

--- a/tests/disas/winch/x64/atomic/notify/notify_offset.wat
+++ b/tests/disas/winch/x64/atomic/notify/notify_offset.wat
@@ -28,7 +28,7 @@
 ;;       movl    $0, %esi
 ;;       movq    8(%rsp), %rdx
 ;;       movl    4(%rsp), %ecx
-;;       callq   0x17e
+;;       callq   0x17c
 ;;       addq    $4, %rsp
 ;;       addq    $0xc, %rsp
 ;;       movq    8(%rsp), %r14

--- a/tests/disas/winch/x64/atomic/wait/wait32.wat
+++ b/tests/disas/winch/x64/atomic/wait/wait32.wat
@@ -30,7 +30,7 @@
 ;;       movq    0x18(%rsp), %rdx
 ;;       movl    0x14(%rsp), %ecx
 ;;       movq    0xc(%rsp), %r8
-;;       callq   0x184
+;;       callq   0x182
 ;;       addq    $0xc, %rsp
 ;;       addq    $0x14, %rsp
 ;;       movq    8(%rsp), %r14

--- a/tests/disas/winch/x64/atomic/wait/wait32_offset.wat
+++ b/tests/disas/winch/x64/atomic/wait/wait32_offset.wat
@@ -34,7 +34,7 @@
 ;;       movq    0x18(%rsp), %rdx
 ;;       movl    0x14(%rsp), %ecx
 ;;       movq    0xc(%rsp), %r8
-;;       callq   0x18b
+;;       callq   0x189
 ;;       addq    $0xc, %rsp
 ;;       addq    $0x14, %rsp
 ;;       movq    8(%rsp), %r14

--- a/tests/disas/winch/x64/atomic/wait/wait64.wat
+++ b/tests/disas/winch/x64/atomic/wait/wait64.wat
@@ -29,7 +29,7 @@
 ;;       movq    0x18(%rsp), %rdx
 ;;       movq    0x10(%rsp), %rcx
 ;;       movq    8(%rsp), %r8
-;;       callq   0x17c
+;;       callq   0x17a
 ;;       addq    $8, %rsp
 ;;       addq    $0x18, %rsp
 ;;       movq    8(%rsp), %r14

--- a/tests/disas/winch/x64/atomic/wait/wait64_offset.wat
+++ b/tests/disas/winch/x64/atomic/wait/wait64_offset.wat
@@ -33,7 +33,7 @@
 ;;       movq    0x18(%rsp), %rdx
 ;;       movq    0x10(%rsp), %rcx
 ;;       movq    8(%rsp), %r8
-;;       callq   0x183
+;;       callq   0x181
 ;;       addq    $8, %rsp
 ;;       addq    $0x18, %rsp
 ;;       movq    8(%rsp), %r14

--- a/tests/disas/winch/x64/call_indirect/call_indirect.wat
+++ b/tests/disas/winch/x64/call_indirect/call_indirect.wat
@@ -76,7 +76,7 @@
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
 ;;       movl    8(%rsp), %edx
-;;       callq   0x335
+;;       callq   0x337
 ;;       addq    $8, %rsp
 ;;       addq    $4, %rsp
 ;;       movq    0x1c(%rsp), %r14
@@ -128,7 +128,7 @@
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
 ;;       movl    4(%rsp), %edx
-;;       callq   0x335
+;;       callq   0x337
 ;;       addq    $4, %rsp
 ;;       addq    $4, %rsp
 ;;       movq    0x20(%rsp), %r14

--- a/tests/disas/winch/x64/call_indirect/local_arg.wat
+++ b/tests/disas/winch/x64/call_indirect/local_arg.wat
@@ -72,7 +72,7 @@
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
 ;;       movl    8(%rsp), %edx
-;;       callq   0x32a
+;;       callq   0x32b
 ;;       addq    $8, %rsp
 ;;       addq    $4, %rsp
 ;;       movq    0x1c(%rsp), %r14

--- a/tests/disas/winch/x64/f32_ceil/f32_ceil_param.wat
+++ b/tests/disas/winch/x64/f32_ceil/f32_ceil_param.wat
@@ -26,7 +26,7 @@
 ;;       subq    $0xc, %rsp
 ;;       movq    %r14, %rdi
 ;;       movss   0xc(%rsp), %xmm0
-;;       callq   0xe1
+;;       callq   0xdc
 ;;       addq    $0xc, %rsp
 ;;       addq    $4, %rsp
 ;;       movq    0x18(%rsp), %r14

--- a/tests/disas/winch/x64/f32_floor/f32_floor_param.wat
+++ b/tests/disas/winch/x64/f32_floor/f32_floor_param.wat
@@ -26,7 +26,7 @@
 ;;       subq    $0xc, %rsp
 ;;       movq    %r14, %rdi
 ;;       movss   0xc(%rsp), %xmm0
-;;       callq   0xe1
+;;       callq   0xdc
 ;;       addq    $0xc, %rsp
 ;;       addq    $4, %rsp
 ;;       movq    0x18(%rsp), %r14

--- a/tests/disas/winch/x64/f32_nearest/f32_nearest_param.wat
+++ b/tests/disas/winch/x64/f32_nearest/f32_nearest_param.wat
@@ -26,7 +26,7 @@
 ;;       subq    $0xc, %rsp
 ;;       movq    %r14, %rdi
 ;;       movss   0xc(%rsp), %xmm0
-;;       callq   0xe1
+;;       callq   0xdc
 ;;       addq    $0xc, %rsp
 ;;       addq    $4, %rsp
 ;;       movq    0x18(%rsp), %r14

--- a/tests/disas/winch/x64/f32_trunc/f32_trunc_param.wat
+++ b/tests/disas/winch/x64/f32_trunc/f32_trunc_param.wat
@@ -26,7 +26,7 @@
 ;;       subq    $0xc, %rsp
 ;;       movq    %r14, %rdi
 ;;       movss   0xc(%rsp), %xmm0
-;;       callq   0xe1
+;;       callq   0xdc
 ;;       addq    $0xc, %rsp
 ;;       addq    $4, %rsp
 ;;       movq    0x18(%rsp), %r14

--- a/tests/disas/winch/x64/f64_ceil/f64_ceil_param.wat
+++ b/tests/disas/winch/x64/f64_ceil/f64_ceil_param.wat
@@ -26,7 +26,7 @@
 ;;       subq    $8, %rsp
 ;;       movq    %r14, %rdi
 ;;       movsd   8(%rsp), %xmm0
-;;       callq   0xe1
+;;       callq   0xdc
 ;;       addq    $8, %rsp
 ;;       addq    $8, %rsp
 ;;       movq    0x18(%rsp), %r14

--- a/tests/disas/winch/x64/f64_floor/f64_floor_param.wat
+++ b/tests/disas/winch/x64/f64_floor/f64_floor_param.wat
@@ -26,7 +26,7 @@
 ;;       subq    $8, %rsp
 ;;       movq    %r14, %rdi
 ;;       movsd   8(%rsp), %xmm0
-;;       callq   0xe1
+;;       callq   0xdc
 ;;       addq    $8, %rsp
 ;;       addq    $8, %rsp
 ;;       movq    0x18(%rsp), %r14

--- a/tests/disas/winch/x64/f64_nearest/f64_nearest_param.wat
+++ b/tests/disas/winch/x64/f64_nearest/f64_nearest_param.wat
@@ -26,7 +26,7 @@
 ;;       subq    $8, %rsp
 ;;       movq    %r14, %rdi
 ;;       movsd   8(%rsp), %xmm0
-;;       callq   0xe1
+;;       callq   0xdc
 ;;       addq    $8, %rsp
 ;;       addq    $8, %rsp
 ;;       movq    0x18(%rsp), %r14

--- a/tests/disas/winch/x64/f64_trunc/f64_trunc_param.wat
+++ b/tests/disas/winch/x64/f64_trunc/f64_trunc_param.wat
@@ -26,7 +26,7 @@
 ;;       subq    $8, %rsp
 ;;       movq    %r14, %rdi
 ;;       movsd   8(%rsp), %xmm0
-;;       callq   0xe1
+;;       callq   0xdc
 ;;       addq    $8, %rsp
 ;;       addq    $8, %rsp
 ;;       movq    0x18(%rsp), %r14

--- a/tests/disas/winch/x64/load/grow_load.wat
+++ b/tests/disas/winch/x64/load/grow_load.wat
@@ -65,7 +65,7 @@
 ;;       movq    %r14, %rdi
 ;;       movl    0xc(%rsp), %esi
 ;;       movl    $0, %edx
-;;       callq   0x2db
+;;       callq   0x2e2
 ;;       addq    $0xc, %rsp
 ;;       addq    $4, %rsp
 ;;       movq    0x58(%rsp), %r14

--- a/tests/disas/winch/x64/table/fill.wat
+++ b/tests/disas/winch/x64/table/fill.wat
@@ -113,7 +113,7 @@
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
 ;;       movl    0xc(%rsp), %edx
-;;       callq   0x4eb
+;;       callq   0x4ee
 ;;       addq    $0xc, %rsp
 ;;       addq    $4, %rsp
 ;;       movq    0x28(%rsp), %r14
@@ -133,7 +133,7 @@
 ;;       movl    0xc(%rsp), %edx
 ;;       movq    4(%rsp), %rcx
 ;;       movl    (%rsp), %r8d
-;;       callq   0x517
+;;       callq   0x51a
 ;;       addq    $0x10, %rsp
 ;;       movq    0x28(%rsp), %r14
 ;;       addq    $0x30, %rsp

--- a/tests/disas/winch/x64/table/get.wat
+++ b/tests/disas/winch/x64/table/get.wat
@@ -65,7 +65,7 @@
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
 ;;       movl    0xc(%rsp), %edx
-;;       callq   0x2ec
+;;       callq   0x2ef
 ;;       addq    $0xc, %rsp
 ;;       addq    $4, %rsp
 ;;       movq    0x18(%rsp), %r14

--- a/tests/disas/winch/x64/table/grow.wat
+++ b/tests/disas/winch/x64/table/grow.wat
@@ -30,7 +30,7 @@
 ;;       movl    $0, %esi
 ;;       movl    $0xa, %edx
 ;;       movq    8(%rsp), %rcx
-;;       callq   0x176
+;;       callq   0x178
 ;;       addq    $8, %rsp
 ;;       addq    $8, %rsp
 ;;       movq    0x18(%rsp), %r14

--- a/tests/disas/winch/x64/table/set.wat
+++ b/tests/disas/winch/x64/table/set.wat
@@ -109,7 +109,7 @@
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
 ;;       movl    8(%rsp), %edx
-;;       callq   0x4b6
+;;       callq   0x4ba
 ;;       addq    $8, %rsp
 ;;       addq    $4, %rsp
 ;;       movq    0x1c(%rsp), %r14


### PR DESCRIPTION
We provide `stack_load`/ `stack_store` / `stack_addr` instructions in Cranelift to operate on stack slots, and the first two are legalized to a `stack_addr` plus an ordinary load or store instruction.

We currently have lowerings for `stack_addr` that materialize an SP-relative address into a register: for example, `leaq 8(%rsp), %rax` on x86-64 or `add x0, sp, #8` on aarch64.

Taken together, we see sequences like (aarch64 / x86-64)

```
    add x0, sp, #8       /   leaq 8(%rsp), %rax
    str x1, [x0]         /   movq %rdx, (%rax)
```

when using `stack_store`s. In particular, we do *not* use the direct SP-relative form, which would look like

```
    str x1, [sp, #8]     /   movq %rdx, 8(%rsp)
```

and which we can already generate in other cases, e.g. spillslot moves (spills/reloads) and clobber saves/restores.

This inefficiency is undesirable whenever the embedder is using stackslots, but in particular when we expect to have high memory traffic to stack slots (e.g., I am seeing this now when implementing debug instrumentation in Wasmtime, and user stack map instrumentation for GC will also benefit).

This PR adds new lowerings that use the existing synthetic address mode we already use for spillslots to emit loads/stores to stackslots directly when possible. The PR does this for x86-64 and aarch64; others could be updated later.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
