### PR TITLE
Update cargo-vet with trusted publishing support

### DIFF
--- a/.github/actions/install-cargo-vet/action.yml
+++ b/.github/actions/install-cargo-vet/action.yml
@@ -5,7 +5,7 @@ inputs:
   version:
     description: 'Version to install'
     required: false
-    default: '0.10.0'
+    default: '8b40d6351ed9758a73a4a0bf2c930c17a35c5e15'
 
 runs:
   using: composite
@@ -16,5 +16,11 @@ runs:
         key: cargo-vet-bin-${{ inputs.version }}
     - run: echo "${{ runner.tool_cache }}/cargo-vet/bin" >> $GITHUB_PATH
       shell: bash
-    - run: cargo install --root ${{ runner.tool_cache }}/cargo-vet --version ${{ inputs.version }} cargo-vet --locked
+    - run: |
+        cargo install \
+          --root ${{ runner.tool_cache }}/cargo-vet \
+          --rev ${{ inputs.version }} \
+          --git https://github.com/mozilla/cargo-vet \
+          --locked \
+          cargo-vet
       shell: bash

--- a/scripts/publish.rs
+++ b/scripts/publish.rs
@@ -31,7 +31,6 @@ const CRATES_TO_PUBLISH: &[&str] = &[
     "cranelift-bforest",
     "cranelift-codegen-shared",
     "cranelift-codegen-meta",
-    "cranelift-egraph",
     "cranelift-control",
     "cranelift-codegen",
     "cranelift-reader",
@@ -52,8 +51,6 @@ const CRATES_TO_PUBLISH: &[&str] = &[
     // wiggle
     "wiggle-generate",
     "wiggle-macro",
-    // winch
-    "winch",
     // wasmtime
     "wasmtime-internal-error",
     "wasmtime-internal-versioned-export-macros",

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -17,12 +17,28 @@ start = "2019-03-16"
 end = "2026-08-21"
 
 [[wildcard-audits.cranelift]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:bytecodealliance/wasmtime"
+start = "2026-01-07"
+end = "2027-01-08"
+notes = "The Bytecode Alliance is the author of this crate"
+
+[[wildcard-audits.cranelift]]
 who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
 start = "2021-10-29"
 end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.cranelift-assembler-x64]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:bytecodealliance/wasmtime"
+start = "2026-01-07"
+end = "2027-01-08"
+notes = "The Bytecode Alliance is the author of this crate"
 
 [[wildcard-audits.cranelift-assembler-x64]]
 who = "Saúl Cabrera <saulecabrera@gmail.com>"
@@ -33,12 +49,28 @@ end = "2026-02-20"
 notes = "The Bytecode Alliance is the author of this crate"
 
 [[wildcard-audits.cranelift-assembler-x64-meta]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:bytecodealliance/wasmtime"
+start = "2026-01-07"
+end = "2027-01-08"
+notes = "The Bytecode Alliance is the author of this crate"
+
+[[wildcard-audits.cranelift-assembler-x64-meta]]
 who = "Saúl Cabrera <saulecabrera@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
 start = "2025-02-20"
 end = "2026-02-20"
 notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.cranelift-bforest]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:bytecodealliance/wasmtime"
+start = "2026-01-07"
+end = "2027-01-08"
+notes = "The Bytecode Alliance is the author of this crate"
 
 [[wildcard-audits.cranelift-bforest]]
 who = "Bobby Holley <bobbyholley@gmail.com>"
@@ -56,6 +88,22 @@ start = "2025-04-21"
 end = "2026-04-21"
 notes = "The Bytecode Alliance is the author of this crate."
 
+[[wildcard-audits.cranelift-bitset]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:bytecodealliance/wasmtime"
+start = "2026-01-07"
+end = "2027-01-08"
+notes = "The Bytecode Alliance is the author of this crate"
+
+[[wildcard-audits.cranelift-codegen]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:bytecodealliance/wasmtime"
+start = "2026-01-07"
+end = "2027-01-08"
+notes = "The Bytecode Alliance is the author of this crate"
+
 [[wildcard-audits.cranelift-codegen]]
 who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
@@ -63,6 +111,14 @@ user-id = 73222 # wasmtime-publish
 start = "2021-10-29"
 end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.cranelift-codegen-meta]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:bytecodealliance/wasmtime"
+start = "2026-01-07"
+end = "2027-01-08"
+notes = "The Bytecode Alliance is the author of this crate"
 
 [[wildcard-audits.cranelift-codegen-meta]]
 who = "Bobby Holley <bobbyholley@gmail.com>"
@@ -73,12 +129,28 @@ end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.cranelift-codegen-shared]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:bytecodealliance/wasmtime"
+start = "2026-01-07"
+end = "2027-01-08"
+notes = "The Bytecode Alliance is the author of this crate"
+
+[[wildcard-audits.cranelift-codegen-shared]]
 who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
 start = "2021-10-29"
 end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.cranelift-control]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:bytecodealliance/wasmtime"
+start = "2026-01-07"
+end = "2027-01-08"
+notes = "The Bytecode Alliance is the author of this crate"
 
 [[wildcard-audits.cranelift-control]]
 who = "Bobby Holley <bobbyholley@gmail.com>"
@@ -89,12 +161,28 @@ end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.cranelift-entity]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:bytecodealliance/wasmtime"
+start = "2026-01-07"
+end = "2027-01-08"
+notes = "The Bytecode Alliance is the author of this crate"
+
+[[wildcard-audits.cranelift-entity]]
 who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
 start = "2021-10-29"
 end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.cranelift-frontend]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:bytecodealliance/wasmtime"
+start = "2026-01-07"
+end = "2027-01-08"
+notes = "The Bytecode Alliance is the author of this crate"
 
 [[wildcard-audits.cranelift-frontend]]
 who = "Bobby Holley <bobbyholley@gmail.com>"
@@ -105,12 +193,28 @@ end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.cranelift-interpreter]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:bytecodealliance/wasmtime"
+start = "2026-01-07"
+end = "2027-01-08"
+notes = "The Bytecode Alliance is the author of this crate"
+
+[[wildcard-audits.cranelift-interpreter]]
 who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
 start = "2021-10-29"
 end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.cranelift-isle]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:bytecodealliance/wasmtime"
+start = "2026-01-07"
+end = "2027-01-08"
+notes = "The Bytecode Alliance is the author of this crate"
 
 [[wildcard-audits.cranelift-isle]]
 who = "Bobby Holley <bobbyholley@gmail.com>"
@@ -121,12 +225,28 @@ end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.cranelift-jit]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:bytecodealliance/wasmtime"
+start = "2026-01-07"
+end = "2027-01-08"
+notes = "The Bytecode Alliance is the author of this crate"
+
+[[wildcard-audits.cranelift-jit]]
 who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
 start = "2021-10-29"
 end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.cranelift-module]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:bytecodealliance/wasmtime"
+start = "2026-01-07"
+end = "2027-01-08"
+notes = "The Bytecode Alliance is the author of this crate"
 
 [[wildcard-audits.cranelift-module]]
 who = "Bobby Holley <bobbyholley@gmail.com>"
@@ -137,12 +257,28 @@ end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.cranelift-native]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:bytecodealliance/wasmtime"
+start = "2026-01-07"
+end = "2027-01-08"
+notes = "The Bytecode Alliance is the author of this crate"
+
+[[wildcard-audits.cranelift-native]]
 who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
 start = "2021-10-29"
 end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.cranelift-object]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:bytecodealliance/wasmtime"
+start = "2026-01-07"
+end = "2027-01-08"
+notes = "The Bytecode Alliance is the author of this crate"
 
 [[wildcard-audits.cranelift-object]]
 who = "Bobby Holley <bobbyholley@gmail.com>"
@@ -153,12 +289,28 @@ end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.cranelift-reader]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:bytecodealliance/wasmtime"
+start = "2026-01-07"
+end = "2027-01-08"
+notes = "The Bytecode Alliance is the author of this crate"
+
+[[wildcard-audits.cranelift-reader]]
 who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
 start = "2021-10-29"
 end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.cranelift-serde]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:bytecodealliance/wasmtime"
