### PR TITLE
Allow calling thread.yield-to in sync contexts

### DIFF
--- a/crates/wasmtime/src/runtime/component/concurrent.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent.rs
@@ -3271,6 +3271,9 @@ impl Instance {
         let reason = if yielding {
             SuspendReason::Yielding {
                 thread: guest_thread,
+                // Tell `StoreOpaque::suspend` it's okay to suspend here since
+                // we're handling a `thread.yield-to` call; otherwise it would
+                // panic if we called it in a non-blocking context.
                 skip_may_block_check: to_thread.is_some(),
             }
         } else {
@@ -3486,6 +3489,8 @@ impl Instance {
 
                         store.suspend(SuspendReason::Yielding {
                             thread: caller,
+                            // `subtask.cancel` is not allowed to be called in a
+                            // sync context, so we cannot skip the may-block check.
                             skip_may_block_check: false,
                         })?;
                         break;


### PR DESCRIPTION
https://github.com/WebAssembly/component-model/commit/7479890cb506d0f8f687595a4d41361ff8a2a194 made blocking calls in sync contexts a trap condition. However, `thread.yield-to` is allowed in these contexts. https://github.com/bytecodealliance/wasmtime/commit/8992b99bf44eb8b91820586b85f58512fd4d7c1c implemented these changes, but also disallowed `thread.yield-to`. This patch relaxes the relevant trap check.

Testing added here: https://github.com/WebAssembly/component-model/pull/590