### PR TITLE
Make some fallible conversions' types explicit

### DIFF
--- a/crates/wasi-http/src/p3/host/types.rs
+++ b/crates/wasi-http/src/p3/host/types.rs
@@ -514,8 +514,7 @@ impl HostRequestOptions for WasiHttpCtxView<'_> {
             return Ok(None);
         };
         let ns = connect_timeout.as_nanos();
-        let ns = ns
-            .try_into()
+        let ns = Duration::try_from(ns)
             .context("connect timeout duration nanoseconds do not fit in u64")?;
         Ok(Some(ns))
     }
@@ -540,8 +539,7 @@ impl HostRequestOptions for WasiHttpCtxView<'_> {
             return Ok(None);
         };
         let ns = first_byte_timeout.as_nanos();
-        let ns = ns
-            .try_into()
+        let ns = Duration::try_from(ns)
             .context("first byte timeout duration nanoseconds do not fit in u64")?;
         Ok(Some(ns))
     }
@@ -566,8 +564,7 @@ impl HostRequestOptions for WasiHttpCtxView<'_> {
             return Ok(None);
         };
         let ns = between_bytes_timeout.as_nanos();
-        let ns = ns
-            .try_into()
+        let ns = Duration::try_from(ns)
             .context("between bytes timeout duration nanoseconds do not fit in u64")?;
         Ok(Some(ns))
     }

--- a/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/memory_pool.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/memory_pool.rs
@@ -680,10 +680,7 @@ impl SlabConstraints {
         let guard_bytes = HostAlignedByteCount::new_rounded_up_u64(tunables.memory_guard_size)
             .context("guard region is too large")?;
 
-        let num_slots = limits
-            .total_memories
-            .try_into()
-            .context("too many memories")?;
+        let num_slots = usize::try_from(limits.total_memories).context("too many memories")?;
 
         let constraints = SlabConstraints {
             max_memory_bytes,


### PR DESCRIPTION
This helps make the `anyhow`-to-`wasmtime-internal-error` transition smoother.

Builds on top of https://github.com/bytecodealliance/wasmtime/pull/12298