### PR TITLE
Allow slicing our OOM-handling `Vec` with ranges

### DIFF
--- a/crates/core/src/alloc/vec.rs
+++ b/crates/core/src/alloc/vec.rs
@@ -1,11 +1,13 @@
 use crate::alloc::{TryClone, try_realloc};
 use crate::error::OutOfMemory;
-use core::cmp::Ordering;
-use core::marker::PhantomData;
-use core::num::NonZeroUsize;
 use core::{
-    fmt, mem,
+    cmp::Ordering,
+    fmt,
+    marker::PhantomData,
+    mem,
+    num::NonZeroUsize,
     ops::{Deref, DerefMut, Index, IndexMut},
+    slice::SliceIndex,
 };
 use serde::ser::SerializeSeq;
 use std_alloc::alloc::Layout;
@@ -302,16 +304,22 @@ impl<T> DerefMut for Vec<T> {
     }
 }
 
-impl<T> Index<usize> for Vec<T> {
-    type Output = T;
+impl<T, I> Index<I> for Vec<T>
+where
+    I: SliceIndex<[T]>,
+{
+    type Output = <I as SliceIndex<[T]>>::Output;
 
-    fn index(&self, index: usize) -> &Self::Output {
+    fn index(&self, index: I) -> &Self::Output {
         &self.inner[index]
     }
 }
 
-impl<T> IndexMut<usize> for Vec<T> {
-    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+impl<T, I> IndexMut<I> for Vec<T>
+where
+    I: SliceIndex<[T]>,
+{
+    fn index_mut(&mut self, index: I) -> &mut Self::Output {
         &mut self.inner[index]
     }
 }


### PR DESCRIPTION
Not just `usize`s.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
