### PR TITLE
Enable `component-model-async` Cargo feature by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -462,6 +462,7 @@ default = [
   "addr2line",
   "debug-builtins",
   "component-model",
+  "component-model-async",
   "threads",
   "gc",
   "gc-drc",

--- a/ci/build-release-artifacts.sh
+++ b/ci/build-release-artifacts.sh
@@ -60,7 +60,7 @@ if [[ "$build" = *-min ]]; then
 else
   # For release builds the CLI is built a bit more feature-ful than the Cargo
   # defaults to provide artifacts that can do as much as possible.
-  bin_flags="--features all-arch,component-model,component-model-async"
+  bin_flags="--features all-arch,component-model"
 fi
 
 if [[ "$target" = "x86_64-pc-windows-msvc" ]]; then

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -147,6 +147,7 @@ default = [
   'debug-builtins',
   'runtime',
   'component-model',
+  'component-model-async',
   'threads',
   'stack-switching',
   'std',


### PR DESCRIPTION
This commit starts Wasmtime on a path to enabling the `component-model-async` wasm feature by default in the future. Up to now it's been an off-by-default compile-time feature but the intention has always been to eventually enable it by default. This commit enables it by default now that it's had time to bake for awhile. Note that the wasm feature is still off-by-default, so this is only changing whether the support for it is compiled in by default.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
