### PR TITLE
perf(wave): avoid Vec allocation in make_tuple

### DIFF
--- a/crates/wasmtime/src/runtime/wave/core.rs
+++ b/crates/wasmtime/src/runtime/wave/core.rs
@@ -70,11 +70,16 @@ impl WasmValue for crate::Val {
                 ));
             }
         }
-        let [l_val, h_val]: [Self; 2] = vals
-            .into_iter()
-            .collect::<Vec<_>>()
-            .try_into()
-            .map_err(|_| WasmValueError::Other("expected 2 values".to_string()))?;
+        let mut iter = vals.into_iter();
+        let Some(l_val) = iter.next() else {
+            return Err(WasmValueError::Other("expected 2 values".to_string()));
+        };
+        let Some(h_val) = iter.next() else {
+            return Err(WasmValueError::Other("expected 2 values".to_string()));
+        };
+        if iter.next().is_some() {
+            return Err(WasmValueError::Other("expected 2 values".to_string()));
+        }
 
         let (Some(l), Some(h)) = (l_val.i64(), h_val.i64()) else {
             return Err(WasmValueError::Other("expected 2 i64s (v64x2)".to_string()));


### PR DESCRIPTION
Before this change, WasmValue::make_tuple for wasmtime::Val always collected the input iterator into a Vec and then tried to convert it into a [Val; 2]. For V128 tuples we always expect exactly two i64 values, so this extra Vec allocation was unnecessary overhead.

This commit rewrites make_tuple to consume the iterator directly, reading exactly two values and returning the same "expected 2 values" / "expected 2 i64s (v64x2)" errors when the arity or types are wrong, without changing any observable behavior.