### PR TITLE
perf(wasi): avoid extra allocations in inherit_env/args

### DIFF
--- a/crates/wasi/src/ctx.rs
+++ b/crates/wasi/src/ctx.rs
@@ -217,7 +217,8 @@ impl WasiCtxBuilder {
     /// This will use [`envs`](WasiCtxBuilder::envs) to append all host-defined
     /// environment variables.
     pub fn inherit_env(&mut self) -> &mut Self {
-        self.envs(&std::env::vars().collect::<Vec<(String, String)>>())
+        self.cli.environment.extend(std::env::vars());
+        self
     }
 
     /// Appends a list of arguments to the argument array to pass to wasm.
@@ -237,7 +238,8 @@ impl WasiCtxBuilder {
     /// Appends all host process arguments to the list of arguments to get
     /// passed to wasm.
     pub fn inherit_args(&mut self) -> &mut Self {
-        self.args(&std::env::args().collect::<Vec<String>>())
+        self.cli.arguments.extend(std::env::args());
+        self
     }
 
     /// Configures a "preopened directory" to be available to WebAssembly.


### PR DESCRIPTION
`WasiCtxBuilder::inherit_env` and `inherit_args` were doing redundant work: they first collected `std::env::vars()` / `std::env::args()` into a `Vec`, and then `envs/args` cloned every string again via `to_owned().` This caused two allocations per environment variable or argument plus an extra temporary vector, without any benefit
