### PR TITLE
Clarify merge etiquette in Wasmtime

### DIFF
--- a/docs/contributing-development-process.md
+++ b/docs/contributing-development-process.md
@@ -68,16 +68,40 @@ If you need help rebasing or merging, please ask!
 ### Review and merge
 
 Anyone may submit a pull request, and anyone may comment on or review others'
-pull requests. However, one review from somebody in the [Core Team] is required
-before the Core Team merges it.
-
-Even Core Team members must create PRs and get review from another Core Team
-member for every change, including minor work items such as version bumps,
+pull requests. However, one approval from a maintainer is required before a PR
+can be merged. Maintainers must also create PRs and get review from another
+maintainer for every change, including minor work items such as version bumps,
 removing warnings, etc.
+
+PR approvals may come with comments about additional minor changes that are
+requested. Contributors and maintainers alike should address these comments, if
+any, and then the PR is ready for merge. Wasmtime uses a [merge queue] to ensure
+that all tests pass before pushing to `main`. Note that the [merge queue] will
+run more tests than is run on PRs by default.
+
+Contributors should expect Wasmtime maintainers to add the PR to the merge queue
+for them. If a PR hasn't been added, and it's approved with all comments
+addressed, feel free to leave a comment to notify maintainers that it's ready.
+Maintainers can add their own PRs to the merge queue. When approving a PR
+maintainers may also add the PR to the merge queue at that time if there are no
+remaining comments.
+
+Note that if CI is failing on a PR then GitHub will automatically block adding a
+PR to the [merge queue]. PR authors will need to resolve PR CI before it can be
+added to the merge queue. If the merge queue CI fails then the PR will be
+removed from the merge queue and GitHub will leave a marker on the timeline and
+send a notification to the PR author. PR authors are expected to review CI logs
+and fix any failures in the PR itself. When ready maintainers can re-add their
+own PR for minor fixes and contributors can leave a comment saying that the PR
+is ready to be re-added to the queue.
+
+To run full CI on the PR before the merge queue, include the string
+`prtest:full` in any commit in the PR. That can help debug CI failures without
+going through the merge queue if necessary.
 
 [issues]: https://guides.github.com/features/issues/
 [pull requests]: https://help.github.com/articles/about-pull-requests/
 [issue keywords]: https://help.github.com/articles/closing-issues-using-keywords/
-[Core Team]: https://github.com/orgs/bytecodealliance/people/
 [newissue]: https://github.com/bytecodealliance/wasmtime/issues/new
 [meetings]: https://github.com/bytecodealliance/meetings/tree/main/wasmtime
+[merge queue]: https://github.com/bytecodealliance/wasmtime/queue/main


### PR DESCRIPTION
Document that we typically expect maintainers themselves to add their own PRs to the merge queue after approval, but clarify that for contributors this is a responsibility of maintainers to add PRs to the merge queue.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
