### PR TITLE
wasi-http: use UnsyncBoxBody to support axum

### DIFF
--- a/crates/wasi-http/src/p3/body.rs
+++ b/crates/wasi-http/src/p3/body.rs
@@ -8,7 +8,7 @@ use core::pin::Pin;
 use core::task::{Context, Poll, ready};
 use http::HeaderMap;
 use http_body::Body as _;
-use http_body_util::combinators::BoxBody;
+use http_body_util::combinators::UnsyncBoxBody;
 use std::any::{Any, TypeId};
 use std::io::Cursor;
 use std::sync::Arc;
@@ -34,7 +34,7 @@ pub(crate) enum Body {
     /// Body constructed by the host.
     Host {
         /// The [`http_body::Body`]
-        body: BoxBody<Bytes, ErrorCode>,
+        body: UnsyncBoxBody<Bytes, ErrorCode>,
         /// Channel, on which transmission result will be written
         result_tx: oneshot::Sender<Box<dyn Future<Output = Result<(), ErrorCode>> + Send>>,
     },
@@ -441,7 +441,7 @@ where
 
 /// [StreamProducer] implementation for bodies originating in the host.
 pub(crate) struct HostBodyStreamProducer<T> {
-    pub(crate) body: BoxBody<Bytes, ErrorCode>,
+    pub(crate) body: UnsyncBoxBody<Bytes, ErrorCode>,
     trailers: Option<oneshot::Sender<Result<Option<Resource<Trailers>>, ErrorCode>>>,
     getter: fn(&mut T) -> WasiHttpCtxView<'_>,
 }

--- a/crates/wasi-http/src/p3/host/handler.rs
+++ b/crates/wasi-http/src/p3/host/handler.rs
@@ -240,7 +240,7 @@ impl HostWithStore for WasiHttp {
                     getter,
                 )
                 .with_state(io_task_rx)
-                .boxed(),
+                .boxed_unsync(),
                 Body::Host { body, result_tx } => {
                     if let Some(limit) = content_length {
                         let (http_result_tx, http_result_rx) = oneshot::channel();
@@ -256,10 +256,10 @@ impl HostWithStore for WasiHttp {
                             ErrorCode::HttpRequestBodySize,
                         )
                         .with_state(io_task_rx)
-                        .boxed()
+                        .boxed_unsync()
                     } else {
                         _ = result_tx.send(Box::new(io_task_result(io_result_rx)));
-                        body.with_state(io_task_rx).boxed()
+                        body.with_state(io_task_rx).boxed_unsync()
                     }
                 }
             };
