### PR TITLE
winch(docs): Small update to outdated docs

### DIFF
--- a/winch/codegen/src/isa/x64/regs.rs
+++ b/winch/codegen/src/isa/x64/regs.rs
@@ -59,9 +59,7 @@ pub(crate) fn r13() -> Reg {
 }
 /// Used as a pinned register to hold
 /// the `VMContext`.
-/// Non-allocatable in Winch's default
-/// ABI, and callee-saved in SystemV and
-/// Fastcall.
+/// Non-allocatable in Winch's default ABI.
 pub(crate) fn r14() -> Reg {
     gpr(ENC_R14)
 }


### PR DESCRIPTION
Winch no longer has a notion of {callee/caller}-saved registers.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
