### PR TITLE
Fix ISLE icmp optimization rules for vector inputs

### DIFF
--- a/cranelift/codegen/src/opts/icmp.isle
+++ b/cranelift/codegen/src/opts/icmp.isle
@@ -313,10 +313,10 @@
 (rule (simplify (bxor ty (ult ty x y) (ult ty y x))) (ne ty x y))
 
 ;; a < b && a > b = false
-(rule (simplify (band ty (sgt ty x y) (slt ty x y))) (iconst_u ty 0))
-(rule (simplify (band ty (slt ty x y) (sgt ty x y))) (iconst_u ty 0))
-(rule (simplify (band ty (ugt ty x y) (ult ty x y))) (iconst_u ty 0))
-(rule (simplify (band ty (ult ty x y) (ugt ty x y))) (iconst_u ty 0))
+(rule (simplify (band (fits_in_64 ty) (sgt ty x y) (slt ty x y))) (iconst_u ty 0))
+(rule (simplify (band (fits_in_64 ty) (slt ty x y) (sgt ty x y))) (iconst_u ty 0))
+(rule (simplify (band (fits_in_64 ty) (ugt ty x y) (ult ty x y))) (iconst_u ty 0))
+(rule (simplify (band (fits_in_64 ty) (ult ty x y) (ugt ty x y))) (iconst_u ty 0))
 (rule
   (simplify (band ty (sgt ty x (iconst_s _ y)) (ult ty x (iconst_s _ y))))
   (if-let true (i64_gt_eq y 0))

--- a/cranelift/filetests/filetests/egraph/issue-12328.clif
+++ b/cranelift/filetests/filetests/egraph/issue-12328.clif
@@ -1,0 +1,59 @@
+test optimize
+set opt_level=speed
+target x86_64
+
+function %sgt_slt_i32x4(i32x4, i32x4) -> i32x4 {
+block0(v0: i32x4, v1: i32x4):
+    v2 = icmp sgt v0, v1
+    v3 = icmp slt v0, v1
+    v4 = band v2, v3
+    return v4
+}
+
+function %slt_sgt_i32x4(i32x4, i32x4) -> i32x4 {
+block0(v0: i32x4, v1: i32x4):
+    v2 = icmp slt v0, v1
+    v3 = icmp sgt v0, v1
+    v4 = band v2, v3
+    return v4
+}
+
+function %ugt_ult_i32x4(i32x4, i32x4) -> i32x4 {
+block0(v0: i32x4, v1: i32x4):
+    v2 = icmp ugt v0, v1
+    v3 = icmp ult v0, v1
+    v4 = band v2, v3
+    return v4
+}
+
+function %ult_ugt_i32x4(i32x4, i32x4) -> i32x4 {
+block0(v0: i32x4, v1: i32x4):
+    v2 = icmp ult v0, v1
+    v3 = icmp ugt v0, v1
+    v4 = band v2, v3
+    return v4
+}
+
+function %sgt_slt_i64x2(i64x2, i64x2) -> i64x2 {
+block0(v0: i64x2, v1: i64x2):
+    v2 = icmp sgt v0, v1
+    v3 = icmp slt v0, v1
+    v4 = band v2, v3
+    return v4
+}
+
+function %slt_sgt_i16x8(i16x8, i16x8) -> i16x8 {
+block0(v0: i16x8, v1: i16x8):
+    v2 = icmp slt v0, v1
+    v3 = icmp sgt v0, v1
+    v4 = band v2, v3
+    return v4
+}
+
+function %ugt_ult_i8x16(i8x16, i8x16) -> i8x16 {
+block0(v0: i8x16, v1: i8x16):
+    v2 = icmp ugt v0, v1
+    v3 = icmp ult v0, v1
+    v4 = band v2, v3
+    return v4
+}


### PR DESCRIPTION
Add `fits_in_64` for a few icmp optimization rules to avoid matching 128-bit vectors.  Rules at line 320 - 351 are contrained by `iconst_s` so don't need the fix.

Closes #12328

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
