### PR TITLE
Cranelift: add a "patchable call" ABI.

### DIFF
--- a/cranelift/codegen/src/isa/riscv64/abi.rs
+++ b/cranelift/codegen/src/isa/riscv64/abi.rs
@@ -489,16 +489,17 @@ impl ABIMachineSpec for Riscv64MachineDeps {
         if stack_size > 0 {
             insts.extend(Self::gen_sp_reg_adjust(-(stack_size as i32)));
 
-            let mut cur_offset = 8;
+            let mut cur_offset = 0;
             for reg in &frame_layout.clobbered_callee_saves {
                 let r_reg = reg.to_reg();
                 let ty = match r_reg.class() {
                     RegClass::Int => I64,
                     RegClass::Float => F64,
-                    RegClass::Vector => unimplemented!("Vector Clobber Saves"),
+                    RegClass::Vector => I8X16,
                 };
+                cur_offset = align_to(cur_offset, ty.bytes());
                 insts.push(Inst::gen_store(
-                    AMode::SPOffset((stack_size - cur_offset) as i64),
+                    AMode::SPOffset(i64::from(stack_size - cur_offset - ty.bytes())),
                     Reg::from(reg.to_reg()),
                     ty,
                     MemFlags::trusted(),
@@ -507,13 +508,14 @@ impl ABIMachineSpec for Riscv64MachineDeps {
                 if flags.unwind_info() {
                     insts.push(Inst::Unwind {
                         inst: UnwindInst::SaveReg {
-                            clobber_offset: frame_layout.clobber_size - cur_offset,
+                            clobber_offset: frame_layout.clobber_size - cur_offset - ty.bytes(),
                             reg: r_reg,
                         },
                     });
                 }
 
-                cur_offset += 8
+                cur_offset += ty.bytes();
+                assert!(cur_offset <= stack_size);
             }
         }
         insts
@@ -529,22 +531,23 @@ impl ABIMachineSpec for Riscv64MachineDeps {
         let stack_size = frame_layout.clobber_size
             + frame_layout.fixed_frame_storage_size
             + frame_layout.outgoing_args_size;
+        let mut cur_offset = 0;
 
-        let mut cur_offset = 8;
         for reg in &frame_layout.clobbered_callee_saves {
             let rreg = reg.to_reg();
             let ty = match rreg.class() {
                 RegClass::Int => I64,
                 RegClass::Float => F64,
-                RegClass::Vector => unimplemented!("Vector Clobber Restores"),
+                RegClass::Vector => I8X16,
             };
+            cur_offset = align_to(cur_offset, ty.bytes());
             insts.push(Inst::gen_load(
                 reg.map(Reg::from),
-                AMode::SPOffset(i64::from(stack_size - cur_offset)),
+                AMode::SPOffset(i64::from(stack_size - cur_offset - ty.bytes())),
                 ty,
                 MemFlags::trusted(),
             ));
-            cur_offset += 8
+            cur_offset += ty.bytes();
         }
 
         if stack_size > 0 {
@@ -619,12 +622,13 @@ impl ABIMachineSpec for Riscv64MachineDeps {
     ) -> PRegSet {
         match call_conv_of_callee {
             isa::CallConv::Tail if is_exception => ALL_CLOBBERS,
+            isa::CallConv::Patchable => NO_CLOBBERS,
             _ => DEFAULT_CLOBBERS,
         }
     }
 
     fn compute_frame_layout(
-        _call_conv: isa::CallConv,
+        call_conv: isa::CallConv,
         flags: &settings::Flags,
         _sig: &Signature,
         regs: &[Writable<RealReg>],
@@ -635,11 +639,12 @@ impl ABIMachineSpec for Riscv64MachineDeps {
         fixed_frame_storage_size: u32,
         outgoing_args_size: u32,
     ) -> FrameLayout {
-        let mut regs: Vec<Writable<RealReg>> = regs
-            .iter()
-            .cloned()
-            .filter(|r| DEFAULT_CALLEE_SAVES.contains(r.to_reg().into()))
-            .collect();
+        let is_callee_saved = |reg: &Writable<RealReg>| match call_conv {
+            isa::CallConv::Patchable => true,
+            _ => DEFAULT_CALLEE_SAVES.contains(reg.to_reg().into()),
+        };
+        let mut regs: Vec<Writable<RealReg>> =
+            regs.iter().cloned().filter(is_callee_saved).collect();
 
         regs.sort_unstable();
 
@@ -760,7 +765,10 @@ fn compute_clobber_size(clobbers: &[Writable<RealReg>]) -> u32 {
             RegClass::Float => {
                 clobbered_size += 8;
             }
-            RegClass::Vector => unimplemented!("Vector Size Clobbered"),
+            RegClass::Vector => {
+                clobbered_size = align_to(clobbered_size, 16);
+                clobbered_size += 16;
+            }
         }
     }
     align_to(clobbered_size, 16)
@@ -936,6 +944,8 @@ const ALL_CLOBBERS: PRegSet = PRegSet::empty()
     .with(pv_reg(29))
     .with(pv_reg(30))
     .with(pv_reg(31));
+
+const NO_CLOBBERS: PRegSet = PRegSet::empty();
 
 fn create_reg_environment() -> MachineEnv {
     // Some C Extension instructions can only use a subset of the registers.

--- a/cranelift/codegen/src/isa/s390x/abi.rs
+++ b/cranelift/codegen/src/isa/s390x/abi.rs
@@ -880,6 +880,7 @@ impl ABIMachineSpec for S390xMachineDeps {
         match call_conv_of_callee {
             isa::CallConv::Tail if is_exception => ALL_CLOBBERS,
             isa::CallConv::Tail => TAIL_CLOBBERS,
+            isa::CallConv::Patchable => NO_CLOBBERS,
             _ => SYSV_CLOBBERS,
         }
     }
@@ -1103,6 +1104,7 @@ fn is_reg_saved_in_prologue(call_conv: isa::CallConv, r: RealReg) -> bool {
             // r8 - r14 inclusive are callee-saves.
             r.hw_enc() >= 8 && r.hw_enc() <= 14
         }
+        (isa::CallConv::Patchable, _) => true,
         (_, RegClass::Int) => {
             // r6 - r15 inclusive are callee-saves.
             r.hw_enc() >= 6 && r.hw_enc() <= 15
@@ -1380,7 +1382,10 @@ const fn all_clobbers() -> PRegSet {
         .with(vr_preg(30))
         .with(vr_preg(31))
 }
+
 const ALL_CLOBBERS: PRegSet = all_clobbers();
+
+const NO_CLOBBERS: PRegSet = PRegSet::empty();
 
 fn sysv_create_machine_env() -> MachineEnv {
     MachineEnv {

--- a/cranelift/filetests/filetests/isa/aarch64/patchable-abi.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/patchable-abi.clif
@@ -1,0 +1,165 @@
+test compile precise-output
+target aarch64
+
+function %call_patchable_abi(i64) system_v {
+    sig0 = (i64, i64, i64, i64) patchable
+block0(v0: i64):
+    call_indirect sig0, v0(v0, v0, v0, v0)
+    call_indirect sig0, v0(v0, v0, v0, v0)
+    return
+}
+
+; VCode:
+;   stp fp, lr, [sp, #-16]!
+;   mov fp, sp
+; block0:
+;   mov x3, x0
+;   mov x1, x3
+;   mov x2, x3
+;   blr x3
+;   blr x3
+;   ldp fp, lr, [sp], #16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+; block1: ; offset 0x8
+;   mov x3, x0
+;   mov x1, x3
+;   mov x2, x3
+;   blr x3
+;   blr x3
+;   ldp x29, x30, [sp], #0x10
+;   ret
+
+function %patchable_abi_trampoline(i64) patchable {
+    fn0 = %libcall(i64) system_v
+block0(v0: i64):
+    call fn0(v0)
+    return
+}
+
+; VCode:
+;   stp fp, lr, [sp, #-16]!
+;   mov fp, sp
+;   stp x16, x17, [sp, #-16]!
+;   stp x14, x15, [sp, #-16]!
+;   stp x12, x13, [sp, #-16]!
+;   stp x10, x11, [sp, #-16]!
+;   stp x8, x9, [sp, #-16]!
+;   stp x6, x7, [sp, #-16]!
+;   stp x4, x5, [sp, #-16]!
+;   stp x2, x3, [sp, #-16]!
+;   stp x0, x1, [sp, #-16]!
+;   stp d30, d31, [sp, #-16]!
+;   stp d28, d29, [sp, #-16]!
+;   stp d26, d27, [sp, #-16]!
+;   stp d24, d25, [sp, #-16]!
+;   stp d22, d23, [sp, #-16]!
+;   stp d20, d21, [sp, #-16]!
+;   stp d18, d19, [sp, #-16]!
+;   stp d16, d17, [sp, #-16]!
+;   stp d14, d15, [sp, #-16]!
+;   stp d12, d13, [sp, #-16]!
+;   stp d10, d11, [sp, #-16]!
+;   stp d8, d9, [sp, #-16]!
+;   stp d6, d7, [sp, #-16]!
+;   stp d4, d5, [sp, #-16]!
+;   stp d2, d3, [sp, #-16]!
+;   stp d0, d1, [sp, #-16]!
+; block0:
+;   load_ext_name_far x2, TestCase(%libcall)+0
+;   blr x2
+;   ldp d0, d1, [sp], #16
+;   ldp d2, d3, [sp], #16
+;   ldp d4, d5, [sp], #16
+;   ldp d6, d7, [sp], #16
+;   ldp d8, d9, [sp], #16
+;   ldp d10, d11, [sp], #16
+;   ldp d12, d13, [sp], #16
+;   ldp d14, d15, [sp], #16
+;   ldp d16, d17, [sp], #16
+;   ldp d18, d19, [sp], #16
+;   ldp d20, d21, [sp], #16
+;   ldp d22, d23, [sp], #16
+;   ldp d24, d25, [sp], #16
+;   ldp d26, d27, [sp], #16
+;   ldp d28, d29, [sp], #16
+;   ldp d30, d31, [sp], #16
+;   ldp x0, x1, [sp], #16
+;   ldp x2, x3, [sp], #16
+;   ldp x4, x5, [sp], #16
+;   ldp x6, x7, [sp], #16
+;   ldp x8, x9, [sp], #16
+;   ldp x10, x11, [sp], #16
+;   ldp x12, x13, [sp], #16
+;   ldp x14, x15, [sp], #16
+;   ldp x16, x17, [sp], #16
+;   ldp fp, lr, [sp], #16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   stp x16, x17, [sp, #-0x10]!
+;   stp x14, x15, [sp, #-0x10]!
+;   stp x12, x13, [sp, #-0x10]!
+;   stp x10, x11, [sp, #-0x10]!
+;   stp x8, x9, [sp, #-0x10]!
+;   stp x6, x7, [sp, #-0x10]!
+;   stp x4, x5, [sp, #-0x10]!
+;   stp x2, x3, [sp, #-0x10]!
+;   stp x0, x1, [sp, #-0x10]!
+;   stp d30, d31, [sp, #-0x10]!
+;   stp d28, d29, [sp, #-0x10]!
+;   stp d26, d27, [sp, #-0x10]!
+;   stp d24, d25, [sp, #-0x10]!
+;   stp d22, d23, [sp, #-0x10]!
+;   stp d20, d21, [sp, #-0x10]!
+;   stp d18, d19, [sp, #-0x10]!
+;   stp d16, d17, [sp, #-0x10]!
+;   stp d14, d15, [sp, #-0x10]!
+;   stp d12, d13, [sp, #-0x10]!
+;   stp d10, d11, [sp, #-0x10]!
+;   stp d8, d9, [sp, #-0x10]!
+;   stp d6, d7, [sp, #-0x10]!
+;   stp d4, d5, [sp, #-0x10]!
+;   stp d2, d3, [sp, #-0x10]!
+;   stp d0, d1, [sp, #-0x10]!
+; block1: ; offset 0x6c
+;   ldr x2, #0x74
+;   b #0x7c
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %libcall 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   blr x2
+;   ldp d0, d1, [sp], #0x10
+;   ldp d2, d3, [sp], #0x10
+;   ldp d4, d5, [sp], #0x10
+;   ldp d6, d7, [sp], #0x10
+;   ldp d8, d9, [sp], #0x10
+;   ldp d10, d11, [sp], #0x10
+;   ldp d12, d13, [sp], #0x10
+;   ldp d14, d15, [sp], #0x10
+;   ldp d16, d17, [sp], #0x10
+;   ldp d18, d19, [sp], #0x10
+;   ldp d20, d21, [sp], #0x10
+;   ldp d22, d23, [sp], #0x10
+;   ldp d24, d25, [sp], #0x10
+;   ldp d26, d27, [sp], #0x10
+;   ldp d28, d29, [sp], #0x10
+;   ldp d30, d31, [sp], #0x10
+;   ldp x0, x1, [sp], #0x10
+;   ldp x2, x3, [sp], #0x10
+;   ldp x4, x5, [sp], #0x10
+;   ldp x6, x7, [sp], #0x10
+;   ldp x8, x9, [sp], #0x10
+;   ldp x10, x11, [sp], #0x10
+;   ldp x12, x13, [sp], #0x10
+;   ldp x14, x15, [sp], #0x10
+;   ldp x16, x17, [sp], #0x10
+;   ldp x29, x30, [sp], #0x10
+;   ret
+

--- a/cranelift/filetests/filetests/isa/pulley32/patchable-abi.clif
+++ b/cranelift/filetests/filetests/isa/pulley32/patchable-abi.clif
@@ -1,0 +1,372 @@
+test compile precise-output
+target pulley32
+
+function %call_patchable_abi(i64) system_v {
+    sig0 = (i64, i64, i64, i64) patchable
+block0(v0: i64):
+    call_indirect sig0, v0(v0, v0, v0, v0)
+    call_indirect sig0, v0(v0, v0, v0, v0)
+    return
+}
+
+; VCode:
+;   push_frame
+; block0:
+;   xmov x3, x0
+;   xmov x1, x3
+;   xmov x2, x3
+;   indirect_call x3, CallInfo { dest: XReg(p3i), uses: [CallArgPair { vreg: p0i, preg: p0i }, CallArgPair { vreg: p1i, preg: p1i }, CallArgPair { vreg: p2i, preg: p2i }, CallArgPair { vreg: p3i, preg: p3i }], defs: [], clobbers: PRegSet { bits: [0, 0, 0, 0] }, callee_conv: Patchable, caller_conv: SystemV, callee_pop_size: 0, try_call_info: None }
+;   indirect_call x3, CallInfo { dest: XReg(p3i), uses: [CallArgPair { vreg: p0i, preg: p0i }, CallArgPair { vreg: p1i, preg: p1i }, CallArgPair { vreg: p2i, preg: p2i }, CallArgPair { vreg: p3i, preg: p3i }], defs: [], clobbers: PRegSet { bits: [0, 0, 0, 0] }, callee_conv: Patchable, caller_conv: SystemV, callee_pop_size: 0, try_call_info: None }
+;   pop_frame
+;   ret
+;
+; Disassembled:
+; push_frame
+; xmov x3, x0
+; xmov x1, x3
+; xmov x2, x3
+; call_indirect x3
+; call_indirect x3
+; pop_frame
+; ret
+
+function %patchable_abi_trampoline(i64) patchable {
+    fn0 = %libcall(i64) system_v
+block0(v0: i64):
+    call fn0(v0)
+    return
+}
+
+; VCode:
+;   push_frame_save 896, {}
+;   xstore64 sp+888, x0 // flags =  notrap aligned
+;   xstore64 sp+880, x1 // flags =  notrap aligned
+;   xstore64 sp+872, x2 // flags =  notrap aligned
+;   xstore64 sp+864, x3 // flags =  notrap aligned
+;   xstore64 sp+856, x4 // flags =  notrap aligned
+;   xstore64 sp+848, x5 // flags =  notrap aligned
+;   xstore64 sp+840, x6 // flags =  notrap aligned
+;   xstore64 sp+832, x7 // flags =  notrap aligned
+;   xstore64 sp+824, x8 // flags =  notrap aligned
+;   xstore64 sp+816, x9 // flags =  notrap aligned
+;   xstore64 sp+808, x10 // flags =  notrap aligned
+;   xstore64 sp+800, x11 // flags =  notrap aligned
+;   xstore64 sp+792, x12 // flags =  notrap aligned
+;   xstore64 sp+784, x13 // flags =  notrap aligned
+;   xstore64 sp+776, x14 // flags =  notrap aligned
+;   xstore64 sp+768, x15 // flags =  notrap aligned
+;   fstore64 sp+760, f0 // flags =  notrap aligned
+;   fstore64 sp+752, f1 // flags =  notrap aligned
+;   fstore64 sp+744, f2 // flags =  notrap aligned
+;   fstore64 sp+736, f3 // flags =  notrap aligned
+;   fstore64 sp+728, f4 // flags =  notrap aligned
+;   fstore64 sp+720, f5 // flags =  notrap aligned
+;   fstore64 sp+712, f6 // flags =  notrap aligned
+;   fstore64 sp+704, f7 // flags =  notrap aligned
+;   fstore64 sp+696, f8 // flags =  notrap aligned
+;   fstore64 sp+688, f9 // flags =  notrap aligned
+;   fstore64 sp+680, f10 // flags =  notrap aligned
+;   fstore64 sp+672, f11 // flags =  notrap aligned
+;   fstore64 sp+664, f12 // flags =  notrap aligned
+;   fstore64 sp+656, f13 // flags =  notrap aligned
+;   fstore64 sp+648, f14 // flags =  notrap aligned
+;   fstore64 sp+640, f15 // flags =  notrap aligned
+;   fstore64 sp+632, f16 // flags =  notrap aligned
+;   fstore64 sp+624, f17 // flags =  notrap aligned
+;   fstore64 sp+616, f18 // flags =  notrap aligned
+;   fstore64 sp+608, f19 // flags =  notrap aligned
+;   fstore64 sp+600, f20 // flags =  notrap aligned
+;   fstore64 sp+592, f21 // flags =  notrap aligned
+;   fstore64 sp+584, f22 // flags =  notrap aligned
+;   fstore64 sp+576, f23 // flags =  notrap aligned
+;   fstore64 sp+568, f24 // flags =  notrap aligned
+;   fstore64 sp+560, f25 // flags =  notrap aligned
+;   fstore64 sp+552, f26 // flags =  notrap aligned
+;   fstore64 sp+544, f27 // flags =  notrap aligned
+;   fstore64 sp+536, f28 // flags =  notrap aligned
+;   fstore64 sp+528, f29 // flags =  notrap aligned
+;   fstore64 sp+520, f30 // flags =  notrap aligned
+;   fstore64 sp+512, f31 // flags =  notrap aligned
+;   vstore128 sp+504, v0 // flags =  notrap aligned
+;   vstore128 sp+496, v1 // flags =  notrap aligned
+;   vstore128 sp+488, v2 // flags =  notrap aligned
+;   vstore128 sp+480, v3 // flags =  notrap aligned
+;   vstore128 sp+472, v4 // flags =  notrap aligned
+;   vstore128 sp+464, v5 // flags =  notrap aligned
+;   vstore128 sp+456, v6 // flags =  notrap aligned
+;   vstore128 sp+448, v7 // flags =  notrap aligned
+;   vstore128 sp+440, v8 // flags =  notrap aligned
+;   vstore128 sp+432, v9 // flags =  notrap aligned
+;   vstore128 sp+424, v10 // flags =  notrap aligned
+;   vstore128 sp+416, v11 // flags =  notrap aligned
+;   vstore128 sp+408, v12 // flags =  notrap aligned
+;   vstore128 sp+400, v13 // flags =  notrap aligned
+;   vstore128 sp+392, v14 // flags =  notrap aligned
+;   vstore128 sp+384, v15 // flags =  notrap aligned
+;   vstore128 sp+376, v16 // flags =  notrap aligned
+;   vstore128 sp+368, v17 // flags =  notrap aligned
+;   vstore128 sp+360, v18 // flags =  notrap aligned
+;   vstore128 sp+352, v19 // flags =  notrap aligned
+;   vstore128 sp+344, v20 // flags =  notrap aligned
+;   vstore128 sp+336, v21 // flags =  notrap aligned
+;   vstore128 sp+328, v22 // flags =  notrap aligned
+;   vstore128 sp+320, v23 // flags =  notrap aligned
+;   vstore128 sp+312, v24 // flags =  notrap aligned
+;   vstore128 sp+304, v25 // flags =  notrap aligned
+;   vstore128 sp+296, v26 // flags =  notrap aligned
+;   vstore128 sp+288, v27 // flags =  notrap aligned
+;   vstore128 sp+280, v28 // flags =  notrap aligned
+;   vstore128 sp+272, v29 // flags =  notrap aligned
+;   vstore128 sp+264, v30 // flags =  notrap aligned
+;   vstore128 sp+256, v31 // flags =  notrap aligned
+; block0:
+;   indirect_call_host CallInfo { dest: TestCase(%libcall), uses: [CallArgPair { vreg: p0i, preg: p0i }], defs: [], clobbers: PRegSet { bits: [65535, 4294967295, 4294967295, 0] }, callee_conv: SystemV, caller_conv: Patchable, callee_pop_size: 0, try_call_info: None }
+;   x0 = xload64 sp+888 // flags = notrap aligned
+;   x1 = xload64 sp+880 // flags = notrap aligned
+;   x2 = xload64 sp+872 // flags = notrap aligned
+;   x3 = xload64 sp+864 // flags = notrap aligned
+;   x4 = xload64 sp+856 // flags = notrap aligned
+;   x5 = xload64 sp+848 // flags = notrap aligned
+;   x6 = xload64 sp+840 // flags = notrap aligned
+;   x7 = xload64 sp+832 // flags = notrap aligned
+;   x8 = xload64 sp+824 // flags = notrap aligned
+;   x9 = xload64 sp+816 // flags = notrap aligned
+;   x10 = xload64 sp+808 // flags = notrap aligned
+;   x11 = xload64 sp+800 // flags = notrap aligned
+;   x12 = xload64 sp+792 // flags = notrap aligned
+;   x13 = xload64 sp+784 // flags = notrap aligned
+;   x14 = xload64 sp+776 // flags = notrap aligned
+;   x15 = xload64 sp+768 // flags = notrap aligned
+;   f0 = fload64 sp+760 // flags = notrap aligned
+;   f1 = fload64 sp+752 // flags = notrap aligned
+;   f2 = fload64 sp+744 // flags = notrap aligned
+;   f3 = fload64 sp+736 // flags = notrap aligned
+;   f4 = fload64 sp+728 // flags = notrap aligned
+;   f5 = fload64 sp+720 // flags = notrap aligned
+;   f6 = fload64 sp+712 // flags = notrap aligned
+;   f7 = fload64 sp+704 // flags = notrap aligned
+;   f8 = fload64 sp+696 // flags = notrap aligned
+;   f9 = fload64 sp+688 // flags = notrap aligned
+;   f10 = fload64 sp+680 // flags = notrap aligned
+;   f11 = fload64 sp+672 // flags = notrap aligned
+;   f12 = fload64 sp+664 // flags = notrap aligned
+;   f13 = fload64 sp+656 // flags = notrap aligned
+;   f14 = fload64 sp+648 // flags = notrap aligned
+;   f15 = fload64 sp+640 // flags = notrap aligned
+;   f16 = fload64 sp+632 // flags = notrap aligned
+;   f17 = fload64 sp+624 // flags = notrap aligned
+;   f18 = fload64 sp+616 // flags = notrap aligned
+;   f19 = fload64 sp+608 // flags = notrap aligned
+;   f20 = fload64 sp+600 // flags = notrap aligned
+;   f21 = fload64 sp+592 // flags = notrap aligned
+;   f22 = fload64 sp+584 // flags = notrap aligned
+;   f23 = fload64 sp+576 // flags = notrap aligned
+;   f24 = fload64 sp+568 // flags = notrap aligned
+;   f25 = fload64 sp+560 // flags = notrap aligned
+;   f26 = fload64 sp+552 // flags = notrap aligned
+;   f27 = fload64 sp+544 // flags = notrap aligned
+;   f28 = fload64 sp+536 // flags = notrap aligned
+;   f29 = fload64 sp+528 // flags = notrap aligned
+;   f30 = fload64 sp+520 // flags = notrap aligned
+;   f31 = fload64 sp+512 // flags = notrap aligned
+;   v0 = vload128 sp+504 // flags = notrap aligned
+;   v1 = vload128 sp+496 // flags = notrap aligned
+;   v2 = vload128 sp+488 // flags = notrap aligned
+;   v3 = vload128 sp+480 // flags = notrap aligned
+;   v4 = vload128 sp+472 // flags = notrap aligned
+;   v5 = vload128 sp+464 // flags = notrap aligned
+;   v6 = vload128 sp+456 // flags = notrap aligned
+;   v7 = vload128 sp+448 // flags = notrap aligned
+;   v8 = vload128 sp+440 // flags = notrap aligned
+;   v9 = vload128 sp+432 // flags = notrap aligned
+;   v10 = vload128 sp+424 // flags = notrap aligned
+;   v11 = vload128 sp+416 // flags = notrap aligned
+;   v12 = vload128 sp+408 // flags = notrap aligned
+;   v13 = vload128 sp+400 // flags = notrap aligned
+;   v14 = vload128 sp+392 // flags = notrap aligned
+;   v15 = vload128 sp+384 // flags = notrap aligned
+;   v16 = vload128 sp+376 // flags = notrap aligned
+;   v17 = vload128 sp+368 // flags = notrap aligned
+;   v18 = vload128 sp+360 // flags = notrap aligned
+;   v19 = vload128 sp+352 // flags = notrap aligned
+;   v20 = vload128 sp+344 // flags = notrap aligned
+;   v21 = vload128 sp+336 // flags = notrap aligned
+;   v22 = vload128 sp+328 // flags = notrap aligned
+;   v23 = vload128 sp+320 // flags = notrap aligned
+;   v24 = vload128 sp+312 // flags = notrap aligned
+;   v25 = vload128 sp+304 // flags = notrap aligned
+;   v26 = vload128 sp+296 // flags = notrap aligned
+;   v27 = vload128 sp+288 // flags = notrap aligned
+;   v28 = vload128 sp+280 // flags = notrap aligned
+;   v29 = vload128 sp+272 // flags = notrap aligned
+;   v30 = vload128 sp+264 // flags = notrap aligned
+;   v31 = vload128 sp+256 // flags = notrap aligned
+;   pop_frame_restore 896, {}
+;   ret
+;
+; Disassembled:
+; push_frame_save 896, 
+; xstore64le_o32 sp, 888, x0
+; xstore64le_o32 sp, 880, x1
+; xstore64le_o32 sp, 872, x2
+; xstore64le_o32 sp, 864, x3
+; xstore64le_o32 sp, 856, x4
+; xstore64le_o32 sp, 848, x5
+; xstore64le_o32 sp, 840, x6
+; xstore64le_o32 sp, 832, x7
+; xstore64le_o32 sp, 824, x8
+; xstore64le_o32 sp, 816, x9
+; xstore64le_o32 sp, 808, x10
+; xstore64le_o32 sp, 800, x11
+; xstore64le_o32 sp, 792, x12
+; xstore64le_o32 sp, 784, x13
+; xstore64le_o32 sp, 776, x14
+; xstore64le_o32 sp, 768, x15
+; fstore64le_o32 sp, 760, f0
+; fstore64le_o32 sp, 752, f1
+; fstore64le_o32 sp, 744, f2
+; fstore64le_o32 sp, 736, f3
+; fstore64le_o32 sp, 728, f4
+; fstore64le_o32 sp, 720, f5
+; fstore64le_o32 sp, 712, f6
+; fstore64le_o32 sp, 704, f7
+; fstore64le_o32 sp, 696, f8
+; fstore64le_o32 sp, 688, f9
+; fstore64le_o32 sp, 680, f10
+; fstore64le_o32 sp, 672, f11
+; fstore64le_o32 sp, 664, f12
+; fstore64le_o32 sp, 656, f13
+; fstore64le_o32 sp, 648, f14
+; fstore64le_o32 sp, 640, f15
+; fstore64le_o32 sp, 632, f16
+; fstore64le_o32 sp, 624, f17
+; fstore64le_o32 sp, 616, f18
+; fstore64le_o32 sp, 608, f19
+; fstore64le_o32 sp, 600, f20
+; fstore64le_o32 sp, 592, f21
+; fstore64le_o32 sp, 584, f22
+; fstore64le_o32 sp, 576, f23
+; fstore64le_o32 sp, 568, f24
+; fstore64le_o32 sp, 560, f25
+; fstore64le_o32 sp, 552, f26
+; fstore64le_o32 sp, 544, f27
+; fstore64le_o32 sp, 536, f28
+; fstore64le_o32 sp, 528, f29
+; fstore64le_o32 sp, 520, f30
+; fstore64le_o32 sp, 512, f31
+; vstore128le_o32 sp, 504, v0
+; vstore128le_o32 sp, 496, v1
+; vstore128le_o32 sp, 488, v2
+; vstore128le_o32 sp, 480, v3
+; vstore128le_o32 sp, 472, v4
+; vstore128le_o32 sp, 464, v5
+; vstore128le_o32 sp, 456, v6
+; vstore128le_o32 sp, 448, v7
+; vstore128le_o32 sp, 440, v8
+; vstore128le_o32 sp, 432, v9
+; vstore128le_o32 sp, 424, v10
+; vstore128le_o32 sp, 416, v11
+; vstore128le_o32 sp, 408, v12
+; vstore128le_o32 sp, 400, v13
+; vstore128le_o32 sp, 392, v14
+; vstore128le_o32 sp, 384, v15
+; vstore128le_o32 sp, 376, v16
+; vstore128le_o32 sp, 368, v17
+; vstore128le_o32 sp, 360, v18
+; vstore128le_o32 sp, 352, v19
+; vstore128le_o32 sp, 344, v20
+; vstore128le_o32 sp, 336, v21
+; vstore128le_o32 sp, 328, v22
+; vstore128le_o32 sp, 320, v23
+; vstore128le_o32 sp, 312, v24
+; vstore128le_o32 sp, 304, v25
+; vstore128le_o32 sp, 296, v26
+; vstore128le_o32 sp, 288, v27
+; vstore128le_o32 sp, 280, v28
+; vstore128le_o32 sp, 272, v29
+; vstore128le_o32 sp, 264, v30
+; vstore128le_o32 sp, 256, v31
+; call_indirect_host 0
+; xload64le_o32 x0, sp, 888
+; xload64le_o32 x1, sp, 880
+; xload64le_o32 x2, sp, 872
+; xload64le_o32 x3, sp, 864
+; xload64le_o32 x4, sp, 856
+; xload64le_o32 x5, sp, 848
+; xload64le_o32 x6, sp, 840
+; xload64le_o32 x7, sp, 832
+; xload64le_o32 x8, sp, 824
+; xload64le_o32 x9, sp, 816
+; xload64le_o32 x10, sp, 808
+; xload64le_o32 x11, sp, 800
+; xload64le_o32 x12, sp, 792
+; xload64le_o32 x13, sp, 784
+; xload64le_o32 x14, sp, 776
+; xload64le_o32 x15, sp, 768
+; fload64le_o32 f0, sp, 760
+; fload64le_o32 f1, sp, 752
+; fload64le_o32 f2, sp, 744
+; fload64le_o32 f3, sp, 736
+; fload64le_o32 f4, sp, 728
+; fload64le_o32 f5, sp, 720
+; fload64le_o32 f6, sp, 712
+; fload64le_o32 f7, sp, 704
+; fload64le_o32 f8, sp, 696
+; fload64le_o32 f9, sp, 688
+; fload64le_o32 f10, sp, 680
+; fload64le_o32 f11, sp, 672
+; fload64le_o32 f12, sp, 664
+; fload64le_o32 f13, sp, 656
+; fload64le_o32 f14, sp, 648
+; fload64le_o32 f15, sp, 640
+; fload64le_o32 f16, sp, 632
+; fload64le_o32 f17, sp, 624
+; fload64le_o32 f18, sp, 616
+; fload64le_o32 f19, sp, 608
+; fload64le_o32 f20, sp, 600
+; fload64le_o32 f21, sp, 592
+; fload64le_o32 f22, sp, 584
+; fload64le_o32 f23, sp, 576
+; fload64le_o32 f24, sp, 568
+; fload64le_o32 f25, sp, 560
+; fload64le_o32 f26, sp, 552
+; fload64le_o32 f27, sp, 544
+; fload64le_o32 f28, sp, 536
+; fload64le_o32 f29, sp, 528
+; fload64le_o32 f30, sp, 520
+; fload64le_o32 f31, sp, 512
+; vload128le_o32 v0, sp, 504
+; vload128le_o32 v1, sp, 496
+; vload128le_o32 v2, sp, 488
+; vload128le_o32 v3, sp, 480
+; vload128le_o32 v4, sp, 472
+; vload128le_o32 v5, sp, 464
+; vload128le_o32 v6, sp, 456
+; vload128le_o32 v7, sp, 448
+; vload128le_o32 v8, sp, 440
+; vload128le_o32 v9, sp, 432
+; vload128le_o32 v10, sp, 424
+; vload128le_o32 v11, sp, 416
+; vload128le_o32 v12, sp, 408
+; vload128le_o32 v13, sp, 400
+; vload128le_o32 v14, sp, 392
+; vload128le_o32 v15, sp, 384
+; vload128le_o32 v16, sp, 376
+; vload128le_o32 v17, sp, 368
+; vload128le_o32 v18, sp, 360
+; vload128le_o32 v19, sp, 352
+; vload128le_o32 v20, sp, 344
+; vload128le_o32 v21, sp, 336
+; vload128le_o32 v22, sp, 328
+; vload128le_o32 v23, sp, 320
+; vload128le_o32 v24, sp, 312
+; vload128le_o32 v25, sp, 304
+; vload128le_o32 v26, sp, 296
+; vload128le_o32 v27, sp, 288
+; vload128le_o32 v28, sp, 280
+; vload128le_o32 v29, sp, 272
+; vload128le_o32 v30, sp, 264
+; vload128le_o32 v31, sp, 256
+; pop_frame_restore 896, 
+; ret
+

--- a/cranelift/filetests/filetests/isa/pulley64/patchable-abi.clif
+++ b/cranelift/filetests/filetests/isa/pulley64/patchable-abi.clif
@@ -1,0 +1,372 @@
+test compile precise-output
+target pulley64
+
+function %call_patchable_abi(i64) system_v {
+    sig0 = (i64, i64, i64, i64) patchable
+block0(v0: i64):
+    call_indirect sig0, v0(v0, v0, v0, v0)
+    call_indirect sig0, v0(v0, v0, v0, v0)
+    return
+}
+
+; VCode:
+;   push_frame
+; block0:
+;   xmov x3, x0
+;   xmov x1, x3
+;   xmov x2, x3
+;   indirect_call x3, CallInfo { dest: XReg(p3i), uses: [CallArgPair { vreg: p0i, preg: p0i }, CallArgPair { vreg: p1i, preg: p1i }, CallArgPair { vreg: p2i, preg: p2i }, CallArgPair { vreg: p3i, preg: p3i }], defs: [], clobbers: PRegSet { bits: [0, 0, 0, 0] }, callee_conv: Patchable, caller_conv: SystemV, callee_pop_size: 0, try_call_info: None }
+;   indirect_call x3, CallInfo { dest: XReg(p3i), uses: [CallArgPair { vreg: p0i, preg: p0i }, CallArgPair { vreg: p1i, preg: p1i }, CallArgPair { vreg: p2i, preg: p2i }, CallArgPair { vreg: p3i, preg: p3i }], defs: [], clobbers: PRegSet { bits: [0, 0, 0, 0] }, callee_conv: Patchable, caller_conv: SystemV, callee_pop_size: 0, try_call_info: None }
+;   pop_frame
+;   ret
+;
+; Disassembled:
+; push_frame
+; xmov x3, x0
+; xmov x1, x3
+; xmov x2, x3
+; call_indirect x3
+; call_indirect x3
+; pop_frame
+; ret
+
+function %patchable_abi_trampoline(i64) patchable {
+    fn0 = %libcall(i64) system_v
+block0(v0: i64):
+    call fn0(v0)
+    return
+}
+
+; VCode:
+;   push_frame_save 896, {}
+;   xstore64 sp+888, x0 // flags =  notrap aligned
+;   xstore64 sp+880, x1 // flags =  notrap aligned
+;   xstore64 sp+872, x2 // flags =  notrap aligned
+;   xstore64 sp+864, x3 // flags =  notrap aligned
+;   xstore64 sp+856, x4 // flags =  notrap aligned
+;   xstore64 sp+848, x5 // flags =  notrap aligned
+;   xstore64 sp+840, x6 // flags =  notrap aligned
+;   xstore64 sp+832, x7 // flags =  notrap aligned
+;   xstore64 sp+824, x8 // flags =  notrap aligned
+;   xstore64 sp+816, x9 // flags =  notrap aligned
+;   xstore64 sp+808, x10 // flags =  notrap aligned
+;   xstore64 sp+800, x11 // flags =  notrap aligned
+;   xstore64 sp+792, x12 // flags =  notrap aligned
+;   xstore64 sp+784, x13 // flags =  notrap aligned
+;   xstore64 sp+776, x14 // flags =  notrap aligned
+;   xstore64 sp+768, x15 // flags =  notrap aligned
+;   fstore64 sp+760, f0 // flags =  notrap aligned
+;   fstore64 sp+752, f1 // flags =  notrap aligned
+;   fstore64 sp+744, f2 // flags =  notrap aligned
+;   fstore64 sp+736, f3 // flags =  notrap aligned
+;   fstore64 sp+728, f4 // flags =  notrap aligned
+;   fstore64 sp+720, f5 // flags =  notrap aligned
+;   fstore64 sp+712, f6 // flags =  notrap aligned
+;   fstore64 sp+704, f7 // flags =  notrap aligned
+;   fstore64 sp+696, f8 // flags =  notrap aligned
+;   fstore64 sp+688, f9 // flags =  notrap aligned
+;   fstore64 sp+680, f10 // flags =  notrap aligned
+;   fstore64 sp+672, f11 // flags =  notrap aligned
+;   fstore64 sp+664, f12 // flags =  notrap aligned
+;   fstore64 sp+656, f13 // flags =  notrap aligned
+;   fstore64 sp+648, f14 // flags =  notrap aligned
+;   fstore64 sp+640, f15 // flags =  notrap aligned
+;   fstore64 sp+632, f16 // flags =  notrap aligned
+;   fstore64 sp+624, f17 // flags =  notrap aligned
+;   fstore64 sp+616, f18 // flags =  notrap aligned
+;   fstore64 sp+608, f19 // flags =  notrap aligned
+;   fstore64 sp+600, f20 // flags =  notrap aligned
+;   fstore64 sp+592, f21 // flags =  notrap aligned
+;   fstore64 sp+584, f22 // flags =  notrap aligned
+;   fstore64 sp+576, f23 // flags =  notrap aligned
+;   fstore64 sp+568, f24 // flags =  notrap aligned
+;   fstore64 sp+560, f25 // flags =  notrap aligned
+;   fstore64 sp+552, f26 // flags =  notrap aligned
+;   fstore64 sp+544, f27 // flags =  notrap aligned
+;   fstore64 sp+536, f28 // flags =  notrap aligned
+;   fstore64 sp+528, f29 // flags =  notrap aligned
+;   fstore64 sp+520, f30 // flags =  notrap aligned
+;   fstore64 sp+512, f31 // flags =  notrap aligned
+;   vstore128 sp+504, v0 // flags =  notrap aligned
+;   vstore128 sp+496, v1 // flags =  notrap aligned
+;   vstore128 sp+488, v2 // flags =  notrap aligned
+;   vstore128 sp+480, v3 // flags =  notrap aligned
+;   vstore128 sp+472, v4 // flags =  notrap aligned
+;   vstore128 sp+464, v5 // flags =  notrap aligned
+;   vstore128 sp+456, v6 // flags =  notrap aligned
+;   vstore128 sp+448, v7 // flags =  notrap aligned
+;   vstore128 sp+440, v8 // flags =  notrap aligned
+;   vstore128 sp+432, v9 // flags =  notrap aligned
+;   vstore128 sp+424, v10 // flags =  notrap aligned
+;   vstore128 sp+416, v11 // flags =  notrap aligned
+;   vstore128 sp+408, v12 // flags =  notrap aligned
+;   vstore128 sp+400, v13 // flags =  notrap aligned
+;   vstore128 sp+392, v14 // flags =  notrap aligned
+;   vstore128 sp+384, v15 // flags =  notrap aligned
+;   vstore128 sp+376, v16 // flags =  notrap aligned
+;   vstore128 sp+368, v17 // flags =  notrap aligned
+;   vstore128 sp+360, v18 // flags =  notrap aligned
+;   vstore128 sp+352, v19 // flags =  notrap aligned
+;   vstore128 sp+344, v20 // flags =  notrap aligned
+;   vstore128 sp+336, v21 // flags =  notrap aligned
+;   vstore128 sp+328, v22 // flags =  notrap aligned
+;   vstore128 sp+320, v23 // flags =  notrap aligned
+;   vstore128 sp+312, v24 // flags =  notrap aligned
+;   vstore128 sp+304, v25 // flags =  notrap aligned
+;   vstore128 sp+296, v26 // flags =  notrap aligned
+;   vstore128 sp+288, v27 // flags =  notrap aligned
+;   vstore128 sp+280, v28 // flags =  notrap aligned
+;   vstore128 sp+272, v29 // flags =  notrap aligned
+;   vstore128 sp+264, v30 // flags =  notrap aligned
+;   vstore128 sp+256, v31 // flags =  notrap aligned
+; block0:
+;   indirect_call_host CallInfo { dest: TestCase(%libcall), uses: [CallArgPair { vreg: p0i, preg: p0i }], defs: [], clobbers: PRegSet { bits: [65535, 4294967295, 4294967295, 0] }, callee_conv: SystemV, caller_conv: Patchable, callee_pop_size: 0, try_call_info: None }
+;   x0 = xload64 sp+888 // flags = notrap aligned
+;   x1 = xload64 sp+880 // flags = notrap aligned
+;   x2 = xload64 sp+872 // flags = notrap aligned
+;   x3 = xload64 sp+864 // flags = notrap aligned
+;   x4 = xload64 sp+856 // flags = notrap aligned
+;   x5 = xload64 sp+848 // flags = notrap aligned
+;   x6 = xload64 sp+840 // flags = notrap aligned
+;   x7 = xload64 sp+832 // flags = notrap aligned
+;   x8 = xload64 sp+824 // flags = notrap aligned
+;   x9 = xload64 sp+816 // flags = notrap aligned
+;   x10 = xload64 sp+808 // flags = notrap aligned
+;   x11 = xload64 sp+800 // flags = notrap aligned
+;   x12 = xload64 sp+792 // flags = notrap aligned
+;   x13 = xload64 sp+784 // flags = notrap aligned
+;   x14 = xload64 sp+776 // flags = notrap aligned
+;   x15 = xload64 sp+768 // flags = notrap aligned
+;   f0 = fload64 sp+760 // flags = notrap aligned
+;   f1 = fload64 sp+752 // flags = notrap aligned
+;   f2 = fload64 sp+744 // flags = notrap aligned
+;   f3 = fload64 sp+736 // flags = notrap aligned
+;   f4 = fload64 sp+728 // flags = notrap aligned
+;   f5 = fload64 sp+720 // flags = notrap aligned
+;   f6 = fload64 sp+712 // flags = notrap aligned
+;   f7 = fload64 sp+704 // flags = notrap aligned
+;   f8 = fload64 sp+696 // flags = notrap aligned
+;   f9 = fload64 sp+688 // flags = notrap aligned
+;   f10 = fload64 sp+680 // flags = notrap aligned
+;   f11 = fload64 sp+672 // flags = notrap aligned
+;   f12 = fload64 sp+664 // flags = notrap aligned
+;   f13 = fload64 sp+656 // flags = notrap aligned
+;   f14 = fload64 sp+648 // flags = notrap aligned
+;   f15 = fload64 sp+640 // flags = notrap aligned
+;   f16 = fload64 sp+632 // flags = notrap aligned
+;   f17 = fload64 sp+624 // flags = notrap aligned
+;   f18 = fload64 sp+616 // flags = notrap aligned
+;   f19 = fload64 sp+608 // flags = notrap aligned
+;   f20 = fload64 sp+600 // flags = notrap aligned
+;   f21 = fload64 sp+592 // flags = notrap aligned
+;   f22 = fload64 sp+584 // flags = notrap aligned
+;   f23 = fload64 sp+576 // flags = notrap aligned
+;   f24 = fload64 sp+568 // flags = notrap aligned
+;   f25 = fload64 sp+560 // flags = notrap aligned
+;   f26 = fload64 sp+552 // flags = notrap aligned
+;   f27 = fload64 sp+544 // flags = notrap aligned
+;   f28 = fload64 sp+536 // flags = notrap aligned
+;   f29 = fload64 sp+528 // flags = notrap aligned
+;   f30 = fload64 sp+520 // flags = notrap aligned
+;   f31 = fload64 sp+512 // flags = notrap aligned
+;   v0 = vload128 sp+504 // flags = notrap aligned
+;   v1 = vload128 sp+496 // flags = notrap aligned
+;   v2 = vload128 sp+488 // flags = notrap aligned
+;   v3 = vload128 sp+480 // flags = notrap aligned
+;   v4 = vload128 sp+472 // flags = notrap aligned
+;   v5 = vload128 sp+464 // flags = notrap aligned
+;   v6 = vload128 sp+456 // flags = notrap aligned
+;   v7 = vload128 sp+448 // flags = notrap aligned
+;   v8 = vload128 sp+440 // flags = notrap aligned
+;   v9 = vload128 sp+432 // flags = notrap aligned
+;   v10 = vload128 sp+424 // flags = notrap aligned
+;   v11 = vload128 sp+416 // flags = notrap aligned
+;   v12 = vload128 sp+408 // flags = notrap aligned
+;   v13 = vload128 sp+400 // flags = notrap aligned
+;   v14 = vload128 sp+392 // flags = notrap aligned
+;   v15 = vload128 sp+384 // flags = notrap aligned
+;   v16 = vload128 sp+376 // flags = notrap aligned
+;   v17 = vload128 sp+368 // flags = notrap aligned
+;   v18 = vload128 sp+360 // flags = notrap aligned
+;   v19 = vload128 sp+352 // flags = notrap aligned
+;   v20 = vload128 sp+344 // flags = notrap aligned
+;   v21 = vload128 sp+336 // flags = notrap aligned
+;   v22 = vload128 sp+328 // flags = notrap aligned
+;   v23 = vload128 sp+320 // flags = notrap aligned
+;   v24 = vload128 sp+312 // flags = notrap aligned
+;   v25 = vload128 sp+304 // flags = notrap aligned
+;   v26 = vload128 sp+296 // flags = notrap aligned
+;   v27 = vload128 sp+288 // flags = notrap aligned
+;   v28 = vload128 sp+280 // flags = notrap aligned
+;   v29 = vload128 sp+272 // flags = notrap aligned
+;   v30 = vload128 sp+264 // flags = notrap aligned
+;   v31 = vload128 sp+256 // flags = notrap aligned
+;   pop_frame_restore 896, {}
+;   ret
+;
+; Disassembled:
+; push_frame_save 896, 
+; xstore64le_o32 sp, 888, x0
+; xstore64le_o32 sp, 880, x1
+; xstore64le_o32 sp, 872, x2
+; xstore64le_o32 sp, 864, x3
+; xstore64le_o32 sp, 856, x4
+; xstore64le_o32 sp, 848, x5
+; xstore64le_o32 sp, 840, x6
+; xstore64le_o32 sp, 832, x7
+; xstore64le_o32 sp, 824, x8
+; xstore64le_o32 sp, 816, x9
+; xstore64le_o32 sp, 808, x10
+; xstore64le_o32 sp, 800, x11
+; xstore64le_o32 sp, 792, x12
+; xstore64le_o32 sp, 784, x13
+; xstore64le_o32 sp, 776, x14
+; xstore64le_o32 sp, 768, x15
+; fstore64le_o32 sp, 760, f0
+; fstore64le_o32 sp, 752, f1
+; fstore64le_o32 sp, 744, f2
+; fstore64le_o32 sp, 736, f3
+; fstore64le_o32 sp, 728, f4
+; fstore64le_o32 sp, 720, f5
+; fstore64le_o32 sp, 712, f6
+; fstore64le_o32 sp, 704, f7
+; fstore64le_o32 sp, 696, f8
+; fstore64le_o32 sp, 688, f9
+; fstore64le_o32 sp, 680, f10
+; fstore64le_o32 sp, 672, f11
+; fstore64le_o32 sp, 664, f12
+; fstore64le_o32 sp, 656, f13
+; fstore64le_o32 sp, 648, f14
+; fstore64le_o32 sp, 640, f15
+; fstore64le_o32 sp, 632, f16
+; fstore64le_o32 sp, 624, f17
+; fstore64le_o32 sp, 616, f18
+; fstore64le_o32 sp, 608, f19
+; fstore64le_o32 sp, 600, f20
+; fstore64le_o32 sp, 592, f21
+; fstore64le_o32 sp, 584, f22
+; fstore64le_o32 sp, 576, f23
+; fstore64le_o32 sp, 568, f24
+; fstore64le_o32 sp, 560, f25
+; fstore64le_o32 sp, 552, f26
+; fstore64le_o32 sp, 544, f27
+; fstore64le_o32 sp, 536, f28
+; fstore64le_o32 sp, 528, f29
+; fstore64le_o32 sp, 520, f30
+; fstore64le_o32 sp, 512, f31
+; vstore128le_o32 sp, 504, v0
+; vstore128le_o32 sp, 496, v1
+; vstore128le_o32 sp, 488, v2
+; vstore128le_o32 sp, 480, v3
+; vstore128le_o32 sp, 472, v4
+; vstore128le_o32 sp, 464, v5
+; vstore128le_o32 sp, 456, v6
+; vstore128le_o32 sp, 448, v7
+; vstore128le_o32 sp, 440, v8
+; vstore128le_o32 sp, 432, v9
+; vstore128le_o32 sp, 424, v10
+; vstore128le_o32 sp, 416, v11
+; vstore128le_o32 sp, 408, v12
+; vstore128le_o32 sp, 400, v13
+; vstore128le_o32 sp, 392, v14
+; vstore128le_o32 sp, 384, v15
+; vstore128le_o32 sp, 376, v16
+; vstore128le_o32 sp, 368, v17
+; vstore128le_o32 sp, 360, v18
+; vstore128le_o32 sp, 352, v19
+; vstore128le_o32 sp, 344, v20
+; vstore128le_o32 sp, 336, v21
+; vstore128le_o32 sp, 328, v22
+; vstore128le_o32 sp, 320, v23
+; vstore128le_o32 sp, 312, v24
+; vstore128le_o32 sp, 304, v25
+; vstore128le_o32 sp, 296, v26
+; vstore128le_o32 sp, 288, v27
+; vstore128le_o32 sp, 280, v28
+; vstore128le_o32 sp, 272, v29
+; vstore128le_o32 sp, 264, v30
+; vstore128le_o32 sp, 256, v31
+; call_indirect_host 0
+; xload64le_o32 x0, sp, 888
+; xload64le_o32 x1, sp, 880
+; xload64le_o32 x2, sp, 872
+; xload64le_o32 x3, sp, 864
+; xload64le_o32 x4, sp, 856
+; xload64le_o32 x5, sp, 848
+; xload64le_o32 x6, sp, 840
+; xload64le_o32 x7, sp, 832
+; xload64le_o32 x8, sp, 824
+; xload64le_o32 x9, sp, 816
+; xload64le_o32 x10, sp, 808
+; xload64le_o32 x11, sp, 800
+; xload64le_o32 x12, sp, 792
+; xload64le_o32 x13, sp, 784
+; xload64le_o32 x14, sp, 776
+; xload64le_o32 x15, sp, 768
+; fload64le_o32 f0, sp, 760
+; fload64le_o32 f1, sp, 752
+; fload64le_o32 f2, sp, 744
+; fload64le_o32 f3, sp, 736
+; fload64le_o32 f4, sp, 728
+; fload64le_o32 f5, sp, 720
+; fload64le_o32 f6, sp, 712
+; fload64le_o32 f7, sp, 704
+; fload64le_o32 f8, sp, 696
+; fload64le_o32 f9, sp, 688
+; fload64le_o32 f10, sp, 680
+; fload64le_o32 f11, sp, 672
+; fload64le_o32 f12, sp, 664
+; fload64le_o32 f13, sp, 656
+; fload64le_o32 f14, sp, 648
+; fload64le_o32 f15, sp, 640
+; fload64le_o32 f16, sp, 632
+; fload64le_o32 f17, sp, 624
+; fload64le_o32 f18, sp, 616
+; fload64le_o32 f19, sp, 608
+; fload64le_o32 f20, sp, 600
+; fload64le_o32 f21, sp, 592
+; fload64le_o32 f22, sp, 584
+; fload64le_o32 f23, sp, 576
+; fload64le_o32 f24, sp, 568
+; fload64le_o32 f25, sp, 560
+; fload64le_o32 f26, sp, 552
+; fload64le_o32 f27, sp, 544
+; fload64le_o32 f28, sp, 536
+; fload64le_o32 f29, sp, 528
+; fload64le_o32 f30, sp, 520
+; fload64le_o32 f31, sp, 512
+; vload128le_o32 v0, sp, 504
+; vload128le_o32 v1, sp, 496
+; vload128le_o32 v2, sp, 488
+; vload128le_o32 v3, sp, 480
+; vload128le_o32 v4, sp, 472
+; vload128le_o32 v5, sp, 464
+; vload128le_o32 v6, sp, 456
+; vload128le_o32 v7, sp, 448
+; vload128le_o32 v8, sp, 440
+; vload128le_o32 v9, sp, 432
+; vload128le_o32 v10, sp, 424
+; vload128le_o32 v11, sp, 416
+; vload128le_o32 v12, sp, 408
+; vload128le_o32 v13, sp, 400
+; vload128le_o32 v14, sp, 392
+; vload128le_o32 v15, sp, 384
+; vload128le_o32 v16, sp, 376
+; vload128le_o32 v17, sp, 368
+; vload128le_o32 v18, sp, 360
+; vload128le_o32 v19, sp, 352
+; vload128le_o32 v20, sp, 344
+; vload128le_o32 v21, sp, 336
+; vload128le_o32 v22, sp, 328
+; vload128le_o32 v23, sp, 320
+; vload128le_o32 v24, sp, 312
+; vload128le_o32 v25, sp, 304
+; vload128le_o32 v26, sp, 296
+; vload128le_o32 v27, sp, 288
+; vload128le_o32 v28, sp, 280
+; vload128le_o32 v29, sp, 272
+; vload128le_o32 v30, sp, 264
+; vload128le_o32 v31, sp, 256
+; pop_frame_restore 896, 
+; ret
+

--- a/cranelift/filetests/filetests/isa/riscv64/patchable-abi.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/patchable-abi.clif
@@ -1,0 +1,426 @@
+test compile precise-output
+target riscv64
+
+function %call_patchable_abi(i64) system_v {
+    sig0 = (i64, i64, i64, i64) patchable
+block0(v0: i64):
+    call_indirect sig0, v0(v0, v0, v0, v0)
+    call_indirect sig0, v0(v0, v0, v0, v0)
+    return
+}
+
+; VCode:
+;   addi sp,sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   mv a3,a0
+;   mv a1,a3
+;   mv a2,a3
+;   callind a3
+;   callind a3
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   addi sp,sp,16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   mv s0, sp
+; block1: ; offset 0x10
+;   mv a3, a0
+;   mv a1, a3
+;   mv a2, a3
+;   jalr a3
+;   jalr a3
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %patchable_abi_trampoline(i64) patchable {
+    fn0 = %libcall(i64) system_v
+block0(v0: i64):
+    call fn0(v0)
+    return
+}
+
+; VCode:
+;   addi sp,sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+;   addi sp,sp,-816
+;   sd ra,808(sp)
+;   sd t0,800(sp)
+;   sd t1,792(sp)
+;   sd t2,784(sp)
+;   sd a0,776(sp)
+;   sd a1,768(sp)
+;   sd a2,760(sp)
+;   sd a3,752(sp)
+;   sd a4,744(sp)
+;   sd a5,736(sp)
+;   sd a6,728(sp)
+;   sd a7,720(sp)
+;   sd t3,712(sp)
+;   sd t4,704(sp)
+;   sd t5,696(sp)
+;   sd t6,688(sp)
+;   fsd ft0,680(sp)
+;   fsd ft1,672(sp)
+;   fsd ft2,664(sp)
+;   fsd ft3,656(sp)
+;   fsd ft4,648(sp)
+;   fsd ft5,640(sp)
+;   fsd ft6,632(sp)
+;   fsd ft7,624(sp)
+;   fsd fs1,616(sp)
+;   fsd fa0,608(sp)
+;   fsd fa1,600(sp)
+;   fsd fa2,592(sp)
+;   fsd fa3,584(sp)
+;   fsd fa4,576(sp)
+;   fsd fa5,568(sp)
+;   fsd fa6,560(sp)
+;   fsd fa7,552(sp)
+;   fsd ft8,544(sp)
+;   fsd ft9,536(sp)
+;   fsd ft10,528(sp)
+;   fsd ft11,520(sp)
+;   vse8.v v0,496(sp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v1,480(sp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v2,464(sp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v3,448(sp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v4,432(sp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v5,416(sp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v6,400(sp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v7,384(sp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v8,368(sp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v9,352(sp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v10,336(sp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v11,320(sp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v12,304(sp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v13,288(sp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v14,272(sp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v15,256(sp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v16,240(sp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v17,224(sp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v18,208(sp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v19,192(sp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v20,176(sp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v21,160(sp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v22,144(sp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v23,128(sp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v24,112(sp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v25,96(sp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v26,80(sp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v27,64(sp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v28,48(sp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v29,32(sp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v30,16(sp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v31,0(sp) #avl=16, #vtype=(e8, m1, ta, ma)
+; block0:
+;   load_ext_name_far a2,%libcall+0
+;   callind a2
+;   ld ra,808(sp)
+;   ld t0,800(sp)
+;   ld t1,792(sp)
+;   ld t2,784(sp)
+;   ld a0,776(sp)
+;   ld a1,768(sp)
+;   ld a2,760(sp)
+;   ld a3,752(sp)
+;   ld a4,744(sp)
+;   ld a5,736(sp)
+;   ld a6,728(sp)
+;   ld a7,720(sp)
+;   ld t3,712(sp)
+;   ld t4,704(sp)
+;   ld t5,696(sp)
+;   ld t6,688(sp)
+;   fld ft0,680(sp)
+;   fld ft1,672(sp)
+;   fld ft2,664(sp)
+;   fld ft3,656(sp)
+;   fld ft4,648(sp)
+;   fld ft5,640(sp)
+;   fld ft6,632(sp)
+;   fld ft7,624(sp)
+;   fld fs1,616(sp)
+;   fld fa0,608(sp)
+;   fld fa1,600(sp)
+;   fld fa2,592(sp)
+;   fld fa3,584(sp)
+;   fld fa4,576(sp)
+;   fld fa5,568(sp)
+;   fld fa6,560(sp)
+;   fld fa7,552(sp)
+;   fld ft8,544(sp)
+;   fld ft9,536(sp)
+;   fld ft10,528(sp)
+;   fld ft11,520(sp)
+;   vle8.v v0,496(sp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v1,480(sp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v2,464(sp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v3,448(sp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v4,432(sp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v5,416(sp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v6,400(sp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v7,384(sp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v8,368(sp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v9,352(sp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v10,336(sp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v11,320(sp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v12,304(sp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v13,288(sp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v14,272(sp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v15,256(sp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v16,240(sp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v17,224(sp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v18,208(sp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v19,192(sp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v20,176(sp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v21,160(sp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v22,144(sp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v23,128(sp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v24,112(sp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v25,96(sp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v26,80(sp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v27,64(sp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v28,48(sp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v29,32(sp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v30,16(sp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v31,0(sp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   addi sp,sp,816
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   addi sp,sp,16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   mv s0, sp
+;   addi sp, sp, -0x330
+;   sd ra, 0x328(sp)
+;   sd t0, 0x320(sp)
+;   sd t1, 0x318(sp)
+;   sd t2, 0x310(sp)
+;   sd a0, 0x308(sp)
+;   sd a1, 0x300(sp)
+;   sd a2, 0x2f8(sp)
+;   sd a3, 0x2f0(sp)
+;   sd a4, 0x2e8(sp)
+;   sd a5, 0x2e0(sp)
+;   sd a6, 0x2d8(sp)
+;   sd a7, 0x2d0(sp)
+;   sd t3, 0x2c8(sp)
+;   sd t4, 0x2c0(sp)
+;   sd t5, 0x2b8(sp)
+;   sd t6, 0x2b0(sp)
+;   fsd ft0, 0x2a8(sp)
+;   fsd ft1, 0x2a0(sp)
+;   fsd ft2, 0x298(sp)
+;   fsd ft3, 0x290(sp)
+;   fsd ft4, 0x288(sp)
+;   fsd ft5, 0x280(sp)
+;   fsd ft6, 0x278(sp)
+;   fsd ft7, 0x270(sp)
+;   fsd fs1, 0x268(sp)
+;   fsd fa0, 0x260(sp)
+;   fsd fa1, 0x258(sp)
+;   fsd fa2, 0x250(sp)
+;   fsd fa3, 0x248(sp)
+;   fsd fa4, 0x240(sp)
+;   fsd fa5, 0x238(sp)
+;   fsd fa6, 0x230(sp)
+;   fsd fa7, 0x228(sp)
+;   fsd ft8, 0x220(sp)
+;   fsd ft9, 0x218(sp)
+;   fsd ft10, 0x210(sp)
+;   fsd ft11, 0x208(sp)
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, sp, 0x1f0
+;   .byte 0x27, 0x80, 0x0f, 0x02
+;   addi t6, sp, 0x1e0
+;   .byte 0xa7, 0x80, 0x0f, 0x02
+;   addi t6, sp, 0x1d0
+;   .byte 0x27, 0x81, 0x0f, 0x02
+;   addi t6, sp, 0x1c0
+;   .byte 0xa7, 0x81, 0x0f, 0x02
+;   addi t6, sp, 0x1b0
+;   .byte 0x27, 0x82, 0x0f, 0x02
+;   addi t6, sp, 0x1a0
+;   .byte 0xa7, 0x82, 0x0f, 0x02
+;   addi t6, sp, 0x190
+;   .byte 0x27, 0x83, 0x0f, 0x02
+;   addi t6, sp, 0x180
+;   .byte 0xa7, 0x83, 0x0f, 0x02
+;   addi t6, sp, 0x170
+;   .byte 0x27, 0x84, 0x0f, 0x02
+;   addi t6, sp, 0x160
+;   .byte 0xa7, 0x84, 0x0f, 0x02
+;   addi t6, sp, 0x150
+;   .byte 0x27, 0x85, 0x0f, 0x02
+;   addi t6, sp, 0x140
+;   .byte 0xa7, 0x85, 0x0f, 0x02
+;   addi t6, sp, 0x130
+;   .byte 0x27, 0x86, 0x0f, 0x02
+;   addi t6, sp, 0x120
+;   .byte 0xa7, 0x86, 0x0f, 0x02
+;   addi t6, sp, 0x110
+;   .byte 0x27, 0x87, 0x0f, 0x02
+;   addi t6, sp, 0x100
+;   .byte 0xa7, 0x87, 0x0f, 0x02
+;   addi t6, sp, 0xf0
+;   .byte 0x27, 0x88, 0x0f, 0x02
+;   addi t6, sp, 0xe0
+;   .byte 0xa7, 0x88, 0x0f, 0x02
+;   addi t6, sp, 0xd0
+;   .byte 0x27, 0x89, 0x0f, 0x02
+;   addi t6, sp, 0xc0
+;   .byte 0xa7, 0x89, 0x0f, 0x02
+;   addi t6, sp, 0xb0
+;   .byte 0x27, 0x8a, 0x0f, 0x02
+;   addi t6, sp, 0xa0
+;   .byte 0xa7, 0x8a, 0x0f, 0x02
+;   addi t6, sp, 0x90
+;   .byte 0x27, 0x8b, 0x0f, 0x02
+;   addi t6, sp, 0x80
+;   .byte 0xa7, 0x8b, 0x0f, 0x02
+;   addi t6, sp, 0x70
+;   .byte 0x27, 0x8c, 0x0f, 0x02
+;   addi t6, sp, 0x60
+;   .byte 0xa7, 0x8c, 0x0f, 0x02
+;   addi t6, sp, 0x50
+;   .byte 0x27, 0x8d, 0x0f, 0x02
+;   addi t6, sp, 0x40
+;   .byte 0xa7, 0x8d, 0x0f, 0x02
+;   addi t6, sp, 0x30
+;   .byte 0x27, 0x8e, 0x0f, 0x02
+;   addi t6, sp, 0x20
+;   .byte 0xa7, 0x8e, 0x0f, 0x02
+;   addi t6, sp, 0x10
+;   .byte 0x27, 0x8f, 0x0f, 0x02
+;   .byte 0xa7, 0x0f, 0x01, 0x02
+; block1: ; offset 0x1a8
+;   auipc a2, 0
+;   ld a2, 0xc(a2)
+;   j 0xc
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %libcall 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   jalr a2
+;   ld ra, 0x328(sp)
+;   ld t0, 0x320(sp)
+;   ld t1, 0x318(sp)
+;   ld t2, 0x310(sp)
+;   ld a0, 0x308(sp)
+;   ld a1, 0x300(sp)
+;   ld a2, 0x2f8(sp)
+;   ld a3, 0x2f0(sp)
+;   ld a4, 0x2e8(sp)
+;   ld a5, 0x2e0(sp)
+;   ld a6, 0x2d8(sp)
+;   ld a7, 0x2d0(sp)
+;   ld t3, 0x2c8(sp)
+;   ld t4, 0x2c0(sp)
+;   ld t5, 0x2b8(sp)
+;   ld t6, 0x2b0(sp)
+;   fld ft0, 0x2a8(sp)
+;   fld ft1, 0x2a0(sp)
+;   fld ft2, 0x298(sp)
+;   fld ft3, 0x290(sp)
+;   fld ft4, 0x288(sp)
+;   fld ft5, 0x280(sp)
+;   fld ft6, 0x278(sp)
+;   fld ft7, 0x270(sp)
+;   fld fs1, 0x268(sp)
+;   fld fa0, 0x260(sp)
+;   fld fa1, 0x258(sp)
+;   fld fa2, 0x250(sp)
+;   fld fa3, 0x248(sp)
+;   fld fa4, 0x240(sp)
+;   fld fa5, 0x238(sp)
+;   fld fa6, 0x230(sp)
+;   fld fa7, 0x228(sp)
+;   fld ft8, 0x220(sp)
+;   fld ft9, 0x218(sp)
+;   fld ft10, 0x210(sp)
+;   fld ft11, 0x208(sp)
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, sp, 0x1f0
+;   .byte 0x07, 0x80, 0x0f, 0x02
+;   addi t6, sp, 0x1e0
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi t6, sp, 0x1d0
+;   .byte 0x07, 0x81, 0x0f, 0x02
+;   addi t6, sp, 0x1c0
+;   .byte 0x87, 0x81, 0x0f, 0x02
+;   addi t6, sp, 0x1b0
+;   .byte 0x07, 0x82, 0x0f, 0x02
+;   addi t6, sp, 0x1a0
+;   .byte 0x87, 0x82, 0x0f, 0x02
+;   addi t6, sp, 0x190
+;   .byte 0x07, 0x83, 0x0f, 0x02
+;   addi t6, sp, 0x180
+;   .byte 0x87, 0x83, 0x0f, 0x02
+;   addi t6, sp, 0x170
+;   .byte 0x07, 0x84, 0x0f, 0x02
+;   addi t6, sp, 0x160
+;   .byte 0x87, 0x84, 0x0f, 0x02
+;   addi t6, sp, 0x150
+;   .byte 0x07, 0x85, 0x0f, 0x02
+;   addi t6, sp, 0x140
+;   .byte 0x87, 0x85, 0x0f, 0x02
+;   addi t6, sp, 0x130
+;   .byte 0x07, 0x86, 0x0f, 0x02
+;   addi t6, sp, 0x120
+;   .byte 0x87, 0x86, 0x0f, 0x02
+;   addi t6, sp, 0x110
+;   .byte 0x07, 0x87, 0x0f, 0x02
+;   addi t6, sp, 0x100
+;   .byte 0x87, 0x87, 0x0f, 0x02
+;   addi t6, sp, 0xf0
+;   .byte 0x07, 0x88, 0x0f, 0x02
+;   addi t6, sp, 0xe0
+;   .byte 0x87, 0x88, 0x0f, 0x02
+;   addi t6, sp, 0xd0
+;   .byte 0x07, 0x89, 0x0f, 0x02
+;   addi t6, sp, 0xc0
+;   .byte 0x87, 0x89, 0x0f, 0x02
+;   addi t6, sp, 0xb0
+;   .byte 0x07, 0x8a, 0x0f, 0x02
+;   addi t6, sp, 0xa0
+;   .byte 0x87, 0x8a, 0x0f, 0x02
+;   addi t6, sp, 0x90
+;   .byte 0x07, 0x8b, 0x0f, 0x02
+;   addi t6, sp, 0x80
+;   .byte 0x87, 0x8b, 0x0f, 0x02
+;   addi t6, sp, 0x70
+;   .byte 0x07, 0x8c, 0x0f, 0x02
+;   addi t6, sp, 0x60
+;   .byte 0x87, 0x8c, 0x0f, 0x02
+;   addi t6, sp, 0x50
+;   .byte 0x07, 0x8d, 0x0f, 0x02
+;   addi t6, sp, 0x40
+;   .byte 0x87, 0x8d, 0x0f, 0x02
+;   addi t6, sp, 0x30
+;   .byte 0x07, 0x8e, 0x0f, 0x02
+;   addi t6, sp, 0x20
+;   .byte 0x87, 0x8e, 0x0f, 0x02
+;   addi t6, sp, 0x10
+;   .byte 0x07, 0x8f, 0x0f, 0x02
+;   .byte 0x87, 0x0f, 0x01, 0x02
+;   addi sp, sp, 0x330
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+

--- a/cranelift/filetests/filetests/isa/s390x/patchable-abi.clif
+++ b/cranelift/filetests/filetests/isa/s390x/patchable-abi.clif
@@ -1,0 +1,195 @@
+test compile precise-output
+target s390x
+
+function %call_patchable_abi(i64) system_v {
+    sig0 = (i64, i64, i64, i64) patchable
+block0(v0: i64):
+    call_indirect sig0, v0(v0, v0, v0, v0)
+    call_indirect sig0, v0(v0, v0, v0, v0)
+    return
+}
+
+; VCode:
+;   stmg %r14, %r15, 112(%r15)
+;   aghi %r15, -160
+; block0:
+;   lgr %r5, %r2
+;   lgr %r3, %r5
+;   lgr %r4, %r5
+;   basr %r14, %r5
+;   basr %r14, %r5
+;   lmg %r14, %r15, 272(%r15)
+;   br %r14
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   stmg %r14, %r15, 0x70(%r15)
+;   aghi %r15, -0xa0
+; block1: ; offset 0xa
+;   lgr %r5, %r2
+;   lgr %r3, %r5
+;   lgr %r4, %r5
+;   basr %r14, %r5
+;   basr %r14, %r5
+;   lmg %r14, %r15, 0x110(%r15)
+;   br %r14
+
+function %patchable_abi_trampoline(i64) patchable {
+    fn0 = %libcall(i64) system_v
+block0(v0: i64):
+    call fn0(v0)
+    return
+}
+
+; VCode:
+;   stmg %r0, %r15, 0(%r15)
+;   aghi %r15, -416
+;   std %f0, 160(%r15)
+;   std %f1, 168(%r15)
+;   std %f2, 176(%r15)
+;   std %f3, 184(%r15)
+;   std %f4, 192(%r15)
+;   std %f5, 200(%r15)
+;   std %f6, 208(%r15)
+;   std %f7, 216(%r15)
+;   std %f8, 224(%r15)
+;   std %f9, 232(%r15)
+;   std %f10, 240(%r15)
+;   std %f11, 248(%r15)
+;   std %f12, 256(%r15)
+;   std %f13, 264(%r15)
+;   std %f14, 272(%r15)
+;   std %f15, 280(%r15)
+;   vsteg %v16, 288(%r15), 0
+;   vsteg %v17, 296(%r15), 0
+;   vsteg %v18, 304(%r15), 0
+;   vsteg %v19, 312(%r15), 0
+;   vsteg %v20, 320(%r15), 0
+;   vsteg %v21, 328(%r15), 0
+;   vsteg %v22, 336(%r15), 0
+;   vsteg %v23, 344(%r15), 0
+;   vsteg %v24, 352(%r15), 0
+;   vsteg %v25, 360(%r15), 0
+;   vsteg %v26, 368(%r15), 0
+;   vsteg %v27, 376(%r15), 0
+;   vsteg %v28, 384(%r15), 0
+;   vsteg %v29, 392(%r15), 0
+;   vsteg %v30, 400(%r15), 0
+;   vsteg %v31, 408(%r15), 0
+; block0:
+;   bras %r1, 12 ; data %libcall + 0 ; lg %r4, 0(%r1)
+;   basr %r14, %r4
+;   ld %f0, 160(%r15)
+;   ld %f1, 168(%r15)
+;   ld %f2, 176(%r15)
+;   ld %f3, 184(%r15)
+;   ld %f4, 192(%r15)
+;   ld %f5, 200(%r15)
+;   ld %f6, 208(%r15)
+;   ld %f7, 216(%r15)
+;   ld %f8, 224(%r15)
+;   ld %f9, 232(%r15)
+;   ld %f10, 240(%r15)
+;   ld %f11, 248(%r15)
+;   ld %f12, 256(%r15)
+;   ld %f13, 264(%r15)
+;   ld %f14, 272(%r15)
+;   ld %f15, 280(%r15)
+;   vleg %v16, 288(%r15), 0
+;   vleg %v17, 296(%r15), 0
+;   vleg %v18, 304(%r15), 0
+;   vleg %v19, 312(%r15), 0
+;   vleg %v20, 320(%r15), 0
+;   vleg %v21, 328(%r15), 0
+;   vleg %v22, 336(%r15), 0
+;   vleg %v23, 344(%r15), 0
+;   vleg %v24, 352(%r15), 0
+;   vleg %v25, 360(%r15), 0
+;   vleg %v26, 368(%r15), 0
+;   vleg %v27, 376(%r15), 0
+;   vleg %v28, 384(%r15), 0
+;   vleg %v29, 392(%r15), 0
+;   vleg %v30, 400(%r15), 0
+;   vleg %v31, 408(%r15), 0
+;   lmg %r0, %r15, 416(%r15)
+;   br %r14
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   stmg %r0, %r15, 0(%r15)
+;   aghi %r15, -0x1a0
+;   std %f0, 0xa0(%r15)
+;   std %f1, 0xa8(%r15)
+;   std %f2, 0xb0(%r15)
+;   std %f3, 0xb8(%r15)
+;   std %f4, 0xc0(%r15)
+;   std %f5, 0xc8(%r15)
+;   std %f6, 0xd0(%r15)
+;   std %f7, 0xd8(%r15)
+;   std %f8, 0xe0(%r15)
+;   std %f9, 0xe8(%r15)
+;   std %f10, 0xf0(%r15)
+;   std %f11, 0xf8(%r15)
+;   std %f12, 0x100(%r15)
+;   std %f13, 0x108(%r15)
+;   std %f14, 0x110(%r15)
+;   std %f15, 0x118(%r15)
+;   vsteg %v16, 0x120(%r15), 0
+;   vsteg %v17, 0x128(%r15), 0
+;   vsteg %v18, 0x130(%r15), 0
+;   vsteg %v19, 0x138(%r15), 0
+;   vsteg %v20, 0x140(%r15), 0
+;   vsteg %v21, 0x148(%r15), 0
+;   vsteg %v22, 0x150(%r15), 0
+;   vsteg %v23, 0x158(%r15), 0
+;   vsteg %v24, 0x160(%r15), 0
+;   vsteg %v25, 0x168(%r15), 0
+;   vsteg %v26, 0x170(%r15), 0
+;   vsteg %v27, 0x178(%r15), 0
+;   vsteg %v28, 0x180(%r15), 0
+;   vsteg %v29, 0x188(%r15), 0
+;   vsteg %v30, 0x190(%r15), 0
+;   vsteg %v31, 0x198(%r15), 0
+; block1: ; offset 0xaa
+;   bras %r1, 0xb6
+;   .byte 0x00, 0x00 ; reloc_external Abs8 %libcall 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   lg %r4, 0(%r1)
+;   basr %r14, %r4
+;   ld %f0, 0xa0(%r15)
+;   ld %f1, 0xa8(%r15)
+;   ld %f2, 0xb0(%r15)
+;   ld %f3, 0xb8(%r15)
+;   ld %f4, 0xc0(%r15)
+;   ld %f5, 0xc8(%r15)
+;   ld %f6, 0xd0(%r15)
+;   ld %f7, 0xd8(%r15)
+;   ld %f8, 0xe0(%r15)
+;   ld %f9, 0xe8(%r15)
+;   ld %f10, 0xf0(%r15)
+;   ld %f11, 0xf8(%r15)
+;   ld %f12, 0x100(%r15)
+;   ld %f13, 0x108(%r15)
+;   ld %f14, 0x110(%r15)
+;   ld %f15, 0x118(%r15)
+;   vleg %v16, 0x120(%r15), 0
+;   vleg %v17, 0x128(%r15), 0
+;   vleg %v18, 0x130(%r15), 0
+;   vleg %v19, 0x138(%r15), 0
+;   vleg %v20, 0x140(%r15), 0
+;   vleg %v21, 0x148(%r15), 0
+;   vleg %v22, 0x150(%r15), 0
+;   vleg %v23, 0x158(%r15), 0
+;   vleg %v24, 0x160(%r15), 0
+;   vleg %v25, 0x168(%r15), 0
+;   vleg %v26, 0x170(%r15), 0
+;   vleg %v27, 0x178(%r15), 0
+;   vleg %v28, 0x180(%r15), 0
+;   vleg %v29, 0x188(%r15), 0
+;   vleg %v30, 0x190(%r15), 0
+;   vleg %v31, 0x198(%r15), 0
+;   lmg %r0, %r15, 0x1a0(%r15)
+;   br %r14
+

--- a/cranelift/filetests/filetests/isa/x64/patchable-abi.clif
+++ b/cranelift/filetests/filetests/isa/x64/patchable-abi.clif
@@ -1,0 +1,170 @@
+test compile precise-output
+target x86_64
+
+function %call_patchable_abi(i64) system_v {
+    sig0 = (i64, i64, i64, i64) patchable
+block0(v0: i64):
+    call_indirect sig0, v0(v0, v0, v0, v0)
+    call_indirect sig0, v0(v0, v0, v0, v0)
+    return
+}
+
+; VCode:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0:
+;   movq %rdi, %rcx
+;   movq %rcx, %rdx
+;   movq %rcx, %rsi
+;   call    *%rcx
+;   call    *%rcx
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movq %rdi, %rcx
+;   movq %rcx, %rdx
+;   movq %rcx, %rsi
+;   callq *%rcx
+;   callq *%rcx
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %patchable_abi_trampoline(i64) patchable {
+    fn0 = %libcall(i64) system_v
+block0(v0: i64):
+    call fn0(v0)
+    return
+}
+
+; VCode:
+;   pushq %rbp
+;   movq %rsp, %rbp
+;   subq $0x150, %rsp
+;   movq %rax, (%rsp)
+;   movq %rcx, 8(%rsp)
+;   movq %rdx, 0x10(%rsp)
+;   movq %rsi, 0x18(%rsp)
+;   movq %rdi, 0x20(%rsp)
+;   movq %r8, 0x28(%rsp)
+;   movq %r9, 0x30(%rsp)
+;   movq %r10, 0x38(%rsp)
+;   movq %r11, 0x40(%rsp)
+;   movdqu %xmm0, 0x50(%rsp)
+;   movdqu %xmm1, 0x60(%rsp)
+;   movdqu %xmm2, 0x70(%rsp)
+;   movdqu %xmm3, 0x80(%rsp)
+;   movdqu %xmm4, 0x90(%rsp)
+;   movdqu %xmm5, 0xa0(%rsp)
+;   movdqu %xmm6, 0xb0(%rsp)
+;   movdqu %xmm7, 0xc0(%rsp)
+;   movdqu %xmm8, 0xd0(%rsp)
+;   movdqu %xmm9, 0xe0(%rsp)
+;   movdqu %xmm10, 0xf0(%rsp)
+;   movdqu %xmm11, 0x100(%rsp)
+;   movdqu %xmm12, 0x110(%rsp)
+;   movdqu %xmm13, 0x120(%rsp)
+;   movdqu %xmm14, 0x130(%rsp)
+;   movdqu %xmm15, 0x140(%rsp)
+; block0:
+;   load_ext_name %libcall+0, %rax
+;   call    *%rax
+;   movq (%rsp), %rax
+;   movq 8(%rsp), %rcx
+;   movq 0x10(%rsp), %rdx
+;   movq 0x18(%rsp), %rsi
+;   movq 0x20(%rsp), %rdi
+;   movq 0x28(%rsp), %r8
+;   movq 0x30(%rsp), %r9
+;   movq 0x38(%rsp), %r10
+;   movq 0x40(%rsp), %r11
+;   movdqu 0x50(%rsp), %xmm0
+;   movdqu 0x60(%rsp), %xmm1
+;   movdqu 0x70(%rsp), %xmm2
+;   movdqu 0x80(%rsp), %xmm3
+;   movdqu 0x90(%rsp), %xmm4
+;   movdqu 0xa0(%rsp), %xmm5
+;   movdqu 0xb0(%rsp), %xmm6
+;   movdqu 0xc0(%rsp), %xmm7
+;   movdqu 0xd0(%rsp), %xmm8
+;   movdqu 0xe0(%rsp), %xmm9
+;   movdqu 0xf0(%rsp), %xmm10
+;   movdqu 0x100(%rsp), %xmm11
+;   movdqu 0x110(%rsp), %xmm12
+;   movdqu 0x120(%rsp), %xmm13
+;   movdqu 0x130(%rsp), %xmm14
+;   movdqu 0x140(%rsp), %xmm15
+;   addq $0x150, %rsp
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+;   subq $0x150, %rsp
+;   movq %rax, (%rsp)
+;   movq %rcx, 8(%rsp)
+;   movq %rdx, 0x10(%rsp)
+;   movq %rsi, 0x18(%rsp)
+;   movq %rdi, 0x20(%rsp)
+;   movq %r8, 0x28(%rsp)
+;   movq %r9, 0x30(%rsp)
+;   movq %r10, 0x38(%rsp)
+;   movq %r11, 0x40(%rsp)
+;   movdqu %xmm0, 0x50(%rsp)
+;   movdqu %xmm1, 0x60(%rsp)
+;   movdqu %xmm2, 0x70(%rsp)
+;   movdqu %xmm3, 0x80(%rsp)
+;   movdqu %xmm4, 0x90(%rsp)
+;   movdqu %xmm5, 0xa0(%rsp)
+;   movdqu %xmm6, 0xb0(%rsp)
+;   movdqu %xmm7, 0xc0(%rsp)
+;   movdqu %xmm8, 0xd0(%rsp)
+;   movdqu %xmm9, 0xe0(%rsp)
+;   movdqu %xmm10, 0xf0(%rsp)
+;   movdqu %xmm11, 0x100(%rsp)
+;   movdqu %xmm12, 0x110(%rsp)
+;   movdqu %xmm13, 0x120(%rsp)
+;   movdqu %xmm14, 0x130(%rsp)
+;   movdqu %xmm15, 0x140(%rsp)
+; block1: ; offset 0xc6
+;   movabsq $0, %rax ; reloc_external Abs8 %libcall 0
+;   callq *%rax
+;   movq (%rsp), %rax
+;   movq 8(%rsp), %rcx
+;   movq 0x10(%rsp), %rdx
+;   movq 0x18(%rsp), %rsi
+;   movq 0x20(%rsp), %rdi
+;   movq 0x28(%rsp), %r8
+;   movq 0x30(%rsp), %r9
+;   movq 0x38(%rsp), %r10
+;   movq 0x40(%rsp), %r11
+;   movdqu 0x50(%rsp), %xmm0
+;   movdqu 0x60(%rsp), %xmm1
+;   movdqu 0x70(%rsp), %xmm2
+;   movdqu 0x80(%rsp), %xmm3
+;   movdqu 0x90(%rsp), %xmm4
+;   movdqu 0xa0(%rsp), %xmm5
+;   movdqu 0xb0(%rsp), %xmm6
+;   movdqu 0xc0(%rsp), %xmm7
+;   movdqu 0xd0(%rsp), %xmm8
+;   movdqu 0xe0(%rsp), %xmm9
+;   movdqu 0xf0(%rsp), %xmm10
+;   movdqu 0x100(%rsp), %xmm11
+;   movdqu 0x110(%rsp), %xmm12
+;   movdqu 0x120(%rsp), %xmm13
+;   movdqu 0x130(%rsp), %xmm14
+;   movdqu 0x140(%rsp), %xmm15
+;   addq $0x150, %rsp
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+

--- a/cranelift/filetests/filetests/verifier/patchable-abi.clif
+++ b/cranelift/filetests/filetests/verifier/patchable-abi.clif
@@ -1,0 +1,29 @@
+test verifier
+
+function %patchable_abi_float(f32) patchable { ; error: signature with patchable ABI does not allow non-I32/I64 arguments
+block0(v0: f32):
+  return
+}
+
+function %patchable_abi_arg_count(i32, i32, i32, i32, i32) patchable { ; error: signature with patchable ABI does not allow more than four arguments
+block0(v0: i32, v1: i32, v2: i32, v3: i32, v4: i32):
+  return
+}
+
+function %patchable_abi_ret_count() -> i32 patchable { ; error: signature with patchable ABI does not allow any returns
+block0():
+  v0 = iconst.i32 42
+  return v0
+}
+
+function %patchable_abi_uext(i32 uext)  patchable { ; error: signature with patchable ABI does not allow sign/zero-extended arguments
+block0(v0: i32):
+  return
+}
+
+function %patchable_abi_sigref(i32) system_v {
+  sig0 = (i32, i32, i32, i32, i32) patchable ; error: signature with patchable ABI does not allow more than four arguments
+
+block0(v0: i32):
+  return
+}


### PR DESCRIPTION
This ABI is intended for use in scenarios where we want a very lightweight callsite that can be turned on and off by patching in one instruction. (The actual patchable call instruction is not in this PR; that will be a separate PR.)

The idea is that we define a call to clobber *no* registers -- not even the arguments! And we restrict signatures such that on all of our supported architectures, all arguments go into registers only. Those two requirements together mean that all callsites for this ABI should have only a raw call instruction, with no loads/stores to stackslots; and have the minimum possible impact on regalloc, by only imposing constraints on args to ensure they are in certain registers but not altering those registers.

Given this, we could implement, e.g., breakpoints with patchable callsites (off by default) at every sequence point in compiled code. In a typical use-case with Wasmtime-compiled Wasm, that would put a bunch of uses of vmctx constrained to the first argument register in every code path, but vmctx likely already sits there most of the time anyway (for any call to other Wasm functions or for libcalls). Thus, the impact is just the one instruction and nothing else.

This PR adds the calling convention itself and tests that show that *two* consecutive callsites can be compiled with no register setup re-occurring from one call to the next (thus demonstrating no clobbers).

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
