### PR TITLE
Release Wasmtime 36.0.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -289,7 +289,7 @@ dependencies = [
 
 [[package]]
 name = "byte-array-literals"
-version = "36.0.5"
+version = "36.0.6"
 
 [[package]]
 name = "byteorder"
@@ -693,7 +693,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift"
-version = "0.123.5"
+version = "0.123.6"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",
@@ -706,7 +706,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.123.5"
+version = "0.123.6"
 dependencies = [
  "arbitrary",
  "arbtest",
@@ -724,21 +724,21 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.123.5"
+version = "0.123.6"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.123.5"
+version = "0.123.6"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.123.5"
+version = "0.123.6"
 dependencies = [
  "arbitrary",
  "serde",
@@ -747,7 +747,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.123.5"
+version = "0.123.6"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -782,7 +782,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.123.5"
+version = "0.123.6"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -793,18 +793,18 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.123.5"
+version = "0.123.6"
 
 [[package]]
 name = "cranelift-control"
-version = "0.123.5"
+version = "0.123.6"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.123.5"
+version = "0.123.6"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.123.5"
+version = "0.123.6"
 dependencies = [
  "cranelift-codegen",
  "env_logger 0.11.5",
@@ -869,7 +869,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-interpreter"
-version = "0.123.5"
+version = "0.123.6"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.123.5"
+version = "0.123.6"
 dependencies = [
  "codespan-reporting",
  "log",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-jit"
-version = "0.123.5"
+version = "0.123.6"
 dependencies = [
  "anyhow",
  "cranelift",
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-module"
-version = "0.123.5"
+version = "0.123.6"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -926,7 +926,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.123.5"
+version = "0.123.6"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-object"
-version = "0.123.5"
+version = "0.123.6"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -950,7 +950,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-reader"
-version = "0.123.5"
+version = "0.123.6"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -960,7 +960,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-serde"
-version = "0.123.5"
+version = "0.123.6"
 dependencies = [
  "clap",
  "cranelift-codegen",
@@ -970,7 +970,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.123.5"
+version = "0.123.6"
 
 [[package]]
 name = "cranelift-tools"
@@ -1221,7 +1221,7 @@ checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
 
 [[package]]
 name = "embedding"
-version = "36.0.5"
+version = "36.0.6"
 dependencies = [
  "anyhow",
  "dlmalloc",
@@ -2373,7 +2373,7 @@ dependencies = [
 
 [[package]]
 name = "min-platform-host"
-version = "36.0.5"
+version = "36.0.6"
 dependencies = [
  "anyhow",
  "libloading",
@@ -2816,7 +2816,7 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "36.0.5"
+version = "36.0.6"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -2840,7 +2840,7 @@ dependencies = [
 
 [[package]]
 name = "pulley-macros"
-version = "36.0.5"
+version = "36.0.6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4066,7 +4066,7 @@ version = "0.1.0"
 
 [[package]]
 name = "verify-component-adapter"
-version = "36.0.5"
+version = "36.0.6"
 dependencies = [
  "anyhow",
  "wasmparser 0.236.0",
@@ -4134,7 +4134,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-common"
-version = "36.0.5"
+version = "36.0.6"
 dependencies = [
  "anyhow",
  "bitflags 2.6.0",
@@ -4173,7 +4173,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-preview1-component-adapter"
-version = "36.0.5"
+version = "36.0.6"
 dependencies = [
  "bitflags 2.6.0",
  "byte-array-literals",
@@ -4444,7 +4444,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "36.0.5"
+version = "36.0.6"
 dependencies = [
  "addr2line 0.25.0",
  "anyhow",
@@ -4509,7 +4509,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-bench-api"
-version = "36.0.5"
+version = "36.0.6"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -4525,14 +4525,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-c-api"
-version = "36.0.5"
+version = "36.0.6"
 dependencies = [
  "wasmtime-c-api-impl",
 ]
 
 [[package]]
 name = "wasmtime-c-api-impl"
-version = "36.0.5"
+version = "36.0.6"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -4549,7 +4549,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli"
-version = "36.0.5"
+version = "36.0.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4622,7 +4622,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli-flags"
-version = "36.0.5"
+version = "36.0.6"
 dependencies = [
  "anyhow",
  "clap",
@@ -4637,7 +4637,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "36.0.5"
+version = "36.0.6"
 dependencies = [
  "anyhow",
  "clap",
@@ -4743,14 +4743,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-asm-macros"
-version = "36.0.5"
+version = "36.0.6"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "wasmtime-internal-c-api-macros"
-version = "36.0.5"
+version = "36.0.6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4758,7 +4758,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cache"
-version = "36.0.5"
+version = "36.0.6"
 dependencies = [
  "anyhow",
  "base64",
@@ -4779,7 +4779,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-macro"
-version = "36.0.5"
+version = "36.0.6"
 dependencies = [
  "anyhow",
  "component-macro-test-helpers",
@@ -4799,11 +4799,11 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-util"
-version = "36.0.5"
+version = "36.0.6"
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "36.0.5"
+version = "36.0.6"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4828,7 +4828,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-explorer"
-version = "36.0.5"
+version = "36.0.6"
 dependencies = [
  "anyhow",
  "capstone",
@@ -4843,7 +4843,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-fiber"
-version = "36.0.5"
+version = "36.0.6"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -4858,7 +4858,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-debug"
-version = "36.0.5"
+version = "36.0.6"
 dependencies = [
  "cc",
  "object 0.37.1",
@@ -4868,7 +4868,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "36.0.5"
+version = "36.0.6"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4878,18 +4878,18 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-math"
-version = "36.0.5"
+version = "36.0.6"
 dependencies = [
  "libm",
 ]
 
 [[package]]
 name = "wasmtime-internal-slab"
-version = "36.0.5"
+version = "36.0.6"
 
 [[package]]
 name = "wasmtime-internal-unwinder"
-version = "36.0.5"
+version = "36.0.6"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4900,7 +4900,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
-version = "36.0.5"
+version = "36.0.6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4909,7 +4909,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-winch"
-version = "36.0.5"
+version = "36.0.6"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -4924,7 +4924,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-wit-bindgen"
-version = "36.0.5"
+version = "36.0.6"
 dependencies = [
  "anyhow",
  "bitflags 2.6.0",
@@ -4935,7 +4935,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-wmemcheck"
-version = "36.0.5"
+version = "36.0.6"
 
 [[package]]
 name = "wasmtime-test-macros"
@@ -4950,7 +4950,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-test-util"
-version = "36.0.5"
+version = "36.0.6"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -4968,7 +4968,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "36.0.5"
+version = "36.0.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5003,7 +5003,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-config"
-version = "36.0.5"
+version = "36.0.6"
 dependencies = [
  "anyhow",
  "test-programs-artifacts",
@@ -5014,7 +5014,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-http"
-version = "36.0.5"
+version = "36.0.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5041,7 +5041,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-io"
-version = "36.0.5"
+version = "36.0.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5052,7 +5052,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-keyvalue"
-version = "36.0.5"
+version = "36.0.6"
 dependencies = [
  "anyhow",
  "test-programs-artifacts",
@@ -5063,7 +5063,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-nn"
-version = "36.0.5"
+version = "36.0.6"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -5084,7 +5084,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-threads"
-version = "36.0.5"
+version = "36.0.6"
 dependencies = [
  "anyhow",
  "log",
@@ -5096,7 +5096,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-tls"
-version = "36.0.5"
+version = "36.0.6"
 dependencies = [
  "anyhow",
  "bytes",
@@ -5112,7 +5112,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-tls-nativetls"
-version = "36.0.5"
+version = "36.0.6"
 dependencies = [
  "anyhow",
  "futures",
@@ -5127,7 +5127,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wast"
-version = "36.0.5"
+version = "36.0.6"
 dependencies = [
  "anyhow",
  "json-from-wast",
@@ -5205,7 +5205,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "36.0.5"
+version = "36.0.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5222,7 +5222,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "36.0.5"
+version = "36.0.6"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -5234,7 +5234,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "36.0.5"
+version = "36.0.6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5289,7 +5289,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "36.0.5"
+version = "36.0.6"
 dependencies = [
  "anyhow",
  "cranelift-assembler-x64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -174,7 +174,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "36.0.5"
+version = "36.0.6"
 authors = ["The Wasmtime Project Developers"]
 edition = "2024"
 # Wasmtime's current policy is that this number can be no larger than the
@@ -226,19 +226,19 @@ redundant_field_names = 'warn'
 # tooling but aren't intended to be widely depended on.
 #
 # All of these crates are supported though in the sense that
-wasmtime = { path = "crates/wasmtime", version = "36.0.5", default-features = false }
-wasmtime-cli-flags = { path = "crates/cli-flags", version = "=36.0.5" }
-wasmtime-environ = { path = "crates/environ", version = "=36.0.5" }
-wasmtime-wasi = { path = "crates/wasi", version = "36.0.5", default-features = false }
-wasmtime-wasi-io = { path = "crates/wasi-io", version = "36.0.5", default-features = false }
-wasmtime-wasi-http = { path = "crates/wasi-http", version = "36.0.5", default-features = false }
-wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "36.0.5" }
-wasmtime-wasi-config = { path = "crates/wasi-config", version = "36.0.5" }
-wasmtime-wasi-keyvalue = { path = "crates/wasi-keyvalue", version = "36.0.5" }
-wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "36.0.5" }
-wasmtime-wasi-tls = { path = "crates/wasi-tls", version = "36.0.5" }
-wasmtime-wasi-tls-nativetls = { path = "crates/wasi-tls-nativetls", version = "36.0.5" }
-wasmtime-wast = { path = "crates/wast", version = "=36.0.5" }
+wasmtime = { path = "crates/wasmtime", version = "36.0.6", default-features = false }
+wasmtime-cli-flags = { path = "crates/cli-flags", version = "=36.0.6" }
+wasmtime-environ = { path = "crates/environ", version = "=36.0.6" }
+wasmtime-wasi = { path = "crates/wasi", version = "36.0.6", default-features = false }
+wasmtime-wasi-io = { path = "crates/wasi-io", version = "36.0.6", default-features = false }
+wasmtime-wasi-http = { path = "crates/wasi-http", version = "36.0.6", default-features = false }
+wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "36.0.6" }
+wasmtime-wasi-config = { path = "crates/wasi-config", version = "36.0.6" }
+wasmtime-wasi-keyvalue = { path = "crates/wasi-keyvalue", version = "36.0.6" }
+wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "36.0.6" }
+wasmtime-wasi-tls = { path = "crates/wasi-tls", version = "36.0.6" }
+wasmtime-wasi-tls-nativetls = { path = "crates/wasi-tls-nativetls", version = "36.0.6" }
+wasmtime-wast = { path = "crates/wast", version = "=36.0.6" }
 
 # Internal Wasmtime-specific crates.
 #
@@ -247,54 +247,54 @@ wasmtime-wast = { path = "crates/wast", version = "=36.0.5" }
 # that these are internal unsupported crates for external use. These exist as
 # part of the project organization of other public crates in Wasmtime and are
 # otherwise not supported in terms of CVEs for example.
-wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=36.0.5", package = 'wasmtime-internal-wmemcheck' }
-wasmtime-c-api-macros = { path = "crates/c-api-macros", version = "=36.0.5", package = 'wasmtime-internal-c-api-macros' }
-wasmtime-cache = { path = "crates/cache", version = "=36.0.5", package = 'wasmtime-internal-cache' }
-wasmtime-cranelift = { path = "crates/cranelift", version = "=36.0.5", package = 'wasmtime-internal-cranelift' }
-wasmtime-winch = { path = "crates/winch", version = "=36.0.5", package = 'wasmtime-internal-winch'  }
-wasmtime-explorer = { path = "crates/explorer", version = "=36.0.5", package = 'wasmtime-internal-explorer'  }
-wasmtime-fiber = { path = "crates/fiber", version = "=36.0.5", package = 'wasmtime-internal-fiber' }
-wasmtime-jit-debug = { path = "crates/jit-debug", version = "=36.0.5", package = 'wasmtime-internal-jit-debug' }
-wasmtime-component-util = { path = "crates/component-util", version = "=36.0.5", package = 'wasmtime-internal-component-util' }
-wasmtime-component-macro = { path = "crates/component-macro", version = "=36.0.5", package = 'wasmtime-internal-component-macro' }
-wasmtime-asm-macros = { path = "crates/asm-macros", version = "=36.0.5", package = 'wasmtime-internal-asm-macros' }
-wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=36.0.5", package = 'wasmtime-internal-versioned-export-macros' }
-wasmtime-slab = { path = "crates/slab", version = "=36.0.5", package = 'wasmtime-internal-slab' }
-wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=36.0.5", package = 'wasmtime-internal-jit-icache-coherence' }
-wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=36.0.5", package = 'wasmtime-internal-wit-bindgen' }
-wasmtime-math = { path = "crates/math", version = "=36.0.5", package = 'wasmtime-internal-math'  }
-wasmtime-unwinder = { path = "crates/unwinder", version = "=36.0.5", package = 'wasmtime-internal-unwinder' }
+wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=36.0.6", package = 'wasmtime-internal-wmemcheck' }
+wasmtime-c-api-macros = { path = "crates/c-api-macros", version = "=36.0.6", package = 'wasmtime-internal-c-api-macros' }
+wasmtime-cache = { path = "crates/cache", version = "=36.0.6", package = 'wasmtime-internal-cache' }
+wasmtime-cranelift = { path = "crates/cranelift", version = "=36.0.6", package = 'wasmtime-internal-cranelift' }
+wasmtime-winch = { path = "crates/winch", version = "=36.0.6", package = 'wasmtime-internal-winch'  }
+wasmtime-explorer = { path = "crates/explorer", version = "=36.0.6", package = 'wasmtime-internal-explorer'  }
+wasmtime-fiber = { path = "crates/fiber", version = "=36.0.6", package = 'wasmtime-internal-fiber' }
+wasmtime-jit-debug = { path = "crates/jit-debug", version = "=36.0.6", package = 'wasmtime-internal-jit-debug' }
+wasmtime-component-util = { path = "crates/component-util", version = "=36.0.6", package = 'wasmtime-internal-component-util' }
+wasmtime-component-macro = { path = "crates/component-macro", version = "=36.0.6", package = 'wasmtime-internal-component-macro' }
+wasmtime-asm-macros = { path = "crates/asm-macros", version = "=36.0.6", package = 'wasmtime-internal-asm-macros' }
+wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=36.0.6", package = 'wasmtime-internal-versioned-export-macros' }
+wasmtime-slab = { path = "crates/slab", version = "=36.0.6", package = 'wasmtime-internal-slab' }
+wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=36.0.6", package = 'wasmtime-internal-jit-icache-coherence' }
+wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=36.0.6", package = 'wasmtime-internal-wit-bindgen' }
+wasmtime-math = { path = "crates/math", version = "=36.0.6", package = 'wasmtime-internal-math'  }
+wasmtime-unwinder = { path = "crates/unwinder", version = "=36.0.6", package = 'wasmtime-internal-unwinder' }
 
 # Miscellaneous crates without a `wasmtime-*` prefix in their name but still
 # used in the `wasmtime-*` family of crates depending on various features/etc.
-wiggle = { path = "crates/wiggle", version = "=36.0.5", default-features = false }
-wiggle-macro = { path = "crates/wiggle/macro", version = "=36.0.5" }
-wiggle-generate = { path = "crates/wiggle/generate", version = "=36.0.5" }
-wasi-common = { path = "crates/wasi-common", version = "=36.0.5", default-features = false }
-pulley-interpreter = { path = 'pulley', version = "=36.0.5" }
-pulley-macros = { path = 'pulley/macros', version = "=36.0.5" }
+wiggle = { path = "crates/wiggle", version = "=36.0.6", default-features = false }
+wiggle-macro = { path = "crates/wiggle/macro", version = "=36.0.6" }
+wiggle-generate = { path = "crates/wiggle/generate", version = "=36.0.6" }
+wasi-common = { path = "crates/wasi-common", version = "=36.0.6", default-features = false }
+pulley-interpreter = { path = 'pulley', version = "=36.0.6" }
+pulley-macros = { path = 'pulley/macros', version = "=36.0.6" }
 
 # Cranelift crates in this workspace
-cranelift-assembler-x64 = { path = "cranelift/assembler-x64", version = "0.123.5" }
-cranelift-codegen = { path = "cranelift/codegen", version = "0.123.5", default-features = false, features = ["std", "unwind"] }
-cranelift-frontend = { path = "cranelift/frontend", version = "0.123.5" }
-cranelift-entity = { path = "cranelift/entity", version = "0.123.5" }
-cranelift-native = { path = "cranelift/native", version = "0.123.5" }
-cranelift-module = { path = "cranelift/module", version = "0.123.5" }
-cranelift-interpreter = { path = "cranelift/interpreter", version = "0.123.5" }
-cranelift-reader = { path = "cranelift/reader", version = "0.123.5" }
+cranelift-assembler-x64 = { path = "cranelift/assembler-x64", version = "0.123.6" }
+cranelift-codegen = { path = "cranelift/codegen", version = "0.123.6", default-features = false, features = ["std", "unwind"] }
+cranelift-frontend = { path = "cranelift/frontend", version = "0.123.6" }
+cranelift-entity = { path = "cranelift/entity", version = "0.123.6" }
+cranelift-native = { path = "cranelift/native", version = "0.123.6" }
+cranelift-module = { path = "cranelift/module", version = "0.123.6" }
+cranelift-interpreter = { path = "cranelift/interpreter", version = "0.123.6" }
+cranelift-reader = { path = "cranelift/reader", version = "0.123.6" }
 cranelift-filetests = { path = "cranelift/filetests" }
-cranelift-object = { path = "cranelift/object", version = "0.123.5" }
-cranelift-jit = { path = "cranelift/jit", version = "0.123.5" }
+cranelift-object = { path = "cranelift/object", version = "0.123.6" }
+cranelift-jit = { path = "cranelift/jit", version = "0.123.6" }
 cranelift-fuzzgen = { path = "cranelift/fuzzgen" }
-cranelift-bforest = { path = "cranelift/bforest", version = "0.123.5" }
-cranelift-bitset = { path = "cranelift/bitset", version = "0.123.5" }
-cranelift-control = { path = "cranelift/control", version = "0.123.5" }
-cranelift-srcgen = { path = "cranelift/srcgen", version = "0.123.5" }
-cranelift = { path = "cranelift/umbrella", version = "0.123.5" }
+cranelift-bforest = { path = "cranelift/bforest", version = "0.123.6" }
+cranelift-bitset = { path = "cranelift/bitset", version = "0.123.6" }
+cranelift-control = { path = "cranelift/control", version = "0.123.6" }
+cranelift-srcgen = { path = "cranelift/srcgen", version = "0.123.6" }
+cranelift = { path = "cranelift/umbrella", version = "0.123.6" }
 
 # Winch crates in this workspace.
-winch-codegen = { path = "winch/codegen", version = "=36.0.5" }
+winch-codegen = { path = "winch/codegen", version = "=36.0.6" }
 
 # Internal crates not published to crates.io used in testing, builds, etc
 wasi-preview1-component-adapter = { path = "crates/wasi-preview1-component-adapter" }

--- a/cranelift/assembler-x64/Cargo.toml
+++ b/cranelift/assembler-x64/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-assembler-x64"
 description = "A Cranelift-specific x64 assembler"
-version = "0.123.5"
+version = "0.123.6"
 license = "Apache-2.0 WITH LLVM-exception"
 edition.workspace = true
 rust-version.workspace = true
@@ -16,7 +16,7 @@ arbtest = "0.3.1"
 capstone = { workspace = true }
 
 [build-dependencies]
-cranelift-assembler-x64-meta = { path = "meta", version = "0.123.5" }
+cranelift-assembler-x64-meta = { path = "meta", version = "0.123.6" }
 
 [lints]
 workspace = true

--- a/cranelift/assembler-x64/meta/Cargo.toml
+++ b/cranelift/assembler-x64/meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-assembler-x64-meta"
 description = "Generate a Cranelift-specific assembler for x64 instructions"
-version = "0.123.5"
+version = "0.123.6"
 license = "Apache-2.0 WITH LLVM-exception"
 edition.workspace = true
 rust-version.workspace = true

--- a/cranelift/bforest/Cargo.toml
+++ b/cranelift/bforest/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bforest"
-version = "0.123.5"
+version = "0.123.6"
 description = "A forest of B+-trees"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-bforest"

--- a/cranelift/bitset/Cargo.toml
+++ b/cranelift/bitset/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bitset"
-version = "0.123.5"
+version = "0.123.6"
 description = "Various bitset stuff for use inside Cranelift"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-bitset"

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen"
-version = "0.123.5"
+version = "0.123.6"
 description = "Low-level code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-codegen"
@@ -25,7 +25,7 @@ anyhow = { workspace = true, optional = true, features = ['std'] }
 bumpalo = "3"
 capstone = { workspace = true, optional = true }
 cranelift-assembler-x64 = { workspace = true }
-cranelift-codegen-shared = { path = "./shared", version = "0.123.5" }
+cranelift-codegen-shared = { path = "./shared", version = "0.123.6" }
 cranelift-entity = { workspace = true }
 cranelift-bforest = { workspace = true }
 cranelift-bitset = { workspace = true }
@@ -56,8 +56,8 @@ env_logger = { workspace = true }
 proptest = { workspace = true }
 
 [build-dependencies]
-cranelift-codegen-meta = { path = "meta", version = "0.123.5" }
-cranelift-isle = { path = "../isle/isle", version = "=0.123.5" }
+cranelift-codegen-meta = { path = "meta", version = "0.123.6" }
+cranelift-isle = { path = "../isle/isle", version = "=0.123.6" }
 
 [features]
 default = ["std", "unwind", "host-arch", "timing"]

--- a/cranelift/codegen/meta/Cargo.toml
+++ b/cranelift/codegen/meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-codegen-meta"
 authors = ["The Cranelift Project Developers"]
-version = "0.123.5"
+version = "0.123.6"
 description = "Metaprogram for cranelift-codegen code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
@@ -17,8 +17,8 @@ rustdoc-args = ["--document-private-items"]
 
 [dependencies]
 cranelift-srcgen = { workspace = true }
-cranelift-assembler-x64-meta = { path = "../../assembler-x64/meta", version = "0.123.5" }
-cranelift-codegen-shared = { path = "../shared", version = "0.123.5" }
+cranelift-assembler-x64-meta = { path = "../../assembler-x64/meta", version = "0.123.6" }
+cranelift-codegen-shared = { path = "../shared", version = "0.123.6" }
 pulley-interpreter = { workspace = true, optional = true }
 heck = "0.5.0"
 

--- a/cranelift/codegen/shared/Cargo.toml
+++ b/cranelift/codegen/shared/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen-shared"
-version = "0.123.5"
+version = "0.123.6"
 description = "For code shared between cranelift-codegen-meta and cranelift-codegen"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/control/Cargo.toml
+++ b/cranelift/control/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-control"
-version = "0.123.5"
+version = "0.123.6"
 description = "White-box fuzz testing framework"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/entity/Cargo.toml
+++ b/cranelift/entity/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-entity"
-version = "0.123.5"
+version = "0.123.6"
 description = "Data structures using entity references as mapping keys"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-entity"

--- a/cranelift/frontend/Cargo.toml
+++ b/cranelift/frontend/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-frontend"
-version = "0.123.5"
+version = "0.123.6"
 description = "Cranelift IR builder helper"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-frontend"

--- a/cranelift/interpreter/Cargo.toml
+++ b/cranelift/interpreter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-interpreter"
-version = "0.123.5"
+version = "0.123.6"
 authors = ["The Cranelift Project Developers"]
 description = "Interpret Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/isle/isle/Cargo.toml
+++ b/cranelift/isle/isle/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 name = "cranelift-isle"
 readme = "../README.md"
 repository = "https://github.com/bytecodealliance/wasmtime/tree/main/cranelift/isle"
-version = "0.123.5"
+version = "0.123.6"
 
 [lints]
 workspace = true

--- a/cranelift/jit/Cargo.toml
+++ b/cranelift/jit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-jit"
-version = "0.123.5"
+version = "0.123.6"
 authors = ["The Cranelift Project Developers"]
 description = "A JIT library backed by Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/module/Cargo.toml
+++ b/cranelift/module/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-module"
-version = "0.123.5"
+version = "0.123.6"
 authors = ["The Cranelift Project Developers"]
 description = "Support for linking functions and data with Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/native/Cargo.toml
+++ b/cranelift/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-native"
-version = "0.123.5"
+version = "0.123.6"
 authors = ["The Cranelift Project Developers"]
 description = "Support for targeting the host with Cranelift"
 documentation = "https://docs.rs/cranelift-native"

--- a/cranelift/object/Cargo.toml
+++ b/cranelift/object/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-object"
-version = "0.123.5"
+version = "0.123.6"
 authors = ["The Cranelift Project Developers"]
 description = "Emit Cranelift output to native object files with `object`"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/reader/Cargo.toml
+++ b/cranelift/reader/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-reader"
-version = "0.123.5"
+version = "0.123.6"
 description = "Cranelift textual IR reader"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-reader"

--- a/cranelift/serde/Cargo.toml
+++ b/cranelift/serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-serde"
-version = "0.123.5"
+version = "0.123.6"
 authors = ["The Cranelift Project Developers"]
 description = "Serializer/Deserializer for Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/srcgen/Cargo.toml
+++ b/cranelift/srcgen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-srcgen"
-version = "0.123.5"
+version = "0.123.6"
 authors = ["The Wasmtime Project Developers"]
 description = "Helper functions for generating Rust and ISLE files"
 license = "Apache-2.0 WITH LLVM-exception"

--- a/cranelift/umbrella/Cargo.toml
+++ b/cranelift/umbrella/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift"
-version = "0.123.5"
+version = "0.123.6"
 description = "Umbrella for commonly-used cranelift crates"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift"

--- a/crates/c-api/include/wasmtime.h
+++ b/crates/c-api/include/wasmtime.h
@@ -213,7 +213,7 @@
 /**
  * \brief Wasmtime version string.
  */
-#define WASMTIME_VERSION "36.0.5"
+#define WASMTIME_VERSION "36.0.6"
 /**
  * \brief Wasmtime major version number.
  */
@@ -225,6 +225,6 @@
 /**
  * \brief Wasmtime patch version number.
  */
-#define WASMTIME_VERSION_PATCH 5
+#define WASMTIME_VERSION_PATCH 6
 
 #endif // WASMTIME_API_H

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -33,6 +33,10 @@ audited_as = "0.123.3"
 version = "0.123.5"
 audited_as = "0.123.4"
 
+[[unpublished.cranelift]]
+version = "0.123.6"
+audited_as = "0.123.5"
+
 [[unpublished.cranelift-assembler-x64]]
 version = "0.121.0"
 audited_as = "0.120.0"
@@ -64,6 +68,10 @@ audited_as = "0.123.3"
 [[unpublished.cranelift-assembler-x64]]
 version = "0.123.5"
 audited_as = "0.123.4"
+
+[[unpublished.cranelift-assembler-x64]]
+version = "0.123.6"
+audited_as = "0.123.5"
 
 [[unpublished.cranelift-assembler-x64-meta]]
 version = "0.121.0"
@@ -97,6 +105,10 @@ audited_as = "0.123.3"
 version = "0.123.5"
 audited_as = "0.123.4"
 
+[[unpublished.cranelift-assembler-x64-meta]]
+version = "0.123.6"
+audited_as = "0.123.5"
+
 [[unpublished.cranelift-bforest]]
 version = "0.121.0"
 audited_as = "0.120.0"
@@ -128,6 +140,10 @@ audited_as = "0.123.3"
 [[unpublished.cranelift-bforest]]
 version = "0.123.5"
 audited_as = "0.123.4"
+
+[[unpublished.cranelift-bforest]]
+version = "0.123.6"
+audited_as = "0.123.5"
 
 [[unpublished.cranelift-bitset]]
 version = "0.121.0"
@@ -161,6 +177,10 @@ audited_as = "0.123.3"
 version = "0.123.5"
 audited_as = "0.123.4"
 
+[[unpublished.cranelift-bitset]]
+version = "0.123.6"
+audited_as = "0.123.5"
+
 [[unpublished.cranelift-codegen]]
 version = "0.121.0"
 audited_as = "0.120.0"
@@ -192,6 +212,10 @@ audited_as = "0.123.3"
 [[unpublished.cranelift-codegen]]
 version = "0.123.5"
 audited_as = "0.123.4"
+
+[[unpublished.cranelift-codegen]]
+version = "0.123.6"
+audited_as = "0.123.5"
 
 [[unpublished.cranelift-codegen-meta]]
 version = "0.121.0"
@@ -225,6 +249,10 @@ audited_as = "0.123.3"
 version = "0.123.5"
 audited_as = "0.123.4"
 
+[[unpublished.cranelift-codegen-meta]]
+version = "0.123.6"
+audited_as = "0.123.5"
+
 [[unpublished.cranelift-codegen-shared]]
 version = "0.121.0"
 audited_as = "0.120.0"
@@ -256,6 +284,10 @@ audited_as = "0.123.3"
 [[unpublished.cranelift-codegen-shared]]
 version = "0.123.5"
 audited_as = "0.123.4"
+
+[[unpublished.cranelift-codegen-shared]]
+version = "0.123.6"
+audited_as = "0.123.5"
 
 [[unpublished.cranelift-control]]
 version = "0.121.0"
@@ -289,6 +321,10 @@ audited_as = "0.123.3"
 version = "0.123.5"
 audited_as = "0.123.4"
 
+[[unpublished.cranelift-control]]
+version = "0.123.6"
+audited_as = "0.123.5"
+
 [[unpublished.cranelift-entity]]
 version = "0.121.0"
 audited_as = "0.120.0"
@@ -320,6 +356,10 @@ audited_as = "0.123.3"
 [[unpublished.cranelift-entity]]
 version = "0.123.5"
 audited_as = "0.123.4"
+
+[[unpublished.cranelift-entity]]
+version = "0.123.6"
+audited_as = "0.123.5"
 
 [[unpublished.cranelift-frontend]]
 version = "0.121.0"
@@ -353,6 +393,10 @@ audited_as = "0.123.3"
 version = "0.123.5"
 audited_as = "0.123.4"
 
+[[unpublished.cranelift-frontend]]
+version = "0.123.6"
+audited_as = "0.123.5"
+
 [[unpublished.cranelift-interpreter]]
 version = "0.121.0"
 audited_as = "0.120.0"
@@ -384,6 +428,10 @@ audited_as = "0.123.3"
 [[unpublished.cranelift-interpreter]]
 version = "0.123.5"
 audited_as = "0.123.4"
+
+[[unpublished.cranelift-interpreter]]
+version = "0.123.6"
+audited_as = "0.123.5"
 
 [[unpublished.cranelift-isle]]
 version = "0.121.0"
@@ -417,6 +465,10 @@ audited_as = "0.123.3"
 version = "0.123.5"
 audited_as = "0.123.4"
 
+[[unpublished.cranelift-isle]]
+version = "0.123.6"
+audited_as = "0.123.5"
+
 [[unpublished.cranelift-jit]]
 version = "0.121.0"
 audited_as = "0.120.0"
@@ -449,6 +501,10 @@ audited_as = "0.123.3"
 version = "0.123.5"
 audited_as = "0.123.4"
 
+[[unpublished.cranelift-jit]]
+version = "0.123.6"
+audited_as = "0.123.5"
+
 [[unpublished.cranelift-module]]
 version = "0.121.0"
 audited_as = "0.120.0"
@@ -481,6 +537,10 @@ audited_as = "0.123.3"
 version = "0.123.5"
 audited_as = "0.123.4"
 
+[[unpublished.cranelift-module]]
+version = "0.123.6"
+audited_as = "0.123.5"
+
 [[unpublished.cranelift-native]]
 version = "0.121.0"
 audited_as = "0.120.0"
@@ -513,6 +573,10 @@ audited_as = "0.123.3"
 version = "0.123.5"
 audited_as = "0.123.4"
 
+[[unpublished.cranelift-native]]
+version = "0.123.6"
+audited_as = "0.123.5"
+
 [[unpublished.cranelift-object]]
 version = "0.121.0"
 audited_as = "0.120.0"
@@ -545,6 +609,10 @@ audited_as = "0.123.3"
 version = "0.123.5"
 audited_as = "0.123.4"
 
+[[unpublished.cranelift-object]]
+version = "0.123.6"
+audited_as = "0.123.5"
+
 [[unpublished.cranelift-reader]]
 version = "0.121.0"
 audited_as = "0.120.0"
@@ -577,6 +645,10 @@ audited_as = "0.123.3"
 version = "0.123.5"
 audited_as = "0.123.4"
 
+[[unpublished.cranelift-reader]]
+version = "0.123.6"
+audited_as = "0.123.5"
+
 [[unpublished.cranelift-serde]]
 version = "0.121.0"
 audited_as = "0.120.0"
@@ -609,6 +681,10 @@ audited_as = "0.123.3"
 version = "0.123.5"
 audited_as = "0.123.4"
 
+[[unpublished.cranelift-serde]]
+version = "0.123.6"
+audited_as = "0.123.5"
+
 [[unpublished.cranelift-srcgen]]
 version = "0.121.0"
 audited_as = "0.120.0"
@@ -640,6 +716,10 @@ audited_as = "0.123.3"
 [[unpublished.cranelift-srcgen]]
 version = "0.123.5"
 audited_as = "0.123.4"
+
+[[unpublished.cranelift-srcgen]]
+version = "0.123.6"
+audited_as = "0.123.5"
 
 [[unpublished.pulley-interpreter]]
 version = "34.0.0"
@@ -672,6 +752,10 @@ audited_as = "36.0.3"
 [[unpublished.pulley-interpreter]]
 version = "36.0.5"
 audited_as = "36.0.4"
+
+[[unpublished.pulley-interpreter]]
+version = "36.0.6"
+audited_as = "36.0.5"
 
 [[unpublished.pulley-macros]]
 version = "35.0.0"
@@ -701,6 +785,10 @@ audited_as = "36.0.3"
 version = "36.0.5"
 audited_as = "36.0.4"
 
+[[unpublished.pulley-macros]]
+version = "36.0.6"
+audited_as = "36.0.5"
+
 [[unpublished.wasi-common]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -733,6 +821,10 @@ audited_as = "36.0.3"
 version = "36.0.5"
 audited_as = "36.0.4"
 
+[[unpublished.wasi-common]]
+version = "36.0.6"
+audited_as = "36.0.5"
+
 [[unpublished.wasmtime]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -764,6 +856,10 @@ audited_as = "36.0.3"
 [[unpublished.wasmtime]]
 version = "36.0.5"
 audited_as = "36.0.4"
+
+[[unpublished.wasmtime]]
+version = "36.0.6"
+audited_as = "36.0.5"
 
 [[unpublished.wasmtime-asm-macros]]
 version = "34.0.0"
@@ -813,6 +909,10 @@ audited_as = "36.0.3"
 version = "36.0.5"
 audited_as = "36.0.4"
 
+[[unpublished.wasmtime-cli]]
+version = "36.0.6"
+audited_as = "36.0.5"
+
 [[unpublished.wasmtime-cli-flags]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -844,6 +944,10 @@ audited_as = "36.0.3"
 [[unpublished.wasmtime-cli-flags]]
 version = "36.0.5"
 audited_as = "36.0.4"
+
+[[unpublished.wasmtime-cli-flags]]
+version = "36.0.6"
+audited_as = "36.0.5"
 
 [[unpublished.wasmtime-component-macro]]
 version = "34.0.0"
@@ -901,6 +1005,10 @@ audited_as = "36.0.3"
 version = "36.0.5"
 audited_as = "36.0.4"
 
+[[unpublished.wasmtime-environ]]
+version = "36.0.6"
+audited_as = "36.0.5"
+
 [[unpublished.wasmtime-explorer]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -941,6 +1049,10 @@ audited_as = "36.0.3"
 version = "36.0.5"
 audited_as = "36.0.4"
 
+[[unpublished.wasmtime-internal-asm-macros]]
+version = "36.0.6"
+audited_as = "36.0.5"
+
 [[unpublished.wasmtime-internal-c-api-macros]]
 version = "36.0.0"
 audited_as = "35.0.0"
@@ -964,6 +1076,10 @@ audited_as = "36.0.3"
 [[unpublished.wasmtime-internal-c-api-macros]]
 version = "36.0.5"
 audited_as = "36.0.4"
+
+[[unpublished.wasmtime-internal-c-api-macros]]
+version = "36.0.6"
+audited_as = "36.0.5"
 
 [[unpublished.wasmtime-internal-cache]]
 version = "36.0.0"
@@ -989,6 +1105,10 @@ audited_as = "36.0.3"
 version = "36.0.5"
 audited_as = "36.0.4"
 
+[[unpublished.wasmtime-internal-cache]]
+version = "36.0.6"
+audited_as = "36.0.5"
+
 [[unpublished.wasmtime-internal-component-macro]]
 version = "36.0.0"
 audited_as = "35.0.0"
@@ -1012,6 +1132,10 @@ audited_as = "36.0.3"
 [[unpublished.wasmtime-internal-component-macro]]
 version = "36.0.5"
 audited_as = "36.0.4"
+
+[[unpublished.wasmtime-internal-component-macro]]
+version = "36.0.6"
+audited_as = "36.0.5"
 
 [[unpublished.wasmtime-internal-component-util]]
 version = "36.0.0"
@@ -1037,6 +1161,10 @@ audited_as = "36.0.3"
 version = "36.0.5"
 audited_as = "36.0.4"
 
+[[unpublished.wasmtime-internal-component-util]]
+version = "36.0.6"
+audited_as = "36.0.5"
+
 [[unpublished.wasmtime-internal-cranelift]]
 version = "36.0.0"
 audited_as = "35.0.0"
@@ -1060,6 +1188,10 @@ audited_as = "36.0.3"
 [[unpublished.wasmtime-internal-cranelift]]
 version = "36.0.5"
 audited_as = "36.0.4"
+
+[[unpublished.wasmtime-internal-cranelift]]
+version = "36.0.6"
+audited_as = "36.0.5"
 
 [[unpublished.wasmtime-internal-explorer]]
 version = "36.0.0"
@@ -1085,6 +1217,10 @@ audited_as = "36.0.3"
 version = "36.0.5"
 audited_as = "36.0.4"
 
+[[unpublished.wasmtime-internal-explorer]]
+version = "36.0.6"
+audited_as = "36.0.5"
+
 [[unpublished.wasmtime-internal-fiber]]
 version = "36.0.0"
 audited_as = "35.0.0"
@@ -1108,6 +1244,10 @@ audited_as = "36.0.3"
 [[unpublished.wasmtime-internal-fiber]]
 version = "36.0.5"
 audited_as = "36.0.4"
+
+[[unpublished.wasmtime-internal-fiber]]
+version = "36.0.6"
+audited_as = "36.0.5"
 
 [[unpublished.wasmtime-internal-jit-debug]]
 version = "36.0.0"
@@ -1133,6 +1273,10 @@ audited_as = "36.0.3"
 version = "36.0.5"
 audited_as = "36.0.4"
 
+[[unpublished.wasmtime-internal-jit-debug]]
+version = "36.0.6"
+audited_as = "36.0.5"
+
 [[unpublished.wasmtime-internal-jit-icache-coherence]]
 version = "36.0.0"
 audited_as = "35.0.0"
@@ -1156,6 +1300,10 @@ audited_as = "36.0.3"
 [[unpublished.wasmtime-internal-jit-icache-coherence]]
 version = "36.0.5"
 audited_as = "36.0.4"
+
+[[unpublished.wasmtime-internal-jit-icache-coherence]]
+version = "36.0.6"
+audited_as = "36.0.5"
 
 [[unpublished.wasmtime-internal-math]]
 version = "36.0.0"
@@ -1181,6 +1329,10 @@ audited_as = "36.0.3"
 version = "36.0.5"
 audited_as = "36.0.4"
 
+[[unpublished.wasmtime-internal-math]]
+version = "36.0.6"
+audited_as = "36.0.5"
+
 [[unpublished.wasmtime-internal-slab]]
 version = "36.0.0"
 audited_as = "35.0.0"
@@ -1204,6 +1356,10 @@ audited_as = "36.0.3"
 [[unpublished.wasmtime-internal-slab]]
 version = "36.0.5"
 audited_as = "36.0.4"
+
+[[unpublished.wasmtime-internal-slab]]
+version = "36.0.6"
+audited_as = "36.0.5"
 
 [[unpublished.wasmtime-internal-unwinder]]
 version = "36.0.0"
@@ -1229,6 +1385,10 @@ audited_as = "36.0.3"
 version = "36.0.5"
 audited_as = "36.0.4"
 
+[[unpublished.wasmtime-internal-unwinder]]
+version = "36.0.6"
+audited_as = "36.0.5"
+
 [[unpublished.wasmtime-internal-versioned-export-macros]]
 version = "36.0.0"
 audited_as = "35.0.0"
@@ -1253,6 +1413,10 @@ audited_as = "36.0.3"
 version = "36.0.5"
 audited_as = "36.0.4"
 
+[[unpublished.wasmtime-internal-versioned-export-macros]]
+version = "36.0.6"
+audited_as = "36.0.5"
+
 [[unpublished.wasmtime-internal-winch]]
 version = "36.0.0"
 audited_as = "35.0.0"
@@ -1277,6 +1441,10 @@ audited_as = "36.0.3"
 version = "36.0.5"
 audited_as = "36.0.4"
 
+[[unpublished.wasmtime-internal-winch]]
+version = "36.0.6"
+audited_as = "36.0.5"
+
 [[unpublished.wasmtime-internal-wit-bindgen]]
 version = "36.0.0"
 audited_as = "35.0.0"
@@ -1301,6 +1469,10 @@ audited_as = "36.0.3"
 version = "36.0.5"
 audited_as = "36.0.4"
 
+[[unpublished.wasmtime-internal-wit-bindgen]]
+version = "36.0.6"
+audited_as = "36.0.5"
+
 [[unpublished.wasmtime-internal-wmemcheck]]
 version = "36.0.0"
 audited_as = "35.0.0"
@@ -1324,6 +1496,10 @@ audited_as = "36.0.3"
 [[unpublished.wasmtime-internal-wmemcheck]]
 version = "36.0.5"
 audited_as = "36.0.4"
+
+[[unpublished.wasmtime-internal-wmemcheck]]
+version = "36.0.6"
+audited_as = "36.0.5"
 
 [[unpublished.wasmtime-jit-debug]]
 version = "34.0.0"
@@ -1389,6 +1565,10 @@ audited_as = "36.0.3"
 version = "36.0.5"
 audited_as = "36.0.4"
 
+[[unpublished.wasmtime-wasi]]
+version = "36.0.6"
+audited_as = "36.0.5"
+
 [[unpublished.wasmtime-wasi-config]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -1421,6 +1601,10 @@ audited_as = "36.0.3"
 version = "36.0.5"
 audited_as = "36.0.4"
 
+[[unpublished.wasmtime-wasi-config]]
+version = "36.0.6"
+audited_as = "36.0.5"
+
 [[unpublished.wasmtime-wasi-http]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -1453,6 +1637,10 @@ audited_as = "36.0.3"
 version = "36.0.5"
 audited_as = "36.0.4"
 
+[[unpublished.wasmtime-wasi-http]]
+version = "36.0.6"
+audited_as = "36.0.5"
+
 [[unpublished.wasmtime-wasi-io]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -1485,6 +1673,10 @@ audited_as = "36.0.3"
 version = "36.0.5"
 audited_as = "36.0.4"
 
+[[unpublished.wasmtime-wasi-io]]
+version = "36.0.6"
+audited_as = "36.0.5"
+
 [[unpublished.wasmtime-wasi-keyvalue]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -1517,6 +1709,10 @@ audited_as = "36.0.3"
 version = "36.0.5"
 audited_as = "36.0.4"
 
+[[unpublished.wasmtime-wasi-keyvalue]]
+version = "36.0.6"
+audited_as = "36.0.5"
+
 [[unpublished.wasmtime-wasi-nn]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -1549,6 +1745,10 @@ audited_as = "36.0.3"
 version = "36.0.5"
 audited_as = "36.0.4"
 
+[[unpublished.wasmtime-wasi-nn]]
+version = "36.0.6"
+audited_as = "36.0.5"
+
 [[unpublished.wasmtime-wasi-threads]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -1581,6 +1781,10 @@ audited_as = "36.0.3"
 version = "36.0.5"
 audited_as = "36.0.4"
 
+[[unpublished.wasmtime-wasi-threads]]
+version = "36.0.6"
+audited_as = "36.0.5"
+
 [[unpublished.wasmtime-wasi-tls]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -1612,6 +1816,10 @@ audited_as = "36.0.3"
 [[unpublished.wasmtime-wasi-tls]]
 version = "36.0.5"
 audited_as = "36.0.4"
+
+[[unpublished.wasmtime-wasi-tls]]
+version = "36.0.6"
+audited_as = "36.0.5"
 
 [[unpublished.wasmtime-wasi-tls-nativetls]]
 version = "36.0.0"
@@ -1637,6 +1845,10 @@ audited_as = "36.0.3"
 version = "36.0.5"
 audited_as = "36.0.4"
 
+[[unpublished.wasmtime-wasi-tls-nativetls]]
+version = "36.0.6"
+audited_as = "36.0.5"
+
 [[unpublished.wasmtime-wast]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -1668,6 +1880,10 @@ audited_as = "36.0.3"
 [[unpublished.wasmtime-wast]]
 version = "36.0.5"
 audited_as = "36.0.4"
+
+[[unpublished.wasmtime-wast]]
+version = "36.0.6"
+audited_as = "36.0.5"
 
 [[unpublished.wasmtime-winch]]
 version = "34.0.0"
@@ -1725,6 +1941,10 @@ audited_as = "36.0.3"
 version = "36.0.5"
 audited_as = "36.0.4"
 
+[[unpublished.wiggle]]
+version = "36.0.6"
+audited_as = "36.0.5"
+
 [[unpublished.wiggle-generate]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -1757,6 +1977,10 @@ audited_as = "36.0.3"
 version = "36.0.5"
 audited_as = "36.0.4"
 
+[[unpublished.wiggle-generate]]
+version = "36.0.6"
+audited_as = "36.0.5"
+
 [[unpublished.wiggle-macro]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -1788,6 +2012,10 @@ audited_as = "36.0.3"
 [[unpublished.wiggle-macro]]
 version = "36.0.5"
 audited_as = "36.0.4"
+
+[[unpublished.wiggle-macro]]
+version = "36.0.6"
+audited_as = "36.0.5"
 
 [[unpublished.wiggle-test]]
 version = "0.0.0"
@@ -1824,6 +2052,10 @@ audited_as = "36.0.3"
 [[unpublished.winch-codegen]]
 version = "36.0.5"
 audited_as = "36.0.4"
+
+[[unpublished.winch-codegen]]
+version = "36.0.6"
+audited_as = "36.0.5"
 
 [[publisher.aho-corasick]]
 version = "1.0.2"


### PR DESCRIPTION
This is an [automated pull request][process] from CI to create a patch release for Wasmtime 36.0.6, requested by @alexcrichton.

It's recommended that maintainers double-check that [RELEASES.md] is up-to-date and that there are no known issues before merging this PR. When this PR is merged a release tag will automatically be created, crates will be published, and CI artifacts will be produced.

[RELEASES.md]: https://github.com/bytecodealliance/wasmtime/blob/release-36.0.6/RELEASES.md
[process]: https://docs.wasmtime.dev/contributing-release-process.html
