### PR TITLE
Switch back to native s390x runners

### DIFF
--- a/.github/actions/install-rust/action.yml
+++ b/.github/actions/install-rust/action.yml
@@ -37,26 +37,6 @@ runs:
           echo "version=${{ inputs.toolchain }}" >> "$GITHUB_OUTPUT"
         fi
 
-
-    # GitHub Actions default runners have `rustup` instaleld, but IBM-provided
-    # s390x runners do not. If we're using the IBM runner then install rustup.
-    - name: Install rustup
-      shell: bash
-      if: runner.arch == 'S390X'
-      run: |
-        export RUSTUP_HOME=${{ runner.tool_cache }}/rustup
-        export CARGO_HOME=${{ runner.tool_cache }}/cargo
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
-          sh -s -- \
-            -y \
-            --default-toolchain ${{ steps.select.outputs.version }} \
-            --profile minimal \
-            --no-modify-path
-        echo "RUSTUP_HOME=$RUSTUP_HOME" >> $GITHUB_ENV
-        echo "CARGO_HOME=$CARGO_HOME" >> $GITHUB_ENV
-        echo "$CARGO_HOME/bin" >> $GITHUB_PATH
-
-
     - name: Install Rust
       shell: bash
       run: |

--- a/ci/build-test-matrix.js
+++ b/ci/build-test-matrix.js
@@ -121,14 +121,18 @@ const FULL_MATRIX = [
   },
   {
     "name": "Test Linux s390x",
-    "os": ubuntu,
+    "os": 'ubuntu-24.04-s390x',
     "target": "s390x-unknown-linux-gnu",
     "filter": "linux-s390x",
     "isa": "s390x",
-    "gcc_package": "gcc-s390x-linux-gnu",
-    "gcc": "s390x-linux-gnu-gcc",
-    "qemu": "qemu-s390x -L /usr/s390x-linux-gnu",
-    "qemu_target": "s390x-linux-user",
+    // These are no longer necessary now that this runner is using an
+    // IBM-provided native runner. If that needs to change, however,
+    // uncommenting these and switching back to `ubuntu` for the os will switch
+    // us back to QEMU emulation.
+    // "gcc_package": "gcc-s390x-linux-gnu",
+    // "gcc": "s390x-linux-gnu-gcc",
+    // "qemu": "qemu-s390x -L /usr/s390x-linux-gnu",
+    // "qemu_target": "s390x-linux-user",
   },
   {
     "name": "Test Linux riscv64",


### PR DESCRIPTION
Also drop the custom rustup-install logic as the runners should have it installed now. In the meantime it sounds like capacity has expanded and a scheduler bug was fixed, so let's give it a go again.


<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
