### PR TITLE
wasmtime-winch: Use `wasmtime_environ::error` instead of `anyhow`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4924,7 +4924,6 @@ dependencies = [
 name = "wasmtime-internal-winch"
 version = "41.0.0"
 dependencies = [
- "anyhow",
  "cranelift-codegen",
  "gimli 0.32.3",
  "log",

--- a/crates/winch/Cargo.toml
+++ b/crates/winch/Cargo.toml
@@ -15,7 +15,6 @@ workspace = true
 winch-codegen = { workspace = true }
 target-lexicon = { workspace = true }
 wasmtime-environ = { workspace = true }
-anyhow = { workspace = true }
 object = { workspace = true, features = ['std'] }
 cranelift-codegen = { workspace = true }
 wasmtime-cranelift = { workspace = true }

--- a/crates/winch/src/builder.rs
+++ b/crates/winch/src/builder.rs
@@ -1,8 +1,8 @@
 use crate::compiler::Compiler;
-use anyhow::{Result, bail};
 use std::sync::Arc;
 use target_lexicon::Triple;
 use wasmtime_cranelift::isa_builder::IsaBuilder;
+use wasmtime_environ::error::{Result, bail};
 use wasmtime_environ::{CompilerBuilder, Setting, Tunables};
 use winch_codegen::{TargetIsa, isa};
 

--- a/crates/winch/src/compiler.rs
+++ b/crates/winch/src/compiler.rs
@@ -1,4 +1,3 @@
-use anyhow::Result;
 use cranelift_codegen::isa::unwind::UnwindInfoKind;
 use object::write::{Object, SymbolId};
 use std::any::Any;
@@ -8,6 +7,7 @@ use wasmparser::FuncValidatorAllocations;
 use wasmtime_cranelift::CompiledFunction;
 #[cfg(feature = "component-model")]
 use wasmtime_environ::component::ComponentTranslation;
+use wasmtime_environ::error::Result;
 use wasmtime_environ::{
     CompileError, CompiledFunctionBody, DefinedFuncIndex, FuncKey, FunctionBodyData, FunctionLoc,
     ModuleTranslation, ModuleTypesBuilder, PrimaryMap, StaticModuleIndex, Tunables, VMOffsets,


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
