### PR TITLE
Implement simple icmp + select optimization

### DIFF
--- a/cranelift/codegen/src/opts/icmp.isle
+++ b/cranelift/codegen/src/opts/icmp.isle
@@ -376,3 +376,11 @@
   (simplify (band ty (ult ty x y) (ne ty (iconst_s _ -1) x)))
    (ult ty x y))
 
+;; icmp on select with two constant inputs compared with one of the two
+;; constants can directly use the inner select condition.
+;; See: https://github.com/bytecodealliance/wasmtime/issues/11578
+(rule (simplify (icmp _ (IntCC.Equal)
+  (select ty inner_cond (iconst ty (u64_from_imm64 k1)) (iconst ty (u64_from_imm64 k2)))
+    (iconst ty (u64_from_imm64 k1))))
+  (if-let false (u64_eq k1 k2))
+  inner_cond)

--- a/cranelift/filetests/filetests/egraph/issue-11578.clif
+++ b/cranelift/filetests/filetests/egraph/issue-11578.clif
@@ -1,0 +1,45 @@
+test optimize
+set opt_level=speed
+target x86_64
+target aarch64
+
+function %a(i64) -> i8 {
+block0(v2: i64):
+    v14 = iconst.i64 -562949953421310
+    v3 = band v2, v14
+    v16 = iconst.i64 0
+    v4 = icmp eq v3, v16
+    v5 = iconst.i64 6
+    v6 = iconst.i64 7
+    v7 = select v4, v5, v6
+    v8 = icmp eq v7, v5
+    return v8
+}
+
+; check:  function %a(i64) -> i8 fast {
+; check:  block0(v2: i64):
+; nextln:      v14 = iconst.i64 -562949953421310
+; nextln:      v3 = band v2, v14
+; nextln:      v16 = iconst.i64 0
+; nextln:      v4 = icmp eq v3, v16
+; nextln:      return v4
+; nextln: }
+
+; select x, k1, k1 should be constant propagated
+function %a(i64) -> i8 {
+block0(v2: i64):
+    v14 = iconst.i64 -562949953421310
+    v3 = band v2, v14
+    v16 = iconst.i64 0
+    v4 = icmp eq v3, v16
+    v5 = iconst.i64 6
+    v6 = select v4, v5, v5
+    v7 = icmp eq v6, v5
+    return v7
+}
+
+; check:  function %a(i64) -> i8 fast {
+; check:  block0(v2: i64):
+; nextln:     v17 = iconst.i8 1
+; nextln:     return v17
+; nextln: }


### PR DESCRIPTION
This optimizes the following:

a = select x, k1, k2
b = icmp eq a, k1

to

b = x

We shouldn't trigger this optimization when k1 == k2 because constant propagation should optimize that case.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
