### PR TITLE
Remove label trigger for triage workflow

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -1,8 +1,6 @@
 name: "Issue / PR Triage"
 
 on:
-  issues:
-    types: ["labeled"]
   schedule:
     # Run pull request triage once an hour. Ideally, this would be on
     # "labeled" types of pull request events, but that doesn't work if the pull


### PR DESCRIPTION
Every time I add labels to issues I routinely get emails about cancelled workflows. I'm kind of tired of getting these emails so let's try moving to just a cron for this workflow.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
