### PR TITLE
docs: fix typos

### DIFF
--- a/crates/wasi-http/src/p3/body.rs
+++ b/crates/wasi-http/src/p3/body.rs
@@ -341,7 +341,7 @@ impl http_body::Body for GuestBody {
                 match res {
                     Ok(buf) => {
                         if let Some(n) = self.content_length.as_mut() {
-                            // Substract frame length from `content_length`,
+                            // Subtract frame length from `content_length`,
                             // [LimitedGuestBodyConsumer] already performs the validation, so
                             // just keep count as optimization for
                             // `is_end_stream` and `size_hint`

--- a/crates/wasi/src/sockets/tcp.rs
+++ b/crates/wasi/src/sockets/tcp.rs
@@ -332,7 +332,7 @@ impl TcpSocket {
         }
     }
 
-    /// For WASIp2 this retreives the result from the future passed to
+    /// For WASIp2 this retrieves the result from the future passed to
     /// `set_pending_connect`.
     ///
     /// Return states here are:

--- a/crates/wasi/src/view.rs
+++ b/crates/wasi/src/view.rs
@@ -39,7 +39,7 @@ pub trait WasiView: Send {
     fn ctx(&mut self) -> WasiCtxView<'_>;
 }
 
-/// Structure returned from [`WasiView::ctx`] which provides accesss to WASI
+/// Structure returned from [`WasiView::ctx`] which provides access to WASI
 /// state for host functions to be implemented with.
 pub struct WasiCtxView<'a> {
     /// The [`WasiCtx`], or configuration, of the guest.


### PR DESCRIPTION
### Description

This PR corrects several minor typos in comments and documentation across the codebase. The changes are non-functional and purely textual to improve clarity and maintain a clean, professional codebase.

### Details

- Corrected misspellings:
  - `Substract` → `Subtract`
  - `retreives` → `retrieves`
  - `accesss` → `access`

These fixes help enhance readability and eliminate minor distractions during development and code reviews.

### Additional Info

No logic or functionality has been modified. All changes are restricted to comments or non-executable doc annotations.