### PR TITLE
Add a link to Wasefire in Wasmtime's documentation

### DIFF
--- a/docs/examples-minimal.md
+++ b/docs/examples-minimal.md
@@ -4,6 +4,14 @@ Wasmtime embeddings may wish to optimize for binary size and runtime footprint
 to fit on a small system. This documentation is intended to guide some features
 of Wasmtime and how to best produce a minimal build of Wasmtime.
 
+An example embedding of Wasmtime optimized for size is [Wasefire] which [runs
+with 256k RAM and ~300k
+flash](https://github.com/google/wasefire/issues/458#issuecomment-3275110991).
+In this embedding [Pulley](./examples-pulley.md) was used for an execution
+engine as well.
+
+[Wasefire]: https://github.com/google/wasefire
+
 ## Building a minimal CLI
 
 > *Note*: the exact numbers in this section were last updated on 2024-12-12 on a


### PR DESCRIPTION
I confirmed [here] it was ok to do so but the minimal-embedding documentation seems as reasonable a place as any to document this and showcase one of the smaller embeddings we know of for Wasmtime.

[here]: https://github.com/google/wasefire/issues/458#issuecomment-3275263801

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
