### PR TITLE
Debugging: add unique-within-store IDs for every entity.

### DIFF
--- a/crates/wasmtime/src/runtime/externals/global.rs
+++ b/crates/wasmtime/src/runtime/externals/global.rs
@@ -397,6 +397,24 @@ impl Global {
         store.id() == self.store
     }
 
+    /// Returns a stable identifier for this global within its store.
+    ///
+    /// This allows distinguishing globals when introspecting them
+    /// e.g. via debug APIs.
+    #[cfg(feature = "debug")]
+    pub fn debug_index_in_store(&self) -> u64 {
+        match self.kind {
+            VMGlobalKind::Instance(idx) => u64::from(self.instance) << 32 | u64::from(idx.as_u32()),
+            VMGlobalKind::Host(idx) => u64::from(u32::MAX) << 32 | u64::from(idx.as_u32()),
+            #[cfg(feature = "component-model")]
+            VMGlobalKind::ComponentFlags(idx) => {
+                u64::from(self.instance) << 32 | u64::from(idx.as_u32())
+            }
+            #[cfg(feature = "component-model")]
+            VMGlobalKind::TaskMayBlock => u64::from(self.instance) << 32 | u64::from(u32::MAX),
+        }
+    }
+
     /// Get a stable hash key for this global.
     ///
     /// Even if the same underlying global definition is added to the

--- a/crates/wasmtime/src/runtime/externals/table.rs
+++ b/crates/wasmtime/src/runtime/externals/table.rs
@@ -571,6 +571,15 @@ impl Table {
         store.id() == self.instance.store_id()
     }
 
+    /// Returns a stable identifier for this table within its store.
+    ///
+    /// This allows distinguishing tables when introspecting them
+    /// e.g. via debug APIs.
+    #[cfg(feature = "debug")]
+    pub fn debug_index_in_store(&self) -> u64 {
+        u64::from(self.instance.instance().as_u32()) << 32 | u64::from(self.index.as_u32())
+    }
+
     /// Get a stable hash key for this table.
     ///
     /// Even if the same underlying table definition is added to the

--- a/crates/wasmtime/src/runtime/externals/tag.rs
+++ b/crates/wasmtime/src/runtime/externals/tag.rs
@@ -60,6 +60,15 @@ impl Tag {
         store.id() == self.instance.store_id()
     }
 
+    /// Returns a stable identifier for this tag within its store.
+    ///
+    /// This allows distinguishing tags when introspecting them
+    /// e.g. via debug APIs.
+    #[cfg(feature = "debug")]
+    pub fn debug_index_in_store(&self) -> u64 {
+        u64::from(self.instance.instance().as_u32()) << 32 | u64::from(self.index.as_u32())
+    }
+
     /// Determines whether this tag is reference equal to the other
     /// given tag in the given store.
     ///

--- a/crates/wasmtime/src/runtime/instance.rs
+++ b/crates/wasmtime/src/runtime/instance.rs
@@ -611,6 +611,18 @@ impl Instance {
         self.id.instance()
     }
 
+    /// Return a unique-within-Store index for this `Instance`.
+    ///
+    /// Allows distinguishing instance identities when introspecting
+    /// the `Store`, e.g. via debug APIs.
+    ///
+    /// This index will match the instance's position in the sequence
+    /// returned by `Store::debug_all_instances()`.
+    #[cfg(feature = "debug")]
+    pub fn debug_index_in_store(&self) -> u32 {
+        self.id.instance().as_u32()
+    }
+
     /// Get all globals within this instance.
     ///
     /// Returns both import and defined globals.

--- a/crates/wasmtime/src/runtime/memory.rs
+++ b/crates/wasmtime/src/runtime/memory.rs
@@ -671,6 +671,15 @@ impl Memory {
         store.id() == self.instance.store_id()
     }
 
+    /// Returns a stable identifier for this memory within its store.
+    ///
+    /// This allows distinguishing memories when introspecting them
+    /// e.g. via debug APIs.
+    #[cfg(feature = "debug")]
+    pub fn debug_index_in_store(&self) -> u64 {
+        u64::from(self.instance.instance().as_u32()) << 32 | u64::from(self.index.as_u32())
+    }
+
     /// Get a stable hash key for this memory.
     ///
     /// Even if the same underlying memory definition is added to the

--- a/crates/wasmtime/src/runtime/module.rs
+++ b/crates/wasmtime/src/runtime/module.rs
@@ -1113,6 +1113,15 @@ impl Module {
         &self.inner.offsets
     }
 
+    /// Return the unique-within-Engine ID for this module.
+    ///
+    /// Allows distinguishing module identities when introspecting
+    /// modules, e.g. via debug APIs.
+    #[cfg(feature = "debug")]
+    pub fn debug_index_in_engine(&self) -> u64 {
+        self.id().as_u64()
+    }
+
     /// Return the address, in memory, of the trampoline that allows Wasm to
     /// call a array function of the given signature.
     ///

--- a/crates/wasmtime/src/runtime/vm/module_id.rs
+++ b/crates/wasmtime/src/runtime/vm/module_id.rs
@@ -16,4 +16,9 @@ impl CompiledModuleId {
         // uniqueness.
         CompiledModuleId(crate::store::StoreId::allocate().as_raw())
     }
+
+    /// Returns the inner unique integer contained in this ID.
+    pub fn as_u64(self) -> u64 {
+        self.0.get()
+    }
 }


### PR DESCRIPTION
When building an introspection API for use by a debugger, we need a way to expose *identity*: that is, to give some way of knowing that a given `Memory`, `Instance`, etc. is *this* one and not *that* one. Our handle types variously have either `Eq` implementations or e.g. `Module::same` for the ones that wrap an `Arc` under-the-covers; but that's not enough to allow a debugger to e.g. build a hashmap for whatever metadata that it might expose via whatever debugging protocol.

For maximal generality and flexibility, we should expose the unique IDs that already more-or-less exist: for instances, that is their instance ID directly; for entities owned by instances, we can build a `u64` with the instance ID in the upper 32 bits and the defined-index in the lower 32 bits. IDs for all entities except modules are unique-within-a-Store (and this is all that is needed); IDs for modules happen to reuse the `CompiledModuleId` and so are unique-within-an-Engine.

I've opted to name these `debug_index_within_store` to scope the feature and intended use-case clearly, but if there's a desire, I could easily rename them to simply `index`. I shied away from that here because I didn't want to give a notion that these indices are somehow canonical or correspond to some order or other.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
