### PR TITLE
`wasmtime-cranelift`: Use `wasmtime_environ::error` instead of `anyhow`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4811,7 +4811,6 @@ version = "41.0.0"
 name = "wasmtime-internal-cranelift"
 version = "41.0.0"
 dependencies = [
- "anyhow",
  "cfg-if",
  "cranelift-codegen",
  "cranelift-control",

--- a/crates/cranelift/Cargo.toml
+++ b/crates/cranelift/Cargo.toml
@@ -15,7 +15,6 @@ rust-version.workspace = true
 workspace = true
 
 [dependencies]
-anyhow = { workspace = true }
 log = { workspace = true }
 wasmtime-environ = { workspace = true, features = ['compile'] }
 cranelift-codegen = { workspace = true, features = ["host-arch", "timing"] }

--- a/crates/cranelift/src/builder.rs
+++ b/crates/cranelift/src/builder.rs
@@ -4,7 +4,6 @@
 //! well as providing a function to return the default configuration to build.
 
 use crate::isa_builder::IsaBuilder;
-use anyhow::Result;
 use cranelift_codegen::{
     CodegenResult,
     isa::{self, OwnedTargetIsa},
@@ -13,6 +12,7 @@ use std::fmt;
 use std::path;
 use std::sync::Arc;
 use target_lexicon::Triple;
+use wasmtime_environ::error::Result;
 use wasmtime_environ::{CacheStore, CompilerBuilder, Setting, Tunables};
 
 struct Builder {

--- a/crates/cranelift/src/compiler.rs
+++ b/crates/cranelift/src/compiler.rs
@@ -4,7 +4,6 @@ use crate::func_environ::FuncEnvironment;
 use crate::translate::FuncTranslator;
 use crate::{BuiltinFunctionSignatures, builder::LinkOptions, wasm_call_signature};
 use crate::{CompiledFunction, ModuleTextBuilder, array_call_signature};
-use anyhow::{Context as _, Result};
 use cranelift_codegen::binemit::CodeOffset;
 use cranelift_codegen::inline::InlineCommand;
 use cranelift_codegen::ir::condcodes::IntCC;
@@ -32,6 +31,7 @@ use std::ops::Range;
 use std::path;
 use std::sync::{Arc, Mutex};
 use wasmparser::{FuncValidatorAllocations, FunctionBody};
+use wasmtime_environ::error::{Context as _, Result};
 use wasmtime_environ::obj::{ELF_WASMTIME_EXCEPTIONS, ELF_WASMTIME_FRAMES};
 use wasmtime_environ::{
     Abi, AddressMapSection, BuiltinFunctionIndex, CacheStore, CompileError, CompiledFunctionBody,
@@ -1579,7 +1579,7 @@ fn clif_to_env_exception_tables<'a>(
     builder: &mut ExceptionTableBuilder,
     range: Range<u64>,
     call_sites: impl Iterator<Item = FinalizedMachCallSite<'a>>,
-) -> anyhow::Result<()> {
+) -> wasmtime_environ::error::Result<()> {
     builder.add_func(CodeOffset::try_from(range.start).unwrap(), call_sites)
 }
 
@@ -1591,7 +1591,7 @@ fn clif_to_env_frame_tables<'a>(
     tag_sites: impl Iterator<Item = MachBufferDebugTagList<'a>>,
     frame_layout: &MachBufferFrameLayout,
     frame_descriptors: &HashMap<FuncKey, Vec<u8>>,
-) -> anyhow::Result<()> {
+) -> wasmtime_environ::error::Result<()> {
     let mut frame_descriptor_indices = HashMap::new();
     for tag_site in tag_sites {
         // Split into frames; each has three debug tags.
@@ -1647,7 +1647,7 @@ fn clif_to_env_breakpoints(
     range: Range<u64>,
     breakpoint_patches: impl Iterator<Item = (u32, Range<u32>)>,
     patch_table: &mut Vec<(u32, Range<u32>)>,
-) -> anyhow::Result<()> {
+) -> wasmtime_environ::error::Result<()> {
     patch_table.extend(breakpoint_patches.map(|(wasm_pc, offset_range)| {
         let start = offset_range.start + u32::try_from(range.start).unwrap();
         let end = offset_range.end + u32::try_from(range.start).unwrap();

--- a/crates/cranelift/src/compiler/component.rs
+++ b/crates/cranelift/src/compiler/component.rs
@@ -1,11 +1,11 @@
 //! Compilation support for the component model.
 
 use crate::{TRAP_ALWAYS, TRAP_CANNOT_ENTER, TRAP_INTERNAL_ASSERT, compiler::Compiler};
-use anyhow::{Result, bail};
 use cranelift_codegen::ir::condcodes::IntCC;
 use cranelift_codegen::ir::{self, InstBuilder, MemFlags, Value};
 use cranelift_codegen::isa::{CallConv, TargetIsa};
 use cranelift_frontend::FunctionBuilder;
+use wasmtime_environ::error::{Result, bail};
 use wasmtime_environ::{
     Abi, CompiledFunctionBody, EntityRef, FuncKey, HostCall, PtrSize, TrapSentinel, Tunables,
     WasmFuncType, WasmValType, component::*, fact::PREPARE_CALL_FIXED_PARAMS,

--- a/crates/cranelift/src/debug/transform/attr.rs
+++ b/crates/cranelift/src/debug/transform/attr.rs
@@ -7,11 +7,11 @@ use super::range_info_builder::RangeInfoBuilder;
 use super::refs::{PendingDebugInfoRefs, PendingUnitRefs};
 use super::unit::InheritedAttr;
 use super::{TransformError, dbi_log};
-use anyhow::{Error, bail};
 use cranelift_codegen::isa::TargetIsa;
 use gimli::{
     AttributeValue, DebugLineOffset, DebuggingInformationEntry, UnitOffset, UnitRef, write,
 };
+use wasmtime_environ::error::{Error, bail};
 
 #[derive(Debug)]
 pub(crate) enum EntryAttributesContext<'a> {

--- a/crates/cranelift/src/debug/transform/expression.rs
+++ b/crates/cranelift/src/debug/transform/expression.rs
@@ -5,7 +5,6 @@ use crate::debug::transform::debug_transform_logging::{
     dbi_log_enabled, log_get_value_loc, log_get_value_name, log_get_value_ranges,
 };
 use crate::translate::get_vmctx_value_label;
-use anyhow::{Context, Error, Result};
 use core::fmt;
 use cranelift_codegen::LabelValueLoc;
 use cranelift_codegen::ValueLabelsRanges;
@@ -17,6 +16,7 @@ use std::cmp::PartialEq;
 use std::collections::{HashMap, HashSet};
 use std::hash::{Hash, Hasher};
 use std::rc::Rc;
+use wasmtime_environ::error::{Context, Error, Result};
 
 #[derive(Debug)]
 pub struct FunctionFrameInfo<'a> {

--- a/crates/cranelift/src/debug/transform/line_program.rs
+++ b/crates/cranelift/src/debug/transform/line_program.rs
@@ -1,9 +1,9 @@
 use super::TransformError;
 use super::address_transform::AddressTransform;
 use crate::debug::Reader;
-use anyhow::{Error, bail};
 use gimli::{DebugLineOffset, LineEncoding, UnitRef, write};
 use wasmtime_environ::DefinedFuncIndex;
+use wasmtime_environ::error::{Error, bail};
 
 #[derive(Debug)]
 enum SavedLineProgramRow {

--- a/crates/cranelift/src/debug/transform/mod.rs
+++ b/crates/cranelift/src/debug/transform/mod.rs
@@ -4,12 +4,12 @@ use self::simulate::generate_simulated_dwarf;
 use self::unit::clone_unit;
 use crate::debug::gc::build_dependencies;
 use crate::debug::{Compilation, Reader};
-use anyhow::Error;
 use cranelift_codegen::isa::TargetIsa;
 use gimli::{Dwarf, DwarfPackage, LittleEndian, Section, Unit, UnitRef, UnitSectionOffset, write};
 use std::{collections::HashSet, fmt::Debug};
 use synthetic::ModuleSyntheticUnit;
 use thiserror::Error;
+use wasmtime_environ::error::Error;
 use wasmtime_environ::{
     DefinedFuncIndex, ModuleTranslation, PrimaryMap, StaticModuleIndex, Tunables,
 };
@@ -54,11 +54,11 @@ pub(crate) struct DebugInputContext<'a> {
 fn load_dwp<'data>(
     translation: ModuleTranslation<'data>,
     buffer: &'data [u8],
-) -> anyhow::Result<DwarfPackage<gimli::EndianSlice<'data, gimli::LittleEndian>>> {
+) -> wasmtime_environ::error::Result<DwarfPackage<gimli::EndianSlice<'data, gimli::LittleEndian>>> {
     let endian_slice = gimli::EndianSlice::new(buffer, LittleEndian);
 
     let dwarf_package = DwarfPackage::load(
-        |id| -> anyhow::Result<_> {
+        |id| -> wasmtime_environ::error::Result<_> {
             let slice = match id {
                 gimli::SectionId::DebugAbbrev => {
                     translation.debuginfo.dwarf.debug_abbrev.reader().slice()

--- a/crates/cranelift/src/debug/transform/range_info_builder.rs
+++ b/crates/cranelift/src/debug/transform/range_info_builder.rs
@@ -1,8 +1,8 @@
 use super::address_transform::AddressTransform;
 use crate::debug::Reader;
-use anyhow::Error;
 use gimli::{AttributeValue, DebuggingInformationEntry, RangeListsOffset, UnitRef, write};
 use wasmtime_environ::DefinedFuncIndex;
+use wasmtime_environ::error::Error;
 
 pub(crate) enum RangeInfoBuilder {
     Undefined,

--- a/crates/cranelift/src/debug/transform/simulate.rs
+++ b/crates/cranelift/src/debug/transform/simulate.rs
@@ -3,13 +3,13 @@ use super::expression::{CompiledExpression, FunctionFrameInfo};
 use super::utils::append_vmctx_info;
 use crate::debug::Compilation;
 use crate::translate::get_vmctx_value_label;
-use anyhow::{Context, Error};
 use cranelift_codegen::isa::TargetIsa;
 use gimli::LineEncoding;
 use gimli::write;
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicUsize, Ordering::SeqCst};
+use wasmtime_environ::error::{Context, Error};
 use wasmtime_environ::{
     DebugInfoData, EntityRef, FunctionMetadata, PrimaryMap, StaticModuleIndex, WasmFileInfo,
     WasmValType,

--- a/crates/cranelift/src/debug/transform/unit.rs
+++ b/crates/cranelift/src/debug/transform/unit.rs
@@ -12,13 +12,13 @@ use super::refs::{PendingDebugInfoRefs, PendingUnitRefs, UnitRefsMap};
 use super::synthetic::ModuleSyntheticUnit;
 use super::utils::{append_vmctx_info, resolve_die_ref};
 use crate::debug::{Compilation, Reader};
-use anyhow::{Context, Error};
 use cranelift_codegen::ir::Endianness;
 use cranelift_codegen::isa::TargetIsa;
 use gimli::write;
 use gimli::{AttributeValue, DebuggingInformationEntry, UnitRef};
 use std::collections::HashSet;
 use wasmtime_environ::StaticModuleIndex;
+use wasmtime_environ::error::{Context, Error};
 use wasmtime_versioned_export_macros::versioned_stringify_ident;
 
 #[derive(Debug)]

--- a/crates/cranelift/src/debug/transform/utils.rs
+++ b/crates/cranelift/src/debug/transform/utils.rs
@@ -2,9 +2,9 @@ use crate::debug::Reader;
 
 use super::address_transform::AddressTransform;
 use super::expression::{CompiledExpression, FunctionFrameInfo};
-use anyhow::Error;
 use cranelift_codegen::isa::TargetIsa;
 use gimli::{AttributeValue, DebuggingInformationEntry, UnitRef, write};
+use wasmtime_environ::error::Error;
 
 pub(crate) fn append_vmctx_info(
     comp_unit: &mut write::Unit,

--- a/crates/cranelift/src/debug/write_debuginfo.rs
+++ b/crates/cranelift/src/debug/write_debuginfo.rs
@@ -32,7 +32,7 @@ fn emit_dwarf_sections(
     isa: &dyn TargetIsa,
     mut dwarf: Dwarf,
     frames: Option<FrameTable>,
-) -> anyhow::Result<Vec<DwarfSection>> {
+) -> wasmtime_environ::error::Result<Vec<DwarfSection>> {
     let endian = match isa.endianness() {
         Endianness::Little => RunTimeEndian::Little,
         Endianness::Big => RunTimeEndian::Big,
@@ -48,7 +48,7 @@ fn emit_dwarf_sections(
     }
 
     let mut result = Vec::new();
-    sections.for_each_mut(|id, s| -> anyhow::Result<()> {
+    sections.for_each_mut(|id, s| -> wasmtime_environ::error::Result<()> {
         let name = id.name();
         let body = s.writer.take();
         if body.is_empty() {
@@ -165,7 +165,7 @@ fn create_frame_table(
 pub fn emit_dwarf(
     isa: &dyn TargetIsa,
     compilation: &mut Compilation<'_>,
-) -> anyhow::Result<Vec<DwarfSection>> {
+) -> wasmtime_environ::error::Result<Vec<DwarfSection>> {
     let dwarf = transform_dwarf(isa, compilation)?;
     let frame_table = create_frame_table(isa, compilation);
     let sections = emit_dwarf_sections(isa, dwarf, frame_table)?;

--- a/crates/cranelift/src/isa_builder.rs
+++ b/crates/cranelift/src/isa_builder.rs
@@ -1,7 +1,7 @@
-use anyhow::Result;
 use cranelift_codegen::isa::IsaBuilder as Builder;
 use cranelift_codegen::settings::{self, Configurable, Flags, SetError};
 use target_lexicon::Triple;
+use wasmtime_environ::error::Result;
 use wasmtime_environ::{Setting, SettingKind};
 
 /// A helper to build an Isa for a compiler implementation.

--- a/crates/cranelift/src/obj.rs
+++ b/crates/cranelift/src/obj.rs
@@ -14,7 +14,6 @@
 //! names have format "_trampoline_N", where N is `SignatureIndex`.
 
 use crate::CompiledFunction;
-use anyhow::Result;
 use cranelift_codegen::TextSectionBuilder;
 use cranelift_codegen::isa::unwind::{UnwindInfo, systemv};
 use cranelift_control::ControlPlane;
@@ -23,6 +22,7 @@ use gimli::write::{Address, EhFrame, EndianVec, FrameTable, Writer};
 use object::write::{Object, SectionId, StandardSegment, Symbol, SymbolId, SymbolSection};
 use object::{Architecture, SectionFlags, SectionKind, SymbolFlags, SymbolKind, SymbolScope};
 use std::ops::Range;
+use wasmtime_environ::error::Result;
 use wasmtime_environ::{Compiler, TripleExt};
 use wasmtime_environ::{FuncKey, obj};
 


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
