### PR TITLE
Release Wasmtime 41.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -290,7 +290,7 @@ dependencies = [
 
 [[package]]
 name = "byte-array-literals"
-version = "41.0.0"
+version = "41.0.1"
 
 [[package]]
 name = "byteorder"
@@ -695,7 +695,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift"
-version = "0.128.0"
+version = "0.128.1"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",
@@ -708,7 +708,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.128.0"
+version = "0.128.1"
 dependencies = [
  "arbitrary",
  "arbtest",
@@ -726,21 +726,21 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.128.0"
+version = "0.128.1"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.128.0"
+version = "0.128.1"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.128.0"
+version = "0.128.1"
 dependencies = [
  "arbitrary",
  "serde",
@@ -749,7 +749,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.128.0"
+version = "0.128.1"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -784,7 +784,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.128.0"
+version = "0.128.1"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -795,18 +795,18 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.128.0"
+version = "0.128.1"
 
 [[package]]
 name = "cranelift-control"
-version = "0.128.0"
+version = "0.128.1"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.128.0"
+version = "0.128.1"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -847,7 +847,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.128.0"
+version = "0.128.1"
 dependencies = [
  "cranelift-codegen",
  "env_logger 0.11.5",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-interpreter"
-version = "0.128.0"
+version = "0.128.1"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -886,7 +886,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.128.0"
+version = "0.128.1"
 dependencies = [
  "codespan-reporting",
  "log",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-jit"
-version = "0.128.0"
+version = "0.128.1"
 dependencies = [
  "anyhow",
  "cranelift",
@@ -917,7 +917,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-module"
-version = "0.128.0"
+version = "0.128.1"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.128.0"
+version = "0.128.1"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-object"
-version = "0.128.0"
+version = "0.128.1"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -953,7 +953,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-reader"
-version = "0.128.0"
+version = "0.128.1"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-serde"
-version = "0.128.0"
+version = "0.128.1"
 dependencies = [
  "clap",
  "cranelift-codegen",
@@ -973,7 +973,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.128.0"
+version = "0.128.1"
 
 [[package]]
 name = "cranelift-tools"
@@ -1223,7 +1223,7 @@ checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "embedding"
-version = "41.0.0"
+version = "41.0.1"
 dependencies = [
  "anyhow",
  "dlmalloc",
@@ -2351,7 +2351,7 @@ dependencies = [
 
 [[package]]
 name = "min-platform-host"
-version = "41.0.0"
+version = "41.0.1"
 dependencies = [
  "anyhow",
  "libloading",
@@ -2783,7 +2783,7 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "41.0.0"
+version = "41.0.1"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -2807,7 +2807,7 @@ dependencies = [
 
 [[package]]
 name = "pulley-macros"
-version = "41.0.0"
+version = "41.0.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4096,7 +4096,7 @@ version = "0.1.0"
 
 [[package]]
 name = "verify-component-adapter"
-version = "41.0.0"
+version = "41.0.1"
 dependencies = [
  "anyhow",
  "wasmparser 0.243.0",
@@ -4155,7 +4155,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-common"
-version = "41.0.0"
+version = "41.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4195,7 +4195,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-preview1-component-adapter"
-version = "41.0.0"
+version = "41.0.1"
 dependencies = [
  "bitflags 2.9.4",
  "byte-array-literals",
@@ -4477,7 +4477,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "41.0.0"
+version = "41.0.1"
 dependencies = [
  "addr2line 0.25.1",
  "anyhow",
@@ -4542,7 +4542,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-bench-api"
-version = "41.0.0"
+version = "41.0.1"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -4558,14 +4558,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-c-api"
-version = "41.0.0"
+version = "41.0.1"
 dependencies = [
  "wasmtime-c-api-impl",
 ]
 
 [[package]]
 name = "wasmtime-c-api-impl"
-version = "41.0.0"
+version = "41.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4585,7 +4585,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli"
-version = "41.0.0"
+version = "41.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4661,7 +4661,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli-flags"
-version = "41.0.0"
+version = "41.0.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -4676,7 +4676,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "41.0.0"
+version = "41.0.1"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -4790,7 +4790,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-c-api-macros"
-version = "41.0.0"
+version = "41.0.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4798,7 +4798,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cache"
-version = "41.0.0"
+version = "41.0.1"
 dependencies = [
  "base64",
  "directories-next",
@@ -4819,7 +4819,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-macro"
-version = "41.0.0"
+version = "41.0.1"
 dependencies = [
  "anyhow",
  "component-macro-test-helpers",
@@ -4839,11 +4839,11 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-util"
-version = "41.0.0"
+version = "41.0.1"
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "41.0.0"
+version = "41.0.1"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -4868,7 +4868,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-debugger"
-version = "41.0.0"
+version = "41.0.1"
 dependencies = [
  "anyhow",
  "env_logger 0.11.5",
@@ -4879,14 +4879,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-error"
-version = "41.0.0"
+version = "41.0.1"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "wasmtime-internal-explorer"
-version = "41.0.0"
+version = "41.0.1"
 dependencies = [
  "anyhow",
  "capstone",
@@ -4901,7 +4901,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-fiber"
-version = "41.0.0"
+version = "41.0.1"
 dependencies = [
  "backtrace",
  "cc",
@@ -4915,7 +4915,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-debug"
-version = "41.0.0"
+version = "41.0.1"
 dependencies = [
  "cc",
  "object 0.37.3",
@@ -4925,7 +4925,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "41.0.0"
+version = "41.0.1"
 dependencies = [
  "cfg-if",
  "libc",
@@ -4935,18 +4935,18 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-math"
-version = "41.0.0"
+version = "41.0.1"
 dependencies = [
  "libm",
 ]
 
 [[package]]
 name = "wasmtime-internal-slab"
-version = "41.0.0"
+version = "41.0.1"
 
 [[package]]
 name = "wasmtime-internal-unwinder"
-version = "41.0.0"
+version = "41.0.1"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -4957,7 +4957,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
-version = "41.0.0"
+version = "41.0.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4966,7 +4966,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-winch"
-version = "41.0.0"
+version = "41.0.1"
 dependencies = [
  "cranelift-codegen",
  "gimli 0.32.3",
@@ -4981,7 +4981,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-wit-bindgen"
-version = "41.0.0"
+version = "41.0.1"
 dependencies = [
  "anyhow",
  "bitflags 2.9.4",
@@ -4992,7 +4992,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-wmemcheck"
-version = "41.0.0"
+version = "41.0.1"
 
 [[package]]
 name = "wasmtime-test-macros"
@@ -5007,7 +5007,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-test-util"
-version = "41.0.0"
+version = "41.0.1"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -5031,7 +5031,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "41.0.0"
+version = "41.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5066,7 +5066,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-config"
-version = "41.0.0"
+version = "41.0.1"
 dependencies = [
  "anyhow",
  "test-programs-artifacts",
@@ -5077,7 +5077,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-http"
-version = "41.0.0"
+version = "41.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5109,7 +5109,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-io"
-version = "41.0.0"
+version = "41.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5120,7 +5120,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-keyvalue"
-version = "41.0.0"
+version = "41.0.1"
 dependencies = [
  "anyhow",
  "test-programs-artifacts",
@@ -5131,7 +5131,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-nn"
-version = "41.0.0"
+version = "41.0.1"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -5152,7 +5152,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-threads"
-version = "41.0.0"
+version = "41.0.1"
 dependencies = [
  "anyhow",
  "log",
@@ -5164,7 +5164,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-tls"
-version = "41.0.0"
+version = "41.0.1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -5180,7 +5180,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-tls-nativetls"
-version = "41.0.0"
+version = "41.0.1"
 dependencies = [
  "anyhow",
  "futures",
@@ -5195,7 +5195,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wast"
-version = "41.0.0"
+version = "41.0.1"
 dependencies = [
  "anyhow",
  "json-from-wast",
@@ -5210,7 +5210,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wizer"
-version = "41.0.0"
+version = "41.0.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -5292,7 +5292,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "41.0.0"
+version = "41.0.1"
 dependencies = [
  "anyhow",
  "bitflags 2.9.4",
@@ -5308,7 +5308,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "41.0.0"
+version = "41.0.1"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -5320,7 +5320,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "41.0.0"
+version = "41.0.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5375,7 +5375,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "41.0.0"
+version = "41.0.1"
 dependencies = [
  "anyhow",
  "cranelift-assembler-x64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -185,7 +185,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "41.0.0"
+version = "41.0.1"
 authors = ["The Wasmtime Project Developers"]
 edition = "2024"
 # Wasmtime's current policy is that this number can be no larger than the
@@ -239,19 +239,19 @@ extra_unused_type_parameters = 'warn'
 # tooling but aren't intended to be widely depended on.
 #
 # All of these crates are supported though in the sense that
-wasmtime = { path = "crates/wasmtime", version = "41.0.0", default-features = false }
-wasmtime-cli-flags = { path = "crates/cli-flags", version = "=41.0.0" }
-wasmtime-environ = { path = "crates/environ", version = "=41.0.0" }
-wasmtime-wasi = { path = "crates/wasi", version = "41.0.0", default-features = false }
-wasmtime-wasi-io = { path = "crates/wasi-io", version = "41.0.0", default-features = false }
-wasmtime-wasi-http = { path = "crates/wasi-http", version = "41.0.0", default-features = false }
-wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "41.0.0" }
-wasmtime-wasi-config = { path = "crates/wasi-config", version = "41.0.0" }
-wasmtime-wasi-keyvalue = { path = "crates/wasi-keyvalue", version = "41.0.0" }
-wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "41.0.0" }
-wasmtime-wasi-tls = { path = "crates/wasi-tls", version = "41.0.0" }
-wasmtime-wasi-tls-nativetls = { path = "crates/wasi-tls-nativetls", version = "41.0.0" }
-wasmtime-wast = { path = "crates/wast", version = "=41.0.0" }
+wasmtime = { path = "crates/wasmtime", version = "41.0.1", default-features = false }
+wasmtime-cli-flags = { path = "crates/cli-flags", version = "=41.0.1" }
+wasmtime-environ = { path = "crates/environ", version = "=41.0.1" }
+wasmtime-wasi = { path = "crates/wasi", version = "41.0.1", default-features = false }
+wasmtime-wasi-io = { path = "crates/wasi-io", version = "41.0.1", default-features = false }
+wasmtime-wasi-http = { path = "crates/wasi-http", version = "41.0.1", default-features = false }
+wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "41.0.1" }
+wasmtime-wasi-config = { path = "crates/wasi-config", version = "41.0.1" }
+wasmtime-wasi-keyvalue = { path = "crates/wasi-keyvalue", version = "41.0.1" }
+wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "41.0.1" }
+wasmtime-wasi-tls = { path = "crates/wasi-tls", version = "41.0.1" }
+wasmtime-wasi-tls-nativetls = { path = "crates/wasi-tls-nativetls", version = "41.0.1" }
+wasmtime-wast = { path = "crates/wast", version = "=41.0.1" }
 
 # Internal Wasmtime-specific crates.
 #
@@ -260,56 +260,56 @@ wasmtime-wast = { path = "crates/wast", version = "=41.0.0" }
 # that these are internal unsupported crates for external use. These exist as
 # part of the project organization of other public crates in Wasmtime and are
 # otherwise not supported in terms of CVEs for example.
-wasmtime-error = { path = "crates/error", version = "=41.0.0", package = 'wasmtime-internal-error' }
-wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=41.0.0", package = 'wasmtime-internal-wmemcheck' }
-wasmtime-c-api-macros = { path = "crates/c-api-macros", version = "=41.0.0", package = 'wasmtime-internal-c-api-macros' }
-wasmtime-cache = { path = "crates/cache", version = "=41.0.0", package = 'wasmtime-internal-cache' }
-wasmtime-cranelift = { path = "crates/cranelift", version = "=41.0.0", package = 'wasmtime-internal-cranelift' }
-wasmtime-winch = { path = "crates/winch", version = "=41.0.0", package = 'wasmtime-internal-winch'  }
-wasmtime-explorer = { path = "crates/explorer", version = "=41.0.0", package = 'wasmtime-internal-explorer'  }
-wasmtime-fiber = { path = "crates/fiber", version = "=41.0.0", package = 'wasmtime-internal-fiber' }
-wasmtime-jit-debug = { path = "crates/jit-debug", version = "=41.0.0", package = 'wasmtime-internal-jit-debug' }
-wasmtime-component-util = { path = "crates/component-util", version = "=41.0.0", package = 'wasmtime-internal-component-util' }
-wasmtime-component-macro = { path = "crates/component-macro", version = "=41.0.0", package = 'wasmtime-internal-component-macro' }
-wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=41.0.0", package = 'wasmtime-internal-versioned-export-macros' }
-wasmtime-slab = { path = "crates/slab", version = "=41.0.0", package = 'wasmtime-internal-slab' }
-wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=41.0.0", package = 'wasmtime-internal-jit-icache-coherence' }
-wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=41.0.0", package = 'wasmtime-internal-wit-bindgen' }
-wasmtime-math = { path = "crates/math", version = "=41.0.0", package = 'wasmtime-internal-math'  }
-wasmtime-unwinder = { path = "crates/unwinder", version = "=41.0.0", package = 'wasmtime-internal-unwinder' }
-wasmtime-debugger = { path = "crates/debugger", version = "=41.0.0", package = "wasmtime-internal-debugger" }
-wasmtime-wizer = { path = "crates/wizer", version = "41.0.0" }
+wasmtime-error = { path = "crates/error", version = "=41.0.1", package = 'wasmtime-internal-error' }
+wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=41.0.1", package = 'wasmtime-internal-wmemcheck' }
+wasmtime-c-api-macros = { path = "crates/c-api-macros", version = "=41.0.1", package = 'wasmtime-internal-c-api-macros' }
+wasmtime-cache = { path = "crates/cache", version = "=41.0.1", package = 'wasmtime-internal-cache' }
+wasmtime-cranelift = { path = "crates/cranelift", version = "=41.0.1", package = 'wasmtime-internal-cranelift' }
+wasmtime-winch = { path = "crates/winch", version = "=41.0.1", package = 'wasmtime-internal-winch'  }
+wasmtime-explorer = { path = "crates/explorer", version = "=41.0.1", package = 'wasmtime-internal-explorer'  }
+wasmtime-fiber = { path = "crates/fiber", version = "=41.0.1", package = 'wasmtime-internal-fiber' }
+wasmtime-jit-debug = { path = "crates/jit-debug", version = "=41.0.1", package = 'wasmtime-internal-jit-debug' }
+wasmtime-component-util = { path = "crates/component-util", version = "=41.0.1", package = 'wasmtime-internal-component-util' }
+wasmtime-component-macro = { path = "crates/component-macro", version = "=41.0.1", package = 'wasmtime-internal-component-macro' }
+wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=41.0.1", package = 'wasmtime-internal-versioned-export-macros' }
+wasmtime-slab = { path = "crates/slab", version = "=41.0.1", package = 'wasmtime-internal-slab' }
+wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=41.0.1", package = 'wasmtime-internal-jit-icache-coherence' }
+wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=41.0.1", package = 'wasmtime-internal-wit-bindgen' }
+wasmtime-math = { path = "crates/math", version = "=41.0.1", package = 'wasmtime-internal-math'  }
+wasmtime-unwinder = { path = "crates/unwinder", version = "=41.0.1", package = 'wasmtime-internal-unwinder' }
+wasmtime-debugger = { path = "crates/debugger", version = "=41.0.1", package = "wasmtime-internal-debugger" }
+wasmtime-wizer = { path = "crates/wizer", version = "41.0.1" }
 
 # Miscellaneous crates without a `wasmtime-*` prefix in their name but still
 # used in the `wasmtime-*` family of crates depending on various features/etc.
-wiggle = { path = "crates/wiggle", version = "=41.0.0", default-features = false }
-wiggle-macro = { path = "crates/wiggle/macro", version = "=41.0.0" }
-wiggle-generate = { path = "crates/wiggle/generate", version = "=41.0.0" }
-wasi-common = { path = "crates/wasi-common", version = "=41.0.0", default-features = false }
-pulley-interpreter = { path = 'pulley', version = "=41.0.0" }
-pulley-macros = { path = 'pulley/macros', version = "=41.0.0" }
+wiggle = { path = "crates/wiggle", version = "=41.0.1", default-features = false }
+wiggle-macro = { path = "crates/wiggle/macro", version = "=41.0.1" }
+wiggle-generate = { path = "crates/wiggle/generate", version = "=41.0.1" }
+wasi-common = { path = "crates/wasi-common", version = "=41.0.1", default-features = false }
+pulley-interpreter = { path = 'pulley', version = "=41.0.1" }
+pulley-macros = { path = 'pulley/macros', version = "=41.0.1" }
 
 # Cranelift crates in this workspace
-cranelift-assembler-x64 = { path = "cranelift/assembler-x64", version = "0.128.0" }
-cranelift-codegen = { path = "cranelift/codegen", version = "0.128.0", default-features = false, features = ["std", "unwind"] }
-cranelift-frontend = { path = "cranelift/frontend", version = "0.128.0" }
-cranelift-entity = { path = "cranelift/entity", version = "0.128.0" }
-cranelift-native = { path = "cranelift/native", version = "0.128.0" }
-cranelift-module = { path = "cranelift/module", version = "0.128.0" }
-cranelift-interpreter = { path = "cranelift/interpreter", version = "0.128.0" }
-cranelift-reader = { path = "cranelift/reader", version = "0.128.0" }
+cranelift-assembler-x64 = { path = "cranelift/assembler-x64", version = "0.128.1" }
+cranelift-codegen = { path = "cranelift/codegen", version = "0.128.1", default-features = false, features = ["std", "unwind"] }
+cranelift-frontend = { path = "cranelift/frontend", version = "0.128.1" }
+cranelift-entity = { path = "cranelift/entity", version = "0.128.1" }
+cranelift-native = { path = "cranelift/native", version = "0.128.1" }
+cranelift-module = { path = "cranelift/module", version = "0.128.1" }
+cranelift-interpreter = { path = "cranelift/interpreter", version = "0.128.1" }
+cranelift-reader = { path = "cranelift/reader", version = "0.128.1" }
 cranelift-filetests = { path = "cranelift/filetests" }
-cranelift-object = { path = "cranelift/object", version = "0.128.0" }
-cranelift-jit = { path = "cranelift/jit", version = "0.128.0" }
+cranelift-object = { path = "cranelift/object", version = "0.128.1" }
+cranelift-jit = { path = "cranelift/jit", version = "0.128.1" }
 cranelift-fuzzgen = { path = "cranelift/fuzzgen" }
-cranelift-bforest = { path = "cranelift/bforest", version = "0.128.0" }
-cranelift-bitset = { path = "cranelift/bitset", version = "0.128.0" }
-cranelift-control = { path = "cranelift/control", version = "0.128.0" }
-cranelift-srcgen = { path = "cranelift/srcgen", version = "0.128.0" }
-cranelift = { path = "cranelift/umbrella", version = "0.128.0" }
+cranelift-bforest = { path = "cranelift/bforest", version = "0.128.1" }
+cranelift-bitset = { path = "cranelift/bitset", version = "0.128.1" }
+cranelift-control = { path = "cranelift/control", version = "0.128.1" }
+cranelift-srcgen = { path = "cranelift/srcgen", version = "0.128.1" }
+cranelift = { path = "cranelift/umbrella", version = "0.128.1" }
 
 # Winch crates in this workspace.
-winch-codegen = { path = "winch/codegen", version = "=41.0.0" }
+winch-codegen = { path = "winch/codegen", version = "=41.0.1" }
 
 # Internal crates not published to crates.io used in testing, builds, etc
 wasi-preview1-component-adapter = { path = "crates/wasi-preview1-component-adapter" }

--- a/cranelift/assembler-x64/Cargo.toml
+++ b/cranelift/assembler-x64/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-assembler-x64"
 description = "A Cranelift-specific x64 assembler"
-version = "0.128.0"
+version = "0.128.1"
 license = "Apache-2.0 WITH LLVM-exception"
 edition.workspace = true
 rust-version.workspace = true
@@ -16,7 +16,7 @@ arbtest = { workspace = true }
 capstone = { workspace = true }
 
 [build-dependencies]
-cranelift-assembler-x64-meta = { path = "meta", version = "0.128.0" }
+cranelift-assembler-x64-meta = { path = "meta", version = "0.128.1" }
 
 [lints]
 workspace = true

--- a/cranelift/assembler-x64/meta/Cargo.toml
+++ b/cranelift/assembler-x64/meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-assembler-x64-meta"
 description = "Generate a Cranelift-specific assembler for x64 instructions"
-version = "0.128.0"
+version = "0.128.1"
 license = "Apache-2.0 WITH LLVM-exception"
 edition.workspace = true
 rust-version.workspace = true

--- a/cranelift/bforest/Cargo.toml
+++ b/cranelift/bforest/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bforest"
-version = "0.128.0"
+version = "0.128.1"
 description = "A forest of B+-trees"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-bforest"

--- a/cranelift/bitset/Cargo.toml
+++ b/cranelift/bitset/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bitset"
-version = "0.128.0"
+version = "0.128.1"
 description = "Various bitset stuff for use inside Cranelift"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-bitset"

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen"
-version = "0.128.0"
+version = "0.128.1"
 description = "Low-level code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-codegen"
@@ -25,7 +25,7 @@ anyhow = { workspace = true, optional = true, features = ['std'] }
 bumpalo = "3"
 capstone = { workspace = true, optional = true }
 cranelift-assembler-x64 = { workspace = true }
-cranelift-codegen-shared = { path = "./shared", version = "0.128.0" }
+cranelift-codegen-shared = { path = "./shared", version = "0.128.1" }
 cranelift-entity = { workspace = true }
 cranelift-bforest = { workspace = true }
 cranelift-bitset = { workspace = true }
@@ -56,8 +56,8 @@ env_logger = { workspace = true }
 proptest = { workspace = true }
 
 [build-dependencies]
-cranelift-codegen-meta = { path = "meta", version = "0.128.0" }
-cranelift-isle = { path = "../isle/isle", version = "=0.128.0" }
+cranelift-codegen-meta = { path = "meta", version = "0.128.1" }
+cranelift-isle = { path = "../isle/isle", version = "=0.128.1" }
 
 [features]
 default = ["std", "unwind", "host-arch", "timing"]

--- a/cranelift/codegen/meta/Cargo.toml
+++ b/cranelift/codegen/meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-codegen-meta"
 authors = ["The Cranelift Project Developers"]
-version = "0.128.0"
+version = "0.128.1"
 description = "Metaprogram for cranelift-codegen code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
@@ -17,8 +17,8 @@ rustdoc-args = ["--document-private-items"]
 
 [dependencies]
 cranelift-srcgen = { workspace = true }
-cranelift-assembler-x64-meta = { path = "../../assembler-x64/meta", version = "0.128.0" }
-cranelift-codegen-shared = { path = "../shared", version = "0.128.0" }
+cranelift-assembler-x64-meta = { path = "../../assembler-x64/meta", version = "0.128.1" }
+cranelift-codegen-shared = { path = "../shared", version = "0.128.1" }
 pulley-interpreter = { workspace = true, optional = true }
 heck = "0.5.0"
 

--- a/cranelift/codegen/shared/Cargo.toml
+++ b/cranelift/codegen/shared/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen-shared"
-version = "0.128.0"
+version = "0.128.1"
 description = "For code shared between cranelift-codegen-meta and cranelift-codegen"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/control/Cargo.toml
+++ b/cranelift/control/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-control"
-version = "0.128.0"
+version = "0.128.1"
 description = "White-box fuzz testing framework"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/entity/Cargo.toml
+++ b/cranelift/entity/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-entity"
-version = "0.128.0"
+version = "0.128.1"
 description = "Data structures using entity references as mapping keys"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-entity"

--- a/cranelift/frontend/Cargo.toml
+++ b/cranelift/frontend/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-frontend"
-version = "0.128.0"
+version = "0.128.1"
 description = "Cranelift IR builder helper"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-frontend"

--- a/cranelift/interpreter/Cargo.toml
+++ b/cranelift/interpreter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-interpreter"
-version = "0.128.0"
+version = "0.128.1"
 authors = ["The Cranelift Project Developers"]
 description = "Interpret Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/isle/isle/Cargo.toml
+++ b/cranelift/isle/isle/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 name = "cranelift-isle"
 readme = "../README.md"
 repository = "https://github.com/bytecodealliance/wasmtime/tree/main/cranelift/isle"
-version = "0.128.0"
+version = "0.128.1"
 
 [lints]
 workspace = true

--- a/cranelift/jit/Cargo.toml
+++ b/cranelift/jit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-jit"
-version = "0.128.0"
+version = "0.128.1"
 authors = ["The Cranelift Project Developers"]
 description = "A JIT library backed by Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/module/Cargo.toml
+++ b/cranelift/module/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-module"
-version = "0.128.0"
+version = "0.128.1"
 authors = ["The Cranelift Project Developers"]
 description = "Support for linking functions and data with Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/native/Cargo.toml
+++ b/cranelift/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-native"
-version = "0.128.0"
+version = "0.128.1"
 authors = ["The Cranelift Project Developers"]
 description = "Support for targeting the host with Cranelift"
 documentation = "https://docs.rs/cranelift-native"

--- a/cranelift/object/Cargo.toml
+++ b/cranelift/object/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-object"
-version = "0.128.0"
+version = "0.128.1"
 authors = ["The Cranelift Project Developers"]
 description = "Emit Cranelift output to native object files with `object`"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/reader/Cargo.toml
+++ b/cranelift/reader/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-reader"
-version = "0.128.0"
+version = "0.128.1"
 description = "Cranelift textual IR reader"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-reader"

--- a/cranelift/serde/Cargo.toml
+++ b/cranelift/serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-serde"
-version = "0.128.0"
+version = "0.128.1"
 authors = ["The Cranelift Project Developers"]
 description = "Serializer/Deserializer for Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/srcgen/Cargo.toml
+++ b/cranelift/srcgen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-srcgen"
-version = "0.128.0"
+version = "0.128.1"
 authors = ["The Wasmtime Project Developers"]
 description = "Helper functions for generating Rust and ISLE files"
 license = "Apache-2.0 WITH LLVM-exception"

--- a/cranelift/umbrella/Cargo.toml
+++ b/cranelift/umbrella/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift"
-version = "0.128.0"
+version = "0.128.1"
 description = "Umbrella for commonly-used cranelift crates"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift"

--- a/crates/c-api/include/wasmtime.h
+++ b/crates/c-api/include/wasmtime.h
@@ -212,7 +212,7 @@
 /**
  * \brief Wasmtime version string.
  */
-#define WASMTIME_VERSION "41.0.0"
+#define WASMTIME_VERSION "41.0.1"
 /**
  * \brief Wasmtime major version number.
  */
@@ -224,6 +224,6 @@
 /**
  * \brief Wasmtime patch version number.
  */
-#define WASMTIME_VERSION_PATCH 0
+#define WASMTIME_VERSION_PATCH 1
 
 #endif // WASMTIME_API_H

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -9,6 +9,10 @@ audited_as = "0.126.1"
 version = "0.128.0"
 audited_as = "0.126.1"
 
+[[unpublished.cranelift]]
+version = "0.128.1"
+audited_as = "0.128.0"
+
 [[unpublished.cranelift-assembler-x64]]
 version = "0.127.0"
 audited_as = "0.126.1"
@@ -16,6 +20,10 @@ audited_as = "0.126.1"
 [[unpublished.cranelift-assembler-x64]]
 version = "0.128.0"
 audited_as = "0.126.1"
+
+[[unpublished.cranelift-assembler-x64]]
+version = "0.128.1"
+audited_as = "0.128.0"
 
 [[unpublished.cranelift-assembler-x64-meta]]
 version = "0.127.0"
@@ -25,6 +33,10 @@ audited_as = "0.126.1"
 version = "0.128.0"
 audited_as = "0.126.1"
 
+[[unpublished.cranelift-assembler-x64-meta]]
+version = "0.128.1"
+audited_as = "0.128.0"
+
 [[unpublished.cranelift-bforest]]
 version = "0.127.0"
 audited_as = "0.126.1"
@@ -32,6 +44,10 @@ audited_as = "0.126.1"
 [[unpublished.cranelift-bforest]]
 version = "0.128.0"
 audited_as = "0.126.1"
+
+[[unpublished.cranelift-bforest]]
+version = "0.128.1"
+audited_as = "0.128.0"
 
 [[unpublished.cranelift-bitset]]
 version = "0.127.0"
@@ -41,6 +57,10 @@ audited_as = "0.126.1"
 version = "0.128.0"
 audited_as = "0.126.1"
 
+[[unpublished.cranelift-bitset]]
+version = "0.128.1"
+audited_as = "0.128.0"
+
 [[unpublished.cranelift-codegen]]
 version = "0.127.0"
 audited_as = "0.126.1"
@@ -48,6 +68,10 @@ audited_as = "0.126.1"
 [[unpublished.cranelift-codegen]]
 version = "0.128.0"
 audited_as = "0.126.1"
+
+[[unpublished.cranelift-codegen]]
+version = "0.128.1"
+audited_as = "0.128.0"
 
 [[unpublished.cranelift-codegen-meta]]
 version = "0.127.0"
@@ -57,6 +81,10 @@ audited_as = "0.126.1"
 version = "0.128.0"
 audited_as = "0.126.1"
 
+[[unpublished.cranelift-codegen-meta]]
+version = "0.128.1"
+audited_as = "0.128.0"
+
 [[unpublished.cranelift-codegen-shared]]
 version = "0.127.0"
 audited_as = "0.126.1"
@@ -64,6 +92,10 @@ audited_as = "0.126.1"
 [[unpublished.cranelift-codegen-shared]]
 version = "0.128.0"
 audited_as = "0.126.1"
+
+[[unpublished.cranelift-codegen-shared]]
+version = "0.128.1"
+audited_as = "0.128.0"
 
 [[unpublished.cranelift-control]]
 version = "0.127.0"
@@ -73,6 +105,10 @@ audited_as = "0.126.1"
 version = "0.128.0"
 audited_as = "0.126.1"
 
+[[unpublished.cranelift-control]]
+version = "0.128.1"
+audited_as = "0.128.0"
+
 [[unpublished.cranelift-entity]]
 version = "0.127.0"
 audited_as = "0.126.1"
@@ -80,6 +116,10 @@ audited_as = "0.126.1"
 [[unpublished.cranelift-entity]]
 version = "0.128.0"
 audited_as = "0.126.1"
+
+[[unpublished.cranelift-entity]]
+version = "0.128.1"
+audited_as = "0.128.0"
 
 [[unpublished.cranelift-frontend]]
 version = "0.127.0"
@@ -89,6 +129,10 @@ audited_as = "0.126.1"
 version = "0.128.0"
 audited_as = "0.126.1"
 
+[[unpublished.cranelift-frontend]]
+version = "0.128.1"
+audited_as = "0.128.0"
+
 [[unpublished.cranelift-interpreter]]
 version = "0.127.0"
 audited_as = "0.126.1"
@@ -96,6 +140,10 @@ audited_as = "0.126.1"
 [[unpublished.cranelift-interpreter]]
 version = "0.128.0"
 audited_as = "0.126.1"
+
+[[unpublished.cranelift-interpreter]]
+version = "0.128.1"
+audited_as = "0.128.0"
 
 [[unpublished.cranelift-isle]]
 version = "0.127.0"
@@ -105,6 +153,10 @@ audited_as = "0.126.1"
 version = "0.128.0"
 audited_as = "0.126.1"
 
+[[unpublished.cranelift-isle]]
+version = "0.128.1"
+audited_as = "0.128.0"
+
 [[unpublished.cranelift-jit]]
 version = "0.127.0"
 audited_as = "0.126.1"
@@ -112,6 +164,10 @@ audited_as = "0.126.1"
 [[unpublished.cranelift-jit]]
 version = "0.128.0"
 audited_as = "0.126.1"
+
+[[unpublished.cranelift-jit]]
+version = "0.128.1"
+audited_as = "0.128.0"
 
 [[unpublished.cranelift-module]]
 version = "0.127.0"
@@ -121,6 +177,10 @@ audited_as = "0.126.1"
 version = "0.128.0"
 audited_as = "0.126.1"
 
+[[unpublished.cranelift-module]]
+version = "0.128.1"
+audited_as = "0.128.0"
+
 [[unpublished.cranelift-native]]
 version = "0.127.0"
 audited_as = "0.126.1"
@@ -128,6 +188,10 @@ audited_as = "0.126.1"
 [[unpublished.cranelift-native]]
 version = "0.128.0"
 audited_as = "0.126.1"
+
+[[unpublished.cranelift-native]]
+version = "0.128.1"
+audited_as = "0.128.0"
 
 [[unpublished.cranelift-object]]
 version = "0.127.0"
@@ -137,6 +201,10 @@ audited_as = "0.126.1"
 version = "0.128.0"
 audited_as = "0.126.1"
 
+[[unpublished.cranelift-object]]
+version = "0.128.1"
+audited_as = "0.128.0"
+
 [[unpublished.cranelift-reader]]
 version = "0.127.0"
 audited_as = "0.126.1"
@@ -144,6 +212,10 @@ audited_as = "0.126.1"
 [[unpublished.cranelift-reader]]
 version = "0.128.0"
 audited_as = "0.126.1"
+
+[[unpublished.cranelift-reader]]
+version = "0.128.1"
+audited_as = "0.128.0"
 
 [[unpublished.cranelift-serde]]
 version = "0.127.0"
@@ -153,6 +225,10 @@ audited_as = "0.126.1"
 version = "0.128.0"
 audited_as = "0.126.1"
 
+[[unpublished.cranelift-serde]]
+version = "0.128.1"
+audited_as = "0.128.0"
+
 [[unpublished.cranelift-srcgen]]
 version = "0.127.0"
 audited_as = "0.126.1"
@@ -161,6 +237,10 @@ audited_as = "0.126.1"
 version = "0.128.0"
 audited_as = "0.126.1"
 
+[[unpublished.cranelift-srcgen]]
+version = "0.128.1"
+audited_as = "0.128.0"
+
 [[unpublished.pulley-interpreter]]
 version = "40.0.0"
 audited_as = "39.0.1"
@@ -168,6 +248,10 @@ audited_as = "39.0.1"
 [[unpublished.pulley-interpreter]]
 version = "41.0.0"
 audited_as = "39.0.1"
+
+[[unpublished.pulley-interpreter]]
+version = "41.0.1"
+audited_as = "41.0.0"
 
 [[unpublished.pulley-macros]]
 version = "40.0.0"
@@ -177,6 +261,10 @@ audited_as = "39.0.1"
 version = "41.0.0"
 audited_as = "39.0.1"
 
+[[unpublished.pulley-macros]]
+version = "41.0.1"
+audited_as = "41.0.0"
+
 [[unpublished.wasi-common]]
 version = "40.0.0"
 audited_as = "39.0.1"
@@ -184,6 +272,10 @@ audited_as = "39.0.1"
 [[unpublished.wasi-common]]
 version = "41.0.0"
 audited_as = "39.0.1"
+
+[[unpublished.wasi-common]]
+version = "41.0.1"
+audited_as = "41.0.0"
 
 [[unpublished.wasmtime]]
 version = "40.0.0"
@@ -193,6 +285,10 @@ audited_as = "39.0.1"
 version = "41.0.0"
 audited_as = "39.0.1"
 
+[[unpublished.wasmtime]]
+version = "41.0.1"
+audited_as = "41.0.0"
+
 [[unpublished.wasmtime-cli]]
 version = "40.0.0"
 audited_as = "39.0.1"
@@ -200,6 +296,10 @@ audited_as = "39.0.1"
 [[unpublished.wasmtime-cli]]
 version = "41.0.0"
 audited_as = "39.0.1"
+
+[[unpublished.wasmtime-cli]]
+version = "41.0.1"
+audited_as = "41.0.0"
 
 [[unpublished.wasmtime-cli-flags]]
 version = "40.0.0"
@@ -209,6 +309,10 @@ audited_as = "39.0.1"
 version = "41.0.0"
 audited_as = "39.0.1"
 
+[[unpublished.wasmtime-cli-flags]]
+version = "41.0.1"
+audited_as = "41.0.0"
+
 [[unpublished.wasmtime-environ]]
 version = "40.0.0"
 audited_as = "39.0.1"
@@ -216,6 +320,10 @@ audited_as = "39.0.1"
 [[unpublished.wasmtime-environ]]
 version = "41.0.0"
 audited_as = "39.0.1"
+
+[[unpublished.wasmtime-environ]]
+version = "41.0.1"
+audited_as = "41.0.0"
 
 [[unpublished.wasmtime-internal-c-api-macros]]
 version = "40.0.0"
@@ -225,6 +333,10 @@ audited_as = "39.0.1"
 version = "41.0.0"
 audited_as = "39.0.1"
 
+[[unpublished.wasmtime-internal-c-api-macros]]
+version = "41.0.1"
+audited_as = "41.0.0"
+
 [[unpublished.wasmtime-internal-cache]]
 version = "40.0.0"
 audited_as = "39.0.1"
@@ -232,6 +344,10 @@ audited_as = "39.0.1"
 [[unpublished.wasmtime-internal-cache]]
 version = "41.0.0"
 audited_as = "39.0.1"
+
+[[unpublished.wasmtime-internal-cache]]
+version = "41.0.1"
+audited_as = "41.0.0"
 
 [[unpublished.wasmtime-internal-component-macro]]
 version = "40.0.0"
@@ -241,6 +357,10 @@ audited_as = "39.0.1"
 version = "41.0.0"
 audited_as = "39.0.1"
 
+[[unpublished.wasmtime-internal-component-macro]]
+version = "41.0.1"
+audited_as = "41.0.0"
+
 [[unpublished.wasmtime-internal-component-util]]
 version = "40.0.0"
 audited_as = "39.0.1"
@@ -248,6 +368,10 @@ audited_as = "39.0.1"
 [[unpublished.wasmtime-internal-component-util]]
 version = "41.0.0"
 audited_as = "39.0.1"
+
+[[unpublished.wasmtime-internal-component-util]]
+version = "41.0.1"
+audited_as = "41.0.0"
 
 [[unpublished.wasmtime-internal-cranelift]]
 version = "40.0.0"
@@ -257,6 +381,14 @@ audited_as = "39.0.1"
 version = "41.0.0"
 audited_as = "39.0.1"
 
+[[unpublished.wasmtime-internal-cranelift]]
+version = "41.0.1"
+audited_as = "41.0.0"
+
+[[unpublished.wasmtime-internal-debugger]]
+version = "41.0.1"
+audited_as = "41.0.0"
+
 [[unpublished.wasmtime-internal-explorer]]
 version = "40.0.0"
 audited_as = "39.0.1"
@@ -264,6 +396,10 @@ audited_as = "39.0.1"
 [[unpublished.wasmtime-internal-explorer]]
 version = "41.0.0"
 audited_as = "39.0.1"
+
+[[unpublished.wasmtime-internal-explorer]]
+version = "41.0.1"
+audited_as = "41.0.0"
 
 [[unpublished.wasmtime-internal-fiber]]
 version = "40.0.0"
@@ -273,6 +409,10 @@ audited_as = "39.0.1"
 version = "41.0.0"
 audited_as = "39.0.1"
 
+[[unpublished.wasmtime-internal-fiber]]
+version = "41.0.1"
+audited_as = "41.0.0"
+
 [[unpublished.wasmtime-internal-jit-debug]]
 version = "40.0.0"
 audited_as = "39.0.1"
@@ -280,6 +420,10 @@ audited_as = "39.0.1"
 [[unpublished.wasmtime-internal-jit-debug]]
 version = "41.0.0"
 audited_as = "39.0.1"
+
+[[unpublished.wasmtime-internal-jit-debug]]
+version = "41.0.1"
+audited_as = "41.0.0"
 
 [[unpublished.wasmtime-internal-jit-icache-coherence]]
 version = "40.0.0"
@@ -289,6 +433,10 @@ audited_as = "39.0.1"
 version = "41.0.0"
 audited_as = "39.0.1"
 
+[[unpublished.wasmtime-internal-jit-icache-coherence]]
+version = "41.0.1"
+audited_as = "41.0.0"
+
 [[unpublished.wasmtime-internal-math]]
 version = "40.0.0"
 audited_as = "39.0.1"
@@ -296,6 +444,10 @@ audited_as = "39.0.1"
 [[unpublished.wasmtime-internal-math]]
 version = "41.0.0"
 audited_as = "39.0.1"
+
+[[unpublished.wasmtime-internal-math]]
+version = "41.0.1"
+audited_as = "41.0.0"
 
 [[unpublished.wasmtime-internal-slab]]
 version = "40.0.0"
@@ -305,6 +457,10 @@ audited_as = "39.0.1"
 version = "41.0.0"
 audited_as = "39.0.1"
 
+[[unpublished.wasmtime-internal-slab]]
+version = "41.0.1"
+audited_as = "41.0.0"
+
 [[unpublished.wasmtime-internal-unwinder]]
 version = "40.0.0"
 audited_as = "39.0.1"
@@ -312,6 +468,10 @@ audited_as = "39.0.1"
 [[unpublished.wasmtime-internal-unwinder]]
 version = "41.0.0"
 audited_as = "39.0.1"
+
+[[unpublished.wasmtime-internal-unwinder]]
+version = "41.0.1"
+audited_as = "41.0.0"
 
 [[unpublished.wasmtime-internal-versioned-export-macros]]
 version = "40.0.0"
@@ -321,6 +481,10 @@ audited_as = "39.0.1"
 version = "41.0.0"
 audited_as = "39.0.1"
 
+[[unpublished.wasmtime-internal-versioned-export-macros]]
+version = "41.0.1"
+audited_as = "41.0.0"
+
 [[unpublished.wasmtime-internal-winch]]
 version = "40.0.0"
 audited_as = "39.0.1"
@@ -328,6 +492,10 @@ audited_as = "39.0.1"
 [[unpublished.wasmtime-internal-winch]]
 version = "41.0.0"
 audited_as = "39.0.1"
+
+[[unpublished.wasmtime-internal-winch]]
+version = "41.0.1"
+audited_as = "41.0.0"
 
 [[unpublished.wasmtime-internal-wit-bindgen]]
 version = "40.0.0"
@@ -337,6 +505,10 @@ audited_as = "39.0.1"
 version = "41.0.0"
 audited_as = "39.0.1"
 
+[[unpublished.wasmtime-internal-wit-bindgen]]
+version = "41.0.1"
+audited_as = "41.0.0"
+
 [[unpublished.wasmtime-internal-wmemcheck]]
 version = "40.0.0"
 audited_as = "39.0.1"
@@ -344,6 +516,10 @@ audited_as = "39.0.1"
 [[unpublished.wasmtime-internal-wmemcheck]]
 version = "41.0.0"
 audited_as = "39.0.1"
+
+[[unpublished.wasmtime-internal-wmemcheck]]
+version = "41.0.1"
+audited_as = "41.0.0"
 
 [[unpublished.wasmtime-wasi]]
 version = "40.0.0"
@@ -353,6 +529,10 @@ audited_as = "39.0.1"
 version = "41.0.0"
 audited_as = "39.0.1"
 
+[[unpublished.wasmtime-wasi]]
+version = "41.0.1"
+audited_as = "41.0.0"
+
 [[unpublished.wasmtime-wasi-config]]
 version = "40.0.0"
 audited_as = "39.0.1"
@@ -360,6 +540,10 @@ audited_as = "39.0.1"
 [[unpublished.wasmtime-wasi-config]]
 version = "41.0.0"
 audited_as = "39.0.1"
+
+[[unpublished.wasmtime-wasi-config]]
+version = "41.0.1"
+audited_as = "41.0.0"
 
 [[unpublished.wasmtime-wasi-http]]
 version = "40.0.0"
@@ -369,6 +553,10 @@ audited_as = "39.0.1"
 version = "41.0.0"
 audited_as = "39.0.1"
 
+[[unpublished.wasmtime-wasi-http]]
+version = "41.0.1"
+audited_as = "41.0.0"
+
 [[unpublished.wasmtime-wasi-io]]
 version = "40.0.0"
 audited_as = "39.0.1"
@@ -376,6 +564,10 @@ audited_as = "39.0.1"
 [[unpublished.wasmtime-wasi-io]]
 version = "41.0.0"
 audited_as = "39.0.1"
+
+[[unpublished.wasmtime-wasi-io]]
+version = "41.0.1"
+audited_as = "41.0.0"
 
 [[unpublished.wasmtime-wasi-keyvalue]]
 version = "40.0.0"
@@ -385,6 +577,10 @@ audited_as = "39.0.1"
 version = "41.0.0"
 audited_as = "39.0.1"
 
+[[unpublished.wasmtime-wasi-keyvalue]]
+version = "41.0.1"
+audited_as = "41.0.0"
+
 [[unpublished.wasmtime-wasi-nn]]
 version = "40.0.0"
 audited_as = "39.0.1"
@@ -392,6 +588,10 @@ audited_as = "39.0.1"
 [[unpublished.wasmtime-wasi-nn]]
 version = "41.0.0"
 audited_as = "39.0.1"
+
+[[unpublished.wasmtime-wasi-nn]]
+version = "41.0.1"
+audited_as = "41.0.0"
 
 [[unpublished.wasmtime-wasi-threads]]
 version = "40.0.0"
@@ -401,6 +601,10 @@ audited_as = "39.0.1"
 version = "41.0.0"
 audited_as = "39.0.1"
 
+[[unpublished.wasmtime-wasi-threads]]
+version = "41.0.1"
+audited_as = "41.0.0"
+
 [[unpublished.wasmtime-wasi-tls]]
 version = "40.0.0"
 audited_as = "39.0.1"
@@ -408,6 +612,10 @@ audited_as = "39.0.1"
 [[unpublished.wasmtime-wasi-tls]]
 version = "41.0.0"
 audited_as = "39.0.1"
+
+[[unpublished.wasmtime-wasi-tls]]
+version = "41.0.1"
+audited_as = "41.0.0"
 
 [[unpublished.wasmtime-wasi-tls-nativetls]]
 version = "40.0.0"
@@ -417,6 +625,10 @@ audited_as = "39.0.1"
 version = "41.0.0"
 audited_as = "39.0.1"
 
+[[unpublished.wasmtime-wasi-tls-nativetls]]
+version = "41.0.1"
+audited_as = "41.0.0"
+
 [[unpublished.wasmtime-wast]]
 version = "40.0.0"
 audited_as = "39.0.1"
@@ -424,6 +636,10 @@ audited_as = "39.0.1"
 [[unpublished.wasmtime-wast]]
 version = "41.0.0"
 audited_as = "39.0.1"
+
+[[unpublished.wasmtime-wast]]
+version = "41.0.1"
+audited_as = "41.0.0"
 
 [[unpublished.wasmtime-wizer]]
 version = "40.0.0"
@@ -433,6 +649,10 @@ audited_as = "39.0.1"
 version = "41.0.0"
 audited_as = "39.0.1"
 
+[[unpublished.wasmtime-wizer]]
+version = "41.0.1"
+audited_as = "41.0.0"
+
 [[unpublished.wiggle]]
 version = "40.0.0"
 audited_as = "39.0.1"
@@ -440,6 +660,10 @@ audited_as = "39.0.1"
 [[unpublished.wiggle]]
 version = "41.0.0"
 audited_as = "39.0.1"
+
+[[unpublished.wiggle]]
+version = "41.0.1"
+audited_as = "41.0.0"
 
 [[unpublished.wiggle-generate]]
 version = "40.0.0"
@@ -449,6 +673,10 @@ audited_as = "39.0.1"
 version = "41.0.0"
 audited_as = "39.0.1"
 
+[[unpublished.wiggle-generate]]
+version = "41.0.1"
+audited_as = "41.0.0"
+
 [[unpublished.wiggle-macro]]
 version = "40.0.0"
 audited_as = "39.0.1"
@@ -456,6 +684,10 @@ audited_as = "39.0.1"
 [[unpublished.wiggle-macro]]
 version = "41.0.0"
 audited_as = "39.0.1"
+
+[[unpublished.wiggle-macro]]
+version = "41.0.1"
+audited_as = "41.0.0"
 
 [[unpublished.wiggle-test]]
 version = "0.0.0"
@@ -468,6 +700,10 @@ audited_as = "39.0.1"
 [[unpublished.winch-codegen]]
 version = "41.0.0"
 audited_as = "39.0.1"
+
+[[unpublished.winch-codegen]]
+version = "41.0.1"
+audited_as = "41.0.0"
 
 [[publisher.aho-corasick]]
 version = "1.0.2"
@@ -686,124 +922,104 @@ user-login = "jrmuizel"
 user-name = "Jeff Muizelaar"
 
 [[publisher.cranelift]]
-version = "0.126.1"
-when = "2025-11-24"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "0.128.0"
+when = "2026-01-20"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-assembler-x64]]
-version = "0.126.1"
-when = "2025-11-24"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "0.128.0"
+when = "2026-01-20"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-assembler-x64-meta]]
-version = "0.126.1"
-when = "2025-11-24"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "0.128.0"
+when = "2026-01-20"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-bforest]]
-version = "0.126.1"
-when = "2025-11-24"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "0.128.0"
+when = "2026-01-20"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-bitset]]
-version = "0.126.1"
-when = "2025-11-24"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "0.128.0"
+when = "2026-01-20"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-codegen]]
-version = "0.126.1"
-when = "2025-11-24"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "0.128.0"
+when = "2026-01-20"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-codegen-meta]]
-version = "0.126.1"
-when = "2025-11-24"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "0.128.0"
+when = "2026-01-20"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-codegen-shared]]
-version = "0.126.1"
-when = "2025-11-24"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "0.128.0"
+when = "2026-01-20"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-control]]
-version = "0.126.1"
-when = "2025-11-24"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "0.128.0"
+when = "2026-01-20"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-entity]]
-version = "0.126.1"
-when = "2025-11-24"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "0.128.0"
+when = "2026-01-20"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-frontend]]
-version = "0.126.1"
-when = "2025-11-24"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "0.128.0"
+when = "2026-01-20"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-interpreter]]
-version = "0.126.1"
-when = "2025-11-24"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "0.128.0"
+when = "2026-01-20"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-isle]]
-version = "0.126.1"
-when = "2025-11-24"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "0.128.0"
+when = "2026-01-20"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-jit]]
-version = "0.126.1"
-when = "2025-11-24"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "0.128.0"
+when = "2026-01-20"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-module]]
-version = "0.126.1"
-when = "2025-11-24"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "0.128.0"
+when = "2026-01-20"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-native]]
-version = "0.126.1"
-when = "2025-11-24"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "0.128.0"
+when = "2026-01-20"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-object]]
-version = "0.126.1"
-when = "2025-11-24"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "0.128.0"
+when = "2026-01-20"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-reader]]
-version = "0.126.1"
-when = "2025-11-24"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "0.128.0"
+when = "2026-01-20"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-serde]]
-version = "0.126.1"
-when = "2025-11-24"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "0.128.0"
+when = "2026-01-20"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-srcgen]]
-version = "0.126.1"
-when = "2025-11-24"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "0.128.0"
+when = "2026-01-20"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.derive_arbitrary]]
 version = "1.4.0"
