### PR TITLE
Migrate test utils to `wasmtime::error`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5045,7 +5045,6 @@ dependencies = [
 name = "wasmtime-test-util"
 version = "42.0.0"
 dependencies = [
- "anyhow",
  "arbitrary",
  "arbtest",
  "env_logger 0.11.5",

--- a/crates/test-util/Cargo.toml
+++ b/crates/test-util/Cargo.toml
@@ -13,7 +13,6 @@ repository = "https://github.com/bytecodealliance/wasmtime"
 workspace = true
 
 [dependencies]
-anyhow = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
 toml = { workspace = true, optional = true }
@@ -41,7 +40,6 @@ arbtest = { workspace = true }
 [features]
 wast = [
   'dep:serde',
-  'dep:anyhow',
   'dep:toml',
   'dep:serde_derive',
 ]
@@ -57,8 +55,6 @@ wasmtime-wast = [
   'dep:target-lexicon',
 ]
 component = [
-  'dep:anyhow',
-  'dep:anyhow',
   'arbitrary/derive',
   'wast',
   'dep:env_logger',

--- a/crates/test-util/src/component.rs
+++ b/crates/test-util/src/component.rs
@@ -5,7 +5,7 @@ use wasmtime::component::__internal::{
 };
 use wasmtime::component::{ComponentNamedList, ComponentType, Func, Lift, Lower, TypedFunc, Val};
 use wasmtime::{AsContextMut, Config, Engine};
-use wasmtime_environ::error::Result;
+use wasmtime_environ::prelude::*;
 
 pub trait TypedFuncExt<P, R> {
     fn call_and_post_return(&self, store: impl AsContextMut<Data: Send>, params: P) -> Result<R>;

--- a/crates/test-util/src/wast.rs
+++ b/crates/test-util/src/wast.rs
@@ -4,7 +4,7 @@ use std::fmt;
 use std::fs;
 use std::path::Path;
 use std::path::PathBuf;
-use wasmtime_environ::error::{Context, Result};
+use wasmtime_environ::prelude::*;
 
 /// Limits for running wast tests.
 ///


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
