### PR TITLE
Update SECURITY.md with vulnerability reporting details

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,11 +1,16 @@
 # Security Policy
 
 Please refer to the [Bytecode Alliance security
-policy](https://bytecodealliance.org/security) for details on how to report
-security issues in Wasmtime, our disclosure policy, and how to receive
+policy](https://bytecodealliance.org/security) for details on our disclosure policy and how to receive
 notifications about security issues.
 
 For classification of what is and what isn't a security issue please see our
 [online
 documentation](https://docs.wasmtime.dev/security-what-is-considered-a-security-vulnerability.html)
 on the subject.
+
+## Reporting a Vulnerability
+
+To report a vulnerability, navigate to the [security](https://github.com/bytecodealliance/wasmtime/security) 
+tab and click the green `Report a Vulnerability` button, or use 
+[this direct link](https://github.com/bytecodealliance/wasmtime/security/advisories/new) to the reporting form.


### PR DESCRIPTION
GitHub changed the UI for vulnerability reporting, so now going to `issues/new` and selecting `Report a security vulnerability` takes one to the `SECURITY.md` file without any UI for actually reporting anything. Hence, this PR changes the document to contain a link to the actual reporting form.