### PR TITLE
Set minimum stacks/instance size in the component-api fuzzer too

### DIFF
--- a/crates/fuzzing/src/oracles/component_api.rs
+++ b/crates/fuzzing/src/oracles/component_api.rs
@@ -158,8 +158,10 @@ fn store<T>(input: &mut Unstructured<'_>, val: T) -> arbitrary::Result<Store<T>>
         set_min(&mut p.total_component_instances, 5);
         set_min(&mut p.total_core_instances, 5);
         set_min(&mut p.total_memories, 2);
+        set_min(&mut p.total_stacks, 4);
         set_min(&mut p.max_memories_per_component, 2);
         set_min(&mut p.max_memories_per_module, 2);
+        set_min(&mut p.component_instance_size, 64 << 10);
         p.memory_protection_keys = Enabled::No;
         p.max_memory_size = 10 << 20; // 10 MiB
     }

--- a/fuzz/build.rs
+++ b/fuzz/build.rs
@@ -38,6 +38,7 @@ mod component {
     }
 
     fn write_static_api_tests(out: &mut String) -> Result<()> {
+        println!("cargo:rerun-if-env-changed=WASMTIME_FUZZ_SEED");
         let seed = if let Ok(seed) = env::var("WASMTIME_FUZZ_SEED") {
             seed.parse::<u64>()
                 .with_context(|| anyhow!("expected u64 in WASMTIME_FUZZ_SEED"))?


### PR DESCRIPTION
Similar to other settings there needs to be a minimum when the pooling allocator is configured to actually be able to run modules.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
