### PR TITLE
Respect signals-based-traps in component trampolines

### DIFF
--- a/crates/cranelift/src/bounds_checks.rs
+++ b/crates/cranelift/src/bounds_checks.rs
@@ -23,6 +23,7 @@ use crate::{
     Reachability,
     func_environ::FuncEnvironment,
     translate::{HeapData, TargetEnvironment},
+    trap::TranslateTrap,
 };
 use Reachability::*;
 use cranelift_codegen::{

--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -1,12 +1,13 @@
 mod gc;
 pub(crate) mod stack_switching;
 
+use crate::BuiltinFunctionSignatures;
 use crate::compiler::Compiler;
 use crate::translate::{
     FuncTranslationStacks, GlobalVariable, Heap, HeapData, StructFieldsVec, TableData, TableSize,
     TargetEnvironment,
 };
-use crate::{BuiltinFunctionSignatures, TRAP_INTERNAL_ASSERT};
+use crate::trap::TranslateTrap;
 use cranelift_codegen::cursor::FuncCursor;
 use cranelift_codegen::ir::condcodes::{FloatCC, IntCC};
 use cranelift_codegen::ir::immediates::{Imm64, Offset32, V128Imm};
@@ -29,9 +30,9 @@ use wasmtime_environ::{
     BuiltinFunctionIndex, DataIndex, DefinedFuncIndex, ElemIndex, EngineOrModuleTypeIndex,
     FrameStateSlotBuilder, FrameValType, FuncIndex, FuncKey, GlobalConstValue, GlobalIndex,
     IndexType, Memory, MemoryIndex, Module, ModuleInternedTypeIndex, ModuleTranslation,
-    ModuleTypesBuilder, PtrSize, Table, TableIndex, TagIndex, TripleExt, Tunables, TypeConvert,
-    TypeIndex, VMOffsets, WasmCompositeInnerType, WasmFuncType, WasmHeapTopType, WasmHeapType,
-    WasmRefType, WasmResult, WasmValType,
+    ModuleTypesBuilder, PtrSize, Table, TableIndex, TagIndex, Tunables, TypeConvert, TypeIndex,
+    VMOffsets, WasmCompositeInnerType, WasmFuncType, WasmHeapTopType, WasmHeapType, WasmRefType,
+    WasmResult, WasmValType,
 };
 use wasmtime_environ::{FUNCREF_INIT_BIT, FUNCREF_MASK};
 
@@ -51,7 +52,7 @@ pub(crate) struct BuiltinFunctions {
 }
 
 impl BuiltinFunctions {
-    fn new(compiler: &Compiler) -> Self {
+    pub(crate) fn new(compiler: &Compiler) -> Self {
         Self {
             types: BuiltinFunctionSignatures::new(compiler),
             builtins: [None; BuiltinFunctionIndex::len() as usize],
@@ -59,7 +60,11 @@ impl BuiltinFunctions {
         }
     }
 
-    fn load_builtin(&mut self, func: &mut Function, builtin: BuiltinFunctionIndex) -> ir::FuncRef {
+    pub(crate) fn load_builtin(
+        &mut self,
+        func: &mut Function,
+        builtin: BuiltinFunctionIndex,
+    ) -> ir::FuncRef {
         let cache = &mut self.builtins[builtin.index() as usize];
         if let Some(f) = cache {
             return *f;
@@ -310,12 +315,6 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
             self.vmctx = Some(vmctx);
             vmctx
         })
-    }
-
-    pub(crate) fn vmctx_val(&mut self, pos: &mut FuncCursor<'_>) -> ir::Value {
-        let pointer_type = self.pointer_type();
-        let vmctx = self.vmctx(&mut pos.func);
-        pos.ins().global_value(pointer_type, vmctx)
     }
 
     fn get_table_copy_func(
@@ -1034,34 +1033,6 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
         self.global_load_with_memory_type(func, vmctx, offset, flags, self.pcc_vmctx_memtype)
     }
 
-    /// Helper to emit a conditional trap based on `trap_cond`.
-    ///
-    /// This should only be used if `self.clif_instruction_traps_enabled()` is
-    /// false, otherwise native CLIF instructions should be used instead.
-    pub fn conditionally_trap(
-        &mut self,
-        builder: &mut FunctionBuilder,
-        trap_cond: ir::Value,
-        trap: ir::TrapCode,
-    ) {
-        assert!(!self.clif_instruction_traps_enabled());
-
-        let trap_block = builder.create_block();
-        builder.set_cold_block(trap_block);
-        let continuation_block = builder.create_block();
-
-        builder
-            .ins()
-            .brif(trap_cond, trap_block, &[], continuation_block, &[]);
-
-        builder.seal_block(trap_block);
-        builder.seal_block(continuation_block);
-
-        builder.switch_to_block(trap_block);
-        self.trap(builder, trap);
-        builder.switch_to_block(continuation_block);
-    }
-
     /// Helper used when `!self.clif_instruction_traps_enabled()` is enabled to
     /// test whether the divisor is zero.
     fn guard_zero_divisor(&mut self, builder: &mut FunctionBuilder, rhs: ir::Value) {
@@ -1392,6 +1363,26 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
             // as a pointer.
             builder.ins().stack_store(vmctx, slot, 0);
         }
+    }
+}
+
+impl TranslateTrap for FuncEnvironment<'_> {
+    fn compiler(&self) -> &Compiler {
+        &self.compiler
+    }
+
+    fn vmctx_val(&mut self, pos: &mut FuncCursor<'_>) -> ir::Value {
+        let pointer_type = self.pointer_type();
+        let vmctx = self.vmctx(&mut pos.func);
+        pos.ins().global_value(pointer_type, vmctx)
+    }
+
+    fn builtin_funcref(
+        &mut self,
+        builder: &mut FunctionBuilder<'_>,
+        index: BuiltinFunctionIndex,
+    ) -> ir::FuncRef {
+        self.builtin_functions.load_builtin(builder.func, index)
     }
 }
 
@@ -4431,70 +4422,6 @@ impl FuncEnvironment<'_> {
         &*self.isa
     }
 
