### PR TITLE
make async tests using `ready` interface more robust

### DIFF
--- a/crates/misc/component-async-tests/src/lib.rs
+++ b/crates/misc/component-async-tests/src/lib.rs
@@ -1,8 +1,5 @@
 #![expect(clippy::allow_attributes_without_reason)]
 
-use std::sync::{Arc, Mutex};
-use std::task::Waker;
-
 use wasmtime::component::{HasData, ResourceTable};
 use wasmtime_wasi::{WasiCtx, WasiCtxView, WasiView};
 
@@ -21,7 +18,6 @@ pub mod yield_host;
 pub struct Ctx {
     pub wasi: WasiCtx,
     pub table: ResourceTable,
-    pub wakers: Arc<Mutex<Option<Vec<Waker>>>>,
     pub continue_: bool,
 }
 

--- a/crates/misc/component-async-tests/src/yield_host.rs
+++ b/crates/misc/component-async-tests/src/yield_host.rs
@@ -1,29 +1,45 @@
 use super::Ctx;
 use futures::future;
 use std::ops::DerefMut;
-use std::task::Poll;
-use wasmtime::component::Accessor;
+use std::sync::{Arc, Mutex};
+use std::task::{Poll, Waker};
+use wasmtime::component::{Accessor, Resource};
 
 pub mod bindings {
     wasmtime::component::bindgen!({
         path: "wit",
         world: "yield-host",
+        imports: { default: trappable },
+        with: {
+            "local:local/ready.thing": super::Thing,
+        },
     });
 }
 
