### PR TITLE
Migrate debugger to `wasmtime::error`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4912,7 +4912,6 @@ dependencies = [
 name = "wasmtime-internal-debugger"
 version = "42.0.0"
 dependencies = [
- "anyhow",
  "env_logger 0.11.5",
  "log",
  "tokio",

--- a/crates/debugger/Cargo.toml
+++ b/crates/debugger/Cargo.toml
@@ -14,7 +14,6 @@ workspace = true
 [dependencies]
 wasmtime = { workspace = true, features = ["debug", "std", "async"] }
 tokio = { workspace = true, features = ["rt", "sync", "macros"] }
-anyhow = { workspace = true }
 log = { workspace = true }
 
 [dev-dependencies]


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
