### PR TITLE
Release Wasmtime 37.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -289,7 +289,7 @@ dependencies = [
 
 [[package]]
 name = "byte-array-literals"
-version = "37.0.1"
+version = "37.0.2"
 
 [[package]]
 name = "byteorder"
@@ -693,7 +693,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift"
-version = "0.124.1"
+version = "0.124.2"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",
@@ -706,7 +706,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.124.1"
+version = "0.124.2"
 dependencies = [
  "arbitrary",
  "arbtest",
@@ -724,21 +724,21 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.124.1"
+version = "0.124.2"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.124.1"
+version = "0.124.2"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.124.1"
+version = "0.124.2"
 dependencies = [
  "arbitrary",
  "serde",
@@ -747,7 +747,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.124.1"
+version = "0.124.2"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -782,7 +782,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.124.1"
+version = "0.124.2"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -793,18 +793,18 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.124.1"
+version = "0.124.2"
 
 [[package]]
 name = "cranelift-control"
-version = "0.124.1"
+version = "0.124.2"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.124.1"
+version = "0.124.2"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.124.1"
+version = "0.124.2"
 dependencies = [
  "cranelift-codegen",
  "env_logger 0.11.5",
@@ -869,7 +869,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-interpreter"
-version = "0.124.1"
+version = "0.124.2"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.124.1"
+version = "0.124.2"
 dependencies = [
  "codespan-reporting",
  "log",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-jit"
-version = "0.124.1"
+version = "0.124.2"
 dependencies = [
  "anyhow",
  "cranelift",
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-module"
-version = "0.124.1"
+version = "0.124.2"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -926,7 +926,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.124.1"
+version = "0.124.2"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-object"
-version = "0.124.1"
+version = "0.124.2"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -950,7 +950,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-reader"
-version = "0.124.1"
+version = "0.124.2"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -960,7 +960,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-serde"
-version = "0.124.1"
+version = "0.124.2"
 dependencies = [
  "clap",
  "cranelift-codegen",
@@ -970,7 +970,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.124.1"
+version = "0.124.2"
 
 [[package]]
 name = "cranelift-tools"
@@ -1221,7 +1221,7 @@ checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
 
 [[package]]
 name = "embedding"
-version = "37.0.1"
+version = "37.0.2"
 dependencies = [
  "anyhow",
  "dlmalloc",
@@ -2374,7 +2374,7 @@ dependencies = [
 
 [[package]]
 name = "min-platform-host"
-version = "37.0.1"
+version = "37.0.2"
 dependencies = [
  "anyhow",
  "libloading",
@@ -2817,7 +2817,7 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "37.0.1"
+version = "37.0.2"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -2841,7 +2841,7 @@ dependencies = [
 
 [[package]]
 name = "pulley-macros"
-version = "37.0.1"
+version = "37.0.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4075,7 +4075,7 @@ version = "0.1.0"
 
 [[package]]
 name = "verify-component-adapter"
-version = "37.0.1"
+version = "37.0.2"
 dependencies = [
  "anyhow",
  "wasmparser 0.239.0",
@@ -4143,7 +4143,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-common"
-version = "37.0.1"
+version = "37.0.2"
 dependencies = [
  "anyhow",
  "bitflags 2.6.0",
@@ -4182,7 +4182,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-preview1-component-adapter"
-version = "37.0.1"
+version = "37.0.2"
 dependencies = [
  "bitflags 2.6.0",
  "byte-array-literals",
@@ -4419,7 +4419,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "37.0.1"
+version = "37.0.2"
 dependencies = [
  "addr2line 0.25.0",
  "anyhow",
@@ -4484,7 +4484,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-bench-api"
-version = "37.0.1"
+version = "37.0.2"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -4500,14 +4500,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-c-api"
-version = "37.0.1"
+version = "37.0.2"
 dependencies = [
  "wasmtime-c-api-impl",
 ]
 
 [[package]]
 name = "wasmtime-c-api-impl"
-version = "37.0.1"
+version = "37.0.2"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -4524,7 +4524,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli"
-version = "37.0.1"
+version = "37.0.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4598,7 +4598,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli-flags"
-version = "37.0.1"
+version = "37.0.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -4613,7 +4613,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "37.0.1"
+version = "37.0.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -4719,14 +4719,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-asm-macros"
-version = "37.0.1"
+version = "37.0.2"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "wasmtime-internal-c-api-macros"
-version = "37.0.1"
+version = "37.0.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4734,7 +4734,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cache"
-version = "37.0.1"
+version = "37.0.2"
 dependencies = [
  "anyhow",
  "base64",
@@ -4755,7 +4755,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-macro"
-version = "37.0.1"
+version = "37.0.2"
 dependencies = [
  "anyhow",
  "component-macro-test-helpers",
@@ -4775,11 +4775,11 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-util"
-version = "37.0.1"
+version = "37.0.2"
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "37.0.1"
+version = "37.0.2"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4805,7 +4805,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-explorer"
-version = "37.0.1"
+version = "37.0.2"
 dependencies = [
  "anyhow",
  "capstone",
@@ -4820,7 +4820,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-fiber"
-version = "37.0.1"
+version = "37.0.2"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -4835,7 +4835,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-debug"
-version = "37.0.1"
+version = "37.0.2"
 dependencies = [
  "cc",
  "object 0.37.3",
@@ -4845,7 +4845,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "37.0.1"
+version = "37.0.2"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4855,18 +4855,18 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-math"
-version = "37.0.1"
+version = "37.0.2"
 dependencies = [
  "libm",
 ]
 
 [[package]]
 name = "wasmtime-internal-slab"
-version = "37.0.1"
+version = "37.0.2"
 
 [[package]]
 name = "wasmtime-internal-unwinder"
-version = "37.0.1"
+version = "37.0.2"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4877,7 +4877,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
-version = "37.0.1"
+version = "37.0.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4886,7 +4886,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-winch"
-version = "37.0.1"
+version = "37.0.2"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -4902,7 +4902,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-wit-bindgen"
-version = "37.0.1"
+version = "37.0.2"
 dependencies = [
  "anyhow",
  "bitflags 2.6.0",
@@ -4913,7 +4913,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-wmemcheck"
-version = "37.0.1"
+version = "37.0.2"
 
 [[package]]
 name = "wasmtime-test-macros"
@@ -4928,7 +4928,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-test-util"
-version = "37.0.1"
+version = "37.0.2"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -4946,7 +4946,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "37.0.1"
+version = "37.0.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4981,7 +4981,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-config"
-version = "37.0.1"
+version = "37.0.2"
 dependencies = [
  "anyhow",
  "test-programs-artifacts",
@@ -4992,7 +4992,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-http"
-version = "37.0.1"
+version = "37.0.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5023,7 +5023,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-io"
-version = "37.0.1"
+version = "37.0.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5034,7 +5034,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-keyvalue"
-version = "37.0.1"
+version = "37.0.2"
 dependencies = [
  "anyhow",
  "test-programs-artifacts",
@@ -5045,7 +5045,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-nn"
-version = "37.0.1"
+version = "37.0.2"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -5066,7 +5066,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-threads"
-version = "37.0.1"
+version = "37.0.2"
 dependencies = [
  "anyhow",
  "log",
@@ -5078,7 +5078,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-tls"
-version = "37.0.1"
+version = "37.0.2"
 dependencies = [
  "anyhow",
  "bytes",
@@ -5094,7 +5094,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-tls-nativetls"
-version = "37.0.1"
+version = "37.0.2"
 dependencies = [
  "anyhow",
  "futures",
@@ -5109,7 +5109,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wast"
-version = "37.0.1"
+version = "37.0.2"
 dependencies = [
  "anyhow",
  "json-from-wast",
@@ -5187,7 +5187,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "37.0.1"
+version = "37.0.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5204,7 +5204,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "37.0.1"
+version = "37.0.2"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -5216,7 +5216,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "37.0.1"
+version = "37.0.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5271,7 +5271,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "37.0.1"
+version = "37.0.2"
 dependencies = [
  "anyhow",
  "cranelift-assembler-x64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -175,7 +175,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "37.0.1"
+version = "37.0.2"
 authors = ["The Wasmtime Project Developers"]
 edition = "2024"
 # Wasmtime's current policy is that this number can be no larger than the
@@ -228,19 +228,19 @@ multiple_bound_locations = 'warn'
 # tooling but aren't intended to be widely depended on.
 #
 # All of these crates are supported though in the sense that
-wasmtime = { path = "crates/wasmtime", version = "37.0.1", default-features = false }
-wasmtime-cli-flags = { path = "crates/cli-flags", version = "=37.0.1" }
-wasmtime-environ = { path = "crates/environ", version = "=37.0.1" }
-wasmtime-wasi = { path = "crates/wasi", version = "37.0.1", default-features = false }
-wasmtime-wasi-io = { path = "crates/wasi-io", version = "37.0.1", default-features = false }
-wasmtime-wasi-http = { path = "crates/wasi-http", version = "37.0.1", default-features = false }
-wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "37.0.1" }
-wasmtime-wasi-config = { path = "crates/wasi-config", version = "37.0.1" }
-wasmtime-wasi-keyvalue = { path = "crates/wasi-keyvalue", version = "37.0.1" }
-wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "37.0.1" }
-wasmtime-wasi-tls = { path = "crates/wasi-tls", version = "37.0.1" }
-wasmtime-wasi-tls-nativetls = { path = "crates/wasi-tls-nativetls", version = "37.0.1" }
-wasmtime-wast = { path = "crates/wast", version = "=37.0.1" }
+wasmtime = { path = "crates/wasmtime", version = "37.0.2", default-features = false }
+wasmtime-cli-flags = { path = "crates/cli-flags", version = "=37.0.2" }
+wasmtime-environ = { path = "crates/environ", version = "=37.0.2" }
+wasmtime-wasi = { path = "crates/wasi", version = "37.0.2", default-features = false }
+wasmtime-wasi-io = { path = "crates/wasi-io", version = "37.0.2", default-features = false }
+wasmtime-wasi-http = { path = "crates/wasi-http", version = "37.0.2", default-features = false }
+wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "37.0.2" }
+wasmtime-wasi-config = { path = "crates/wasi-config", version = "37.0.2" }
+wasmtime-wasi-keyvalue = { path = "crates/wasi-keyvalue", version = "37.0.2" }
+wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "37.0.2" }
+wasmtime-wasi-tls = { path = "crates/wasi-tls", version = "37.0.2" }
+wasmtime-wasi-tls-nativetls = { path = "crates/wasi-tls-nativetls", version = "37.0.2" }
+wasmtime-wast = { path = "crates/wast", version = "=37.0.2" }
 
 # Internal Wasmtime-specific crates.
 #
@@ -249,54 +249,54 @@ wasmtime-wast = { path = "crates/wast", version = "=37.0.1" }
 # that these are internal unsupported crates for external use. These exist as
 # part of the project organization of other public crates in Wasmtime and are
 # otherwise not supported in terms of CVEs for example.
-wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=37.0.1", package = 'wasmtime-internal-wmemcheck' }
-wasmtime-c-api-macros = { path = "crates/c-api-macros", version = "=37.0.1", package = 'wasmtime-internal-c-api-macros' }
-wasmtime-cache = { path = "crates/cache", version = "=37.0.1", package = 'wasmtime-internal-cache' }
-wasmtime-cranelift = { path = "crates/cranelift", version = "=37.0.1", package = 'wasmtime-internal-cranelift' }
-wasmtime-winch = { path = "crates/winch", version = "=37.0.1", package = 'wasmtime-internal-winch'  }
-wasmtime-explorer = { path = "crates/explorer", version = "=37.0.1", package = 'wasmtime-internal-explorer'  }
-wasmtime-fiber = { path = "crates/fiber", version = "=37.0.1", package = 'wasmtime-internal-fiber' }
-wasmtime-jit-debug = { path = "crates/jit-debug", version = "=37.0.1", package = 'wasmtime-internal-jit-debug' }
-wasmtime-component-util = { path = "crates/component-util", version = "=37.0.1", package = 'wasmtime-internal-component-util' }
-wasmtime-component-macro = { path = "crates/component-macro", version = "=37.0.1", package = 'wasmtime-internal-component-macro' }
-wasmtime-asm-macros = { path = "crates/asm-macros", version = "=37.0.1", package = 'wasmtime-internal-asm-macros' }
-wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=37.0.1", package = 'wasmtime-internal-versioned-export-macros' }
-wasmtime-slab = { path = "crates/slab", version = "=37.0.1", package = 'wasmtime-internal-slab' }
-wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=37.0.1", package = 'wasmtime-internal-jit-icache-coherence' }
-wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=37.0.1", package = 'wasmtime-internal-wit-bindgen' }
-wasmtime-math = { path = "crates/math", version = "=37.0.1", package = 'wasmtime-internal-math'  }
-wasmtime-unwinder = { path = "crates/unwinder", version = "=37.0.1", package = 'wasmtime-internal-unwinder' }
+wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=37.0.2", package = 'wasmtime-internal-wmemcheck' }
+wasmtime-c-api-macros = { path = "crates/c-api-macros", version = "=37.0.2", package = 'wasmtime-internal-c-api-macros' }
+wasmtime-cache = { path = "crates/cache", version = "=37.0.2", package = 'wasmtime-internal-cache' }
+wasmtime-cranelift = { path = "crates/cranelift", version = "=37.0.2", package = 'wasmtime-internal-cranelift' }
+wasmtime-winch = { path = "crates/winch", version = "=37.0.2", package = 'wasmtime-internal-winch'  }
+wasmtime-explorer = { path = "crates/explorer", version = "=37.0.2", package = 'wasmtime-internal-explorer'  }
+wasmtime-fiber = { path = "crates/fiber", version = "=37.0.2", package = 'wasmtime-internal-fiber' }
+wasmtime-jit-debug = { path = "crates/jit-debug", version = "=37.0.2", package = 'wasmtime-internal-jit-debug' }
+wasmtime-component-util = { path = "crates/component-util", version = "=37.0.2", package = 'wasmtime-internal-component-util' }
+wasmtime-component-macro = { path = "crates/component-macro", version = "=37.0.2", package = 'wasmtime-internal-component-macro' }
+wasmtime-asm-macros = { path = "crates/asm-macros", version = "=37.0.2", package = 'wasmtime-internal-asm-macros' }
+wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=37.0.2", package = 'wasmtime-internal-versioned-export-macros' }
+wasmtime-slab = { path = "crates/slab", version = "=37.0.2", package = 'wasmtime-internal-slab' }
+wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=37.0.2", package = 'wasmtime-internal-jit-icache-coherence' }
+wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=37.0.2", package = 'wasmtime-internal-wit-bindgen' }
+wasmtime-math = { path = "crates/math", version = "=37.0.2", package = 'wasmtime-internal-math'  }
+wasmtime-unwinder = { path = "crates/unwinder", version = "=37.0.2", package = 'wasmtime-internal-unwinder' }
 
 # Miscellaneous crates without a `wasmtime-*` prefix in their name but still
 # used in the `wasmtime-*` family of crates depending on various features/etc.
-wiggle = { path = "crates/wiggle", version = "=37.0.1", default-features = false }
-wiggle-macro = { path = "crates/wiggle/macro", version = "=37.0.1" }
-wiggle-generate = { path = "crates/wiggle/generate", version = "=37.0.1" }
-wasi-common = { path = "crates/wasi-common", version = "=37.0.1", default-features = false }
-pulley-interpreter = { path = 'pulley', version = "=37.0.1" }
-pulley-macros = { path = 'pulley/macros', version = "=37.0.1" }
+wiggle = { path = "crates/wiggle", version = "=37.0.2", default-features = false }
+wiggle-macro = { path = "crates/wiggle/macro", version = "=37.0.2" }
+wiggle-generate = { path = "crates/wiggle/generate", version = "=37.0.2" }
+wasi-common = { path = "crates/wasi-common", version = "=37.0.2", default-features = false }
+pulley-interpreter = { path = 'pulley', version = "=37.0.2" }
+pulley-macros = { path = 'pulley/macros', version = "=37.0.2" }
 
 # Cranelift crates in this workspace
-cranelift-assembler-x64 = { path = "cranelift/assembler-x64", version = "0.124.1" }
-cranelift-codegen = { path = "cranelift/codegen", version = "0.124.1", default-features = false, features = ["std", "unwind"] }
-cranelift-frontend = { path = "cranelift/frontend", version = "0.124.1" }
-cranelift-entity = { path = "cranelift/entity", version = "0.124.1" }
-cranelift-native = { path = "cranelift/native", version = "0.124.1" }
-cranelift-module = { path = "cranelift/module", version = "0.124.1" }
-cranelift-interpreter = { path = "cranelift/interpreter", version = "0.124.1" }
-cranelift-reader = { path = "cranelift/reader", version = "0.124.1" }
+cranelift-assembler-x64 = { path = "cranelift/assembler-x64", version = "0.124.2" }
+cranelift-codegen = { path = "cranelift/codegen", version = "0.124.2", default-features = false, features = ["std", "unwind"] }
+cranelift-frontend = { path = "cranelift/frontend", version = "0.124.2" }
+cranelift-entity = { path = "cranelift/entity", version = "0.124.2" }
+cranelift-native = { path = "cranelift/native", version = "0.124.2" }
+cranelift-module = { path = "cranelift/module", version = "0.124.2" }
+cranelift-interpreter = { path = "cranelift/interpreter", version = "0.124.2" }
+cranelift-reader = { path = "cranelift/reader", version = "0.124.2" }
 cranelift-filetests = { path = "cranelift/filetests" }
-cranelift-object = { path = "cranelift/object", version = "0.124.1" }
-cranelift-jit = { path = "cranelift/jit", version = "0.124.1" }
+cranelift-object = { path = "cranelift/object", version = "0.124.2" }
+cranelift-jit = { path = "cranelift/jit", version = "0.124.2" }
 cranelift-fuzzgen = { path = "cranelift/fuzzgen" }
-cranelift-bforest = { path = "cranelift/bforest", version = "0.124.1" }
-cranelift-bitset = { path = "cranelift/bitset", version = "0.124.1" }
-cranelift-control = { path = "cranelift/control", version = "0.124.1" }
-cranelift-srcgen = { path = "cranelift/srcgen", version = "0.124.1" }
-cranelift = { path = "cranelift/umbrella", version = "0.124.1" }
+cranelift-bforest = { path = "cranelift/bforest", version = "0.124.2" }
+cranelift-bitset = { path = "cranelift/bitset", version = "0.124.2" }
+cranelift-control = { path = "cranelift/control", version = "0.124.2" }
+cranelift-srcgen = { path = "cranelift/srcgen", version = "0.124.2" }
+cranelift = { path = "cranelift/umbrella", version = "0.124.2" }
 
 # Winch crates in this workspace.
-winch-codegen = { path = "winch/codegen", version = "=37.0.1" }
+winch-codegen = { path = "winch/codegen", version = "=37.0.2" }
 
 # Internal crates not published to crates.io used in testing, builds, etc
 wasi-preview1-component-adapter = { path = "crates/wasi-preview1-component-adapter" }

--- a/cranelift/assembler-x64/Cargo.toml
+++ b/cranelift/assembler-x64/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-assembler-x64"
 description = "A Cranelift-specific x64 assembler"
-version = "0.124.1"
+version = "0.124.2"
 license = "Apache-2.0 WITH LLVM-exception"
 edition.workspace = true
 rust-version.workspace = true
@@ -16,7 +16,7 @@ arbtest = "0.3.1"
 capstone = { workspace = true }
 
 [build-dependencies]
-cranelift-assembler-x64-meta = { path = "meta", version = "0.124.1" }
+cranelift-assembler-x64-meta = { path = "meta", version = "0.124.2" }
 
 [lints]
 workspace = true

--- a/cranelift/assembler-x64/meta/Cargo.toml
+++ b/cranelift/assembler-x64/meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-assembler-x64-meta"
 description = "Generate a Cranelift-specific assembler for x64 instructions"
-version = "0.124.1"
+version = "0.124.2"
 license = "Apache-2.0 WITH LLVM-exception"
 edition.workspace = true
 rust-version.workspace = true

--- a/cranelift/bforest/Cargo.toml
+++ b/cranelift/bforest/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bforest"
-version = "0.124.1"
+version = "0.124.2"
 description = "A forest of B+-trees"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-bforest"

--- a/cranelift/bitset/Cargo.toml
+++ b/cranelift/bitset/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bitset"
-version = "0.124.1"
+version = "0.124.2"
 description = "Various bitset stuff for use inside Cranelift"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-bitset"

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen"
-version = "0.124.1"
+version = "0.124.2"
 description = "Low-level code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-codegen"
@@ -25,7 +25,7 @@ anyhow = { workspace = true, optional = true, features = ['std'] }
 bumpalo = "3"
 capstone = { workspace = true, optional = true }
 cranelift-assembler-x64 = { workspace = true }
-cranelift-codegen-shared = { path = "./shared", version = "0.124.1" }
+cranelift-codegen-shared = { path = "./shared", version = "0.124.2" }
 cranelift-entity = { workspace = true }
 cranelift-bforest = { workspace = true }
 cranelift-bitset = { workspace = true }
@@ -56,8 +56,8 @@ env_logger = { workspace = true }
 proptest = { workspace = true }
 
 [build-dependencies]
-cranelift-codegen-meta = { path = "meta", version = "0.124.1" }
-cranelift-isle = { path = "../isle/isle", version = "=0.124.1" }
+cranelift-codegen-meta = { path = "meta", version = "0.124.2" }
+cranelift-isle = { path = "../isle/isle", version = "=0.124.2" }
 
 [features]
 default = ["std", "unwind", "host-arch", "timing"]

--- a/cranelift/codegen/meta/Cargo.toml
+++ b/cranelift/codegen/meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-codegen-meta"
 authors = ["The Cranelift Project Developers"]
-version = "0.124.1"
+version = "0.124.2"
 description = "Metaprogram for cranelift-codegen code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
@@ -17,8 +17,8 @@ rustdoc-args = ["--document-private-items"]
 
 [dependencies]
 cranelift-srcgen = { workspace = true }
-cranelift-assembler-x64-meta = { path = "../../assembler-x64/meta", version = "0.124.1" }
-cranelift-codegen-shared = { path = "../shared", version = "0.124.1" }
+cranelift-assembler-x64-meta = { path = "../../assembler-x64/meta", version = "0.124.2" }
+cranelift-codegen-shared = { path = "../shared", version = "0.124.2" }
 pulley-interpreter = { workspace = true, optional = true }
 heck = "0.5.0"
 

--- a/cranelift/codegen/shared/Cargo.toml
+++ b/cranelift/codegen/shared/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen-shared"
-version = "0.124.1"
+version = "0.124.2"
 description = "For code shared between cranelift-codegen-meta and cranelift-codegen"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/control/Cargo.toml
+++ b/cranelift/control/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-control"
-version = "0.124.1"
+version = "0.124.2"
 description = "White-box fuzz testing framework"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/entity/Cargo.toml
+++ b/cranelift/entity/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-entity"
-version = "0.124.1"
+version = "0.124.2"
 description = "Data structures using entity references as mapping keys"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-entity"

--- a/cranelift/frontend/Cargo.toml
+++ b/cranelift/frontend/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-frontend"
-version = "0.124.1"
+version = "0.124.2"
 description = "Cranelift IR builder helper"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-frontend"

--- a/cranelift/interpreter/Cargo.toml
+++ b/cranelift/interpreter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-interpreter"
-version = "0.124.1"
+version = "0.124.2"
 authors = ["The Cranelift Project Developers"]
 description = "Interpret Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/isle/isle/Cargo.toml
+++ b/cranelift/isle/isle/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 name = "cranelift-isle"
 readme = "../README.md"
 repository = "https://github.com/bytecodealliance/wasmtime/tree/main/cranelift/isle"
-version = "0.124.1"
+version = "0.124.2"
 
 [lints]
 workspace = true

--- a/cranelift/jit/Cargo.toml
+++ b/cranelift/jit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-jit"
-version = "0.124.1"
+version = "0.124.2"
 authors = ["The Cranelift Project Developers"]
 description = "A JIT library backed by Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/module/Cargo.toml
+++ b/cranelift/module/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-module"
-version = "0.124.1"
+version = "0.124.2"
 authors = ["The Cranelift Project Developers"]
 description = "Support for linking functions and data with Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/native/Cargo.toml
+++ b/cranelift/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-native"
-version = "0.124.1"
+version = "0.124.2"
 authors = ["The Cranelift Project Developers"]
 description = "Support for targeting the host with Cranelift"
 documentation = "https://docs.rs/cranelift-native"

--- a/cranelift/object/Cargo.toml
+++ b/cranelift/object/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-object"
-version = "0.124.1"
+version = "0.124.2"
 authors = ["The Cranelift Project Developers"]
 description = "Emit Cranelift output to native object files with `object`"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/reader/Cargo.toml
+++ b/cranelift/reader/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-reader"
-version = "0.124.1"
+version = "0.124.2"
 description = "Cranelift textual IR reader"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-reader"

--- a/cranelift/serde/Cargo.toml
+++ b/cranelift/serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-serde"
-version = "0.124.1"
+version = "0.124.2"
 authors = ["The Cranelift Project Developers"]
 description = "Serializer/Deserializer for Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/srcgen/Cargo.toml
+++ b/cranelift/srcgen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-srcgen"
-version = "0.124.1"
+version = "0.124.2"
 authors = ["The Wasmtime Project Developers"]
 description = "Helper functions for generating Rust and ISLE files"
 license = "Apache-2.0 WITH LLVM-exception"

--- a/cranelift/umbrella/Cargo.toml
+++ b/cranelift/umbrella/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift"
-version = "0.124.1"
+version = "0.124.2"
 description = "Umbrella for commonly-used cranelift crates"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift"

--- a/crates/c-api/include/wasmtime.h
+++ b/crates/c-api/include/wasmtime.h
@@ -213,7 +213,7 @@
 /**
  * \brief Wasmtime version string.
  */
-#define WASMTIME_VERSION "37.0.1"
+#define WASMTIME_VERSION "37.0.2"
 /**
  * \brief Wasmtime major version number.
  */
@@ -225,6 +225,6 @@
 /**
  * \brief Wasmtime patch version number.
  */
-#define WASMTIME_VERSION_PATCH 1
+#define WASMTIME_VERSION_PATCH 2
 
 #endif // WASMTIME_API_H

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -9,6 +9,10 @@ audited_as = "0.123.2"
 version = "0.124.1"
 audited_as = "0.124.0"
 
+[[unpublished.cranelift]]
+version = "0.124.2"
+audited_as = "0.124.1"
+
 [[unpublished.cranelift-assembler-x64]]
 version = "0.124.0"
 audited_as = "0.123.2"
@@ -16,6 +20,10 @@ audited_as = "0.123.2"
 [[unpublished.cranelift-assembler-x64]]
 version = "0.124.1"
 audited_as = "0.124.0"
+
+[[unpublished.cranelift-assembler-x64]]
+version = "0.124.2"
+audited_as = "0.124.1"
 
 [[unpublished.cranelift-assembler-x64-meta]]
 version = "0.124.0"
@@ -25,6 +33,10 @@ audited_as = "0.123.2"
 version = "0.124.1"
 audited_as = "0.124.0"
 
+[[unpublished.cranelift-assembler-x64-meta]]
+version = "0.124.2"
+audited_as = "0.124.1"
+
 [[unpublished.cranelift-bforest]]
 version = "0.124.0"
 audited_as = "0.123.2"
@@ -32,6 +44,10 @@ audited_as = "0.123.2"
 [[unpublished.cranelift-bforest]]
 version = "0.124.1"
 audited_as = "0.124.0"
+
+[[unpublished.cranelift-bforest]]
+version = "0.124.2"
+audited_as = "0.124.1"
 
 [[unpublished.cranelift-bitset]]
 version = "0.124.0"
@@ -41,6 +57,10 @@ audited_as = "0.123.2"
 version = "0.124.1"
 audited_as = "0.124.0"
 
+[[unpublished.cranelift-bitset]]
+version = "0.124.2"
+audited_as = "0.124.1"
+
 [[unpublished.cranelift-codegen]]
 version = "0.124.0"
 audited_as = "0.123.2"
@@ -48,6 +68,10 @@ audited_as = "0.123.2"
 [[unpublished.cranelift-codegen]]
 version = "0.124.1"
 audited_as = "0.124.0"
+
+[[unpublished.cranelift-codegen]]
+version = "0.124.2"
+audited_as = "0.124.1"
 
 [[unpublished.cranelift-codegen-meta]]
 version = "0.124.0"
@@ -57,6 +81,10 @@ audited_as = "0.123.2"
 version = "0.124.1"
 audited_as = "0.124.0"
 
+[[unpublished.cranelift-codegen-meta]]
+version = "0.124.2"
+audited_as = "0.124.1"
+
 [[unpublished.cranelift-codegen-shared]]
 version = "0.124.0"
 audited_as = "0.123.2"
@@ -64,6 +92,10 @@ audited_as = "0.123.2"
 [[unpublished.cranelift-codegen-shared]]
 version = "0.124.1"
 audited_as = "0.124.0"
+
+[[unpublished.cranelift-codegen-shared]]
+version = "0.124.2"
+audited_as = "0.124.1"
 
 [[unpublished.cranelift-control]]
 version = "0.124.0"
@@ -73,6 +105,10 @@ audited_as = "0.123.2"
 version = "0.124.1"
 audited_as = "0.124.0"
 
+[[unpublished.cranelift-control]]
+version = "0.124.2"
+audited_as = "0.124.1"
+
 [[unpublished.cranelift-entity]]
 version = "0.124.0"
 audited_as = "0.123.2"
@@ -80,6 +116,10 @@ audited_as = "0.123.2"
 [[unpublished.cranelift-entity]]
 version = "0.124.1"
 audited_as = "0.124.0"
+
+[[unpublished.cranelift-entity]]
+version = "0.124.2"
+audited_as = "0.124.1"
 
 [[unpublished.cranelift-frontend]]
 version = "0.124.0"
@@ -89,6 +129,10 @@ audited_as = "0.123.2"
 version = "0.124.1"
 audited_as = "0.124.0"
 
+[[unpublished.cranelift-frontend]]
+version = "0.124.2"
+audited_as = "0.124.1"
+
 [[unpublished.cranelift-interpreter]]
 version = "0.124.0"
 audited_as = "0.123.2"
@@ -96,6 +140,10 @@ audited_as = "0.123.2"
 [[unpublished.cranelift-interpreter]]
 version = "0.124.1"
 audited_as = "0.124.0"
+
+[[unpublished.cranelift-interpreter]]
+version = "0.124.2"
+audited_as = "0.124.1"
 
 [[unpublished.cranelift-isle]]
 version = "0.124.0"
@@ -105,6 +153,10 @@ audited_as = "0.123.2"
 version = "0.124.1"
 audited_as = "0.124.0"
 
+[[unpublished.cranelift-isle]]
+version = "0.124.2"
+audited_as = "0.124.1"
+
 [[unpublished.cranelift-jit]]
 version = "0.124.0"
 audited_as = "0.123.2"
@@ -112,6 +164,10 @@ audited_as = "0.123.2"
 [[unpublished.cranelift-jit]]
 version = "0.124.1"
 audited_as = "0.124.0"
+
+[[unpublished.cranelift-jit]]
+version = "0.124.2"
+audited_as = "0.124.1"
 
 [[unpublished.cranelift-module]]
 version = "0.124.0"
@@ -121,6 +177,10 @@ audited_as = "0.123.2"
 version = "0.124.1"
 audited_as = "0.124.0"
 
+[[unpublished.cranelift-module]]
+version = "0.124.2"
+audited_as = "0.124.1"
+
 [[unpublished.cranelift-native]]
 version = "0.124.0"
 audited_as = "0.123.2"
@@ -128,6 +188,10 @@ audited_as = "0.123.2"
 [[unpublished.cranelift-native]]
 version = "0.124.1"
 audited_as = "0.124.0"
+
+[[unpublished.cranelift-native]]
+version = "0.124.2"
+audited_as = "0.124.1"
 
 [[unpublished.cranelift-object]]
 version = "0.124.0"
@@ -137,6 +201,10 @@ audited_as = "0.123.2"
 version = "0.124.1"
 audited_as = "0.124.0"
 
+[[unpublished.cranelift-object]]
+version = "0.124.2"
+audited_as = "0.124.1"
+
 [[unpublished.cranelift-reader]]
 version = "0.124.0"
 audited_as = "0.123.2"
@@ -144,6 +212,10 @@ audited_as = "0.123.2"
 [[unpublished.cranelift-reader]]
 version = "0.124.1"
 audited_as = "0.124.0"
+
+[[unpublished.cranelift-reader]]
+version = "0.124.2"
+audited_as = "0.124.1"
 
 [[unpublished.cranelift-serde]]
 version = "0.124.0"
@@ -153,6 +225,10 @@ audited_as = "0.123.2"
 version = "0.124.1"
 audited_as = "0.124.0"
 
+[[unpublished.cranelift-serde]]
+version = "0.124.2"
+audited_as = "0.124.1"
+
 [[unpublished.cranelift-srcgen]]
 version = "0.124.0"
 audited_as = "0.123.2"
@@ -161,6 +237,10 @@ audited_as = "0.123.2"
 version = "0.124.1"
 audited_as = "0.124.0"
 
+[[unpublished.cranelift-srcgen]]
+version = "0.124.2"
+audited_as = "0.124.1"
+
 [[unpublished.pulley-interpreter]]
 version = "37.0.0"
 audited_as = "36.0.2"
@@ -168,6 +248,10 @@ audited_as = "36.0.2"
 [[unpublished.pulley-interpreter]]
 version = "37.0.1"
 audited_as = "37.0.0"
+
+[[unpublished.pulley-interpreter]]
+version = "37.0.2"
+audited_as = "37.0.1"
 
 [[unpublished.pulley-macros]]
 version = "37.0.0"
@@ -177,6 +261,10 @@ audited_as = "36.0.2"
 version = "37.0.1"
 audited_as = "37.0.0"
 
+[[unpublished.pulley-macros]]
+version = "37.0.2"
+audited_as = "37.0.1"
+
 [[unpublished.wasi-common]]
 version = "37.0.0"
 audited_as = "36.0.2"
@@ -184,6 +272,10 @@ audited_as = "36.0.2"
 [[unpublished.wasi-common]]
 version = "37.0.1"
 audited_as = "37.0.0"
+
+[[unpublished.wasi-common]]
+version = "37.0.2"
+audited_as = "37.0.1"
 
 [[unpublished.wasmtime]]
 version = "37.0.0"
@@ -193,6 +285,10 @@ audited_as = "36.0.2"
 version = "37.0.1"
 audited_as = "37.0.0"
 
+[[unpublished.wasmtime]]
+version = "37.0.2"
+audited_as = "37.0.1"
+
 [[unpublished.wasmtime-cli]]
 version = "37.0.0"
 audited_as = "36.0.2"
@@ -200,6 +296,10 @@ audited_as = "36.0.2"
 [[unpublished.wasmtime-cli]]
 version = "37.0.1"
 audited_as = "37.0.0"
+
+[[unpublished.wasmtime-cli]]
+version = "37.0.2"
+audited_as = "37.0.1"
 
 [[unpublished.wasmtime-cli-flags]]
 version = "37.0.0"
@@ -209,6 +309,10 @@ audited_as = "36.0.2"
 version = "37.0.1"
 audited_as = "37.0.0"
 
+[[unpublished.wasmtime-cli-flags]]
+version = "37.0.2"
+audited_as = "37.0.1"
+
 [[unpublished.wasmtime-environ]]
 version = "37.0.0"
 audited_as = "36.0.2"
@@ -216,6 +320,10 @@ audited_as = "36.0.2"
 [[unpublished.wasmtime-environ]]
 version = "37.0.1"
 audited_as = "37.0.0"
+
+[[unpublished.wasmtime-environ]]
+version = "37.0.2"
+audited_as = "37.0.1"
 
 [[unpublished.wasmtime-internal-asm-macros]]
 version = "37.0.0"
@@ -225,6 +333,10 @@ audited_as = "36.0.2"
 version = "37.0.1"
 audited_as = "37.0.0"
 
+[[unpublished.wasmtime-internal-asm-macros]]
+version = "37.0.2"
+audited_as = "37.0.1"
+
 [[unpublished.wasmtime-internal-c-api-macros]]
 version = "37.0.0"
 audited_as = "36.0.2"
@@ -232,6 +344,10 @@ audited_as = "36.0.2"
 [[unpublished.wasmtime-internal-c-api-macros]]
 version = "37.0.1"
 audited_as = "37.0.0"
+
+[[unpublished.wasmtime-internal-c-api-macros]]
+version = "37.0.2"
+audited_as = "37.0.1"
 
 [[unpublished.wasmtime-internal-cache]]
 version = "37.0.0"
@@ -241,6 +357,10 @@ audited_as = "36.0.2"
 version = "37.0.1"
 audited_as = "37.0.0"
 
+[[unpublished.wasmtime-internal-cache]]
+version = "37.0.2"
+audited_as = "37.0.1"
+
 [[unpublished.wasmtime-internal-component-macro]]
 version = "37.0.0"
 audited_as = "36.0.2"
@@ -248,6 +368,10 @@ audited_as = "36.0.2"
 [[unpublished.wasmtime-internal-component-macro]]
 version = "37.0.1"
 audited_as = "37.0.0"
+
+[[unpublished.wasmtime-internal-component-macro]]
+version = "37.0.2"
+audited_as = "37.0.1"
 
 [[unpublished.wasmtime-internal-component-util]]
 version = "37.0.0"
@@ -257,6 +381,10 @@ audited_as = "36.0.2"
 version = "37.0.1"
 audited_as = "37.0.0"
 
+[[unpublished.wasmtime-internal-component-util]]
+version = "37.0.2"
+audited_as = "37.0.1"
+
 [[unpublished.wasmtime-internal-cranelift]]
 version = "37.0.0"
 audited_as = "36.0.2"
@@ -264,6 +392,10 @@ audited_as = "36.0.2"
 [[unpublished.wasmtime-internal-cranelift]]
 version = "37.0.1"
 audited_as = "37.0.0"
+
+[[unpublished.wasmtime-internal-cranelift]]
+version = "37.0.2"
+audited_as = "37.0.1"
 
 [[unpublished.wasmtime-internal-explorer]]
 version = "37.0.0"
@@ -273,6 +405,10 @@ audited_as = "36.0.2"
 version = "37.0.1"
 audited_as = "37.0.0"
 
+[[unpublished.wasmtime-internal-explorer]]
+version = "37.0.2"
+audited_as = "37.0.1"
+
 [[unpublished.wasmtime-internal-fiber]]
 version = "37.0.0"
 audited_as = "36.0.2"
@@ -280,6 +416,10 @@ audited_as = "36.0.2"
 [[unpublished.wasmtime-internal-fiber]]
 version = "37.0.1"
 audited_as = "37.0.0"
+
+[[unpublished.wasmtime-internal-fiber]]
+version = "37.0.2"
+audited_as = "37.0.1"
 
 [[unpublished.wasmtime-internal-jit-debug]]
 version = "37.0.0"
@@ -289,6 +429,10 @@ audited_as = "36.0.2"
 version = "37.0.1"
 audited_as = "37.0.0"
 
+[[unpublished.wasmtime-internal-jit-debug]]
+version = "37.0.2"
+audited_as = "37.0.1"
+
 [[unpublished.wasmtime-internal-jit-icache-coherence]]
 version = "37.0.0"
 audited_as = "36.0.2"
@@ -296,6 +440,10 @@ audited_as = "36.0.2"
 [[unpublished.wasmtime-internal-jit-icache-coherence]]
 version = "37.0.1"
 audited_as = "37.0.0"
+
+[[unpublished.wasmtime-internal-jit-icache-coherence]]
+version = "37.0.2"
+audited_as = "37.0.1"
 
 [[unpublished.wasmtime-internal-math]]
 version = "37.0.0"
@@ -305,6 +453,10 @@ audited_as = "36.0.2"
 version = "37.0.1"
 audited_as = "37.0.0"
 
+[[unpublished.wasmtime-internal-math]]
+version = "37.0.2"
+audited_as = "37.0.1"
+
 [[unpublished.wasmtime-internal-slab]]
 version = "37.0.0"
 audited_as = "36.0.2"
@@ -312,6 +464,10 @@ audited_as = "36.0.2"
 [[unpublished.wasmtime-internal-slab]]
 version = "37.0.1"
 audited_as = "37.0.0"
+
+[[unpublished.wasmtime-internal-slab]]
+version = "37.0.2"
+audited_as = "37.0.1"
 
 [[unpublished.wasmtime-internal-unwinder]]
 version = "37.0.0"
@@ -321,6 +477,10 @@ audited_as = "36.0.2"
 version = "37.0.1"
 audited_as = "37.0.0"
 
+[[unpublished.wasmtime-internal-unwinder]]
+version = "37.0.2"
+audited_as = "37.0.1"
+
 [[unpublished.wasmtime-internal-versioned-export-macros]]
 version = "37.0.0"
 audited_as = "36.0.2"
@@ -328,6 +488,10 @@ audited_as = "36.0.2"
 [[unpublished.wasmtime-internal-versioned-export-macros]]
 version = "37.0.1"
 audited_as = "37.0.0"
+
+[[unpublished.wasmtime-internal-versioned-export-macros]]
+version = "37.0.2"
+audited_as = "37.0.1"
 
 [[unpublished.wasmtime-internal-winch]]
 version = "37.0.0"
@@ -337,6 +501,10 @@ audited_as = "36.0.2"
 version = "37.0.1"
 audited_as = "37.0.0"
 
+[[unpublished.wasmtime-internal-winch]]
+version = "37.0.2"
+audited_as = "37.0.1"
+
 [[unpublished.wasmtime-internal-wit-bindgen]]
 version = "37.0.0"
 audited_as = "36.0.2"
@@ -344,6 +512,10 @@ audited_as = "36.0.2"
 [[unpublished.wasmtime-internal-wit-bindgen]]
 version = "37.0.1"
 audited_as = "37.0.0"
+
+[[unpublished.wasmtime-internal-wit-bindgen]]
+version = "37.0.2"
+audited_as = "37.0.1"
 
 [[unpublished.wasmtime-internal-wmemcheck]]
 version = "37.0.0"
@@ -353,6 +525,10 @@ audited_as = "36.0.2"
 version = "37.0.1"
 audited_as = "37.0.0"
 
+[[unpublished.wasmtime-internal-wmemcheck]]
+version = "37.0.2"
+audited_as = "37.0.1"
+
 [[unpublished.wasmtime-wasi]]
 version = "37.0.0"
 audited_as = "36.0.2"
@@ -360,6 +536,10 @@ audited_as = "36.0.2"
 [[unpublished.wasmtime-wasi]]
 version = "37.0.1"
 audited_as = "37.0.0"
+
+[[unpublished.wasmtime-wasi]]
+version = "37.0.2"
+audited_as = "37.0.1"
 
 [[unpublished.wasmtime-wasi-config]]
 version = "37.0.0"
@@ -369,6 +549,10 @@ audited_as = "36.0.2"
 version = "37.0.1"
 audited_as = "37.0.0"
 
+[[unpublished.wasmtime-wasi-config]]
+version = "37.0.2"
+audited_as = "37.0.1"
+
 [[unpublished.wasmtime-wasi-http]]
 version = "37.0.0"
 audited_as = "36.0.2"
@@ -376,6 +560,10 @@ audited_as = "36.0.2"
 [[unpublished.wasmtime-wasi-http]]
 version = "37.0.1"
 audited_as = "37.0.0"
+
+[[unpublished.wasmtime-wasi-http]]
+version = "37.0.2"
+audited_as = "37.0.1"
 
 [[unpublished.wasmtime-wasi-io]]
 version = "37.0.0"
@@ -385,6 +573,10 @@ audited_as = "36.0.2"
 version = "37.0.1"
 audited_as = "37.0.0"
 
+[[unpublished.wasmtime-wasi-io]]
+version = "37.0.2"
+audited_as = "37.0.1"
+
 [[unpublished.wasmtime-wasi-keyvalue]]
 version = "37.0.0"
 audited_as = "36.0.2"
@@ -392,6 +584,10 @@ audited_as = "36.0.2"
 [[unpublished.wasmtime-wasi-keyvalue]]
 version = "37.0.1"
 audited_as = "37.0.0"
+
+[[unpublished.wasmtime-wasi-keyvalue]]
+version = "37.0.2"
+audited_as = "37.0.1"
 
 [[unpublished.wasmtime-wasi-nn]]
 version = "37.0.0"
@@ -401,6 +597,10 @@ audited_as = "36.0.2"
 version = "37.0.1"
 audited_as = "37.0.0"
 
+[[unpublished.wasmtime-wasi-nn]]
+version = "37.0.2"
+audited_as = "37.0.1"
+
 [[unpublished.wasmtime-wasi-threads]]
 version = "37.0.0"
 audited_as = "36.0.2"
@@ -408,6 +608,10 @@ audited_as = "36.0.2"
 [[unpublished.wasmtime-wasi-threads]]
 version = "37.0.1"
 audited_as = "37.0.0"
+
+[[unpublished.wasmtime-wasi-threads]]
+version = "37.0.2"
+audited_as = "37.0.1"
 
 [[unpublished.wasmtime-wasi-tls]]
 version = "37.0.0"
@@ -417,6 +621,10 @@ audited_as = "36.0.2"
 version = "37.0.1"
 audited_as = "37.0.0"
 
+[[unpublished.wasmtime-wasi-tls]]
+version = "37.0.2"
+audited_as = "37.0.1"
+
 [[unpublished.wasmtime-wasi-tls-nativetls]]
 version = "37.0.0"
 audited_as = "36.0.2"
@@ -424,6 +632,10 @@ audited_as = "36.0.2"
 [[unpublished.wasmtime-wasi-tls-nativetls]]
 version = "37.0.1"
 audited_as = "37.0.0"
+
+[[unpublished.wasmtime-wasi-tls-nativetls]]
+version = "37.0.2"
+audited_as = "37.0.1"
 
 [[unpublished.wasmtime-wast]]
 version = "37.0.0"
@@ -433,6 +645,10 @@ audited_as = "36.0.2"
 version = "37.0.1"
 audited_as = "37.0.0"
 
+[[unpublished.wasmtime-wast]]
+version = "37.0.2"
+audited_as = "37.0.1"
+
 [[unpublished.wiggle]]
 version = "37.0.0"
 audited_as = "36.0.2"
@@ -440,6 +656,10 @@ audited_as = "36.0.2"
 [[unpublished.wiggle]]
 version = "37.0.1"
 audited_as = "37.0.0"
+
+[[unpublished.wiggle]]
+version = "37.0.2"
+audited_as = "37.0.1"
 
 [[unpublished.wiggle-generate]]
 version = "37.0.0"
@@ -449,6 +669,10 @@ audited_as = "36.0.2"
 version = "37.0.1"
 audited_as = "37.0.0"
 
+[[unpublished.wiggle-generate]]
+version = "37.0.2"
+audited_as = "37.0.1"
+
 [[unpublished.wiggle-macro]]
 version = "37.0.0"
 audited_as = "36.0.2"
@@ -456,6 +680,10 @@ audited_as = "36.0.2"
 [[unpublished.wiggle-macro]]
 version = "37.0.1"
 audited_as = "37.0.0"
+
+[[unpublished.wiggle-macro]]
+version = "37.0.2"
+audited_as = "37.0.1"
 
 [[unpublished.wiggle-test]]
 version = "0.0.0"
@@ -468,6 +696,10 @@ audited_as = "36.0.2"
 [[unpublished.winch-codegen]]
 version = "37.0.1"
 audited_as = "37.0.0"
+
+[[unpublished.winch-codegen]]
+version = "37.0.2"
+audited_as = "37.0.1"
 
 [[publisher.aho-corasick]]
 version = "1.0.2"
@@ -672,122 +904,122 @@ user-login = "jrmuizel"
 user-name = "Jeff Muizelaar"
 
 [[publisher.cranelift]]
-version = "0.124.0"
-when = "2025-09-20"
+version = "0.124.1"
+when = "2025-09-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-assembler-x64]]
-version = "0.124.0"
-when = "2025-09-20"
+version = "0.124.1"
+when = "2025-09-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-assembler-x64-meta]]
-version = "0.124.0"
-when = "2025-09-20"
+version = "0.124.1"
+when = "2025-09-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-bforest]]
-version = "0.124.0"
-when = "2025-09-20"
+version = "0.124.1"
+when = "2025-09-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-bitset]]
-version = "0.124.0"
-when = "2025-09-20"
+version = "0.124.1"
+when = "2025-09-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-codegen]]
-version = "0.124.0"
-when = "2025-09-20"
+version = "0.124.1"
+when = "2025-09-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-codegen-meta]]
-version = "0.124.0"
-when = "2025-09-20"
+version = "0.124.1"
+when = "2025-09-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-codegen-shared]]
-version = "0.124.0"
-when = "2025-09-20"
+version = "0.124.1"
+when = "2025-09-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-control]]
-version = "0.124.0"
-when = "2025-09-20"
+version = "0.124.1"
+when = "2025-09-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-entity]]
-version = "0.124.0"
-when = "2025-09-20"
+version = "0.124.1"
+when = "2025-09-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-frontend]]
-version = "0.124.0"
-when = "2025-09-20"
+version = "0.124.1"
+when = "2025-09-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-interpreter]]
-version = "0.124.0"
-when = "2025-09-20"
+version = "0.124.1"
+when = "2025-09-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-isle]]
-version = "0.124.0"
-when = "2025-09-20"
+version = "0.124.1"
+when = "2025-09-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-jit]]
-version = "0.124.0"
-when = "2025-09-20"
+version = "0.124.1"
+when = "2025-09-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-module]]
-version = "0.124.0"
-when = "2025-09-20"
+version = "0.124.1"
+when = "2025-09-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-native]]
-version = "0.124.0"
-when = "2025-09-20"
+version = "0.124.1"
+when = "2025-09-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-object]]
-version = "0.124.0"
-when = "2025-09-20"
+version = "0.124.1"
+when = "2025-09-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-reader]]
-version = "0.124.0"
-when = "2025-09-20"
+version = "0.124.1"
+when = "2025-09-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-serde]]
-version = "0.124.0"
-when = "2025-09-20"
+version = "0.124.1"
+when = "2025-09-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-srcgen]]
-version = "0.124.0"
-when = "2025-09-20"
+version = "0.124.1"
+when = "2025-09-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1001,14 +1233,14 @@ user-login = "dtolnay"
 user-name = "David Tolnay"
 
 [[publisher.pulley-interpreter]]
-version = "37.0.0"
-when = "2025-09-20"
+version = "37.0.1"
+when = "2025-09-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.pulley-macros]]
-version = "37.0.0"
-when = "2025-09-20"
+version = "37.0.1"
+when = "2025-09-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1279,8 +1511,8 @@ user-login = "sunfishcode"
 user-name = "Dan Gohman"
 
 [[publisher.wasi-common]]
-version = "37.0.0"
-when = "2025-09-20"
+version = "37.0.1"
+when = "2025-09-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1374,188 +1606,188 @@ user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime]]
-version = "37.0.0"
-when = "2025-09-20"
+version = "37.0.1"
+when = "2025-09-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-cli]]
-version = "37.0.0"
-when = "2025-09-20"
+version = "37.0.1"
+when = "2025-09-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-cli-flags]]
-version = "37.0.0"
-when = "2025-09-20"
+version = "37.0.1"
+when = "2025-09-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-environ]]
-version = "37.0.0"
-when = "2025-09-20"
+version = "37.0.1"
+when = "2025-09-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-internal-asm-macros]]
-version = "37.0.0"
-when = "2025-09-20"
+version = "37.0.1"
+when = "2025-09-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-internal-c-api-macros]]
-version = "37.0.0"
-when = "2025-09-20"
+version = "37.0.1"
+when = "2025-09-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-internal-cache]]
-version = "37.0.0"
-when = "2025-09-20"
+version = "37.0.1"
+when = "2025-09-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-internal-component-macro]]
-version = "37.0.0"
-when = "2025-09-20"
+version = "37.0.1"
+when = "2025-09-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-internal-component-util]]
-version = "37.0.0"
-when = "2025-09-20"
+version = "37.0.1"
+when = "2025-09-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-internal-cranelift]]
-version = "37.0.0"
-when = "2025-09-20"
+version = "37.0.1"
+when = "2025-09-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-internal-explorer]]
-version = "37.0.0"
-when = "2025-09-20"
+version = "37.0.1"
+when = "2025-09-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-internal-fiber]]
-version = "37.0.0"
-when = "2025-09-20"
+version = "37.0.1"
+when = "2025-09-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-internal-jit-debug]]
-version = "37.0.0"
-when = "2025-09-20"
+version = "37.0.1"
+when = "2025-09-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-internal-jit-icache-coherence]]
-version = "37.0.0"
-when = "2025-09-20"
+version = "37.0.1"
+when = "2025-09-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-internal-math]]
-version = "37.0.0"
-when = "2025-09-20"
+version = "37.0.1"
+when = "2025-09-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-internal-slab]]
-version = "37.0.0"
-when = "2025-09-20"
+version = "37.0.1"
+when = "2025-09-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-internal-unwinder]]
-version = "37.0.0"
-when = "2025-09-20"
+version = "37.0.1"
+when = "2025-09-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-internal-versioned-export-macros]]
-version = "37.0.0"
-when = "2025-09-20"
+version = "37.0.1"
+when = "2025-09-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-internal-winch]]
-version = "37.0.0"
-when = "2025-09-20"
+version = "37.0.1"
+when = "2025-09-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-internal-wit-bindgen]]
-version = "37.0.0"
-when = "2025-09-20"
+version = "37.0.1"
+when = "2025-09-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-internal-wmemcheck]]
-version = "37.0.0"
-when = "2025-09-20"
+version = "37.0.1"
+when = "2025-09-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi]]
-version = "37.0.0"
-when = "2025-09-20"
+version = "37.0.1"
+when = "2025-09-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-config]]
-version = "37.0.0"
-when = "2025-09-20"
+version = "37.0.1"
+when = "2025-09-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-http]]
-version = "37.0.0"
-when = "2025-09-20"
+version = "37.0.1"
+when = "2025-09-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-io]]
-version = "37.0.0"
-when = "2025-09-20"
+version = "37.0.1"
+when = "2025-09-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-keyvalue]]
-version = "37.0.0"
-when = "2025-09-20"
+version = "37.0.1"
+when = "2025-09-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-nn]]
-version = "37.0.0"
-when = "2025-09-20"
+version = "37.0.1"
+when = "2025-09-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-threads]]
-version = "37.0.0"
-when = "2025-09-20"
+version = "37.0.1"
+when = "2025-09-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-tls]]
-version = "37.0.0"
-when = "2025-09-20"
+version = "37.0.1"
+when = "2025-09-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-tls-nativetls]]
-version = "37.0.0"
-when = "2025-09-20"
+version = "37.0.1"
+when = "2025-09-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wast]]
-version = "37.0.0"
-when = "2025-09-20"
+version = "37.0.1"
+when = "2025-09-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1579,20 +1811,20 @@ user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
 [[publisher.wiggle]]
-version = "37.0.0"
-when = "2025-09-20"
+version = "37.0.1"
+when = "2025-09-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wiggle-generate]]
-version = "37.0.0"
-when = "2025-09-20"
+version = "37.0.1"
+when = "2025-09-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wiggle-macro]]
-version = "37.0.0"
-when = "2025-09-20"
+version = "37.0.1"
+when = "2025-09-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1611,8 +1843,8 @@ user-login = "BurntSushi"
 user-name = "Andrew Gallant"
 
 [[publisher.winch-codegen]]
-version = "37.0.0"
-when = "2025-09-20"
+version = "37.0.1"
+when = "2025-09-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 


### PR DESCRIPTION
This is an [automated pull request][process] from CI to create a patch release for Wasmtime 37.0.2, requested by @alexcrichton.

It's recommended that maintainers double-check that [RELEASES.md] is up-to-date and that there are no known issues before merging this PR. When this PR is merged a release tag will automatically be created, crates will be published, and CI artifacts will be produced.

[RELEASES.md]: https://github.com/bytecodealliance/wasmtime/blob/release-37.0.2/RELEASES.md
[process]: https://docs.wasmtime.dev/contributing-release-process.html
