### PR TITLE
[wasi-sockets] disallow sending unpermitted datagrams

### DIFF
--- a/crates/test-programs/src/bin/p2_udp_send_too_much.rs
+++ b/crates/test-programs/src/bin/p2_udp_send_too_much.rs
@@ -1,0 +1,34 @@
+use test_programs::wasi::sockets::network::{IpAddress, IpAddressFamily, IpSocketAddress, Network};
+use test_programs::wasi::sockets::udp::{OutgoingDatagram, UdpSocket};
+
+/// `outgoing-datagram-stream.send` should trap we attempt to send more
+/// datagrams than `check-send` gave permission for.
+fn main() {
+    let net = Network::default();
+    let family = IpAddressFamily::Ipv4;
+    let unspecified_port = IpSocketAddress::new(IpAddress::new_loopback(family), 0);
+    let remote = IpSocketAddress::new(IpAddress::new_loopback(family), 4320);
+
+    let client = UdpSocket::new(family).unwrap();
+    client.blocking_bind(&net, unspecified_port).unwrap();
+
+    let (_, tx) = client.stream(Some(remote)).unwrap();
+    assert_eq!(client.remote_address(), Ok(remote));
+
+    tx.subscribe().block();
+
+    let permits = tx.check_send().unwrap();
+    assert!(permits > 0);
+    // This should trap according to the `wasi-sockets` spec since we're trying
+    // to send more than `check_send` gave permission for:
+    tx.send(
+        &std::iter::repeat_with(|| OutgoingDatagram {
+            data: b"hello".into(),
+            remote_address: None,
+        })
+        .take(usize::try_from(permits + 1).unwrap())
+        .collect::<Vec<_>>(),
+    )
+    .unwrap();
+    unreachable!("attempt to send excess datagrams should have trapped");
+}

--- a/crates/wasi/src/p2/udp.rs
+++ b/crates/wasi/src/p2/udp.rs
@@ -20,4 +20,8 @@ pub struct OutgoingDatagramStream {
 
     /// The check of allowed addresses
     pub(crate) socket_addr_check: Option<SocketAddrCheck>,
+
+    /// Remaining number of datagrams permitted by most recent `check-send`
+    /// call.
+    pub(crate) check_send_permit_count: usize,
 }

--- a/crates/wasi/tests/all/p2/async_.rs
+++ b/crates/wasi/tests/all/p2/async_.rs
@@ -361,6 +361,16 @@ async fn p2_adapter_badfd() {
 async fn p2_file_read_write() {
     run(P2_FILE_READ_WRITE_COMPONENT, false).await.unwrap()
 }
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
+async fn p2_udp_send_too_much() {
+    let e = run(P2_UDP_SEND_TOO_MUCH_COMPONENT, false)
+        .await
+        .unwrap_err();
+    assert_eq!(
+        format!("{}", e.source().expect("trap source")),
+        "unpermitted: argument exceeds permitted size"
+    )
+}
 #[expect(
     dead_code,
     reason = "tested in the wasi-cli crate, satisfying foreach_api! macro"

--- a/crates/wasi/tests/all/p2/sync.rs
+++ b/crates/wasi/tests/all/p2/sync.rs
@@ -343,6 +343,14 @@ fn p2_adapter_badfd() {
 fn p2_file_read_write() {
     run(P2_FILE_READ_WRITE_COMPONENT, false).unwrap()
 }
+#[test_log::test]
+fn p2_udp_send_too_much() {
+    let e = run(P2_UDP_SEND_TOO_MUCH_COMPONENT, false).unwrap_err();
+    assert_eq!(
+        format!("{}", e.source().expect("trap source")),
+        "unpermitted: argument exceeds permitted size"
+    )
+}
 #[expect(
     dead_code,
     reason = "tested in the wasi-cli crate, satisfying foreach_api! macro"


### PR DESCRIPTION
In #12629, I removed the enforcement of `outgoing-datagram-stream.check-send` permits, which turned out to be incorrect according to [the spec].  This restores the enforcement to conform to the spec while still fixing the issue addressed by the original PR.

[the spec]: https://github.com/WebAssembly/WASI/blob/41d0de898ec7568e032129156a3bc567d7ebea5d/proposals/sockets/wit/udp.wit#L256C1-L257C111

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
