### PR TITLE
Bump Wasmtime to 41.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -290,7 +290,7 @@ dependencies = [
 
 [[package]]
 name = "byte-array-literals"
-version = "40.0.0"
+version = "41.0.0"
 
 [[package]]
 name = "byteorder"
@@ -695,7 +695,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift"
-version = "0.127.0"
+version = "0.128.0"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",
@@ -708,7 +708,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.127.0"
+version = "0.128.0"
 dependencies = [
  "arbitrary",
  "arbtest",
@@ -726,21 +726,21 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.127.0"
+version = "0.128.0"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.127.0"
+version = "0.128.0"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.127.0"
+version = "0.128.0"
 dependencies = [
  "arbitrary",
  "serde",
@@ -749,7 +749,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.127.0"
+version = "0.128.0"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -784,7 +784,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.127.0"
+version = "0.128.0"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -795,18 +795,18 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.127.0"
+version = "0.128.0"
 
 [[package]]
 name = "cranelift-control"
-version = "0.127.0"
+version = "0.128.0"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.127.0"
+version = "0.128.0"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -847,7 +847,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.127.0"
+version = "0.128.0"
 dependencies = [
  "cranelift-codegen",
  "env_logger 0.11.5",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-interpreter"
-version = "0.127.0"
+version = "0.128.0"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -886,7 +886,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.127.0"
+version = "0.128.0"
 dependencies = [
  "codespan-reporting",
  "log",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-jit"
-version = "0.127.0"
+version = "0.128.0"
 dependencies = [
  "anyhow",
  "cranelift",
@@ -917,7 +917,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-module"
-version = "0.127.0"
+version = "0.128.0"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.127.0"
+version = "0.128.0"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-object"
-version = "0.127.0"
+version = "0.128.0"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -953,7 +953,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-reader"
-version = "0.127.0"
+version = "0.128.0"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-serde"
-version = "0.127.0"
+version = "0.128.0"
 dependencies = [
  "clap",
  "cranelift-codegen",
@@ -973,7 +973,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.127.0"
+version = "0.128.0"
 
 [[package]]
 name = "cranelift-tools"
@@ -1223,7 +1223,7 @@ checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "embedding"
-version = "40.0.0"
+version = "41.0.0"
 dependencies = [
  "anyhow",
  "dlmalloc",
@@ -2351,7 +2351,7 @@ dependencies = [
 
 [[package]]
 name = "min-platform-host"
-version = "40.0.0"
+version = "41.0.0"
 dependencies = [
  "anyhow",
  "libloading",
@@ -2783,7 +2783,7 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "40.0.0"
+version = "41.0.0"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -2807,7 +2807,7 @@ dependencies = [
 
 [[package]]
 name = "pulley-macros"
-version = "40.0.0"
+version = "41.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4093,7 +4093,7 @@ version = "0.1.0"
 
 [[package]]
 name = "verify-component-adapter"
-version = "40.0.0"
+version = "41.0.0"
 dependencies = [
  "anyhow",
  "wasmparser 0.243.0",
@@ -4152,7 +4152,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-common"
-version = "40.0.0"
+version = "41.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4192,7 +4192,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-preview1-component-adapter"
-version = "40.0.0"
+version = "41.0.0"
 dependencies = [
  "bitflags 2.9.4",
  "byte-array-literals",
@@ -4440,7 +4440,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "40.0.0"
+version = "41.0.0"
 dependencies = [
  "addr2line 0.25.1",
  "anyhow",
@@ -4505,7 +4505,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-bench-api"
-version = "40.0.0"
+version = "41.0.0"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -4521,14 +4521,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-c-api"
-version = "40.0.0"
+version = "41.0.0"
 dependencies = [
  "wasmtime-c-api-impl",
 ]
 
 [[package]]
 name = "wasmtime-c-api-impl"
-version = "40.0.0"
+version = "41.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4548,7 +4548,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli"
-version = "40.0.0"
+version = "41.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4623,7 +4623,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli-flags"
-version = "40.0.0"
+version = "41.0.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -4638,7 +4638,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "40.0.0"
+version = "41.0.0"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -4747,7 +4747,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-c-api-macros"
-version = "40.0.0"
+version = "41.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4755,7 +4755,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cache"
-version = "40.0.0"
+version = "41.0.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -4776,7 +4776,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-macro"
-version = "40.0.0"
+version = "41.0.0"
 dependencies = [
  "anyhow",
  "component-macro-test-helpers",
@@ -4796,11 +4796,11 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-util"
-version = "40.0.0"
+version = "41.0.0"
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "40.0.0"
+version = "41.0.0"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4826,7 +4826,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-explorer"
-version = "40.0.0"
+version = "41.0.0"
 dependencies = [
  "anyhow",
  "capstone",
@@ -4841,7 +4841,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-fiber"
-version = "40.0.0"
+version = "41.0.0"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -4855,7 +4855,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-debug"
-version = "40.0.0"
+version = "41.0.0"
 dependencies = [
  "cc",
  "object 0.37.3",
@@ -4865,7 +4865,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "40.0.0"
+version = "41.0.0"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4875,18 +4875,18 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-math"
-version = "40.0.0"
+version = "41.0.0"
 dependencies = [
  "libm",
 ]
 
 [[package]]
 name = "wasmtime-internal-slab"
-version = "40.0.0"
+version = "41.0.0"
 
 [[package]]
 name = "wasmtime-internal-unwinder"
-version = "40.0.0"
+version = "41.0.0"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4897,7 +4897,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
-version = "40.0.0"
+version = "41.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4906,7 +4906,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-winch"
-version = "40.0.0"
+version = "41.0.0"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -4922,7 +4922,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-wit-bindgen"
-version = "40.0.0"
+version = "41.0.0"
 dependencies = [
  "anyhow",
  "bitflags 2.9.4",
@@ -4933,7 +4933,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-wmemcheck"
-version = "40.0.0"
+version = "41.0.0"
 
 [[package]]
 name = "wasmtime-test-macros"
@@ -4948,7 +4948,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-test-util"
-version = "40.0.0"
+version = "41.0.0"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -4972,7 +4972,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "40.0.0"
+version = "41.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5007,7 +5007,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-config"
-version = "40.0.0"
+version = "41.0.0"
 dependencies = [
  "anyhow",
  "test-programs-artifacts",
@@ -5018,7 +5018,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-http"
-version = "40.0.0"
+version = "41.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5050,7 +5050,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-io"
-version = "40.0.0"
+version = "41.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5061,7 +5061,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-keyvalue"
-version = "40.0.0"
+version = "41.0.0"
 dependencies = [
  "anyhow",
  "test-programs-artifacts",
@@ -5072,7 +5072,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-nn"
-version = "40.0.0"
+version = "41.0.0"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -5093,7 +5093,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-threads"
-version = "40.0.0"
+version = "41.0.0"
 dependencies = [
  "anyhow",
  "log",
@@ -5105,7 +5105,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-tls"
-version = "40.0.0"
+version = "41.0.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -5121,7 +5121,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-tls-nativetls"
-version = "40.0.0"
+version = "41.0.0"
 dependencies = [
  "anyhow",
  "futures",
@@ -5136,7 +5136,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wast"
-version = "40.0.0"
+version = "41.0.0"
 dependencies = [
  "anyhow",
  "json-from-wast",
@@ -5151,7 +5151,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wizer"
-version = "40.0.0"
+version = "41.0.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -5233,7 +5233,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "40.0.0"
+version = "41.0.0"
 dependencies = [
  "anyhow",
  "bitflags 2.9.4",
@@ -5249,7 +5249,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "40.0.0"
+version = "41.0.0"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -5261,7 +5261,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "40.0.0"
+version = "41.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5316,7 +5316,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "40.0.0"
+version = "41.0.0"
 dependencies = [
  "anyhow",
  "cranelift-assembler-x64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -182,7 +182,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "40.0.0"
+version = "41.0.0"
 authors = ["The Wasmtime Project Developers"]
 edition = "2024"
 # Wasmtime's current policy is that this number can be no larger than the
@@ -236,19 +236,19 @@ extra_unused_type_parameters = 'warn'
 # tooling but aren't intended to be widely depended on.
 #
 # All of these crates are supported though in the sense that
-wasmtime = { path = "crates/wasmtime", version = "40.0.0", default-features = false }
-wasmtime-cli-flags = { path = "crates/cli-flags", version = "=40.0.0" }
-wasmtime-environ = { path = "crates/environ", version = "=40.0.0" }
-wasmtime-wasi = { path = "crates/wasi", version = "40.0.0", default-features = false }
-wasmtime-wasi-io = { path = "crates/wasi-io", version = "40.0.0", default-features = false }
-wasmtime-wasi-http = { path = "crates/wasi-http", version = "40.0.0", default-features = false }
-wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "40.0.0" }
-wasmtime-wasi-config = { path = "crates/wasi-config", version = "40.0.0" }
-wasmtime-wasi-keyvalue = { path = "crates/wasi-keyvalue", version = "40.0.0" }
-wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "40.0.0" }
-wasmtime-wasi-tls = { path = "crates/wasi-tls", version = "40.0.0" }
-wasmtime-wasi-tls-nativetls = { path = "crates/wasi-tls-nativetls", version = "40.0.0" }
-wasmtime-wast = { path = "crates/wast", version = "=40.0.0" }
+wasmtime = { path = "crates/wasmtime", version = "41.0.0", default-features = false }
+wasmtime-cli-flags = { path = "crates/cli-flags", version = "=41.0.0" }
+wasmtime-environ = { path = "crates/environ", version = "=41.0.0" }
+wasmtime-wasi = { path = "crates/wasi", version = "41.0.0", default-features = false }
+wasmtime-wasi-io = { path = "crates/wasi-io", version = "41.0.0", default-features = false }
+wasmtime-wasi-http = { path = "crates/wasi-http", version = "41.0.0", default-features = false }
+wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "41.0.0" }
+wasmtime-wasi-config = { path = "crates/wasi-config", version = "41.0.0" }
+wasmtime-wasi-keyvalue = { path = "crates/wasi-keyvalue", version = "41.0.0" }
+wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "41.0.0" }
+wasmtime-wasi-tls = { path = "crates/wasi-tls", version = "41.0.0" }
+wasmtime-wasi-tls-nativetls = { path = "crates/wasi-tls-nativetls", version = "41.0.0" }
+wasmtime-wast = { path = "crates/wast", version = "=41.0.0" }
 
 # Internal Wasmtime-specific crates.
 #
@@ -257,54 +257,54 @@ wasmtime-wast = { path = "crates/wast", version = "=40.0.0" }
 # that these are internal unsupported crates for external use. These exist as
 # part of the project organization of other public crates in Wasmtime and are
 # otherwise not supported in terms of CVEs for example.
-wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=40.0.0", package = 'wasmtime-internal-wmemcheck' }
-wasmtime-c-api-macros = { path = "crates/c-api-macros", version = "=40.0.0", package = 'wasmtime-internal-c-api-macros' }
-wasmtime-cache = { path = "crates/cache", version = "=40.0.0", package = 'wasmtime-internal-cache' }
-wasmtime-cranelift = { path = "crates/cranelift", version = "=40.0.0", package = 'wasmtime-internal-cranelift' }
-wasmtime-winch = { path = "crates/winch", version = "=40.0.0", package = 'wasmtime-internal-winch'  }
-wasmtime-explorer = { path = "crates/explorer", version = "=40.0.0", package = 'wasmtime-internal-explorer'  }
-wasmtime-fiber = { path = "crates/fiber", version = "=40.0.0", package = 'wasmtime-internal-fiber' }
-wasmtime-jit-debug = { path = "crates/jit-debug", version = "=40.0.0", package = 'wasmtime-internal-jit-debug' }
-wasmtime-component-util = { path = "crates/component-util", version = "=40.0.0", package = 'wasmtime-internal-component-util' }
-wasmtime-component-macro = { path = "crates/component-macro", version = "=40.0.0", package = 'wasmtime-internal-component-macro' }
-wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=40.0.0", package = 'wasmtime-internal-versioned-export-macros' }
-wasmtime-slab = { path = "crates/slab", version = "=40.0.0", package = 'wasmtime-internal-slab' }
-wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=40.0.0", package = 'wasmtime-internal-jit-icache-coherence' }
-wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=40.0.0", package = 'wasmtime-internal-wit-bindgen' }
-wasmtime-math = { path = "crates/math", version = "=40.0.0", package = 'wasmtime-internal-math'  }
-wasmtime-unwinder = { path = "crates/unwinder", version = "=40.0.0", package = 'wasmtime-internal-unwinder' }
-wasmtime-wizer = { path = "crates/wizer", version = "40.0.0" }
+wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=41.0.0", package = 'wasmtime-internal-wmemcheck' }
+wasmtime-c-api-macros = { path = "crates/c-api-macros", version = "=41.0.0", package = 'wasmtime-internal-c-api-macros' }
+wasmtime-cache = { path = "crates/cache", version = "=41.0.0", package = 'wasmtime-internal-cache' }
+wasmtime-cranelift = { path = "crates/cranelift", version = "=41.0.0", package = 'wasmtime-internal-cranelift' }
+wasmtime-winch = { path = "crates/winch", version = "=41.0.0", package = 'wasmtime-internal-winch'  }
+wasmtime-explorer = { path = "crates/explorer", version = "=41.0.0", package = 'wasmtime-internal-explorer'  }
+wasmtime-fiber = { path = "crates/fiber", version = "=41.0.0", package = 'wasmtime-internal-fiber' }
+wasmtime-jit-debug = { path = "crates/jit-debug", version = "=41.0.0", package = 'wasmtime-internal-jit-debug' }
+wasmtime-component-util = { path = "crates/component-util", version = "=41.0.0", package = 'wasmtime-internal-component-util' }
+wasmtime-component-macro = { path = "crates/component-macro", version = "=41.0.0", package = 'wasmtime-internal-component-macro' }
+wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=41.0.0", package = 'wasmtime-internal-versioned-export-macros' }
+wasmtime-slab = { path = "crates/slab", version = "=41.0.0", package = 'wasmtime-internal-slab' }
+wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=41.0.0", package = 'wasmtime-internal-jit-icache-coherence' }
+wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=41.0.0", package = 'wasmtime-internal-wit-bindgen' }
+wasmtime-math = { path = "crates/math", version = "=41.0.0", package = 'wasmtime-internal-math'  }
+wasmtime-unwinder = { path = "crates/unwinder", version = "=41.0.0", package = 'wasmtime-internal-unwinder' }
+wasmtime-wizer = { path = "crates/wizer", version = "41.0.0" }
 
 # Miscellaneous crates without a `wasmtime-*` prefix in their name but still
 # used in the `wasmtime-*` family of crates depending on various features/etc.
-wiggle = { path = "crates/wiggle", version = "=40.0.0", default-features = false }
-wiggle-macro = { path = "crates/wiggle/macro", version = "=40.0.0" }
-wiggle-generate = { path = "crates/wiggle/generate", version = "=40.0.0" }
-wasi-common = { path = "crates/wasi-common", version = "=40.0.0", default-features = false }
-pulley-interpreter = { path = 'pulley', version = "=40.0.0" }
-pulley-macros = { path = 'pulley/macros', version = "=40.0.0" }
+wiggle = { path = "crates/wiggle", version = "=41.0.0", default-features = false }
+wiggle-macro = { path = "crates/wiggle/macro", version = "=41.0.0" }
+wiggle-generate = { path = "crates/wiggle/generate", version = "=41.0.0" }
+wasi-common = { path = "crates/wasi-common", version = "=41.0.0", default-features = false }
+pulley-interpreter = { path = 'pulley', version = "=41.0.0" }
+pulley-macros = { path = 'pulley/macros', version = "=41.0.0" }
 
 # Cranelift crates in this workspace
-cranelift-assembler-x64 = { path = "cranelift/assembler-x64", version = "0.127.0" }
-cranelift-codegen = { path = "cranelift/codegen", version = "0.127.0", default-features = false, features = ["std", "unwind"] }
-cranelift-frontend = { path = "cranelift/frontend", version = "0.127.0" }
-cranelift-entity = { path = "cranelift/entity", version = "0.127.0" }
-cranelift-native = { path = "cranelift/native", version = "0.127.0" }
-cranelift-module = { path = "cranelift/module", version = "0.127.0" }
-cranelift-interpreter = { path = "cranelift/interpreter", version = "0.127.0" }
-cranelift-reader = { path = "cranelift/reader", version = "0.127.0" }
+cranelift-assembler-x64 = { path = "cranelift/assembler-x64", version = "0.128.0" }
+cranelift-codegen = { path = "cranelift/codegen", version = "0.128.0", default-features = false, features = ["std", "unwind"] }
+cranelift-frontend = { path = "cranelift/frontend", version = "0.128.0" }
+cranelift-entity = { path = "cranelift/entity", version = "0.128.0" }
+cranelift-native = { path = "cranelift/native", version = "0.128.0" }
+cranelift-module = { path = "cranelift/module", version = "0.128.0" }
+cranelift-interpreter = { path = "cranelift/interpreter", version = "0.128.0" }
+cranelift-reader = { path = "cranelift/reader", version = "0.128.0" }
 cranelift-filetests = { path = "cranelift/filetests" }
-cranelift-object = { path = "cranelift/object", version = "0.127.0" }
-cranelift-jit = { path = "cranelift/jit", version = "0.127.0" }
+cranelift-object = { path = "cranelift/object", version = "0.128.0" }
+cranelift-jit = { path = "cranelift/jit", version = "0.128.0" }
 cranelift-fuzzgen = { path = "cranelift/fuzzgen" }
-cranelift-bforest = { path = "cranelift/bforest", version = "0.127.0" }
-cranelift-bitset = { path = "cranelift/bitset", version = "0.127.0" }
-cranelift-control = { path = "cranelift/control", version = "0.127.0" }
-cranelift-srcgen = { path = "cranelift/srcgen", version = "0.127.0" }
-cranelift = { path = "cranelift/umbrella", version = "0.127.0" }
+cranelift-bforest = { path = "cranelift/bforest", version = "0.128.0" }
+cranelift-bitset = { path = "cranelift/bitset", version = "0.128.0" }
+cranelift-control = { path = "cranelift/control", version = "0.128.0" }
+cranelift-srcgen = { path = "cranelift/srcgen", version = "0.128.0" }
+cranelift = { path = "cranelift/umbrella", version = "0.128.0" }
 
 # Winch crates in this workspace.
-winch-codegen = { path = "winch/codegen", version = "=40.0.0" }
+winch-codegen = { path = "winch/codegen", version = "=41.0.0" }
 
 # Internal crates not published to crates.io used in testing, builds, etc
 wasi-preview1-component-adapter = { path = "crates/wasi-preview1-component-adapter" }

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,4 +1,4 @@
-## 40.0.0
+## 41.0.0
 
 Unreleased.
 
@@ -12,6 +12,7 @@ Release notes for previous releases of Wasmtime can be found on the respective
 release branches of the Wasmtime repository.
 
 <!-- ARCHIVE_START -->
+* [40.0.x](https://github.com/bytecodealliance/wasmtime/blob/release-40.0.0/RELEASES.md)
 * [39.0.x](https://github.com/bytecodealliance/wasmtime/blob/release-39.0.0/RELEASES.md)
 * [38.0.x](https://github.com/bytecodealliance/wasmtime/blob/release-38.0.0/RELEASES.md)
 * [37.0.x](https://github.com/bytecodealliance/wasmtime/blob/release-37.0.0/RELEASES.md)

--- a/cranelift/assembler-x64/Cargo.toml
+++ b/cranelift/assembler-x64/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-assembler-x64"
 description = "A Cranelift-specific x64 assembler"
-version = "0.127.0"
+version = "0.128.0"
 license = "Apache-2.0 WITH LLVM-exception"
 edition.workspace = true
 rust-version.workspace = true
@@ -16,7 +16,7 @@ arbtest = { workspace = true }
 capstone = { workspace = true }
 
 [build-dependencies]
-cranelift-assembler-x64-meta = { path = "meta", version = "0.127.0" }
+cranelift-assembler-x64-meta = { path = "meta", version = "0.128.0" }
 
 [lints]
 workspace = true

--- a/cranelift/assembler-x64/meta/Cargo.toml
+++ b/cranelift/assembler-x64/meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-assembler-x64-meta"
 description = "Generate a Cranelift-specific assembler for x64 instructions"
-version = "0.127.0"
+version = "0.128.0"
 license = "Apache-2.0 WITH LLVM-exception"
 edition.workspace = true
 rust-version.workspace = true

--- a/cranelift/bforest/Cargo.toml
+++ b/cranelift/bforest/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bforest"
-version = "0.127.0"
+version = "0.128.0"
 description = "A forest of B+-trees"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-bforest"

--- a/cranelift/bitset/Cargo.toml
+++ b/cranelift/bitset/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bitset"
-version = "0.127.0"
+version = "0.128.0"
 description = "Various bitset stuff for use inside Cranelift"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-bitset"

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen"
-version = "0.127.0"
+version = "0.128.0"
 description = "Low-level code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-codegen"
@@ -25,7 +25,7 @@ anyhow = { workspace = true, optional = true, features = ['std'] }
 bumpalo = "3"
 capstone = { workspace = true, optional = true }
 cranelift-assembler-x64 = { workspace = true }
-cranelift-codegen-shared = { path = "./shared", version = "0.127.0" }
+cranelift-codegen-shared = { path = "./shared", version = "0.128.0" }
 cranelift-entity = { workspace = true }
 cranelift-bforest = { workspace = true }
 cranelift-bitset = { workspace = true }
@@ -56,8 +56,8 @@ env_logger = { workspace = true }
 proptest = { workspace = true }
 
 [build-dependencies]
-cranelift-codegen-meta = { path = "meta", version = "0.127.0" }
-cranelift-isle = { path = "../isle/isle", version = "=0.127.0" }
+cranelift-codegen-meta = { path = "meta", version = "0.128.0" }
+cranelift-isle = { path = "../isle/isle", version = "=0.128.0" }
 
 [features]
 default = ["std", "unwind", "host-arch", "timing"]

--- a/cranelift/codegen/meta/Cargo.toml
+++ b/cranelift/codegen/meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-codegen-meta"
 authors = ["The Cranelift Project Developers"]
-version = "0.127.0"
+version = "0.128.0"
 description = "Metaprogram for cranelift-codegen code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
@@ -17,8 +17,8 @@ rustdoc-args = ["--document-private-items"]
 
 [dependencies]
 cranelift-srcgen = { workspace = true }
-cranelift-assembler-x64-meta = { path = "../../assembler-x64/meta", version = "0.127.0" }
-cranelift-codegen-shared = { path = "../shared", version = "0.127.0" }
+cranelift-assembler-x64-meta = { path = "../../assembler-x64/meta", version = "0.128.0" }
+cranelift-codegen-shared = { path = "../shared", version = "0.128.0" }
 pulley-interpreter = { workspace = true, optional = true }
 heck = "0.5.0"
 

--- a/cranelift/codegen/shared/Cargo.toml
+++ b/cranelift/codegen/shared/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen-shared"
-version = "0.127.0"
+version = "0.128.0"
 description = "For code shared between cranelift-codegen-meta and cranelift-codegen"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/control/Cargo.toml
+++ b/cranelift/control/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-control"
-version = "0.127.0"
+version = "0.128.0"
 description = "White-box fuzz testing framework"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/entity/Cargo.toml
+++ b/cranelift/entity/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-entity"
-version = "0.127.0"
+version = "0.128.0"
 description = "Data structures using entity references as mapping keys"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-entity"

--- a/cranelift/frontend/Cargo.toml
+++ b/cranelift/frontend/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-frontend"
-version = "0.127.0"
+version = "0.128.0"
 description = "Cranelift IR builder helper"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-frontend"

--- a/cranelift/interpreter/Cargo.toml
+++ b/cranelift/interpreter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-interpreter"
-version = "0.127.0"
+version = "0.128.0"
 authors = ["The Cranelift Project Developers"]
 description = "Interpret Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/isle/isle/Cargo.toml
+++ b/cranelift/isle/isle/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 name = "cranelift-isle"
 readme = "../README.md"
 repository = "https://github.com/bytecodealliance/wasmtime/tree/main/cranelift/isle"
-version = "0.127.0"
+version = "0.128.0"
 
 [lints]
 workspace = true

--- a/cranelift/jit/Cargo.toml
+++ b/cranelift/jit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-jit"
-version = "0.127.0"
+version = "0.128.0"
 authors = ["The Cranelift Project Developers"]
 description = "A JIT library backed by Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/module/Cargo.toml
+++ b/cranelift/module/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-module"
-version = "0.127.0"
+version = "0.128.0"
 authors = ["The Cranelift Project Developers"]
 description = "Support for linking functions and data with Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/native/Cargo.toml
+++ b/cranelift/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-native"
-version = "0.127.0"
+version = "0.128.0"
 authors = ["The Cranelift Project Developers"]
 description = "Support for targeting the host with Cranelift"
 documentation = "https://docs.rs/cranelift-native"

--- a/cranelift/object/Cargo.toml
+++ b/cranelift/object/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-object"
-version = "0.127.0"
+version = "0.128.0"
 authors = ["The Cranelift Project Developers"]
 description = "Emit Cranelift output to native object files with `object`"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/reader/Cargo.toml
+++ b/cranelift/reader/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-reader"
-version = "0.127.0"
+version = "0.128.0"
 description = "Cranelift textual IR reader"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-reader"

--- a/cranelift/serde/Cargo.toml
+++ b/cranelift/serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-serde"
-version = "0.127.0"
+version = "0.128.0"
 authors = ["The Cranelift Project Developers"]
 description = "Serializer/Deserializer for Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/srcgen/Cargo.toml
+++ b/cranelift/srcgen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-srcgen"
-version = "0.127.0"
+version = "0.128.0"
 authors = ["The Wasmtime Project Developers"]
 description = "Helper functions for generating Rust and ISLE files"
 license = "Apache-2.0 WITH LLVM-exception"

--- a/cranelift/umbrella/Cargo.toml
+++ b/cranelift/umbrella/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift"
-version = "0.127.0"
+version = "0.128.0"
 description = "Umbrella for commonly-used cranelift crates"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift"

--- a/crates/c-api/include/wasmtime.h
+++ b/crates/c-api/include/wasmtime.h
@@ -212,11 +212,11 @@
 /**
  * \brief Wasmtime version string.
  */
-#define WASMTIME_VERSION "40.0.0"
+#define WASMTIME_VERSION "41.0.0"
 /**
  * \brief Wasmtime major version number.
  */
-#define WASMTIME_VERSION_MAJOR 40
+#define WASMTIME_VERSION_MAJOR 41
 /**
  * \brief Wasmtime minor version number.
  */

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -5,228 +5,456 @@
 version = "0.127.0"
 audited_as = "0.126.1"
 
+[[unpublished.cranelift]]
+version = "0.128.0"
+audited_as = "0.126.1"
+
 [[unpublished.cranelift-assembler-x64]]
 version = "0.127.0"
+audited_as = "0.126.1"
+
+[[unpublished.cranelift-assembler-x64]]
+version = "0.128.0"
 audited_as = "0.126.1"
 
 [[unpublished.cranelift-assembler-x64-meta]]
 version = "0.127.0"
 audited_as = "0.126.1"
 
+[[unpublished.cranelift-assembler-x64-meta]]
+version = "0.128.0"
+audited_as = "0.126.1"
+
 [[unpublished.cranelift-bforest]]
 version = "0.127.0"
+audited_as = "0.126.1"
+
+[[unpublished.cranelift-bforest]]
+version = "0.128.0"
 audited_as = "0.126.1"
 
 [[unpublished.cranelift-bitset]]
 version = "0.127.0"
 audited_as = "0.126.1"
 
+[[unpublished.cranelift-bitset]]
+version = "0.128.0"
+audited_as = "0.126.1"
+
 [[unpublished.cranelift-codegen]]
 version = "0.127.0"
+audited_as = "0.126.1"
+
+[[unpublished.cranelift-codegen]]
+version = "0.128.0"
 audited_as = "0.126.1"
 
 [[unpublished.cranelift-codegen-meta]]
 version = "0.127.0"
 audited_as = "0.126.1"
 
+[[unpublished.cranelift-codegen-meta]]
+version = "0.128.0"
+audited_as = "0.126.1"
+
 [[unpublished.cranelift-codegen-shared]]
 version = "0.127.0"
+audited_as = "0.126.1"
+
+[[unpublished.cranelift-codegen-shared]]
+version = "0.128.0"
 audited_as = "0.126.1"
 
 [[unpublished.cranelift-control]]
 version = "0.127.0"
 audited_as = "0.126.1"
 
+[[unpublished.cranelift-control]]
+version = "0.128.0"
+audited_as = "0.126.1"
+
 [[unpublished.cranelift-entity]]
 version = "0.127.0"
+audited_as = "0.126.1"
+
+[[unpublished.cranelift-entity]]
+version = "0.128.0"
 audited_as = "0.126.1"
 
 [[unpublished.cranelift-frontend]]
 version = "0.127.0"
 audited_as = "0.126.1"
 
+[[unpublished.cranelift-frontend]]
+version = "0.128.0"
+audited_as = "0.126.1"
+
 [[unpublished.cranelift-interpreter]]
 version = "0.127.0"
+audited_as = "0.126.1"
+
+[[unpublished.cranelift-interpreter]]
+version = "0.128.0"
 audited_as = "0.126.1"
 
 [[unpublished.cranelift-isle]]
 version = "0.127.0"
 audited_as = "0.126.1"
 
+[[unpublished.cranelift-isle]]
+version = "0.128.0"
+audited_as = "0.126.1"
+
 [[unpublished.cranelift-jit]]
 version = "0.127.0"
+audited_as = "0.126.1"
+
+[[unpublished.cranelift-jit]]
+version = "0.128.0"
 audited_as = "0.126.1"
 
 [[unpublished.cranelift-module]]
 version = "0.127.0"
 audited_as = "0.126.1"
 
+[[unpublished.cranelift-module]]
+version = "0.128.0"
+audited_as = "0.126.1"
+
 [[unpublished.cranelift-native]]
 version = "0.127.0"
+audited_as = "0.126.1"
+
+[[unpublished.cranelift-native]]
+version = "0.128.0"
 audited_as = "0.126.1"
 
 [[unpublished.cranelift-object]]
 version = "0.127.0"
 audited_as = "0.126.1"
 
+[[unpublished.cranelift-object]]
+version = "0.128.0"
+audited_as = "0.126.1"
+
 [[unpublished.cranelift-reader]]
 version = "0.127.0"
+audited_as = "0.126.1"
+
+[[unpublished.cranelift-reader]]
+version = "0.128.0"
 audited_as = "0.126.1"
 
 [[unpublished.cranelift-serde]]
 version = "0.127.0"
 audited_as = "0.126.1"
 
+[[unpublished.cranelift-serde]]
+version = "0.128.0"
+audited_as = "0.126.1"
+
 [[unpublished.cranelift-srcgen]]
 version = "0.127.0"
+audited_as = "0.126.1"
+
+[[unpublished.cranelift-srcgen]]
+version = "0.128.0"
 audited_as = "0.126.1"
 
 [[unpublished.pulley-interpreter]]
 version = "40.0.0"
 audited_as = "39.0.1"
 
+[[unpublished.pulley-interpreter]]
+version = "41.0.0"
+audited_as = "39.0.1"
+
 [[unpublished.pulley-macros]]
 version = "40.0.0"
+audited_as = "39.0.1"
+
+[[unpublished.pulley-macros]]
+version = "41.0.0"
 audited_as = "39.0.1"
 
 [[unpublished.wasi-common]]
 version = "40.0.0"
 audited_as = "39.0.1"
 
+[[unpublished.wasi-common]]
+version = "41.0.0"
+audited_as = "39.0.1"
+
 [[unpublished.wasmtime]]
 version = "40.0.0"
+audited_as = "39.0.1"
+
+[[unpublished.wasmtime]]
+version = "41.0.0"
 audited_as = "39.0.1"
 
 [[unpublished.wasmtime-cli]]
 version = "40.0.0"
 audited_as = "39.0.1"
 
+[[unpublished.wasmtime-cli]]
+version = "41.0.0"
+audited_as = "39.0.1"
+
 [[unpublished.wasmtime-cli-flags]]
 version = "40.0.0"
+audited_as = "39.0.1"
+
+[[unpublished.wasmtime-cli-flags]]
+version = "41.0.0"
 audited_as = "39.0.1"
 
 [[unpublished.wasmtime-environ]]
 version = "40.0.0"
 audited_as = "39.0.1"
 
+[[unpublished.wasmtime-environ]]
+version = "41.0.0"
+audited_as = "39.0.1"
+
 [[unpublished.wasmtime-internal-c-api-macros]]
 version = "40.0.0"
+audited_as = "39.0.1"
+
+[[unpublished.wasmtime-internal-c-api-macros]]
+version = "41.0.0"
 audited_as = "39.0.1"
 
 [[unpublished.wasmtime-internal-cache]]
 version = "40.0.0"
 audited_as = "39.0.1"
 
+[[unpublished.wasmtime-internal-cache]]
+version = "41.0.0"
+audited_as = "39.0.1"
+
 [[unpublished.wasmtime-internal-component-macro]]
 version = "40.0.0"
+audited_as = "39.0.1"
+
+[[unpublished.wasmtime-internal-component-macro]]
+version = "41.0.0"
 audited_as = "39.0.1"
 
 [[unpublished.wasmtime-internal-component-util]]
 version = "40.0.0"
 audited_as = "39.0.1"
 
+[[unpublished.wasmtime-internal-component-util]]
+version = "41.0.0"
+audited_as = "39.0.1"
+
 [[unpublished.wasmtime-internal-cranelift]]
 version = "40.0.0"
+audited_as = "39.0.1"
+
+[[unpublished.wasmtime-internal-cranelift]]
+version = "41.0.0"
 audited_as = "39.0.1"
 
 [[unpublished.wasmtime-internal-explorer]]
 version = "40.0.0"
 audited_as = "39.0.1"
 
+[[unpublished.wasmtime-internal-explorer]]
+version = "41.0.0"
+audited_as = "39.0.1"
+
 [[unpublished.wasmtime-internal-fiber]]
 version = "40.0.0"
+audited_as = "39.0.1"
+
+[[unpublished.wasmtime-internal-fiber]]
+version = "41.0.0"
 audited_as = "39.0.1"
 
 [[unpublished.wasmtime-internal-jit-debug]]
 version = "40.0.0"
 audited_as = "39.0.1"
 
+[[unpublished.wasmtime-internal-jit-debug]]
+version = "41.0.0"
+audited_as = "39.0.1"
+
 [[unpublished.wasmtime-internal-jit-icache-coherence]]
 version = "40.0.0"
+audited_as = "39.0.1"
+
+[[unpublished.wasmtime-internal-jit-icache-coherence]]
+version = "41.0.0"
 audited_as = "39.0.1"
 
 [[unpublished.wasmtime-internal-math]]
 version = "40.0.0"
 audited_as = "39.0.1"
 
+[[unpublished.wasmtime-internal-math]]
+version = "41.0.0"
+audited_as = "39.0.1"
+
 [[unpublished.wasmtime-internal-slab]]
 version = "40.0.0"
+audited_as = "39.0.1"
+
+[[unpublished.wasmtime-internal-slab]]
+version = "41.0.0"
 audited_as = "39.0.1"
 
 [[unpublished.wasmtime-internal-unwinder]]
 version = "40.0.0"
 audited_as = "39.0.1"
 
+[[unpublished.wasmtime-internal-unwinder]]
+version = "41.0.0"
+audited_as = "39.0.1"
+
 [[unpublished.wasmtime-internal-versioned-export-macros]]
 version = "40.0.0"
+audited_as = "39.0.1"
+
+[[unpublished.wasmtime-internal-versioned-export-macros]]
+version = "41.0.0"
 audited_as = "39.0.1"
 
 [[unpublished.wasmtime-internal-winch]]
 version = "40.0.0"
 audited_as = "39.0.1"
 
+[[unpublished.wasmtime-internal-winch]]
+version = "41.0.0"
+audited_as = "39.0.1"
+
 [[unpublished.wasmtime-internal-wit-bindgen]]
 version = "40.0.0"
+audited_as = "39.0.1"
+
+[[unpublished.wasmtime-internal-wit-bindgen]]
+version = "41.0.0"
 audited_as = "39.0.1"
 
 [[unpublished.wasmtime-internal-wmemcheck]]
 version = "40.0.0"
 audited_as = "39.0.1"
 
+[[unpublished.wasmtime-internal-wmemcheck]]
+version = "41.0.0"
+audited_as = "39.0.1"
+
 [[unpublished.wasmtime-wasi]]
 version = "40.0.0"
+audited_as = "39.0.1"
+
+[[unpublished.wasmtime-wasi]]
+version = "41.0.0"
 audited_as = "39.0.1"
 
 [[unpublished.wasmtime-wasi-config]]
 version = "40.0.0"
 audited_as = "39.0.1"
 
+[[unpublished.wasmtime-wasi-config]]
+version = "41.0.0"
+audited_as = "39.0.1"
+
 [[unpublished.wasmtime-wasi-http]]
 version = "40.0.0"
+audited_as = "39.0.1"
+
+[[unpublished.wasmtime-wasi-http]]
+version = "41.0.0"
 audited_as = "39.0.1"
 
 [[unpublished.wasmtime-wasi-io]]
 version = "40.0.0"
 audited_as = "39.0.1"
 
+[[unpublished.wasmtime-wasi-io]]
+version = "41.0.0"
+audited_as = "39.0.1"
+
 [[unpublished.wasmtime-wasi-keyvalue]]
 version = "40.0.0"
+audited_as = "39.0.1"
+
+[[unpublished.wasmtime-wasi-keyvalue]]
+version = "41.0.0"
 audited_as = "39.0.1"
 
 [[unpublished.wasmtime-wasi-nn]]
 version = "40.0.0"
 audited_as = "39.0.1"
 
+[[unpublished.wasmtime-wasi-nn]]
+version = "41.0.0"
+audited_as = "39.0.1"
+
 [[unpublished.wasmtime-wasi-threads]]
 version = "40.0.0"
+audited_as = "39.0.1"
+
+[[unpublished.wasmtime-wasi-threads]]
+version = "41.0.0"
 audited_as = "39.0.1"
 
 [[unpublished.wasmtime-wasi-tls]]
 version = "40.0.0"
 audited_as = "39.0.1"
 
+[[unpublished.wasmtime-wasi-tls]]
+version = "41.0.0"
+audited_as = "39.0.1"
+
 [[unpublished.wasmtime-wasi-tls-nativetls]]
 version = "40.0.0"
+audited_as = "39.0.1"
+
+[[unpublished.wasmtime-wasi-tls-nativetls]]
+version = "41.0.0"
 audited_as = "39.0.1"
 
 [[unpublished.wasmtime-wast]]
 version = "40.0.0"
 audited_as = "39.0.1"
 
+[[unpublished.wasmtime-wast]]
+version = "41.0.0"
+audited_as = "39.0.1"
+
 [[unpublished.wasmtime-wizer]]
 version = "40.0.0"
+audited_as = "39.0.1"
+
+[[unpublished.wasmtime-wizer]]
+version = "41.0.0"
 audited_as = "39.0.1"
 
 [[unpublished.wiggle]]
 version = "40.0.0"
 audited_as = "39.0.1"
 
+[[unpublished.wiggle]]
+version = "41.0.0"
+audited_as = "39.0.1"
+
 [[unpublished.wiggle-generate]]
 version = "40.0.0"
 audited_as = "39.0.1"
 
+[[unpublished.wiggle-generate]]
+version = "41.0.0"
+audited_as = "39.0.1"
+
 [[unpublished.wiggle-macro]]
 version = "40.0.0"
+audited_as = "39.0.1"
+
+[[unpublished.wiggle-macro]]
+version = "41.0.0"
 audited_as = "39.0.1"
 
 [[unpublished.wiggle-test]]
@@ -235,6 +463,10 @@ audited_as = "0.1.0"
 
 [[unpublished.winch-codegen]]
 version = "40.0.0"
+audited_as = "39.0.1"
+
+[[unpublished.winch-codegen]]
+version = "41.0.0"
 audited_as = "39.0.1"
 
 [[publisher.aho-corasick]]


### PR DESCRIPTION
This is an [automated pull request][process] from CI which indicates that the next [`release-40.0.0` branch][branch] has been created and the `main` branch is getting its version number bumped from 40.0.0 to 41.0.0.

Maintainers should take a moment to review the [release notes][RELEASES.md] for 40.0.0 and any updates should be made directly to the [release branch][branch].

Another automated PR will be made in roughly 2 weeks time when for the actual release itself.

If any issues arise on the `main` branch before the release is made then the issue should first be fixed on `main` and then backport to the `release-40.0.0` branch.

[RELEASES.md]: https://github.com/bytecodealliance/wasmtime/blob/release-40.0.0/RELEASES.md
[branch]: https://github.com/bytecodealliance/wasmtime/tree/release-40.0.0
[process]: https://docs.wasmtime.dev/contributing-release-process.html
