### PR TITLE
don't set `TransmitState::done` until future value delivered

### DIFF
--- a/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams.rs
@@ -3468,13 +3468,16 @@ impl Instance {
                 assert!(!cancel);
                 assert_eq!(0, guest_offset);
 
-                if let TransmitIndex::Future(_) = ty {
-                    transmit.done = true;
-                }
-
                 set_guest_ready(concurrent_state)?;
 
-                self.produce(store.0, ty.kind(), transmit_id, produce, try_into, 0, false)?
+                let code =
+                    self.produce(store.0, ty.kind(), transmit_id, produce, try_into, 0, false)?;
+
+                if let (TransmitIndex::Future(_), ReturnCode::Completed(_)) = (ty, code) {
+                    store.0.concurrent_state_mut().get_mut(transmit_id)?.done = true;
+                }
+
+                code
             }
 
             WriteState::Open => {


### PR DESCRIPTION
Thanks to Alex for the test case!

Fixes #12092

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
