### PR TITLE
Remove subtask reparenting

### DIFF
--- a/crates/component-macro/src/bindgen.rs
+++ b/crates/component-macro/src/bindgen.rs
@@ -265,7 +265,6 @@ mod kw {
     syn::custom_keyword!(trappable);
     syn::custom_keyword!(ignore_wit);
     syn::custom_keyword!(exact);
-    syn::custom_keyword!(task_exit);
 }
 
 enum Opt {
@@ -540,9 +539,6 @@ fn parse_function_config(input: ParseStream<'_>) -> Result<FunctionConfig> {
                 } else if l.peek(kw::exact) {
                     input.parse::<kw::exact>()?;
                     flags |= FunctionFlags::EXACT;
-                } else if l.peek(kw::task_exit) {
-                    input.parse::<kw::task_exit>()?;
-                    flags |= FunctionFlags::TASK_EXIT;
                 } else {
                     return Err(l.error());
                 }

--- a/crates/component-macro/tests/expanded/char_concurrent.rs
+++ b/crates/component-macro/tests/expanded/char_concurrent.rs
@@ -330,7 +330,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.take_char)
                         };
-                        let ((), _) = callee.call_concurrent(accessor, (arg0,)).await?;
+                        let () = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
                     }
                     /// A function that returns a character
@@ -348,7 +348,7 @@ pub mod exports {
                                 (char,),
                             >::new_unchecked(self.return_char)
                         };
-                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                 }

--- a/crates/component-macro/tests/expanded/conventions_concurrent.rs
+++ b/crates/component-macro/tests/expanded/conventions_concurrent.rs
@@ -635,7 +635,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.kebab_case)
                         };
-                        let ((), _) = callee.call_concurrent(accessor, ()).await?;
+                        let () = callee.call_concurrent(accessor, ()).await?;
                         Ok(())
                     }
                     pub async fn call_foo<_T, _D>(
@@ -653,7 +653,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.foo)
                         };
-                        let ((), _) = callee.call_concurrent(accessor, (arg0,)).await?;
+                        let () = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
                     }
                     pub async fn call_function_with_dashes<_T, _D>(
@@ -670,7 +670,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.function_with_dashes)
                         };
-                        let ((), _) = callee.call_concurrent(accessor, ()).await?;
+                        let () = callee.call_concurrent(accessor, ()).await?;
                         Ok(())
                     }
                     pub async fn call_function_with_no_weird_characters<_T, _D>(
@@ -687,7 +687,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.function_with_no_weird_characters)
                         };
-                        let ((), _) = callee.call_concurrent(accessor, ()).await?;
+                        let () = callee.call_concurrent(accessor, ()).await?;
                         Ok(())
                     }
                     pub async fn call_apple<_T, _D>(
@@ -704,7 +704,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.apple)
                         };
-                        let ((), _) = callee.call_concurrent(accessor, ()).await?;
+                        let () = callee.call_concurrent(accessor, ()).await?;
                         Ok(())
                     }
                     pub async fn call_apple_pear<_T, _D>(
@@ -721,7 +721,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.apple_pear)
                         };
-                        let ((), _) = callee.call_concurrent(accessor, ()).await?;
+                        let () = callee.call_concurrent(accessor, ()).await?;
                         Ok(())
                     }
                     pub async fn call_apple_pear_grape<_T, _D>(
@@ -738,7 +738,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.apple_pear_grape)
                         };
-                        let ((), _) = callee.call_concurrent(accessor, ()).await?;
+                        let () = callee.call_concurrent(accessor, ()).await?;
                         Ok(())
                     }
                     pub async fn call_a0<_T, _D>(
@@ -755,7 +755,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.a0)
                         };
-                        let ((), _) = callee.call_concurrent(accessor, ()).await?;
+                        let () = callee.call_concurrent(accessor, ()).await?;
                         Ok(())
                     }
                     /// Comment out identifiers that collide when mapped to snake_case, for now; see
@@ -777,7 +777,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.is_xml)
                         };
-                        let ((), _) = callee.call_concurrent(accessor, ()).await?;
+                        let () = callee.call_concurrent(accessor, ()).await?;
                         Ok(())
                     }
                     pub async fn call_explicit<_T, _D>(
@@ -794,7 +794,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.explicit)
                         };
-                        let ((), _) = callee.call_concurrent(accessor, ()).await?;
+                        let () = callee.call_concurrent(accessor, ()).await?;
                         Ok(())
                     }
                     pub async fn call_explicit_kebab<_T, _D>(
@@ -811,7 +811,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.explicit_kebab)
                         };
-                        let ((), _) = callee.call_concurrent(accessor, ()).await?;
+                        let () = callee.call_concurrent(accessor, ()).await?;
                         Ok(())
                     }
                     /// Identifiers with the same name as keywords are quoted.
@@ -829,7 +829,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.bool)
                         };
-                        let ((), _) = callee.call_concurrent(accessor, ()).await?;
+                        let () = callee.call_concurrent(accessor, ()).await?;
                         Ok(())
                     }
                 }

--- a/crates/component-macro/tests/expanded/flags_concurrent.rs
+++ b/crates/component-macro/tests/expanded/flags_concurrent.rs
@@ -729,9 +729,7 @@ pub mod exports {
                                 (Flag1,),
                             >::new_unchecked(self.roundtrip_flag1)
                         };
-                        let ((ret0,), _) = callee
-                            .call_concurrent(accessor, (arg0,))
-                            .await?;
+                        let (ret0,) = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(ret0)
                     }
                     pub async fn call_roundtrip_flag2<_T, _D>(
@@ -749,9 +747,7 @@ pub mod exports {
                                 (Flag2,),
                             >::new_unchecked(self.roundtrip_flag2)
                         };
-                        let ((ret0,), _) = callee
-                            .call_concurrent(accessor, (arg0,))
-                            .await?;
+                        let (ret0,) = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(ret0)
                     }
                     pub async fn call_roundtrip_flag4<_T, _D>(
@@ -769,9 +765,7 @@ pub mod exports {
                                 (Flag4,),
                             >::new_unchecked(self.roundtrip_flag4)
                         };
-                        let ((ret0,), _) = callee
-                            .call_concurrent(accessor, (arg0,))
-                            .await?;
+                        let (ret0,) = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(ret0)
                     }
                     pub async fn call_roundtrip_flag8<_T, _D>(
@@ -789,9 +783,7 @@ pub mod exports {
                                 (Flag8,),
                             >::new_unchecked(self.roundtrip_flag8)
                         };
-                        let ((ret0,), _) = callee
-                            .call_concurrent(accessor, (arg0,))
-                            .await?;
+                        let (ret0,) = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(ret0)
                     }
                     pub async fn call_roundtrip_flag16<_T, _D>(
@@ -809,9 +801,7 @@ pub mod exports {
                                 (Flag16,),
                             >::new_unchecked(self.roundtrip_flag16)
                         };
-                        let ((ret0,), _) = callee
-                            .call_concurrent(accessor, (arg0,))
-                            .await?;
+                        let (ret0,) = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(ret0)
                     }
                     pub async fn call_roundtrip_flag32<_T, _D>(
@@ -829,9 +819,7 @@ pub mod exports {
                                 (Flag32,),
                             >::new_unchecked(self.roundtrip_flag32)
                         };
-                        let ((ret0,), _) = callee
-                            .call_concurrent(accessor, (arg0,))
-                            .await?;
+                        let (ret0,) = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(ret0)
                     }
                     pub async fn call_roundtrip_flag64<_T, _D>(
@@ -849,9 +837,7 @@ pub mod exports {
                                 (Flag64,),
                             >::new_unchecked(self.roundtrip_flag64)
                         };
-                        let ((ret0,), _) = callee
-                            .call_concurrent(accessor, (arg0,))
-                            .await?;
+                        let (ret0,) = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(ret0)
                     }
                 }

--- a/crates/component-macro/tests/expanded/floats_concurrent.rs
+++ b/crates/component-macro/tests/expanded/floats_concurrent.rs
@@ -372,7 +372,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.f32_param)
                         };
-                        let ((), _) = callee.call_concurrent(accessor, (arg0,)).await?;
+                        let () = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
                     }
                     pub async fn call_f64_param<_T, _D>(
@@ -390,7 +390,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.f64_param)
                         };
