### PR TITLE
Build Android binaries with a larger page size

### DIFF
--- a/ci/build-build-matrix.js
+++ b/ci/build-build-matrix.js
@@ -68,6 +68,10 @@ const array = [
     "build": "aarch64-android",
     "os": ubuntu,
     "target": "aarch64-linux-android",
+    // See https://developer.android.com/guide/practices/page-sizes
+    // for some more commentary, but apparently Google recommends passing this
+    // linker flag.
+    "env": { "RUSTFLAGS": "-Clink-arg=-z -Clink-arg=max-page-size=16384" },
   },
   {
     "build": "x86_64-android",


### PR DESCRIPTION
Apparently Google says we should do this. Also apparently Google's version of the NDK doesn't do this by default. Thread the needle by manually passing it.

Closes #12220

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
