### PR TITLE
Use OOM-handling collections for `Metadata`

### DIFF
--- a/crates/wasmtime/src/engine/serialization.rs
+++ b/crates/wasmtime/src/engine/serialization.rs
@@ -463,7 +463,7 @@ mod test {
     fn test_architecture_mismatch() -> Result<()> {
         let engine = Engine::default();
         let mut metadata = Metadata::new(&engine)?;
-        metadata.target = "unknown-generic-linux".to_string();
+        metadata.target = "unknown-generic-linux".to_string().into();
 
         match metadata.check_compatible(&engine) {
             Ok(_) => unreachable!(),
@@ -486,7 +486,8 @@ mod test {
         metadata.target = format!(
             "{}-generic-unknown",
             target_lexicon::Triple::host().architecture
-        );
+        )
+        .into();
 
         match metadata.check_compatible(&engine) {
             Ok(_) => unreachable!(),
@@ -515,7 +516,7 @@ mod test {
 
         metadata
             .shared_flags
-            .push(("preserve_frame_pointers", FlagValue::Bool(false)));
+            .push(("preserve_frame_pointers", FlagValue::Bool(false)))?;
 
         match metadata.check_compatible(&engine) {
             Ok(_) => unreachable!(),
@@ -541,7 +542,7 @@ mod test {
 
         metadata
             .isa_flags
-            .push(("not_a_flag", FlagValue::Bool(true)));
+            .push(("not_a_flag", FlagValue::Bool(true)))?;
 
         match metadata.check_compatible(&engine) {
             Ok(_) => unreachable!(),


### PR DESCRIPTION
These are created in the compiler, where we don't need to worry about OOM, but are deserialized in the "data-plane" where we do. The OOM-handling collections' `Deserialize` implementations automatically handle OOM for us here.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
