### PR TITLE
[41.0.0] Fix ISLE icmp optimization rules for vector inputs 

### DIFF
--- a/cranelift/codegen/src/opts/icmp.isle
+++ b/cranelift/codegen/src/opts/icmp.isle
@@ -313,10 +313,10 @@
 (rule (simplify (bxor ty (ult ty x y) (ult ty y x))) (ne ty x y))
 
 ;; a < b && a > b = false
-(rule (simplify (band ty (sgt ty x y) (slt ty x y))) (iconst_u ty 0))
-(rule (simplify (band ty (slt ty x y) (sgt ty x y))) (iconst_u ty 0))
-(rule (simplify (band ty (ugt ty x y) (ult ty x y))) (iconst_u ty 0))
-(rule (simplify (band ty (ult ty x y) (ugt ty x y))) (iconst_u ty 0))
+(rule (simplify (band (fits_in_64 ty) (sgt ty x y) (slt ty x y))) (iconst_u ty 0))
+(rule (simplify (band (fits_in_64 ty) (slt ty x y) (sgt ty x y))) (iconst_u ty 0))
+(rule (simplify (band (fits_in_64 ty) (ugt ty x y) (ult ty x y))) (iconst_u ty 0))
+(rule (simplify (band (fits_in_64 ty) (ult ty x y) (ugt ty x y))) (iconst_u ty 0))
 (rule
   (simplify (band ty (sgt ty x (iconst_s _ y)) (ult ty x (iconst_s _ y))))
   (if-let true (i64_gt_eq y 0))

--- a/cranelift/filetests/filetests/egraph/issue-12328.clif
+++ b/cranelift/filetests/filetests/egraph/issue-12328.clif
@@ -1,0 +1,59 @@
+test optimize
+set opt_level=speed
+target x86_64
+
+function %sgt_slt_i32x4(i32x4, i32x4) -> i32x4 {
+block0(v0: i32x4, v1: i32x4):
+    v2 = icmp sgt v0, v1
+    v3 = icmp slt v0, v1
+    v4 = band v2, v3
+    return v4
+}
+
+function %slt_sgt_i32x4(i32x4, i32x4) -> i32x4 {
+block0(v0: i32x4, v1: i32x4):
+    v2 = icmp slt v0, v1
+    v3 = icmp sgt v0, v1
+    v4 = band v2, v3
+    return v4
+}
+
+function %ugt_ult_i32x4(i32x4, i32x4) -> i32x4 {
+block0(v0: i32x4, v1: i32x4):
+    v2 = icmp ugt v0, v1
+    v3 = icmp ult v0, v1
+    v4 = band v2, v3
+    return v4
+}
+
+function %ult_ugt_i32x4(i32x4, i32x4) -> i32x4 {
+block0(v0: i32x4, v1: i32x4):
+    v2 = icmp ult v0, v1
+    v3 = icmp ugt v0, v1
+    v4 = band v2, v3
+    return v4
+}
+
+function %sgt_slt_i64x2(i64x2, i64x2) -> i64x2 {
+block0(v0: i64x2, v1: i64x2):
+    v2 = icmp sgt v0, v1
+    v3 = icmp slt v0, v1
+    v4 = band v2, v3
+    return v4
+}
+
+function %slt_sgt_i16x8(i16x8, i16x8) -> i16x8 {
+block0(v0: i16x8, v1: i16x8):
+    v2 = icmp slt v0, v1
+    v3 = icmp sgt v0, v1
+    v4 = band v2, v3
+    return v4
+}
+
+function %ugt_ult_i8x16(i8x16, i8x16) -> i8x16 {
+block0(v0: i8x16, v1: i8x16):
+    v2 = icmp ugt v0, v1
+    v3 = icmp ult v0, v1
+    v4 = band v2, v3
+    return v4
+}


### PR DESCRIPTION
Backport of #12335. Note that this is not to be confused with https://github.com/bytecodealliance/wasmtime/pull/12333