### PR TITLE
Don't panic in duration underflow

### DIFF
--- a/cranelift/codegen/src/timing.rs
+++ b/cranelift/codegen/src/timing.rs
@@ -171,7 +171,10 @@ mod enabled {
 
         /// Returns the total amount of time taken by all the passes measured.
         pub fn total(&self) -> Duration {
-            self.pass.iter().map(|p| p.total - p.child).sum()
+            self.pass
+                .iter()
+                .map(|p| p.total.saturating_sub(p.child))
+                .sum()
         }
     }
 


### PR DESCRIPTION
In debug mode we check for tokens being dropped out of order, but in a
release build this can fail.

Closes #12692
