### PR TITLE
Document panics from using CM async machinery when CM async is not enabled

### DIFF
--- a/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams.rs
@@ -1116,6 +1116,10 @@ pub struct FutureReader<T> {
 
 impl<T> FutureReader<T> {
     /// Create a new future with the specified producer.
+    ///
+    /// # Panics
+    ///
+    /// Panics if component-model-async is not enabled in this store's config.
     pub fn new<S: AsContextMut>(
         mut store: S,
         producer: impl FutureProducer<S::Data, Item = T>,
@@ -1123,7 +1127,10 @@ impl<T> FutureReader<T> {
     where
         T: func::Lower + func::Lift + Send + Sync + 'static,
     {
-        assert!(store.as_context().0.cm_concurrency_enabled());
+        assert!(
+            store.as_context().0.cm_concurrency_enabled(),
+            "cannot use `FutureReader::new` when component-model-async is not enabled on the config"
+        );
 
         struct Producer<P>(P);
 
@@ -1451,11 +1458,16 @@ where
     A: AsAccessor,
 {
     /// Create a new `GuardedFutureReader` with the specified `accessor` and `reader`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if component-model-async is not enabled in this store's config.
     pub fn new(accessor: A, reader: FutureReader<T>) -> Self {
         assert!(
             accessor
                 .as_accessor()
-                .with(|a| a.as_context().0.cm_concurrency_enabled())
+                .with(|a| a.as_context().0.cm_concurrency_enabled()),
+            "cannot use `GuardedFutureReader` when component-model-async is not enabled on the config"
         );
         Self {
             reader: Some(reader),
@@ -1503,6 +1515,10 @@ pub struct StreamReader<T> {
 
 impl<T> StreamReader<T> {
     /// Create a new stream with the specified producer.
+    ///
+    /// # Panics
+    ///
+    /// Panics if component-model-async is not enabled in this store's config.
     pub fn new<S: AsContextMut>(
         mut store: S,
         producer: impl StreamProducer<S::Data, Item = T>,
@@ -1510,7 +1526,10 @@ impl<T> StreamReader<T> {
     where
         T: func::Lower + func::Lift + Send + Sync + 'static,
     {
-        assert!(store.as_context().0.cm_concurrency_enabled());
+        assert!(
+            store.as_context().0.cm_concurrency_enabled(),
+            "cannot use `StreamReader` when component-model-async is not enabled on the config"
+        );
         Self::new_(
             store
                 .as_context_mut()
@@ -1785,11 +1804,16 @@ where
 {
     /// Create a new `GuardedStreamReader` with the specified `accessor` and
     /// `reader`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if component-model-async is not enabled in this store's config.
     pub fn new(accessor: A, reader: StreamReader<T>) -> Self {
         assert!(
             accessor
                 .as_accessor()
-                .with(|a| a.as_context().0.cm_concurrency_enabled())
+                .with(|a| a.as_context().0.cm_concurrency_enabled()),
+            "cannot use `GuardedStreamReader` when component-model-async is not enabled on the config"
         );
         Self {
             reader: Some(reader),

--- a/crates/wasmtime/src/runtime/component/func/typed.rs
+++ b/crates/wasmtime/src/runtime/component/func/typed.rs
@@ -278,6 +278,8 @@ where
     /// Panics if the store that the [`Accessor`] is derived from does not own
     /// this function.
     ///
+    /// Panics if component-model-async is not enabled in this store's config.
+    ///
     /// # Example
     ///
     /// Using [`StoreContextMut::run_concurrent`] to get an [`Accessor`]:
@@ -320,7 +322,10 @@ where
     {
         let result = accessor.as_accessor().with(|mut store| {
             let mut store = store.as_context_mut();
-            assert!(store.0.cm_concurrency_enabled());
+            assert!(
+                store.0.cm_concurrency_enabled(),
+                "cannot use `call_concurrent` when component-model-async is not enabled on the config"
+            );
             assert!(
                 store.0.async_support(),
                 "cannot use `call_concurrent` when async support is not enabled on the config"


### PR DESCRIPTION


<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
