### PR TITLE
Attempt to use github immutable releases

### DIFF
--- a/.github/actions/github-release/main.js
+++ b/.github/actions/github-release/main.js
@@ -99,6 +99,7 @@ async function runOnce() {
       repo,
       tag_name: name,
       prerelease: name === 'dev',
+      draft: name !== 'dev',
     };
     if (name !== 'dev') {
       for (let x of releaseNotes.split(/^---+$/m)) {
@@ -138,6 +139,15 @@ async function runOnce() {
       headers: { 'content-length': size, 'content-type': 'application/octet-stream' },
       name,
       url: release.data.upload_url,
+    });
+  }
+
+  if (name !== 'dev') {
+    octokit.rest.repos.updateRelease({
+        owner,
+        repo,
+        release_id: release.id,
+        draft: false,
     });
   }
 }


### PR DESCRIPTION
[Immutable Releases] look to be a relatively new feature on github which is a natural fit for us where we have no need to modify release assets after creation. My failed attempt to enable this earlier turned out to, expectedly, not work. This commit is an attempt to make things work. Specifically releases are now created as a draft initially, then release assets are attached, and finally it's automatically marked as a non-draft. While one could make a reasonable argument that a human should be involved in making the release a non-draft there's also something nice about just hitting merge on a PR and letting the release ride through CI.

[Immutable Releases]: https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/immutable-releases

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
