### PR TITLE
Upgrade regalloc2 to 0.13.3.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3020,9 +3020,9 @@ dependencies = [
 
 [[package]]
 name = "regalloc2"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd8138ce7c3d7c13be4f61893154b5d711bd798d2d7be3ecb8dcc7e7a06ca98"
+checksum = "4e249c660440317032a71ddac302f25f1d5dff387667bcc3978d1f77aa31ac34"
 dependencies = [
  "allocator-api2",
  "bumpalo",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -317,7 +317,7 @@ component-async-tests = { path = "crates/misc/component-async-tests" }
 
 # Bytecode Alliance maintained dependencies:
 # ---------------------------
-regalloc2 = "0.13.2"
+regalloc2 = "0.13.3"
 
 # cap-std family:
 target-lexicon = "0.13.0"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1087,8 +1087,8 @@ user-login = "dtolnay"
 user-name = "David Tolnay"
 
 [[publisher.regalloc2]]
-version = "0.13.2"
-when = "2025-09-18"
+version = "0.13.3"
+when = "2025-11-13"
 user-id = 3726
 user-login = "cfallin"
 user-name = "Chris Fallin"


### PR DESCRIPTION
Pulls in bytecodealliance/regalloc2#246, a fix to the single-pass register allocator.

Fixes #11850 (via that pulled-in fix from d-sonuga).

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
