### PR TITLE
Migrate this workspace to using trusted publishing

### DIFF
--- a/.github/workflows/publish-to-cratesio.yml
+++ b/.github/workflows/publish-to-cratesio.yml
@@ -9,21 +9,27 @@ on:
     tags:
     - 'v*'
 
+permissions:
+  id-token: write
+
 jobs:
   publish:
     if: github.repository == 'bytecodealliance/wasmtime'
     runs-on: ubuntu-latest
+    environment: publish
     steps:
     - uses: actions/checkout@v4
       with:
         submodules: true
     - run: rustup update stable && rustup default stable
+    - uses: rust-lang/crates-io-auth-action@v1
+      id: auth
     - run: |
         rustc scripts/publish.rs
         ./publish publish
       env:
-        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-    
+        CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+
     # Manifest and publish the wasi-preview1-component-adapter-provider
     - uses: ./.github/actions/fetch-run-id
     - uses: ./.github/actions/build-adapter-provider
@@ -31,4 +37,4 @@ jobs:
         run-id: ${{ env.COMMIT_RUN_ID }}
     - run: cargo publish -p wasi-preview1-component-adapter-provider --allow-dirty
       env:
-        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}


### PR DESCRIPTION
This commit updates CI config and such to ensure that we're compatible with crates.io-based trusted publishing. Eventually we'll want the restriction that only `wasmtime-publish` is the user on all of our crates, but for now this needs to land and get backported before that's done.

Changes here are:

* The `publish-to-cratesio.yml` workflow now uses `rust-lang/crates-io-auth-action@v1` to get a crates.io-based token. The in-repository secret is no longer used.
* The `publish-to-cratesio.yml` workflow has a new github "Environment" it runs in named `publish`
* The publish script no longer adds the `github:bytecodealliance:wasmtime-publish` user to crates.
* The publish script now verifies that the `wasmtime-publish` github users is on all crates.
* Eventually the publish script will verify that it's the only user on all the crates, but that's left for a future PR.

External changes are:

* A new `publish` "Environment" was added to this repository.
* All crates are configured on crates.io to have a trusted publishing workflow for this repository.
* All crates now require being published through a trusted publishing workflow.

My plan is to backport this to the 40.0.0 branch, run a point release, fix anything that comes up, and then backport this to all supported branches of Wasmtime. Once that's all done and sorted I'll follow-up with more contributor-facing documentation about how to add new crates.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
