### PR TITLE
wasi:http: Restrict valid set of HTTP response codes to 100-599

### DIFF
--- a/crates/wasi-http/src/p3/host/types.rs
+++ b/crates/wasi-http/src/p3/host/types.rs
@@ -679,11 +679,13 @@ impl HostResponse for WasiHttpCtxView<'_> {
         status_code: StatusCode,
     ) -> wasmtime::Result<Result<(), ()>> {
         let res = get_response_mut(self.table, &res)?;
-        let Ok(status) = http::StatusCode::from_u16(status_code) else {
-            return Ok(Err(()));
-        };
-        res.status = status;
-        Ok(Ok(()))
+        match http::StatusCode::from_u16(status_code) {
+            Ok(status) if matches!(status_code, 100..=599) => {
+                res.status = status;
+                Ok(Ok(()))
+            }
+            _ => Ok(Err(())),
+        }
     }
 
     fn get_headers(&mut self, res: Resource<Response>) -> wasmtime::Result<Resource<Headers>> {

--- a/tests/wasi.rs
+++ b/tests/wasi.rs
@@ -16,7 +16,6 @@ use wit_component::ComponentEncoder;
 
 const KNOWN_FAILURES: &[&str] = &[
     "filesystem-hard-links",
-    "http-response",
     "filesystem-read-directory",
     // FIXME(#11524)
     "remove_directory_trailing_slashes",


### PR DESCRIPTION
For wasip3, ensure that response codes are in the RFC 9110-specified ranges.  See https://github.com/WebAssembly/WASI/issues/849.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
