### PR TITLE
wasmtime-wasi-http: Replace new_incoming_request's hyper::Error to Into<ErrorCode>

### DIFF
--- a/crates/wasi-http/src/error.rs
+++ b/crates/wasi-http/src/error.rs
@@ -112,3 +112,9 @@ pub fn hyper_response_error(err: hyper::Error) -> ErrorCode {
 
     ErrorCode::HttpProtocolError
 }
+
+impl From<hyper::Error> for ErrorCode {
+    fn from(err: hyper::Error) -> Self {
+        hyper_response_error(err)
+    }
+}


### PR DESCRIPTION
Currently, `WasiHttpView::new_incoming_request` enforces that the request body's error type must be exactly `hyper::Error`. This limits flexibility for implementations that might use a custom body type with a different error type that is still compatible with WASI HTTP errors.

This PR relaxes the trait bound on `B::Error` from strict `hyper::Error` to `Into<ErrorCode>`. To support this, a `From<hyper::Error>` implementation for `ErrorCode` has been added. This allows `new_incoming_request` to accept any body whose errors can be converted into an `ErrorCode`, making the API more generic and reusable.