### PR TITLE
Debug: clarify safety around ActivationBacktrace::new.

### DIFF
--- a/crates/wasmtime/src/runtime/vm/traphandlers/backtrace.rs
+++ b/crates/wasmtime/src/runtime/vm/traphandlers/backtrace.rs
@@ -514,14 +514,7 @@ impl<'a, T> StoreBacktrace<'a, T> {
     }
 
     /// Get the Store underlying this iteration.
-    ///
-    /// # Safety
-    ///
-    /// This mutable store access *must not* be used to mutate the
-    /// stack itself that this iterator is visiting by removing
-    /// frames, even though the `store` technically owns the stack in
-    /// question.
-    pub unsafe fn store_mut(&mut self) -> StoreContextMut<'_, T> {
+    pub fn store_mut(&mut self) -> StoreContextMut<'_, T> {
         match self.current.as_mut().unwrap() {
             StoreOrActivationBacktrace::Activation(activation) => {
                 StoreContextMut(activation.store.0)


### PR DESCRIPTION
As per [this discussion], we decided that we would handle potential frame-cursor invalidation unsafety (with a hypothetical future frame-editing debugger API) by putting `unsafe` on that future hypothetical API rather than on the cursor construction. With the APIs available today on the `Store`, there is no way to invalidate the frame cursor while within its lifetime-bounded scope (with lifetime tied to the `Store` that is passed into the hostcall creating the cursor), so the API today should be completely safe. This PR makes it so.

[this discussion]: https://github.com/bytecodealliance/wasmtime/pull/12176#discussion_r2636431864

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
