### PR TITLE
Change separator style for `new_indirect`, `spawn_indirect`, and `spawn_ref` intrinsics

### DIFF
--- a/crates/environ/src/component/info.rs
+++ b/crates/environ/src/component/info.rs
@@ -291,7 +291,7 @@ pub enum GlobalInitializer {
     /// from its `export` and stored into the `VMComponentContext` at the
     /// `index` specified. During this extraction, we will also capture the
     /// table's containing instance pointer to access the table at runtime. This
-    /// extraction is useful for `thread.spawn_indirect`.
+    /// extraction is useful for `thread.spawn-indirect`.
     ExtractTable(ExtractTable),
 
     /// Declares a new defined resource within this component.
@@ -1127,7 +1127,7 @@ pub enum Trampoline {
     /// Intrinsic used to implement the `thread.index` component model builtin.
     ThreadIndex,
 
-    /// Intrinsic used to implement the `thread.new_indirect` component model builtin.
+    /// Intrinsic used to implement the `thread.new-indirect` component model builtin.
     ThreadNewIndirect {
         /// The specific component instance which is calling the intrinsic.
         instance: RuntimeComponentInstanceIndex,

--- a/crates/test-util/src/wast.rs
+++ b/crates/test-util/src/wast.rs
@@ -666,16 +666,6 @@ impl WastTest {
         let failing_component_model_tests = [
             // FIXME(#11683)
             "component-model/test/values/trap-in-post-return.wast",
-            // Awaiting https://github.com/WebAssembly/component-model/pull/570
-            "component-model/test/resources/multiple-resources.wast",
-            "component-model/test/async/empty-wait.wast",
-            "component-model/test/async/drop-stream.wast",
-            "component-model/test/async/passing-resources.wast",
-            "component-model/test/async/async-calls-sync.wast",
-            "component-model/test/async/partial-stream-copies.wast",
-            "component-model/test/async/futures-must-write.wast",
-            "component-model/test/async/cancel-stream.wast",
-            "component-model/test/async/drop-waitable-set.wast",
         ];
         if failing_component_model_tests
             .iter()

--- a/crates/wasmtime/src/runtime/component/concurrent.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent.rs
@@ -2924,7 +2924,7 @@ impl Instance {
             .unwrap())
     }
 
-    /// Implements the `thread.new_indirect` intrinsic.
+    /// Implements the `thread.new-indirect` intrinsic.
     pub(crate) fn thread_new_indirect<T: 'static>(
         self,
         mut store: StoreContextMut<T>,
@@ -3495,7 +3495,7 @@ pub trait VMComponentAsyncStore {
         debug_msg_address: u32,
     ) -> Result<()>;
 
-    /// The `thread.new_indirect` intrinsic
+    /// The `thread.new-indirect` intrinsic
     fn thread_new_indirect(
         &mut self,
         instance: Instance,

--- a/tests/all/component_model/async.rs
+++ b/tests/all/component_model/async.rs
@@ -342,7 +342,7 @@ async fn task_deletion() -> Result<()> {
             (import "" "mem" (memory 1))
             (import "" "task.return" (func $task-return (param i32)))
             (import "" "task.cancel" (func $task-cancel))
-            (import "" "thread.new_indirect" (func $thread-new-indirect (param i32 i32) (result i32)))
+            (import "" "thread.new-indirect" (func $thread-new-indirect (param i32 i32) (result i32)))
             (import "" "thread.suspend" (func $thread-suspend (result i32)))
             (import "" "thread.suspend-cancellable" (func $thread-suspend-cancellable (result i32)))
             (import "" "thread.yield-to" (func $thread-yield-to (param i32) (result i32)))
@@ -419,7 +419,7 @@ async fn task_deletion() -> Result<()> {
                 (i32.const 0 (; EXIT ;)))
             
 
-            ;; Initialize the function table that will be used by thread.new_indirect
+            ;; Initialize the function table that will be used by thread.new-indirect
             (elem (table $indirect-function-table) (i32.const 0 (; call-return-ftbl-idx ;)) func $call-return)
             (elem (table $indirect-function-table) (i32.const 1 (; suspend-ftbl-idx ;)) func $suspend)
             (elem (table $indirect-function-table) (i32.const 2 (; yield-loop-ftbl-idx ;)) func $yield-loop)
@@ -427,14 +427,14 @@ async fn task_deletion() -> Result<()> {
 
         ;; Instantiate the libc module to get the table
         (core instance $libc (instantiate $libc))
-        ;; Get access to `thread.new_indirect` that uses the table from libc
+        ;; Get access to `thread.new-indirect` that uses the table from libc
         (core type $start-func-ty (func (param i32)))
         (alias core export $libc "__indirect_function_table" (core table $indirect-function-table))
 
         (core func $task-return (canon task.return (result u32)))
         (core func $task-cancel (canon task.cancel))
         (core func $thread-new-indirect 
-            (canon thread.new_indirect $start-func-ty (table $indirect-function-table)))
+            (canon thread.new-indirect $start-func-ty (table $indirect-function-table)))
         (core func $thread-yield (canon thread.yield))
         (core func $thread-yield-cancellable (canon thread.yield cancellable))
         (core func $thread-index (canon thread.index))
@@ -456,7 +456,7 @@ async fn task_deletion() -> Result<()> {
                     (export "mem" (memory $memory "mem"))
                     (export "task.return" (func $task-return))
                     (export "task.cancel" (func $task-cancel))
-                    (export "thread.new_indirect" (func $thread-new-indirect))
+                    (export "thread.new-indirect" (func $thread-new-indirect))
                     (export "thread.index" (func $thread-index))
                     (export "thread.yield-to" (func $thread-yield-to))
                     (export "thread.yield-to-cancellable" (func $thread-yield-to-cancellable))

--- a/tests/all/component_model/func.rs
+++ b/tests/all/component_model/func.rs
@@ -968,7 +968,7 @@ async fn missing_task_return_call_stackless_explicit_thread() -> Result<()> {
                 (table (export "__indirect_function_table") 1 funcref))
             (core module $m
                 (import "" "task.return" (func $task-return))
-                (import "" "thread.new_indirect" (func $thread-new-indirect (param i32 i32) (result i32)))
+                (import "" "thread.new-indirect" (func $thread-new-indirect (param i32 i32) (result i32)))
                 (import "" "thread.resume-later" (func $thread-resume-later (param i32)))
                 (import "libc" "__indirect_function_table" (table $indirect-function-table 1 funcref))
                 (func $thread-start (param i32) (; empty ;))
@@ -984,12 +984,12 @@ async fn missing_task_return_call_stackless_explicit_thread() -> Result<()> {
             (core type $start-func-ty (func (param i32)))
             (alias core export $libc "__indirect_function_table" (core table $indirect-function-table))
             (core func $thread-new-indirect 
-                (canon thread.new_indirect $start-func-ty (table $indirect-function-table)))
+                (canon thread.new-indirect $start-func-ty (table $indirect-function-table)))
             (core func $thread-resume-later (canon thread.resume-later))
             (core func $task-return (canon task.return))
             (core instance $i (instantiate $m
                 (with "" (instance 
-                    (export "thread.new_indirect" (func $thread-new-indirect))
+                    (export "thread.new-indirect" (func $thread-new-indirect))
                     (export "thread.resume-later" (func $thread-resume-later))
                     (export "task.return" (func $task-return))
                 ))
@@ -1010,7 +1010,7 @@ async fn missing_task_return_call_stackful_explicit_thread() -> Result<()> {
                 (table (export "__indirect_function_table") 1 funcref))
             (core module $m
                 (import "" "task.return" (func $task-return))
-                (import "" "thread.new_indirect" (func $thread-new-indirect (param i32 i32) (result i32)))
+                (import "" "thread.new-indirect" (func $thread-new-indirect (param i32 i32) (result i32)))
                 (import "" "thread.resume-later" (func $thread-resume-later (param i32)))
                 (import "libc" "__indirect_function_table" (table $indirect-function-table 1 funcref))
                 (func $thread-start (param i32) (; empty ;))
@@ -1024,12 +1024,12 @@ async fn missing_task_return_call_stackful_explicit_thread() -> Result<()> {
             (core type $start-func-ty (func (param i32)))
             (alias core export $libc "__indirect_function_table" (core table $indirect-function-table))
             (core func $thread-new-indirect 
-                (canon thread.new_indirect $start-func-ty (table $indirect-function-table)))
+                (canon thread.new-indirect $start-func-ty (table $indirect-function-table)))
             (core func $thread-resume-later (canon thread.resume-later))
             (core func $task-return (canon task.return))
             (core instance $i (instantiate $m
                 (with "" (instance 
-                    (export "thread.new_indirect" (func $thread-new-indirect))
+                    (export "thread.new-indirect" (func $thread-new-indirect))
                     (export "thread.resume-later" (func $thread-resume-later))
                     (export "task.return" (func $task-return))
                 ))

--- a/tests/misc_testsuite/component-model-threading/many-threads-indexed.wast
+++ b/tests/misc_testsuite/component-model-threading/many-threads-indexed.wast
@@ -27,10 +27,10 @@
     ;; Defines the table for the thread start function
     (core module $libc
         (table (export "__indirect_function_table") 1 funcref))
-    ;; Defines the thread start function and a function that calls thread.new_indirect
+    ;; Defines the thread start function and a function that calls thread.new-indirect
     (core module $m
         ;; Import the threading builtins and the table from libc
-        (import "" "thread.new_indirect" (func $thread-new-indirect (param i32 i32) (result i32)))
+        (import "" "thread.new-indirect" (func $thread-new-indirect (param i32 i32) (result i32)))
         (import "" "thread.suspend" (func $thread-suspend (result i32)))
         (import "" "thread.yield-to" (func $thread-yield-to (param i32) (result i32)))
         (import "" "thread.switch-to" (func $thread-switch-to (param i32) (result i32)))
@@ -58,7 +58,7 @@
         (export "thread-start" (func $thread-start))
 
         ;; Initialize the function table with our thread-start function; this will be
-        ;; used by thread.new_indirect
+        ;; used by thread.new-indirect
         (elem (table $indirect-function-table) (i32.const 0) func $thread-start)
 
         (func $new-thread (param i32)
@@ -94,12 +94,12 @@
     
     ;; Instantiate the libc module to get the table
     (core instance $libc (instantiate $libc))
-    ;; Get access to `thread.new_indirect` that uses the table from libc
+    ;; Get access to `thread.new-indirect` that uses the table from libc
     (core type $start-func-ty (func (param i32)))
     (alias core export $libc "__indirect_function_table" (core table $indirect-function-table))
 
     (core func $thread-new-indirect 
-        (canon thread.new_indirect $start-func-ty (table $indirect-function-table)))
+        (canon thread.new-indirect $start-func-ty (table $indirect-function-table)))
     (core func $thread-yield (canon thread.yield))
     (core func $thread-index (canon thread.index))
     (core func $thread-yield-to (canon thread.yield-to))
@@ -111,7 +111,7 @@
     (core instance $i (
         instantiate $m 
             (with "" (instance
-                (export "thread.new_indirect" (func $thread-new-indirect))
+                (export "thread.new-indirect" (func $thread-new-indirect))
                 (export "thread.index" (func $thread-index))
                 (export "thread.yield-to" (func $thread-yield-to))
                 (export "thread.yield" (func $thread-yield))

--- a/tests/misc_testsuite/component-model-threading/stackful-cancellation.wast
+++ b/tests/misc_testsuite/component-model-threading/stackful-cancellation.wast
@@ -46,7 +46,7 @@
         (core module $CM
             (import "" "mem" (memory 1))
             (import "" "task.cancel" (func $task-cancel))
-            (import "" "thread.new_indirect" (func $thread-new-indirect (param i32 i32) (result i32)))
+            (import "" "thread.new-indirect" (func $thread-new-indirect (param i32 i32) (result i32)))
             (import "" "thread.suspend" (func $thread-suspend (result i32)))
             (import "" "thread.suspend-cancellable" (func $thread-suspend-cancellable (result i32)))
             (import "" "thread.yield-to" (func $thread-yield-to (param i32) (result i32)))
@@ -102,7 +102,7 @@
                 (if (i32.ne (call $thread-yield) (i32.const 0)) (then unreachable))
             )
 
-            ;; Initialize the function table that will be used by thread.new_indirect
+            ;; Initialize the function table that will be used by thread.new-indirect
             (elem (table $indirect-function-table) (i32.const 0 (; wake-from-suspend-ftbl-idx ;)) func $wake-from-suspend)
             (elem (table $indirect-function-table) (i32.const 1 (; just-yield-ftbl-idx ;)) func $just-yield)
 
@@ -177,13 +177,13 @@
 
         ;; Instantiate the libc module to get the table
         (core instance $libc (instantiate $libc))
-        ;; Get access to `thread.new_indirect` that uses the table from libc
+        ;; Get access to `thread.new-indirect` that uses the table from libc
         (core type $start-func-ty (func (param i32)))
         (alias core export $libc "__indirect_function_table" (core table $indirect-function-table))
 
         (core func $task-cancel (canon task.cancel))
         (core func $thread-new-indirect 
-            (canon thread.new_indirect $start-func-ty (table $indirect-function-table)))
+            (canon thread.new-indirect $start-func-ty (table $indirect-function-table)))
         (core func $thread-yield (canon thread.yield))
         (core func $thread-yield-cancellable (canon thread.yield cancellable))
         (core func $thread-index (canon thread.index))
@@ -205,7 +205,7 @@
                 (with "" (instance
                     (export "mem" (memory $memory "mem"))
                     (export "task.cancel" (func $task-cancel))
-                    (export "thread.new_indirect" (func $thread-new-indirect))
+                    (export "thread.new-indirect" (func $thread-new-indirect))
                     (export "thread.index" (func $thread-index))
                     (export "thread.yield-to" (func $thread-yield-to))
                     (export "thread.yield-to-cancellable" (func $thread-yield-to-cancellable))

--- a/tests/misc_testsuite/component-model-threading/threading-builtins.wast
+++ b/tests/misc_testsuite/component-model-threading/threading-builtins.wast
@@ -8,10 +8,10 @@
     ;; Defines the table for the thread start function
     (core module $libc
         (table (export "__indirect_function_table") 1 funcref))
-    ;; Defines the thread start function and a function that calls thread.new_indirect
+    ;; Defines the thread start function and a function that calls thread.new-indirect
     (core module $m
         ;; Import the threading builtins and the table from libc
-        (import "" "thread.new_indirect" (func $thread-new-indirect (param i32 i32) (result i32)))
+        (import "" "thread.new-indirect" (func $thread-new-indirect (param i32 i32) (result i32)))
         (import "" "thread.suspend" (func $thread-suspend (result i32)))
         (import "" "thread.yield-to" (func $thread-yield-to (param i32) (result i32)))
         (import "" "thread.switch-to" (func $thread-switch-to (param i32) (result i32)))
@@ -43,7 +43,7 @@
         (export "thread-start" (func $thread-start))
 
         ;; Initialize the function table with our thread-start function; this will be
-        ;; used by thread.new_indirect
+        ;; used by thread.new-indirect
         (elem (table $indirect-function-table) (i32.const 0) func $thread-start)
 
         ;; The main entry point, which spawns a new thread to run `thread-start`, passing 42
@@ -70,12 +70,12 @@
     
     ;; Instantiate the libc module to get the table
     (core instance $libc (instantiate $libc))
-    ;; Get access to `thread.new_indirect` that uses the table from libc
+    ;; Get access to `thread.new-indirect` that uses the table from libc
     (core type $start-func-ty (func (param i32)))
     (alias core export $libc "__indirect_function_table" (core table $indirect-function-table))
 
     (core func $thread-new-indirect 
-        (canon thread.new_indirect $start-func-ty (table $indirect-function-table)))
+        (canon thread.new-indirect $start-func-ty (table $indirect-function-table)))
     (core func $thread-yield (canon thread.yield))
     (core func $thread-index (canon thread.index))
     (core func $thread-yield-to (canon thread.yield-to))
@@ -87,7 +87,7 @@
     (core instance $i (
         instantiate $m 
             (with "" (instance  
-                (export "thread.new_indirect" (func $thread-new-indirect))
+                (export "thread.new-indirect" (func $thread-new-indirect))
                 (export "thread.index" (func $thread-index))
                 (export "thread.yield-to" (func $thread-yield-to))
                 (export "thread.yield" (func $thread-yield))


### PR DESCRIPTION
The component model spec [was updated](https://github.com/WebAssembly/component-model/commit/1ba749ebb91c52ceb9040bac4dec0705cb034a96) to change the underscores in `thread.new_indirect`, `thread.spawn_indirect`, and `thread.spawn_ref` to hyphens, for consistency with other intrinsics. This PR applies this change to `wasm-tools`.

This PR also re-enables tests that were awaiting the above component model PR to merge.

Marked as draft awaiting https://github.com/bytecodealliance/wasm-tools/pull/2366