+#[derive(Default)]
+pub struct Thing {
+    wakers: Arc<Mutex<Option<Vec<Waker>>>>,
+}
+
 impl bindings::local::local::continue_::Host for Ctx {
-    fn set_continue(&mut self, v: bool) {
+    fn set_continue(&mut self, v: bool) -> wasmtime::Result<()> {
         self.continue_ = v;
+        Ok(())
     }
 
-    fn get_continue(&mut self) -> bool {
-        self.continue_
+    fn get_continue(&mut self) -> wasmtime::Result<bool> {
+        Ok(self.continue_)
     }
 }
 
-impl bindings::local::local::ready::Host for Ctx {
-    fn set_ready(&mut self, ready: bool) {
-        let mut wakers = self.wakers.lock().unwrap();
+impl bindings::local::local::ready::HostThing for Ctx {
+    fn new(&mut self) -> wasmtime::Result<Resource<Thing>> {
+        Ok(self.table.push(Thing::default())?)
+    }
+
+    fn set_ready(&mut self, thing: Resource<Thing>, ready: bool) -> wasmtime::Result<()> {
+        let thing = self.table.get(&thing)?;
+        let mut wakers = thing.wakers.lock().unwrap();
         if ready {
             if let Some(wakers) = wakers.take() {
                 for waker in wakers {
@@ -33,12 +49,24 @@ impl bindings::local::local::ready::Host for Ctx {
         } else if wakers.is_none() {
             *wakers = Some(Vec::new());
         }
+        Ok(())
+    }
+
+    fn drop(&mut self, thing: Resource<Thing>) -> wasmtime::Result<()> {
+        self.table.delete(thing)?;
+        Ok(())
     }
 }
 
-impl bindings::local::local::ready::HostWithStore for Ctx {
-    async fn when_ready<T>(accessor: &Accessor<T, Self>) {
-        let wakers = accessor.with(|mut view| view.get().wakers.clone());
+impl bindings::local::local::ready::HostThingWithStore for Ctx {
+    async fn when_ready<T>(
+        accessor: &Accessor<T, Self>,
+        thing: Resource<Thing>,
+    ) -> wasmtime::Result<()> {
+        let wakers = accessor.with(|mut view| {
+            Ok::<_, wasmtime::Error>(view.get().table.get(&thing)?.wakers.clone())
+        })?;
+
         future::poll_fn(move |cx| {
             let mut wakers = wakers.lock().unwrap();
             if let Some(wakers) = wakers.deref_mut() {
@@ -48,6 +76,10 @@ impl bindings::local::local::ready::HostWithStore for Ctx {
                 Poll::Ready(())
             }
         })
-        .await
+        .await;
+
+        Ok(())
     }
 }
+
+impl bindings::local::local::ready::Host for Ctx {}

--- a/crates/misc/component-async-tests/tests/scenario/borrowing.rs
+++ b/crates/misc/component-async-tests/tests/scenario/borrowing.rs
@@ -1,5 +1,4 @@
 use std::env;
-use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use super::util::{config, make_component};
@@ -89,7 +88,6 @@ pub async fn test_run_bool(components: &[&str], v: bool) -> Result<()> {
             wasi: WasiCtxBuilder::new().inherit_stdio().build(),
             table: ResourceTable::default(),
             continue_: false,
-            wakers: Arc::new(Mutex::new(None)),
         },
     );
 

--- a/crates/misc/component-async-tests/tests/scenario/post_return.rs
+++ b/crates/misc/component-async-tests/tests/scenario/post_return.rs
@@ -4,7 +4,6 @@ use component_async_tests::util;
 use component_async_tests::{Ctx, sleep};
 use std::future;
 use std::pin::pin;
-use std::sync::{Arc, Mutex};
 use std::task::Poll;
 use std::time::Duration;
 use wasmtime::Result;
@@ -67,7 +66,6 @@ async fn test_sleep_post_return(components: &[&str]) -> Result<()> {
             wasi: WasiCtxBuilder::new().inherit_stdio().build(),
             table: ResourceTable::default(),
             continue_: false,
-            wakers: Arc::new(Mutex::new(None)),
         },
     );
 

--- a/crates/misc/component-async-tests/tests/scenario/round_trip.rs
+++ b/crates/misc/component-async-tests/tests/scenario/round_trip.rs
@@ -1,7 +1,5 @@
-use std::sync::{
-    Arc, Mutex,
-    atomic::{AtomicU32, Ordering::Relaxed},
-};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, Ordering::Relaxed};
 use std::time::Duration;
 
 use super::util::{config, make_component};
@@ -355,7 +353,6 @@ pub async fn test_round_trip(
                 wasi: WasiCtxBuilder::new().inherit_stdio().build(),
                 table: ResourceTable::default(),
                 continue_: false,
-                wakers: Arc::new(Mutex::new(None)),
             },
         )
     };

--- a/crates/misc/component-async-tests/tests/scenario/round_trip_direct.rs
+++ b/crates/misc/component-async-tests/tests/scenario/round_trip_direct.rs
@@ -1,4 +1,3 @@
-use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use super::util::{config, make_component};
@@ -40,7 +39,6 @@ async fn test_round_trip_direct(
                 wasi: WasiCtxBuilder::new().inherit_stdio().build(),
                 table: ResourceTable::default(),
                 continue_: false,
-                wakers: Arc::new(Mutex::new(None)),
             },
         )
     };

--- a/crates/misc/component-async-tests/tests/scenario/round_trip_many.rs
+++ b/crates/misc/component-async-tests/tests/scenario/round_trip_many.rs
@@ -1,8 +1,5 @@
 use std::iter;
-use std::sync::{
-    Arc, Mutex,
-    atomic::{AtomicU32, Ordering::Relaxed},
-};
+use std::sync::atomic::{AtomicU32, Ordering::Relaxed};
 use std::time::Duration;
 
 use super::util::{config, make_component};
@@ -208,7 +205,6 @@ async fn test_round_trip_many(
                 wasi: WasiCtxBuilder::new().inherit_stdio().build(),
                 table: ResourceTable::default(),
                 continue_: false,
-                wakers: Arc::new(Mutex::new(None)),
             },
         )
     };

--- a/crates/misc/component-async-tests/tests/scenario/streams.rs
+++ b/crates/misc/component-async-tests/tests/scenario/streams.rs
@@ -119,7 +119,6 @@ pub async fn async_closed_streams() -> Result<()> {
             wasi: WasiCtxBuilder::new().inherit_stdio().build(),
             table: ResourceTable::default(),
             continue_: false,
-            wakers: Arc::new(Mutex::new(None)),
         },
     );
 
