### PR TITLE
cranelift: fix x86_64_v3 flag and normalise all generic microarchitecture flags

### DIFF
--- a/cranelift/codegen/meta/src/isa/x86.rs
+++ b/cranelift/codegen/meta/src/isa/x86.rs
@@ -407,20 +407,20 @@ pub(crate) fn define() -> TargetIsa {
 
     // Generic
 
-    settings.add_preset("x86-64", "Generic x86-64 microarchitecture.", preset!());
+    settings.add_preset("x86_64", "Generic x86-64 microarchitecture.", preset!());
     let x86_64_v2 = settings.add_preset(
-        "x86-64-v2",
+        "x86_64_v2",
         "Generic x86-64 (V2) microarchitecture.",
         preset!(sse42 && has_popcnt && has_cmpxchg16b),
     );
     let x86_64_v3 = settings.add_preset(
-        "x84_64_v3",
-        "Generic x86_64 (V3) microarchitecture.",
+        "x86_64_v3",
+        "Generic x86-64 (V3) microarchitecture.",
         preset!(x86_64_v2 && has_bmi1 && has_bmi2 && has_fma && has_lzcnt && has_avx2),
     );
     settings.add_preset(
         "x86_64_v4",
-        "Generic x86_64 (V4) microarchitecture.",
+        "Generic x86-64 (V4) microarchitecture.",
         preset!(x86_64_v3 && has_avx512dq && has_avx512vl),
     );
 


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->

There is a typo in the x86_64_v3 flag: `x84_64_v3` — note `x84` vs `x86`.                                                                                                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                                                                                                                              
Also these flags should be normalised to use underscores or hyphens consistently, not a mix of hyphens and underscores.