### PR TITLE
Do not include `anyhow!` macro in `wasmtime_environ::prelude`

### DIFF
--- a/crates/cache/src/config.rs
+++ b/crates/cache/src/config.rs
@@ -10,7 +10,7 @@ use std::fmt::Debug;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
-use wasmtime_environ::error::{Context, Result, anyhow, bail};
+use wasmtime_environ::prelude::*;
 
 // wrapped, so we have named section in config,
 // also, for possible future compatibility
@@ -132,7 +132,7 @@ pub fn create_new_config<P: AsRef<Path> + Debug>(config_file: Option<P>) -> Resu
 
     let parent_dir = config_file
         .parent()
-        .ok_or_else(|| anyhow!("Invalid cache config path: {}", config_file.display()))?;
+        .ok_or_else(|| format_err!("Invalid cache config path: {}", config_file.display()))?;
 
     fs::create_dir_all(parent_dir).with_context(|| {
         format!(

--- a/crates/environ/src/compile/mod.rs
+++ b/crates/environ/src/compile/mod.rs
@@ -97,7 +97,7 @@ pub trait CompilerBuilder: Send + Sync + fmt::Debug {
 
     /// Enables clif output in the directory specified.
     fn clif_dir(&mut self, _path: &path::Path) -> Result<()> {
-        anyhow::bail!("clif output not supported");
+        bail!("clif output not supported");
     }
 
     /// Returns the currently configured target triple that compilation will
@@ -364,7 +364,7 @@ pub trait Compiler: Send + Sync {
             Pulley32 | Pulley32be => (Architecture::Riscv64, obj::EF_WASMTIME_PULLEY32),
             Pulley64 | Pulley64be => (Architecture::Riscv64, obj::EF_WASMTIME_PULLEY64),
             architecture => {
-                anyhow::bail!("target architecture {architecture:?} is unsupported");
+                bail!("target architecture {architecture:?} is unsupported");
             }
         };
         let mut obj = Object::new(

--- a/crates/environ/src/component/intrinsic.rs
+++ b/crates/environ/src/component/intrinsic.rs
@@ -1,8 +1,7 @@
 //! Wasmtime compile-time intrinsic definitions.
 
+use crate::prelude::*;
 use core::str::FromStr;
-
-use crate::error::{Result, bail};
 use serde_derive::{Deserialize, Serialize};
 
 /// Invoke a macro for each of our unsafe intrinsics.
@@ -120,7 +119,7 @@ macro_rules! define_unsafe_intrinsics {
         }
 
         impl FromStr for UnsafeIntrinsic {
-            type Err = anyhow::Error;
+            type Err = Error;
 
             fn from_str(s: &str) -> Result<Self> {
                 match s {

--- a/crates/environ/src/component/translate.rs
+++ b/crates/environ/src/component/translate.rs
@@ -1,10 +1,6 @@
 use crate::Abi;
 use crate::component::dfg::AbstractInstantiations;
 use crate::component::*;
-use crate::error::Context;
-use crate::error::anyhow;
-use crate::error::ensure;
-use crate::error::{Result, bail};
 use crate::prelude::*;
 use crate::{
     EngineOrModuleTypeIndex, EntityIndex, FuncKey, ModuleEnvironment, ModuleInternedTypeIndex,
@@ -1205,7 +1201,7 @@ impl<'a, 'data> Translator<'a, 'data> {
                     component
                         .get(unchecked_range.start..unchecked_range.end)
                         .ok_or_else(|| {
-                            anyhow!(
+                            format_err!(
                                 "section range {}..{} is out of bounds (bound = {})",
                                 unchecked_range.start,
                                 unchecked_range.end,
@@ -1682,7 +1678,7 @@ impl<'a, 'data> Translator<'a, 'data> {
                 kind: &str,
                 import: &str,
                 name: &str,
-            ) -> core::result::Result<(), anyhow::Error> {
+            ) -> Result<()> {
                 let expected_len = expected.len();
                 let actual_len = actual.len();
                 ensure!(

--- a/crates/environ/src/prelude.rs
+++ b/crates/environ/src/prelude.rs
@@ -19,7 +19,7 @@
 //!
 //! and then `use crate::*` works as usual.
 
-pub use crate::error::{Context, Error, Result, anyhow, bail, ensure};
+pub use crate::error::{Context, Error, Result, bail, ensure, format_err};
 pub use alloc::borrow::ToOwned;
 pub use alloc::boxed::Box;
 pub use alloc::format;

--- a/crates/environ/src/tunables.rs
+++ b/crates/environ/src/tunables.rs
@@ -1,4 +1,4 @@
-use crate::error::{Error, Result, anyhow, bail};
+use crate::prelude::*;
 use crate::{IndexType, Limits, Memory, TripleExt};
 use core::{fmt, str::FromStr};
 use serde_derive::{Deserialize, Serialize};
@@ -168,7 +168,7 @@ impl Tunables {
         }
         let mut ret = match target
             .pointer_width()
-            .map_err(|_| anyhow!("failed to retrieve target pointer width"))?
+            .map_err(|_| format_err!("failed to retrieve target pointer width"))?
         {
             PointerWidth::U32 => Tunables::default_u32(),
             PointerWidth::U64 => Tunables::default_u64(),

--- a/crates/unwinder/src/exception_table.rs
+++ b/crates/unwinder/src/exception_table.rs
@@ -257,29 +257,29 @@ impl<'a> ExceptionTable<'a> {
         let mut data = Bytes(data);
         let callsite_count = data
             .read::<U32Bytes<LittleEndian>>()
-            .map_err(|_| anyhow!("Unable to read callsite count prefix"))?;
+            .map_err(|_| format_err!("Unable to read callsite count prefix"))?;
         let callsite_count = usize::try_from(callsite_count.get(LittleEndian))?;
         let handler_count = data
             .read::<U32Bytes<LittleEndian>>()
-            .map_err(|_| anyhow!("Unable to read handler count prefix"))?;
+            .map_err(|_| format_err!("Unable to read handler count prefix"))?;
         let handler_count = usize::try_from(handler_count.get(LittleEndian))?;
         let (callsites, data) =
             object::slice_from_bytes::<U32Bytes<LittleEndian>>(data.0, callsite_count)
-                .map_err(|_| anyhow!("Unable to read callsites slice"))?;
+                .map_err(|_| format_err!("Unable to read callsites slice"))?;
         let (frame_offsets, data) =
             object::slice_from_bytes::<U32Bytes<LittleEndian>>(data, callsite_count)
-                .map_err(|_| anyhow!("Unable to read frame_offsets slice"))?;
+                .map_err(|_| format_err!("Unable to read frame_offsets slice"))?;
         let (ranges, data) =
             object::slice_from_bytes::<U32Bytes<LittleEndian>>(data, callsite_count)
-                .map_err(|_| anyhow!("Unable to read ranges slice"))?;
+                .map_err(|_| format_err!("Unable to read ranges slice"))?;
         let (tags, data) = object::slice_from_bytes::<U32Bytes<LittleEndian>>(data, handler_count)
-            .map_err(|_| anyhow!("Unable to read tags slice"))?;
+            .map_err(|_| format_err!("Unable to read tags slice"))?;
         let (contexts, data) =
             object::slice_from_bytes::<U32Bytes<LittleEndian>>(data, handler_count)
-                .map_err(|_| anyhow!("Unable to read contexts slice"))?;
+                .map_err(|_| format_err!("Unable to read contexts slice"))?;
         let (handlers, data) =
             object::slice_from_bytes::<U32Bytes<LittleEndian>>(data, handler_count)
-                .map_err(|_| anyhow!("Unable to read handlers slice"))?;
+                .map_err(|_| format_err!("Unable to read handlers slice"))?;
 
         if !data.is_empty() {
             bail!("Unexpected data at end of serialized exception table");


### PR DESCRIPTION
Builds on https://github.com/bytecodealliance/wasmtime/pull/12295

Okay this should *really* be the last thing before we swap out `anyhow` for `wasmtime-internal-error`.