### PR TITLE
Consolidate component-related store data 

### DIFF
--- a/crates/wasmtime/src/runtime/component/concurrent.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent.rs
@@ -1805,7 +1805,7 @@ impl StoreOpaque {
         if !task.returned_or_cancelled() {
             log::trace!("push call context for {guest_task:?}");
             let call_context = task.call_context.take().unwrap();
-            self.component_resource_state().0.push(call_context);
+            self.component_call_contexts_mut().push(call_context);
         }
         Ok(())
     }
@@ -1820,7 +1820,7 @@ impl StoreOpaque {
             .returned_or_cancelled()
         {
             log::trace!("pop call context for {guest_task:?}");
-            let call_context = Some(self.component_resource_state().0.pop().unwrap());
+            let call_context = Some(self.component_call_contexts_mut().pop().unwrap());
             self.concurrent_state_mut()
                 .get_mut(guest_task)?
                 .call_context = call_context;
@@ -2745,8 +2745,7 @@ impl Instance {
                         token
                             .as_context_mut(store)
                             .0
-                            .component_resource_state()
-                            .0
+                            .component_call_contexts_mut()
                             .push(call_context);
                     }
                 });
@@ -2761,8 +2760,7 @@ impl Instance {
                             token
                                 .as_context_mut(store)
                                 .0
-                                .component_resource_state()
-                                .0
+                                .component_call_contexts_mut()
                                 .pop()
                                 .unwrap(),
                         );

--- a/crates/wasmtime/src/runtime/component/instance.rs
+++ b/crates/wasmtime/src/runtime/component/instance.rs
@@ -728,7 +728,8 @@ impl<'a> Instantiator<'a> {
         imports: &'a Arc<PrimaryMap<RuntimeImportIndex, RuntimeImport>>,
     ) -> Result<Instantiator<'a>> {
         let env_component = component.env_component();
-        store.register_component(component)?;
+        let (modules, engine) = store.modules_and_engine_mut();
+        modules.register_component(component, engine)?;
         let imported_resources: ImportedResources =
             PrimaryMap::with_capacity(env_component.imported_resources.len());
 

