### PR TITLE
Implements `Response::from_http`

### DIFF
--- a/crates/wasi-http/src/p3/response.rs
+++ b/crates/wasi-http/src/p3/response.rs
@@ -147,11 +147,12 @@ mod tests {
             "value123"
         );
         match wasi_resp.body {
-            Body::Host { body, .. } => {
+            Body::Host { body, result_tx } => {
                 let collected = body.collect().await;
                 assert!(collected.is_ok(), "Body stream failed unexpectedly");
                 let chunks = collected.unwrap().to_bytes();
                 assert_eq!(chunks, &b"hello wasm"[..]);
+                _ = result_tx.send(Box::new(async { Ok(()) }));
             }
             _ => panic!("Response body should be of type Host"),
         }


### PR DESCRIPTION
Per [#wasi > wasi-http Request and pub(crate) Body @ 💬](https://bytecodealliance.zulipchat.com/#narrow/channel/219900-wasi/topic/wasi-http.20Request.20and.20pub.28crate.29.20Body/near/558533562)

Hope this is okay, happy to receive and address any feedback.