### PR TITLE
Append RUSTFLAGS in CI, don't clobber

### DIFF
--- a/.github/actions/install-rust/action.yml
+++ b/.github/actions/install-rust/action.yml
@@ -58,7 +58,7 @@ runs:
         EOF
 
         # Deny warnings on CI to keep our code warning-free as it lands in-tree.
-        echo RUSTFLAGS="-D warnings" >> "$GITHUB_ENV"
+        echo RUSTFLAGS="-D warnings $RUSTFLAGS" >> "$GITHUB_ENV"
 
         if [[ "${{ runner.os }}" = "macOS" ]]; then
           cat >> "$GITHUB_ENV" <<EOF


### PR DESCRIPTION
This fixes an issues where for release binaries we set some `RUSTFLAGS` for some targets but that was getting clobbered by setting `-Dwarnings`. This only affects Windows binaries right now and in theory means that all future Windows binaries will be a bit more portable.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
