### PR TITLE
[24.0.0] Rename `doc_auto_cfg` to `doc_cfg`

### DIFF
--- a/crates/wasi/src/lib.rs
+++ b/crates/wasi/src/lib.rs
@@ -180,7 +180,7 @@
 //! [async]: https://docs.rs/wasmtime/latest/wasmtime/struct.Config.html#method.async_support
 //! [`ResourceTable`]: wasmtime::component::ResourceTable
 
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 use wasmtime::component::Linker;
 

--- a/crates/wasmtime/src/lib.rs
+++ b/crates/wasmtime/src/lib.rs
@@ -274,7 +274,7 @@
 #![deny(missing_docs)]
 #![doc(test(attr(deny(warnings))))]
 #![doc(test(attr(allow(dead_code, unused_variables, unused_mut))))]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(not(feature = "default"), allow(dead_code, unused_imports))]
 // Allow broken links when the default features is disabled because most of our
 // documentation is written for the "one build" of the `main` branch which has

--- a/pulley/src/lib.rs
+++ b/pulley/src/lib.rs
@@ -1,6 +1,6 @@
 //! The pulley bytecode for fast interpreters.
 
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![deny(missing_docs)]
 #![no_std]
 


### PR DESCRIPTION
This is a partial backport of #11755 to fix generation of documentation on docs.rs. For example docs.rs documentation for `wasmtime` currently failed to build -- https://docs.rs/crate/wasmtime/latest -- since this change wasn't on the 37.0.0 branch, only 38 and main.

I don't plan on doing a point release for this since it'll be fixed in a few weeks, but for future possible security releases it seemed like a nice-to-have.