### PR TITLE
s390x-z17: Implement load indexed address instruction

### DIFF
--- a/cranelift/codegen/src/isa/s390x/inst.isle
+++ b/cranelift/codegen/src/isa/s390x/inst.isle
@@ -1008,6 +1008,22 @@
       (rd WritableReg)
       (mem MemArg))
 
+    ;; Load address referenced by `mem` into `rd`.
+    (LoadIndexedAddr
+      (rd WritableReg)
+      (base Reg)
+      (index Reg)
+      (offset SImm20)
+      (size u8))
+
+    ;; Load address referenced by `mem` into `rd`.
+    (LoadLogicalIndexedAddr
+      (rd WritableReg)
+      (base Reg)
+      (index Reg)
+      (offset SImm20)
+      (size u8))
+
     ;; Meta-instruction to emit a loop around a sequence of instructions.
     ;; This control flow is not visible to the compiler core, in particular
     ;; the register allocator.  Therefore, instructions in the loop may not
@@ -1774,6 +1790,9 @@
 (decl uimm16shifted_from_value (UImm16Shifted) Value)
 (extern extractor uimm16shifted_from_value uimm16shifted_from_value)
 
+(decl simm20_from_value (SImm20) Value)
+(extern extractor simm20_from_value simm20_from_value)
+
 (decl uimm32shifted_from_value (UImm32Shifted) Value)
 (extern extractor uimm32shifted_from_value uimm32shifted_from_value)
 
@@ -1927,6 +1946,23 @@
       (if-let final_offset (memarg_symbol_offset_sum offset sym_offset))
       (memarg_symbol name final_offset flags))
 
+(rule 2 (lower_address flags (has_type (mie4_enabled)
+          (iadd $I64 (ishl $I64 (uextend $I64 (iadd $I32 x (simm20_from_value z)))
+                       (u8_from_value shift)) y)) (i64_from_offset offset))
+      (memarg_reg_plus_off (load_logical_indexed_addr x y z shift) offset 0 flags))
+
+(rule 3 (lower_address flags (has_type (mie4_enabled)
+          (iadd $I64 y (ishl $I64 (uextend $I64 (iadd $I32 x (simm20_from_value z)))
+                         (u8_from_value shift)))) (i64_from_offset offset))
+      (memarg_reg_plus_off (load_logical_indexed_addr y x z shift) offset 0 flags))
+
+(rule 4 (lower_address flags (has_type (mie4_enabled)
+          (iadd $I64 (ishl $I64 (sextend $I64 (iadd $I32 x (simm20_from_value z))) (u8_from_value shift)) y)) (i64_from_offset offset))
+      (memarg_reg_plus_off (load_indexed_addr x y z shift) offset 0 flags))
+
+(rule 5 (lower_address flags (has_type (mie4_enabled)
+          (iadd $I64 y (ishl $I64 (sextend $I64 (iadd $I32 x (simm20_from_value z))) (u8_from_value shift)))) (i64_from_offset offset))
+      (memarg_reg_plus_off (load_indexed_addr y x z shift) offset 0 flags))
 
 ;; Lower an address plus a small bias into a `MemArg`.
 
@@ -2815,6 +2851,20 @@
 (rule (load_addr mem)
       (let ((dst WritableReg (temp_writable_reg $I64))
             (_ Unit (emit (MInst.LoadAddr dst mem))))
+        dst))
+
+;; Helper for emitting `MInst.LoadIndexedAddr` instructions.
+(decl load_indexed_addr (Reg Reg SImm20 u8) Reg)
+(rule (load_indexed_addr base index offset size)
+      (let ((dst WritableReg (temp_writable_reg $I64))
+            (_ Unit (emit (MInst.LoadIndexedAddr dst base index offset size))))
+        dst))
+
+;; Helper for emitting `MInst.LoadLogicalIndexedAddr` instructions.
+(decl load_logical_indexed_addr (Reg Reg SImm20 u8) Reg)
+(rule (load_logical_indexed_addr base index offset size)
+      (let ((dst WritableReg (temp_writable_reg $I64))
+            (_ Unit (emit (MInst.LoadLogicalIndexedAddr dst base index offset size))))
         dst))
 
 ;; Helper for emitting `MInst.Call` instructions.

