### PR TITLE
Document stability tiers of Rust/C/C++ Embedding APIs

### DIFF
--- a/docs/stability-tiers.md
+++ b/docs/stability-tiers.md
@@ -49,6 +49,8 @@ For explanations of what each tier means see below.
 | WASI Proposal        | [`wasi-http`]                              |
 | WASI Proposal        | `wasi_snapshot_preview1`                   |
 | WASI Proposal        | `wasi_unstable`                            |
+| Embedding API        | Rust                                       |
+| Embedding API        | C                                          |
 
 [`mutable-globals`]: https://github.com/WebAssembly/mutable-global/blob/master/proposals/mutable-global/Overview.md
 [`sign-extension-ops`]: https://github.com/WebAssembly/spec/blob/master/proposals/sign-extension-ops/Overview.md
@@ -85,6 +87,7 @@ For explanations of what each tier means see below.
 | WebAssembly Proposal | [`custom-page-sizes`]      | Unstable wasm proposal      |
 | WebAssembly Proposal | [`exception-handling`]     | fuzzing, dependence on GC   |
 | Execution Backend    | Pulley                     | More time fuzzing/baking    |
+| Embedding API        | C++                        | Full-time maintainer        |
 
 [`memory64`]: https://github.com/WebAssembly/memory64/blob/master/proposals/memory64/Overview.md
 [`custom-page-sizes`]: https://github.com/WebAssembly/custom-page-sizes


### PR DESCRIPTION
I was thinking today that I'd like to explicitly say in the docs that the C++ embedding API is not a tier 1 feature of Wasmtime. It's mostly written by me and I don't know C++. I also think it's worthwhile to call out that Rust/C are explicitly tier 1 and we support CVEs with them, for example.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
