### PR TITLE
[37.0.0] Fix externref/anyref ownership in C/C++ API

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,14 @@
+## 37.0.2
+
+Released 2025-10-07.
+
+### Fixed
+
+* Fix a memory leak in the C API when using `anyref` or `externref`.
+  [CVE-2025-61670](https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-vvp9-h8p2-xwfc).
+
+--------------------------------------------------------------------------------
+
 ## 37.0.1
 
 Released 2025-09-23.
@@ -8,6 +19,8 @@ Released 2025-09-23.
   instructions on aarch64; a zero-extension on the offset was fixed to properly
   sign-extend instead.
   [#11734](https://github.com/bytecodealliance/wasmtime/pull/11734)
+
+--------------------------------------------------------------------------------
 
 ## 37.0.0
 

--- a/crates/c-api/include/wasmtime/func.hh
+++ b/crates/c-api/include/wasmtime/func.hh
@@ -87,6 +87,14 @@ template <> struct WasmType<std::optional<ExternRef>> {
   static const bool valid = true;
   static const ValKind kind = ValKind::ExternRef;
   static void store(Store::Context cx, wasmtime_val_raw_t *p,
+                    std::optional<ExternRef> &&ref) {
+    if (ref) {
+      p->externref = ref->take_raw(cx);
+    } else {
+      p->externref = 0;
+    }
+  }
+  static void store(Store::Context cx, wasmtime_val_raw_t *p,
                     const std::optional<ExternRef> &ref) {
     if (ref) {
       p->externref = wasmtime_externref_to_raw(cx.raw_context(), ref->raw());
@@ -129,6 +137,9 @@ template <typename T> struct WasmTypeList {
   static bool matches(ValType::ListRef types) {
     return WasmTypeList<std::tuple<T>>::matches(types);
   }
+  static void store(Store::Context cx, wasmtime_val_raw_t *storage, T &&t) {
+    WasmType<T>::store(cx, storage, t);
+  }
   static void store(Store::Context cx, wasmtime_val_raw_t *storage,
                     const T &t) {
     WasmType<T>::store(cx, storage, t);
@@ -168,6 +179,15 @@ template <typename... T> struct WasmTypeList<std::tuple<T...>> {
     }
     size_t n = 0;
     return ((WasmType<T>::kind == types.begin()[n++].kind()) && ...);
+  }
+  static void store(Store::Context cx, wasmtime_val_raw_t *storage,
+                    std::tuple<T...> &&t) {
+    size_t n = 0;
+    std::apply(
+        [&](auto &...val) {
+          (WasmType<T>::store(cx, &storage[n++], val), ...); // NOLINT
+        },
+        t);
   }
   static void store(Store::Context cx, wasmtime_val_raw_t *storage,
                     const std::tuple<T...> &t) {

--- a/crates/c-api/include/wasmtime/val.hh
+++ b/crates/c-api/include/wasmtime/val.hh
@@ -82,7 +82,7 @@ public:
 
   /// Creates a new `ExternRef` which is separately rooted from this one.
   ExternRef clone(Store::Context cx) {
-    (void) cx;
+    (void)cx;
     return *this;
   }
 
@@ -94,7 +94,7 @@ public:
   /// Unroots this value from the context provided, enabling a future GC to
   /// collect the internal object if there are no more references.
   void unroot(Store::Context cx) {
-    (void) cx;
+    (void)cx;
     wasmtime_externref_unroot(NULL, &val);
     wasmtime_externref_set_null(&val);
   }
@@ -161,14 +161,14 @@ public:
 
   /// Creates a new `AnyRef` which is separately rooted from this one.
   AnyRef clone(Store::Context cx) {
-    (void) cx;
+    (void)cx;
     return *this;
   }
 
   /// Unroots this value from the context provided, enabling a future GC to
   /// collect the internal object if there are no more references.
   void unroot(Store::Context cx) {
-    (void) cx;
+    (void)cx;
     wasmtime_anyref_unroot(NULL, &val);
     wasmtime_anyref_set_null(&val);
   }
@@ -394,7 +394,7 @@ public:
   /// Note that `externref` is a nullable reference, hence the `optional` return
   /// value.
   std::optional<ExternRef> externref(Store::Context cx) const {
-    (void) cx;
+    (void)cx;
     if (val.kind != WASMTIME_EXTERNREF) {
       std::abort();
     }
@@ -412,7 +412,7 @@ public:
   /// Note that `anyref` is a nullable reference, hence the `optional` return
   /// value.
   std::optional<AnyRef> anyref(Store::Context cx) const {
-    (void) cx;
+    (void)cx;
     if (val.kind != WASMTIME_ANYREF) {
       std::abort();
     }
@@ -431,10 +431,9 @@ public:
   /// value.
   std::optional<Func> funcref() const;
 
-
   /// Unroots any GC references this `Val` points to within the `cx` provided.
   void unroot(Store::Context cx) {
-    (void) cx;
+    (void)cx;
     wasmtime_val_unroot(NULL, &val);
     val.kind = WASMTIME_I32;
     val.of.i32 = 0;

--- a/crates/c-api/include/wasmtime/val.hh
+++ b/crates/c-api/include/wasmtime/val.hh
@@ -38,6 +38,34 @@ public:
   /// Creates a new `ExternRef` directly from its C-API representation.
   explicit ExternRef(wasmtime_externref_t val) : val(val) {}
 
+  /// Copy constructor to clone `other`.
+  ExternRef(const ExternRef &other) {
+    wasmtime_externref_clone(NULL, &other.val, &val);
+  }
+
+  /// Copy assignment to clone from `other`.
+  ExternRef &operator=(const ExternRef &other) {
+    wasmtime_externref_unroot(NULL, &val);
+    wasmtime_externref_clone(NULL, &other.val, &val);
+    return *this;
+  }
+
+  /// Move constructor to move the contents of `other`.
+  ExternRef(ExternRef &&other) {
+    val = other.val;
+    wasmtime_externref_set_null(&other.val);
+  }
+
+  /// Move assignment to move the contents of `other`.
+  ExternRef &operator=(ExternRef &&other) {
+    wasmtime_externref_unroot(NULL, &val);
+    val = other.val;
+    wasmtime_externref_set_null(&other.val);
+    return *this;
+  }
+
+  ~ExternRef() { wasmtime_externref_unroot(NULL, &val); }
+
   /// Creates a new `externref` value from the provided argument.
   ///
   /// Note that `val` should be safe to send across threads and should own any
@@ -54,9 +82,8 @@ public:
 
   /// Creates a new `ExternRef` which is separately rooted from this one.
   ExternRef clone(Store::Context cx) {
-    wasmtime_externref_t other;
-    wasmtime_externref_clone(cx.ptr, &val, &other);
-    return ExternRef(other);
+    (void) cx;
+    return *this;
   }
 
   /// Returns the underlying host data associated with this `ExternRef`.
@@ -66,12 +93,24 @@ public:
 
   /// Unroots this value from the context provided, enabling a future GC to
   /// collect the internal object if there are no more references.
-  void unroot(Store::Context cx) { wasmtime_externref_unroot(cx.ptr, &val); }
+  void unroot(Store::Context cx) {
+    (void) cx;
+    wasmtime_externref_unroot(NULL, &val);
+    wasmtime_externref_set_null(&val);
+  }
 
   /// Returns the raw underlying C API value.
   ///
   /// This class still retains ownership of the pointer.
   const wasmtime_externref_t *raw() const { return &val; }
+
+  /// Consumes ownership of the underlying `wasmtime_externref_t` and returns
+  /// the result of `wasmtime_externref_to_raw`.
+  uint32_t take_raw(Store::Context cx) {
+    uint32_t ret = wasmtime_externref_to_raw(cx.raw_context(), &val);
+    wasmtime_externref_set_null(&val);
+    return ret;
+  }
 };
 
 /**
@@ -86,6 +125,32 @@ public:
   /// Creates a new `AnyRef` directly from its C-API representation.
   explicit AnyRef(wasmtime_anyref_t val) : val(val) {}
 
+  /// Copy constructor to clone `other`.
+  AnyRef(const AnyRef &other) { wasmtime_anyref_clone(NULL, &other.val, &val); }
+
+  /// Copy assignment to clone from `other`.
+  AnyRef &operator=(const AnyRef &other) {
+    wasmtime_anyref_unroot(NULL, &val);
+    wasmtime_anyref_clone(NULL, &other.val, &val);
+    return *this;
+  }
+
+  /// Move constructor to move the contents of `other`.
+  AnyRef(AnyRef &&other) {
+    val = other.val;
+    wasmtime_anyref_set_null(&other.val);
+  }
+
+  /// Move assignment to move the contents of `other`.
+  AnyRef &operator=(AnyRef &&other) {
+    wasmtime_anyref_unroot(NULL, &val);
+    val = other.val;
+    wasmtime_anyref_set_null(&other.val);
+    return *this;
+  }
+
+  ~AnyRef() { wasmtime_anyref_unroot(NULL, &val); }
+
   /// Creates a new `AnyRef` which is an `i31` with the given `value`,
   /// truncated if the upper bit is set.
   static AnyRef i31(Store::Context cx, uint32_t value) {
@@ -96,14 +161,17 @@ public:
 
   /// Creates a new `AnyRef` which is separately rooted from this one.
   AnyRef clone(Store::Context cx) {
-    wasmtime_anyref_t other;
-    wasmtime_anyref_clone(cx.ptr, &val, &other);
-    return AnyRef(other);
+    (void) cx;
+    return *this;
   }
 
   /// Unroots this value from the context provided, enabling a future GC to
   /// collect the internal object if there are no more references.
-  void unroot(Store::Context cx) { wasmtime_anyref_unroot(cx.ptr, &val); }
+  void unroot(Store::Context cx) {
+    (void) cx;
+    wasmtime_anyref_unroot(NULL, &val);
+    wasmtime_anyref_set_null(&val);
+  }
 
   /// Returns the raw underlying C API value.
   ///
@@ -201,6 +269,7 @@ public:
     val.kind = WASMTIME_EXTERNREF;
     if (ptr) {
       val.of.externref = ptr->val;
+      wasmtime_externref_set_null(&ptr->val);
     } else {
       wasmtime_externref_set_null(&val.of.externref);
     }
@@ -210,6 +279,7 @@ public:
     val.kind = WASMTIME_ANYREF;
     if (ptr) {
       val.of.anyref = ptr->val;
+      wasmtime_anyref_set_null(&ptr->val);
     } else {
       wasmtime_anyref_set_null(&val.of.anyref);
     }
@@ -220,6 +290,35 @@ public:
   /// Creates a new `anyref` WebAssembly value which is not `ref.null
   /// any`.
   Val(AnyRef ptr);
+
+  /// Copy constructor to clone `other`.
+  Val(const Val &other) { wasmtime_val_clone(NULL, &other.val, &val); }
+
+  /// Copy assignment to clone from `other`.
+  Val &operator=(const Val &other) {
+    wasmtime_val_unroot(NULL, &val);
+    wasmtime_val_clone(NULL, &other.val, &val);
+    return *this;
+  }
+
+  /// Move constructor to move the contents of `other`.
+  Val(Val &&other) {
+    val = other.val;
+    other.val.kind = WASMTIME_I32;
+    other.val.of.i32 = 0;
+  }
+
+  /// Move assignment to move the contents of `other`.
+  Val &operator=(Val &&other) {
+    wasmtime_val_unroot(NULL, &val);
+    val = other.val;
+    other.val.kind = WASMTIME_I32;
+    other.val.of.i32 = 0;
+    return *this;
+  }
+
+  /// Unroots the values in `val`, if any.
+  ~Val() { wasmtime_val_unroot(NULL, &val); }
 
   /// Returns the kind of value that this value has.
   ValKind kind() const {
@@ -295,6 +394,7 @@ public:
   /// Note that `externref` is a nullable reference, hence the `optional` return
   /// value.
   std::optional<ExternRef> externref(Store::Context cx) const {
+    (void) cx;
     if (val.kind != WASMTIME_EXTERNREF) {
       std::abort();
     }
@@ -302,7 +402,7 @@ public:
       return std::nullopt;
     }
     wasmtime_externref_t other;
-    wasmtime_externref_clone(cx.ptr, &val.of.externref, &other);
+    wasmtime_externref_clone(NULL, &val.of.externref, &other);
     return ExternRef(other);
   }
 
@@ -312,6 +412,7 @@ public:
   /// Note that `anyref` is a nullable reference, hence the `optional` return
   /// value.
   std::optional<AnyRef> anyref(Store::Context cx) const {
+    (void) cx;
     if (val.kind != WASMTIME_ANYREF) {
       std::abort();
     }
@@ -319,7 +420,7 @@ public:
       return std::nullopt;
     }
     wasmtime_anyref_t other;
-    wasmtime_anyref_clone(cx.ptr, &val.of.anyref, &other);
+    wasmtime_anyref_clone(NULL, &val.of.anyref, &other);
     return AnyRef(other);
   }
 
@@ -330,8 +431,14 @@ public:
   /// value.
   std::optional<Func> funcref() const;
 
+
   /// Unroots any GC references this `Val` points to within the `cx` provided.
-  void unroot(Store::Context cx) { wasmtime_val_unroot(cx.ptr, &val); }
+  void unroot(Store::Context cx) {
+    (void) cx;
+    wasmtime_val_unroot(NULL, &val);
+    val.kind = WASMTIME_I32;
+    val.of.i32 = 0;
+  }
 };
 
 } // namespace wasmtime

--- a/crates/c-api/tests/component/call_func.cc
+++ b/crates/c-api/tests/component/call_func.cc
@@ -78,6 +78,7 @@ TEST(component, call_func) {
 
   wasmtime_component_export_index_delete(f);
   wasmtime_component_linker_delete(linker);
+  wasmtime_component_delete(component);
 
   wasmtime_store_delete(store);
   wasm_engine_delete(engine);

--- a/crates/c-api/tests/component/define_module.cc
+++ b/crates/c-api/tests/component/define_module.cc
@@ -36,6 +36,7 @@ TEST(component, define_module) {
   err = wasmtime_module_new(
       engine, reinterpret_cast<const uint8_t *>(wasm.data), wasm.size, &module);
   CHECK_ERR(err);
+  wasm_byte_vec_delete(&wasm);
 
   const auto store = wasmtime_store_new(engine, nullptr, nullptr);
   const auto context = wasmtime_store_context(store);
@@ -70,6 +71,8 @@ TEST(component, define_module) {
   CHECK_ERR(err);
 
   wasmtime_component_linker_delete(linker);
+  wasmtime_component_delete(component);
+  wasmtime_module_delete(module);
 
   wasmtime_store_delete(store);
   wasm_engine_delete(engine);

--- a/crates/c-api/tests/component/instantiate.cc
+++ b/crates/c-api/tests/component/instantiate.cc
@@ -38,6 +38,7 @@ TEST(component, instantiate) {
   CHECK_ERR(error);
 
   wasmtime_component_linker_delete(linker);
+  wasmtime_component_delete(component);
 
   wasmtime_store_delete(store);
   wasm_engine_delete(engine);

--- a/crates/c-api/tests/component/lookup_func.cc
+++ b/crates/c-api/tests/component/lookup_func.cc
@@ -60,6 +60,7 @@ TEST(component, lookup_func) {
 
   wasmtime_component_export_index_delete(f);
   wasmtime_component_linker_delete(linker);
+  wasmtime_component_delete(component);
 
   wasmtime_store_delete(store);
   wasm_engine_delete(engine);

--- a/crates/c-api/tests/wasip2.cc
+++ b/crates/c-api/tests/wasip2.cc
@@ -40,6 +40,7 @@ TEST(wasip2, smoke) {
   CHECK_ERR(err);
 
   wasmtime_component_linker_delete(linker);
+  wasmtime_component_delete(component);
 
   wasmtime_store_delete(store);
   wasm_engine_delete(engine);

--- a/examples/fib-debug/main.c
+++ b/examples/fib-debug/main.c
@@ -45,7 +45,7 @@ extern struct jit_descriptor __jit_debug_descriptor;
 static void exit_with_error(const char *message, wasmtime_error_t *error,
                             wasm_trap_t *trap);
 
-int main(int argc, const char *argv[]) {
+int main() {
   // Configuring engine to support generating of DWARF info.
   // lldb can be used to attach to the program and observe
   // original fib-wasm.c source code and variables.

--- a/examples/fuel.c
+++ b/examples/fuel.c
@@ -94,7 +94,10 @@ int main() {
         wasmtime_trap_code_t code;
         assert(wasmtime_trap_code(trap, &code));
         assert(code == WASMTIME_TRAP_CODE_OUT_OF_FUEL);
+        wasm_trap_delete(trap);
       }
+      if (error != NULL)
+        wasmtime_error_delete(error);
       printf("Exhausted fuel computing fib(%d)\n", n);
       break;
     }

--- a/examples/hello.c
+++ b/examples/hello.c
@@ -19,6 +19,12 @@ static void exit_with_error(const char *message, wasmtime_error_t *error,
 static wasm_trap_t *hello_callback(void *env, wasmtime_caller_t *caller,
                                    const wasmtime_val_t *args, size_t nargs,
                                    wasmtime_val_t *results, size_t nresults) {
+  (void) env;
+  (void) caller;
+  (void) args;
+  (void) nargs;
+  (void) results;
+  (void) nresults;
   printf("Calling back...\n");
   printf("> Hello World!\n");
   return NULL;
@@ -77,6 +83,7 @@ int main() {
   wasm_functype_t *hello_ty = wasm_functype_new_0_0();
   wasmtime_func_t hello;
   wasmtime_func_new(context, hello_ty, hello_callback, NULL, NULL, &hello);
+  wasm_functype_delete(hello_ty);
 
   // With our callback function we can now instantiate the compiled module,
   // giving us an instance we can then execute exports from. Note that

--- a/examples/hello.c
+++ b/examples/hello.c
@@ -19,12 +19,12 @@ static void exit_with_error(const char *message, wasmtime_error_t *error,
 static wasm_trap_t *hello_callback(void *env, wasmtime_caller_t *caller,
                                    const wasmtime_val_t *args, size_t nargs,
                                    wasmtime_val_t *results, size_t nresults) {
-  (void) env;
-  (void) caller;
-  (void) args;
-  (void) nargs;
-  (void) results;
-  (void) nresults;
+  (void)env;
+  (void)caller;
+  (void)args;
+  (void)nargs;
+  (void)results;
+  (void)nresults;
   printf("Calling back...\n");
   printf("> Hello World!\n");
   return NULL;

--- a/examples/interrupt.c
+++ b/examples/interrupt.c
@@ -107,6 +107,7 @@ int main() {
   assert(error == NULL);
   assert(trap != NULL);
   printf("Got a trap!...\n");
+  wasm_trap_delete(trap);
 
   wasmtime_store_delete(store);
   wasm_engine_delete(engine);

--- a/examples/linking.c
+++ b/examples/linking.c
@@ -18,8 +18,7 @@ mkdir build && cd build && cmake .. && cmake --build . --target wasmtime-linking
 
 static void exit_with_error(const char *message, wasmtime_error_t *error,
                             wasm_trap_t *trap);
-static void read_wat_file(wasm_engine_t *engine, wasm_byte_vec_t *bytes,
-                          const char *file);
+static void read_wat_file(wasm_byte_vec_t *bytes, const char *file);
 
 int main() {
   // Set up our context
@@ -30,8 +29,8 @@ int main() {
   wasmtime_context_t *context = wasmtime_store_context(store);
 
   wasm_byte_vec_t linking1_wasm, linking2_wasm;
-  read_wat_file(engine, &linking1_wasm, "examples/linking1.wat");
-  read_wat_file(engine, &linking2_wasm, "examples/linking2.wat");
+  read_wat_file(&linking1_wasm, "examples/linking1.wat");
+  read_wat_file(&linking2_wasm, "examples/linking2.wat");
 
   // Compile our two modules
   wasmtime_error_t *error;
@@ -106,8 +105,7 @@ int main() {
   return 0;
 }
 
-static void read_wat_file(wasm_engine_t *engine, wasm_byte_vec_t *bytes,
-                          const char *filename) {
+static void read_wat_file(wasm_byte_vec_t *bytes, const char *filename) {
   wasm_byte_vec_t wat;
   // Load our input file to parse it next
   FILE *file = fopen(filename, "r");

--- a/examples/memory.c
+++ b/examples/memory.c
@@ -118,7 +118,7 @@ void check_trap2(wasmtime_context_t *store, wasmtime_func_t *func, int32_t arg1,
   check_trap(store, func, args, 2, 0);
 }
 
-int main(int argc, const char *argv[]) {
+int main() {
   // Initialize.
   printf("Initializing...\n");
   wasm_engine_t *engine = wasm_engine_new();

--- a/examples/multi.c
+++ b/examples/multi.c
@@ -25,6 +25,11 @@ static void exit_with_error(const char *message, wasmtime_error_t *error,
 wasm_trap_t *callback(void *env, wasmtime_caller_t *caller,
                       const wasmtime_val_t *args, size_t nargs,
                       wasmtime_val_t *results, size_t nresults) {
+  (void) env;
+  (void) caller;
+  (void) nargs;
+  (void) nresults;
+
   printf("Calling back...\n");
   printf("> %" PRIu32 " %" PRIu64 "\n", args[0].of.i32, args[1].of.i64);
   printf("\n");
@@ -38,6 +43,11 @@ wasm_trap_t *callback(void *env, wasmtime_caller_t *caller,
 wasm_trap_t *closure_callback(void *env, wasmtime_caller_t *caller,
                               const wasmtime_val_t *args, size_t nargs,
                               wasmtime_val_t *results, size_t nresults) {
+  (void) caller;
+  (void) args;
+  (void) nargs;
+  (void) nresults;
+
   int i = *(int *)env;
   printf("Calling back closure...\n");
   printf("> %d\n", i);
@@ -47,7 +57,7 @@ wasm_trap_t *closure_callback(void *env, wasmtime_caller_t *caller,
   return NULL;
 }
 
-int main(int argc, const char *argv[]) {
+int main() {
   // Initialize.
   printf("Initializing...\n");
   wasm_engine_t *engine = wasm_engine_new();

--- a/examples/multi.c
+++ b/examples/multi.c
@@ -25,10 +25,10 @@ static void exit_with_error(const char *message, wasmtime_error_t *error,
 wasm_trap_t *callback(void *env, wasmtime_caller_t *caller,
                       const wasmtime_val_t *args, size_t nargs,
                       wasmtime_val_t *results, size_t nresults) {
-  (void) env;
-  (void) caller;
-  (void) nargs;
-  (void) nresults;
+  (void)env;
+  (void)caller;
+  (void)nargs;
+  (void)nresults;
 
   printf("Calling back...\n");
   printf("> %" PRIu32 " %" PRIu64 "\n", args[0].of.i32, args[1].of.i64);
@@ -43,10 +43,10 @@ wasm_trap_t *callback(void *env, wasmtime_caller_t *caller,
 wasm_trap_t *closure_callback(void *env, wasmtime_caller_t *caller,
                               const wasmtime_val_t *args, size_t nargs,
                               wasmtime_val_t *results, size_t nresults) {
-  (void) caller;
-  (void) args;
-  (void) nargs;
-  (void) nresults;
+  (void)caller;
+  (void)args;
+  (void)nargs;
+  (void)nresults;
 
   int i = *(int *)env;
   printf("Calling back closure...\n");

--- a/examples/serialize.c
+++ b/examples/serialize.c
@@ -20,6 +20,12 @@ static void exit_with_error(const char *message, wasmtime_error_t *error,
 static wasm_trap_t *hello_callback(void *env, wasmtime_caller_t *caller,
                                    const wasmtime_val_t *args, size_t nargs,
                                    wasmtime_val_t *results, size_t nresults) {
+  (void) env;
+  (void) caller;
+  (void) args;
+  (void) nargs;
+  (void) results;
+  (void) nresults;
   printf("Calling back...\n");
   printf("> Hello World!\n");
   return NULL;
@@ -102,6 +108,7 @@ int deserialize(wasm_byte_vec_t *buffer) {
   wasm_functype_t *hello_ty = wasm_functype_new_0_0();
   wasmtime_func_t hello;
   wasmtime_func_new(context, hello_ty, hello_callback, NULL, NULL, &hello);
+  wasm_functype_delete(hello_ty);
 
   // With our callback function we can now instantiate the compiled module,
   // giving us an instance we can then execute exports from. Note that

--- a/examples/serialize.c
+++ b/examples/serialize.c
@@ -20,12 +20,12 @@ static void exit_with_error(const char *message, wasmtime_error_t *error,
 static wasm_trap_t *hello_callback(void *env, wasmtime_caller_t *caller,
                                    const wasmtime_val_t *args, size_t nargs,
                                    wasmtime_val_t *results, size_t nresults) {
-  (void) env;
-  (void) caller;
-  (void) args;
-  (void) nargs;
-  (void) results;
-  (void) nresults;
+  (void)env;
+  (void)caller;
+  (void)args;
+  (void)nargs;
+  (void)results;
+  (void)nresults;
   printf("Calling back...\n");
   printf("> Hello World!\n");
   return NULL;

--- a/examples/threads.c
+++ b/examples/threads.c
@@ -43,8 +43,8 @@ uint64_t get_thread_id() {
 
 // A function to be called from Wasm code.
 own wasm_trap_t *callback(const wasm_val_vec_t *args, wasm_val_vec_t *results) {
-  (void) args;
-  (void) results;
+  (void)args;
+  (void)results;
   printf("> Thread %lu running\n", (uint64_t)get_thread_id());
   return NULL;
 }

--- a/examples/threads.c
+++ b/examples/threads.c
@@ -43,6 +43,8 @@ uint64_t get_thread_id() {
 
 // A function to be called from Wasm code.
 own wasm_trap_t *callback(const wasm_val_vec_t *args, wasm_val_vec_t *results) {
+  (void) args;
+  (void) results;
   printf("> Thread %lu running\n", (uint64_t)get_thread_id());
   return NULL;
 }
@@ -117,7 +119,7 @@ void *run(void *args_abs) {
   return NULL;
 }
 
-int main(int argc, const char *argv[]) {
+int main() {
   // Initialize.
   wasm_engine_t *engine = wasm_engine_new();
 

--- a/examples/wasip1/main.c
+++ b/examples/wasip1/main.c
@@ -99,6 +99,7 @@ int main() {
     exit_with_error("error calling default export", error, trap);
 
   // Clean up after ourselves at this point
+  wasmtime_linker_delete(linker);
   wasmtime_module_delete(module);
   wasmtime_store_delete(store);
   wasm_engine_delete(engine);


### PR DESCRIPTION
This commit is a follow-up to #11514 which was discovered through failing tests in the wasmtime-py repository when updating to Wasmtime 37.0.0. This is a backport to the 37.0.x release branch which contains the minimal infrastructure necessary to get to parity with `main` in terms of avoiding leaks. Care is taken to avoid changing any public APIs here which means that some previously-provided parameters are no longer used, for example.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
