### PR TITLE
Capturing caller instance support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1714,6 +1714,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4649,6 +4655,7 @@ dependencies = [
  "cranelift-entity",
  "env_logger 0.11.5",
  "gimli 0.32.3",
+ "hex",
  "indexmap 2.11.4",
  "log",
  "object 0.37.3",
@@ -4657,6 +4664,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_derive",
+ "sha2",
  "smallvec",
  "target-lexicon",
  "wasm-encoder",

--- a/crates/environ/Cargo.toml
+++ b/crates/environ/Cargo.toml
@@ -37,6 +37,9 @@ wasmprinter = { workspace = true, optional = true }
 wasmtime-component-util = { workspace = true, optional = true }
 semver = { workspace = true, optional = true, features = ['serde'] }
 smallvec = { workspace = true, features = ['serde'] }
+# Needed for the binary digest of modules in the instantiation graph
+hex = "0.4.3"
+sha2 = "0.10.9"
 
 [dev-dependencies]
 clap = { workspace = true, features = ['default'] }

--- a/crates/environ/Cargo.toml
+++ b/crates/environ/Cargo.toml
@@ -39,7 +39,7 @@ semver = { workspace = true, optional = true, features = ['serde'] }
 smallvec = { workspace = true, features = ['serde'] }
 # Needed for the binary digest of modules in the instantiation graph
 hex = "0.4.3"
-sha2 = "0.10.9"
+sha2 = "0.10.2"
 
 [dev-dependencies]
 clap = { workspace = true, features = ['default'] }

--- a/crates/environ/src/component.rs
+++ b/crates/environ/src/component.rs
@@ -52,7 +52,10 @@ pub const PREPARE_ASYNC_WITH_RESULT: u32 = u32::MAX - 1;
 pub const START_FLAG_ASYNC_CALLEE: i32 = 1 << 0;
 
 mod artifacts;
-mod info;
+/// Expose the generated component internals
+///
+pub mod info;
+
 mod intrinsic;
 mod names;
 mod types;

--- a/crates/environ/src/component/dfg.rs
+++ b/crates/environ/src/component/dfg.rs
@@ -34,6 +34,7 @@ use anyhow::Result;
 use cranelift_entity::packed_option::PackedOption;
 use indexmap::IndexMap;
 use info::LinearMemoryOptions;
+use serde_derive::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::hash::Hash;
 use std::ops::Index;
@@ -150,6 +151,93 @@ pub struct ComponentDfg {
     /// Interned map of id-to-`CanonicalOptions`, or all sets-of-options used by
     /// this component.
     pub options: Intern<OptionsId, CanonicalOptions>,
+
+    /// Structure describing the component internal layout, useful for debugging, attestation, etc...
+    pub instantiation_graph: RootComponentInstanceStructure,
+}
+
+/// A view over the runtime interactions between the subcomponents of a webassembly application.
+/// The elements within [`Self::instances`] correspond to the runtime component
+/// instances which directly instantiate core modules. Each element should contain the information
+/// needed to identify the source of their imports. Specific information about how that is
+/// implemented is available in [`dfg::RuntimeComponentInstanceStructure`]
+#[derive(Serialize, Deserialize, Default, Clone, Debug)]
+pub struct RootComponentInstanceStructure {
+    /// Subcomponent instances that instantiate core modules directly. The keys are the [`RuntimeComponentInstanceStructure.path`]
+    pub instances: HashMap<String, RuntimeComponentInstanceStructure>,
+
+    /// Re-mapping table from the [`RuntimeComponentInstanceIndex`] to [`RuntimeComponentInstanceStructure.path`]
+    pub table: HashMap<u32, String>,
+}
+
+impl RootComponentInstanceStructure {
+    pub(crate) fn runtime_instances_mut(
+        &mut self,
+    ) -> &mut HashMap<String, RuntimeComponentInstanceStructure> {
+        &mut self.instances
+    }
+
+    pub(crate) fn table_mut(&mut self) -> &mut HashMap<u32, String> {
+        &mut self.table
+    }
+}
+
+/// Part of the instantiation graph, it represents a core instance of a component instance
+#[derive(Serialize, Deserialize, Default, Clone, Debug)]
+pub struct CoreInstanceStructure {
+    /// Hex encoded sha256 digest of the core module binary.
+    pub module_code_digest: String,
+    /// Exported items from this core instance
+    pub core_exports: HashMap<u32, String>,
+    /// Imported items by this core instance
+    pub core_imports: HashMap<u32, String>,
+    /// The sources of the imported items
+    pub sources: HashMap<u32, Source>,
+}
+
+/// Represents a core export definition in the instantiation graph, used to track the source of
+/// core module imports or the source of component exports
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct Source {
+    /// Dot [`.`] separated indices to identify a component instance entry in the instantiation graph
+    pub path: String,
+    /// Index of the referenced core instance within the instance represented by the path
+    pub core_instance: u32,
+    /// Index of the referenced export entry
+    pub export: u32,
+}
+
+impl Source {
+    /// Associates imports with the host as the source.
+    pub fn host() -> Source {
+        Source {
+            path: "host".to_string(),
+            core_instance: 0,
+            export: 0,
+        }
+    }
+
+    /// Full path through the instantiation graph to a core export entry
+    pub fn full_path(self) -> String {
+        format!("{}.{}.{}", self.path, self.core_instance, self.export)
+    }
+}
+
+/// Part of the instantiation graph. Represents a component instance which instantiates *statically*
+/// known modules. Corresponds to a [`RuntimeComponentInstanceIndex`].
+#[derive(Serialize, Deserialize, Default, Clone, Debug)]
+pub struct RuntimeComponentInstanceStructure {
+    /// The path of this runtime component instance starting from the root.
+    /// E.g. `0.1.4` where each number corresponds to the instance index in the
+    /// previous component index space. So instance 4 of instance 1 of .
+    pub path: String,
+
+    /// Maps to the core definitions that are being exported by this component.
+    pub component_exports: HashMap<u32, Source>,
+
+    /// Map of the core instances associated with this component instance.
+    /// The index represents the core instance index within the index space of this component.
+    pub core_instances: HashMap<u32, CoreInstanceStructure>,
 }
 
 /// Possible side effects that are possible with instantiating this component.
@@ -658,6 +746,7 @@ impl ComponentDfg {
         Ok(ComponentTranslation {
             trampolines: linearize.trampoline_defs,
             component: Component {
+                instantiation_graph: linearize.dfg.instantiation_graph.clone(),
                 exports,
                 export_items,
                 initializers: linearize.initializers,

--- a/crates/environ/src/component/info.rs
+++ b/crates/environ/src/component/info.rs
@@ -72,6 +72,9 @@ pub struct ComponentTranslation {
 /// this is going to undergo a lot of churn.
 #[derive(Default, Debug, Serialize, Deserialize)]
 pub struct Component {
+    /// Component Structure keeping track of the runtime instances dependency graph
+    pub instantiation_graph: dfg::RootComponentInstanceStructure,
+
     /// A list of typed values that this component imports.
     ///
     /// Note that each name is given an `ImportIndex` here for the next map to

--- a/crates/environ/src/component/info.rs
+++ b/crates/environ/src/component/info.rs
@@ -51,6 +51,7 @@ use crate::prelude::*;
 use crate::{EntityIndex, ModuleInternedTypeIndex, PrimaryMap, WasmValType};
 use cranelift_entity::packed_option::PackedOption;
 use serde_derive::{Deserialize, Serialize};
+use wasmparser::collections::Map;
 
 /// Metadata as a result of compiling a component.
 pub struct ComponentTranslation {
@@ -59,6 +60,91 @@ pub struct ComponentTranslation {
 
     /// Metadata about required trampolines and what they're supposed to do.
     pub trampolines: PrimaryMap<TrampolineIndex, Trampoline>,
+}
+
+/// A view over the runtime interactions between the subcomponents of a webassembly application.
+/// The elements within [`Self::instances`] correspond to the runtime component
+/// instances which directly instantiate core modules. Each element should contain the information
+/// needed to identify the source of their imports. Specific information about how that is
+/// implemented is available in [`info::RuntimeComponentInstanceStructure`]
+#[derive(Serialize, Deserialize, Default, Clone, Debug)]
+pub struct RootComponentInstanceStructure {
+    /// Subcomponent instances that instantiate core modules directly. The keys are the [`RuntimeComponentInstanceStructure.path`]
+    pub instances: Map<String, RuntimeComponentInstanceStructure>,
+
+    /// Re-mapping table from the [`RuntimeComponentInstanceIndex`] to [`RuntimeComponentInstanceStructure.path`]
+    pub table: Map<u32, String>,
+}
+
+impl RootComponentInstanceStructure {
+    /// Returns a mutable reference to the map of runtime component instances
+    /// contained within this root component.
+    pub fn runtime_instances_mut(&mut self) -> &mut Map<String, RuntimeComponentInstanceStructure> {
+        &mut self.instances
+    }
+
+    /// Returns a mutable reference to the component table associated with this  root component.
+    pub fn table_mut(&mut self) -> &mut Map<u32, String> {
+        &mut self.table
+    }
+}
+
+/// Part of the instantiation graph, it represents a core instance of a component instance
+#[derive(Serialize, Deserialize, Default, Clone, Debug)]
+pub struct CoreInstanceStructure {
+    /// Hex encoded sha256 digest of the core module binary.
+    pub module_code_digest: String,
+    /// Exported items from this core instance
+    pub core_exports: Map<u32, String>,
+    /// Imported items by this core instance
+    pub core_imports: Map<u32, String>,
+    /// The sources of the imported items
+    pub sources: Map<u32, Source>,
+}
+
+/// Represents a core export definition in the instantiation graph, used to track the source of
+/// core module imports or the source of component exports
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct Source {
+    /// Dot [`.`] separated indices to identify a component instance entry in the instantiation graph
+    pub path: String,
+    /// Index of the referenced core instance within the instance represented by the path
+    pub core_instance: u32,
+    /// Index of the referenced export entry
+    pub export: u32,
+}
+
+impl Source {
+    /// Associates imports with the host as the source.
+    pub fn host() -> Source {
+        Source {
+            path: "host".to_string(),
+            core_instance: 0,
+            export: 0,
+        }
+    }
+
+    /// Full path through the instantiation graph to a core export entry
+    pub fn full_path(self) -> String {
+        format!("{}.{}.{}", self.path, self.core_instance, self.export)
+    }
+}
+
+/// Part of the instantiation graph. Represents a component instance which instantiates *statically*
+/// known modules. Corresponds to a [`RuntimeComponentInstanceIndex`].
+#[derive(Serialize, Deserialize, Default, Clone, Debug)]
+pub struct RuntimeComponentInstanceStructure {
+    /// The path of this runtime component instance starting from the root.
+    /// E.g. `0.1.4` where each number corresponds to the instance index in the
+    /// previous component index space. So instance 4 of instance 1 of .
+    pub path: String,
+
+    /// Maps to the core definitions that are being exported by this component.
+    pub component_exports: Map<u32, Source>,
+
+    /// Map of the core instances associated with this component instance.
+    /// The index represents the core instance index within the index space of this component.
+    pub core_instances: Map<u32, CoreInstanceStructure>,
 }
 
 /// Run-time-type-information about a `Component`, its structure, and how to
@@ -73,7 +159,7 @@ pub struct ComponentTranslation {
 #[derive(Default, Debug, Serialize, Deserialize)]
 pub struct Component {
     /// Component Structure keeping track of the runtime instances dependency graph
-    pub instantiation_graph: dfg::RootComponentInstanceStructure,
+    pub instantiation_graph: RootComponentInstanceStructure,
 
     /// A list of typed values that this component imports.
     ///

--- a/crates/environ/src/component/translate/inline.rs
+++ b/crates/environ/src/component/translate/inline.rs
@@ -177,13 +177,14 @@ struct Inliner<'a> {
     /// inliner.
     result: dfg::ComponentDfg,
 
-    // Maps used to "intern" various runtime items to only save them once at
-    // runtime instead of multiple times.
+    /// Maps used to "intern" various runtime items to only save them once at
+    /// runtime instead of multiple times.
     import_path_interner: HashMap<ImportPath<'a>, RuntimeImportIndex>,
 
     /// Origin information about where each runtime instance came from
     runtime_instances: PrimaryMap<dfg::InstanceId, InstanceModule>,
 
+    /// Origin informatino about where each core definition came from.
     core_def_to_sources: HashMap<dfg::CoreDef, Source>,
 }
 
@@ -490,7 +491,11 @@ impl<'a> Inliner<'a> {
         }
     }
 
-    //TODO: Add some docs here
+    /// Records the runtime sources for each component export, 
+    /// so the instantiation graph later knows which 
+    /// core definitions they depend on.
+    /// Here internal component exports are recorded in addition to the 
+    /// exports recoreded for the top level component.
     fn add_component_exports(
         &mut self,
         types: &mut ComponentTypesBuilder,
@@ -1332,7 +1337,7 @@ impl<'a> Inliner<'a> {
                                 _ => module.to_string(),
                             };
 
-                            //TODO: Docs here
+                            // CoreDef which is hashable is used as key to retrieve the source
                             core_imports.insert(count, name.clone());
                             sources.insert(
                                 count,

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -425,3 +425,6 @@ debug = [
 
 # Enables support for defining compile-time builtins.
 compile-time-builtins = ['dep:wasm-compose', 'dep:tempfile']
+
+# For attestation/performance/debugging purposes. Make the caller_instance runtime index available to the host call
+caller = []

--- a/crates/wasmtime/src/runtime/component/component.rs
+++ b/crates/wasmtime/src/runtime/component/component.rs
@@ -18,7 +18,7 @@ use std::path::Path;
 use wasmtime_environ::component::{
     CompiledComponentInfo, ComponentArtifacts, ComponentTypes, CoreDef, Export, ExportIndex,
     GlobalInitializer, InstantiateModule, NameMapNoIntern, OptionsIndex, StaticModuleIndex,
-    TrampolineIndex, TypeComponentIndex, TypeFuncIndex, UnsafeIntrinsic, VMComponentOffsets, dfg,
+    TrampolineIndex, TypeComponentIndex, TypeFuncIndex, UnsafeIntrinsic, VMComponentOffsets, info,
 };
 use wasmtime_environ::{Abi, CompiledFunctionsTable, FuncKey, TypeTrace};
 use wasmtime_environ::{FunctionLoc, HostPtr, ObjectKind, PrimaryMap};
@@ -882,7 +882,7 @@ impl Component {
     }
 
     /// Returns the Instantiation Graph.
-    pub fn instantiation_graph(&self) -> &dfg::RootComponentInstanceStructure {
+    pub fn instantiation_graph(&self) -> &info::RootComponentInstanceStructure {
         &self.inner.info.component.instantiation_graph
     }
 }

--- a/crates/wasmtime/src/runtime/component/component.rs
+++ b/crates/wasmtime/src/runtime/component/component.rs
@@ -18,7 +18,7 @@ use std::path::Path;
 use wasmtime_environ::component::{
     CompiledComponentInfo, ComponentArtifacts, ComponentTypes, CoreDef, Export, ExportIndex,
     GlobalInitializer, InstantiateModule, NameMapNoIntern, OptionsIndex, StaticModuleIndex,
-    TrampolineIndex, TypeComponentIndex, TypeFuncIndex, UnsafeIntrinsic, VMComponentOffsets,
+    TrampolineIndex, TypeComponentIndex, TypeFuncIndex, UnsafeIntrinsic, VMComponentOffsets, dfg,
 };
 use wasmtime_environ::{Abi, CompiledFunctionsTable, FuncKey, TypeTrace};
 use wasmtime_environ::{FunctionLoc, HostPtr, ObjectKind, PrimaryMap};
@@ -879,6 +879,12 @@ impl Component {
             Export::LiftedFunction { ty, func, options } => (*ty, func, *options),
             _ => unreachable!(),
         }
+    }
+
+    //TODO: rename?
+    /// Returns the Component Structure needed for Remote Attestation.
+    pub fn component_structure(&self) -> &dfg::RootComponentInstanceStructure {
+        &self.inner.info.component.instantiation_graph
     }
 }
 

--- a/crates/wasmtime/src/runtime/component/component.rs
+++ b/crates/wasmtime/src/runtime/component/component.rs
@@ -881,9 +881,8 @@ impl Component {
         }
     }
 
-    //TODO: rename?
-    /// Returns the Component Structure needed for Remote Attestation.
-    pub fn component_structure(&self) -> &dfg::RootComponentInstanceStructure {
+    /// Returns the Instantiation Graph.
+    pub fn instantiation_graph(&self) -> &dfg::RootComponentInstanceStructure {
         &self.inner.info.component.instantiation_graph
     }
 }

--- a/crates/wasmtime/src/runtime/component/linker.rs
+++ b/crates/wasmtime/src/runtime/component/linker.rs
@@ -17,6 +17,18 @@ use core::{future::Future, pin::Pin};
 use wasmtime_environ::PrimaryMap;
 use wasmtime_environ::component::{NameMap, NameMapIntern};
 
+#[cfg(feature = "caller")]
+#[derive(Debug)]
+/// Identifies the runtime instance from which a host function call originated
+/// Because nested components are flattened during compilation, this requires identifying both
+/// the top-level instance within the store and the runtime instance within it.
+pub struct CallerInstance {
+    /// The top-level instance within the store
+    pub instance: Instance,
+    /// The runtime component instance index within the top-level component instance
+    pub caller: u32,
+}
+
 /// A type used to instantiate [`Component`]s.
 ///
 /// This type is used to both link components together as well as supply host
@@ -489,6 +501,50 @@ impl<T: 'static> LinkerInstance<'_, T> {
             store.block_on(|store| f(store, params).into())?
         };
         self.func_wrap(name, ff)
+    }
+
+    #[cfg(feature = "caller")]
+    /// Same as [`Self::func_wrap`] but the generic function type takes an additional parameter for the caller instance
+    pub fn func_wrap_with_caller<F, Params, Return>(&mut self, name: &str, func: F) -> Result<()>
+    where
+        F: Fn(StoreContextMut<T>, CallerInstance, Params) -> Result<Return> + Send + Sync + 'static,
+        Params: ComponentNamedList + Lift + 'static,
+        Return: ComponentNamedList + Lower + 'static,
+    {
+        self.insert(
+            name,
+            Definition::Func(HostFunc::from_closure_with_caller(func)),
+        )?;
+        Ok(())
+    }
+
+    #[cfg(feature = "caller")]
+    #[cfg(feature = "async")]
+    /// Same as [`Self::func_wrap_async`] but the generic function type takes an additional parameter for the caller instance
+    pub fn func_wrap_with_caller_async<Params, Return, F>(&mut self, name: &str, f: F) -> Result<()>
+    where
+        F: Fn(
+                StoreContextMut<'_, T>,
+                CallerInstance,
+                Params,
+            ) -> Box<dyn Future<Output = Result<Return>> + Send + '_>
+            + Send
+            + Sync
+            + 'static,
+        Params: ComponentNamedList + Lift + 'static,
+        Return: ComponentNamedList + Lower + 'static,
+    {
+        assert!(
+            self.engine.config().async_support,
+            "cannot use `func_wrap_async` without enabling async support in the config"
+        );
+        let ff = move |store: StoreContextMut<'_, T>,
+                       caller_instance: CallerInstance,
+                       params: Params|
+              -> Result<Return> {
+            store.block_on(|store| f(store, caller_instance, params).into())?
+        };
+        self.func_wrap_with_caller(name, ff)
     }
 
     /// Defines a new host-provided async function into this [`LinkerInstance`].

--- a/crates/wasmtime/src/runtime/component/mod.rs
+++ b/crates/wasmtime/src/runtime/component/mod.rs
@@ -131,9 +131,9 @@ pub use self::func::{
 };
 pub use self::has_data::*;
 pub use self::instance::{Instance, InstanceExportLookup, InstancePre};
-pub use self::linker::{Linker, LinkerInstance};
 #[cfg(feature = "caller")]
 pub use self::linker::CallerInstance;
+pub use self::linker::{Linker, LinkerInstance};
 pub use self::resource_table::{ResourceTable, ResourceTableError};
 pub use self::resources::{Resource, ResourceAny, ResourceDynamic};
 pub use self::types::{ResourceType, Type};

--- a/crates/wasmtime/src/runtime/component/mod.rs
+++ b/crates/wasmtime/src/runtime/component/mod.rs
@@ -132,6 +132,8 @@ pub use self::func::{
 pub use self::has_data::*;
 pub use self::instance::{Instance, InstanceExportLookup, InstancePre};
 pub use self::linker::{Linker, LinkerInstance};
+#[cfg(feature = "caller")]
+pub use self::linker::CallerInstance;
 pub use self::resource_table::{ResourceTable, ResourceTableError};
 pub use self::resources::{Resource, ResourceAny, ResourceDynamic};
 pub use self::types::{ResourceType, Type};


### PR DESCRIPTION
Previous conversation about this pull request available at:
https://bytecodealliance.zulipchat.com/#narrow/channel/217126-wasmtime/topic/New.20functionality.20useful.20for.20attestation/with/553956315

Also there is a discussion about request of this feature available at:
https://bytecodealliance.zulipchat.com/#narrow/channel/217126-wasmtime/topic/Getting.20component.20information.20on.20host.20calls/with/558000999


### Summary

We have modified Wasmtime to expose the identity of the caller identity to host function implementations, in order to support functionality such as remote attestation or component-specific access control policies.  This includes both the addition of an extended host function API for embedders that provides the caller identity, as well as analysis of components during compilation in order to capture enough structure to allow the caller to be identified within the application.  

---

### Goal

To provide a supported way for embedders to identify which part of a multi-component Wasm application has called a host function. This can serve a number of purposes, but in our case the goal is to enable a platform to implement Wasm-aware _attestation_ functionality.

Attestation allows one platform, the prover, to prove properties of its state to another platform, the verifier.  A common property to prove is the hashes of the code running on the platform, and to link them to e.g. a TLS handshake, that allows a client to obtain a guarantee such as "at the other end of this TLS connection is application X".

Since WebAssembly provides individual sandboxes for each core module instance, we can meaningfully attest the identity of a piece of code at the granularity of a core module, rather than treating the application as a monolithic whole.  This allows for libraries and applications that use attestation to be transparently composed into larger systems while maintaining their individual identities.

To achieve this, we require two main additions to Wasmtime, and this PR is oriented towards these two goals:

1. When a component is loaded, we need to extract enough information on its internal structure to allow the embedder to work out which part of the application called a host function.

2. We need to extend the host function API to allow the implementation to identify the source of the function call, in a backwards-compatible manner.

---

### General implementation notes


1. **Component structure analysis**

This is implemented in _crates/environ/src/component/dfg.rs_, _‎crates/environ/src/component/info.rs_, and _‎crates/environ/src/component/translate/inline.rs_. And the public API is at _‎crates/wasmtime/src/runtime/component/component.rs_.

During component compilation/instantiation, we track the creation of core module instances and the resolution of their imports/exports.  These instances are named using a sequence of indices that uniquely identify its location relative to the top-level component (e.g. [5.1] is the first core module instance in the fifth component instantiated in the top-level component).

In many applications, linking the caller back to this identifier will be enough, and probably we will end up minimising these changes down to this.  However, this ties the identity of part of the application to its location in the component hierarchy.  We might expect that some future applications may rearrange the component hierarchy, e.g. in order to optimise an application binary for size, or to distribute an application across several physical machines.  We therefore aim to represent the application at a lower level.

For each imported core function, we record which core module instance it ultimately comes from, following the same resolution steps that the inliner uses.  The result is an *instantiation graph* whose nodes are core module instances and whose edges represent dependency and call relationships as resolved by Wasmtime.

The result is an accurate graph of how core module instances are wired together at runtime inside a component (after linking, lowering, aliasing, etc.), along with identifiers that allow parts of the graph to be identified with their location in the component hierarchy, allowing comparison with a reference binary, even if its overall structure is completely different to a mangled binary loaded at runtime.

The instantiation graph is exposed via a method _`Component::component_structure`_ that allows embedders (or tools) to obtain the instantiation graph structure of the runtime structure.

2. **Caller-aware host functions**

This is implemented in _crates/wasmtime/src/runtime/component/linker.rs_ and _crates/wasmtime/src/runtime/component/func/host.rs‎_ and hidden behind the feature flag `caller`.

We introduce new `func_wrap` variants (identified by the suffix `_caller`) in the component linker that allow a host function to receive not only its usual arguments, but also an identifier for the calling component/core module instance.

We capture the runtime index OptionsIndex that, in combination with an `Instance`, identifies the core module in the `Store`. We then correlate this index with the identifier sequence described above.  It is important to note that the naming matches the components' index spaces used by wasmtime and present in WebAssembly Text Format (WAT). Using this we can correlate the calling instance with its instantiation in the component binary.