@@ -280,7 +279,6 @@ pub async fn async_closed_stream() -> Result<()> {
             wasi: WasiCtxBuilder::new().inherit_stdio().build(),
             table: ResourceTable::default(),
             continue_: false,
-            wakers: Arc::new(Mutex::new(None)),
         },
     );
 
@@ -415,7 +413,6 @@ async fn test_async_short_reads(delay: bool) -> Result<()> {
             wasi: WasiCtxBuilder::new().inherit_stdio().build(),
             table: ResourceTable::default(),
             continue_: false,
-            wakers: Arc::new(Mutex::new(None)),
         },
     );
 

--- a/crates/misc/component-async-tests/tests/scenario/transmit.rs
+++ b/crates/misc/component-async-tests/tests/scenario/transmit.rs
@@ -1,6 +1,5 @@
 use std::future::Future;
 use std::pin::Pin;
-use std::sync::{Arc, Mutex};
 use std::task::{self, Context, Poll};
 use std::time::Duration;
 
@@ -349,7 +348,6 @@ pub async fn async_readiness() -> Result<()> {
             wasi: WasiCtxBuilder::new().inherit_stdio().build(),
             table: ResourceTable::default(),
             continue_: false,
-            wakers: Arc::new(Mutex::new(None)),
         },
     );
 
@@ -492,7 +490,6 @@ async fn test_cancel(mode: Mode) -> Result<()> {
             wasi: WasiCtxBuilder::new().inherit_stdio().build(),
             table: ResourceTable::default(),
             continue_: false,
-            wakers: Arc::new(Mutex::new(None)),
         },
     );
 
@@ -737,7 +734,6 @@ async fn test_transmit_with<Test: TransmitTest + 'static>(component: &str) -> Re
             wasi: WasiCtxBuilder::new().inherit_stdio().build(),
             table: ResourceTable::default(),
             continue_: false,
-            wakers: Arc::new(Mutex::new(None)),
         },
     );
 
@@ -940,7 +936,6 @@ async fn test_synchronous_transmit(component: &str, procrastinate: bool) -> Resu
             wasi: WasiCtxBuilder::new().inherit_stdio().build(),
             table: ResourceTable::default(),
             continue_: false,
-            wakers: Arc::new(Mutex::new(None)),
         },
     );
 

--- a/crates/misc/component-async-tests/tests/scenario/util.rs
+++ b/crates/misc/component-async-tests/tests/scenario/util.rs
@@ -204,7 +204,6 @@ pub async fn test_run_with_count(components: &[&str], count: usize) -> Result<()
             wasi: WasiCtxBuilder::new().inherit_stdio().build(),
             table: ResourceTable::default(),
             continue_: false,
-            wakers: Arc::new(std::sync::Mutex::new(None)),
         },
     );
 

--- a/crates/misc/component-async-tests/wit/test.wit
+++ b/crates/misc/component-async-tests/wit/test.wit
@@ -43,8 +43,11 @@ world round-trip-direct {
 }
 
 interface ready {
-  set-ready: func(ready: bool);
-  when-ready: async func();
+  resource thing {
+    constructor();
+    set-ready: func(ready: bool);
+    when-ready: async func();
+  }
 }
 
 interface continue {

--- a/crates/test-programs/src/bin/async_poll_synchronous.rs
+++ b/crates/test-programs/src/bin/async_poll_synchronous.rs
@@ -17,9 +17,10 @@ use {
     },
 };
 
