### PR TITLE
Our OOM-handling `Vec`'s `into_boxed_slice` method need not `realloc` when `len == cap`

### DIFF
--- a/crates/core/src/alloc/vec.rs
+++ b/crates/core/src/alloc/vec.rs
@@ -150,10 +150,12 @@ impl<T> Vec<T> {
         // * If `len == 0` and `cap != 0` then this function effectively frees
         //   the memory.
         // * If `T` is a zero-sized type then nothing's been allocated either.
+        // * If `len == cap` then the allocation doesn't need to be shrunken.
         //
         // In all of these cases delegate to the standard library's
         // `into_boxed_slice` which is guaranteed to not perform a `realloc`.
-        if self.is_empty() || mem::size_of::<T>() == 0 {
+        if self.is_empty() || mem::size_of::<T>() == 0 || self.inner.len() == self.inner.capacity()
+        {
             return Ok(self.inner.into_boxed_slice());
         }
 

--- a/crates/fuzzing/tests/oom.rs
+++ b/crates/fuzzing/tests/oom.rs
@@ -363,22 +363,34 @@ fn vec_and_boxed_slice() -> Result<()> {
     use wasmtime_core::alloc::Vec;
 
     OomTest::new().test(|| {
-        // nonzero-sized type
+        // Nonzero-sized type.
         let mut vec = Vec::new();
         vec.push(1)?;
         let slice = vec.into_boxed_slice()?; // len > 0, cap > 0
+
         let mut vec = Vec::from(slice);
         vec.pop();
         let slice = vec.into_boxed_slice()?; // len = 0, cap > 0
-        let vec = Vec::from(slice);
-        let slice = vec.into_boxed_slice()?; // len = 0, cap = 0
-        let mut vec = Vec::from(slice);
-        vec.push(2)?;
-        vec.push(2)?;
-        vec.push(2)?;
-        let _ = vec.into_boxed_slice()?;
 
-        // zero-sized type
+        let vec = Vec::from(slice);
+        let _slice = vec.into_boxed_slice()?; // len = 0, cap = 0
+
+        let mut vec = Vec::new();
+        vec.reserve_exact(3)?;
+        vec.push(2)?;
+        vec.push(2)?;
+        vec.push(2)?;
+        let _slice = vec.into_boxed_slice()?; // len = cap, len > 0
+
+        for i in 0..12 {
+            let mut vec = Vec::new();
+            for j in 0..i {
+                vec.push(j)?;
+            }
+            let _slice = vec.into_boxed_slice()?; // len ?= cap
+        }
+
+        // Zero-sized type.
         let mut vec = Vec::new();
         vec.push(())?;
         let slice = vec.into_boxed_slice()?; // len > 0, cap > 0


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
