### PR TITLE
Translate `global.get`s of defined, immutable globals into constants

### DIFF
--- a/crates/cranelift/src/translate/environ/mod.rs
+++ b/crates/cranelift/src/translate/environ/mod.rs
@@ -3,4 +3,6 @@
 #[macro_use]
 mod spec;
 
-pub use crate::translate::environ::spec::{GlobalVariable, StructFieldsVec, TargetEnvironment};
+pub use crate::translate::environ::spec::{
+    GlobalConstValue, GlobalVariable, StructFieldsVec, TargetEnvironment,
+};

--- a/crates/cranelift/src/translate/environ/spec.rs
+++ b/crates/cranelift/src/translate/environ/spec.rs
@@ -10,11 +10,17 @@ use cranelift_codegen::ir;
 use cranelift_codegen::ir::immediates::Offset32;
 use cranelift_codegen::isa::TargetFrontendConfig;
 use smallvec::SmallVec;
-use wasmtime_environ::{Tunables, TypeConvert, WasmHeapType};
+use wasmtime_environ::{ConstExpr, ConstOp, Tunables, TypeConvert, WasmHeapType};
 
 /// The value of a WebAssembly global variable.
 #[derive(Clone, Copy)]
 pub enum GlobalVariable {
+    /// The global is known to be a constant value.
+    Constant {
+        /// The global's known value.
+        value: GlobalConstValue,
+    },
+
     /// This is a variable in memory that should be referenced through a `GlobalValue`.
     Memory {
         /// The address of the global variable storage.
@@ -27,6 +33,32 @@ pub enum GlobalVariable {
 
     /// This is a global variable that needs to be handled by the environment.
     Custom,
+}
+
+/// A global's constant value, known at compile time.
+#[derive(Clone, Copy)]
+pub enum GlobalConstValue {
+    I32(i32),
+    I64(i64),
+    F32(u32),
+    F64(u64),
+    V128(u128),
+}
+
+impl GlobalConstValue {
+    /// Attempt to evaluate the given const-expr at compile time.
+    pub fn const_eval(init: &ConstExpr) -> Option<GlobalConstValue> {
+        // TODO: Actually maintain an evaluation stack and handle `i32.add`,
+        // `i32.sub`, etc... const ops.
+        match init.ops() {
+            [ConstOp::I32Const(x)] => Some(Self::I32(*x)),
+            [ConstOp::I64Const(x)] => Some(Self::I64(*x)),
+            [ConstOp::F32Const(x)] => Some(Self::F32(*x)),
+            [ConstOp::F64Const(x)] => Some(Self::F64(*x)),
+            [ConstOp::V128Const(x)] => Some(Self::V128(*x)),
+            _ => None,
+        }
+    }
 }
 
 /// Environment affecting the translation of a WebAssembly.

--- a/crates/cranelift/src/translate/mod.rs
+++ b/crates/cranelift/src/translate/mod.rs
@@ -18,7 +18,7 @@ mod stack;
 mod table;
 mod translation_utils;
 
-pub use self::environ::{GlobalVariable, StructFieldsVec, TargetEnvironment};
+pub use self::environ::{GlobalConstValue, GlobalVariable, StructFieldsVec, TargetEnvironment};
 pub use self::func_translator::FuncTranslator;
 pub use self::heap::{Heap, HeapData};
 pub use self::stack::FuncTranslationStacks;

--- a/tests/disas/global-get.wat
+++ b/tests/disas/global-get.wat
@@ -1,0 +1,94 @@
+;;! target = "x86_64"
+
+(module
+  ;; Imported and immutable: should become a vmctx load.
+  (import "env" "a" (global $imp-imm i32))
+
+  ;; Imported and mutable: should become a vmctx load.
+  (import "env" "b" (global $imp-mut (mut i32)))
+
+  ;; Defined and immutable: should become a constant.
+  (global $def-imm i32 (i32.const 42))
+
+  ;; Defined and mutable: should become a vmctx load.
+  (global $def-mut (mut i32) (i32.const 36))
+
+  (func $f0 (result i32)
+    (global.get $imp-imm)
+  )
+
+  (func $f1 (result i32)
+    (global.get $imp-mut)
+  )
+
+  (func $f2 (result i32)
+    (global.get $def-imm)
+  )
+
+  (func $f3 (result i32)
+    (global.get $def-mut)
+  )
+)
+
+;; function u0:0(i64 vmctx, i64) -> i32 tail {
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv2 = load.i64 notrap aligned gv1+16
+;;     gv3 = vmctx
+;;     gv4 = load.i64 notrap aligned readonly can_move gv3+48
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64):
+;; @003d                               v3 = load.i64 notrap aligned readonly can_move v0+48
+;; @003d                               v4 = load.i32 notrap aligned table v3
+;; @003f                               jump block1
+;;
+;;                                 block1:
+;; @003f                               return v4
+;; }
+;;
+;; function u0:1(i64 vmctx, i64) -> i32 tail {
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv2 = load.i64 notrap aligned gv1+16
+;;     gv3 = vmctx
+;;     gv4 = load.i64 notrap aligned readonly can_move gv3+72
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64):
+;; @0042                               v3 = load.i64 notrap aligned readonly can_move v0+72
+;; @0042                               v4 = load.i32 notrap aligned table v3
+;; @0044                               jump block1
+;;
+;;                                 block1:
+;; @0044                               return v4
+;; }
+;;
+;; function u0:2(i64 vmctx, i64) -> i32 tail {
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv2 = load.i64 notrap aligned gv1+16
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64):
+;; @0047                               v3 = iconst.i32 42
+;; @0049                               jump block1
+;;
+;;                                 block1:
+;; @0049                               return v3  ; v3 = 42
+;; }
+;;
+;; function u0:3(i64 vmctx, i64) -> i32 tail {
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv2 = load.i64 notrap aligned gv1+16
+;;     gv3 = vmctx
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64):
+;; @004c                               v4 = load.i32 notrap aligned table v0+112
+;; @004e                               jump block1
+;;
+;;                                 block1:
+;; @004e                               return v4
+;; }


