### PR TITLE
Add `Global::value_ptr()` for cross-thread cooperative signaling

### DIFF
--- a/crates/wasmtime/src/runtime/externals/global.rs
+++ b/crates/wasmtime/src/runtime/externals/global.rs
@@ -243,7 +243,10 @@ impl Global {
         let binding = self._ty(store);
         let content = binding.content();
         assert!(
-            matches!(content, ValType::I32 | ValType::I64 | ValType::F32 | ValType::F64),
+            matches!(
+                content,
+                ValType::I32 | ValType::I64 | ValType::F32 | ValType::F64
+            ),
             "value_ptr only supports numeric types, got {:?}",
             content,
         );


### PR DESCRIPTION
## Summary

- Adds `unsafe fn value_ptr(&self, store: impl AsContext) -> *mut u8` to `Global`
- Returns a raw pointer to a mutable numeric global's underlying `VMGlobalDefinition` storage
- Enables cross-thread cooperative scheduling without requiring `&mut Store`

## Motivation

There is currently no way to signal a running WebAssembly instance from another thread using a wasm-visible global. The existing `Global::set()` requires `&mut Store`, which is exclusively held by the thread executing the module. This creates a deadlock in the API: you can't mutate the global until execution finishes, but execution won't finish until the global is mutated.

The concrete use case is **cooperative suspend/resume** (checkpoint/restore). A WASM transform inserts `global.get $flag; br_if $suspend` checks at loop heads and after call sites. The host signals suspension by writing `1` to that flag from a control thread. The module sees the flag, saves its locals to a shadow stack, and returns. On resume, the host clears the flag and re-calls the function, which restores locals and continues from where it left off.

Wasmtime's existing interruption mechanisms don't solve this:

- **Epoch interruption** traps the instance — the module never gets a chance to save its own state before stopping, so it can't be resumed.
- **Fuel** has the same problem — exhaustion causes a trap, not a cooperative yield.

What's needed is a way for the module itself to *observe* a host-written flag and *choose* to suspend, preserving its own stack. That requires the host to write to a global that the running module can read — without holding `&mut Store`.

## Design

`value_ptr()` is deliberately narrow:

- **`unsafe`** — the caller is responsible for lifetime management (pointer is valid only while the `Store` lives) and data-race avoidance (`write_volatile` or `AtomicI32::from_ptr`).
- **Restricted to numeric types** — panics on `funcref`/`externref`, which require GC coordination.
- **Restricted to mutable globals** — panics on `Mutability::Const`.
- **Only needs `AsContext`** (shared ref) — the point is to obtain the pointer *before* moving the store to a worker thread. No `&mut Store` required.

## Example

```rust
let flag = instance.get_global(&mut store, "suspending").unwrap();
let ptr = unsafe { flag.value_ptr(&store) } as *mut i32;

// Move store to worker thread
std::thread::spawn(move || {
    run.call(&mut store, ()).unwrap();
});

// Signal from control thread
unsafe { std::ptr::write_volatile(ptr, 1); }
```