### PR TITLE
trap on read from and write to intra-component stream/future

### DIFF
--- a/crates/wasi-http/tests/all/p3/mod.rs
+++ b/crates/wasi-http/tests/all/p3/mod.rs
@@ -330,8 +330,15 @@ async fn p3_http_middleware() -> Result<()> {
 }
 
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
-async fn p3_http_middleware_host_to_host() -> Result<()> {
-    test_http_middleware(true).await
+async fn p3_http_middleware_host_to_host() {
+    let error = format!("{:?}", test_http_middleware(true).await.unwrap_err());
+
+    let expected = "cannot read from and write to intra-component stream with non-unit payload";
+
+    assert!(
+        error.contains(expected),
+        "expected `{expected}`; got `{error}`"
+    );
 }
 
 async fn test_http_middleware(host_to_host: bool) -> Result<()> {

--- a/crates/wasmtime/src/runtime/component/concurrent.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent.rs
@@ -3608,6 +3608,7 @@ impl<T: 'static> VMComponentAsyncStore for StoreInner<T> {
         instance
             .guest_write(
                 StoreContextMut(self),
+                caller,
                 TransmitIndex::Future(ty),
                 options,
                 None,
@@ -3631,6 +3632,7 @@ impl<T: 'static> VMComponentAsyncStore for StoreInner<T> {
         instance
             .guest_read(
                 StoreContextMut(self),
+                caller,
                 TransmitIndex::Future(ty),
                 options,
                 None,
@@ -3655,6 +3657,7 @@ impl<T: 'static> VMComponentAsyncStore for StoreInner<T> {
         instance
             .guest_write(
                 StoreContextMut(self),
+                caller,
                 TransmitIndex::Stream(ty),
                 options,
                 None,
@@ -3679,6 +3682,7 @@ impl<T: 'static> VMComponentAsyncStore for StoreInner<T> {
         instance
             .guest_read(
                 StoreContextMut(self),
+                caller,
                 TransmitIndex::Stream(ty),
                 options,
                 None,
@@ -3716,6 +3720,7 @@ impl<T: 'static> VMComponentAsyncStore for StoreInner<T> {
         instance
             .guest_write(
                 StoreContextMut(self),
+                caller,
                 TransmitIndex::Stream(ty),
                 options,
                 Some(FlatAbi {
@@ -3745,6 +3750,7 @@ impl<T: 'static> VMComponentAsyncStore for StoreInner<T> {
         instance
             .guest_read(
                 StoreContextMut(self),
+                caller,
                 TransmitIndex::Stream(ty),
                 options,
                 Some(FlatAbi {

--- a/tests/misc_testsuite/component-model/async/intra-futures.wast
+++ b/tests/misc_testsuite/component-model/async/intra-futures.wast
@@ -1,0 +1,48 @@
+;;! component_model_async = true
+;;! component_model_async_builtins = true
+
+(component
+  (core module $libc (memory (export "m") 1))
+  (core instance $libc (instantiate $libc))
+
+  (type $s (future u32))
+  (core func $future.new (canon future.new $s))
+  (core func $future.read (canon future.read $s async (memory $libc "m")))
+  (core func $future.write (canon future.write $s async (memory $libc "m")))
+
+  (core module $m
+    (import "" "future.new" (func $future.new (result i64)))
+    (import "" "future.read" (func $future.read (param i32 i32) (result i32)))
+    (import "" "future.write" (func $future.write (param i32 i32) (result i32)))
+
+    (func (export "run")
+      (local $tmp i64)
+      (local $r i32)
+      (local $w i32)
+      (local.set $tmp (call $future.new))
+
+      (local.set $r (i32.wrap_i64 (local.get $tmp)))
+      (local.set $w (i32.wrap_i64 (i64.shr_u (local.get $tmp) (i64.const 32))))
+
+      (call $future.read (local.get $r) (i32.const 0))
+      i32.const -1 ;; BLOCKED
+      i32.ne
+      if unreachable end
+
+      (call $future.write (local.get $w) (i32.const 0))
+      drop
+    )
+  )
+
+  (core instance $i (instantiate $m
+    (with "" (instance
+      (export "future.new" (func $future.new))
+      (export "future.read" (func $future.read))
+      (export "future.write" (func $future.write))
+    ))
+  ))
+
+  (func (export "run") (canon lift (core func $i "run")))
+)
+
+(assert_trap (invoke "run") "cannot read from and write to intra-component future with non-unit payload")

--- a/tests/misc_testsuite/component-model/async/intra-streams.wast
+++ b/tests/misc_testsuite/component-model/async/intra-streams.wast
@@ -1,0 +1,48 @@
+;;! component_model_async = true
+;;! component_model_async_builtins = true
+
+(component
+  (core module $libc (memory (export "m") 1))
+  (core instance $libc (instantiate $libc))
+
+  (type $s (stream u32))
+  (core func $stream.new (canon stream.new $s))
+  (core func $stream.read (canon stream.read $s async (memory $libc "m")))
+  (core func $stream.write (canon stream.write $s async (memory $libc "m")))
+
+  (core module $m
+    (import "" "stream.new" (func $stream.new (result i64)))
+    (import "" "stream.read" (func $stream.read (param i32 i32 i32) (result i32)))
+    (import "" "stream.write" (func $stream.write (param i32 i32 i32) (result i32)))
+
+    (func (export "run")
+      (local $tmp i64)
+      (local $r i32)
+      (local $w i32)
+      (local.set $tmp (call $stream.new))
+
+      (local.set $r (i32.wrap_i64 (local.get $tmp)))
+      (local.set $w (i32.wrap_i64 (i64.shr_u (local.get $tmp) (i64.const 32))))
+
+      (call $stream.read (local.get $r) (i32.const 0) (i32.const 4))
+      i32.const -1 ;; BLOCKED
+      i32.ne
+      if unreachable end
+
+      (call $stream.write (local.get $w) (i32.const 0) (i32.const 4))
+      drop
+    )
+  )
+
+  (core instance $i (instantiate $m
+    (with "" (instance
+      (export "stream.new" (func $stream.new))
+      (export "stream.read" (func $stream.read))
+      (export "stream.write" (func $stream.write))
+    ))
+  ))
+
+  (func (export "run") (canon lift (core func $i "run")))
+)
+
+(assert_trap (invoke "run") "cannot read from and write to intra-component stream with non-unit payload")


### PR DESCRIPTION
The spec says we need to do this for streams and futures that have a payload type.

Note that `p3_http_middleware_host_to_host` triggers this trap, which is expected given how it functions, so now we assert accordingly.

Thanks to Alex for the tests!

Fixes #12108

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
