### PR TITLE
Remove `out_of_line_slow_path!` macro from `wasmtime-error` crate

### DIFF
--- a/crates/error/src/boxed.rs
+++ b/crates/error/src/boxed.rs
@@ -19,9 +19,7 @@ pub(crate) unsafe fn try_alloc(layout: Layout) -> Result<NonNull<u8>, OutOfMemor
     if let Some(ptr) = NonNull::new(ptr) {
         Ok(ptr)
     } else {
-        out_of_line_slow_path! {
-            Err(OutOfMemory::new(layout.size()))
-        }
+        Err(OutOfMemory::new(layout.size()))
     }
 }
 

--- a/crates/error/src/context.rs
+++ b/crates/error/src/context.rs
@@ -140,7 +140,7 @@ where
     {
         match self {
             Ok(x) => Ok(x),
-            Err(e) => out_of_line_slow_path!(Err(Error::new(e).context(context))),
+            Err(e) => Err(Error::new(e).context(context)),
         }
     }
 
@@ -152,7 +152,7 @@ where
     {
         match self {
             Ok(x) => Ok(x),
-            Err(e) => out_of_line_slow_path!(Err(Error::new(e).context(f()))),
+            Err(e) => Err(Error::new(e).context(f())),
         }
     }
 }
@@ -164,7 +164,7 @@ impl<T> Context<T, Error> for Result<T> {
     {
         match self {
             Ok(x) => Ok(x),
-            Err(e) => out_of_line_slow_path!(Err(e.context(context))),
+            Err(e) => Err(e.context(context)),
         }
     }
 
@@ -175,7 +175,7 @@ impl<T> Context<T, Error> for Result<T> {
     {
         match self {
             Ok(x) => Ok(x),
-            Err(e) => out_of_line_slow_path!(Err(e.context(f()))),
+            Err(e) => Err(e.context(f())),
         }
     }
 }
@@ -187,10 +187,10 @@ impl<T> Context<T, core::convert::Infallible> for Option<T> {
     {
         match self {
             Some(x) => Ok(x),
-            None => out_of_line_slow_path!(Err(Error::from_error_ext(ContextError {
+            None => Err(Error::from_error_ext(ContextError {
                 context,
-                error: None
-            }))),
+                error: None,
+            })),
         }
     }
 
@@ -201,10 +201,10 @@ impl<T> Context<T, core::convert::Infallible> for Option<T> {
     {
         match self {
             Some(x) => Ok(x),
-            None => out_of_line_slow_path!(Err(Error::from_error_ext(ContextError {
+            None => Err(Error::from_error_ext(ContextError {
                 context: f(),
-                error: None
-            }))),
+                error: None,
+            })),
         }
     }
 }

--- a/crates/error/src/error.rs
+++ b/crates/error/src/error.rs
@@ -757,7 +757,7 @@ impl Error {
             Ok(boxed) => Error {
                 inner: boxed.into(),
             },
-            Err(oom) => out_of_line_slow_path!(Error { inner: oom.into() }),
+            Err(oom) => Error { inner: oom.into() },
         }
     }
 

--- a/crates/error/src/lib.rs
+++ b/crates/error/src/lib.rs
@@ -15,44 +15,6 @@ extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
 
-/// Internal macro to mark a block as a slow path, pulling it out into its own
-/// cold function that is never inlined.
-///
-/// This should be applied to the whole consequent/alternative block for a
-/// conditional, never to a single expression within a larger block.
-///
-/// # Example
-///
-/// ```ignore
-/// fn hot_function(x: u32) -> Result<()> {
-///     if very_rare_condition(x) {
-///         return out_of_line_slow_path!({
-///             // Handle the rare case...
-///             //
-///             // This pulls the handling of the rare condition out into
-///             // its own, separate function, which keeps the generated code
-///             // tight, handling only the common cases inline.
-///             Ok(())
-///         });
-///     }
-///
-///     // Handle the common case inline...
-///     Ok(())
-/// }
-/// ```
-macro_rules! out_of_line_slow_path {
-    ( $e:expr ) => {{
-        #[cold]
-        #[inline(never)]
-        #[track_caller]
-        fn out_of_line_slow_path<T>(f: impl FnOnce() -> T) -> T {
-            f()
-        }
-
-        out_of_line_slow_path(|| $e)
-    }};
-}
-
 #[cfg(feature = "backtrace")]
 mod backtrace;
 mod boxed;

--- a/crates/error/src/to_wasmtime_result.rs
+++ b/crates/error/src/to_wasmtime_result.rs
@@ -45,7 +45,7 @@ impl<T> ToWasmtimeResult<T> for anyhow::Result<T> {
     fn to_wasmtime_result(self) -> Result<T> {
         match self {
             Ok(x) => Ok(x),
-            Err(e) => out_of_line_slow_path! { Err(crate::Error::from_anyhow(e)) },
+            Err(e) => Err(crate::Error::from_anyhow(e)),
         }
     }
 }


### PR DESCRIPTION
I had at one point observed improved codegen with this, but I can't anymore, and if it isn't consistent then we shouldn't be going out of our way to do weird stuff and constrain the compiler.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
