### PR TITLE
Fix HeadType::matches fallthrough for NoExn

### DIFF
--- a/crates/wasmtime/src/runtime/types.rs
+++ b/crates/wasmtime/src/runtime/types.rs
@@ -1233,7 +1233,7 @@ impl HeapType {
             (HeapType::Any, _) => false,
 
             (HeapType::NoExn, HeapType::Exn | HeapType::ConcreteExn(_) | HeapType::NoExn) => true,
-            (HeapType::NoExn, _) => true,
+            (HeapType::NoExn, _) => false,
 
             (HeapType::ConcreteExn(_), HeapType::Exn) => true,
             (HeapType::ConcreteExn(a), HeapType::ConcreteExn(b)) => a.matches(b),

--- a/tests/all/types.rs
+++ b/tests/all/types.rs
@@ -681,3 +681,29 @@ fn func_subtyping() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn heap_type_matches_noexn() -> Result<()> {
+    // Test that NoExn only matches exception-related types.
+    // NoExn should NOT match unrelated heap types like Func, Extern, Any, etc.
+
+    // NoExn should match exception hierarchy types
+    assert!(HeapType::NoExn.matches(&HeapType::Exn));
+    assert!(HeapType::NoExn.matches(&HeapType::NoExn));
+
+    // NoExn should NOT match types outside the exception hierarchy
+    assert!(!HeapType::NoExn.matches(&HeapType::Func));
+    assert!(!HeapType::NoExn.matches(&HeapType::NoFunc));
+    assert!(!HeapType::NoExn.matches(&HeapType::Extern));
+    assert!(!HeapType::NoExn.matches(&HeapType::NoExtern));
+    assert!(!HeapType::NoExn.matches(&HeapType::Any));
+    assert!(!HeapType::NoExn.matches(&HeapType::Eq));
+    assert!(!HeapType::NoExn.matches(&HeapType::I31));
+    assert!(!HeapType::NoExn.matches(&HeapType::Struct));
+    assert!(!HeapType::NoExn.matches(&HeapType::Array));
+    assert!(!HeapType::NoExn.matches(&HeapType::None));
+    assert!(!HeapType::NoExn.matches(&HeapType::Cont));
+    assert!(!HeapType::NoExn.matches(&HeapType::NoCont));
+
+    Ok(())
+}


### PR DESCRIPTION
`HeapType::NoExn.matches()` returns true for all types due to probably a typo in the fallthrough arm. Without the fix, the newly added test would fail with:

```
thread 'types::heap_type_matches_noexn' (3801618) panicked at tests/all/types.rs:695:5:
assertion failed: !HeapType::NoExn.matches(&HeapType::Func)
```

Skipped raising an issue since it's quite trivial but please let me know if having an issue helps the bookkeeping. Thanks for looking into this!

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
