### PR TITLE
fuzz: Enable winch-aarch64

### DIFF
--- a/crates/fuzzing/src/generators/config.rs
+++ b/crates/fuzzing/src/generators/config.rs
@@ -671,7 +671,7 @@ impl WasmtimeConfig {
                 // config features are enabled based on the compiler strategy, and we
                 // don't want to make the same fuzz input DNA generate different test
                 // cases on different targets.
-                if cfg!(not(target_arch = "x86_64")) {
+                if cfg!(not(any(target_arch = "x86_64", target_arch = "aarch64"))) {
                     log::warn!(
                         "want to compile with Winch but host architecture does not support it"
                     );
@@ -698,6 +698,14 @@ impl WasmtimeConfig {
                         .is_some_and(|value| value == "false")
                 {
                     config.config.simd_enabled = false;
+                }
+
+                // Account for the proposals that are currently only
+                // supported on x64.
+                if cfg!(target_arch = "aarch64") {
+                    config.config.simd_enabled = false;
+                    config.config.wide_arithmetic_enabled = false;
+                    config.config.threads_enabled = false;
                 }
 
                 // Tuning  the following engine options is currently not supported

--- a/crates/fuzzing/src/oracles/diff_wasmtime.rs
+++ b/crates/fuzzing/src/oracles/diff_wasmtime.rs
@@ -273,7 +273,7 @@ mod tests {
 
     #[test]
     fn smoke_winch() {
-        if !cfg!(target_arch = "x86_64") {
+        if !cfg!(target_arch = "x86_64") || !cfg!(target_arch = "aarch64") {
             return;
         }
         crate::oracles::engine::smoke_test_engine(|u, config| {

--- a/crates/fuzzing/src/oracles/engine.rs
+++ b/crates/fuzzing/src/oracles/engine.rs
@@ -28,9 +28,9 @@ pub fn build(
         )?),
         "wasmi" => Box::new(WasmiEngine::new(config)),
 
-        #[cfg(target_arch = "x86_64")]
+        #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
         "winch" => Box::new(WasmtimeEngine::new(u, config, CompilerStrategy::Winch)?),
-        #[cfg(not(target_arch = "x86_64"))]
+        #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
         "winch" => return Ok(None),
 
         #[cfg(feature = "fuzz-spec-interpreter")]

--- a/fuzz/fuzz_targets/differential.rs
+++ b/fuzz/fuzz_targets/differential.rs
@@ -271,7 +271,7 @@ impl RuntimeStats {
         let total = v8 + spec + wasmi + wasmtime + winch + pulley;
         println!(
             "\twasmi: {:.02}%, spec: {:.02}%, wasmtime: {:.02}%, v8: {:.02}%, \
-             winch: {:.02}, \
+             winch: {:.02}%, \
              pulley: {:.02}%",
             wasmi as f64 / total as f64 * 100f64,
             spec as f64 / total as f64 * 100f64,


### PR DESCRIPTION
As of https://github.com/bytecodealliance/wasmtime/pull/11051, Winch supports all of Core Wasm on aarch64. This commit enables fuzzing respectively.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
