### PR TITLE
Improve `Config`-related coverage of `component_api`

### DIFF
--- a/crates/fuzzing/src/generators.rs
+++ b/crates/fuzzing/src/generators.rs
@@ -11,7 +11,6 @@
 pub mod api;
 mod async_config;
 mod codegen_settings;
-pub mod component_types;
 mod config;
 pub mod gc_ops;
 mod instance_allocation_strategy;

--- a/crates/fuzzing/src/oracles/component_api.rs
+++ b/crates/fuzzing/src/oracles/component_api.rs
@@ -7,13 +7,19 @@
 //! lifting and lowering code and verify the values remain intact during both processes.
 
 use crate::block_on;
+use crate::generators::{self, CompilerStrategy, InstanceAllocationStrategy};
+use crate::oracles::log_wasm;
 use arbitrary::{Arbitrary, Unstructured};
 use std::any::Any;
 use std::fmt::Debug;
 use std::ops::ControlFlow;
-use wasmtime::component::{self, Component, ComponentNamedList, Lift, Linker, Lower, Val};
-use wasmtime::{AsContextMut, Config, Engine, Store, StoreContextMut};
-use wasmtime_test_util::component_fuzz::{Declarations, EXPORT_FUNCTION, IMPORT_FUNCTION};
+use wasmtime::component::{
+    self, Accessor, Component, ComponentNamedList, Lift, Linker, Lower, Val,
+};
+use wasmtime::{AsContextMut, Enabled, Engine, Result, Store, StoreContextMut};
+use wasmtime_test_util::component_fuzz::{
+    Declarations, EXPORT_FUNCTION, IMPORT_FUNCTION, MAX_TYPE_DEPTH, TestCase, Type,
+};
 
 /// Minimum length of an arbitrary list value generated for a test case
 const MIN_LIST_LENGTH: u32 = 0;
@@ -22,7 +28,7 @@ const MIN_LIST_LENGTH: u32 = 0;
 const MAX_LIST_LENGTH: u32 = 10;
 
 /// Generate an arbitrary instance of the specified type.
-pub fn arbitrary_val(ty: &component::Type, input: &mut Unstructured) -> arbitrary::Result<Val> {
+fn arbitrary_val(ty: &component::Type, input: &mut Unstructured) -> arbitrary::Result<Val> {
     use component::Type;
 
     Ok(match ty {
@@ -116,6 +122,63 @@ pub fn arbitrary_val(ty: &component::Type, input: &mut Unstructured) -> arbitrar
     })
 }
 
+fn store<T>(input: &mut Unstructured<'_>, val: T) -> arbitrary::Result<Store<T>> {
+    crate::init_fuzzing();
+
+    let mut config = input.arbitrary::<generators::Config>()?;
+    config.enable_async(input)?;
+    config.module_config.config.multi_value_enabled = true;
+    config.module_config.config.reference_types_enabled = true;
+    config.module_config.config.max_memories = 2;
+    config.module_config.component_model_async = true;
+    config.module_config.component_model_async_stackful = true;
+    if config.wasmtime.compiler_strategy == CompilerStrategy::Winch {
+        config.wasmtime.compiler_strategy = CompilerStrategy::CraneliftNative;
+    }
+
+    fn set_min<T>(a: &mut T, min: T)
+    where
+        T: Ord + Copy,
+    {
+        if *a < min {
+            *a = min;
+        }
+    }
+
+    fn set_opt_min<T>(a: &mut Option<T>, min: T)
+    where
+        T: Ord + Copy,
+    {
+        if let Some(a) = a {
+            set_min(a, min);
+        }
+    }
+
+    if let InstanceAllocationStrategy::Pooling(p) = &mut config.wasmtime.strategy {
+        set_min(&mut p.total_component_instances, 5);
+        set_min(&mut p.total_core_instances, 5);
+        set_min(&mut p.total_memories, 2);
+        set_min(&mut p.max_memories_per_component, 2);
+        set_min(&mut p.max_memories_per_module, 2);
+        p.memory_protection_keys = Enabled::No;
+        p.max_memory_size = 10 << 20; // 10 MiB
+    }
+    set_opt_min(
+        &mut config.wasmtime.memory_config.memory_reservation,
+        10 << 20,
+    );
+
+    let engine = Engine::new(
+        config
+            .to_wasmtime()
+            .debug_adapter_modules(input.arbitrary()?),
+    )
+    .unwrap();
+    let mut store = Store::new(&engine, val);
+    config.configure_store_epoch_and_fuel(&mut store);
+    Ok(store)
+}
+
 /// Generate zero or more sets of arbitrary argument and result values and execute the test using those
 /// values, asserting that they flow from host-to-guest and guest-to-host unchanged.
 pub fn static_api_test<'a, P, R>(
@@ -146,13 +209,8 @@ where
 {
     crate::init_fuzzing();
 
-    let mut config = Config::new();
-    config.wasm_component_model(true);
-    config.wasm_component_model_async(true);
-    config.wasm_component_model_async_stackful(true);
-    config.async_support(true);
-    config.debug_adapter_modules(input.arbitrary()?);
-    let engine = Engine::new(&config).unwrap();
+    let mut store = store::<Box<dyn Any + Send>>(input, Box::new(()))?;
+    let engine = store.engine();
     let wat = declarations.make_component();
     let wat = wat.as_bytes();
     crate::oracles::log_wasm(wat);
@@ -192,7 +250,6 @@ where
             })
             .unwrap();
     }
-    let mut store: Store<Box<dyn Any + Send>> = Store::new(&engine, Box::new(()));
 
     block_on(async {
         let instance = linker
@@ -226,11 +283,116 @@ where
     })
 }
 
