### PR TITLE
Remove `--offline` from `publish.rs`

### DIFF
--- a/scripts/publish.rs
+++ b/scripts/publish.rs
@@ -176,7 +176,7 @@ fn main() {
             // update C API version in wasmtime.h
             update_capi_version();
             // update the lock file
-            run_cmd(Command::new("cargo").arg("fetch").arg("--offline"));
+            run_cmd(Command::new("cargo").arg("fetch"));
         }
 
         "publish" => {


### PR DESCRIPTION
This was added in #12164 but I don't believe that it's necessary for that operation. That may change the lock file if the crates weren't previously vendored, so this enables using the network to fetch dependencies in the lock file that aren't present locally.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
