### PR TITLE
Log the backtrace of attempted allocations after OOM in OOM tests

### DIFF
--- a/crates/fuzzing/src/oom.rs
+++ b/crates/fuzzing/src/oom.rs
@@ -97,6 +97,10 @@ unsafe impl GlobalAlloc for OomTestAllocator {
                     ptr = unsafe { std::alloc::System.alloc(layout) };
                 }
                 OomState::DidOom => {
+                    log::trace!(
+                        "Attempt to allocate {layout:?} after OOM:\n{:?}",
+                        Backtrace::new(),
+                    );
                     panic!("OOM test attempted to allocate after OOM: {layout:?}")
                 }
             }


### PR DESCRIPTION
Makes debugging these simple and easy.