-    pub fn trap(&mut self, builder: &mut FunctionBuilder, trap: ir::TrapCode) {
-        match (
-            self.clif_instruction_traps_enabled(),
-            crate::clif_trap_to_env_trap(trap),
-        ) {
-            // If libcall traps are disabled or there's no wasmtime-defined trap
-            // code for this, then emit a native trap instruction.
-            (true, _) | (_, None) => {
-                builder.ins().trap(trap);
-            }
-            // ... otherwise with libcall traps explicitly enabled and a
-            // wasmtime-based trap code invoke the libcall to raise a trap and
-            // pass in our trap code. Leave a debug `unreachable` in place
-            // afterwards as a defense-in-depth measure.
-            (false, Some(trap)) => {
-                let libcall = self.builtin_functions.trap(&mut builder.func);
-                let vmctx = self.vmctx_val(&mut builder.cursor());
-                let trap_code = builder.ins().iconst(I8, i64::from(trap as u8));
-                builder.ins().call(libcall, &[vmctx, trap_code]);
-                let raise = self.builtin_functions.raise(&mut builder.func);
-                builder.ins().call(raise, &[vmctx]);
-                builder.ins().trap(TRAP_INTERNAL_ASSERT);
-            }
-        }
-    }
-
-    pub fn trapz(&mut self, builder: &mut FunctionBuilder, value: ir::Value, trap: ir::TrapCode) {
-        if self.clif_instruction_traps_enabled() {
-            builder.ins().trapz(value, trap);
-        } else {
-            let ty = builder.func.dfg.value_type(value);
-            let zero = builder.ins().iconst(ty, 0);
-            let cmp = builder.ins().icmp(IntCC::Equal, value, zero);
-            self.conditionally_trap(builder, cmp, trap);
-        }
-    }
-
-    pub fn trapnz(&mut self, builder: &mut FunctionBuilder, value: ir::Value, trap: ir::TrapCode) {
-        if self.clif_instruction_traps_enabled() {
-            builder.ins().trapnz(value, trap);
-        } else {
-            let ty = builder.func.dfg.value_type(value);
-            let zero = builder.ins().iconst(ty, 0);
-            let cmp = builder.ins().icmp(IntCC::NotEqual, value, zero);
-            self.conditionally_trap(builder, cmp, trap);
-        }
-    }
-
-    pub fn uadd_overflow_trap(
-        &mut self,
-        builder: &mut FunctionBuilder,
-        lhs: ir::Value,
-        rhs: ir::Value,
-        trap: ir::TrapCode,
-    ) -> ir::Value {
-        if self.clif_instruction_traps_enabled() {
-            builder.ins().uadd_overflow_trap(lhs, rhs, trap)
-        } else {
-            let (ret, overflow) = builder.ins().uadd_overflow(lhs, rhs);
-            self.conditionally_trap(builder, overflow, trap);
-            ret
-        }
-    }
-
     pub fn translate_sdiv(
         &mut self,
         builder: &mut FunctionBuilder,
@@ -4572,19 +4499,6 @@ impl FuncEnvironment<'_> {
         self.tunables.signals_based_traps && !self.is_pulley()
     }
 