@@ -1076,16 +1292,14 @@ user-login = "dtolnay"
 user-name = "David Tolnay"
 
 [[publisher.pulley-interpreter]]
-version = "39.0.1"
-when = "2025-11-24"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "41.0.0"
+when = "2026-01-20"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.pulley-macros]]
-version = "39.0.1"
-when = "2025-11-24"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "41.0.0"
+when = "2026-01-20"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.quote]]
 version = "1.0.41"
@@ -1410,10 +1624,9 @@ user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
 [[publisher.wasi-common]]
-version = "39.0.1"
-when = "2025-11-24"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "41.0.0"
+when = "2026-01-20"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasip1]]
 version = "1.0.0"
@@ -1516,58 +1729,49 @@ user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime]]
-version = "39.0.1"
-when = "2025-11-24"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "41.0.0"
+when = "2026-01-20"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-cli]]
-version = "39.0.1"
-when = "2025-11-24"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "41.0.0"
+when = "2026-01-20"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-cli-flags]]
-version = "39.0.1"
-when = "2025-11-24"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "41.0.0"
+when = "2026-01-20"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-environ]]
-version = "39.0.1"
-when = "2025-11-24"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "41.0.0"
+when = "2026-01-20"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-c-api-macros]]
-version = "39.0.1"
-when = "2025-11-24"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "41.0.0"
+when = "2026-01-20"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-cache]]
-version = "39.0.1"
-when = "2025-11-24"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "41.0.0"
+when = "2026-01-20"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-component-macro]]
-version = "39.0.1"
-when = "2025-11-24"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "41.0.0"
+when = "2026-01-20"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-component-util]]
-version = "39.0.1"
-when = "2025-11-24"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "41.0.0"
+when = "2026-01-20"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-cranelift]]
-version = "39.0.1"
-when = "2025-11-24"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "41.0.0"
+when = "2026-01-20"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-debugger]]
 version = "41.0.0"
