### PR TITLE
Add incremental snapshotting support to wizer

### DIFF
--- a/crates/wizer/src/component/parse.rs
+++ b/crates/wizer/src/component/parse.rs
@@ -39,7 +39,7 @@ fn parse_into<'a>(
             // Module sections get parsed with wizer's core wasm support.
             Payload::ModuleSection { .. } => match &mut cx {
                 Some(component) => {
-                    let info = crate::parse::parse_with(&full_wasm, &mut iter)?;
+                    let info = crate::parse::parse_with(&full_wasm, &mut iter, false)?;
                     component.push_module_section(info);
                 }
                 None => {

--- a/crates/wizer/src/component/rewrite.rs
+++ b/crates/wizer/src/component/rewrite.rs
@@ -37,8 +37,13 @@ impl Wizer {
                         // and the results of that are spliced into the
                         // component.
                         Some(snapshot) => {
-                            let rewritten_wasm =
-                                self.rewrite(module, snapshot, &FuncRenames::default(), false);
+                            let rewritten_wasm = self.rewrite(
+                                module,
+                                snapshot,
+                                &FuncRenames::default(),
+                                false,
+                                false,
+                            );
                             encoder.section(&wasm_encoder::RawSection {
                                 id: wasm_encoder::ComponentSectionId::CoreModule as u8,
                                 data: &rewritten_wasm,

--- a/crates/wizer/src/lib.rs
+++ b/crates/wizer/src/lib.rs
@@ -29,6 +29,7 @@ use std::collections::{HashMap, HashSet};
 pub use wasmparser::ValType;
 
 const DEFAULT_KEEP_INIT_FUNC: bool = false;
+const DEFAULT_KEEP_INSTRUMENTATION: bool = false;
 
 /// Wizer: the WebAssembly pre-initializer!
 ///
@@ -98,6 +99,18 @@ pub struct Wizer {
         arg(long, require_equals = true, value_name = "true|false")
     )]
     keep_init_func: Option<Option<bool>>,
+
+    /// After initialization, should the Wasm module still contain the
+    /// instrumentation needed for further snapshotting?
+    ///
+    /// This is `false` by default, meaning that instrumentation is stripped
+    /// from the output module. Set to `true` to enable incremental
+    /// snapshotting (savestate) workflows.
+    #[cfg_attr(
+        feature = "clap",
+        arg(long, require_equals = true, value_name = "true|false")
+    )]
+    keep_instrumentation: Option<Option<bool>>,
 }
 
 #[cfg(feature = "clap")]
@@ -151,6 +164,7 @@ impl Wizer {
             init_func: "wizer-initialize".to_string(),
             func_renames: vec![],
             keep_init_func: None,
+            keep_instrumentation: None,
         }
     }
 
@@ -184,6 +198,17 @@ impl Wizer {
         self
     }
 
+    /// After initialization, should the Wasm module still contain the
+    /// instrumentation needed for further snapshotting?
+    ///
+    /// This is `false` by default, meaning that instrumentation is stripped
+    /// from the output module. Set to `true` to enable incremental
+    /// snapshotting (savestate) workflows.
+    pub fn keep_instrumentation(&mut self, keep: bool) -> &mut Self {
+        self.keep_instrumentation = Some(Some(keep));
+        self
+    }
+
     /// First half of [`Self::run`] which instruments the provided `wasm` and
     /// produces a new wasm module which should be run by a runtime.
     ///
@@ -193,7 +218,7 @@ impl Wizer {
         // Make sure we're given valid Wasm from the get go.
         self.wasm_validate(&wasm)?;
 
-        let mut cx = parse::parse(wasm)?;
+        let mut cx = parse::parse(wasm, false)?;
 
         // When wizening core modules directly some imports aren't supported,
         // so check for those here.
@@ -220,6 +245,18 @@ impl Wizer {
         Ok((cx, instrumented_wasm))
     }
 
+    /// Parse a previously instrumented Wasm module, returning its
+    /// [`ModuleContext`].
+    ///
+    /// This is used in incremental snapshotting workflows where the module
+    /// was already instrumented by a prior call to [`Self::instrument`] or
+    /// [`Self::snapshot`] (with [`Self::keep_instrumentation`] enabled). The returned context can be
+    /// passed to [`Self::snapshot`] to produce a new snapshot.
+    pub fn parse_instrumented<'a>(&self, wasm: &'a [u8]) -> Result<ModuleContext<'a>> {
+        self.wasm_validate(wasm)?;
+        parse::parse(wasm, true)
+    }
+
     /// Second half of [`Self::run`] which takes the [`ModuleContext`] returned
     /// by [`Self::instrument`] and the state of the `instance` after it has
     /// possibly executed its initialization function.
@@ -233,12 +270,16 @@ impl Wizer {
     ) -> Result<Vec<u8>> {
         // Parse rename spec.
         let renames = FuncRenames::parse(&self.func_renames)?;
-
         let snapshot = snapshot::snapshot(&cx, instance).await;
-        let rewritten_wasm = self.rewrite(&mut cx, &snapshot, &renames, true);
+        let rewritten_wasm = self.rewrite(
+            &mut cx,
+            &snapshot,
+            &renames,
+            true,
+            self.get_keep_instrumentation(),
+        );
 
         self.debug_assert_valid_wasm(&rewritten_wasm);
-
         Ok(rewritten_wasm)
     }
 
@@ -367,6 +408,13 @@ impl Wizer {
         match self.keep_init_func {
             Some(keep) => keep.unwrap_or(true),
             None => DEFAULT_KEEP_INIT_FUNC,
+        }
+    }
+
+    fn get_keep_instrumentation(&self) -> bool {
+        match self.keep_instrumentation {
+            Some(keep) => keep.unwrap_or(true),
+            None => DEFAULT_KEEP_INSTRUMENTATION,
         }
     }
 }


### PR DESCRIPTION
Rationale: If you keep the instrumentation information inside the output wasm file, then you can at any time use wizer to snapshot it again, allowing you to effectively save and resume later or on another machine

- adds a `keep_instrumentation` option that preserves `__wizer_*` exports in the output module
- adds a `parse_instrumented` method that re-parses a previously snapshotted module so it can be snapshotted again.
- parser::parse has been adjusted to either reject or require existing `__wizer_*` exports depending on new bool arg