### PR TITLE
Debugging: add event for epoch yields.

### DIFF
--- a/crates/wasmtime/src/runtime/debug.rs
+++ b/crates/wasmtime/src/runtime/debug.rs
@@ -527,6 +527,8 @@ pub enum DebugEvent<'a> {
     Trap(Trap),
     /// A breakpoint was reached.
     Breakpoint,
+    /// An epoch yield occurred.
+    EpochYield,
 }
 
 /// A handler for debug events.

--- a/crates/wasmtime/src/runtime/vm/libcalls.rs
+++ b/crates/wasmtime/src/runtime/vm/libcalls.rs
@@ -1256,6 +1256,11 @@ fn out_of_gas(store: &mut dyn VMStore, _instance: InstanceId) -> Result<()> {
 fn new_epoch(store: &mut dyn VMStore, _instance: InstanceId) -> Result<NextEpoch> {
     use crate::UpdateDeadline;
 
+    #[cfg(feature = "debug")]
+    {
+        store.block_on_debug_handler(crate::DebugEvent::EpochYield)?;
+    }
+
     let update_deadline = store.new_epoch_updated_deadline()?;
     block_on!(store, async move |store| {
         let delta = match update_deadline {


### PR DESCRIPTION
This will almost certainly be needed to implement "Ctrl-C" behavior for a gdbstub server or other user-facing debugger top-half, so the user can interrupt the debuggee and return control to the debugger.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
