### PR TITLE
Add `{into,from}_raw_parts` for our OOM-handling `Vec`

### DIFF
--- a/crates/core/src/alloc/vec.rs
+++ b/crates/core/src/alloc/vec.rs
@@ -84,8 +84,12 @@ impl<T> Vec<T> {
     }
 
     /// Same as [`std::vec::Vec::into_raw_parts`].
-    pub fn into_raw_parts(self) -> (*mut T, usize, usize) {
-        self.inner.into_raw_parts()
+    pub fn into_raw_parts(mut self) -> (*mut T, usize, usize) {
+        // NB: Can't use `Vec::into_raw_parts` until our MSRV is >= 1.93.
+        let ptr = self.as_mut_ptr();
+        let len = self.len();
+        let cap = self.capacity();
+        (ptr, len, cap)
     }
 
     /// Same as [`std::vec::Vec::from_raw_parts`].


### PR DESCRIPTION
Depends on https://github.com/bytecodealliance/wasmtime/pull/12448