### PR TITLE
Remove unnecessary `memory_tys` param from `vm::Instance::new`

### DIFF
--- a/crates/wasmtime/src/runtime/vm/instance/allocator.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator.rs
@@ -344,7 +344,6 @@ impl dyn InstanceAllocator + '_ {
                 request,
                 mem::take(&mut guard.memories),
                 mem::take(&mut guard.tables),
-                &module.memories,
             ))
         };
 


### PR DESCRIPTION
We already have this information in the `InstanceAllocationRequest`, and by avoiding a parameter we can never accidentally pass the wrong memory types.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
