### PR TITLE
Enable `anyhow` feature by default in `wasmtime`

### DIFF
--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -131,6 +131,7 @@ harness = false
 # for a particular embedding.
 [features]
 default = [
+  'anyhow',
   'async',
   'backtrace',
   'cache',


### PR DESCRIPTION
Relative to our other optional deps `anyhow` is pretty lightweight, so enable the functionality by default.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
