### PR TITLE
Work around invalid HTTP server behavior for status 204 and 304 responses

### DIFF
--- a/crates/wasi-http/src/p3/request.rs
+++ b/crates/wasi-http/src/p3/request.rs
@@ -465,8 +465,15 @@ pub async fn default_send_request(
             match res {
                 // `hyper` connection has successfully completed, optimistically poll for response
                 Ok(()) => send.as_mut().poll(cx),
-                // `hyper` connection has failed, return the error
-                Err(err) => Poll::Ready(Err(ErrorCode::from_hyper_request_error(err))),
+                // `hyper` connection has failed. However, the error may have happened after the
+                // response was fully received. That can happen when a server sends a body for a
+                // 204 or 304 response, in violation of the HTTP spec.
+                // In that case, do what browsers do* and ignore the connection error.
+                // *: https://github.com/web-platform-tests/wpt/blob/master/fetch/api/basic/response-null-body.any.js
+                Err(err) => match send.as_mut().poll(cx) {
+                    Poll::Ready(Ok(res)) => Poll::Ready(Ok(res)),
+                    _ => Poll::Ready(Err(ErrorCode::from_hyper_request_error(err))),
+                },
             }
         }
     })


### PR DESCRIPTION
Per spec, an HTTP server isn't allowed to send a body for these status code. Nothing's stopping it from doing so nevertheless, though. This is admittedly very niche and might only actually happen in test suites. It does happen in those, leading to flaky results because whether we report an error here or not depends on whether the body is contained in the same packet as the headers or not.

I think it'd also be okay to instead make these cases always error, though for all I know it's possible that there are niche compatibility concerns with that.

I'm not sure how to add a test to this, because it requires an external server and is flaky, but I put together a [repro in a gist](https://gist.github.com/tschneidereit/972d2ba836e42668fe383a596dde8125). Note that that uses the wasip3 crate, which targets `0.3.0-rc-2026-01-06`, so this won't work as-is with Wasmtime's `main`.