### PR TITLE
Migrate Wizer to `wasmtime::error`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5254,7 +5254,6 @@ dependencies = [
 name = "wasmtime-wizer"
 version = "42.0.0"
 dependencies = [
- "anyhow",
  "clap",
  "criterion",
  "env_logger 0.11.5",

--- a/crates/wizer/Cargo.toml
+++ b/crates/wizer/Cargo.toml
@@ -25,14 +25,13 @@ name = "uap"
 harness = false
 
 [dependencies]
-anyhow = { workspace = true }
 log = { workspace = true }
 rayon = { workspace = true }
 clap = { workspace = true, optional = true }
 wasm-encoder = { workspace = true, features = ['wasmparser'] }
 wasmparser = { workspace = true, features = ['validate', 'features'] }
 wasmprinter = { workspace = true, optional = true }
-wasmtime = { workspace = true, optional = true, features = ['std', 'runtime', 'cranelift', 'cache', 'threads', 'gc', 'gc-null', 'async'] }
+wasmtime = { workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true }
@@ -49,10 +48,19 @@ tokio = { workspace = true, features = ['macros'] }
 wasmprinter = ['dep:wasmprinter']
 
 # Enables default runtime implementations based on the `wasmtime` crate.
-wasmtime = ['dep:wasmtime']
+wasmtime = [
+  'wasmtime/std',
+  'wasmtime/runtime',
+  'wasmtime/cranelift',
+  'wasmtime/cache',
+  'wasmtime/threads',
+  'wasmtime/gc',
+  'wasmtime/gc-null',
+  'wasmtime/async',
+]
 
 # Enable support for wizening components.
-component-model = ['wasmtime?/component-model']
+component-model = ['wasmtime/component-model']
 
 [[test]]
 name = "all"

--- a/crates/wizer/src/component.rs
+++ b/crates/wizer/src/component.rs
@@ -1,5 +1,5 @@
 use crate::Wizer;
-use anyhow::bail;
+use ::wasmtime::{Result, bail};
 
 mod info;
 mod instrument;
@@ -20,7 +20,7 @@ impl Wizer {
     pub fn instrument_component<'a>(
         &self,
         wasm: &'a [u8],
-    ) -> anyhow::Result<(ComponentContext<'a>, Vec<u8>)> {
+    ) -> Result<(ComponentContext<'a>, Vec<u8>)> {
         // Make sure we're given valid Wasm from the get go.
         self.wasm_validate(&wasm)?;
 
@@ -36,7 +36,7 @@ impl Wizer {
         &self,
         mut cx: ComponentContext<'_>,
         instance: &mut impl ComponentInstanceState,
-    ) -> anyhow::Result<Vec<u8>> {
+    ) -> Result<Vec<u8>> {
         if !self.func_renames.is_empty() {
             bail!("components do not support renaming functions");
         }

--- a/crates/wizer/src/component/instrument.rs
+++ b/crates/wizer/src/component/instrument.rs
@@ -1,8 +1,8 @@
 use crate::ModuleContext;
 use crate::component::info::{Accessor, RawSection};
 use crate::component::{ComponentContext, WIZER_INSTANCE};
-use anyhow::{Result, bail};
 use wasm_encoder::reencode::{Reencode, RoundtripReencoder};
+use wasmtime::{Result, bail};
 
 /// Instrumentation phase of wizening a component.
 ///

--- a/crates/wizer/src/component/parse.rs
+++ b/crates/wizer/src/component/parse.rs
@@ -1,10 +1,10 @@
 use crate::component::ComponentContext;
-use anyhow::{Result, bail};
 use std::collections::hash_map::Entry;
 use wasmparser::{
     CanonicalFunction, ComponentAlias, ComponentExternalKind, ComponentOuterAliasKind, Encoding,
     Instance, Parser, Payload,
 };
+use wasmtime::{Result, bail};
 
 /// Parse the given Wasm bytes into a `ComponentContext` tree.
 ///
@@ -19,7 +19,7 @@ use wasmparser::{
 /// * Component-level start functions are not supported.
 ///
 /// Some of these restrictions are likely to be loosened over time, however.
-pub(crate) fn parse<'a>(full_wasm: &'a [u8]) -> anyhow::Result<ComponentContext<'a>> {
+pub(crate) fn parse<'a>(full_wasm: &'a [u8]) -> wasmtime::Result<ComponentContext<'a>> {
     let mut component = ComponentContext::default();
     let parser = Parser::new(0).parse_all(full_wasm);
     parse_into(Some(&mut component), full_wasm, parser)?;
@@ -30,7 +30,7 @@ fn parse_into<'a>(
     mut cx: Option<&mut ComponentContext<'a>>,
     full_wasm: &'a [u8],
     mut iter: impl Iterator<Item = wasmparser::Result<Payload<'a>>>,
-) -> anyhow::Result<()> {
+) -> wasmtime::Result<()> {
     let mut stack = Vec::new();
     while let Some(payload) = iter.next() {
         let payload = payload?;

--- a/crates/wizer/src/parse.rs
+++ b/crates/wizer/src/parse.rs
@@ -1,16 +1,16 @@
 use crate::info::ModuleContext;
-use anyhow::{Context, bail};
 use wasmparser::{Encoding, Parser};
+use wasmtime::{bail, error::Context as _};
 
 /// Parse the given Wasm bytes into a `ModuleInfo` tree.
-pub(crate) fn parse<'a>(full_wasm: &'a [u8]) -> anyhow::Result<ModuleContext<'a>> {
+pub(crate) fn parse<'a>(full_wasm: &'a [u8]) -> wasmtime::Result<ModuleContext<'a>> {
     parse_with(full_wasm, &mut Parser::new(0).parse_all(full_wasm))
 }
 
 pub(crate) fn parse_with<'a>(
     full_wasm: &'a [u8],
     payloads: &mut impl Iterator<Item = wasmparser::Result<wasmparser::Payload<'a>>>,
-) -> anyhow::Result<ModuleContext<'a>> {
+) -> wasmtime::Result<ModuleContext<'a>> {
     log::debug!("Parsing the input Wasm");
 
     let mut module = ModuleContext::default();