### PR DESCRIPTION
When a global is both defined locally within the module and immutable, we can emit a constant value, rather than a vmctx load, when translating a `global.get` of that global from Wasm to CLIF.

This provides a surprising amount of speed ups on sightglass benchmarks, including a 1.12x speed up for the new spidermonkey-json benchmark:

<details>

```
execution :: instructions-retired :: benchmarks/spidermonkey/spidermonkey-json.wasm

  Δ = 159602263.67 ± 211.65 (confidence = 99%)

  const-globals.so is 1.12x to 1.12x faster than main.so!

  [1293484118 1293484381.73 1293485153] const-globals.so
  [1453086549 1453086645.40 1453087556] main.so

execution :: instructions-retired :: benchmarks/spidermonkey/spidermonkey-regex.wasm

  Δ = 13152398.33 ± 57.47 (confidence = 99%)

  const-globals.so is 1.03x to 1.03x faster than main.so!

  [387099586 387099699.10 387099862] const-globals.so
  [400251990 400252097.43 400252306] main.so

execution :: instructions-retired :: benchmarks/spidermonkey/spidermonkey-markdown.wasm

  Δ = 15034097.07 ± 10655.88 (confidence = 99%)

  const-globals.so is 1.02x to 1.02x faster than main.so!

  [763628883 763651147.87 763678416] const-globals.so
  [778659903 778685244.93 778735782] main.so

execution :: instructions-retired :: benchmarks/hashset/benchmark.wasm

  Δ = 44391.93 ± 11.74 (confidence = 99%)

  const-globals.so is 1.00x to 1.00x faster than main.so!

  [256202796 256202806.90 256202889] const-globals.so
  [256247196 256247198.83 256247206] main.so

execution :: instructions-retired :: benchmarks/libsodium/libsodium-aead_aes256gcm.wasm

  Δ = 0.03 ± 0.00 (confidence = 99%)

  main.so is 1.00x to 1.00x faster than const-globals.so!

  [231 231.03 232] const-globals.so
  [231 231.00 231] main.so

execution :: instructions-retired :: benchmarks/libsodium/libsodium-secretbox_easy.wasm

  Δ = 5.10 ± 0.00 (confidence = 99%)

  const-globals.so is 1.00x to 1.00x faster than main.so!

  [142584 142584.00 142584] const-globals.so
  [142584 142589.10 142736] main.so

execution :: instructions-retired :: benchmarks/libsodium/libsodium-core4.wasm

  Δ = 0.03 ± 0.00 (confidence = 99%)

  const-globals.so is 1.00x to 1.00x faster than main.so!

  [1712 1712.00 1712] const-globals.so
  [1712 1712.03 1713] main.so

execution :: instructions-retired :: benchmarks/libsodium/libsodium-aead_xchacha20poly1305.wasm

  Δ = 14.03 ± 5.04 (confidence = 99%)

  main.so is 1.00x to 1.00x faster than const-globals.so!

  [1749396 1749410.20 1749418] const-globals.so
  [1749396 1749396.17 1749397] main.so

execution :: instructions-retired :: benchmarks/libsodium/libsodium-chacha20.wasm

  Δ = 20.77 ± 0.52 (confidence = 99%)

  const-globals.so is 1.00x to 1.00x faster than main.so!

  [3669797 3669797.77 3669802] const-globals.so
  [3669818 3669818.53 3669819] main.so

execution :: instructions-retired :: benchmarks/libsodium/libsodium-stream4.wasm

  Δ = 0.03 ± 0.00 (confidence = 99%)

  const-globals.so is 1.00x to 1.00x faster than main.so!

  [7704 7704.00 7704] const-globals.so
  [7704 7704.03 7705] main.so

execution :: instructions-retired :: benchmarks/libsodium/libsodium-kdf_hkdf.wasm

  Δ = 28.63 ± 20.56 (confidence = 99%)

  const-globals.so is 1.00x to 1.00x faster than main.so!

  [11832986 11832986.07 11832987] const-globals.so
  [11833007 11833014.70 11833231] main.so

execution :: instructions-retired :: benchmarks/libsodium/libsodium-kx.wasm

  Δ = 27.03 ± 8.96 (confidence = 99%)

  const-globals.so is 1.00x to 1.00x faster than main.so!

  [42174047 42174047.80 42174049] const-globals.so
  [42174071 42174074.83 42174169] main.so

execution :: instructions-retired :: benchmarks/libsodium/libsodium-box_easy.wasm

  Δ = 7.03 ± 5.85 (confidence = 99%)

  main.so is 1.00x to 1.00x faster than const-globals.so!

  [14607649 14607657.37 14607674] const-globals.so
  [14607649 14607650.33 14607656] main.so

execution :: instructions-retired :: benchmarks/libsodium/libsodium-scalarmult_ed25519.wasm

  Δ = 15.13 ± 6.00 (confidence = 99%)

  main.so is 1.00x to 1.00x faster than const-globals.so!

  [69623939 69623956.20 69623967] const-globals.so
  [69623939 69623941.07 69623948] main.so

execution :: instructions-retired :: benchmarks/shootout/shootout-memmove.wasm

  Δ = 10.27 ± 7.81 (confidence = 99%)

  main.so is 1.00x to 1.00x faster than const-globals.so!

  [127094323 127094334.60 127094359] const-globals.so
  [127094322 127094324.33 127094328] main.so

execution :: instructions-retired :: benchmarks/rust-html-rewriter/benchmark.wasm

  Δ = 1.00 ± 0.79 (confidence = 99%)

  const-globals.so is 1.00x to 1.00x faster than main.so!

  [19351722 19351723.50 19351725] const-globals.so
  [19351723 19351724.50 19351728] main.so

execution :: instructions-retired :: benchmarks/shootout/shootout-switch.wasm

  Δ = 6.10 ± 4.85 (confidence = 99%)

  main.so is 1.00x to 1.00x faster than const-globals.so!

  [162346015 162346025.03 162346043] const-globals.so
  [162346015 162346018.93 162346029] main.so

execution :: instructions-retired :: benchmarks/bz2/benchmark.wasm

  Δ = 7.00 ± 6.01 (confidence = 99%)

  main.so is 1.00x to 1.00x faster than const-globals.so!

  [221270644 221270655.00 221270687] const-globals.so
  [221270643 221270648.00 221270660] main.so

execution :: instructions-retired :: benchmarks/shootout/shootout-keccak.wasm

  Δ = 1.27 ± 1.27 (confidence = 99%)

  main.so is 1.00x to 1.00x faster than const-globals.so!

  [77020158 77020160.20 77020167] const-globals.so
  [77020158 77020158.93 77020161] main.so

execution :: instructions-retired :: benchmarks/libsodium/libsodium-sign.wasm

  Δ = 142.13 ± 116.31 (confidence = 99%)

  const-globals.so is 1.00x to 1.00x faster than main.so!

  [10962329294 10962329441.17 10962329786] const-globals.so
  [10962329386 10962329583.30 10962330163] main.so

execution :: instructions-retired :: benchmarks/libsodium/libsodium-pwhash_scrypt_ll.wasm

  Δ = 9.20 ± 7.92 (confidence = 99%)

  const-globals.so is 1.00x to 1.00x faster than main.so!

  [869339510 869339515.17 869339524] const-globals.so
  [869339511 869339524.37 869339568] main.so

execution :: instructions-retired :: benchmarks/gcc-loops/benchmark.wasm

  Δ = 784.27 ± 309.85 (confidence = 99%)

  const-globals.so is 1.00x to 1.00x faster than main.so!

  [74362830008 74362830127.20 74362830790] const-globals.so
  [74362830308 74362830911.47 74362832876] main.so

execution :: instructions-retired :: benchmarks/libsodium/libsodium-stream2.wasm

  Δ = 5.60 ± 4.20 (confidence = 99%)

  const-globals.so is 1.00x to 1.00x faster than main.so!

  [626659894 626659899.27 626659912] const-globals.so
  [626659896 626659904.87 626659922] main.so

execution :: instructions-retired :: benchmarks/libsodium/libsodium-pwhash_scrypt.wasm

  Δ = 98.67 ± 82.17 (confidence = 99%)

  main.so is 1.00x to 1.00x faster than const-globals.so!

  [13152494757 13152494926.27 13152495383] const-globals.so
  [13152494768 13152494827.60 13152495097] main.so

execution :: instructions-retired :: benchmarks/shootout/shootout-ratelimit.wasm

  Δ = 1.27 ± 0.97 (confidence = 99%)

  const-globals.so is 1.00x to 1.00x faster than main.so!

  [175149590 175149591.37 175149594] const-globals.so
  [175149590 175149592.63 175149597] main.so

execution :: instructions-retired :: benchmarks/shootout/shootout-sieve.wasm

  Δ = 11.50 ± 9.59 (confidence = 99%)

  main.so is 1.00x to 1.00x faster than const-globals.so!

  [3233944543 3233944562.03 3233944615] const-globals.so
  [3233944542 3233944550.53 3233944561] main.so

execution :: instructions-retired :: benchmarks/libsodium/libsodium-box_easy2.wasm

  No difference in performance.

  [49726677 983789516.60 2793874378] const-globals.so
  [75238587 877793884.97 1876844760] main.so

execution :: instructions-retired :: benchmarks/libsodium/libsodium-sodium_utils.wasm

  No difference in performance.

  [111905571 177945377.97 251390843] const-globals.so
  [109756498 161402407.73 241287377] main.so

execution :: instructions-retired :: benchmarks/libsodium/libsodium-secretstream.wasm

  No difference in performance.

  [692182 1151252.33 1525086] const-globals.so
  [537504 1069691.37 1567439] main.so

execution :: instructions-retired :: benchmarks/libsodium/libsodium-secretstream_xchacha20poly1305.wasm

  No difference in performance.

  [558450 1058015.77 1495400] const-globals.so
  [727777 1049762.87 1607655] main.so

execution :: instructions-retired :: benchmarks/libsodium/libsodium-secretbox_easy2.wasm

  No difference in performance.

  [820755 544888840.37 1741297134] const-globals.so
  [1905303 542356897.47 1846687120] main.so

execution :: instructions-retired :: benchmarks/libsodium/libsodium-keygen.wasm

  No difference in performance.

  [86869 87301.00 92053] const-globals.so
  [86893 86979.40 89485] main.so

execution :: instructions-retired :: benchmarks/libsodium/libsodium-aead_aegis256.wasm

  No difference in performance.

  [121347810 124839812.40 127901128] const-globals.so
  [121113415 124532015.60 127363026] main.so

execution :: instructions-retired :: benchmarks/libsodium/libsodium-metamorphic.wasm

  No difference in performance.

  [253403413 255557329.33 257742703] const-globals.so
  [253413445 255203119.77 257113695] main.so

execution :: instructions-retired :: benchmarks/libsodium/libsodium-aead_aegis128l.wasm

  No difference in performance.

  [110612323 112358979.77 115589830] const-globals.so
  [108810849 112481902.83 114989404] main.so

execution :: instructions-retired :: benchmarks/libsodium/libsodium-codecs.wasm

  No difference in performance.

  [15774967 16222629.73 16784448] const-globals.so
  [15649696 16207671.50 16630684] main.so

execution :: instructions-retired :: benchmarks/libsodium/libsodium-core_ed25519.wasm

  No difference in performance.

  [25295127465 25536548061.60 25774505815] const-globals.so
  [25289814477 25555543225.53 25805892358] main.so

execution :: instructions-retired :: benchmarks/libsodium/libsodium-box8.wasm

  No difference in performance.

  [21556149565 21577547899.83 21604361637] const-globals.so
  [21556152576 21581254223.57 21604393549] main.so

execution :: instructions-retired :: benchmarks/libsodium/libsodium-box_seal.wasm

  No difference in performance.

  [38405894 38578934.67 38754505] const-globals.so
  [38424652 38573018.57 38678020] main.so

execution :: instructions-retired :: benchmarks/libsodium/libsodium-xchacha20.wasm

  No difference in performance.

  [232771060 232857737.23 233003227] const-globals.so
  [232762254 232880229.37 232987880] main.so

execution :: instructions-retired :: benchmarks/libsodium/libsodium-secretbox8.wasm

  No difference in performance.

  [285981451 286298596.33 286720158] const-globals.so
  [286117189 286304236.33 286548876] main.so

execution :: instructions-retired :: benchmarks/libsodium/libsodium-verify1.wasm

  No difference in performance.

  [444930870 445059332.87 445183428] const-globals.so
  [444949602 445064341.57 445189685] main.so

execution :: instructions-retired :: benchmarks/rust-protobuf/benchmark.wasm

  No difference in performance.

  [15918618 15919132.77 15919797] const-globals.so
  [15918530 15919211.53 15919607] main.so

execution :: instructions-retired :: benchmarks/libsodium/libsodium-core_ristretto255.wasm

  No difference in performance.

  [28328812516 28329081203.83 28329383500] const-globals.so
  [28328818779 28329010032.83 28329246158] main.so

execution :: instructions-retired :: benchmarks/libsodium/libsodium-ed25519_convert.wasm

  No difference in performance.

  [3027360343 3027399188.03 3027448316] const-globals.so
  [3027364895 3027395456.10 3027448060] main.so

execution :: instructions-retired :: benchmarks/blind-sig/benchmark.wasm

  No difference in performance.

  [1329547322 1329671466.33 1329835926] const-globals.so
  [1329578791 1329673031.20 1329811888] main.so

execution :: instructions-retired :: benchmarks/tract-onnx-image-classification/benchmark.wasm

  No difference in performance.

  [4102103117 4102123508.43 4102160849] const-globals.so
  [4102112269 4102128322.40 4102147555] main.so

execution :: instructions-retired :: benchmarks/rust-json/benchmark.wasm

  No difference in performance.

  [38122633 38123313.27 38124114] const-globals.so
  [38122846 38123350.10 38123895] main.so

execution :: instructions-retired :: benchmarks/pulldown-cmark/benchmark.wasm

  No difference in performance.

  [20771195 20771224.40 20771488] const-globals.so
  [20771203 20771234.90 20771467] main.so

execution :: instructions-retired :: benchmarks/regex/benchmark.wasm

  No difference in performance.

  [744373531 744376020.40 744380370] const-globals.so
  [744373242 744376333.90 744383147] main.so

execution :: instructions-retired :: benchmarks/libsodium/libsodium-secretbox7.wasm

  No difference in performance.

  [88018607 88018618.40 88018832] const-globals.so
  [88018628 88018644.70 88018853] main.so

execution :: instructions-retired :: benchmarks/libsodium/libsodium-aead_chacha20poly1305.wasm

  No difference in performance.

  [1872724 1872724.67 1872728] const-globals.so
  [1872724 1872724.20 1872725] main.so

execution :: instructions-retired :: benchmarks/quicksort/benchmark.wasm

  No difference in performance.

  [92263435 92272535.97 92354350] const-globals.so
  [92263407 92272558.30 92355111] main.so

execution :: instructions-retired :: benchmarks/intgemm-simd/benchmark.wasm

  No difference in performance.

  [2782418375 2782428339.13 2782518124] const-globals.so
  [2782418701 2782428908.27 2782518087] main.so

execution :: instructions-retired :: benchmarks/libsodium/libsodium-generichash2.wasm

  No difference in performance.

  [608950 608950.03 608951] const-globals.so
  [608950 608950.13 608951] main.so

execution :: instructions-retired :: benchmarks/libsodium/libsodium-onetimeauth7.wasm

  No difference in performance.

  [89920328 89920344.63 89920554] const-globals.so
  [89920349 89920358.07 89920574] main.so

execution :: instructions-retired :: benchmarks/libsodium/libsodium-kdf.wasm

  No difference in performance.

  [376989 376989.07 376990] const-globals.so
  [376989 376989.03 376990] main.so

execution :: instructions-retired :: benchmarks/libsodium/libsodium-box_seed.wasm

  No difference in performance.

  [1145094 1145094.13 1145095] const-globals.so
  [1145094 1145094.03 1145095] main.so

execution :: instructions-retired :: benchmarks/libsodium/libsodium-scalarmult7.wasm

  No difference in performance.

  [7276772 7276772.77 7276773] const-globals.so
  [7276772 7276773.23 7276777] main.so

execution :: instructions-retired :: benchmarks/libsodium/libsodium-scalarmult2.wasm

  No difference in performance.

  [1135962 1135962.03 1135963] const-globals.so
  [1135962 1135962.10 1135963] main.so

execution :: instructions-retired :: benchmarks/libsodium/libsodium-generichash3.wasm

  No difference in performance.

  [584616 584616.07 584617] const-globals.so
  [584616 584616.03 584617] main.so

execution :: instructions-retired :: benchmarks/libsodium/libsodium-generichash.wasm

  No difference in performance.

  [9506095 9506095.87 9506098] const-globals.so
  [9506095 9506095.50 9506098] main.so

execution :: instructions-retired :: benchmarks/libsodium/libsodium-scalarmult6.wasm

  No difference in performance.

  [3639833 3639833.47 3639834] const-globals.so
  [3639833 3639833.33 3639834] main.so

execution :: instructions-retired :: benchmarks/libsodium/libsodium-scalarmult8.wasm

  No difference in performance.

  [215675203 215675228.57 215675456] const-globals.so
  [215675202 215675220.73 215675433] main.so

execution :: instructions-retired :: benchmarks/blake3-simd/benchmark.wasm

  No difference in performance.

  [1432879 1432879.10 1432880] const-globals.so
  [1432879 1432879.13 1432880] main.so

execution :: instructions-retired :: benchmarks/blake3-scalar/benchmark.wasm

  No difference in performance.

  [1481473 1481473.17 1481474] const-globals.so
  [1481473 1481473.13 1481474] main.so

execution :: instructions-retired :: benchmarks/libsodium/libsodium-scalarmult.wasm

  No difference in performance.

  [13188546 13188546.13 13188547] const-globals.so
  [13188546 13188546.40 13188548] main.so

execution :: instructions-retired :: benchmarks/shootout/shootout-xblabla20.wasm

  No difference in performance.

  [14307156 14307156.33 14307157] const-globals.so
  [14307156 14307156.57 14307159] main.so

execution :: instructions-retired :: benchmarks/shootout/shootout-xchacha20.wasm

  No difference in performance.

  [20317153 20317154.20 20317156] const-globals.so
  [20317153 20317153.90 20317155] main.so

execution :: instructions-retired :: benchmarks/libsodium/libsodium-box.wasm

  No difference in performance.

  [7308812 7308812.73 7308815] const-globals.so
  [7308812 7308812.83 7308815] main.so

execution :: instructions-retired :: benchmarks/libsodium/libsodium-box2.wasm

  No difference in performance.

  [7316174 7316174.70 7316176] const-globals.so
  [7316174 7316174.60 7316175] main.so

execution :: instructions-retired :: benchmarks/shootout/shootout-gimli.wasm

  No difference in performance.

  [32540194 32540194.50 32540196] const-globals.so
  [32540194 32540194.90 32540200] main.so

execution :: instructions-retired :: benchmarks/libsodium/libsodium-scalarmult5.wasm

  No difference in performance.

  [3639369 3639369.23 3639370] const-globals.so
  [3639369 3639369.20 3639370] main.so

execution :: instructions-retired :: benchmarks/shootout/shootout-base64.wasm

  No difference in performance.

  [1763190279 1763190305.83 1763190468] const-globals.so
  [1763190279 1763190293.73 1763190475] main.so

execution :: instructions-retired :: benchmarks/shootout/shootout-ed25519.wasm

  No difference in performance.

  [39316304089 39316304466.07 39316305704] const-globals.so
  [39316304147 39316304708.87 39316305724] main.so

execution :: instructions-retired :: benchmarks/shootout/shootout-ackermann.wasm

  No difference in performance.

  [11094470 11094470.07 11094471] const-globals.so
  [11094469 11094470.00 11094471] main.so

execution :: instructions-retired :: benchmarks/shootout/shootout-random.wasm

  No difference in performance.

  [270000313 270000319.97 270000341] const-globals.so
  [270000314 270000321.30 270000337] main.so

execution :: instructions-retired :: benchmarks/libsodium/libsodium-pwhash_argon2i.wasm

  No difference in performance.

  [3954742471 3954742529.90 3954742900] const-globals.so
  [3954742477 3954742512.30 3954742738] main.so

execution :: instructions-retired :: benchmarks/richards/benchmark.wasm

  No difference in performance.

  [12520753206 12520753328.03 12520753758] const-globals.so
  [12520753204 12520753276.90 12520753560] main.so

execution :: instructions-retired :: benchmarks/libsodium/libsodium-pwhash_argon2id.wasm

  No difference in performance.

  [4498555857 4498555884.93 4498555942] const-globals.so
  [4498555861 4498555902.53 4498556116] main.so

execution :: instructions-retired :: benchmarks/libsodium/libsodium-auth7.wasm

  No difference in performance.

  [121908087 121908089.27 121908103] const-globals.so
  [121908087 121908088.90 121908097] main.so

execution :: instructions-retired :: benchmarks/shootout/shootout-seqhash.wasm

  No difference in performance.

  [40795541579 40795541753.33 40795542512] const-globals.so
  [40795541577 40795541869.60 40795543495] main.so

execution :: instructions-retired :: benchmarks/libsodium/libsodium-scalarmult_ristretto255.wasm

  No difference in performance.

  [82348883 82348884.17 82348886] const-globals.so
  [82348883 82348883.97 82348885] main.so

execution :: instructions-retired :: benchmarks/shootout/shootout-ctype.wasm

  No difference in performance.

  [3950019268 3950019283.77 3950019338] const-globals.so
  [3950019267 3950019292.10 3950019373] main.so

execution :: instructions-retired :: benchmarks/libsodium/libsodium-core3.wasm

  No difference in performance.

  [999325951 999325957.20 999325978] const-globals.so
  [999325949 999325955.17 999325973] main.so

execution :: instructions-retired :: benchmarks/libsodium/libsodium-auth5.wasm

  No difference in performance.

  [232226482 232226483.80 232226488] const-globals.so
  [232226482 232226484.27 232226488] main.so

execution :: instructions-retired :: benchmarks/shootout/shootout-matrix.wasm

  No difference in performance.

  [2686800367 2686800377.97 2686800424] const-globals.so
  [2686800367 2686800382.53 2686800392] main.so

execution :: instructions-retired :: benchmarks/shootout/shootout-minicsv.wasm

  No difference in performance.

  [5718001502 5718001531.13 5718001584] const-globals.so
  [5718001496 5718001522.30 5718001588] main.so

execution :: instructions-retired :: benchmarks/libsodium/libsodium-stream.wasm

  No difference in performance.

  [664961855 664961865.20 664962083] const-globals.so
  [664961854 664961866.00 664961903] main.so

execution :: instructions-retired :: benchmarks/libsodium/libsodium-randombytes.wasm

  No difference in performance.

  [28199076 28199172.73 28199536] const-globals.so
  [28199076 28199172.77 28199422] main.so

execution :: instructions-retired :: benchmarks/shootout/shootout-fib2.wasm

  No difference in performance.

  [14037403282 14037403342.67 14037403651] const-globals.so
  [14037403289 14037403328.27 14037403646] main.so

execution :: instructions-retired :: benchmarks/libsodium/libsodium-box7.wasm

  No difference in performance.

  [7135571315 7135571383.27 7135571928] const-globals.so
  [7135571315 7135571389.20 7135571546] main.so

execution :: instructions-retired :: benchmarks/shootout/shootout-heapsort.wasm

  No difference in performance.

  [3217113500 3217113532.67 3217114011] const-globals.so
  [3217113502 3217113534.53 3217113600] main.so

execution :: instructions-retired :: benchmarks/meshoptimizer/benchmark.wasm

  No difference in performance.

  [13220474840 13220474933.17 13220475932] const-globals.so
  [13220474846 13220474927.97 13220475830] main.so

execution :: instructions-retired :: benchmarks/rust-compression/benchmark.wasm

  No difference in performance.

  [20784023030 20784023199.77 20784023894] const-globals.so
  [20784023002 20784023202.93 20784024056] main.so

execution :: instructions-retired :: benchmarks/hex-simd/benchmark.wasm

  No difference in performance.

  [2162941 2162941.17 2162942] const-globals.so
  [2162941 2162941.17 2162942] main.so

execution :: instructions-retired :: benchmarks/libsodium/libsodium-aead_aes256gcm2.wasm

  No difference in performance.

  [166 166.00 166] const-globals.so
  [166 166.00 166] main.so

execution :: instructions-retired :: benchmarks/libsodium/libsodium-aead_chacha20poly13052.wasm

  No difference in performance.

  [4094498 4094498.40 4094499] const-globals.so
  [4094498 4094498.40 4094499] main.so

execution :: instructions-retired :: benchmarks/libsodium/libsodium-auth.wasm

  No difference in performance.

  [458099 458099.00 458099] const-globals.so
  [458099 458099.00 458099] main.so

execution :: instructions-retired :: benchmarks/libsodium/libsodium-auth2.wasm

  No difference in performance.

  [24185 24185.00 24185] const-globals.so
  [24185 24185.00 24185] main.so

execution :: instructions-retired :: benchmarks/libsodium/libsodium-auth3.wasm

  No difference in performance.

  [48930 48930.00 48930] const-globals.so
  [48930 48930.00 48930] main.so

execution :: instructions-retired :: benchmarks/libsodium/libsodium-auth6.wasm

  No difference in performance.

  [36143 36143.00 36143] const-globals.so
  [36143 36143.00 36143] main.so

execution :: instructions-retired :: benchmarks/libsodium/libsodium-core1.wasm

  No difference in performance.

  [1145 1145.00 1145] const-globals.so
  [1145 1145.00 1145] main.so

execution :: instructions-retired :: benchmarks/libsodium/libsodium-core2.wasm

  No difference in performance.

  [1100 1100.00 1100] const-globals.so
  [1100 1100.00 1100] main.so

execution :: instructions-retired :: benchmarks/libsodium/libsodium-core5.wasm

  No difference in performance.

  [1100 1100.00 1100] const-globals.so
  [1100 1100.00 1100] main.so

execution :: instructions-retired :: benchmarks/libsodium/libsodium-core6.wasm

  No difference in performance.

  [1712 1712.00 1712] const-globals.so
  [1712 1712.00 1712] main.so

execution :: instructions-retired :: benchmarks/libsodium/libsodium-hash.wasm

  No difference in performance.

  [52679 52679.00 52679] const-globals.so
  [52679 52679.00 52679] main.so

execution :: instructions-retired :: benchmarks/libsodium/libsodium-hash3.wasm

  No difference in performance.

  [9449 9449.00 9449] const-globals.so
  [9449 9449.00 9449] main.so

execution :: instructions-retired :: benchmarks/libsodium/libsodium-misuse.wasm

  No difference in performance.

  [151 151.00 151] const-globals.so
  [151 151.00 151] main.so

execution :: instructions-retired :: benchmarks/libsodium/libsodium-onetimeauth.wasm

  No difference in performance.

  [17405 17405.00 17405] const-globals.so
  [17405 17405.00 17405] main.so

execution :: instructions-retired :: benchmarks/libsodium/libsodium-onetimeauth2.wasm

  No difference in performance.

  [151 151.00 151] const-globals.so
  [151 151.00 151] main.so

execution :: instructions-retired :: benchmarks/libsodium/libsodium-secretbox.wasm

  No difference in performance.

  [30690 30690.00 30690] const-globals.so
  [30690 30690.00 30690] main.so

execution :: instructions-retired :: benchmarks/libsodium/libsodium-secretbox2.wasm

  No difference in performance.

  [19740 19740.00 19740] const-globals.so
  [19740 19740.00 19740] main.so

execution :: instructions-retired :: benchmarks/libsodium/libsodium-shorthash.wasm

  No difference in performance.

  [20967 20967.00 20967] const-globals.so
  [20967 20967.00 20967] main.so

execution :: instructions-retired :: benchmarks/libsodium/libsodium-siphashx24.wasm

  No difference in performance.

  [24332 24332.00 24332] const-globals.so
  [24332 24332.00 24332] main.so

execution :: instructions-retired :: benchmarks/libsodium/libsodium-sodium_core.wasm

  No difference in performance.

  [474 474.00 474] const-globals.so
  [474 474.00 474] main.so

execution :: instructions-retired :: benchmarks/libsodium/libsodium-sodium_version.wasm

  No difference in performance.

  [162 162.00 162] const-globals.so
  [162 162.00 162] main.so

execution :: instructions-retired :: benchmarks/libsodium/libsodium-stream3.wasm

  No difference in performance.

  [4334 4334.00 4334] const-globals.so
  [4334 4334.00 4334] main.so

execution :: instructions-retired :: benchmarks/noop/benchmark.wasm

  No difference in performance.

  [151 151.00 151] const-globals.so
  [151 151.00 151] main.so

execution :: instructions-retired :: benchmarks/shootout/shootout-nestedloop.wasm

  No difference in performance.

  [164 164.00 164] const-globals.so
  [164 164.00 164] main.so
```

</details>

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
