### PR TITLE
Cleanup/add some testing in `wasmtime-fuzzing`

### DIFF
--- a/crates/fuzzing/src/generators/component_types.rs
+++ b/crates/fuzzing/src/generators/component_types.rs
@@ -187,3 +187,25 @@ where
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test::test_n_times;
+    use wasmtime_test_util::component_fuzz::{TestCase, Type};
+
+    #[test]
+    fn static_api_smoke_test() {
+        test_n_times(10, |(), u| {
+            let case = TestCase {
+                params: vec![&Type::S32, &Type::Bool, &Type::String],
+                result: Some(&Type::String),
+                encoding1: u.arbitrary()?,
+                encoding2: u.arbitrary()?,
+            };
+
+            let declarations = case.declarations();
+            static_api_test::<(i32, bool, String), (String,)>(u, &declarations)
+        });
+    }
+}

--- a/crates/fuzzing/src/generators/stacks.rs
+++ b/crates/fuzzing/src/generators/stacks.rs
@@ -404,21 +404,15 @@ impl Stacks {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rand::prelude::*;
     use wasmparser::Validator;
 
     #[test]
     fn stacks_generates_valid_wasm_modules() {
-        let mut rng = SmallRng::seed_from_u64(0);
-        let mut buf = vec![0; 2048];
-        for _ in 0..1024 {
-            rng.fill_bytes(&mut buf);
-            let u = Unstructured::new(&buf);
-            if let Ok(stacks) = Stacks::arbitrary_take_rest(u) {
-                let wasm = stacks.wasm();
-                validate(&wasm);
-            }
-        }
+        crate::test::test_n_times(10, |stacks: Stacks, _u| {
+            let wasm = stacks.wasm();
+            validate(&wasm);
+            Ok(())
+        })
     }
 
     fn validate(wasm: &[u8]) {

--- a/crates/fuzzing/src/oracles/engine.rs
+++ b/crates/fuzzing/src/oracles/engine.rs
@@ -181,27 +181,16 @@ pub fn smoke_test_engine<T>(
 ) where
     T: DiffEngine,
 {
-    use rand::prelude::*;
-
-    let mut rng = SmallRng::seed_from_u64(0);
-    let mut buf = vec![0; 2048];
-    let n = 100;
-    for _ in 0..n {
-        rng.fill_bytes(&mut buf);
-        let mut u = Unstructured::new(&buf);
-        let mut config = match u.arbitrary::<Config>() {
-            Ok(config) => config,
-            Err(_) => continue,
-        };
+    crate::test::test_n_times(5, |mut config: Config, u| {
         // This will ensure that wasmtime, which uses this configuration
         // settings, can guaranteed instantiate a module.
         config.set_differential_config();
 
-        let mut engine = match mk_engine(&mut u, &mut config) {
+        let mut engine = match mk_engine(u, &mut config) {
             Ok(engine) => engine,
             Err(e) => {
                 println!("skip {e:?}");
-                continue;
+                return Ok(());
             }
         };
 
@@ -240,8 +229,6 @@ pub fn smoke_test_engine<T>(
             }
         }
 
-        return;
-    }
-
-    panic!("after {n} runs nothing ever ran, something is probably wrong");
+        Ok(())
+    })
 }

--- a/crates/fuzzing/src/oracles/memory.rs
+++ b/crates/fuzzing/src/oracles/memory.rs
@@ -392,20 +392,13 @@ fn build_wasm(image: &HeapImage, offset: u32) -> Vec<u8> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arbitrary::{Arbitrary, Unstructured};
-    use rand::prelude::*;
+    use crate::test::test_n_times;
 
     #[test]
     fn smoke_test_memory_access() {
-        let mut rng = SmallRng::seed_from_u64(0);
-        let mut buf = vec![0; 1024];
-
-        for _ in 0..1024 {
-            rng.fill_bytes(&mut buf);
-            let u = Unstructured::new(&buf);
-            if let Ok(input) = MemoryAccesses::arbitrary_take_rest(u) {
-                check_memory_accesses(input);
-            }
-        }
+        test_n_times(50, |input: MemoryAccesses, _u| {
+            check_memory_accesses(input);
+            Ok(())
+        })
     }
 }

--- a/crates/fuzzing/src/oracles/stacks.rs
+++ b/crates/fuzzing/src/oracles/stacks.rs
@@ -138,30 +138,15 @@ fn assert_stack_matches(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arbitrary::{Arbitrary, Unstructured};
-    use rand::prelude::*;
+    use crate::test::gen_until_pass;
 
     const TARGET_STACK_DEPTH: usize = 10;
 
     #[test]
     fn smoke_test() {
-        let mut rng = SmallRng::seed_from_u64(0);
-        let mut buf = vec![0; 2048];
-
-        for _ in 0..1024 {
-            rng.fill_bytes(&mut buf);
-            let u = Unstructured::new(&buf);
-            if let Ok(stacks) = Stacks::arbitrary_take_rest(u) {
-                let max_stack_depth = check_stacks(stacks);
-                if max_stack_depth >= TARGET_STACK_DEPTH {
-                    return;
-                }
-            }
-        }
-
-        panic!(
-            "never generated a `Stacks` test case that reached {TARGET_STACK_DEPTH} \
-             deep stack frames",
-        );
+        gen_until_pass(|stacks: Stacks, _u| {
+            let max_stack_depth = check_stacks(stacks);
+            Ok(max_stack_depth >= TARGET_STACK_DEPTH)
+        });
     }
 }


### PR DESCRIPTION
Share the fuzz-generator-helpers across more tests and add smoke tests for the dynamic/static component API tests too.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
