### PR TITLE
Fix spelling errors

### DIFF
--- a/ci/build-release-artifacts.sh
+++ b/ci/build-release-artifacts.sh
@@ -58,7 +58,7 @@ if [[ "$build" = *-min ]]; then
   cmake_flags="$cmake_flags -DWASMTIME_FEATURE_DISABLE_LOGGING=ON"
   cmake_flags="$cmake_flags -DWASMTIME_USER_CARGO_BUILD_OPTIONS:LIST=$build_std;$build_std_features"
 else
-  # For release builds the CLI is built a bit more feature-ful than the Cargo
+  # For release builds the CLI is built a bit more feature-full than the Cargo
   # defaults to provide artifacts that can do as much as possible.
   bin_flags="--features all-arch,component-model"
 fi

--- a/cranelift/codegen/src/isa/pulley_shared/abi.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/abi.rs
@@ -166,7 +166,7 @@ where
 
     fn gen_load_stack(mem: StackAMode, into_reg: Writable<Reg>, ty: Type) -> Self::I {
         let mut flags = MemFlags::trusted();
-        // Stack loads/stores of vectors always use little-endianess to avoid
+        // Stack loads/stores of vectors always use little-endianness to avoid
         // implementing a byte-swap of vectors on big-endian platforms.
         if ty.is_vector() {
             flags.set_endianness(ir::Endianness::Little);
@@ -176,7 +176,7 @@ where
 
     fn gen_store_stack(mem: StackAMode, from_reg: Reg, ty: Type) -> Self::I {
         let mut flags = MemFlags::trusted();
-        // Stack loads/stores of vectors always use little-endianess to avoid
+        // Stack loads/stores of vectors always use little-endianness to avoid
         // implementing a byte-swap of vectors on big-endian platforms.
         if ty.is_vector() {
             flags.set_endianness(ir::Endianness::Little);

--- a/cranelift/codegen/src/isa/pulley_shared/inst/emit.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/inst/emit.rs
@@ -125,7 +125,7 @@ fn pulley_emit<P>(
     P: PulleyTargetKind,
 {
     match inst {
-        // Pseduo-instructions that don't actually encode to anything.
+        // Pseudo-instructions that don't actually encode to anything.
         Inst::Args { .. } | Inst::Rets { .. } | Inst::DummyUse { .. } => {}
 
         Inst::TrapIf { cond, code } => {

--- a/crates/wizer/README.md
+++ b/crates/wizer/README.md
@@ -131,7 +131,7 @@ initialization function. Then we record the Wasm instance's state:
 * What are the values of its globals?
 * What regions of memory are non-zero?
 
-Then we rewrite the Wasm binary by intializing its globals directly to their
+Then we rewrite the Wasm binary by initializing its globals directly to their
 recorded state, and removing the module's old data segments and replacing them
 with data segments for each of the non-zero regions of memory we recorded.
 


### PR DESCRIPTION
  Corrected 4 spelling mistakes found by typos-cli:

  - `feature-ful` → `feature-full` in build script comment
  - `Pseduo` → `Pseudo` in Pulley codegen comment
  - `endianess` → `endianness` in Pulley ABI comments (2 occurrences)
  - `intializing` → `initializing` in Wizer README