### PR TITLE
Add some fallible allocation methods to `cranelift_entity::SecondaryMap`

### DIFF
--- a/cranelift/entity/src/map.rs
+++ b/cranelift/entity/src/map.rs
@@ -15,6 +15,7 @@ use serde::{
     de::{Deserializer, SeqAccess, Visitor},
     ser::{SerializeSeq, Serializer},
 };
+use wasmtime_core::error::OutOfMemory;
 
 /// A mapping `K -> V` for densely indexed entity references.
 ///
@@ -67,6 +68,22 @@ where
         }
     }
 
+    /// Like `with_capacity` but returns an error on allocation failure.
+    pub fn try_with_capacity(capacity: usize) -> Result<Self, OutOfMemory>
+    where
+        V: Default,
+    {
+        let mut elems = Vec::new();
+        elems
+            .try_reserve(capacity)
+            .map_err(|_| OutOfMemory::new(core::mem::size_of::<V>().saturating_mul(capacity)))?;
+        Ok(Self {
+            elems,
+            default: Default::default(),
+            unused: PhantomData,
+        })
+    }
+
     /// Create a new empty map with a specified default value.
     ///
     /// This constructor does not require V to implement Default.
@@ -87,6 +104,35 @@ where
     #[inline(always)]
     pub fn get(&self, k: K) -> Option<&V> {
         self.elems.get(k.index())
+    }
+
+    /// Get the element at `k` mutably, if it exists.
+    pub fn get_mut(&mut self, k: K) -> Option<&mut V> {
+        self.elems.get_mut(k.index())
+    }
+
+    /// Insert the given key-value pair, returning the old value if it exists.
+    pub fn insert(&mut self, k: K, v: V) -> Option<V> {
+        let i = k.index();
+        if i < self.elems.len() {
+            Some(core::mem::replace(&mut self.elems[i], v))
+        } else {
+            self.resize(i + 1);
+            self.elems[i] = v;
+            None
+        }
+    }
+
+    /// Like `insert` but returns an error on allocation failure.
+    pub fn try_insert(&mut self, k: K, v: V) -> Result<Option<V>, OutOfMemory> {
+        let i = k.index();
+        if i < self.elems.len() {
+            Ok(Some(core::mem::replace(&mut self.elems[i], v)))
+        } else {
+            self.try_resize(i + 1)?;
+            self.elems[i] = v;
+            Ok(None)
+        }
     }
 
     /// Is this map completely empty?
@@ -129,6 +175,18 @@ where
     /// Resize the map to have `n` entries by adding default entries as needed.
     pub fn resize(&mut self, n: usize) {
         self.elems.resize(n, self.default.clone());
+    }
+
+    /// Like `resize` but returns an error on allocation failure.
+    pub fn try_resize(&mut self, n: usize) -> Result<(), OutOfMemory> {
+        if self.elems.capacity() < n {
+            self.elems
+                .try_reserve(n - self.elems.len())
+                .map_err(|_| OutOfMemory::new(core::mem::size_of::<V>().saturating_mul(n)))?;
+        }
+        debug_assert!(self.elems.capacity() >= n);
+        self.elems.resize(n, self.default.clone());
+        Ok(())
     }
 
     /// Slow path for `index_mut` which resizes the vector.
@@ -331,6 +389,7 @@ mod tests {
         let r0 = E(0);
         let r1 = E(1);
         let r2 = E(2);
+        let r3 = E(3);
         let mut m = SecondaryMap::new();
 
         let v: Vec<E> = m.keys().collect();
@@ -342,12 +401,30 @@ mod tests {
         assert_eq!(m[r1], 5);
         assert_eq!(m[r2], 3);
 
+        assert!(m.get(r3).is_none());
+        assert!(m.get_mut(r3).is_none());
+
+        let old = m.insert(r3, 99);
+        assert!(old.is_none());
+        assert_eq!(m.get(r3), Some(&99));
+        assert_eq!(m[r3], 99);
+
+        *m.get_mut(r3).unwrap() += 1;
+        assert_eq!(m.get(r3), Some(&100));
+        assert_eq!(m[r3], 100);
+
+        let old = m.insert(r3, 42);
+        assert_eq!(old, Some(100));
+        assert_eq!(m.get(r3), Some(&42));
+        assert_eq!(m[r3], 42);
+
         let v: Vec<E> = m.keys().collect();
-        assert_eq!(v, [r0, r1, r2]);
+        assert_eq!(v, [r0, r1, r2, r3]);
 
         let shared = &m;
         assert_eq!(shared[r0], 0);
         assert_eq!(shared[r1], 5);
         assert_eq!(shared[r2], 3);
+        assert_eq!(shared[r3], 42);
     }
 }


### PR DESCRIPTION
We will use these in the fallible-allocations-only version of this type that we will add to Wasmtime.

In the cases where there wasn't already an infallible version of the method (e.g. `try_insert`, because we have just used mutable indexing up till now instead of `insert`) I still defined the infallible version, since it seemed weird to have one but not the other.

Part of https://github.com/bytecodealliance/wasmtime/issues/12069

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
