### PR TITLE
Shrink job names on CI

### DIFF
--- a/ci/build-test-matrix.js
+++ b/ci/build-test-matrix.js
@@ -249,7 +249,7 @@ async function shard(configs) {
 
     let nbucket = 1;
     for (const bucket of buckets) {
-      let bucket_name = `${nbucket}/${buckets.size}`;
+      let bucket_name = `${nbucket}/${buckets.length}`;
       if (bucket.size === 1)
         bucket_name = Array.from(bucket)[0];
 


### PR DESCRIPTION
I find GitHub's UI a bit maddening where it provides maybe 10 characters of description of a job before it cuts it off. Most of the UI also doesn't display the name when you otherwise mouse over it or similar, so the only way to actually view a full job name is to click on it which takes you to a whole different page that loses the context of where you were on the prior page. This has bugged me enough that I want to do something about it.

This commit shrinks the size of job names on CI to being a bit more terse. For example `Test MSRV on Linux x86_64` is now `Test MSRV`. Additionally the full set of crates being tested is no longer in the job name but instead it just has a bucket number (e.g. `1/5`). My hope is that this makes it more predictable over time what the job name is (jobs don't shuffle names if we add crates) and it's also easier to see in CI (less is cut off hopefully).

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
