### PR TITLE
Switch to `check` for fuzz targets

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -635,11 +635,11 @@ jobs:
     - run: sudo apt-get update && sudo apt install -y ocaml-nox ocamlbuild ocaml-findlib libzarith-ocaml-dev
     - run: cargo fetch
       working-directory: ./fuzz
-    - run: cargo fuzz build --dev
-    - run: cargo fuzz build --dev --fuzz-dir ./cranelift/isle/fuzz
-    - run: cargo fuzz build --dev --fuzz-dir ./crates/environ/fuzz --features component-model
-    - run: cargo fuzz build --dev --fuzz-dir ./cranelift/assembler-x64/fuzz
-    - run: cargo fuzz build --dev --fuzz-dir ./crates/wizer/fuzz
+    - run: cargo fuzz check --dev
+    - run: cargo fuzz check --dev --fuzz-dir ./cranelift/isle/fuzz
+    - run: cargo fuzz check --dev --fuzz-dir ./crates/environ/fuzz --features component-model
+    - run: cargo fuzz check --dev --fuzz-dir ./cranelift/assembler-x64/fuzz
+    - run: cargo fuzz check --dev --fuzz-dir ./crates/wizer/fuzz
 
   # Perform all tests of the c-api
   test_capi:


### PR DESCRIPTION
We seem to be exceeding the available disk space limit on github actions so try to cut down on disk space usage. Locally this drops from ~20G usage to ~6G so hopefully that's enough headroom for now...

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
