### PR TITLE
Fix `Module::image_range` to include non-text part of module.

### DIFF
--- a/crates/wasmtime/src/runtime/component/component.rs
+++ b/crates/wasmtime/src/runtime/component/component.rs
@@ -936,6 +936,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn image_range_is_whole_image() {
         let wat = r#"
                 (component

--- a/crates/wasmtime/src/runtime/module.rs
+++ b/crates/wasmtime/src/runtime/module.rs
@@ -1257,6 +1257,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn image_range_is_whole_image() {
         let wat = r#"
                 (module


### PR DESCRIPTION
This method is informational for embedders to be able to, for example, ensure an image in memory is `mlock`'d (not swapped out). In the refactors around the StoreCode/EngineCode split, I mistakenly redefined this to only the text section. This is not a Wasm execution correctness issue but may lead to performance issues if an embedder relies on this behavior. This PR fixes the definition.

Fixes #12284.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
