### PR TITLE
Debugging: apply single-stepping patches to modules instantiated after setting changes.

### DIFF
--- a/crates/wasmtime/src/runtime/component/instance.rs
+++ b/crates/wasmtime/src/runtime/component/instance.rs
@@ -724,8 +724,8 @@ impl<'a> Instantiator<'a> {
         imports: &'a Arc<PrimaryMap<RuntimeImportIndex, RuntimeImport>>,
     ) -> Result<Instantiator<'a>> {
         let env_component = component.env_component();
-        let (modules, engine) = store.modules_and_engine_mut();
-        modules.register_component(component, engine)?;
+        let (modules, engine, breakpoints) = store.modules_and_engine_and_breakpoints_mut();
+        modules.register_component(component, engine, breakpoints)?;
         let imported_resources: ImportedResources =
             PrimaryMap::with_capacity(env_component.imported_resources.len());
 

--- a/crates/wasmtime/src/runtime/instance.rs
+++ b/crates/wasmtime/src/runtime/instance.rs
@@ -225,8 +225,8 @@ impl Instance {
         // Note that under normal operation this shouldn't do much as the list
         // of funcs-with-holes should generally be empty. As a result the
         // process of filling this out is not super optimized at this point.
-        let (modules, engine) = store.modules_and_engine_mut();
-        modules.register_module(module, engine)?;
+        let (modules, engine, breakpoints) = store.modules_and_engine_and_breakpoints_mut();
+        modules.register_module(module, engine, breakpoints)?;
         let (funcrefs, modules) = store.func_refs_and_modules();
         funcrefs.fill(modules);
 
@@ -305,8 +305,8 @@ impl Instance {
 
         // Register the module just before instantiation to ensure we keep the module
         // properly referenced while in use by the store.
-        let (modules, engine) = store.modules_and_engine_mut();
-        let module_id = modules.register_module(module, engine)?;
+        let (modules, engine, breakpoints) = store.modules_and_engine_and_breakpoints_mut();
+        let module_id = modules.register_module(module, engine, breakpoints)?;
 
         // The first thing we do is issue an instance allocation request
         // to the instance allocator. This, on success, will give us an
@@ -966,8 +966,8 @@ fn pre_instantiate_raw(
 ) -> Result<OwnedImports> {
     // Register this module and use it to fill out any funcref wasm_call holes
     // we can. For more comments on this see `typecheck_externs`.
-    let (modules, engine) = store.modules_and_engine_mut();
-    modules.register_module(module, engine)?;
+    let (modules, engine, breakpoints) = store.modules_and_engine_and_breakpoints_mut();
+    modules.register_module(module, engine, breakpoints)?;
     let (funcrefs, modules) = store.func_refs_and_modules();
     funcrefs.fill(modules);
 

--- a/crates/wasmtime/src/runtime/store.rs
+++ b/crates/wasmtime/src/runtime/store.rs
@@ -84,7 +84,7 @@ use crate::ThrownException;
 use crate::error::OutOfMemory;
 #[cfg(feature = "async")]
 use crate::fiber;
-use crate::module::RegisteredModuleId;
+use crate::module::{RegisterBreakpointState, RegisteredModuleId};
 use crate::prelude::*;
 #[cfg(feature = "gc")]
 use crate::runtime::vm::GcRootsList;
@@ -1670,8 +1670,15 @@ impl StoreOpaque {
     }
 
     #[inline]
-    pub(crate) fn modules_and_engine_mut(&mut self) -> (&mut ModuleRegistry, &Engine) {
-        (&mut self.modules, &self.engine)
+    pub(crate) fn modules_and_engine_and_breakpoints_mut(
+        &mut self,
+    ) -> (&mut ModuleRegistry, &Engine, RegisterBreakpointState<'_>) {
+        #[cfg(feature = "debug")]
+        let breakpoints = RegisterBreakpointState(&self.breakpoints);
+        #[cfg(not(feature = "debug"))]
+        let breakpoints = RegisterBreakpointState(core::marker::PhantomData);
+
+        (&mut self.modules, &self.engine, breakpoints)
     }
 
     pub(crate) fn func_refs_and_modules(&mut self) -> (&mut FuncRefs, &ModuleRegistry) {


### PR DESCRIPTION
We currently do a store-wide state-change on all registered modules when the "single stepping" flag changes, patching in or out all breakpoints. However, this design didn't account for modules registered with the store *after* single-stepping is enabled (and new modules may be registered any time an instantiation occurs). In particular this is problematic when a debugger, e.g., sets the single-step flag right at the beginning of execution of a "host main function" that calls Wasm, before the main instantiation occurs.

This PR threads through the breakpoint state in the registration path, with the narrow waist at `ModuleRegistry::register` which is the only place where modules are added to the `LoadedCode`.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
