### PR TITLE
Additional matching

### DIFF
--- a/crates/wasmtime/src/runtime/types.rs
+++ b/crates/wasmtime/src/runtime/types.rs
@@ -3041,6 +3041,19 @@ impl GlobalType {
             _ => false,
         }
     }
+
+    /// Is global type `a` precisely equal to global type `b`?
+    ///
+    /// Returns `false` even if `a` is a subtype of `b` or vice versa, if they
+    /// are not exactly the same global type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if either type is associated with a different engine from the
+    /// other.
+    pub fn eq(a: &GlobalType, b: &GlobalType) -> bool {
+        ValType::eq(&a.content, &b.content) && a.mutability == b.mutability
+    }
 }
 
 // Tag Types
@@ -3092,6 +3105,19 @@ impl TagType {
     /// other.
     pub fn matches(&self, other: &TagType) -> bool {
         self.ty.matches(&other.ty) && other.ty.matches(&self.ty)
+    }
+
+    /// Is tag type `a` precisely equal to tag type `b`?
+    ///
+    /// Returns `false` even if `a` is a subtype of `b` or vice versa, if they
+    /// are not exactly the same tag type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if either type is associated with a different engine from the
+    /// other.
+    pub fn eq(a: &TagType, b: &TagType) -> bool {
+        FuncType::eq(&a.ty, &b.ty)
     }
 }
 
@@ -3223,6 +3249,21 @@ impl TableType {
             (other.minimum(), other.maximum()),
         ) && self.element.matches(other.element())
             && other.element().matches(self.element());
+    }
+
+    /// Is table type `a` precisely equal to table type `b`?
+    ///
+    /// Returns `false` even if `a` is a subtype of `b` or vice versa, if they
+    /// are not exactly the same table type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if either type is associated with a different engine from the
+    /// other.
+    pub fn eq(a: &TableType, b: &TableType) -> bool {
+        a.minimum() == b.minimum()
+            && a.maximum() == b.maximum()
+            && RefType::eq(&a.element, &b.element)
     }
 }
 
@@ -3607,6 +3648,19 @@ impl MemoryType {
             (self.minimum(), self.maximum()),
             (other.minimum(), other.maximum()),
         );
+    }
+
+    /// Is memory type `a` precisely equal to memory type `b`?
+    ///
+    /// Returns `false` even if `a` is a subtype of `b` or vice versa, if they
+    /// are not exactly the same memory type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if either type is associated with a different engine from the
+    /// other.
+    pub fn eq(a: &MemoryType, b: &MemoryType) -> bool {
+        a.maximum() == b.maximum() && a.minimum() == b.minimum()
     }
 }
 

--- a/crates/wasmtime/src/runtime/types.rs
+++ b/crates/wasmtime/src/runtime/types.rs
@@ -1529,6 +1529,53 @@ impl ExternType {
             ExternType::Tag(tag_ty) => tag_ty.default_value(store).map(Extern::Tag),
         }
     }
+
+    /// Does this extern type match the other extern type?
+    ///
+    /// That is, is this extern type a subtype of the other?
+    ///
+    /// # Panics
+    ///
+    /// Panics if either type is associated with a different engine from the
+    /// other.
+    pub fn matches(&self, other: &ExternType) -> bool {
+        match (self, other) {
+            (ExternType::Func(a), ExternType::Func(b)) => a.matches(b),
+            (ExternType::Func(_), _) => false,
+            (ExternType::Global(a), ExternType::Global(b)) => a.matches(b),
+            (ExternType::Global(_), _) => false,
+            (ExternType::Memory(a), ExternType::Memory(b)) => a.matches(b),
+            (ExternType::Memory(_), _) => false,
+            (ExternType::Tag(a), ExternType::Tag(b)) => a.matches(b),
+            (ExternType::Tag(_), _) => false,
+            (ExternType::Table(a), ExternType::Table(b)) => a.matches(b),
+            (ExternType::Table(_), _) => false,
+        }
+    }
+
+    /// Is extern type `a` precisely equal to extern type `b`?
+    ///
+    /// Returns `false` even if `a` is a subtype of `b` or vice versa, if they
+    /// are not exactly the same extern type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if either type is associated with a different engine from the
+    /// other.
+    pub fn eq(a: &ExternType, b: &ExternType) -> bool {
+        match (a, b) {
+            (ExternType::Func(a), ExternType::Func(b)) => FuncType::eq(a, b),
+            (ExternType::Func(_), _) => false,
+            (ExternType::Global(a), ExternType::Global(b)) => GlobalType::eq(a, b),
+            (ExternType::Global(_), _) => false,
+            (ExternType::Memory(a), ExternType::Memory(b)) => MemoryType::eq(a, b),
+            (ExternType::Memory(_), _) => false,
+            (ExternType::Tag(a), ExternType::Tag(b)) => TagType::eq(a, b),
+            (ExternType::Tag(_), _) => false,
+            (ExternType::Table(a), ExternType::Table(b)) => TableType::eq(a, b),
+            (ExternType::Table(_), _) => false,
+        }
+    }
 }
 
 impl From<FuncType> for ExternType {


### PR DESCRIPTION
Add Add `matches` function to all types structs

closes #12193

For the `matching` functions it follows [these specs](https://webassembly.github.io/spec/core/valid/matching.html).

Adds:
- `ExternType::matches`
- `ExternType::eq`
- `GlobalType::matches`
- `GlobalType::eq`
- `TableType::matches`
- `TableType::eq`
- `MemoryType::matches`
- `MemoryType::eq`
- `TagType::matches`
- `TagType::eq`