### PR TITLE
Fix leaks of already-initialized fields when struct/array init fails

### DIFF
--- a/crates/wasmtime/src/runtime/vm/gc.rs
+++ b/crates/wasmtime/src/runtime/vm/gc.rs
@@ -252,7 +252,8 @@ impl GcStore {
 
     /// Deallocate an uninitialized struct.
     pub fn dealloc_uninit_struct(&mut self, structref: VMStructRef) {
-        self.gc_heap.dealloc_uninit_struct_or_exn(structref.into())
+        self.gc_heap
+            .dealloc_uninit_struct_or_exn(&mut self.host_data_table, structref.into())
     }
 
     /// Get the data for the given object reference.
@@ -291,7 +292,8 @@ impl GcStore {
 
     /// Deallocate an uninitialized array.
     pub fn dealloc_uninit_array(&mut self, arrayref: VMArrayRef) {
-        self.gc_heap.dealloc_uninit_array(arrayref);
+        self.gc_heap
+            .dealloc_uninit_array(&mut self.host_data_table, arrayref);
     }
 
     /// Get the length of the given array.
@@ -318,6 +320,7 @@ impl GcStore {
 
     /// Deallocate an uninitialized exception object.
     pub fn dealloc_uninit_exn(&mut self, exnref: VMExnRef) {
-        self.gc_heap.dealloc_uninit_struct_or_exn(exnref.into());
+        self.gc_heap
+            .dealloc_uninit_struct_or_exn(&mut self.host_data_table, exnref.into());
     }
 }

--- a/crates/wasmtime/src/runtime/vm/gc/enabled/null.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/enabled/null.rs
@@ -299,7 +299,12 @@ unsafe impl GcHeap for NullHeap {
         self.alloc(VMGcHeader::from_kind_and_index(kind, ty), layout.layout())
     }
 
-    fn dealloc_uninit_struct_or_exn(&mut self, _struct_ref: VMGcRef) {}
+    fn dealloc_uninit_struct_or_exn(
+        &mut self,
+        _host_data_table: &mut ExternRefHostDataTable,
+        _struct_ref: VMGcRef,
+    ) {
+    }
 
     fn alloc_uninit_array(
         &mut self,
@@ -320,7 +325,12 @@ unsafe impl GcHeap for NullHeap {
         })
     }
 
-    fn dealloc_uninit_array(&mut self, _array_ref: VMArrayRef) {}
+    fn dealloc_uninit_array(
+        &mut self,
+        _host_data_table: &mut ExternRefHostDataTable,
+        _array_ref: VMArrayRef,
+    ) {
+    }
 
     fn array_len(&self, arrayref: &VMArrayRef) -> u32 {
         let arrayref = VMNullArrayHeader::typed_ref(self, arrayref);

--- a/crates/wasmtime/src/runtime/vm/gc/gc_runtime.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/gc_runtime.rs
@@ -302,7 +302,11 @@ pub unsafe trait GcHeap: 'static + Send + Sync {
     /// that the struct's allocation can be eagerly reclaimed, and so that the
     /// collector doesn't attempt to treat any of the uninitialized fields as
     /// valid GC references, or something like that.
-    fn dealloc_uninit_struct_or_exn(&mut self, structref: VMGcRef);
+    fn dealloc_uninit_struct_or_exn(
+        &mut self,
+        host_data_table: &mut ExternRefHostDataTable,
+        structref: VMGcRef,
+    );
 
     /// * `Ok(Ok(_))`: The allocation was successful.
     ///
@@ -328,7 +332,11 @@ pub unsafe trait GcHeap: 'static + Send + Sync {
     /// that the array's allocation can be eagerly reclaimed, and so that the
     /// collector doesn't attempt to treat any of the uninitialized fields as
     /// valid GC references, or something like that.
-    fn dealloc_uninit_array(&mut self, arrayref: VMArrayRef);
+    fn dealloc_uninit_array(
+        &mut self,
+        host_data_table: &mut ExternRefHostDataTable,
+        arrayref: VMArrayRef,
+    );
 
     /// Get the length of the given array.
     ///


### PR DESCRIPTION
When `StructRef::new` or `ArrayRef::new_fixed` fails midway, `dealloc_uninit` frees the object without dec-refing GC refs already written to earlier fields, leaking them. Fix by zero-filling the object body in `alloc_raw` so trace_gc_ref skips uninitialized slots, then tracing and dec-refing children in `dealloc_uninit` before freeing.

Fixes #12456

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
