### PR TITLE
Fix various broken links in docs.

### DIFF
--- a/cranelift/isle/docs/language-reference.md
+++ b/cranelift/isle/docs/language-reference.md
@@ -952,7 +952,7 @@ and also to use constructors in place of extractors during the match
 phase when this is more convenient.
 
 To introduce the concept, an example follows (this is taken from the
-[RFC](https://github.com/bytecodealliance/rfcs/tree/main/isle-extended-patterns.md)
+[RFC](https://github.com/bytecodealliance/rfcs/tree/main/accepted/isle-extended-patterns.md)
 that proposed if-lets):
 
 ```lisp
@@ -1412,10 +1412,6 @@ when an enum-typed value is destructured into different variants by
 various edges; we can use a Rust `match` statement in the generated
 source and have `O(1)` (or close to it) cost for the dispatch at this
 level.[^8]
-
-Building the trie is a somewhat subtle procedure; see [this block
-comment](https://github.com/bytecodealliance/wasmtime/blob/main/cranelift/isle/isle/src/trie.rs#L15-L166)
-for more information regarding the trie construction algorithm.
 
 [^8]: The worst-case complexity for a single term rewriting operation
       is still the cost of evaluating each rule's left-hand side

--- a/crates/wasi-common/README.md
+++ b/crates/wasi-common/README.md
@@ -35,7 +35,7 @@ In our *nix implementation, we currently support the entire [WASI API]
 with the exception of the `proc_raise` hostcall, as it is expected to
 be dropped entirely from WASI.
 
-[WASI API]: https://github.com/WebAssembly/WASI/blob/master/phases/snapshot/docs.md
+[WASI API]: https://github.com/WebAssembly/WASI/blob/main/legacy/preview1/docs.md
 
 ### Windows
 In our Windows implementation, we currently support the minimal subset of [WASI API]

--- a/crates/wizer/README.md
+++ b/crates/wizer/README.md
@@ -46,8 +46,8 @@ initialization with Wizer, depending on the workload:
 | [`regex`][regex-bench] | 248.85 us     | 183.99 us  | **1.35x faster** |
 | [UAP][uap-bench]       | 98.297 ms     | 16.385 ms  | **6.00x faster** |
 
-[regex-bench]: https://github.com/bytecodealliance/wizer/tree/main/benches/regex-bench
-[uap-bench]: https://github.com/bytecodealliance/wizer/tree/main/benches/uap-bench
+[regex-bench]: https://github.com/bytecodealliance/wasmtime/tree/main/crates/wizer/benches/regex-bench
+[uap-bench]: https://github.com/bytecodealliance/wasmtime/tree/main/crates/wizer/benches/uap-bench
 
 Not every program will see an improvement to instantiation and start up
 latency. For example, Wizer will often increase the size of the Wasm module's

--- a/docs/contributing-implementing-wasm-proposals.md
+++ b/docs/contributing-implementing-wasm-proposals.md
@@ -21,7 +21,7 @@ multiple pull requests.
 * [ ] Add `-Wyour-proposal` to the `wasmtime-cli-flags` crate.
 * [ ] Update `tests/wast.rs` to spec tests should pass for this proposal.
 * [ ] Write custom tests in `tests/misc_testsuite/*.wast` for this proposal.
-* [ ] Enable the proposal in [the fuzz targets](./contributing-fuzzing.html).
+* [ ] Enable the proposal in [the fuzz targets](./contributing-fuzzing.md).
   * [ ] Write a custom fuzz target, oracle, and/or test
     case generator for fuzzing this proposal in particular.
 

--- a/docs/contributing-reducing-test-cases.md
+++ b/docs/contributing-reducing-test-cases.md
@@ -7,7 +7,7 @@ need to wade through megabytes of unrelated Wasm that isn't necessary to
 showcase the bug. The process of taking a large test case and stripping out the
 unnecessary bits is called *test case reduction*.
 
-[The `wasm-tools shrink` tool](github.com/bytecodealliance/wasm-tools) can
+[The `wasm-tools shrink` tool](https://github.com/bytecodealliance/wasm-tools) can
 automatically reduce Wasm test cases when given
 
 1. the original, unreduced test case, and

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -2,7 +2,7 @@
 
 We're excited to work on Wasmtime and/or Cranelift together with you! This guide
 should help you get up and running with Wasmtime and Cranelift development. But
-first, make sure you've read the [Code of Conduct](./contributing-coc.html)!
+first, make sure you've read the [Code of Conduct](./contributing-coc.md)!
 
 Wasmtime and Cranelift are very ambitious projects with many goals, and while
 we're confident we can achieve some of them, we see many opportunities for

--- a/docs/examples-debugging-core-dumps.md
+++ b/docs/examples-debugging-core-dumps.md
@@ -7,7 +7,7 @@ consumed by external tooling (such as [`wasmgdb`][wasmgdb]) for post-mortem anal
 This page focuses on generating and inspecting core dumps via the Wasmtime
 command-line interface. For details on how to generate core dumps via the
 `wasmtime` embedding API, see [Core Dumps in a Rust
-Embedding](./examples-rust-core-dumps.md).
+Embedding](./examples-core-dumps.md).
 
 First, we need to compile some code to Wasm that can trap. Consider the
 following Rust code:

--- a/docs/examples-debugging-native-debugger.md
+++ b/docs/examples-debugging-native-debugger.md
@@ -13,7 +13,7 @@ the same time:
 
 2. Run Wasmtime with the debug info enabled; this is `-D debug-info` from the
    CLI and `Config::debug_info(true)` in an embedding (e.g. see [debugging in a
-   Rust embedding](./examples-rust-debugging.md)). It's also recommended to use
+   Rust embedding](./examples-debugging.md)). It's also recommended to use
    `-O opt-level=0` for better inspection of local variables if desired.
 
 3. Use a supported debugger:

--- a/docs/lang.md
+++ b/docs/lang.md
@@ -38,7 +38,7 @@ Rust code.
 The C API can also be installed through `*-c-api-*` [release artifacts].
 
 [README of the C API]: https://github.com/bytecodealliance/wasmtime/blob/main/crates/c-api/README.md
-[release artifacts]: github.com/bytecodealliance/wasmtime/releases/latest
+[release artifacts]: https://github.com/bytecodealliance/wasmtime/releases/latest
 
 ## C++
 

--- a/docs/stability-tiers.md
+++ b/docs/stability-tiers.md
@@ -92,7 +92,7 @@ For explanations of what each tier means see below.
 [`memory64`]: https://github.com/WebAssembly/memory64/blob/master/proposals/memory64/Overview.md
 [`custom-page-sizes`]: https://github.com/WebAssembly/custom-page-sizes
 [`multi-memory`]: https://github.com/WebAssembly/multi-memory/blob/master/proposals/multi-memory/Overview.md
-[`threads`]: https://github.com/WebAssembly/threads/blob/master/proposals/threads/Overview.md
+[`threads`]: https://github.com/WebAssembly/threads/blob/main-legacy/proposals/threads/Overview.md
 [`component-model`]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/Explainer.md
 [`relaxed-simd`]: https://github.com/WebAssembly/relaxed-simd/blob/main/proposals/relaxed-simd/Overview.md
 [`function-references`]: https://github.com/WebAssembly/function-references/blob/main/proposals/function-references/Overview.md


### PR DESCRIPTION
We've gotten a few one-off link-fix PRs, so in the Wasmtime meeting today we decided to just fix them all ourselves so we don't get these drive-by PRs anymore (or at least not for a while, until links start to rot again).

This PR fixes all applicable broken links we could find via the `lychee` link-checker (thanks abrown for running that!). There are a few broken links in subrepositories that this doesn't fix. And the link-checker doesn't like links to subheaders on `.html` paths derived from `.md` files by mdbook -- mdbook doesn't support these (rust-lang/mdBook#167) but they render fine once published to the Web.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
