### PR TITLE
Update wasm-tools/wit-bindgen dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -640,7 +640,7 @@ dependencies = [
  "test-programs-artifacts",
  "tokio",
  "wasm-compose",
- "wasmparser 0.242.0",
+ "wasmparser 0.243.0",
  "wasmtime",
  "wasmtime-wasi",
 ]
@@ -1306,7 +1306,7 @@ dependencies = [
 name = "example-component-wasm"
 version = "0.0.0"
 dependencies = [
- "wit-bindgen 0.48.0",
+ "wit-bindgen 0.49.0",
 ]
 
 [[package]]
@@ -1317,7 +1317,7 @@ version = "0.0.0"
 name = "example-resource-component-wasm"
 version = "0.1.0"
 dependencies = [
- "wit-bindgen 0.48.0",
+ "wit-bindgen 0.49.0",
 ]
 
 [[package]]
@@ -2151,14 +2151,14 @@ dependencies = [
 
 [[package]]
 name = "json-from-wast"
-version = "0.242.0"
+version = "0.243.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "733f93c5ce57e1e8dd5482deb3e93f08e7c39eaed4fc526bf578e248f27d9d0d"
+checksum = "5f47aa6916e07fa82816d3b845e41828be0670f81466ae5ed84a595f8f762d6b"
 dependencies = [
  "anyhow",
  "serde",
  "serde_derive",
- "wast 242.0.0",
+ "wast 243.0.0",
 ]
 
 [[package]]
@@ -3649,7 +3649,7 @@ dependencies = [
  "wasi-nn",
  "wasip1",
  "wasip2",
- "wit-bindgen 0.48.0",
+ "wit-bindgen 0.49.0",
 ]
 
 [[package]]
@@ -3663,7 +3663,7 @@ dependencies = [
  "wasmtime",
  "wasmtime-test-util",
  "wat",
- "wit-component 0.242.0",
+ "wit-component",
 ]
 
 [[package]]
@@ -4096,7 +4096,7 @@ name = "verify-component-adapter"
 version = "40.0.0"
 dependencies = [
  "anyhow",
- "wasmparser 0.242.0",
+ "wasmparser 0.243.0",
  "wat",
 ]
 
@@ -4198,7 +4198,7 @@ dependencies = [
  "byte-array-literals",
  "object 0.37.3",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "wasm-encoder 0.242.0",
+ "wasm-encoder",
  "wit-bindgen-rust-macro",
 ]
 
@@ -4274,9 +4274,9 @@ checksum = "6ee99da9c5ba11bd675621338ef6fa52296b76b83305e9b6e5c77d4c286d6d49"
 
 [[package]]
 name = "wasm-compose"
-version = "0.242.0"
+version = "0.243.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccaa3800e42f253a3f58e20ba311b0dea1a5de012258615a397226c22af7a445"
+checksum = "af801b6f36459023eaec63fdbaedad2fd5a4ab7dc74ecc110a8b5d375c5775e4"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -4288,81 +4288,59 @@ dependencies = [
  "serde_derive",
  "serde_yaml",
  "smallvec",
- "wasm-encoder 0.242.0",
- "wasmparser 0.242.0",
+ "wasm-encoder",
+ "wasmparser 0.243.0",
  "wat",
 ]
 
 [[package]]
 name = "wasm-encoder"
-version = "0.241.2"
+version = "0.243.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e01164c9dda68301e34fdae536c23ed6fe90ce6d97213ccc171eebbd3d02d6b8"
+checksum = "c55db9c896d70bd9fa535ce83cd4e1f2ec3726b0edd2142079f594fc3be1cb35"
 dependencies = [
  "leb128fmt",
- "wasmparser 0.241.2",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.242.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67f90e55bc9c6ee6954a757cc6eb3424d96b442e5252ed10fea627e518878d36"
-dependencies = [
- "leb128fmt",
- "wasmparser 0.242.0",
+ "wasmparser 0.243.0",
 ]
 
 [[package]]
 name = "wasm-metadata"
-version = "0.241.2"
+version = "0.243.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876fe286f2fa416386deedebe8407e6f19e0b5aeaef3d03161e77a15fa80f167"
+checksum = "eae05bf9579f45a62e8d0a4e3f52eaa8da518883ac5afa482ec8256c329ecd56"
 dependencies = [
  "anyhow",
  "indexmap 2.11.4",
- "wasm-encoder 0.241.2",
- "wasmparser 0.241.2",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.242.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53cc3deb1bc19b28fa43bd5773ad712ab0ddabea785b78166d6791b14e955fe1"
-dependencies = [
- "anyhow",
- "indexmap 2.11.4",
- "wasm-encoder 0.242.0",
- "wasmparser 0.242.0",
+ "wasm-encoder",
+ "wasmparser 0.243.0",
 ]
 
 [[package]]
 name = "wasm-mutate"
-version = "0.242.0"
+version = "0.243.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87511533c0fd89ed665a58b3376fe983cd49f7bf9dddbc7a4ee6990e8d8893d5"
+checksum = "f56c94870d1398b2f01e7cd7c44efd9f557e9baaf306f0d246b6b9c862c22b8a"
 dependencies = [
  "egg",
  "log",
  "rand 0.9.2",
  "thiserror 2.0.17",
- "wasm-encoder 0.242.0",
- "wasmparser 0.242.0",
+ "wasm-encoder",
+ "wasmparser 0.243.0",
 ]
 
 [[package]]
 name = "wasm-smith"
-version = "0.242.0"
+version = "0.243.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de05912dc914b1b3073184acbbbe8f3d7d86dea2863f44f64a50bbf299bad86e"
+checksum = "119b7dd7690868543d344025ee894271d9c66fa00d5c1cd233a5c72eb7a2ea03"
 dependencies = [
  "anyhow",
  "arbitrary",
  "flagset",
  "serde",
  "serde_derive",
- "wasm-encoder 0.242.0",
+ "wasm-encoder",
  "wat",
 ]
 
@@ -4376,14 +4354,14 @@ dependencies = [
 
 [[package]]
 name = "wasm-wave"
-version = "0.242.0"
+version = "0.243.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9bd24e20927a8add1ffe45ba7b461b2b02b1c2ae30c07c908bd940113b7ff4b"
+checksum = "4bd23c879ec35d708f4eff3456f33c415d113363a2e38420098bf42976bacb31"
 dependencies = [
  "indexmap 2.11.4",
  "logos",
  "thiserror 2.0.17",
- "wit-parser 0.242.0",
+ "wit-parser",
 ]
 
 [[package]]
@@ -4438,21 +4416,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.241.2"
+version = "0.243.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46d90019b1afd4b808c263e428de644f3003691f243387d30d673211ee0cb8e8"
-dependencies = [
- "bitflags 2.9.4",
- "hashbrown 0.15.2",
- "indexmap 2.11.4",
- "semver",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.242.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed3c6e611f4cd748d85c767815823b777dc56afca793fcda27beae4e85028849"
+checksum = "f6d8db401b0528ec316dfbe579e6ab4152d61739cfe076706d2009127970159d"
 dependencies = [
  "bitflags 2.9.4",
  "hashbrown 0.15.2",
@@ -4463,13 +4429,13 @@ dependencies = [
 
 [[package]]
 name = "wasmprinter"
-version = "0.242.0"
+version = "0.243.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "936a79bf33649f3aa0cd7cdf495e62ac0c718b3630ab53946df6dc2eff73a0d6"
+checksum = "eb2b6035559e146114c29a909a3232928ee488d6507a1504d8934e8607b36d7b"
 dependencies = [
  "anyhow",
  "termcolor",
- "wasmparser 0.242.0",
+ "wasmparser 0.243.0",
 ]
 
 [[package]]
@@ -4515,9 +4481,9 @@ dependencies = [
  "tempfile",
  "tokio",
  "wasm-compose",
- "wasm-encoder 0.242.0",
+ "wasm-encoder",
  "wasm-wave",
- "wasmparser 0.242.0",
+ "wasmparser 0.243.0",
  "wasmtime-environ",
  "wasmtime-internal-cache",
  "wasmtime-internal-component-macro",
@@ -4628,8 +4594,8 @@ dependencies = [
  "tracing",
  "walkdir",
  "wasi-common",
- "wasm-encoder 0.242.0",
- "wasmparser 0.242.0",
+ "wasm-encoder",
+ "wasmparser 0.243.0",
  "wasmtime",
  "wasmtime-cli-flags",
  "wasmtime-environ",
@@ -4649,10 +4615,10 @@ dependencies = [
  "wasmtime-wasi-tls",
  "wasmtime-wast",
  "wasmtime-wizer",
- "wast 242.0.0",
+ "wast 243.0.0",
  "wat",
  "windows-sys 0.61.2",
- "wit-component 0.242.0",
+ "wit-component",
 ]
 
 [[package]]
@@ -4693,8 +4659,8 @@ dependencies = [
  "serde_derive",
  "smallvec",
  "target-lexicon",
- "wasm-encoder 0.242.0",
- "wasmparser 0.242.0",
+ "wasm-encoder",
+ "wasmparser 0.243.0",
  "wasmprinter",
  "wasmtime-internal-component-util",
  "wat",
@@ -4707,7 +4673,7 @@ dependencies = [
  "arbitrary",
  "env_logger 0.11.5",
  "libfuzzer-sys",
- "wasmparser 0.242.0",
+ "wasmparser 0.243.0",
  "wasmprinter",
  "wasmtime-environ",
  "wasmtime-test-util",
@@ -4740,7 +4706,7 @@ dependencies = [
  "rand 0.9.2",
  "smallvec",
  "target-lexicon",
- "wasmparser 0.242.0",
+ "wasmparser 0.243.0",
  "wasmtime",
  "wasmtime-fuzzing",
  "wasmtime-test-util",
@@ -4765,12 +4731,12 @@ dependencies = [
  "target-lexicon",
  "tempfile",
  "v8",
- "wasm-encoder 0.242.0",
+ "wasm-encoder",
  "wasm-mutate",
  "wasm-smith",
  "wasm-spec-interpreter",
  "wasmi",
- "wasmparser 0.242.0",
+ "wasmparser 0.243.0",
  "wasmprinter",
  "wasmtime",
  "wasmtime-cli-flags",
@@ -4825,7 +4791,7 @@ dependencies = [
  "wasmtime",
  "wasmtime-internal-component-util",
  "wasmtime-internal-wit-bindgen",
- "wit-parser 0.242.0",
+ "wit-parser",
 ]
 
 [[package]]
@@ -4851,7 +4817,7 @@ dependencies = [
  "smallvec",
  "target-lexicon",
  "thiserror 2.0.17",
- "wasmparser 0.242.0",
+ "wasmparser 0.243.0",
  "wasmtime-environ",
  "wasmtime-internal-math",
  "wasmtime-internal-unwinder",
@@ -4948,7 +4914,7 @@ dependencies = [
  "log",
  "object 0.37.3",
  "target-lexicon",
- "wasmparser 0.242.0",
+ "wasmparser 0.243.0",
  "wasmtime-environ",
  "wasmtime-internal-cranelift",
  "winch-codegen",
@@ -4962,7 +4928,7 @@ dependencies = [
  "bitflags 2.9.4",
  "heck 0.5.0",
  "indexmap 2.11.4",
- "wit-parser 0.242.0",
+ "wit-parser",
 ]
 
 [[package]]
@@ -4996,7 +4962,7 @@ dependencies = [
  "serde_derive",
  "target-lexicon",
  "toml",
- "wasmparser 0.242.0",
+ "wasmparser 0.243.0",
  "wasmprinter",
  "wasmtime",
  "wasmtime-environ",
@@ -5178,9 +5144,9 @@ dependencies = [
  "object 0.37.3",
  "serde_json",
  "tokio",
- "wasmparser 0.242.0",
+ "wasmparser 0.243.0",
  "wasmtime",
- "wast 242.0.0",
+ "wast 243.0.0",
 ]
 
 [[package]]
@@ -5194,8 +5160,8 @@ dependencies = [
  "log",
  "rayon",
  "tokio",
- "wasm-encoder 0.242.0",
- "wasmparser 0.242.0",
+ "wasm-encoder",
+ "wasmparser 0.243.0",
  "wasmprinter",
  "wasmtime",
  "wasmtime-wasi",
@@ -5213,25 +5179,25 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "242.0.0"
+version = "243.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50a61ae2997784a4ae2a47b3a99f7cf0ad2a54db09624a28a0c2e9d7a24408ce"
+checksum = "df21d01c2d91e46cb7a221d79e58a2d210ea02020d57c092e79255cc2999ca7f"
 dependencies = [
  "bumpalo",
  "gimli 0.31.1",
  "leb128fmt",
  "memchr",
  "unicode-width 0.2.0",
- "wasm-encoder 0.242.0",
+ "wasm-encoder",
 ]
 
 [[package]]
 name = "wat"
-version = "1.242.0"
+version = "1.243.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ae8cf6adfb79b5d89cb3fe68bd56aaab9409d9cf23b588097eae7d75585dae2"
+checksum = "226a9a91cd80a50449312fef0c75c23478fcecfcc4092bdebe1dc8e760ef521b"
 dependencies = [
- "wast 242.0.0",
+ "wast 243.0.0",
 ]
 
 [[package]]
@@ -5360,7 +5326,7 @@ dependencies = [
  "smallvec",
  "target-lexicon",
  "thiserror 2.0.17",
- "wasmparser 0.242.0",
+ "wasmparser 0.243.0",
  "wasmtime-environ",
  "wasmtime-internal-cranelift",
  "wasmtime-internal-math",
@@ -5604,9 +5570,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.48.0"
+version = "0.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c558f2d2929c6367736762d5593bd3276c88efa34945ed642e7bf512712bf163"
+checksum = "c64be1abfe5d4fdb2d41581fac134e8c9204da1e604b5500926478b7f264e36f"
 dependencies = [
  "bitflags 2.9.4",
  "futures",
@@ -5615,13 +5581,13 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-core"
-version = "0.48.0"
+version = "0.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a64f7435c8448e456bc6e8f14e27ee4f65926cbdfe72b7bf95badeae2501bacf"
+checksum = "886e8e938e4e9fe54143c080cbb99d7db5d19242b62ef225dbb28e17b3223bd8"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
- "wit-parser 0.241.2",
+ "wit-parser",
 ]
 
 [[package]]
@@ -5635,25 +5601,25 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-rust"
-version = "0.48.0"
+version = "0.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612651c001e0de8bfb7138af5551f80461f25caa627b64d7014a80914cf4f407"
+checksum = "145cac8fb12d99aea13a3f9e0d07463fa030edeebab2c03805eda0e1cc229bba"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
  "indexmap 2.11.4",
  "prettyplease",
  "syn 2.0.106",
- "wasm-metadata 0.241.2",
+ "wasm-metadata",
  "wit-bindgen-core",
- "wit-component 0.241.2",
+ "wit-component",
 ]
 
 [[package]]
 name = "wit-bindgen-rust-macro"
-version = "0.48.0"
+version = "0.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16c64812d84284d45ce7d7371dc9eb0bcda2f0f747128bd1b4dae1e08217bad3"
+checksum = "6042452ac4e58891cdb6321bb98aabb9827dbaf6f4e971734d8dd86813319aea"
 dependencies = [
  "anyhow",
  "prettyplease",
@@ -5666,9 +5632,9 @@ dependencies = [
 
 [[package]]
 name = "wit-component"
-version = "0.241.2"
+version = "0.243.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0c57df25e7ee612d946d3b7646c1ddb2310f8280aa2c17e543b66e0812241"
+checksum = "36f9fc53513e461ce51dcf17a3e331752cb829f1d187069e54af5608fc998fe4"
 dependencies = [
  "anyhow",
  "bitflags 2.9.4",
@@ -5677,36 +5643,17 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "wasm-encoder 0.241.2",
- "wasm-metadata 0.241.2",
- "wasmparser 0.241.2",
- "wit-parser 0.241.2",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.242.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e5b1fcd7a9ff7ea5ef1850673ed124a810901481b728ca9632f62ee274f856"
-dependencies = [
- "anyhow",
- "bitflags 2.9.4",
- "indexmap 2.11.4",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder 0.242.0",
- "wasm-metadata 0.242.0",
- "wasmparser 0.242.0",
- "wit-parser 0.242.0",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser 0.243.0",
+ "wit-parser",
 ]
 
 [[package]]
 name = "wit-parser"
-version = "0.241.2"
+version = "0.243.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ef1c6ad67f35c831abd4039c02894de97034100899614d1c44e2268ad01c91"
+checksum = "df983a8608e513d8997f435bb74207bf0933d0e49ca97aa9d8a6157164b9b7fc"
 dependencies = [
  "anyhow",
  "id-arena",
@@ -5717,25 +5664,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-xid",
- "wasmparser 0.241.2",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.242.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b451c00aeb62cdc67fb52674e3920d84169e212c2dc625231beb59470a0edbd"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap 2.11.4",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser 0.242.0",
+ "wasmparser 0.243.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -333,22 +333,22 @@ io-lifetimes = { version = "2.0.3", default-features = false }
 io-extras = "0.18.4"
 rustix = "1.0.8"
 # wit-bindgen:
-wit-bindgen = { version = "0.48.0", default-features = false }
-wit-bindgen-rust-macro = { version = "0.48.0", default-features = false }
+wit-bindgen = { version = "0.49.0", default-features = false }
+wit-bindgen-rust-macro = { version = "0.49.0", default-features = false }
 
 # wasm-tools family:
-wasmparser = { version = "0.242.0", default-features = false, features = ['simd'] }
-wat = "1.242.0"
-wast = "242.0.0"
-wasmprinter = "0.242.0"
-wasm-encoder = "0.242.0"
-wasm-smith = "0.242.0"
-wasm-mutate = "0.242.0"
-wit-parser = "0.242.0"
-wit-component = "0.242.0"
-wasm-wave = "0.242.0"
-wasm-compose = "0.242.0"
-json-from-wast = "0.242.0"
+wasmparser = { version = "0.243.0", default-features = false, features = ['simd'] }
+wat = "1.243.0"
+wast = "243.0.0"
+wasmprinter = "0.243.0"
+wasm-encoder = "0.243.0"
+wasm-smith = "0.243.0"
+wasm-mutate = "0.243.0"
+wit-parser = "0.243.0"
+wit-component = "0.243.0"
+wasm-wave = "0.243.0"
+wasm-compose = "0.243.0"
+json-from-wast = "0.243.0"
 
 # Non-Bytecode Alliance maintained dependencies:
 # --------------------------

--- a/crates/environ/src/compile/module_environ.rs
+++ b/crates/environ/src/compile/module_environ.rs
@@ -369,6 +369,9 @@ impl<'a, 'data> ModuleEnvironment<'a, 'data> {
                             self.result.module.num_imported_tags += 1;
                             EntityType::Tag(tag)
                         }
+                        TypeRef::FuncExact(_) => {
+                            bail!("custom-descriptors proposal not implemented yet");
+                        }
                     };
                     self.declare_import(import.module, import.name, ty);
                 }
@@ -471,7 +474,7 @@ impl<'a, 'data> ModuleEnvironment<'a, 'data> {
                 for entry in exports {
                     let wasmparser::Export { name, kind, index } = entry?;
                     let entity = match kind {
-                        ExternalKind::Func => {
+                        ExternalKind::Func | ExternalKind::FuncExact => {
                             let index = FuncIndex::from_u32(index);
                             self.flag_func_escaped(index);
                             EntityIndex::Function(index)

--- a/crates/environ/src/component/translate.rs
+++ b/crates/environ/src/component/translate.rs
@@ -1394,7 +1394,7 @@ impl<'a, 'data> Translator<'a, 'data> {
         let mut map = HashMap::with_capacity(exports.len());
         for export in exports {
             let idx = match export.kind {
-                wasmparser::ExternalKind::Func => {
+                wasmparser::ExternalKind::Func | wasmparser::ExternalKind::FuncExact => {
                     let index = FuncIndex::from_u32(export.index);
                     EntityIndex::Function(index)
                 }
@@ -1491,7 +1491,9 @@ impl<'a, 'data> Translator<'a, 'data> {
         name: &'data str,
     ) -> LocalInitializer<'data> {
         match kind {
-            wasmparser::ExternalKind::Func => LocalInitializer::AliasExportFunc(instance, name),
+            wasmparser::ExternalKind::Func | wasmparser::ExternalKind::FuncExact => {
+                LocalInitializer::AliasExportFunc(instance, name)
+            }
             wasmparser::ExternalKind::Memory => LocalInitializer::AliasExportMemory(instance, name),
             wasmparser::ExternalKind::Table => LocalInitializer::AliasExportTable(instance, name),
             wasmparser::ExternalKind::Global => LocalInitializer::AliasExportGlobal(instance, name),

--- a/crates/environ/src/component/types_builder.rs
+++ b/crates/environ/src/component/types_builder.rs
@@ -412,6 +412,7 @@ impl ComponentTypesBuilder {
             Memory(ty) => EntityType::Memory((*ty).into()),
             Global(ty) => EntityType::Global(self.convert_global_type(ty)?),
             Tag(_) => bail!("exceptions proposal not implemented"),
+            FuncExact(_) => bail!("custom-descriptors proposal not implemented"),
         })
     }
 

--- a/crates/wasi-preview1-component-adapter/verify/src/main.rs
+++ b/crates/wasi-preview1-component-adapter/verify/src/main.rs
@@ -37,6 +37,7 @@ fn main() -> Result<()> {
                         TypeRef::Global(_) => bail!("should not import globals"),
                         TypeRef::Memory(_) => {}
                         TypeRef::Tag(_) => bail!("unsupported `tag` type"),
+                        TypeRef::FuncExact(_) => bail!("unsupported exact `func` type"),
                     }
                 }
             }

--- a/crates/wizer/src/component/info.rs
+++ b/crates/wizer/src/component/info.rs
@@ -112,7 +112,7 @@ impl<'a> ComponentContext<'a> {
 
     pub(crate) fn inc_core(&mut self, kind: wasmparser::ExternalKind) {
         match kind {
-            wasmparser::ExternalKind::Func => {
+            wasmparser::ExternalKind::Func | wasmparser::ExternalKind::FuncExact => {
                 self.inc_core_funcs();
             }
             wasmparser::ExternalKind::Memory => {

--- a/crates/wizer/src/info.rs
+++ b/crates/wizer/src/info.rs
@@ -128,6 +128,9 @@ impl<'a> ModuleContext<'a> {
             wasmparser::TypeRef::Tag(_) => {
                 unreachable!("exceptions are unsupported; checked in validation")
             }
+            wasmparser::TypeRef::FuncExact(_) => {
+                unreachable!("custom-descriptors are unsupported; checked in validation")
+            }
         }
     }
 

--- a/crates/wizer/src/lib.rs
+++ b/crates/wizer/src/lib.rs
@@ -206,6 +206,7 @@ impl Wizer {
                     anyhow::bail!("imported memories are not supported")
                 }
                 wasmparser::TypeRef::Func(_) => {}
+                wasmparser::TypeRef::FuncExact(_) => {}
                 wasmparser::TypeRef::Tag(_) => {}
             }
         }

--- a/crates/wizer/src/parse.rs
+++ b/crates/wizer/src/parse.rs
@@ -120,6 +120,7 @@ fn export_section<'a>(
         match export.kind {
             wasmparser::ExternalKind::Tag
             | wasmparser::ExternalKind::Func
+            | wasmparser::ExternalKind::FuncExact
             | wasmparser::ExternalKind::Table
             | wasmparser::ExternalKind::Memory
             | wasmparser::ExternalKind::Global => {

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -2895,6 +2895,12 @@ criteria = "safe-to-deploy"
 delta = "0.241.2 -> 0.242.0"
 notes = "The Bytecode Alliance is the author of this crate"
 
+[[audits.json-from-wast]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.242.0 -> 0.243.0"
+notes = "The Bytecode Alliance is the author of this crate"
+
 [[audits.leb128]]
 who = "Nick Fitzgerald <fitzgen@gmail.com>"
 criteria = "safe-to-deploy"
@@ -4289,6 +4295,12 @@ criteria = "safe-to-deploy"
 delta = "0.241.2 -> 0.242.0"
 notes = "The Bytecode Alliance is the author of this crate"
 
+[[audits.wasm-compose]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.242.0 -> 0.243.0"
+notes = "The Bytecode Alliance is the author of this crate"
+
 [[audits.wasm-coredump-builder]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
@@ -4451,6 +4463,12 @@ criteria = "safe-to-deploy"
 delta = "0.241.2 -> 0.242.0"
 notes = "The Bytecode Alliance is the author of this crate"
 
+[[audits.wasm-encoder]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.242.0 -> 0.243.0"
+notes = "The Bytecode Alliance is the author of this crate"
+
 [[audits.wasm-metadata]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
@@ -4491,6 +4509,12 @@ notes = "The Bytecode Alliance is the author of this crate"
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
 delta = "0.241.2 -> 0.242.0"
+notes = "The Bytecode Alliance is the author of this crate"
+
+[[audits.wasm-metadata]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.242.0 -> 0.243.0"
 notes = "The Bytecode Alliance is the author of this crate"
 
 [[audits.wasm-mutate]]
@@ -4691,6 +4715,12 @@ criteria = "safe-to-deploy"
 delta = "0.241.2 -> 0.242.0"
 notes = "The Bytecode Alliance is the author of this crate"
 
+[[audits.wasm-wave]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.242.0 -> 0.243.0"
+notes = "The Bytecode Alliance is the author of this crate"
+
 [[audits.wasmi]]
 who = "Robin Freyler <robin.freyler@gmail.com>"
 criteria = "safe-to-run"
@@ -4859,6 +4889,12 @@ criteria = "safe-to-deploy"
 delta = "0.241.2 -> 0.242.0"
 notes = "The Bytecode Alliance is the author of this crate"
 
+[[audits.wasmparser]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.242.0 -> 0.243.0"
+notes = "The Bytecode Alliance is the author of this crate"
+
 [[audits.wasmparser-nostd]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-run"
@@ -4996,6 +5032,12 @@ criteria = "safe-to-deploy"
 delta = "0.241.2 -> 0.242.0"
 notes = "The Bytecode Alliance is the author of this crate"
 
+[[audits.wasmprinter]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.242.0 -> 0.243.0"
+notes = "The Bytecode Alliance is the author of this crate"
+
 [[audits.wast]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
@@ -5116,6 +5158,12 @@ criteria = "safe-to-deploy"
 delta = "241.0.2 -> 242.0.0"
 notes = "The Bytecode Alliance is the author of this crate"
 
+[[audits.wast]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "242.0.0 -> 243.0.0"
+notes = "The Bytecode Alliance is the author of this crate"
+
 [[audits.wat]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
@@ -5224,6 +5272,18 @@ criteria = "safe-to-deploy"
 delta = "1.241.2 -> 1.242.0"
 notes = "The Bytecode Alliance is the author of this crate"
 
+[[audits.wat]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "1.242.0 -> 1.243.0"
+notes = "The Bytecode Alliance is the author of this crate"
+
+[[audits.wat]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "1.242.2 -> 1.243.0"
+notes = "The Bytecode Alliance is the author of this crate"
+
 [[audits.webpki-roots]]
 who = "Pat Hickey <phickey@fastly.com>"
 criteria = "safe-to-deploy"
@@ -5293,6 +5353,12 @@ criteria = "safe-to-deploy"
 delta = "0.46.0 -> 0.48.0"
 notes = "The Bytecode Alliance is the author of this crate"
 
+[[audits.wit-bindgen]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.48.0 -> 0.49.0"
+notes = "The Bytecode Alliance is the author of this crate"
+
 [[audits.wit-bindgen-core]]
 who = "Joel Dice <joel.dice@gmail.com>"
 criteria = "safe-to-run"
@@ -5320,6 +5386,12 @@ notes = "The Bytecode Alliance is the author of this crate"
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
 delta = "0.46.0 -> 0.48.0"
+notes = "The Bytecode Alliance is the author of this crate"
+
+[[audits.wit-bindgen-core]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.48.0 -> 0.49.0"
 notes = "The Bytecode Alliance is the author of this crate"
 
 [[audits.wit-bindgen-rt]]
@@ -5356,6 +5428,12 @@ criteria = "safe-to-deploy"
 delta = "0.46.0 -> 0.48.0"
 notes = "The Bytecode Alliance is the author of this crate"
 
+[[audits.wit-bindgen-rust]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.48.0 -> 0.49.0"
+notes = "The Bytecode Alliance is the author of this crate"
+
 [[audits.wit-bindgen-rust-macro]]
 who = "Joel Dice <joel.dice@gmail.com>"
 criteria = "safe-to-run"
@@ -5383,6 +5461,12 @@ notes = "The Bytecode Alliance is the author of this crate"
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
 delta = "0.46.0 -> 0.48.0"
+notes = "The Bytecode Alliance is the author of this crate"
+
+[[audits.wit-bindgen-rust-macro]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.48.0 -> 0.49.0"
 notes = "The Bytecode Alliance is the author of this crate"
 
 [[audits.wit-component]]
@@ -5425,6 +5509,12 @@ notes = "The Bytecode Alliance is the author of this crate"
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
 delta = "0.241.2 -> 0.242.0"
+notes = "The Bytecode Alliance is the author of this crate"
+
+[[audits.wit-component]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.242.0 -> 0.243.0"
 notes = "The Bytecode Alliance is the author of this crate"
 
 [[audits.wit-parser]]
@@ -5515,6 +5605,12 @@ notes = "The Bytecode Alliance is the author of this crate"
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
 delta = "0.241.2 -> 0.242.0"
+notes = "The Bytecode Alliance is the author of this crate"
+
+[[audits.wit-parser]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.242.0 -> 0.243.0"
 notes = "The Bytecode Alliance is the author of this crate"
 
 [[audits.xattr]]

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -246,10 +246,6 @@ criteria = "safe-to-deploy"
 version = "0.16.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.console]]
-version = "0.15.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.constant_time_eq]]
 version = "0.1.5"
 criteria = "safe-to-deploy"
@@ -298,10 +294,6 @@ criteria = "safe-to-deploy"
 version = "0.1.2"
 criteria = "safe-to-deploy"
 
-[[exemptions.encode_unicode]]
-version = "0.3.6"
-criteria = "safe-to-deploy"
-
 [[exemptions.fallible-iterator]]
 version = "0.2.0"
 criteria = "safe-to-deploy"
@@ -338,10 +330,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.im-rc]]
 version = "15.1.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.indicatif]]
-version = "0.13.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.ipnet]]
@@ -397,10 +385,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.num-complex]]
 version = "0.4.6"
-criteria = "safe-to-deploy"
-
-[[exemptions.number_prefix]]
-version = "0.3.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.object]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -3,231 +3,231 @@
 
 [[unpublished.cranelift]]
 version = "0.127.0"
-audited_as = "0.125.4"
+audited_as = "0.126.1"
 
 [[unpublished.cranelift-assembler-x64]]
 version = "0.127.0"
-audited_as = "0.125.4"
+audited_as = "0.126.1"
 
 [[unpublished.cranelift-assembler-x64-meta]]
 version = "0.127.0"
-audited_as = "0.125.4"
+audited_as = "0.126.1"
 
 [[unpublished.cranelift-bforest]]
 version = "0.127.0"
-audited_as = "0.125.4"
+audited_as = "0.126.1"
 
 [[unpublished.cranelift-bitset]]
 version = "0.127.0"
-audited_as = "0.125.4"
+audited_as = "0.126.1"
 
 [[unpublished.cranelift-codegen]]
 version = "0.127.0"
-audited_as = "0.125.4"
+audited_as = "0.126.1"
 
 [[unpublished.cranelift-codegen-meta]]
 version = "0.127.0"
-audited_as = "0.125.4"
+audited_as = "0.126.1"
 
 [[unpublished.cranelift-codegen-shared]]
 version = "0.127.0"
-audited_as = "0.125.4"
+audited_as = "0.126.1"
 
 [[unpublished.cranelift-control]]
 version = "0.127.0"
-audited_as = "0.125.4"
+audited_as = "0.126.1"
 
 [[unpublished.cranelift-entity]]
 version = "0.127.0"
-audited_as = "0.125.4"
+audited_as = "0.126.1"
 
 [[unpublished.cranelift-frontend]]
 version = "0.127.0"
-audited_as = "0.125.4"
+audited_as = "0.126.1"
 
 [[unpublished.cranelift-interpreter]]
 version = "0.127.0"
-audited_as = "0.125.4"
+audited_as = "0.126.1"
 
 [[unpublished.cranelift-isle]]
 version = "0.127.0"
-audited_as = "0.125.4"
+audited_as = "0.126.1"
 
 [[unpublished.cranelift-jit]]
 version = "0.127.0"
-audited_as = "0.125.4"
+audited_as = "0.126.1"
 
 [[unpublished.cranelift-module]]
 version = "0.127.0"
-audited_as = "0.125.4"
+audited_as = "0.126.1"
 
 [[unpublished.cranelift-native]]
 version = "0.127.0"
-audited_as = "0.125.4"
+audited_as = "0.126.1"
 
 [[unpublished.cranelift-object]]
 version = "0.127.0"
-audited_as = "0.125.4"
+audited_as = "0.126.1"
 
 [[unpublished.cranelift-reader]]
 version = "0.127.0"
-audited_as = "0.125.4"
+audited_as = "0.126.1"
 
 [[unpublished.cranelift-serde]]
 version = "0.127.0"
-audited_as = "0.125.4"
+audited_as = "0.126.1"
 
 [[unpublished.cranelift-srcgen]]
 version = "0.127.0"
-audited_as = "0.125.4"
+audited_as = "0.126.1"
 
 [[unpublished.pulley-interpreter]]
 version = "40.0.0"
-audited_as = "38.0.4"
+audited_as = "39.0.1"
 
 [[unpublished.pulley-macros]]
 version = "40.0.0"
-audited_as = "38.0.4"
+audited_as = "39.0.1"
 
 [[unpublished.wasi-common]]
 version = "40.0.0"
-audited_as = "38.0.4"
+audited_as = "39.0.1"
 
 [[unpublished.wasmtime]]
 version = "40.0.0"
-audited_as = "38.0.4"
+audited_as = "39.0.1"
 
 [[unpublished.wasmtime-cli]]
 version = "40.0.0"
-audited_as = "38.0.4"
+audited_as = "39.0.1"
 
 [[unpublished.wasmtime-cli-flags]]
 version = "40.0.0"
-audited_as = "38.0.4"
+audited_as = "39.0.1"
 
 [[unpublished.wasmtime-environ]]
 version = "40.0.0"
-audited_as = "38.0.4"
+audited_as = "39.0.1"
 
 [[unpublished.wasmtime-internal-c-api-macros]]
 version = "40.0.0"
-audited_as = "38.0.4"
+audited_as = "39.0.1"
 
 [[unpublished.wasmtime-internal-cache]]
 version = "40.0.0"
-audited_as = "38.0.4"
+audited_as = "39.0.1"
 
 [[unpublished.wasmtime-internal-component-macro]]
 version = "40.0.0"
-audited_as = "38.0.4"
+audited_as = "39.0.1"
 
 [[unpublished.wasmtime-internal-component-util]]
 version = "40.0.0"
-audited_as = "38.0.4"
+audited_as = "39.0.1"
 
 [[unpublished.wasmtime-internal-cranelift]]
 version = "40.0.0"
-audited_as = "38.0.4"
+audited_as = "39.0.1"
 
 [[unpublished.wasmtime-internal-explorer]]
 version = "40.0.0"
-audited_as = "38.0.4"
+audited_as = "39.0.1"
 
 [[unpublished.wasmtime-internal-fiber]]
 version = "40.0.0"
-audited_as = "38.0.4"
+audited_as = "39.0.1"
 
 [[unpublished.wasmtime-internal-jit-debug]]
 version = "40.0.0"
-audited_as = "38.0.4"
+audited_as = "39.0.1"
 
 [[unpublished.wasmtime-internal-jit-icache-coherence]]
 version = "40.0.0"
-audited_as = "38.0.4"
+audited_as = "39.0.1"
 
 [[unpublished.wasmtime-internal-math]]
 version = "40.0.0"
-audited_as = "38.0.4"
+audited_as = "39.0.1"
 
 [[unpublished.wasmtime-internal-slab]]
 version = "40.0.0"
-audited_as = "38.0.4"
+audited_as = "39.0.1"
 
 [[unpublished.wasmtime-internal-unwinder]]
 version = "40.0.0"
-audited_as = "38.0.4"
+audited_as = "39.0.1"
 
 [[unpublished.wasmtime-internal-versioned-export-macros]]
 version = "40.0.0"
-audited_as = "38.0.4"
+audited_as = "39.0.1"
 
 [[unpublished.wasmtime-internal-winch]]
 version = "40.0.0"
-audited_as = "38.0.4"
+audited_as = "39.0.1"
 
 [[unpublished.wasmtime-internal-wit-bindgen]]
 version = "40.0.0"
-audited_as = "38.0.4"
+audited_as = "39.0.1"
 
 [[unpublished.wasmtime-internal-wmemcheck]]
 version = "40.0.0"
-audited_as = "38.0.4"
+audited_as = "39.0.1"
 
 [[unpublished.wasmtime-wasi]]
 version = "40.0.0"
-audited_as = "38.0.4"
+audited_as = "39.0.1"
 
 [[unpublished.wasmtime-wasi-config]]
 version = "40.0.0"
-audited_as = "38.0.4"
+audited_as = "39.0.1"
 
 [[unpublished.wasmtime-wasi-http]]
 version = "40.0.0"
-audited_as = "38.0.4"
+audited_as = "39.0.1"
 
 [[unpublished.wasmtime-wasi-io]]
 version = "40.0.0"
-audited_as = "38.0.4"
+audited_as = "39.0.1"
 
 [[unpublished.wasmtime-wasi-keyvalue]]
 version = "40.0.0"
-audited_as = "38.0.4"
+audited_as = "39.0.1"
 
 [[unpublished.wasmtime-wasi-nn]]
 version = "40.0.0"
-audited_as = "38.0.4"
+audited_as = "39.0.1"
 
 [[unpublished.wasmtime-wasi-threads]]
 version = "40.0.0"
-audited_as = "38.0.4"
+audited_as = "39.0.1"
 
 [[unpublished.wasmtime-wasi-tls]]
 version = "40.0.0"
-audited_as = "38.0.4"
+audited_as = "39.0.1"
 
 [[unpublished.wasmtime-wasi-tls-nativetls]]
 version = "40.0.0"
-audited_as = "38.0.4"
+audited_as = "39.0.1"
 
 [[unpublished.wasmtime-wast]]
 version = "40.0.0"
-audited_as = "38.0.4"
+audited_as = "39.0.1"
 
 [[unpublished.wasmtime-wizer]]
 version = "40.0.0"
-audited_as = "39.0.0"
+audited_as = "39.0.1"
 
 [[unpublished.wiggle]]
 version = "40.0.0"
-audited_as = "38.0.4"
+audited_as = "39.0.1"
 
 [[unpublished.wiggle-generate]]
 version = "40.0.0"
-audited_as = "38.0.4"
+audited_as = "39.0.1"
 
 [[unpublished.wiggle-macro]]
 version = "40.0.0"
-audited_as = "38.0.4"
+audited_as = "39.0.1"
 
 [[unpublished.wiggle-test]]
 version = "0.0.0"
@@ -235,7 +235,7 @@ audited_as = "0.1.0"
 
 [[unpublished.winch-codegen]]
 version = "40.0.0"
-audited_as = "38.0.4"
+audited_as = "39.0.1"
 
 [[publisher.aho-corasick]]
 version = "1.0.2"
@@ -454,122 +454,122 @@ user-login = "jrmuizel"
 user-name = "Jeff Muizelaar"
 
 [[publisher.cranelift]]
-version = "0.125.4"
-when = "2025-11-11"
+version = "0.126.1"
+when = "2025-11-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-assembler-x64]]
-version = "0.125.4"
-when = "2025-11-11"
+version = "0.126.1"
+when = "2025-11-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-assembler-x64-meta]]
-version = "0.125.4"
-when = "2025-11-11"
+version = "0.126.1"
+when = "2025-11-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-bforest]]
-version = "0.125.4"
-when = "2025-11-11"
+version = "0.126.1"
+when = "2025-11-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-bitset]]
-version = "0.125.4"
-when = "2025-11-11"
+version = "0.126.1"
+when = "2025-11-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-codegen]]
-version = "0.125.4"
-when = "2025-11-11"
+version = "0.126.1"
+when = "2025-11-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-codegen-meta]]
-version = "0.125.4"
-when = "2025-11-11"
+version = "0.126.1"
+when = "2025-11-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-codegen-shared]]
-version = "0.125.4"
-when = "2025-11-11"
+version = "0.126.1"
+when = "2025-11-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-control]]
-version = "0.125.4"
-when = "2025-11-11"
+version = "0.126.1"
+when = "2025-11-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-entity]]
-version = "0.125.4"
-when = "2025-11-11"
+version = "0.126.1"
+when = "2025-11-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-frontend]]
-version = "0.125.4"
-when = "2025-11-11"
+version = "0.126.1"
+when = "2025-11-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-interpreter]]
-version = "0.125.4"
-when = "2025-11-11"
+version = "0.126.1"
+when = "2025-11-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-isle]]
-version = "0.125.4"
-when = "2025-11-11"
+version = "0.126.1"
+when = "2025-11-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-jit]]
-version = "0.125.4"
-when = "2025-11-11"
+version = "0.126.1"
+when = "2025-11-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-module]]
-version = "0.125.4"
-when = "2025-11-11"
+version = "0.126.1"
+when = "2025-11-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-native]]
-version = "0.125.4"
-when = "2025-11-11"
+version = "0.126.1"
+when = "2025-11-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-object]]
-version = "0.125.4"
-when = "2025-11-11"
+version = "0.126.1"
+when = "2025-11-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-reader]]
-version = "0.125.4"
-when = "2025-11-11"
+version = "0.126.1"
+when = "2025-11-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-serde]]
-version = "0.125.4"
-when = "2025-11-11"
+version = "0.126.1"
+when = "2025-11-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-srcgen]]
-version = "0.125.4"
-when = "2025-11-11"
+version = "0.126.1"
+when = "2025-11-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -844,14 +844,14 @@ user-login = "dtolnay"
 user-name = "David Tolnay"
 
 [[publisher.pulley-interpreter]]
-version = "38.0.4"
-when = "2025-11-11"
+version = "39.0.1"
+when = "2025-11-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.pulley-macros]]
-version = "38.0.4"
-when = "2025-11-11"
+version = "39.0.1"
+when = "2025-11-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1178,8 +1178,8 @@ user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
 [[publisher.wasi-common]]
-version = "38.0.4"
-when = "2025-11-11"
+version = "39.0.1"
+when = "2025-11-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1269,188 +1269,188 @@ user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime]]
-version = "38.0.4"
-when = "2025-11-11"
+version = "39.0.1"
+when = "2025-11-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-cli]]
-version = "38.0.4"
-when = "2025-11-11"
+version = "39.0.1"
+when = "2025-11-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-cli-flags]]
-version = "38.0.4"
-when = "2025-11-11"
+version = "39.0.1"
+when = "2025-11-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-environ]]
-version = "38.0.4"
-when = "2025-11-11"
+version = "39.0.1"
+when = "2025-11-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-internal-c-api-macros]]
-version = "38.0.4"
-when = "2025-11-11"
+version = "39.0.1"
+when = "2025-11-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-internal-cache]]
-version = "38.0.4"
-when = "2025-11-11"
+version = "39.0.1"
+when = "2025-11-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-internal-component-macro]]
-version = "38.0.4"
-when = "2025-11-11"
+version = "39.0.1"
+when = "2025-11-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-internal-component-util]]
-version = "38.0.4"
-when = "2025-11-11"
+version = "39.0.1"
+when = "2025-11-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-internal-cranelift]]
-version = "38.0.4"
-when = "2025-11-11"
+version = "39.0.1"
+when = "2025-11-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-internal-explorer]]
-version = "38.0.4"
-when = "2025-11-11"
+version = "39.0.1"
+when = "2025-11-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-internal-fiber]]
-version = "38.0.4"
-when = "2025-11-11"
+version = "39.0.1"
+when = "2025-11-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-internal-jit-debug]]
-version = "38.0.4"
-when = "2025-11-11"
+version = "39.0.1"
+when = "2025-11-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-internal-jit-icache-coherence]]
-version = "38.0.4"
-when = "2025-11-11"
+version = "39.0.1"
+when = "2025-11-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-internal-math]]
-version = "38.0.4"
-when = "2025-11-11"
+version = "39.0.1"
+when = "2025-11-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-internal-slab]]
-version = "38.0.4"
-when = "2025-11-11"
+version = "39.0.1"
+when = "2025-11-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-internal-unwinder]]
-version = "38.0.4"
-when = "2025-11-11"
+version = "39.0.1"
+when = "2025-11-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-internal-versioned-export-macros]]
-version = "38.0.4"
-when = "2025-11-11"
+version = "39.0.1"
+when = "2025-11-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-internal-winch]]
-version = "38.0.4"
-when = "2025-11-11"
+version = "39.0.1"
+when = "2025-11-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-internal-wit-bindgen]]
-version = "38.0.4"
-when = "2025-11-11"
+version = "39.0.1"
+when = "2025-11-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-internal-wmemcheck]]
-version = "38.0.4"
-when = "2025-11-11"
+version = "39.0.1"
+when = "2025-11-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi]]
-version = "38.0.4"
-when = "2025-11-11"
+version = "39.0.1"
+when = "2025-11-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-config]]
-version = "38.0.4"
-when = "2025-11-11"
+version = "39.0.1"
+when = "2025-11-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-http]]
-version = "38.0.4"
-when = "2025-11-11"
+version = "39.0.1"
+when = "2025-11-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-io]]
-version = "38.0.4"
-when = "2025-11-11"
+version = "39.0.1"
+when = "2025-11-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-keyvalue]]
-version = "38.0.4"
-when = "2025-11-11"
+version = "39.0.1"
+when = "2025-11-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-nn]]
-version = "38.0.4"
-when = "2025-11-11"
+version = "39.0.1"
+when = "2025-11-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-threads]]
-version = "38.0.4"
-when = "2025-11-11"
+version = "39.0.1"
+when = "2025-11-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-tls]]
-version = "38.0.4"
-when = "2025-11-11"
+version = "39.0.1"
+when = "2025-11-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-tls-nativetls]]
-version = "38.0.4"
-when = "2025-11-11"
+version = "39.0.1"
+when = "2025-11-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wast]]
-version = "38.0.4"
-when = "2025-11-11"
+version = "39.0.1"
+when = "2025-11-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wizer]]
-version = "39.0.0"
-when = "2025-11-20"
+version = "39.0.1"
+when = "2025-11-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1474,20 +1474,20 @@ user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
 [[publisher.wiggle]]
-version = "38.0.4"
-when = "2025-11-11"
+version = "39.0.1"
+when = "2025-11-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wiggle-generate]]
-version = "38.0.4"
-when = "2025-11-11"
+version = "39.0.1"
+when = "2025-11-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wiggle-macro]]
-version = "38.0.4"
-when = "2025-11-11"
+version = "39.0.1"
+when = "2025-11-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1506,8 +1506,8 @@ user-login = "BurntSushi"
 user-name = "Andrew Gallant"
 
 [[publisher.winch-codegen]]
-version = "38.0.4"
-when = "2025-11-11"
+version = "39.0.1"
+when = "2025-11-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 


### PR DESCRIPTION
This pulls in wasm-tools support for custom-descriptors which required adding more match arms in a few locations. Wasmtime doesn't support this, however, so it should all be rejected during validation.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
