### PR TITLE
Do not allocate when cloning `ModuleRuntimeInfo`

### DIFF
--- a/crates/wasmtime/src/runtime/vm.rs
+++ b/crates/wasmtime/src/runtime/vm.rs
@@ -290,7 +290,7 @@ unsafe impl Sync for VMStoreRawPtr {}
 #[derive(Clone)]
 pub enum ModuleRuntimeInfo {
     Module(crate::Module),
-    Bare(Box<BareModuleInfo>),
+    Bare(Arc<BareModuleInfo>),
 }
 
 /// A barebones implementation of ModuleRuntimeInfo that is useful for


### PR DESCRIPTION
We need to clone the info from the allocation request, into the allocated instance, so we should keep it a cheap operation.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
