### PR TITLE
fix(cranelift): fix sdiv by most negative number

### DIFF
--- a/cranelift/codegen/src/opts/arithmetic.isle
+++ b/cranelift/codegen/src/opts/arithmetic.isle
@@ -86,6 +86,10 @@
 ;; Signed `x / d` when d is a power of two is a bit more involved...
 (rule (simplify_skeleton (sdiv x (iconst_u ty (u64_extract_power_of_two d))))
       (if-let true (u64_gt d 1))
+      ;; This rule musn't fire for the most negative number - which looks like
+      ;; a power of two (sign bit set and otherwise all zeros)
+      (if-let true (u32_lt (u64_trailing_zeros d)
+                           (u32_sub (ty_bits ty) 1)))
       (let ((k u32 (u64_trailing_zeros d))
             (t1 Value (sshr ty x (iconst_u ty (u32_sub k 1))))
             (t2 Value (ushr ty t1 (iconst_u ty (u32_sub (ty_bits ty) k))))

--- a/cranelift/filetests/filetests/runtests/sdiv.clif
+++ b/cranelift/filetests/filetests/runtests/sdiv.clif
@@ -1,5 +1,7 @@
 test interpret
 test run
+;; if opt_level=none, none of the constant denominator optimisations fire
+set opt_level=speed
 target aarch64
 target s390x
 target riscv64
@@ -190,3 +192,23 @@ block0(v0: i64):
 ; run: %sdiv_by_const_neg_1337_i64(-56155) == 42
 ; run: %sdiv_by_const_neg_1337_i64(-57490) == 42
 ; run: %sdiv_by_const_neg_1337_i64(-57491) == 43
+
+function %sdiv_by_const_neg_i64min_i64(i64) -> i64 {
+block0(v0: i64):
+    v1 = iconst.i64 -9223372036854775808
+    v2 = sdiv v0, v1
+    return v2
+}
+
+; run: %sdiv_by_const_neg_i64min_i64(-9223372036854775808) == 1
+
+
+function %sdiv_by_const_neg_i32min_i32(i32) -> i32 {
+block0(v0: i32):
+    v1 = iconst.i32 -2147483648
+    v2 = sdiv v0, v1
+    return v2
+}
+
+; run: %sdiv_by_const_neg_i32min_i32(-2147483648) == 1
+


### PR DESCRIPTION
Closes #11927 

When `opt_level="speed" || opt_level="speed_and_size"`, `i32::MIN/i32::MIN` and `i64::MIN/i64::MIN` both give `-1` instead of `1`.

The signed `x / d` rule when `d` is a power of two was too broad in it's constraints: namely that it accidentally picked up `ty::MIN` too - which should have instead triggered the rule for signed division by a negative power of two.

The tests in `sdiv.clif` const tests added in f678260bb3b2fa07ae10737f581b2d395d3349da unfortunately missed this edge case. Even if the edge case had been tested for, however, the test would have passed - as it seems the `sdiv.clif` test file was tested with `opt_level=none` before.
