### PR TITLE
Add first-class type access of `component::Func`

### DIFF
--- a/crates/fuzzing/src/oracles.rs
+++ b/crates/fuzzing/src/oracles.rs
@@ -1108,17 +1108,16 @@ pub fn dynamic_component_api_target(input: &mut arbitrary::Unstructured) -> arbi
 
     let instance = linker.instantiate(&mut store, &component).unwrap();
     let func = instance.get_func(&mut store, EXPORT_FUNCTION).unwrap();
-    let param_tys = func.params(&store);
-    let result_tys = func.results(&store);
+    let ty = func.ty(&store);
 
     while input.arbitrary()? {
-        let params = param_tys
-            .iter()
-            .map(|(_, ty)| component_types::arbitrary_val(ty, input))
+        let params = ty
+            .params()
+            .map(|(_, ty)| component_types::arbitrary_val(&ty, input))
             .collect::<arbitrary::Result<Vec<_>>>()?;
-        let results = result_tys
-            .iter()
-            .map(|ty| component_types::arbitrary_val(ty, input))
+        let results = ty
+            .results()
+            .map(|ty| component_types::arbitrary_val(&ty, input))
             .collect::<arbitrary::Result<Vec<_>>>()?;
 
         *store.data_mut() = (params.clone(), Some(results.clone()));

--- a/crates/wast/src/wast.rs
+++ b/crates/wast/src/wast.rs
@@ -302,7 +302,8 @@ impl WastContext {
                         })
                         .collect::<Result<Vec<_>>>()?;
 
-                    let mut results = vec![component::Val::Bool(false); func.results(&store).len()];
+                    let mut results =
+                        vec![component::Val::Bool(false); func.ty(&store).results().len()];
                     let result = match &replace.rt {
                         Some(rt) => {
                             rt.block_on(func.call_async(&mut *store, &values, &mut results))

--- a/tests/all/component_model/resources.rs
+++ b/tests/all/component_model/resources.rs
@@ -541,13 +541,13 @@ fn dynamic_type() -> Result<()> {
     let b = i.get_func(&mut store, "b").unwrap();
     let t2 = i.get_resource(&mut store, "t2").unwrap();
 
-    let a_params = a.params(&store);
+    let aty = a.ty(&store);
     assert_eq!(
-        a_params[0],
-        ("x".to_string(), Type::Own(ResourceType::host::<MyType>()))
+        aty.params().next().unwrap(),
+        ("x", Type::Own(ResourceType::host::<MyType>()))
     );
-    let b_params = b.params(&store);
-    match &b_params[0] {
+    let bty = b.ty(&store);
+    match bty.params().next().unwrap() {
         (name, Type::Tuple(t)) => {
             assert_eq!(name, "x");
             assert_eq!(t.types().len(), 1);


### PR DESCRIPTION
When `Func:::{params,results}` was added we didn't have `types::ComponentFunc` at the time. Now that `ComponentFunc` exists it's cheaper and easier to access and work with that instead of the one-off accessors on `Func`.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
