### PR TITLE
Fix divide-by-zero during optimizations

### DIFF
--- a/cranelift/codegen/src/opts/arithmetic.isle
+++ b/cranelift/codegen/src/opts/arithmetic.isle
@@ -350,45 +350,43 @@
 ;; (x * C) (==/!=) D --> x (==/!=) (D / C) when C is odd and divides D
 (rule
   (simplify (ne ty (iconst_u ty1 x) (imul ty1 y (iconst_u ty1 z))))
-  (if-let 0 (u64_rem x z))
+  (if-let 0 (u64_checked_rem x z))
   (if-let 1 (u64_rem z 2))
   (ne ty y (iconst ty1 (imm64 (u64_div x z)))))
 (rule
   (simplify (ne ty (iconst_u ty1 x) (imul ty1 (iconst_u ty1 y) z)))
-  (if-let 0 (u64_rem x y))
+  (if-let 0 (u64_checked_rem x y))
   (if-let 1 (u64_rem y 2))
   (ne ty z (iconst ty1 (imm64 (u64_div x y)))))
 (rule
   (simplify (ne ty (imul ty1 x (iconst_u ty1 y)) (iconst_u ty1 z)))
-  (if-let 0 (u64_rem z y))
+  (if-let 0 (u64_checked_rem z y))
   (if-let 1 (u64_rem y 2))
   (ne ty x (iconst ty1 (imm64 (u64_div z y)))))
 (rule
   (simplify (ne ty (imul ty1 (iconst_u ty1 x) y) (iconst_u ty1 z)))
-  (if-let 0 (u64_rem z x))
+  (if-let 0 (u64_checked_rem z x))
   (if-let 1 (u64_rem x 2))
   (ne ty y (iconst ty1 (imm64 (u64_div z x)))))
 
 
 (rule
   (simplify (eq ty (iconst_u ty1 x) (imul ty1 y (iconst_u ty1 z))))
-  (if-let 0 (u64_rem x z))
+  (if-let 0 (u64_checked_rem x z))
   (if-let 1 (u64_rem z 2))
   (eq ty y (iconst ty1 (imm64 (u64_div x z)))))
 (rule
   (simplify (eq ty (iconst_u ty1 x) (imul ty1 (iconst_u ty1 y) z)))
-  (if-let 0 (u64_rem x y))
+  (if-let 0 (u64_checked_rem x y))
   (if-let 1 (u64_rem y 2))
   (eq ty z (iconst ty1 (imm64 (u64_div x y)))))
 (rule
   (simplify (eq ty (imul ty1 x (iconst_u ty1 y)) (iconst_u ty1 z)))
-  (if-let 0 (u64_rem z y))
+  (if-let 0 (u64_checked_rem z y))
   (if-let 1 (u64_rem y 2))
   (eq ty x (iconst ty1 (imm64 (u64_div z y)))))
 (rule
   (simplify (eq ty (imul ty1 (iconst_u ty1 x) y) (iconst_u ty1 z)))
-  (if-let 0 (u64_rem z x))
+  (if-let 0 (u64_checked_rem z x))
   (if-let 1 (u64_rem x 2))
   (eq ty y (iconst ty1 (imm64 (u64_div z x)))))
-
-

--- a/tests/misc_testsuite/no-opt-panic-dividing-by-zero.wast
+++ b/tests/misc_testsuite/no-opt-panic-dividing-by-zero.wast
@@ -1,0 +1,30 @@
+(module
+  (func (result i32)
+    (local i64 i32 i32)
+    i32.const 1
+    i32.clz
+    i32.clz
+    i32.popcnt
+    i64.extend_i32_s
+    local.get 0
+    i64.mul
+    local.get 0
+    i64.mul
+    i32.wrap_i64
+    i64.extend_i32_s
+    local.get 1
+    local.get 0
+    i32.const 1
+    i32.clz
+    i32.clz
+    i32.popcnt
+    i64.extend_i32_s
+    i64.mul
+    i64.const 0
+    i64.eq
+    i32.rotl
+    i64.extend_i32_s
+    i64.mul
+    i32.wrap_i64
+  )
+)


### PR DESCRIPTION
This commit fixes a minor regression from #11994 where a divide-by-zero was happening in a fuzz-generated input.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
