### PR TITLE
Reduce scope of scratch registers for SIMD shifts

### DIFF
--- a/tests/disas/winch/x64/i64x2/shift/shr_s_all_fprs_float_local.wat
+++ b/tests/disas/winch/x64/i64x2/shift/shr_s_all_fprs_float_local.wat
@@ -1,0 +1,176 @@
+;;! target = "x86_64"
+;;! test = "winch"
+;;! flags = [ "-Ccranelift-has-avx" ]
+
+(module
+  (func (param f64)
+    f64.const 0
+    f64.neg
+    f64.const 0
+    f64.neg
+    f64.const 0
+    f64.neg
+    f64.const 0
+    f64.neg
+    f64.const 0
+    f64.neg
+    f64.const 0
+    f64.neg
+    f64.const 0
+    f64.neg
+    f64.const 0
+    f64.neg
+    f64.const 0
+    f64.neg
+    f64.const 0
+    f64.neg
+    f64.const 0
+    f64.neg
+    f64.const 0
+    f64.neg
+    f64.const 0
+    f64.neg
+    f64.const 0
+    f64.neg
+
+    local.get 0
+
+    v128.const i64x2 0 0
+    i32.const 0
+    i64x2.shr_s
+    unreachable
+  )
+)
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    0x10(%r11), %r11
+;;       addq    $0x98, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x2c2
+;;   1c: movq    %rdi, %r14
+;;       subq    $0x20, %rsp
+;;       movq    %rdi, 0x18(%rsp)
+;;       movq    %rsi, 0x10(%rsp)
+;;       movsd   %xmm0, 8(%rsp)
+;;       movsd   0x28a(%rip), %xmm0
+;;       movabsq $9223372036854775808, %r11
+;;       movq    %r11, %xmm15
+;;       xorpd   %xmm15, %xmm0
+;;       movsd   0x26e(%rip), %xmm1
+;;       movabsq $9223372036854775808, %r11
+;;       movq    %r11, %xmm15
+;;       xorpd   %xmm15, %xmm1
+;;       movsd   0x252(%rip), %xmm2
+;;       movabsq $9223372036854775808, %r11
+;;       movq    %r11, %xmm15
+;;       xorpd   %xmm15, %xmm2
+;;       movsd   0x236(%rip), %xmm3
+;;       movabsq $9223372036854775808, %r11
+;;       movq    %r11, %xmm15
+;;       xorpd   %xmm15, %xmm3
+;;       movsd   0x21a(%rip), %xmm4
+;;       movabsq $9223372036854775808, %r11
+;;       movq    %r11, %xmm15
+;;       xorpd   %xmm15, %xmm4
+;;       movsd   0x1fe(%rip), %xmm5
+;;       movabsq $9223372036854775808, %r11
+;;       movq    %r11, %xmm15
+;;       xorpd   %xmm15, %xmm5
+;;       movsd   0x1e2(%rip), %xmm6
+;;       movabsq $9223372036854775808, %r11
+;;       movq    %r11, %xmm15
+;;       xorpd   %xmm15, %xmm6
+;;       movsd   0x1c6(%rip), %xmm7
+;;       movabsq $9223372036854775808, %r11
+;;       movq    %r11, %xmm15
+;;       xorpd   %xmm15, %xmm7
+;;       movsd   0x1a9(%rip), %xmm8
+;;       movabsq $9223372036854775808, %r11
+;;       movq    %r11, %xmm15
+;;       xorpd   %xmm15, %xmm8
+;;       movsd   0x18c(%rip), %xmm9
+;;       movabsq $9223372036854775808, %r11
+;;       movq    %r11, %xmm15
+;;       xorpd   %xmm15, %xmm9
+;;       movsd   0x16f(%rip), %xmm10
+;;       movabsq $9223372036854775808, %r11
+;;       movq    %r11, %xmm15
+;;       xorpd   %xmm15, %xmm10
+;;       movsd   0x152(%rip), %xmm11
+;;       movabsq $9223372036854775808, %r11
+;;       movq    %r11, %xmm15
+;;       xorpd   %xmm15, %xmm11
+;;       movsd   0x135(%rip), %xmm12
+;;       movabsq $9223372036854775808, %r11
+;;       movq    %r11, %xmm15
+;;       xorpd   %xmm15, %xmm12
+;;       movsd   0x118(%rip), %xmm13
+;;       movabsq $9223372036854775808, %r11
+;;       movq    %r11, %xmm15
+;;       xorpd   %xmm15, %xmm13
+;;       movl    $0, %eax
+;;       movdqu  0xfe(%rip), %xmm14
+;;       andl    $0x3f, %eax
+;;       subq    $8, %rsp
+;;       movsd   %xmm0, (%rsp)
+;;       subq    $8, %rsp
+;;       movsd   %xmm1, (%rsp)
+;;       subq    $8, %rsp
+;;       movsd   %xmm2, (%rsp)
+;;       subq    $8, %rsp
+;;       movsd   %xmm3, (%rsp)
+;;       subq    $8, %rsp
+;;       movsd   %xmm4, (%rsp)
+;;       subq    $8, %rsp
+;;       movsd   %xmm5, (%rsp)
+;;       subq    $8, %rsp
+;;       movsd   %xmm6, (%rsp)
+;;       subq    $8, %rsp
+;;       movsd   %xmm7, (%rsp)
+;;       subq    $8, %rsp
+;;       movsd   %xmm8, (%rsp)
+;;       subq    $8, %rsp
+;;       movsd   %xmm9, (%rsp)
+;;       subq    $8, %rsp
+;;       movsd   %xmm10, (%rsp)
+;;       subq    $8, %rsp
+;;       movsd   %xmm11, (%rsp)
+;;       subq    $8, %rsp
+;;       movsd   %xmm12, (%rsp)
+;;       subq    $8, %rsp
+;;       movsd   %xmm13, (%rsp)
+;;       movsd   0x78(%rsp), %xmm15
+;;       subq    $8, %rsp
+;;       movsd   %xmm15, (%rsp)
+;;       vmovd   %eax, %xmm15
+;;       vmovdqu 0x3b(%rip), %xmm0
+;;       vpsrlq  %xmm15, %xmm0, %xmm0
+;;       vpsrlq  %xmm15, %xmm14, %xmm14
+;;       vpxor   %xmm0, %xmm14, %xmm14
+;;       vpsubq  %xmm0, %xmm14, %xmm14
+;;       ud2
+;;       addq    $0x20, %rsp
+;;       popq    %rbp
+;;       retq
+;;  2c2: ud2
+;;  2c4: addb    %al, (%rax)
+;;  2c6: addb    %al, (%rax)
+;;  2c8: addb    %al, (%rax)
+;;  2ca: addb    %al, (%rax)
+;;  2cc: addb    %al, (%rax)
+;;  2ce: addb    %al, (%rax)
+;;  2d0: addb    %al, (%rax)
+;;  2d2: addb    %al, (%rax)
+;;  2d4: addb    %al, (%rax)
+;;  2d6: addb    %al, (%rax)
+;;  2d8: addb    %al, (%rax)
+;;  2da: addb    %al, (%rax)
+;;  2dc: addb    %al, (%rax)
+;;  2de: addb    %al, (%rax)
+;;  2e0: addb    %al, (%rax)
+;;  2e2: addb    %al, (%rax)
+;;  2e4: addb    %al, (%rax)
+;;  2e6: addb    %al, (%rax)
+;;  2ec: addb    %al, (%rax)

