### PR TITLE
Fix vmctx used in component traps

### DIFF
--- a/crates/cranelift/src/compiler/component.rs
+++ b/crates/cranelift/src/compiler/component.rs
@@ -1551,7 +1551,7 @@ impl<'a> TrampolineCompiler<'a> {
         (
             TrapTranslator {
                 compiler: self.compiler,
-                vmctx: self.builder.func.dfg.block_params(self.block0)[0],
+                vmctx: self.caller_vmctx(),
                 builtins: &mut self.builtins,
             },
             &mut self.builder,

--- a/tests/disas/component-may-leave-without-signals-based-traps.wat
+++ b/tests/disas/component-may-leave-without-signals-based-traps.wat
@@ -45,11 +45,11 @@
 ;;  129: movq    %rbx, %rsi
 ;;  12c: movq    0x10(%rsi), %rax
 ;;  130: movq    0x198(%rax), %rax
-;;  137: movq    %rsi, %rdi
+;;  137: movq    %rbx, %rdi
 ;;  13a: callq   *%rax
 ;;  13c: ud2
-;;  13e: movq    %rdi, %rbx
-;;  141: movl    $0x17, %esi
+;;  13e: movl    $0x17, %esi
+;;  143: movq    %rbx, %rdi
 ;;  146: callq   0x6a
 ;;  14b: movq    %rbx, %rdi
 ;;  14e: callq   0x9b


### PR DESCRIPTION
Fixes a typo from #12626

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
