### PR TITLE
Fix `memory.init` with Wizer

### DIFF
--- a/crates/wizer/tests/all/tests.rs
+++ b/crates/wizer/tests/all/tests.rs
@@ -921,3 +921,45 @@ fn mixture_of_globals() -> Result<()> {
     let wizer = get_wizer();
     wizen_and_run_wasm(&[], 42 + 2 + 43 + 4, &wasm, wizer)
 }
+
+#[test]
+fn memory_init_and_data_segments() -> Result<()> {
+    let _ = env_logger::try_init();
+    let wasm = wat_to_wasm(
+        r#"
+(module
+  (memory 1)
+
+  (func (export "wizer.initialize")
+    i32.const 2
+    i32.const 0
+    i32.const 2
+    memory.init $a
+  )
+
+  (func (export "run") (result i32)
+    i32.const 4
+    i32.const 0
+    i32.const 2
+    memory.init $a
+    i32.const 6
+    i32.const 0
+    i32.const 2
+    memory.init $c
+
+    i32.const 0
+    i32.load
+    i32.const 4
+    i32.load
+    i32.add
+  )
+
+  (data $a "\01\02")
+  (data $b (i32.const 0) "\03\04")
+  (data $c "\05\06")
+)
+        "#,
+    )?;
+    let wizer = get_wizer();
+    wizen_and_run_wasm(&[], 0x02010403 + 0x06050201, &wasm, wizer)
+}


### PR DESCRIPTION
* Preserve all data segments by default, but turn all previously active data segments into empty passive data segments.
* Preserve all passive data segments.
* Append all new data segments to preserve the preexisting index space.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
