### PR TITLE
Add methods for fallible allocation to `cranelift_entity::EntitySet`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -812,6 +812,7 @@ dependencies = [
  "cranelift-bitset",
  "serde",
  "serde_derive",
+ "wasmtime-internal-error",
 ]
 
 [[package]]

--- a/cranelift/entity/Cargo.toml
+++ b/cranelift/entity/Cargo.toml
@@ -19,6 +19,7 @@ workspace = true
 cranelift-bitset = { workspace=true }
 serde = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
+wasmtime-error = { workspace = true }
 
 [features]
 enable-serde = ["serde", "serde_derive", "cranelift-bitset/enable-serde"]

--- a/cranelift/entity/src/set.rs
+++ b/cranelift/entity/src/set.rs
@@ -5,6 +5,7 @@ use crate::keys::Keys;
 use core::fmt;
 use core::marker::PhantomData;
 use cranelift_bitset::CompoundBitSet;
+use wasmtime_error::OutOfMemory;
 
 /// A set of `K` for densely indexed entity references.
 ///
@@ -67,10 +68,23 @@ where
         }
     }
 
+    /// Like `with_capacity` but returns an error on allocation failure.
+    pub fn try_with_capacity(capacity: usize) -> Result<Self, OutOfMemory> {
+        Ok(Self {
+            bitset: CompoundBitSet::try_with_capacity(capacity)?,
+            unused: PhantomData,
+        })
+    }
+
     /// Ensure that the set has enough capacity to hold `capacity` total
     /// elements.
     pub fn ensure_capacity(&mut self, capacity: usize) {
         self.bitset.ensure_capacity(capacity);
+    }
+
+    /// Like `ensure_capacity` but returns an error on allocation failure.
+    pub fn try_ensure_capacity(&mut self, capacity: usize) -> Result<(), OutOfMemory> {
+        self.bitset.try_ensure_capacity(capacity)
     }
 
     /// Get the element at `k` if it exists.


### PR DESCRIPTION
Builds on top of https://github.com/bytecodealliance/wasmtime/pull/12381

I opted not to define OOM tests for these, since they are just transparent wrappers over the underlying `CompoundBitSet` methods, which do have OOM tests already.