### PR TITLE
fix: skip drop_fibers_and_futures when concurrency support is disabled

### DIFF
--- a/crates/wasmtime/src/runtime/component/store.rs
+++ b/crates/wasmtime/src/runtime/component/store.rs
@@ -55,6 +55,13 @@ impl ComponentStoreData {
 
     #[cfg(feature = "component-model-async")]
     pub(crate) fn drop_fibers_and_futures(store: &mut dyn VMStore) {
+        // Skip cleanup if concurrency support is not enabled.
+        // This prevents panics when the component-model-async feature is compiled in
+        // but the store was created without concurrency support (concurrent_state is None).
+        if !store.concurrency_support() {
+            return;
+        }
+
         let mut fibers = Vec::new();
         let mut futures = Vec::new();
         store


### PR DESCRIPTION
## Summary

When the `component-model-async` feature is compiled in but the store was created without concurrency support, `concurrent_state` is `None`. During `Store::drop`, `drop_fibers_and_futures` is called which then calls `concurrent_state_mut()`. This panics because `concurrent_state_mut()` unwraps the `None` value.

This fix adds a runtime check to early-return when `concurrency_support()` returns `false`, preventing the panic during Store drop.

## Problem

In `crates/wasmtime/src/runtime/store.rs`:
```rust
pub(crate) fn concurrent_state_mut(&mut self) -> &mut concurrent::ConcurrentState {
    debug_assert!(self.concurrency_support());
    self.concurrent_state.as_mut().unwrap()  // Panics if concurrent_state is None
}
```

The `debug_assert!` only catches this in debug builds, but in release builds the `unwrap()` will panic.

## Fix

Add a guard in `drop_fibers_and_futures`:
```rust
pub(crate) fn drop_fibers_and_futures(store: &mut dyn VMStore) {
    if !store.concurrency_support() {
        return;
    }
    // ... rest of cleanup
}
```

## Test Plan

- Builds successfully with `cargo check -p wasmtime --features component-model,component-model-async,async`
- Confirmed fix prevents panic when dropping stores created without concurrency support