### PR TITLE
Do not do `result.context(format!(".."))`

### DIFF
--- a/crates/cache/src/config.rs
+++ b/crates/cache/src/config.rs
@@ -355,14 +355,12 @@ impl CacheConfig {
         match (entity_exists, user_custom_file) {
             (false, false) => Ok(Self::new()),
             _ => {
-                let contents = fs::read_to_string(&config_file).context(format!(
-                    "failed to read config file: {}",
-                    config_file.display()
-                ))?;
-                let config = toml::from_str::<Config>(&contents).context(format!(
-                    "failed to parse config file: {}",
-                    config_file.display()
-                ))?;
+                let contents = fs::read_to_string(&config_file).with_context(|| {
+                    format!("failed to read config file: {}", config_file.display())
+                })?;
+                let config = toml::from_str::<Config>(&contents).with_context(|| {
+                    format!("failed to parse config file: {}", config_file.display())
+                })?;
                 Ok(config.cache)
             }
         }
@@ -537,14 +535,15 @@ impl CacheConfig {
             );
         }
 
-        fs::create_dir_all(cache_dir).context(format!(
-            "failed to create cache directory: {}",
-            cache_dir.display()
-        ))?;
-        let canonical = fs::canonicalize(cache_dir).context(format!(
-            "failed to canonicalize cache directory: {}",
-            cache_dir.display()
-        ))?;
+        fs::create_dir_all(cache_dir).with_context(|| {
+            format!("failed to create cache directory: {}", cache_dir.display())
+        })?;
+        let canonical = fs::canonicalize(cache_dir).with_context(|| {
+            format!(
+                "failed to canonicalize cache directory: {}",
+                cache_dir.display()
+            )
+        })?;
         self.directory = Some(canonical);
         Ok(())
     }

--- a/crates/wasmtime/src/runtime/vm/mmap.rs
+++ b/crates/wasmtime/src/runtime/vm/mmap.rs
@@ -91,13 +91,13 @@ impl Mmap<AlignedLength> {
         } else if accessible_size == mapping_size {
             Ok(Mmap {
                 sys: mmap::Mmap::new(mapping_size)
-                    .context(format!("mmap failed to allocate {mapping_size:#x} bytes"))?,
+                    .with_context(|| format!("mmap failed to allocate {mapping_size:#x} bytes"))?,
                 data: AlignedLength {},
             })
         } else {
             let result = Mmap {
                 sys: mmap::Mmap::reserve(mapping_size)
-                    .context(format!("mmap failed to reserve {mapping_size:#x} bytes"))?,
+                    .with_context(|| format!("mmap failed to reserve {mapping_size:#x} bytes"))?,
                 data: AlignedLength {},
             };
             if !accessible_size.is_zero() {
@@ -105,9 +105,9 @@ impl Mmap<AlignedLength> {
                 unsafe {
                     result
                         .make_accessible(HostAlignedByteCount::ZERO, accessible_size)
-                        .context(format!(
-                            "mmap failed to allocate {accessible_size:#x} bytes"
-                        ))?;
+                        .with_context(|| {
+                            format!("mmap failed to allocate {accessible_size:#x} bytes")
+                        })?;
                 }
             }
             Ok(result)

--- a/crates/wasmtime/src/runtime/vm/sys/unix/mmap.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/unix/mmap.rs
@@ -98,7 +98,7 @@ impl Mmap {
                 &file,
                 0,
             )
-            .context(format!("mmap failed to allocate {len:#x} bytes"))?
+            .with_context(|| format!("mmap failed to allocate {len:#x} bytes"))?
         };
         let memory = std::ptr::slice_from_raw_parts_mut(ptr.cast(), len);
         let memory = SendSyncPtr::new(NonNull::new(memory).unwrap());

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -255,11 +255,13 @@ impl RunCommand {
                         linker
                             .module_async(&mut *store, name, &preload_module)
                             .await
-                            .context(format!(
-                                "failed to process preload `{}` at `{}`",
-                                name,
-                                path.display()
-                            ))?;
+                            .with_context(|| {
+                                format!(
+                                    "failed to process preload `{}` at `{}`",
+                                    name,
+                                    path.display()
+                                )
+                            })?;
                     }
                     #[cfg(not(feature = "cranelift"))]
                     CliLinker::Core(_) => {
@@ -512,10 +514,9 @@ impl RunCommand {
                 let instance = linker
                     .instantiate_async(&mut *store, &module)
                     .await
-                    .context(format!(
-                        "failed to instantiate {:?}",
-                        self.module_and_args[0]
-                    ))?;
+                    .with_context(|| {
+                        format!("failed to instantiate {:?}", self.module_and_args[0])
+                    })?;
 
                 // If `_initialize` is present, meaning a reactor, then invoke
                 // the function.
@@ -1336,7 +1337,7 @@ fn write_core_dump(
     let core_dump = core_dump.serialize(store, name);
 
     let mut core_dump_file =
-        File::create(path).context(format!("failed to create file at `{path}`"))?;
+        File::create(path).with_context(|| format!("failed to create file at `{path}`"))?;
     core_dump_file
         .write_all(&core_dump)
         .with_context(|| format!("failed to write core dump file at `{path}`"))?;

--- a/tests/all/native_debug/dump.rs
+++ b/tests/all/native_debug/dump.rs
@@ -15,7 +15,7 @@ pub fn get_dwarfdump(obj: &str, section: DwarfDumpSection) -> Result<String> {
     let output = Command::new(&dwarfdump)
         .args(&[section_flag, obj])
         .output()
-        .context(format!("failed to spawn `{dwarfdump}`"))?;
+        .with_context(|| format!("failed to spawn `{dwarfdump}`"))?;
     if !output.status.success() {
         bail!(
             "failed to execute {}: {}",


### PR DESCRIPTION
Use `result.with_context(|| format!(".."))` instead, to delay the formatting and string allocation until if/when we actually encounter an error.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