--- a/crates/wasmtime/src/runtime/instance.rs
+++ b/crates/wasmtime/src/runtime/instance.rs
@@ -225,7 +225,8 @@ impl Instance {
         // Note that under normal operation this shouldn't do much as the list
         // of funcs-with-holes should generally be empty. As a result the
         // process of filling this out is not super optimized at this point.
-        store.register_module(module)?;
+        let (modules, engine) = store.modules_and_engine_mut();
+        modules.register_module(module, engine)?;
         let (funcrefs, modules) = store.func_refs_and_modules();
         funcrefs.fill(modules);
 
@@ -304,7 +305,8 @@ impl Instance {
 
         // Register the module just before instantiation to ensure we keep the module
         // properly referenced while in use by the store.
-        let module_id = store.register_module(module)?;
+        let (modules, engine) = store.modules_and_engine_mut();
+        let module_id = modules.register_module(module, engine)?;
 
         // The first thing we do is issue an instance allocation request
         // to the instance allocator. This, on success, will give us an
@@ -950,7 +952,8 @@ fn pre_instantiate_raw(
 ) -> Result<OwnedImports> {
     // Register this module and use it to fill out any funcref wasm_call holes
     // we can. For more comments on this see `typecheck_externs`.
-    store.register_module(module)?;
+    let (modules, engine) = store.modules_and_engine_mut();
+    modules.register_module(module, engine)?;
     let (funcrefs, modules) = store.func_refs_and_modules();
     funcrefs.fill(modules);
 

--- a/crates/wasmtime/src/runtime/store.rs
+++ b/crates/wasmtime/src/runtime/store.rs
@@ -81,10 +81,6 @@ use crate::OwnedRooted;
 use crate::RootSet;
 #[cfg(feature = "gc")]
 use crate::ThrownException;
-#[cfg(feature = "component-model-async")]
-use crate::component::ComponentStoreData;
-#[cfg(feature = "component-model")]
-use crate::component::concurrent;
 use crate::error::OutOfMemory;
 #[cfg(feature = "async")]
 use crate::fiber;
@@ -479,8 +475,6 @@ pub struct StoreOpaque {
 
     instances: wasmtime_environ::collections::PrimaryMap<InstanceId, StoreInstance>,
 
-    #[cfg(feature = "component-model")]
-    num_component_instances: usize,
     signal_handler: Option<SignalHandler>,
     modules: ModuleRegistry,
     func_refs: FuncRefs,
@@ -539,18 +533,6 @@ pub struct StoreOpaque {
     /// that the right memory pages can be enabled when entering WebAssembly
     /// guest code.
     pkey: Option<ProtectionKey>,
-
-    /// Runtime state for components used in the handling of resources, borrow,
-    /// and calls. These also interact with the `ResourceAny` type and its
-    /// internal representation.
-    #[cfg(feature = "component-model")]
-    component_host_table: vm::component::HandleTable,
-    #[cfg(feature = "component-model")]
-    component_calls: vm::component::CallContexts,
-    #[cfg(feature = "component-model")]
-    host_resource_data: crate::component::HostResourceData,
-    #[cfg(feature = "component-model")]
-    concurrent_state: Option<concurrent::ConcurrentState>,
 
     /// State related to the executor of wasm code.
     ///
@@ -735,7 +717,7 @@ impl<T> Store<T> {
 
     /// Like `Store::new` but returns an error on allocation failure.
     pub fn try_new(engine: &Engine, data: T) -> Result<Self> {
-        let store_data = StoreData::new();
+        let store_data = StoreData::new(engine);
         log::trace!("creating new store {:?}", store_data.id());
 
         let pkey = engine.allocator().next_available_pkey();
@@ -747,8 +729,6 @@ impl<T> Store<T> {
             #[cfg(feature = "stack-switching")]
             continuations: Vec::new(),
             instances: wasmtime_environ::collections::PrimaryMap::new(),
-            #[cfg(feature = "component-model")]
-            num_component_instances: 0,
             signal_handler: None,
             gc_store: None,
             gc_roots: RootSet::default(),
@@ -777,26 +757,7 @@ impl<T> Store<T> {
             hostcall_val_storage: Vec::new(),
             wasm_val_raw_storage: Vec::new(),
             pkey,
-            #[cfg(feature = "component-model")]
-            component_host_table: Default::default(),
-            #[cfg(feature = "component-model")]
-            component_calls: Default::default(),
-            #[cfg(feature = "component-model")]
-            host_resource_data: Default::default(),
             executor: Executor::new(engine)?,
-            #[cfg(feature = "component-model")]
-            concurrent_state: if engine.tunables().concurrency_support {
-                #[cfg(feature = "component-model-async")]
-                {
-                    Some(Default::default())
-                }
-                #[cfg(not(feature = "component-model-async"))]
-                {
-                    unreachable!()
-                }
-            } else {
-                None
-            },
             #[cfg(feature = "debug")]
             breakpoints: Default::default(),
         };
@@ -874,18 +835,7 @@ impl<T> Store<T> {
     }
 
     fn run_manual_drop_routines(&mut self) {
-        // We need to drop the fibers of each component instance before
-        // attempting to drop the instances themselves since the fibers may need
-        // to be resumed and allowed to exit cleanly before we yank the state
-        // out from under them.
-        //
-        // This will also drop any futures which might use a `&Accessor` fields
-        // in their `Drop::drop` implementations, in which case they'll need to
-        // be called from with in the context of a `tls::set` closure.
-        #[cfg(feature = "component-model-async")]
-        if self.inner.concurrent_state.is_some() {
-            ComponentStoreData::drop_fibers_and_futures(&mut **self.inner);
-        }
+        StoreData::run_manual_drop_routines(StoreContextMut(&mut self.inner));
 
         // Ensure all fiber stacks, even cached ones, are all flushed out to the
         // instance allocator.
@@ -1711,16 +1661,9 @@ impl StoreOpaque {
         &self.modules
     }
 
-    pub(crate) fn register_module(&mut self, module: &Module) -> Result<RegisteredModuleId> {
-        self.modules.register_module(module, &self.engine)
-    }
-
-    #[cfg(feature = "component-model")]
-    pub(crate) fn register_component(
-        &mut self,
-        component: &crate::component::Component,
-    ) -> Result<()> {
-        self.modules.register_component(component, &self.engine)
+    #[inline]
+    pub(crate) fn modules_and_engine_mut(&mut self) -> (&mut ModuleRegistry, &Engine) {
+        (&mut self.modules, &self.engine)
     }
 
     pub(crate) fn func_refs_and_modules(&mut self) -> (&mut FuncRefs, &ModuleRegistry) {
@@ -2548,102 +2491,9 @@ at https://bytecodealliance.org/security.
         self.pkey
     }
 
-    #[inline]
-    #[cfg(feature = "component-model-async")]
-    pub(crate) fn component_resource_state(
-        &mut self,
-    ) -> (
-        &mut vm::component::CallContexts,
-        &mut vm::component::HandleTable,
-        &mut crate::component::HostResourceData,
-    ) {
-        (
-            &mut self.component_calls,
-            &mut self.component_host_table,
-            &mut self.host_resource_data,
-        )
-    }
-
-    #[cfg(feature = "component-model")]
-    pub(crate) fn push_component_instance(&mut self, instance: crate::component::Instance) {
-        // We don't actually need the instance itself right now, but it seems
-        // like something we will almost certainly eventually want to keep
-        // around, so force callers to provide it.
-        let _ = instance;
-
-        self.num_component_instances += 1;
-    }
-
-    #[cfg(feature = "component-model")]
-    pub(crate) fn component_resource_state_with_instance_and_concurrent_state(
-        &mut self,
-        instance: crate::component::Instance,
-    ) -> (
-        &mut vm::component::CallContexts,
-        &mut vm::component::HandleTable,
-        &mut crate::component::HostResourceData,
-        Pin<&mut vm::component::ComponentInstance>,
-        Option<&mut concurrent::ConcurrentState>,
-    ) {
-        (
-            &mut self.component_calls,
-            &mut self.component_host_table,
-            &mut self.host_resource_data,
-            instance.id().from_data_get_mut(&mut self.store_data),
-            self.concurrent_state.as_mut(),
-        )
-    }
-
-    #[cfg(feature = "component-model")]
-    pub(crate) fn component_resource_tables(
-        &mut self,
-        instance: Option<crate::component::Instance>,
-    ) -> vm::component::ResourceTables<'_> {
-        self.component_resource_tables_and_host_resource_data(instance)
-            .0
-    }
-
-    #[cfg(feature = "component-model")]
-    pub(crate) fn component_resource_tables_and_host_resource_data(
-        &mut self,
-        instance: Option<crate::component::Instance>,
-    ) -> (
-        vm::component::ResourceTables<'_>,
-        &mut crate::component::HostResourceData,
-    ) {
-        let guest = instance.map(|i| {
-            i.id()
-                .from_data_get_mut(&mut self.store_data)
-                .instance_states()
-        });
-
-        (
-            vm::component::ResourceTables {
-                host_table: Some(&mut self.component_host_table),
-                calls: &mut self.component_calls,
-                guest,
-            },
-            &mut self.host_resource_data,
-        )
-    }
-
     #[cfg(feature = "async")]
     pub(crate) fn fiber_async_state_mut(&mut self) -> &mut fiber::AsyncState {
         &mut self.async_state
-    }
-
-    #[cfg(feature = "component-model-async")]
-    pub(crate) fn concurrent_state_mut(&mut self) -> &mut concurrent::ConcurrentState {
-        debug_assert!(self.concurrency_support());
-        self.concurrent_state.as_mut().unwrap()
-    }
-
-    #[inline]
-    #[cfg(feature = "component-model")]
-    pub(crate) fn concurrency_support(&self) -> bool {
-        let support = self.concurrent_state.is_some();
-        debug_assert_eq!(support, self.engine().tunables().concurrency_support);
-        support
     }
 
     #[cfg(feature = "async")]
@@ -2889,6 +2739,11 @@ unsafe impl<T> VMStore for StoreInner<T> {
         self
     }
 
+    #[cfg(feature = "component-model")]
+    fn component_calls(&mut self) -> &mut vm::component::CallContexts {
+        self.component_call_contexts_mut()
+    }
+
     fn store_opaque(&self) -> &StoreOpaque {
         &self.inner
     }
@@ -2924,11 +2779,6 @@ unsafe impl<T> VMStore for StoreInner<T> {
         // Put back the original behavior which was replaced by `take`.
         self.epoch_deadline_behavior = behavior;
         update
-    }
-
-    #[cfg(feature = "component-model")]
-    fn component_calls(&mut self) -> &mut vm::component::CallContexts {
-        &mut self.component_calls
     }
 
     #[cfg(feature = "debug")]
@@ -3019,12 +2869,7 @@ impl Drop for StoreOpaque {
                 allocator.deallocate_module(&mut instance.handle);
             }
 
-            #[cfg(feature = "component-model")]
-            {
-                for _ in 0..self.num_component_instances {
-                    allocator.decrement_component_instance_count();
-                }
-            }
+            self.store_data.decrement_allocator_resources(allocator);
         }
     }
 }


### PR DESCRIPTION
Instead of having `#[cfg]` within `store.rs` move it all to
`component/store.rs` to cut down on `#[cfg]`. It's a bit awkward in some
places trying to borrow a bunch of fields at once, but it's not the end
of the world.

Depends on https://github.com/bytecodealliance/wasmtime/pull/12546