### PR TITLE
wasmtime-cache: use `wasmtime_environ::Error` instead of `anyhow`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4766,7 +4766,6 @@ dependencies = [
 name = "wasmtime-internal-cache"
 version = "41.0.0"
 dependencies = [
- "anyhow",
  "base64",
  "directories-next",
  "env_logger 0.11.5",
@@ -4779,6 +4778,7 @@ dependencies = [
  "sha2",
  "tempfile",
  "toml",
+ "wasmtime-environ",
  "windows-sys 0.61.2",
  "zstd 0.13.0",
 ]

--- a/crates/cache/Cargo.toml
+++ b/crates/cache/Cargo.toml
@@ -13,7 +13,6 @@ rust-version.workspace = true
 workspace = true
 
 [dependencies]
-anyhow = { workspace = true, features = ['std'] }
 base64 = { workspace = true }
 postcard = { workspace = true }
 directories-next = "2.0"
@@ -23,6 +22,7 @@ serde_derive = { workspace = true }
 sha2 = "0.10.2"
 toml = { workspace = true }
 zstd = { version = "0.13.0", default-features = false }
+wasmtime-environ = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dependencies.windows-sys]
 workspace = true

--- a/crates/cache/src/config.rs
+++ b/crates/cache/src/config.rs
@@ -1,6 +1,5 @@
 //! Module for configuring the cache system.
 
-use anyhow::{Context, Result, anyhow, bail};
 use directories_next::ProjectDirs;
 use log::{trace, warn};
 use serde::{
@@ -11,6 +10,7 @@ use std::fmt::Debug;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
+use wasmtime_environ::error::{Context, Result, anyhow, bail};
 
 // wrapped, so we have named section in config,
 // also, for possible future compatibility

--- a/crates/cache/src/lib.rs
+++ b/crates/cache/src/lib.rs
@@ -5,7 +5,6 @@
 //! > Wasmtime repository to start a discussion about doing so, but otherwise
 //! > be aware that your usage of this crate is not supported.
 
-use anyhow::Result;
 use base64::Engine;
 use log::{debug, trace, warn};
 use serde::{Deserialize, Serialize};
@@ -18,6 +17,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering::SeqCst};
 use std::time::Duration;
 use std::{fs, io};
+use wasmtime_environ::error::Result;
 
 #[macro_use] // for tests
 mod config;


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
