### PR TITLE
Add F16 and F128 support to NaN canonicalization

### DIFF
--- a/cranelift/filetests/filetests/isa/riscv64/nan-canonicalization-f16.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/nan-canonicalization-f16.clif
@@ -1,0 +1,9 @@
+test compile
+set enable_nan_canonicalization=true
+target riscv64 has_zfhmin has_zfh
+
+function %fadd_f16(f16, f16) -> f16 {
+block0(v0: f16, v1: f16):
+    v2 = fadd v0, v1
+    return v2
+}

--- a/cranelift/filetests/filetests/isa/s390x/nan-canonicalization-f128.clif
+++ b/cranelift/filetests/filetests/isa/s390x/nan-canonicalization-f128.clif
@@ -1,0 +1,10 @@
+test compile
+set enable_nan_canonicalization=true
+target s390x
+
+function %fadd_f128(i64, f128, f128) {
+block0(v0: i64, v1: f128, v2: f128):
+    v3 = fadd v1, v2
+    store v3, v0
+    return
+}


### PR DESCRIPTION
Extend the NaN canonicalization pass to handle f16 and f128 floating point types, which were previously unsupported and would cause a panic.

Closes #12336

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
