### PR TITLE
Add support for fine-grained operator costs

### DIFF
--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -420,23 +420,7 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
             return;
         }
 
-        self.fuel_consumed += match op {
-            // Nop and drop generate no code, so don't consume fuel for them.
-            Operator::Nop | Operator::Drop => 0,
-
-            // Control flow may create branches, but is generally cheap and
-            // free, so don't consume fuel. Note the lack of `if` since some
-            // cost is incurred with the conditional check.
-            Operator::Block { .. }
-            | Operator::Loop { .. }
-            | Operator::Unreachable
-            | Operator::Return
-            | Operator::Else
-            | Operator::End => 0,
-
-            // everything else, just call it one operation.
-            _ => 1,
-        };
+        self.fuel_consumed += self.tunables.operator_cost.cost(op);
 
         match op {
             // Exiting a function (via a return or unreachable) or otherwise

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -7,7 +7,7 @@ use core::str::FromStr;
 #[cfg(any(feature = "cranelift", feature = "winch"))]
 use std::path::Path;
 pub use wasmparser::WasmFeatures;
-use wasmtime_environ::{ConfigTunables, TripleExt, Tunables};
+use wasmtime_environ::{ConfigTunables, OperatorCost, OperatorCostStrategy, TripleExt, Tunables};
 
 #[cfg(feature = "runtime")]
 use crate::memory::MemoryCreator;
@@ -604,6 +604,14 @@ impl Config {
     /// [`Store`]: crate::Store
     pub fn consume_fuel(&mut self, enable: bool) -> &mut Self {
         self.tunables.consume_fuel = Some(enable);
+        self
+    }
+
+    /// Configures the fuel cost of each WebAssembly operator.
+    ///
+    /// This is only relevant when [`Config::consume_fuel`] is enabled.
+    pub fn operator_cost(&mut self, cost: OperatorCost) -> &mut Self {
+        self.tunables.operator_cost = Some(OperatorCostStrategy::table(cost));
         self
     }
 

--- a/crates/wasmtime/src/lib.rs
+++ b/crates/wasmtime/src/lib.rs
@@ -515,6 +515,7 @@ mod sync_nostd;
 #[cfg(not(feature = "std"))]
 use sync_nostd as sync;
 
+pub use wasmtime_environ::OperatorCost;
 #[doc(inline)]
 pub use wasmtime_environ::error;
 

--- a/crates/wasmtime/src/runtime/vm/memory/malloc.rs
+++ b/crates/wasmtime/src/runtime/vm/memory/malloc.rs
@@ -157,16 +157,18 @@ mod tests {
     };
 
     // Valid tunables that can be used to create a `MallocMemory`.
-    const TUNABLES: Tunables = Tunables {
-        memory_reservation: 0,
-        memory_guard_size: 0,
-        memory_init_cow: false,
-        ..Tunables::default_miri()
-    };
+    fn tunables() -> Tunables {
+        Tunables {
+            memory_reservation: 0,
+            memory_guard_size: 0,
+            memory_init_cow: false,
+            ..Tunables::default_miri()
+        }
+    }
 
     #[test]
     fn simple() {
-        let mut memory = MallocMemory::new(&TY, &TUNABLES, 10).unwrap();
+        let mut memory = MallocMemory::new(&TY, &tunables(), 10).unwrap();
         assert_eq!(memory.storage.len(), 1);
         assert_valid(&memory);
 
@@ -191,7 +193,7 @@ mod tests {
     fn reservation_not_initialized() {
         let tunables = Tunables {
             memory_reservation_for_growth: 1 << 20,
-            ..TUNABLES
+            ..tunables()
         };
         let mut memory = MallocMemory::new(&TY, &tunables, 10).unwrap();
         assert_eq!(memory.storage.len(), 1);

--- a/winch/codegen/src/codegen/mod.rs
+++ b/winch/codegen/src/codegen/mod.rs
@@ -1343,16 +1343,7 @@ where
         // potential optimization is to designate a register as non-allocatable,
         // when fuel consumption is enabled, effectively using it as a local
         // fuel cache.
-        self.fuel_consumed += match op {
-            Operator::Nop | Operator::Drop => 0,
-            Operator::Block { .. }
-            | Operator::Loop { .. }
-            | Operator::Unreachable
-            | Operator::Return
-            | Operator::Else
-            | Operator::End => 0,
-            _ => 1,
-        };
+        self.fuel_consumed += self.tunables.operator_cost.cost(op);
 
         match op {
             Operator::Unreachable


### PR DESCRIPTION
Closes https://github.com/bytecodealliance/wasmtime/issues/11572.

Adds support for setting custom operator costs per operator.