-                        let ((), _) = callee.call_concurrent(accessor, (arg0,)).await?;
+                        let () = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
                     }
                     pub async fn call_f32_result<_T, _D>(
@@ -407,7 +407,7 @@ pub mod exports {
                                 (f32,),
                             >::new_unchecked(self.f32_result)
                         };
-                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_f64_result<_T, _D>(
@@ -424,7 +424,7 @@ pub mod exports {
                                 (f64,),
                             >::new_unchecked(self.f64_result)
                         };
-                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                 }

--- a/crates/component-macro/tests/expanded/function-new_concurrent.rs
+++ b/crates/component-macro/tests/expanded/function-new_concurrent.rs
@@ -191,7 +191,7 @@ const _: () = {
             let callee = unsafe {
                 wasmtime::component::TypedFunc::<(), ()>::new_unchecked(self.new)
             };
-            let ((), _) = callee.call_concurrent(accessor, ()).await?;
+            let () = callee.call_concurrent(accessor, ()).await?;
             Ok(())
         }
     }

--- a/crates/component-macro/tests/expanded/integers_concurrent.rs
+++ b/crates/component-macro/tests/expanded/integers_concurrent.rs
@@ -709,7 +709,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.a1)
                         };
-                        let ((), _) = callee.call_concurrent(accessor, (arg0,)).await?;
+                        let () = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
                     }
                     pub async fn call_a2<_T, _D>(
@@ -727,7 +727,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.a2)
                         };
-                        let ((), _) = callee.call_concurrent(accessor, (arg0,)).await?;
+                        let () = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
                     }
                     pub async fn call_a3<_T, _D>(
@@ -745,7 +745,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.a3)
                         };
-                        let ((), _) = callee.call_concurrent(accessor, (arg0,)).await?;
+                        let () = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
                     }
                     pub async fn call_a4<_T, _D>(
@@ -763,7 +763,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.a4)
                         };
-                        let ((), _) = callee.call_concurrent(accessor, (arg0,)).await?;
+                        let () = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
                     }
                     pub async fn call_a5<_T, _D>(
@@ -781,7 +781,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.a5)
                         };
-                        let ((), _) = callee.call_concurrent(accessor, (arg0,)).await?;
+                        let () = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
                     }
                     pub async fn call_a6<_T, _D>(
@@ -799,7 +799,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.a6)
                         };
-                        let ((), _) = callee.call_concurrent(accessor, (arg0,)).await?;
+                        let () = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
                     }
                     pub async fn call_a7<_T, _D>(
@@ -817,7 +817,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.a7)
                         };
-                        let ((), _) = callee.call_concurrent(accessor, (arg0,)).await?;
+                        let () = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
                     }
                     pub async fn call_a8<_T, _D>(
@@ -835,7 +835,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.a8)
                         };
-                        let ((), _) = callee.call_concurrent(accessor, (arg0,)).await?;
+                        let () = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
                     }
                     pub async fn call_a9<_T, _D>(
@@ -860,7 +860,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.a9)
                         };
-                        let ((), _) = callee
+                        let () = callee
                             .call_concurrent(
                                 accessor,
                                 (arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7),
@@ -882,7 +882,7 @@ pub mod exports {
                                 (u8,),
                             >::new_unchecked(self.r1)
                         };
-                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_r2<_T, _D>(
@@ -899,7 +899,7 @@ pub mod exports {
                                 (i8,),
                             >::new_unchecked(self.r2)
                         };
-                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_r3<_T, _D>(
@@ -916,7 +916,7 @@ pub mod exports {
                                 (u16,),
                             >::new_unchecked(self.r3)
                         };
-                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_r4<_T, _D>(
@@ -933,7 +933,7 @@ pub mod exports {
                                 (i16,),
                             >::new_unchecked(self.r4)
                         };
-                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_r5<_T, _D>(
@@ -950,7 +950,7 @@ pub mod exports {
                                 (u32,),
                             >::new_unchecked(self.r5)
                         };
-                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_r6<_T, _D>(
@@ -967,7 +967,7 @@ pub mod exports {
                                 (i32,),
                             >::new_unchecked(self.r6)
                         };
-                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_r7<_T, _D>(
@@ -984,7 +984,7 @@ pub mod exports {
                                 (u64,),
                             >::new_unchecked(self.r7)
                         };
-                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_r8<_T, _D>(
@@ -1001,7 +1001,7 @@ pub mod exports {
                                 (i64,),
                             >::new_unchecked(self.r8)
                         };
-                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_pair_ret<_T, _D>(
@@ -1018,7 +1018,7 @@ pub mod exports {
                                 ((i64, u8),),
                             >::new_unchecked(self.pair_ret)
                         };
-                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                 }

--- a/crates/component-macro/tests/expanded/lists_concurrent.rs
+++ b/crates/component-macro/tests/expanded/lists_concurrent.rs
@@ -1525,7 +1525,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.list_u8_param)
                         };
-                        let ((), _) = callee.call_concurrent(accessor, (arg0,)).await?;
+                        let () = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
                     }
                     pub async fn call_list_u16_param<_T, _D>(
@@ -1543,7 +1543,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.list_u16_param)
                         };
-                        let ((), _) = callee.call_concurrent(accessor, (arg0,)).await?;
+                        let () = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
                     }
                     pub async fn call_list_u32_param<_T, _D>(
@@ -1561,7 +1561,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.list_u32_param)
                         };
-                        let ((), _) = callee.call_concurrent(accessor, (arg0,)).await?;
+                        let () = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
                     }
                     pub async fn call_list_u64_param<_T, _D>(
@@ -1579,7 +1579,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.list_u64_param)
                         };
-                        let ((), _) = callee.call_concurrent(accessor, (arg0,)).await?;
+                        let () = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
                     }
                     pub async fn call_list_s8_param<_T, _D>(
@@ -1597,7 +1597,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.list_s8_param)
                         };
-                        let ((), _) = callee.call_concurrent(accessor, (arg0,)).await?;
+                        let () = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
                     }
                     pub async fn call_list_s16_param<_T, _D>(
@@ -1615,7 +1615,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.list_s16_param)
                         };
-                        let ((), _) = callee.call_concurrent(accessor, (arg0,)).await?;
+                        let () = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
                     }
                     pub async fn call_list_s32_param<_T, _D>(
@@ -1633,7 +1633,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.list_s32_param)
                         };
-                        let ((), _) = callee.call_concurrent(accessor, (arg0,)).await?;
+                        let () = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
                     }
                     pub async fn call_list_s64_param<_T, _D>(
@@ -1651,7 +1651,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.list_s64_param)
                         };
-                        let ((), _) = callee.call_concurrent(accessor, (arg0,)).await?;
+                        let () = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
                     }
                     pub async fn call_list_f32_param<_T, _D>(
@@ -1669,7 +1669,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.list_f32_param)
                         };
-                        let ((), _) = callee.call_concurrent(accessor, (arg0,)).await?;
+                        let () = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
                     }
                     pub async fn call_list_f64_param<_T, _D>(
@@ -1687,7 +1687,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.list_f64_param)
                         };