@@ -1575,136 +1779,114 @@ when = "2026-01-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-explorer]]
-version = "39.0.1"
-when = "2025-11-24"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "41.0.0"
+when = "2026-01-20"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-fiber]]
-version = "39.0.1"
-when = "2025-11-24"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "41.0.0"
+when = "2026-01-20"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-jit-debug]]
-version = "39.0.1"
-when = "2025-11-24"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "41.0.0"
+when = "2026-01-20"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-jit-icache-coherence]]
-version = "39.0.1"
-when = "2025-11-24"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "41.0.0"
+when = "2026-01-20"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-math]]
-version = "39.0.1"
-when = "2025-11-24"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "41.0.0"
+when = "2026-01-20"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-slab]]
-version = "39.0.1"
-when = "2025-11-24"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "41.0.0"
+when = "2026-01-20"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-unwinder]]
-version = "39.0.1"
-when = "2025-11-24"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "41.0.0"
+when = "2026-01-20"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-versioned-export-macros]]
-version = "39.0.1"
-when = "2025-11-24"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "41.0.0"
+when = "2026-01-20"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-winch]]
-version = "39.0.1"
-when = "2025-11-24"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "41.0.0"
+when = "2026-01-20"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-wit-bindgen]]
-version = "39.0.1"
-when = "2025-11-24"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "41.0.0"
+when = "2026-01-20"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-wmemcheck]]
-version = "39.0.1"
-when = "2025-11-24"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "41.0.0"
+when = "2026-01-20"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wasi]]
-version = "39.0.1"
-when = "2025-11-24"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "41.0.0"
+when = "2026-01-20"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wasi-config]]
-version = "39.0.1"
-when = "2025-11-24"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "41.0.0"
+when = "2026-01-20"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wasi-http]]
-version = "39.0.1"
-when = "2025-11-24"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "41.0.0"
+when = "2026-01-20"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wasi-io]]
-version = "39.0.1"
-when = "2025-11-24"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "41.0.0"
+when = "2026-01-20"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wasi-keyvalue]]
-version = "39.0.1"
-when = "2025-11-24"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "41.0.0"
+when = "2026-01-20"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wasi-nn]]
-version = "39.0.1"
-when = "2025-11-24"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "41.0.0"
+when = "2026-01-20"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wasi-threads]]
-version = "39.0.1"
-when = "2025-11-24"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "41.0.0"
+when = "2026-01-20"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wasi-tls]]
-version = "39.0.1"
-when = "2025-11-24"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "41.0.0"
+when = "2026-01-20"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wasi-tls-nativetls]]
-version = "39.0.1"
-when = "2025-11-24"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "41.0.0"
+when = "2026-01-20"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wast]]
-version = "39.0.1"
-when = "2025-11-24"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "41.0.0"
+when = "2026-01-20"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wizer]]
-version = "39.0.1"
-when = "2025-11-24"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "41.0.0"
+when = "2026-01-20"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wast]]
 version = "236.0.0"
