### PR TITLE
Check that symbols that needs to be defined are defined in cranelift-object

### DIFF
--- a/cranelift/module/src/module.rs
+++ b/cranelift/module/src/module.rs
@@ -182,6 +182,14 @@ impl Linkage {
         }
     }
 
+    /// Test whether this linkage must have a definition.
+    pub fn requires_definition(self) -> bool {
+        match self {
+            Self::Import | Self::Preemptible => false,
+            Self::Local | Self::Hidden | Self::Export => true,
+        }
+    }
+
     /// Test whether this linkage will have a definition that cannot be preempted.
     pub fn is_final(self) -> bool {
         match self {

--- a/cranelift/object/src/backend.rs
+++ b/cranelift/object/src/backend.rs
@@ -536,6 +536,34 @@ impl ObjectModule {
 
     /// Finalize all relocations and output an object.
     pub fn finish(mut self) -> ObjectProduct {
+        if cfg!(debug_assertions) {
+            for (func_id, decl) in self.declarations.get_functions() {
+                if !decl.linkage.requires_definition() {
+                    continue;
+                }
+
+                assert!(
+                    self.functions[func_id].unwrap().1,
+                    "function \"{}\" with linkage {:?} must be defined but is not",
+                    decl.linkage_name(func_id),
+                    decl.linkage,
+                );
+            }
+
+            for (data_id, decl) in self.declarations.get_data_objects() {
+                if !decl.linkage.requires_definition() {
+                    continue;
+                }
+
+                assert!(
+                    self.data_objects[data_id].unwrap().1,
+                    "data object \"{}\" with linkage {:?} must be defined but is not",
+                    decl.linkage_name(data_id),
+                    decl.linkage,
+                );
+            }
+        }
+
         let symbol_relocs = mem::take(&mut self.relocs);
         for symbol in symbol_relocs {
             for &ObjectRelocRecord {

--- a/cranelift/object/tests/basic.rs
+++ b/cranelift/object/tests/basic.rs
@@ -73,6 +73,25 @@ fn panic_on_define_after_finalize() {
 }
 
 #[test]
+#[cfg_attr(not(debug_assertions), ignore = "checks a debug assertion")]
+#[should_panic(expected = "function \"abc\" with linkage Local must be defined but is not")]
+fn panic_on_declare_without_define() {
+    let flag_builder = settings::builder();
+    let isa_builder = cranelift_codegen::isa::lookup_by_name("x86_64-unknown-linux-gnu").unwrap();
+    let isa = isa_builder
+        .finish(settings::Flags::new(flag_builder))
+        .unwrap();
+    let mut module =
+        ObjectModule::new(ObjectBuilder::new(isa, "foo", default_libcall_names()).unwrap());
+
+    module
+        .declare_function("abc", Linkage::Local, &Signature::new(CallConv::SystemV))
+        .unwrap();
+
+    module.finish();
+}
+
+#[test]
 fn switch_error() {
     use cranelift_codegen::settings;
 


### PR DESCRIPTION
They aren't defined, you get weird errors and crashes at link time.

Fixes https://github.com/bytecodealliance/wasmtime/issues/8600