### PR TITLE
Move macos build back to stable

### DIFF
--- a/ci/build-build-matrix.js
+++ b/ci/build-build-matrix.js
@@ -44,11 +44,6 @@ const array = [
     // On OSX all we need to do is configure our deployment target as old as
     // possible. For now 10.12 is the limit.
     "env": { "MACOSX_DEPLOYMENT_TARGET": "10.12" },
-    // FIXME(#11783) we saw weird build errors with Rust 1.90 related to being
-    // unable to link stack-switching related symbols using #[naked] and such.
-    // Looks to be solved on beta, and once Rust 1.91 is stable this can be
-    // removed.
-    "rust": "beta",
   },
   {
     "build": "aarch64-macos",


### PR DESCRIPTION
This commit resolves a workaround added in #11783 and switches the macOS builders back to stable now that 1.91 is out.


<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
