### PR TITLE
feat: add support for wasi:config@0.2.0-rc.1 to wasi-config

### DIFF
--- a/ci/vendor-wit.sh
+++ b/ci/vendor-wit.sh
@@ -65,7 +65,7 @@ make_vendor "wasi-tls" "
   tls@v0.2.0-draft+505fc98
 "
 
-make_vendor "wasi-config" "config@f4d699b"
+make_vendor "wasi-config" "config@v0.2.0-rc.1"
 
 make_vendor "wasi-keyvalue" "keyvalue@219ea36"
 

--- a/crates/test-programs/src/lib.rs
+++ b/crates/test-programs/src/lib.rs
@@ -13,7 +13,7 @@ wit_bindgen::generate!({
         world test {
             include wasi:cli/imports@0.2.6;
             include wasi:http/imports@0.2.6;
-            include wasi:config/imports@0.2.0-draft;
+            include wasi:config/imports@0.2.0-rc.1;
             include wasi:keyvalue/imports@0.2.0-draft;
             include wasi:tls/imports@0.2.0-draft;
         }

--- a/crates/wasi-config/wit/deps/config/world.wit
+++ b/crates/wasi-config/wit/deps/config/world.wit
@@ -1,4 +1,4 @@
-package wasi:config@0.2.0-draft;
+package wasi:config@0.2.0-rc.1;
 
 world imports {
     /// The interface for wasi:config/store

--- a/crates/wasi-config/wit/world.wit
+++ b/crates/wasi-config/wit/world.wit
@@ -2,5 +2,5 @@
 package wasmtime:wasi-config;
 
 world bindings {
-  include wasi:config/imports@0.2.0-draft;
+  include wasi:config/imports@0.2.0-rc.1;
 }


### PR DESCRIPTION
This commit adds support for [the newly released `wasi:config@0.2.0-rc.1`](https://github.com/WebAssembly/WASI/pkgs/container/wasi%2Fconfig/565778971?tag=0.2.0-rc.1) to the `wasi-config` crate, maintaining support for `wasi:config@0.2.0-draft`.

To avoid breaking downstream users who are using the older versions,
it looks like some duplication of WIT is required as we can't include
the same interface at two different versions in the same WIT world.

This commit also updates the test programs to use
wasi:config@0.2.0-rc.1 going forward.


<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