+/// Generate and execute a `crate::generators::component_types::TestCase` using the specified `input` to create
+/// arbitrary types and values.
+pub fn dynamic_component_api_target(input: &mut arbitrary::Unstructured) -> arbitrary::Result<()> {
+    crate::init_fuzzing();
+
+    let mut types = Vec::new();
+    let mut type_fuel = 500;
+
+    for _ in 0..5 {
+        types.push(Type::generate(input, MAX_TYPE_DEPTH, &mut type_fuel)?);
+    }
+
+    let case = TestCase::generate(&types, input)?;
+
+    let mut store = store(input, (Vec::new(), None))?;
+    let engine = store.engine();
+    let wat = case.declarations().make_component();
+    let wat = wat.as_bytes();
+    log_wasm(wat);
+    let component = Component::new(&engine, wat).unwrap();
+    let mut linker = Linker::new(&engine);
+
+    fn host_function(
+        mut cx: StoreContextMut<'_, (Vec<Val>, Option<Vec<Val>>)>,
+        params: &[Val],
+        results: &mut [Val],
+    ) -> Result<()> {
+        log::trace!("received params {params:?}");
+        let (expected_args, expected_results) = cx.data_mut();
+        assert_eq!(params.len(), expected_args.len());
+        for (expected, actual) in expected_args.iter().zip(params) {
+            assert_eq!(expected, actual);
+        }
+        results.clone_from_slice(&expected_results.take().unwrap());
+        log::trace!("returning results {results:?}");
+        Ok(())
+    }
+
+    if case.options.host_async {
+        linker
+            .root()
+            .func_new_concurrent(IMPORT_FUNCTION, {
+                move |cx: &Accessor<_, _>, _, params: &[Val], results: &mut [Val]| {
+                    Box::pin(async move {
+                        cx.with(|mut store| host_function(store.as_context_mut(), params, results))
+                    })
+                }
+            })
+            .unwrap();
+    } else {
+        linker
+            .root()
+            .func_new(IMPORT_FUNCTION, {
+                move |cx, _, params, results| host_function(cx, params, results)
+            })
+            .unwrap();
+    }
+
+    block_on(async {
+        let instance = linker
+            .instantiate_async(&mut store, &component)
+            .await
+            .unwrap();
+        let func = instance.get_func(&mut store, EXPORT_FUNCTION).unwrap();
+        let ty = func.ty(&store);
+
+        while input.arbitrary()? {
+            let params = ty
+                .params()
+                .map(|(_, ty)| arbitrary_val(&ty, input))
+                .collect::<arbitrary::Result<Vec<_>>>()?;
+            let results = ty
+                .results()
+                .map(|ty| arbitrary_val(&ty, input))
+                .collect::<arbitrary::Result<Vec<_>>>()?;
+
+            *store.data_mut() = (params.clone(), Some(results.clone()));
+
+            log::trace!("passing params {params:?}");
+            let mut actual = vec![Val::Bool(false); results.len()];
+            if case.options.guest_caller_async {
+                store
+                    .run_concurrent(async |a| {
+                        func.call_concurrent(a, &params, &mut actual).await.unwrap();
+                    })
+                    .await
+                    .unwrap();
+            } else {
+                func.call_async(&mut store, &params, &mut actual)
+                    .await
+                    .unwrap();
+                func.post_return_async(&mut store).await.unwrap();
+            }
+            log::trace!("received results {actual:?}");
+            assert_eq!(actual, results);
+        }
+        Ok(())
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::test::test_n_times;
     use wasmtime_test_util::component_fuzz::{TestCase, Type};
+
+    #[test]
+    fn dynamic_component_api_smoke_test() {
+        test_n_times(50, |(), u| super::dynamic_component_api_target(u));
+    }
 
     #[test]
     fn static_api_smoke_test() {

--- a/fuzz/build.rs
+++ b/fuzz/build.rs
@@ -121,7 +121,7 @@ mod component {
                 options,
             } = case.declarations();
 
-            let test = quote!(#index => component_types::static_api_test::<(#rust_params), (#rust_results)>(
+            let test = quote!(#index => component_api::static_api_test::<(#rust_params), (#rust_results)>(
                 input,
                 {
                     static DECLS: Declarations = Declarations {
@@ -150,7 +150,7 @@ mod component {
                 use std::borrow::Cow;
                 use std::sync::{Arc, Once};
                 use wasmtime::component::{ComponentType, Lift, Lower};
-                use wasmtime_fuzzing::generators::component_types;
+                use wasmtime_fuzzing::oracles::component_api;
 
                 const SEED: u64 = #seed;
 

--- a/fuzz/fuzz_targets/component_api.rs
+++ b/fuzz/fuzz_targets/component_api.rs
@@ -10,13 +10,10 @@ fn target(input: &mut arbitrary::Unstructured) -> arbitrary::Result<()> {
     if input.arbitrary()? {
         static_component_api_target(input)
     } else {
-        oracles::dynamic_component_api_target(input)
+        oracles::component_api::dynamic_component_api_target(input)
     }
 }
 
 fuzz_target!(|bytes: &[u8]| {
-    match target(&mut arbitrary::Unstructured::new(bytes)) {
-        Ok(()) | Err(arbitrary::Error::NotEnoughData) => (),
-        Err(error) => panic!("{}", error),
-    }
+    let _ = target(&mut arbitrary::Unstructured::new(bytes));
 });


### PR DESCRIPTION
This commit improves the preexisting `component_api` fuzz target to use arbitrary `Config` data. This, for example, helps exercise Pulley in addition to native. In general this also helps stress and ensure that no config knobs are accidentally breaking ABI assumptions.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
