### PR TITLE
wasmtime-wizer: add type_hints to global_get

### DIFF
--- a/crates/wizer/src/component/snapshot.rs
+++ b/crates/wizer/src/component/snapshot.rs
@@ -1,3 +1,5 @@
+use wasmparser::ValType;
+
 use crate::component::info::Accessor;
 use crate::component::{ComponentContext, ComponentInstanceState, WIZER_INSTANCE};
 use crate::snapshot::Snapshot;
@@ -80,7 +82,7 @@ impl<S> InstanceState for ViaComponent<'_, '_, S>
 where
     S: ComponentInstanceState,
 {
-    async fn global_get(&mut self, name: &str) -> SnapshotVal {
+    async fn global_get(&mut self, name: &str, _: ValType) -> SnapshotVal {
         let Accessor::Global {
             accessor_export_name,
             ty,

--- a/crates/wizer/src/lib.rs
+++ b/crates/wizer/src/lib.rs
@@ -24,6 +24,7 @@ pub use crate::info::ModuleContext;
 pub use crate::snapshot::SnapshotVal;
 use ::wasmtime::{Result, bail, error::Context as _};
 use std::collections::{HashMap, HashSet};
+pub use wasmparser::ValType;
 
 const DEFAULT_KEEP_INIT_FUNC: bool = false;
 
@@ -377,7 +378,11 @@ pub trait InstanceState {
     ///
     /// This function panics if `name` isn't an exported global or if the type
     /// of the global doesn't fit in `SnapshotVal`.
-    fn global_get(&mut self, name: &str) -> impl Future<Output = SnapshotVal> + Send;
+    fn global_get(
+        &mut self,
+        name: &str,
+        type_hint: ValType,
+    ) -> impl Future<Output = SnapshotVal> + Send;
 
     /// Loads the contents of the memory specified by `name`, returning the
     /// entier contents as a `Vec<u8>`.

--- a/crates/wizer/src/snapshot.rs
+++ b/crates/wizer/src/snapshot.rs
@@ -75,9 +75,11 @@ async fn snapshot_globals(
     log::debug!("Snapshotting global values");
 
     let mut ret = Vec::new();
-    for (i, name) in module.defined_global_exports.as_ref().unwrap().iter() {
-        let val = ctx.global_get(&name).await;
-        ret.push((*i, val));
+    for (i, ty, name) in module.defined_globals() {
+        if let Some(name) = name {
+            let val = ctx.global_get(name, ty.content_type).await;
+            ret.push((i, val));
+        }
     }
     ret
 }

--- a/crates/wizer/src/wasmtime.rs
+++ b/crates/wizer/src/wasmtime.rs
@@ -1,5 +1,7 @@
 use crate::{InstanceState, SnapshotVal, Wizer};
+use wasmparser::ValType;
 use wasmtime::error::Context;
+
 use wasmtime::{Extern, Instance, Module, Result, Store, Val};
 
 impl Wizer {
@@ -93,7 +95,7 @@ pub struct WasmtimeWizer<'a, T: 'static> {
 }
 
 impl<T: Send> InstanceState for WasmtimeWizer<'_, T> {
-    async fn global_get(&mut self, name: &str) -> SnapshotVal {
+    async fn global_get(&mut self, name: &str, _: ValType) -> SnapshotVal {
         let global = self.instance.get_global(&mut *self.store, name).unwrap();
         match global.get(&mut *self.store) {
             Val::I32(x) => SnapshotVal::I32(x),


### PR DESCRIPTION
InstanceState::global_get now takes a parameter to tell the system what type this global expects

in JS, WebAssembly.Instance hides the actual underlying type information, so there needs to be a way to tell the runtime what type the global needs to be