### PR TITLE
sys/miri: fix `Mmap::from_file` to seek to start of file.

### DIFF
--- a/crates/wasmtime/src/runtime/vm/sys/miri/mmap.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/miri/mmap.rs
@@ -10,7 +10,7 @@ use crate::runtime::vm::sys::vm::MemoryImageSource;
 use crate::runtime::vm::{HostAlignedByteCount, SendSyncPtr};
 use std::alloc::{self, Layout};
 use std::fs::File;
-use std::io::Read;
+use std::io::{Read, Seek, SeekFrom};
 use std::ops::Range;
 use std::path::Path;
 use std::ptr::NonNull;
@@ -63,6 +63,7 @@ impl Mmap {
         // Read the file and copy it in to a fresh "mmap" to have allocation for
         // an mmap only in one location.
         let mut dst = Vec::new();
+        file.seek(SeekFrom::Start(0))?;
         file.read_to_end(&mut dst)?;
         let count = HostAlignedByteCount::new_rounded_up(dst.len())?;
         let result = Mmap::new(count)?;


### PR DESCRIPTION
The constructor takes a `&File` but `&File` still allows mutation of the underlying state, e.g., the seek position. It turns out that this matters when we try to `Mmap::from_file` more than once, e.g. when enabling guest debugging and thus mapping private copies of code.

No test yet as this will be covered by upcoming miri coverage of guest debugging.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
