### PR TITLE
Cranelift: Tweak cost function to make `imul` more expensive

### DIFF
--- a/cranelift/codegen/src/egraph/cost.rs
+++ b/cranelift/codegen/src/egraph/cost.rs
@@ -134,14 +134,6 @@ impl Cost {
             // "Expensive" arithmetic.
             Opcode::Imul => Cost::new(10, 0),
 
-            // Selects cannot be speculated through on some of our targets
-            // (e.g. x64) so strongly prefer not choosing them.
-            //
-            // TODO(#12005): Use target-specific cost functions so that `select`
-            // isn't avoided if the target can speculate through it or doesn't
-            // do speculation.
-            Opcode::Select => Cost::new(50, 0),
-
             // Everything else.
             _ => {
                 // By default, be slightly more expensive than "simple"


### PR DESCRIPTION
`select`s cannot be speculated through on some of our targets (e.g. x64) so strongly prefer not choosing them.

Using a target-specific cost function, so that we only pessimize `select` when it makes sense for the target, is left for follow up work and is tracked in #12005. FWIW, no CPUs on the market do value speculation today, as far as I am aware, so this particular case is somewhat hypothetical (but the larger goal of target-specific cost functions would still be useful).

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
