### PR TITLE
Fixes #12458

### DIFF
--- a/crates/wasi-http/src/p3/body.rs
+++ b/crates/wasi-http/src/p3/body.rs
@@ -494,7 +494,7 @@ where
                         Ok(mut frame) => {
                             // Libraries like `Reqwest` generate a 0-length frame after sensing end-of-stream,
                             // so we have to check for the body's end-of-stream indicator here too
-                            if self.body.is_end_stream() {
+                            if frame.len() == 0 && self.body.is_end_stream() {
                                 break 'result Ok(None);
                             }
 


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
- Fixes #12458 and added test to validate
- This fix is necessary so that the `StreamProducer` implementation for `HostBodyStreamProvider` handles 0-length frames correctly 
