### PR TITLE
Use wasmtime-core rather than wasmtime-environ in wasmtime-jit-icache-coherence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4951,7 +4951,7 @@ version = "42.0.0"
 dependencies = [
  "cfg-if",
  "libc",
- "wasmtime-environ",
+ "wasmtime-internal-core",
  "windows-sys 0.61.2",
 ]
 

--- a/crates/jit-icache-coherence/Cargo.toml
+++ b/crates/jit-icache-coherence/Cargo.toml
@@ -14,7 +14,7 @@ workspace = true
 
 [dependencies]
 cfg-if = { workspace = true }
-wasmtime-environ = { workspace = true }
+wasmtime-core = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dependencies.windows-sys]
 workspace = true

--- a/crates/jit-icache-coherence/src/lib.rs
+++ b/crates/jit-icache-coherence/src/lib.rs
@@ -41,7 +41,7 @@
 //! #   len: usize,
 //! # }
 //! #
-//! # fn main() -> wasmtime_environ::error::Result<()> {
+//! # fn main() -> wasmtime_core::error::Result<()> {
 //! #
 //! # let run_code = || {};
 //! # let code = vec![0u8; 64];

--- a/crates/jit-icache-coherence/src/libc.rs
+++ b/crates/jit-icache-coherence/src/libc.rs
@@ -4,7 +4,7 @@ use std::ffi::c_void;
 pub use std::io::Result;
 
 #[cfg(not(any(target_os = "linux", target_os = "android")))]
-pub use wasmtime_environ::error::Result;
+pub use wasmtime_core::error::Result;
 
 #[cfg(all(
     target_arch = "aarch64",

--- a/crates/jit-icache-coherence/src/miri.rs
+++ b/crates/jit-icache-coherence/src/miri.rs
@@ -1,5 +1,5 @@
 use std::ffi::c_void;
-pub use wasmtime_environ::error::Result;
+pub use wasmtime_core::error::Result;
 
 pub(crate) fn pipeline_flush_mt() -> Result<()> {
     Ok(())


### PR DESCRIPTION
This avoids unnecessarily pulling in a lot of wasmtime dependencies for cranelift-jit.

Fixes https://github.com/bytecodealliance/wasmtime/issues/12443