### PR TITLE
Document all features in repo documentation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -295,6 +295,9 @@ jobs:
           --exclude wasmtime-cli \
           --exclude test-programs \
           --exclude cranelift-codegen-meta \
+          --exclude wasmtime-wasi-nn \
+          --exclude wasmtime-fuzzing \
+          --exclude wasm-spec-interpreter \
           --all-features
       env:
         RUSTDOCFLAGS: --cfg=docsrs

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -295,7 +295,7 @@ jobs:
           --exclude wasmtime-cli \
           --exclude test-programs \
           --exclude cranelift-codegen-meta \
-          --features call-hook
+          --all-features
       env:
         RUSTDOCFLAGS: --cfg=docsrs
     - run: cargo doc --package cranelift-codegen-meta --document-private-items


### PR DESCRIPTION
This commit updates our CI config to pass `--all-features` when building the API documentation hosted on gh-pages for the `main` branch as opposed to just the single `call-hook` feature previously passed in.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
