### PR TITLE
Cap iterations of `component_api` fuzzer

### DIFF
--- a/crates/fuzzing/src/oracles/component_api.rs
+++ b/crates/fuzzing/src/oracles/component_api.rs
@@ -27,6 +27,9 @@ const MIN_LIST_LENGTH: u32 = 0;
 /// Maximum length of an arbitrary list value generated for a test case
 const MAX_LIST_LENGTH: u32 = 10;
 
+/// Maximum number of invocations of one fuzz case.
+const MAX_ITERS: usize = 1_000;
+
 /// Generate an arbitrary instance of the specified type.
 fn arbitrary_val(ty: &component::Type, input: &mut Unstructured) -> arbitrary::Result<Val> {
     use component::Type;
@@ -263,7 +266,8 @@ where
             .get_typed_func::<P, R>(&mut store, EXPORT_FUNCTION)
             .unwrap();
 
-        while input.arbitrary()? {
+        let mut iters = 0..MAX_ITERS;
+        while iters.next().is_some() && input.arbitrary()? {
             let params = input.arbitrary::<P>()?;
             let result = input.arbitrary::<R>()?;
             *store.data_mut() = Box::new((params.clone(), result.clone()));
@@ -352,7 +356,8 @@ pub fn dynamic_component_api_target(input: &mut arbitrary::Unstructured) -> arbi
         let func = instance.get_func(&mut store, EXPORT_FUNCTION).unwrap();
         let ty = func.ty(&store);
 
-        while input.arbitrary()? {
+        let mut iters = 0..MAX_ITERS;
+        while iters.next().is_some() && input.arbitrary()? {
             let params = ty
                 .params()
                 .map(|(_, ty)| arbitrary_val(&ty, input))


### PR DESCRIPTION
This timed out over the weekend on OSS-Fuzz and running locally it just runs quite a lot of iterations of the test case in question. There's no need to run so much in one fuzz test case so cap the total number of iterations at a constant to avoid timing out.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
