### PR TITLE
docs: fix logical typo in bitselect documentation

### DIFF
--- a/cranelift/codegen/meta/src/shared/instructions.rs
+++ b/cranelift/codegen/meta/src/shared/instructions.rs
@@ -1652,7 +1652,7 @@ pub(crate) fn define(
         Conditional select of bits.
 
         For each bit in `c`, this instruction selects the corresponding bit from `x` if the bit
-        in `x` is 1 and the corresponding bit from `y` if the bit in `c` is 0. See also:
+        in `c` is 1 and the corresponding bit from `y` if the bit in `c` is 0. See also:
         `select`.
         "#,
             &formats.ternary,


### PR DESCRIPTION
Found this while implementing aarch64 emulation with BIF instruction.

The actual behavior tested to be selecting x if c is 1 and y if c is 0.