### PR TITLE
Fix ISLE optimization for vector inputs

### DIFF
--- a/cranelift/codegen/src/opts/selects.isle
+++ b/cranelift/codegen/src/opts/selects.isle
@@ -103,14 +103,14 @@
 (rule (simplify (select ty d (select ty d x _) a)) (select ty d x a))
 
 ;; min x y < x => false and its commutative versions
-(rule (simplify (sgt ty (smin _ x y) x)) (iconst_u ty 0))
-(rule (simplify (sgt ty (smin _ x y) y)) (iconst_u ty 0))
-(rule (simplify (slt ty x (smin _ x z))) (iconst_u ty 0))
-(rule (simplify (slt ty x (smin _ y x))) (iconst_u ty 0))
-(rule (simplify (ugt ty (umin _ x y) x)) (iconst_u ty 0))
-(rule (simplify (ugt ty (umin _ x y) y)) (iconst_u ty 0))
-(rule (simplify (ult ty x (umin _ x z))) (iconst_u ty 0))
-(rule (simplify (ult ty x (umin _ y x))) (iconst_u ty 0))
+(rule (simplify (sgt (fits_in_64 ty) (smin _ x y) x)) (iconst_u ty 0))
+(rule (simplify (sgt (fits_in_64 ty) (smin _ x y) y)) (iconst_u ty 0))
+(rule (simplify (slt (fits_in_64 ty) x (smin _ x z))) (iconst_u ty 0))
+(rule (simplify (slt (fits_in_64 ty) x (smin _ y x))) (iconst_u ty 0))
+(rule (simplify (ugt (fits_in_64 ty) (umin _ x y) x)) (iconst_u ty 0))
+(rule (simplify (ugt (fits_in_64 ty) (umin _ x y) y)) (iconst_u ty 0))
+(rule (simplify (ult (fits_in_64 ty) x (umin _ x z))) (iconst_u ty 0))
+(rule (simplify (ult (fits_in_64 ty) x (umin _ y x))) (iconst_u ty 0))
 
 
 

--- a/tests/misc_testsuite/issue12170.wat
+++ b/tests/misc_testsuite/issue12170.wat
@@ -1,0 +1,13 @@
+(module
+  (func (export "hi") (result v128)
+    (local $i v128)
+    v128.const i64x2 0xfa2675c080000000 0xe8a433230a7479e5
+    local.set $i
+    local.get $i
+    local.get $i
+    local.get $i
+    i32x4.min_s
+    i32x4.lt_s
+  )
+
+)


### PR DESCRIPTION
Add some more `fits_in_64` constraints to types to handle the fact that `iconst_u` can't construct a 128-bit output.

Closes #12170

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
