### PR TITLE
Fix OOM-handling `SecondaryMap`'s serialization/deserialization so that it matches `cranelift_entity::SecondaryMap`

### DIFF
--- a/cranelift/entity/src/map.rs
+++ b/cranelift/entity/src/map.rs
@@ -194,6 +194,16 @@ where
         Ok(())
     }
 
+    /// Get this map's underlying values as a slice.
+    pub fn as_values_slice(&self) -> &[V] {
+        &self.elems
+    }
+
+    /// Get this map's default value.
+    pub fn default_value(&self) -> &V {
+        &self.default
+    }
+
     /// Slow path for `index_mut` which resizes the vector.
     #[cold]
     fn resize_for_index_mut(&mut self, i: usize) -> &mut V {


### PR DESCRIPTION


<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
