### PR TITLE
Fix more broken links

### DIFF
--- a/docs/examples-profiling-vtune.md
+++ b/docs/examples-profiling-vtune.md
@@ -1,6 +1,6 @@
 # Using `VTune`
 
-[VTune][help] is a popular performance profiling tool that targets both 32-bit
+[VTune][main] is a popular performance profiling tool that targets both 32-bit
 and 64-bit x86 architectures. The tool collects profiling data during runtime
 and then, either through the command line or GUI, provides a variety of options
 for viewing and analyzing that data. VTune Profiler is available in both
@@ -20,9 +20,9 @@ the [`ittapi-rs`] crate.
 For more information on VTune and the analysis tools it provides see its
 [documentation].
 
-[help]: https://software.intel.com/en-us/vtune-help
-[download]: https://software.intel.com/en-us/vtune/choose-download#standalone
-[documentation]: https://software.intel.com/en-us/vtune-help
+[main]: https://www.intel.com/content/www/us/en/developer/tools/oneapi/vtune-profiler.html
+[download]: https://www.intel.com/content/www/us/en/docs/vtune-profiler/installation-guide/current/overview.html
+[documentation]: https://www.intel.com/content/www/us/en/docs/vtune-profiler/user-guide/current/overview.html
 [`ittapi`]: https://github.com/intel/ittapi
 [`ittapi-rs`]: https://crates.io/crates/ittapi-rs
 

--- a/docs/stability-tiers.md
+++ b/docs/stability-tiers.md
@@ -92,7 +92,7 @@ For explanations of what each tier means see below.
 [`memory64`]: https://github.com/WebAssembly/memory64/blob/master/proposals/memory64/Overview.md
 [`custom-page-sizes`]: https://github.com/WebAssembly/custom-page-sizes
 [`multi-memory`]: https://github.com/WebAssembly/multi-memory/blob/master/proposals/multi-memory/Overview.md
-[`threads`]: https://github.com/WebAssembly/threads/blob/main-legacy/proposals/threads/Overview.md
+[`threads`]: https://github.com/WebAssembly/threads
 [`component-model`]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/Explainer.md
 [`relaxed-simd`]: https://github.com/WebAssembly/relaxed-simd/blob/main/proposals/relaxed-simd/Overview.md
 [`function-references`]: https://github.com/WebAssembly/function-references/blob/main/proposals/function-references/Overview.md

--- a/docs/stability-wasm-proposals.md
+++ b/docs/stability-wasm-proposals.md
@@ -117,7 +117,7 @@ The emoji legend is:
 [`shared-everything-threads`]: https://github.com/WebAssembly/shared-everything-threads
 [`memory64`]: https://github.com/WebAssembly/memory64/blob/master/proposals/memory64/Overview.md
 [`multi-memory`]: https://github.com/WebAssembly/multi-memory/blob/master/proposals/multi-memory/Overview.md
-[`threads`]: https://github.com/WebAssembly/threads/blob/master/proposals/threads/Overview.md
+[`threads`]: https://github.com/WebAssembly/threads
 [`component-model`]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/Explainer.md
 [`relaxed-simd`]: https://github.com/WebAssembly/relaxed-simd/blob/main/proposals/relaxed-simd/Overview.md
 [`function-references`]: https://github.com/WebAssembly/function-references/blob/main/proposals/function-references/Overview.md


### PR DESCRIPTION
This is a follow-up to #12125 to fix links for documentation I had helped add.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
