### PR TITLE
Cranelift: support fuzzing `patchable_call`.

### DIFF
--- a/cranelift/fuzzgen/src/function_generator.rs
+++ b/cranelift/fuzzgen/src/function_generator.rs
@@ -117,8 +117,14 @@ fn insert_call(
     _args: &[Type],
     _rets: &[Type],
 ) -> Result<()> {
-    assert!(matches!(opcode, Opcode::Call | Opcode::CallIndirect));
+    assert!(matches!(
+        opcode,
+        Opcode::Call | Opcode::CallIndirect | Opcode::PatchableCall
+    ));
     let (sig, sig_ref, func_ref) = fgen.u.choose(&fgen.resources.func_refs)?.clone();
+    if opcode == Opcode::PatchableCall && sig.call_conv != CallConv::Patchable {
+        return Err(arbitrary::Error::IncorrectFormat.into());
+    }
 
     insert_call_to_function(fgen, builder, opcode, &sig, sig_ref, func_ref)
 }


### PR DESCRIPTION
This allows the opcode for call-format instructions and verifies that we are calling it with the patchable ABI.

Fixes https://oss-fuzz.com/testcase-detail/6014638929281024.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
