### PR TITLE
Migrate winch-codegen to `wasmtime_environ::error`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5395,7 +5395,6 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 name = "winch-codegen"
 version = "42.0.0"
 dependencies = [
- "anyhow",
  "cranelift-assembler-x64",
  "cranelift-codegen",
  "gimli 0.32.3",

--- a/winch/codegen/Cargo.toml
+++ b/winch/codegen/Cargo.toml
@@ -14,7 +14,6 @@ workspace = true
 [dependencies]
 wasmparser = { workspace = true }
 smallvec = { workspace = true }
-anyhow = { workspace = true }
 target-lexicon = { workspace = true, features = ["std"] }
 # The following two dependencies (cranelift-codegen, regalloc2) are temporary;
 # mostly to have access to `PReg`s and the calling convention.

--- a/winch/codegen/src/abi/mod.rs
+++ b/winch/codegen/src/abi/mod.rs
@@ -45,10 +45,10 @@
 //! |        + arguments            |
 //! |                               | ----> Space allocated for calls
 //! |                               |
+use crate::Result;
 use crate::codegen::ptr_type_from_ptr_size;
 use crate::isa::{CallingConvention, reg::Reg};
 use crate::masm::SPOffset;
-use anyhow::Result;
 use smallvec::SmallVec;
 use std::collections::HashSet;
 use std::ops::{Add, BitAnd, Not, Sub};

--- a/winch/codegen/src/codegen/bounds.rs
+++ b/winch/codegen/src/codegen/bounds.rs
@@ -3,13 +3,13 @@
 //! recommended when working on this area of Winch.
 use super::env::HeapData;
 use crate::{
+    Result,
     abi::vmctx,
     codegen::{CodeGenContext, Emission},
     isa::reg::{Reg, writable},
     masm::{IntCmpKind, IntScratch, MacroAssembler, OperandSize, RegImm, TrapCode},
     stack::TypedReg,
 };
-use anyhow::Result;
 
 /// A newtype to represent an immediate offset argument for a heap access.
 #[derive(Debug, Copy, Clone)]

--- a/winch/codegen/src/codegen/builtin.rs
+++ b/winch/codegen/src/codegen/builtin.rs
@@ -1,11 +1,10 @@
 //! Builtin function handling.
 
 use crate::{
-    CallingConvention,
+    CallingConvention, Result,
     abi::{ABI, ABISig},
     codegen::env::ptr_type_from_ptr_size,
 };
-use anyhow::Result;
 use std::sync::Arc;
 use wasmtime_environ::{BuiltinFunctionIndex, PtrSize, VMOffsets, WasmValType};
 

--- a/winch/codegen/src/codegen/call.rs
+++ b/winch/codegen/src/codegen/call.rs
@@ -59,9 +59,10 @@
 //! └──────────────────────────────────────────────────┘ ------> Stack pointer when emitting the call
 
 use crate::{
-    FuncEnv,
+    FuncEnv, Result,
     abi::{ABIOperand, ABISig, RetArea, vmctx},
     codegen::{BuiltinFunction, BuiltinType, Callee, CodeGenContext, CodeGenError, Emission},
+    ensure,
     masm::{
         CalleeKind, ContextArgs, IntScratch, MacroAssembler, MemMoveDirection, OperandSize,
         SPOffset, VMContextLoc,
@@ -69,7 +70,6 @@ use crate::{
     reg::{Reg, writable},
     stack::Val,
 };
-use anyhow::{Result, ensure};
 use wasmtime_environ::{DefinedFuncIndex, FuncIndex, PtrSize, VMOffsets};
 
 /// All the information needed to emit a function call.
@@ -285,7 +285,7 @@ impl FnCall {
                     masm.load(addr, writable!(*reg), (*ty).try_into()?)?;
                 }
                 (VMContextLoc::OffsetFromPinned(_), ABIOperand::Stack { .. }) => {
-                    anyhow::bail!("unimplemented load from vmctx into stack");
+                    crate::bail!("unimplemented load from vmctx into stack");
                 }
 
                 (VMContextLoc::Reg(src), ABIOperand::Reg { ty, reg, .. }) => {

--- a/winch/codegen/src/codegen/context.rs
+++ b/winch/codegen/src/codegen/context.rs
@@ -1,11 +1,10 @@
-use anyhow::{Result, bail, ensure};
-use wasmparser::{Ieee32, Ieee64};
-use wasmtime_environ::{VMOffsets, WasmHeapType, WasmValType};
-
 use super::ControlStackFrame;
 use crate::{
+    Result,
     abi::{ABIOperand, ABIResults, RetArea, vmctx},
+    bail,
     codegen::{BranchState, CodeGenError, CodeGenPhase, Emission, Prologue},
+    ensure,
     frame::Frame,
     isa::reg::RegClass,
     masm::{
@@ -16,6 +15,8 @@ use crate::{
     regalloc::RegAlloc,
     stack::{Stack, TypedReg, Val},
 };
+use wasmparser::{Ieee32, Ieee64};
+use wasmtime_environ::{VMOffsets, WasmHeapType, WasmValType};
 
 /// The code generation context.
 /// The code generation context is made up of three
@@ -609,7 +610,7 @@ impl<'a> CodeGenContext<'a, Emission> {
         }
         .map_or_else(
             || Ok(RegImm::reg(self.pop_to_reg(masm, None)?.into())),
-            Ok::<_, anyhow::Error>,
+            Ok::<_, crate::Error>,
         )?;
 
         let dst = self.pop_to_reg(masm, None)?;
@@ -850,7 +851,7 @@ impl<'a> CodeGenContext<'a, Emission> {
                         masm.load(addr, scratch.writable(), slot.ty.try_into()?)?;
                         let stack_slot = masm.push(scratch.inner(), slot.ty.try_into()?)?;
                         *v = Val::mem(slot.ty, stack_slot);
-                        anyhow::Ok(())
+                        wasmtime_environ::error::Ok(())
                     })?;
                 }
                 _ => {}

--- a/winch/codegen/src/codegen/control.rs
+++ b/winch/codegen/src/codegen/control.rs
@@ -8,13 +8,13 @@
 //! a conditional jump inline when emitting the control flow instruction.
 use super::{CodeGenContext, CodeGenError, Emission, OperandSize, Reg, TypedReg};
 use crate::{
-    CallingConvention,
+    CallingConvention, Result,
     abi::{ABI, ABIOperand, ABIResults, ABISig, RetArea},
+    bail, ensure, format_err,
     masm::{IntCmpKind, MacroAssembler, MemMoveDirection, RegImm, SPOffset},
     reg::writable,
     stack::Val,
 };
-use anyhow::{Result, anyhow, bail, ensure};
 use cranelift_codegen::MachLabel;
 use wasmtime_environ::{WasmFuncType, WasmValType};
 
@@ -466,7 +466,7 @@ impl ControlStackFrame {
                 masm.bind(head)?;
                 Ok(())
             }
-            _ => Err(anyhow!(CodeGenError::if_control_frame_expected())),
+            _ => Err(format_err!(CodeGenError::if_control_frame_expected())),
         }
     }
 

--- a/winch/codegen/src/codegen/env.rs
+++ b/winch/codegen/src/codegen/env.rs
@@ -1,9 +1,9 @@
 use crate::{
+    Result,
     abi::{ABI, ABISig, wasm_sig},
     codegen::{BlockSig, BuiltinFunction, BuiltinFunctions, OperandSize, control},
     isa::TargetIsa,
 };
-use anyhow::Result;
 use cranelift_codegen::ir::{UserExternalName, UserExternalNameRef};
 use std::collections::{
     HashMap,

--- a/winch/codegen/src/frame/mod.rs
+++ b/winch/codegen/src/frame/mod.rs
@@ -1,9 +1,9 @@
 use crate::{
+    Result,
     abi::{ABI, ABIOperand, ABISig, LocalSlot, align_to},
     codegen::{CodeGenPhase, Emission, Prologue},
     masm::MacroAssembler,
 };
-use anyhow::Result;
 use smallvec::SmallVec;
 use std::marker::PhantomData;
 use std::ops::Range;

--- a/winch/codegen/src/isa/aarch64/abi.rs
+++ b/winch/codegen/src/isa/aarch64/abi.rs
@@ -1,9 +1,8 @@
 use super::regs;
-use crate::RegIndexEnv;
 use crate::abi::{ABI, ABIOperand, ABIParams, ABIResults, ABISig, ParamsOrReturns, align_to};
 use crate::codegen::CodeGenError;
 use crate::isa::{CallingConvention, reg::Reg};
-use anyhow::{Result, bail};
+use crate::{RegIndexEnv, Result, bail};
 use wasmtime_environ::{WasmHeapType, WasmValType};
 
 #[derive(Default)]
@@ -198,6 +197,7 @@ impl Aarch64ABI {
 mod tests {
     use super::Aarch64ABI;
     use crate::{
+        Result,
         abi::{ABI, ABIOperand},
         isa::CallingConvention,
         isa::aarch64::regs,
@@ -207,8 +207,6 @@ mod tests {
         WasmFuncType,
         WasmValType::{self, *},
     };
-
-    use anyhow::Result;
 
     #[test]
     fn xreg_abi_sig() -> Result<()> {

--- a/winch/codegen/src/isa/aarch64/address.rs
+++ b/winch/codegen/src/isa/aarch64/address.rs
@@ -1,14 +1,13 @@
 //! Aarch64 addressing mode.
 
-use anyhow::{Context, Result, anyhow};
+use super::regs;
+use crate::reg::Reg;
+use crate::{Context as _, Result, format_err};
 use cranelift_codegen::VCodeConstant;
 use cranelift_codegen::{
     ir::types,
     isa::aarch64::inst::{AMode, PairAMode, SImm7Scaled, SImm9},
 };
-
-use super::regs;
-use crate::reg::Reg;
 
 /// Aarch64 indexing mode.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -108,7 +107,7 @@ impl Address {
 // and `cranelift-codegen`s addressing mode representation for aarch64.
 
 impl TryFrom<Address> for PairAMode {
-    type Error = anyhow::Error;
+    type Error = crate::Error;
 
     fn try_from(addr: Address) -> Result<Self> {
         use Address::*;
@@ -126,7 +125,7 @@ impl TryFrom<Address> for PairAMode {
                     Ok(PairAMode::SPPostIndexed { simm7 })
                 }
             }
-            other => Err(anyhow!(
+            other => Err(format_err!(
                 "Could not convert {other:?} to addressing mode for register pairs"
             )),
         }
@@ -134,7 +133,7 @@ impl TryFrom<Address> for PairAMode {
 }
 
 impl TryFrom<Address> for AMode {
-    type Error = anyhow::Error;
+    type Error = crate::Error;
 
     fn try_from(addr: Address) -> Result<Self> {
         use Address::*;
@@ -144,7 +143,7 @@ impl TryFrom<Address> for AMode {
             IndexedSPOffset { offset, indexing } => {
                 let simm9 = SImm9::maybe_from_i64(offset).ok_or_else(|| {
                     // TODO: non-string error
-                    anyhow!("Failed to convert {offset} to signed 9-bit offset")
+                    format_err!("Failed to convert {offset} to signed 9-bit offset")
                 })?;
 
                 if indexing == Pre {

--- a/winch/codegen/src/isa/aarch64/masm.rs
+++ b/winch/codegen/src/isa/aarch64/masm.rs
@@ -6,8 +6,11 @@ use super::{
     regs::{self, scratch_fpr_bitset, scratch_gpr_bitset},
 };
 use crate::{
+    Result,
     abi::{self, align_to, calculate_frame_adjustment, local::LocalSlot, vmctx},
+    bail,
     codegen::{CodeGenContext, CodeGenError, Emission, FuncEnv, ptr_type_from_ptr_size},
+    format_err,
     isa::{
         CallingConvention,
         aarch64::abi::SHADOW_STACK_POINTER_SLOT_SIZE,
@@ -24,7 +27,6 @@ use crate::{
     },
     stack::TypedReg,
 };
-use anyhow::{Result, anyhow, bail};
 use cranelift_codegen::{
     Final, MachBufferFinalized, MachLabel,
     binemit::CodeOffset,
@@ -357,10 +359,10 @@ impl Masm for MacroAssembler {
                 Ok(())
             }
             StoreKind::Atomic(_size) => {
-                Err(anyhow!(CodeGenError::unimplemented_masm_instruction()))
+                Err(format_err!(CodeGenError::unimplemented_masm_instruction()))
             }
             StoreKind::VectorLane(_selector) => {
-                Err(anyhow!(CodeGenError::unimplemented_masm_instruction()))
+                Err(format_err!(CodeGenError::unimplemented_masm_instruction()))
             }
         })
     }
@@ -503,7 +505,7 @@ impl Masm for MacroAssembler {
                 self.asm
                     .fpu_csel(src, dst.to_reg(), dst, Cond::from(cc), size)
             }
-            _ => return Err(anyhow!(CodeGenError::invalid_operand_combination())),
+            _ => return Err(format_err!(CodeGenError::invalid_operand_combination())),
         }
 
         Ok(())
@@ -806,7 +808,7 @@ impl Masm for MacroAssembler {
             match size {
                 OperandSize::S32 => Ok(TypedReg::new(WasmValType::I32, dividend)),
                 OperandSize::S64 => Ok(TypedReg::new(WasmValType::I64, dividend)),
-                _ => Err(anyhow!(CodeGenError::unexpected_operand_size())),
+                _ => Err(format_err!(CodeGenError::unexpected_operand_size())),
             }
         })
     }
@@ -834,7 +836,7 @@ impl Masm for MacroAssembler {
             match size {
                 OperandSize::S32 => Ok(TypedReg::new(WasmValType::I32, dividend)),
                 OperandSize::S64 => Ok(TypedReg::new(WasmValType::I64, dividend)),
-                _ => Err(anyhow!(CodeGenError::unexpected_operand_size())),
+                _ => Err(format_err!(CodeGenError::unexpected_operand_size())),
             }
         })
     }
@@ -1163,7 +1165,7 @@ impl Masm for MacroAssembler {
         rhs_hi: Reg,
     ) -> Result<()> {
         let _ = (dst_lo, dst_hi, lhs_lo, lhs_hi, rhs_lo, rhs_hi);
-        Err(anyhow!(CodeGenError::unimplemented_masm_instruction()))
+        Err(format_err!(CodeGenError::unimplemented_masm_instruction()))
     }
 
     fn sub128(
@@ -1176,7 +1178,7 @@ impl Masm for MacroAssembler {
         rhs_hi: Reg,
     ) -> Result<()> {
         let _ = (dst_lo, dst_hi, lhs_lo, lhs_hi, rhs_lo, rhs_hi);
-        Err(anyhow!(CodeGenError::unimplemented_masm_instruction()))
+        Err(format_err!(CodeGenError::unimplemented_masm_instruction()))
     }
 
     fn mul_wide(
@@ -1185,7 +1187,7 @@ impl Masm for MacroAssembler {
         kind: MulWideKind,
     ) -> Result<()> {
         let _ = (context, kind);
-        Err(anyhow!(CodeGenError::unimplemented_masm_instruction()))
+        Err(format_err!(CodeGenError::unimplemented_masm_instruction()))
     }
 
     fn splat(&mut self, _context: &mut CodeGenContext<Emission>, _size: SplatKind) -> Result<()> {
@@ -1209,7 +1211,7 @@ impl Masm for MacroAssembler {
         _flags: MemFlags,
         _extend: Option<Extend<Zero>>,
     ) -> Result<()> {
-        Err(anyhow!(CodeGenError::unimplemented_masm_instruction()))
+        Err(format_err!(CodeGenError::unimplemented_masm_instruction()))
     }
 
     fn extract_lane(
@@ -1240,7 +1242,7 @@ impl Masm for MacroAssembler {
         _flags: MemFlags,
         _extend: Option<Extend<Zero>>,
     ) -> Result<()> {
-        Err(anyhow!(CodeGenError::unimplemented_masm_instruction()))
+        Err(format_err!(CodeGenError::unimplemented_masm_instruction()))
     }
 
     fn v128_eq(
@@ -1304,27 +1306,27 @@ impl Masm for MacroAssembler {
     }
 
     fn v128_not(&mut self, _dst: WritableReg) -> Result<()> {
-        Err(anyhow!(CodeGenError::unimplemented_masm_instruction()))
+        Err(format_err!(CodeGenError::unimplemented_masm_instruction()))
     }
 
     fn fence(&mut self) -> Result<()> {
-        Err(anyhow!(CodeGenError::unimplemented_masm_instruction()))
+        Err(format_err!(CodeGenError::unimplemented_masm_instruction()))
     }
 
     fn v128_and(&mut self, _src1: Reg, _src2: Reg, _dst: WritableReg) -> Result<()> {
-        Err(anyhow!(CodeGenError::unimplemented_masm_instruction()))
+        Err(format_err!(CodeGenError::unimplemented_masm_instruction()))
     }
 
     fn v128_and_not(&mut self, _src1: Reg, _src2: Reg, _dst: WritableReg) -> Result<()> {
-        Err(anyhow!(CodeGenError::unimplemented_masm_instruction()))
+        Err(format_err!(CodeGenError::unimplemented_masm_instruction()))
     }
 
     fn v128_or(&mut self, _src1: Reg, _src2: Reg, _dst: WritableReg) -> Result<()> {
-        Err(anyhow!(CodeGenError::unimplemented_masm_instruction()))
+        Err(format_err!(CodeGenError::unimplemented_masm_instruction()))
     }
 
     fn v128_xor(&mut self, _src1: Reg, _src2: Reg, _dst: WritableReg) -> Result<()> {
-        Err(anyhow!(CodeGenError::unimplemented_masm_instruction()))
+        Err(format_err!(CodeGenError::unimplemented_masm_instruction()))
     }
 
     fn v128_bitselect(
@@ -1334,11 +1336,11 @@ impl Masm for MacroAssembler {
         _mask: Reg,
         _dst: WritableReg,
     ) -> Result<()> {
-        Err(anyhow!(CodeGenError::unimplemented_masm_instruction()))
+        Err(format_err!(CodeGenError::unimplemented_masm_instruction()))
     }
 
     fn v128_any_true(&mut self, _src: Reg, _dst: WritableReg) -> Result<()> {
-        Err(anyhow!(CodeGenError::unimplemented_masm_instruction()))
+        Err(format_err!(CodeGenError::unimplemented_masm_instruction()))
     }
 
     fn v128_convert(&mut self, _src: Reg, _dst: WritableReg, _kind: V128ConvertKind) -> Result<()> {
@@ -1374,7 +1376,7 @@ impl Masm for MacroAssembler {
         _dst: WritableReg,
         _kind: V128AddKind,
     ) -> Result<()> {
-        Err(anyhow!(CodeGenError::unimplemented_masm_instruction()))
+        Err(format_err!(CodeGenError::unimplemented_masm_instruction()))
     }
 
     fn v128_sub(
@@ -1384,7 +1386,7 @@ impl Masm for MacroAssembler {
         _dst: WritableReg,
         _kind: V128SubKind,
     ) -> Result<()> {
-        Err(anyhow!(CodeGenError::unimplemented_masm_instruction()))
+        Err(format_err!(CodeGenError::unimplemented_masm_instruction()))
     }
 
     fn v128_mul(
@@ -1392,7 +1394,7 @@ impl Masm for MacroAssembler {
         _context: &mut CodeGenContext<Emission>,
         _kind: V128MulKind,
     ) -> Result<()> {
-        Err(anyhow!(CodeGenError::unimplemented_masm_instruction()))
+        Err(format_err!(CodeGenError::unimplemented_masm_instruction()))
     }
 
     fn v128_abs(&mut self, _src: Reg, _dst: WritableReg, _kind: V128AbsKind) -> Result<()> {
@@ -1400,7 +1402,7 @@ impl Masm for MacroAssembler {
     }
 
     fn v128_neg(&mut self, _op: WritableReg, _kind: V128NegKind) -> Result<()> {
-        Err(anyhow!(CodeGenError::unimplemented_masm_instruction()))
+        Err(format_err!(CodeGenError::unimplemented_masm_instruction()))
     }
 
     fn v128_shift(
@@ -1409,7 +1411,7 @@ impl Masm for MacroAssembler {
         _lane_width: OperandSize,
         _shift_kind: ShiftKind,
     ) -> Result<()> {
-        Err(anyhow!(CodeGenError::unimplemented_masm_instruction()))
+        Err(format_err!(CodeGenError::unimplemented_masm_instruction()))
     }
 
     fn v128_q15mulr_sat_s(
@@ -1445,7 +1447,7 @@ impl Masm for MacroAssembler {
         _dst: WritableReg,
         _kind: V128MinKind,
     ) -> Result<()> {
-        Err(anyhow!(CodeGenError::unimplemented_masm_instruction()))
+        Err(format_err!(CodeGenError::unimplemented_masm_instruction()))
     }
 
     fn v128_max(
@@ -1455,7 +1457,7 @@ impl Masm for MacroAssembler {
         _dst: WritableReg,
         _kind: V128MaxKind,
     ) -> Result<()> {
-        Err(anyhow!(CodeGenError::unimplemented_masm_instruction()))
+        Err(format_err!(CodeGenError::unimplemented_masm_instruction()))
     }
 
     fn v128_extmul(
@@ -1463,7 +1465,7 @@ impl Masm for MacroAssembler {
         _context: &mut CodeGenContext<Emission>,
         _kind: V128ExtMulKind,
     ) -> Result<()> {
-        Err(anyhow!(CodeGenError::unimplemented_masm_instruction()))
+        Err(format_err!(CodeGenError::unimplemented_masm_instruction()))
     }
 
     fn v128_extadd_pairwise(
@@ -1472,7 +1474,7 @@ impl Masm for MacroAssembler {
         _dst: WritableReg,
         _kind: V128ExtAddKind,
     ) -> Result<()> {
-        Err(anyhow!(CodeGenError::unimplemented_masm_instruction()))
+        Err(format_err!(CodeGenError::unimplemented_masm_instruction()))
     }
 
     fn v128_dot(&mut self, _lhs: Reg, _rhs: Reg, _dst: WritableReg) -> Result<()> {

--- a/winch/codegen/src/isa/aarch64/mod.rs
+++ b/winch/codegen/src/isa/aarch64/mod.rs
@@ -1,6 +1,6 @@
 use self::regs::{fpr_bit_set, gpr_bit_set};
 use crate::{
-    BuiltinFunctions,
+    BuiltinFunctions, Result,
     abi::{ABI, wasm_sig},
     codegen::{CodeGen, CodeGenContext, FuncEnv, TypeConverter},
     frame::{DefinedLocals, Frame},
@@ -9,7 +9,6 @@ use crate::{
     regalloc::RegAlloc,
     stack::Stack,
 };
-use anyhow::Result;
 use cranelift_codegen::settings::{self, Flags};
 use cranelift_codegen::{Final, MachBufferFinalized, isa::aarch64::settings as aarch64_settings};
 use cranelift_codegen::{MachTextSectionBuilder, TextSectionBuilder};

--- a/winch/codegen/src/isa/mod.rs
+++ b/winch/codegen/src/isa/mod.rs
@@ -1,5 +1,4 @@
-use crate::BuiltinFunctions;
-use anyhow::{Result, anyhow};
+use crate::{BuiltinFunctions, Result, format_err};
 use core::fmt::Formatter;
 use cranelift_codegen::isa::unwind::{UnwindInfo, UnwindInfoKind};
 use cranelift_codegen::isa::{CallConv, IsaBuilder};
@@ -30,7 +29,7 @@ macro_rules! isa_builder {
         }
         #[cfg(not $cfg_terms)]
         {
-            Err(anyhow!(LookupError::SupportDisabled))
+            Err(format_err!(LookupError::SupportDisabled))
         }
     }};
 }
@@ -47,7 +46,7 @@ pub fn lookup(triple: Triple) -> Result<Builder> {
             isa_builder!(aarch64, (feature = "arm64"), triple)
         }
 
-        _ => Err(anyhow!(LookupError::Unsupported)),
+        _ => Err(format_err!(LookupError::Unsupported)),
     }
 }
 

--- a/winch/codegen/src/isa/x64/abi.rs
+++ b/winch/codegen/src/isa/x64/abi.rs
@@ -1,11 +1,11 @@
 use super::regs;
 use crate::{
-    RegIndexEnv,
+    RegIndexEnv, Result,
     abi::{ABI, ABIOperand, ABIParams, ABIResults, ABISig, ParamsOrReturns, align_to},
+    bail,
     codegen::CodeGenError,
     isa::{CallingConvention, reg::Reg},
 };
-use anyhow::{Result, bail};
 use wasmtime_environ::{WasmHeapType, WasmValType};
 
 #[derive(Default)]
@@ -273,12 +273,10 @@ impl X64ABI {
 mod tests {
     use super::X64ABI;
     use crate::{
+        Result,
         abi::{ABI, ABIOperand},
         isa::{CallingConvention, reg::Reg, x64::regs},
     };
-
-    use anyhow::Result;
-
     use wasmtime_environ::{
         WasmFuncType,
         WasmValType::{self, *},

--- a/winch/codegen/src/isa/x64/masm.rs
+++ b/winch/codegen/src/isa/x64/masm.rs
@@ -5,8 +5,6 @@ use super::{
     asm::{Assembler, PatchableAddToReg, VcmpKind, VcvtKind, VroundMode},
     regs::{self, rbp, rsp, scratch_fpr_bitset, scratch_gpr_bitset},
 };
-use anyhow::{Result, anyhow, bail};
-
 use crate::masm::{
     DivKind, Extend, ExtendKind, ExtractLaneKind, FloatCmpKind, FloatScratch, Imm as I, IntCmpKind,
     IntScratch, LaneSelector, LoadKind, MacroAssembler as Masm, MulWideKind, OperandSize, RegImm,
@@ -17,8 +15,11 @@ use crate::masm::{
     VectorEqualityKind, Zero,
 };
 use crate::{
+    Result,
     abi::{self, LocalSlot, align_to, calculate_frame_adjustment},
+    bail,
     codegen::{CodeGenContext, CodeGenError, Emission, FuncEnv, ptr_type_from_ptr_size},
+    format_err,
     stack::{TypedReg, Val},
 };
 use crate::{
@@ -144,7 +145,7 @@ impl Masm for MacroAssembler {
 
             masm.asm.cmp_rr(scratch.inner(), regs::rsp(), masm.ptr_size);
             masm.asm.trapif(IntCmpKind::GtU, TrapCode::STACK_OVERFLOW);
-            anyhow::Ok(())
+            wasmtime_environ::error::Ok(())
         })?;
 
         // Emit unwind info.
@@ -406,7 +407,7 @@ impl Masm for MacroAssembler {
                     masm.load_impl(src, byte_tmp.writable(), size, UNTRUSTED_FLAGS)?;
                     masm.asm
                         .xmm_vpinsr_rrr(dst, dst.to_reg(), byte_tmp.inner(), lane, size);
-                    anyhow::Ok(())
+                    wasmtime_environ::error::Ok(())
                 })?;
             }
             LoadKind::VectorZero(size) => {
@@ -414,7 +415,7 @@ impl Masm for MacroAssembler {
                 self.with_scratch::<IntScratch, _>(|masm, scratch| {
                     masm.load_impl(src, scratch.writable(), size, UNTRUSTED_FLAGS)?;
                     masm.asm.avx_gpr_to_xmm(scratch.inner(), dst, size);
-                    anyhow::Ok(())
+                    wasmtime_environ::error::Ok(())
                 })?;
             }
         }
@@ -456,7 +457,7 @@ impl Masm for MacroAssembler {
         match (src.class(), dst.to_reg().class()) {
             (RegClass::Int, RegClass::Int) => Ok(self.asm.cmov(src, dst, cc, size)),
             (RegClass::Float, RegClass::Float) => Ok(self.asm.xmm_cmov(src, dst, cc, size)),
-            _ => Err(anyhow!(CodeGenError::invalid_operand_combination())),
+            _ => Err(format_err!(CodeGenError::invalid_operand_combination())),
         }
     }
 
@@ -470,7 +471,7 @@ impl Masm for MacroAssembler {
                     self.with_scratch::<IntScratch, _>(|masm, scratch| {
                         masm.load_constant(&imm, scratch.writable(), size)?;
                         masm.asm.add_rr(scratch.inner(), dst, size);
-                        anyhow::Ok(())
+                        wasmtime_environ::error::Ok(())
                     })?;
                 }
             }
@@ -506,7 +507,7 @@ impl Masm for MacroAssembler {
                     self.with_scratch::<IntScratch, _>(|masm, scratch| {
                         masm.load_constant(&imm, scratch.writable(), size)?;
                         masm.asm.sub_rr(scratch.inner(), reg, size);
-                        anyhow::Ok(())
+                        wasmtime_environ::error::Ok(())
                     })?;
                 }
             }
@@ -529,7 +530,7 @@ impl Masm for MacroAssembler {
                     self.with_scratch::<IntScratch, _>(|masm, scratch| {
                         masm.load_constant(&imm, scratch.writable(), size)?;
                         masm.asm.mul_rr(scratch.inner(), dst, size);
-                        anyhow::Ok(())
+                        wasmtime_environ::error::Ok(())
                     })?;
                 }
             }
@@ -695,7 +696,7 @@ impl Masm for MacroAssembler {
                     self.with_scratch::<IntScratch, _>(|masm, scratch| {
                         masm.load_constant(&imm, scratch.writable(), size)?;
                         masm.asm.and_rr(scratch.inner(), dst, size);
-                        anyhow::Ok(())
+                        wasmtime_environ::error::Ok(())
                     })?;
                 }
             }
@@ -718,7 +719,7 @@ impl Masm for MacroAssembler {
                     self.with_scratch::<IntScratch, _>(|masm, scratch| {
                         masm.load_constant(&imm, scratch.writable(), size)?;
                         masm.asm.or_rr(scratch.inner(), dst, size);
-                        anyhow::Ok(())
+                        wasmtime_environ::error::Ok(())
                     })?;
                 }
             }
@@ -741,7 +742,7 @@ impl Masm for MacroAssembler {
                     self.with_scratch::<IntScratch, _>(|masm, scratch| {
                         masm.load_constant(&imm, scratch.writable(), size)?;
                         masm.asm.xor_rr(scratch.inner(), dst, size);
-                        anyhow::Ok(())
+                        wasmtime_environ::error::Ok(())
                     })?;
                 }
             }
@@ -872,7 +873,7 @@ impl Masm for MacroAssembler {
                     self.with_scratch::<IntScratch, _>(|masm, scratch| {
                         masm.load_constant(&imm, scratch.writable(), size)?;
                         masm.asm.cmp_rr(src1, scratch.inner(), size);
-                        anyhow::Ok(())
+                        wasmtime_environ::error::Ok(())
                     })?;
                 }
             }
@@ -1080,7 +1081,7 @@ impl Masm for MacroAssembler {
                 masm.asm.and_rr(scratch.inner(), dst, size);
                 masm.asm.shift_ir(2u8, tmp, ShiftKind::ShrU, size);
                 masm.asm.and_rr(scratch.inner(), tmp, size);
-                anyhow::Ok(())
+                wasmtime_environ::error::Ok(())
             })?;
             self.asm.add_rr(dst.to_reg(), tmp, size);
 
@@ -2356,7 +2357,7 @@ impl Masm for MacroAssembler {
                 self.with_scratch::<FloatScratch, _>(|masm, tmp| {
                     masm.v128_xor(tmp.inner(), tmp.inner(), tmp.writable())?;
                     masm.v128_sub(tmp.inner(), op.to_reg(), op, kind.into())?;
-                    anyhow::Ok(())
+                    wasmtime_environ::error::Ok(())
                 })?;
             }
             V128NegKind::F32x4 | V128NegKind::F64x2 => {
@@ -3117,7 +3118,7 @@ impl Masm for MacroAssembler {
             // total number of bits set.
             masm.asm
                 .xmm_vpadd_rrr(reg.to_reg(), scratch.inner(), reg, OperandSize::S8);
-            anyhow::Ok(())
+            wasmtime_environ::error::Ok(())
         })?;
 
         context.stack.push(TypedReg::v128(reg.to_reg()).into());
@@ -3211,17 +3212,17 @@ impl MacroAssembler {
     }
 
     fn ensure_has_avx(&self) -> Result<()> {
-        anyhow::ensure!(self.flags.has_avx(), CodeGenError::UnimplementedForNoAvx);
+        crate::ensure!(self.flags.has_avx(), CodeGenError::UnimplementedForNoAvx);
         Ok(())
     }
 
     fn ensure_has_avx2(&self) -> Result<()> {
-        anyhow::ensure!(self.flags.has_avx2(), CodeGenError::UnimplementedForNoAvx2);
+        crate::ensure!(self.flags.has_avx2(), CodeGenError::UnimplementedForNoAvx2);
         Ok(())
     }
 
     fn ensure_has_avx512vl(&self) -> Result<()> {
-        anyhow::ensure!(
+        crate::ensure!(
             self.flags.has_avx512vl(),
             CodeGenError::UnimplementedForNoAvx512VL
         );
@@ -3229,7 +3230,7 @@ impl MacroAssembler {
     }
 
     fn ensure_has_avx512dq(&self) -> Result<()> {
-        anyhow::ensure!(
+        crate::ensure!(
             self.flags.has_avx512dq(),
             CodeGenError::UnimplementedForNoAvx512DQ
         );
@@ -3365,7 +3366,7 @@ impl MacroAssembler {
 
     fn ensure_two_argument_form(dst: &Reg, lhs: &Reg) -> Result<()> {
         if dst != lhs {
-            Err(anyhow!(CodeGenError::invalid_two_arg_form()))
+            Err(format_err!(CodeGenError::invalid_two_arg_form()))
         } else {
             Ok(())
         }

--- a/winch/codegen/src/isa/x64/mod.rs
+++ b/winch/codegen/src/isa/x64/mod.rs
@@ -1,15 +1,14 @@
-use crate::{
-    abi::{ABI, wasm_sig},
-    codegen::{BuiltinFunctions, CodeGen, CodeGenContext, FuncEnv, TypeConverter},
-};
-
 use crate::frame::{DefinedLocals, Frame};
 use crate::isa::x64::masm::MacroAssembler as X64Masm;
 use crate::isa::{Builder, TargetIsa};
 use crate::masm::MacroAssembler;
 use crate::regalloc::RegAlloc;
 use crate::stack::Stack;
-use anyhow::Result;
+use crate::{
+    Result,
+    abi::{ABI, wasm_sig},
+    codegen::{BuiltinFunctions, CodeGen, CodeGenContext, FuncEnv, TypeConverter},
+};
 use cranelift_codegen::settings::{self, Flags};
 use cranelift_codegen::{Final, MachBufferFinalized, isa::x64::settings as x64_settings};
 use cranelift_codegen::{MachTextSectionBuilder, TextSectionBuilder};

--- a/winch/codegen/src/lib.rs
+++ b/winch/codegen/src/lib.rs
@@ -22,3 +22,5 @@ mod regalloc;
 mod regset;
 mod stack;
 mod visitor;
+
+pub use wasmtime_environ::error::{Context, Error, Result, bail, ensure, format_err};

--- a/winch/codegen/src/masm.rs
+++ b/winch/codegen/src/masm.rs
@@ -1,10 +1,10 @@
+use crate::Result;
 use crate::abi::{self, LocalSlot, align_to};
 use crate::codegen::{CodeGenContext, Emission, FuncEnv};
 use crate::isa::{
     CallingConvention,
     reg::{Reg, RegClass, WritableReg, writable},
 };
-use anyhow::Result;
 use cranelift_codegen::{
     Final, MachBufferFinalized, MachLabel,
     binemit::CodeOffset,
@@ -1566,7 +1566,7 @@ pub(crate) trait MacroAssembler {
                             masm.address_from_sp(SPOffset::from_u32(dst_offs))?,
                         )?;
                     }
-                    anyhow::Ok(())
+                    wasmtime_environ::error::Ok(())
                 })?;
             }
             MemMoveDirection::HighToLow => {
@@ -1588,7 +1588,7 @@ pub(crate) trait MacroAssembler {
                         src_offs -= word_bytes;
                         dst_offs -= word_bytes;
                     }
-                    anyhow::Ok(())
+                    wasmtime_environ::error::Ok(())
                 })?;
             }
         }
@@ -1615,7 +1615,7 @@ pub(crate) trait MacroAssembler {
                     masm.address_from_sp(SPOffset::from_u32(dst_offs))?,
                     ptr_size,
                 )?;
-                anyhow::Ok(())
+                wasmtime_environ::error::Ok(())
             })?;
         }
         Ok(())
@@ -1926,7 +1926,7 @@ pub(crate) trait MacroAssembler {
                     let addr: Self::Address = masm.local_address(&slot)?;
                     masm.store(zero, addr, OperandSize::S64)?;
                 }
-                anyhow::Ok(())
+                wasmtime_environ::error::Ok(())
             })?;
         }
 

--- a/winch/codegen/src/regalloc.rs
+++ b/winch/codegen/src/regalloc.rs
@@ -1,10 +1,10 @@
 use crate::{
+    Result,
     codegen::CodeGenError,
+    format_err,
     isa::reg::{Reg, RegClass},
     regset::{RegBitSet, RegSet},
 };
-
-use anyhow::{Result, anyhow};
 
 /// The register allocator.
 ///
@@ -41,7 +41,7 @@ impl RegAlloc {
                 spill(self)?;
                 self.regset
                     .reg_for_class(class)
-                    .ok_or_else(|| anyhow!(CodeGenError::expected_register_to_be_available()))
+                    .ok_or_else(|| format_err!(CodeGenError::expected_register_to_be_available()))
             }
         }
     }
@@ -62,7 +62,7 @@ impl RegAlloc {
                 spill(self)?;
                 self.regset
                     .reg(named)
-                    .ok_or_else(|| anyhow!(CodeGenError::expected_register_to_be_available()))
+                    .ok_or_else(|| format_err!(CodeGenError::expected_register_to_be_available()))
             }
         }
     }

--- a/winch/codegen/src/stack.rs
+++ b/winch/codegen/src/stack.rs
@@ -1,5 +1,4 @@
-use crate::{codegen::CodeGenError, isa::reg::Reg, masm::StackSlot};
-use anyhow::{Result, anyhow};
+use crate::{Result, codegen::CodeGenError, format_err, isa::reg::Reg, masm::StackSlot};
 use smallvec::SmallVec;
 use wasmparser::{Ieee32, Ieee64};
 use wasmtime_environ::WasmValType;
@@ -125,7 +124,7 @@ impl From<Memory> for Val {
 }
 
 impl TryFrom<u32> for Val {
-    type Error = anyhow::Error;
+    type Error = crate::Error;
     fn try_from(value: u32) -> Result<Self, Self::Error> {
         i32::try_from(value).map(Val::i32).map_err(Into::into)
     }
@@ -334,7 +333,7 @@ impl Stack {
         if self.len() >= n {
             Ok(self.len() - n)
         } else {
-            Err(anyhow!(CodeGenError::missing_values_in_stack()))
+            Err(format_err!(CodeGenError::missing_values_in_stack()))
         }
     }
 

--- a/winch/codegen/src/visitor.rs
+++ b/winch/codegen/src/visitor.rs
@@ -17,10 +17,9 @@ use crate::masm::{
     V128LoadExtendKind, V128MaxKind, V128MinKind, V128MulKind, V128NarrowKind, V128NegKind,
     V128SubKind, V128TruncKind, VectorCompareKind, VectorEqualityKind, Zero,
 };
-
 use crate::reg::{Reg, writable};
 use crate::stack::{TypedReg, Val};
-use anyhow::{Result, anyhow, bail, ensure};
+use crate::{Result, bail, ensure, format_err};
 use regalloc2::RegClass;
 use smallvec::{SmallVec, smallvec};
 use wasmparser::{
@@ -48,7 +47,7 @@ macro_rules! def_unsupported {
                 fn $visit(&mut self $($(,$arg: $argty)*)?) -> Self::Output {
                     $($(let _ = $arg;)*)?
 
-                    Err(anyhow!(CodeGenError::unimplemented_wasm_instruction()))
+                    Err(format_err!(CodeGenError::unimplemented_wasm_instruction()))
                 }
             );
         )*
@@ -1695,7 +1694,7 @@ where
 
         match heap_type {
             WasmHeapType::Func => self.emit_lazy_init_funcref(table_index),
-            _ => Err(anyhow!(CodeGenError::unsupported_wasm_type())),
+            _ => Err(format_err!(CodeGenError::unsupported_wasm_type())),
         }
     }
 
@@ -1786,7 +1785,7 @@ where
                 self.context.free_reg(base);
                 Ok(())
             }
-            _ => Err(anyhow!(CodeGenError::unsupported_wasm_type())),
+            _ => Err(format_err!(CodeGenError::unsupported_wasm_type())),
         }
     }
 
@@ -1883,7 +1882,7 @@ where
                 self.context.stack.push(TypedReg::i32(top).into());
                 Ok(())
             }
-            _ => Err(anyhow!(CodeGenError::unsupported_32_bit_platform())),
+            _ => Err(format_err!(CodeGenError::unsupported_32_bit_platform())),
         }
     }
 
@@ -4617,7 +4616,7 @@ where
 }
 
 impl TryFrom<WasmValType> for OperandSize {
-    type Error = anyhow::Error;
+    type Error = crate::Error;
     fn try_from(ty: WasmValType) -> Result<OperandSize> {
         let ty = match ty {
             WasmValType::I32 | WasmValType::F32 => OperandSize::S32,


### PR DESCRIPTION
Builds on top of https://github.com/bytecodealliance/wasmtime/pull/12296

Turns out we need to either do this migration or enable the `wasmtime-internal-error` crate's `anyhow` feature to convert winch compilation errors in `wasmtime-internal-winch`. This migration is preferable because we can avoid an `anyhow` dependency.