### PR TITLE
Fix externref/anyref ownership in C/C++ API

### DIFF
--- a/crates/c-api/include/wasmtime/error.hh
+++ b/crates/c-api/include/wasmtime/error.hh
@@ -103,6 +103,16 @@ public:
   const T &&ok() const { return std::get<T>(std::move(data)); }
 
   /// \brief Returns the success, if present, aborts if this is an error.
+  T &ok_ref() { return std::get<T>(data); }
+  /// \brief Returns the success, if present, aborts if this is an error.
+  const T &ok_ref() const { return std::get<T>(data); }
+
+  /// \brief Returns the error, if present, aborts if this is not an error.
+  E &err_ref() { return std::get<T>(data); }
+  /// \brief Returns the error, if present, aborts if this is not an error.
+  const E &err_ref() const { return std::get<T>(data); }
+
+  /// \brief Returns the success, if present, aborts if this is an error.
   T unwrap() {
     if (*this) {
       return this->ok();

--- a/crates/c-api/include/wasmtime/store.hh
+++ b/crates/c-api/include/wasmtime/store.hh
@@ -191,6 +191,10 @@ public:
 
   /// Explicit function to acquire a `Context` from this store.
   Context context() { return this; }
+
+  /// Runs a garbage collection pass in the referenced store to collect loose
+  /// GC-managed objects, if any are available.
+  void gc() { context().gc(); }
 };
 
 } // namespace wasmtime

