### PR TITLE
fuzzgen: Don't generate float unordered vector ops on aarch64

### DIFF
--- a/cranelift/fuzzgen/src/function_generator.rs
+++ b/cranelift/fuzzgen/src/function_generator.rs
@@ -200,6 +200,14 @@ fn insert_cmp(
             (Architecture::Aarch64(_), FloatCC::OrderedNotEqual) => true,
             (Architecture::Aarch64(_), FloatCC::UnorderedOrEqual) => true,
 
+            // Not implemented on aarch64 for vectors
+            (Architecture::Aarch64(_), FloatCC::UnorderedOrLessThan)
+            | (Architecture::Aarch64(_), FloatCC::UnorderedOrLessThanOrEqual)
+            | (Architecture::Aarch64(_), FloatCC::UnorderedOrGreaterThan)
+            | (Architecture::Aarch64(_), FloatCC::UnorderedOrGreaterThanOrEqual) => {
+                args[0].is_vector()
+            }
+
             // These are not implemented on x86_64, for vectors.
             (Architecture::X86_64, FloatCC::UnorderedOrEqual | FloatCC::OrderedNotEqual) => {
                 args[0].is_vector()


### PR DESCRIPTION
This is a refinement of the change in #12196 to fix fuzzgen on oss-fuzz because aarch64 doesn't currently have lowerings for these float orderings, only the scalar versions were added in #12196.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