+start = "2026-01-07"
+end = "2027-01-08"
+notes = "The Bytecode Alliance is the author of this crate"
 
 [[wildcard-audits.cranelift-serde]]
 who = "Bobby Holley <bobbyholley@gmail.com>"
@@ -175,6 +327,14 @@ user-id = 73222 # wasmtime-publish
 start = "2025-04-21"
 end = "2026-04-21"
 notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.cranelift-srcgen]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:bytecodealliance/wasmtime"
+start = "2026-01-07"
+end = "2027-01-08"
+notes = "The Bytecode Alliance is the author of this crate"
 
 [[wildcard-audits.cranelift-wasm]]
 who = "Bobby Holley <bobbyholley@gmail.com>"
@@ -202,6 +362,14 @@ notes = """
 The Bytecode Alliance is the author of this crate.
 """
 
+[[wildcard-audits.json-from-wast]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:bytecodealliance/wasm-tools"
+start = "2025-08-14"
+end = "2027-01-08"
+notes = "The Bytecode Alliance is the author of this crate"
+
 [[wildcard-audits.mutatis]]
 who = "Nick Fitzgerald <fitzgen@gmail.com>"
 criteria = "safe-to-deploy"
@@ -220,6 +388,14 @@ start = "2024-09-20"
 end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
 
+[[wildcard-audits.pulley-interpreter]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:bytecodealliance/wasmtime"
+start = "2026-01-07"
+end = "2027-01-08"
+notes = "The Bytecode Alliance is the author of this crate"
+
 [[wildcard-audits.pulley-macros]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
@@ -242,6 +418,14 @@ user-id = 73222 # wasmtime-publish
 start = "2025-06-20"
 end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.pulley-macros]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:bytecodealliance/wasmtime"
+start = "2026-01-07"
+end = "2027-01-08"
+notes = "The Bytecode Alliance is the author of this crate"
 
 [[wildcard-audits.regalloc2]]
 who = "Chris Fallin <chris@cfallin.org>"
@@ -281,6 +465,14 @@ user-id = 73222 # wasmtime-publish
 start = "2021-10-29"
 end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.wasi-common]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:bytecodealliance/wasmtime"
+start = "2026-01-07"
+end = "2027-01-08"
+notes = "The Bytecode Alliance is the author of this crate"
 
 [[wildcard-audits.wasi-common]]
 who = "Bobby Holley <bobbyholley@gmail.com>"
@@ -346,6 +538,14 @@ notes = """
 The Bytecode Alliance is the author of this crate
 """
 
+[[wildcard-audits.wasm-compose]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:bytecodealliance/wasm-tools"
+start = "2025-08-14"
+end = "2027-01-08"
+notes = "The Bytecode Alliance is the author of this crate"
+
 [[wildcard-audits.wasm-encoder]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
@@ -378,6 +578,14 @@ user-id = 73222 # wasmtime-publish
 start = "2024-02-15"
 end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.wasm-encoder]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:bytecodealliance/wasm-tools"
+start = "2025-08-14"
+end = "2027-01-08"
+notes = "The Bytecode Alliance is the author of this crate"
 
 [[wildcard-audits.wasm-metadata]]
 who = "Alex Crichton <alex@alexcrichton.com>"
@@ -426,6 +634,14 @@ so and will actively maintain this crate over time.
 """
 
 [[wildcard-audits.wasm-mutate]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:bytecodealliance/wasm-tools"
+start = "2025-08-14"
+end = "2027-01-08"
+notes = "The Bytecode Alliance is the author of this crate"
+
+[[wildcard-audits.wasm-mutate]]
 who = "Nick Fitzgerald <fitzgen@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 696 # Nick Fitzgerald (fitzgen)
@@ -445,6 +661,14 @@ I am employed by a member of the Bytecode Alliance and plan to continue doing
 so and will actively maintain this crate over time.
 """
 
+[[wildcard-audits.wasm-smith]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:bytecodealliance/wasm-tools"
+start = "2025-08-14"
+end = "2027-01-08"
+notes = "The Bytecode Alliance is the author of this crate"
+
 [[wildcard-audits.wasm-wave]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
@@ -452,6 +676,14 @@ user-id = 73222 # wasmtime-publish
 start = "2024-06-19"
 end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.wasm-wave]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:bytecodealliance/wasm-tools"
+start = "2025-08-14"
+end = "2027-01-08"
+notes = "The Bytecode Alliance is the author of this crate"
 
 [[wildcard-audits.wasmparser]]
 who = "Alex Crichton <alex@alexcrichton.com>"
@@ -485,6 +717,14 @@ user-id = 73222 # wasmtime-publish
 start = "2024-02-15"
 end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.wasmparser]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:bytecodealliance/wasm-tools"
+start = "2025-08-14"
+end = "2027-01-08"
+notes = "The Bytecode Alliance is the author of this crate"
 
 [[wildcard-audits.wasmprinter]]
 who = "Alex Crichton <alex@alexcrichton.com>"
@@ -520,11 +760,27 @@ end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.wasmprinter]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:bytecodealliance/wasm-tools"
+start = "2025-08-14"
+end = "2027-01-08"
+notes = "The Bytecode Alliance is the author of this crate"
+
+[[wildcard-audits.wasmprinter]]
 who = "Nick Fitzgerald <fitzgen@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 696 # Nick Fitzgerald (fitzgen)
 start = "2021-04-28"
 end = "2026-08-21"
+
+[[wildcard-audits.wasmtime]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:bytecodealliance/wasmtime"
+start = "2026-01-07"
+end = "2027-01-08"
+notes = "The Bytecode Alliance is the author of this crate"
 
 [[wildcard-audits.wasmtime]]
 who = "Bobby Holley <bobbyholley@gmail.com>"
@@ -567,12 +823,28 @@ end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.wasmtime-cli]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:bytecodealliance/wasmtime"
+start = "2026-01-07"
+end = "2027-01-08"
+notes = "The Bytecode Alliance is the author of this crate"
+
+[[wildcard-audits.wasmtime-cli]]
 who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
 start = "2021-10-29"
 end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.wasmtime-cli-flags]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:bytecodealliance/wasmtime"
+start = "2026-01-07"
+end = "2027-01-08"
+notes = "The Bytecode Alliance is the author of this crate"
 
 [[wildcard-audits.wasmtime-cli-flags]]
 who = "Bobby Holley <bobbyholley@gmail.com>"
@@ -613,6 +885,14 @@ user-id = 73222 # wasmtime-publish
 start = "2023-04-20"
 end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.wasmtime-environ]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:bytecodealliance/wasmtime"
+start = "2026-01-07"
+end = "2027-01-08"
+notes = "The Bytecode Alliance is the author of this crate"
 
 [[wildcard-audits.wasmtime-environ]]
 who = "Bobby Holley <bobbyholley@gmail.com>"
@@ -662,6 +942,14 @@ start = "2025-07-20"
 end = "2026-07-20"
 notes = "The Bytecode Alliance is the author of this crate."
 
