### PR TITLE
Allow usage of `ensure!` without an error message

### DIFF
--- a/crates/error/src/macros.rs
+++ b/crates/error/src/macros.rs
@@ -189,6 +189,10 @@ macro_rules! bail {
 /// ```
 #[macro_export]
 macro_rules! ensure {
+    ( $condition:expr ) => {{
+        $crate::ensure!($condition, concat!("Condition failed: `", stringify!($condition), "`"))
+    }};
+
     ( $condition:expr , $( $args:tt )* ) => {{
         if $crate::macros::ensure::not($condition) {
             $crate::bail!( $( $args )* );

--- a/crates/error/tests/tests.rs
+++ b/crates/error/tests/tests.rs
@@ -398,6 +398,16 @@ fn ensure_macro() {
     }
     assert!(ensure_bool_ref(&true).is_ok());
     assert_eq!(ensure_bool_ref(&false).unwrap_err().to_string(), "whoops");
+
+    fn ensure_no_message(a: u32) -> Result<()> {
+        ensure!(a == 42);
+        Ok(())
+    }
+    assert!(ensure_no_message(42).is_ok());
+    assert_eq!(
+        ensure_no_message(0).unwrap_err().to_string(),
+        "Condition failed: `a == 42`"
+    );
 }
 
 #[test]


### PR DESCRIPTION
`anyhow::ensure!` does not require a message, so `wasmtime_error::ensure!` should not either.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
