### PR TITLE
Add `PanicOnOom` extension trait

### DIFF
--- a/crates/wasmtime/src/runtime/type_registry.rs
+++ b/crates/wasmtime/src/runtime/type_registry.rs
@@ -21,6 +21,7 @@ use core::{
         Ordering::{AcqRel, Acquire, Release},
     },
 };
+use wasmtime_core::alloc::PanicOnOom;
 use wasmtime_core::slab::{Id as SlabId, Slab};
 use wasmtime_environ::{
     EngineOrModuleTypeIndex, GcLayout, ModuleInternedTypeIndex, ModuleTypes, PrimaryMap,
@@ -743,7 +744,7 @@ impl TypeRegistryInner {
         // `?`-propagate an error when we have applied partial side effects.
         //
         // TODO(#12069): handle allocation failure here.
-        self.types.reserve(non_canon_types.len()).unwrap();
+        self.types.reserve(non_canon_types.len()).panic_on_oom();
 
         // Inter-group edges: increment the referenced group's ref
         // count, because these other rec groups shouldn't be dropped

--- a/crates/wasmtime/src/runtime/vm/gc/func_ref.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/func_ref.rs
@@ -13,7 +13,10 @@ use crate::{
     type_registry::TypeRegistry,
     vm::{SendSyncPtr, VMFuncRef},
 };
-use wasmtime_core::slab::{Id, Slab};
+use wasmtime_core::{
+    alloc::PanicOnOom,
+    slab::{Id, Slab},
+};
 use wasmtime_environ::VMSharedTypeIndex;
 
 /// An identifier into the `FuncRefTable`.
@@ -52,7 +55,7 @@ impl FuncRefTable {
     pub unsafe fn intern(&mut self, func_ref: Option<SendSyncPtr<VMFuncRef>>) -> FuncRefTableId {
         *self.interned.entry(func_ref).or_insert_with(|| {
             // TODO(#12069): handle allocation failure here
-            FuncRefTableId(self.slab.alloc(func_ref).unwrap())
+            FuncRefTableId(self.slab.alloc(func_ref).panic_on_oom())
         })
     }
 

--- a/crates/wasmtime/src/runtime/vm/gc/host_data.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/host_data.rs
@@ -15,7 +15,10 @@
 
 use crate::prelude::*;
 use core::any::Any;
-use wasmtime_core::slab::{Id, Slab};
+use wasmtime_core::{
+    alloc::PanicOnOom,
+    slab::{Id, Slab},
+};
 
 /// Side table for each `externref`'s host data value.
 #[derive(Default)]
@@ -40,7 +43,7 @@ impl ExternRefHostDataTable {
     /// Allocate a new `externref` host data value.
     pub fn alloc(&mut self, value: Box<dyn Any + Send + Sync>) -> ExternRefHostDataId {
         // TODO(#12069): handle allocation failure here
-        let id = self.slab.alloc(value).unwrap();
+        let id = self.slab.alloc(value).panic_on_oom();
         let id = ExternRefHostDataId(id);
         log::trace!("allocated new externref host data: {id:?}");
         id

--- a/crates/wasmtime/src/runtime/vm/traphandlers.rs
+++ b/crates/wasmtime/src/runtime/vm/traphandlers.rs
@@ -833,12 +833,14 @@ impl CallThreadState {
             let result = match &unwind {
                 #[cfg(feature = "gc")]
                 UnwindState::UnwindToWasm(_) => {
+                    use wasmtime_core::alloc::PanicOnOom;
+
                     assert!(store.as_store_opaque().has_pending_exception());
                     let exn = store
                         .as_store_opaque()
                         .pending_exception_owned_rooted()
                         // TODO(#12069): handle allocation failure here
-                        .unwrap()
+                        .panic_on_oom()
                         .expect("exception should be set when we are throwing");
                     store.block_on_debug_handler(crate::DebugEvent::CaughtExceptionThrown(exn))
                 }
@@ -847,11 +849,13 @@ impl CallThreadState {
                     reason: UnwindReason::Trap(TrapReason::Exception),
                     ..
                 } => {
+                    use wasmtime_core::alloc::PanicOnOom;
+
                     let exn = store
                         .as_store_opaque()
                         .pending_exception_owned_rooted()
                         // TODO(#12069): handle allocation failure here
-                        .unwrap()
+                        .panic_on_oom()
                         .expect("exception should be set when we are throwing");
                     store.block_on_debug_handler(crate::DebugEvent::UncaughtExceptionThrown(
                         exn.clone(),


### PR DESCRIPTION
To make it clear that we are only ignoring OOM errors, and not hiding the unwrapping of other kinds of errors, in our various TODOs for https://github.com/bytecodealliance/wasmtime/issues/12069

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
