### PR TITLE
Add `-Shttp,p3` support to `wasmtime run`

### DIFF
--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -46,7 +46,7 @@ struct Host {
     http_outgoing_body_chunk_size: Option<usize>,
 
     #[cfg(feature = "component-model-async")]
-    p3_http: DefaultP3Ctx,
+    p3_http: crate::common::DefaultP3Ctx,
 
     limits: StoreLimits,
 
@@ -90,11 +90,6 @@ impl WasiHttpView for Host {
             .unwrap_or_else(|| DEFAULT_OUTGOING_BODY_CHUNK_SIZE)
     }
 }
-
-#[cfg(feature = "component-model-async")]
-struct DefaultP3Ctx;
-#[cfg(feature = "component-model-async")]
-impl wasmtime_wasi_http::p3::WasiHttpCtx for DefaultP3Ctx {}
 
 #[cfg(feature = "component-model-async")]
 impl wasmtime_wasi_http::p3::WasiHttpView for Host {
@@ -212,7 +207,7 @@ impl ServeCommand {
             #[cfg(feature = "profiling")]
             guest_profiler: None,
             #[cfg(feature = "component-model-async")]
-            p3_http: DefaultP3Ctx,
+            p3_http: crate::common::DefaultP3Ctx,
         };
 
         if self.run.common.wasi.nn == Some(true) {

--- a/src/common.rs
+++ b/src/common.rs
@@ -429,3 +429,9 @@ impl Profile {
         }
     }
 }
+
+#[derive(Default, Clone)]
+#[cfg(all(feature = "wasi-http", feature = "component-model-async"))]
+pub struct DefaultP3Ctx;
+#[cfg(all(feature = "wasi-http", feature = "component-model-async"))]
+impl wasmtime_wasi_http::p3::WasiHttpCtx for DefaultP3Ctx {}


### PR DESCRIPTION
Omitted from previous inclusions by accident due to how things developed, but now it's there!

Closes #11736

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