-                        let ((), _) = callee.call_concurrent(accessor, (arg0,)).await?;
+                        let () = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
                     }
                     pub async fn call_list_u8_ret<_T, _D>(
@@ -1704,7 +1704,7 @@ pub mod exports {
                                 (wasmtime::component::__internal::Vec<u8>,),
                             >::new_unchecked(self.list_u8_ret)
                         };
-                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_list_u16_ret<_T, _D>(
@@ -1721,7 +1721,7 @@ pub mod exports {
                                 (wasmtime::component::__internal::Vec<u16>,),
                             >::new_unchecked(self.list_u16_ret)
                         };
-                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_list_u32_ret<_T, _D>(
@@ -1738,7 +1738,7 @@ pub mod exports {
                                 (wasmtime::component::__internal::Vec<u32>,),
                             >::new_unchecked(self.list_u32_ret)
                         };
-                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_list_u64_ret<_T, _D>(
@@ -1755,7 +1755,7 @@ pub mod exports {
                                 (wasmtime::component::__internal::Vec<u64>,),
                             >::new_unchecked(self.list_u64_ret)
                         };
-                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_list_s8_ret<_T, _D>(
@@ -1772,7 +1772,7 @@ pub mod exports {
                                 (wasmtime::component::__internal::Vec<i8>,),
                             >::new_unchecked(self.list_s8_ret)
                         };
-                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_list_s16_ret<_T, _D>(
@@ -1789,7 +1789,7 @@ pub mod exports {
                                 (wasmtime::component::__internal::Vec<i16>,),
                             >::new_unchecked(self.list_s16_ret)
                         };
-                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_list_s32_ret<_T, _D>(
@@ -1806,7 +1806,7 @@ pub mod exports {
                                 (wasmtime::component::__internal::Vec<i32>,),
                             >::new_unchecked(self.list_s32_ret)
                         };
-                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_list_s64_ret<_T, _D>(
@@ -1823,7 +1823,7 @@ pub mod exports {
                                 (wasmtime::component::__internal::Vec<i64>,),
                             >::new_unchecked(self.list_s64_ret)
                         };
-                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_list_f32_ret<_T, _D>(
@@ -1840,7 +1840,7 @@ pub mod exports {
                                 (wasmtime::component::__internal::Vec<f32>,),
                             >::new_unchecked(self.list_f32_ret)
                         };
-                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_list_f64_ret<_T, _D>(
@@ -1857,7 +1857,7 @@ pub mod exports {
                                 (wasmtime::component::__internal::Vec<f64>,),
                             >::new_unchecked(self.list_f64_ret)
                         };
-                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_tuple_list<_T, _D>(
@@ -1877,9 +1877,7 @@ pub mod exports {
                                 (wasmtime::component::__internal::Vec<(i64, u32)>,),
                             >::new_unchecked(self.tuple_list)
                         };
-                        let ((ret0,), _) = callee
-                            .call_concurrent(accessor, (arg0,))
-                            .await?;
+                        let (ret0,) = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(ret0)
                     }
                     pub async fn call_string_list_arg<_T, _D>(
@@ -1903,7 +1901,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.string_list_arg)
                         };
-                        let ((), _) = callee.call_concurrent(accessor, (arg0,)).await?;
+                        let () = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
                     }
                     pub async fn call_string_list_ret<_T, _D>(
@@ -1928,7 +1926,7 @@ pub mod exports {
                                 ),
                             >::new_unchecked(self.string_list_ret)
                         };
-                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_tuple_string_list<_T, _D>(
@@ -1960,9 +1958,7 @@ pub mod exports {
                                 ),
                             >::new_unchecked(self.tuple_string_list)
                         };
-                        let ((ret0,), _) = callee
-                            .call_concurrent(accessor, (arg0,))
-                            .await?;
+                        let (ret0,) = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(ret0)
                     }
                     pub async fn call_string_list<_T, _D>(
@@ -1994,9 +1990,7 @@ pub mod exports {
                                 ),
                             >::new_unchecked(self.string_list)
                         };
-                        let ((ret0,), _) = callee
-                            .call_concurrent(accessor, (arg0,))
-                            .await?;
+                        let (ret0,) = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(ret0)
                     }
                     pub async fn call_record_list<_T, _D>(
@@ -2016,9 +2010,7 @@ pub mod exports {
                                 (wasmtime::component::__internal::Vec<OtherRecord>,),
                             >::new_unchecked(self.record_list)
                         };
-                        let ((ret0,), _) = callee
-                            .call_concurrent(accessor, (arg0,))
-                            .await?;
+                        let (ret0,) = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(ret0)
                     }
                     pub async fn call_record_list_reverse<_T, _D>(
@@ -2038,9 +2030,7 @@ pub mod exports {
                                 (wasmtime::component::__internal::Vec<SomeRecord>,),
                             >::new_unchecked(self.record_list_reverse)
                         };
-                        let ((ret0,), _) = callee
-                            .call_concurrent(accessor, (arg0,))
-                            .await?;
+                        let (ret0,) = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(ret0)
                     }
                     pub async fn call_variant_list<_T, _D>(
@@ -2060,9 +2050,7 @@ pub mod exports {
                                 (wasmtime::component::__internal::Vec<OtherVariant>,),
                             >::new_unchecked(self.variant_list)
                         };
-                        let ((ret0,), _) = callee
-                            .call_concurrent(accessor, (arg0,))
-                            .await?;
+                        let (ret0,) = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(ret0)
                     }
                     pub async fn call_load_store_everything<_T, _D>(
@@ -2080,9 +2068,7 @@ pub mod exports {
                                 (LoadStoreAllSizes,),
                             >::new_unchecked(self.load_store_everything)
                         };
-                        let ((ret0,), _) = callee
-                            .call_concurrent(accessor, (arg0,))
-                            .await?;
+                        let (ret0,) = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(ret0)
                     }
                 }

--- a/crates/component-macro/tests/expanded/many-arguments_concurrent.rs
+++ b/crates/component-macro/tests/expanded/many-arguments_concurrent.rs
@@ -622,7 +622,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.many_args)
                         };
-                        let ((), _) = callee
+                        let () = callee
                             .call_concurrent(
                                 accessor,
                                 (
@@ -662,7 +662,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.big_argument)
                         };
-                        let ((), _) = callee.call_concurrent(accessor, (arg0,)).await?;
+                        let () = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
                     }
                 }

--- a/crates/component-macro/tests/expanded/multiversion_concurrent.rs
+++ b/crates/component-macro/tests/expanded/multiversion_concurrent.rs
@@ -347,7 +347,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.x)
                         };
-                        let ((), _) = callee.call_concurrent(accessor, ()).await?;
+                        let () = callee.call_concurrent(accessor, ()).await?;
                         Ok(())
                     }
                 }
@@ -430,7 +430,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.x)
                         };
-                        let ((), _) = callee.call_concurrent(accessor, ()).await?;
+                        let () = callee.call_concurrent(accessor, ()).await?;
                         Ok(())
                     }
                 }

--- a/crates/component-macro/tests/expanded/records_concurrent.rs
+++ b/crates/component-macro/tests/expanded/records_concurrent.rs
@@ -996,7 +996,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.tuple_arg)
                         };
-                        let ((), _) = callee.call_concurrent(accessor, (arg0,)).await?;
+                        let () = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
                     }
                     pub async fn call_tuple_result<_T, _D>(
@@ -1013,7 +1013,7 @@ pub mod exports {
                                 ((char, u32),),
                             >::new_unchecked(self.tuple_result)
                         };
-                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_empty_arg<_T, _D>(
@@ -1031,7 +1031,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.empty_arg)
                         };
-                        let ((), _) = callee.call_concurrent(accessor, (arg0,)).await?;
+                        let () = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
                     }
                     pub async fn call_empty_result<_T, _D>(
@@ -1048,7 +1048,7 @@ pub mod exports {
                                 (Empty,),
                             >::new_unchecked(self.empty_result)
                         };
-                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_scalar_arg<_T, _D>(
@@ -1066,7 +1066,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.scalar_arg)
                         };
-                        let ((), _) = callee.call_concurrent(accessor, (arg0,)).await?;
+                        let () = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
                     }
                     pub async fn call_scalar_result<_T, _D>(
@@ -1083,7 +1083,7 @@ pub mod exports {
                                 (Scalars,),
                             >::new_unchecked(self.scalar_result)
                         };
-                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_flags_arg<_T, _D>(
@@ -1101,7 +1101,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.flags_arg)
                         };
-                        let ((), _) = callee.call_concurrent(accessor, (arg0,)).await?;
+                        let () = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
                     }
                     pub async fn call_flags_result<_T, _D>(
@@ -1118,7 +1118,7 @@ pub mod exports {
                                 (ReallyFlags,),
                             >::new_unchecked(self.flags_result)
                         };
-                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_aggregate_arg<_T, _D>(
@@ -1136,7 +1136,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.aggregate_arg)
                         };
