### PR TITLE
Add OpenBSD support in wasmtime for setjmp/longjmp

### DIFF
--- a/crates/wasmtime/src/runtime/vm/sys/unix/signals.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/unix/signals.rs
@@ -383,6 +383,13 @@ unsafe fn store_handler_in_ucontext(cx: *mut libc::c_void, handler: &Handler) {
             cx.uc_mcontext.mc_rsp = handler.sp as _;
             cx.uc_mcontext.mc_rax = 0;
             cx.uc_mcontext.mc_rdx = 0;
+        } else if #[cfg(all(target_os = "openbsd", target_arch = "x86_64"))] {
+            let cx = unsafe { cx.cast::<libc::ucontext_t>().as_mut().unwrap() };
+            cx.sc_rip = handler.pc as _;
+            cx.sc_rbp = handler.fp as _;
+            cx.sc_rsp = handler.sp as _;
+            cx.sc_rax = 0;
+            cx.sc_rdx = 0;
         } else if #[cfg(all(target_os = "linux", target_arch = "riscv64"))] {
             let cx = unsafe { cx.cast::<libc::ucontext_t>().as_mut().unwrap() };
             cx.uc_mcontext.__gregs[libc::REG_PC] = handler.pc as _;


### PR DESCRIPTION
In `crates/wasmtime/src/runtime/vm/sys/unix/signals.rs`, add case for OpenBSD/x86_64 according to `libc` https://github.com/rust-lang/libc/blob/main/src/unix/bsd/netbsdlike/openbsd/x86_64.rs

This fix is needed after this commit https://github.com/bytecodealliance/wasmtime/commit/192f2fcdadfec9d0cf6b58548a85a7307450cbf5

**Build and tests OK on OpenBSD/current amd64**:
- with example from https://github.com/bytecodealliance/wasmtime/tree/main/crates/wasmtime
- build of Yara-X version v1.10.0 (https://github.com/VirusTotal/yara-x/releases/tag/v1.10.0) that uses `wasmtime` crate.