### PR TITLE
Add some small niceties to our OOM-handling `String`

### DIFF
--- a/crates/core/src/alloc/string.rs
+++ b/crates/core/src/alloc/string.rs
@@ -7,7 +7,7 @@ use std_alloc::{alloc::Layout, boxed::Box, string as inner};
 
 /// A newtype wrapper around [`std::string::String`] that only exposes
 /// fallible-allocation methods.
-#[derive(Default)]
+#[derive(Default, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct String {
     inner: inner::String,
 }
@@ -77,6 +77,12 @@ impl String {
     #[inline]
     pub fn capacity(&self) -> usize {
         self.inner.capacity()
+    }
+
+    /// Same as [`std::string::String::as_str`].
+    #[inline]
+    pub const fn as_str(&self) -> &str {
+        self.inner.as_str()
     }
 
     /// Same as [`std::string::String::reserve`] but returns an error on


### PR DESCRIPTION
Derive some traits and expose the `as_str` method.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