-    /// Returns whether it's acceptable to have CLIF instructions natively trap,
-    /// such as division-by-zero.
-    ///
-    /// This is enabled if `signals_based_traps` is `true` or on
-    /// Pulley unconditionally since Pulley doesn't use hardware-based
-    /// traps in its runtime. However, if guest debugging is enabled,
-    /// then we cannot rely on Pulley traps and still need a libcall
-    /// to gain proper ownership of the store in the runtime's
-    /// debugger hooks.
-    pub fn clif_instruction_traps_enabled(&self) -> bool {
-        self.tunables.signals_based_traps || (self.is_pulley() && !self.tunables.debug_guest)
-    }
-
     /// Returns whether loads from the null address are allowed as signals of
     /// whether to trap or not.
     pub fn load_from_zero_allowed(&self) -> bool {
@@ -4592,11 +4506,6 @@ impl FuncEnvironment<'_> {
         // traps + spectre mitigations.
         self.is_pulley()
             || (self.clif_memory_traps_enabled() && self.heap_access_spectre_mitigation())
-    }
-
-    /// Returns whether translation is happening for Pulley bytecode.
-    pub fn is_pulley(&self) -> bool {
-        self.isa.triple().is_pulley()
     }
 
     /// Returns whether the current location is reachable.

--- a/crates/cranelift/src/func_environ/gc/enabled.rs
+++ b/crates/cranelift/src/func_environ/gc/enabled.rs
@@ -2,6 +2,7 @@ use super::{ArrayInit, GcCompiler};
 use crate::bounds_checks::BoundsCheck;
 use crate::func_environ::{Extension, FuncEnvironment};
 use crate::translate::{Heap, HeapData, StructFieldsVec, TargetEnvironment};
+use crate::trap::TranslateTrap;
 use crate::{Reachability, TRAP_INTERNAL_ASSERT};
 use cranelift_codegen::ir::immediates::Offset32;
 use cranelift_codegen::ir::{BlockArg, ExceptionTableData, ExceptionTableItem};

--- a/crates/cranelift/src/func_environ/gc/enabled/drc.rs
+++ b/crates/cranelift/src/func_environ/gc/enabled/drc.rs
@@ -3,6 +3,7 @@
 
 use super::*;
 use crate::translate::TargetEnvironment;
+use crate::trap::TranslateTrap;
 use crate::{TRAP_INTERNAL_ASSERT, func_environ::FuncEnvironment};
 use cranelift_codegen::ir::condcodes::IntCC;
 use cranelift_codegen::ir::{self, InstBuilder};

--- a/crates/cranelift/src/func_environ/gc/enabled/null.rs
+++ b/crates/cranelift/src/func_environ/gc/enabled/null.rs
@@ -6,6 +6,7 @@
 
 use super::*;
 use crate::func_environ::FuncEnvironment;
+use crate::trap::TranslateTrap;
 use cranelift_codegen::ir::{self, InstBuilder};
 use cranelift_frontend::FunctionBuilder;
 use wasmtime_environ::VMSharedTypeIndex;

--- a/crates/cranelift/src/func_environ/stack_switching/instructions.rs
+++ b/crates/cranelift/src/func_environ/stack_switching/instructions.rs
@@ -1,6 +1,7 @@
 use cranelift_codegen::ir::BlockArg;
 use itertools::{Either, Itertools};
 
+use crate::trap::TranslateTrap;
 use cranelift_codegen::ir::condcodes::*;
 use cranelift_codegen::ir::types::*;
 use cranelift_codegen::ir::{self, MemFlags};

--- a/crates/cranelift/src/lib.rs
+++ b/crates/cranelift/src/lib.rs
@@ -43,6 +43,7 @@ mod compiler;
 mod debug;
 mod func_environ;
 mod translate;
+mod trap;
 
 use self::compiler::Compiler;
 

--- a/crates/cranelift/src/translate/code_translator.rs
+++ b/crates/cranelift/src/translate/code_translator.rs
@@ -80,6 +80,7 @@ use crate::translate::stack::{ControlStackFrame, ElseData};
 use crate::translate::translation_utils::{
     block_with_params, blocktype_params_results, f32_translation, f64_translation,
 };
