### PR TITLE
Add some more metrics to the pooling allocator

### DIFF
--- a/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/gc_heap_pool.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/gc_heap_pool.rs
@@ -133,7 +133,7 @@ impl GcHeapPool {
             heaps[allocation_index.index()].dealloc(heap)
         };
 
-        self.index_allocator.free(SlotId(allocation_index.0));
+        self.index_allocator.free(SlotId(allocation_index.0), 0);
 
         (memory_alloc_index, memory)
     }

--- a/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/generic_stack_pool.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/generic_stack_pool.rs
@@ -28,6 +28,11 @@ pub struct StackPool {
 }
 
 impl StackPool {
+    #[cfg(test)]
+    pub fn enabled() -> bool {
+        false
+    }
+
     pub fn new(config: &PoolingInstanceAllocatorConfig) -> Result<Self> {
         Ok(StackPool {
             stack_size: config.stack_size,

--- a/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/generic_stack_pool.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/generic_stack_pool.rs
@@ -69,15 +69,24 @@ impl StackPool {
         &self,
         _stack: &mut wasmtime_fiber::FiberStack,
         _decommit: impl FnMut(*mut u8, usize),
-    ) {
+    ) -> usize {
         // No need to actually zero the stack, since the stack won't ever be
         // reused on non-unix systems.
+        0
     }
 
     /// Safety: see the unix implementation.
-    pub unsafe fn deallocate(&self, stack: wasmtime_fiber::FiberStack) {
+    pub unsafe fn deallocate(&self, stack: wasmtime_fiber::FiberStack, _bytes_resident: usize) {
         self.live_stacks.fetch_sub(1, Ordering::AcqRel);
         // A no-op as we don't actually own the fiber stack on Windows.
         let _ = stack;
+    }
+
+    pub fn unused_warm_slots(&self) -> u32 {
+        0
+    }
+
+    pub fn unused_bytes_resident(&self) -> Option<usize> {
+        None
     }
 }

--- a/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/index_allocator.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/index_allocator.rs
@@ -48,10 +48,20 @@ impl SimpleIndexAllocator {
         self.0.free(index, bytes_resident);
     }
 
+    /// Returns the number of previously-used slots in this allocator which are
+    /// not currently in use.
+    ///
+    /// Note that this acquires a `Mutex` for synchronization at this time to
+    /// read the internal counter information.
     pub fn unused_warm_slots(&self) -> u32 {
         self.0.unused_warm_slots()
     }
 
+    /// Returns the number of bytes that are resident in previously-used slots
+    /// in this allocator which are not currently in use.
+    ///
+    /// Note that this acquires a `Mutex` for synchronization at this time to
+    /// read the internal counter information.
     pub fn unused_bytes_resident(&self) -> usize {
         self.0.unused_bytes_resident()
     }
@@ -359,10 +369,20 @@ impl ModuleAffinityIndexAllocator {
         inner.module_affine.keys().copied().collect()
     }
 
+    /// Returns the number of previously-used slots in this allocator which are
+    /// not currently in use.
+    ///
+    /// Note that this acquires a `Mutex` for synchronization at this time to
+    /// read the internal counter information.
     pub fn unused_warm_slots(&self) -> u32 {
         self.0.lock().unwrap().unused_warm_slots
     }
 
+    /// Returns the number of bytes that are resident in previously-used slots
+    /// in this allocator which are not currently in use.
+    ///
+    /// Note that this acquires a `Mutex` for synchronization at this time to
+    /// read the internal counter information.
     pub fn unused_bytes_resident(&self) -> usize {
         self.0.lock().unwrap().unused_bytes_resident
     }

--- a/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/index_allocator.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/index_allocator.rs
@@ -39,8 +39,21 @@ impl SimpleIndexAllocator {
         self.0.alloc(None)
     }
 
-    pub(crate) fn free(&self, index: SlotId) {
-        self.0.free(index);
+    /// Frees the `index` slot to be available for allocation elsewhere.
+    ///
+    /// The `bytes_resident` argument is a counter to keep track of how many
+    /// bytse are still resident in this slot, if any, for reporting later via
+    /// the [`Self::unused_bytes_resident`] method.
+    pub(crate) fn free(&self, index: SlotId, bytes_resident: usize) {
+        self.0.free(index, bytes_resident);
+    }
+
+    pub fn unused_warm_slots(&self) -> u32 {
+        self.0.unused_warm_slots()
+    }
+
+    pub fn unused_bytes_resident(&self) -> usize {
+        self.0.unused_bytes_resident()
     }
 
     #[cfg(test)]
@@ -96,6 +109,9 @@ struct Inner {
     /// The `List` here is appended to during deallocation and removal happens
     /// from the tail during allocation.
     module_affine: HashMap<MemoryInModule, List>,
+
+    /// Cache for the sum of the `bytes_resident` of all `UnusedWarm` slots.
+    unused_bytes_resident: usize,
 }
 
 /// A helper "linked list" data structure which is based on indices.
@@ -142,6 +158,10 @@ struct Unused {
     /// Which module this slot was historically affine to, if any.
     affinity: Option<MemoryInModule>,
 
+    /// Number of bytes that are part of `UnusedWarm` slots and are currently
+    /// kept resident (vs paged out).
+    bytes_resident: usize,
+
     /// Metadata about the linked list for all slots affine to `affinity`.
     affine_list_link: Link,
 
@@ -164,6 +184,7 @@ impl ModuleAffinityIndexAllocator {
             module_affine: HashMap::new(),
             slot_state: (0..capacity).map(|_| SlotState::UnusedCold).collect(),
             warm: List::default(),
+            unused_bytes_resident: 0,
         }))
     }
 
@@ -256,7 +277,11 @@ impl ModuleAffinityIndexAllocator {
             }
         })?;
 
-        inner.slot_state[slot_id.index()] = SlotState::Used(match mode {
+        let slot = &mut inner.slot_state[slot_id.index()];
+        if let SlotState::UnusedWarm(Unused { bytes_resident, .. }) = slot {
+            inner.unused_bytes_resident -= *bytes_resident;
+        }
+        *slot = SlotState::Used(match mode {
             AllocMode::ForceAffineAndClear => None,
             AllocMode::AnySlot => for_memory,
         });
@@ -264,7 +289,7 @@ impl ModuleAffinityIndexAllocator {
         Some(slot_id)
     }
 
-    pub(crate) fn free(&self, index: SlotId) {
+    pub(crate) fn free(&self, index: SlotId, bytes_resident: usize) {
         let mut inner = self.0.lock().unwrap();
         let inner = &mut *inner;
         let module_memory = match inner.slot_state[index.index()] {
@@ -298,8 +323,10 @@ impl ModuleAffinityIndexAllocator {
             None => Link::default(),
         };
 
+        inner.unused_bytes_resident += bytes_resident;
         inner.slot_state[index.index()] = SlotState::UnusedWarm(Unused {
             affinity: module_memory,
+            bytes_resident,
             affine_list_link,
             unused_list_link,
         });
@@ -330,6 +357,14 @@ impl ModuleAffinityIndexAllocator {
     pub(crate) fn testing_module_affinity_list(&self) -> Vec<MemoryInModule> {
         let inner = self.0.lock().unwrap();
         inner.module_affine.keys().copied().collect()
+    }
+
+    pub fn unused_warm_slots(&self) -> u32 {
+        self.0.lock().unwrap().unused_warm_slots
+    }
+
+    pub fn unused_bytes_resident(&self) -> usize {
+        self.0.lock().unwrap().unused_bytes_resident
     }
 }
 
@@ -507,15 +542,15 @@ mod test {
         assert_eq!(index2.index(), 1);
         assert_ne!(index1, index2);
 
-        state.free(index1);
+        state.free(index1, 0);
         assert_eq!(state.num_empty_slots(), 99);
 
         // Allocate to the same `index1` slot again.
         let index3 = state.alloc(Some(id1)).unwrap();
         assert_eq!(index3, index1);
-        state.free(index3);
+        state.free(index3, 0);
 
-        state.free(index2);
+        state.free(index2, 0);
 
         // Both id1 and id2 should have some slots with affinity.
         let affinity_modules = state.testing_module_affinity_list();
@@ -537,7 +572,7 @@ mod test {
         assert_eq!(state.num_empty_slots(), 0);
 
         for i in indices {
-            state.free(i);
+            state.free(i, 0);
         }
 
         // Now there should be no slots left with affinity for id1.
@@ -548,7 +583,7 @@ mod test {
         // Allocate an index we know previously had an instance but
         // now does not (list ran empty).
         let index = state.alloc(Some(id1)).unwrap();
-        state.free(index);
+        state.free(index, 0);
     }
 
     #[test]
@@ -561,8 +596,8 @@ mod test {
 
             let index1 = state.alloc(Some(MemoryInModule(id, memory_index))).unwrap();
             let index2 = state.alloc(Some(MemoryInModule(id, memory_index))).unwrap();
-            state.free(index2);
-            state.free(index1);
+            state.free(index2, 0);
+            state.free(index1, 0);
             assert!(
                 state
                     .alloc_affine_and_clear_affinity(id, memory_index)
@@ -601,7 +636,7 @@ mod test {
                 if !allocated.is_empty() && rng.random_bool(0.5) {
                     let i = rng.random_range(0..allocated.len());
                     let to_free_idx = allocated.swap_remove(i);
-                    state.free(to_free_idx);
+                    state.free(to_free_idx, 0);
                 } else {
                     let id = ids[rng.random_range(0..ids.len())];
                     let index = match state.alloc(Some(id)) {
@@ -636,14 +671,14 @@ mod test {
 
         // Set some slot affinities
         assert_eq!(state.alloc(Some(id1)), Some(SlotId(0)));
-        state.free(SlotId(0));
+        state.free(SlotId(0), 0);
         assert_eq!(state.alloc(Some(id2)), Some(SlotId(1)));
-        state.free(SlotId(1));
+        state.free(SlotId(1), 0);
 
         // Only 2 slots are allowed to be unused and warm, so we're at our
         // threshold, meaning one must now be evicted.
         assert_eq!(state.alloc(Some(id3)), Some(SlotId(0)));
-        state.free(SlotId(0));
+        state.free(SlotId(0), 0);
 
         // pickup `id2` again, it should be affine.
         assert_eq!(state.alloc(Some(id2)), Some(SlotId(1)));
@@ -652,17 +687,17 @@ mod test {
         // fresh slot
         assert_eq!(state.alloc(Some(id1)), Some(SlotId(2)));
 
-        state.free(SlotId(1));
-        state.free(SlotId(2));
+        state.free(SlotId(1), 0);
+        state.free(SlotId(2), 0);
 
         // ensure everything stays affine
         assert_eq!(state.alloc(Some(id1)), Some(SlotId(2)));
         assert_eq!(state.alloc(Some(id2)), Some(SlotId(1)));
         assert_eq!(state.alloc(Some(id3)), Some(SlotId(0)));
 
-        state.free(SlotId(1));
-        state.free(SlotId(2));
-        state.free(SlotId(0));
+        state.free(SlotId(1), 0);
+        state.free(SlotId(2), 0);
+        state.free(SlotId(0), 0);
 
         // LRU is 1, so that should be picked
         assert_eq!(
@@ -691,9 +726,9 @@ mod test {
             Some(SlotId(3))
         );
 
-        state.free(SlotId(1));
-        state.free(SlotId(2));
-        state.free(SlotId(3));
+        state.free(SlotId(1), 0);
+        state.free(SlotId(2), 0);
+        state.free(SlotId(3), 0);
 
         // for good measure make sure id3 is still affine
         assert_eq!(state.alloc(Some(id3)), Some(SlotId(0)));
@@ -705,15 +740,15 @@ mod test {
         assert_eq!(allocator.testing_freelist(), []);
         let a = allocator.alloc().unwrap();
         assert_eq!(allocator.testing_freelist(), []);
-        allocator.free(a);
+        allocator.free(a, 0);
         assert_eq!(allocator.testing_freelist(), [a]);
         assert_eq!(allocator.alloc(), Some(a));
         assert_eq!(allocator.testing_freelist(), []);
         let b = allocator.alloc().unwrap();
         assert_eq!(allocator.testing_freelist(), []);
-        allocator.free(b);
+        allocator.free(b, 0);
         assert_eq!(allocator.testing_freelist(), [b]);
-        allocator.free(a);
+        allocator.free(a, 0);
         assert_eq!(allocator.testing_freelist(), [b, a]);
     }
 }

--- a/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/metrics.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/metrics.rs
@@ -140,13 +140,23 @@ mod tests {
         )
     ";
 
+    pub(crate) fn small_pool_config() -> PoolingAllocationConfig {
+        let mut config = PoolingAllocationConfig::new();
+
+        config.total_memories(10);
+        config.max_memory_size(2 << 16);
+        config.total_tables(10);
+        config.table_elements(10);
+        config.total_stacks(1);
+
+        config
+    }
+
     #[test]
     #[cfg_attr(miri, ignore)]
     fn smoke_test() {
         // Start with nothing
-        let engine =
-            Engine::new(&Config::new().allocation_strategy(InstanceAllocationStrategy::pooling()))
-                .unwrap();
+        let engine = Engine::new(&Config::new().allocation_strategy(small_pool_config())).unwrap();
         let metrics = engine.pooling_allocator_metrics().unwrap();
 
         assert_eq!(metrics.core_instances(), 0);
@@ -187,7 +197,7 @@ mod tests {
     #[test]
     #[cfg_attr(any(miri, not(target_os = "linux")), ignore)]
     fn unused_memories_tables_and_more() -> Result<()> {
-        let mut pool = PoolingAllocationConfig::default();
+        let mut pool = small_pool_config();
         pool.linear_memory_keep_resident(65536);
         pool.table_keep_resident(65536);
         pool.pagemap_scan(Enabled::Auto);
@@ -301,7 +311,7 @@ mod tests {
     #[test]
     #[cfg_attr(miri, ignore)]
     fn gc_heaps() -> Result<()> {
-        let pool = PoolingAllocationConfig::default();
+        let pool = small_pool_config();
         let mut config = Config::new();
         config.allocation_strategy(pool);
         let engine = Engine::new(&config)?;
@@ -321,7 +331,7 @@ mod tests {
     #[tokio::test]
     #[cfg_attr(miri, ignore)]
     async fn stacks() -> Result<()> {
-        let pool = PoolingAllocationConfig::default();
+        let pool = small_pool_config();
         let mut config = Config::new();
         config.allocation_strategy(pool);
         config.async_support(true);

--- a/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/metrics.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/metrics.rs
@@ -42,11 +42,13 @@ impl PoolingAllocatorMetrics {
     }
 
     /// Returns the number of WebAssembly stacks currently allocated.
+    #[cfg(feature = "async")]
     pub fn stacks(&self) -> usize {
         self.allocator().live_stacks.load(Ordering::Relaxed)
     }
 
     /// Returns the number of WebAssembly GC heaps currently allocated.
+    #[cfg(feature = "gc")]
     pub fn gc_heaps(&self) -> usize {
         self.allocator().live_gc_heaps.load(Ordering::Relaxed)
     }
@@ -91,6 +93,7 @@ impl PoolingAllocatorMetrics {
     /// A "warm" slot means that there was a previous use of a stack
     /// in that slot. Warm slots are favored in general for allocating new
     /// stacks over using a slot that has never been used before.
+    #[cfg(feature = "async")]
     pub fn unused_warm_stacks(&self) -> u32 {
         self.allocator().stacks.unused_warm_slots()
     }
@@ -101,6 +104,7 @@ impl PoolingAllocatorMetrics {
     ///
     /// This returns `None` if the `async_stack_zeroing` option is disabled or
     /// if the platform doesn't manage stacks (e.g. Windows returns `None`).
+    #[cfg(feature = "async")]
     pub fn unused_stack_bytes_resident(&self) -> Option<usize> {
         self.allocator().stacks.unused_bytes_resident()
     }

--- a/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/metrics.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/metrics.rs
@@ -184,7 +184,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
+    #[cfg_attr(any(miri, not(target_os = "linux")), ignore)]
     fn unused_memories_tables_and_more() -> Result<()> {
         let mut pool = PoolingAllocationConfig::default();
         pool.linear_memory_keep_resident(65536);

--- a/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/metrics.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/metrics.rs
@@ -119,6 +119,7 @@ impl PoolingAllocatorMetrics {
 
 #[cfg(test)]
 mod tests {
+    use crate::vm::instance::allocator::pooling::StackPool;
     use crate::{
         Config, Enabled, InstanceAllocationStrategy, Module, PoolingAllocationConfig, Result,
         Store,
@@ -339,7 +340,7 @@ mod tests {
         drop(store);
         assert_eq!(metrics.stacks(), 0);
         assert_eq!(metrics.unused_stack_bytes_resident(), None);
-        if cfg!(unix) {
+        if StackPool::enabled() {
             assert_eq!(metrics.unused_warm_stacks(), 1);
         } else {
             assert_eq!(metrics.unused_warm_stacks(), 0);

--- a/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/unix_stack_pool.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/unix_stack_pool.rs
@@ -29,6 +29,11 @@ pub struct StackPool {
 }
 
 impl StackPool {
+    #[cfg(test)]
+    pub fn enabled() -> bool {
+        true
+    }
+
     pub fn new(config: &PoolingInstanceAllocatorConfig) -> Result<Self> {
         use rustix::mm::{MprotectFlags, mprotect};
 

--- a/crates/wasmtime/src/runtime/vm/pagemap_disabled.rs
+++ b/crates/wasmtime/src/runtime/vm/pagemap_disabled.rs
@@ -13,6 +13,8 @@ impl PageMap {
 
 /// Resets `ptr` for `len` bytes.
 ///
+/// Returns the number of bytse that are still resident after this returns.
+///
 /// # Safety
 ///
 /// Requires that `ptr` is valid to read and write for `len` bytes.
@@ -23,7 +25,7 @@ pub unsafe fn reset_with_pagemap(
     mut keep_resident: HostAlignedByteCount,
     mut reset_manually: impl FnMut(&mut [u8]),
     mut decommit: impl FnMut(*mut u8, usize),
-) {
+) -> usize {
     keep_resident = keep_resident.min(len);
 
     // `memset` the first `keep_resident` bytes.
@@ -42,5 +44,7 @@ pub unsafe fn reset_with_pagemap(
     len = len.checked_sub(keep_resident).unwrap();
 
     // decommit the rest of it.
-    decommit(ptr, len.byte_count())
+    decommit(ptr, len.byte_count());
+
+    keep_resident.byte_count()
 }


### PR DESCRIPTION
This commit adds a few more metrics to the `PoolingAllocatorMetrics` type along the lines of accounting for more items as well as the unused slots in the pooling allocator. Notably the count of unused memory and table slots is exposed along with the number of bytes which are kept resident in these slots despite them not being in use. This involved a bit of plumbing to thread around the number of bytes that are actually kept resident to some more locations but is otherwise a pretty straightforward plumbing of accounting information we already had internally.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
