### PR TITLE
Don't fuzz `sequence_point` in `cranelift-fuzzgen`

### DIFF
--- a/cranelift/fuzzgen/src/function_generator.rs
+++ b/cranelift/fuzzgen/src/function_generator.rs
@@ -1059,6 +1059,7 @@ static OPCODE_SIGNATURES: LazyLock<Vec<OpcodeSignature>> = LazyLock::new(|| {
                 (Opcode::AtomicCas, _, &[I128]),
                 (Opcode::AtomicLoad, _, &[I128]),
                 (Opcode::AtomicStore, &[I128, _], _),
+                (Opcode::SequencePoint),
             )
         })
         .filter(|(op, ..)| {


### PR DESCRIPTION
It's not implemented in the interpreter right now so add it to the list of opcodes to exclude.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
