### PR TITLE
Move `wasmtime_environ::collections::Vec` to `wasmtime_core::alloc::Vec`

### DIFF
--- a/crates/core/src/alloc.rs
+++ b/crates/core/src/alloc.rs
@@ -3,9 +3,11 @@
 mod arc;
 mod boxed;
 mod try_new;
+mod vec;
 
 pub use boxed::{BoxedSliceFromIterError, new_boxed_slice_from_iter};
 pub use try_new::{TryNew, try_new};
+pub use vec::Vec;
 
 use crate::error::OutOfMemory;
 use core::{alloc::Layout, ptr::NonNull};

--- a/crates/core/src/alloc/vec.rs
+++ b/crates/core/src/alloc/vec.rs
@@ -1,9 +1,9 @@
 use crate::error::OutOfMemory;
-use alloc::vec::Vec as StdVec;
 use core::{
     fmt,
     ops::{Deref, DerefMut, Index, IndexMut},
 };
+use std_alloc::vec::Vec as StdVec;
 
 /// Like `std::vec::Vec` but all methods that allocate force handling allocation
 /// failure.

--- a/crates/environ/src/collections.rs
+++ b/crates/environ/src/collections.rs
@@ -2,9 +2,7 @@
 
 mod entity_set;
 mod primary_map;
-mod vec;
 
 pub use entity_set::EntitySet;
 pub use primary_map::PrimaryMap;
-pub use vec::Vec;
-pub use wasmtime_core::alloc::{TryNew, try_new};
+pub use wasmtime_core::alloc::{TryNew, Vec, try_new};


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
