### PR TITLE
Make profiling more amenable to other in-process engines

### DIFF
--- a/crates/wasmtime/src/profiling_agent/perfmap.rs
+++ b/crates/wasmtime/src/profiling_agent/perfmap.rs
@@ -1,11 +1,12 @@
 use crate::prelude::*;
 use crate::profiling_agent::ProfilingAgent;
-use std::io::{self, BufWriter, Write};
+use std::fs::OpenOptions;
+use std::io::{self, Write};
 use std::process;
 use std::{fs::File, sync::Mutex};
 
 /// Process-wide perf map file. Perf only reads a unique file per process.
-static PERFMAP_FILE: Mutex<Option<BufWriter<File>>> = Mutex::new(None);
+static PERFMAP_FILE: Mutex<Option<File>> = Mutex::new(None);
 
 /// Interface for driving the creation of jitdump files
 struct PerfMapAgent;
@@ -15,24 +16,38 @@ pub fn new() -> Result<Box<dyn ProfilingAgent>> {
     let mut file = PERFMAP_FILE.lock().unwrap();
     if file.is_none() {
         let filename = format!("/tmp/perf-{}.map", process::id());
-        *file = Some(BufWriter::new(File::create(filename)?));
+
+        // Open the file specifically in append mode to handle the case where
+        // multiple engines in the same process are all writing to this file.
+        *file = Some(
+            OpenOptions::new()
+                .append(true)
+                .write(true)
+                .create(true)
+                .open(&filename)?,
+        );
     }
     Ok(Box::new(PerfMapAgent))
 }
 
 impl PerfMapAgent {
-    fn make_line(writer: &mut dyn Write, name: &str, code: &[u8]) -> io::Result<()> {
+    fn make_line(writer: &mut File, name: &str, code: &[u8]) -> io::Result<()> {
         // Format is documented here: https://github.com/torvalds/linux/blob/master/tools/perf/Documentation/jit-interface.txt
         // Try our best to sanitize the name, since wasm allows for any utf8 string in there.
         let sanitized_name = name.replace('\n', "_").replace('\r', "_");
-        write!(
-            writer,
-            "{:p} {:x} {}\n",
-            code.as_ptr(),
-            code.len(),
-            sanitized_name
-        )?;
-        writer.flush()?;
+        let line = format!("{:p} {:x} {sanitized_name}\n", code.as_ptr(), code.len());
+
+        // To handle multiple concurrent engines in the same process writing to
+        // this file an attempt is made to issue a single `write` syscall with
+        // all of the contents. This would mean, though, that partial writes
+        // would be an error. In lieu of returning an error the `write_all`
+        // helper is used instead which may result in a corrupt file if there
+        // are other engines writing to the file at the same time.
+        //
+        // For more discussion of the tradeoffs here see the `perf_jitdump.rs`
+        // file which has to deal with the same problem.
+        writer.write_all(line.as_bytes())?;
+
         Ok(())
     }
 }


### PR DESCRIPTION
Both the perfmap and jitdump protocols for profiling JITs require that there's a single file with metadata per-process. This has the unfortunate side effect of if there are multiple engines in the same process there's no real way for them to coordinate when writing out records to this file. In an attempt to at least try to synchronize this commit updates these two implementations to issue a single `write` syscall with the full contents of the record to a file opened in `O_APPEND` mode.

If all the stars align and a partial write doesn't happen then that means we're doing our best effort to cooperate with other engines in the same process. If a partial write happens the decision in this PR is to go ahead and retry the rest of the write (using the `write_all` helper). This is a tradeoff where it makes the single-engine use case more robust (partial writes are handled correctly) but the multi-engine use case will produce corrupt files. It doesn't feel like a great tradeoff to say that profiling can't be done in Wasmtime when a partial write would happen for this niche use case of multiple engines, hence the direction of this tradeoff.

Closes #11862

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
