### PR TITLE
fix: skip importing `std::path::Path` regardless of `cache` feature

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -364,6 +364,7 @@ jobs:
               -p wasmtime --no-default-features --features runtime,stack-switching
               -p wasmtime --no-default-features --features debug
               -p wasmtime --no-default-features --features debug,gc
+              -p wasmtime --no-default-features --features runtime,cache
               -p wasmtime --features incremental-cache
               -p wasmtime --features profile-pulley
               -p wasmtime --all-features

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -3,7 +3,7 @@ use alloc::sync::Arc;
 use bitflags::Flags;
 use core::fmt;
 use core::str::FromStr;
-#[cfg(any(feature = "cache", feature = "cranelift", feature = "winch"))]
+#[cfg(any(feature = "cranelift", feature = "winch"))]
 use std::path::Path;
 pub use wasmparser::WasmFeatures;
 use wasmtime_environ::{ConfigTunables, TripleExt, Tunables};


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->

This PR just skips importing `std::path::Path` on `crates/wasmtime/src/config.rs` regardless of `cache` feature.

Currently, only either `cranelift` and `winit` feature requires importing it. `cache` feature is now unrelated.

The only use-case is here below:

https://github.com/bytecodealliance/wasmtime/blob/fdd8ed9e44f1df296568b1845c18d072b5e56681/crates/wasmtime/src/config.rs#L2706-L2711
