### PR TITLE
Reduce duplication amongst `debug_*` helpers

### DIFF
--- a/crates/environ/src/module.rs
+++ b/crates/environ/src/module.rs
@@ -648,6 +648,17 @@ impl Module {
     pub fn num_defined_tags(&self) -> usize {
         self.tags.len() - self.num_imported_tags
     }
+
+    /// Tests whether `index` is valid for this module.
+    pub fn is_valid(&self, index: EntityIndex) -> bool {
+        match index {
+            EntityIndex::Function(i) => self.functions.is_valid(i),
+            EntityIndex::Table(i) => self.tables.is_valid(i),
+            EntityIndex::Memory(i) => self.memories.is_valid(i),
+            EntityIndex::Global(i) => self.globals.is_valid(i),
+            EntityIndex::Tag(i) => self.tags.is_valid(i),
+        }
+    }
 }
 
 impl TypeTrace for Module {

--- a/crates/wasmtime/src/runtime/externals.rs
+++ b/crates/wasmtime/src/runtime/externals.rs
@@ -249,6 +249,12 @@ impl<'instance> Export<'instance> {
         self.definition.into_memory()
     }
 
+    /// Consume this `Export` and return the contained `SharedMemory`, if it's
+    /// a shared memory, or `None` otherwise.
+    pub fn into_shared_memory(self) -> Option<SharedMemory> {
+        self.definition.into_shared_memory()
+    }
+
     /// Consume this `Export` and return the contained `Global`, if it's a global,
     /// or `None` otherwise.
     pub fn into_global(self) -> Option<Global> {

--- a/crates/wasmtime/src/runtime/instance.rs
+++ b/crates/wasmtime/src/runtime/instance.rs
@@ -394,7 +394,7 @@ impl Instance {
         self._module(store.into().0)
     }
 
-    fn _module<'a>(&self, store: &'a StoreOpaque) -> &'a Module {
+    pub(crate) fn _module<'a>(&self, store: &'a StoreOpaque) -> &'a Module {
         store.module_for_instance(self.id).unwrap()
     }
 


### PR DESCRIPTION
Deduplicate the check for `guest_debug`, validity checks, and conversion from `Export` to `Extern`. No functional change here, just a refactoring.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
