### PR TITLE
Use `UnsyncBoxBody` everywhere in wasi-http

### DIFF
--- a/crates/wasi-http/src/body.rs
+++ b/crates/wasi-http/src/body.rs
@@ -5,7 +5,7 @@ use anyhow::anyhow;
 use bytes::Bytes;
 use http_body::{Body, Frame};
 use http_body_util::BodyExt;
-use http_body_util::combinators::BoxBody;
+use http_body_util::combinators::UnsyncBoxBody;
 use std::future::Future;
 use std::mem;
 use std::task::{Context, Poll};
@@ -15,10 +15,10 @@ use wasmtime_wasi::p2::{InputStream, OutputStream, Pollable, StreamError};
 use wasmtime_wasi::runtime::{AbortOnDropJoinHandle, poll_noop};
 
 /// Common type for incoming bodies.
-pub type HyperIncomingBody = BoxBody<Bytes, types::ErrorCode>;
+pub type HyperIncomingBody = UnsyncBoxBody<Bytes, types::ErrorCode>;
 
 /// Common type for outgoing bodies.
-pub type HyperOutgoingBody = BoxBody<Bytes, types::ErrorCode>;
+pub type HyperOutgoingBody = UnsyncBoxBody<Bytes, types::ErrorCode>;
 
 /// The concrete type behind a `was:http/types.incoming-body` resource.
 #[derive(Debug)]
@@ -481,7 +481,7 @@ impl HostOutgoingBody {
             body_receiver,
             finish_receiver: Some(finish_receiver),
         }
-        .boxed();
+        .boxed_unsync();
 
         let output_stream = BodyWriteStream::new(context, chunk_size, body_sender, written.clone());
 

--- a/crates/wasi-http/src/http_impl.rs
+++ b/crates/wasi-http/src/http_impl.rs
@@ -86,7 +86,7 @@ where
         let body = req.body.unwrap_or_else(|| {
             Empty::<Bytes>::new()
                 .map_err(|_| unreachable!("Infallible error"))
-                .boxed()
+                .boxed_unsync()
         });
 
         let request = builder

--- a/crates/wasi-http/tests/all/p2.rs
+++ b/crates/wasi-http/tests/all/p2.rs
@@ -285,7 +285,7 @@ async fn do_wasi_http_hash_all(override_send_request: bool) -> Result<()> {
                     Ok(IncomingResponse {
                         resp: resp.map(|body| {
                             body.map_err(wasmtime_wasi_http::hyper_response_error)
-                                .boxed()
+                                .boxed_unsync()
                         }),
                         worker: None,
                         between_bytes_timeout,


### PR DESCRIPTION
This applies the changes from #11941 to the entire crate as opposed to just the WASIp3 side of things. This is required, for example, to update Wasmtime in Spin without more invasive surgery.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
