### PR TITLE
capi: Improve header management during build

### DIFF
--- a/crates/c-api/CMakeLists.txt
+++ b/crates/c-api/CMakeLists.txt
@@ -106,12 +106,15 @@ else()
     endif()
 endif()
 
-target_include_directories(wasmtime INTERFACE ${CMAKE_BINARY_DIR}/include)
-set(WASMTIME_HEADER_DST ${CMAKE_BINARY_DIR}/include)
-include(cmake/install-headers.cmake)
+target_include_directories(wasmtime
+  INTERFACE include
+  INTERFACE ${CMAKE_CURRENT_BINARY_DIR}/include)
+configure_file(include/wasmtime/conf.h.in include/wasmtime/conf.h)
 
 include(GNUInstallDirs)
-install(DIRECTORY "${WASMTIME_HEADER_DST}/" TYPE INCLUDE)
+install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/include/ TYPE INCLUDE)
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/ TYPE INCLUDE
+        FILES_MATCHING REGEX "\\.hh?$")
 install(FILES ${WASMTIME_SHARED_FILES} ${WASMTIME_STATIC_FILES}
         DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
@@ -130,15 +133,6 @@ add_custom_target(doc
     COMMAND doxygen ${DOXYGEN_CONF_OUT}
     DEPENDS ${WASMTIME_GENERATED_CONF_H} ${DOXYGEN_CONF_OUT}
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-add_dependencies(doc headers-to-doc)
-
-file(GLOB headers "include/*.h")
-add_custom_target(headers-to-doc
-  COMMAND
-    ${CMAKE_COMMAND}
-      -DWASMTIME_HEADER_DST=${CMAKE_BINARY_DIR}/include
-      -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/install-headers.cmake
-  DEPENDS ${headers})
 
 if (NOT CMAKE_CXX_STANDARD)
   message(STATUS "Cannot detect C++ Standard. Switching to C++17 by default !!")
@@ -167,11 +161,6 @@ if (MSVC)
 else()
   target_link_libraries(wasmtime-cpp INTERFACE stdc++ pthread)
 endif()
-
-target_include_directories(
-        wasmtime-cpp
-        INTERFACE
-        ${PROJECT_SOURCE_DIR}/include)
 
 if (BUILD_TESTS)
   message(STATUS "Building tests")

--- a/crates/c-api/doxygen.conf.in
+++ b/crates/c-api/doxygen.conf.in
@@ -864,7 +864,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = @CMAKE_BINARY_DIR@/include
+INPUT                  = @CMAKE_SOURCE_DIR@/include @CMAKE_BINARY_DIR@/include
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses


### PR DESCRIPTION
This commit improves the management of header files in cmake to pick up changes to them after-configure in some situations. Previously the cmake scripts would copy all wasmtime headers into the build directory to live adjacent to the `conf.h`-generated header. This meant that there was only one `-I` directory, for example, but it meant that changes to the source files after configuration weren't reflected in the output. This commit fixes this by leaving the source headers in-place. This means that there are now two include directories during building.

Various rules/targets should all be updated to handle this, and notably the build script of the C API still copies headers around as it did before (when built via Rust).

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