--- a/cranelift/codegen/src/isa/s390x/inst/emit.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/emit.rs
@@ -2321,6 +2321,32 @@ impl Inst {
                     rd, &mem, opcode_rx, opcode_rxy, opcode_ril, false, sink, emit_info, state,
                 );
             }
+            &Inst::LoadIndexedAddr {
+                rd,
+                base,
+                index,
+                offset,
+                size,
+            } => {
+                let opcode: u16 = 0xe360 | (size as u16 & 0xf) << 1;
+                put(
+                    sink,
+                    &enc_rxy(opcode, rd.to_reg(), base, index, offset.bits()),
+                );
+            }
+            &Inst::LoadLogicalIndexedAddr {
+                rd,
+                base,
+                index,
+                offset,
+                size,
+            } => {
+                let opcode: u16 = 0xe361 | (size as u16 & 0xf) << 1;
+                put(
+                    sink,
+                    &enc_rxy(opcode, rd.to_reg(), base, index, offset.bits()),
+                );
+            }
 
             &Inst::Mov64 { rd, rm } => {
                 let opcode = 0xb904; // LGR

--- a/cranelift/codegen/src/isa/s390x/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/emit_tests.rs
@@ -13929,6 +13929,50 @@ fn test_s390x_binemit() {
         "E7480001384D",
         "vrepg %v20, %v8, 1",
     ));
+    insns.push((
+        Inst::LoadIndexedAddr {
+            rd: writable_gpr(1),
+            base: gpr(2),
+            index: gpr(3),
+            offset: SImm20::maybe_from_i64(0x7ffff).unwrap(),
+            size: 3,
+        },
+        "E3132FFF7F66",
+        "lxag %r1, 524287(%r3,%r2)",
+    ));
+    insns.push((
+        Inst::LoadIndexedAddr {
+            rd: writable_gpr(1),
+            base: gpr(2),
+            index: gpr(3),
+            offset: SImm20::maybe_from_i64(-2).unwrap(),
+            size: 4,
+        },
+        "E3132FFEFF68",
+        "lxaq %r1, -2(%r3,%r2)",
+    ));
+    insns.push((
+        Inst::LoadLogicalIndexedAddr {
+            rd: writable_gpr(1),
+            base: gpr(2),
+            index: gpr(3),
+            offset: SImm20::maybe_from_i64(0x7ffff).unwrap(),
+            size: 2,
+        },
+        "E3132FFF7F65",
+        "llxaf %r1, 524287(%r3,%r2)",
+    ));
+    insns.push((
+        Inst::LoadLogicalIndexedAddr {
+            rd: writable_gpr(1),
+            base: gpr(2),
+            index: gpr(3),
+            offset: SImm20::maybe_from_i64(-2).unwrap(),
+            size: 1,
+        },
+        "E3132FFEFF63",
+        "llxah %r1, -2(%r3,%r2)",
+    ));
 
     let flags = settings::Flags::new(settings::builder());
 

--- a/cranelift/codegen/src/isa/s390x/inst/mod.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/mod.rs
@@ -1,7 +1,7 @@
 //! This module defines s390x-specific machine instruction types.
 
 use crate::binemit::{Addend, CodeOffset, Reloc};
-use crate::ir::{ExternalName, Type, types};
+use crate::ir::{ExternalName, MemFlags, Type, types};
 use crate::isa::s390x::abi::S390xMachineDeps;
 use crate::isa::{CallConv, FunctionAlignment};
 use crate::machinst::*;
