### PR TITLE
filesystem: Paper over fadvise harmless failure on macos

### DIFF
--- a/crates/wasi/src/filesystem.rs
+++ b/crates/wasi/src/filesystem.rs
@@ -752,15 +752,25 @@ impl File {
         advice: system_interface::fs::Advice,
     ) -> Result<(), ErrorCode> {
         use system_interface::fs::FileIoExt as _;
+        let is_emulated_willneed = cfg!(any(target_os = "macos", target_os = "ios"))
+            && advice == system_interface::fs::Advice::WillNeed;
         match self
             .run_blocking(move |f| f.advise(offset, len, advice))
             .await
         {
-            #[cfg(any(target_os = "macos", target_os = "ios"))]
-            Err(ErrorCode::FileTooLarge) if advice == system_interface::fs::Advice::WillNeed => {
-                Ok(())
+            Err(err) => {
+                let code: ErrorCode = err.into();
+
+                // Paper over a difference in behavior; we implement
+                // MADV_WILLNEED on macos via the F_RDADVISE fnctl,
+                // which errors on out-of-bounds ranges whereas POSIX
+                // silently succeeds.
+                if is_emulated_willneed && matches!(code, ErrorCode::FileTooLarge) {
+                    return Ok(());
+                }
+
+                Err(code)
             }
-            Err(err) => Err(err.into()),
             Ok(()) => Ok(()),
         }
     }

--- a/tests/wasi.rs
+++ b/tests/wasi.rs
@@ -20,8 +20,6 @@ const KNOWN_FAILURES: &[&str] = &[
     "filesystem-read-directory",
     // FIXME(#11524)
     "remove_directory_trailing_slashes",
-    #[cfg(target_vendor = "apple")]
-    "filesystem-advise",
     // FIXME(WebAssembly/wasi-testsuite#128)
     #[cfg(windows)]
     "fd_fdstat_set_rights",


### PR DESCRIPTION
On macos and ios, fadvise is only implemented for WillNeed and dispatches via the system-interface crate to the F_RDADVISE fcntl.  If you call WillNeed on an out-of-bounds offset, this fcntl returns FileTooLarge.  Here we paper over this harmless error code to avoid this needless platform-dependent nonuniformity.  Should fix wasmtime for https://github.com/WebAssembly/wasi-testsuite/issues/178.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
