### PR TITLE
Fix `#[derive(Lift)]` for enums of 256 cases

### DIFF
--- a/crates/component-macro/src/component.rs
+++ b/crates/component-macro/src/component.rs
@@ -631,7 +631,7 @@ impl Expander for LiftExpander {
                 quote!(u32),
             ),
         };
-        let discrim_limit = proc_macro2::Literal::usize_unsuffixed(cases.len());
+        let discrim_limit = proc_macro2::Literal::u32_suffixed(cases.len().try_into().unwrap());
 
         let extract_ty = quote! {
             let ty = match ty {
@@ -667,7 +667,7 @@ impl Expander for LiftExpander {
                     let align = <Self as #wt::component::ComponentType>::ALIGN32;
                     debug_assert!((bytes.as_ptr() as usize) % (align as usize) == 0);
                     let discrim = #from_bytes;
-                    if discrim >= #discrim_limit {
+                    if u32::from(discrim) >= #discrim_limit {
                         #internal::anyhow::bail!("unexpected discriminant: {discrim}");
                     }
                     Ok(unsafe {


### PR DESCRIPTION
This commit fixes a longstanding bug in the implementation of `#[derive(Lift)]` which was found by the component_api fuzzer recently. Specifically when an enum or variant had exactly 256 cases the comparison of the discriminant for being out-of-bounds was done in the n-bit space of the discriminant rather than a bit-space that can hold the entire discriminant. The fix here is to compare with a `u32` instead of a `u8` to ensure that if there are 256 variants it actually compares against 256 instead of 0 by accident.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
