### PR TITLE
Use `ensure!(cond, ...)` instead of `if !cond { bail!(...) }` in config validation

### DIFF
--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -2410,12 +2410,14 @@ impl Config {
         };
 
         if tunables.debug_guest {
-            if !cfg!(feature = "debug") {
-                bail!("debug instrumentation support was disabled at compile time");
-            }
-            if tunables.signals_based_traps {
-                bail!("cannot use signals-based traps with guest debugging enabled");
-            }
+            ensure!(
+                cfg!(feature = "debug"),
+                "debug instrumentation support was disabled at compile time"
+            );
+            ensure!(
+                !tunables.signals_based_traps,
+                "cannot use signals-based traps with guest debugging enabled"
+            );
         }
 
         Ok((tunables, features))


### PR DESCRIPTION
Tiny follow up to https://github.com/bytecodealliance/wasmtime/pull/12052

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
