### PR TITLE
Cranelift: remove de-morgan mid-end rules (speedup up to 39.64%)

### DIFF
--- a/cranelift/codegen/src/opts/bitops.isle
+++ b/cranelift/codegen/src/opts/bitops.isle
@@ -41,14 +41,6 @@
 ;; not(not(x)) == x.
 (rule (simplify (bnot ty (bnot ty x))) (subsume x))
 
-;; DeMorgan's rule (two versions):
-;; bnot(bor(x, y)) == band(bnot(x), bnot(y))
-(rule (simplify (bnot ty (bor ty x y)))
-      (band ty (bnot ty x) (bnot ty y)))
-;; bnot(band(x, y)) == bor(bnot(x), bnot(y))
-(rule (simplify (bnot ty (band t x y)))
-      (bor ty (bnot ty x) (bnot ty y)))
-
 ;; `or(and(x, y), not(y)) == or(x, not(y))`
 (rule (simplify (bor ty
                      (band ty x y)


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->

This resolves https://github.com/bytecodealliance/wasmtime/issues/12106.

The following table shows the data backing this patch, where the removal of the canonicalizing de-morgan rules boosts execution and compilation performance for `keccak` benchmark. This is primarily because it confuses our e-graph based optimizer which selects the fastest expression among equivalent expressions collected by performing (bounded) equality saturation using the rules defined in ISLE. The selection happens during elaboration on each basic block where the cost model evaluates each expression by accumulating costs of instructions in each basic block. Each instruction has an assigned cost for its opcode. This can be confirmed by the following codes:

https://github.com/bytecodealliance/wasmtime/blob/9dc6a7d01fb5f5573666bd9aa4788da05af4bb09/cranelift/codegen/src/egraph/elaborate.rs#L222-L354

https://github.com/bytecodealliance/wasmtime/blob/9dc6a7d01fb5f5573666bd9aa4788da05af4bb09/cranelift/codegen/src/egraph/cost.rs#L73-L173

However, in a large sequential function with only a single block, the cost can saturate to infinity, where our cost model cannot decide the fastest expression, ending up selecting suboptimal expressions.

Benchmark | HEAD Exec | No DeMorgan Exec | Exec Speedup | HEAD Comp | No DeMorgan Comp | Comp Speedup
-- | -- | -- | -- | -- | -- | --
shootout-keccak | 29,514,301 | 21,135,969 | 39.64% | 100383275.4 | 74489436.9 | 34.76%
shootout-nestedloop | 433 | 405 | 6.85% | 62986270.12 | 62895037.2 | 0.15%
shootout-seqhash | 8,641,777,537 | 8,579,060,454 | 0.73% | 100553182.4 | 100005923.8 | 0.55%
blake3-scalar | 317,195 | 315,877 | 0.42% | 268166443.5 | 268150662.4 | 0.01%
shootout-xblabla20 | 2,927,213 | 2,916,862 | 0.35% | 88557190.04 | 88280759.04 | 0.31%
shootout-ackermann | 7,781,877 | 7,762,843 | 0.25% | 92660624.26 | 92236280.38 | 0.46%
shootout-ed25519 | 9,421,698,075 | 9,401,086,401 | 0.22% | 371753577.1 | 361934260.4 | 2.71%
shootout-matrix | 539,420,132 | 538,256,278 | 0.22% | 89971884.74 | 86974292.06 | 3.45%
regex | 211,067,251 | 210,714,847 | 0.17% | 1535901765 | 1532204889 | 0.24%
shootout-base64 | 353,052,919 | 352,747,070 | 0.09% | 88998859.4 | 88132267.24 | 0.98%
shootout-sieve | 841,972,639 | 841,375,673 | 0.07% | 63777036.32 | 63575041.26 | 0.32%
shootout-random | 439,817,997 | 439,827,859 | 0.00% | 63900104.52 | 63538830.34 | 0.57%
shootout-heapsort | 2,375,624,074 | 2,375,698,263 | 0.00% | 28196732.02 | 28125294.96 | 0.25%
shootout-ratelimit | 39,821,276 | 39,826,019 | -0.01% | 86722577.82 | 85973142.94 | 0.87%
shootout-minicsv | 1,290,801,636 | 1,291,097,063 | -0.02% | 15083307.78 | 15097025.52 | -0.09%
shootout-switch | 153,666,266 | 153,712,564 | -0.03% | 131105772.9 | 130938195.3 | 0.13%
spidermonkey | 633,415,685 | 633,770,903 | -0.06% | 22407719269 | 22354707118 | 0.24%
shootout-fib2 | 3,009,743,387 | 3,011,674,216 | -0.06% | 64783294.42 | 64608033.96 | 0.27%
blake3-simd | 305,358 | 305,565 | -0.07% | 86174589.6 | 85577620.54 | 0.70%
shootout-gimli | 5,416,594 | 5,428,633 | -0.22% | 5729545.32 | 5750271.64 | -0.36%
bz2 | 86,355,971 | 86,624,547 | -0.31% | 285047295.8 | 282723762.6 | 0.82%
shootout-memmove | 36,113,795 | 36,259,007 | -0.40% | 90058395.36 | 89318279.06 | 0.83%
shootout-xchacha20 | 4,407,751 | 4,435,038 | -0.62% | 88598416.98 | 87785480.78 | 0.93%
pulldown-cmark | 6,600,830 | 6,654,919 | -0.81% | 644222877.5 | 642976024.9 | 0.19%
shootout-ctype | 796,935,215 | 813,571,858 | -2.04% | 85272502.8 | 84941865.04 | 0.39%

