### PR TITLE
Debugging: set vmctx slot before top-of-function epoch yield point.

### DIFF
--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -3865,6 +3865,8 @@ impl FuncEnvironment<'_> {
             self.conditionally_trap(builder, overflow, ir::TrapCode::STACK_OVERFLOW);
         }
 
+        self.update_state_slot_vmctx(builder);
+
         // Additionally we initialize `fuel_var` if it will get used.
         if self.tunables.consume_fuel {
             self.fuel_function_entry(builder);
@@ -3884,8 +3886,6 @@ impl FuncEnvironment<'_> {
                 self.check_free_start(builder);
             }
         }
-
-        self.update_state_slot_vmctx(builder);
 
         Ok(())
     }


### PR DESCRIPTION
Epoch yields emit debug events, and the debug event handler can walk the stack and look at the instance associated with each frame, which requires `vmctx`. We weren't setting the `vmctx` slot until after the epoch check in the function preamble, exposing a null or uninitialized slot to the accessor. This PR fixes that by hoisting the initialization to the very top of the preamble.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
