### PR TITLE
cranelift: improve debug value locations around cold blocks

### DIFF
--- a/cranelift/codegen/src/machinst/vcode.rs
+++ b/cranelift/codegen/src/machinst/vcode.rs
@@ -1253,21 +1253,23 @@ impl<I: VCodeInst> VCode<I> {
                 }
                 inst.index()
             };
+            let inst_to_offset = |inst_index: usize| {
+                // Skip over cold blocks.
+                for offset in &inst_offsets[inst_index..] {
+                    if *offset != NO_INST_OFFSET {
+                        return *offset;
+                    }
+                }
+                func_body_len
+            };
             let from_inst_index = prog_point_to_inst(from);
             let to_inst_index = prog_point_to_inst(to);
-            let from_offset = inst_offsets[from_inst_index];
-            let to_offset = if to_inst_index == inst_offsets.len() {
-                func_body_len
-            } else {
-                inst_offsets[to_inst_index]
-            };
+            let from_offset = inst_to_offset(from_inst_index);
+            let to_offset = inst_to_offset(to_inst_index);
 
             // Empty ranges or unavailable offsets can happen
             // due to cold blocks and branch removal (see above).
-            if from_offset == NO_INST_OFFSET
-                || to_offset == NO_INST_OFFSET
-                || from_offset == to_offset
-            {
+            if from_offset == to_offset {
                 continue;
             }
 

--- a/crates/test-programs/src/bin/dwarf_cold_block.c
+++ b/crates/test-programs/src/bin/dwarf_cold_block.c
@@ -1,0 +1,20 @@
+struct myfile {
+  int data;
+  void (*f)();
+} myfile;
+
+void f() {}
+
+int foo(struct myfile *f1) {
+  f1->f();
+  if (f1->data == 42)
+    return 0;
+  return 1;
+}
+
+int main() {
+  struct myfile f1;
+  f1.f = &f;
+  f1.data = 42;
+  return foo(&f1);
+}

--- a/tests/all/native_debug/lldb.rs
+++ b/tests/all/native_debug/lldb.rs
@@ -554,3 +554,42 @@ check: exited with status = 0
     }
     Ok(())
 }
+
+#[test]
+#[ignore]
+pub fn dwarf_cold_block() -> Result<()> {
+    let output = lldb_with_script(
+        &[
+            "-Ccache=n",
+            "-Oopt-level=0",
+            "-Ddebug-info",
+            DWARF_COLD_BLOCK,
+        ],
+        r#"b foo
+r
+p __vmctx->set(),*f1
+n
+p __vmctx->set(),*f1
+n
+p __vmctx->set(),*f1
+n
+p __vmctx->set(),*f1
+c"#,
+    )?;
+
+    check_lldb_output(
+        &output,
+        r#"
+check: Breakpoint 1: no locations (pending)
+check: stop reason = breakpoint 1.1
+check: frame #0
+sameln: foo(f1=(__ptr =
+check: data = 42
+check: data = 42
+check: data = 42
+check: data = 42
+check: resuming
+"#,
+    )?;
+    Ok(())
+}


### PR DESCRIPTION
If a debug range started or ended on an instruction from a cold block, we omitted the entire range. Fix by skipping the instructions in the cold block to find the next valid offset.

Closes #11337