### PR TITLE
Add `--async[=true|false]` flag to `wast` CLI

### DIFF
--- a/crates/fuzzing/src/oracles.rs
+++ b/crates/fuzzing/src/oracles.rs
@@ -758,6 +758,7 @@ pub fn wast_test(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<()> {
     } else {
         wasmtime_wast::Async::Yes
     };
+    log::debug!("async: {async_:?}");
     let engine = Engine::new(&fuzz_config.to_wasmtime()).unwrap();
     let mut wast_context = WastContext::new(&engine, async_, move |store| {
         fuzz_config.configure_store_epoch_and_fuel(store);

--- a/crates/wast/src/wast.rs
+++ b/crates/wast/src/wast.rs
@@ -92,7 +92,7 @@ enum Export<'a> {
 /// Whether or not to use async APIs when calling wasm during wast testing.
 ///
 /// Passed to [`WastContext::new`].
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 #[expect(missing_docs, reason = "self-describing variants")]
 pub enum Async {
     Yes,


### PR DESCRIPTION
This was needed to reproduce a fuzz bug recently and seemed like a good piece of functionality to have.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
