### PR TITLE
Don't spawn thread-per-request in `wasmtime serve`

### DIFF
--- a/crates/test-programs/src/bin/cli_serve_sleep.rs
+++ b/crates/test-programs/src/bin/cli_serve_sleep.rs
@@ -1,0 +1,15 @@
+use test_programs::proxy;
+use test_programs::wasi::http::types::{IncomingRequest, ResponseOutparam};
+
+struct T;
+
+proxy::export!(T);
+
+impl proxy::exports::wasi::http::incoming_handler::Guest for T {
+    fn handle(_: IncomingRequest, _outparam: ResponseOutparam) {
+        std::thread::sleep(std::time::Duration::MAX);
+        unreachable!()
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
Refactor how the epoch thread is managed in `wasmtime serve` by only spawning one thread for the entire serve rather than one-per-request. This is likely just an artifact of copying the implementation from `wasmtime run` but for `wasmtime serve` it needs to be different.

This puts performance of `-Wtimeout=1`-and-not back on the same playing field, as expected.

Closes #11814

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
