### PR TITLE
Disable sync testing of wast for now

### DIFF
--- a/crates/fuzzing/src/oracles.rs
+++ b/crates/fuzzing/src/oracles.rs
@@ -713,7 +713,9 @@ pub fn wast_test(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<()> {
 
     let test = &test.test;
 
-    if test.config.component_model_async() || u.arbitrary()? {
+    // FIXME(#11954) async is unconditional for now due to preexisting tests not
+    // playing well with/without async when combined with coop multithreading.
+    if true || test.config.component_model_async() || u.arbitrary()? {
         fuzz_config.enable_async(u)?;
     }
 


### PR DESCRIPTION
This is causing failures due to #11954 so to help unblock fuzzing just disable sync for now.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
