### PR TITLE
Add `truncate` and `resize` methods to our OOM-handling `Vec`

### DIFF
--- a/crates/fuzzing/tests/oom.rs
+++ b/crates/fuzzing/tests/oom.rs
@@ -709,6 +709,19 @@ fn vec_shrink_to_fit() -> Result<()> {
 }
 
 #[test]
+fn vec_resize() -> Result<()> {
+    OomTest::new().test(|| {
+        let mut v = Vec::new();
+        v.resize(10, 'a')?; // Grow.
+        v.resize(1, 'b')?; // Truncate.
+        v.resize(1, 'c')?; // Same length.
+        v.resize(3, 'd')?; // Grow again.
+        assert_eq!(&*v, &['a', 'd', 'd']);
+        Ok(())
+    })
+}
+
+#[test]
 fn vec_try_collect() -> Result<()> {
     OomTest::new().test(|| {
         iter::repeat(1).take(0).try_collect::<Vec<_>, _>()?;


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
