### PR TITLE
Fix off-by-one error in enum discriminant validation

### DIFF
--- a/crates/environ/src/fact/trampoline.rs
+++ b/crates/environ/src/fact/trampoline.rs
@@ -3046,7 +3046,7 @@ impl<'a, 'b> Compiler<'a, 'b> {
 
         // Assert that the discriminant is valid.
         self.instruction(I32Const(i32::try_from(src_ty.names.len()).unwrap()));
-        self.instruction(I32GtU);
+        self.instruction(I32GeU);
         self.instruction(If(BlockType::Empty));
         self.trap(Trap::InvalidDiscriminant);
         self.instruction(End);

--- a/tests/misc_testsuite/component-model/enum_discriminant.wast
+++ b/tests/misc_testsuite/component-model/enum_discriminant.wast
@@ -1,0 +1,26 @@
+(assert_trap
+  (component
+    (type $enum (enum "case0" "case1" "case2"))
+
+    ;; Returns invalid discriminant 3 (valid range: 0-2)
+    (component $producer
+      (import "enum" (type $enum' (eq $enum)))
+      (core module $core
+        (func (export "get") (result i32) (i32.const 3)))
+      (core instance $inst (instantiate $core))
+      (func (export "get") (result $enum') (canon lift (core func $inst "get"))))
+
+    ;; Calls producer through adapter - validation should trap here
+    (component $consumer
+      (import "enum" (type $enum' (eq $enum)))
+      (import "get" (func $get (result $enum')))
+      (core func $lowered (canon lower (func $get)))
+      (core module $core
+        (import "" "get" (func (result i32)))
+        (func $start (call 0) drop)
+        (start $start))
+      (core instance (instantiate $core (with "" (instance (export "get" (func $lowered)))))))
+
+    (instance $prod (instantiate $producer (with "enum" (type $enum))))
+    (instance (instantiate $consumer (with "enum" (type $enum)) (with "get" (func $prod "get")))))
+  "invalid variant discriminant")


### PR DESCRIPTION
The discriminant check used `i32.gt_u` when it should use `i32.ge_u`. For an enum with N cases (valid discriminants 0 to N-1), a discriminant of exactly N was incorrectly accepted.

Closes #12354

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
