### PR TITLE
Remove doc of cargo `signals-based-traps` feature

### DIFF
--- a/crates/wasmtime/src/lib.rs
+++ b/crates/wasmtime/src/lib.rs
@@ -365,12 +365,6 @@
 //!   with the same overhead as the `call-hook` feature where entries/exits into
 //!   WebAssembly will have more overhead than before.
 //!
-//! * `signals-based-traps` - Enabled by default, this enables support for using
-//!   host signal handlers to implement WebAssembly traps. For example virtual
-//!   memory is used to catch out-of-bounds accesses in WebAssembly that result
-//!   in segfaults. This is implicitly enabled by the `std` feature and is the
-//!   best way to get high-performance WebAssembly.
-//!
 //! More crate features can be found in the [manifest] of Wasmtime itself for
 //! seeing what can be enabled and disabled.
 //!


### PR DESCRIPTION
This was removed awhile back, so remove the misleading documentation.

Closes #12634

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
