### PR TITLE
wizer: Refactor snapshotting of globals/memories

### DIFF
--- a/crates/wizer/src/info.rs
+++ b/crates/wizer/src/info.rs
@@ -50,6 +50,12 @@ pub struct ModuleContext<'a> {
     ///
     /// If this is `None`, then there are no locally defined memories.
     defined_memories_index: Option<u32>,
+
+    /// Export names of defined globals injected by the instrumentation pass.
+    pub(crate) defined_global_exports: Option<Vec<String>>,
+
+    /// Export names of defined memories injected by the instrumentation pass.
+    pub(crate) defined_memory_exports: Option<Vec<String>>,
 }
 
 impl<'a> ModuleContext<'a> {

--- a/crates/wizer/src/lib.rs
+++ b/crates/wizer/src/lib.rs
@@ -203,7 +203,7 @@ impl Wizer {
         // Make sure we're given valid Wasm from the get go.
         self.wasm_validate(&wasm)?;
 
-        let cx = parse::parse(wasm)?;
+        let mut cx = parse::parse(wasm)?;
 
         // When wizening core modules directly some imports aren't supported,
         // so check for those here.
@@ -223,7 +223,7 @@ impl Wizer {
             }
         }
 
-        let instrumented_wasm = instrument::instrument(&cx);
+        let instrumented_wasm = instrument::instrument(&mut cx);
 
         if cfg!(debug_assertions) {
             if let Err(error) = self.wasm_validate(&instrumented_wasm) {
@@ -254,7 +254,7 @@ impl Wizer {
         // Parse rename spec.
         let renames = FuncRenames::parse(&self.func_renames)?;
 
-        let snapshot = snapshot::snapshot(&mut *store, &instance);
+        let snapshot = snapshot::snapshot(&cx, &mut *store, &instance);
         let rewritten_wasm = self.rewrite(&mut cx, store, &snapshot, &renames);
 
         if cfg!(debug_assertions) {


### PR DESCRIPTION
This commit updates the loop-over-globals approach of snapshotting to instead use a list of names produced from the instrumentation pass. This removes the hardcoding of the `__wizer_*` names in the snapshotting pass and instead centralizes the naming in one location.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
