### PR TITLE
[41.0.x] Add vets for `wasmtime-internal-debugger` 

### DIFF
--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -1038,6 +1038,14 @@ start = "2026-01-07"
 end = "2027-01-08"
 notes = "The Bytecode Alliance is the author of this crate"
 
+[[wildcard-audits.wasmtime-internal-debugger]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+trusted-publisher = "github:bytecodealliance/wasmtime"
+start = "2026-01-07"
+end = "2027-01-08"
+notes = "The Bytecode Alliance is the author of this crate"
+
 [[wildcard-audits.wasmtime-internal-explorer]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -142,6 +142,9 @@ audit-as-crates-io = true
 [policy.wasmtime-internal-cranelift]
 audit-as-crates-io = true
 
+[policy.wasmtime-internal-debugger]
+audit-as-crates-io = true
+
 [policy.wasmtime-internal-error]
 audit-as-crates-io = true
 

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1569,6 +1569,11 @@ when = "2025-11-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-internal-debugger]]
+version = "41.0.0"
+when = "2026-01-20"
+trusted-publisher = "github:bytecodealliance/wasmtime"
+
 [[publisher.wasmtime-internal-explorer]]
 version = "39.0.1"
 when = "2025-11-24"


### PR DESCRIPTION
Backport of #12376