### PR TITLE
Migrate the wasip2 plugins example to `wasmtime::error`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -335,7 +335,6 @@ dependencies = [
 name = "calculator"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "clap",
  "wasmtime",
  "wasmtime-wasi",

--- a/examples/wasip2-plugins/Cargo.toml
+++ b/examples/wasip2-plugins/Cargo.toml
@@ -9,7 +9,6 @@ with plugins for arithmetic operations.
 publish = false
 
 [dependencies]
-anyhow = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
 wasmtime = { workspace = true, features = ['std', 'cranelift'] }
 wasmtime-wasi = { workspace = true }


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
