### PR TITLE
Add the library version

### DIFF
--- a/crates/wasmtime/src/lib.rs
+++ b/crates/wasmtime/src/lib.rs
@@ -306,6 +306,9 @@ pub(crate) mod prelude {
 
 pub(crate) use hashbrown::{hash_map, hash_set};
 
+/// Version of Wasmtime library formatted in semver style.
+pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+
 /// A helper macro to safely map `MaybeUninit<T>` to `MaybeUninit<U>` where `U`
 /// is a field projection within `T`.
 ///


### PR DESCRIPTION
Dearest Reviewer,

While using wasmtime I found myself wanting to pre-compile my functions. According to https://github.com/bytecodealliance/wasmtime/pull/11687 The pre-compiled functions should work across minor and patch version changes.  I would like to use the version in my cache keys.

My current options are a build script that parses Cargo.toml  or I can hard code the current version when I updated my Cargo.toml version.

Providing the built version will allow users of wasttime to ergonomically access the version to use.

Discussed in https://bytecodealliance.zulipchat.com/#narrow/channel/217126-wasmtime/topic/wasmtime.20version.20access/with/541092841 I opted for a const instead of a function.

Thanks for reviewing,
becker

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
