### PR TITLE
Migrate C API to `wasmtime::error`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4609,7 +4609,6 @@ dependencies = [
 name = "wasmtime-c-api-impl"
 version = "42.0.0"
 dependencies = [
- "anyhow",
  "async-trait",
  "bytes",
  "cap-std",

--- a/crates/c-api/Cargo.toml
+++ b/crates/c-api/Cargo.toml
@@ -21,7 +21,6 @@ doctest = false
 
 [dependencies]
 env_logger = { workspace = true, optional = true }
-anyhow = { workspace = true }
 wasmtime = { workspace = true, features = ['runtime', 'gc', 'std'] }
 wasmtime-c-api-macros = { workspace = true }
 log = { workspace = true }

--- a/crates/c-api/src/component/component.rs
+++ b/crates/c-api/src/component/component.rs
@@ -1,9 +1,9 @@
 use crate::{
     wasm_byte_vec_t, wasm_config_t, wasm_engine_t, wasmtime_component_type_t, wasmtime_error_t,
 };
-use anyhow::Context;
 use std::ffi::{CStr, c_char};
 use wasmtime::component::{Component, ComponentExportIndex};
+use wasmtime::error::Context;
 
 #[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_config_wasm_component_model_set(c: &mut wasm_config_t, enable: bool) {

--- a/crates/c-api/src/config.rs
+++ b/crates/c-api/src/config.rs
@@ -439,7 +439,7 @@ unsafe impl MemoryCreator for CHostMemoryCreator {
                 }))
             }
             Some(err) => {
-                let err: anyhow::Error = (*err).into();
+                let err: wasmtime::Error = (*err).into();
                 Err(format!("{err}"))
             }
         }

--- a/crates/c-api/src/error.rs
+++ b/crates/c-api/src/error.rs
@@ -1,5 +1,5 @@
 use crate::{wasm_frame_vec_t, wasm_name_t};
