### PR TITLE
Try to fix x86_64-apple-darwin release builds

### DIFF
--- a/crates/wasmtime/src/runtime/vm/stack_switching/stack/unix.rs
+++ b/crates/wasmtime/src/runtime/vm/stack_switching/stack/unix.rs
@@ -258,7 +258,7 @@ impl VMContinuationStack {
 
             let to_store = [
                 // Data near top of stack:
-                (0x08, (wasmtime_continuation_start as *const ()).addr()),
+                (0x08, wasmtime_continuation_start_address().addr()),
                 (0x10, tos.sub(0x10).addr()),
                 (0x18, tos.sub(0x40 + args_data_size).addr()),
                 (0x20, usize::try_from(args_capacity).unwrap()),

--- a/crates/wasmtime/src/runtime/vm/stack_switching/stack/unix/x86_64.rs
+++ b/crates/wasmtime/src/runtime/vm/stack_switching/stack/unix/x86_64.rs
@@ -7,6 +7,11 @@
 
 use core::arch::naked_asm;
 
+#[inline(never)] // FIXME(rust-lang/rust#148307)
+pub fn wasmtime_continuation_start_address() -> *const () {
+    wasmtime_continuation_start as *const ()
+}
+
 // This is a pretty special function that has no real signature. Its use is to
 // be the "base" function of all fibers. This entrypoint is used in
 // `wasmtime_continuation_init` to bootstrap the execution of a new fiber.


### PR DESCRIPTION
This is an attempt to address #12217 which applies a similar workaround found in #11960 to this naked function as well. Effectively it looks like `#[unsafe(naked)]` is buggy to the point that the user of the function symbol must be `#[inline(never)]` and in the same module, otherwise it won't work correctly.

Closes #12217

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