-                        let ((), _) = callee.call_concurrent(accessor, (arg0,)).await?;
+                        let () = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
                     }
                     pub async fn call_aggregate_result<_T, _D>(
@@ -1153,7 +1153,7 @@ pub mod exports {
                                 (Aggregates,),
                             >::new_unchecked(self.aggregate_result)
                         };
-                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_typedef_inout<_T, _D>(
@@ -1171,9 +1171,7 @@ pub mod exports {
                                 (i32,),
                             >::new_unchecked(self.typedef_inout)
                         };
-                        let ((ret0,), _) = callee
-                            .call_concurrent(accessor, (arg0,))
-                            .await?;
+                        let (ret0,) = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(ret0)
                     }
                 }

--- a/crates/component-macro/tests/expanded/resources-export_concurrent.rs
+++ b/crates/component-macro/tests/expanded/resources-export_concurrent.rs
@@ -398,7 +398,7 @@ pub mod exports {
                                 (wasmtime::component::ResourceAny,),
                             >::new_unchecked(self.funcs.constructor_a_constructor)
                         };
-                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_static_a<_T, _D>(
@@ -415,7 +415,7 @@ pub mod exports {
                                 (u32,),
                             >::new_unchecked(self.funcs.static_a_static_a)
                         };
-                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_method_a<_T, _D>(
@@ -433,9 +433,7 @@ pub mod exports {
                                 (u32,),
                             >::new_unchecked(self.funcs.method_a_method_a)
                         };
-                        let ((ret0,), _) = callee
-                            .call_concurrent(accessor, (arg0,))
-                            .await?;
+                        let (ret0,) = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(ret0)
                     }
                 }
@@ -559,9 +557,7 @@ pub mod exports {
                                 (wasmtime::component::ResourceAny,),
                             >::new_unchecked(self.funcs.constructor_a_constructor)
                         };
-                        let ((ret0,), _) = callee
-                            .call_concurrent(accessor, (arg0,))
-                            .await?;
+                        let (ret0,) = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(ret0)
                     }
                     pub async fn call_static_a<_T, _D>(
@@ -578,7 +574,7 @@ pub mod exports {
                                 (wasmtime::component::Resource<Y>,),
                             >::new_unchecked(self.funcs.static_a_static_a)
                         };
-                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_method_a<_T, _D>(
@@ -600,7 +596,7 @@ pub mod exports {
                                 (wasmtime::component::Resource<Y>,),
                             >::new_unchecked(self.funcs.method_a_method_a)
                         };
-                        let ((ret0,), _) = callee
+                        let (ret0,) = callee
                             .call_concurrent(accessor, (arg0, arg1))
                             .await?;
                         Ok(ret0)
@@ -697,7 +693,7 @@ pub mod exports {
                                 (wasmtime::component::ResourceAny,),
                             >::new_unchecked(self.funcs.constructor_a_constructor)
                         };
-                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                 }
@@ -794,9 +790,7 @@ pub mod exports {
                                 (wasmtime::component::ResourceAny,),
                             >::new_unchecked(self.funcs.constructor_b_constructor)
                         };
-                        let ((ret0,), _) = callee
-                            .call_concurrent(accessor, (arg0,))
-                            .await?;
+                        let (ret0,) = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(ret0)
                     }
                 }

--- a/crates/component-macro/tests/expanded/resources-import_concurrent.rs
+++ b/crates/component-macro/tests/expanded/resources-import_concurrent.rs
@@ -367,7 +367,7 @@ const _: () = {
                     (wasmtime::component::Resource<WorldResource>,),
                 >::new_unchecked(self.some_world_func2)
             };
-            let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
+            let (ret0,) = callee.call_concurrent(accessor, ()).await?;
             Ok(ret0)
         }
         pub fn foo_foo_uses_resource_transitively(
@@ -1181,7 +1181,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.handle)
                         };
-                        let ((), _) = callee.call_concurrent(accessor, (arg0,)).await?;
+                        let () = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
                     }
                 }

--- a/crates/component-macro/tests/expanded/share-types_concurrent.rs
+++ b/crates/component-macro/tests/expanded/share-types_concurrent.rs
@@ -386,7 +386,7 @@ pub mod exports {
                         (Response,),
                     >::new_unchecked(self.handle_request)
                 };
-                let ((ret0,), _) = callee.call_concurrent(accessor, (arg0,)).await?;
+                let (ret0,) = callee.call_concurrent(accessor, (arg0,)).await?;
                 Ok(ret0)
             }
         }

--- a/crates/component-macro/tests/expanded/simple-functions_concurrent.rs
+++ b/crates/component-macro/tests/expanded/simple-functions_concurrent.rs
@@ -420,7 +420,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.f1)
                         };
-                        let ((), _) = callee.call_concurrent(accessor, ()).await?;
+                        let () = callee.call_concurrent(accessor, ()).await?;
                         Ok(())
                     }
                     pub async fn call_f2<_T, _D>(
@@ -438,7 +438,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.f2)
                         };
-                        let ((), _) = callee.call_concurrent(accessor, (arg0,)).await?;
+                        let () = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
                     }
                     pub async fn call_f3<_T, _D>(
@@ -457,9 +457,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.f3)
                         };
-                        let ((), _) = callee
-                            .call_concurrent(accessor, (arg0, arg1))
-                            .await?;
+                        let () = callee.call_concurrent(accessor, (arg0, arg1)).await?;
                         Ok(())
                     }
                     pub async fn call_f4<_T, _D>(
@@ -476,7 +474,7 @@ pub mod exports {
                                 (u32,),
                             >::new_unchecked(self.f4)
                         };
-                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_f5<_T, _D>(
@@ -493,7 +491,7 @@ pub mod exports {
                                 ((u32, u32),),
                             >::new_unchecked(self.f5)
                         };
-                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_f6<_T, _D>(
@@ -513,7 +511,7 @@ pub mod exports {
                                 ((u32, u32, u32),),
                             >::new_unchecked(self.f6)
                         };
-                        let ((ret0,), _) = callee
+                        let (ret0,) = callee
                             .call_concurrent(accessor, (arg0, arg1, arg2))
                             .await?;
                         Ok(ret0)

--- a/crates/component-macro/tests/expanded/simple-lists_concurrent.rs
+++ b/crates/component-macro/tests/expanded/simple-lists_concurrent.rs
@@ -430,7 +430,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.simple_list1)
                         };
-                        let ((), _) = callee.call_concurrent(accessor, (arg0,)).await?;
+                        let () = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
                     }
                     pub async fn call_simple_list2<_T, _D>(
@@ -447,7 +447,7 @@ pub mod exports {
                                 (wasmtime::component::__internal::Vec<u32>,),
                             >::new_unchecked(self.simple_list2)
                         };
-                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_simple_list3<_T, _D>(
@@ -479,7 +479,7 @@ pub mod exports {
                                 ),
                             >::new_unchecked(self.simple_list3)
                         };
-                        let ((ret0,), _) = callee
+                        let (ret0,) = callee
                             .call_concurrent(accessor, (arg0, arg1))
                             .await?;
                         Ok(ret0)
@@ -513,9 +513,7 @@ pub mod exports {
                                 ),
                             >::new_unchecked(self.simple_list4)
                         };
-                        let ((ret0,), _) = callee
-                            .call_concurrent(accessor, (arg0,))
-                            .await?;
+                        let (ret0,) = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(ret0)
                     }
                 }

--- a/crates/component-macro/tests/expanded/small-anonymous_concurrent.rs
+++ b/crates/component-macro/tests/expanded/small-anonymous_concurrent.rs
@@ -420,7 +420,7 @@ pub mod exports {
                                 ),
                             >::new_unchecked(self.option_test)
                         };
-                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                 }

--- a/crates/component-macro/tests/expanded/smoke-default_concurrent.rs
+++ b/crates/component-macro/tests/expanded/smoke-default_concurrent.rs
@@ -191,7 +191,7 @@ const _: () = {
             let callee = unsafe {
                 wasmtime::component::TypedFunc::<(), ()>::new_unchecked(self.y)
             };
-            let ((), _) = callee.call_concurrent(accessor, ()).await?;
+            let () = callee.call_concurrent(accessor, ()).await?;
             Ok(())
         }
     }

--- a/crates/component-macro/tests/expanded/smoke-export_concurrent.rs
+++ b/crates/component-macro/tests/expanded/smoke-export_concurrent.rs
@@ -241,7 +241,7 @@ pub mod exports {
                 let callee = unsafe {
                     wasmtime::component::TypedFunc::<(), ()>::new_unchecked(self.y)
                 };
-                let ((), _) = callee.call_concurrent(accessor, ()).await?;
+                let () = callee.call_concurrent(accessor, ()).await?;
                 Ok(())
             }
         }