--- a/tests/disas/winch/x64/i64x2/shift/shr_s_all_fprs_int_local.wat
+++ b/tests/disas/winch/x64/i64x2/shift/shr_s_all_fprs_int_local.wat
@@ -1,0 +1,174 @@
+;;! target = "x86_64"
+;;! test = "winch"
+;;! flags = [ "-Ccranelift-has-avx" ]
+
+(module
+  (func (param i64)
+    f64.const 0
+    f64.neg
+    f64.const 0
+    f64.neg
+    f64.const 0
+    f64.neg
+    f64.const 0
+    f64.neg
+    f64.const 0
+    f64.neg
+    f64.const 0
+    f64.neg
+    f64.const 0
+    f64.neg
+    f64.const 0
+    f64.neg
+    f64.const 0
+    f64.neg
+    f64.const 0
+    f64.neg
+    f64.const 0
+    f64.neg
+    f64.const 0
+    f64.neg
+    f64.const 0
+    f64.neg
+    f64.const 0
+    f64.neg
+
+    local.get 0
+
+    v128.const i64x2 0 0
+    i32.const 0
+    i64x2.shr_s
+    unreachable
+  )
+)
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    0x10(%r11), %r11
+;;       addq    $0x98, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x2b4
+;;   1c: movq    %rdi, %r14
+;;       subq    $0x20, %rsp
+;;       movq    %rdi, 0x18(%rsp)
+;;       movq    %rsi, 0x10(%rsp)
+;;       movq    %rdx, 8(%rsp)
+;;       movsd   0x27b(%rip), %xmm0
+;;       movabsq $9223372036854775808, %r11
+;;       movq    %r11, %xmm15
+;;       xorpd   %xmm15, %xmm0
+;;       movsd   0x25f(%rip), %xmm1
+;;       movabsq $9223372036854775808, %r11
+;;       movq    %r11, %xmm15
+;;       xorpd   %xmm15, %xmm1
+;;       movsd   0x243(%rip), %xmm2
+;;       movabsq $9223372036854775808, %r11
+;;       movq    %r11, %xmm15
+;;       xorpd   %xmm15, %xmm2
+;;       movsd   0x227(%rip), %xmm3
+;;       movabsq $9223372036854775808, %r11
+;;       movq    %r11, %xmm15
+;;       xorpd   %xmm15, %xmm3
+;;       movsd   0x20b(%rip), %xmm4
+;;       movabsq $9223372036854775808, %r11
+;;       movq    %r11, %xmm15
+;;       xorpd   %xmm15, %xmm4
+;;       movsd   0x1ef(%rip), %xmm5
+;;       movabsq $9223372036854775808, %r11
+;;       movq    %r11, %xmm15
+;;       xorpd   %xmm15, %xmm5
+;;       movsd   0x1d3(%rip), %xmm6
+;;       movabsq $9223372036854775808, %r11
+;;       movq    %r11, %xmm15
+;;       xorpd   %xmm15, %xmm6
+;;       movsd   0x1b7(%rip), %xmm7
+;;       movabsq $9223372036854775808, %r11
+;;       movq    %r11, %xmm15
+;;       xorpd   %xmm15, %xmm7
+;;       movsd   0x19a(%rip), %xmm8
+;;       movabsq $9223372036854775808, %r11
+;;       movq    %r11, %xmm15
+;;       xorpd   %xmm15, %xmm8
+;;       movsd   0x17d(%rip), %xmm9
+;;       movabsq $9223372036854775808, %r11
+;;       movq    %r11, %xmm15
+;;       xorpd   %xmm15, %xmm9
+;;       movsd   0x160(%rip), %xmm10
+;;       movabsq $9223372036854775808, %r11
+;;       movq    %r11, %xmm15
+;;       xorpd   %xmm15, %xmm10
+;;       movsd   0x143(%rip), %xmm11
+;;       movabsq $9223372036854775808, %r11
+;;       movq    %r11, %xmm15
+;;       xorpd   %xmm15, %xmm11
+;;       movsd   0x126(%rip), %xmm12
+;;       movabsq $9223372036854775808, %r11
+;;       movq    %r11, %xmm15
+;;       xorpd   %xmm15, %xmm12
+;;       movsd   0x109(%rip), %xmm13
+;;       movabsq $9223372036854775808, %r11
+;;       movq    %r11, %xmm15
+;;       xorpd   %xmm15, %xmm13
+;;       movl    $0, %eax
+;;       movdqu  0xef(%rip), %xmm14
+;;       andl    $0x3f, %eax
+;;       subq    $8, %rsp
+;;       movsd   %xmm0, (%rsp)
+;;       subq    $8, %rsp
+;;       movsd   %xmm1, (%rsp)
+;;       subq    $8, %rsp
+;;       movsd   %xmm2, (%rsp)
+;;       subq    $8, %rsp
+;;       movsd   %xmm3, (%rsp)
+;;       subq    $8, %rsp
+;;       movsd   %xmm4, (%rsp)
+;;       subq    $8, %rsp
+;;       movsd   %xmm5, (%rsp)
+;;       subq    $8, %rsp
+;;       movsd   %xmm6, (%rsp)
+;;       subq    $8, %rsp
+;;       movsd   %xmm7, (%rsp)
+;;       subq    $8, %rsp
+;;       movsd   %xmm8, (%rsp)
+;;       subq    $8, %rsp
+;;       movsd   %xmm9, (%rsp)
+;;       subq    $8, %rsp
+;;       movsd   %xmm10, (%rsp)
+;;       subq    $8, %rsp
+;;       movsd   %xmm11, (%rsp)
+;;       subq    $8, %rsp
+;;       movsd   %xmm12, (%rsp)
+;;       subq    $8, %rsp
+;;       movsd   %xmm13, (%rsp)
+;;       movq    0x78(%rsp), %r11
+;;       pushq   %r11
+;;       vmovd   %eax, %xmm15
+;;       vmovdqu 0x39(%rip), %xmm0
+;;       vpsrlq  %xmm15, %xmm0, %xmm0
+;;       vpsrlq  %xmm15, %xmm14, %xmm14
+;;       vpxor   %xmm0, %xmm14, %xmm14
+;;       vpsubq  %xmm0, %xmm14, %xmm14
+;;       ud2
+;;       addq    $0x20, %rsp
+;;       popq    %rbp
+;;       retq
+;;  2b4: ud2
+;;  2b6: addb    %al, (%rax)
+;;  2b8: addb    %al, (%rax)
+;;  2ba: addb    %al, (%rax)
+;;  2bc: addb    %al, (%rax)
+;;  2be: addb    %al, (%rax)
+;;  2c0: addb    %al, (%rax)
+;;  2c2: addb    %al, (%rax)
+;;  2c4: addb    %al, (%rax)
+;;  2c6: addb    %al, (%rax)
+;;  2c8: addb    %al, (%rax)
+;;  2ca: addb    %al, (%rax)
+;;  2cc: addb    %al, (%rax)
+;;  2ce: addb    %al, (%rax)
+;;  2d0: addb    %al, (%rax)
+;;  2d2: addb    %al, (%rax)
+;;  2d4: addb    %al, (%rax)
+;;  2d6: addb    %al, (%rax)
+;;  2dc: addb    %al, (%rax)

