### PR TITLE
c-api: Fix CMakeLists to work properly on ios & other apple targets

### DIFF
--- a/crates/c-api/CMakeLists.txt
+++ b/crates/c-api/CMakeLists.txt
@@ -34,7 +34,7 @@ endif()
 
 set(WASMTIME_TARGET_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../target/${WASMTIME_TARGET}/${WASMTIME_BUILD_TYPE})
 
-if(WASMTIME_TARGET MATCHES "darwin")
+if(WASMTIME_TARGET MATCHES "apple")
   set(WASMTIME_SHARED_FILES libwasmtime.dylib)
   set(WASMTIME_STATIC_FILES libwasmtime.a)
 elseif(WASMTIME_TARGET MATCHES "windows-gnu")


### PR DESCRIPTION
The `WASMTIME_TARGET` check in cmake looks to see if the .dylib path is used. This is used on all apple platforms - including macos ("darwin"), ios and visionos and so on.

Fixes #11759

```
$ rustc --print target-list | grep apple                   
aarch64-apple-darwin
aarch64-apple-ios
aarch64-apple-ios-macabi
aarch64-apple-ios-sim
aarch64-apple-tvos
aarch64-apple-tvos-sim
aarch64-apple-visionos
aarch64-apple-visionos-sim
aarch64-apple-watchos
aarch64-apple-watchos-sim
...
```

The test currently only checks for `darwin`, so it only works correctly on macos.

This change fixes the test to support all apple platforms.


