### PR TITLE
fuzzing: Prevent division by zero in table_ops fixup

### DIFF
--- a/crates/fuzzing/src/generators/table_ops.rs
+++ b/crates/fuzzing/src/generators/table_ops.rs
@@ -319,6 +319,20 @@ impl TableOps {
         let mut stack = 0;
 
         for mut op in self.ops.iter().copied() {
+            if self.limits.max_types == 0 && matches!(op, TableOp::StructNew(..)) {
+                continue;
+            }
+            if self.limits.num_params == 0
+                && matches!(op, TableOp::LocalGet(..) | TableOp::LocalSet(..))
+            {
+                continue;
+            }
+            if self.limits.num_globals == 0
+                && matches!(op, TableOp::GlobalGet(..) | TableOp::GlobalSet(..))
+            {
+                continue;
+            }
+
             op.fixup(&self.limits);
 
             let mut temp = SmallVec::<[_; 4]>::new();
@@ -746,6 +760,63 @@ mod tests {
                 wat
             );
         }
+        Ok(())
+    }
+
+    #[test]
+    fn struct_new_removed_when_no_types() -> mutatis::Result<()> {
+        let _ = env_logger::try_init();
+
+        let mut ops = test_ops(0, 0, 0);
+        ops.limits.max_types = 0;
+        ops.ops = vec![TableOp::StructNew(42)];
+
+        let _ = ops.fixup();
+
+        assert!(
+            ops.ops
+                .iter()
+                .all(|op| !matches!(op, TableOp::StructNew(..))),
+            "StructNew should be removed when there are no types"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn local_ops_removed_when_no_params() -> mutatis::Result<()> {
+        let _ = env_logger::try_init();
+
+        let mut ops = test_ops(0, 0, 0);
+        ops.limits.num_params = 0;
+        ops.ops = vec![TableOp::LocalGet(42), TableOp::LocalSet(99)];
+
+        ops.fixup();
+
+        assert!(
+            ops.ops
+                .iter()
+                .all(|op| !matches!(op, TableOp::LocalGet(..) | TableOp::LocalSet(..))),
+            "LocalGet/LocalSet should be removed when there are no params"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn global_ops_removed_when_no_globals() -> mutatis::Result<()> {
+        let _ = env_logger::try_init();
+
+        let mut ops = test_ops(0, 0, 0);
+        ops.limits.num_globals = 0;
+        ops.ops = vec![TableOp::GlobalGet(42), TableOp::GlobalSet(99)];
+
+        ops.fixup();
+
+        assert!(
+            ops.ops
+                .iter()
+                .all(|op| !matches!(op, TableOp::GlobalGet(..) | TableOp::GlobalSet(..))),
+            "GlobalGet/GlobalSet should be removed when there are no globals"
+        );
         Ok(())
     }
 


### PR DESCRIPTION
Fix by filtering out problematic operations before fixup() runs:
- Skip StructNew when max_types = 0
- Skip LocalGet/LocalSet when num_params = 0
- Skip GlobalGet/GlobalSet when num_globals = 0

This prevents the division by zero and ensures generated Wasm is valid.