### PR TITLE
Fix running multiple `*.wast` files with overlapping names

### DIFF
--- a/crates/wast/src/wast.rs
+++ b/crates/wast/src/wast.rs
@@ -563,6 +563,12 @@ impl WastContext {
             .dwarf(self.generate_dwarf)
             .convert(filename, wast, ast)
             .to_wasmtime_result()?;
+
+        // Clear out any modules, if any, from a previous `*.wast` file being
+        // run, if any.
+        if !self.modules_by_filename.is_empty() {
+            self.modules_by_filename = Arc::default();
+        }
         let modules_by_filename = Arc::get_mut(&mut self.modules_by_filename).unwrap();
         for (name, bytes) in ast.wasms.drain(..) {
             let prev = modules_by_filename.insert(name, bytes);


### PR DESCRIPTION
Fixes an assertion that trips when `*.wast` files are run in succession and happen to have overlapping names that may conflict with internal module names.

Closes #12352

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
