### PR TITLE
Disallow fewer instructions in Wizer

### DIFF
--- a/crates/wizer/tests/all/tests.rs
+++ b/crates/wizer/tests/all/tests.rs
@@ -266,7 +266,7 @@ fn reject_table_get_set() -> Result<()> {
     let err = result.unwrap_err();
     assert!(
         err.to_string()
-            .contains("unsupported `table.get` instruction"),
+            .contains("unsupported `table.set` instruction"),
         "bad error: {err}",
     );
 
@@ -300,7 +300,7 @@ fn reject_table_get_set_with_reference_types_enabled() -> Result<()> {
     let err = result.unwrap_err();
     assert!(
         err.to_string()
-            .contains("unsupported `table.get` instruction"),
+            .contains("unsupported `table.set` instruction"),
     );
 
     Ok(())
@@ -330,7 +330,7 @@ fn reject_table_grow_with_reference_types_enabled() -> anyhow::Result<()> {
     let err = result.unwrap_err();
     assert!(
         err.to_string()
-            .contains("unsupported `ref.func` instruction")
+            .contains("unsupported `table.grow` instruction")
     );
 
     Ok(())


### PR DESCRIPTION
Specifically allow `table.get`, `ref.null`, `ref.is_null`, `select` (typed), `ref.func`, and `table.size`. These are fine to execute and the incompatibility with Wizer instead comes when a table or a reference type global is mutated. That mutation is disallowed elsewhere, however, so there's no need to reject these instructions.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
