### PR TITLE
Remove support for `backpressure.set`

### DIFF
--- a/crates/cranelift/src/compiler/component.rs
+++ b/crates/cranelift/src/compiler/component.rs
@@ -204,16 +204,6 @@ impl<'a> TrampolineCompiler<'a> {
             Trampoline::ResourceDrop { instance, ty } => {
                 self.translate_resource_drop(*instance, *ty);
             }
-            Trampoline::BackpressureSet { instance } => {
-                self.translate_libcall(
-                    host::backpressure_set,
-                    TrapSentinel::Falsy,
-                    WasmArgs::InRegisters,
-                    |me, params| {
-                        params.push(me.index_value(*instance));
-                    },
-                );
-            }
             Trampoline::BackpressureInc { instance } => {
                 self.translate_libcall(
                     host::backpressure_modify,

--- a/crates/environ/src/component.rs
+++ b/crates/environ/src/component.rs
@@ -100,8 +100,6 @@ macro_rules! foreach_builtin_component_function {
             resource_exit_call(vmctx: vmctx) -> bool;
 
             #[cfg(feature = "component-model-async")]
-            backpressure_set(vmctx: vmctx, caller_instance: u32, enabled: u32) -> bool;
-            #[cfg(feature = "component-model-async")]
             backpressure_modify(vmctx: vmctx, caller_instance: u32, increment: u8) -> bool;
             #[cfg(feature = "component-model-async")]
             task_return(vmctx: vmctx, caller_instance: u32, ty: u32, options: u32, storage: ptr_u8, storage_len: size) -> bool;

--- a/crates/environ/src/component/dfg.rs
+++ b/crates/environ/src/component/dfg.rs
@@ -338,9 +338,6 @@ pub enum Trampoline {
         instance: RuntimeComponentInstanceIndex,
         ty: TypeResourceTableIndex,
     },
-    BackpressureSet {
-        instance: RuntimeComponentInstanceIndex,
-    },
     BackpressureInc {
         instance: RuntimeComponentInstanceIndex,
     },
@@ -957,9 +954,6 @@ impl LinearizeDfg<'_> {
             Trampoline::ResourceRep { instance, ty } => info::Trampoline::ResourceRep {
                 instance: *instance,
                 ty: *ty,
-            },
-            Trampoline::BackpressureSet { instance } => info::Trampoline::BackpressureSet {
-                instance: *instance,
             },
             Trampoline::BackpressureInc { instance } => info::Trampoline::BackpressureInc {
                 instance: *instance,

--- a/crates/environ/src/component/info.rs
+++ b/crates/environ/src/component/info.rs
@@ -759,13 +759,6 @@ pub enum Trampoline {
         ty: TypeResourceTableIndex,
     },
 
-    /// A `backpressure.set` intrinsic, which tells the host to enable or
-    /// disable backpressure for the caller's instance.
-    BackpressureSet {
-        /// The specific component instance which is calling the intrinsic.
-        instance: RuntimeComponentInstanceIndex,
-    },
-
     /// A `backpressure.inc` intrinsic.
     BackpressureInc {
         /// The specific component instance which is calling the intrinsic.
@@ -1202,7 +1195,6 @@ impl Trampoline {
             ResourceNew { ty, .. } => format!("component-resource-new[{}]", ty.as_u32()),
             ResourceRep { ty, .. } => format!("component-resource-rep[{}]", ty.as_u32()),
             ResourceDrop { ty, .. } => format!("component-resource-drop[{}]", ty.as_u32()),
-            BackpressureSet { .. } => format!("backpressure-set"),
             BackpressureInc { .. } => format!("backpressure-inc"),
             BackpressureDec { .. } => format!("backpressure-dec"),
             TaskReturn { .. } => format!("task-return"),

--- a/crates/environ/src/component/translate.rs
+++ b/crates/environ/src/component/translate.rs
@@ -199,9 +199,6 @@ enum LocalInitializer<'data> {
     ResourceRep(AliasableResourceId, ModuleInternedTypeIndex),
     ResourceDrop(AliasableResourceId, ModuleInternedTypeIndex),
 
-    BackpressureSet {
-        func: ModuleInternedTypeIndex,
-    },
     BackpressureInc {
         func: ModuleInternedTypeIndex,
     },
@@ -871,9 +868,7 @@ impl<'a, 'data> Translator<'a, 'data> {
                             bail!("unsupported intrinsic")
                         }
                         wasmparser::CanonicalFunction::BackpressureSet => {
-                            let core_type = self.core_func_signature(core_func_index)?;
-                            core_func_index += 1;
-                            LocalInitializer::BackpressureSet { func: core_type }
+                            bail!("unsupported intrinsic")
                         }
                         wasmparser::CanonicalFunction::BackpressureInc => {
                             let core_type = self.core_func_signature(core_func_index)?;

--- a/crates/environ/src/component/translate/inline.rs
+++ b/crates/environ/src/component/translate/inline.rs
@@ -699,15 +699,6 @@ impl<'a> Inliner<'a> {
                 ));
                 frame.funcs.push((*ty, dfg::CoreDef::Trampoline(index)));
             }
-            BackpressureSet { func } => {
-                let index = self.result.trampolines.push((
-                    *func,
-                    dfg::Trampoline::BackpressureSet {
-                        instance: frame.instance,
-                    },
-                ));
-                frame.funcs.push((*func, dfg::CoreDef::Trampoline(index)));
-            }
             BackpressureInc { func } => {
                 let index = self.result.trampolines.push((
                     *func,

--- a/crates/test-programs/src/bin/async_backpressure_callee.rs
+++ b/crates/test-programs/src/bin/async_backpressure_callee.rs
@@ -20,8 +20,11 @@ impl Run for Component {
 
 impl Backpressure for Component {
     fn set_backpressure(enabled: bool) {
-        #[expect(deprecated, reason = "will replace with backpressure.inc/dec soon")]
-        wit_bindgen::backpressure_set(enabled);
+        if enabled {
+            wit_bindgen::backpressure_inc();
+        } else {
+            wit_bindgen::backpressure_dec();
+        }
     }
     fn inc_backpressure() {
         wit_bindgen::backpressure_inc();

--- a/crates/test-programs/src/bin/async_cancel_callee.rs
+++ b/crates/test-programs/src/bin/async_cancel_callee.rs
@@ -80,8 +80,11 @@ enum State {
 
 #[unsafe(export_name = "local:local/backpressure#set-backpressure")]
 unsafe extern "C" fn export_set_backpressure(enabled: bool) {
-    #[expect(deprecated, reason = "will replace with backpressure.inc/dec soon")]
-    wit_bindgen::backpressure_set(enabled);
+    if enabled {
+        wit_bindgen::backpressure_inc();
+    } else {
+        wit_bindgen::backpressure_dec();
+    }
 }
 
 #[unsafe(export_name = "local:local/backpressure#inc-backpressure")]

--- a/crates/wasmtime/src/runtime/component/concurrent.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent.rs
@@ -4709,7 +4709,7 @@ impl ConcurrentState {
         Ok(())
     }
 
-    /// Implements the `backpressure.{set,inc,dec}` intrinsics.
+    /// Implements the `backpressure.{inc,dec}` intrinsics.
     pub(crate) fn backpressure_modify(
         &mut self,
         caller_instance: RuntimeComponentInstanceIndex,

--- a/crates/wasmtime/src/runtime/vm/component/libcalls.rs
+++ b/crates/wasmtime/src/runtime/vm/component/libcalls.rs
@@ -670,19 +670,6 @@ fn trap(_store: &mut dyn VMStore, _instance: Instance, code: u8) -> Result<()> {
 }
 
 #[cfg(feature = "component-model-async")]
-fn backpressure_set(
-    store: &mut dyn VMStore,
-    _instance: Instance,
-    caller_instance: u32,
-    enabled: u32,
-) -> Result<()> {
-    store.concurrent_state_mut().backpressure_modify(
-        RuntimeComponentInstanceIndex::from_u32(caller_instance),
-        |_| Some(if enabled != 0 { 1 } else { 0 }),
-    )
-}
-
-#[cfg(feature = "component-model-async")]
 fn backpressure_modify(
     store: &mut dyn VMStore,
     _instance: Instance,

--- a/tests/misc_testsuite/component-model/async/task-builtins.wast
+++ b/tests/misc_testsuite/component-model/async/task-builtins.wast
@@ -1,14 +1,5 @@
 ;;! component_model_async = true
 
-;; backpressure.set
-(component
-  (core module $m
-    (import "" "backpressure.set" (func $backpressure-set (param i32)))
-  )
-  (core func $backpressure-set (canon backpressure.set))
-  (core instance $i (instantiate $m (with "" (instance (export "backpressure.set" (func $backpressure-set))))))
-)
-
 ;; backpressure.inc
 (component
   (core module $m


### PR DESCRIPTION
This canonical intrinsic which is part of component-model-async support is supplanted by `backpressure.{inc,dec}`. This wasn't removed when they were added to keep existing programs working, but that's no longer necessary.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
