### PR TITLE
wizer: Disallow GC mutations

### DIFF
--- a/crates/wizer/src/lib.rs
+++ b/crates/wizer/src/lib.rs
@@ -306,6 +306,29 @@ impl Wizer {
                                 anyhow::bail!("unsupported `data.drop` instruction")
                             }
 
+                            // Wizer can't snapshot GC references, so disallow
+                            // any mutation of GC references. This prevents, for
+                            // example, reading something from a table and then
+                            // mutating it.
+                            wasmparser::Operator::StructSet { .. } => {
+                                anyhow::bail!("unsupported `struct.set` instruction")
+                            }
+                            wasmparser::Operator::ArraySet { .. } => {
+                                anyhow::bail!("unsupported `array.set` instruction")
+                            }
+                            wasmparser::Operator::ArrayFill { .. } => {
+                                anyhow::bail!("unsupported `array.fill` instruction")
+                            }
+                            wasmparser::Operator::ArrayCopy { .. } => {
+                                anyhow::bail!("unsupported `array.copy` instruction")
+                            }
+                            wasmparser::Operator::ArrayInitData { .. } => {
+                                anyhow::bail!("unsupported `array.init_data` instruction")
+                            }
+                            wasmparser::Operator::ArrayInitElem { .. } => {
+                                anyhow::bail!("unsupported `array.init_elem` instruction")
+                            }
+
                             _ => continue,
                         }
                     }


### PR DESCRIPTION
Explicitly disallow mutation-related GC instructions in Wizer. This avoids forcibly disabling the wasm GC proposal in Wizer since that has type system effects as well. Instead this disallows the subset of the proposal which is incompatible with Wizer, specifically mutating GC references which can't be snapshot.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
