### PR TITLE
Migrate `wasmtime-wasi-tls-openssl` to `wasmtime::Error`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5196,7 +5196,6 @@ dependencies = [
 name = "wasmtime-wasi-tls-openssl"
 version = "42.0.0"
 dependencies = [
- "anyhow",
  "futures",
  "openssl",
  "test-programs-artifacts",

--- a/crates/wasi-tls-openssl/Cargo.toml
+++ b/crates/wasi-tls-openssl/Cargo.toml
@@ -18,7 +18,6 @@ tokio-openssl = { workspace = true }
 openssl = { workspace = true }
 
 [dev-dependencies]
-anyhow = { workspace = true }
 test-programs-artifacts = { workspace = true }
 wasmtime = { workspace = true, features = ["runtime", "component-model"] }
 wasmtime-wasi = { workspace = true }

--- a/crates/wasi-tls-openssl/tests/main.rs
+++ b/crates/wasi-tls-openssl/tests/main.rs
@@ -1,7 +1,7 @@
-use anyhow::{Result, anyhow};
 use wasmtime::{
-    Store,
+    Result, Store,
     component::{Component, Linker, ResourceTable},
+    format_err,
 };
 use wasmtime_wasi::{WasiCtx, WasiCtxView, WasiView, p2::bindings::Command};
 use wasmtime_wasi_tls::{LinkOptions, WasiTls, WasiTlsCtx, WasiTlsCtxBuilder};
@@ -52,7 +52,7 @@ async fn run_test(path: &str) -> Result<()> {
         .wasi_cli_run()
         .call_run(&mut store)
         .await?
-        .map_err(|()| anyhow!("command returned with failing exit status"))
+        .map_err(|()| format_err!("command returned with failing exit status"))
 }
 
 macro_rules! assert_test_exists {


### PR DESCRIPTION
Somehow this got missed in the earlier wave of migrations.