### PR TITLE
avoid sending redundant `Status::Started` for subtask

### DIFF
--- a/crates/misc/component-async-tests/tests/scenario/round_trip.rs
+++ b/crates/misc/component-async-tests/tests/scenario/round_trip.rs
@@ -43,6 +43,16 @@ pub async fn async_round_trip_stackless_plus_stackless() -> Result<()> {
 }
 
 #[tokio::test]
+pub async fn async_round_trip_stackless_plus_stackless_plus_stackless() -> Result<()> {
+    test_round_trip_composed_more(
+        test_programs_artifacts::ASYNC_ROUND_TRIP_STACKLESS_COMPONENT,
+        test_programs_artifacts::ASYNC_ROUND_TRIP_STACKLESS_COMPONENT,
+        test_programs_artifacts::ASYNC_ROUND_TRIP_STACKLESS_COMPONENT,
+    )
+    .await
+}
+
+#[tokio::test]
 async fn async_round_trip_synchronous_plus_stackless() -> Result<()> {
     test_round_trip_composed(
         test_programs_artifacts::ASYNC_ROUND_TRIP_SYNCHRONOUS_COMPONENT,
@@ -473,6 +483,30 @@ pub async fn test_round_trip_composed(a: &str, b: &str) -> Result<()> {
                 "hi y'all!",
                 "hi y'all! - entered guest - entered guest - entered host \
                  - exited host - exited guest - exited guest",
+            ),
+        ],
+    )
+    .await
+}
+
+pub async fn test_round_trip_composed_more(a: &str, b: &str, c: &str) -> Result<()> {
+    test_round_trip(
+        &[a, b, c],
+        &[
+            (
+                "hello, world!",
+                "hello, world! - entered guest - entered guest - entered guest - entered host \
+                 - exited host - exited guest - exited guest - exited guest",
+            ),
+            (
+                "¡hola, mundo!",
+                "¡hola, mundo! - entered guest - entered guest - entered guest - entered host \
+                 - exited host - exited guest - exited guest - exited guest",
+            ),
+            (
+                "hi y'all!",
+                "hi y'all! - entered guest - entered guest - entered guest - entered host \
+                 - exited host - exited guest - exited guest - exited guest",
             ),
         ],
     )


### PR DESCRIPTION
Previously, we sent this event both immediately after lowering parameters and when the async-with-callback-lifted export returned.  The latter was redundant, but it didn't matter in most cases because the second event usually overwrote the first one such that it was only delivered once.  However, in cases of three or more components composed together, both events got delivered, and that made `wit-bindgen` justifiably upset.

This removes the redundant event and adds a three component composition test to cover the scenario.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
