### PR TITLE
Update the `cargo audit` cron CI job

### DIFF
--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -4,13 +4,21 @@ on:
     - cron: '0 0 * * *'
 jobs:
   security_audit:
-    if: github.repository == 'bytecodealliance/wasmtime'
     runs-on: ubuntu-latest
+    env:
+      CARGO_AUDIT_VERSION: 0.22.1
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: true
-      - uses: rustsec/audit-check@v1.4.1
+      - uses: actions/cache@v4
+        with:
+          path: ${{ runner.tool_cache }}/cargo-audit
+          key: cargo-audit-${{ env.CARGO_AUDIT_VERSION }}
+      - run: |
+          echo "${{ runner.tool_cache }}/cargo-audit/bin" >> $GITHUB_PATH
+          cargo install --root ${{ runner.tool_cache }}/cargo-audit --version ${{ env.CARGO_AUDIT_VERSION }} cargo-audit --locked
+      - uses: rustsec/audit-check@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
         # This seems to hit rate limits about 50% of the time, unclear why, but


### PR DESCRIPTION
* Use a pinned version of `cargo audit`
* Update the `rustsec/audit-check` dependency
* Use a cache when installing `cargo audit` to speed up the job

I noticed that the audit runs currently execute
`cargo generate-lockfile` which means it's not actually auditing our dependencies but an updated version of our dependencies. Local testing shows that I think this'll resolve things, although we'll figure that out on the next run.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
