### PR TITLE
Migrate the min-platform example to `wasmtime::error`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1236,7 +1236,6 @@ checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 name = "embedding"
 version = "42.0.0"
 dependencies = [
- "anyhow",
  "dlmalloc",
  "raw-cpuid",
  "wasmtime",
@@ -2364,7 +2363,6 @@ dependencies = [
 name = "min-platform-host"
 version = "42.0.0"
 dependencies = [
- "anyhow",
  "libloading",
  "object 0.37.3",
  "wasmtime",

--- a/examples/min-platform/Cargo.toml
+++ b/examples/min-platform/Cargo.toml
@@ -9,7 +9,6 @@ rust-version.workspace = true
 workspace = true
 
 [dependencies]
-anyhow = { workspace = true, features = ['std'] }
 libloading = "0.8"
 object = { workspace = true, features = ['std'] }
 wasmtime = { workspace = true, features = ['cranelift', 'wat'] }

--- a/examples/min-platform/embedding/Cargo.toml
+++ b/examples/min-platform/embedding/Cargo.toml
@@ -9,8 +9,6 @@ rust-version.workspace = true
 workspace = true
 
 [dependencies]
-anyhow = { workspace = true }
-
 # Note that default-features of wasmtime are disabled and only those required
 # are enabled, in this case compilation is done in the guest from the wasm text
 # format so `cranelift` and `wat` are enabled.

--- a/examples/min-platform/embedding/src/lib.rs
+++ b/examples/min-platform/embedding/src/lib.rs
@@ -4,9 +4,8 @@
 extern crate alloc;
 
 use alloc::string::ToString;
-use anyhow::{Result, ensure};
 use core::ptr;
-use wasmtime::{Config, Engine, Instance, Linker, Module, Store};
+use wasmtime::{Config, Engine, Instance, Linker, Module, Result, Store, ensure};
 
 mod allocator;
 mod panic;

--- a/examples/min-platform/embedding/src/wasi.rs
+++ b/examples/min-platform/embedding/src/wasi.rs
@@ -26,14 +26,13 @@ use alloc::collections::VecDeque;
 use alloc::rc::Rc;
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
-use anyhow::{Result, bail};
 use core::cell::{Cell, RefCell};
 use core::fmt::Write as _;
 use core::future::Future;
 use core::pin::Pin;
 use core::task::{Context, Poll, Waker};
 use wasmtime::component::{Component, Linker, Resource, ResourceTable};
-use wasmtime::{Engine, Store};
+use wasmtime::{Engine, Result, Store, bail};
 use wasmtime_wasi_io::{
     IoView,
     bytes::Bytes,
@@ -120,7 +119,7 @@ fn run(wasi_component: &[u8]) -> Result<String> {
             .wasi_cli_run()
             .call_run(&mut store)
             .await?
-            .map_err(|()| anyhow::anyhow!("wasi cli run returned error"))?;
+            .map_err(|()| wasmtime::format_err!("wasi cli run returned error"))?;
 
         store.into_data().output()
     })

--- a/examples/min-platform/src/main.rs
+++ b/examples/min-platform/src/main.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use wasmtime::Result;
 
 #[cfg(not(target_os = "linux"))]
 fn main() -> Result<()> {
@@ -8,22 +8,21 @@ fn main() -> Result<()> {
 
 #[cfg(target_os = "linux")]
 fn main() -> Result<()> {
-    use anyhow::{Context, anyhow, bail};
     use libloading::os::unix::{Library, RTLD_GLOBAL, RTLD_NOW, Symbol};
     use object::{Object, ObjectSymbol};
-    use wasmtime::{Config, Engine};
+    use wasmtime::{Config, Engine, bail, error::Context as _, format_err};
 
     let mut args = std::env::args();
     let _current_exe = args.next();
     let triple = args
         .next()
-        .ok_or_else(|| anyhow!("missing argument 1: triple"))?;
+        .ok_or_else(|| format_err!("missing argument 1: triple"))?;
     let embedding_so_path = args
         .next()
-        .ok_or_else(|| anyhow!("missing argument 2: path to libembedding.so"))?;
+        .ok_or_else(|| format_err!("missing argument 2: path to libembedding.so"))?;
     let platform_so_path = args
         .next()
-        .ok_or_else(|| anyhow!("missing argument 3: path to libwasmtime-platform.so"))?;
+        .ok_or_else(|| format_err!("missing argument 3: path to libwasmtime-platform.so"))?;
 
     // Path to the artifact which is the build of the embedding.
     //
@@ -192,7 +191,7 @@ fn main() -> Result<()> {
         {
             let wasi_component_path = args
                 .next()
-                .ok_or_else(|| anyhow!("missing argument 4: path to wasi component"))?;
+                .ok_or_else(|| format_err!("missing argument 4: path to wasi component"))?;
             let wasi_component = std::fs::read(&wasi_component_path)?;
             let wasi_component = engine.precompile_component(&wasi_component)?;
 


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