@@ -239,6 +239,10 @@ impl Inst {
             | Inst::CondBreak { .. }
             | Inst::Unwind { .. }
             | Inst::ElfTlsGetOffset { .. } => InstructionSet::Base,
+
+            Inst::LoadIndexedAddr { .. } | Inst::LoadLogicalIndexedAddr { .. } => {
+                InstructionSet::MIE4
+            }
 
             // These depend on the opcode
             Inst::AluRRR { alu_op, .. } => match alu_op {
@@ -1029,6 +1033,20 @@ fn s390x_get_operands(inst: &mut Inst, collector: &mut DenyReuseVisitor<impl Ope
         Inst::LoadAddr { rd, mem } => {
             collector.reg_def(rd);
             memarg_operands(mem, collector);
+        }
+        Inst::LoadIndexedAddr {
+            rd, base, index, ..
+        } => {
+            collector.reg_def(rd);
+            collector.reg_use(base);
+            collector.reg_use(index);
+        }
+        Inst::LoadLogicalIndexedAddr {
+            rd, base, index, ..
+        } => {
+            collector.reg_def(rd);
+            collector.reg_use(base);
+            collector.reg_use(index);
         }
         Inst::StackProbeLoop { probe_count, .. } => {
             collector.reg_early_def(probe_count);
@@ -3506,6 +3524,56 @@ impl Inst {
                 let mem = mem.pretty_print_default();
 
                 format!("{mem_str}{op} {rd}, {mem}")
+            }
+            &Inst::LoadIndexedAddr {
+                rd,
+                base,
+                index,
+                offset,
+                size,
+            } => {
+                let rd = pretty_print_reg(rd.to_reg());
+                let op = match size {
+                    1 => "lxah",
+                    2 => "lxaf",
+                    3 => "lxag",
+                    4 => "lxaq",
+                    _ => unreachable!(),
+                };
+                let flags = MemFlags::trusted();
+                let mem = MemArg::BXD20 {
+                    base,
+                    index,
+                    disp: offset,
+                    flags,
+                };
+                let mem = mem.pretty_print_default();
+                format!("{op} {rd}, {mem}")
+            }
+            &Inst::LoadLogicalIndexedAddr {
+                rd,
+                base,
+                index,
+                offset,
+                size,
+            } => {
+                let rd = pretty_print_reg(rd.to_reg());
+                let op = match size {
+                    1 => "llxah",
+                    2 => "llxaf",
+                    3 => "llxag",
+                    4 => "llxaq",
+                    _ => unreachable!(),
+                };
+                let flags = MemFlags::trusted();
+                let mem = MemArg::BXD20 {
+                    base,
+                    index,
+                    disp: offset,
+                    flags,
+                };
+                let mem = mem.pretty_print_default();
+                format!("{op} {rd}, {mem}")
             }
             &Inst::StackProbeLoop {
                 probe_count,

--- a/cranelift/codegen/src/isa/s390x/lower.isle
+++ b/cranelift/codegen/src/isa/s390x/lower.isle
@@ -115,6 +115,21 @@
 (rule 1 (lower (has_type (vr128_ty ty) (iadd _ x y)))
       (vec_add ty x y))
 
+(rule 16 (lower (has_type (mie4_enabled)
+          (iadd $I64 (ishl $I64 (uextend $I64 (iadd $I32 x (simm20_from_value z))) (u8_from_value shift)) y)))
+      (load_logical_indexed_addr x y z shift))
+
+(rule 17 (lower (has_type (mie4_enabled)
+          (iadd $I64 y (ishl $I64 (uextend $I64 (iadd $I32 x (simm20_from_value z))) (u8_from_value shift)))))
+      (load_logical_indexed_addr y x z shift))
+
+(rule 18 (lower (has_type (and (ty_addr64 _) (mie4_enabled))
+          (iadd $I64 (ishl $I64 (sextend $I64 (iadd $I32 x (simm20_from_value z))) (u8_from_value shift)) y)))
+      (load_indexed_addr x y z shift))
+
+(rule 19 (lower (has_type (and (ty_addr64 _) (mie4_enabled))
+          (iadd $I64 y (ishl $I64 (sextend $I64 (iadd $I32 x (simm20_from_value z))) (u8_from_value shift)))))
+      (load_indexed_addr y x z shift))
 
 ;;;; Rules for `uadd_sat` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/cranelift/codegen/src/isa/s390x/lower/isle.rs
+++ b/cranelift/codegen/src/isa/s390x/lower/isle.rs
@@ -548,6 +548,12 @@ impl generated_code::Context for IsleContext<'_, '_, MInst, S390xBackend> {
     }
 
     #[inline]
+    fn simm20_from_value(&mut self, val: Value) -> Option<SImm20> {
+        let constant = self.u64_from_signed_value(val)? as i64;
+        SImm20::maybe_from_i64(constant)
+    }
+
+    #[inline]
     fn uimm32shifted_from_value(&mut self, val: Value) -> Option<UImm32Shifted> {
         let constant = self.u64_from_value(val)?;
         UImm32Shifted::maybe_from_u64(constant)

--- a/cranelift/filetests/filetests/isa/s390x/arithmetic-arch15.clif
+++ b/cranelift/filetests/filetests/isa/s390x/arithmetic-arch15.clif
@@ -327,3 +327,49 @@ block0(v0: i128):
 ;   vst %v4, 0(%r2)
 ;   br %r14
 
+function %i64_i32_offset_mul_unsigned(i64, i32) -> i64 {
+block0(v0: i64, v1: i32):
+  v2 = iconst.i8 4
+  v3 = iconst.i32 8000
+  v4 = iadd v1, v3
+  v5 = uextend.i64 v4
+  v6 = ishl v5, v2
+  v7 = iadd v0, v6
+  return v7
+}
+
+; VCode:
+; block0:
+;   llxaq %r2, 8000(%r3,%r2)
+;   br %r14
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe3, 0x23
+;   swr %f4, %f0
+;   .byte 0x01, 0x69
+;   br %r14
+
+function %uload8_i64_i64_offset_mul_signed(i64, i32) -> i64 {
+block0(v0: i64, v1: i32):
+  v2 = iconst.i8 4
+  v3 = iconst.i32 8000
+  v4 = iadd v1, v3
+  v5 = sextend.i64 v4
+  v6 = ishl v5, v2
+  v7 = iadd v0, v6
+  return v7
+}
+
+; VCode:
+; block0:
+;   lxaq %r2, 8000(%r3,%r2)
+;   br %r14
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe3, 0x23
+;   swr %f4, %f0
+;   .byte 0x01, 0x68
+;   br %r14
+

--- a/cranelift/filetests/filetests/isa/s390x/load-arch15.clif
+++ b/cranelift/filetests/filetests/isa/s390x/load-arch15.clif
@@ -1,0 +1,80 @@
+test compile precise-output
+set enable_multi_ret_implicit_sret
+target s390x arch15
+
+function %uload8_i64_i32_offset_mul_unsigned(i64, i32) -> i64 {
+block0(v0: i64, v1: i32):
+  v2 = iconst.i8 4
+  v3 = iconst.i32 8000
+  v4 = iadd v1, v3
+  v5 = uextend.i64 v4
+  v6 = ishl v5, v2
+  v7 = iadd v0, v6
+  v8 = uload8.i64 v7
+  return v8
+}
+
+; VCode:
+; block0:
+;   llxaq %r3, 8000(%r3,%r2)
+;   llgc %r2, 0(%r3)
+;   br %r14
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe3, 0x33
+;   swr %f4, %f0
+;   .byte 0x01, 0x69
+;   llgc %r2, 0(%r3) ; trap: heap_oob
+;   br %r14
+
+function %uload8_i64_i64_offset_mul_signed(i64, i32) -> i64 {
+block0(v0: i64, v1: i32):
+  v2 = iconst.i8 4
+  v3 = iconst.i32 8000
+  v4 = iadd v1, v3
+  v5 = sextend.i64 v4
+  v6 = ishl v5, v2
+  v7 = iadd v0, v6
+  v8 = uload8.i64 v7
+  return v8
+}
+
+; VCode:
+; block0:
+;   lxaq %r3, 8000(%r3,%r2)
+;   llgc %r2, 0(%r3)
+;   br %r14
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0xe3, 0x33
+;   swr %f4, %f0
+;   .byte 0x01, 0x68
+;   llgc %r2, 0(%r3) ; trap: heap_oob
+;   br %r14
+
+function %uload8_i64_i64_offset_shifted0(i64, i32) -> i64 {
+block0(v0: i64, v1: i32):
+  v2 = iconst.i8 0
+  v3 = uextend.i64 v1
+  v4 = ishl v3, v2
+  v5 = iadd v0, v4
+  v6 = uload8.i64 v5+1000
+  return v6
+}
+
+; VCode:
+; block0:
+;   llgfr %r5, %r3
+;   sllg %r5, %r5, 0
+;   llgc %r2, 1000(%r5,%r2)
+;   br %r14
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   llgfr %r5, %r3
+;   sllg %r5, %r5, 0
+;   llgc %r2, 0x3e8(%r5, %r2) ; trap: heap_oob
+;   br %r14
+

--- a/cranelift/filetests/filetests/runtests/s390x-lxa.clif
+++ b/cranelift/filetests/filetests/runtests/s390x-lxa.clif
@@ -1,0 +1,40 @@
+test interpret
+test run
+target pulley64
+target s390x arch15
+
+function %i64_i32_offset_mul_unsigned(i64, i32) -> i64 {
+block0(v0: i64, v1: i32):
+  v2 = iconst.i8 4
+  v3 = iconst.i32 0x7fff
+  v4 = iadd v1, v3
+  v5 = uextend.i64 v4
+  v6 = ishl v5, v2
+  v7 = iadd v0, v6
+  return v7
+}
+
+; run: %i64_i32_offset_mul_unsigned(0, 0) == 0x7fff0
+; run: %i64_i32_offset_mul_unsigned(0, -1) == 0x7ffe0
+; run: %i64_i32_offset_mul_unsigned(-1, -1) == 0x7ffdf
+; run: %i64_i32_offset_mul_unsigned(0, 0x7fff_ffff) == 0x8_0007ffe0
+; run: %i64_i32_offset_mul_unsigned(0x7fffffff_ffffffff, 0x7fff_ffff) == 0x80000008_0007ffdf
+; run: %i64_i32_offset_mul_unsigned(0x7fffffff_ffffffff, 0x8000_0000) == 0x80000008_0007ffef
+
+function %i64_i32_offset_mul_signed(i64, i32) -> i64 {
+block0(v0: i64, v1: i32):
+  v2 = iconst.i8 4
+  v3 = iconst.i32 0x7fff
+  v4 = iadd v1, v3
+  v5 = sextend.i64 v4
+  v6 = ishl v5, v2
+  v7 = iadd v0, v6
+  return v7
+}
+
+; run: %i64_i32_offset_mul_signed(0, 0) == 0x7fff0
+; run: %i64_i32_offset_mul_signed(0, -1) == 0x7ffe0
+; run: %i64_i32_offset_mul_signed(-1, -1) == 0x7ffdf
+; run: %i64_i32_offset_mul_signed(0, 0x7fff_ffff) == 0xfffffff8_0007ffe0
+; run: %i64_i32_offset_mul_signed(0x7fffffff_ffffffff, 0x7fff_ffff) == 0x7ffffff8_0007ffdf
+; run: %i64_i32_offset_mul_signed(0x7fffffff_ffffffff, 0x8000_0000) == 0x7ffffff8_0007ffef


### PR DESCRIPTION
Starting with Z17, s390x includes some specialized indexed address computation instruction that allow for computing addresses in a way that could map to finding an element within an array, skipping over a structure header of a constant size. While this does not also load the address, it is usually more efficient, at least in terms of code size, to use this newer load indexed address (lxa, llxa) instruction instead of expanded address computations using add instructions.

This is currently created as a draft, as I'm figuring out how to test this. I think testing is needed, as it's a specific sequence of IR instructions, and while I'm confident that I have them correct, it's better to be certain with testing.