### PR TITLE
Release Wasmtime 36.0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -289,7 +289,7 @@ dependencies = [
 
 [[package]]
 name = "byte-array-literals"
-version = "36.0.2"
+version = "36.0.3"
 
 [[package]]
 name = "byteorder"
@@ -693,7 +693,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift"
-version = "0.123.2"
+version = "0.123.3"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",
@@ -706,7 +706,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.123.2"
+version = "0.123.3"
 dependencies = [
  "arbitrary",
  "arbtest",
@@ -724,21 +724,21 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.123.2"
+version = "0.123.3"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.123.2"
+version = "0.123.3"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.123.2"
+version = "0.123.3"
 dependencies = [
  "arbitrary",
  "serde",
@@ -747,7 +747,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.123.2"
+version = "0.123.3"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -782,7 +782,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.123.2"
+version = "0.123.3"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -793,18 +793,18 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.123.2"
+version = "0.123.3"
 
 [[package]]
 name = "cranelift-control"
-version = "0.123.2"
+version = "0.123.3"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.123.2"
+version = "0.123.3"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.123.2"
+version = "0.123.3"
 dependencies = [
  "cranelift-codegen",
  "env_logger 0.11.5",
@@ -869,7 +869,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-interpreter"
-version = "0.123.2"
+version = "0.123.3"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.123.2"
+version = "0.123.3"
 dependencies = [
  "codespan-reporting",
  "log",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-jit"
-version = "0.123.2"
+version = "0.123.3"
 dependencies = [
  "anyhow",
  "cranelift",
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-module"
-version = "0.123.2"
+version = "0.123.3"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -926,7 +926,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.123.2"
+version = "0.123.3"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-object"
-version = "0.123.2"
+version = "0.123.3"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -950,7 +950,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-reader"
-version = "0.123.2"
+version = "0.123.3"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -960,7 +960,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-serde"
-version = "0.123.2"
+version = "0.123.3"
 dependencies = [
  "clap",
  "cranelift-codegen",
@@ -970,7 +970,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.123.2"
+version = "0.123.3"
 
 [[package]]
 name = "cranelift-tools"
@@ -1221,7 +1221,7 @@ checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
 
 [[package]]
 name = "embedding"
-version = "36.0.2"
+version = "36.0.3"
 dependencies = [
  "anyhow",
  "dlmalloc",
@@ -2373,7 +2373,7 @@ dependencies = [
 
 [[package]]
 name = "min-platform-host"
-version = "36.0.2"
+version = "36.0.3"
 dependencies = [
  "anyhow",
  "libloading",
@@ -2816,7 +2816,7 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "36.0.2"
+version = "36.0.3"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -2840,7 +2840,7 @@ dependencies = [
 
 [[package]]
 name = "pulley-macros"
-version = "36.0.2"
+version = "36.0.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4066,7 +4066,7 @@ version = "0.1.0"
 
 [[package]]
 name = "verify-component-adapter"
-version = "36.0.2"
+version = "36.0.3"
 dependencies = [
  "anyhow",
  "wasmparser 0.236.0",
@@ -4134,7 +4134,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-common"
-version = "36.0.2"
+version = "36.0.3"
 dependencies = [
  "anyhow",
  "bitflags 2.6.0",
@@ -4173,7 +4173,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-preview1-component-adapter"
-version = "36.0.2"
+version = "36.0.3"
 dependencies = [
  "bitflags 2.6.0",
  "byte-array-literals",
@@ -4444,7 +4444,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "36.0.2"
+version = "36.0.3"
 dependencies = [
  "addr2line 0.25.0",
  "anyhow",
@@ -4509,7 +4509,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-bench-api"
-version = "36.0.2"
+version = "36.0.3"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -4525,14 +4525,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-c-api"
-version = "36.0.2"
+version = "36.0.3"
 dependencies = [
  "wasmtime-c-api-impl",
 ]
 
 [[package]]
 name = "wasmtime-c-api-impl"
-version = "36.0.2"
+version = "36.0.3"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -4549,7 +4549,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli"
-version = "36.0.2"
+version = "36.0.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4622,7 +4622,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli-flags"
-version = "36.0.2"
+version = "36.0.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -4637,7 +4637,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "36.0.2"
+version = "36.0.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -4743,14 +4743,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-asm-macros"
-version = "36.0.2"
+version = "36.0.3"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "wasmtime-internal-c-api-macros"
-version = "36.0.2"
+version = "36.0.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4758,7 +4758,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cache"
-version = "36.0.2"
+version = "36.0.3"
 dependencies = [
  "anyhow",
  "base64",
@@ -4779,7 +4779,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-macro"
-version = "36.0.2"
+version = "36.0.3"
 dependencies = [
  "anyhow",
  "component-macro-test-helpers",
@@ -4799,11 +4799,11 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-util"
-version = "36.0.2"
+version = "36.0.3"
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "36.0.2"
+version = "36.0.3"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4828,7 +4828,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-explorer"
-version = "36.0.2"
+version = "36.0.3"
 dependencies = [
  "anyhow",
  "capstone",
@@ -4843,7 +4843,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-fiber"
-version = "36.0.2"
+version = "36.0.3"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -4858,7 +4858,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-debug"
-version = "36.0.2"
+version = "36.0.3"
 dependencies = [
  "cc",
  "object 0.37.1",
@@ -4868,7 +4868,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "36.0.2"
+version = "36.0.3"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4878,18 +4878,18 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-math"
-version = "36.0.2"
+version = "36.0.3"
 dependencies = [
  "libm",
 ]
 
 [[package]]
 name = "wasmtime-internal-slab"
-version = "36.0.2"
+version = "36.0.3"
 
 [[package]]
 name = "wasmtime-internal-unwinder"
-version = "36.0.2"
+version = "36.0.3"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4900,7 +4900,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
-version = "36.0.2"
+version = "36.0.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4909,7 +4909,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-winch"
-version = "36.0.2"
+version = "36.0.3"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -4924,7 +4924,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-wit-bindgen"
-version = "36.0.2"
+version = "36.0.3"
 dependencies = [
  "anyhow",
  "bitflags 2.6.0",
@@ -4935,7 +4935,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-wmemcheck"
-version = "36.0.2"
+version = "36.0.3"
 
 [[package]]
 name = "wasmtime-test-macros"
@@ -4950,7 +4950,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-test-util"
-version = "36.0.2"
+version = "36.0.3"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -4968,7 +4968,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "36.0.2"
+version = "36.0.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5003,7 +5003,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-config"
-version = "36.0.2"
+version = "36.0.3"
 dependencies = [
  "anyhow",
  "test-programs-artifacts",
@@ -5014,7 +5014,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-http"
-version = "36.0.2"
+version = "36.0.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5041,7 +5041,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-io"
-version = "36.0.2"
+version = "36.0.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5052,7 +5052,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-keyvalue"
-version = "36.0.2"
+version = "36.0.3"
 dependencies = [
  "anyhow",
  "test-programs-artifacts",
@@ -5063,7 +5063,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-nn"
-version = "36.0.2"
+version = "36.0.3"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -5084,7 +5084,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-threads"
-version = "36.0.2"
+version = "36.0.3"
 dependencies = [
  "anyhow",
  "log",
@@ -5096,7 +5096,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-tls"
-version = "36.0.2"
+version = "36.0.3"
 dependencies = [
  "anyhow",
  "bytes",
@@ -5112,7 +5112,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-tls-nativetls"
-version = "36.0.2"
+version = "36.0.3"
 dependencies = [
  "anyhow",
  "futures",
@@ -5127,7 +5127,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wast"
-version = "36.0.2"
+version = "36.0.3"
 dependencies = [
  "anyhow",
  "json-from-wast",
@@ -5205,7 +5205,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "36.0.2"
+version = "36.0.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5222,7 +5222,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "36.0.2"
+version = "36.0.3"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -5234,7 +5234,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "36.0.2"
+version = "36.0.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5289,7 +5289,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "36.0.2"
+version = "36.0.3"
 dependencies = [
  "anyhow",
  "cranelift-assembler-x64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -174,7 +174,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "36.0.2"
+version = "36.0.3"
 authors = ["The Wasmtime Project Developers"]
 edition = "2024"
 # Wasmtime's current policy is that this number can be no larger than the
@@ -226,19 +226,19 @@ redundant_field_names = 'warn'
 # tooling but aren't intended to be widely depended on.
 #
 # All of these crates are supported though in the sense that
-wasmtime = { path = "crates/wasmtime", version = "36.0.2", default-features = false }
-wasmtime-cli-flags = { path = "crates/cli-flags", version = "=36.0.2" }
-wasmtime-environ = { path = "crates/environ", version = "=36.0.2" }
-wasmtime-wasi = { path = "crates/wasi", version = "36.0.2", default-features = false }
-wasmtime-wasi-io = { path = "crates/wasi-io", version = "36.0.2", default-features = false }
-wasmtime-wasi-http = { path = "crates/wasi-http", version = "36.0.2", default-features = false }
-wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "36.0.2" }
-wasmtime-wasi-config = { path = "crates/wasi-config", version = "36.0.2" }
-wasmtime-wasi-keyvalue = { path = "crates/wasi-keyvalue", version = "36.0.2" }
-wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "36.0.2" }
-wasmtime-wasi-tls = { path = "crates/wasi-tls", version = "36.0.2" }
-wasmtime-wasi-tls-nativetls = { path = "crates/wasi-tls-nativetls", version = "36.0.2" }
-wasmtime-wast = { path = "crates/wast", version = "=36.0.2" }
+wasmtime = { path = "crates/wasmtime", version = "36.0.3", default-features = false }
+wasmtime-cli-flags = { path = "crates/cli-flags", version = "=36.0.3" }
+wasmtime-environ = { path = "crates/environ", version = "=36.0.3" }
+wasmtime-wasi = { path = "crates/wasi", version = "36.0.3", default-features = false }
+wasmtime-wasi-io = { path = "crates/wasi-io", version = "36.0.3", default-features = false }
+wasmtime-wasi-http = { path = "crates/wasi-http", version = "36.0.3", default-features = false }
+wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "36.0.3" }
+wasmtime-wasi-config = { path = "crates/wasi-config", version = "36.0.3" }
+wasmtime-wasi-keyvalue = { path = "crates/wasi-keyvalue", version = "36.0.3" }
+wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "36.0.3" }
+wasmtime-wasi-tls = { path = "crates/wasi-tls", version = "36.0.3" }
+wasmtime-wasi-tls-nativetls = { path = "crates/wasi-tls-nativetls", version = "36.0.3" }
+wasmtime-wast = { path = "crates/wast", version = "=36.0.3" }
 
 # Internal Wasmtime-specific crates.
 #
@@ -247,54 +247,54 @@ wasmtime-wast = { path = "crates/wast", version = "=36.0.2" }
 # that these are internal unsupported crates for external use. These exist as
 # part of the project organization of other public crates in Wasmtime and are
 # otherwise not supported in terms of CVEs for example.
-wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=36.0.2", package = 'wasmtime-internal-wmemcheck' }
-wasmtime-c-api-macros = { path = "crates/c-api-macros", version = "=36.0.2", package = 'wasmtime-internal-c-api-macros' }
-wasmtime-cache = { path = "crates/cache", version = "=36.0.2", package = 'wasmtime-internal-cache' }
-wasmtime-cranelift = { path = "crates/cranelift", version = "=36.0.2", package = 'wasmtime-internal-cranelift' }
-wasmtime-winch = { path = "crates/winch", version = "=36.0.2", package = 'wasmtime-internal-winch'  }
-wasmtime-explorer = { path = "crates/explorer", version = "=36.0.2", package = 'wasmtime-internal-explorer'  }
-wasmtime-fiber = { path = "crates/fiber", version = "=36.0.2", package = 'wasmtime-internal-fiber' }
-wasmtime-jit-debug = { path = "crates/jit-debug", version = "=36.0.2", package = 'wasmtime-internal-jit-debug' }
-wasmtime-component-util = { path = "crates/component-util", version = "=36.0.2", package = 'wasmtime-internal-component-util' }
-wasmtime-component-macro = { path = "crates/component-macro", version = "=36.0.2", package = 'wasmtime-internal-component-macro' }
-wasmtime-asm-macros = { path = "crates/asm-macros", version = "=36.0.2", package = 'wasmtime-internal-asm-macros' }
-wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=36.0.2", package = 'wasmtime-internal-versioned-export-macros' }
-wasmtime-slab = { path = "crates/slab", version = "=36.0.2", package = 'wasmtime-internal-slab' }
-wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=36.0.2", package = 'wasmtime-internal-jit-icache-coherence' }
-wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=36.0.2", package = 'wasmtime-internal-wit-bindgen' }
-wasmtime-math = { path = "crates/math", version = "=36.0.2", package = 'wasmtime-internal-math'  }
-wasmtime-unwinder = { path = "crates/unwinder", version = "=36.0.2", package = 'wasmtime-internal-unwinder' }
+wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=36.0.3", package = 'wasmtime-internal-wmemcheck' }
+wasmtime-c-api-macros = { path = "crates/c-api-macros", version = "=36.0.3", package = 'wasmtime-internal-c-api-macros' }
+wasmtime-cache = { path = "crates/cache", version = "=36.0.3", package = 'wasmtime-internal-cache' }
+wasmtime-cranelift = { path = "crates/cranelift", version = "=36.0.3", package = 'wasmtime-internal-cranelift' }
+wasmtime-winch = { path = "crates/winch", version = "=36.0.3", package = 'wasmtime-internal-winch'  }
+wasmtime-explorer = { path = "crates/explorer", version = "=36.0.3", package = 'wasmtime-internal-explorer'  }
+wasmtime-fiber = { path = "crates/fiber", version = "=36.0.3", package = 'wasmtime-internal-fiber' }
+wasmtime-jit-debug = { path = "crates/jit-debug", version = "=36.0.3", package = 'wasmtime-internal-jit-debug' }
+wasmtime-component-util = { path = "crates/component-util", version = "=36.0.3", package = 'wasmtime-internal-component-util' }
+wasmtime-component-macro = { path = "crates/component-macro", version = "=36.0.3", package = 'wasmtime-internal-component-macro' }
+wasmtime-asm-macros = { path = "crates/asm-macros", version = "=36.0.3", package = 'wasmtime-internal-asm-macros' }
+wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=36.0.3", package = 'wasmtime-internal-versioned-export-macros' }
+wasmtime-slab = { path = "crates/slab", version = "=36.0.3", package = 'wasmtime-internal-slab' }
+wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=36.0.3", package = 'wasmtime-internal-jit-icache-coherence' }
+wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=36.0.3", package = 'wasmtime-internal-wit-bindgen' }
+wasmtime-math = { path = "crates/math", version = "=36.0.3", package = 'wasmtime-internal-math'  }
+wasmtime-unwinder = { path = "crates/unwinder", version = "=36.0.3", package = 'wasmtime-internal-unwinder' }
 
 # Miscellaneous crates without a `wasmtime-*` prefix in their name but still
 # used in the `wasmtime-*` family of crates depending on various features/etc.
-wiggle = { path = "crates/wiggle", version = "=36.0.2", default-features = false }
-wiggle-macro = { path = "crates/wiggle/macro", version = "=36.0.2" }
-wiggle-generate = { path = "crates/wiggle/generate", version = "=36.0.2" }
-wasi-common = { path = "crates/wasi-common", version = "=36.0.2", default-features = false }
-pulley-interpreter = { path = 'pulley', version = "=36.0.2" }
-pulley-macros = { path = 'pulley/macros', version = "=36.0.2" }
+wiggle = { path = "crates/wiggle", version = "=36.0.3", default-features = false }
+wiggle-macro = { path = "crates/wiggle/macro", version = "=36.0.3" }
+wiggle-generate = { path = "crates/wiggle/generate", version = "=36.0.3" }
+wasi-common = { path = "crates/wasi-common", version = "=36.0.3", default-features = false }
+pulley-interpreter = { path = 'pulley', version = "=36.0.3" }
+pulley-macros = { path = 'pulley/macros', version = "=36.0.3" }
 
 # Cranelift crates in this workspace
-cranelift-assembler-x64 = { path = "cranelift/assembler-x64", version = "0.123.2" }
-cranelift-codegen = { path = "cranelift/codegen", version = "0.123.2", default-features = false, features = ["std", "unwind"] }
-cranelift-frontend = { path = "cranelift/frontend", version = "0.123.2" }
-cranelift-entity = { path = "cranelift/entity", version = "0.123.2" }
-cranelift-native = { path = "cranelift/native", version = "0.123.2" }
-cranelift-module = { path = "cranelift/module", version = "0.123.2" }
-cranelift-interpreter = { path = "cranelift/interpreter", version = "0.123.2" }
-cranelift-reader = { path = "cranelift/reader", version = "0.123.2" }
+cranelift-assembler-x64 = { path = "cranelift/assembler-x64", version = "0.123.3" }
+cranelift-codegen = { path = "cranelift/codegen", version = "0.123.3", default-features = false, features = ["std", "unwind"] }
+cranelift-frontend = { path = "cranelift/frontend", version = "0.123.3" }
+cranelift-entity = { path = "cranelift/entity", version = "0.123.3" }
+cranelift-native = { path = "cranelift/native", version = "0.123.3" }
+cranelift-module = { path = "cranelift/module", version = "0.123.3" }
+cranelift-interpreter = { path = "cranelift/interpreter", version = "0.123.3" }
+cranelift-reader = { path = "cranelift/reader", version = "0.123.3" }
 cranelift-filetests = { path = "cranelift/filetests" }
-cranelift-object = { path = "cranelift/object", version = "0.123.2" }
-cranelift-jit = { path = "cranelift/jit", version = "0.123.2" }
+cranelift-object = { path = "cranelift/object", version = "0.123.3" }
+cranelift-jit = { path = "cranelift/jit", version = "0.123.3" }
 cranelift-fuzzgen = { path = "cranelift/fuzzgen" }
-cranelift-bforest = { path = "cranelift/bforest", version = "0.123.2" }
-cranelift-bitset = { path = "cranelift/bitset", version = "0.123.2" }
-cranelift-control = { path = "cranelift/control", version = "0.123.2" }
-cranelift-srcgen = { path = "cranelift/srcgen", version = "0.123.2" }
-cranelift = { path = "cranelift/umbrella", version = "0.123.2" }
+cranelift-bforest = { path = "cranelift/bforest", version = "0.123.3" }
+cranelift-bitset = { path = "cranelift/bitset", version = "0.123.3" }
+cranelift-control = { path = "cranelift/control", version = "0.123.3" }
+cranelift-srcgen = { path = "cranelift/srcgen", version = "0.123.3" }
+cranelift = { path = "cranelift/umbrella", version = "0.123.3" }
 
 # Winch crates in this workspace.
-winch-codegen = { path = "winch/codegen", version = "=36.0.2" }
+winch-codegen = { path = "winch/codegen", version = "=36.0.3" }
 
 # Internal crates not published to crates.io used in testing, builds, etc
 wasi-preview1-component-adapter = { path = "crates/wasi-preview1-component-adapter" }

--- a/cranelift/assembler-x64/Cargo.toml
+++ b/cranelift/assembler-x64/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-assembler-x64"
 description = "A Cranelift-specific x64 assembler"
-version = "0.123.2"
+version = "0.123.3"
 license = "Apache-2.0 WITH LLVM-exception"
 edition.workspace = true
 rust-version.workspace = true
@@ -16,7 +16,7 @@ arbtest = "0.3.1"
 capstone = { workspace = true }
 
 [build-dependencies]
-cranelift-assembler-x64-meta = { path = "meta", version = "0.123.2" }
+cranelift-assembler-x64-meta = { path = "meta", version = "0.123.3" }
 
 [lints]
 workspace = true

--- a/cranelift/assembler-x64/meta/Cargo.toml
+++ b/cranelift/assembler-x64/meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-assembler-x64-meta"
 description = "Generate a Cranelift-specific assembler for x64 instructions"
-version = "0.123.2"
+version = "0.123.3"
 license = "Apache-2.0 WITH LLVM-exception"
 edition.workspace = true
 rust-version.workspace = true

--- a/cranelift/bforest/Cargo.toml
+++ b/cranelift/bforest/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bforest"
-version = "0.123.2"
+version = "0.123.3"
 description = "A forest of B+-trees"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-bforest"

--- a/cranelift/bitset/Cargo.toml
+++ b/cranelift/bitset/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bitset"
-version = "0.123.2"
+version = "0.123.3"
 description = "Various bitset stuff for use inside Cranelift"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-bitset"

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen"
-version = "0.123.2"
+version = "0.123.3"
 description = "Low-level code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-codegen"
@@ -25,7 +25,7 @@ anyhow = { workspace = true, optional = true, features = ['std'] }
 bumpalo = "3"
 capstone = { workspace = true, optional = true }
 cranelift-assembler-x64 = { workspace = true }
-cranelift-codegen-shared = { path = "./shared", version = "0.123.2" }
+cranelift-codegen-shared = { path = "./shared", version = "0.123.3" }
 cranelift-entity = { workspace = true }
 cranelift-bforest = { workspace = true }
 cranelift-bitset = { workspace = true }
@@ -56,8 +56,8 @@ env_logger = { workspace = true }
 proptest = { workspace = true }
 
 [build-dependencies]
-cranelift-codegen-meta = { path = "meta", version = "0.123.2" }
-cranelift-isle = { path = "../isle/isle", version = "=0.123.2" }
+cranelift-codegen-meta = { path = "meta", version = "0.123.3" }
+cranelift-isle = { path = "../isle/isle", version = "=0.123.3" }
 
 [features]
 default = ["std", "unwind", "host-arch", "timing"]

--- a/cranelift/codegen/meta/Cargo.toml
+++ b/cranelift/codegen/meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-codegen-meta"
 authors = ["The Cranelift Project Developers"]
-version = "0.123.2"
+version = "0.123.3"
 description = "Metaprogram for cranelift-codegen code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
@@ -17,8 +17,8 @@ rustdoc-args = ["--document-private-items"]
 
 [dependencies]
 cranelift-srcgen = { workspace = true }
-cranelift-assembler-x64-meta = { path = "../../assembler-x64/meta", version = "0.123.2" }
-cranelift-codegen-shared = { path = "../shared", version = "0.123.2" }
+cranelift-assembler-x64-meta = { path = "../../assembler-x64/meta", version = "0.123.3" }
+cranelift-codegen-shared = { path = "../shared", version = "0.123.3" }
 pulley-interpreter = { workspace = true, optional = true }
 heck = "0.5.0"
 

--- a/cranelift/codegen/shared/Cargo.toml
+++ b/cranelift/codegen/shared/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen-shared"
-version = "0.123.2"
+version = "0.123.3"
 description = "For code shared between cranelift-codegen-meta and cranelift-codegen"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/control/Cargo.toml
+++ b/cranelift/control/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-control"
-version = "0.123.2"
+version = "0.123.3"
 description = "White-box fuzz testing framework"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/entity/Cargo.toml
+++ b/cranelift/entity/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-entity"
-version = "0.123.2"
+version = "0.123.3"
 description = "Data structures using entity references as mapping keys"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-entity"

--- a/cranelift/frontend/Cargo.toml
+++ b/cranelift/frontend/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-frontend"
-version = "0.123.2"
+version = "0.123.3"
 description = "Cranelift IR builder helper"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-frontend"

--- a/cranelift/interpreter/Cargo.toml
+++ b/cranelift/interpreter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-interpreter"
-version = "0.123.2"
+version = "0.123.3"
 authors = ["The Cranelift Project Developers"]
 description = "Interpret Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/isle/isle/Cargo.toml
+++ b/cranelift/isle/isle/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 name = "cranelift-isle"
 readme = "../README.md"
 repository = "https://github.com/bytecodealliance/wasmtime/tree/main/cranelift/isle"
-version = "0.123.2"
+version = "0.123.3"
 
 [lints]
 workspace = true

--- a/cranelift/jit/Cargo.toml
+++ b/cranelift/jit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-jit"
-version = "0.123.2"
+version = "0.123.3"
 authors = ["The Cranelift Project Developers"]
 description = "A JIT library backed by Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/module/Cargo.toml
+++ b/cranelift/module/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-module"
-version = "0.123.2"
+version = "0.123.3"
 authors = ["The Cranelift Project Developers"]
 description = "Support for linking functions and data with Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/native/Cargo.toml
+++ b/cranelift/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-native"
-version = "0.123.2"
+version = "0.123.3"
 authors = ["The Cranelift Project Developers"]
 description = "Support for targeting the host with Cranelift"
 documentation = "https://docs.rs/cranelift-native"

--- a/cranelift/object/Cargo.toml
+++ b/cranelift/object/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-object"
-version = "0.123.2"
+version = "0.123.3"
 authors = ["The Cranelift Project Developers"]
 description = "Emit Cranelift output to native object files with `object`"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/reader/Cargo.toml
+++ b/cranelift/reader/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-reader"
-version = "0.123.2"
+version = "0.123.3"
 description = "Cranelift textual IR reader"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-reader"

--- a/cranelift/serde/Cargo.toml
+++ b/cranelift/serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-serde"
-version = "0.123.2"
+version = "0.123.3"
 authors = ["The Cranelift Project Developers"]
 description = "Serializer/Deserializer for Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/srcgen/Cargo.toml
+++ b/cranelift/srcgen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-srcgen"
-version = "0.123.2"
+version = "0.123.3"
 authors = ["The Wasmtime Project Developers"]
 description = "Helper functions for generating Rust and ISLE files"
 license = "Apache-2.0 WITH LLVM-exception"

--- a/cranelift/umbrella/Cargo.toml
+++ b/cranelift/umbrella/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift"
-version = "0.123.2"
+version = "0.123.3"
 description = "Umbrella for commonly-used cranelift crates"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift"

--- a/crates/c-api/include/wasmtime.h
+++ b/crates/c-api/include/wasmtime.h
@@ -213,7 +213,7 @@
 /**
  * \brief Wasmtime version string.
  */
-#define WASMTIME_VERSION "36.0.2"
+#define WASMTIME_VERSION "36.0.3"
 /**
  * \brief Wasmtime major version number.
  */
@@ -225,6 +225,6 @@
 /**
  * \brief Wasmtime patch version number.
  */
-#define WASMTIME_VERSION_PATCH 2
+#define WASMTIME_VERSION_PATCH 3
 
 #endif // WASMTIME_API_H

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -21,6 +21,10 @@ audited_as = "0.123.0"
 version = "0.123.2"
 audited_as = "0.123.1"
 
+[[unpublished.cranelift]]
+version = "0.123.3"
+audited_as = "0.123.2"
+
 [[unpublished.cranelift-assembler-x64]]
 version = "0.121.0"
 audited_as = "0.120.0"
@@ -40,6 +44,10 @@ audited_as = "0.123.0"
 [[unpublished.cranelift-assembler-x64]]
 version = "0.123.2"
 audited_as = "0.123.1"
+
+[[unpublished.cranelift-assembler-x64]]
+version = "0.123.3"
+audited_as = "0.123.2"
 
 [[unpublished.cranelift-assembler-x64-meta]]
 version = "0.121.0"
@@ -61,6 +69,10 @@ audited_as = "0.123.0"
 version = "0.123.2"
 audited_as = "0.123.1"
 
+[[unpublished.cranelift-assembler-x64-meta]]
+version = "0.123.3"
+audited_as = "0.123.2"
+
 [[unpublished.cranelift-bforest]]
 version = "0.121.0"
 audited_as = "0.120.0"
@@ -80,6 +92,10 @@ audited_as = "0.123.0"
 [[unpublished.cranelift-bforest]]
 version = "0.123.2"
 audited_as = "0.123.1"
+
+[[unpublished.cranelift-bforest]]
+version = "0.123.3"
+audited_as = "0.123.2"
 
 [[unpublished.cranelift-bitset]]
 version = "0.121.0"
@@ -101,6 +117,10 @@ audited_as = "0.123.0"
 version = "0.123.2"
 audited_as = "0.123.1"
 
+[[unpublished.cranelift-bitset]]
+version = "0.123.3"
+audited_as = "0.123.2"
+
 [[unpublished.cranelift-codegen]]
 version = "0.121.0"
 audited_as = "0.120.0"
@@ -120,6 +140,10 @@ audited_as = "0.123.0"
 [[unpublished.cranelift-codegen]]
 version = "0.123.2"
 audited_as = "0.123.1"
+
+[[unpublished.cranelift-codegen]]
+version = "0.123.3"
+audited_as = "0.123.2"
 
 [[unpublished.cranelift-codegen-meta]]
 version = "0.121.0"
@@ -141,6 +165,10 @@ audited_as = "0.123.0"
 version = "0.123.2"
 audited_as = "0.123.1"
 
+[[unpublished.cranelift-codegen-meta]]
+version = "0.123.3"
+audited_as = "0.123.2"
+
 [[unpublished.cranelift-codegen-shared]]
 version = "0.121.0"
 audited_as = "0.120.0"
@@ -160,6 +188,10 @@ audited_as = "0.123.0"
 [[unpublished.cranelift-codegen-shared]]
 version = "0.123.2"
 audited_as = "0.123.1"
+
+[[unpublished.cranelift-codegen-shared]]
+version = "0.123.3"
+audited_as = "0.123.2"
 
 [[unpublished.cranelift-control]]
 version = "0.121.0"
@@ -181,6 +213,10 @@ audited_as = "0.123.0"
 version = "0.123.2"
 audited_as = "0.123.1"
 
+[[unpublished.cranelift-control]]
+version = "0.123.3"
+audited_as = "0.123.2"
+
 [[unpublished.cranelift-entity]]
 version = "0.121.0"
 audited_as = "0.120.0"
@@ -200,6 +236,10 @@ audited_as = "0.123.0"
 [[unpublished.cranelift-entity]]
 version = "0.123.2"
 audited_as = "0.123.1"
+
+[[unpublished.cranelift-entity]]
+version = "0.123.3"
+audited_as = "0.123.2"
 
 [[unpublished.cranelift-frontend]]
 version = "0.121.0"
@@ -221,6 +261,10 @@ audited_as = "0.123.0"
 version = "0.123.2"
 audited_as = "0.123.1"
 
+[[unpublished.cranelift-frontend]]
+version = "0.123.3"
+audited_as = "0.123.2"
+
 [[unpublished.cranelift-interpreter]]
 version = "0.121.0"
 audited_as = "0.120.0"
@@ -240,6 +284,10 @@ audited_as = "0.123.0"
 [[unpublished.cranelift-interpreter]]
 version = "0.123.2"
 audited_as = "0.123.1"
+
+[[unpublished.cranelift-interpreter]]
+version = "0.123.3"
+audited_as = "0.123.2"
 
 [[unpublished.cranelift-isle]]
 version = "0.121.0"
@@ -261,6 +309,10 @@ audited_as = "0.123.0"
 version = "0.123.2"
 audited_as = "0.123.1"
 
+[[unpublished.cranelift-isle]]
+version = "0.123.3"
+audited_as = "0.123.2"
+
 [[unpublished.cranelift-jit]]
 version = "0.121.0"
 audited_as = "0.120.0"
@@ -280,6 +332,10 @@ audited_as = "0.123.0"
 [[unpublished.cranelift-jit]]
 version = "0.123.2"
 audited_as = "0.123.1"
+
+[[unpublished.cranelift-jit]]
+version = "0.123.3"
+audited_as = "0.123.2"
 
 [[unpublished.cranelift-module]]
 version = "0.121.0"
@@ -301,6 +357,10 @@ audited_as = "0.123.0"
 version = "0.123.2"
 audited_as = "0.123.1"
 
+[[unpublished.cranelift-module]]
+version = "0.123.3"
+audited_as = "0.123.2"
+
 [[unpublished.cranelift-native]]
 version = "0.121.0"
 audited_as = "0.120.0"
@@ -320,6 +380,10 @@ audited_as = "0.123.0"
 [[unpublished.cranelift-native]]
 version = "0.123.2"
 audited_as = "0.123.1"
+
+[[unpublished.cranelift-native]]
+version = "0.123.3"
+audited_as = "0.123.2"
 
 [[unpublished.cranelift-object]]
 version = "0.121.0"
@@ -341,6 +405,10 @@ audited_as = "0.123.0"
 version = "0.123.2"
 audited_as = "0.123.1"
 
+[[unpublished.cranelift-object]]
+version = "0.123.3"
+audited_as = "0.123.2"
+
 [[unpublished.cranelift-reader]]
 version = "0.121.0"
 audited_as = "0.120.0"
@@ -361,6 +429,10 @@ audited_as = "0.123.0"
 version = "0.123.2"
 audited_as = "0.123.1"
 
+[[unpublished.cranelift-reader]]
+version = "0.123.3"
+audited_as = "0.123.2"
+
 [[unpublished.cranelift-serde]]
 version = "0.121.0"
 audited_as = "0.120.0"
@@ -381,6 +453,10 @@ audited_as = "0.123.0"
 version = "0.123.2"
 audited_as = "0.123.1"
 
+[[unpublished.cranelift-serde]]
+version = "0.123.3"
+audited_as = "0.123.2"
+
 [[unpublished.cranelift-srcgen]]
 version = "0.121.0"
 audited_as = "0.120.0"
@@ -400,6 +476,10 @@ audited_as = "0.123.0"
 [[unpublished.cranelift-srcgen]]
 version = "0.123.2"
 audited_as = "0.123.1"
+
+[[unpublished.cranelift-srcgen]]
+version = "0.123.3"
+audited_as = "0.123.2"
 
 [[unpublished.pulley-interpreter]]
 version = "34.0.0"
@@ -420,6 +500,10 @@ audited_as = "36.0.0"
 [[unpublished.pulley-interpreter]]
 version = "36.0.2"
 audited_as = "36.0.1"
+
+[[unpublished.pulley-interpreter]]
+version = "36.0.3"
+audited_as = "36.0.2"
 
 [[unpublished.pulley-macros]]
 version = "35.0.0"
@@ -437,6 +521,10 @@ audited_as = "36.0.0"
 version = "36.0.2"
 audited_as = "36.0.1"
 
+[[unpublished.pulley-macros]]
+version = "36.0.3"
+audited_as = "36.0.2"
+
 [[unpublished.wasi-common]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -457,6 +545,10 @@ audited_as = "36.0.0"
 version = "36.0.2"
 audited_as = "36.0.1"
 
+[[unpublished.wasi-common]]
+version = "36.0.3"
+audited_as = "36.0.2"
+
 [[unpublished.wasmtime]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -476,6 +568,10 @@ audited_as = "36.0.0"
 [[unpublished.wasmtime]]
 version = "36.0.2"
 audited_as = "36.0.1"
+
+[[unpublished.wasmtime]]
+version = "36.0.3"
+audited_as = "36.0.2"
 
 [[unpublished.wasmtime-asm-macros]]
 version = "34.0.0"
@@ -513,6 +609,10 @@ audited_as = "36.0.0"
 version = "36.0.2"
 audited_as = "36.0.1"
 
+[[unpublished.wasmtime-cli]]
+version = "36.0.3"
+audited_as = "36.0.2"
+
 [[unpublished.wasmtime-cli-flags]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -532,6 +632,10 @@ audited_as = "36.0.0"
 [[unpublished.wasmtime-cli-flags]]
 version = "36.0.2"
 audited_as = "36.0.1"
+
+[[unpublished.wasmtime-cli-flags]]
+version = "36.0.3"
+audited_as = "36.0.2"
 
 [[unpublished.wasmtime-component-macro]]
 version = "34.0.0"
@@ -577,6 +681,10 @@ audited_as = "36.0.0"
 version = "36.0.2"
 audited_as = "36.0.1"
 
+[[unpublished.wasmtime-environ]]
+version = "36.0.3"
+audited_as = "36.0.2"
+
 [[unpublished.wasmtime-explorer]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -605,6 +713,10 @@ audited_as = "36.0.0"
 version = "36.0.2"
 audited_as = "36.0.1"
 
+[[unpublished.wasmtime-internal-asm-macros]]
+version = "36.0.3"
+audited_as = "36.0.2"
+
 [[unpublished.wasmtime-internal-c-api-macros]]
 version = "36.0.0"
 audited_as = "35.0.0"
@@ -616,6 +728,10 @@ audited_as = "36.0.0"
 [[unpublished.wasmtime-internal-c-api-macros]]
 version = "36.0.2"
 audited_as = "36.0.1"
+
+[[unpublished.wasmtime-internal-c-api-macros]]
+version = "36.0.3"
+audited_as = "36.0.2"
 
 [[unpublished.wasmtime-internal-cache]]
 version = "36.0.0"
@@ -629,6 +745,10 @@ audited_as = "36.0.0"
 version = "36.0.2"
 audited_as = "36.0.1"
 
+[[unpublished.wasmtime-internal-cache]]
+version = "36.0.3"
+audited_as = "36.0.2"
+
 [[unpublished.wasmtime-internal-component-macro]]
 version = "36.0.0"
 audited_as = "35.0.0"
@@ -640,6 +760,10 @@ audited_as = "36.0.0"
 [[unpublished.wasmtime-internal-component-macro]]
 version = "36.0.2"
 audited_as = "36.0.1"
+
+[[unpublished.wasmtime-internal-component-macro]]
+version = "36.0.3"
+audited_as = "36.0.2"
 
 [[unpublished.wasmtime-internal-component-util]]
 version = "36.0.0"
@@ -653,6 +777,10 @@ audited_as = "36.0.0"
 version = "36.0.2"
 audited_as = "36.0.1"
 
+[[unpublished.wasmtime-internal-component-util]]
+version = "36.0.3"
+audited_as = "36.0.2"
+
 [[unpublished.wasmtime-internal-cranelift]]
 version = "36.0.0"
 audited_as = "35.0.0"
@@ -664,6 +792,10 @@ audited_as = "36.0.0"
 [[unpublished.wasmtime-internal-cranelift]]
 version = "36.0.2"
 audited_as = "36.0.1"
+
+[[unpublished.wasmtime-internal-cranelift]]
+version = "36.0.3"
+audited_as = "36.0.2"
 
 [[unpublished.wasmtime-internal-explorer]]
 version = "36.0.0"
@@ -677,6 +809,10 @@ audited_as = "36.0.0"
 version = "36.0.2"
 audited_as = "36.0.1"
 
+[[unpublished.wasmtime-internal-explorer]]
+version = "36.0.3"
+audited_as = "36.0.2"
+
 [[unpublished.wasmtime-internal-fiber]]
 version = "36.0.0"
 audited_as = "35.0.0"
@@ -688,6 +824,10 @@ audited_as = "36.0.0"
 [[unpublished.wasmtime-internal-fiber]]
 version = "36.0.2"
 audited_as = "36.0.1"
+
+[[unpublished.wasmtime-internal-fiber]]
+version = "36.0.3"
+audited_as = "36.0.2"
 
 [[unpublished.wasmtime-internal-jit-debug]]
 version = "36.0.0"
@@ -701,6 +841,10 @@ audited_as = "36.0.0"
 version = "36.0.2"
 audited_as = "36.0.1"
 
+[[unpublished.wasmtime-internal-jit-debug]]
+version = "36.0.3"
+audited_as = "36.0.2"
+
 [[unpublished.wasmtime-internal-jit-icache-coherence]]
 version = "36.0.0"
 audited_as = "35.0.0"
@@ -712,6 +856,10 @@ audited_as = "36.0.0"
 [[unpublished.wasmtime-internal-jit-icache-coherence]]
 version = "36.0.2"
 audited_as = "36.0.1"
+
+[[unpublished.wasmtime-internal-jit-icache-coherence]]
+version = "36.0.3"
+audited_as = "36.0.2"
 
 [[unpublished.wasmtime-internal-math]]
 version = "36.0.0"
@@ -725,6 +873,10 @@ audited_as = "36.0.0"
 version = "36.0.2"
 audited_as = "36.0.1"
 
+[[unpublished.wasmtime-internal-math]]
+version = "36.0.3"
+audited_as = "36.0.2"
+
 [[unpublished.wasmtime-internal-slab]]
 version = "36.0.0"
 audited_as = "35.0.0"
@@ -736,6 +888,10 @@ audited_as = "36.0.0"
 [[unpublished.wasmtime-internal-slab]]
 version = "36.0.2"
 audited_as = "36.0.1"
+
+[[unpublished.wasmtime-internal-slab]]
+version = "36.0.3"
+audited_as = "36.0.2"
 
 [[unpublished.wasmtime-internal-unwinder]]
 version = "36.0.0"
@@ -749,6 +905,10 @@ audited_as = "36.0.0"
 version = "36.0.2"
 audited_as = "36.0.1"
 
+[[unpublished.wasmtime-internal-unwinder]]
+version = "36.0.3"
+audited_as = "36.0.2"
+
 [[unpublished.wasmtime-internal-versioned-export-macros]]
 version = "36.0.0"
 audited_as = "35.0.0"
@@ -760,6 +920,10 @@ audited_as = "36.0.0"
 [[unpublished.wasmtime-internal-versioned-export-macros]]
 version = "36.0.2"
 audited_as = "36.0.1"
+
+[[unpublished.wasmtime-internal-versioned-export-macros]]
+version = "36.0.3"
+audited_as = "36.0.2"
 
 [[unpublished.wasmtime-internal-winch]]
 version = "36.0.0"
@@ -773,6 +937,10 @@ audited_as = "36.0.0"
 version = "36.0.2"
 audited_as = "36.0.1"
 
+[[unpublished.wasmtime-internal-winch]]
+version = "36.0.3"
+audited_as = "36.0.2"
+
 [[unpublished.wasmtime-internal-wit-bindgen]]
 version = "36.0.0"
 audited_as = "35.0.0"
@@ -785,6 +953,10 @@ audited_as = "36.0.0"
 version = "36.0.2"
 audited_as = "36.0.1"
 
+[[unpublished.wasmtime-internal-wit-bindgen]]
+version = "36.0.3"
+audited_as = "36.0.2"
+
 [[unpublished.wasmtime-internal-wmemcheck]]
 version = "36.0.0"
 audited_as = "35.0.0"
@@ -796,6 +968,10 @@ audited_as = "36.0.0"
 [[unpublished.wasmtime-internal-wmemcheck]]
 version = "36.0.2"
 audited_as = "36.0.1"
+
+[[unpublished.wasmtime-internal-wmemcheck]]
+version = "36.0.3"
+audited_as = "36.0.2"
 
 [[unpublished.wasmtime-jit-debug]]
 version = "34.0.0"
@@ -849,6 +1025,10 @@ audited_as = "36.0.0"
 version = "36.0.2"
 audited_as = "36.0.1"
 
+[[unpublished.wasmtime-wasi]]
+version = "36.0.3"
+audited_as = "36.0.2"
+
 [[unpublished.wasmtime-wasi-config]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -868,6 +1048,10 @@ audited_as = "36.0.0"
 [[unpublished.wasmtime-wasi-config]]
 version = "36.0.2"
 audited_as = "36.0.1"
+
+[[unpublished.wasmtime-wasi-config]]
+version = "36.0.3"
+audited_as = "36.0.2"
 
 [[unpublished.wasmtime-wasi-http]]
 version = "34.0.0"
@@ -889,6 +1073,10 @@ audited_as = "36.0.0"
 version = "36.0.2"
 audited_as = "36.0.1"
 
+[[unpublished.wasmtime-wasi-http]]
+version = "36.0.3"
+audited_as = "36.0.2"
+
 [[unpublished.wasmtime-wasi-io]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -908,6 +1096,10 @@ audited_as = "36.0.0"
 [[unpublished.wasmtime-wasi-io]]
 version = "36.0.2"
 audited_as = "36.0.1"
+
+[[unpublished.wasmtime-wasi-io]]
+version = "36.0.3"
+audited_as = "36.0.2"
 
 [[unpublished.wasmtime-wasi-keyvalue]]
 version = "34.0.0"
@@ -929,6 +1121,10 @@ audited_as = "36.0.0"
 version = "36.0.2"
 audited_as = "36.0.1"
 
+[[unpublished.wasmtime-wasi-keyvalue]]
+version = "36.0.3"
+audited_as = "36.0.2"
+
 [[unpublished.wasmtime-wasi-nn]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -949,6 +1145,10 @@ audited_as = "36.0.0"
 version = "36.0.2"
 audited_as = "36.0.1"
 
+[[unpublished.wasmtime-wasi-nn]]
+version = "36.0.3"
+audited_as = "36.0.2"
+
 [[unpublished.wasmtime-wasi-threads]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -969,6 +1169,10 @@ audited_as = "36.0.0"
 version = "36.0.2"
 audited_as = "36.0.1"
 
+[[unpublished.wasmtime-wasi-threads]]
+version = "36.0.3"
+audited_as = "36.0.2"
+
 [[unpublished.wasmtime-wasi-tls]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -988,6 +1192,10 @@ audited_as = "36.0.0"
 [[unpublished.wasmtime-wasi-tls]]
 version = "36.0.2"
 audited_as = "36.0.1"
+
+[[unpublished.wasmtime-wasi-tls]]
+version = "36.0.3"
+audited_as = "36.0.2"
 
 [[unpublished.wasmtime-wasi-tls-nativetls]]
 version = "36.0.0"
@@ -1001,6 +1209,10 @@ audited_as = "36.0.0"
 version = "36.0.2"
 audited_as = "36.0.1"
 
+[[unpublished.wasmtime-wasi-tls-nativetls]]
+version = "36.0.3"
+audited_as = "36.0.2"
+
 [[unpublished.wasmtime-wast]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -1020,6 +1232,10 @@ audited_as = "36.0.0"
 [[unpublished.wasmtime-wast]]
 version = "36.0.2"
 audited_as = "36.0.1"
+
+[[unpublished.wasmtime-wast]]
+version = "36.0.3"
+audited_as = "36.0.2"
 
 [[unpublished.wasmtime-winch]]
 version = "34.0.0"
@@ -1065,6 +1281,10 @@ audited_as = "36.0.0"
 version = "36.0.2"
 audited_as = "36.0.1"
 
+[[unpublished.wiggle]]
+version = "36.0.3"
+audited_as = "36.0.2"
+
 [[unpublished.wiggle-generate]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -1085,6 +1305,10 @@ audited_as = "36.0.0"
 version = "36.0.2"
 audited_as = "36.0.1"
 
+[[unpublished.wiggle-generate]]
+version = "36.0.3"
+audited_as = "36.0.2"
+
 [[unpublished.wiggle-macro]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -1104,6 +1328,10 @@ audited_as = "36.0.0"
 [[unpublished.wiggle-macro]]
 version = "36.0.2"
 audited_as = "36.0.1"
+
+[[unpublished.wiggle-macro]]
+version = "36.0.3"
+audited_as = "36.0.2"
 
 [[unpublished.wiggle-test]]
 version = "0.0.0"
@@ -1128,6 +1356,10 @@ audited_as = "36.0.0"
 [[unpublished.winch-codegen]]
 version = "36.0.2"
 audited_as = "36.0.1"
+
+[[unpublished.winch-codegen]]
+version = "36.0.3"
+audited_as = "36.0.2"
 
 [[publisher.aho-corasick]]
 version = "1.0.2"
@@ -1338,14 +1570,14 @@ user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-assembler-x64]]
-version = "0.123.1"
-when = "2025-08-21"
+version = "0.123.2"
+when = "2025-08-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-assembler-x64-meta]]
-version = "0.123.1"
-when = "2025-08-21"
+version = "0.123.2"
+when = "2025-08-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1446,8 +1678,8 @@ user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-srcgen]]
-version = "0.123.1"
-when = "2025-08-21"
+version = "0.123.2"
+when = "2025-08-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1661,14 +1893,14 @@ user-login = "dtolnay"
 user-name = "David Tolnay"
 
 [[publisher.pulley-interpreter]]
-version = "36.0.1"
-when = "2025-08-21"
+version = "36.0.2"
+when = "2025-08-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.pulley-macros]]
-version = "36.0.1"
-when = "2025-08-21"
+version = "36.0.2"
+when = "2025-08-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2058,104 +2290,104 @@ user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-internal-asm-macros]]
-version = "36.0.1"
-when = "2025-08-21"
+version = "36.0.2"
+when = "2025-08-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-internal-c-api-macros]]
-version = "36.0.1"
-when = "2025-08-21"
+version = "36.0.2"
+when = "2025-08-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-internal-cache]]
-version = "36.0.1"
-when = "2025-08-21"
+version = "36.0.2"
+when = "2025-08-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-internal-component-macro]]
-version = "36.0.1"
-when = "2025-08-21"
+version = "36.0.2"
+when = "2025-08-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-internal-component-util]]
-version = "36.0.1"
-when = "2025-08-21"
+version = "36.0.2"
+when = "2025-08-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-internal-cranelift]]
-version = "36.0.1"
-when = "2025-08-21"
+version = "36.0.2"
+when = "2025-08-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-internal-explorer]]
-version = "36.0.1"
-when = "2025-08-21"
+version = "36.0.2"
+when = "2025-08-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-internal-fiber]]
-version = "36.0.1"
-when = "2025-08-21"
+version = "36.0.2"
+when = "2025-08-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-internal-jit-debug]]
-version = "36.0.1"
-when = "2025-08-21"
+version = "36.0.2"
+when = "2025-08-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-internal-jit-icache-coherence]]
-version = "36.0.1"
-when = "2025-08-21"
+version = "36.0.2"
+when = "2025-08-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-internal-math]]
-version = "36.0.1"
-when = "2025-08-21"
+version = "36.0.2"
+when = "2025-08-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-internal-slab]]
-version = "36.0.1"
-when = "2025-08-21"
+version = "36.0.2"
+when = "2025-08-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-internal-unwinder]]
-version = "36.0.1"
-when = "2025-08-21"
+version = "36.0.2"
+when = "2025-08-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-internal-versioned-export-macros]]
-version = "36.0.1"
-when = "2025-08-21"
+version = "36.0.2"
+when = "2025-08-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-internal-winch]]
-version = "36.0.1"
-when = "2025-08-21"
+version = "36.0.2"
+when = "2025-08-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-internal-wit-bindgen]]
-version = "36.0.1"
-when = "2025-08-21"
+version = "36.0.2"
+when = "2025-08-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-internal-wmemcheck]]
-version = "36.0.1"
-when = "2025-08-21"
+version = "36.0.2"
+when = "2025-08-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2178,8 +2410,8 @@ user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-io]]
-version = "36.0.1"
-when = "2025-08-21"
+version = "36.0.2"
+when = "2025-08-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2202,14 +2434,14 @@ user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-tls]]
-version = "36.0.1"
-when = "2025-08-21"
+version = "36.0.2"
+when = "2025-08-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-tls-nativetls]]
-version = "36.0.1"
-when = "2025-08-21"
+version = "36.0.2"
+when = "2025-08-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 


### PR DESCRIPTION
This is an [automated pull request][process] from CI to create a patch release for Wasmtime 36.0.3, requested by @alexcrichton.

It's recommended that maintainers double-check that [RELEASES.md] is up-to-date and that there are no known issues before merging this PR. When this PR is merged a release tag will automatically be created, crates will be published, and CI artifacts will be produced.

[RELEASES.md]: https://github.com/bytecodealliance/wasmtime/blob/release-36.0.3/RELEASES.md
[process]: https://docs.wasmtime.dev/contributing-release-process.html
