### PR TITLE
Fix some panics compiling components and resources

### DIFF
--- a/crates/cranelift/src/compiler/component.rs
+++ b/crates/cranelift/src/compiler/component.rs
@@ -1058,7 +1058,7 @@ impl<'a> TrampolineCompiler<'a> {
         let should_run_destructor =
             self.raise_if_negative_one(self.builder.func.dfg.inst_results(call)[0]);
 
-        let resource_ty = self.types[resource].ty;
+        let resource_ty = self.types[resource].unwrap_concrete_ty();
         let resource_def = self
             .component
             .defined_resource_index(resource_ty)
@@ -1136,7 +1136,7 @@ impl<'a> TrampolineCompiler<'a> {
         // the same component instance that defined the resource as the
         // component is calling itself.
         if let Some(def) = resource_def {
-            if self.types[resource].instance != def.instance {
+            if self.types[resource].unwrap_concrete_instance() != def.instance {
                 let flags = self.builder.ins().load(
                     ir::types::I32,
                     trusted,
@@ -1156,7 +1156,7 @@ impl<'a> TrampolineCompiler<'a> {
         if has_destructor {
             let rep = self.builder.ins().ushr_imm(should_run_destructor, 1);
             let rep = self.builder.ins().ireduce(ir::types::I32, rep);
-            let index = self.types[resource].ty;
+            let index = self.types[resource].unwrap_concrete_ty();
             // NB: despite the vmcontext storing nullable funcrefs for function
             // pointers we know this is statically never null due to the
             // `has_destructor` check above.

--- a/crates/environ/src/component/translate/inline.rs
+++ b/crates/environ/src/component/translate/inline.rs
@@ -1854,7 +1854,7 @@ impl<'a> ComponentItemDef<'a> {
         // Once `path` has been iterated over it must be the case that the final
         // item is a resource type, in which case a lookup can be performed.
         match cur {
-            ComponentItemDef::Type(TypeDef::Resource(idx)) => types[idx].ty,
+            ComponentItemDef::Type(TypeDef::Resource(idx)) => types[idx].unwrap_concrete_ty(),
             _ => unreachable!(),
         }
     }

--- a/crates/wasmtime/src/runtime/component/resources.rs
+++ b/crates/wasmtime/src/runtime/component/resources.rs
@@ -15,8 +15,8 @@ use core::mem::MaybeUninit;
 use core::ptr::NonNull;
 use core::sync::atomic::{AtomicU32, Ordering::Relaxed};
 use wasmtime_environ::component::{
-    CanonicalAbiInfo, ComponentTypes, DefinedResourceIndex, InterfaceType, ResourceIndex,
-    TypeResourceTableIndex,
+    AbstractResourceIndex, CanonicalAbiInfo, ComponentTypes, DefinedResourceIndex, InterfaceType,
+    ResourceIndex, TypeResourceTableIndex,
 };
 
 /// Representation of a resource type in the component model.
@@ -80,6 +80,15 @@ impl ResourceType {
             },
         }
     }
+
+    pub(crate) fn abstract_(types: &ComponentTypes, index: AbstractResourceIndex) -> ResourceType {
+        ResourceType {
+            kind: ResourceTypeKind::Abstract {
+                component: types as *const _ as usize,
+                index,
+            },
+        }
+    }
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -100,6 +109,13 @@ enum ResourceTypeKind {
         // to a new resource so there's not really any issue with that.
         component: usize,
         index: ResourceIndex,
+    },
+    /// The type of this resource is considered "abstract" meaning that it
+    /// doesn't actually correspond to anything at runtime but instead it just
+    /// needs to be kept distinct from everything but itself.
+    Abstract {
+        component: usize,
+        index: AbstractResourceIndex,
     },
 }
 

--- a/crates/wasmtime/src/runtime/vm/component/resources.rs
+++ b/crates/wasmtime/src/runtime/vm/component/resources.rs
@@ -197,7 +197,7 @@ impl ResourceTables<'_> {
             TypedResource::Host(_) => self.host_table.as_mut().unwrap(),
             TypedResource::Component { ty, .. } => {
                 let (tables, types) = self.guest.as_mut().unwrap();
-                &mut tables[types[*ty].instance]
+                &mut tables[types[*ty].unwrap_concrete_instance()]
             }
         }
     }
@@ -207,7 +207,7 @@ impl ResourceTables<'_> {
             TypedResourceIndex::Host(_) => self.host_table.as_mut().unwrap(),
             TypedResourceIndex::Component { ty, .. } => {
                 let (tables, types) = self.guest.as_mut().unwrap();
-                &mut tables[types[*ty].instance]
+                &mut tables[types[*ty].unwrap_concrete_instance()]
             }
         }
     }

--- a/tests/misc_testsuite/component-model/restrictions.wast
+++ b/tests/misc_testsuite/component-model/restrictions.wast
@@ -1,0 +1,22 @@
+(assert_invalid
+  (component (import "x" (component)))
+  "root-level component imports are not supported")
+
+(assert_invalid
+  (component (component (export "x")))
+  "exporting a component from the root component is not supported")
+
+(assert_invalid
+  (component
+    (import "f" (func $f))
+    (export "f" (func $f))
+  )
+  "component export `f` is a reexport of an imported function which is not implemented")
+
+(assert_invalid
+  (component
+    (import "x" (component
+      (export "x" (type (sub resource)))
+    ))
+  )
+  "root-level component imports are not supported")

--- a/tests/misc_testsuite/component-model/types.wast
+++ b/tests/misc_testsuite/component-model/types.wast
@@ -335,3 +335,21 @@
     (export "b" (type (eq $t2)))
   ))
 )
+
+(component
+  (type (export "x") (component
+    (type $t' (instance
+      (export "r" (type (sub resource)))
+    ))
+    (export "t" (instance $t (type $t')))
+  ))
+)
+
+(component
+  (type (export "x") (instance
+    (type $t' (instance
+      (export "r" (type (sub resource)))
+    ))
+    (export "t" (instance $t (type $t')))
+  ))
+)


### PR DESCRIPTION
In working on bytecodealliance/wasm-tools#2335 I found that there's a few test cases in wasm-tools which Wasmtime was panicking to compile. The issues were all related to resource types and how information wasn't registered ahead of time before it was translated from wasmparser's representation to Wasmtime's representation. The high-level cause for this had to do with how component and instance types are handled, as opposed to concrete components or instances themselves. This was effectively a hole in Wasmtime's translation process for components which has never been filled out since the original implementation of resources. The reason that this never came up before is:

* Most components don't currently import or export a component itself.
* Most components don't currently import or export component or instance types (as opposed to values).

One of these was required to trigger this issue. The solution implemented in this commit is to plumb the concept of an "abstract resource" which is part of a type but not actually ever used at runtime except for type equality during type reflection. This is expected to have little-to-no impact on real-world components given that these situations are rarely occurring.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
