### PR TITLE
Put Linker::define_wasi under WASMTIME_FEATURE_WASI

### DIFF
--- a/crates/c-api/include/wasmtime/linker.hh
+++ b/crates/c-api/include/wasmtime/linker.hh
@@ -55,6 +55,7 @@ public:
     return std::monostate();
   }
 
+#ifdef WASMTIME_FEATURE_WASI
   /// Defines WASI functions within this linker.
   ///
   /// Note that `Store::Context::set_wasi` must also be used for instantiated
@@ -66,6 +67,7 @@ public:
     }
     return std::monostate();
   }
+#endif // WASMTIME_FEATURE_WASI
 
   /// Defines all exports of the `instance` provided in this linker with the
   /// given module name of `name`.


### PR DESCRIPTION
`wasmtime_linker_define_wasi` in `linker.h` is under build option, so `linker.hh` cannot compile