### PR TITLE
Disable mach ports during fuzzing

### DIFF
--- a/crates/fuzzing/src/generators/config.rs
+++ b/crates/fuzzing/src/generators/config.rs
@@ -448,6 +448,15 @@ impl Config {
             self.wasmtime.async_config.configure(&mut cfg);
         }
 
+        // Fuzzing on macOS with mach ports seems to sometimes bypass the mach
+        // port handling thread entirely and go straight to asan's or fuzzing's
+        // signal handler. No idea why and for me at least it's just easier to
+        // disable mach ports when fuzzing because there's no need to use that
+        // over signal handlers.
+        if cfg!(target_vendor = "apple") {
+            cfg.macos_use_mach_ports(false);
+        }
+
         return cfg;
     }
 


### PR DESCRIPTION
Reported [here] and confirmed locally for myself it appears that sometimes exceptions bypass our mach port thread and go to signal handlers instead. I've got no idea why myself and it seems non-deterministic. Instead of trying to bottom this out I've gone ahead and just disabled mach ports during fuzzing. Mach ports are mainly there to play nice with Breakpad and such which isn't a concern during fuzzing, so using signals should work just as well.

[here]: https://github.com/bytecodealliance/wasmtime/issues/11850#issuecomment-3493237271

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
