### PR TITLE
Fix UEFI compilation for cranelift-jit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2870,6 +2870,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3087,12 +3093,12 @@ dependencies = [
 [[package]]
 name = "region"
 version = "3.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6b6ebd13bc009aef9cd476c1310d49ac354d36e240cf1bd753290f3dc7199a7"
+source = "git+https://github.com/RossComputerGuy/region-rs?branch=fix%2Fuefi#8f86bd4cd9951e61c20b9c2ed1048fd3f5e5955f"
 dependencies = [
  "bitflags 1.3.2",
  "libc",
  "mach2",
+ "r-efi",
  "windows-sys 0.52.0",
 ]
 

--- a/cranelift/jit/Cargo.toml
+++ b/cranelift/jit/Cargo.toml
@@ -21,7 +21,7 @@ cranelift-entity = { workspace = true }
 cranelift-control = { workspace = true }
 wasmtime-unwinder = { workspace = true, optional = true, features = ["cranelift"] }
 anyhow = { workspace = true }
-region = "3.0.2"
+region = { git = "https://github.com/RossComputerGuy/region-rs", branch = "fix/uefi" }
 libc = { workspace = true }
 target-lexicon = { workspace = true }
 memmap2 = { version = "0.2.1", optional = true }

--- a/cranelift/jit/src/memory/system.rs
+++ b/cranelift/jit/src/memory/system.rs
@@ -1,6 +1,10 @@
 use cranelift_module::{ModuleError, ModuleResult};
 
-#[cfg(all(not(target_os = "windows"), feature = "selinux-fix"))]
+#[cfg(all(
+    not(target_os = "windows"),
+    not(target_os = "uefi"),
+    feature = "selinux-fix"
+))]
 use memmap2::MmapMut;
 
 #[cfg(not(any(feature = "selinux-fix", windows)))]


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->

Fixes enough of the errors to get cranelift-jit compiled to UEFI via:
```
$ RUSTFLAGS="--cfg uefi_std" cargo build --target aarch64-unknown-uefi
```

Requires changes to `region-rs` but it hasn't been touched in 2 years. https://github.com/darfink/region-rs/pull/39