### PR TITLE
Remove indicatif dependency from bugpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -654,19 +654,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "console"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b430743a6eb14e9764d4260d4c0d8123087d504eeb9c48f2b2a5e810dd369df4"
-dependencies = [
- "encode_unicode",
- "libc",
- "once_cell",
- "unicode-width 0.2.0",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1009,7 +996,6 @@ dependencies = [
  "cranelift-reader",
  "env_logger 0.11.5",
  "filecheck",
- "indicatif",
  "log",
  "pulley-interpreter",
  "rayon",
@@ -1245,12 +1231,6 @@ dependencies = [
  "wasmtime",
  "wasmtime-wasi-io",
 ]
-
-[[package]]
-name = "encode_unicode"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
@@ -2031,18 +2011,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indicatif"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8572bccfb0665e70b7faf44ee28841b8e0823450cd4ad562a76b5a3c4bf48487"
-dependencies = [
- "console",
- "lazy_static",
- "number_prefix",
- "regex",
-]
-
-[[package]]
 name = "inout"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2518,12 +2486,6 @@ dependencies = [
  "hermit-abi",
  "libc",
 ]
-
-[[package]]
-name = "number_prefix"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b02fc0ff9a9e4b35b3342880f48e896ebf69f2967921fe8646bf5b7125956a"
 
 [[package]]
 name = "object"

--- a/cranelift/Cargo.toml
+++ b/cranelift/Cargo.toml
@@ -40,7 +40,6 @@ capstone = { workspace = true, optional = true }
 target-lexicon = { workspace = true, features = ["std"] }
 env_logger = { workspace = true }
 rayon = { version = "1", optional = true }
-indicatif = "0.13.0"
 thiserror = { workspace = true }
 walkdir = { workspace = true }
 anyhow = { workspace = true }


### PR DESCRIPTION
This has fallen pretty far behind the development of upstream, it now has unmaintained dependencies, and AFAIK it's not a load-bearing dependency at this time. Remove it in favor of simple prints for now.

Closes #12045

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
