### PR TITLE
Enable default features in wasmtime-wasi testing

### DIFF
--- a/crates/wasi-http/Cargo.toml
+++ b/crates/wasi-http/Cargo.toml
@@ -47,7 +47,7 @@ wasmtime-wasi-http = { path = ".", features = ['default-send-request'] }
 test-programs-artifacts = { workspace = true }
 test-log = { workspace = true }
 tracing-subscriber = { workspace = true }
-wasmtime = { workspace = true, features = ['cranelift', 'anyhow'] }
+wasmtime = { workspace = true, features = ['default', 'anyhow'] }
 tokio = { workspace = true, features = ['fs', 'macros'] }
 futures = { workspace = true, default-features = false, features = ['alloc', 'async-await'] }
 sha2 = "0.10.2"

--- a/crates/wasi/Cargo.toml
+++ b/crates/wasi/Cargo.toml
@@ -42,7 +42,7 @@ test-log = { workspace = true }
 tracing-subscriber = { workspace = true }
 test-programs-artifacts = { workspace = true }
 tempfile = { workspace = true }
-wasmtime = { workspace = true, features = ['cranelift', 'incremental-cache'] }
+wasmtime = { workspace = true, features = ['default', 'incremental-cache'] }
 wasmtime-test-util = { workspace = true }
 env_logger = { workspace = true }
 


### PR DESCRIPTION
Provides more on-by-default utilities which helps with debugging such as symbol demangling, debuginfo parsing, etc.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
