### PR TITLE
fix(cranelift): correct sign extension operators to use ireduce result

### DIFF
--- a/crates/cranelift/src/translate/code_translator.rs
+++ b/crates/cranelift/src/translate/code_translator.rs
@@ -1161,33 +1161,28 @@ pub fn translate_operator(
         }
         Operator::I32Extend8S => {
             let val = environ.stacks.pop1();
-            environ.stacks.push1(builder.ins().ireduce(I8, val));
-            let val = environ.stacks.pop1();
-            environ.stacks.push1(builder.ins().sextend(I32, val));
+            let reduced = builder.ins().ireduce(I8, val);
+            environ.stacks.push1(builder.ins().sextend(I32, reduced));
         }
         Operator::I32Extend16S => {
             let val = environ.stacks.pop1();
-            environ.stacks.push1(builder.ins().ireduce(I16, val));
-            let val = environ.stacks.pop1();
-            environ.stacks.push1(builder.ins().sextend(I32, val));
+            let reduced = builder.ins().ireduce(I16, val);
+            environ.stacks.push1(builder.ins().sextend(I32, reduced));
         }
         Operator::I64Extend8S => {
             let val = environ.stacks.pop1();
-            environ.stacks.push1(builder.ins().ireduce(I8, val));
-            let val = environ.stacks.pop1();
-            environ.stacks.push1(builder.ins().sextend(I64, val));
+            let reduced = builder.ins().ireduce(I8, val);
+            environ.stacks.push1(builder.ins().sextend(I64, reduced));
         }
         Operator::I64Extend16S => {
             let val = environ.stacks.pop1();
-            environ.stacks.push1(builder.ins().ireduce(I16, val));
-            let val = environ.stacks.pop1();
-            environ.stacks.push1(builder.ins().sextend(I64, val));
+            let reduced = builder.ins().ireduce(I16, val);
+            environ.stacks.push1(builder.ins().sextend(I64, reduced));
         }
         Operator::I64Extend32S => {
             let val = environ.stacks.pop1();
-            environ.stacks.push1(builder.ins().ireduce(I32, val));
-            let val = environ.stacks.pop1();
-            environ.stacks.push1(builder.ins().sextend(I64, val));
+            let reduced = builder.ins().ireduce(I32, val);
+            environ.stacks.push1(builder.ins().sextend(I64, reduced));
         }
         /****************************** Binary Operators ************************************/
         Operator::I32Add | Operator::I64Add => {


### PR DESCRIPTION
What was wrong: The sign extension operators (`i32.extend8_s`, `i32.extend16_s`, `i64.extend8_s`, `i64.extend16_s`, `i64.extend32_s`) were incorrectly discarding the `ireduce` result. The code was pushing the `ireduce` result to the value stack and then immediately popping a different value (the next value on the stack) for the `sextend` operation.
Changes: Store the `ireduce` result in a local variable and use it directly in `sextend` instead of popping from the stack.