--- a/tests/disas/winch/x64/i8x16/shift/shr_s_all_fprs_float_local.wat
+++ b/tests/disas/winch/x64/i8x16/shift/shr_s_all_fprs_float_local.wat
@@ -1,0 +1,170 @@
+;;! target = "x86_64"
+;;! test = "winch"
+;;! flags = [ "-Ccranelift-has-avx" ]
+
+(module
+  (func (param f64)
+    f64.const 0
+    f64.neg
+    f64.const 0
+    f64.neg
+    f64.const 0
+    f64.neg
+    f64.const 0
+    f64.neg
+    f64.const 0
+    f64.neg
+    f64.const 0
+    f64.neg
+    f64.const 0
+    f64.neg
+    f64.const 0
+    f64.neg
+    f64.const 0
+    f64.neg
+    f64.const 0
+    f64.neg
+    f64.const 0
+    f64.neg
+    f64.const 0
+    f64.neg
+    f64.const 0
+    f64.neg
+    f64.const 0
+    f64.neg
+
+    local.get 0
+
+    v128.const i64x2 0 0
+    i32.const 0
+    i8x16.shr_s
+    unreachable
+  )
+)
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    0x10(%r11), %r11
+;;       addq    $0x98, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x2c5
+;;   1c: movq    %rdi, %r14
+;;       subq    $0x20, %rsp
+;;       movq    %rdi, 0x18(%rsp)
+;;       movq    %rsi, 0x10(%rsp)
+;;       movsd   %xmm0, 8(%rsp)
+;;       movsd   0x28a(%rip), %xmm0
+;;       movabsq $9223372036854775808, %r11
+;;       movq    %r11, %xmm15
+;;       xorpd   %xmm15, %xmm0
+;;       movsd   0x26e(%rip), %xmm1
+;;       movabsq $9223372036854775808, %r11
+;;       movq    %r11, %xmm15
+;;       xorpd   %xmm15, %xmm1
+;;       movsd   0x252(%rip), %xmm2
+;;       movabsq $9223372036854775808, %r11
+;;       movq    %r11, %xmm15
+;;       xorpd   %xmm15, %xmm2
+;;       movsd   0x236(%rip), %xmm3
+;;       movabsq $9223372036854775808, %r11
+;;       movq    %r11, %xmm15
+;;       xorpd   %xmm15, %xmm3
+;;       movsd   0x21a(%rip), %xmm4
+;;       movabsq $9223372036854775808, %r11
+;;       movq    %r11, %xmm15
+;;       xorpd   %xmm15, %xmm4
+;;       movsd   0x1fe(%rip), %xmm5
+;;       movabsq $9223372036854775808, %r11
+;;       movq    %r11, %xmm15
+;;       xorpd   %xmm15, %xmm5
+;;       movsd   0x1e2(%rip), %xmm6
+;;       movabsq $9223372036854775808, %r11
+;;       movq    %r11, %xmm15
+;;       xorpd   %xmm15, %xmm6
+;;       movsd   0x1c6(%rip), %xmm7
+;;       movabsq $9223372036854775808, %r11
+;;       movq    %r11, %xmm15
+;;       xorpd   %xmm15, %xmm7
+;;       movsd   0x1a9(%rip), %xmm8
+;;       movabsq $9223372036854775808, %r11
+;;       movq    %r11, %xmm15
+;;       xorpd   %xmm15, %xmm8
+;;       movsd   0x18c(%rip), %xmm9
+;;       movabsq $9223372036854775808, %r11
+;;       movq    %r11, %xmm15
+;;       xorpd   %xmm15, %xmm9
+;;       movsd   0x16f(%rip), %xmm10
+;;       movabsq $9223372036854775808, %r11
+;;       movq    %r11, %xmm15
+;;       xorpd   %xmm15, %xmm10
+;;       movsd   0x152(%rip), %xmm11
+;;       movabsq $9223372036854775808, %r11
+;;       movq    %r11, %xmm15
+;;       xorpd   %xmm15, %xmm11
+;;       movsd   0x135(%rip), %xmm12
+;;       movabsq $9223372036854775808, %r11
+;;       movq    %r11, %xmm15
+;;       xorpd   %xmm15, %xmm12
+;;       movsd   0x118(%rip), %xmm13
+;;       movabsq $9223372036854775808, %r11
+;;       movq    %r11, %xmm15
+;;       xorpd   %xmm15, %xmm13
+;;       movl    $0, %eax
+;;       movdqu  0xfe(%rip), %xmm14
+;;       andl    $7, %eax
+;;       subq    $8, %rsp
+;;       movsd   %xmm0, (%rsp)
+;;       subq    $8, %rsp
+;;       movsd   %xmm1, (%rsp)
+;;       subq    $8, %rsp
+;;       movsd   %xmm2, (%rsp)
+;;       subq    $8, %rsp
+;;       movsd   %xmm3, (%rsp)
+;;       subq    $8, %rsp
+;;       movsd   %xmm4, (%rsp)
+;;       subq    $8, %rsp
+;;       movsd   %xmm5, (%rsp)
+;;       subq    $8, %rsp
+;;       movsd   %xmm6, (%rsp)
+;;       subq    $8, %rsp
+;;       movsd   %xmm7, (%rsp)
+;;       subq    $8, %rsp
+;;       movsd   %xmm8, (%rsp)
+;;       subq    $8, %rsp
+;;       movsd   %xmm9, (%rsp)
+;;       subq    $8, %rsp
+;;       movsd   %xmm10, (%rsp)
+;;       subq    $8, %rsp
+;;       movsd   %xmm11, (%rsp)
+;;       subq    $8, %rsp
+;;       movsd   %xmm12, (%rsp)
+;;       subq    $8, %rsp
+;;       movsd   %xmm13, (%rsp)
+;;       movsd   0x78(%rsp), %xmm15
+;;       subq    $8, %rsp
+;;       movsd   %xmm15, (%rsp)
+;;       addl    $8, %eax
+;;       vmovd   %eax, %xmm15
+;;       vpunpcklbw %xmm14, %xmm14, %xmm0
+;;       vpunpckhbw %xmm14, %xmm14, %xmm1
+;;       vpsraw  %xmm15, %xmm0, %xmm0
+;;       vpsraw  %xmm15, %xmm1, %xmm1
+;;       vpacksswb %xmm1, %xmm0, %xmm14
+;;       ud2
+;;       addq    $0x20, %rsp
+;;       popq    %rbp
+;;       retq
+;;  2c5: ud2
+;;  2c7: addb    %al, (%rax)
+;;  2c9: addb    %al, (%rax)
+;;  2cb: addb    %al, (%rax)
+;;  2cd: addb    %al, (%rax)
+;;  2cf: addb    %al, (%rax)
+;;  2d1: addb    %al, (%rax)
+;;  2d3: addb    %al, (%rax)
+;;  2d5: addb    %al, (%rax)
+;;  2d7: addb    %al, (%rax)
+;;  2d9: addb    %al, (%rax)
+;;  2db: addb    %al, (%rax)
+;;  2dd: addb    %al, (%rax)