+[[wildcard-audits.wasmtime-internal-c-api-macros]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:bytecodealliance/wasmtime"
+start = "2026-01-07"
+end = "2027-01-08"
+notes = "The Bytecode Alliance is the author of this crate"
+
 [[wildcard-audits.wasmtime-internal-cache]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
@@ -671,6 +959,22 @@ end = "2026-07-20"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.wasmtime-internal-cache]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2025-07-20"
+end = "2026-07-20"
+notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.wasmtime-internal-cache]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:bytecodealliance/wasmtime"
+start = "2026-01-07"
+end = "2027-01-08"
+notes = "The Bytecode Alliance is the author of this crate"
+
+[[wildcard-audits.wasmtime-internal-component-macro]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
@@ -681,10 +985,10 @@ notes = "The Bytecode Alliance is the author of this crate."
 [[wildcard-audits.wasmtime-internal-component-macro]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
-user-id = 73222 # wasmtime-publish
-start = "2025-07-20"
-end = "2026-07-20"
-notes = "The Bytecode Alliance is the author of this crate."
+trusted-publisher = "github:bytecodealliance/wasmtime"
+start = "2026-01-07"
+end = "2027-01-08"
+notes = "The Bytecode Alliance is the author of this crate"
 
 [[wildcard-audits.wasmtime-internal-component-util]]
 who = "Alex Crichton <alex@alexcrichton.com>"
@@ -694,6 +998,14 @@ start = "2025-07-20"
 end = "2026-07-20"
 notes = "The Bytecode Alliance is the author of this crate."
 
+[[wildcard-audits.wasmtime-internal-component-util]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:bytecodealliance/wasmtime"
+start = "2026-01-07"
+end = "2027-01-08"
+notes = "The Bytecode Alliance is the author of this crate"
+
 [[wildcard-audits.wasmtime-internal-cranelift]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
@@ -710,6 +1022,14 @@ start = "2025-07-20"
 end = "2026-07-20"
 notes = "The Bytecode Alliance is the author of this crate."
 
+[[wildcard-audits.wasmtime-internal-cranelift]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:bytecodealliance/wasmtime"
+start = "2026-01-07"
+end = "2027-01-08"
+notes = "The Bytecode Alliance is the author of this crate"
+
 [[wildcard-audits.wasmtime-internal-explorer]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
@@ -719,6 +1039,22 @@ end = "2026-07-20"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.wasmtime-internal-explorer]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2025-07-20"
+end = "2026-07-20"
+notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.wasmtime-internal-explorer]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:bytecodealliance/wasmtime"
+start = "2026-01-07"
+end = "2027-01-08"
+notes = "The Bytecode Alliance is the author of this crate"
+
+[[wildcard-audits.wasmtime-internal-fiber]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
@@ -729,12 +1065,28 @@ notes = "The Bytecode Alliance is the author of this crate."
 [[wildcard-audits.wasmtime-internal-fiber]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
+trusted-publisher = "github:bytecodealliance/wasmtime"
+start = "2026-01-07"
+end = "2027-01-08"
+notes = "The Bytecode Alliance is the author of this crate"
+
+[[wildcard-audits.wasmtime-internal-jit-debug]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
 start = "2025-07-20"
 end = "2026-07-20"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.wasmtime-internal-jit-debug]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:bytecodealliance/wasmtime"
+start = "2026-01-07"
+end = "2027-01-08"
+notes = "The Bytecode Alliance is the author of this crate"
+
+[[wildcard-audits.wasmtime-internal-jit-icache-coherence]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
@@ -745,12 +1097,28 @@ notes = "The Bytecode Alliance is the author of this crate."
 [[wildcard-audits.wasmtime-internal-jit-icache-coherence]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
+trusted-publisher = "github:bytecodealliance/wasmtime"
+start = "2026-01-07"
+end = "2027-01-08"
+notes = "The Bytecode Alliance is the author of this crate"
+
+[[wildcard-audits.wasmtime-internal-math]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
 start = "2025-07-20"
 end = "2026-07-20"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.wasmtime-internal-math]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:bytecodealliance/wasmtime"
+start = "2026-01-07"
+end = "2027-01-08"
+notes = "The Bytecode Alliance is the author of this crate"
+
+[[wildcard-audits.wasmtime-internal-slab]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
@@ -761,12 +1129,28 @@ notes = "The Bytecode Alliance is the author of this crate."
 [[wildcard-audits.wasmtime-internal-slab]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
+trusted-publisher = "github:bytecodealliance/wasmtime"
+start = "2026-01-07"
+end = "2027-01-08"
+notes = "The Bytecode Alliance is the author of this crate"
+
+[[wildcard-audits.wasmtime-internal-unwinder]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
 start = "2025-07-20"
 end = "2026-07-20"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.wasmtime-internal-unwinder]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:bytecodealliance/wasmtime"
+start = "2026-01-07"
+end = "2027-01-08"
+notes = "The Bytecode Alliance is the author of this crate"
+
+[[wildcard-audits.wasmtime-internal-versioned-export-macros]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
@@ -777,10 +1161,10 @@ notes = "The Bytecode Alliance is the author of this crate."
 [[wildcard-audits.wasmtime-internal-versioned-export-macros]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
-user-id = 73222 # wasmtime-publish
-start = "2025-07-20"
-end = "2026-07-20"
-notes = "The Bytecode Alliance is the author of this crate."
+trusted-publisher = "github:bytecodealliance/wasmtime"
+start = "2026-01-07"
+end = "2027-01-08"
+notes = "The Bytecode Alliance is the author of this crate"
 
 [[wildcard-audits.wasmtime-internal-winch]]
 who = "Alex Crichton <alex@alexcrichton.com>"
@@ -798,7 +1182,31 @@ start = "2025-07-20"
 end = "2026-07-20"
 notes = "The Bytecode Alliance is the author of this crate."
 
+[[wildcard-audits.wasmtime-internal-winch]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:bytecodealliance/wasmtime"
+start = "2026-01-07"
+end = "2027-01-08"
+notes = "The Bytecode Alliance is the author of this crate"
+
 [[wildcard-audits.wasmtime-internal-wit-bindgen]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2025-07-20"
+end = "2026-07-20"
+notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.wasmtime-internal-wit-bindgen]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:bytecodealliance/wasmtime"
+start = "2026-01-07"
+end = "2027-01-08"
+notes = "The Bytecode Alliance is the author of this crate"
+
+[[wildcard-audits.wasmtime-internal-wmemcheck]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
@@ -809,10 +1217,10 @@ notes = "The Bytecode Alliance is the author of this crate."
 [[wildcard-audits.wasmtime-internal-wmemcheck]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
-user-id = 73222 # wasmtime-publish
-start = "2025-07-20"
-end = "2026-07-20"
-notes = "The Bytecode Alliance is the author of this crate."
+trusted-publisher = "github:bytecodealliance/wasmtime"
+start = "2026-01-07"
+end = "2027-01-08"
+notes = "The Bytecode Alliance is the author of this crate"
 
 [[wildcard-audits.wasmtime-jit]]
 who = "Bobby Holley <bobbyholley@gmail.com>"
@@ -875,6 +1283,14 @@ end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.wasmtime-wasi]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:bytecodealliance/wasmtime"
+start = "2026-01-07"
+end = "2027-01-08"
+notes = "The Bytecode Alliance is the author of this crate"
+
+[[wildcard-audits.wasmtime-wasi]]
 who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
@@ -890,6 +1306,14 @@ start = "2021-10-29"
 end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
 
+[[wildcard-audits.wasmtime-wasi-config]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:bytecodealliance/wasmtime"
+start = "2026-01-07"
+end = "2027-01-08"
+notes = "The Bytecode Alliance is the author of this crate"
+
 [[wildcard-audits.wasmtime-wasi-crypto]]
 who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
@@ -899,12 +1323,28 @@ end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.wasmtime-wasi-http]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:bytecodealliance/wasmtime"
+start = "2026-01-07"
+end = "2027-01-08"
+notes = "The Bytecode Alliance is the author of this crate"
+
+[[wildcard-audits.wasmtime-wasi-http]]
 who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
 start = "2023-05-22"
 end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.wasmtime-wasi-io]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:bytecodealliance/wasmtime"
+start = "2026-01-07"
+end = "2027-01-08"
+notes = "The Bytecode Alliance is the author of this crate"
 
 [[wildcard-audits.wasmtime-wasi-io]]
 who = "Saúl Cabrera <saulecabrera@gmail.com>"
@@ -921,6 +1361,22 @@ user-id = 73222 # wasmtime-publish
 start = "2021-10-29"
 end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.wasmtime-wasi-keyvalue]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:bytecodealliance/wasmtime"
+start = "2026-01-07"
+end = "2027-01-08"
+notes = "The Bytecode Alliance is the author of this crate"
+
+[[wildcard-audits.wasmtime-wasi-nn]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:bytecodealliance/wasmtime"
+start = "2026-01-07"
+end = "2027-01-08"
+notes = "The Bytecode Alliance is the author of this crate"
 
 [[wildcard-audits.wasmtime-wasi-nn]]
 who = "Bobby Holley <bobbyholley@gmail.com>"
@@ -939,6 +1395,14 @@ end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.wasmtime-wasi-threads]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:bytecodealliance/wasmtime"
+start = "2026-01-07"
+end = "2027-01-08"
+notes = "The Bytecode Alliance is the author of this crate"
+
+[[wildcard-audits.wasmtime-wasi-threads]]
 who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
@@ -953,6 +1417,14 @@ user-id = 73222 # wasmtime-publish
 start = "2025-04-21"
 end = "2026-04-21"
 notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.wasmtime-wasi-tls]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:bytecodealliance/wasmtime"
+start = "2026-01-07"
+end = "2027-01-08"
+notes = "The Bytecode Alliance is the author of this crate"
 
 [[wildcard-audits.wasmtime-wasi-tls-nativetls]]
 who = "Alex Crichton <alex@alexcrichton.com>"
@@ -969,6 +1441,22 @@ user-id = 73222 # wasmtime-publish
 start = "2025-07-20"
 end = "2026-07-20"
 notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.wasmtime-wasi-tls-nativetls]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:bytecodealliance/wasmtime"
+start = "2026-01-07"
+end = "2027-01-08"
+notes = "The Bytecode Alliance is the author of this crate"
+
+[[wildcard-audits.wasmtime-wast]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:bytecodealliance/wasmtime"
+start = "2026-01-07"
+end = "2027-01-08"
+notes = "The Bytecode Alliance is the author of this crate"
 
 [[wildcard-audits.wasmtime-wast]]
 who = "Bobby Holley <bobbyholley@gmail.com>"
@@ -1001,6 +1489,14 @@ user-id = 73222 # wasmtime-publish
 start = "2025-11-19"
 end = "2026-11-19"
 notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.wasmtime-wizer]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:bytecodealliance/wasmtime"
+start = "2026-01-07"
+end = "2027-01-08"
+notes = "The Bytecode Alliance is the author of this crate"
 
 [[wildcard-audits.wasmtime-wmemcheck]]
 who = "Pat Hickey <pat@moreproductive.org>"
@@ -1043,6 +1539,14 @@ start = "2024-02-15"
 end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
 
+[[wildcard-audits.wast]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:bytecodealliance/wasm-tools"
+start = "2025-08-14"
+end = "2027-01-08"
+notes = "The Bytecode Alliance is the author of this crate"
+
 [[wildcard-audits.wat]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
@@ -1076,6 +1580,22 @@ start = "2024-02-15"
 end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
 
+[[wildcard-audits.wat]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:bytecodealliance/wasm-tools"
+start = "2025-08-14"
+end = "2027-01-08"
+notes = "The Bytecode Alliance is the author of this crate"
+
+[[wildcard-audits.wiggle]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:bytecodealliance/wasmtime"
+start = "2026-01-07"
+end = "2027-01-08"
+notes = "The Bytecode Alliance is the author of this crate"
+
 [[wildcard-audits.wiggle]]
 who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
@@ -1085,12 +1605,28 @@ end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.wiggle-generate]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:bytecodealliance/wasmtime"
+start = "2026-01-07"
+end = "2027-01-08"
+notes = "The Bytecode Alliance is the author of this crate"
+
+[[wildcard-audits.wiggle-generate]]
 who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
 start = "2021-10-29"
 end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.wiggle-macro]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:bytecodealliance/wasmtime"
+start = "2026-01-07"
+end = "2027-01-08"
+notes = "The Bytecode Alliance is the author of this crate"
 
 [[wildcard-audits.wiggle-macro]]
 who = "Bobby Holley <bobbyholley@gmail.com>"
@@ -1107,6 +1643,14 @@ user-id = 18162 # Pat Hickey (pchickey)
 start = "2020-03-12"
 end = "2025-07-30"
 notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.winch-codegen]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:bytecodealliance/wasmtime"
+start = "2026-01-07"
+end = "2027-01-08"
+notes = "The Bytecode Alliance is the author of this crate"
 
 [[wildcard-audits.winch-codegen]]
 who = "Bobby Holley <bobbyholley@gmail.com>"
@@ -1141,6 +1685,14 @@ publication of this crate from CI. This repository requires all PRs are reviewed
 by a Bytecode Alliance maintainer and it owned by the Bytecode Alliance itself.
 """
 
+[[wildcard-audits.wit-bindgen]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:bytecodealliance/wit-bindgen"
+start = "2025-08-13"
+end = "2027-01-08"
+notes = "The Bytecode Alliance is the author of this crate"
+
 [[wildcard-audits.wit-bindgen-core]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
@@ -1165,6 +1717,14 @@ The Bytecode Alliance uses the `wasmtime-publish` crates.io account to automate
 publication of this crate from CI. This repository requires all PRs are reviewed
 by a Bytecode Alliance maintainer and it owned by the Bytecode Alliance itself.
 """
+
+[[wildcard-audits.wit-bindgen-core]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:bytecodealliance/wit-bindgen"
+start = "2025-08-13"
+end = "2027-01-08"
+notes = "The Bytecode Alliance is the author of this crate"
 
 [[wildcard-audits.wit-bindgen-rt]]
 who = "Alex Crichton <alex@alexcrichton.com>"
@@ -1241,6 +1801,14 @@ publication of this crate from CI. This repository requires all PRs are reviewed
 by a Bytecode Alliance maintainer and it owned by the Bytecode Alliance itself.
 """
 
+[[wildcard-audits.wit-bindgen-rust-macro]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:bytecodealliance/wit-bindgen"
+start = "2025-08-13"
+end = "2027-01-08"
+notes = "The Bytecode Alliance is the author of this crate"
+
 [[wildcard-audits.wit-component]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
@@ -1273,6 +1841,14 @@ user-id = 73222 # wasmtime-publish
 start = "2024-02-15"
 end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.wit-component]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:bytecodealliance/wasm-tools"
+start = "2025-08-14"
+end = "2027-01-08"
+notes = "The Bytecode Alliance is the author of this crate"
 
 [[wildcard-audits.wit-component]]
 who = "Nick Fitzgerald <fitzgen@gmail.com>"
@@ -1313,6 +1889,14 @@ user-id = 73222 # wasmtime-publish
 start = "2024-02-15"
 end = "2026-08-21"
 notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.wit-parser]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:bytecodealliance/wasm-tools"
+start = "2025-08-14"
+end = "2027-01-08"
+notes = "The Bytecode Alliance is the author of this crate"
 
 [[audits.addr2line]]
 who = "Alex Crichton <alex@alexcrichton.com>"
@@ -2483,7 +3067,7 @@ delta = "0.3.27 -> 0.3.31"
 who = "Pat Hickey <pat@moreproductive.org>"
 criteria = "safe-to-deploy"
 delta = "0.3.27 -> 0.3.31"
-notes = "New waker_ref module contains \"FIXME: panics on Arc::clone / refcount changes could wreak havoc...\" comment, but this corner case feels low risk."
+notes = 'New waker_ref module contains "FIXME: panics on Arc::clone / refcount changes could wreak havoc..." comment, but this corner case feels low risk.'
 
 [[audits.fxprof-processed-profile]]
 who = "Jamey Sharp <jsharp@fastly.com>"
@@ -2491,7 +3075,7 @@ criteria = "safe-to-deploy"
 version = "0.6.0"
 notes = """
 No unsafe code, I/O, or powerful imports. This is a straightforward set of data
-structures representing the Firefox \"processed\" profile format, with serde
+structures representing the Firefox "processed" profile format, with serde
 serialization support. All logic is trivial: either unit conversion, or
 hash-consing to support de-duplication required by the format.
 """

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -2,704 +2,240 @@
 # cargo-vet imports lock
 
 [[unpublished.cranelift]]
-version = "0.127.0"
-audited_as = "0.126.1"
-
-[[unpublished.cranelift]]
-version = "0.128.0"
-audited_as = "0.126.1"
-
-[[unpublished.cranelift]]
 version = "0.129.0"
-audited_as = "0.127.0"
-
-[[unpublished.cranelift-assembler-x64]]
-version = "0.127.0"
-audited_as = "0.126.1"
-
-[[unpublished.cranelift-assembler-x64]]
-version = "0.128.0"
-audited_as = "0.126.1"
+audited_as = "0.127.1"
 
 [[unpublished.cranelift-assembler-x64]]
 version = "0.129.0"
-audited_as = "0.127.0"
-
-[[unpublished.cranelift-assembler-x64-meta]]
-version = "0.127.0"
-audited_as = "0.126.1"
-
-[[unpublished.cranelift-assembler-x64-meta]]
-version = "0.128.0"
-audited_as = "0.126.1"
+audited_as = "0.127.1"
 
 [[unpublished.cranelift-assembler-x64-meta]]
 version = "0.129.0"
-audited_as = "0.127.0"
-
-[[unpublished.cranelift-bforest]]
-version = "0.127.0"
-audited_as = "0.126.1"
-
-[[unpublished.cranelift-bforest]]
-version = "0.128.0"
-audited_as = "0.126.1"
+audited_as = "0.127.1"
 
 [[unpublished.cranelift-bforest]]
 version = "0.129.0"
-audited_as = "0.127.0"
-
-[[unpublished.cranelift-bitset]]
-version = "0.127.0"
-audited_as = "0.126.1"
-
-[[unpublished.cranelift-bitset]]
-version = "0.128.0"
-audited_as = "0.126.1"
+audited_as = "0.127.1"
 
 [[unpublished.cranelift-bitset]]
 version = "0.129.0"
-audited_as = "0.127.0"
-
-[[unpublished.cranelift-codegen]]
-version = "0.127.0"
-audited_as = "0.126.1"
-
-[[unpublished.cranelift-codegen]]
-version = "0.128.0"
-audited_as = "0.126.1"
+audited_as = "0.127.1"
 
 [[unpublished.cranelift-codegen]]
 version = "0.129.0"
-audited_as = "0.127.0"
-
-[[unpublished.cranelift-codegen-meta]]
-version = "0.127.0"
-audited_as = "0.126.1"
-
-[[unpublished.cranelift-codegen-meta]]
-version = "0.128.0"
-audited_as = "0.126.1"
+audited_as = "0.127.1"
 
 [[unpublished.cranelift-codegen-meta]]
 version = "0.129.0"
-audited_as = "0.127.0"
-
-[[unpublished.cranelift-codegen-shared]]
-version = "0.127.0"
-audited_as = "0.126.1"
-
-[[unpublished.cranelift-codegen-shared]]
-version = "0.128.0"
-audited_as = "0.126.1"
+audited_as = "0.127.1"
 
 [[unpublished.cranelift-codegen-shared]]
 version = "0.129.0"
-audited_as = "0.127.0"
-
-[[unpublished.cranelift-control]]
-version = "0.127.0"
-audited_as = "0.126.1"
-
-[[unpublished.cranelift-control]]
-version = "0.128.0"
-audited_as = "0.126.1"
+audited_as = "0.127.1"
 
 [[unpublished.cranelift-control]]
 version = "0.129.0"
-audited_as = "0.127.0"
-
-[[unpublished.cranelift-entity]]
-version = "0.127.0"
-audited_as = "0.126.1"
-
-[[unpublished.cranelift-entity]]
-version = "0.128.0"
-audited_as = "0.126.1"
+audited_as = "0.127.1"
 
 [[unpublished.cranelift-entity]]
 version = "0.129.0"
-audited_as = "0.127.0"
-
-[[unpublished.cranelift-frontend]]
-version = "0.127.0"
-audited_as = "0.126.1"
-
-[[unpublished.cranelift-frontend]]
-version = "0.128.0"
-audited_as = "0.126.1"
+audited_as = "0.127.1"
 
 [[unpublished.cranelift-frontend]]
 version = "0.129.0"
-audited_as = "0.127.0"
-
-[[unpublished.cranelift-interpreter]]
-version = "0.127.0"
-audited_as = "0.126.1"
-
-[[unpublished.cranelift-interpreter]]
-version = "0.128.0"
-audited_as = "0.126.1"
+audited_as = "0.127.1"
 
 [[unpublished.cranelift-interpreter]]
 version = "0.129.0"
-audited_as = "0.127.0"
-
-[[unpublished.cranelift-isle]]
-version = "0.127.0"
-audited_as = "0.126.1"
-
-[[unpublished.cranelift-isle]]
-version = "0.128.0"
-audited_as = "0.126.1"
+audited_as = "0.127.1"
 
 [[unpublished.cranelift-isle]]
 version = "0.129.0"
-audited_as = "0.127.0"
-
-[[unpublished.cranelift-jit]]
-version = "0.127.0"
-audited_as = "0.126.1"
-
-[[unpublished.cranelift-jit]]
-version = "0.128.0"
-audited_as = "0.126.1"
+audited_as = "0.127.1"
 
 [[unpublished.cranelift-jit]]
 version = "0.129.0"
-audited_as = "0.127.0"
-
-[[unpublished.cranelift-module]]
-version = "0.127.0"
-audited_as = "0.126.1"
-
-[[unpublished.cranelift-module]]
-version = "0.128.0"
-audited_as = "0.126.1"
+audited_as = "0.127.1"
 
 [[unpublished.cranelift-module]]
 version = "0.129.0"
-audited_as = "0.127.0"
-
-[[unpublished.cranelift-native]]
-version = "0.127.0"
-audited_as = "0.126.1"
-
-[[unpublished.cranelift-native]]
-version = "0.128.0"
-audited_as = "0.126.1"
+audited_as = "0.127.1"
 
 [[unpublished.cranelift-native]]
 version = "0.129.0"
-audited_as = "0.127.0"
-
-[[unpublished.cranelift-object]]
-version = "0.127.0"
-audited_as = "0.126.1"
-
-[[unpublished.cranelift-object]]
-version = "0.128.0"
-audited_as = "0.126.1"
+audited_as = "0.127.1"
 
 [[unpublished.cranelift-object]]
 version = "0.129.0"
-audited_as = "0.127.0"
-
-[[unpublished.cranelift-reader]]
-version = "0.127.0"
-audited_as = "0.126.1"
-
-[[unpublished.cranelift-reader]]
-version = "0.128.0"
-audited_as = "0.126.1"
+audited_as = "0.127.1"
 
 [[unpublished.cranelift-reader]]
 version = "0.129.0"
-audited_as = "0.127.0"
-
-[[unpublished.cranelift-serde]]
-version = "0.127.0"
-audited_as = "0.126.1"
-
-[[unpublished.cranelift-serde]]
-version = "0.128.0"
-audited_as = "0.126.1"
+audited_as = "0.127.1"
 
 [[unpublished.cranelift-serde]]
 version = "0.129.0"
-audited_as = "0.127.0"
-
-[[unpublished.cranelift-srcgen]]
-version = "0.127.0"
-audited_as = "0.126.1"
-
-[[unpublished.cranelift-srcgen]]
-version = "0.128.0"
-audited_as = "0.126.1"
+audited_as = "0.127.1"
 
 [[unpublished.cranelift-srcgen]]
 version = "0.129.0"
-audited_as = "0.127.0"
-
-[[unpublished.pulley-interpreter]]
-version = "40.0.0"
-audited_as = "39.0.1"
-
-[[unpublished.pulley-interpreter]]
-version = "41.0.0"
-audited_as = "39.0.1"
+audited_as = "0.127.1"
 
 [[unpublished.pulley-interpreter]]
 version = "42.0.0"
-audited_as = "40.0.0"
-
-[[unpublished.pulley-macros]]
-version = "40.0.0"
-audited_as = "39.0.1"
-
-[[unpublished.pulley-macros]]
-version = "41.0.0"
-audited_as = "39.0.1"
+audited_as = "40.0.1"
 
 [[unpublished.pulley-macros]]
 version = "42.0.0"
-audited_as = "40.0.0"
-
-[[unpublished.wasi-common]]
-version = "40.0.0"
-audited_as = "39.0.1"
-
-[[unpublished.wasi-common]]
-version = "41.0.0"
-audited_as = "39.0.1"
+audited_as = "40.0.1"
 
 [[unpublished.wasi-common]]
 version = "42.0.0"
-audited_as = "40.0.0"
-
-[[unpublished.wasmtime]]
-version = "40.0.0"
-audited_as = "39.0.1"
-
-[[unpublished.wasmtime]]
-version = "41.0.0"
-audited_as = "39.0.1"
+audited_as = "40.0.1"
 
 [[unpublished.wasmtime]]
 version = "42.0.0"
-audited_as = "40.0.0"
-
-[[unpublished.wasmtime-cli]]
-version = "40.0.0"
-audited_as = "39.0.1"
-
-[[unpublished.wasmtime-cli]]
-version = "41.0.0"
-audited_as = "39.0.1"
+audited_as = "40.0.1"
 
 [[unpublished.wasmtime-cli]]
 version = "42.0.0"
-audited_as = "40.0.0"
-
-[[unpublished.wasmtime-cli-flags]]
-version = "40.0.0"
-audited_as = "39.0.1"
-
-[[unpublished.wasmtime-cli-flags]]
-version = "41.0.0"
-audited_as = "39.0.1"
+audited_as = "40.0.1"
 
 [[unpublished.wasmtime-cli-flags]]
 version = "42.0.0"
-audited_as = "40.0.0"
-
-[[unpublished.wasmtime-environ]]
-version = "40.0.0"
-audited_as = "39.0.1"
-
-[[unpublished.wasmtime-environ]]
-version = "41.0.0"
-audited_as = "39.0.1"
+audited_as = "40.0.1"
 
 [[unpublished.wasmtime-environ]]
 version = "42.0.0"
-audited_as = "40.0.0"
-
-[[unpublished.wasmtime-internal-c-api-macros]]
-version = "40.0.0"
-audited_as = "39.0.1"
-
-[[unpublished.wasmtime-internal-c-api-macros]]
-version = "41.0.0"
-audited_as = "39.0.1"
+audited_as = "40.0.1"
 
 [[unpublished.wasmtime-internal-c-api-macros]]
 version = "42.0.0"
-audited_as = "40.0.0"
-
-[[unpublished.wasmtime-internal-cache]]
-version = "40.0.0"
-audited_as = "39.0.1"
-
-[[unpublished.wasmtime-internal-cache]]
-version = "41.0.0"
-audited_as = "39.0.1"
+audited_as = "40.0.1"
 
 [[unpublished.wasmtime-internal-cache]]
 version = "42.0.0"
-audited_as = "40.0.0"
-
-[[unpublished.wasmtime-internal-component-macro]]
-version = "40.0.0"
-audited_as = "39.0.1"
-
-[[unpublished.wasmtime-internal-component-macro]]
-version = "41.0.0"
-audited_as = "39.0.1"
+audited_as = "40.0.1"
 
 [[unpublished.wasmtime-internal-component-macro]]
 version = "42.0.0"
-audited_as = "40.0.0"
-
-[[unpublished.wasmtime-internal-component-util]]
-version = "40.0.0"
-audited_as = "39.0.1"
-
-[[unpublished.wasmtime-internal-component-util]]
-version = "41.0.0"
-audited_as = "39.0.1"
+audited_as = "40.0.1"
 
 [[unpublished.wasmtime-internal-component-util]]
 version = "42.0.0"
-audited_as = "40.0.0"
-
-[[unpublished.wasmtime-internal-cranelift]]
-version = "40.0.0"
-audited_as = "39.0.1"
-
-[[unpublished.wasmtime-internal-cranelift]]
-version = "41.0.0"
-audited_as = "39.0.1"
+audited_as = "40.0.1"
 
 [[unpublished.wasmtime-internal-cranelift]]
 version = "42.0.0"
-audited_as = "40.0.0"
-
-[[unpublished.wasmtime-internal-explorer]]
-version = "40.0.0"
-audited_as = "39.0.1"
-
-[[unpublished.wasmtime-internal-explorer]]
-version = "41.0.0"
-audited_as = "39.0.1"
+audited_as = "40.0.1"
 
 [[unpublished.wasmtime-internal-explorer]]
 version = "42.0.0"
-audited_as = "40.0.0"
-
-[[unpublished.wasmtime-internal-fiber]]
-version = "40.0.0"
-audited_as = "39.0.1"
-
-[[unpublished.wasmtime-internal-fiber]]
-version = "41.0.0"
-audited_as = "39.0.1"
+audited_as = "40.0.1"
 
 [[unpublished.wasmtime-internal-fiber]]
 version = "42.0.0"
-audited_as = "40.0.0"
-
-[[unpublished.wasmtime-internal-jit-debug]]
-version = "40.0.0"
-audited_as = "39.0.1"
-
-[[unpublished.wasmtime-internal-jit-debug]]
-version = "41.0.0"
-audited_as = "39.0.1"
+audited_as = "40.0.1"
 
 [[unpublished.wasmtime-internal-jit-debug]]
 version = "42.0.0"
-audited_as = "40.0.0"
-
-[[unpublished.wasmtime-internal-jit-icache-coherence]]
-version = "40.0.0"
-audited_as = "39.0.1"
-
-[[unpublished.wasmtime-internal-jit-icache-coherence]]
-version = "41.0.0"
-audited_as = "39.0.1"
+audited_as = "40.0.1"
 
 [[unpublished.wasmtime-internal-jit-icache-coherence]]
 version = "42.0.0"
-audited_as = "40.0.0"
-
-[[unpublished.wasmtime-internal-math]]
-version = "40.0.0"
-audited_as = "39.0.1"
-
-[[unpublished.wasmtime-internal-math]]
-version = "41.0.0"
-audited_as = "39.0.1"
+audited_as = "40.0.1"
 
 [[unpublished.wasmtime-internal-math]]
 version = "42.0.0"
-audited_as = "40.0.0"
-
-[[unpublished.wasmtime-internal-slab]]
-version = "40.0.0"
-audited_as = "39.0.1"
-
-[[unpublished.wasmtime-internal-slab]]
-version = "41.0.0"
-audited_as = "39.0.1"
+audited_as = "40.0.1"
 
 [[unpublished.wasmtime-internal-slab]]
 version = "42.0.0"
-audited_as = "40.0.0"
-
-[[unpublished.wasmtime-internal-unwinder]]
-version = "40.0.0"
-audited_as = "39.0.1"
-
-[[unpublished.wasmtime-internal-unwinder]]
-version = "41.0.0"
-audited_as = "39.0.1"
+audited_as = "40.0.1"
 
 [[unpublished.wasmtime-internal-unwinder]]
 version = "42.0.0"
-audited_as = "40.0.0"
-
-[[unpublished.wasmtime-internal-versioned-export-macros]]
-version = "40.0.0"
-audited_as = "39.0.1"
-
-[[unpublished.wasmtime-internal-versioned-export-macros]]
-version = "41.0.0"
-audited_as = "39.0.1"
+audited_as = "40.0.1"
 
 [[unpublished.wasmtime-internal-versioned-export-macros]]
 version = "42.0.0"
-audited_as = "40.0.0"
-
-[[unpublished.wasmtime-internal-winch]]
-version = "40.0.0"
-audited_as = "39.0.1"
-
-[[unpublished.wasmtime-internal-winch]]
-version = "41.0.0"
-audited_as = "39.0.1"
+audited_as = "40.0.1"
 
 [[unpublished.wasmtime-internal-winch]]
 version = "42.0.0"
-audited_as = "40.0.0"
-
-[[unpublished.wasmtime-internal-wit-bindgen]]
-version = "40.0.0"
-audited_as = "39.0.1"
-
-[[unpublished.wasmtime-internal-wit-bindgen]]
-version = "41.0.0"
-audited_as = "39.0.1"
+audited_as = "40.0.1"
 
 [[unpublished.wasmtime-internal-wit-bindgen]]
 version = "42.0.0"
-audited_as = "40.0.0"
-
-[[unpublished.wasmtime-internal-wmemcheck]]
-version = "40.0.0"
-audited_as = "39.0.1"
-
-[[unpublished.wasmtime-internal-wmemcheck]]
-version = "41.0.0"
-audited_as = "39.0.1"
+audited_as = "40.0.1"
 
 [[unpublished.wasmtime-internal-wmemcheck]]
 version = "42.0.0"
-audited_as = "40.0.0"
-
-[[unpublished.wasmtime-wasi]]
-version = "40.0.0"
-audited_as = "39.0.1"
-
-[[unpublished.wasmtime-wasi]]
-version = "41.0.0"
-audited_as = "39.0.1"
+audited_as = "40.0.1"
 
 [[unpublished.wasmtime-wasi]]
 version = "42.0.0"
-audited_as = "40.0.0"
-
-[[unpublished.wasmtime-wasi-config]]
-version = "40.0.0"
-audited_as = "39.0.1"
-
-[[unpublished.wasmtime-wasi-config]]
-version = "41.0.0"
-audited_as = "39.0.1"
+audited_as = "40.0.1"
 
 [[unpublished.wasmtime-wasi-config]]
 version = "42.0.0"
-audited_as = "40.0.0"
-
-[[unpublished.wasmtime-wasi-http]]
-version = "40.0.0"
-audited_as = "39.0.1"
-
-[[unpublished.wasmtime-wasi-http]]
-version = "41.0.0"
-audited_as = "39.0.1"
+audited_as = "40.0.1"
 
 [[unpublished.wasmtime-wasi-http]]
 version = "42.0.0"
-audited_as = "40.0.0"
-
-[[unpublished.wasmtime-wasi-io]]
-version = "40.0.0"
-audited_as = "39.0.1"
-
-[[unpublished.wasmtime-wasi-io]]
-version = "41.0.0"
-audited_as = "39.0.1"
+audited_as = "40.0.1"
 
 [[unpublished.wasmtime-wasi-io]]
 version = "42.0.0"
-audited_as = "40.0.0"
-
-[[unpublished.wasmtime-wasi-keyvalue]]
-version = "40.0.0"
-audited_as = "39.0.1"
-
-[[unpublished.wasmtime-wasi-keyvalue]]
-version = "41.0.0"
-audited_as = "39.0.1"
+audited_as = "40.0.1"
 
 [[unpublished.wasmtime-wasi-keyvalue]]
 version = "42.0.0"
-audited_as = "40.0.0"
-
-[[unpublished.wasmtime-wasi-nn]]
-version = "40.0.0"
-audited_as = "39.0.1"
-
-[[unpublished.wasmtime-wasi-nn]]
-version = "41.0.0"
-audited_as = "39.0.1"
+audited_as = "40.0.1"
 
 [[unpublished.wasmtime-wasi-nn]]
 version = "42.0.0"
-audited_as = "40.0.0"
-
-[[unpublished.wasmtime-wasi-threads]]
-version = "40.0.0"
-audited_as = "39.0.1"
-
-[[unpublished.wasmtime-wasi-threads]]
-version = "41.0.0"
-audited_as = "39.0.1"
+audited_as = "40.0.1"
 
 [[unpublished.wasmtime-wasi-threads]]
 version = "42.0.0"
-audited_as = "40.0.0"
-
-[[unpublished.wasmtime-wasi-tls]]
-version = "40.0.0"
-audited_as = "39.0.1"
-
-[[unpublished.wasmtime-wasi-tls]]
-version = "41.0.0"
-audited_as = "39.0.1"
+audited_as = "40.0.1"
 
 [[unpublished.wasmtime-wasi-tls]]
 version = "42.0.0"
-audited_as = "40.0.0"
-
-[[unpublished.wasmtime-wasi-tls-nativetls]]
-version = "40.0.0"
-audited_as = "39.0.1"
-
-[[unpublished.wasmtime-wasi-tls-nativetls]]
-version = "41.0.0"
-audited_as = "39.0.1"
+audited_as = "40.0.1"
 
 [[unpublished.wasmtime-wasi-tls-nativetls]]
 version = "42.0.0"
-audited_as = "40.0.0"
-
-[[unpublished.wasmtime-wast]]
-version = "40.0.0"
-audited_as = "39.0.1"
-
-[[unpublished.wasmtime-wast]]
-version = "41.0.0"
-audited_as = "39.0.1"
+audited_as = "40.0.1"
 
 [[unpublished.wasmtime-wast]]
 version = "42.0.0"
-audited_as = "40.0.0"
-
-[[unpublished.wasmtime-wizer]]
-version = "40.0.0"
-audited_as = "39.0.1"
-
-[[unpublished.wasmtime-wizer]]
-version = "41.0.0"
-audited_as = "39.0.1"
+audited_as = "40.0.1"
 
 [[unpublished.wasmtime-wizer]]
 version = "42.0.0"
-audited_as = "40.0.0"
-
-[[unpublished.wiggle]]
-version = "40.0.0"
-audited_as = "39.0.1"
-
-[[unpublished.wiggle]]
-version = "41.0.0"
-audited_as = "39.0.1"
+audited_as = "40.0.1"
 
 [[unpublished.wiggle]]
 version = "42.0.0"
-audited_as = "40.0.0"
-
-[[unpublished.wiggle-generate]]
-version = "40.0.0"
-audited_as = "39.0.1"
-
-[[unpublished.wiggle-generate]]
-version = "41.0.0"
-audited_as = "39.0.1"
+audited_as = "40.0.1"
 
 [[unpublished.wiggle-generate]]
 version = "42.0.0"
-audited_as = "40.0.0"
-
-[[unpublished.wiggle-macro]]
-version = "40.0.0"
-audited_as = "39.0.1"
-
-[[unpublished.wiggle-macro]]
-version = "41.0.0"
-audited_as = "39.0.1"
+audited_as = "40.0.1"
 
 [[unpublished.wiggle-macro]]
 version = "42.0.0"
-audited_as = "40.0.0"
+audited_as = "40.0.1"
 
 [[unpublished.wiggle-test]]
 version = "0.0.0"
 audited_as = "0.1.0"
 
 [[unpublished.winch-codegen]]
-version = "40.0.0"
-audited_as = "39.0.1"
-
-[[unpublished.winch-codegen]]
-version = "41.0.0"
-audited_as = "39.0.1"
-
-[[unpublished.winch-codegen]]
 version = "42.0.0"
-audited_as = "40.0.0"
+audited_as = "40.0.1"
 
 [[publisher.aho-corasick]]
 version = "1.0.2"
@@ -918,124 +454,104 @@ user-login = "jrmuizel"
 user-name = "Jeff Muizelaar"
 
 [[publisher.cranelift]]
-version = "0.127.0"
-when = "2025-12-22"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "0.127.1"
+when = "2026-01-07"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-assembler-x64]]
-version = "0.127.0"
-when = "2025-12-22"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "0.127.1"
+when = "2026-01-07"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-assembler-x64-meta]]
-version = "0.127.0"
-when = "2025-12-22"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "0.127.1"
+when = "2026-01-07"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-bforest]]
-version = "0.127.0"
-when = "2025-12-22"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "0.127.1"
+when = "2026-01-07"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-bitset]]
-version = "0.127.0"
-when = "2025-12-22"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "0.127.1"
+when = "2026-01-07"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-codegen]]
-version = "0.127.0"
-when = "2025-12-22"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "0.127.1"
+when = "2026-01-07"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-codegen-meta]]
-version = "0.127.0"
-when = "2025-12-22"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "0.127.1"
+when = "2026-01-07"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-codegen-shared]]
-version = "0.127.0"
-when = "2025-12-22"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "0.127.1"
+when = "2026-01-07"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-control]]
-version = "0.127.0"
-when = "2025-12-22"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "0.127.1"
+when = "2026-01-07"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-entity]]
-version = "0.127.0"
-when = "2025-12-22"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "0.127.1"
+when = "2026-01-07"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-frontend]]
-version = "0.127.0"
-when = "2025-12-22"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "0.127.1"
+when = "2026-01-07"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-interpreter]]
-version = "0.127.0"
-when = "2025-12-22"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "0.127.1"
+when = "2026-01-07"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-isle]]
-version = "0.127.0"
-when = "2025-12-22"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "0.127.1"
+when = "2026-01-07"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-jit]]
-version = "0.127.0"
-when = "2025-12-22"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "0.127.1"
+when = "2026-01-07"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-module]]
-version = "0.127.0"
-when = "2025-12-22"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "0.127.1"
+when = "2026-01-07"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-native]]
-version = "0.127.0"
-when = "2025-12-22"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "0.127.1"
+when = "2026-01-07"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-object]]
-version = "0.127.0"
-when = "2025-12-22"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "0.127.1"
+when = "2026-01-07"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-reader]]
-version = "0.127.0"
-when = "2025-12-22"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "0.127.1"
+when = "2026-01-07"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-serde]]
-version = "0.127.0"
-when = "2025-12-22"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "0.127.1"
+when = "2026-01-07"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-srcgen]]
-version = "0.127.0"
-when = "2025-12-22"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "0.127.1"
+when = "2026-01-07"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.derive_arbitrary]]
 version = "1.4.0"
@@ -1308,16 +824,14 @@ user-login = "dtolnay"
 user-name = "David Tolnay"
 
 [[publisher.pulley-interpreter]]
-version = "40.0.0"
-when = "2025-12-22"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "40.0.1"
+when = "2026-01-07"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.pulley-macros]]
-version = "40.0.0"
-when = "2025-12-22"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "40.0.1"
+when = "2026-01-07"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.quote]]
 version = "1.0.41"
@@ -1642,10 +1156,9 @@ user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
 [[publisher.wasi-common]]
-version = "40.0.0"
-when = "2025-12-22"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "40.0.1"
+when = "2026-01-07"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasip1]]
 version = "1.0.0"
@@ -1733,190 +1246,159 @@ user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime]]
-version = "40.0.0"
-when = "2025-12-22"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "40.0.1"
+when = "2026-01-07"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-cli]]
-version = "40.0.0"
-when = "2025-12-22"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "40.0.1"
+when = "2026-01-07"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-cli-flags]]
-version = "40.0.0"
-when = "2025-12-22"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "40.0.1"
+when = "2026-01-07"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-environ]]
-version = "40.0.0"
-when = "2025-12-22"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "40.0.1"
+when = "2026-01-07"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-c-api-macros]]
-version = "40.0.0"
-when = "2025-12-22"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "40.0.1"
+when = "2026-01-07"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-cache]]
-version = "40.0.0"
-when = "2025-12-22"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "40.0.1"
+when = "2026-01-07"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-component-macro]]
-version = "40.0.0"
-when = "2025-12-22"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "40.0.1"
+when = "2026-01-07"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-component-util]]
-version = "40.0.0"
-when = "2025-12-22"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "40.0.1"
+when = "2026-01-07"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-cranelift]]
-version = "40.0.0"
-when = "2025-12-22"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "40.0.1"
+when = "2026-01-07"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-explorer]]
-version = "40.0.0"
-when = "2025-12-22"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "40.0.1"
+when = "2026-01-07"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-fiber]]
-version = "40.0.0"
-when = "2025-12-22"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "40.0.1"
+when = "2026-01-07"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-jit-debug]]
-version = "40.0.0"
-when = "2025-12-22"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "40.0.1"
+when = "2026-01-07"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-jit-icache-coherence]]
-version = "40.0.0"
-when = "2025-12-22"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "40.0.1"
+when = "2026-01-07"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-math]]
-version = "40.0.0"
-when = "2025-12-22"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "40.0.1"
+when = "2026-01-07"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-slab]]
-version = "40.0.0"
-when = "2025-12-22"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "40.0.1"
+when = "2026-01-07"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-unwinder]]
-version = "40.0.0"
-when = "2025-12-22"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "40.0.1"
+when = "2026-01-07"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-versioned-export-macros]]
-version = "40.0.0"
-when = "2025-12-22"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "40.0.1"
+when = "2026-01-07"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-winch]]
-version = "40.0.0"
-when = "2025-12-22"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "40.0.1"
+when = "2026-01-07"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-wit-bindgen]]
-version = "40.0.0"
-when = "2025-12-22"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "40.0.1"
+when = "2026-01-07"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-wmemcheck]]
-version = "40.0.0"
-when = "2025-12-22"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "40.0.1"
+when = "2026-01-07"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wasi]]
-version = "40.0.0"
-when = "2025-12-22"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "40.0.1"
+when = "2026-01-07"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wasi-config]]
-version = "40.0.0"
-when = "2025-12-22"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "40.0.1"
+when = "2026-01-07"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wasi-http]]
-version = "40.0.0"
-when = "2025-12-22"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "40.0.1"
+when = "2026-01-07"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wasi-io]]
-version = "40.0.0"
-when = "2025-12-22"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "40.0.1"
+when = "2026-01-07"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wasi-keyvalue]]
-version = "40.0.0"
-when = "2025-12-22"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "40.0.1"
+when = "2026-01-07"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wasi-nn]]
-version = "40.0.0"
-when = "2025-12-22"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "40.0.1"
+when = "2026-01-07"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wasi-threads]]
-version = "40.0.0"
-when = "2025-12-22"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "40.0.1"
+when = "2026-01-07"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wasi-tls]]
-version = "40.0.0"
-when = "2025-12-22"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "40.0.1"
+when = "2026-01-07"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wasi-tls-nativetls]]
-version = "40.0.0"
-when = "2025-12-22"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "40.0.1"
+when = "2026-01-07"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wast]]
-version = "40.0.0"
-when = "2025-12-22"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "40.0.1"
+when = "2026-01-07"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wizer]]
-version = "40.0.0"
-when = "2025-12-22"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "40.0.1"
+when = "2026-01-07"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wast]]
 version = "236.0.0"
@@ -1931,22 +1413,19 @@ user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wiggle]]
-version = "40.0.0"
-when = "2025-12-22"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "40.0.1"
+when = "2026-01-07"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wiggle-generate]]
-version = "40.0.0"
-when = "2025-12-22"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "40.0.1"
+when = "2026-01-07"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wiggle-macro]]
-version = "40.0.0"
-when = "2025-12-22"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "40.0.1"
+when = "2026-01-07"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wiggle-test]]
 version = "0.1.0"
@@ -1963,10 +1442,9 @@ user-login = "BurntSushi"
 user-name = "Andrew Gallant"
 
 [[publisher.winch-codegen]]
-version = "40.0.0"
-when = "2025-12-22"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "40.0.1"
+when = "2026-01-07"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.windows]]
 version = "0.52.0"
@@ -3648,7 +3126,7 @@ aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-ch
 who = "Makoto Kato <m_kato@ga2.so-net.ne.jp>"
 criteria = "safe-to-deploy"
 version = "0.1.2"
-notes = "This crate is zero-copy version of \"From\". This has no unsafe code and uses no ambient capabilities."
+notes = 'This crate is zero-copy version of "From". This has no unsafe code and uses no ambient capabilities.'
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.zerofrom]]


### PR DESCRIPTION
This updates the `cargo vet` used in CI to include support for trusted publishing. This is necessary now that the latest version of Wasmtime (40.0.1) is published with trusted publishing. I'm not entirely sure why this is necessary, but it's going to be inevitable in the future anyway as we transition to trusted publishing.

The `cargo vet` tool is now installed from git and new wildcard audits for all wasmtime, wasm-tools, and wit-bindgen crates are added for the appropriate trusted-publisher. Maintainers will need to install cargo-vet from git as well, but unfortunately after the publish of 40.0.1 yesterday I don't think we have an option as otherwise CI is broken.

Closes #12283
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