+use crate::trap::TranslateTrap;
 use cranelift_codegen::ir::condcodes::{FloatCC, IntCC};
 use cranelift_codegen::ir::immediates::Offset32;
 use cranelift_codegen::ir::{

--- a/crates/cranelift/src/translate/table.rs
+++ b/crates/cranelift/src/translate/table.rs
@@ -1,4 +1,5 @@
 use crate::func_environ::FuncEnvironment;
+use crate::trap::TranslateTrap;
 use cranelift_codegen::cursor::FuncCursor;
 use cranelift_codegen::ir::{self, InstBuilder, condcodes::IntCC, immediates::Imm64};
 use cranelift_codegen::isa::TargetIsa;

--- a/crates/cranelift/src/trap.rs
+++ b/crates/cranelift/src/trap.rs
@@ -1,0 +1,134 @@
+use crate::TRAP_INTERNAL_ASSERT;
+use crate::compiler::Compiler;
+use cranelift_codegen::cursor::FuncCursor;
+use cranelift_codegen::ir::condcodes::IntCC;
+use cranelift_codegen::ir::types::I8;
+use cranelift_codegen::ir::{self, InstBuilder};
+use cranelift_frontend::FunctionBuilder;
+use wasmtime_environ::{BuiltinFunctionIndex, TripleExt};
+
+/// Helper trait to share translation of traps between core functions and
+/// component trampolines.
+///
+/// Traps are conditionally performed as libcalls when signals-based-traps are
+/// disabled, for example, but otherwise use the native CLIF `trap` instruction.
+pub trait TranslateTrap {
+    fn compiler(&self) -> &Compiler;
+    fn vmctx_val(&mut self, cursor: &mut FuncCursor<'_>) -> ir::Value;
+    fn builtin_funcref(
+        &mut self,
+        builder: &mut FunctionBuilder<'_>,
+        index: BuiltinFunctionIndex,
+    ) -> ir::FuncRef;
+
+    fn trap(&mut self, builder: &mut FunctionBuilder, trap: ir::TrapCode) {
+        match (
+            self.clif_instruction_traps_enabled(),
+            crate::clif_trap_to_env_trap(trap),
+        ) {
+            // If libcall traps are disabled or there's no wasmtime-defined trap
+            // code for this, then emit a native trap instruction.
+            (true, _) | (_, None) => {
+                builder.ins().trap(trap);
+            }
+            // ... otherwise with libcall traps explicitly enabled and a
+            // wasmtime-based trap code invoke the libcall to raise a trap and
+            // pass in our trap code. Leave a debug `unreachable` in place
+            // afterwards as a defense-in-depth measure.
+            (false, Some(trap)) => {
+                let trap_libcall = self.builtin_funcref(builder, BuiltinFunctionIndex::trap());
+                let vmctx = self.vmctx_val(&mut builder.cursor());
+                let trap_code = builder.ins().iconst(I8, i64::from(trap as u8));
+                builder.ins().call(trap_libcall, &[vmctx, trap_code]);
+                let raise_libcall = self.builtin_funcref(builder, BuiltinFunctionIndex::raise());
+                builder.ins().call(raise_libcall, &[vmctx]);
+                builder.ins().trap(TRAP_INTERNAL_ASSERT);
+            }
+        }
+    }
+
+    fn trapz(&mut self, builder: &mut FunctionBuilder, value: ir::Value, trap: ir::TrapCode) {
+        if self.clif_instruction_traps_enabled() {
+            builder.ins().trapz(value, trap);
+        } else {
+            let ty = builder.func.dfg.value_type(value);
+            let zero = builder.ins().iconst(ty, 0);
+            let cmp = builder.ins().icmp(IntCC::Equal, value, zero);
+            self.conditionally_trap(builder, cmp, trap);
+        }
+    }
+
+    fn trapnz(&mut self, builder: &mut FunctionBuilder, value: ir::Value, trap: ir::TrapCode) {
+        if self.clif_instruction_traps_enabled() {
+            builder.ins().trapnz(value, trap);
+        } else {
+            let ty = builder.func.dfg.value_type(value);
+            let zero = builder.ins().iconst(ty, 0);
+            let cmp = builder.ins().icmp(IntCC::NotEqual, value, zero);
+            self.conditionally_trap(builder, cmp, trap);
+        }
+    }
+
+    fn uadd_overflow_trap(
+        &mut self,
+        builder: &mut FunctionBuilder,
+        lhs: ir::Value,
+        rhs: ir::Value,
+        trap: ir::TrapCode,
+    ) -> ir::Value {
+        if self.clif_instruction_traps_enabled() {
+            builder.ins().uadd_overflow_trap(lhs, rhs, trap)
+        } else {
+            let (ret, overflow) = builder.ins().uadd_overflow(lhs, rhs);
+            self.conditionally_trap(builder, overflow, trap);
+            ret
+        }
+    }
+
+    /// Helper to emit a conditional trap based on `trap_cond`.
+    ///
+    /// This should only be used if `self.clif_instruction_traps_enabled()` is
+    /// false, otherwise native CLIF instructions should be used instead.
+    fn conditionally_trap(
+        &mut self,
+        builder: &mut FunctionBuilder,
+        trap_cond: ir::Value,
+        trap: ir::TrapCode,
+    ) {
+        assert!(!self.clif_instruction_traps_enabled());
+
+        let trap_block = builder.create_block();
+        builder.set_cold_block(trap_block);
+        let continuation_block = builder.create_block();
+
+        builder
+            .ins()
+            .brif(trap_cond, trap_block, &[], continuation_block, &[]);
+
+        builder.seal_block(trap_block);
+        builder.seal_block(continuation_block);
+
+        builder.switch_to_block(trap_block);
+        self.trap(builder, trap);
+        builder.switch_to_block(continuation_block);
+    }
+
+    /// Returns whether it's acceptable to have CLIF instructions natively trap,
+    /// such as division-by-zero.
+    ///
+    /// This is enabled if `signals_based_traps` is `true` or on
+    /// Pulley unconditionally since Pulley doesn't use hardware-based
+    /// traps in its runtime. However, if guest debugging is enabled,
+    /// then we cannot rely on Pulley traps and still need a libcall
+    /// to gain proper ownership of the store in the runtime's
+    /// debugger hooks.
+    fn clif_instruction_traps_enabled(&self) -> bool {
+        let tunables = self.compiler().tunables();
+        tunables.signals_based_traps || (self.is_pulley() && !tunables.debug_guest)
+    }
+
+    /// Returns whether translation is happening for Pulley bytecode.
+    fn is_pulley(&self) -> bool {
+        self.compiler().isa().triple().is_pulley()
+    }
+}

--- a/tests/disas/component-may-leave-without-signals-based-traps.wat
+++ b/tests/disas/component-may-leave-without-signals-based-traps.wat
@@ -1,0 +1,56 @@
+;;! target = "x86_64-unknown-linux-gnu"
+;;! test = "compile"
+;;! flags = "-Osignals-based-traps=n"
+;;! objdump = "--funcs all --filter wasm-call-component-resource-new"
+
+(component
+  (type $r (resource (rep i32)))
+
+  (core module $m (import "" "" (func (param i32) (result i32))))
+
+  (core func $f (canon resource.new $r))
+  (core instance $i (instantiate $m (with "" (instance (export "" (func $f))))))
+)
+;; component-trampolines[0]-wasm-call-component-resource-new[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       subq    $0x10, %rsp
+;;       movq    %rbx, (%rsp)
+;;       movq    %rsi, %rbx
+;;       movq    %rdx, %r8
+;;       movq    0x10(%rdi), %rax
+;;       movq    %rbp, %rcx
+;;       movq    %rcx, 0x30(%rax)
+;;       movq    %rbp, %rcx
+;;       movq    8(%rcx), %rcx
+;;       movq    %rcx, 0x38(%rax)
+;;       movl    0x20(%rdi), %eax
+;;       testl   $1, %eax
+;;       je      0x13e
+;;   fe: movq    8(%rdi), %rax
+;;       movq    (%rax), %rax
+;;       xorl    %ecx, %ecx
+;;       movl    %ecx, %esi
+;;       movl    %ecx, %edx
+;;       movq    %r8, %rcx
+;;       movl    %ecx, %ecx
+;;       callq   *%rax
+;;       cmpq    $-1, %rax
+;;       je      0x129
+;;  11c: movq    (%rsp), %rbx
+;;       addq    $0x10, %rsp
+;;       movq    %rbp, %rsp
+;;       popq    %rbp
+;;       retq
+;;  129: movq    %rbx, %rsi
+;;  12c: movq    0x10(%rsi), %rax
+;;  130: movq    0x198(%rax), %rax
+;;  137: movq    %rsi, %rdi
+;;  13a: callq   *%rax
+;;  13c: ud2
+;;  13e: movq    %rdi, %rbx
+;;  141: movl    $0x17, %esi
+;;  146: callq   0x6a
+;;  14b: movq    %rbx, %rdi
+;;  14e: callq   0x9b
+;;  153: ud2


### PR DESCRIPTION
This commit fixes a regression from #12547 where traps happening in component trampolines weren't respecting the signals-based-traps configuration of the `Engine` meaning that native CLIF traps could be executed in environments which weren't configured to catch it. This refactors the implementation internally to share more code with `FuncEnvironment` through some traits to ensure that the same knobs and plumbing are used to translate traps.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
