### PR TITLE
wizer: Reject mutable reference-typed globals

### DIFF
--- a/crates/wizer/src/info.rs
+++ b/crates/wizer/src/info.rs
@@ -52,7 +52,9 @@ pub struct ModuleContext<'a> {
     defined_memories_index: Option<u32>,
 
     /// Export names of defined globals injected by the instrumentation pass.
-    pub(crate) defined_global_exports: Option<Vec<String>>,
+    ///
+    /// Note that this only tracks defined mutable globals, not all globals.
+    pub(crate) defined_global_exports: Option<Vec<(u32, String)>>,
 
     /// Export names of defined memories injected by the instrumentation pass.
     pub(crate) defined_memory_exports: Option<Vec<String>>,

--- a/crates/wizer/src/instrument.rs
+++ b/crates/wizer/src/instrument.rs
@@ -83,10 +83,13 @@ pub(crate) fn instrument(module: &mut ModuleContext<'_>) -> Vec<u8> {
                 // Now export all of this module's defined globals, memories,
                 // and instantiations under well-known names so we can inspect
                 // them after initialization.
-                for (i, (j, _)) in module.defined_globals().enumerate() {
+                for (i, ty) in module.defined_globals() {
+                    if !ty.mutable {
+                        continue;
+                    }
                     let name = format!("__wizer_global_{i}");
-                    exports.export(&name, wasm_encoder::ExportKind::Global, j);
-                    defined_global_exports.push(name);
+                    exports.export(&name, wasm_encoder::ExportKind::Global, i);
+                    defined_global_exports.push((i, name));
                 }
                 for (i, (j, _)) in module.defined_memories().enumerate() {
                     let name = format!("__wizer_memory_{i}");

--- a/crates/wizer/src/rewrite.rs
+++ b/crates/wizer/src/rewrite.rs
@@ -78,24 +78,44 @@ impl Wizer {
                 // Encode the initialized global values from the snapshot,
                 // rather than the original values.
                 s if s.id == u8::from(SectionId::Global) => {
+                    let original_globals = wasmparser::GlobalSectionReader::new(
+                        wasmparser::BinaryReader::new(s.data, 0),
+                    )
+                    .unwrap();
                     let mut globals = wasm_encoder::GlobalSection::new();
-                    for ((_, glob_ty), val) in module.defined_globals().zip(snapshot.globals.iter())
-                    {
-                        let glob_ty = RoundtripReencoder.global_type(glob_ty).unwrap();
-                        globals.global(
-                            glob_ty,
-                            &match val {
-                                SnapshotVal::I32(x) => ConstExpr::i32_const(*x),
-                                SnapshotVal::I64(x) => ConstExpr::i64_const(*x),
-                                SnapshotVal::F32(x) => {
-                                    ConstExpr::f32_const(wasm_encoder::Ieee32::new(*x))
-                                }
-                                SnapshotVal::F64(x) => {
-                                    ConstExpr::f64_const(wasm_encoder::Ieee64::new(*x))
-                                }
-                                SnapshotVal::V128(x) => ConstExpr::v128_const(x.cast_signed()),
-                            },
-                        );
+                    let mut snapshot = snapshot.globals.iter().peekable();
+                    for ((i, glob_ty), global) in module.defined_globals().zip(original_globals) {
+                        let global = global.unwrap();
+                        match snapshot.next_if(|(j, _)| *j == i) {
+                            // This is a mutable global and it was present in
+                            // the snapshot, so translate the snapshot value to
+                            // a constant expression and insert it.
+                            Some((_, val)) => {
+                                assert!(glob_ty.mutable);
+                                let init = match val {
+                                    SnapshotVal::I32(x) => ConstExpr::i32_const(*x),
+                                    SnapshotVal::I64(x) => ConstExpr::i64_const(*x),
+                                    SnapshotVal::F32(x) => {
+                                        ConstExpr::f32_const(wasm_encoder::Ieee32::new(*x))
+                                    }
+                                    SnapshotVal::F64(x) => {
+                                        ConstExpr::f64_const(wasm_encoder::Ieee64::new(*x))
+                                    }
+                                    SnapshotVal::V128(x) => ConstExpr::v128_const(x.cast_signed()),
+                                };
+                                let glob_ty = RoundtripReencoder.global_type(glob_ty).unwrap();
+                                globals.global(glob_ty, &init);
+                            }
+
+                            // This global isn't mutable so preserve its value
+                            // as-is.
+                            None => {
+                                assert!(!glob_ty.mutable);
+                                RoundtripReencoder
+                                    .parse_global(&mut globals, global)
+                                    .unwrap();
+                            }
+                        }
                     }
                     encoder.section(&globals);
                 }

--- a/crates/wizer/src/snapshot.rs
+++ b/crates/wizer/src/snapshot.rs
@@ -12,7 +12,9 @@ const MAX_DATA_SEGMENTS: usize = 10_000;
 /// A "snapshot" of Wasm state from its default value after having been initialized.
 pub struct Snapshot {
     /// Maps global index to its initialized value.
-    pub globals: Vec<SnapshotVal>,
+    ///
+    /// Note that this only tracks defined mutable globals, not all globals.
+    pub globals: Vec<(u32, SnapshotVal)>,
 
     /// A new minimum size for each memory (in units of pages).
     pub memory_mins: Vec<u64>,
@@ -100,7 +102,10 @@ pub fn snapshot(module: &ModuleContext<'_>, ctx: &mut dyn InstanceState) -> Snap
 }
 
 /// Get the initialized values of all globals.
-fn snapshot_globals(module: &ModuleContext<'_>, ctx: &mut dyn InstanceState) -> Vec<SnapshotVal> {
+fn snapshot_globals(
+    module: &ModuleContext<'_>,
+    ctx: &mut dyn InstanceState,
+) -> Vec<(u32, SnapshotVal)> {
     log::debug!("Snapshotting global values");
 
     module
@@ -108,7 +113,7 @@ fn snapshot_globals(module: &ModuleContext<'_>, ctx: &mut dyn InstanceState) -> 
         .as_ref()
         .unwrap()
         .iter()
-        .map(|name| ctx.global_get(&name))
+        .map(|(i, name)| (*i, ctx.global_get(&name)))
         .collect()
 }
 


### PR DESCRIPTION
These can't currently be snapshotted, so they're rejected. This involved building out support for readonly reference-typed globals where the snapshot now only contains mutable globals, not all globals.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
