### PR TITLE
[41.0.0] Directly use anyhow rather than wasmtime-environ in wasmtime-jit-icache-coherence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4893,9 +4893,9 @@ dependencies = [
 name = "wasmtime-internal-jit-icache-coherence"
 version = "41.0.0"
 dependencies = [
+ "anyhow",
  "cfg-if",
  "libc",
- "wasmtime-environ",
  "windows-sys 0.61.2",
 ]
 

--- a/crates/jit-icache-coherence/Cargo.toml
+++ b/crates/jit-icache-coherence/Cargo.toml
@@ -13,8 +13,8 @@ rust-version.workspace = true
 workspace = true
 
 [dependencies]
+anyhow = { workspace = true }
 cfg-if = { workspace = true }
-wasmtime-environ = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dependencies.windows-sys]
 workspace = true

--- a/crates/jit-icache-coherence/src/lib.rs
+++ b/crates/jit-icache-coherence/src/lib.rs
@@ -41,7 +41,7 @@
 //! #   len: usize,
 //! # }
 //! #
-//! # fn main() -> wasmtime_environ::error::Result<()> {
+//! # fn main() -> anyhow::Result<()> {
 //! #
 //! # let run_code = || {};
 //! # let code = vec![0u8; 64];

--- a/crates/jit-icache-coherence/src/libc.rs
+++ b/crates/jit-icache-coherence/src/libc.rs
@@ -4,7 +4,7 @@ use std::ffi::c_void;
 pub use std::io::Result;
 
 #[cfg(not(any(target_os = "linux", target_os = "android")))]
-pub use wasmtime_environ::error::Result;
+pub use anyhow::Result;
 
 #[cfg(all(
     target_arch = "aarch64",

--- a/crates/jit-icache-coherence/src/miri.rs
+++ b/crates/jit-icache-coherence/src/miri.rs
@@ -1,5 +1,5 @@
+pub use anyhow::Result;
 use std::ffi::c_void;
-pub use wasmtime_environ::error::Result;
 
 pub(crate) fn pipeline_flush_mt() -> Result<()> {
     Ok(())


### PR DESCRIPTION
Backport of https://github.com/bytecodealliance/wasmtime/pull/12444 to 41.0.0 adapted for the wasmtime-core crate not yet being introduced. This should be backwards compatible as `wasmtime_environ::error::Result` is a re-export of `anyhow::Result` in 41.0.0.