### PR TITLE
Fix the hello-stdout-post-return-test

### DIFF
--- a/crates/test-programs/src/bin/p3_cli_hello_stdout_post_return.rs
+++ b/crates/test-programs/src/bin/p3_cli_hello_stdout_post_return.rs
@@ -7,23 +7,19 @@ export!(Component);
 impl exports::wasi::cli::run::Guest for Component {
     async fn run() -> Result<(), ()> {
         let (mut tx, rx) = wit_stream::new();
-        futures::join!(
-            async {
-                wasi::cli::stdout::write_via_stream(rx).await.unwrap();
-            },
-            async {
-                tx.write_all(b"hello, world\n".to_vec()).await;
-                wit_bindgen::spawn(async move {
-                    // Yield a few times to allow the host to accept and process
-                    // the `run` result.
-                    for _ in 0..10 {
-                        wit_bindgen::yield_async().await;
-                    }
-                    tx.write_all(b"hello again, after return\n".to_vec()).await;
-                    drop(tx);
-                });
-            },
-        );
+        wit_bindgen::spawn(async move {
+            wasi::cli::stdout::write_via_stream(rx).await.unwrap();
+        });
+        tx.write_all(b"hello, world\n".to_vec()).await;
+        wit_bindgen::spawn(async move {
+            // Yield a few times to allow the host to accept and process
+            // the `run` result.
+            for _ in 0..10 {
+                wit_bindgen::yield_async().await;
+            }
+            tx.write_all(b"hello again, after return\n".to_vec()).await;
+            drop(tx);
+        });
         Ok(())
     }
 }


### PR DESCRIPTION
This fixes a mistake in the test added in #12185 where the test passes both with and without the changes in that commit due to the way it was structured. Restructuring the test, notably not waiting for `write_via_stream` to return, means that it's now accurately testing that the `TaskExit` value is used.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
