### PR TITLE
Migrate fuzzing to `wasmtime::error`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4761,7 +4761,6 @@ dependencies = [
 name = "wasmtime-fuzz"
 version = "0.0.0"
 dependencies = [
- "anyhow",
  "arbitrary",
  "cranelift-assembler-x64",
  "cranelift-codegen",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -15,7 +15,6 @@ cargo-fuzz = true
 mutatis = { workspace = true }
 rand = { workspace = true }
 postcard = { workspace = true }
-anyhow = { workspace = true }
 env_logger = { workspace = true }
 cranelift-assembler-x64 = { workspace = true, features = ["fuzz"] }
 cranelift-codegen = { workspace = true, features = ["incremental-cache", "x86", "arm64", "s390x", "riscv64"] }
@@ -36,11 +35,11 @@ wasmtime-test-util = { workspace = true }
 log = { workspace = true }
 
 [build-dependencies]
-anyhow = { workspace = true }
 proc-macro2 = { workspace = true }
 arbitrary = { workspace = true, features = ["derive"] }
 rand = { version = "0.8.0" }
 quote = { workspace = true }
+wasmtime = { workspace = true }
 wasmtime-test-util = { workspace = true, features = ['component-fuzz'] }
 
 [features]

--- a/fuzz/build.rs
+++ b/fuzz/build.rs
@@ -1,11 +1,10 @@
-fn main() -> anyhow::Result<()> {
+fn main() -> wasmtime::Result<()> {
     component::generate_static_api_tests()?;
 
     Ok(())
 }
 
 mod component {
-    use anyhow::{Context, Error, Result, anyhow};
     use arbitrary::Unstructured;
     use proc_macro2::TokenStream;
     use quote::quote;
@@ -18,6 +17,7 @@ mod component {
     use std::iter;
     use std::path::PathBuf;
     use std::process::Command;
+    use wasmtime::{Error, Result, error::Context as _, format_err};
     use wasmtime_test_util::component_fuzz::{Declarations, MAX_TYPE_DEPTH, TestCase, Type};
 
     pub fn generate_static_api_tests() -> Result<()> {
@@ -41,7 +41,7 @@ mod component {
         println!("cargo:rerun-if-env-changed=WASMTIME_FUZZ_SEED");
         let seed = if let Ok(seed) = env::var("WASMTIME_FUZZ_SEED") {
             seed.parse::<u64>()
-                .with_context(|| anyhow!("expected u64 in WASMTIME_FUZZ_SEED"))?
+                .with_context(|| format_err!("expected u64 in WASMTIME_FUZZ_SEED"))?
         } else {
             StdRng::from_entropy().r#gen()
         };
@@ -144,7 +144,7 @@ mod component {
         let module = quote! {
             #[allow(unused_imports, reason = "macro-generated code")]
             fn static_component_api_target(input: &mut libfuzzer_sys::arbitrary::Unstructured) -> libfuzzer_sys::arbitrary::Result<()> {
-                use anyhow::Result;
+                use wasmtime::Result;
                 use wasmtime_test_util::component_fuzz::Declarations;
                 use wasmtime_test_util::component::{Float32, Float64};
                 use libfuzzer_sys::arbitrary::{self, Arbitrary};

--- a/fuzz/fuzz_targets/cranelift-fuzzgen.rs
+++ b/fuzz/fuzz_targets/cranelift-fuzzgen.rs
@@ -183,7 +183,7 @@ impl<'a> Arbitrary<'a> for TestCase {
 }
 
 impl TestCase {
-    pub fn generate(u: &mut Unstructured) -> anyhow::Result<Self> {
+    pub fn generate(u: &mut Unstructured) -> wasmtime::Result<Self> {
         let mut generator = FuzzGen::new(u);
 
         let compare_against_host = generator.u.arbitrary()?;

--- a/fuzz/fuzz_targets/cranelift-icache.rs
+++ b/fuzz/fuzz_targets/cranelift-icache.rs
@@ -43,7 +43,7 @@ pub struct FunctionWithIsa {
 }
 
 impl FunctionWithIsa {
-    pub fn generate(u: &mut Unstructured) -> anyhow::Result<Self> {
+    pub fn generate(u: &mut Unstructured) -> wasmtime::Result<Self> {
         let _ = env_logger::try_init();
 
         // We filter out targets that aren't supported in the current build
@@ -77,7 +77,7 @@ impl FunctionWithIsa {
                 let sig = generator.generate_signature(&*isa)?;
                 Ok((name, sig))
             })
-            .collect::<anyhow::Result<Vec<(UserExternalName, Signature)>>>()
+            .collect::<wasmtime::Result<Vec<(UserExternalName, Signature)>>>()
             .map_err(|_| arbitrary::Error::IncorrectFormat)?;
 
         let func = generator


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
