### PR TITLE
Use rust beta for x86_64 macos artifacts

### DIFF
--- a/ci/build-build-matrix.js
+++ b/ci/build-build-matrix.js
@@ -46,9 +46,10 @@ const array = [
     "env": { "MACOSX_DEPLOYMENT_TARGET": "10.12" },
     // Similar to https://github.com/bytecodealliance/wasmtime/pull/12245, we
     // need to avoid a rustc bug that results in linker errors depending on the
-    // order and division of code into CGUs. This is fixed on nightly but not
-    // stable yet.
-    "rust": "wasmtime-ci-pinned-nightly",
+    // order and division of code into CGUs. This is fixed on beta but not
+    // stable yet. Once Rust 1.94 is released this configuration option can be
+    // deleted to use stable by default.
+    "rust": "beta-2026-01-20",
   },
   {
     "build": "aarch64-macos",


### PR DESCRIPTION
Looks like the upstream bug is fixed in beta, so rely on that instead of nightly.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