--- a/crates/component-macro/tests/expanded/strings_concurrent.rs
+++ b/crates/component-macro/tests/expanded/strings_concurrent.rs
@@ -366,7 +366,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.a)
                         };
-                        let ((), _) = callee.call_concurrent(accessor, (arg0,)).await?;
+                        let () = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
                     }
                     pub async fn call_b<_T, _D>(
@@ -383,7 +383,7 @@ pub mod exports {
                                 (wasmtime::component::__internal::String,),
                             >::new_unchecked(self.b)
                         };
-                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_c<_T, _D>(
@@ -405,7 +405,7 @@ pub mod exports {
                                 (wasmtime::component::__internal::String,),
                             >::new_unchecked(self.c)
                         };
-                        let ((ret0,), _) = callee
+                        let (ret0,) = callee
                             .call_concurrent(accessor, (arg0, arg1))
                             .await?;
                         Ok(ret0)

--- a/crates/component-macro/tests/expanded/variants_concurrent.rs
+++ b/crates/component-macro/tests/expanded/variants_concurrent.rs
@@ -1537,7 +1537,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.e1_arg)
                         };
-                        let ((), _) = callee.call_concurrent(accessor, (arg0,)).await?;
+                        let () = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
                     }
                     pub async fn call_e1_result<_T, _D>(
@@ -1554,7 +1554,7 @@ pub mod exports {
                                 (E1,),
                             >::new_unchecked(self.e1_result)
                         };
-                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_v1_arg<_T, _D>(
@@ -1572,7 +1572,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.v1_arg)
                         };
-                        let ((), _) = callee.call_concurrent(accessor, (arg0,)).await?;
+                        let () = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
                     }
                     pub async fn call_v1_result<_T, _D>(
@@ -1589,7 +1589,7 @@ pub mod exports {
                                 (V1,),
                             >::new_unchecked(self.v1_result)
                         };
-                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_bool_arg<_T, _D>(
@@ -1607,7 +1607,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.bool_arg)
                         };
-                        let ((), _) = callee.call_concurrent(accessor, (arg0,)).await?;
+                        let () = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
                     }
                     pub async fn call_bool_result<_T, _D>(
@@ -1624,7 +1624,7 @@ pub mod exports {
                                 (bool,),
                             >::new_unchecked(self.bool_result)
                         };
-                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_option_arg<_T, _D>(
@@ -1654,7 +1654,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.option_arg)
                         };
-                        let ((), _) = callee
+                        let () = callee
                             .call_concurrent(
                                 accessor,
                                 (arg0, arg1, arg2, arg3, arg4, arg5),
@@ -1694,7 +1694,7 @@ pub mod exports {
                                 ),
                             >::new_unchecked(self.option_result)
                         };
-                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_casts<_T, _D>(
@@ -1719,7 +1719,7 @@ pub mod exports {
                                 ((Casts1, Casts2, Casts3, Casts4, Casts5, Casts6),),
                             >::new_unchecked(self.casts)
                         };
-                        let ((ret0,), _) = callee
+                        let (ret0,) = callee
                             .call_concurrent(
                                 accessor,
                                 (arg0, arg1, arg2, arg3, arg4, arg5),
@@ -1760,7 +1760,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.result_arg)
                         };
-                        let ((), _) = callee
+                        let () = callee
                             .call_concurrent(
                                 accessor,
                                 (arg0, arg1, arg2, arg3, arg4, arg5),
@@ -1806,7 +1806,7 @@ pub mod exports {
                                 ),
                             >::new_unchecked(self.result_result)
                         };
-                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_return_result_sugar<_T, _D>(
@@ -1823,7 +1823,7 @@ pub mod exports {
                                 (Result<i32, MyErrno>,),
                             >::new_unchecked(self.return_result_sugar)
                         };
-                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_return_result_sugar2<_T, _D>(
@@ -1840,7 +1840,7 @@ pub mod exports {
                                 (Result<(), MyErrno>,),
                             >::new_unchecked(self.return_result_sugar2)
                         };
-                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_return_result_sugar3<_T, _D>(
@@ -1857,7 +1857,7 @@ pub mod exports {
                                 (Result<MyErrno, MyErrno>,),
                             >::new_unchecked(self.return_result_sugar3)
                         };
-                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_return_result_sugar4<_T, _D>(
@@ -1874,7 +1874,7 @@ pub mod exports {
                                 (Result<(i32, u32), MyErrno>,),
                             >::new_unchecked(self.return_result_sugar4)
                         };
-                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_return_option_sugar<_T, _D>(
@@ -1891,7 +1891,7 @@ pub mod exports {
                                 (Option<i32>,),
                             >::new_unchecked(self.return_option_sugar)
                         };
-                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_return_option_sugar2<_T, _D>(
@@ -1908,7 +1908,7 @@ pub mod exports {
                                 (Option<MyErrno>,),
                             >::new_unchecked(self.return_option_sugar2)
                         };
-                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_result_simple<_T, _D>(
@@ -1925,7 +1925,7 @@ pub mod exports {
                                 (Result<u32, i32>,),
                             >::new_unchecked(self.result_simple)
                         };
-                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                     pub async fn call_is_clone_arg<_T, _D>(
@@ -1943,7 +1943,7 @@ pub mod exports {
                                 (),
                             >::new_unchecked(self.is_clone_arg)
                         };
-                        let ((), _) = callee.call_concurrent(accessor, (arg0,)).await?;
+                        let () = callee.call_concurrent(accessor, (arg0,)).await?;
                         Ok(())
                     }
                     pub async fn call_is_clone_return<_T, _D>(
@@ -1960,7 +1960,7 @@ pub mod exports {
                                 (IsClone,),
                             >::new_unchecked(self.is_clone_return)
                         };
-                        let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
+                        let (ret0,) = callee.call_concurrent(accessor, ()).await?;
                         Ok(ret0)
                     }
                 }

--- a/crates/component-macro/tests/expanded/worlds-with-types_concurrent.rs
+++ b/crates/component-macro/tests/expanded/worlds-with-types_concurrent.rs
@@ -230,7 +230,7 @@ const _: () = {
             let callee = unsafe {
                 wasmtime::component::TypedFunc::<(), ((T, U, R),)>::new_unchecked(self.f)
             };
-            let ((ret0,), _) = callee.call_concurrent(accessor, ()).await?;
+            let (ret0,) = callee.call_concurrent(accessor, ()).await?;
             Ok(ret0)
         }
     }

--- a/crates/fuzzing/src/oracles/component_api.rs
+++ b/crates/fuzzing/src/oracles/component_api.rs
@@ -274,7 +274,7 @@ where
             log::trace!("passing in parameters {params:?}");
             let actual = if declarations.options.guest_caller_async {
                 store
-                    .run_concurrent(async |a| func.call_concurrent(a, params).await.unwrap().0)
+                    .run_concurrent(async |a| func.call_concurrent(a, params).await.unwrap())
                     .await
                     .unwrap()
             } else {

--- a/crates/misc/component-async-tests/tests/scenario/transmit.rs
+++ b/crates/misc/component-async-tests/tests/scenario/transmit.rs
@@ -327,7 +327,6 @@ mod readiness {
     wasmtime::component::bindgen!({
         path: "wit",
         world: "readiness-guest",
-        exports: { default: task_exit },
     });
 }
 
@@ -366,7 +365,7 @@ pub async fn async_readiness() -> Result<()> {
     );
     store
         .run_concurrent(async move |accessor| {
-            let ((rx, expected), task_exit) = readiness_guest
+            let (rx, expected) = readiness_guest
                 .local_local_readiness()
                 .call_start(accessor, rx, expected)
                 .await?;
@@ -380,8 +379,6 @@ pub async fn async_readiness() -> Result<()> {
                     },
                 )
             });
-
-            task_exit.block(accessor).await;
 
             Ok(())
         })
@@ -402,7 +399,7 @@ mod cancel {
     wasmtime::component::bindgen!({
         path: "wit",
         world: "cancel-host",
-        exports: { default: async | store | task_exit },
+        exports: { default: async | store },
     });
 }
 
@@ -488,11 +485,10 @@ async fn test_cancel(mode: Mode) -> Result<()> {
         cancel::CancelHost::instantiate_async(&mut store, &component, &linker).await?;
     store
         .run_concurrent(async move |accessor| {
-            let ((), task) = cancel_host
+            cancel_host
                 .local_local_cancel()
                 .call_run(accessor, mode, 100)
                 .await?;
-            task.block(accessor).await;
             Ok::<_, wasmtime::Error>(())
         })
         .await??;
@@ -890,7 +886,6 @@ mod synchronous_transmit {
     wasmtime::component::bindgen!({
         path: "wit",
         world: "synchronous-transmit-guest",
-        exports: { default: task_exit },
     });
 }
 
@@ -958,7 +953,7 @@ async fn test_synchronous_transmit(component: &str, procrastinate: bool) -> Resu
     };
     store
         .run_concurrent(async move |accessor| {
-            let ((stream, stream_expected, future, future_expected), task_exit) = guest
+            let (stream, stream_expected, future, future_expected) = guest
                 .local_local_synchronous_transmit()
                 .call_start(accessor, stream, stream_expected, future, future_expected)
                 .await?;
@@ -987,8 +982,6 @@ async fn test_synchronous_transmit(component: &str, procrastinate: bool) -> Resu
                     future.pipe(access, consumer);
                 }
             });
-
-            task_exit.block(accessor).await;
 
             Ok(())
         })

