### PR TITLE
Fix x-register argument count in Pulley VM to match ABI

### DIFF
--- a/pulley/src/interp.rs
+++ b/pulley/src/interp.rs
@@ -111,7 +111,7 @@ impl Vm {
         // NB: make sure this method stays in sync with
         // `PulleyMachineDeps::compute_arg_locs`!
 
-        let mut x_args = (0..16).map(|x| unsafe { XReg::new_unchecked(x) });
+        let mut x_args = (0..15).map(|x| unsafe { XReg::new_unchecked(x) });
         let mut f_args = (0..16).map(|f| unsafe { FReg::new_unchecked(f) });
         #[cfg(not(pulley_disable_interp_simd))]
         let mut v_args = (0..16).map(|v| unsafe { VReg::new_unchecked(v) });


### PR DESCRIPTION
x15 is reserved for ReturnCallIndirect to hold the jump target location.

Closes #12353

I have a lengthy Rust test but I guess it might not be needed. Please let me know if you would like a test. Thanks!

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
