### PR TITLE
Revert "Constant propagation opts (#11748)" 

### DIFF
--- a/cranelift/codegen/src/opts/arithmetic.isle
+++ b/cranelift/codegen/src/opts/arithmetic.isle
@@ -125,6 +125,7 @@
 ;; x % 1 == 0
 (rule (simplify_skeleton (urem x (iconst_u ty 1))) (iconst_u ty 0))
 (rule (simplify_skeleton (srem x (iconst_u ty 1))) (iconst_u ty 0))
+(rule (simplify_skeleton (srem x (iconst_s ty -1))) (iconst_u ty 0))
 
 ;; Unsigned `x % d == x & ((1 << ilog2(d)) - 1)` when `d` is a power of two.
 (rule (simplify_skeleton (urem x (iconst_u ty (u64_extract_power_of_two d))))
@@ -338,3 +339,5 @@
 ;; (x + y) - y --> x
 (rule (simplify (isub ty (iadd ty x y) x)) y)
 (rule (simplify (isub ty (iadd ty x y) y)) x)
+
+

--- a/cranelift/codegen/src/opts/cprop.isle
+++ b/cranelift/codegen/src/opts/cprop.isle
@@ -1,17 +1,6 @@
 ;; Constant propagation.
 
 (rule (simplify
-       (clz (fits_in_64 ty)
-             (iconst ty kx)))
-      (subsume (iconst ty (imm64_clz ty kx))))
-
-
-(rule (simplify
-       (ctz (fits_in_64 ty)
-             (iconst ty (u64_from_imm64 kx))))
-      (subsume (iconst ty (imm64_masked ty (u64_trailing_zeros kx)))))
-
-(rule (simplify
        (iadd (fits_in_64 ty)
              (iconst ty (u64_from_imm64 k1))
              (iconst ty (u64_from_imm64 k2))))
@@ -31,26 +20,14 @@
 
 (rule (simplify_skeleton
        (sdiv (iconst ty k1)
-             (iconst ty k2)))
+             (iconst _ k2)))
       (if-let d (imm64_sdiv ty k1 k2))
-      (iconst ty d))
-
-(rule (simplify_skeleton
-       (srem (iconst ty k1)
-             (iconst ty k2)))
-      (if-let d (imm64_srem ty k1 k2))
       (iconst ty d))
 
 (rule (simplify_skeleton
        (udiv (iconst_u ty k1)
              (iconst_u ty k2)))
       (if-let d (u64_checked_div k1 k2))
-      (iconst ty (imm64_masked ty d)))
-
-(rule (simplify_skeleton
-       (urem (iconst_u ty k1)
-             (iconst_u ty k2)))
-      (if-let d (u64_checked_rem k1 k2))
       (iconst ty (imm64_masked ty d)))
 
 (rule (simplify

--- a/cranelift/codegen/src/prelude.isle
+++ b/cranelift/codegen/src/prelude.isle
@@ -73,9 +73,6 @@
 (decl pure partial imm64_sdiv (Type Imm64 Imm64) Imm64)
 (extern constructor imm64_sdiv imm64_sdiv)
 
-(decl pure partial imm64_srem (Type Imm64 Imm64) Imm64)
-(extern constructor imm64_srem imm64_srem)
-
 (decl pure imm64_shl (Type Imm64 Imm64) Imm64)
 (extern constructor imm64_shl imm64_shl)
 
@@ -98,10 +95,6 @@
 
 (decl pure imm64_icmp (Type IntCC Imm64 Imm64) Imm64)
 (extern constructor imm64_icmp imm64_icmp)
-
-(decl pure imm64_clz (Type Imm64) Imm64)
-(extern constructor imm64_clz imm64_clz)
-
 
 ;; Each of these extractors tests whether the upper half of the input equals the
 ;; lower half of the input

--- a/cranelift/filetests/filetests/egraph/cprop.clif
+++ b/cranelift/filetests/filetests/egraph/cprop.clif
@@ -22,33 +22,6 @@ block0:
 ; check: v3 = iconst.i16 -2
 ; nextln: return v3
 
-function %f0() -> i8 {
-block0:
-    v1 = iconst.i8 51
-    v2 = clz.i8 v1
-    return v2
-}
-
-function %f0() -> i16 {
-block0:
-    v1 = iconst.i16 51
-    v2 = clz.i16 v1
-    return v2
-}
-
-; check: v3 = iconst.i16 10
-; nextln: return v3
-
-function %f0() -> i16 {
-block0:
-    v1 = iconst.i16 48
-    v2 = ctz.i16 v1
-    return v2
-}
-
-; check: v3 = iconst.i16 4
-; nextln: return v3
-
 function %ishl() -> i8 {
 block0:
     v0 = iconst.i8 1

--- a/cranelift/filetests/filetests/egraph/skeleton.clif
+++ b/cranelift/filetests/filetests/egraph/skeleton.clif
@@ -95,21 +95,6 @@ block0:
 ;     return v18  ; v18 = 1
 ; }
 
-function %cprop_urem() -> i32 {
-block0:
-    v0 = iconst.i32 13
-    v1 = iconst.i32 7
-    v2 = urem v0, v1
-    return v2
-}
-
-; function %cprop_urem() -> i32 fast {
-; block0:
-;     v37 = iconst.i32 6
-;     v2 -> v37
-;     return v37  ; v37 = 6
-; }
-
 function %cprop_sdiv() -> i32 {
 block0:
     v0 = iconst.i32 -7
@@ -124,70 +109,6 @@ block0:
 ;     v2 -> v11
 ;     return v11  ; v11 = -1
 ; }
-
-function %cprop_sdiv_i8_min() -> i8 {
-block0:
-    v0 = iconst.i8 -128
-    v1 = iconst.i8 -1
-    v2 = sdiv v0, v1
-    return v2
-}
-
-;function %cprop_sdiv_i8_min() -> i8 fast {
-;block0:
-;     v0 = iconst.i8 -128
-;     v1 = iconst.i8 -1
-;     v2 = sdiv v0, v1  ; v0 = -128, v1 = -1
-;     return v2
-;}
-
-function %cprop_srem_i8_min() -> i8 {
-block0:
-    v0 = iconst.i8 -128
-    v1 = iconst.i8 -1
-    v2 = srem v0, v1
-    return v2
-}
-
-;function %cprop_srem_i8_min() -> i8 fast {
-;block0:
-;     v0 = iconst.i8 -128
-;     v1 = iconst.i8 -1
-;     v2 = srem v0, v1  ; v0 = -128, v1 = -1
-;     return v2
-;}
-
-function %cprop_srem_i64_min() -> i64 {
-block0:
-    v0 = iconst.i64 -9223372036854775808
-    v1 = iconst.i64 -1
-    v2 = srem v0, v1
-    return v2
-}
-
-;function %cprop_srem_i64_min() -> i64 fast {
-;block0:
-;     v0 = iconst.i64 -9223372036854775808
-;     v1 = iconst.i64 -1
-;     v2 = srem v0, v1  ; v0 = -9223372036854775808, v1 = -1
-;     return v2
-;}
-
-function %cprop_srem() -> i32 {
-block0:
-    v0 = iconst.i32 -17
-    v1 = iconst.i32 7
-    v2 = srem v0, v1
-    return v2
-}
-
-; function %cprop_srem() -> i32 fast {
-; block0:
-;     v28 = iconst.i32 -3
-;     v2 -> v28
-;     return v28  ; v28 = -3
-; }
-
 
 function %udiv_by_one(i32) -> i32 {
 block0(v0: i32):
@@ -307,3 +228,4 @@ block0:
 ;     v2 = uadd_overflow_trap v0, v1, user42  ; v0 = -1, v1 = 1
 ;     return v2
 ; }
+

--- a/tests/misc_testsuite/issue11748.wast
+++ b/tests/misc_testsuite/issue11748.wast
@@ -1,0 +1,8 @@
+(module
+  (func (export "x") (result i32)
+    i32.const 0
+    i32.ctz
+  )
+)
+
+(assert_return (invoke "x") (i32.const 32))


### PR DESCRIPTION
This reverts #11748 as fuzzing turned up a differential execution error which bisected to this PR. The original failing test case is:

<details>

<summary><code>testcase0.wat</code></summary>

```wasm
(module
  (type (;0;) (func (param i32 i32) (result i32)))
  (global (;0;) (mut i32) i32.const 0)
  (global (;1;) (mut i32) i32.const 1000)
  (export "r_ coatin-1not r e*_e*A__se*r  ,r,r_ coatin-1not r e*_e*A__se*_," (func 0))
  (export "r,r_ coatin-1not r e*_,r,rt_co ain-1not r  _ coatin-1not r e*\u{1f},r,rt_co ain-1not r  ,_,r,r_ ocatin-0not r  ,r,r_ " (global 0))
  (elem (;0;) func)
  (func (;0;) (type 0) (param i32 i32) (result i32)
    global.get 1
    i32.eqz
    if ;; label = @1
      unreachable
    end
    global.get 1
    i32.const 1
    i32.sub
    global.set 1
    local.get 1
    local.set 0
    local.get 1
    i32.popcnt
    i32.popcnt
    i32.extend8_s
    i32.popcnt
    i64.extend_i32_u
    i64.clz
    i64.clz
    i64.extend8_s
    i32.const -131072
    local.tee 1
    i32.extend8_s
    i32.popcnt
    local.set 0
    i64.extend8_s
    local.get 1
    i32.extend8_s
    local.get 0
    i32.lt_s
    i64.extend_i32_u
    i64.popcnt
    i64.shr_u
    local.get 0
    local.set 0
    i32.const 825060969
    local.get 0
    i32.lt_s
    local.set 0
    i64.ctz
    i64.clz
    i64.ctz
    elem.drop 0
    i64.clz
    i64.ctz
    elem.drop 0
    i64.ctz
    i32.const -513
    local.get 1
    i32.xor
    local.set 1
    local.get 0
    i64.extend_i32_u
    i64.or
    i64.extend8_s
    i64.ctz
    local.get 1
    i64.extend_i32_u
    i64.shr_s
    i64.clz
    i64.extend8_s
    i32.const -131072
    local.tee 1
    i32.extend8_s
    i32.extend8_s
    local.set 0
    i32.const 825060969
    local.get 0
    i32.lt_s
    local.set 0
    i64.extend8_s
    local.get 1
    i32.extend8_s
    local.get 0
    i32.lt_s
    i32.ctz
    i32.extend8_s
    i64.extend_i32_u
    i64.gt_s
    local.get 1
    i32.xor
    local.set 0
    local.get 0
    local.set 0
    i32.const 808283753
    local.get 0
    i32.lt_s
    local.set 0
    local.get 1
    local.set 0
    local.get 1
    i32.popcnt
    i32.extend8_s
    i32.extend8_s
    local.set 1
    local.get 1
    local.get 1
    i32.xor
    local.set 0
    local.get 1
    local.set 0
    local.get 1
    i32.popcnt
    i32.extend8_s
    i32.extend8_s
    local.set 1
    local.get 1
    local.get 1
    i32.xor
    local.set 0
    local.get 0
    local.set 0
    i32.const 808283753
    local.get 0
    i32.lt_s
    local.set 0
    local.get 1
    local.set 0
    local.get 1
    i32.popcnt
    i32.extend8_s
    i32.extend8_s
    i32.popcnt
    i64.extend_i32_u
    i64.clz
    i64.clz
    i64.extend8_s
    i64.extend8_s
    elem.drop 0
    i64.extend8_s
    local.get 1
    i32.extend8_s
    local.get 0
    i32.lt_s
    i32.ctz
    i32.extend8_s
    i64.extend_i32_u
    i64.gt_s
    local.get 1
    i32.xor
    local.set 0
    local.get 0
    local.set 0
    i32.const 808283753
    local.get 0
    i32.lt_s
    local.set 0
    local.get 1
    local.set 0
    local.get 1
    i32.popcnt
    i32.extend8_s
    i32.extend8_s
    local.set 1
    local.get 1
    local.get 1
    i32.xor
    local.set 0
    local.get 1
    local.set 0
    local.get 1
    i32.popcnt
    i32.extend8_s
    i32.extend8_s
    local.set 1
    local.get 1
    local.get 1
    i32.xor
    local.set 0
    local.get 0
    local.set 0
    i32.const 808283753
    local.get 0
    i32.lt_s
    local.set 0
    local.get 1
    local.set 0
    local.get 1
    i32.popcnt
    i32.extend8_s
    i32.extend8_s
    local.set 1
    local.get 1
    local.set 0
    local.get 1
    local.set 0
    local.get 1
    i32.popcnt
    i32.extend8_s
    i32.extend8_s
    local.set 1
    local.get 1
    local.get 1
    i32.xor
    local.set 0
    local.get 1
    local.set 0
    local.get 1
    i32.popcnt
    i32.extend8_s
    i32.extend8_s
    local.set 1
    local.get 1
    local.get 1
    i32.xor
    local.set 0
    local.get 0
    local.set 0
    i32.const 808283753
    local.get 0
    i32.lt_s
    local.set 0
    local.get 1
    local.set 0
    local.get 1
    i32.popcnt
    i32.extend8_s
    i32.extend8_s
    i32.popcnt
    i64.extend_i32_u
    i64.clz
    i64.clz
    i64.extend8_s
    i64.extend8_s
    elem.drop 0
    i64.extend8_s
    local.get 1
    i32.extend8_s
    local.get 0
    i32.lt_s
    i32.ctz
    i32.extend8_s
    i64.extend_i32_u
    i64.gt_s
    local.get 1
    i32.xor
    local.set 0
    local.get 0
    local.set 0
    i32.const 808283753
    local.get 0
    i32.lt_s
    local.set 0
    local.get 1
    local.set 0
    local.get 1
    i32.popcnt
    i32.extend8_s
    i32.extend8_s
    local.set 1
    local.get 1
    local.get 1
    i32.xor
    local.set 0
    local.get 1
    local.set 0
    local.get 1
    i32.popcnt
    i32.extend8_s
    i32.extend8_s
    local.set 1
    local.get 1
    local.get 1
    i32.xor
    local.set 0
    local.get 0
    local.set 0
    i32.const 808283753
    local.get 0
    i32.lt_s
    local.set 0
    local.get 1
    local.set 0
    local.get 1
    i32.popcnt
    i32.extend8_s
    i32.extend8_s
    local.set 1
    local.get 1
    local.set 0
    local.get 1
    local.set 0
    local.get 1
    i32.popcnt
    i32.extend8_s
    i32.extend8_s
    local.set 1
    local.get 1
    local.get 1
    i32.xor
    local.set 0
    local.get 1
    local.set 0
    local.get 1
    i32.popcnt
    i32.extend8_s
    i32.extend8_s
    local.set 1
    local.get 1
    local.get 1
    i32.xor
    local.set 0
    local.get 0
    local.set 0
    i32.const 808283753
    local.get 0
    i32.lt_s
    local.set 0
    local.get 1
    local.set 0
    local.get 1
    i32.popcnt
    i32.extend8_s
    i32.extend8_s
    i32.popcnt
    i64.extend_i32_u
    i64.clz
    i64.clz
    i64.extend8_s
    i64.extend8_s
    elem.drop 0
    i64.extend8_s
    local.get 1
    i32.extend8_s
    local.get 0
    i32.lt_s
    i32.ctz
    i32.extend8_s
    i64.extend_i32_u
    i64.gt_s
    local.get 1
    i32.xor
    local.set 0
    local.get 0
    local.set 0
    i32.const 808283753
    local.get 0
    global.get 0
    i32.xor
    global.set 0
  )

  (func (export "x")  (result i32)
      i32.const -1 i32.const -1
      call 0
      drop
      global.get 0)
)
```

</details>

and `wasm-tools shrink`-minimized version is attached to this PR as a regression test as well.