### PR TITLE
Add a case for wasmi trap code on error

### DIFF
--- a/crates/fuzzing/src/oracles/diff_wasmi.rs
+++ b/crates/fuzzing/src/oracles/diff_wasmi.rs
@@ -54,6 +54,9 @@ impl WasmiEngine {
             wasmi::errors::ErrorKind::Memory(wasmi::errors::MemoryError::OutOfBoundsAccess) => {
                 Some(wasmi::core::TrapCode::MemoryOutOfBounds)
             }
+            wasmi::errors::ErrorKind::Table(wasmi::errors::TableError::CopyOutOfBounds) => {
+                Some(wasmi::core::TrapCode::TableOutOfBounds)
+            }
             _ => {
                 log::trace!("unknown wasmi error: {:?}", err.kind());
                 None


### PR DESCRIPTION
Looks like the crate itself doesn't handle this in `as_trap_code`, so handle it manually.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
