### PR TITLE
s390x: add lowering for `uadd_overflow`.

### DIFF
--- a/cranelift/codegen/src/isa/s390x/lower.isle
+++ b/cranelift/codegen/src/isa/s390x/lower.isle
@@ -3948,6 +3948,15 @@
         (add_logical_mem_zext32_with_flags_paired ty y (sink_uload32 x))
         (trap_if_impl (mask_as_cond 3) tc)))
 
+;;;; Rules for `uadd_overflow` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(rule 0 (lower (has_type (ty_32_or_64 ty) (uadd_overflow x y)))
+      (let ((sum Reg (add_reg ty x y))
+            (overflow Reg
+              (lower_bool $I8
+                          (bool (icmpu_reg ty sum x) (intcc_as_cond (IntCC.UnsignedLessThan))))))
+        (output_pair sum overflow)))
+
 ;;;; Rules for `return` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (return args))

--- a/cranelift/filetests/filetests/isa/s390x/uadd_overflow.clif
+++ b/cranelift/filetests/filetests/isa/s390x/uadd_overflow.clif
@@ -1,0 +1,51 @@
+test compile precise-output
+target s390x
+
+function %f2(i32, i32) -> i32, i8 {
+block0(v0: i32, v1: i32):
+    v2, v3 = uadd_overflow v0, v1
+    return v2, v3
+}
+
+; VCode:
+; block0:
+;   ark %r5, %r2, %r3
+;   clr %r5, %r2
+;   lhi %r3, 0
+;   lochil %r3, 1
+;   lgr %r2, %r5
+;   br %r14
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   ark %r5, %r2, %r3
+;   clr %r5, %r2
+;   lhi %r3, 0
+;   lochil %r3, 1
+;   lgr %r2, %r5
+;   br %r14
+
+function %f4(i64, i64) -> i64, i8 {
+block0(v0: i64, v1: i64):
+    v2, v3 = uadd_overflow v0, v1
+    return v2, v3
+}
+
+; VCode:
+; block0:
+;   agrk %r5, %r2, %r3
+;   clgr %r5, %r2
+;   lhi %r3, 0
+;   lochil %r3, 1
+;   lgr %r2, %r5
+;   br %r14
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   agrk %r5, %r2, %r3
+;   clgr %r5, %r2
+;   lhi %r3, 0
+;   lochil %r3, 1
+;   lgr %r2, %r5
+;   br %r14
+

--- a/cranelift/filetests/filetests/runtests/uadd_overflow.clif
+++ b/cranelift/filetests/filetests/runtests/uadd_overflow.clif
@@ -1,10 +1,11 @@
 test interpret
 test run
 set enable_llvm_abi_extensions=true
-target aarch64
 set enable_multi_ret_implicit_sret
 target x86_64
+target aarch64
 target riscv64
+target s390x
 target pulley32
 target pulley32be
 target pulley64


### PR DESCRIPTION
This is needed to configure Wasmtime for hostcall-based traps on s390x for some kinds of code, and was not previously tested before #12052.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
