### PR TITLE
Migrate wasi-tls-nativetls to `wasmtime::error`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5218,7 +5218,6 @@ dependencies = [
 name = "wasmtime-wasi-tls-nativetls"
 version = "42.0.0"
 dependencies = [
- "anyhow",
  "futures",
  "native-tls",
  "test-programs-artifacts",

--- a/crates/wasi-tls-nativetls/Cargo.toml
+++ b/crates/wasi-tls-nativetls/Cargo.toml
@@ -18,7 +18,6 @@ tokio-native-tls = { workspace = true }
 native-tls = { workspace = true }
 
 [dev-dependencies]
-anyhow = { workspace = true }
 test-programs-artifacts = { workspace = true }
 wasmtime = { workspace = true, features = ["runtime", "component-model"] }
 wasmtime-wasi = { workspace = true }

--- a/crates/wasi-tls-nativetls/tests/main.rs
+++ b/crates/wasi-tls-nativetls/tests/main.rs
@@ -1,7 +1,7 @@
-use anyhow::{Result, anyhow};
 use wasmtime::{
-    Store,
+    Result, Store,
     component::{Component, Linker, ResourceTable},
+    format_err,
 };
 use wasmtime_wasi::{WasiCtx, WasiCtxView, WasiView, p2::bindings::Command};
 use wasmtime_wasi_tls::{LinkOptions, WasiTls, WasiTlsCtx, WasiTlsCtxBuilder};
@@ -52,7 +52,7 @@ async fn run_test(path: &str) -> Result<()> {
         .wasi_cli_run()
         .call_run(&mut store)
         .await?
-        .map_err(|()| anyhow!("command returned with failing exit status"))
+        .map_err(|()| format_err!("command returned with failing exit status"))
 }
 
 macro_rules! assert_test_exists {


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
