### PR TITLE
Migrate explorer to `wasmtime::error`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4930,7 +4930,6 @@ dependencies = [
 name = "wasmtime-internal-explorer"
 version = "42.0.0"
 dependencies = [
- "anyhow",
  "capstone",
  "serde",
  "serde_derive",

--- a/crates/explorer/Cargo.toml
+++ b/crates/explorer/Cargo.toml
@@ -13,7 +13,6 @@ version.workspace = true
 workspace = true
 
 [dependencies]
-anyhow = { workspace = true }
 capstone = { workspace = true }
 serde = { workspace = true }
 serde_derive = { workspace = true }


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
