### PR TITLE
Fix component-async fuzzer on OSS-Fuzz

### DIFF
--- a/crates/fuzzing/src/oracles/component_async.rs
+++ b/crates/fuzzing/src/oracles/component_async.rs
@@ -55,11 +55,13 @@ pub fn init() {
     });
 
     fn compile(engine: &Engine) -> Component {
-        let wasm = test_programs_artifacts::FUZZ_ASYNC_COMPONENT;
+        let wasm_path = test_programs_artifacts::FUZZ_ASYNC_COMPONENT;
+        let wasm = test_programs_artifacts::fuzz_async_component_bytes!();
+        let wasm = &wasm[..];
         let cwasm_cache = std::env::var("COMPONENT_ASYNC_CWASM_CACHE").ok();
         if let Some(path) = &cwasm_cache
             && let Ok(cwasm_mtime) = std::fs::metadata(&path).and_then(|m| m.modified())
-            && let Ok(wasm_mtime) = std::fs::metadata(wasm).and_then(|m| m.modified())
+            && let Ok(wasm_mtime) = std::fs::metadata(wasm_path).and_then(|m| m.modified())
             && cwasm_mtime > wasm_mtime
         {
             log::debug!("Using cached component async cwasm at {path}");
@@ -72,7 +74,7 @@ pub fn init() {
             let mut config = wasm_compose::config::Config::default();
             let tempdir = tempfile::TempDir::new().unwrap();
             let path = tempdir.path().join("fuzz-async.wasm");
-            std::fs::copy(wasm, &path).unwrap();
+            std::fs::write(&path, wasm).unwrap();
             config.definitions.push(path.clone());
 
             wasm_compose::composer::ComponentComposer::new(&path, &config)

--- a/crates/test-programs/artifacts/build.rs
+++ b/crates/test-programs/artifacts/build.rs
@@ -63,11 +63,16 @@ impl Artifacts {
         let missing_sdk_path =
             PathBuf::from("Asset not compiled, WASI_SDK_PATH missing at compile time");
         for test in tests.iter() {
-            let camel = test.name.to_shouty_snake_case();
+            let shouty_snake = test.name.to_shouty_snake_case();
+            let snake = test.name.to_snake_case();
 
+            let core_wasm = test.core_wasm.as_deref().unwrap_or(&missing_sdk_path);
+            generated_code +=
+                &format!("pub const {shouty_snake}: &'static str = {core_wasm:?};\n",);
             generated_code += &format!(
-                "pub const {camel}: &'static str = {:?};\n",
-                test.core_wasm.as_deref().unwrap_or(&missing_sdk_path)
+                "#[macro_export] macro_rules! {snake}_bytes {{
+                    () => {{ include_bytes!({core_wasm:?}) }}
+                }}",
             );
 
             // Bucket, based on the name of the test, into a "kind" which
@@ -119,7 +124,13 @@ impl Artifacts {
                 Some(path) => self.compile_component(path, adapter),
                 None => missing_sdk_path.clone(),
             };
-            generated_code += &format!("pub const {camel}_COMPONENT: &'static str = {path:?};\n");
+            generated_code +=
+                &format!("pub const {shouty_snake}_COMPONENT: &'static str = {path:?};\n");
+            generated_code += &format!(
+                "#[macro_export] macro_rules! {snake}_component_bytes {{
+                    () => {{ include_bytes!({path:?}) }}
+                }}",
+            );
         }
 
         for (kind, targets) in kinds {


### PR DESCRIPTION
On OSS-Fuzz the fuzzers are built in one place and run in another, so `include_bytes!` is needed to get the wasm into the final binary. This is done with a layer of macros to avoid an `include_bytes!` for all wasm programs which would make the generated Rust metadata a bit... large.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
