### PR TITLE
[36.0.x] Use github immutable releases

### DIFF
--- a/.github/actions/github-release/main.js
+++ b/.github/actions/github-release/main.js
@@ -146,7 +146,7 @@ async function runOnce() {
     octokit.rest.repos.updateRelease({
         owner,
         repo,
-        release_id: release.id,
+        release_id: release.data.id,
         draft: false,
     });
   }


### PR DESCRIPTION
Backport of https://github.com/bytecodealliance/wasmtime/pull/11902 and https://github.com/bytecodealliance/wasmtime/pull/11906 to the 36.0.x branch.