### PR TITLE
wasmtime-unwinder: Use `wasmtime_environ::error` instead of `anyhow`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4904,11 +4904,11 @@ version = "41.0.0"
 name = "wasmtime-internal-unwinder"
 version = "41.0.0"
 dependencies = [
- "anyhow",
  "cfg-if",
  "cranelift-codegen",
  "log",
  "object 0.37.3",
+ "wasmtime-environ",
 ]
 
 [[package]]

--- a/crates/unwinder/Cargo.toml
+++ b/crates/unwinder/Cargo.toml
@@ -20,7 +20,7 @@ cranelift-codegen = { workspace = true, optional = true }
 log = { workspace = true }
 cfg-if = { workspace = true }
 object = { workspace = true }
-anyhow = { workspace = true }
+wasmtime-environ = { workspace = true }
 
 [features]
 default = []

--- a/crates/unwinder/src/exception_table.rs
+++ b/crates/unwinder/src/exception_table.rs
@@ -127,7 +127,7 @@ impl ExceptionTableBuilder {
         &mut self,
         start_offset: CodeOffset,
         call_sites: impl Iterator<Item = FinalizedMachCallSite<'a>>,
-    ) -> anyhow::Result<()> {
+    ) -> wasmtime_environ::error::Result<()> {
         // Ensure that we see functions in offset order.
         assert!(start_offset >= self.last_start_offset);
         self.last_start_offset = start_offset;
@@ -252,36 +252,37 @@ pub struct ExceptionHandler {
 impl<'a> ExceptionTable<'a> {
     /// Parse exception tables from a byte-slice as produced by
     /// [`ExceptionTableBuilder::serialize`].
-    pub fn parse(data: &'a [u8]) -> anyhow::Result<ExceptionTable<'a>> {
+    pub fn parse(data: &'a [u8]) -> wasmtime_environ::error::Result<ExceptionTable<'a>> {
         let mut data = Bytes(data);
-        let callsite_count = data
-            .read::<U32Bytes<LittleEndian>>()
-            .map_err(|_| anyhow::anyhow!("Unable to read callsite count prefix"))?;
+        let callsite_count = data.read::<U32Bytes<LittleEndian>>().map_err(|_| {
+            wasmtime_environ::error::anyhow!("Unable to read callsite count prefix")
+        })?;
         let callsite_count = usize::try_from(callsite_count.get(LittleEndian))?;
         let handler_count = data
             .read::<U32Bytes<LittleEndian>>()
-            .map_err(|_| anyhow::anyhow!("Unable to read handler count prefix"))?;
+            .map_err(|_| wasmtime_environ::error::anyhow!("Unable to read handler count prefix"))?;
         let handler_count = usize::try_from(handler_count.get(LittleEndian))?;
         let (callsites, data) =
             object::slice_from_bytes::<U32Bytes<LittleEndian>>(data.0, callsite_count)
-                .map_err(|_| anyhow::anyhow!("Unable to read callsites slice"))?;
+                .map_err(|_| wasmtime_environ::error::anyhow!("Unable to read callsites slice"))?;
         let (frame_offsets, data) =
-            object::slice_from_bytes::<U32Bytes<LittleEndian>>(data, callsite_count)
-                .map_err(|_| anyhow::anyhow!("Unable to read frame_offsets slice"))?;
+            object::slice_from_bytes::<U32Bytes<LittleEndian>>(data, callsite_count).map_err(
+                |_| wasmtime_environ::error::anyhow!("Unable to read frame_offsets slice"),
+            )?;
         let (ranges, data) =
             object::slice_from_bytes::<U32Bytes<LittleEndian>>(data, callsite_count)
-                .map_err(|_| anyhow::anyhow!("Unable to read ranges slice"))?;
+                .map_err(|_| wasmtime_environ::error::anyhow!("Unable to read ranges slice"))?;
         let (tags, data) = object::slice_from_bytes::<U32Bytes<LittleEndian>>(data, handler_count)
-            .map_err(|_| anyhow::anyhow!("Unable to read tags slice"))?;
+            .map_err(|_| wasmtime_environ::error::anyhow!("Unable to read tags slice"))?;
         let (contexts, data) =
             object::slice_from_bytes::<U32Bytes<LittleEndian>>(data, handler_count)
-                .map_err(|_| anyhow::anyhow!("Unable to read contexts slice"))?;
+                .map_err(|_| wasmtime_environ::error::anyhow!("Unable to read contexts slice"))?;
         let (handlers, data) =
             object::slice_from_bytes::<U32Bytes<LittleEndian>>(data, handler_count)
-                .map_err(|_| anyhow::anyhow!("Unable to read handlers slice"))?;
+                .map_err(|_| wasmtime_environ::error::anyhow!("Unable to read handlers slice"))?;
 
         if !data.is_empty() {
-            anyhow::bail!("Unexpected data at end of serialized exception table");
+            wasmtime_environ::error::bail!("Unexpected data at end of serialized exception table");
         }
 
         Ok(ExceptionTable {


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
