### PR TITLE
chore: fix broken link

### DIFF
--- a/crates/c-api/include/wasmtime/linker.h
+++ b/crates/c-api/include/wasmtime/linker.h
@@ -242,7 +242,7 @@ wasmtime_linker_instantiate(const wasmtime_linker_t *linker,
  * on success.
  *
  * This function automatically handles [Commands and
- * Reactors](https://github.com/WebAssembly/WASI/blob/master/design/application-abi.md#current-unstable-abi)
+ * Reactors](https://github.com/WebAssembly/WASI/blob/main/legacy/application-abi.md#current-unstable-abi)
  * instantiation and initialization.
  *
  * For more information see the [Rust


### PR DESCRIPTION
https://github.com/WebAssembly/WASI/blob/master/design/application-abi.md#current-unstable-abi - 404
https://github.com/WebAssembly/WASI/blob/main/legacy/application-abi.md#current-unstable-abi - looks correct