### PR TITLE
Fix off-by-one bounds check for atomic operations

### DIFF
--- a/crates/test-util/src/wast.rs
+++ b/crates/test-util/src/wast.rs
@@ -411,6 +411,7 @@ impl WastTest {
                 "misc_testsuite/memory64/more-than-4gb.wast",
                 // shared memories + pooling allocator aren't supported yet
                 "misc_testsuite/memory-combos.wast",
+                "misc_testsuite/threads/atomics-end-of-memory.wast",
                 "misc_testsuite/threads/LB.wast",
                 "misc_testsuite/threads/LB_atomic.wast",
                 "misc_testsuite/threads/MP.wast",

--- a/crates/wasmtime/src/runtime/vm/memory.rs
+++ b/crates/wasmtime/src/runtime/vm/memory.rs
@@ -747,7 +747,7 @@ pub fn validate_atomic_addr(
     }
 
     let length = u64::try_from(def.current_length()).unwrap();
-    if !(addr.saturating_add(access_size) < length) {
+    if !(addr.saturating_add(access_size) <= length) {
         return Err(Trap::MemoryOutOfBounds);
     }
 

--- a/tests/misc_testsuite/threads/atomics-end-of-memory.wast
+++ b/tests/misc_testsuite/threads/atomics-end-of-memory.wast
@@ -1,0 +1,18 @@
+;;! threads = true
+
+(module
+  (memory (export "mem") 1 1 shared)
+  (func (export "notify_last") (result i32)
+    (memory.atomic.notify (i32.const 65532) (i32.const 0))
+  )
+  (func (export "wait_last32") (result i32)
+    (memory.atomic.wait32 (i32.const 65532) (i32.const 0) (i64.const 0))
+  )
+  (func (export "wait_last64") (result i32)
+    (memory.atomic.wait64 (i32.const 65528) (i64.const 0) (i64.const 0))
+  )
+)
+
+(assert_return (invoke "notify_last") (i32.const 0))
+(assert_return (invoke "wait_last32") (i32.const 2))
+(assert_return (invoke "wait_last64") (i32.const 2))


### PR DESCRIPTION
They're allowed to happen if the final address is the memory's length, as opposed to being one-less-than-the-memory's length.

Closes #11975

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
