### PR TITLE
Adjust Wasmtime's prelude/hash collections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4518,8 +4518,6 @@ dependencies = [
  "futures",
  "fxprof-processed-profile",
  "gimli 0.33.0",
- "hashbrown 0.15.2",
- "indexmap 2.11.4",
  "ittapi",
  "libc",
  "libtest-mimic",

--- a/crates/environ/src/collections.rs
+++ b/crates/environ/src/collections.rs
@@ -10,3 +10,18 @@ pub use hash_set::HashSet;
 pub use primary_map::PrimaryMap;
 pub use secondary_map::SecondaryMap;
 pub use wasmtime_core::alloc::{TryNew, Vec, try_new};
+
+/// Collections which abort on OOM.
+//
+// FIXME(#12069) this is just here for Wasmtime at this time. Ideally
+// collections would only be fallible in this module and would handle OOM. We're
+// in a bit of a transition period though.
+pub mod oom_abort {
+    #[cfg(not(feature = "std"))]
+    pub use hashbrown::{hash_map, hash_set};
+    #[cfg(feature = "std")]
+    pub use std::collections::{hash_map, hash_set};
+
+    pub use self::hash_map::HashMap;
+    pub use self::hash_set::HashSet;
+}

--- a/crates/environ/src/prelude.rs
+++ b/crates/environ/src/prelude.rs
@@ -28,3 +28,4 @@ pub use alloc::string::{String, ToString};
 pub use alloc::vec;
 pub use alloc::vec::Vec;
 pub use wasmparser::collections::{IndexMap, IndexSet};
+pub use wasmtime_core::alloc::{TryCollect, TryExtend, TryFromIterator};

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -45,7 +45,6 @@ serde = { workspace = true }
 serde_derive = { workspace = true }
 serde_json = { workspace = true, optional = true }
 postcard = { workspace = true }
-indexmap = { workspace = true }
 once_cell = { version = "1.12.0", optional = true }
 rayon = { workspace = true, optional = true }
 object = { workspace = true, features = ['unaligned'] }
@@ -57,7 +56,6 @@ gimli = { workspace = true, optional = true }
 addr2line = { workspace = true, optional = true }
 semver = { workspace = true, optional = true }
 smallvec = { workspace = true, optional = true }
-hashbrown = { workspace = true, features = ["default-hasher"] }
 bitflags = { workspace = true }
 futures = { workspace = true, features = ["alloc"], optional = true }
 bytes = { workspace = true, optional = true }

--- a/crates/wasmtime/src/lib.rs
+++ b/crates/wasmtime/src/lib.rs
@@ -409,12 +409,15 @@
 extern crate std;
 extern crate alloc;
 
-pub(crate) mod prelude {
-    pub use crate::error::{Context, Error, Result, bail, ensure, format_err};
-    pub use wasmtime_environ::prelude::*;
-}
+// Internal `use` statement which isn't used in this module but enable
+// `use crate::prelude::*;` everywhere else within this crate, for example.
+use wasmtime_environ::prelude;
 
-pub(crate) use hashbrown::{hash_map, hash_set};
+// FIXME(#12069) should transition to OOM-handling versions of these collections
+// for all internal usage instead of using abort-on-OOM versions. Once that's
+// done this can be removed and the collections should be directly imported from
+// `wasmtime_environ::collections::*`.
+use wasmtime_environ::collections::oom_abort::{hash_map, hash_set};
 
 /// A helper macro to safely map `MaybeUninit<T>` to `MaybeUninit<U>` where `U`
 /// is a field projection within `T`.


### PR DESCRIPTION
This commit updates Wasmtime's internal usage of hash maps and hash sets to use the standard library when the `std` feature is enabled, as opposed to using `hashbrown`. When `std` is disabled `hashbrown` is still used, however. Additionally the prelude of `wasmtime` is now a simple reexport of `wasmtime_environ`.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
