### PR TITLE
Disable `Tombstone` insertion in `ResourceTable` by default

### DIFF
--- a/crates/wasmtime/src/runtime/component/resource_table.rs
+++ b/crates/wasmtime/src/runtime/component/resource_table.rs
@@ -62,6 +62,10 @@ impl Entry {
 
 struct Tombstone;
 
+// Change this to `true` to assist with handle debugging in development if
+// necessary.
+const DELETE_WITH_TOMBSTONE: bool = false;
+
 /// This structure tracks parent and child relationships for a given table entry.
 ///
 /// Parents and children are referred to by table index. We maintain the
@@ -311,7 +315,7 @@ impl ResourceTable {
     where
         T: Any,
     {
-        self.delete_maybe_debug(resource, cfg!(debug_assertions))
+        self.delete_maybe_debug(resource, DELETE_WITH_TOMBSTONE)
     }
 
     fn delete_maybe_debug<T>(


### PR DESCRIPTION
This was useful in the development of WASIp3 but given the relatively big change in behavior to a foundational data structure I don't think it's best to keep this tied to `cfg!(debug_assertions)`. Instead disable it by default and use a source-editing approach to change it.

cc #12113
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
