### PR TITLE
run task to completion in `wasmtime run --invoke 'foo()'`

### DIFF
--- a/tests/all/cli_tests.rs
+++ b/tests/all/cli_tests.rs
@@ -2182,6 +2182,25 @@ start a print 1234
         Ok(())
     }
 
+    #[test]
+    fn p2_cli_p3_hello_stdout_post_return_invoke() -> Result<()> {
+        let output = run_wasmtime(&[
+            "run",
+            "-Wcomponent-model-async",
+            "-Sp3",
+            "--invoke",
+            "run()",
+            P3_CLI_HELLO_STDOUT_POST_RETURN_COMPONENT,
+        ]);
+        if cfg!(feature = "component-model-async") {
+            let output = output?;
+            assert_eq!(output, "hello, world\nhello again, after return\nok\n");
+        } else {
+            assert!(output.is_err());
+        }
+        Ok(())
+    }
+
     mod invoke {
         use super::*;
 


### PR DESCRIPTION
Analogous to https://github.com/bytecodealliance/wasmtime/pull/12185, this ensures we run async tasks to completion when the `--invoke` option is used.

Fixes #12187

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
