### PR TITLE
Release Wasmtime 38.0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -289,7 +289,7 @@ dependencies = [
 
 [[package]]
 name = "byte-array-literals"
-version = "38.0.3"
+version = "38.0.4"
 
 [[package]]
 name = "byteorder"
@@ -693,7 +693,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift"
-version = "0.125.3"
+version = "0.125.4"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",
@@ -706,7 +706,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.125.3"
+version = "0.125.4"
 dependencies = [
  "arbitrary",
  "arbtest",
@@ -724,21 +724,21 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.125.3"
+version = "0.125.4"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.125.3"
+version = "0.125.4"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.125.3"
+version = "0.125.4"
 dependencies = [
  "arbitrary",
  "serde",
@@ -747,7 +747,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.125.3"
+version = "0.125.4"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -782,7 +782,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.125.3"
+version = "0.125.4"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -793,18 +793,18 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.125.3"
+version = "0.125.4"
 
 [[package]]
 name = "cranelift-control"
-version = "0.125.3"
+version = "0.125.4"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.125.3"
+version = "0.125.4"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.125.3"
+version = "0.125.4"
 dependencies = [
  "cranelift-codegen",
  "env_logger 0.11.5",
@@ -869,7 +869,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-interpreter"
-version = "0.125.3"
+version = "0.125.4"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.125.3"
+version = "0.125.4"
 dependencies = [
  "codespan-reporting",
  "log",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-jit"
-version = "0.125.3"
+version = "0.125.4"
 dependencies = [
  "anyhow",
  "cranelift",
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-module"
-version = "0.125.3"
+version = "0.125.4"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -926,7 +926,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.125.3"
+version = "0.125.4"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-object"
-version = "0.125.3"
+version = "0.125.4"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -950,7 +950,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-reader"
-version = "0.125.3"
+version = "0.125.4"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -960,7 +960,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-serde"
-version = "0.125.3"
+version = "0.125.4"
 dependencies = [
  "clap",
  "cranelift-codegen",
@@ -970,7 +970,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.125.3"
+version = "0.125.4"
 
 [[package]]
 name = "cranelift-tools"
@@ -1221,7 +1221,7 @@ checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
 
 [[package]]
 name = "embedding"
-version = "38.0.3"
+version = "38.0.4"
 dependencies = [
  "anyhow",
  "dlmalloc",
@@ -2366,7 +2366,7 @@ dependencies = [
 
 [[package]]
 name = "min-platform-host"
-version = "38.0.3"
+version = "38.0.4"
 dependencies = [
  "anyhow",
  "libloading",
@@ -2809,7 +2809,7 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "38.0.3"
+version = "38.0.4"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -2833,7 +2833,7 @@ dependencies = [
 
 [[package]]
 name = "pulley-macros"
-version = "38.0.3"
+version = "38.0.4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4067,7 +4067,7 @@ version = "0.1.0"
 
 [[package]]
 name = "verify-component-adapter"
-version = "38.0.3"
+version = "38.0.4"
 dependencies = [
  "anyhow",
  "wasmparser 0.239.0",
@@ -4126,7 +4126,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-common"
-version = "38.0.3"
+version = "38.0.4"
 dependencies = [
  "anyhow",
  "bitflags 2.6.0",
@@ -4165,7 +4165,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-preview1-component-adapter"
-version = "38.0.3"
+version = "38.0.4"
 dependencies = [
  "bitflags 2.6.0",
  "byte-array-literals",
@@ -4417,7 +4417,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "38.0.3"
+version = "38.0.4"
 dependencies = [
  "addr2line 0.25.0",
  "anyhow",
@@ -4481,7 +4481,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-bench-api"
-version = "38.0.3"
+version = "38.0.4"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -4497,14 +4497,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-c-api"
-version = "38.0.3"
+version = "38.0.4"
 dependencies = [
  "wasmtime-c-api-impl",
 ]
 
 [[package]]
 name = "wasmtime-c-api-impl"
-version = "38.0.3"
+version = "38.0.4"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -4521,7 +4521,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli"
-version = "38.0.3"
+version = "38.0.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4595,7 +4595,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli-flags"
-version = "38.0.3"
+version = "38.0.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -4610,7 +4610,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "38.0.3"
+version = "38.0.4"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -4718,7 +4718,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-c-api-macros"
-version = "38.0.3"
+version = "38.0.4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4726,7 +4726,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cache"
-version = "38.0.3"
+version = "38.0.4"
 dependencies = [
  "anyhow",
  "base64",
@@ -4747,7 +4747,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-macro"
-version = "38.0.3"
+version = "38.0.4"
 dependencies = [
  "anyhow",
  "component-macro-test-helpers",
@@ -4767,11 +4767,11 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-util"
-version = "38.0.3"
+version = "38.0.4"
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "38.0.3"
+version = "38.0.4"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4797,7 +4797,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-explorer"
-version = "38.0.3"
+version = "38.0.4"
 dependencies = [
  "anyhow",
  "capstone",
@@ -4812,7 +4812,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-fiber"
-version = "38.0.3"
+version = "38.0.4"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -4826,7 +4826,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-debug"
-version = "38.0.3"
+version = "38.0.4"
 dependencies = [
  "cc",
  "object 0.37.3",
@@ -4836,7 +4836,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "38.0.3"
+version = "38.0.4"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4846,18 +4846,18 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-math"
-version = "38.0.3"
+version = "38.0.4"
 dependencies = [
  "libm",
 ]
 
 [[package]]
 name = "wasmtime-internal-slab"
-version = "38.0.3"
+version = "38.0.4"
 
 [[package]]
 name = "wasmtime-internal-unwinder"
-version = "38.0.3"
+version = "38.0.4"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4868,7 +4868,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
-version = "38.0.3"
+version = "38.0.4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4877,7 +4877,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-winch"
-version = "38.0.3"
+version = "38.0.4"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -4893,7 +4893,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-wit-bindgen"
-version = "38.0.3"
+version = "38.0.4"
 dependencies = [
  "anyhow",
  "bitflags 2.6.0",
@@ -4904,7 +4904,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-wmemcheck"
-version = "38.0.3"
+version = "38.0.4"
 
 [[package]]
 name = "wasmtime-test-macros"
@@ -4919,7 +4919,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-test-util"
-version = "38.0.3"
+version = "38.0.4"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -4937,7 +4937,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "38.0.3"
+version = "38.0.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4972,7 +4972,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-config"
-version = "38.0.3"
+version = "38.0.4"
 dependencies = [
  "anyhow",
  "test-programs-artifacts",
@@ -4983,7 +4983,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-http"
-version = "38.0.3"
+version = "38.0.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5015,7 +5015,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-io"
-version = "38.0.3"
+version = "38.0.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5026,7 +5026,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-keyvalue"
-version = "38.0.3"
+version = "38.0.4"
 dependencies = [
  "anyhow",
  "test-programs-artifacts",
@@ -5037,7 +5037,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-nn"
-version = "38.0.3"
+version = "38.0.4"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -5058,7 +5058,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-threads"
-version = "38.0.3"
+version = "38.0.4"
 dependencies = [
  "anyhow",
  "log",
@@ -5070,7 +5070,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-tls"
-version = "38.0.3"
+version = "38.0.4"
 dependencies = [
  "anyhow",
  "bytes",
@@ -5086,7 +5086,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-tls-nativetls"
-version = "38.0.3"
+version = "38.0.4"
 dependencies = [
  "anyhow",
  "futures",
@@ -5101,7 +5101,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wast"
-version = "38.0.3"
+version = "38.0.4"
 dependencies = [
  "anyhow",
  "json-from-wast",
@@ -5179,7 +5179,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "38.0.3"
+version = "38.0.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5196,7 +5196,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "38.0.3"
+version = "38.0.4"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -5208,7 +5208,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "38.0.3"
+version = "38.0.4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5263,7 +5263,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "38.0.3"
+version = "38.0.4"
 dependencies = [
  "anyhow",
  "cranelift-assembler-x64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -175,7 +175,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "38.0.3"
+version = "38.0.4"
 authors = ["The Wasmtime Project Developers"]
 edition = "2024"
 # Wasmtime's current policy is that this number can be no larger than the
@@ -228,19 +228,19 @@ multiple_bound_locations = 'warn'
 # tooling but aren't intended to be widely depended on.
 #
 # All of these crates are supported though in the sense that
-wasmtime = { path = "crates/wasmtime", version = "38.0.3", default-features = false }
-wasmtime-cli-flags = { path = "crates/cli-flags", version = "=38.0.3" }
-wasmtime-environ = { path = "crates/environ", version = "=38.0.3" }
-wasmtime-wasi = { path = "crates/wasi", version = "38.0.3", default-features = false }
-wasmtime-wasi-io = { path = "crates/wasi-io", version = "38.0.3", default-features = false }
-wasmtime-wasi-http = { path = "crates/wasi-http", version = "38.0.3", default-features = false }
-wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "38.0.3" }
-wasmtime-wasi-config = { path = "crates/wasi-config", version = "38.0.3" }
-wasmtime-wasi-keyvalue = { path = "crates/wasi-keyvalue", version = "38.0.3" }
-wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "38.0.3" }
-wasmtime-wasi-tls = { path = "crates/wasi-tls", version = "38.0.3" }
-wasmtime-wasi-tls-nativetls = { path = "crates/wasi-tls-nativetls", version = "38.0.3" }
-wasmtime-wast = { path = "crates/wast", version = "=38.0.3" }
+wasmtime = { path = "crates/wasmtime", version = "38.0.4", default-features = false }
+wasmtime-cli-flags = { path = "crates/cli-flags", version = "=38.0.4" }
+wasmtime-environ = { path = "crates/environ", version = "=38.0.4" }
+wasmtime-wasi = { path = "crates/wasi", version = "38.0.4", default-features = false }
+wasmtime-wasi-io = { path = "crates/wasi-io", version = "38.0.4", default-features = false }
+wasmtime-wasi-http = { path = "crates/wasi-http", version = "38.0.4", default-features = false }
+wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "38.0.4" }
+wasmtime-wasi-config = { path = "crates/wasi-config", version = "38.0.4" }
+wasmtime-wasi-keyvalue = { path = "crates/wasi-keyvalue", version = "38.0.4" }
+wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "38.0.4" }
+wasmtime-wasi-tls = { path = "crates/wasi-tls", version = "38.0.4" }
+wasmtime-wasi-tls-nativetls = { path = "crates/wasi-tls-nativetls", version = "38.0.4" }
+wasmtime-wast = { path = "crates/wast", version = "=38.0.4" }
 
 # Internal Wasmtime-specific crates.
 #
@@ -249,53 +249,53 @@ wasmtime-wast = { path = "crates/wast", version = "=38.0.3" }
 # that these are internal unsupported crates for external use. These exist as
 # part of the project organization of other public crates in Wasmtime and are
 # otherwise not supported in terms of CVEs for example.
-wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=38.0.3", package = 'wasmtime-internal-wmemcheck' }
-wasmtime-c-api-macros = { path = "crates/c-api-macros", version = "=38.0.3", package = 'wasmtime-internal-c-api-macros' }
-wasmtime-cache = { path = "crates/cache", version = "=38.0.3", package = 'wasmtime-internal-cache' }
-wasmtime-cranelift = { path = "crates/cranelift", version = "=38.0.3", package = 'wasmtime-internal-cranelift' }
-wasmtime-winch = { path = "crates/winch", version = "=38.0.3", package = 'wasmtime-internal-winch'  }
-wasmtime-explorer = { path = "crates/explorer", version = "=38.0.3", package = 'wasmtime-internal-explorer'  }
-wasmtime-fiber = { path = "crates/fiber", version = "=38.0.3", package = 'wasmtime-internal-fiber' }
-wasmtime-jit-debug = { path = "crates/jit-debug", version = "=38.0.3", package = 'wasmtime-internal-jit-debug' }
-wasmtime-component-util = { path = "crates/component-util", version = "=38.0.3", package = 'wasmtime-internal-component-util' }
-wasmtime-component-macro = { path = "crates/component-macro", version = "=38.0.3", package = 'wasmtime-internal-component-macro' }
-wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=38.0.3", package = 'wasmtime-internal-versioned-export-macros' }
-wasmtime-slab = { path = "crates/slab", version = "=38.0.3", package = 'wasmtime-internal-slab' }
-wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=38.0.3", package = 'wasmtime-internal-jit-icache-coherence' }
-wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=38.0.3", package = 'wasmtime-internal-wit-bindgen' }
-wasmtime-math = { path = "crates/math", version = "=38.0.3", package = 'wasmtime-internal-math'  }
-wasmtime-unwinder = { path = "crates/unwinder", version = "=38.0.3", package = 'wasmtime-internal-unwinder' }
+wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=38.0.4", package = 'wasmtime-internal-wmemcheck' }
+wasmtime-c-api-macros = { path = "crates/c-api-macros", version = "=38.0.4", package = 'wasmtime-internal-c-api-macros' }
+wasmtime-cache = { path = "crates/cache", version = "=38.0.4", package = 'wasmtime-internal-cache' }
+wasmtime-cranelift = { path = "crates/cranelift", version = "=38.0.4", package = 'wasmtime-internal-cranelift' }
+wasmtime-winch = { path = "crates/winch", version = "=38.0.4", package = 'wasmtime-internal-winch'  }
+wasmtime-explorer = { path = "crates/explorer", version = "=38.0.4", package = 'wasmtime-internal-explorer'  }
+wasmtime-fiber = { path = "crates/fiber", version = "=38.0.4", package = 'wasmtime-internal-fiber' }
+wasmtime-jit-debug = { path = "crates/jit-debug", version = "=38.0.4", package = 'wasmtime-internal-jit-debug' }
+wasmtime-component-util = { path = "crates/component-util", version = "=38.0.4", package = 'wasmtime-internal-component-util' }
+wasmtime-component-macro = { path = "crates/component-macro", version = "=38.0.4", package = 'wasmtime-internal-component-macro' }
+wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=38.0.4", package = 'wasmtime-internal-versioned-export-macros' }
+wasmtime-slab = { path = "crates/slab", version = "=38.0.4", package = 'wasmtime-internal-slab' }
+wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=38.0.4", package = 'wasmtime-internal-jit-icache-coherence' }
+wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=38.0.4", package = 'wasmtime-internal-wit-bindgen' }
+wasmtime-math = { path = "crates/math", version = "=38.0.4", package = 'wasmtime-internal-math'  }
+wasmtime-unwinder = { path = "crates/unwinder", version = "=38.0.4", package = 'wasmtime-internal-unwinder' }
 
 # Miscellaneous crates without a `wasmtime-*` prefix in their name but still
 # used in the `wasmtime-*` family of crates depending on various features/etc.
-wiggle = { path = "crates/wiggle", version = "=38.0.3", default-features = false }
-wiggle-macro = { path = "crates/wiggle/macro", version = "=38.0.3" }
-wiggle-generate = { path = "crates/wiggle/generate", version = "=38.0.3" }
-wasi-common = { path = "crates/wasi-common", version = "=38.0.3", default-features = false }
-pulley-interpreter = { path = 'pulley', version = "=38.0.3" }
-pulley-macros = { path = 'pulley/macros', version = "=38.0.3" }
+wiggle = { path = "crates/wiggle", version = "=38.0.4", default-features = false }
+wiggle-macro = { path = "crates/wiggle/macro", version = "=38.0.4" }
+wiggle-generate = { path = "crates/wiggle/generate", version = "=38.0.4" }
+wasi-common = { path = "crates/wasi-common", version = "=38.0.4", default-features = false }
+pulley-interpreter = { path = 'pulley', version = "=38.0.4" }
+pulley-macros = { path = 'pulley/macros', version = "=38.0.4" }
 
 # Cranelift crates in this workspace
-cranelift-assembler-x64 = { path = "cranelift/assembler-x64", version = "0.125.3" }
-cranelift-codegen = { path = "cranelift/codegen", version = "0.125.3", default-features = false, features = ["std", "unwind"] }
-cranelift-frontend = { path = "cranelift/frontend", version = "0.125.3" }
-cranelift-entity = { path = "cranelift/entity", version = "0.125.3" }
-cranelift-native = { path = "cranelift/native", version = "0.125.3" }
-cranelift-module = { path = "cranelift/module", version = "0.125.3" }
-cranelift-interpreter = { path = "cranelift/interpreter", version = "0.125.3" }
-cranelift-reader = { path = "cranelift/reader", version = "0.125.3" }
+cranelift-assembler-x64 = { path = "cranelift/assembler-x64", version = "0.125.4" }
+cranelift-codegen = { path = "cranelift/codegen", version = "0.125.4", default-features = false, features = ["std", "unwind"] }
+cranelift-frontend = { path = "cranelift/frontend", version = "0.125.4" }
+cranelift-entity = { path = "cranelift/entity", version = "0.125.4" }
+cranelift-native = { path = "cranelift/native", version = "0.125.4" }
+cranelift-module = { path = "cranelift/module", version = "0.125.4" }
+cranelift-interpreter = { path = "cranelift/interpreter", version = "0.125.4" }
+cranelift-reader = { path = "cranelift/reader", version = "0.125.4" }
 cranelift-filetests = { path = "cranelift/filetests" }
-cranelift-object = { path = "cranelift/object", version = "0.125.3" }
-cranelift-jit = { path = "cranelift/jit", version = "0.125.3" }
+cranelift-object = { path = "cranelift/object", version = "0.125.4" }
+cranelift-jit = { path = "cranelift/jit", version = "0.125.4" }
 cranelift-fuzzgen = { path = "cranelift/fuzzgen" }
-cranelift-bforest = { path = "cranelift/bforest", version = "0.125.3" }
-cranelift-bitset = { path = "cranelift/bitset", version = "0.125.3" }
-cranelift-control = { path = "cranelift/control", version = "0.125.3" }
-cranelift-srcgen = { path = "cranelift/srcgen", version = "0.125.3" }
-cranelift = { path = "cranelift/umbrella", version = "0.125.3" }
+cranelift-bforest = { path = "cranelift/bforest", version = "0.125.4" }
+cranelift-bitset = { path = "cranelift/bitset", version = "0.125.4" }
+cranelift-control = { path = "cranelift/control", version = "0.125.4" }
+cranelift-srcgen = { path = "cranelift/srcgen", version = "0.125.4" }
+cranelift = { path = "cranelift/umbrella", version = "0.125.4" }
 
 # Winch crates in this workspace.
-winch-codegen = { path = "winch/codegen", version = "=38.0.3" }
+winch-codegen = { path = "winch/codegen", version = "=38.0.4" }
 
 # Internal crates not published to crates.io used in testing, builds, etc
 wasi-preview1-component-adapter = { path = "crates/wasi-preview1-component-adapter" }

--- a/cranelift/assembler-x64/Cargo.toml
+++ b/cranelift/assembler-x64/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-assembler-x64"
 description = "A Cranelift-specific x64 assembler"
-version = "0.125.3"
+version = "0.125.4"
 license = "Apache-2.0 WITH LLVM-exception"
 edition.workspace = true
 rust-version.workspace = true
@@ -16,7 +16,7 @@ arbtest = { workspace = true }
 capstone = { workspace = true }
 
 [build-dependencies]
-cranelift-assembler-x64-meta = { path = "meta", version = "0.125.3" }
+cranelift-assembler-x64-meta = { path = "meta", version = "0.125.4" }
 
 [lints]
 workspace = true

--- a/cranelift/assembler-x64/meta/Cargo.toml
+++ b/cranelift/assembler-x64/meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-assembler-x64-meta"
 description = "Generate a Cranelift-specific assembler for x64 instructions"
-version = "0.125.3"
+version = "0.125.4"
 license = "Apache-2.0 WITH LLVM-exception"
 edition.workspace = true
 rust-version.workspace = true

--- a/cranelift/bforest/Cargo.toml
+++ b/cranelift/bforest/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bforest"
-version = "0.125.3"
+version = "0.125.4"
 description = "A forest of B+-trees"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-bforest"

--- a/cranelift/bitset/Cargo.toml
+++ b/cranelift/bitset/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bitset"
-version = "0.125.3"
+version = "0.125.4"
 description = "Various bitset stuff for use inside Cranelift"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-bitset"

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen"
-version = "0.125.3"
+version = "0.125.4"
 description = "Low-level code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-codegen"
@@ -25,7 +25,7 @@ anyhow = { workspace = true, optional = true, features = ['std'] }
 bumpalo = "3"
 capstone = { workspace = true, optional = true }
 cranelift-assembler-x64 = { workspace = true }
-cranelift-codegen-shared = { path = "./shared", version = "0.125.3" }
+cranelift-codegen-shared = { path = "./shared", version = "0.125.4" }
 cranelift-entity = { workspace = true }
 cranelift-bforest = { workspace = true }
 cranelift-bitset = { workspace = true }
@@ -56,8 +56,8 @@ env_logger = { workspace = true }
 proptest = { workspace = true }
 
 [build-dependencies]
-cranelift-codegen-meta = { path = "meta", version = "0.125.3" }
-cranelift-isle = { path = "../isle/isle", version = "=0.125.3" }
+cranelift-codegen-meta = { path = "meta", version = "0.125.4" }
+cranelift-isle = { path = "../isle/isle", version = "=0.125.4" }
 
 [features]
 default = ["std", "unwind", "host-arch", "timing"]

--- a/cranelift/codegen/meta/Cargo.toml
+++ b/cranelift/codegen/meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-codegen-meta"
 authors = ["The Cranelift Project Developers"]
-version = "0.125.3"
+version = "0.125.4"
 description = "Metaprogram for cranelift-codegen code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
@@ -17,8 +17,8 @@ rustdoc-args = ["--document-private-items"]
 
 [dependencies]
 cranelift-srcgen = { workspace = true }
-cranelift-assembler-x64-meta = { path = "../../assembler-x64/meta", version = "0.125.3" }
-cranelift-codegen-shared = { path = "../shared", version = "0.125.3" }
+cranelift-assembler-x64-meta = { path = "../../assembler-x64/meta", version = "0.125.4" }
+cranelift-codegen-shared = { path = "../shared", version = "0.125.4" }
 pulley-interpreter = { workspace = true, optional = true }
 heck = "0.5.0"
 

--- a/cranelift/codegen/shared/Cargo.toml
+++ b/cranelift/codegen/shared/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen-shared"
-version = "0.125.3"
+version = "0.125.4"
 description = "For code shared between cranelift-codegen-meta and cranelift-codegen"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/control/Cargo.toml
+++ b/cranelift/control/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-control"
-version = "0.125.3"
+version = "0.125.4"
 description = "White-box fuzz testing framework"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/entity/Cargo.toml
+++ b/cranelift/entity/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-entity"
-version = "0.125.3"
+version = "0.125.4"
 description = "Data structures using entity references as mapping keys"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-entity"

--- a/cranelift/frontend/Cargo.toml
+++ b/cranelift/frontend/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-frontend"
-version = "0.125.3"
+version = "0.125.4"
 description = "Cranelift IR builder helper"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-frontend"

--- a/cranelift/interpreter/Cargo.toml
+++ b/cranelift/interpreter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-interpreter"
-version = "0.125.3"
+version = "0.125.4"
 authors = ["The Cranelift Project Developers"]
 description = "Interpret Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/isle/isle/Cargo.toml
+++ b/cranelift/isle/isle/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 name = "cranelift-isle"
 readme = "../README.md"
 repository = "https://github.com/bytecodealliance/wasmtime/tree/main/cranelift/isle"
-version = "0.125.3"
+version = "0.125.4"
 
 [lints]
 workspace = true

--- a/cranelift/jit/Cargo.toml
+++ b/cranelift/jit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-jit"
-version = "0.125.3"
+version = "0.125.4"
 authors = ["The Cranelift Project Developers"]
 description = "A JIT library backed by Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/module/Cargo.toml
+++ b/cranelift/module/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-module"
-version = "0.125.3"
+version = "0.125.4"
 authors = ["The Cranelift Project Developers"]
 description = "Support for linking functions and data with Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/native/Cargo.toml
+++ b/cranelift/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-native"
-version = "0.125.3"
+version = "0.125.4"
 authors = ["The Cranelift Project Developers"]
 description = "Support for targeting the host with Cranelift"
 documentation = "https://docs.rs/cranelift-native"

--- a/cranelift/object/Cargo.toml
+++ b/cranelift/object/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-object"
-version = "0.125.3"
+version = "0.125.4"
 authors = ["The Cranelift Project Developers"]
 description = "Emit Cranelift output to native object files with `object`"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/reader/Cargo.toml
+++ b/cranelift/reader/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-reader"
-version = "0.125.3"
+version = "0.125.4"
 description = "Cranelift textual IR reader"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-reader"

--- a/cranelift/serde/Cargo.toml
+++ b/cranelift/serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-serde"
-version = "0.125.3"
+version = "0.125.4"
 authors = ["The Cranelift Project Developers"]
 description = "Serializer/Deserializer for Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/srcgen/Cargo.toml
+++ b/cranelift/srcgen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-srcgen"
-version = "0.125.3"
+version = "0.125.4"
 authors = ["The Wasmtime Project Developers"]
 description = "Helper functions for generating Rust and ISLE files"
 license = "Apache-2.0 WITH LLVM-exception"

--- a/cranelift/umbrella/Cargo.toml
+++ b/cranelift/umbrella/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift"
-version = "0.125.3"
+version = "0.125.4"
 description = "Umbrella for commonly-used cranelift crates"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift"

--- a/crates/c-api/include/wasmtime.h
+++ b/crates/c-api/include/wasmtime.h
@@ -213,7 +213,7 @@
 /**
  * \brief Wasmtime version string.
  */
-#define WASMTIME_VERSION "38.0.3"
+#define WASMTIME_VERSION "38.0.4"
 /**
  * \brief Wasmtime major version number.
  */
@@ -225,6 +225,6 @@
 /**
  * \brief Wasmtime patch version number.
  */
-#define WASMTIME_VERSION_PATCH 3
+#define WASMTIME_VERSION_PATCH 4
 
 #endif // WASMTIME_API_H

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -21,6 +21,10 @@ audited_as = "0.125.1"
 version = "0.125.3"
 audited_as = "0.125.2"
 
+[[unpublished.cranelift]]
+version = "0.125.4"
+audited_as = "0.125.3"
+
 [[unpublished.cranelift-assembler-x64]]
 version = "0.124.0"
 audited_as = "0.123.2"
@@ -40,6 +44,10 @@ audited_as = "0.125.1"
 [[unpublished.cranelift-assembler-x64]]
 version = "0.125.3"
 audited_as = "0.125.2"
+
+[[unpublished.cranelift-assembler-x64]]
+version = "0.125.4"
+audited_as = "0.125.3"
 
 [[unpublished.cranelift-assembler-x64-meta]]
 version = "0.124.0"
@@ -61,6 +69,10 @@ audited_as = "0.125.1"
 version = "0.125.3"
 audited_as = "0.125.2"
 
+[[unpublished.cranelift-assembler-x64-meta]]
+version = "0.125.4"
+audited_as = "0.125.3"
+
 [[unpublished.cranelift-bforest]]
 version = "0.124.0"
 audited_as = "0.123.2"
@@ -80,6 +92,10 @@ audited_as = "0.125.1"
 [[unpublished.cranelift-bforest]]
 version = "0.125.3"
 audited_as = "0.125.2"
+
+[[unpublished.cranelift-bforest]]
+version = "0.125.4"
+audited_as = "0.125.3"
 
 [[unpublished.cranelift-bitset]]
 version = "0.124.0"
@@ -101,6 +117,10 @@ audited_as = "0.125.1"
 version = "0.125.3"
 audited_as = "0.125.2"
 
+[[unpublished.cranelift-bitset]]
+version = "0.125.4"
+audited_as = "0.125.3"
+
 [[unpublished.cranelift-codegen]]
 version = "0.124.0"
 audited_as = "0.123.2"
@@ -120,6 +140,10 @@ audited_as = "0.125.1"
 [[unpublished.cranelift-codegen]]
 version = "0.125.3"
 audited_as = "0.125.2"
+
+[[unpublished.cranelift-codegen]]
+version = "0.125.4"
+audited_as = "0.125.3"
 
 [[unpublished.cranelift-codegen-meta]]
 version = "0.124.0"
@@ -141,6 +165,10 @@ audited_as = "0.125.1"
 version = "0.125.3"
 audited_as = "0.125.2"
 
+[[unpublished.cranelift-codegen-meta]]
+version = "0.125.4"
+audited_as = "0.125.3"
+
 [[unpublished.cranelift-codegen-shared]]
 version = "0.124.0"
 audited_as = "0.123.2"
@@ -160,6 +188,10 @@ audited_as = "0.125.1"
 [[unpublished.cranelift-codegen-shared]]
 version = "0.125.3"
 audited_as = "0.125.2"
+
+[[unpublished.cranelift-codegen-shared]]
+version = "0.125.4"
+audited_as = "0.125.3"
 
 [[unpublished.cranelift-control]]
 version = "0.124.0"
@@ -181,6 +213,10 @@ audited_as = "0.125.1"
 version = "0.125.3"
 audited_as = "0.125.2"
 
+[[unpublished.cranelift-control]]
+version = "0.125.4"
+audited_as = "0.125.3"
+
 [[unpublished.cranelift-entity]]
 version = "0.124.0"
 audited_as = "0.123.2"
@@ -200,6 +236,10 @@ audited_as = "0.125.1"
 [[unpublished.cranelift-entity]]
 version = "0.125.3"
 audited_as = "0.125.2"
+
+[[unpublished.cranelift-entity]]
+version = "0.125.4"
+audited_as = "0.125.3"
 
 [[unpublished.cranelift-frontend]]
 version = "0.124.0"
@@ -221,6 +261,10 @@ audited_as = "0.125.1"
 version = "0.125.3"
 audited_as = "0.125.2"
 
+[[unpublished.cranelift-frontend]]
+version = "0.125.4"
+audited_as = "0.125.3"
+
 [[unpublished.cranelift-interpreter]]
 version = "0.124.0"
 audited_as = "0.123.2"
@@ -240,6 +284,10 @@ audited_as = "0.125.1"
 [[unpublished.cranelift-interpreter]]
 version = "0.125.3"
 audited_as = "0.125.2"
+
+[[unpublished.cranelift-interpreter]]
+version = "0.125.4"
+audited_as = "0.125.3"
 
 [[unpublished.cranelift-isle]]
 version = "0.124.0"
@@ -261,6 +309,10 @@ audited_as = "0.125.1"
 version = "0.125.3"
 audited_as = "0.125.2"
 
+[[unpublished.cranelift-isle]]
+version = "0.125.4"
+audited_as = "0.125.3"
+
 [[unpublished.cranelift-jit]]
 version = "0.124.0"
 audited_as = "0.123.2"
@@ -280,6 +332,10 @@ audited_as = "0.125.1"
 [[unpublished.cranelift-jit]]
 version = "0.125.3"
 audited_as = "0.125.2"
+
+[[unpublished.cranelift-jit]]
+version = "0.125.4"
+audited_as = "0.125.3"
 
 [[unpublished.cranelift-module]]
 version = "0.124.0"
@@ -301,6 +357,10 @@ audited_as = "0.125.1"
 version = "0.125.3"
 audited_as = "0.125.2"
 
+[[unpublished.cranelift-module]]
+version = "0.125.4"
+audited_as = "0.125.3"
+
 [[unpublished.cranelift-native]]
 version = "0.124.0"
 audited_as = "0.123.2"
@@ -320,6 +380,10 @@ audited_as = "0.125.1"
 [[unpublished.cranelift-native]]
 version = "0.125.3"
 audited_as = "0.125.2"
+
+[[unpublished.cranelift-native]]
+version = "0.125.4"
+audited_as = "0.125.3"
 
 [[unpublished.cranelift-object]]
 version = "0.124.0"
@@ -341,6 +405,10 @@ audited_as = "0.125.1"
 version = "0.125.3"
 audited_as = "0.125.2"
 
+[[unpublished.cranelift-object]]
+version = "0.125.4"
+audited_as = "0.125.3"
+
 [[unpublished.cranelift-reader]]
 version = "0.124.0"
 audited_as = "0.123.2"
@@ -361,6 +429,10 @@ audited_as = "0.125.1"
 version = "0.125.3"
 audited_as = "0.125.2"
 
+[[unpublished.cranelift-reader]]
+version = "0.125.4"
+audited_as = "0.125.3"
+
 [[unpublished.cranelift-serde]]
 version = "0.124.0"
 audited_as = "0.123.2"
@@ -381,6 +453,10 @@ audited_as = "0.125.1"
 version = "0.125.3"
 audited_as = "0.125.2"
 
+[[unpublished.cranelift-serde]]
+version = "0.125.4"
+audited_as = "0.125.3"
+
 [[unpublished.cranelift-srcgen]]
 version = "0.124.0"
 audited_as = "0.123.2"
@@ -401,6 +477,10 @@ audited_as = "0.125.1"
 version = "0.125.3"
 audited_as = "0.125.2"
 
+[[unpublished.cranelift-srcgen]]
+version = "0.125.4"
+audited_as = "0.125.3"
+
 [[unpublished.pulley-interpreter]]
 version = "37.0.0"
 audited_as = "36.0.2"
@@ -420,6 +500,10 @@ audited_as = "38.0.1"
 [[unpublished.pulley-interpreter]]
 version = "38.0.3"
 audited_as = "38.0.2"
+
+[[unpublished.pulley-interpreter]]
+version = "38.0.4"
+audited_as = "38.0.3"
 
 [[unpublished.pulley-macros]]
 version = "37.0.0"
@@ -441,6 +525,10 @@ audited_as = "38.0.1"
 version = "38.0.3"
 audited_as = "38.0.2"
 
+[[unpublished.pulley-macros]]
+version = "38.0.4"
+audited_as = "38.0.3"
+
 [[unpublished.wasi-common]]
 version = "37.0.0"
 audited_as = "36.0.2"
@@ -460,6 +548,10 @@ audited_as = "38.0.1"
 [[unpublished.wasi-common]]
 version = "38.0.3"
 audited_as = "38.0.2"
+
+[[unpublished.wasi-common]]
+version = "38.0.4"
+audited_as = "38.0.3"
 
 [[unpublished.wasmtime]]
 version = "37.0.0"
@@ -481,6 +573,10 @@ audited_as = "38.0.1"
 version = "38.0.3"
 audited_as = "38.0.2"
 
+[[unpublished.wasmtime]]
+version = "38.0.4"
+audited_as = "38.0.3"
+
 [[unpublished.wasmtime-cli]]
 version = "37.0.0"
 audited_as = "36.0.2"
@@ -501,6 +597,10 @@ audited_as = "38.0.1"
 version = "38.0.3"
 audited_as = "38.0.2"
 
+[[unpublished.wasmtime-cli]]
+version = "38.0.4"
+audited_as = "38.0.3"
+
 [[unpublished.wasmtime-cli-flags]]
 version = "37.0.0"
 audited_as = "36.0.2"
@@ -521,6 +621,10 @@ audited_as = "38.0.1"
 version = "38.0.3"
 audited_as = "38.0.2"
 
+[[unpublished.wasmtime-cli-flags]]
+version = "38.0.4"
+audited_as = "38.0.3"
+
 [[unpublished.wasmtime-environ]]
 version = "37.0.0"
 audited_as = "36.0.2"
@@ -540,6 +644,10 @@ audited_as = "38.0.1"
 [[unpublished.wasmtime-environ]]
 version = "38.0.3"
 audited_as = "38.0.2"
+
+[[unpublished.wasmtime-environ]]
+version = "38.0.4"
+audited_as = "38.0.3"
 
 [[unpublished.wasmtime-internal-asm-macros]]
 version = "37.0.0"
@@ -569,6 +677,10 @@ audited_as = "38.0.1"
 version = "38.0.3"
 audited_as = "38.0.2"
 
+[[unpublished.wasmtime-internal-c-api-macros]]
+version = "38.0.4"
+audited_as = "38.0.3"
+
 [[unpublished.wasmtime-internal-cache]]
 version = "37.0.0"
 audited_as = "36.0.2"
@@ -588,6 +700,10 @@ audited_as = "38.0.1"
 [[unpublished.wasmtime-internal-cache]]
 version = "38.0.3"
 audited_as = "38.0.2"
+
+[[unpublished.wasmtime-internal-cache]]
+version = "38.0.4"
+audited_as = "38.0.3"
 
 [[unpublished.wasmtime-internal-component-macro]]
 version = "37.0.0"
@@ -609,6 +725,10 @@ audited_as = "38.0.1"
 version = "38.0.3"
 audited_as = "38.0.2"
 
+[[unpublished.wasmtime-internal-component-macro]]
+version = "38.0.4"
+audited_as = "38.0.3"
+
 [[unpublished.wasmtime-internal-component-util]]
 version = "37.0.0"
 audited_as = "36.0.2"
@@ -628,6 +748,10 @@ audited_as = "38.0.1"
 [[unpublished.wasmtime-internal-component-util]]
 version = "38.0.3"
 audited_as = "38.0.2"
+
+[[unpublished.wasmtime-internal-component-util]]
+version = "38.0.4"
+audited_as = "38.0.3"
 
 [[unpublished.wasmtime-internal-cranelift]]
 version = "37.0.0"
@@ -649,6 +773,10 @@ audited_as = "38.0.1"
 version = "38.0.3"
 audited_as = "38.0.2"
 
+[[unpublished.wasmtime-internal-cranelift]]
+version = "38.0.4"
+audited_as = "38.0.3"
+
 [[unpublished.wasmtime-internal-explorer]]
 version = "37.0.0"
 audited_as = "36.0.2"
@@ -668,6 +796,10 @@ audited_as = "38.0.1"
 [[unpublished.wasmtime-internal-explorer]]
 version = "38.0.3"
 audited_as = "38.0.2"
+
+[[unpublished.wasmtime-internal-explorer]]
+version = "38.0.4"
+audited_as = "38.0.3"
 
 [[unpublished.wasmtime-internal-fiber]]
 version = "37.0.0"
@@ -689,6 +821,10 @@ audited_as = "38.0.1"
 version = "38.0.3"
 audited_as = "38.0.2"
 
+[[unpublished.wasmtime-internal-fiber]]
+version = "38.0.4"
+audited_as = "38.0.3"
+
 [[unpublished.wasmtime-internal-jit-debug]]
 version = "37.0.0"
 audited_as = "36.0.2"
@@ -708,6 +844,10 @@ audited_as = "38.0.1"
 [[unpublished.wasmtime-internal-jit-debug]]
 version = "38.0.3"
 audited_as = "38.0.2"
+
+[[unpublished.wasmtime-internal-jit-debug]]
+version = "38.0.4"
+audited_as = "38.0.3"
 
 [[unpublished.wasmtime-internal-jit-icache-coherence]]
 version = "37.0.0"
@@ -729,6 +869,10 @@ audited_as = "38.0.1"
 version = "38.0.3"
 audited_as = "38.0.2"
 
+[[unpublished.wasmtime-internal-jit-icache-coherence]]
+version = "38.0.4"
+audited_as = "38.0.3"
+
 [[unpublished.wasmtime-internal-math]]
 version = "37.0.0"
 audited_as = "36.0.2"
@@ -748,6 +892,10 @@ audited_as = "38.0.1"
 [[unpublished.wasmtime-internal-math]]
 version = "38.0.3"
 audited_as = "38.0.2"
+
+[[unpublished.wasmtime-internal-math]]
+version = "38.0.4"
+audited_as = "38.0.3"
 
 [[unpublished.wasmtime-internal-slab]]
 version = "37.0.0"
@@ -769,6 +917,10 @@ audited_as = "38.0.1"
 version = "38.0.3"
 audited_as = "38.0.2"
 
+[[unpublished.wasmtime-internal-slab]]
+version = "38.0.4"
+audited_as = "38.0.3"
+
 [[unpublished.wasmtime-internal-unwinder]]
 version = "37.0.0"
 audited_as = "36.0.2"
@@ -788,6 +940,10 @@ audited_as = "38.0.1"
 [[unpublished.wasmtime-internal-unwinder]]
 version = "38.0.3"
 audited_as = "38.0.2"
+
+[[unpublished.wasmtime-internal-unwinder]]
+version = "38.0.4"
+audited_as = "38.0.3"
 
 [[unpublished.wasmtime-internal-versioned-export-macros]]
 version = "37.0.0"
@@ -809,6 +965,10 @@ audited_as = "38.0.1"
 version = "38.0.3"
 audited_as = "38.0.2"
 
+[[unpublished.wasmtime-internal-versioned-export-macros]]
+version = "38.0.4"
+audited_as = "38.0.3"
+
 [[unpublished.wasmtime-internal-winch]]
 version = "37.0.0"
 audited_as = "36.0.2"
@@ -828,6 +988,10 @@ audited_as = "38.0.1"
 [[unpublished.wasmtime-internal-winch]]
 version = "38.0.3"
 audited_as = "38.0.2"
+
+[[unpublished.wasmtime-internal-winch]]
+version = "38.0.4"
+audited_as = "38.0.3"
 
 [[unpublished.wasmtime-internal-wit-bindgen]]
 version = "37.0.0"
@@ -849,6 +1013,10 @@ audited_as = "38.0.1"
 version = "38.0.3"
 audited_as = "38.0.2"
 
+[[unpublished.wasmtime-internal-wit-bindgen]]
+version = "38.0.4"
+audited_as = "38.0.3"
+
 [[unpublished.wasmtime-internal-wmemcheck]]
 version = "37.0.0"
 audited_as = "36.0.2"
@@ -868,6 +1036,10 @@ audited_as = "38.0.1"
 [[unpublished.wasmtime-internal-wmemcheck]]
 version = "38.0.3"
 audited_as = "38.0.2"
+
+[[unpublished.wasmtime-internal-wmemcheck]]
+version = "38.0.4"
+audited_as = "38.0.3"
 
 [[unpublished.wasmtime-wasi]]
 version = "37.0.0"
@@ -889,6 +1061,10 @@ audited_as = "38.0.1"
 version = "38.0.3"
 audited_as = "38.0.2"
 
+[[unpublished.wasmtime-wasi]]
+version = "38.0.4"
+audited_as = "38.0.3"
+
 [[unpublished.wasmtime-wasi-config]]
 version = "37.0.0"
 audited_as = "36.0.2"
@@ -908,6 +1084,10 @@ audited_as = "38.0.1"
 [[unpublished.wasmtime-wasi-config]]
 version = "38.0.3"
 audited_as = "38.0.2"
+
+[[unpublished.wasmtime-wasi-config]]
+version = "38.0.4"
+audited_as = "38.0.3"
 
 [[unpublished.wasmtime-wasi-http]]
 version = "37.0.0"
@@ -929,6 +1109,10 @@ audited_as = "38.0.1"
 version = "38.0.3"
 audited_as = "38.0.2"
 
+[[unpublished.wasmtime-wasi-http]]
+version = "38.0.4"
+audited_as = "38.0.3"
+
 [[unpublished.wasmtime-wasi-io]]
 version = "37.0.0"
 audited_as = "36.0.2"
@@ -948,6 +1132,10 @@ audited_as = "38.0.1"
 [[unpublished.wasmtime-wasi-io]]
 version = "38.0.3"
 audited_as = "38.0.2"
+
+[[unpublished.wasmtime-wasi-io]]
+version = "38.0.4"
+audited_as = "38.0.3"
 
 [[unpublished.wasmtime-wasi-keyvalue]]
 version = "37.0.0"
@@ -969,6 +1157,10 @@ audited_as = "38.0.1"
 version = "38.0.3"
 audited_as = "38.0.2"
 
+[[unpublished.wasmtime-wasi-keyvalue]]
+version = "38.0.4"
+audited_as = "38.0.3"
+
 [[unpublished.wasmtime-wasi-nn]]
 version = "37.0.0"
 audited_as = "36.0.2"
@@ -988,6 +1180,10 @@ audited_as = "38.0.1"
 [[unpublished.wasmtime-wasi-nn]]
 version = "38.0.3"
 audited_as = "38.0.2"
+
+[[unpublished.wasmtime-wasi-nn]]
+version = "38.0.4"
+audited_as = "38.0.3"
 
 [[unpublished.wasmtime-wasi-threads]]
 version = "37.0.0"
@@ -1009,6 +1205,10 @@ audited_as = "38.0.1"
 version = "38.0.3"
 audited_as = "38.0.2"
 
+[[unpublished.wasmtime-wasi-threads]]
+version = "38.0.4"
+audited_as = "38.0.3"
+
 [[unpublished.wasmtime-wasi-tls]]
 version = "37.0.0"
 audited_as = "36.0.2"
@@ -1028,6 +1228,10 @@ audited_as = "38.0.1"
 [[unpublished.wasmtime-wasi-tls]]
 version = "38.0.3"
 audited_as = "38.0.2"
+
+[[unpublished.wasmtime-wasi-tls]]
+version = "38.0.4"
+audited_as = "38.0.3"
 
 [[unpublished.wasmtime-wasi-tls-nativetls]]
 version = "37.0.0"
@@ -1049,6 +1253,10 @@ audited_as = "38.0.1"
 version = "38.0.3"
 audited_as = "38.0.2"
 
+[[unpublished.wasmtime-wasi-tls-nativetls]]
+version = "38.0.4"
+audited_as = "38.0.3"
+
 [[unpublished.wasmtime-wast]]
 version = "37.0.0"
 audited_as = "36.0.2"
@@ -1069,6 +1277,10 @@ audited_as = "38.0.1"
 version = "38.0.3"
 audited_as = "38.0.2"
 
+[[unpublished.wasmtime-wast]]
+version = "38.0.4"
+audited_as = "38.0.3"
+
 [[unpublished.wiggle]]
 version = "37.0.0"
 audited_as = "36.0.2"
@@ -1089,6 +1301,10 @@ audited_as = "38.0.1"
 version = "38.0.3"
 audited_as = "38.0.2"
 
+[[unpublished.wiggle]]
+version = "38.0.4"
+audited_as = "38.0.3"
+
 [[unpublished.wiggle-generate]]
 version = "37.0.0"
 audited_as = "36.0.2"
@@ -1109,6 +1325,10 @@ audited_as = "38.0.1"
 version = "38.0.3"
 audited_as = "38.0.2"
 
+[[unpublished.wiggle-generate]]
+version = "38.0.4"
+audited_as = "38.0.3"
+
 [[unpublished.wiggle-macro]]
 version = "37.0.0"
 audited_as = "36.0.2"
@@ -1128,6 +1348,10 @@ audited_as = "38.0.1"
 [[unpublished.wiggle-macro]]
 version = "38.0.3"
 audited_as = "38.0.2"
+
+[[unpublished.wiggle-macro]]
+version = "38.0.4"
+audited_as = "38.0.3"
 
 [[unpublished.wiggle-test]]
 version = "0.0.0"
@@ -1152,6 +1376,10 @@ audited_as = "38.0.1"
 [[unpublished.winch-codegen]]
 version = "38.0.3"
 audited_as = "38.0.2"
+
+[[unpublished.winch-codegen]]
+version = "38.0.4"
+audited_as = "38.0.3"
 
 [[publisher.aho-corasick]]
 version = "1.0.2"
@@ -1356,122 +1584,122 @@ user-login = "jrmuizel"
 user-name = "Jeff Muizelaar"
 
 [[publisher.cranelift]]
-version = "0.125.2"
-when = "2025-10-21"
+version = "0.125.3"
+when = "2025-10-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-assembler-x64]]
-version = "0.125.2"
-when = "2025-10-21"
+version = "0.125.3"
+when = "2025-10-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-assembler-x64-meta]]
-version = "0.125.2"
-when = "2025-10-21"
+version = "0.125.3"
+when = "2025-10-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-bforest]]
-version = "0.125.2"
-when = "2025-10-21"
+version = "0.125.3"
+when = "2025-10-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-bitset]]
-version = "0.125.2"
-when = "2025-10-21"
+version = "0.125.3"
+when = "2025-10-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-codegen]]
-version = "0.125.2"
-when = "2025-10-21"
+version = "0.125.3"
+when = "2025-10-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-codegen-meta]]
-version = "0.125.2"
-when = "2025-10-21"
+version = "0.125.3"
+when = "2025-10-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-codegen-shared]]
-version = "0.125.2"
-when = "2025-10-21"
+version = "0.125.3"
+when = "2025-10-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-control]]
-version = "0.125.2"
-when = "2025-10-21"
+version = "0.125.3"
+when = "2025-10-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-entity]]
-version = "0.125.2"
-when = "2025-10-21"
+version = "0.125.3"
+when = "2025-10-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-frontend]]
-version = "0.125.2"
-when = "2025-10-21"
+version = "0.125.3"
+when = "2025-10-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-interpreter]]
-version = "0.125.2"
-when = "2025-10-21"
+version = "0.125.3"
+when = "2025-10-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-isle]]
-version = "0.125.2"
-when = "2025-10-21"
+version = "0.125.3"
+when = "2025-10-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-jit]]
-version = "0.125.2"
-when = "2025-10-21"
+version = "0.125.3"
+when = "2025-10-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-module]]
-version = "0.125.2"
-when = "2025-10-21"
+version = "0.125.3"
+when = "2025-10-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-native]]
-version = "0.125.2"
-when = "2025-10-21"
+version = "0.125.3"
+when = "2025-10-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-object]]
-version = "0.125.2"
-when = "2025-10-21"
+version = "0.125.3"
+when = "2025-10-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-reader]]
-version = "0.125.2"
-when = "2025-10-21"
+version = "0.125.3"
+when = "2025-10-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-serde]]
-version = "0.125.2"
-when = "2025-10-21"
+version = "0.125.3"
+when = "2025-10-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-srcgen]]
-version = "0.125.2"
-when = "2025-10-21"
+version = "0.125.3"
+when = "2025-10-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1685,14 +1913,14 @@ user-login = "dtolnay"
 user-name = "David Tolnay"
 
 [[publisher.pulley-interpreter]]
-version = "38.0.2"
-when = "2025-10-21"
+version = "38.0.3"
+when = "2025-10-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.pulley-macros]]
-version = "38.0.2"
-when = "2025-10-21"
+version = "38.0.3"
+when = "2025-10-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1963,8 +2191,8 @@ user-login = "sunfishcode"
 user-name = "Dan Gohman"
 
 [[publisher.wasi-common]]
-version = "38.0.2"
-when = "2025-10-21"
+version = "38.0.3"
+when = "2025-10-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2072,182 +2300,182 @@ user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime]]
-version = "38.0.2"
-when = "2025-10-21"
+version = "38.0.3"
+when = "2025-10-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-cli]]
-version = "38.0.2"
-when = "2025-10-21"
+version = "38.0.3"
+when = "2025-10-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-cli-flags]]
-version = "38.0.2"
-when = "2025-10-21"
+version = "38.0.3"
+when = "2025-10-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-environ]]
-version = "38.0.2"
-when = "2025-10-21"
+version = "38.0.3"
+when = "2025-10-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-internal-c-api-macros]]
-version = "38.0.2"
-when = "2025-10-21"
+version = "38.0.3"
+when = "2025-10-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-internal-cache]]
-version = "38.0.2"
-when = "2025-10-21"
+version = "38.0.3"
+when = "2025-10-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-internal-component-macro]]
-version = "38.0.2"
-when = "2025-10-21"
+version = "38.0.3"
+when = "2025-10-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-internal-component-util]]
-version = "38.0.2"
-when = "2025-10-21"
+version = "38.0.3"
+when = "2025-10-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-internal-cranelift]]
-version = "38.0.2"
-when = "2025-10-21"
+version = "38.0.3"
+when = "2025-10-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-internal-explorer]]
-version = "38.0.2"
-when = "2025-10-21"
+version = "38.0.3"
+when = "2025-10-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-internal-fiber]]
-version = "38.0.2"
-when = "2025-10-21"
+version = "38.0.3"
+when = "2025-10-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-internal-jit-debug]]
-version = "38.0.2"
-when = "2025-10-21"
+version = "38.0.3"
+when = "2025-10-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-internal-jit-icache-coherence]]
-version = "38.0.2"
-when = "2025-10-21"
+version = "38.0.3"
+when = "2025-10-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-internal-math]]
-version = "38.0.2"
-when = "2025-10-21"
+version = "38.0.3"
+when = "2025-10-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-internal-slab]]
-version = "38.0.2"
-when = "2025-10-21"
+version = "38.0.3"
+when = "2025-10-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-internal-unwinder]]
-version = "38.0.2"
-when = "2025-10-21"
+version = "38.0.3"
+when = "2025-10-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-internal-versioned-export-macros]]
-version = "38.0.2"
-when = "2025-10-21"
+version = "38.0.3"
+when = "2025-10-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-internal-winch]]
-version = "38.0.2"
-when = "2025-10-21"
+version = "38.0.3"
+when = "2025-10-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-internal-wit-bindgen]]
-version = "38.0.2"
-when = "2025-10-21"
+version = "38.0.3"
+when = "2025-10-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-internal-wmemcheck]]
-version = "38.0.2"
-when = "2025-10-21"
+version = "38.0.3"
+when = "2025-10-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi]]
-version = "38.0.2"
-when = "2025-10-21"
+version = "38.0.3"
+when = "2025-10-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-config]]
-version = "38.0.2"
-when = "2025-10-21"
+version = "38.0.3"
+when = "2025-10-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-http]]
-version = "38.0.2"
-when = "2025-10-21"
+version = "38.0.3"
+when = "2025-10-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-io]]
-version = "38.0.2"
-when = "2025-10-21"
+version = "38.0.3"
+when = "2025-10-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-keyvalue]]
-version = "38.0.2"
-when = "2025-10-21"
+version = "38.0.3"
+when = "2025-10-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-nn]]
-version = "38.0.2"
-when = "2025-10-21"
+version = "38.0.3"
+when = "2025-10-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-threads]]
-version = "38.0.2"
-when = "2025-10-21"
+version = "38.0.3"
+when = "2025-10-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-tls]]
-version = "38.0.2"
-when = "2025-10-21"
+version = "38.0.3"
+when = "2025-10-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-tls-nativetls]]
-version = "38.0.2"
-when = "2025-10-21"
+version = "38.0.3"
+when = "2025-10-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wast]]
-version = "38.0.2"
-when = "2025-10-21"
+version = "38.0.3"
+when = "2025-10-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2271,20 +2499,20 @@ user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
 [[publisher.wiggle]]
-version = "38.0.2"
-when = "2025-10-21"
+version = "38.0.3"
+when = "2025-10-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wiggle-generate]]
-version = "38.0.2"
-when = "2025-10-21"
+version = "38.0.3"
+when = "2025-10-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wiggle-macro]]
-version = "38.0.2"
-when = "2025-10-21"
+version = "38.0.3"
+when = "2025-10-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2303,8 +2531,8 @@ user-login = "BurntSushi"
 user-name = "Andrew Gallant"
 
 [[publisher.winch-codegen]]
-version = "38.0.2"
-when = "2025-10-21"
+version = "38.0.3"
+when = "2025-10-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 


### PR DESCRIPTION
This is an [automated pull request][process] from CI to create a patch release for Wasmtime 38.0.4, requested by @alexcrichton.

It's recommended that maintainers double-check that [RELEASES.md] is up-to-date and that there are no known issues before merging this PR. When this PR is merged a release tag will automatically be created, crates will be published, and CI artifacts will be produced.

[RELEASES.md]: https://github.com/bytecodealliance/wasmtime/blob/release-38.0.4/RELEASES.md
[process]: https://docs.wasmtime.dev/contributing-release-process.html
