### PR TITLE
Cranelift: fuzzgen: avoid generating `preserve_all`-ABI functions with return values.

### DIFF
--- a/cranelift/fuzzgen/src/cranelift_arbitrary.rs
+++ b/cranelift/fuzzgen/src/cranelift_arbitrary.rs
@@ -97,7 +97,7 @@ impl<'a> CraneliftArbitrary for &mut Unstructured<'a> {
         mut simd_enabled: bool,
         architecture: Architecture,
         max_params: usize,
-        max_rets: usize,
+        mut max_rets: usize,
     ) -> Result<Signature> {
         let callconv = self.callconv(architecture)?;
 
@@ -105,6 +105,11 @@ impl<'a> CraneliftArbitrary for &mut Unstructured<'a> {
         // https://github.com/bytecodealliance/wasmtime/issues/8093
         if callconv == CallConv::Winch {
             simd_enabled = false;
+        }
+
+        // We can't have any returns in the `preserve_all` calling convention.
+        if callconv == CallConv::PreserveAll {
+            max_rets = 0;
         }
 
         let mut sig = Signature::new(callconv);


### PR DESCRIPTION
Fixes #12488.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
