### PR TITLE
Simplify C++ binding definitions

### DIFF
--- a/crates/c-api/include/wasmtime/component/component.hh
+++ b/crates/c-api/include/wasmtime/component/component.hh
@@ -29,76 +29,14 @@ namespace component {
  * instances.
  */
 class ExportIndex {
-  friend class Component;
-
-  struct deleter {
-    void operator()(wasmtime_component_export_index_t *p) const {
-      wasmtime_component_export_index_delete(p);
-    }
-  };
-
-  std::unique_ptr<wasmtime_component_export_index_t, deleter> ptr;
-
-public:
-  /// \brief Constructs an ExportIndex from the underlying C API struct.
-  explicit ExportIndex(wasmtime_component_export_index_t *raw) : ptr(raw) {}
-
-  /// Copies another index into this one.
-  ExportIndex(const ExportIndex &other)
-      : ptr(wasmtime_component_export_index_clone(other.ptr.get())) {}
-  /// Copies another index into this one.
-  ExportIndex &operator=(const ExportIndex &other) {
-    ptr.reset(wasmtime_component_export_index_clone(other.ptr.get()));
-    return *this;
-  }
-
-  ~ExportIndex() = default;
-  /// Moves resources from another component into this one.
-  ExportIndex(ExportIndex &&other) = default;
-  /// Moves resources from another component into this one.
-  ExportIndex &operator=(ExportIndex &&other) = default;
-
-  /// \brief Returns the underlying C API pointer.
-  const wasmtime_component_export_index_t *capi() const { return ptr.get(); }
-
-  /// \brief Returns the underlying C API pointer.
-  wasmtime_component_export_index_t *capi() { return ptr.get(); }
+  WASMTIME_CLONE_WRAPPER(ExportIndex, wasmtime_component_export_index);
 };
 
 /**
  * \brief Representation of a compiled WebAssembly component.
  */
 class Component {
-  struct deleter {
-    void operator()(wasmtime_component_t *p) const {
-      wasmtime_component_delete(p);
-    }
-  };
-
-  std::unique_ptr<wasmtime_component_t, deleter> ptr;
-
-  Component(wasmtime_component_t *raw) : ptr(raw) {}
-
-public:
-  /// Copies another component into this one.
-  Component(const Component &other)
-      : ptr(wasmtime_component_clone(other.ptr.get())) {}
-  /// Copies another component into this one.
-  Component &operator=(const Component &other) {
-    ptr.reset(wasmtime_component_clone(other.ptr.get()));
-    return *this;
-  }
-  ~Component() = default;
-  /// Moves resources from another component into this one.
-  Component(Component &&other) = default;
-  /// Moves resources from another component into this one.
-  Component &operator=(Component &&other) = default;
-
-  /// \brief Returns the underlying C API pointer.
-  const wasmtime_component_t *capi() const { return ptr.get(); }
-
-  /// \brief Returns the underlying C API pointer.
-  wasmtime_component_t *capi() { return ptr.get(); }
+  WASMTIME_CLONE_WRAPPER(Component, wasmtime_component);
 
 #ifdef WASMTIME_FEATURE_COMPILER
   /**

--- a/crates/c-api/include/wasmtime/component/linker.hh
+++ b/crates/c-api/include/wasmtime/component/linker.hh
@@ -26,24 +26,7 @@ namespace component {
  * `Linker` can also be used to link in WASI functions to instantiate a module.
  */
 class LinkerInstance {
-  struct deleter {
-    void operator()(wasmtime_component_linker_instance_t *p) const {
-      wasmtime_component_linker_instance_delete(p);
-    }
-  };
-
-  std::unique_ptr<wasmtime_component_linker_instance_t, deleter> ptr;
-
-public:
-  /// Creates a new linker instance from the given C API pointer.
-  explicit LinkerInstance(wasmtime_component_linker_instance_t *ptr)
-      : ptr(ptr) {}
-
-  /// \brief Returns the underlying C API pointer.
-  const wasmtime_component_linker_instance_t *capi() const { return ptr.get(); }
-
-  /// \brief Returns the underlying C API pointer.
-  wasmtime_component_linker_instance_t *capi() { return ptr.get(); }
+  WASMTIME_OWN_WRAPPER(LinkerInstance, wasmtime_component_linker_instance);
 
   /**
    * \brief Adds a module to this linker instance under the specified name.
@@ -88,7 +71,7 @@ private:
     Result<std::monostate> result =
         (*func)(Store::Context(store), args_span, results_span);
     if (!result) {
-      return result.err().release();
+      return result.err().capi_release();
     }
     return nullptr;
   }
@@ -127,7 +110,7 @@ private:
     F *func = reinterpret_cast<F *>(env);
     Result<std::monostate> result = (*func)(Store::Context(store), rep);
     if (!result) {
-      return result.err().release();
+      return result.err().capi_release();
     }
     return nullptr;
   }
@@ -160,15 +143,8 @@ public:
  * \brief Class used to instantiate a `Component` into an instance.
  */
 class Linker {
-  struct deleter {
-    void operator()(wasmtime_component_linker_t *p) const {
-      wasmtime_component_linker_delete(p);
-    }
-  };
+  WASMTIME_OWN_WRAPPER(Linker, wasmtime_component_linker);
 
-  std::unique_ptr<wasmtime_component_linker_t, deleter> ptr;
-
-public:
   /// Creates a new linker which will instantiate in the given engine.
   explicit Linker(Engine &engine)
       : ptr(wasmtime_component_linker_new(engine.capi())) {}
@@ -234,12 +210,6 @@ public:
     return std::monostate();
   }
 #endif // WASMTIME_FEATURE_WASI
-
-  /// \brief Returns the underlying C API pointer.
-  const wasmtime_component_linker_t *capi() const { return ptr.get(); }
-
-  /// \brief Returns the underlying C API pointer.
-  wasmtime_component_linker_t *capi() { return ptr.get(); }
 };
 
 } // namespace component

--- a/crates/c-api/include/wasmtime/component/val.hh
+++ b/crates/c-api/include/wasmtime/component/val.hh
@@ -419,36 +419,12 @@ public:
 /// Class representing a component model `resource` value which is either a
 /// guest or host-defined resource.
 class ResourceType {
-  struct deleter {
-    void operator()(wasmtime_component_resource_type_t *p) const {
-      wasmtime_component_resource_type_delete(p);
-    }
-  };
-
-  std::unique_ptr<wasmtime_component_resource_type_t, deleter> ptr;
-
-public:
-  /// \brief Takes ownership of `raw` and wraps it with this class.
-  explicit ResourceType(wasmtime_component_resource_type_t *raw) : ptr(raw) {}
+  WASMTIME_CLONE_WRAPPER(ResourceType, wasmtime_component_resource_type);
 
   /// \brief Creates a new host resource type with the specified `ty`
   /// identifier.
   explicit ResourceType(uint32_t ty)
       : ptr(wasmtime_component_resource_type_new_host(ty)) {}
-
-  /// Copies another resource into this one.
-  ResourceType(const ResourceType &other)
-      : ptr(wasmtime_component_resource_type_clone(other.ptr.get())) {}
-  /// Copies another resource into this one.
-  ResourceType &operator=(const ResourceType &other) {
-    ptr.reset(wasmtime_component_resource_type_clone(other.ptr.get()));
-    return *this;
-  }
-  ~ResourceType() = default;
-  /// Moves resources from another resource into this one.
-  ResourceType(ResourceType &&other) = default;
-  /// Moves resources from another resource into this one.
-  ResourceType &operator=(ResourceType &&other) = default;
 
   /// \brief Compares two resource types for equality.
   bool operator==(const ResourceType &b) const {
@@ -459,12 +435,6 @@ public:
   bool operator!=(const ResourceType &b) const {
     return !wasmtime_component_resource_type_equal(capi(), b.capi());
   }
-
-  /// \brief Returns the underlying C API pointer.
-  const wasmtime_component_resource_type_t *capi() const { return ptr.get(); }
-
-  /// \brief Returns the underlying C API pointer.
-  wasmtime_component_resource_type_t *capi() { return ptr.get(); }
 };
 
 class ResourceHost;
@@ -472,40 +442,7 @@ class ResourceHost;
 /// Class representing a component model `resource` value which is either a
 /// guest or host-defined resource.
 class ResourceAny {
-  struct deleter {
-    void operator()(wasmtime_component_resource_any_t *p) const {
-      wasmtime_component_resource_any_delete(p);
-    }
-  };
-
-  std::unique_ptr<wasmtime_component_resource_any_t, deleter> ptr;
-
-public:
-  /// \brief Takes ownership of `raw` and wraps it with this class.
-  explicit ResourceAny(wasmtime_component_resource_any_t *raw) : ptr(raw) {}
-
-  /// Copies another resource into this one.
-  ResourceAny(const ResourceAny &other)
-      : ptr(wasmtime_component_resource_any_clone(other.ptr.get())) {}
-  /// Copies another resource into this one.
-  ResourceAny &operator=(const ResourceAny &other) {
-    ptr.reset(wasmtime_component_resource_any_clone(other.ptr.get()));
-    return *this;
-  }
-  ~ResourceAny() = default;
-  /// Moves resources from another resource into this one.
-  ResourceAny(ResourceAny &&other) = default;
-  /// Moves resources from another resource into this one.
-  ResourceAny &operator=(ResourceAny &&other) = default;
-
-  /// \brief Returns the underlying C API pointer.
-  const wasmtime_component_resource_any_t *capi() const { return ptr.get(); }
-
-  /// \brief Returns the underlying C API pointer.
-  wasmtime_component_resource_any_t *capi() { return ptr.get(); }
-
-  /// \brief Gives up ownership of the underlying C pointer to the caller.
-  wasmtime_component_resource_any_t *capi_release() { return ptr.release(); }
+  WASMTIME_CLONE_WRAPPER(ResourceAny, wasmtime_component_resource_any);
 
   /// \brief Returns whether this resource is owned.
   bool owned() const { return wasmtime_component_resource_any_owned(capi()); }
@@ -529,51 +466,12 @@ public:
 
   /// \brief Attempts to convert this resource to a host-defined resource.
   Result<ResourceHost> to_host(Store::Context cx) const;
-
-  /**
-   * Converts the raw C API representation to this class without taking
-   * ownership.
-   */
-  static const ResourceAny *
-  from_capi(wasmtime_component_resource_any_t *const *capi) {
-    return reinterpret_cast<const ResourceAny *>(capi);
-  }
 };
 
 /// Class representing a component model `resource` value which is a host-owned
 /// resource.
 class ResourceHost {
-  struct deleter {
-    void operator()(wasmtime_component_resource_host_t *p) const {
-      wasmtime_component_resource_host_delete(p);
-    }
-  };
-
-  std::unique_ptr<wasmtime_component_resource_host_t, deleter> ptr;
-
-public:
-  /// \brief Takes ownership of `raw` and wraps it with this class.
-  explicit ResourceHost(wasmtime_component_resource_host_t *raw) : ptr(raw) {}
-
-  /// Copies another resource into this one.
-  ResourceHost(const ResourceHost &other)
-      : ptr(wasmtime_component_resource_host_clone(other.ptr.get())) {}
-  /// Copies another resource into this one.
-  ResourceHost &operator=(const ResourceHost &other) {
-    ptr.reset(wasmtime_component_resource_host_clone(other.ptr.get()));
-    return *this;
-  }
-  ~ResourceHost() = default;
-  /// Moves resources from another resource into this one.
-  ResourceHost(ResourceHost &&other) = default;
-  /// Moves resources from another resource into this one.
-  ResourceHost &operator=(ResourceHost &&other) = default;
-
-  /// \brief Returns the underlying C API pointer.
-  const wasmtime_component_resource_host_t *capi() const { return ptr.get(); }
-
-  /// \brief Returns the underlying C API pointer.
-  wasmtime_component_resource_host_t *capi() { return ptr.get(); }
+  WASMTIME_CLONE_WRAPPER(ResourceHost, wasmtime_component_resource_host);
 
   /// \brief Creates a new host-defined resource with the specified `owned`,
   /// `rep`, and `ty` identifiers.

--- a/crates/c-api/include/wasmtime/error.hh
+++ b/crates/c-api/include/wasmtime/error.hh
@@ -11,6 +11,7 @@
 #include <string>
 #include <variant>
 #include <wasmtime/error.h>
+#include <wasmtime/helpers.hh>
 
 namespace wasmtime {
 
@@ -23,17 +24,7 @@ class Trace;
  * description of the error that occurred.
  */
 class Error {
-  struct deleter {
-    void operator()(wasmtime_error_t *p) const { wasmtime_error_delete(p); }
-  };
-
-  std::unique_ptr<wasmtime_error_t, deleter> ptr;
-
-public:
-  /// \brief Creates an error from the raw C API representation
-  ///
-  /// Takes ownership of the provided `error`.
-  Error(wasmtime_error_t *error) : ptr(error) {}
+  WASMTIME_OWN_WRAPPER(Error, wasmtime_error);
 
   /// \brief Creates an error with the provided message.
   Error(const std::string &s) : ptr(wasmtime_error_new(s.c_str())) {}
@@ -61,9 +52,6 @@ public:
   ///
   /// Note that the `trace` cannot outlive this error object.
   Trace trace() const;
-
-  /// Release ownership of this error, acquiring the underlying C raw pointer.
-  wasmtime_error_t *release() { return ptr.release(); }
 };
 
 /// \brief Used to print an error.

--- a/crates/c-api/include/wasmtime/func.hh
+++ b/crates/c-api/include/wasmtime/func.hh
@@ -355,7 +355,7 @@ class Func {
     Result<std::monostate, Trap> result =
         (*func)(Caller(caller), args_span, results_span);
     if (!result) {
-      return result.err().ptr.release();
+      return result.err().capi_release();
     }
     return nullptr;
   }
@@ -371,7 +371,7 @@ class Func {
     F *func = reinterpret_cast<F *>(env); // NOLINT
     auto trap = HostFunc::invoke(*func, cx, args_and_results);
     if (trap) {
-      return trap->ptr.release();
+      return trap->capi_release();
     }
     return nullptr;
   }

--- a/crates/c-api/include/wasmtime/helpers.hh
+++ b/crates/c-api/include/wasmtime/helpers.hh
@@ -1,0 +1,79 @@
+#ifndef WASMTIME_HELPERS_HH
+#define WASMTIME_HELPERS_HH
+
+#include <memory>
+
+#define WASMTIME_OWN_WRAPPER(name, capi_type)                                  \
+public:                                                                        \
+  /**                                                                          \
+   * \brief Non-owning reference to an instance of this type.                  \
+   */                                                                          \
+  using Raw = capi_type##_t;                                                   \
+                                                                               \
+private:                                                                       \
+  struct deleter {                                                             \
+    void operator()(Raw *p) const { capi_type##_delete(p); }                   \
+  };                                                                           \
+                                                                               \
+  std::unique_ptr<Raw, deleter> ptr;                                           \
+                                                                               \
+public:                                                                        \
+  /**                                                                          \
+   * \brief Takes ownership of `raw` and wraps it with this class.             \
+   */                                                                          \
+  explicit name(Raw *raw) : ptr(raw) {}                                        \
+                                                                               \
+  ~name() = default;                                                           \
+                                                                               \
+  /**                                                                          \
+   * \brief Moves type information from another type into this one.            \
+   */                                                                          \
+  name(name &&other) = default;                                                \
+                                                                               \
+  /**                                                                          \
+   * \brief Moves type information from another type into this one.            \
+   */                                                                          \
+  name &operator=(name &&other) = default;                                     \
+                                                                               \
+  /**                                                                          \
+   * \brief Returns the underlying C API pointer.                              \
+   */                                                                          \
+  const Raw *capi() const { return ptr.get(); }                                \
+                                                                               \
+  /**                                                                          \
+   * \brief Returns the underlying C API pointer.                              \
+   */                                                                          \
+  Raw *capi() { return ptr.get(); }                                            \
+                                                                               \
+  /**                                                                          \
+   * \brief Releases the underlying C API pointer.                             \
+   */                                                                          \
+  Raw *capi_release() { return ptr.release(); }                                \
+                                                                               \
+  /**                                                                          \
+   * Converts the raw C API representation to this class without taking        \
+   * ownership.                                                                \
+   */                                                                          \
+  static const name *from_capi(Raw *const *capi) {                             \
+    static_assert(sizeof(name) == sizeof(void *));                             \
+    return reinterpret_cast<const name *>(capi);                               \
+  }
+
+#define WASMTIME_CLONE_WRAPPER(name, capi_type)                                \
+  WASMTIME_OWN_WRAPPER(name, capi_type)                                        \
+                                                                               \
+public:                                                                        \
+  /**                                                                          \
+   * \brief Copies another type into this one.                                 \
+   */                                                                          \
+  name(const name &other) : ptr(capi_type##_clone(other.ptr.get())) {}         \
+                                                                               \
+  /**                                                                          \
+   * \brief Copies another type into this one.                                 \
+   */                                                                          \
+  name &operator=(const name &other) {                                         \
+    ptr.reset(capi_type##_clone(other.ptr.get()));                             \
+    return *this;                                                              \
+  }
+
+#endif // WASMTIME_HELPERS_HH

--- a/crates/c-api/include/wasmtime/instance.hh
+++ b/crates/c-api/include/wasmtime/instance.hh
@@ -64,7 +64,7 @@ public:
     }
     wasmtime_instance_t instance;
     wasm_trap_t *trap = nullptr;
-    auto *error = wasmtime_instance_new(cx.ptr, m.ptr.get(), raw_imports.data(),
+    auto *error = wasmtime_instance_new(cx.ptr, m.capi(), raw_imports.data(),
                                         raw_imports.size(), &instance, &trap);
     if (error != nullptr) {
       return TrapError(Error(error));

--- a/crates/c-api/include/wasmtime/trap.hh
+++ b/crates/c-api/include/wasmtime/trap.hh
@@ -111,20 +111,8 @@ inline Trace Error::trace() const {
  * frames on the stack.
  */
 class Trap {
-  friend class Linker;
-  friend class Instance;
-  friend class Func;
-  template <typename Params, typename Results> friend class TypedFunc;
+  WASMTIME_OWN_WRAPPER(Trap, wasm_trap);
 
-  struct deleter {
-    void operator()(wasm_trap_t *p) const { wasm_trap_delete(p); }
-  };
-
-  std::unique_ptr<wasm_trap_t, deleter> ptr;
-
-  Trap(wasm_trap_t *ptr) : ptr(ptr) {}
-
-public:
   /// Creates a new host-defined trap with the specified message.
   explicit Trap(std::string_view msg)
       : Trap(wasmtime_trap_new(msg.data(), msg.size())) {}

--- a/crates/c-api/include/wasmtime/wasi.hh
+++ b/crates/c-api/include/wasmtime/wasi.hh
@@ -10,6 +10,7 @@
 #include <vector>
 #include <wasi.h>
 #include <wasmtime/conf.h>
+#include <wasmtime/helpers.hh>
 
 #ifdef WASMTIME_FEATURE_WASI
 
@@ -21,15 +22,8 @@ namespace wasmtime {
  * This is inserted into a store with `Store::Context::set_wasi`.
  */
 class WasiConfig {
-  friend class Store;
+  WASMTIME_OWN_WRAPPER(WasiConfig, wasi_config);
 
-  struct deleter {
-    void operator()(wasi_config_t *p) const { wasi_config_delete(p); }
-  };
-
-  std::unique_ptr<wasi_config_t, deleter> ptr;
-
-public:
   /// Creates a new configuration object with default settings.
   WasiConfig() : ptr(wasi_config_new()) {}
 
@@ -102,9 +96,6 @@ public:
     return wasi_config_preopen_dir(ptr.get(), path.c_str(), guest_path.c_str(),
                                    dir_perms, file_perms);
   }
-
-  /// \brief Returns the underlying C API pointer.
-  [[nodiscard]] wasi_config_t *capi() { return ptr.get(); }
 };
 
 } // namespace wasmtime


### PR DESCRIPTION
This commit adds a shared macro to simplify ownership management in the C++ API and to additionally have a uniform API across types. This is inspired by the component model work where I felt like I was copy/pasting quite a lot and wanted to cut down on that.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
