### PR TITLE
chore: update wit files to 0.2.10

### DIFF
--- a/ci/vendor-wit.sh
+++ b/ci/vendor-wit.sh
@@ -33,7 +33,7 @@ get_github() {
   cp -r $cached_extracted_dir/wit/* $path
 }
 
-p2=0.2.6
+p2=0.2.10
 p3=0.3.0-rc-2026-02-09
 
 rm -rf crates/wasi-io/wit/deps

--- a/crates/test-programs/src/lib.rs
+++ b/crates/test-programs/src/lib.rs
@@ -11,8 +11,8 @@ wit_bindgen::generate!({
         package wasmtime:test;
 
         world test {
-            include wasi:cli/imports@0.2.6;
-            include wasi:http/imports@0.2.6;
+            include wasi:cli/imports@0.2.10;
+            include wasi:http/imports@0.2.10;
             include wasi:config/imports@0.2.0-rc.1;
             include wasi:keyvalue/imports@0.2.0-draft;
             include wasi:tls/imports@0.2.0-draft;
@@ -36,17 +36,17 @@ pub mod proxy {
         default_bindings_module: "test_programs::proxy",
         pub_export_macro: true,
         with: {
-            "wasi:http/types@0.2.6": crate::wasi::http::types,
-            "wasi:http/outgoing-handler@0.2.6": crate::wasi::http::outgoing_handler,
-            "wasi:random/random@0.2.6": crate::wasi::random::random,
-            "wasi:io/error@0.2.6": crate::wasi::io::error,
-            "wasi:io/poll@0.2.6": crate::wasi::io::poll,
-            "wasi:io/streams@0.2.6": crate::wasi::io::streams,
-            "wasi:cli/stdout@0.2.6": crate::wasi::cli::stdout,
-            "wasi:cli/stderr@0.2.6": crate::wasi::cli::stderr,
-            "wasi:cli/stdin@0.2.6": crate::wasi::cli::stdin,
-            "wasi:clocks/monotonic-clock@0.2.6": crate::wasi::clocks::monotonic_clock,
-            "wasi:clocks/wall-clock@0.2.6": crate::wasi::clocks::wall_clock,
+            "wasi:http/types@0.2.10": crate::wasi::http::types,
+            "wasi:http/outgoing-handler@0.2.10": crate::wasi::http::outgoing_handler,
+            "wasi:random/random@0.2.10": crate::wasi::random::random,
+            "wasi:io/error@0.2.10": crate::wasi::io::error,
+            "wasi:io/poll@0.2.10": crate::wasi::io::poll,
+            "wasi:io/streams@0.2.10": crate::wasi::io::streams,
+            "wasi:cli/stdout@0.2.10": crate::wasi::cli::stdout,
+            "wasi:cli/stderr@0.2.10": crate::wasi::cli::stderr,
+            "wasi:cli/stdin@0.2.10": crate::wasi::cli::stdin,
+            "wasi:clocks/monotonic-clock@0.2.10": crate::wasi::clocks::monotonic_clock,
+            "wasi:clocks/wall-clock@0.2.10": crate::wasi::clocks::wall_clock,
         },
     });
 }

--- a/crates/wasi-http/wit/deps/cli.wit
+++ b/crates/wasi-http/wit/deps/cli.wit
@@ -1,4 +1,4 @@
-package wasi:cli@0.2.6;
+package wasi:cli@0.2.10;
 
 @since(version = 0.2.0)
 interface environment {
@@ -51,7 +51,7 @@ interface run {
 @since(version = 0.2.0)
 interface stdin {
   @since(version = 0.2.0)
-  use wasi:io/streams@0.2.6.{input-stream};
+  use wasi:io/streams@0.2.10.{input-stream};
 
   @since(version = 0.2.0)
   get-stdin: func() -> input-stream;
@@ -60,7 +60,7 @@ interface stdin {
 @since(version = 0.2.0)
 interface stdout {
   @since(version = 0.2.0)
-  use wasi:io/streams@0.2.6.{output-stream};
+  use wasi:io/streams@0.2.10.{output-stream};
 
   @since(version = 0.2.0)
   get-stdout: func() -> output-stream;
@@ -69,7 +69,7 @@ interface stdout {
 @since(version = 0.2.0)
 interface stderr {
   @since(version = 0.2.0)
-  use wasi:io/streams@0.2.6.{output-stream};
+  use wasi:io/streams@0.2.10.{output-stream};
 
   @since(version = 0.2.0)
   get-stderr: func() -> output-stream;
@@ -145,11 +145,11 @@ world imports {
   @since(version = 0.2.0)
   import exit;
   @since(version = 0.2.0)
-  import wasi:io/error@0.2.6;
+  import wasi:io/error@0.2.10;
   @since(version = 0.2.0)
-  import wasi:io/poll@0.2.6;
+  import wasi:io/poll@0.2.10;
   @since(version = 0.2.0)
-  import wasi:io/streams@0.2.6;
+  import wasi:io/streams@0.2.10;
   @since(version = 0.2.0)
   import stdin;
   @since(version = 0.2.0)
@@ -166,36 +166,22 @@ world imports {
   import terminal-stdout;
   @since(version = 0.2.0)
   import terminal-stderr;
-  @since(version = 0.2.0)
-  import wasi:clocks/monotonic-clock@0.2.6;
-  @since(version = 0.2.0)
-  import wasi:clocks/wall-clock@0.2.6;
+  import wasi:clocks/monotonic-clock@0.2.10;
+  import wasi:clocks/wall-clock@0.2.10;
   @unstable(feature = clocks-timezone)
-  import wasi:clocks/timezone@0.2.6;
-  @since(version = 0.2.0)
-  import wasi:filesystem/types@0.2.6;
-  @since(version = 0.2.0)
-  import wasi:filesystem/preopens@0.2.6;
-  @since(version = 0.2.0)
-  import wasi:sockets/network@0.2.6;
-  @since(version = 0.2.0)
-  import wasi:sockets/instance-network@0.2.6;
-  @since(version = 0.2.0)
-  import wasi:sockets/udp@0.2.6;
-  @since(version = 0.2.0)
-  import wasi:sockets/udp-create-socket@0.2.6;
-  @since(version = 0.2.0)
-  import wasi:sockets/tcp@0.2.6;
-  @since(version = 0.2.0)
-  import wasi:sockets/tcp-create-socket@0.2.6;
-  @since(version = 0.2.0)
-  import wasi:sockets/ip-name-lookup@0.2.6;
-  @since(version = 0.2.0)
-  import wasi:random/random@0.2.6;
-  @since(version = 0.2.0)
-  import wasi:random/insecure@0.2.6;
-  @since(version = 0.2.0)
-  import wasi:random/insecure-seed@0.2.6;
+  import wasi:clocks/timezone@0.2.10;
+  import wasi:filesystem/types@0.2.10;
+  import wasi:filesystem/preopens@0.2.10;
+  import wasi:sockets/network@0.2.10;
+  import wasi:sockets/instance-network@0.2.10;
+  import wasi:sockets/udp@0.2.10;
+  import wasi:sockets/udp-create-socket@0.2.10;
+  import wasi:sockets/tcp@0.2.10;
+  import wasi:sockets/tcp-create-socket@0.2.10;
+  import wasi:sockets/ip-name-lookup@0.2.10;
+  import wasi:random/random@0.2.10;
+  import wasi:random/insecure@0.2.10;
+  import wasi:random/insecure-seed@0.2.10;
 }
 @since(version = 0.2.0)
 world command {
@@ -204,11 +190,11 @@ world command {
   @since(version = 0.2.0)
   import exit;
   @since(version = 0.2.0)
-  import wasi:io/error@0.2.6;
+  import wasi:io/error@0.2.10;
   @since(version = 0.2.0)
-  import wasi:io/poll@0.2.6;
+  import wasi:io/poll@0.2.10;
   @since(version = 0.2.0)
-  import wasi:io/streams@0.2.6;
+  import wasi:io/streams@0.2.10;
   @since(version = 0.2.0)
   import stdin;
   @since(version = 0.2.0)
@@ -225,36 +211,22 @@ world command {
   import terminal-stdout;
   @since(version = 0.2.0)
   import terminal-stderr;
-  @since(version = 0.2.0)
-  import wasi:clocks/monotonic-clock@0.2.6;
-  @since(version = 0.2.0)
-  import wasi:clocks/wall-clock@0.2.6;
+  import wasi:clocks/monotonic-clock@0.2.10;
+  import wasi:clocks/wall-clock@0.2.10;
   @unstable(feature = clocks-timezone)
-  import wasi:clocks/timezone@0.2.6;
-  @since(version = 0.2.0)
-  import wasi:filesystem/types@0.2.6;
-  @since(version = 0.2.0)
-  import wasi:filesystem/preopens@0.2.6;
-  @since(version = 0.2.0)
-  import wasi:sockets/network@0.2.6;
-  @since(version = 0.2.0)
-  import wasi:sockets/instance-network@0.2.6;
-  @since(version = 0.2.0)
-  import wasi:sockets/udp@0.2.6;
-  @since(version = 0.2.0)
-  import wasi:sockets/udp-create-socket@0.2.6;
-  @since(version = 0.2.0)
-  import wasi:sockets/tcp@0.2.6;
-  @since(version = 0.2.0)
-  import wasi:sockets/tcp-create-socket@0.2.6;
-  @since(version = 0.2.0)
-  import wasi:sockets/ip-name-lookup@0.2.6;
-  @since(version = 0.2.0)
-  import wasi:random/random@0.2.6;
-  @since(version = 0.2.0)
-  import wasi:random/insecure@0.2.6;
-  @since(version = 0.2.0)
-  import wasi:random/insecure-seed@0.2.6;
+  import wasi:clocks/timezone@0.2.10;
+  import wasi:filesystem/types@0.2.10;
+  import wasi:filesystem/preopens@0.2.10;
+  import wasi:sockets/network@0.2.10;
+  import wasi:sockets/instance-network@0.2.10;
+  import wasi:sockets/udp@0.2.10;
+  import wasi:sockets/udp-create-socket@0.2.10;
+  import wasi:sockets/tcp@0.2.10;
+  import wasi:sockets/tcp-create-socket@0.2.10;
+  import wasi:sockets/ip-name-lookup@0.2.10;
+  import wasi:random/random@0.2.10;
+  import wasi:random/insecure@0.2.10;
+  import wasi:random/insecure-seed@0.2.10;
 
   @since(version = 0.2.0)
   export run;

--- a/crates/wasi-http/wit/deps/clocks.wit
+++ b/crates/wasi-http/wit/deps/clocks.wit
@@ -1,4 +1,4 @@
-package wasi:clocks@0.2.6;
+package wasi:clocks@0.2.10;
 
 /// WASI Monotonic Clock is a clock API intended to let users measure elapsed
 /// time.
@@ -11,7 +11,7 @@ package wasi:clocks@0.2.6;
 @since(version = 0.2.0)
 interface monotonic-clock {
   @since(version = 0.2.0)
-  use wasi:io/poll@0.2.6.{pollable};
+  use wasi:io/poll@0.2.10.{pollable};
 
   /// An instant in time, in nanoseconds. An instant is relative to an
   /// unspecified initial value, and can only be compared to instances from
@@ -27,6 +27,11 @@ interface monotonic-clock {
   ///
   /// The clock is monotonic, therefore calling this function repeatedly will
   /// produce a sequence of non-decreasing values.
+  ///
+  /// For completeness, this function traps if it's not possible to represent
+  /// the value of the clock in an `instant`. Consequently, implementations
+  /// should ensure that the starting time is low enough to avoid the
+  /// possibility of overflow in practice.
   @since(version = 0.2.0)
   now: func() -> instant;
 
@@ -147,7 +152,7 @@ interface timezone {
 @since(version = 0.2.0)
 world imports {
   @since(version = 0.2.0)
-  import wasi:io/poll@0.2.6;
+  import wasi:io/poll@0.2.10;
   @since(version = 0.2.0)
   import monotonic-clock;
   @since(version = 0.2.0)

--- a/crates/wasi-http/wit/deps/filesystem.wit
+++ b/crates/wasi-http/wit/deps/filesystem.wit
@@ -1,4 +1,4 @@
-package wasi:filesystem@0.2.6;
+package wasi:filesystem@0.2.10;
 
 /// WASI filesystem is a filesystem API primarily intended to let users run WASI
 /// programs that access their files on their existing filesystems, without
@@ -27,9 +27,9 @@ package wasi:filesystem@0.2.6;
 @since(version = 0.2.0)
 interface types {
   @since(version = 0.2.0)
-  use wasi:io/streams@0.2.6.{input-stream, output-stream, error};
+  use wasi:io/streams@0.2.10.{input-stream, output-stream, error};
   @since(version = 0.2.0)
-  use wasi:clocks/wall-clock@0.2.6.{datetime};
+  use wasi:clocks/wall-clock@0.2.10.{datetime};
 
   /// File size or length of a region within a file.
   @since(version = 0.2.0)
@@ -170,6 +170,7 @@ interface types {
   }
 
   /// A directory entry.
+  @since(version = 0.2.0)
   record directory-entry {
     /// The type of the file referred to by this directory entry.
     %type: descriptor-type,
@@ -181,6 +182,7 @@ interface types {
   /// Not all of these error codes are returned by the functions provided by this
   /// API; some are used in higher-level library layers, and others are provided
   /// merely for alignment with POSIX.
+  @since(version = 0.2.0)
   enum error-code {
     /// Permission denied, similar to `EACCES` in POSIX.
     access,
@@ -573,13 +575,13 @@ interface preopens {
 @since(version = 0.2.0)
 world imports {
   @since(version = 0.2.0)
-  import wasi:io/error@0.2.6;
+  import wasi:io/error@0.2.10;
   @since(version = 0.2.0)
-  import wasi:io/poll@0.2.6;
+  import wasi:io/poll@0.2.10;
   @since(version = 0.2.0)
-  import wasi:io/streams@0.2.6;
+  import wasi:io/streams@0.2.10;
   @since(version = 0.2.0)
-  import wasi:clocks/wall-clock@0.2.6;
+  import wasi:clocks/wall-clock@0.2.10;
   @since(version = 0.2.0)
   import types;
   @since(version = 0.2.0)

--- a/crates/wasi-http/wit/deps/http.wit
+++ b/crates/wasi-http/wit/deps/http.wit
@@ -1,4 +1,4 @@
-package wasi:http@0.2.6;
+package wasi:http@0.2.10;
 
 /// This interface defines all of the types and methods for implementing
 /// HTTP Requests and Responses, both incoming and outgoing, as well as
@@ -6,13 +6,13 @@ package wasi:http@0.2.6;
 @since(version = 0.2.0)
 interface types {
   @since(version = 0.2.0)
-  use wasi:clocks/monotonic-clock@0.2.6.{duration};
+  use wasi:clocks/monotonic-clock@0.2.10.{duration};
   @since(version = 0.2.0)
-  use wasi:io/streams@0.2.6.{input-stream, output-stream};
+  use wasi:io/streams@0.2.10.{input-stream, output-stream};
   @since(version = 0.2.0)
-  use wasi:io/error@0.2.6.{error as io-error};
+  use wasi:io/error@0.2.10.{error as io-error};
   @since(version = 0.2.0)
-  use wasi:io/poll@0.2.6.{pollable};
+  use wasi:io/poll@0.2.10.{pollable};
 
   /// This type corresponds to HTTP standard Methods.
   @since(version = 0.2.0)
@@ -619,8 +619,8 @@ interface types {
   /// provided.
   ///
   /// Stream operations which return
-  /// `wasi:io/stream/stream-error::last-operation-failed` have a payload of
-  /// type `wasi:io/error/error` with more information about the operation
+  /// `wasi:io/stream.stream-error.last-operation-failed` have a payload of
+  /// type `wasi:io/error.error` with more information about the operation
   /// that failed. This payload can be passed through to this function to see
   /// if there's http-related information about the error to return.
   ///
@@ -677,23 +677,23 @@ interface outgoing-handler {
 @since(version = 0.2.0)
 world imports {
   @since(version = 0.2.0)
-  import wasi:io/poll@0.2.6;
+  import wasi:io/poll@0.2.10;
   @since(version = 0.2.0)
-  import wasi:clocks/monotonic-clock@0.2.6;
+  import wasi:clocks/monotonic-clock@0.2.10;
   @since(version = 0.2.0)
-  import wasi:clocks/wall-clock@0.2.6;
+  import wasi:clocks/wall-clock@0.2.10;
   @since(version = 0.2.0)
-  import wasi:random/random@0.2.6;
+  import wasi:random/random@0.2.10;
   @since(version = 0.2.0)
-  import wasi:io/error@0.2.6;
+  import wasi:io/error@0.2.10;
   @since(version = 0.2.0)
-  import wasi:io/streams@0.2.6;
+  import wasi:io/streams@0.2.10;
   @since(version = 0.2.0)
-  import wasi:cli/stdout@0.2.6;
+  import wasi:cli/stdout@0.2.10;
   @since(version = 0.2.0)
-  import wasi:cli/stderr@0.2.6;
+  import wasi:cli/stderr@0.2.10;
   @since(version = 0.2.0)
-  import wasi:cli/stdin@0.2.6;
+  import wasi:cli/stdin@0.2.10;
   @since(version = 0.2.0)
   import types;
   @since(version = 0.2.0)
@@ -706,23 +706,23 @@ world imports {
 @since(version = 0.2.0)
 world proxy {
   @since(version = 0.2.0)
-  import wasi:io/poll@0.2.6;
+  import wasi:io/poll@0.2.10;
   @since(version = 0.2.0)
-  import wasi:clocks/monotonic-clock@0.2.6;
+  import wasi:clocks/monotonic-clock@0.2.10;
   @since(version = 0.2.0)
-  import wasi:clocks/wall-clock@0.2.6;
+  import wasi:clocks/wall-clock@0.2.10;
   @since(version = 0.2.0)
-  import wasi:random/random@0.2.6;
+  import wasi:random/random@0.2.10;
   @since(version = 0.2.0)
-  import wasi:io/error@0.2.6;
+  import wasi:io/error@0.2.10;
   @since(version = 0.2.0)
-  import wasi:io/streams@0.2.6;
+  import wasi:io/streams@0.2.10;
   @since(version = 0.2.0)
-  import wasi:cli/stdout@0.2.6;
+  import wasi:cli/stdout@0.2.10;
   @since(version = 0.2.0)
-  import wasi:cli/stderr@0.2.6;
+  import wasi:cli/stderr@0.2.10;
   @since(version = 0.2.0)
-  import wasi:cli/stdin@0.2.6;
+  import wasi:cli/stdin@0.2.10;
   @since(version = 0.2.0)
   import types;
   @since(version = 0.2.0)

--- a/crates/wasi-http/wit/deps/io.wit
+++ b/crates/wasi-http/wit/deps/io.wit
@@ -1,4 +1,4 @@
-package wasi:io@0.2.6;
+package wasi:io@0.2.10;
 
 @since(version = 0.2.0)
 interface error {
@@ -8,14 +8,14 @@ interface error {
   /// which provides some human-readable information about the error.
   ///
   /// In the `wasi:io` package, this resource is returned through the
-  /// `wasi:io/streams/stream-error` type.
+  /// `wasi:io/streams.stream-error` type.
   ///
   /// To provide more specific error information, other interfaces may
   /// offer functions to "downcast" this error into more specific types. For example,
   /// errors returned from streams derived from filesystem types can be described using
   /// the filesystem's own error-code type. This is done using the function
-  /// `wasi:filesystem/types/filesystem-error-code`, which takes a `borrow<error>`
-  /// parameter and returns an `option<wasi:filesystem/types/error-code>`.
+  /// `wasi:filesystem/types.filesystem-error-code`, which takes a `borrow<error>`
+  /// parameter and returns an `option<wasi:filesystem/types.error-code>`.
   ///
   /// The set of functions which can "downcast" an `error` into a more
   /// concrete type is open.
@@ -210,27 +210,13 @@ interface streams {
     /// Perform a write of up to 4096 bytes, and then flush the stream. Block
     /// until all of these operations are complete, or an error occurs.
     ///
-    /// This is a convenience wrapper around the use of `check-write`,
-    /// `subscribe`, `write`, and `flush`, and is implemented with the
-    /// following pseudo-code:
-    ///
-    /// ```text
-    /// let pollable = this.subscribe();
-    /// while !contents.is_empty() {
-    ///     // Wait for the stream to become writable
-    ///     pollable.block();
-    ///     let Ok(n) = this.check-write(); // eliding error handling
-    ///     let len = min(n, contents.len());
-    ///     let (chunk, rest) = contents.split_at(len);
-    ///     this.write(chunk  );            // eliding error handling
-    ///     contents = rest;
-    /// }
-    /// this.flush();
-    /// // Wait for completion of `flush`
-    /// pollable.block();
-    /// // Check for any errors that arose during `flush`
-    /// let _ = this.check-write();         // eliding error handling
-    /// ```
+    /// Returns success when all of the contents written are successfully
+    /// flushed to output. If an error occurs at any point before all
+    /// contents are successfully flushed, that error is returned as soon as
+    /// possible. If writing and flushing the complete contents causes the
+    /// stream to become closed, this call should return success, and
+    /// subsequent calls to check-write or other interfaces should return
+    /// stream-error::closed.
     @since(version = 0.2.0)
     blocking-write-and-flush: func(contents: list<u8>) -> result<_, stream-error>;
     /// Request to flush buffered output. This function never blocks.
@@ -273,26 +259,8 @@ interface streams {
     /// Block until all of these operations are complete, or an error
     /// occurs.
     ///
-    /// This is a convenience wrapper around the use of `check-write`,
-    /// `subscribe`, `write-zeroes`, and `flush`, and is implemented with
-    /// the following pseudo-code:
-    ///
-    /// ```text
-    /// let pollable = this.subscribe();
-    /// while num_zeroes != 0 {
-    ///     // Wait for the stream to become writable
-    ///     pollable.block();
-    ///     let Ok(n) = this.check-write(); // eliding error handling
-    ///     let len = min(n, num_zeroes);
-    ///     this.write-zeroes(len);         // eliding error handling
-    ///     num_zeroes -= len;
-    /// }
-    /// this.flush();
-    /// // Wait for completion of `flush`
-    /// pollable.block();
-    /// // Check for any errors that arose during `flush`
-    /// let _ = this.check-write();         // eliding error handling
-    /// ```
+    /// Functionality is equivelant to `blocking-write-and-flush` with
+    /// contents given as a list of len containing only zeroes.
     @since(version = 0.2.0)
     blocking-write-zeroes-and-flush: func(len: u64) -> result<_, stream-error>;
     /// Read from one stream and write to another.

--- a/crates/wasi-http/wit/deps/random.wit
+++ b/crates/wasi-http/wit/deps/random.wit
@@ -1,4 +1,4 @@
-package wasi:random@0.2.6;
+package wasi:random@0.2.10;
 
 /// The insecure-seed interface for seeding hash-map DoS resistance.
 ///

--- a/crates/wasi-http/wit/deps/sockets.wit
+++ b/crates/wasi-http/wit/deps/sockets.wit
@@ -1,9 +1,9 @@
-package wasi:sockets@0.2.6;
+package wasi:sockets@0.2.10;
 
 @since(version = 0.2.0)
 interface network {
   @unstable(feature = network-error-code)
-  use wasi:io/error@0.2.6.{error};
+  use wasi:io/error@0.2.10.{error};
 
   /// An opaque resource that represents access to (a subset of) the network.
   /// This enables context-based security for networking.
@@ -160,7 +160,7 @@ interface instance-network {
 @since(version = 0.2.0)
 interface ip-name-lookup {
   @since(version = 0.2.0)
-  use wasi:io/poll@0.2.6.{pollable};
+  use wasi:io/poll@0.2.10.{pollable};
   @since(version = 0.2.0)
   use network.{network, error-code, ip-address};
 
@@ -216,11 +216,11 @@ interface ip-name-lookup {
 @since(version = 0.2.0)
 interface tcp {
   @since(version = 0.2.0)
-  use wasi:io/streams@0.2.6.{input-stream, output-stream};
+  use wasi:io/streams@0.2.10.{input-stream, output-stream};
   @since(version = 0.2.0)
-  use wasi:io/poll@0.2.6.{pollable};
+  use wasi:io/poll@0.2.10.{pollable};
   @since(version = 0.2.0)
-  use wasi:clocks/monotonic-clock@0.2.6.{duration};
+  use wasi:clocks/monotonic-clock@0.2.10.{duration};
   @since(version = 0.2.0)
   use network.{network, error-code, ip-socket-address, ip-address-family};
 
@@ -617,7 +617,7 @@ interface tcp-create-socket {
 @since(version = 0.2.0)
 interface udp {
   @since(version = 0.2.0)
-  use wasi:io/poll@0.2.6.{pollable};
+  use wasi:io/poll@0.2.10.{pollable};
   @since(version = 0.2.0)
   use network.{network, error-code, ip-socket-address, ip-address-family};
 
@@ -925,21 +925,21 @@ interface udp-create-socket {
 @since(version = 0.2.0)
 world imports {
   @since(version = 0.2.0)
-  import wasi:io/error@0.2.6;
+  import wasi:io/error@0.2.10;
   @since(version = 0.2.0)
   import network;
   @since(version = 0.2.0)
   import instance-network;
   @since(version = 0.2.0)
-  import wasi:io/poll@0.2.6;
+  import wasi:io/poll@0.2.10;
   @since(version = 0.2.0)
   import udp;
   @since(version = 0.2.0)
   import udp-create-socket;
   @since(version = 0.2.0)
-  import wasi:io/streams@0.2.6;
+  import wasi:io/streams@0.2.10;
   @since(version = 0.2.0)
-  import wasi:clocks/monotonic-clock@0.2.6;
+  import wasi:clocks/monotonic-clock@0.2.10;
   @since(version = 0.2.0)
   import tcp;
   @since(version = 0.2.0)

--- a/crates/wasi-http/wit/world.wit
+++ b/crates/wasi-http/wit/world.wit
@@ -2,5 +2,5 @@
 package wasmtime:wasi-http;
 
 world bindings {
-  include wasi:http/proxy@0.2.6;
+  include wasi:http/proxy@0.2.10;
 }

--- a/crates/wasi-io/wit/deps/io.wit
+++ b/crates/wasi-io/wit/deps/io.wit
@@ -1,4 +1,4 @@
-package wasi:io@0.2.6;
+package wasi:io@0.2.10;
 
 @since(version = 0.2.0)
 interface error {
@@ -8,14 +8,14 @@ interface error {
   /// which provides some human-readable information about the error.
   ///
   /// In the `wasi:io` package, this resource is returned through the
-  /// `wasi:io/streams/stream-error` type.
+  /// `wasi:io/streams.stream-error` type.
   ///
   /// To provide more specific error information, other interfaces may
   /// offer functions to "downcast" this error into more specific types. For example,
   /// errors returned from streams derived from filesystem types can be described using
   /// the filesystem's own error-code type. This is done using the function
-  /// `wasi:filesystem/types/filesystem-error-code`, which takes a `borrow<error>`
-  /// parameter and returns an `option<wasi:filesystem/types/error-code>`.
+  /// `wasi:filesystem/types.filesystem-error-code`, which takes a `borrow<error>`
+  /// parameter and returns an `option<wasi:filesystem/types.error-code>`.
   ///
   /// The set of functions which can "downcast" an `error` into a more
   /// concrete type is open.
@@ -210,27 +210,13 @@ interface streams {
     /// Perform a write of up to 4096 bytes, and then flush the stream. Block
     /// until all of these operations are complete, or an error occurs.
     ///
-    /// This is a convenience wrapper around the use of `check-write`,
-    /// `subscribe`, `write`, and `flush`, and is implemented with the
-    /// following pseudo-code:
-    ///
-    /// ```text
-    /// let pollable = this.subscribe();
-    /// while !contents.is_empty() {
-    ///     // Wait for the stream to become writable
-    ///     pollable.block();
-    ///     let Ok(n) = this.check-write(); // eliding error handling
-    ///     let len = min(n, contents.len());
-    ///     let (chunk, rest) = contents.split_at(len);
-    ///     this.write(chunk  );            // eliding error handling
-    ///     contents = rest;
-    /// }
-    /// this.flush();
-    /// // Wait for completion of `flush`
-    /// pollable.block();
-    /// // Check for any errors that arose during `flush`
-    /// let _ = this.check-write();         // eliding error handling
-    /// ```
+    /// Returns success when all of the contents written are successfully
+    /// flushed to output. If an error occurs at any point before all
+    /// contents are successfully flushed, that error is returned as soon as
+    /// possible. If writing and flushing the complete contents causes the
+    /// stream to become closed, this call should return success, and
+    /// subsequent calls to check-write or other interfaces should return
+    /// stream-error::closed.
     @since(version = 0.2.0)
     blocking-write-and-flush: func(contents: list<u8>) -> result<_, stream-error>;
     /// Request to flush buffered output. This function never blocks.
@@ -273,26 +259,8 @@ interface streams {
     /// Block until all of these operations are complete, or an error
     /// occurs.
     ///
-    /// This is a convenience wrapper around the use of `check-write`,
-    /// `subscribe`, `write-zeroes`, and `flush`, and is implemented with
-    /// the following pseudo-code:
-    ///
-    /// ```text
-    /// let pollable = this.subscribe();
-    /// while num_zeroes != 0 {
-    ///     // Wait for the stream to become writable
-    ///     pollable.block();
-    ///     let Ok(n) = this.check-write(); // eliding error handling
-    ///     let len = min(n, num_zeroes);
-    ///     this.write-zeroes(len);         // eliding error handling
-    ///     num_zeroes -= len;
-    /// }
-    /// this.flush();
-    /// // Wait for completion of `flush`
-    /// pollable.block();
-    /// // Check for any errors that arose during `flush`
-    /// let _ = this.check-write();         // eliding error handling
-    /// ```
+    /// Functionality is equivelant to `blocking-write-and-flush` with
+    /// contents given as a list of len containing only zeroes.
     @since(version = 0.2.0)
     blocking-write-zeroes-and-flush: func(len: u64) -> result<_, stream-error>;
     /// Read from one stream and write to another.

--- a/crates/wasi-io/wit/world.wit
+++ b/crates/wasi-io/wit/world.wit
@@ -2,5 +2,5 @@
 package wasmtime:wasi-io;
 
 world bindings {
-  include wasi:io/imports@0.2.6;
+  include wasi:io/imports@0.2.10;
 }

--- a/crates/wasi-preview1-component-adapter/src/descriptors.rs
+++ b/crates/wasi-preview1-component-adapter/src/descriptors.rs
@@ -149,7 +149,7 @@ pub struct Descriptors {
 }
 
 #[cfg(not(feature = "proxy"))]
-#[link(wasm_import_module = "wasi:filesystem/preopens@0.2.6")]
+#[link(wasm_import_module = "wasi:filesystem/preopens@0.2.10")]
 unsafe extern "C" {
     #[link_name = "get-directories"]
     fn wasi_filesystem_get_directories(rval: *mut PreopenList);

--- a/crates/wasi-preview1-component-adapter/src/lib.rs
+++ b/crates/wasi-preview1-component-adapter/src/lib.rs
@@ -99,12 +99,12 @@ pub mod bindings {
             package wasmtime:adapter;
 
             world adapter {
-                import wasi:clocks/wall-clock@0.2.6;
-                import wasi:clocks/monotonic-clock@0.2.6;
-                import wasi:random/random@0.2.6;
-                import wasi:cli/stdout@0.2.6;
-                import wasi:cli/stderr@0.2.6;
-                import wasi:cli/stdin@0.2.6;
+                import wasi:clocks/wall-clock@0.2.10;
+                import wasi:clocks/monotonic-clock@0.2.10;
+                import wasi:random/random@0.2.10;
+                import wasi:cli/stdout@0.2.10;
+                import wasi:cli/stderr@0.2.10;
+                import wasi:cli/stdin@0.2.10;
             }
         "#,
         world: "wasmtime:adapter/adapter",
@@ -122,7 +122,7 @@ pub mod bindings {
     }
 }
 
-#[unsafe(export_name = "wasi:cli/run@0.2.6#run")]
+#[unsafe(export_name = "wasi:cli/run@0.2.10#run")]
 #[cfg(feature = "command")]
 pub extern "C" fn run() -> u32 {
     #[link(wasm_import_module = "__main_module__")]
@@ -469,7 +469,7 @@ impl BumpAlloc {
 }
 
 #[cfg(not(feature = "proxy"))]
-#[link(wasm_import_module = "wasi:cli/environment@0.2.6")]
+#[link(wasm_import_module = "wasi:cli/environment@0.2.10")]
 unsafe extern "C" {
     #[link_name = "get-arguments"]
     fn wasi_cli_get_arguments(rval: *mut WasmStrList);
@@ -2209,7 +2209,7 @@ pub unsafe extern "C" fn poll_oneoff(
             }
         }
 
-        #[link(wasm_import_module = "wasi:io/poll@0.2.6")]
+        #[link(wasm_import_module = "wasi:io/poll@0.2.10")]
         unsafe extern "C" {
             #[link_name = "poll"]
             fn poll_import(pollables: *const Pollable, len: usize, rval: *mut ReadyList);

--- a/crates/wasi-tls/wit/deps/io.wit
+++ b/crates/wasi-tls/wit/deps/io.wit
@@ -1,4 +1,4 @@
-package wasi:io@0.2.6;
+package wasi:io@0.2.10;
 
 @since(version = 0.2.0)
 interface error {
@@ -8,14 +8,14 @@ interface error {
   /// which provides some human-readable information about the error.
   ///
   /// In the `wasi:io` package, this resource is returned through the
-  /// `wasi:io/streams/stream-error` type.
+  /// `wasi:io/streams.stream-error` type.
   ///
   /// To provide more specific error information, other interfaces may
   /// offer functions to "downcast" this error into more specific types. For example,
   /// errors returned from streams derived from filesystem types can be described using
   /// the filesystem's own error-code type. This is done using the function
-  /// `wasi:filesystem/types/filesystem-error-code`, which takes a `borrow<error>`
-  /// parameter and returns an `option<wasi:filesystem/types/error-code>`.
+  /// `wasi:filesystem/types.filesystem-error-code`, which takes a `borrow<error>`
+  /// parameter and returns an `option<wasi:filesystem/types.error-code>`.
   ///
   /// The set of functions which can "downcast" an `error` into a more
   /// concrete type is open.
@@ -210,27 +210,13 @@ interface streams {
     /// Perform a write of up to 4096 bytes, and then flush the stream. Block
     /// until all of these operations are complete, or an error occurs.
     ///
-    /// This is a convenience wrapper around the use of `check-write`,
-    /// `subscribe`, `write`, and `flush`, and is implemented with the
-    /// following pseudo-code:
-    ///
-    /// ```text
-    /// let pollable = this.subscribe();
-    /// while !contents.is_empty() {
-    ///     // Wait for the stream to become writable
-    ///     pollable.block();
-    ///     let Ok(n) = this.check-write(); // eliding error handling
-    ///     let len = min(n, contents.len());
-    ///     let (chunk, rest) = contents.split_at(len);
-    ///     this.write(chunk  );            // eliding error handling
-    ///     contents = rest;
-    /// }
-    /// this.flush();
-    /// // Wait for completion of `flush`
-    /// pollable.block();
-    /// // Check for any errors that arose during `flush`
-    /// let _ = this.check-write();         // eliding error handling
-    /// ```
+    /// Returns success when all of the contents written are successfully
+    /// flushed to output. If an error occurs at any point before all
+    /// contents are successfully flushed, that error is returned as soon as
+    /// possible. If writing and flushing the complete contents causes the
+    /// stream to become closed, this call should return success, and
+    /// subsequent calls to check-write or other interfaces should return
+    /// stream-error::closed.
     @since(version = 0.2.0)
     blocking-write-and-flush: func(contents: list<u8>) -> result<_, stream-error>;
     /// Request to flush buffered output. This function never blocks.
@@ -273,26 +259,8 @@ interface streams {
     /// Block until all of these operations are complete, or an error
     /// occurs.
     ///
-    /// This is a convenience wrapper around the use of `check-write`,
-    /// `subscribe`, `write-zeroes`, and `flush`, and is implemented with
-    /// the following pseudo-code:
-    ///
-    /// ```text
-    /// let pollable = this.subscribe();
-    /// while num_zeroes != 0 {
-    ///     // Wait for the stream to become writable
-    ///     pollable.block();
-    ///     let Ok(n) = this.check-write(); // eliding error handling
-    ///     let len = min(n, num_zeroes);
-    ///     this.write-zeroes(len);         // eliding error handling
-    ///     num_zeroes -= len;
-    /// }
-    /// this.flush();
-    /// // Wait for completion of `flush`
-    /// pollable.block();
-    /// // Check for any errors that arose during `flush`
-    /// let _ = this.check-write();         // eliding error handling
-    /// ```
+    /// Functionality is equivelant to `blocking-write-and-flush` with
+    /// contents given as a list of len containing only zeroes.
     @since(version = 0.2.0)
     blocking-write-zeroes-and-flush: func(len: u64) -> result<_, stream-error>;
     /// Read from one stream and write to another.

--- a/crates/wasi-tls/wit/deps/tls/types.wit
+++ b/crates/wasi-tls/wit/deps/tls/types.wit
@@ -1,11 +1,11 @@
 @unstable(feature = tls)
 interface types {
     @unstable(feature = tls)
-    use wasi:io/streams@0.2.10.{input-stream, output-stream};
+    use wasi:io/streams@0.2.6.{input-stream, output-stream};
     @unstable(feature = tls)
-    use wasi:io/poll@0.2.10.{pollable};
+    use wasi:io/poll@0.2.6.{pollable};
     @unstable(feature = tls)
-    use wasi:io/error@0.2.10.{error as io-error};
+    use wasi:io/error@0.2.6.{error as io-error};
 
     @unstable(feature = tls)
     resource client-handshake {

--- a/crates/wasi-tls/wit/deps/tls/types.wit
+++ b/crates/wasi-tls/wit/deps/tls/types.wit
@@ -1,11 +1,11 @@
 @unstable(feature = tls)
 interface types {
     @unstable(feature = tls)
-    use wasi:io/streams@0.2.6.{input-stream, output-stream};
+    use wasi:io/streams@0.2.10.{input-stream, output-stream};
     @unstable(feature = tls)
-    use wasi:io/poll@0.2.6.{pollable};
+    use wasi:io/poll@0.2.10.{pollable};
     @unstable(feature = tls)
-    use wasi:io/error@0.2.6.{error as io-error};
+    use wasi:io/error@0.2.10.{error as io-error};
 
     @unstable(feature = tls)
     resource client-handshake {

--- a/crates/wasi/src/p2/bindings.rs
+++ b/crates/wasi/src/p2/bindings.rs
@@ -26,7 +26,7 @@
 //!         // An example of extending the `wasi:cli/command` world with a
 //!         // custom host interface.
 //!         world my-world {
-//!             include wasi:cli/command@0.2.6;
+//!             include wasi:cli/command@0.2.10;
 //!
 //!             import custom-host;
 //!         }
@@ -94,7 +94,7 @@
 ///         // An example of extending the `wasi:cli/command` world with a
 ///         // custom host interface.
 ///         world my-world {
-///             include wasi:cli/command@0.2.6;
+///             include wasi:cli/command@0.2.10;
 ///
 ///             import custom-host;
 ///         }

--- a/crates/wasi/src/p2/wit/deps/cli.wit
+++ b/crates/wasi/src/p2/wit/deps/cli.wit
@@ -1,4 +1,4 @@
-package wasi:cli@0.2.6;
+package wasi:cli@0.2.10;
 
 @since(version = 0.2.0)
 interface environment {
@@ -51,7 +51,7 @@ interface run {
 @since(version = 0.2.0)
 interface stdin {
   @since(version = 0.2.0)
-  use wasi:io/streams@0.2.6.{input-stream};
+  use wasi:io/streams@0.2.10.{input-stream};
 
   @since(version = 0.2.0)
   get-stdin: func() -> input-stream;
@@ -60,7 +60,7 @@ interface stdin {
 @since(version = 0.2.0)
 interface stdout {
   @since(version = 0.2.0)
-  use wasi:io/streams@0.2.6.{output-stream};
+  use wasi:io/streams@0.2.10.{output-stream};
 
   @since(version = 0.2.0)
   get-stdout: func() -> output-stream;
@@ -69,7 +69,7 @@ interface stdout {
 @since(version = 0.2.0)
 interface stderr {
   @since(version = 0.2.0)
-  use wasi:io/streams@0.2.6.{output-stream};
+  use wasi:io/streams@0.2.10.{output-stream};
 
   @since(version = 0.2.0)
   get-stderr: func() -> output-stream;
@@ -145,11 +145,11 @@ world imports {
   @since(version = 0.2.0)
   import exit;
   @since(version = 0.2.0)
-  import wasi:io/error@0.2.6;
+  import wasi:io/error@0.2.10;
   @since(version = 0.2.0)
-  import wasi:io/poll@0.2.6;
+  import wasi:io/poll@0.2.10;
   @since(version = 0.2.0)
-  import wasi:io/streams@0.2.6;
+  import wasi:io/streams@0.2.10;
   @since(version = 0.2.0)
   import stdin;
   @since(version = 0.2.0)
@@ -166,36 +166,22 @@ world imports {
   import terminal-stdout;
   @since(version = 0.2.0)
   import terminal-stderr;
-  @since(version = 0.2.0)
-  import wasi:clocks/monotonic-clock@0.2.6;
-  @since(version = 0.2.0)
-  import wasi:clocks/wall-clock@0.2.6;
+  import wasi:clocks/monotonic-clock@0.2.10;
+  import wasi:clocks/wall-clock@0.2.10;
   @unstable(feature = clocks-timezone)
-  import wasi:clocks/timezone@0.2.6;
-  @since(version = 0.2.0)
-  import wasi:filesystem/types@0.2.6;
-  @since(version = 0.2.0)
-  import wasi:filesystem/preopens@0.2.6;
-  @since(version = 0.2.0)
-  import wasi:sockets/network@0.2.6;
-  @since(version = 0.2.0)
-  import wasi:sockets/instance-network@0.2.6;
-  @since(version = 0.2.0)
-  import wasi:sockets/udp@0.2.6;
-  @since(version = 0.2.0)
-  import wasi:sockets/udp-create-socket@0.2.6;
-  @since(version = 0.2.0)
-  import wasi:sockets/tcp@0.2.6;
-  @since(version = 0.2.0)
-  import wasi:sockets/tcp-create-socket@0.2.6;
-  @since(version = 0.2.0)
-  import wasi:sockets/ip-name-lookup@0.2.6;
-  @since(version = 0.2.0)
-  import wasi:random/random@0.2.6;
-  @since(version = 0.2.0)
-  import wasi:random/insecure@0.2.6;
-  @since(version = 0.2.0)
-  import wasi:random/insecure-seed@0.2.6;
+  import wasi:clocks/timezone@0.2.10;
+  import wasi:filesystem/types@0.2.10;
+  import wasi:filesystem/preopens@0.2.10;
+  import wasi:sockets/network@0.2.10;
+  import wasi:sockets/instance-network@0.2.10;
+  import wasi:sockets/udp@0.2.10;
+  import wasi:sockets/udp-create-socket@0.2.10;
+  import wasi:sockets/tcp@0.2.10;
+  import wasi:sockets/tcp-create-socket@0.2.10;
+  import wasi:sockets/ip-name-lookup@0.2.10;
+  import wasi:random/random@0.2.10;
+  import wasi:random/insecure@0.2.10;
+  import wasi:random/insecure-seed@0.2.10;
 }
 @since(version = 0.2.0)
 world command {
@@ -204,11 +190,11 @@ world command {
   @since(version = 0.2.0)
   import exit;
   @since(version = 0.2.0)
-  import wasi:io/error@0.2.6;
+  import wasi:io/error@0.2.10;
   @since(version = 0.2.0)
-  import wasi:io/poll@0.2.6;
+  import wasi:io/poll@0.2.10;
   @since(version = 0.2.0)
-  import wasi:io/streams@0.2.6;
+  import wasi:io/streams@0.2.10;
   @since(version = 0.2.0)
   import stdin;
   @since(version = 0.2.0)
@@ -225,36 +211,22 @@ world command {
   import terminal-stdout;
   @since(version = 0.2.0)
   import terminal-stderr;
-  @since(version = 0.2.0)
-  import wasi:clocks/monotonic-clock@0.2.6;
-  @since(version = 0.2.0)
-  import wasi:clocks/wall-clock@0.2.6;
+  import wasi:clocks/monotonic-clock@0.2.10;
+  import wasi:clocks/wall-clock@0.2.10;
   @unstable(feature = clocks-timezone)
-  import wasi:clocks/timezone@0.2.6;
-  @since(version = 0.2.0)
-  import wasi:filesystem/types@0.2.6;
-  @since(version = 0.2.0)
-  import wasi:filesystem/preopens@0.2.6;
-  @since(version = 0.2.0)
-  import wasi:sockets/network@0.2.6;
-  @since(version = 0.2.0)
-  import wasi:sockets/instance-network@0.2.6;
-  @since(version = 0.2.0)
-  import wasi:sockets/udp@0.2.6;
-  @since(version = 0.2.0)
-  import wasi:sockets/udp-create-socket@0.2.6;
-  @since(version = 0.2.0)
-  import wasi:sockets/tcp@0.2.6;
-  @since(version = 0.2.0)
-  import wasi:sockets/tcp-create-socket@0.2.6;
-  @since(version = 0.2.0)
-  import wasi:sockets/ip-name-lookup@0.2.6;
-  @since(version = 0.2.0)
-  import wasi:random/random@0.2.6;
-  @since(version = 0.2.0)
-  import wasi:random/insecure@0.2.6;
-  @since(version = 0.2.0)
-  import wasi:random/insecure-seed@0.2.6;
+  import wasi:clocks/timezone@0.2.10;
+  import wasi:filesystem/types@0.2.10;
+  import wasi:filesystem/preopens@0.2.10;
+  import wasi:sockets/network@0.2.10;
+  import wasi:sockets/instance-network@0.2.10;
+  import wasi:sockets/udp@0.2.10;
+  import wasi:sockets/udp-create-socket@0.2.10;
+  import wasi:sockets/tcp@0.2.10;
+  import wasi:sockets/tcp-create-socket@0.2.10;
+  import wasi:sockets/ip-name-lookup@0.2.10;
+  import wasi:random/random@0.2.10;
+  import wasi:random/insecure@0.2.10;
+  import wasi:random/insecure-seed@0.2.10;
 
   @since(version = 0.2.0)
   export run;

--- a/crates/wasi/src/p2/wit/deps/clocks.wit
+++ b/crates/wasi/src/p2/wit/deps/clocks.wit
@@ -1,4 +1,4 @@
-package wasi:clocks@0.2.6;
+package wasi:clocks@0.2.10;
 
 /// WASI Monotonic Clock is a clock API intended to let users measure elapsed
 /// time.
@@ -11,7 +11,7 @@ package wasi:clocks@0.2.6;
 @since(version = 0.2.0)
 interface monotonic-clock {
   @since(version = 0.2.0)
-  use wasi:io/poll@0.2.6.{pollable};
+  use wasi:io/poll@0.2.10.{pollable};
 
   /// An instant in time, in nanoseconds. An instant is relative to an
   /// unspecified initial value, and can only be compared to instances from
@@ -27,6 +27,11 @@ interface monotonic-clock {
   ///
   /// The clock is monotonic, therefore calling this function repeatedly will
   /// produce a sequence of non-decreasing values.
+  ///
+  /// For completeness, this function traps if it's not possible to represent
+  /// the value of the clock in an `instant`. Consequently, implementations
+  /// should ensure that the starting time is low enough to avoid the
+  /// possibility of overflow in practice.
   @since(version = 0.2.0)
   now: func() -> instant;
 
@@ -147,7 +152,7 @@ interface timezone {
 @since(version = 0.2.0)
 world imports {
   @since(version = 0.2.0)
-  import wasi:io/poll@0.2.6;
+  import wasi:io/poll@0.2.10;
   @since(version = 0.2.0)
   import monotonic-clock;
   @since(version = 0.2.0)

--- a/crates/wasi/src/p2/wit/deps/filesystem.wit
+++ b/crates/wasi/src/p2/wit/deps/filesystem.wit
@@ -1,4 +1,4 @@
-package wasi:filesystem@0.2.6;
+package wasi:filesystem@0.2.10;
 
 /// WASI filesystem is a filesystem API primarily intended to let users run WASI
 /// programs that access their files on their existing filesystems, without
@@ -27,9 +27,9 @@ package wasi:filesystem@0.2.6;
 @since(version = 0.2.0)
 interface types {
   @since(version = 0.2.0)
-  use wasi:io/streams@0.2.6.{input-stream, output-stream, error};
+  use wasi:io/streams@0.2.10.{input-stream, output-stream, error};
   @since(version = 0.2.0)
-  use wasi:clocks/wall-clock@0.2.6.{datetime};
+  use wasi:clocks/wall-clock@0.2.10.{datetime};
 
   /// File size or length of a region within a file.
   @since(version = 0.2.0)
@@ -170,6 +170,7 @@ interface types {
   }
 
   /// A directory entry.
+  @since(version = 0.2.0)
   record directory-entry {
     /// The type of the file referred to by this directory entry.
     %type: descriptor-type,
@@ -181,6 +182,7 @@ interface types {
   /// Not all of these error codes are returned by the functions provided by this
   /// API; some are used in higher-level library layers, and others are provided
   /// merely for alignment with POSIX.
+  @since(version = 0.2.0)
   enum error-code {
     /// Permission denied, similar to `EACCES` in POSIX.
     access,
@@ -573,13 +575,13 @@ interface preopens {
 @since(version = 0.2.0)
 world imports {
   @since(version = 0.2.0)
-  import wasi:io/error@0.2.6;
+  import wasi:io/error@0.2.10;
   @since(version = 0.2.0)
-  import wasi:io/poll@0.2.6;
+  import wasi:io/poll@0.2.10;
   @since(version = 0.2.0)
-  import wasi:io/streams@0.2.6;
+  import wasi:io/streams@0.2.10;
   @since(version = 0.2.0)
-  import wasi:clocks/wall-clock@0.2.6;
+  import wasi:clocks/wall-clock@0.2.10;
   @since(version = 0.2.0)
   import types;
   @since(version = 0.2.0)

--- a/crates/wasi/src/p2/wit/deps/io.wit
+++ b/crates/wasi/src/p2/wit/deps/io.wit
@@ -1,4 +1,4 @@
-package wasi:io@0.2.6;
+package wasi:io@0.2.10;
 
 @since(version = 0.2.0)
 interface error {
@@ -8,14 +8,14 @@ interface error {
   /// which provides some human-readable information about the error.
   ///
   /// In the `wasi:io` package, this resource is returned through the
-  /// `wasi:io/streams/stream-error` type.
+  /// `wasi:io/streams.stream-error` type.
   ///
   /// To provide more specific error information, other interfaces may
   /// offer functions to "downcast" this error into more specific types. For example,
   /// errors returned from streams derived from filesystem types can be described using
   /// the filesystem's own error-code type. This is done using the function
-  /// `wasi:filesystem/types/filesystem-error-code`, which takes a `borrow<error>`
-  /// parameter and returns an `option<wasi:filesystem/types/error-code>`.
+  /// `wasi:filesystem/types.filesystem-error-code`, which takes a `borrow<error>`
+  /// parameter and returns an `option<wasi:filesystem/types.error-code>`.
   ///
   /// The set of functions which can "downcast" an `error` into a more
   /// concrete type is open.
@@ -210,27 +210,13 @@ interface streams {
     /// Perform a write of up to 4096 bytes, and then flush the stream. Block
     /// until all of these operations are complete, or an error occurs.
     ///
-    /// This is a convenience wrapper around the use of `check-write`,
-    /// `subscribe`, `write`, and `flush`, and is implemented with the
-    /// following pseudo-code:
-    ///
-    /// ```text
-    /// let pollable = this.subscribe();
-    /// while !contents.is_empty() {
-    ///     // Wait for the stream to become writable
-    ///     pollable.block();
-    ///     let Ok(n) = this.check-write(); // eliding error handling
-    ///     let len = min(n, contents.len());
-    ///     let (chunk, rest) = contents.split_at(len);
-    ///     this.write(chunk  );            // eliding error handling
-    ///     contents = rest;
-    /// }
-    /// this.flush();
-    /// // Wait for completion of `flush`
-    /// pollable.block();
-    /// // Check for any errors that arose during `flush`
-    /// let _ = this.check-write();         // eliding error handling
-    /// ```
+    /// Returns success when all of the contents written are successfully
+    /// flushed to output. If an error occurs at any point before all
+    /// contents are successfully flushed, that error is returned as soon as
+    /// possible. If writing and flushing the complete contents causes the
+    /// stream to become closed, this call should return success, and
+    /// subsequent calls to check-write or other interfaces should return
+    /// stream-error::closed.
     @since(version = 0.2.0)
     blocking-write-and-flush: func(contents: list<u8>) -> result<_, stream-error>;
     /// Request to flush buffered output. This function never blocks.
@@ -273,26 +259,8 @@ interface streams {
     /// Block until all of these operations are complete, or an error
     /// occurs.
     ///
-    /// This is a convenience wrapper around the use of `check-write`,
-    /// `subscribe`, `write-zeroes`, and `flush`, and is implemented with
-    /// the following pseudo-code:
-    ///
-    /// ```text
-    /// let pollable = this.subscribe();
-    /// while num_zeroes != 0 {
-    ///     // Wait for the stream to become writable
-    ///     pollable.block();
-    ///     let Ok(n) = this.check-write(); // eliding error handling
-    ///     let len = min(n, num_zeroes);
-    ///     this.write-zeroes(len);         // eliding error handling
-    ///     num_zeroes -= len;
-    /// }
-    /// this.flush();
-    /// // Wait for completion of `flush`
-    /// pollable.block();
-    /// // Check for any errors that arose during `flush`
-    /// let _ = this.check-write();         // eliding error handling
-    /// ```
+    /// Functionality is equivelant to `blocking-write-and-flush` with
+    /// contents given as a list of len containing only zeroes.
     @since(version = 0.2.0)
     blocking-write-zeroes-and-flush: func(len: u64) -> result<_, stream-error>;
     /// Read from one stream and write to another.

--- a/crates/wasi/src/p2/wit/deps/random.wit
+++ b/crates/wasi/src/p2/wit/deps/random.wit
@@ -1,4 +1,4 @@
-package wasi:random@0.2.6;
+package wasi:random@0.2.10;
 
 /// The insecure-seed interface for seeding hash-map DoS resistance.
 ///

--- a/crates/wasi/src/p2/wit/deps/sockets.wit
+++ b/crates/wasi/src/p2/wit/deps/sockets.wit
@@ -1,9 +1,9 @@
-package wasi:sockets@0.2.6;
+package wasi:sockets@0.2.10;
 
 @since(version = 0.2.0)
 interface network {
   @unstable(feature = network-error-code)
-  use wasi:io/error@0.2.6.{error};
+  use wasi:io/error@0.2.10.{error};
 
   /// An opaque resource that represents access to (a subset of) the network.
   /// This enables context-based security for networking.
@@ -160,7 +160,7 @@ interface instance-network {
 @since(version = 0.2.0)
 interface ip-name-lookup {
   @since(version = 0.2.0)
-  use wasi:io/poll@0.2.6.{pollable};
+  use wasi:io/poll@0.2.10.{pollable};
   @since(version = 0.2.0)
   use network.{network, error-code, ip-address};
 
@@ -216,11 +216,11 @@ interface ip-name-lookup {
 @since(version = 0.2.0)
 interface tcp {
   @since(version = 0.2.0)
-  use wasi:io/streams@0.2.6.{input-stream, output-stream};
+  use wasi:io/streams@0.2.10.{input-stream, output-stream};
   @since(version = 0.2.0)
-  use wasi:io/poll@0.2.6.{pollable};
+  use wasi:io/poll@0.2.10.{pollable};
   @since(version = 0.2.0)
-  use wasi:clocks/monotonic-clock@0.2.6.{duration};
+  use wasi:clocks/monotonic-clock@0.2.10.{duration};
   @since(version = 0.2.0)
   use network.{network, error-code, ip-socket-address, ip-address-family};
 
@@ -617,7 +617,7 @@ interface tcp-create-socket {
 @since(version = 0.2.0)
 interface udp {
   @since(version = 0.2.0)
-  use wasi:io/poll@0.2.6.{pollable};
+  use wasi:io/poll@0.2.10.{pollable};
   @since(version = 0.2.0)
   use network.{network, error-code, ip-socket-address, ip-address-family};
 
@@ -925,21 +925,21 @@ interface udp-create-socket {
 @since(version = 0.2.0)
 world imports {
   @since(version = 0.2.0)
-  import wasi:io/error@0.2.6;
+  import wasi:io/error@0.2.10;
   @since(version = 0.2.0)
   import network;
   @since(version = 0.2.0)
   import instance-network;
   @since(version = 0.2.0)
-  import wasi:io/poll@0.2.6;
+  import wasi:io/poll@0.2.10;
   @since(version = 0.2.0)
   import udp;
   @since(version = 0.2.0)
   import udp-create-socket;
   @since(version = 0.2.0)
-  import wasi:io/streams@0.2.6;
+  import wasi:io/streams@0.2.10;
   @since(version = 0.2.0)
-  import wasi:clocks/monotonic-clock@0.2.6;
+  import wasi:clocks/monotonic-clock@0.2.10;
   @since(version = 0.2.0)
   import tcp;
   @since(version = 0.2.0)

--- a/crates/wasi/src/p2/wit/test.wit
+++ b/crates/wasi/src/p2/wit/test.wit
@@ -1,13 +1,13 @@
 world test-reactor {
-  include wasi:cli/imports@0.2.6;
+  include wasi:cli/imports@0.2.10;
 
   export add-strings: func(s: list<string>) -> u32;
   export get-strings: func() -> list<string>;
 
-  use wasi:io/streams@0.2.6.{output-stream};
+  use wasi:io/streams@0.2.10.{output-stream};
 
   export write-strings-to: func(o: output-stream) -> result;
 
-  use wasi:filesystem/types@0.2.6.{descriptor-stat};
+  use wasi:filesystem/types@0.2.10.{descriptor-stat};
   export pass-an-imported-record: func(d: descriptor-stat) -> string;
 }

--- a/crates/wasi/src/p2/wit/world.wit
+++ b/crates/wasi/src/p2/wit/world.wit
@@ -2,5 +2,5 @@
 package wasmtime:wasi;
 
 world bindings {
-  include wasi:cli/imports@0.2.6;
+  include wasi:cli/imports@0.2.10;
 }


### PR DESCRIPTION
Successor to https://github.com/bytecodealliance/wasmtime/pull/12247, made possible by fixes to ci/vendo-wit.sh and wkg