### PR TITLE
x64: Fix `has_native_fma`

### DIFF
--- a/cranelift/codegen/src/isa/x64/mod.rs
+++ b/cranelift/codegen/src/isa/x64/mod.rs
@@ -177,7 +177,7 @@ impl TargetIsa for X64Backend {
     }
 
     fn has_native_fma(&self) -> bool {
-        self.x64_flags.has_fma()
+        self.x64_flags.has_avx() && self.x64_flags.has_fma()
     }
 
     fn has_round(&self) -> bool {


### PR DESCRIPTION
This commit synchronizes the implementation of lowering and `has_native_fma` where lowering requires both AVX + FMA but `has_native_fma` was just testing FMA, meaning that if `has_fma` was enabled but `has_avx` was disabled it would be possible to generate a link-time error with Wasmtime.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
