### PR TITLE
capi: Fix testing stand-alone inclusion of headers

### DIFF
--- a/crates/c-api/include/wasmtime/component/linker.h
+++ b/crates/c-api/include/wasmtime/component/linker.h
@@ -8,6 +8,7 @@
 #include <wasmtime/component/instance.h>
 #include <wasmtime/conf.h>
 #include <wasmtime/error.h>
+#include <wasmtime/module.h>
 #include <wasmtime/store.h>
 
 #ifdef WASMTIME_FEATURE_COMPONENT_MODEL

--- a/crates/c-api/include/wasmtime/component/val.h
+++ b/crates/c-api/include/wasmtime/component/val.h
@@ -7,6 +7,9 @@
 
 #ifdef WASMTIME_FEATURE_COMPONENT_MODEL
 
+#include <stdint.h>
+#include <wasm.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/crates/c-api/tests/CMakeLists.txt
+++ b/crates/c-api/tests/CMakeLists.txt
@@ -68,15 +68,14 @@ foreach(header IN LISTS cpp_headers)
   if(header_extension STREQUAL ".h.in")
     continue()
   endif()
-  cmake_path(GET header FILENAME header_filename)
-  cmake_path(APPEND CMAKE_CURRENT_BINARY_DIR "header-test" "${header_filename}.cc"
-    OUTPUT_VARIABLE test_filename)
-  list(APPEND header_tests ${test_filename})
-
   cmake_path(
     RELATIVE_PATH header
     BASE_DIRECTORY ${header_root}
     OUTPUT_VARIABLE rel_header)
+  cmake_path(APPEND CMAKE_CURRENT_BINARY_DIR "header-test" "${rel_header}.cc"
+    OUTPUT_VARIABLE test_filename)
+  list(APPEND header_tests ${test_filename})
+
   file(WRITE ${test_filename} "#include <${rel_header}>")
 endforeach()
 add_capi_test(standalone-headers FILES ${header_tests})


### PR DESCRIPTION
If headers with the same filename were in different directories their tests would clobber each other, so this fixes the test paths and filenames to ensure that each header is indeed tested. This then fixes issues with `component/val.h` and `component/linker.h` to add some missing includes.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
