### PR TITLE
Use low-level ELF-parsing APIs in `CodeMemory::new`

### DIFF
--- a/crates/wasmtime/src/runtime/code_memory.rs
+++ b/crates/wasmtime/src/runtime/code_memory.rs
@@ -218,12 +218,7 @@ impl CodeMemory {
 
                 // These sections are expected, but we do not need to retain any
                 // info about them.
-                ""
-                | ".symtab"
-                | ".strtab"
-                | ".shstrtab"
-                | ".xdata"
-                | obj::ELF_WASM_ENGINE => {
+                "" | ".symtab" | ".strtab" | ".shstrtab" | ".xdata" | obj::ELF_WASM_ENGINE => {
                     log::debug!("ignoring section {name:?}")
                 }
                 _ if name.starts_with(".debug_") || name.starts_with(".rela.debug_") => {


### PR DESCRIPTION
These avoid allocations and should generally be faster because they avoid unnecessary work.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
