### PR TITLE
Get finalized function with size in cranelift-jit

### DIFF
--- a/cranelift/jit/src/backend.rs
+++ b/cranelift/jit/src/backend.rs
@@ -264,14 +264,24 @@ impl JITModule {
     /// The pointer remains valid until either [`JITModule::free_memory`] is called or in the future
     /// some way of deallocating this individual function is used.
     pub fn get_finalized_function(&self, func_id: FuncId) -> *const u8 {
+        self.get_finalized_function_with_size(func_id).0
+    }
+
+    /// Returns the address and size of a finalized function.
+    ///
+    /// The pointer remains valid until either [`JITModule::free_memory`] is called or in the future
+    /// some way of deallocating this individual function is used.
+    pub fn get_finalized_function_with_size(&self, func_id: FuncId) -> (*const u8, usize) {
         let info = &self.compiled_functions[func_id];
         assert!(
             !self.functions_to_finalize.iter().any(|x| *x == func_id),
             "function not yet finalized"
         );
-        info.as_ref()
-            .expect("function must be compiled before it can be finalized")
-            .ptr
+        let compiled = info
+            .as_ref()
+            .expect("function must be compiled before it can be finalized");
+
+        (compiled.ptr, compiled.size)
     }
 
     /// Returns the address and size of a finalized data object.


### PR DESCRIPTION
When emitting the ELF object with related DWARF debuginfo for an in-memory generated code, one typically needs to set the size of the `.text` section, this API is for such advanced usage.

See some related discussions in [this Zulip chat](https://bytecodealliance.zulipchat.com/#narrow/channel/217117-cranelift/topic/.E2.9C.94.20Cranelift.20debuginfo.20with.20set_srcloc.3F/with/554666785).