### PR TITLE
Debugging: avoid re-patching code on single-step update when state doesn't change.

### DIFF
--- a/crates/wasmtime/src/runtime/debug.rs
+++ b/crates/wasmtime/src/runtime/debug.rs
@@ -1017,6 +1017,11 @@ impl<'a> BreakpointEdit<'a> {
             "single_step({enabled}) with breakpoint set {:?}",
             self.state.breakpoints
         );
+        if self.state.single_step == enabled {
+            // No change to current state; don't go through the effort of re-patching and
+            // re-publishing code.
+            return Ok(());
+        }
         let modules = self.registry.all_modules().cloned().collect::<Vec<_>>();
         for module in modules {
             let mem = Self::get_code_memory(self.registry, &mut self.dirty_modules, &module)?;


### PR DESCRIPTION
When the setter for the single-step flag is given an `enable` boolean that matches the existing state (i.e., enabling when already enabled or disabling when already disabled), we should not loop through and re-patch all breakpoint patch sites. This is an optimization, not required for correctness, but a rather obvious optimization to make (and important when building higher-level APIs for e.g. a single-step command that always set the flag).

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
