### PR TITLE
Pin fuzz build in CI to oss-fuzz's Rust version

### DIFF
--- a/.github/actions/install-rust/action.yml
+++ b/.github/actions/install-rust/action.yml
@@ -33,6 +33,12 @@ runs:
           echo "version=1.$msrv.0" >> "$GITHUB_OUTPUT"
         elif [ "${{ inputs.toolchain }}" = "wasmtime-ci-pinned-nightly" ]; then
           echo "version=nightly-2026-01-26" >> "$GITHUB_OUTPUT"
+        elif [ "${{ inputs.toolchain }}" = "wasmtime-ci-oss-fuzz-pin" ]; then
+          # Do not change this number unless OSS-Fuzz has updated. If you update
+          # this version and do not update OSS-Fuzz then you will break our
+          # fuzzer build. Update OSS-Fuzz first, wait for that, then land the PR
+          # in Wasmtime that needs to update this.
+          echo "version=nightly-2026-01-28" >> "$GITHUB_OUTPUT"
         else
           echo "version=${{ inputs.toolchain }}" >> "$GITHUB_OUTPUT"
         fi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -614,11 +614,11 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    # Note that nightly is pinned here to insulate us from breakage that might
-    # happen upstream. This is periodically updated through a PR.
     - uses: ./.github/actions/install-rust
       with:
-        toolchain: wasmtime-ci-pinned-nightly
+        # This is pinned to match the version of Rust used on OSS-Fuzz to build
+        # Wasmtime. Do not change this `toolchain` version.
+        toolchain: wasmtime-ci-oss-fuzz-pin
 
     # Check that `pulley-interpreter` works with tail calls enabled.
     - run: cargo test -p pulley-interpreter --all-features


### PR DESCRIPTION
We updated our MSRV recently and that broke the build on OSS-Fuzz. To avoid this happening again set things up in CI to ensure that this doesn't happen again without informing us we should update OSS-Fuzz first.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
