### PR TITLE
Some minor no_std adjustments for `cranelift-codegen`

### DIFF
--- a/cranelift/codegen/src/ir/immediates.rs
+++ b/cranelift/codegen/src/ir/immediates.rs
@@ -706,7 +706,23 @@ macro_rules! ieee_float {
                 pub fn round_ties_even(self) -> Self {
                     // TODO: when libm v0.2.16 is published line below can be used instead
                     // Self::with_float(Libm::<$float_ty>::roundeven(self.$as_float()))
-                    Self::with_float(self.$as_float().round_ties_even())
+                    return Self::with_float(self.$as_float().roundeven());
+
+                    trait Roundeven {
+                        fn roundeven(self) -> Self;
+                    }
+
+                    impl Roundeven for f32 {
+                        fn roundeven(self) -> Self {
+                            libm::roundevenf(self)
+                        }
+                    }
+
+                    impl Roundeven for f64 {
+                        fn roundeven(self) -> Self {
+                            libm::roundeven(self)
+                        }
+                    }
                 }
             )?
         }

--- a/cranelift/codegen/src/isa/mod.rs
+++ b/cranelift/codegen/src/isa/mod.rs
@@ -50,7 +50,7 @@ use crate::CodegenResult;
 use crate::ir::{self, Function, Type};
 #[cfg(feature = "unwind")]
 use crate::isa::unwind::{UnwindInfoKind, systemv::RegisterMappingError};
-use crate::machinst::{CompiledCode, CompiledCodeStencil, TextSectionBuilder};
+use crate::machinst::{CompiledCodeStencil, TextSectionBuilder};
 use crate::settings;
 use crate::settings::Configurable;
 use crate::settings::SetResult;
@@ -329,7 +329,7 @@ pub trait TargetIsa: fmt::Display + Send + Sync {
     #[cfg(feature = "unwind")]
     fn emit_unwind_info(
         &self,
-        result: &CompiledCode,
+        result: &crate::machinst::CompiledCode,
         kind: UnwindInfoKind,
     ) -> CodegenResult<Option<crate::isa::unwind::UnwindInfo>>;
 

--- a/cranelift/codegen/src/isa/x64/mod.rs
+++ b/cranelift/codegen/src/isa/x64/mod.rs
@@ -10,8 +10,8 @@ use crate::isa::unwind::systemv;
 use crate::isa::x64::settings as x64_settings;
 use crate::isa::{Builder as IsaBuilder, FunctionAlignment, IsaFlagsHashKey};
 use crate::machinst::{
-    CompiledCode, CompiledCodeStencil, MachInst, MachTextSectionBuilder, Reg, SigSet,
-    TextSectionBuilder, VCode, compile,
+    CompiledCodeStencil, MachInst, MachTextSectionBuilder, Reg, SigSet, TextSectionBuilder, VCode,
+    compile,
 };
 use crate::result::{CodegenError, CodegenResult};
 use crate::settings::{self as shared_settings, Flags};
@@ -127,7 +127,7 @@ impl TargetIsa for X64Backend {
     #[cfg(feature = "unwind")]
     fn emit_unwind_info(
         &self,
-        result: &CompiledCode,
+        result: &crate::machinst::CompiledCode,
         kind: crate::isa::unwind::UnwindInfoKind,
     ) -> CodegenResult<Option<crate::isa::unwind::UnwindInfo>> {
         emit_unwind_info(&result.buffer, kind)
@@ -216,7 +216,10 @@ pub fn emit_unwind_info(
     buffer: &MachBufferFinalized<Final>,
     kind: crate::isa::unwind::UnwindInfoKind,
 ) -> CodegenResult<Option<crate::isa::unwind::UnwindInfo>> {
+    #[cfg(feature = "unwind")]
     use crate::isa::unwind::{UnwindInfo, UnwindInfoKind};
+    #[cfg(not(feature = "unwind"))]
+    let _ = buffer;
     Ok(match kind {
         #[cfg(feature = "unwind")]
         UnwindInfoKind::SystemV => {


### PR DESCRIPTION
* Resolve some warnings about unused variables/imports
* Replace a std-requiring `round_ties_even` method with the equivalent from `libm`.

The crate still doesn't compile with `no_std` just yet, but it's down to just one error about `OnceLock`.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
