### PR TITLE
Update to using `wasip1`-the-crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4197,7 +4197,7 @@ dependencies = [
  "bitflags 2.9.4",
  "byte-array-literals",
  "object 0.37.3",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasip1",
  "wasm-encoder",
  "wit-bindgen-rust-macro",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -318,6 +318,7 @@ component-async-tests = { path = "crates/misc/component-async-tests" }
 # Bytecode Alliance maintained dependencies:
 # ---------------------------
 regalloc2 = "0.13.3"
+wasip1 = { version = "1.0.0", default-features = false }
 
 # cap-std family:
 target-lexicon = "0.13.0"

--- a/crates/test-programs/Cargo.toml
+++ b/crates/test-programs/Cargo.toml
@@ -19,7 +19,7 @@ futures = { workspace = true, default-features = false, features = ['alloc', 'as
 url = { workspace = true }
 sha2 = "0.10.2"
 base64 = { workspace = true }
-wasip1 = "1.0.0"
+wasip1 = { version = "1.0.0", default-features = true }
 wasip2 = "1.0.0"
 once_cell = "1.19.0"
 flate2 = "1.0.28"

--- a/crates/wasi-preview1-component-adapter/Cargo.toml
+++ b/crates/wasi-preview1-component-adapter/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 workspace = true
 
 [dependencies]
-wasi = { version = "0.11.0", default-features = false }
+wasip1 = { workspace = true }
 wit-bindgen-rust-macro = { workspace = true }
 byte-array-literals = { workspace = true }
 bitflags = { workspace = true }


### PR DESCRIPTION
Switch away from `wasi`, which while it isn't changing might as well be explicit.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
