### PR TITLE
Make `wasmtime_internal_error`'s error formatting more-compatible with `anyhow`'s

### DIFF
--- a/crates/error/src/context.rs
+++ b/crates/error/src/context.rs
@@ -73,7 +73,7 @@ mod sealed {
 /// failed to convert `999` into a `u8` (max = `255`)
 ///
 /// Caused by:
-/// 	0: out of range integral type conversion attempted
+///     out of range integral type conversion attempted
 ///     "#.trim(),
 /// );
 /// ```

--- a/crates/error/src/error.rs
+++ b/crates/error/src/error.rs
@@ -446,8 +446,14 @@ impl fmt::Debug for Error {
 
         if let Some(source) = inner.source() {
             f.write_str("\n\nCaused by:\n")?;
+            let multiple_causes = source.source().is_some();
             for (i, e) in Chain::new(source).enumerate() {
-                writeln!(f, "\t{i}: {e}")?;
+                if multiple_causes {
+                    write!(f, "{i: >5}: ")?;
+                } else {
+                    write!(f, "    ")?;
+                }
+                writeln!(f, "{e}")?;
             }
         }
 
@@ -717,8 +723,8 @@ impl Error {
     /// cannot frob the blobbins
     ///
     /// Caused by:
-    /// 	0: failed to bonkinate
-    /// 	1: root cause
+    ///     0: failed to bonkinate
+    ///     1: root cause
     ///         "#.trim(),
     ///     ),
     /// );


### PR DESCRIPTION
For the "caused by" error chain, anyhow doesn't use tabs and only prints a number when there are multiple causes.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
