### PR TITLE
wizer: Don't provide WASI by default

### DIFF
--- a/src/commands/wizer.rs
+++ b/src/commands/wizer.rs
@@ -41,6 +41,13 @@ impl WizerCommand {
             self.run.common.wasm.relaxed_simd_deterministic = Some(true);
         }
 
+        // Don't provide any WASI imports by default to wizened components. The
+        // `run` command provides the "cli" world as a default so turn that off
+        // here if the command line flags don't otherwise say what to do.
+        if self.run.common.wasi.cli.is_none() {
+            self.run.common.wasi.cli = Some(false);
+        }
+
         // Read the input wasm, possibly from stdin.
         let mut wasm = Vec::new();
         if self.input.to_str() == Some("-") {


### PR DESCRIPTION
This is intended to mirror the preexisting `wizer` CLI and was something I forgot when merging into Wasmtime earlier.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
