### PR TITLE
Remove `#[derive(Clone)]` from our OOM-handling `Vec<T>`

### DIFF
--- a/crates/core/src/alloc/vec.rs
+++ b/crates/core/src/alloc/vec.rs
@@ -48,7 +48,7 @@ macro_rules! private_len {
 
 /// Like `std::vec::Vec` but all methods that allocate force handling allocation
 /// failure.
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Vec<T> {
     inner: StdVec<T>,
 }

--- a/crates/environ/src/gc.rs
+++ b/crates/environ/src/gc.rs
@@ -370,7 +370,7 @@ impl GcArrayLayout {
 /// tuples of typed fields with a certain size. The only difference in
 /// practice is that an exception object also carries a tag reference
 /// (at a fixed offset as per `GcTypeLayouts::exception_tag_offset`).
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct GcStructLayout {
     /// The size (in bytes) of this struct.
     pub size: u32,

--- a/crates/environ/src/module.rs
+++ b/crates/environ/src/module.rs
@@ -237,7 +237,7 @@ pub struct TableInitialization {
 }
 
 /// Initial value for all elements in a table.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub enum TableInitialValue {
     /// Initialize each table element to null, optionally setting some elements
     /// to non-null given the precomputed image.


### PR DESCRIPTION
If the `Vec<T>` is non-empty, then cloning will allocate, so we should only implement `TryClone`, not `Clone`.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
