### PR TITLE
Supply type information in `func_new` for components

### DIFF
--- a/benches/call.rs
+++ b/benches/call.rs
@@ -797,10 +797,10 @@ mod component {
             bench_instance(group, store, &instance, "typed", is_async);
 
             let mut untyped = component::Linker::new(&engine);
-            untyped.root().func_new("nop", |_, _, _| Ok(())).unwrap();
+            untyped.root().func_new("nop", |_, _, _, _| Ok(())).unwrap();
             untyped
                 .root()
-                .func_new("nop-params-and-results", |_caller, params, results| {
+                .func_new("nop-params-and-results", |_caller, _ty, params, results| {
                     assert_eq!(params.len(), 2);
                     match params[0] {
                         component::Val::U32(0) => {}

--- a/crates/c-api/src/component/linker.rs
+++ b/crates/c-api/src/component/linker.rs
@@ -123,7 +123,7 @@ pub unsafe extern "C" fn wasmtime_component_linker_instance_add_func(
 
     let result = linker_instance
         .linker_instance
-        .func_new(&name, move |ctx, args, rets| {
+        .func_new(&name, move |ctx, _ty, args, rets| {
             let _ = &foreign;
 
             let args = args

--- a/crates/fuzzing/src/oracles.rs
+++ b/crates/fuzzing/src/oracles.rs
@@ -1090,6 +1090,7 @@ pub fn dynamic_component_api_target(input: &mut arbitrary::Unstructured) -> arbi
         .root()
         .func_new(IMPORT_FUNCTION, {
             move |mut cx: StoreContextMut<'_, (Vec<Val>, Option<Vec<Val>>)>,
+                  _,
                   params: &[Val],
                   results: &mut [Val]|
                   -> Result<()> {

--- a/crates/misc/component-async-tests/tests/scenario/round_trip.rs
+++ b/crates/misc/component-async-tests/tests/scenario/round_trip.rs
@@ -352,7 +352,7 @@ pub async fn test_round_trip(
         linker
             .root()
             .instance("local:local/baz")?
-            .func_new_concurrent("[async]foo", |_, params, results| {
+            .func_new_concurrent("[async]foo", |_, _, params, results| {
                 Box::pin(async move {
                     sleep(Duration::from_millis(10)).await;
                     let Some(Val::String(s)) = params.into_iter().next() else {

--- a/crates/misc/component-async-tests/tests/scenario/round_trip_direct.rs
+++ b/crates/misc/component-async-tests/tests/scenario/round_trip_direct.rs
@@ -94,7 +94,7 @@ async fn test_round_trip_direct(
         wasmtime_wasi::p2::add_to_linker_async(&mut linker)?;
         linker
             .root()
-            .func_new_concurrent("[async]foo", |_, params, results| {
+            .func_new_concurrent("[async]foo", |_, _, params, results| {
                 Box::pin(async move {
                     sleep(Duration::from_millis(10)).await;
                     let Some(Val::String(s)) = params.into_iter().next() else {

--- a/crates/misc/component-async-tests/tests/scenario/round_trip_many.rs
+++ b/crates/misc/component-async-tests/tests/scenario/round_trip_many.rs
@@ -341,7 +341,7 @@ async fn test_round_trip_many(
         linker
             .root()
             .instance("local:local/many")?
-            .func_new_concurrent("[async]foo", |_, params, results| {
+            .func_new_concurrent("[async]foo", |_, _, params, results| {
                 Box::pin(async move {
                     sleep(Duration::from_millis(10)).await;
                     let mut params = params.into_iter();

--- a/tests/all/component_model/import.rs
+++ b/tests/all/component_model/import.rs
@@ -148,7 +148,7 @@ fn simple() -> Result<()> {
     let mut linker = Linker::new(&engine);
     linker.root().func_new(
         "a",
-        |mut store: StoreContextMut<'_, Option<String>>, args, _results| {
+        |mut store: StoreContextMut<'_, Option<String>>, _, args, _results| {
             if let Val::String(s) = &args[0] {
                 assert!(store.data().is_none());
                 *store.data_mut() = Some(s.to_string());
@@ -249,7 +249,7 @@ fn functions_in_instances() -> Result<()> {
     let mut linker = Linker::new(&engine);
     linker.instance("test:test/foo")?.func_new(
         "a",
-        |mut store: StoreContextMut<'_, Option<String>>, args, _results| {
+        |mut store: StoreContextMut<'_, Option<String>>, _, args, _results| {
             if let Val::String(s) = &args[0] {
                 assert!(store.data().is_none());
                 *store.data_mut() = Some(s.to_string());
@@ -462,7 +462,7 @@ fn attempt_to_reenter_during_host() -> Result<()> {
     let mut linker = Linker::new(&engine);
     linker.root().func_new(
         "thunk",
-        |mut store: StoreContextMut<'_, DynamicState>, _, _| {
+        |mut store: StoreContextMut<'_, DynamicState>, _, _, _| {
             let func = store.data_mut().func.take().unwrap();
             let trap = func.call(&mut store, &[], &mut []).unwrap_err();
             assert_eq!(
@@ -848,7 +848,7 @@ async fn test_stack_and_heap_args_and_rets(concurrent: bool) -> Result<()> {
     if concurrent {
         linker
             .root()
-            .func_new_concurrent("f1", |_, args, results| {
+            .func_new_concurrent("f1", |_, _, args, results| {
                 if let Val::U32(x) = &args[0] {
                     assert_eq!(*x, 1);
                     Box::pin(async {
@@ -861,7 +861,7 @@ async fn test_stack_and_heap_args_and_rets(concurrent: bool) -> Result<()> {
             })?;
         linker
             .root()
-            .func_new_concurrent("f2", |_, args, results| {
+            .func_new_concurrent("f2", |_, _, args, results| {
                 if let Val::Tuple(tuple) = &args[0] {
                     if let Val::String(s) = &tuple[0] {
                         assert_eq!(s.deref(), "abc");
@@ -878,7 +878,7 @@ async fn test_stack_and_heap_args_and_rets(concurrent: bool) -> Result<()> {
             })?;
         linker
             .root()
-            .func_new_concurrent("f3", |_, args, results| {
+            .func_new_concurrent("f3", |_, _, args, results| {
                 if let Val::U32(x) = &args[0] {
                     assert_eq!(*x, 8);
                     Box::pin(async {
@@ -891,7 +891,7 @@ async fn test_stack_and_heap_args_and_rets(concurrent: bool) -> Result<()> {
             })?;
         linker
             .root()
-            .func_new_concurrent("f4", |_, args, results| {
+            .func_new_concurrent("f4", |_, _, args, results| {
                 if let Val::Tuple(tuple) = &args[0] {
                     if let Val::String(s) = &tuple[0] {
                         assert_eq!(s.deref(), "abc");
@@ -907,7 +907,7 @@ async fn test_stack_and_heap_args_and_rets(concurrent: bool) -> Result<()> {
                 }
             })?;
     } else {
-        linker.root().func_new("f1", |_, args, results| {
+        linker.root().func_new("f1", |_, _, args, results| {
             if let Val::U32(x) = &args[0] {
                 assert_eq!(*x, 1);
                 results[0] = Val::U32(2);
@@ -916,7 +916,7 @@ async fn test_stack_and_heap_args_and_rets(concurrent: bool) -> Result<()> {
                 panic!()
             }
         })?;
-        linker.root().func_new("f2", |_, args, results| {
+        linker.root().func_new("f2", |_, _, args, results| {
             if let Val::Tuple(tuple) = &args[0] {
                 if let Val::String(s) = &tuple[0] {
                     assert_eq!(s.deref(), "abc");
@@ -929,7 +929,7 @@ async fn test_stack_and_heap_args_and_rets(concurrent: bool) -> Result<()> {
                 panic!()
             }
         })?;
-        linker.root().func_new("f3", |_, args, results| {
+        linker.root().func_new("f3", |_, _, args, results| {
             if let Val::U32(x) = &args[0] {
                 assert_eq!(*x, 8);
                 results[0] = Val::String("xyz".into());
@@ -938,7 +938,7 @@ async fn test_stack_and_heap_args_and_rets(concurrent: bool) -> Result<()> {
                 panic!();
             }
         })?;
-        linker.root().func_new("f4", |_, args, results| {
+        linker.root().func_new("f4", |_, _, args, results| {
             if let Val::Tuple(tuple) = &args[0] {
                 if let Val::String(s) = &tuple[0] {
                     assert_eq!(s.deref(), "abc");
@@ -1126,7 +1126,7 @@ fn no_actual_wasm_code() -> Result<()> {
     let mut linker = Linker::new(&engine);
     linker
         .root()
-        .func_new("f", |mut store: StoreContextMut<'_, u32>, _, _| {
+        .func_new("f", |mut store: StoreContextMut<'_, u32>, _, _, _| {
             *store.data_mut() += 1;
             Ok(())
         })?;

--- a/tests/all/intrinsics.rs
+++ b/tests/all/intrinsics.rs
@@ -93,7 +93,7 @@ fn native_loads_and_stores() -> Result<()> {
         linker.instance("host")?.func_new("get-pointer", {
             let ptr = ptr as usize;
             let ptr = u64::try_from(ptr).unwrap();
-            move |_cx, _args, results| {
+            move |_cx, _, _args, results| {
                 results[0] = component::Val::U64(ptr);
                 Ok(())
             }

--- a/tests/all/pulley.rs
+++ b/tests/all/pulley.rs
@@ -319,28 +319,34 @@ fn pulley_provenance_test_components() -> Result<()> {
         let mut linker = component::Linker::new(&engine);
         linker
             .root()
-            .func_new("host-empty", |_, _args, _results| Ok(()))?;
-        linker.root().func_new("host-u32", |_, args, results| {
+            .func_new("host-empty", |_, _, _args, _results| Ok(()))?;
+        linker.root().func_new("host-u32", |_, _, args, results| {
             results[0] = args[0].clone();
             Ok(())
         })?;
-        linker.root().func_new("host-enum", |_, args, results| {
+        linker.root().func_new("host-enum", |_, _, args, results| {
             results[0] = args[0].clone();
             Ok(())
         })?;
-        linker.root().func_new("host-option", |_, args, results| {
-            results[0] = args[0].clone();
-            Ok(())
-        })?;
-        linker.root().func_new("host-result", |_, args, results| {
-            results[0] = args[0].clone();
-            Ok(())
-        })?;
-        linker.root().func_new("host-string", |_, args, results| {
-            results[0] = args[0].clone();
-            Ok(())
-        })?;
-        linker.root().func_new("host-list", |_, args, results| {
+        linker
+            .root()
+            .func_new("host-option", |_, _, args, results| {
+                results[0] = args[0].clone();
+                Ok(())
+            })?;
+        linker
+            .root()
+            .func_new("host-result", |_, _, args, results| {
+                results[0] = args[0].clone();
+                Ok(())
+            })?;
+        linker
+            .root()
+            .func_new("host-string", |_, _, args, results| {
+                results[0] = args[0].clone();
+                Ok(())
+            })?;
+        linker.root().func_new("host-list", |_, _, args, results| {
             results[0] = args[0].clone();
             Ok(())
         })?;


### PR DESCRIPTION
Originally the `Linker::func_new` type for components was modeled after core wasm where a type was provided when the type was defined. This was difficult, however, because there's no way to construct types right now and instead a component had to be created and compiled to acquire type information from it. Later various refactorings meant that it was possible to drop the type information entirely from `func_new` meaning that it was "typeless" in a sense, and the functionality relied on the tagged nature of `Val` which always knows its type.

This has proven a bit difficult to integrate into Python in some work I've been doing. Namely in Python component values are (at least IMO) best represented as native Python values where possible. Native Python doesn't distinguish, however, between integer bit widths (or signededness). This means that converting a Python value to a component value requires type information to guide the conversion process. Currently when defining a function in a linker there's no way to get at this type information meaning that the types would need to be supplied in Python, bringing up the same shortcomings of not being able to create types.

In lieu of filling out type constructors, which is itself quite nontrivial, I've opted to do the next-most-easiest thing which is to supply the type to the callee when an import is invoked. This means that the callee has all the type information necessary. While this is somewhat costly in that it clones a few arcs it's expected to be a drop in the bucket compared to the inefficiencies of `Val` so it's at least in the same spirit of the cost of the API right now.

My intention is to use this to update the C API for components and eventually end up with type information when Python is invoked in wasmtime-py. Also while I'm using wasmtime-py as a motivating case here that's sort of just one example of a host embedding which doesn't have the full fidelity of Rust's type system and might benefit from this.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