@@ -331,7 +331,7 @@ impl HostWithStore for WasiHttp {
                 let io = Arc::new(AbortOnDropJoinHandle(io));
                 _ = io_result_tx.send((Arc::clone(&io), rx));
                 _ = io_task_tx.send(Arc::clone(&io));
-                body.with_state(io).boxed()
+                body.with_state(io).boxed_unsync()
             }
         };
         let res = Response {

--- a/crates/wasi-http/src/p3/mod.rs
+++ b/crates/wasi-http/src/p3/mod.rs
@@ -28,7 +28,7 @@ use bytes::Bytes;
 use core::ops::Deref;
 use http::HeaderName;
 use http::uri::Scheme;
-use http_body_util::combinators::BoxBody;
+use http_body_util::combinators::UnsyncBoxBody;
 use std::sync::Arc;
 use wasmtime::component::{HasData, Linker, ResourceTable};
 use wasmtime_wasi::TrappableError;
@@ -95,13 +95,13 @@ pub trait WasiHttpCtx: Send {
     #[cfg(feature = "default-send-request")]
     fn send_request(
         &mut self,
-        request: http::Request<BoxBody<Bytes, ErrorCode>>,
+        request: http::Request<UnsyncBoxBody<Bytes, ErrorCode>>,
         options: Option<RequestOptions>,
         fut: Box<dyn Future<Output = Result<(), ErrorCode>> + Send>,
     ) -> Box<
         dyn Future<
                 Output = HttpResult<(
-                    http::Response<BoxBody<Bytes, ErrorCode>>,
+                    http::Response<UnsyncBoxBody<Bytes, ErrorCode>>,
                     Box<dyn Future<Output = Result<(), ErrorCode>> + Send>,
                 )>,
             > + Send,
@@ -112,7 +112,7 @@ pub trait WasiHttpCtx: Send {
 
             let (res, io) = default_send_request(request, options).await?;
             Ok((
-                res.map(BodyExt::boxed),
+                res.map(BodyExt::boxed_unsync),
                 Box::new(io) as Box<dyn Future<Output = _> + Send>,
             ))
         })
@@ -137,13 +137,13 @@ pub trait WasiHttpCtx: Send {
     #[cfg(not(feature = "default-send-request"))]
     fn send_request(
         &mut self,
-        request: http::Request<BoxBody<Bytes, ErrorCode>>,
+        request: http::Request<UnsyncBoxBody<Bytes, ErrorCode>>,
         options: Option<RequestOptions>,
         fut: Box<dyn Future<Output = Result<(), ErrorCode>> + Send>,
     ) -> Box<
         dyn Future<
                 Output = HttpResult<(
-                    http::Response<BoxBody<Bytes, ErrorCode>>,
+                    http::Response<UnsyncBoxBody<Bytes, ErrorCode>>,
                     Box<dyn Future<Output = Result<(), ErrorCode>> + Send>,
                 )>,
             > + Send,

--- a/crates/wasi-http/src/p3/request.rs
+++ b/crates/wasi-http/src/p3/request.rs
@@ -5,7 +5,7 @@ use core::time::Duration;
 use http::uri::{Authority, PathAndQuery, Scheme};
 use http::{HeaderMap, Method};
 use http_body_util::BodyExt as _;
-use http_body_util::combinators::BoxBody;
+use http_body_util::combinators::UnsyncBoxBody;
 use std::sync::Arc;
 use tokio::sync::oneshot;
 
@@ -52,7 +52,7 @@ impl Request {
         path_with_query: Option<PathAndQuery>,
         headers: impl Into<Arc<HeaderMap>>,
         options: Option<Arc<RequestOptions>>,
-        body: impl Into<BoxBody<Bytes, ErrorCode>>,
+        body: impl Into<UnsyncBoxBody<Bytes, ErrorCode>>,
     ) -> (
         Self,
         impl Future<Output = Result<(), ErrorCode>> + Send + 'static,
@@ -91,7 +91,7 @@ impl Request {
         impl Future<Output = Result<(), ErrorCode>> + Send + 'static,
     )
     where
-        T: http_body::Body<Data = Bytes> + Send + Sync + 'static,
+        T: http_body::Body<Data = Bytes> + Send + 'static,
         T::Error: Into<ErrorCode>,
     {
         let (
@@ -116,7 +116,7 @@ impl Request {
             path_and_query,
             headers,
             None,
-            body.map_err(Into::into).boxed(),
+            body.map_err(Into::into).boxed_unsync(),
         )
     }
 }

--- a/crates/wasi-http/src/p3/response.rs
+++ b/crates/wasi-http/src/p3/response.rs
@@ -6,7 +6,7 @@ use anyhow::Context as _;
 use bytes::Bytes;
 use http::{HeaderMap, StatusCode};
 use http_body_util::BodyExt as _;
-use http_body_util::combinators::BoxBody;
+use http_body_util::combinators::UnsyncBoxBody;
 use std::sync::Arc;
 use wasmtime::AsContextMut;
 
@@ -47,7 +47,7 @@ impl Response {
         self,
         store: impl AsContextMut<Data = T>,
         fut: impl Future<Output = Result<(), ErrorCode>> + Send + 'static,
-    ) -> wasmtime::Result<http::Response<BoxBody<Bytes, ErrorCode>>> {
+    ) -> wasmtime::Result<http::Response<UnsyncBoxBody<Bytes, ErrorCode>>> {
         self.into_http_with_getter(store, fut, T::http)
     }
 
@@ -58,7 +58,7 @@ impl Response {
         store: impl AsContextMut<Data = T>,
         fut: impl Future<Output = Result<(), ErrorCode>> + Send + 'static,
         getter: fn(&mut T) -> WasiHttpCtxView<'_>,
-    ) -> wasmtime::Result<http::Response<BoxBody<Bytes, ErrorCode>>> {
+    ) -> wasmtime::Result<http::Response<UnsyncBoxBody<Bytes, ErrorCode>>> {
         let res = http::Response::try_from(self)?;
         let (res, body) = res.into_parts();
         let body = match body {
@@ -80,7 +80,7 @@ impl Response {
                     ErrorCode::HttpResponseBodySize,
                     getter,
                 )
-                .boxed()
+                .boxed_unsync()
             }
             Body::Host { body, result_tx } => {
                 _ = result_tx.send(Box::new(fut));


### PR DESCRIPTION
This is a bit of a drive-by PR -- I do not entirely know what I am doing and am very open to pointers or feedback.

This PR replaces the BoxBody used in the p3 wasi-http implementation with UnsyncBoxBody. It is the same type, without the Sync constraint. The axum framework uses UnsyncBoxBody everywhere and is not compatible with the conversion functions in the p3 crate otherwise.

Since axum already happily uses the UnsyncBoxBody internally, I would guess it is a reasonable choice to use here, but I am not sure.

I tested code by running `cargo test --features=p3` in the wasi-http crate, and `cargo test all serve` for the CLI. I also got my own code locally to work against this branch and was able to forward an axum request to a wasm handler.