### PR TITLE
Cranelift: preserve_all: disallow return values.

### DIFF
--- a/cranelift/codegen/src/isa/call_conv.rs
+++ b/cranelift/codegen/src/isa/call_conv.rs
@@ -53,7 +53,8 @@ pub enum CallConv {
     /// as little as possible.
     ///
     /// The ABI is based on the native register-argument ABI on each
-    /// respective platform. It does not support tail-calls.
+    /// respective platform. It does not support tail-calls. It also
+    /// does not support return values.
     PreserveAll,
 }
 

--- a/cranelift/codegen/src/machinst/abi.rs
+++ b/cranelift/codegen/src/machinst/abi.rs
@@ -2500,7 +2500,7 @@ impl<T> CallInfo<T> {
         // The temporary must be noted as clobbered unless there are
         // no returns (hence it isn't needed). The latter can only be
         // the case statically for an ABI when the ABI doesn't allow
-        // any returns at all (e.g., patchable-call ABI).
+        // any returns at all (e.g., preserve-all ABI).
         debug_assert!(
             self.defs.is_empty()
                 || M::get_regs_clobbered_by_call(self.callee_conv, self.try_call_info.is_some())

--- a/cranelift/filetests/filetests/verifier/preserve-all-abi.clif
+++ b/cranelift/filetests/filetests/verifier/preserve-all-abi.clif
@@ -1,0 +1,22 @@
+test verifier
+
+function %f0(i8) -> i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 preserve_all { ; error: Signature with `preserve_all` ABI cannot have return values
+block0(v0: i8):
+    return v0, v0, v0, v0, v0, v0, v0, v0, v0, v0, v0, v0, v0, v0, v0
+}
+
+function %f1(i64) {
+    sig0 = () -> i8, i8, i8, i8 preserve_all ; error: Signature with `preserve_all` ABI cannot have return values
+
+block0(v0: i64):
+    v1, v2, v3, v4 = call_indirect sig0, v0()
+    return
+}
+
+function %f2() {
+    fn0 = %g() -> i8, i8, i8, i8 preserve_all ; error: Signature with `preserve_all` ABI cannot have return values
+
+block0():
+    v1, v2, v3, v4 = call fn0()
+    return
+}


### PR DESCRIPTION
In #12399 a fuzzbug uncovered an issue whereby a function with `preserve_all` and with many return values cannot be called, because `emit_retval_loads` cannot codegen memory-to-memory moves (from on-stack return value slots directly to spillslots) without a temporary/clobberable register, and `preserve_all` implies no such registers exist.

I thought about trying to support this by shuffling registers -- such a case implies many return values, and at least some of them will be in registers, so we might be able to temporarily spill one of those and use it as a scratch to move other values memory-to-memory. But the complexity doesn't seem worthwhile, and this path is not actually needed at the moment.

Thinking more broadly, anyone using `preserve_all` for hooks meant to minimally perturb register state will likely not want to use many return values anyway (that defeats the point). We could allow *one* return value, with the knowledge that this always fits in a register in our existing ABIs, but that also feels somewhat arbitrary, and I could make the argument that "preserve all" should really mean preserve *all*. Someone wanting to return a value anyway from such a hook could use indirect means (pass in a pointer to a stackslot, for example). I'm happy to tweak this limit if others have more thoughts, however.

Fixes #12399.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
