### PR TITLE
Add a `clear` method to our OOM-handling `Vec`

### DIFF
--- a/crates/core/src/alloc/vec.rs
+++ b/crates/core/src/alloc/vec.rs
@@ -288,6 +288,11 @@ impl<T> Vec<T> {
         // use `std`'s `into_boxed_slice` without fear of `realloc`.
         Ok(self.inner.into_boxed_slice())
     }
+
+    /// Same as [`std::vec::Vec::clear`].
+    pub fn clear(&mut self) {
+        self.inner.clear();
+    }
 }
 
 impl<T> Deref for Vec<T> {


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
