### PR TITLE
fix(cranelift): use saturating_sub in PassTimes::total to prevent panic

### DIFF
--- a/cranelift/codegen/src/timing.rs
+++ b/cranelift/codegen/src/timing.rs
@@ -171,7 +171,10 @@ mod enabled {
 
         /// Returns the total amount of time taken by all the passes measured.
         pub fn total(&self) -> Duration {
-            self.pass.iter().map(|p| p.total.saturating_sub(p.child)).sum()
+            self.pass
+                .iter()
+                .map(|p| p.total.saturating_sub(p.child))
+                .sum()
         }
     }
 


### PR DESCRIPTION
## Bug

`PassTimes::total()` panics with "overflow when subtracting durations" when compiling certain WASM modules. This was reported by Zed via telemetry on Windows x86 with Cranelift 33.0.2.

Stack trace:
```
core::time::impl$3::sub (time.rs:1164)
cranelift_codegen::timing::enabled::impl$0::total::closure$0 (timing.rs:174)
...
cranelift_codegen::timing::enabled::PassTimes::total (timing.rs:174)
wasmtime_cranelift::compiler::impl$3::compile_function (compiler.rs:284)
```

## Root Cause

`PassTimes::total()` computes self-time per pass as `p.total - p.child` using the `-` operator on `Duration`, which panics on underflow. When timing tokens are dropped out of order (which is guarded by a `debug_assert` that is elided in release builds), the accumulated `child` duration can exceed `total`, triggering the panic.

The `Display` implementation for `PassTimes` already handles this edge case correctly by using `checked_sub`:
```rust
if let Some(s) = time.total.checked_sub(time.child) {
    fmtdur(s, f)?;
}
```

But `total()` was not given the same treatment.

## Fix

Replace `p.total - p.child` with `p.total.saturating_sub(p.child)` in `PassTimes::total()`. This is consistent with how the `Display` impl handles the same subtraction and prevents the panic in production builds where the ordering assertion is not checked.

Closes #12692