@@ -48,13 +48,13 @@ pub(crate) fn parse_with<'a>(
 fn import_section<'a>(
     module: &mut ModuleContext<'a>,
     imports: wasmparser::ImportSectionReader<'a>,
-) -> anyhow::Result<()> {
+) -> wasmtime::Result<()> {
     // Check that we can properly handle all imports.
     for imp in imports.into_imports() {
         let imp = imp?;
 
         if imp.module.starts_with("__wizer_") || imp.name.starts_with("__wizer_") {
-            anyhow::bail!(
+            wasmtime::bail!(
                 "input Wasm module already imports entities named with the `__wizer_*` prefix"
             );
         }
@@ -67,7 +67,7 @@ fn import_section<'a>(
 fn function_section<'a>(
     module: &mut ModuleContext<'a>,
     funcs: wasmparser::FunctionSectionReader<'a>,
-) -> anyhow::Result<()> {
+) -> wasmtime::Result<()> {
     for ty_idx in funcs {
         module.push_function(ty_idx?);
     }
@@ -77,7 +77,7 @@ fn function_section<'a>(
 fn table_section<'a>(
     module: &mut ModuleContext<'a>,
     tables: wasmparser::TableSectionReader<'a>,
-) -> anyhow::Result<()> {
+) -> wasmtime::Result<()> {
     for table in tables {
         module.push_table(table?.ty);
     }
@@ -87,7 +87,7 @@ fn table_section<'a>(
 fn memory_section<'a>(
     module: &mut ModuleContext<'a>,
     mems: wasmparser::MemorySectionReader<'a>,
-) -> anyhow::Result<()> {
+) -> wasmtime::Result<()> {
     for m in mems {
         module.push_defined_memory(m?);
     }
@@ -97,7 +97,7 @@ fn memory_section<'a>(
 fn global_section<'a>(
     module: &mut ModuleContext<'a>,
     globals: wasmparser::GlobalSectionReader<'a>,
-) -> anyhow::Result<()> {
+) -> wasmtime::Result<()> {
     for g in globals {
         module.push_defined_global(g?.ty);
     }
@@ -107,12 +107,12 @@ fn global_section<'a>(
 fn export_section<'a>(
     module: &mut ModuleContext<'a>,
     exports: wasmparser::ExportSectionReader<'a>,
-) -> anyhow::Result<()> {
+) -> wasmtime::Result<()> {
     for export in exports {
         let export = export?;
 
         if export.name.starts_with("__wizer_") {
-            anyhow::bail!(
+            wasmtime::bail!(
                 "input Wasm module already exports entities named with the `__wizer_*` prefix"
             );
         }

--- a/crates/wizer/tests/all/component.rs
+++ b/crates/wizer/tests/all/component.rs
@@ -1,6 +1,5 @@
-use anyhow::{Context, Result, bail};
 use wasmtime::component::{Component, Instance, Linker, Val};
-use wasmtime::{Config, Engine, Store};
+use wasmtime::{Config, Engine, Result, Store, bail, error::Context as _};
 use wasmtime_wizer::Wizer;
 
 fn fail_wizening(msg: &str, wasm: &[u8]) -> Result<()> {
@@ -171,16 +170,16 @@ async fn wizen_and_run_wasm(expected: u32, wat: &str) -> Result<()> {
     let instance = linker.instantiate_async(&mut store, &module).await?;
 
     let run = instance.get_func(&mut store, "run").ok_or_else(|| {
-        anyhow::anyhow!("the test Wasm component does not export a `run` function")
+        wasmtime::format_err!("the test Wasm component does not export a `run` function")
     })?;
 
     let mut actual = [Val::U8(0)];
     run.call_async(&mut store, &[], &mut actual).await?;
     let actual = match actual[0] {
         Val::U32(x) => x,
-        _ => anyhow::bail!("expected an u32 result"),
+        _ => wasmtime::bail!("expected an u32 result"),
     };
-    anyhow::ensure!(
+    wasmtime::ensure!(
         expected == actual,
         "expected `{expected}`, found `{actual}`",
     );

--- a/crates/wizer/tests/all/make_linker.rs
+++ b/crates/wizer/tests/all/make_linker.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result, anyhow};
+use wasmtime::{Result, error::Context as _, format_err};
 use wasmtime_wasi::WasiCtxBuilder;
 use wasmtime_wizer::Wizer;
 use wat::parse_str as wat_to_wasm;
@@ -41,23 +41,23 @@ async fn run_wasm(args: &[wasmtime::Val], expected: i32, wasm: &[u8]) -> Result<
 
     let mut linker = wasmtime::Linker::new(&engine);
     linker.func_wrap("foo", "bar", |_: i32| -> Result<i32> {
-        Err(anyhow!("shouldn't be called"))
+        Err(format_err!("shouldn't be called"))
     })?;
 
     let instance = linker.instantiate_async(&mut store, &module).await?;
 
-    let run = instance
-        .get_func(&mut store, "run")
-        .ok_or_else(|| anyhow::anyhow!("the test Wasm module does not export a `run` function"))?;
+    let run = instance.get_func(&mut store, "run").ok_or_else(|| {
+        wasmtime::format_err!("the test Wasm module does not export a `run` function")
+    })?;
 
     let mut actual = vec![wasmtime::Val::I32(0)];
     run.call_async(&mut store, args, &mut actual).await?;
-    anyhow::ensure!(actual.len() == 1, "expected one result");
+    wasmtime::ensure!(actual.len() == 1, "expected one result");
     let actual = match actual[0] {
         wasmtime::Val::I32(x) => x,
-        _ => anyhow::bail!("expected an i32 result"),
+        _ => wasmtime::bail!("expected an i32 result"),
     };
-    anyhow::ensure!(
+    wasmtime::ensure!(
         expected == actual,
         "expected `{expected}`, found `{actual}`",
     );

--- a/crates/wizer/tests/all/preloads.rs
+++ b/crates/wizer/tests/all/preloads.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use wasmtime::Result;
 use wasmtime::{Instance, Linker, Module};
 use wasmtime_wizer::Wizer;
 use wat::parse_str as wat_to_wasm;
@@ -50,7 +50,7 @@ async fn run_with_preloads(args: &[wasmtime::Val], wat: &str) -> Result<wasmtime
     let inst = linker.instantiate_async(&mut store, &testmod).await?;
     let run = inst
         .get_func(&mut store, "run")
-        .ok_or_else(|| anyhow::anyhow!("no `run` function on test module"))?;
+        .ok_or_else(|| wasmtime::format_err!("no `run` function on test module"))?;
     let mut returned = vec![wasmtime::Val::I32(0)];
     run.call_async(&mut store, args, &mut returned).await?;
     Ok(returned[0])

--- a/crates/wizer/tests/all/tests.rs
+++ b/crates/wizer/tests/all/tests.rs
@@ -1,7 +1,6 @@
-use anyhow::{Context, Result};
 use std::process::Command;
 use wasm_encoder::ConstExpr;
-use wasmtime::{Config, Engine, Instance, Linker, Module, Store};
+use wasmtime::{Config, Engine, Instance, Linker, Module, Result, Store, error::Context as _};
 use wasmtime_wasi::{WasiCtxBuilder, p1};
 use wasmtime_wizer::Wizer;
 use wat::parse_str as wat_to_wasm;
@@ -73,18 +72,18 @@ async fn wizen_and_run_wasm(
 
     let instance = linker.instantiate_async(&mut store, &module).await?;
 
-    let run = instance
-        .get_func(&mut store, "run")
-        .ok_or_else(|| anyhow::anyhow!("the test Wasm module does not export a `run` function"))?;
+    let run = instance.get_func(&mut store, "run").ok_or_else(|| {
+        wasmtime::format_err!("the test Wasm module does not export a `run` function")
+    })?;
 
     let mut actual = vec![wasmtime::Val::I32(0)];
     run.call_async(&mut store, args, &mut actual).await?;
-    anyhow::ensure!(actual.len() == 1, "expected one result");
+    wasmtime::ensure!(actual.len() == 1, "expected one result");
     let actual = match actual[0] {
         wasmtime::Val::I32(x) => x,
-        _ => anyhow::bail!("expected an i32 result"),
+        _ => wasmtime::bail!("expected an i32 result"),
     };
-    anyhow::ensure!(
+    wasmtime::ensure!(
         expected == actual,
         "expected `{expected}`, found `{actual}`",
     );
@@ -105,7 +104,7 @@ async fn fails_wizening(wat: &str) -> Result<()> {
         .validate_all(&wasm)
         .context("initial Wasm should be valid")?;
 
-    anyhow::ensure!(
+    wasmtime::ensure!(
         get_wizer()
             .run(&mut store()?, &wasm, instantiate)
             .await
@@ -319,7 +318,7 @@ async fn reject_table_get_set_with_reference_types_enabled() -> Result<()> {
 }
 
 #[tokio::test]
-async fn reject_table_grow_with_reference_types_enabled() -> anyhow::Result<()> {
+async fn reject_table_grow_with_reference_types_enabled() -> wasmtime::Result<()> {
     let wat = r#"
       (module
         (elem declare func $f)
@@ -349,7 +348,7 @@ async fn reject_table_grow_with_reference_types_enabled() -> anyhow::Result<()> 
 }
 
 #[tokio::test]
-async fn indirect_call_with_reference_types() -> anyhow::Result<()> {
+async fn indirect_call_with_reference_types() -> wasmtime::Result<()> {
     let wat = r#"
       (module
         (type $sig (func (result i32)))
@@ -602,7 +601,7 @@ async fn rename_functions() -> Result<()> {
 }
 
 #[tokio::test]
-async fn wasi_reactor() -> anyhow::Result<()> {
+async fn wasi_reactor() -> wasmtime::Result<()> {
     run_wat(
         &[],
         42,
@@ -628,7 +627,7 @@ async fn wasi_reactor() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
-async fn wasi_reactor_initializer_as_init_func() -> anyhow::Result<()> {
+async fn wasi_reactor_initializer_as_init_func() -> wasmtime::Result<()> {
     let wat = r#"
       (module
         (global $g (mut i32) i32.const 0)
@@ -652,7 +651,7 @@ async fn wasi_reactor_initializer_as_init_func() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
-async fn wasi_reactor_initializer_with_keep_init() -> anyhow::Result<()> {
+async fn wasi_reactor_initializer_with_keep_init() -> wasmtime::Result<()> {
     let wat = r#"
       (module
         (global $g (mut i32) i32.const 0)


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