--- a/crates/wasi-http/src/p3/bindings.rs
+++ b/crates/wasi-http/src/p3/bindings.rs
@@ -15,7 +15,7 @@ mod generated {
             "wasi:http/types.[static]response.new": store | trappable | tracing,
             default: trappable | tracing,
         },
-        exports: { default: async | store | task_exit },
+        exports: { default: async | store },
         with: {
             "wasi:http/types.fields": with::Fields,
             "wasi:http/types.request": crate::p3::Request,

--- a/crates/wasi/src/p3/bindings.rs
+++ b/crates/wasi/src/p3/bindings.rs
@@ -93,7 +93,7 @@ mod generated {
             "wasi:sockets/types.[method]udp-socket.connect": async | tracing | trappable,
             default: tracing | trappable,
         },
-        exports: { default: async | store | task_exit },
+        exports: { default: async | store },
         with: {
             "wasi:cli/terminal-input.terminal-input": crate::p3::cli::TerminalInput,
             "wasi:cli/terminal-output.terminal-output": crate::p3::cli::TerminalOutput,
@@ -161,7 +161,7 @@ pub use self::generated::wasi::*;
 ///     let command = Command::instantiate_async(&mut store, &component, &linker).await?;
 ///     let program_result = store.run_concurrent(async move |store| {
 ///         command.wasi_cli_run().call_run(store).await
-///     }).await??.0;
+///     }).await??;
 ///     match program_result {
 ///         Ok(()) => Ok(()),
 ///         Err(()) => std::process::exit(1),

--- a/crates/wasi/tests/all/p3/mod.rs
+++ b/crates/wasi/tests/all/p3/mod.rs
@@ -39,7 +39,6 @@ async fn run_allow_blocking_current_thread(
         .await
         .context("failed to call `wasi:cli/run#run`")?
         .context("guest trapped")?
-        .0
         .map_err(|()| format_err!("`wasi:cli/run#run` failed"))
 }
 

--- a/crates/wasmtime/src/runtime/component/concurrent.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent.rs
@@ -80,7 +80,6 @@ use std::mem::{self, ManuallyDrop, MaybeUninit};
 use std::ops::DerefMut;
 use std::pin::{Pin, pin};
 use std::ptr::{self, NonNull};
-use std::sync::Arc;
 use std::task::{Context, Poll, Waker};
 use std::vec::Vec;
 use table::{TableDebug, TableId};
@@ -1076,7 +1075,7 @@ impl<T> StoreContextMut<'_, T> {
     /// # let bar = instance.get_typed_func::<(u32,), ()>(&mut store, "bar")?;
     /// store.run_concurrent(async |accessor| -> wasmtime::Result<_> {
     ///    let resource = accessor.with(|mut access| access.get().table.push(MyResource(42)))?;
-    ///    let (another_resource,) = foo.call_concurrent(accessor, (resource,)).await?.0;
+    ///    let (another_resource,) = foo.call_concurrent(accessor, (resource,)).await?;
     ///    let value = accessor.with(|mut access| access.get().table.delete(another_resource))?;
     ///    bar.call_concurrent(accessor, (value.0,)).await?;
     ///    Ok(())
@@ -1469,7 +1468,6 @@ impl StoreOpaque {
             } else {
                 Caller::Host {
                     tx: None,
-                    exit_tx: Arc::new(oneshot::channel().0),
                     host_future_present: false,
                     caller: thread,
                 }
@@ -1490,10 +1488,6 @@ impl StoreOpaque {
 
         let state = self.concurrent_state_mut();
         state.get_mut(guest_task)?.threads.insert(guest_thread);
-        if guest_caller.is_some() {
-            let thread = thread.guest().unwrap();
-            state.get_mut(thread.task)?.subtasks.insert(guest_task);
-        }
 
         self.set_thread(QualifiedThreadId {
             task: guest_task,
@@ -1534,7 +1528,7 @@ impl StoreOpaque {
         let state = self.concurrent_state_mut();
         let task = state.get_mut(thread.task)?;
         if task.ready_to_delete() {
-            state.delete(thread.task)?.dispose(state, thread.task)?;
+            state.delete(thread.task)?.dispose(state)?;
         }
 
         Ok(())
@@ -1952,17 +1946,12 @@ impl Instance {
                 if task.threads.is_empty() && !task.returned_or_cancelled() {
                     bail!(Trap::NoAsyncResult);
                 }
-                match &task.caller {
-                    Caller::Host { .. } => {
-                        if task.ready_to_delete() {
-                            Waitable::Guest(guest_thread.task)
-                                .delete_from(store.concurrent_state_mut())?;
-                        }
-                    }
-                    Caller::Guest { .. } => {
-                        task.exited = true;
-                        task.callback = None;
-                    }
+                if let Caller::Guest { .. } = task.caller {
+                    task.exited = true;
+                    task.callback = None;
+                }
+                if task.ready_to_delete() {
+                    Waitable::Guest(guest_thread.task).delete_from(store.concurrent_state_mut())?;
                 }
                 None
             }
@@ -2505,13 +2494,6 @@ impl Instance {
         let new_thread = GuestThread::new_implicit(guest_task);
         let guest_thread = state.push(new_thread)?;
         state.get_mut(guest_task)?.threads.insert(guest_thread);
-
-        store
-            .0
-            .concurrent_state_mut()
-            .get_mut(old_thread.task)?
-            .subtasks
-            .insert(guest_task);
 
         // Make the new thread the current one so that `Self::start_call` knows
         // which one to start.
@@ -4183,13 +4165,6 @@ enum Caller {
     Host {
         /// If present, may be used to deliver the result.
         tx: Option<oneshot::Sender<LiftedResult>>,
-        /// Channel to notify once all subtasks spawned by this caller have
-        /// completed.
-        ///
-        /// Note that we'll never actually send anything to this channel;
-        /// dropping it when the refcount goes to zero is sufficient to notify
-        /// the receiver.
-        exit_tx: Arc<oneshot::Sender<()>>,
         /// If true, there's a host future that must be dropped before the task
         /// can be deleted.
         host_future_present: bool,
@@ -4372,11 +4347,6 @@ pub(crate) struct GuestTask {
     /// Whether or not we've sent a `Status::Starting` event to any current or
     /// future waiters for this waitable.
     starting_sent: bool,
-    /// Pending guest subtasks created by this task (directly or indirectly).
-    ///
-    /// This is used to re-parent subtasks which are still running when their
-    /// parent task is disposed.
-    subtasks: HashSet<TableId<GuestTask>>,
     /// Scratch waitable set used to watch subtasks during synchronous calls.
     sync_call_set: TableId<WaitableSet>,
     /// The runtime instance to which the exported function for this guest task
@@ -4469,7 +4439,6 @@ impl GuestTask {
             sync_result: SyncResult::NotProduced,
             cancel_sent: false,
             starting_sent: false,
-            subtasks: HashSet::new(),
             sync_call_set,
             instance,
             event: None,
@@ -4482,7 +4451,7 @@ impl GuestTask {
 
     /// Dispose of this guest task, reparenting any pending subtasks to the
     /// caller.
-    fn dispose(self, state: &mut ConcurrentState, me: TableId<GuestTask>) -> Result<()> {
+    fn dispose(self, state: &mut ConcurrentState) -> Result<()> {
         // If there are not-yet-delivered completion events for subtasks in
         // `self.sync_call_set`, recursively dispose of those subtasks as well.
         for waitable in mem::take(&mut state.get_mut(self.sync_call_set)?.ready) {
@@ -4497,45 +4466,6 @@ impl GuestTask {
         assert!(self.threads.is_empty());
 
         state.delete(self.sync_call_set)?;
-
-        // Reparent any pending subtasks to the caller.
-        match &self.caller {
-            Caller::Guest { thread } => {
-                let task_mut = state.get_mut(thread.task)?;
-                let present = task_mut.subtasks.remove(&me);
-                assert!(present);
-
-                for subtask in &self.subtasks {
-                    task_mut.subtasks.insert(*subtask);
-                }
-
-                for subtask in &self.subtasks {
-                    state.get_mut(*subtask)?.caller = Caller::Guest { thread: *thread };
-                }
-            }
-            Caller::Host {
-                exit_tx, caller, ..
-            } => {
-                for subtask in &self.subtasks {
-                    state.get_mut(*subtask)?.caller = Caller::Host {
-                        tx: None,
-                        // Clone `exit_tx` to ensure that it is only dropped
-                        // once all transitive subtasks of the host call have
-                        // exited:
-                        exit_tx: exit_tx.clone(),
-                        host_future_present: false,
-                        caller: *caller,
-                    };
-                }
-            }
-        }
-
-        for subtask in self.subtasks {
-            let task = state.get_mut(subtask)?;
-            if task.exited && task.ready_to_delete() {
-                Waitable::Guest(subtask).delete_from(state)?;
-            }
-        }
 
         Ok(())
     }
@@ -4699,7 +4629,7 @@ impl Waitable {
             }
             Self::Guest(task) => {
                 log::trace!("delete guest task {task:?}");
-                state.delete(*task)?.dispose(state, *task)?;
+                state.delete(*task)?.dispose(state)?;
             }
             Self::Transmit(task) => {
                 state.delete(*task)?;
@@ -5226,9 +5156,6 @@ pub(crate) struct PreparedCall<R> {
     /// The `oneshot::Receiver` to which the result of the call will be
     /// delivered when it is available.
     rx: oneshot::Receiver<LiftedResult>,
-    /// The `oneshot::Receiver` which will resolve when the task -- and any
-    /// transitive subtasks -- have all exited.
-    exit_rx: oneshot::Receiver<()>,
     _phantom: PhantomData<R>,
 }
 
@@ -5303,7 +5230,6 @@ pub(crate) fn prepare_call<T, R>(
     let state = store.0.concurrent_state_mut();
 
     let (tx, rx) = oneshot::channel();
-    let (exit_tx, exit_rx) = oneshot::channel();
 
     let instance = RuntimeInstance {
         instance: handle.instance().id().instance(),
@@ -5325,7 +5251,6 @@ pub(crate) fn prepare_call<T, R>(
         },
         Caller::Host {
             tx: Some(tx),
-            exit_tx: Arc::new(exit_tx),
             host_future_present,
             caller,
         },
@@ -5356,7 +5281,6 @@ pub(crate) fn prepare_call<T, R>(
         thread: QualifiedThreadId { task, thread },
         param_count,
         rx,
-        exit_rx,
         _phantom: PhantomData,
     })
 }
@@ -5370,13 +5294,12 @@ pub(crate) fn prepare_call<T, R>(
 pub(crate) fn queue_call<T: 'static, R: Send + 'static>(
     mut store: StoreContextMut<T>,
     prepared: PreparedCall<R>,
-) -> Result<impl Future<Output = Result<(R, oneshot::Receiver<()>)>> + Send + 'static + use<T, R>> {
+) -> Result<impl Future<Output = Result<R>> + Send + 'static + use<T, R>> {
     let PreparedCall {
         handle,
         thread,
         param_count,
         rx,
-        exit_rx,
         ..
     } = prepared;
 
@@ -5386,7 +5309,7 @@ pub(crate) fn queue_call<T: 'static, R: Send + 'static>(
         store.0.id(),
         rx.map(move |result| {
             result
-                .map(|v| (*v.downcast().unwrap(), exit_rx))
+                .map(|v| *v.downcast().unwrap())
                 .map_err(crate::Error::from)
         }),
     ))

--- a/crates/wasmtime/src/runtime/component/mod.rs
+++ b/crates/wasmtime/src/runtime/component/mod.rs
@@ -124,8 +124,6 @@ pub use self::concurrent::{
     GuardedStreamReader, JoinHandle, ReadBuffer, Source, StreamAny, StreamConsumer, StreamProducer,
     StreamReader, StreamResult, VMComponentAsyncStore, VecBuffer, WriteBuffer,
 };
-#[cfg(feature = "component-model-async")]
-pub use self::func::TaskExit;
 pub use self::func::{
     ComponentNamedList, ComponentType, Func, Lift, Lower, TypedFunc, WasmList, WasmStr,
 };

--- a/crates/wit-bindgen/src/config.rs
+++ b/crates/wit-bindgen/src/config.rs
@@ -12,7 +12,6 @@ bitflags::bitflags! {
         const VERBOSE_TRACING = 1 << 4;
         const IGNORE_WIT = 1 << 5;
         const EXACT = 1 << 6;
-        const TASK_EXIT = 1 << 7;
     }
 }
 

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -636,11 +636,7 @@ impl RunCommand {
         #[cfg(feature = "component-model-async")]
         if self.run.common.wasm.concurrency_support.unwrap_or(true) {
             store
-                .run_concurrent(async |store| {
-                    let task = func.call_concurrent(store, params, results).await?;
-                    task.block(store).await;
-                    wasmtime::error::Ok(())
-                })
+                .run_concurrent(async |store| func.call_concurrent(store, params, results).await)
                 .await??;
             return Ok(());
         }
@@ -670,11 +666,7 @@ impl RunCommand {
             if let Ok(command) = wasmtime_wasi::p3::bindings::Command::new(&mut *store, &instance) {
                 result = Some(
                     store
-                        .run_concurrent(async |store| {
-                            let (result, task) = command.wasi_cli_run().call_run(store).await?;
-                            task.block(store).await;
-                            Ok(result)
-                        })
+                        .run_concurrent(async |store| command.wasi_cli_run().call_run(store).await)
                         .await?,
                 );
             }

--- a/tests/all/cli_tests.rs
+++ b/tests/all/cli_tests.rs
@@ -2175,7 +2175,7 @@ start a print 1234
         ]);
         if cfg!(feature = "component-model-async") {
             let output = output?;
-            assert_eq!(output, "hello, world\nhello again, after return\n");
+            assert_eq!(output, "hello, world\n");
         } else {
             assert!(output.is_err());
         }
@@ -2194,7 +2194,7 @@ start a print 1234
         ]);
         if cfg!(feature = "component-model-async") {
             let output = output?;
-            assert_eq!(output, "hello, world\nhello again, after return\nok\n");
+            assert_eq!(output, "hello, world\nok\n");
         } else {
             assert!(output.is_err());
         }

--- a/tests/all/component_model.rs
+++ b/tests/all/component_model.rs
@@ -77,8 +77,7 @@ impl ApiStyle {
             }
             ApiStyle::Concurrent => Ok(store
                 .run_concurrent(async |access| func.call_concurrent(access, params).await)
-                .await??
-                .0),
+                .await??),
         }
     }
 

--- a/tests/all/component_model/func.rs
+++ b/tests/all/component_model/func.rs
@@ -1126,7 +1126,7 @@ async fn task_return_trap(component: &str, substring: &str) -> Result<()> {
     let func = instance.get_typed_func::<(), ()>(&mut store, "foo")?;
     match store
         .run_concurrent(async move |accessor| {
-            wasmtime::error::Ok(func.call_concurrent(accessor, ()).await?.0)
+            wasmtime::error::Ok(func.call_concurrent(accessor, ()).await?)
         })
         .await
     {
@@ -1369,7 +1369,7 @@ async fn test_many_parameters(dynamic: bool, concurrent: bool) -> Result<()> {
         if concurrent {
             store
                 .run_concurrent(async move |accessor| {
-                    wasmtime::error::Ok(func.call_concurrent(accessor, input).await?.0)
+                    wasmtime::error::Ok(func.call_concurrent(accessor, input).await?)
                 })
                 .await??
                 .0
@@ -1847,7 +1847,7 @@ async fn test_many_results(dynamic: bool, concurrent: bool) -> Result<()> {
         if concurrent {
             store
                 .run_concurrent(async move |accessor| {
-                    wasmtime::error::Ok(func.call_concurrent(accessor, ()).await?.0)
+                    wasmtime::error::Ok(func.call_concurrent(accessor, ()).await?)
                 })
                 .await??
                 .0

--- a/tests/all/component_model/import.rs
+++ b/tests/all/component_model/import.rs
@@ -844,7 +844,7 @@ async fn test_stack_and_heap_args_and_rets(concurrent: bool) -> Result<()> {
     if concurrent {
         store
             .run_concurrent(async move |accessor| {
-                wasmtime::error::Ok(run.call_concurrent(accessor, ()).await?.0)
+                wasmtime::error::Ok(run.call_concurrent(accessor, ()).await?)
             })
             .await??;
     } else {

--- a/tests/all/pulley.rs
+++ b/tests/all/pulley.rs
@@ -457,28 +457,28 @@ async fn pulley_provenance_test_async_components() -> Result<()> {
         let run = instance.get_typed_func::<(), ()>(&mut store, "run-stackless")?;
         store
             .run_concurrent(async move |accessor| {
-                wasmtime::error::Ok(run.call_concurrent(accessor, ()).await?.0)
+                wasmtime::error::Ok(run.call_concurrent(accessor, ()).await?)
             })
             .await??;
 
         let run = instance.get_typed_func::<(), ()>(&mut store, "run-stackful")?;
         store
             .run_concurrent(async move |accessor| {
-                wasmtime::error::Ok(run.call_concurrent(accessor, ()).await?.0)
+                wasmtime::error::Ok(run.call_concurrent(accessor, ()).await?)
             })
             .await??;
 
         let run = instance.get_typed_func::<(), ()>(&mut store, "run-stackless-stackless")?;
         store
             .run_concurrent(async move |accessor| {
-                wasmtime::error::Ok(run.call_concurrent(accessor, ()).await?.0)
+                wasmtime::error::Ok(run.call_concurrent(accessor, ()).await?)
             })
             .await??;
 
         let run = instance.get_typed_func::<(), ()>(&mut store, "run-stackful-stackful")?;
         store
             .run_concurrent(async move |accessor| {
-                wasmtime::error::Ok(run.call_concurrent(accessor, ()).await?.0)
+                wasmtime::error::Ok(run.call_concurrent(accessor, ()).await?)
             })
             .await??;
     }

--- a/tests/misc_testsuite/component-model/async/cancel-sibling-subtask.wast
+++ b/tests/misc_testsuite/component-model/async/cancel-sibling-subtask.wast
@@ -1,0 +1,109 @@
+;;! reference_types = true
+;;! component_model_async = true
+
+(component definition $A
+  ;; A component with a single export that's just an infinitely looping
+  ;; subtask. Used to represent a pending subtask that has yet to resolve.
+  (component $a
+    (core module $m
+      (import "" "cancel" (func $cancel))
+      (func (export "a") (result i32) i32.const 1) ;; CALLBACK_CODE_YIELD
+      (func (export "cb") (param i32 i32 i32) (result i32)
+        local.get 0
+        i32.const 6 ;; EVENT_TASK_CANCELLED
+        i32.eq
+        if (result i32)
+          call $cancel
+          i32.const 0 ;; CALLBACK_CODE_EXIT
+        else
+          i32.const 1 ;; CALLBACK_CODE_YIELD
+        end
+
+        )
+    )
+    (core func $cancel (canon task.cancel))
+    (core instance $i (instantiate $m
+      (with "" (instance
+        (export "cancel" (func $cancel))
+      ))
+    ))
+    (func (export "f") async
+      (canon lift (core func $i "a") async (callback (func $i "cb"))))
+  )
+
+  (component $b
+    (import "f" (func $f async))
+    (core module $m
+      (import "" "f" (func $f (result i32)))
+      (import "" "cancel" (func $cancel (param i32) (result i32)))
+      (import "" "drop" (func $drop (param i32)))
+      (global $subtask (mut i32) (i32.const 0))
+
+      ;; This export starts a call to `$f` in the above component but doesn't
+      ;; await it or complete it. Instead this task exits.
+      (func (export "a") (param $cancel i32)
+        (local $ret i32)
+
+        ;; start the subtask
+        (local.set $ret (call $f))
+
+        ;; verify it's in the `SUBTASK_STARTED` state
+        (i32.ne
+          (i32.and (local.get $ret) (i32.const 0xf))
+          (i32.const 1)) ;; SUBTASK_STARTED
+        if unreachable end
+
+        ;; store the subtask id in a global.
+        (global.set $subtask
+          (i32.shr_u
+            (local.get $ret)
+            (i32.const 4)))
+
+        local.get $cancel
+        if call $call-cancel end
+      )
+
+      (func $call-cancel
+        (i32.ne
+          (call $cancel (global.get $subtask))
+          (i32.const 4)) ;; RETURN_CANCELLED
+        if unreachable end
+      )
+
+      ;; This export tries to cancel/drop the subtask started by "a" above and
+      ;; this shouldn't cause any issues...
+      (func (export "b") (param $cancel i32)
+        local.get $cancel
+        if call $call-cancel end
+        (call $drop (global.get $subtask))
+      )
+    )
+    (core func $f (canon lower (func $f) async))
+    (core func $cancel (canon subtask.cancel))
+    (core func $drop (canon subtask.drop))
+    (core instance $i (instantiate $m
+      (with "" (instance
+        (export "f" (func $f))
+        (export "cancel" (func $cancel))
+        (export "drop" (func $drop))
+      ))
+    ))
+    (func (export "a") async (param "cancel" bool) (canon lift (core func $i "a")))
+    (func (export "b") async (param "cancel" bool) (canon lift (core func $i "b")))
+  )
+
+  (instance $a (instantiate $a))
+  (instance $b (instantiate $b (with "f" (func $a "f"))))
+  (export "a" (func $b "a"))
+  (export "b" (func $b "b"))
+)
+
+;; start subtask in "a", cancel/drop it in "b"
+(component instance $A $A)
+(assert_return (invoke "a" (bool.const false)))
+(assert_return (invoke "b" (bool.const true)))
+
+;; start/cancel subtask in "a", drop it in "b"
+(component instance $A $A)
+(assert_return (invoke "a" (bool.const true)))
+(assert_return (invoke "b" (bool.const false)))


### PR DESCRIPTION
This commit updates the implementation of component-model-async primitives to remove the manual subtask reparenting process. This is required to fix #12544 at a semantic level because a subtask isn't ever actually reparented, even if its parent exits. The first part of this change is to remove the `GuestTask::subtasks` field and all relevant manipulations of it.

This field, however, powered the `TaskExit` abstraction returned from `call_concurrent`. This commit then subsequently deletes `TaskExit` and all related infrastructure as it's no longer directly applicable as-is. The rest of this change is then updating tests/bindings/etc to account for these two changes.

The main semantic changes related to tests are:

* `wasmtime run`, with and without `--invoke`, no longer waits for all subtasks. This instead only waits for the main task returning before exiting. Whether or not this is the correct behavior is under discussion in WebAssembly/component-model#608

* `wasmtime serve` has been updated to keep the store alive at least until the response body has been fully transmitted. This is also part of WebAssembly/component-model#608.

* Some `component-async-tests`-related tests were updated to either avoid blocking the store as it wasn't needed or yield enough times to ensure that the test passes.

Closes #12544


<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