--- a/tests/disas/winch/x64/i8x16/shift/shr_s_all_fprs_int_local.wat
+++ b/tests/disas/winch/x64/i8x16/shift/shr_s_all_fprs_int_local.wat
@@ -1,0 +1,176 @@
+;;! target = "x86_64"
+;;! test = "winch"
+;;! flags = [ "-Ccranelift-has-avx" ]
+
+(module
+  (func (param i64)
+    f64.const 0
+    f64.neg
+    f64.const 0
+    f64.neg
+    f64.const 0
+    f64.neg
+    f64.const 0
+    f64.neg
+    f64.const 0
+    f64.neg
+    f64.const 0
+    f64.neg
+    f64.const 0
+    f64.neg
+    f64.const 0
+    f64.neg
+    f64.const 0
+    f64.neg
+    f64.const 0
+    f64.neg
+    f64.const 0
+    f64.neg
+    f64.const 0
+    f64.neg
+    f64.const 0
+    f64.neg
+    f64.const 0
+    f64.neg
+
+    local.get 0
+
+    v128.const i64x2 0 0
+    i32.const 0
+    i8x16.shr_s
+    unreachable
+  )
+)
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    0x10(%r11), %r11
+;;       addq    $0x98, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x2b7
+;;   1c: movq    %rdi, %r14
+;;       subq    $0x20, %rsp
+;;       movq    %rdi, 0x18(%rsp)
+;;       movq    %rsi, 0x10(%rsp)
+;;       movq    %rdx, 8(%rsp)
+;;       movsd   0x283(%rip), %xmm0
+;;       movabsq $9223372036854775808, %r11
+;;       movq    %r11, %xmm15
+;;       xorpd   %xmm15, %xmm0
+;;       movsd   0x267(%rip), %xmm1
+;;       movabsq $9223372036854775808, %r11
+;;       movq    %r11, %xmm15
+;;       xorpd   %xmm15, %xmm1
+;;       movsd   0x24b(%rip), %xmm2
+;;       movabsq $9223372036854775808, %r11
+;;       movq    %r11, %xmm15
+;;       xorpd   %xmm15, %xmm2
+;;       movsd   0x22f(%rip), %xmm3
+;;       movabsq $9223372036854775808, %r11
+;;       movq    %r11, %xmm15
+;;       xorpd   %xmm15, %xmm3
+;;       movsd   0x213(%rip), %xmm4
+;;       movabsq $9223372036854775808, %r11
+;;       movq    %r11, %xmm15
+;;       xorpd   %xmm15, %xmm4
+;;       movsd   0x1f7(%rip), %xmm5
+;;       movabsq $9223372036854775808, %r11
+;;       movq    %r11, %xmm15
+;;       xorpd   %xmm15, %xmm5
+;;       movsd   0x1db(%rip), %xmm6
+;;       movabsq $9223372036854775808, %r11
+;;       movq    %r11, %xmm15
+;;       xorpd   %xmm15, %xmm6
+;;       movsd   0x1bf(%rip), %xmm7
+;;       movabsq $9223372036854775808, %r11
+;;       movq    %r11, %xmm15
+;;       xorpd   %xmm15, %xmm7
+;;       movsd   0x1a2(%rip), %xmm8
+;;       movabsq $9223372036854775808, %r11
+;;       movq    %r11, %xmm15
+;;       xorpd   %xmm15, %xmm8
+;;       movsd   0x185(%rip), %xmm9
+;;       movabsq $9223372036854775808, %r11
+;;       movq    %r11, %xmm15
+;;       xorpd   %xmm15, %xmm9
+;;       movsd   0x168(%rip), %xmm10
+;;       movabsq $9223372036854775808, %r11
+;;       movq    %r11, %xmm15
+;;       xorpd   %xmm15, %xmm10
+;;       movsd   0x14b(%rip), %xmm11
+;;       movabsq $9223372036854775808, %r11
+;;       movq    %r11, %xmm15
+;;       xorpd   %xmm15, %xmm11
+;;       movsd   0x12e(%rip), %xmm12
+;;       movabsq $9223372036854775808, %r11
+;;       movq    %r11, %xmm15
+;;       xorpd   %xmm15, %xmm12
+;;       movsd   0x111(%rip), %xmm13
+;;       movabsq $9223372036854775808, %r11
+;;       movq    %r11, %xmm15
+;;       xorpd   %xmm15, %xmm13
+;;       movl    $0, %eax
+;;       movdqu  0xff(%rip), %xmm14
+;;       andl    $7, %eax
+;;       subq    $8, %rsp
+;;       movsd   %xmm0, (%rsp)
+;;       subq    $8, %rsp
+;;       movsd   %xmm1, (%rsp)
+;;       subq    $8, %rsp
+;;       movsd   %xmm2, (%rsp)
+;;       subq    $8, %rsp
+;;       movsd   %xmm3, (%rsp)
+;;       subq    $8, %rsp
+;;       movsd   %xmm4, (%rsp)
+;;       subq    $8, %rsp
+;;       movsd   %xmm5, (%rsp)
+;;       subq    $8, %rsp
+;;       movsd   %xmm6, (%rsp)
+;;       subq    $8, %rsp
+;;       movsd   %xmm7, (%rsp)
+;;       subq    $8, %rsp
+;;       movsd   %xmm8, (%rsp)
+;;       subq    $8, %rsp
+;;       movsd   %xmm9, (%rsp)
+;;       subq    $8, %rsp
+;;       movsd   %xmm10, (%rsp)
+;;       subq    $8, %rsp
+;;       movsd   %xmm11, (%rsp)
+;;       subq    $8, %rsp
+;;       movsd   %xmm12, (%rsp)
+;;       subq    $8, %rsp
+;;       movsd   %xmm13, (%rsp)
+;;       movq    0x78(%rsp), %r11
+;;       pushq   %r11
+;;       addl    $8, %eax
+;;       vmovd   %eax, %xmm15
+;;       vpunpcklbw %xmm14, %xmm14, %xmm0
+;;       vpunpckhbw %xmm14, %xmm14, %xmm1
+;;       vpsraw  %xmm15, %xmm0, %xmm0
+;;       vpsraw  %xmm15, %xmm1, %xmm1
+;;       vpacksswb %xmm1, %xmm0, %xmm14
+;;       ud2
+;;       addq    $0x20, %rsp
+;;       popq    %rbp
+;;       retq
+;;  2b7: ud2
+;;  2b9: addb    %al, (%rax)
+;;  2bb: addb    %al, (%rax)
+;;  2bd: addb    %al, (%rax)
+;;  2bf: addb    %al, (%rax)
+;;  2c1: addb    %al, (%rax)
+;;  2c3: addb    %al, (%rax)
+;;  2c5: addb    %al, (%rax)
+;;  2c7: addb    %al, (%rax)
+;;  2c9: addb    %al, (%rax)
+;;  2cb: addb    %al, (%rax)
+;;  2cd: addb    %al, (%rax)
+;;  2cf: addb    %al, (%rax)
+;;  2d1: addb    %al, (%rax)
+;;  2d3: addb    %al, (%rax)
+;;  2d5: addb    %al, (%rax)
+;;  2d7: addb    %al, (%rax)
+;;  2d9: addb    %al, (%rax)
+;;  2db: addb    %al, (%rax)
+;;  2dd: addb    %al, (%rax)

--- a/winch/codegen/src/masm.rs
+++ b/winch/codegen/src/masm.rs
@@ -217,6 +217,7 @@ impl ScratchType for FloatScratch {
 }
 
 /// A scratch register scope.
+#[derive(Debug, Clone, Copy)]
 pub struct Scratch(Reg);
 
 impl Scratch {


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
Fixes #11868.

Narrows the scope of using the general purpose scratch register and the floating point scratch register so that allocating new registers happen outside those scopes. The reason that fixes the issue is register allocation can trigger a spill if the all registers of the desired type are allocated and spilling requires a scratch register to move locals into memory.