### PR TITLE
Fix `OwnedRooted<T>::wasm_ty_store` missing `i31ref` check

### DIFF
--- a/crates/wasmtime/src/runtime/gc/enabled/rooting.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/rooting.rs
@@ -1823,7 +1823,15 @@ where
         val_raw: impl Fn(u32) -> ValRaw,
     ) -> Result<()> {
         let gc_ref = self.try_clone_gc_ref(store)?;
-        let raw = store.require_gc_store_mut()?.expose_gc_ref_to_wasm(gc_ref);
+
+        let raw = match store.optional_gc_store_mut() {
+            Some(s) => s.expose_gc_ref_to_wasm(gc_ref),
+            None => {
+                debug_assert!(gc_ref.is_i31());
+                gc_ref.as_raw_non_zero_u32()
+            }
+        };
+
         ptr.write(val_raw(raw.get()));
         Ok(())
     }


### PR DESCRIPTION
`OwnedRooted<T>::wasm_ty_store` unconditionally called `require_gc_store_mut()`, which fails with "GC heap not initialized yet" when passing an `i31ref` through a typed function and no GC heap has been allocated yet.

https://github.com/bytecodealliance/wasmtime/blob/ab1ab705dd93e7c944c13d4d4b2683e049f4ff73/crates/wasmtime/src/runtime/gc/enabled/rooting.rs#L1817-L1829

The sibling method `Rooted<T>::wasm_ty_store` already handles this by using `optional_gc_store_mut()` with an i31 fallback.

https://github.com/bytecodealliance/wasmtime/blob/ab1ab705dd93e7c944c13d4d4b2683e049f4ff73/crates/wasmtime/src/runtime/gc/enabled/rooting.rs#L1214-L1222

This PR makes `OwnedRooted` match that behavior and adds a regression test that fails without the fix and passes with it.

Without the fix, running `cargo test -p wasmtime-cli --test all i31ref::owned_rooted_i31ref_through_typed_wasm_func` gives:

```
running 1 test
test i31ref::owned_rooted_i31ref_through_typed_wasm_func ... FAILED

failures:

---- i31ref::owned_rooted_i31ref_through_typed_wasm_func stdout ----
Error: GC heap not initialized yet


failures:
    i31ref::owned_rooted_i31ref_through_typed_wasm_func

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1043 filtered out; finished in 0.01s
```

Thanks for looking into this!