### PR TITLE
[Cranelift] (x | y) + (-y) => x & (~y)

### DIFF
--- a/cranelift/codegen/src/opts/bitops.isle
+++ b/cranelift/codegen/src/opts/bitops.isle
@@ -235,3 +235,15 @@
 (rule (simplify (bor ty (bnot ty (bxor ty x y)) (band ty y x))) (bnot ty (bxor ty x y)))
 (rule (simplify (bor ty (band ty y x) (bnot ty (bxor ty y x)))) (bnot ty (bxor ty x y)))
 (rule (simplify (bor ty (bnot ty (bxor ty y x)) (band ty y x))) (bnot ty (bxor ty x y)))
+
+; (x | y) + (-y) --> x & ~y
+(rule (simplify (iadd ty (bor ty x y) (ineg ty y)))
+      (band ty x (bnot ty y)))
+(rule (simplify (iadd ty (ineg ty y) (bor ty x y)))
+      (band ty x (bnot ty y)))
+(rule (simplify (iadd ty (bor ty y x) (ineg ty y)))
+      (band ty x (bnot ty y)))
+(rule (simplify (iadd ty (ineg ty y) (bor ty y x)))
+      (band ty x (bnot ty y)))
+
+

--- a/cranelift/filetests/filetests/egraph/fold-bitops.clif
+++ b/cranelift/filetests/filetests/egraph/fold-bitops.clif
@@ -90,3 +90,20 @@ block0(v0: i32, v1: i32):
 ;     v7 = bnot v6
 ;     return v7
 ; }
+
+;; (iadd ty (bor ty x y) (ineg ty y)) -> (band ty x (bnot ty y))
+function %test_iadd_bor_ineg(i32, i32) -> i32 fast {
+block0(v0: i32, v1: i32):
+    v2 = bor v0, v1
+    v3 = ineg v1
+    v4 = iadd v2, v3
+    return v4
+}
+
+; function %test_iadd_bor_ineg(i32, i32) -> i32 fast {
+; block0(v0: i32, v1: i32):
+;     v2 = bor v0, v1
+;     v7 = isub v2, v1
+;     return v7
+; }
+

--- a/cranelift/filetests/filetests/runtests/bitops.clif
+++ b/cranelift/filetests/filetests/runtests/bitops.clif
@@ -245,3 +245,16 @@ block0(v0: i32, v1: i32):
 ; run: %test_bor_band_bnot_bxor(1, 1) == 0xffffffff
 ; run: %test_bor_band_bnot_bxor(0, 1) == 0xfffffffe
 ; run: %test_bor_band_bnot_bxor(2, 1) == 0xfffffffc
+
+function %test_iadd_bor_ineg(i32, i32) -> i32 fast {
+block0(v0: i32, v1: i32):
+    v2 = bor v0, v1
+    v3 = ineg v1
+    v4 = iadd v2, v3
+    return v4
+}
+
+; run: %test_iadd_bor_ineg(0, 0) == 0
+; run: %test_iadd_bor_ineg(1, 1) == 0
+; run: %test_iadd_bor_ineg(2, 1) == 2
+; run: %test_iadd_bor_ineg(0xffffffff, 0) == -1


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->

This PR adds a Cranelift bitops simplification rule:

`(x | y) + (-y) => x & (~y)`

