### PR TITLE
Fix documentation examples in pipe.rs

### DIFF
--- a/crates/wasi-common/src/pipe.rs
+++ b/crates/wasi-common/src/pipe.rs
@@ -20,10 +20,11 @@ use std::sync::{Arc, RwLock};
 /// ```no_run
 /// use wasi_common::{pipe::ReadPipe, WasiCtx, Table};
 /// let stdin = ReadPipe::from("hello from stdin!");
-/// // Brint these instances from elsewhere (e.g. wasi-cap-std-sync):
-/// let random = todo!();
-/// let clocks = todo!();
-/// let sched = todo!();
+/// // Bring these instances from elsewhere (e.g. wasi-cap-std-sync or wasi-cap-std-tokio):
+/// use wasi_common::sync::{random_ctx, clocks_ctx, sched_ctx};
+/// let random = random_ctx();
+/// let clocks = clocks_ctx();
+/// let sched = sched_ctx();
 /// let table = Table::new();
 /// let mut ctx = WasiCtx::new(random, clocks, sched, table);
 /// ctx.set_stdin(Box::new(stdin.clone()));
@@ -116,10 +117,11 @@ impl<R: Read + Any + Send + Sync> WasiFile for ReadPipe<R> {
 /// ```no_run
 /// use wasi_common::{pipe::WritePipe, WasiCtx, Table};
 /// let stdout = WritePipe::new_in_memory();
-/// // Brint these instances from elsewhere (e.g. wasi-cap-std-sync):
-/// let random = todo!();
-/// let clocks = todo!();
-/// let sched = todo!();
+/// // Bring these instances from elsewhere (e.g. wasi-cap-std-sync or wasi-cap-std-tokio):
+/// use wasi_common::sync::{random_ctx, clocks_ctx, sched_ctx};
+/// let random = random_ctx();
+/// let clocks = clocks_ctx();
+/// let sched = sched_ctx();
 /// let table = Table::new();
 /// let mut ctx = WasiCtx::new(random, clocks, sched, table);
 /// ctx.set_stdout(Box::new(stdout.clone()));

--- a/crates/wasi-common/src/pipe.rs
+++ b/crates/wasi-common/src/pipe.rs
@@ -17,7 +17,7 @@ use std::sync::{Arc, RwLock};
 ///
 /// A variety of `From` impls are provided so that common pipe types are easy to create. For example:
 ///
-/// ```no_run
+/// ```rust
 /// use wasi_common::{pipe::ReadPipe, WasiCtx, Table};
 /// let stdin = ReadPipe::from("hello from stdin!");
 /// // Bring these instances from elsewhere (e.g. wasi-cap-std-sync or wasi-cap-std-tokio):
@@ -114,7 +114,7 @@ impl<R: Read + Any + Send + Sync> WasiFile for ReadPipe<R> {
 
 /// A virtual pipe write end.
 ///
-/// ```no_run
+/// ```rust
 /// use wasi_common::{pipe::WritePipe, WasiCtx, Table};
 /// let stdout = WritePipe::new_in_memory();
 /// // Bring these instances from elsewhere (e.g. wasi-cap-std-sync or wasi-cap-std-tokio):


### PR DESCRIPTION
Replace todo!() placeholders in documentation examples with actual working code.
The examples now show how to properly create random, clocks, and sched instances needed for WasiCtx::new() function.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
