### PR TITLE
Pulley: Only return exception registers for supported calling conventions

### DIFF
--- a/cranelift/codegen/src/isa/pulley_shared/abi.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/abi.rs
@@ -560,12 +560,21 @@ where
         Writable::from_reg(regs::x_reg(15))
     }
 
-    fn exception_payload_regs(_call_conv: isa::CallConv) -> &'static [Reg] {
+    fn exception_payload_regs(call_conv: isa::CallConv) -> &'static [Reg] {
         const PAYLOAD_REGS: &'static [Reg] = &[
             Reg::from_real_reg(regs::px_reg(0)),
             Reg::from_real_reg(regs::px_reg(1)),
         ];
-        PAYLOAD_REGS
+        match call_conv {
+            isa::CallConv::SystemV | isa::CallConv::Tail | isa::CallConv::PreserveAll => {
+                PAYLOAD_REGS
+            }
+            isa::CallConv::Fast
+            | isa::CallConv::WindowsFastcall
+            | isa::CallConv::AppleAarch64
+            | isa::CallConv::Probestack
+            | isa::CallConv::Winch => &[],
+        }
     }
 }
 

--- a/cranelift/filetests/filetests/isa/pulley64/issue-12317.clif
+++ b/cranelift/filetests/filetests/isa/pulley64/issue-12317.clif
@@ -1,0 +1,19 @@
+test compile
+target pulley64
+
+function %trigger_bug(i32) -> i32 {
+    sig0 = (i32) -> i32 winch
+    fn0 = %callee(i32) -> i32 winch
+
+    block0(v0: i32):
+        ; try_call triggers the bug by invoking exception handling codegen
+        ; Note: We omit exn0 because exception_payload_types is empty
+        try_call fn0(v0), sig0, block1(ret0), [ default: block2 ]
+
+    block1(v1: i32):
+        return v1
+
+    block2:
+        v3 = iconst.i32 -1
+        return v3
+}


### PR DESCRIPTION
Fixes #12317

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