-fn async_when_ready() -> u32 {
+fn async_when_ready(handle: u32) -> u32 {
     #[cfg(not(target_arch = "wasm32"))]
     {
+        _ = handle;
         unreachable!()
     }
 
@@ -27,10 +28,10 @@ fn async_when_ready() -> u32 {
     {
         #[link(wasm_import_module = "local:local/ready")]
         unsafe extern "C" {
-            #[link_name = "[async-lower]when-ready"]
-            fn call_when_ready() -> u32;
+            #[link_name = "[async-lower][method]thing.when-ready"]
+            fn call_when_ready(handle: u32) -> u32;
         }
-        unsafe { call_when_ready() }
+        unsafe { call_when_ready(handle) }
     }
 }
 
@@ -39,13 +40,14 @@ struct Component;
 impl Guest for Component {
     fn run() {
         unsafe {
-            ready::set_ready(false);
+            let thing = ready::Thing::new();
+            thing.set_ready(false);
 
             let set = waitable_set_new();
 
             assert_eq!(waitable_set_poll(set), (EVENT_NONE, 0, 0));
 
-            let result = async_when_ready();
+            let result = async_when_ready(thing.handle());
             let status = result & 0xf;
             let call = result >> 4;
             assert!(status != STATUS_RETURNED);
@@ -53,7 +55,7 @@ impl Guest for Component {
 
             assert_eq!(waitable_set_poll(set), (EVENT_NONE, 0, 0));
 
-            ready::set_ready(true);
+            thing.set_ready(true);
 
             assert_eq!(thread_yield(), SUSPEND_RESULT_NOT_CANCELLED);
 
@@ -66,7 +68,7 @@ impl Guest for Component {
 
             assert_eq!(waitable_set_poll(set), (EVENT_NONE, 0, 0));
 
-            assert_eq!(async_when_ready(), STATUS_RETURNED);
+            assert_eq!(async_when_ready(thing.handle()), STATUS_RETURNED);
 
             assert_eq!(waitable_set_poll(set), (EVENT_NONE, 0, 0));
 

--- a/crates/test-programs/src/bin/async_yield_caller.rs
+++ b/crates/test-programs/src/bin/async_yield_caller.rs
@@ -21,14 +21,15 @@ struct Component;
 
 impl Guest for Component {
     async fn run() {
-        ready::set_ready(false);
+        let thing = ready::Thing::new();
+        thing.set_ready(false);
         continue_::set_continue(true);
 
-        let mut ready = Some(Box::pin(ready::when_ready()));
+        let mut ready = Some(Box::pin(thing.when_ready()));
         let mut run = Some(Box::pin(run::run()));
-        future::poll_fn(move |cx| {
+        future::poll_fn(|cx| {
             let ready_poll = ready.as_mut().map(|v| v.as_mut().poll(cx));
-            ready::set_ready(true);
+            thing.set_ready(true);
             let run_poll = run.as_mut().map(|v| v.as_mut().poll(cx));
 
             match (run_poll, ready_poll) {

--- a/crates/test-programs/src/bin/async_yield_caller_cancel.rs
+++ b/crates/test-programs/src/bin/async_yield_caller_cancel.rs
@@ -31,7 +31,8 @@ struct Component;
 
 impl Guest for Component {
     async fn run() {
-        ready::set_ready(true);
+        let thing = ready::Thing::new();
+        thing.set_ready(true);
         continue_::set_continue(true);
 
         unsafe {


### PR DESCRIPTION
This changes the `ready` interface used by `component-async-tests` from:

```
interface ready {
  // Set the `ready` state
  set-ready: func(ready: bool);
  // Block until `ready` is `true`
  when-ready: async func();
}
```
to:
```
interface ready {
  resource thing {
    constructor();
    set-ready: func(ready: bool);
    when-ready: async func();
  }
}
```

The problem with the original version was that it required global state and thus caused cross-talk across concurrent tasks.  Due to implementation details inside Wasmtime, the tests worked anyway, but
https://github.com/bytecodealliance/wasmtime/pull/12357 perturbed that and revealed how fragile tests based on that interface were.

The new version puts the state inside a resource type, allowing each task create its own instance of that resource type and thereby avoid crosstalk.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
