### PR TITLE
Add a few `From`, `Deref`, and `AsRef` impls for `wasmtime_internal_error::Error`

### DIFF
--- a/crates/error/tests/tests.rs
+++ b/crates/error/tests/tests.rs
@@ -201,6 +201,14 @@ fn is() {
 }
 
 #[test]
+fn is_for_root_cause_with_initial_error_source() {
+    let error = std::fmt::Error;
+    let error = ChainError::new("whoops", Some(Box::new(error)));
+    let error = Error::new(error);
+    assert!(error.root_cause().is::<std::fmt::Error>());
+}
+
+#[test]
 #[cfg(feature = "backtrace")]
 fn backtrace() {
     // Backtrace on OOM.


### PR DESCRIPTION
This matches `anyhow::Error` and makes migrating existing code easier. Found while migrating existing code.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