--- a/crates/c-api/include/wasmtime/val.h
+++ b/crates/c-api/include/wasmtime/val.h
@@ -74,8 +74,7 @@ static inline bool wasmtime_anyref_is_null(const wasmtime_anyref_t *ref) {
  *
  * The returned reference is stored in `out`.
  */
-WASM_API_EXTERN void wasmtime_anyref_clone(wasmtime_context_t *context,
-                                           const wasmtime_anyref_t *anyref,
+WASM_API_EXTERN void wasmtime_anyref_clone(const wasmtime_anyref_t *anyref,
                                            wasmtime_anyref_t *out);
 
 /**
@@ -91,8 +90,7 @@ WASM_API_EXTERN void wasmtime_anyref_clone(wasmtime_context_t *context,
  * Note that null or i32 anyref values do not need to be unrooted but are still
  * valid to pass to this function.
  */
-WASM_API_EXTERN void wasmtime_anyref_unroot(wasmtime_context_t *context,
-                                            wasmtime_anyref_t *ref);
+WASM_API_EXTERN void wasmtime_anyref_unroot(wasmtime_anyref_t *ref);
 
 /**
  * \brief Converts a raw `anyref` value coming from #wasmtime_val_raw_t into
@@ -250,8 +248,7 @@ WASM_API_EXTERN void *wasmtime_externref_data(wasmtime_context_t *context,
  * eventually be unrooted with #wasmtime_externref_unroot in the future to
  * enable GC'ing it.
  */
-WASM_API_EXTERN void wasmtime_externref_clone(wasmtime_context_t *context,
-                                              const wasmtime_externref_t *ref,
+WASM_API_EXTERN void wasmtime_externref_clone(const wasmtime_externref_t *ref,
                                               wasmtime_externref_t *out);
 
 /**
@@ -265,8 +262,7 @@ WASM_API_EXTERN void wasmtime_externref_clone(wasmtime_context_t *context,
  * Note that null externref values do not need to be unrooted but are still
  * valid to pass to this function.
  */
-WASM_API_EXTERN void wasmtime_externref_unroot(wasmtime_context_t *context,
-                                               wasmtime_externref_t *ref);
+WASM_API_EXTERN void wasmtime_externref_unroot(wasmtime_externref_t *ref);
 
 /**
  * \brief Converts a raw `externref` value coming from #wasmtime_val_raw_t into
@@ -475,8 +471,7 @@ typedef struct wasmtime_val {
  * This method does not need to be called for integers, floats, v128, or
  * funcref values.
  */
-WASM_API_EXTERN void wasmtime_val_unroot(wasmtime_context_t *context,
-                                         wasmtime_val_t *val);
+WASM_API_EXTERN void wasmtime_val_unroot(wasmtime_val_t *val);
 
 /**
  * \brief Clones the value pointed to by `src` into the `dst` provided.
@@ -485,8 +480,7 @@ WASM_API_EXTERN void wasmtime_val_unroot(wasmtime_context_t *context,
  * newly rooted inside of `dst`. When using this API the `dst` should be
  * later unrooted with #wasmtime_val_unroot if it contains GC values.
  */
-WASM_API_EXTERN void wasmtime_val_clone(wasmtime_context_t *context,
-                                        const wasmtime_val_t *src,
+WASM_API_EXTERN void wasmtime_val_clone(const wasmtime_val_t *src,
                                         wasmtime_val_t *dst);
 
 #ifdef __cplusplus

--- a/crates/c-api/src/ref.rs
+++ b/crates/c-api/src/ref.rs
@@ -1,5 +1,6 @@
 use crate::{WasmtimeStoreContextMut, abort};
-use std::{mem::MaybeUninit, num::NonZeroU64, os::raw::c_void, ptr};
+use std::mem::{ManuallyDrop, MaybeUninit};
+use std::{num::NonZeroU64, os::raw::c_void, ptr};
 use wasmtime::{AnyRef, ExternRef, I31, OwnedRooted, Ref, RootScope, Val};
 
 /// `*mut wasm_ref_t` is a reference type (`externref` or `funcref`), as seen by
@@ -207,11 +208,23 @@ macro_rules! ref_wrapper {
                 ))
             }
 
-            pub unsafe fn from_wasmtime(self) -> Option<OwnedRooted<$wasmtime>> {
+            pub unsafe fn into_wasmtime(self) -> Option<OwnedRooted<$wasmtime>> {
+                ManuallyDrop::new(self).to_owned()
+            }
+
+            unsafe fn to_owned(&self) -> Option<OwnedRooted<$wasmtime>> {
                 let store_id = NonZeroU64::new(self.store_id)?;
                 Some(OwnedRooted::from_owned_raw_parts_for_c_api(
                     store_id, self.a, self.b, self.c,
                 ))
+            }
+        }
+
+        impl Drop for $c {
+            fn drop(&mut self) {
+                unsafe {
+                    let _ = self.to_owned();
+                }
             }
         }
 
@@ -248,7 +261,6 @@ ref_wrapper!(ExternRef => wasmtime_externref_t);
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasmtime_anyref_clone(
-    _cx: WasmtimeStoreContextMut<'_>,
     anyref: Option<&wasmtime_anyref_t>,
     out: &mut MaybeUninit<wasmtime_anyref_t>,
 ) {
@@ -257,12 +269,11 @@ pub unsafe extern "C" fn wasmtime_anyref_clone(
 }
 
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn wasmtime_anyref_unroot(
-    _cx: WasmtimeStoreContextMut<'_>,
-    val: Option<&mut MaybeUninit<wasmtime_anyref_t>>,
-) {
-    if let Some(val) = val.and_then(|v| v.assume_init_read().from_wasmtime()) {
-        drop(val);
+pub unsafe extern "C" fn wasmtime_anyref_unroot(val: Option<&mut ManuallyDrop<wasmtime_anyref_t>>) {
+    if let Some(val) = val {
+        unsafe {
+            ManuallyDrop::drop(val);
+        }
     }
 }
 
@@ -371,7 +382,6 @@ pub unsafe extern "C" fn wasmtime_externref_data(
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasmtime_externref_clone(
-    _cx: WasmtimeStoreContextMut<'_>,
     externref: Option<&wasmtime_externref_t>,
     out: &mut MaybeUninit<wasmtime_externref_t>,
 ) {
@@ -381,11 +391,12 @@ pub unsafe extern "C" fn wasmtime_externref_clone(
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasmtime_externref_unroot(
-    _cx: WasmtimeStoreContextMut<'_>,
-    val: Option<&mut MaybeUninit<wasmtime_externref_t>>,
+    val: Option<&mut ManuallyDrop<wasmtime_externref_t>>,
 ) {
-    if let Some(val) = val.and_then(|v| v.assume_init_read().from_wasmtime()) {
-        drop(val);
+    if let Some(val) = val {
+        unsafe {
+            ManuallyDrop::drop(val);
+        }
     }
 }
 

--- a/crates/c-api/src/val.rs
+++ b/crates/c-api/src/val.rs
@@ -1,7 +1,7 @@
 use crate::r#ref::ref_to_val;
 use crate::{
-    WASM_I32, WasmtimeStoreContextMut, from_valtype, into_valtype, wasm_ref_t, wasm_valkind_t,
-    wasmtime_anyref_t, wasmtime_externref_t, wasmtime_valkind_t,
+    WASM_I32, from_valtype, into_valtype, wasm_ref_t, wasm_valkind_t, wasmtime_anyref_t,
+    wasmtime_externref_t, wasmtime_valkind_t,
 };
 use std::mem::{ManuallyDrop, MaybeUninit};
 use std::ptr;
@@ -158,6 +158,22 @@ const _: () = {
     assert!(std::mem::align_of::<wasmtime_val_union>() == std::mem::align_of::<u64>());
 };
 
+impl Drop for wasmtime_val_t {
+    fn drop(&mut self) {
+        unsafe {
+            match self.kind {
+                crate::WASMTIME_ANYREF => {
+                    let _ = ManuallyDrop::take(&mut self.of.anyref);
+                }
+                crate::WASMTIME_EXTERNREF => {
+                    let _ = ManuallyDrop::take(&mut self.of.externref);
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
 // The raw pointers are actually optional boxes.
 unsafe impl Send for wasmtime_val_union
 where
@@ -298,33 +314,31 @@ impl wasmtime_val_t {
 }
 
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn wasmtime_val_unroot(
-    _cx: WasmtimeStoreContextMut<'_>,
-    val: &mut MaybeUninit<wasmtime_val_t>,
-) {
-    let val = val.assume_init_read();
-    match val.kind {
-        crate::WASMTIME_ANYREF => {
-            if let Some(val) = ManuallyDrop::into_inner(val.of.anyref).as_wasmtime() {
-                drop(val);
-            }
-        }
-        crate::WASMTIME_EXTERNREF => {
-            if let Some(val) = ManuallyDrop::into_inner(val.of.externref).as_wasmtime() {
-                drop(val);
-            }
-        }
-        _ => {}
-    }
+pub unsafe extern "C" fn wasmtime_val_unroot(val: &mut ManuallyDrop<wasmtime_val_t>) {
+    ManuallyDrop::drop(val);
 }
 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasmtime_val_clone(
-    cx: WasmtimeStoreContextMut<'_>,
     src: &wasmtime_val_t,
     dst: &mut MaybeUninit<wasmtime_val_t>,
 ) {
-    let mut scope = RootScope::new(cx);
-    let val = src.to_val(&mut scope);
-    crate::initialize(dst, wasmtime_val_t::from_val(&mut scope, val))
+    let of = match src.kind {
+        crate::WASMTIME_ANYREF => wasmtime_val_union {
+            anyref: ManuallyDrop::new(src.of.anyref.as_wasmtime().into()),
+        },
+        crate::WASMTIME_EXTERNREF => wasmtime_val_union {
+            externref: ManuallyDrop::new(src.of.externref.as_wasmtime().into()),
+        },
+        crate::WASMTIME_I32 => wasmtime_val_union { i32: src.of.i32 },
+        crate::WASMTIME_I64 => wasmtime_val_union { i64: src.of.i64 },
+        crate::WASMTIME_F32 => wasmtime_val_union { f32: src.of.f32 },
+        crate::WASMTIME_F64 => wasmtime_val_union { f64: src.of.f64 },
+        crate::WASMTIME_V128 => wasmtime_val_union { v128: src.of.v128 },
+        crate::WASMTIME_FUNCREF => wasmtime_val_union {
+            funcref: src.of.funcref,
+        },
+        _ => unreachable!(),
+    };
+    dst.write(wasmtime_val_t { kind: src.kind, of });
 }

--- a/crates/c-api/tests/component/call_func.cc
+++ b/crates/c-api/tests/component/call_func.cc
@@ -78,6 +78,7 @@ TEST(component, call_func) {
 
   wasmtime_component_export_index_delete(f);
   wasmtime_component_linker_delete(linker);
+  wasmtime_component_delete(component);
 
   wasmtime_store_delete(store);
   wasm_engine_delete(engine);

--- a/crates/c-api/tests/component/define_module.cc
+++ b/crates/c-api/tests/component/define_module.cc
@@ -36,6 +36,7 @@ TEST(component, define_module) {
   err = wasmtime_module_new(
       engine, reinterpret_cast<const uint8_t *>(wasm.data), wasm.size, &module);
   CHECK_ERR(err);
+  wasm_byte_vec_delete(&wasm);
 
   const auto store = wasmtime_store_new(engine, nullptr, nullptr);
   const auto context = wasmtime_store_context(store);
@@ -70,6 +71,8 @@ TEST(component, define_module) {
   CHECK_ERR(err);
 
   wasmtime_component_linker_delete(linker);
+  wasmtime_component_delete(component);
+  wasmtime_module_delete(module);
 
   wasmtime_store_delete(store);
   wasm_engine_delete(engine);

--- a/crates/c-api/tests/component/instantiate.cc
+++ b/crates/c-api/tests/component/instantiate.cc
@@ -38,6 +38,7 @@ TEST(component, instantiate) {
   CHECK_ERR(error);
 
   wasmtime_component_linker_delete(linker);
+  wasmtime_component_delete(component);
 
   wasmtime_store_delete(store);
   wasm_engine_delete(engine);

--- a/crates/c-api/tests/component/lookup_func.cc
+++ b/crates/c-api/tests/component/lookup_func.cc
@@ -60,6 +60,7 @@ TEST(component, lookup_func) {
 
   wasmtime_component_export_index_delete(f);
   wasmtime_component_linker_delete(linker);
+  wasmtime_component_delete(component);
 
   wasmtime_store_delete(store);
   wasm_engine_delete(engine);

--- a/crates/c-api/tests/func.cc
+++ b/crates/c-api/tests/func.cc
@@ -88,10 +88,9 @@ TEST(TypedFunc, Call) {
                 {ValKind::ExternRef, ValKind::ExternRef});
     Func f(store, ty, [](auto caller, auto params, auto results) {
       caller.context().gc();
-      EXPECT_TRUE(params[0].externref(caller));
-      EXPECT_EQ(std::any_cast<int>(params[0].externref(caller)->data(caller)),
-                100);
-      EXPECT_FALSE(params[1].externref(caller));
+      EXPECT_TRUE(params[0].externref());
+      EXPECT_EQ(std::any_cast<int>(params[0].externref()->data(caller)), 100);
+      EXPECT_FALSE(params[1].externref());
       results[0] = ExternRef(caller, int(3));
       results[1] = std::optional<ExternRef>(std::nullopt);
       caller.context().gc();

--- a/crates/c-api/tests/simple.cc
+++ b/crates/c-api/tests/simple.cc
@@ -63,7 +63,6 @@ TEST(ExternRef, Smoke) {
   ExternRef b(store, 3);
   EXPECT_STREQ(std::any_cast<const char *>(a.data(store)), "foo");
   EXPECT_EQ(std::any_cast<int>(b.data(store)), 3);
-  a.unroot(store);
   a = b;
 }
 

--- a/crates/c-api/tests/wasip2.cc
+++ b/crates/c-api/tests/wasip2.cc
@@ -40,6 +40,7 @@ TEST(wasip2, smoke) {
   CHECK_ERR(err);
 
   wasmtime_component_linker_delete(linker);
+  wasmtime_component_delete(component);
 
   wasmtime_store_delete(store);
   wasm_engine_delete(engine);

--- a/examples/anyref.c
+++ b/examples/anyref.c
@@ -117,7 +117,7 @@ int main() {
   is_i31 = wasmtime_anyref_i31_get_u(context, &elem.of.anyref, &i31val);
   assert(is_i31);
   assert(i31val == 1234);
-  wasmtime_val_unroot(context, &elem);
+  wasmtime_val_unroot(&elem);
 
   printf("Touching `anyref` global...\n");
 
@@ -141,7 +141,7 @@ int main() {
   is_i31 = wasmtime_anyref_i31_get_u(context, &global_val.of.anyref, &i31val);
   assert(is_i31);
   assert(i31val == 1234);
-  wasmtime_val_unroot(context, &global_val);
+  wasmtime_val_unroot(&global_val);
 
   printf("Passing `anyref` into func...\n");
 
@@ -179,8 +179,8 @@ int main() {
   is_i31 = wasmtime_anyref_i31_get_u(context, &results[0].of.anyref, &i31val);
   assert(is_i31);
   assert(i31val == 42);
-  wasmtime_val_unroot(context, &results[0]);
-  wasmtime_val_unroot(context, &anyref_val);
+  wasmtime_val_unroot(&results[0]);
+  wasmtime_val_unroot(&anyref_val);
 
   // We can GC any now-unused references to our anyref that the store is
   // holding.

--- a/examples/anyref.cc
+++ b/examples/anyref.cc
@@ -47,7 +47,7 @@ int main() {
   auto cx = store.context();
   AnyRef i31 = AnyRef::i31(cx, 1234);
   Val anyref_val(i31);
-  auto opt_any = anyref_val.anyref(cx);
+  auto opt_any = anyref_val.anyref();
   if (!opt_any || !opt_any->u31(cx) || *opt_any->u31(cx) != 1234) {
     std::cerr << "> Error creating i31 anyref\n";
     return 1;
@@ -61,7 +61,7 @@ int main() {
     std::cerr << "> Error getting table element\n";
     return 1;
   }
-  auto elem_any = elem_opt->anyref(cx);
+  auto elem_any = elem_opt->anyref();
   if (!elem_any || !elem_any->u31(cx) || *elem_any->u31(cx) != 1234) {
     std::cerr << "> Error verifying table element\n";
     return 1;
@@ -71,7 +71,7 @@ int main() {
   Global global = std::get<Global>(*instance.get(store, "global"));
   global.set(store, anyref_val).unwrap();
   Val global_val = global.get(store);
-  auto global_any = global_val.anyref(cx);
+  auto global_any = global_val.anyref();
   if (!global_any || !global_any->u31(cx) || *global_any->u31(cx) != 1234) {
     std::cerr << "> Error verifying global value\n";
     return 1;
@@ -88,7 +88,7 @@ int main() {
     std::cerr << "> Unexpected number of results\n";
     return 1;
   }
-  auto ret_any = results[0].anyref(cx);
+  auto ret_any = results[0].anyref();
   if (!ret_any || !ret_any->u31(cx) || *ret_any->u31(cx) != 42) {
     std::cerr << "> Error verifying returned anyref\n";
     return 1;

--- a/examples/externref.c
+++ b/examples/externref.c
@@ -112,7 +112,7 @@ int main() {
     assert(elem.kind == WASMTIME_EXTERNREF);
     assert(strcmp((char *)wasmtime_externref_data(context, &elem.of.externref),
                   "Hello, World!") == 0);
-    wasmtime_val_unroot(context, &elem);
+    wasmtime_val_unroot(&elem);
   }
 
   printf("Touching `externref` global...\n");
@@ -136,7 +136,7 @@ int main() {
     assert(strcmp((char *)wasmtime_externref_data(context,
                                                   &global_val.of.externref),
                   "Hello, World!") == 0);
-    wasmtime_val_unroot(context, &global_val);
+    wasmtime_val_unroot(&global_val);
   }
 
   printf("Calling `externref` func...\n");
@@ -161,9 +161,9 @@ int main() {
     assert(strcmp((char *)wasmtime_externref_data(context,
                                                   &results[0].of.externref),
                   "Hello, World!") == 0);
-    wasmtime_val_unroot(context, &results[0]);
+    wasmtime_val_unroot(&results[0]);
   }
-  wasmtime_val_unroot(context, &externref_val);
+  wasmtime_val_unroot(&externref_val);
 
   // We can GC any now-unused references to our externref that the store is
   // holding.

--- a/examples/externref.cc
+++ b/examples/externref.cc
@@ -31,21 +31,21 @@ int main() {
   std::cout << "Touching `externref` table..\n";
   Table table = std::get<Table>(*instance.get(store, "table"));
   table.set(store, 3, externref).unwrap();
-  ExternRef val = *table.get(store, 3)->externref(store);
+  ExternRef val = *table.get(store, 3)->externref();
   std::cout << "externref data: " << std::any_cast<std::string>(val.data(store))
             << "\n";
 
   std::cout << "Touching `externref` global..\n";
   Global global = std::get<Global>(*instance.get(store, "global"));
   global.set(store, externref).unwrap();
-  val = *global.get(store).externref(store);
+  val = *global.get(store).externref();
   std::cout << "externref data: " << std::any_cast<std::string>(val.data(store))
             << "\n";
 
   std::cout << "Calling `externref` func..\n";
   Func func = std::get<Func>(*instance.get(store, "func"));
   auto results = func.call(store, {externref}).unwrap();
-  val = *results[0].externref(store);
+  val = *results[0].externref();
   std::cout << "externref data: " << std::any_cast<std::string>(val.data(store))
             << "\n";
 

--- a/examples/fib-debug/main.c
+++ b/examples/fib-debug/main.c
@@ -45,7 +45,7 @@ extern struct jit_descriptor __jit_debug_descriptor;
 static void exit_with_error(const char *message, wasmtime_error_t *error,
                             wasm_trap_t *trap);
 
-int main(int argc, const char *argv[]) {
+int main() {
   // Configuring engine to support generating of DWARF info.
   // lldb can be used to attach to the program and observe
   // original fib-wasm.c source code and variables.

--- a/examples/fuel.c
+++ b/examples/fuel.c
@@ -94,7 +94,10 @@ int main() {
         wasmtime_trap_code_t code;
         assert(wasmtime_trap_code(trap, &code));
         assert(code == WASMTIME_TRAP_CODE_OUT_OF_FUEL);
+        wasm_trap_delete(trap);
       }
+      if (error != NULL)
+        wasmtime_error_delete(error);
       printf("Exhausted fuel computing fib(%d)\n", n);
       break;
     }

--- a/examples/hello.c
+++ b/examples/hello.c
@@ -19,6 +19,12 @@ static void exit_with_error(const char *message, wasmtime_error_t *error,
 static wasm_trap_t *hello_callback(void *env, wasmtime_caller_t *caller,
                                    const wasmtime_val_t *args, size_t nargs,
                                    wasmtime_val_t *results, size_t nresults) {
+  (void) env;
+  (void) caller;
+  (void) args;
+  (void) nargs;
+  (void) results;
+  (void) nresults;
   printf("Calling back...\n");
   printf("> Hello World!\n");
   return NULL;
@@ -77,6 +83,7 @@ int main() {
   wasm_functype_t *hello_ty = wasm_functype_new_0_0();
   wasmtime_func_t hello;
   wasmtime_func_new(context, hello_ty, hello_callback, NULL, NULL, &hello);
+  wasm_functype_delete(hello_ty);
 
   // With our callback function we can now instantiate the compiled module,
   // giving us an instance we can then execute exports from. Note that

--- a/examples/interrupt.c
+++ b/examples/interrupt.c
@@ -107,6 +107,7 @@ int main() {
   assert(error == NULL);
   assert(trap != NULL);
   printf("Got a trap!...\n");
+  wasm_trap_delete(trap);
 
   wasmtime_store_delete(store);
   wasm_engine_delete(engine);

--- a/examples/linking.c
+++ b/examples/linking.c
@@ -18,8 +18,7 @@ mkdir build && cd build && cmake .. && cmake --build . --target wasmtime-linking
 
 static void exit_with_error(const char *message, wasmtime_error_t *error,
                             wasm_trap_t *trap);
-static void read_wat_file(wasm_engine_t *engine, wasm_byte_vec_t *bytes,
-                          const char *file);
+static void read_wat_file(wasm_byte_vec_t *bytes, const char *file);
 
 int main() {
   // Set up our context
@@ -30,8 +29,8 @@ int main() {
   wasmtime_context_t *context = wasmtime_store_context(store);
 
   wasm_byte_vec_t linking1_wasm, linking2_wasm;
-  read_wat_file(engine, &linking1_wasm, "examples/linking1.wat");
-  read_wat_file(engine, &linking2_wasm, "examples/linking2.wat");
+  read_wat_file(&linking1_wasm, "examples/linking1.wat");
+  read_wat_file(&linking2_wasm, "examples/linking2.wat");
 
   // Compile our two modules
   wasmtime_error_t *error;
@@ -106,8 +105,7 @@ int main() {
   return 0;
 }
 
-static void read_wat_file(wasm_engine_t *engine, wasm_byte_vec_t *bytes,
-                          const char *filename) {
+static void read_wat_file(wasm_byte_vec_t *bytes, const char *filename) {
   wasm_byte_vec_t wat;
   // Load our input file to parse it next
   FILE *file = fopen(filename, "r");

--- a/examples/memory.c
+++ b/examples/memory.c
@@ -118,7 +118,7 @@ void check_trap2(wasmtime_context_t *store, wasmtime_func_t *func, int32_t arg1,
   check_trap(store, func, args, 2, 0);
 }
 
-int main(int argc, const char *argv[]) {
+int main() {
   // Initialize.
   printf("Initializing...\n");
   wasm_engine_t *engine = wasm_engine_new();

--- a/examples/multi.c
+++ b/examples/multi.c
@@ -25,6 +25,11 @@ static void exit_with_error(const char *message, wasmtime_error_t *error,
 wasm_trap_t *callback(void *env, wasmtime_caller_t *caller,
                       const wasmtime_val_t *args, size_t nargs,
                       wasmtime_val_t *results, size_t nresults) {
+  (void) env;
+  (void) caller;
+  (void) nargs;
+  (void) nresults;
+
   printf("Calling back...\n");
   printf("> %" PRIu32 " %" PRIu64 "\n", args[0].of.i32, args[1].of.i64);
   printf("\n");
@@ -38,6 +43,11 @@ wasm_trap_t *callback(void *env, wasmtime_caller_t *caller,
 wasm_trap_t *closure_callback(void *env, wasmtime_caller_t *caller,
                               const wasmtime_val_t *args, size_t nargs,
                               wasmtime_val_t *results, size_t nresults) {
+  (void) caller;
+  (void) args;
+  (void) nargs;
+  (void) nresults;
+
   int i = *(int *)env;
   printf("Calling back closure...\n");
   printf("> %d\n", i);
@@ -47,7 +57,7 @@ wasm_trap_t *closure_callback(void *env, wasmtime_caller_t *caller,
   return NULL;
 }
 
-int main(int argc, const char *argv[]) {
+int main() {
   // Initialize.
   printf("Initializing...\n");
   wasm_engine_t *engine = wasm_engine_new();

--- a/examples/serialize.c
+++ b/examples/serialize.c
@@ -20,6 +20,12 @@ static void exit_with_error(const char *message, wasmtime_error_t *error,
 static wasm_trap_t *hello_callback(void *env, wasmtime_caller_t *caller,
                                    const wasmtime_val_t *args, size_t nargs,
                                    wasmtime_val_t *results, size_t nresults) {
+  (void) env;
+  (void) caller;
+  (void) args;
+  (void) nargs;
+  (void) results;
+  (void) nresults;
   printf("Calling back...\n");
   printf("> Hello World!\n");
   return NULL;
@@ -102,6 +108,7 @@ int deserialize(wasm_byte_vec_t *buffer) {
   wasm_functype_t *hello_ty = wasm_functype_new_0_0();
   wasmtime_func_t hello;
   wasmtime_func_new(context, hello_ty, hello_callback, NULL, NULL, &hello);
+  wasm_functype_delete(hello_ty);
 
   // With our callback function we can now instantiate the compiled module,
   // giving us an instance we can then execute exports from. Note that

--- a/examples/threads.c
+++ b/examples/threads.c
@@ -43,6 +43,8 @@ uint64_t get_thread_id() {
 
 // A function to be called from Wasm code.
 own wasm_trap_t *callback(const wasm_val_vec_t *args, wasm_val_vec_t *results) {
+  (void) args;
+  (void) results;
   printf("> Thread %lu running\n", (uint64_t)get_thread_id());
   return NULL;
 }
@@ -117,7 +119,7 @@ void *run(void *args_abs) {
   return NULL;
 }
 
-int main(int argc, const char *argv[]) {
+int main() {
   // Initialize.
   wasm_engine_t *engine = wasm_engine_new();
 

--- a/examples/wasip1/main.c
+++ b/examples/wasip1/main.c
@@ -99,6 +99,7 @@ int main() {
     exit_with_error("error calling default export", error, trap);
 
   // Clean up after ourselves at this point
+  wasmtime_linker_delete(linker);
   wasmtime_module_delete(module);
   wasmtime_store_delete(store);
   wasm_engine_delete(engine);


### PR DESCRIPTION
This commit is a follow-up to #11514 which was discovered through failing tests in the wasmtime-py repository when updating to Wasmtime 37.0.0. Effectively a combination of bugs in the Rust API meant that it wasn't possible to use `externref` or `anyref` bindings correctly. The Rust changes in this commit are:

* `wasmtime_val_unroot` correctly drops the value now as opposed to effectively being a noop from before (typo of using `as_externref` vs `from_externref`).
* `wasmtime_{anyref,externref,val}_t` now have a `Drop` implementation in Rust to correctly drop them if a value in Rust is dropped. This is required to correctly manage memory in the `wasmtime_func_{call,new}` implementations, for example.
* `wasmtime_{anyref,externref,val}_clone` no longer have an unnecessary context parameter.
* `wasmtime_{anyref,externref,val}_unroot` no longer have an unnecessary context parameter.

Changes in the C/C++ APIs are:

* `Result::{ok,err}_ref` APIs were added in addition to the preexisting rvalue accessors.
* Loading/storing typed arguments now has an overload for `const T&` and `T&&` which behaves differently. Notably transferring ownership for `T&&` and not for `const T&`. This means that passing parameters when calling a wasm function uses `const T&`, but passing results from a host import uses `T&&`.
* `TypedFunc::call` now uses `const Params&` instead of `Params` to explicitly specify it doesn't modify the parameters and forces using the `const T&` store method.
* `Store::gc` is now a convenience method for `store.context().gc()`
* `ExternRef`, `AnyRef`, and `Val` now have ownership semantics and destructors. This matches the spirit of #11514 for Rust but models it in C++ as well. This required filling out move/copy constructors/assignments.
* The explicit `ExternRef` now takes `std::any` instead of `T`.
* Minor issues related to ownership are fixed in `Val` bindings.

Valgrind was used to ensure that there were no leaks for the test suite which additionally resulted in a number of `*_delete` calls being added to tests using the C API (accidental omissions).

The original goal of this change was to be a patch release for 37.0.1 to enable updating wasmtime-py to the 37.0.x releases of Wasmtime. In the end though the changes here were broad enough that I no longer feel that this is a good idea, so wasmtime-py will be skipping the 37 version of Wasmtime.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
