### PR TITLE
capi: Add `define_unknown_imports_as_traps`

### DIFF
--- a/crates/c-api/include/wasmtime/component/linker.h
+++ b/crates/c-api/include/wasmtime/component/linker.h
@@ -76,6 +76,13 @@ WASM_API_EXTERN wasmtime_error_t *wasmtime_component_linker_instantiate(
     wasmtime_component_instance_t *instance_out);
 
 /**
+ * \brief Defines all unknown imports of `component` as trapping functions.
+ */
+WASM_API_EXTERN wasmtime_error_t *
+wasmtime_component_linker_define_unknown_imports_as_traps(
+    wasmtime_component_linker_t *linker, const wasmtime_component_t *component);
+
+/**
  * \brief Deletes a #wasmtime_component_linker_t created by
  * #wasmtime_component_linker_new
  *

--- a/crates/c-api/include/wasmtime/component/linker.hh
+++ b/crates/c-api/include/wasmtime/component/linker.hh
@@ -187,6 +187,18 @@ public:
     return LinkerInstance(instance_capi);
   }
 
+  /**
+   * \brief Defines all unknown imports of `component` as trapping functions.
+   */
+  Result<std::monostate>
+  define_unknown_imports_as_traps(const Component &component) {
+    auto err = wasmtime_component_linker_define_unknown_imports_as_traps(
+        ptr.get(), component.capi());
+    if (err)
+      return Error(err);
+    return std::monostate();
+  }
+
   /// Configures whether shadowing previous names is allowed or not.
   ///
   /// By default shadowing is not allowed.

--- a/crates/c-api/src/component/linker.rs
+++ b/crates/c-api/src/component/linker.rs
@@ -165,6 +165,17 @@ pub unsafe extern "C" fn wasmtime_component_linker_add_wasip2(
     crate::handle_result(result, |_| ())
 }
 
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn wasmtime_component_linker_define_unknown_imports_as_traps(
+    linker: &mut wasmtime_component_linker_t,
+    component: &wasmtime_component_t,
+) -> Option<Box<wasmtime_error_t>> {
+    let result = linker
+        .linker
+        .define_unknown_imports_as_traps(&component.component);
+    crate::handle_result(result, |_| ())
+}
+
 pub type wasmtime_component_resource_destructor_t =
     extern "C" fn(*mut c_void, WasmtimeStoreContextMut<'_>, u32) -> Option<Box<wasmtime_error_t>>;
 

--- a/crates/c-api/tests/component/linker.cc
+++ b/crates/c-api/tests/component/linker.cc
@@ -14,3 +14,20 @@ TEST(Linker, allow_shadowing) {
   linker.allow_shadowing(true);
   linker.root().add_module("x", m).unwrap();
 }
+
+TEST(Linker, unknown_imports_trap) {
+  wasmtime::Engine engine;
+  Linker linker(engine);
+  wasmtime::Store store(engine);
+
+  auto c = Component::compile(engine, R"(
+    (component
+      (import "a" (func))
+    )
+  )")
+               .unwrap();
+
+  EXPECT_FALSE(linker.instantiate(store, c));
+  EXPECT_TRUE(linker.define_unknown_imports_as_traps(c));
+  EXPECT_TRUE(linker.instantiate(store, c));
+}


### PR DESCRIPTION
Specifically add this to the component-side of the API to mirror the functionality for core wasm.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
