### PR TITLE
[36.0.x] Allow dead code in `component_api` fuzz target 

### DIFF
--- a/fuzz/fuzz_targets/component_api.rs
+++ b/fuzz/fuzz_targets/component_api.rs
@@ -1,4 +1,5 @@
 #![no_main]
+#![allow(dead_code, reason = "fuzz-generation sometimes generates unused types")]
 
 use libfuzzer_sys::{arbitrary, fuzz_target};
 use wasmtime_fuzzing::oracles;


### PR DESCRIPTION
Backport of #11575