### PR TITLE
Migrate wasi-tls to `wasmtime::error`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5202,7 +5202,6 @@ dependencies = [
 name = "wasmtime-wasi-tls"
 version = "42.0.0"
 dependencies = [
- "anyhow",
  "bytes",
  "futures",
  "rustls",

--- a/crates/wasi-tls/Cargo.toml
+++ b/crates/wasi-tls/Cargo.toml
@@ -12,7 +12,6 @@ description = "Wasmtime implementation of the wasi-tls API"
 workspace = true
 
 [dependencies]
-anyhow = { workspace = true }
 bytes = { workspace = true }
 tokio = { workspace = true, features = [
     "net",

--- a/crates/wasi-tls/src/host.rs
+++ b/crates/wasi-tls/src/host.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use wasmtime::Result;
 use wasmtime::component::Resource;
 use wasmtime_wasi::async_trait;
 use wasmtime_wasi::p2::Pollable;

--- a/crates/wasi-tls/src/io.rs
+++ b/crates/wasi-tls/src/io.rs
@@ -1,7 +1,6 @@
 //! Utility types for converting Rust & Tokio I/O types into WASI I/O types,
 //! and vice versa.
 
-use anyhow::Result;
 use bytes::Bytes;
 use std::io;
 use std::sync::Arc;
@@ -9,6 +8,7 @@ use std::task::{Poll, ready};
 use std::{future::Future, mem, pin::Pin};
 use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
 use tokio::sync::Mutex;
+use wasmtime::Result;
 use wasmtime_wasi::async_trait;
 use wasmtime_wasi::p2::{
     DynInputStream, DynOutputStream, OutputStream, Pollable, StreamError, StreamResult,
@@ -281,7 +281,7 @@ where
 
     fn write(&mut self, mut bytes: bytes::Bytes) -> StreamResult<()> {
         let WriteState::Ready(_) = self else {
-            return Err(StreamError::Trap(anyhow::anyhow!(
+            return Err(StreamError::Trap(wasmtime::format_err!(
                 "unpermitted: must call check_write first"
             )));
         };

--- a/crates/wasi-tls/src/lib.rs
+++ b/crates/wasi-tls/src/lib.rs
@@ -100,7 +100,7 @@ pub fn add_to_linker<T: Send + 'static>(
     l: &mut wasmtime::component::Linker<T>,
     opts: &mut LinkOptions,
     f: fn(&mut T) -> WasiTls<'_>,
-) -> anyhow::Result<()> {
+) -> wasmtime::Result<()> {
     bindings::types::add_to_linker::<_, HasWasiTls>(l, &opts, f)?;
     Ok(())
 }

--- a/crates/wasi-tls/tests/main.rs
+++ b/crates/wasi-tls/tests/main.rs
@@ -1,7 +1,7 @@
-use anyhow::{Result, anyhow};
 use wasmtime::{
-    Store,
+    Result, Store,
     component::{Component, Linker, ResourceTable},
+    format_err,
 };
 use wasmtime_wasi::{WasiCtx, WasiCtxView, WasiView, p2::bindings::Command};
 use wasmtime_wasi_tls::{LinkOptions, WasiTls, WasiTlsCtx, WasiTlsCtxBuilder};
@@ -52,7 +52,7 @@ async fn run_test(path: &str) -> Result<()> {
         .wasi_cli_run()
         .call_run(&mut store)
         .await?
-        .map_err(|()| anyhow!("command returned with failing exit status"))
+        .map_err(|()| format_err!("command returned with failing exit status"))
 }
 
 macro_rules! assert_test_exists {


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
