### PR TITLE
Migrate `crates/bench-api` to `wasmtime::error` instead of `anyhow`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4586,7 +4586,6 @@ dependencies = [
 name = "wasmtime-bench-api"
 version = "42.0.0"
 dependencies = [
- "anyhow",
  "cap-std",
  "clap",
  "shuffling-allocator",

--- a/crates/bench-api/Cargo.toml
+++ b/crates/bench-api/Cargo.toml
@@ -19,7 +19,6 @@ crate-type = ["cdylib"]
 doctest = false
 
 [dependencies]
-anyhow = { workspace = true }
 shuffling-allocator = { version = "1.1.1", optional = true }
 target-lexicon = { workspace = true }
 wasmtime = { workspace = true, default-features = true, features = ["winch", "pulley"] }

--- a/crates/bench-api/src/lib.rs
+++ b/crates/bench-api/src/lib.rs
@@ -136,12 +136,11 @@
 mod unsafe_send_sync;
 
 use crate::unsafe_send_sync::UnsafeSendSync;
-use anyhow::{Context, Result};
 use clap::Parser;
 use std::os::raw::{c_int, c_void};
 use std::slice;
 use std::{env, path::PathBuf};
-use wasmtime::{Engine, Instance, Linker, Module, Store};
+use wasmtime::{Engine, Instance, Linker, Module, Result, Store, error::Context as _};
 use wasmtime_cli_flags::CommonOptions;
 use wasmtime_wasi::cli::{InputFile, OutputFile};
 use wasmtime_wasi::{DirPerms, FilePerms, I32Exit, WasiCtx, p1::WasiP1Ctx};


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
