### PR TITLE
Never use `colocated` symbols in `cranelift-fuzzgen`

### DIFF
--- a/cranelift/fuzzgen/src/function_generator.rs
+++ b/cranelift/fuzzgen/src/function_generator.rs
@@ -1586,8 +1586,7 @@ where
             .map(|(name, signature)| {
                 let user_func_ref = builder.func.declare_imported_user_function(name.clone());
                 let name = ExternalName::User(user_func_ref);
-                let never_colocated = false;
-                (name, signature.clone(), never_colocated)
+                (name, signature.clone())
             })
             .collect();
 
@@ -1603,24 +1602,21 @@ where
                 .unwrap();
                 let signature = libcall.signature(lib_callconv, pointer_type);
                 let name = ExternalName::LibCall(*libcall);
-                // libcalls can't be colocated to generated code because we
-                // don't know where in the address space the function will go
-                // relative to where the libcall is.
-                let never_colocated = true;
-                (name, signature, never_colocated)
+                (name, signature)
             })
             .collect();
 
-        for (name, signature, never_colocated) in usercalls.into_iter().chain(libcalls) {
+        for (name, signature) in usercalls.into_iter().chain(libcalls) {
             let sig_ref = builder.import_signature(signature.clone());
             let func_ref = builder.import_function(ExtFuncData {
                 name,
                 signature: sig_ref,
-                colocated: if never_colocated {
-                    false
-                } else {
-                    self.u.arbitrary()?
-                },
+
+                // Libcalls can't be colocated because they can be very far away
+                // from allocated memory at runtime, and additionally at this
+                // time cranelift-jit puts all functions in their own mmap so
+                // they also cannot be colocated.
+                colocated: false,
             });
 
             self.resources


### PR DESCRIPTION
As I've just discovered it turns out that all functions are in their own mmap, and mmaps aren't guaranteed to be anywhere near one another. This means that functions cannot ever be `colocated` and must always have absolute relocations to one another.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
