### PR TITLE
Debug: handle `Store::debug_frames()` with no activation.

### DIFF
--- a/tests/all/debug.rs
+++ b/tests/all/debug.rs
@@ -186,3 +186,17 @@ fn gc_access_during_call() -> anyhow::Result<()> {
         },
     )
 }
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn debug_frames_on_store_with_no_wasm_activation() -> anyhow::Result<()> {
+    let mut config = Config::default();
+    config.guest_debug(true);
+    let engine = Engine::new(&config)?;
+    let mut store = Store::new(&engine, ());
+    let frames = store
+        .debug_frames()
+        .expect("Debug frames should be available");
+    assert!(frames.done());
+    Ok(())
+}


### PR DESCRIPTION
This was a corner case I missed in #11769. When the last-exited state on the `Store` is all zeroes because there is no current activation, we need to return an empty iterator rather than hit an assert in the stackwalk.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
