### PR TITLE
[36.0.0] Rename `doc_auto_cfg` to `doc_cfg`

### DIFF
--- a/cranelift/codegen/src/lib.rs
+++ b/cranelift/codegen/src/lib.rs
@@ -1,7 +1,7 @@
 //! Cranelift code generation library.
 #![deny(missing_docs)]
 // Display feature requirements in the documentation when building on docs.rs
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![no_std]
 // Various bits and pieces of this crate might only be used for one platform or
 // another, but it's not really too useful to learn about that all the time. On

--- a/crates/wasi/src/lib.rs
+++ b/crates/wasi/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 //! # Wasmtime's WASI Implementation
 //!

--- a/crates/wasmtime/src/lib.rs
+++ b/crates/wasmtime/src/lib.rs
@@ -279,7 +279,7 @@
 #![deny(missing_docs)]
 #![doc(test(attr(deny(warnings))))]
 #![doc(test(attr(allow(dead_code, unused_variables, unused_mut))))]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 // NB: this list is currently being burned down to remove all features listed
 // here to get warnings in all configurations of Wasmtime.
 #![cfg_attr(

--- a/pulley/src/lib.rs
+++ b/pulley/src/lib.rs
@@ -1,6 +1,6 @@
 //! The pulley bytecode for fast interpreters.
 
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(pulley_tail_calls, feature(explicit_tail_calls))]
 #![cfg_attr(pulley_tail_calls, allow(incomplete_features, unstable_features))]
 #![deny(missing_docs)]


### PR DESCRIPTION
This is a partial backport of #11755 to fix generation of documentation on docs.rs. For example docs.rs documentation for `wasmtime` currently failed to build -- https://docs.rs/crate/wasmtime/latest -- since this change wasn't on the 37.0.0 branch, only 38 and main.

I don't plan on doing a point release for this since it'll be fixed in a few weeks, but for future possible security releases it seemed like a nice-to-have.