### PR TITLE
Move back to emulation of s390x in CI

### DIFF
--- a/ci/build-test-matrix.js
+++ b/ci/build-test-matrix.js
@@ -124,7 +124,7 @@ const FULL_MATRIX = [
     "target": "s390x-unknown-linux-gnu",
     "name": "Test Linux s390x",
     "filter": "linux-s390x",
-    "isa": "s390x"
+    "isa": "s390x",
     "gcc_package": "gcc-s390x-linux-gnu",
     "gcc": "s390x-linux-gnu-gcc",
     "qemu": "qemu-s390x -L /usr/s390x-linux-gnu",


### PR DESCRIPTION
This commit moves away from s390x runners provided by IBM back to github actions runners with QEMU emulation. Watching the queue today it looks like PRs are spending quite a lot of time waiting for runners to become available to execute jobs on. Looking at the data for the past week jobs are frequently queuing for 10+ minutes before being able to run. Given that our CI completes in ~15 minutes that more-or-less defeats the purpose of the native runners, so this commit switches back to github actions for now which should resolve the queueing issues.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