-use anyhow::{Error, Result, anyhow};
+use wasmtime::{Error, Result, format_err};
 
 #[repr(C)]
 pub struct wasmtime_error_t {
@@ -26,7 +26,7 @@ pub extern "C" fn wasmtime_error_new(
 ) -> Option<Box<wasmtime_error_t>> {
     let msg_bytes = unsafe { std::ffi::CStr::from_ptr(msg).to_bytes() };
     let msg_string = String::from_utf8_lossy(msg_bytes).into_owned();
-    Some(Box::new(wasmtime_error_t::from(anyhow!(msg_string))))
+    Some(Box::new(wasmtime_error_t::from(format_err!(msg_string))))
 }
 
 pub(crate) fn handle_result<T>(
@@ -44,7 +44,7 @@ pub(crate) fn handle_result<T>(
 
 pub(crate) fn bad_utf8() -> Option<Box<wasmtime_error_t>> {
     Some(Box::new(wasmtime_error_t {
-        error: anyhow!("input was not valid utf-8"),
+        error: format_err!("input was not valid utf-8"),
     }))
 }
 

--- a/crates/c-api/src/func.rs
+++ b/crates/c-api/src/func.rs
@@ -4,7 +4,6 @@ use crate::{
     wasm_val_t, wasm_val_vec_t, wasmtime_error_t, wasmtime_extern_t, wasmtime_val_t,
     wasmtime_val_union,
 };
-use anyhow::{Error, Result};
 use std::any::Any;
 use std::ffi::c_void;
 use std::mem::{self, MaybeUninit};
@@ -12,8 +11,8 @@ use std::panic::{self, AssertUnwindSafe};
 use std::ptr;
 use std::str;
 use wasmtime::{
-    AsContext, AsContextMut, Extern, Func, RootScope, StoreContext, StoreContextMut, Trap, Val,
-    ValRaw,
+    AsContext, AsContextMut, Error, Extern, Func, Result, RootScope, StoreContext, StoreContextMut,
+    Trap, Val, ValRaw,
 };
 
 #[derive(Clone)]

--- a/crates/c-api/src/instance.rs
+++ b/crates/c-api/src/instance.rs
@@ -90,7 +90,7 @@ pub unsafe extern "C" fn wasmtime_instance_new(
 }
 
 pub(crate) fn handle_instantiate(
-    instance: anyhow::Result<Instance>,
+    instance: wasmtime::Result<Instance>,
     instance_ptr: &mut Instance,
     trap_ptr: &mut *mut wasm_trap_t,
 ) -> Option<Box<wasmtime_error_t>> {

--- a/crates/c-api/src/module.rs
+++ b/crates/c-api/src/module.rs
@@ -3,9 +3,9 @@ use crate::{
     wasm_exporttype_vec_t, wasm_importtype_t, wasm_importtype_vec_t, wasm_store_t,
     wasmtime_error_t,
 };
-use anyhow::Context;
 use std::ffi::CStr;
 use std::os::raw::c_char;
+use wasmtime::error::Context;
 use wasmtime::{Engine, Module};
 
 #[derive(Clone)]

--- a/crates/c-api/src/table.rs
+++ b/crates/c-api/src/table.rs
@@ -2,9 +2,8 @@ use crate::{
     WasmtimeStoreContext, WasmtimeStoreContextMut, handle_result, wasm_extern_t, wasm_ref_t,
     wasm_store_t, wasm_tabletype_t, wasmtime_error_t, wasmtime_val_t,
 };
-use anyhow::anyhow;
 use std::mem::MaybeUninit;
-use wasmtime::{Extern, Ref, RootScope, Table, TableType};
+use wasmtime::{Extern, Ref, RootScope, Table, TableType, format_err};
 
 #[derive(Clone)]
 #[repr(transparent)]
@@ -125,7 +124,7 @@ pub unsafe extern "C" fn wasmtime_table_new(
     handle_result(
         init.to_val(&mut scope)
             .ref_()
-            .ok_or_else(|| anyhow!("wasmtime_table_new init value is not a reference"))
+            .ok_or_else(|| format_err!("wasmtime_table_new init value is not a reference"))
             .and_then(|init| Table::new(scope, tt.ty().ty.clone(), init)),
         |table| *out = table,
     )
@@ -167,7 +166,7 @@ pub unsafe extern "C" fn wasmtime_table_set(
     handle_result(
         val.to_val(&mut scope)
             .ref_()
-            .ok_or_else(|| anyhow!("wasmtime_table_set value is not a reference"))
+            .ok_or_else(|| format_err!("wasmtime_table_set value is not a reference"))
             .and_then(|val| table.set(scope, index, val)),
         |()| {},
     )
@@ -190,7 +189,7 @@ pub unsafe extern "C" fn wasmtime_table_grow(
     handle_result(
         val.to_val(&mut scope)
             .ref_()
-            .ok_or_else(|| anyhow!("wasmtime_table_grow value is not a reference"))
+            .ok_or_else(|| format_err!("wasmtime_table_grow value is not a reference"))
             .and_then(|val| table.grow(scope, delta, val)),
         |prev| *prev_size = prev,
     )

--- a/crates/c-api/src/trap.rs
+++ b/crates/c-api/src/trap.rs
@@ -1,7 +1,6 @@
 use crate::{wasm_frame_vec_t, wasm_instance_t, wasm_name_t, wasm_store_t};
-use anyhow::{Error, anyhow};
 use std::cell::OnceCell;
-use wasmtime::{Trap, WasmBacktrace};
+use wasmtime::{Error, Trap, WasmBacktrace, format_err};
 
 #[repr(C)]
 pub struct wasm_trap_t {
@@ -15,7 +14,7 @@ pub struct wasm_trap_t {
 impl Clone for wasm_trap_t {
     fn clone(&self) -> wasm_trap_t {
         wasm_trap_t {
-            error: anyhow!("{:?}", self.error),
+            error: format_err!("{:?}", self.error),
         }
     }
 }

--- a/crates/c-api/src/wasi.rs
+++ b/crates/c-api/src/wasi.rs
@@ -1,7 +1,6 @@
 //! The WASI embedding API definitions for Wasmtime.
 
 use crate::wasm_byte_vec_t;
-use anyhow::Result;
 use bytes::Bytes;
 use std::ffi::{CStr, c_char, c_void};
 use std::fs::File;
@@ -10,6 +9,7 @@ use std::pin::Pin;
 use std::slice;
 use std::task::{Context, Poll};
 use tokio::io::{self, AsyncWrite};
+use wasmtime::Result;
 use wasmtime_wasi::WasiCtxBuilder;
 use wasmtime_wasi::p1::WasiP1Ctx;
 use wasmtime_wasi_io::streams::StreamError;
@@ -204,7 +204,7 @@ impl wasmtime_wasi::p2::OutputStream for CustomOutputStream {
             .map_err(|e| StreamError::LastOperationFailed(e.into()))?;
 
         if wrote != bytes.len() {
-            return Err(StreamError::LastOperationFailed(anyhow::anyhow!(
+            return Err(StreamError::LastOperationFailed(wasmtime::format_err!(
                 "Partial writes in wasip2 implementation are not allowed"
             )));
         }


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
