### PR TITLE
Docs: update exceptions proposal fuzzing and C-API status.

### DIFF
--- a/docs/stability-tiers.md
+++ b/docs/stability-tiers.md
@@ -85,7 +85,7 @@ For explanations of what each tier means see below.
 | WebAssembly Proposal | [`gc`]                     | production quality          |
 | WebAssembly Proposal | [`wide-arithmetic`]        | Unstable wasm proposal      |
 | WebAssembly Proposal | [`custom-page-sizes`]      | Unstable wasm proposal      |
-| WebAssembly Proposal | [`exception-handling`]     | dependence on GC            |
+| WebAssembly Proposal | [`exception-handling`]     | fuzzing, dependence on GC   |
 | Execution Backend    | Pulley                     | More time fuzzing/baking    |
 | Embedding API        | C++                        | Full-time maintainer        |
 

--- a/docs/stability-wasm-proposals.md
+++ b/docs/stability-wasm-proposals.md
@@ -52,14 +52,14 @@ The emoji legend is:
 
 ## Off-by-default proposals
 
-|  Proposal                   | Phase 4 | Tests | Finished | Fuzzed | API | C API |
-|-----------------------------|---------|-------|----------|--------|-----|-------|
-| [`function-references`]     | ✅      | ✅    | ✅       | 🚧     | ✅  | ❌    |
-| [`gc`] [^6]                 | ✅      | ✅    | 🚧[^7]   | 🚧[^8] | ✅  | ❌    |
-| [`wide-arithmetic`]         | ❌      | ✅    | ✅       | ✅     | ✅  | ✅    |
-| [`custom-page-sizes`]       | ❌      | ✅    | ✅       | ✅     | ✅  | ✅    |
-| [`exception-handling`]      | ✅      | ✅    | ✅       | ✅     | ✅  | ✅    |
-| [`stack-switching`] [^10]   | ❌      | 🚧    | 🚧       | ❌     | ❌  | ❌    |
+|  Proposal                   | Phase 4 | Tests | Finished | Fuzzed | API | C API  |
+|-----------------------------|---------|-------|----------|--------|-----|--------|
+| [`function-references`]     | ✅      | ✅    | ✅       | 🚧     | ✅  | ❌     |
+| [`gc`] [^6]                 | ✅      | ✅    | 🚧[^7]   | 🚧[^8] | ✅  | ❌     |
+| [`wide-arithmetic`]         | ❌      | ✅    | ✅       | ✅     | ✅  | ✅     |
+| [`custom-page-sizes`]       | ❌      | ✅    | ✅       | ✅     | ✅  | ✅     |
+| [`exception-handling`]      | ✅      | ✅    | ✅       | 🚧[^11]| ✅  | 🚧[^12]|
+| [`stack-switching`] [^10]   | ❌      | 🚧    | 🚧       | ❌     | ❌  | ❌     |
 
 [^6]: There is also a [tracking
     issue](https://github.com/bytecodealliance/wasmtime/issues/5032) for the
@@ -75,6 +75,12 @@ The emoji legend is:
 [^10]: The stack-switching proposal is a work-in-progress being tracked
     at [#9465](https://github.com/bytecodealliance/wasmtime/issues/9465).
     Currently the implementation is only for x86\_64 Linux.
+[^11]: The exception-handling proposal is fuzzed by our whole-module fuzzer,
+       but we do not have an exception-specific fuzzer that attempts to create
+       interesting throw/catch patterns or payloads.
+[^12]: The exception-handling proposal can be enabled for exceptions in the guest
+       via the C API, but exception objects have no C API to examine, clone,
+       rethrow, or drop exceptions that propagate to the host.
 
 ## Unimplemented proposals
 


### PR DESCRIPTION
Noticed while reviewing another docs update: we still state that the exceptions proposal is not fuzzed, and has no C API support. Neither is true anymore, AFAIK:

- We fuzz exceptions via our usual infrastructure and we had a number of fuzzbugs come in when we first merged support.
- We added C API support for enabling exceptions in #11861.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
