### PR TITLE
Implement `TryClone` for `GcLayout`

### DIFF
--- a/crates/wasmtime/src/runtime/gc/enabled/exnref.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/exnref.rs
@@ -11,6 +11,7 @@ use crate::{
     store::{AutoAssertNoGc, StoreOpaque},
 };
 use crate::{ExnType, FieldType, GcHeapOutOfMemory, StoreContextMut, Tag, prelude::*};
+use alloc::sync::Arc;
 use core::mem;
 use core::mem::MaybeUninit;
 use wasmtime_environ::{GcLayout, GcStructLayout, VMGcKind, VMSharedTypeIndex};
@@ -563,7 +564,7 @@ impl ExnRef {
         Ok(gc_ref.as_exnref_unchecked())
     }
 
-    fn layout(&self, store: &AutoAssertNoGc<'_>) -> Result<GcStructLayout> {
+    fn layout(&self, store: &AutoAssertNoGc<'_>) -> Result<Arc<GcStructLayout>> {
         assert!(self.comes_from_same_store(&store));
         let type_index = self.type_index(store)?;
         let layout = store

--- a/crates/wasmtime/src/runtime/gc/enabled/structref.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/structref.rs
@@ -12,6 +12,7 @@ use crate::{
     prelude::*,
     store::{AutoAssertNoGc, StoreContextMut, StoreOpaque, StoreResourceLimiter},
 };
+use alloc::sync::Arc;
 use core::mem::{self, MaybeUninit};
 use wasmtime_environ::{GcLayout, GcStructLayout, VMGcKind, VMSharedTypeIndex};
 
@@ -515,7 +516,7 @@ impl StructRef {
         Ok(gc_ref.as_structref_unchecked())
     }
 
-    fn layout(&self, store: &AutoAssertNoGc<'_>) -> Result<GcStructLayout> {
+    fn layout(&self, store: &AutoAssertNoGc<'_>) -> Result<Arc<GcStructLayout>> {
         assert!(self.comes_from_same_store(&store));
         let type_index = self.type_index(store)?;
         let layout = store

--- a/crates/wasmtime/src/runtime/type_registry.rs
+++ b/crates/wasmtime/src/runtime/type_registry.rs
@@ -1107,10 +1107,10 @@ impl TypeRegistryInner {
                     gc_runtime.layouts().array_layout(a).into()
                 }
                 wasmtime_environ::WasmCompositeInnerType::Struct(s) => {
-                    gc_runtime.layouts().struct_layout(s).into()
+                    try_new::<Arc<_>>(gc_runtime.layouts().struct_layout(s))?.into()
                 }
                 wasmtime_environ::WasmCompositeInnerType::Exn(e) => {
-                    gc_runtime.layouts().exn_layout(e).into()
+                    try_new::<Arc<_>>(gc_runtime.layouts().exn_layout(e))?.into()
                 }
                 wasmtime_environ::WasmCompositeInnerType::Cont(_) => continue, // FIXME: #10248 stack switching support.
             };


### PR DESCRIPTION
Depends on https://github.com/bytecodealliance/wasmtime/pull/12615

And also make it so that cloning it doesn't actually require any allocations by
wrapping the inner `GcStructLayout` in an `Arc`.
