### PR TITLE
component model: drop borrows when cancelling host tasks

### DIFF
--- a/crates/wasmtime/src/runtime/vm/component/resources.rs
+++ b/crates/wasmtime/src/runtime/vm/component/resources.rs
@@ -321,6 +321,20 @@ impl ResourceTables<'_> {
         }
         Ok(())
     }
+
+    /// Releases resource lends for a cancelled scope.
+    ///
+    /// This decrements the lend counts on owned resources that were lent
+    /// to the specified scope, allowing them to be dropped by the caller.
+    #[cfg(feature = "component-model-async")]
+    pub fn cancel_scope(&mut self, scope_id: u32) {
+        let cx = self.task_state.call_context(scope_id);
+        for lender in mem::take(&mut cx.lenders) {
+            self.table_for_index(&lender)
+                .resource_undo_lend(lender)
+                .unwrap();
+        }
+    }
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
Update the component model resource tracking to handle cancelling host tasks. Before this change, when cancelling a read on a UDP socket and then dropping the socket failed because of outstanding borrows: the read never released its borrow. Now it does.

I debugged this issue and wrote the code with Claude. I've tested this code for my use case and it seems to work, but I don't fully understand the implications. I worry that it might not be safe to release the borrow count because maybe the host function can still run.