@@ -1726,22 +1908,19 @@ user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
 [[publisher.wiggle]]
-version = "39.0.1"
-when = "2025-11-24"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "41.0.0"
+when = "2026-01-20"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wiggle-generate]]
-version = "39.0.1"
-when = "2025-11-24"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "41.0.0"
+when = "2026-01-20"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wiggle-macro]]
-version = "39.0.1"
-when = "2025-11-24"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "41.0.0"
+when = "2026-01-20"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wiggle-test]]
 version = "0.1.0"
@@ -1758,10 +1937,9 @@ user-login = "BurntSushi"
 user-name = "Andrew Gallant"
 
 [[publisher.winch-codegen]]
-version = "39.0.1"
-when = "2025-11-24"
-user-id = 73222
-user-login = "wasmtime-publish"
+version = "41.0.0"
+when = "2026-01-20"
+trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.windows]]
 version = "0.52.0"


### PR DESCRIPTION
This is an [automated pull request][process] from CI to create a patch release for Wasmtime 41.0.1, requested by @cfallin.

It's recommended that maintainers double-check that [RELEASES.md] is up-to-date and that there are no known issues before merging this PR. When this PR is merged a release tag will automatically be created, crates will be published, and CI artifacts will be produced.

[RELEASES.md]: https://github.com/bytecodealliance/wasmtime/blob/release-41.0.1/RELEASES.md
[process]: https://docs.wasmtime.dev/contributing-release-process.html
