### PR TITLE
Bump Wasmtime to 44.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -290,7 +290,7 @@ dependencies = [
 
 [[package]]
 name = "byte-array-literals"
-version = "43.0.0"
+version = "44.0.0"
 
 [[package]]
 name = "byteorder"
@@ -693,7 +693,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift"
-version = "0.130.0"
+version = "0.131.0"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",
@@ -706,7 +706,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.130.0"
+version = "0.131.0"
 dependencies = [
  "arbitrary",
  "arbtest",
@@ -724,14 +724,14 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.130.0"
+version = "0.131.0"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.130.0"
+version = "0.131.0"
 dependencies = [
  "cranelift-entity",
  "wasmtime-internal-core",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.130.0"
+version = "0.131.0"
 dependencies = [
  "arbitrary",
  "serde",
@@ -749,7 +749,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.130.0"
+version = "0.131.0"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -785,7 +785,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.130.0"
+version = "0.131.0"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -796,18 +796,18 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.130.0"
+version = "0.131.0"
 
 [[package]]
 name = "cranelift-control"
-version = "0.130.0"
+version = "0.131.0"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.130.0"
+version = "0.131.0"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -849,7 +849,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.130.0"
+version = "0.131.0"
 dependencies = [
  "cranelift-codegen",
  "env_logger 0.11.5",
@@ -874,7 +874,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-interpreter"
-version = "0.130.0"
+version = "0.131.0"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -888,7 +888,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.130.0"
+version = "0.131.0"
 dependencies = [
  "codespan-reporting",
  "log",
@@ -897,7 +897,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-jit"
-version = "0.130.0"
+version = "0.131.0"
 dependencies = [
  "anyhow",
  "cranelift",
@@ -919,7 +919,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-module"
-version = "0.130.0"
+version = "0.131.0"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -931,7 +931,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.130.0"
+version = "0.131.0"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-object"
-version = "0.130.0"
+version = "0.131.0"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-reader"
-version = "0.130.0"
+version = "0.131.0"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -965,7 +965,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-serde"
-version = "0.130.0"
+version = "0.131.0"
 dependencies = [
  "clap",
  "cranelift-codegen",
@@ -975,7 +975,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.130.0"
+version = "0.131.0"
 
 [[package]]
 name = "cranelift-tools"
@@ -1235,7 +1235,7 @@ checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "embedding"
-version = "43.0.0"
+version = "44.0.0"
 dependencies = [
  "dlmalloc",
  "raw-cpuid",
@@ -2379,7 +2379,7 @@ dependencies = [
 
 [[package]]
 name = "min-platform-host"
-version = "43.0.0"
+version = "44.0.0"
 dependencies = [
  "libloading",
  "object 0.38.1",
@@ -2818,7 +2818,7 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "43.0.0"
+version = "44.0.0"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -2842,7 +2842,7 @@ dependencies = [
 
 [[package]]
 name = "pulley-macros"
-version = "43.0.0"
+version = "44.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4168,7 +4168,7 @@ version = "0.1.0"
 
 [[package]]
 name = "verify-component-adapter"
-version = "43.0.0"
+version = "44.0.0"
 dependencies = [
  "anyhow",
  "wasmparser 0.245.0",
@@ -4227,7 +4227,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-common"
-version = "43.0.0"
+version = "44.0.0"
 dependencies = [
  "async-trait",
  "bitflags 2.9.4",
@@ -4267,7 +4267,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-preview1-component-adapter"
-version = "43.0.0"
+version = "44.0.0"
 dependencies = [
  "bitflags 2.9.4",
  "byte-array-literals",
@@ -4514,7 +4514,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "43.0.0"
+version = "44.0.0"
 dependencies = [
  "addr2line 0.26.0",
  "async-trait",
@@ -4575,7 +4575,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-bench-api"
-version = "43.0.0"
+version = "44.0.0"
 dependencies = [
  "cap-std",
  "clap",
@@ -4590,14 +4590,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-c-api"
-version = "43.0.0"
+version = "44.0.0"
 dependencies = [
  "wasmtime-c-api-impl",
 ]
 
 [[package]]
 name = "wasmtime-c-api-impl"
-version = "43.0.0"
+version = "44.0.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4616,7 +4616,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli"
-version = "43.0.0"
+version = "44.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4693,7 +4693,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli-flags"
-version = "43.0.0"
+version = "44.0.0"
 dependencies = [
  "clap",
  "file-per-thread-logger",
@@ -4707,7 +4707,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "43.0.0"
+version = "44.0.0"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -4827,7 +4827,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-c-api-macros"
-version = "43.0.0"
+version = "44.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4835,7 +4835,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cache"
-version = "43.0.0"
+version = "44.0.0"
 dependencies = [
  "base64",
  "directories-next",
@@ -4856,7 +4856,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-macro"
-version = "43.0.0"
+version = "44.0.0"
 dependencies = [
  "anyhow",
  "component-macro-test-helpers",
@@ -4876,11 +4876,11 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-util"
-version = "43.0.0"
+version = "44.0.0"
 
 [[package]]
 name = "wasmtime-internal-core"
-version = "43.0.0"
+version = "44.0.0"
 dependencies = [
  "anyhow",
  "hashbrown 0.16.1",
@@ -4890,7 +4890,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "43.0.0"
+version = "44.0.0"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -4915,7 +4915,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-debugger"
-version = "43.0.0"
+version = "44.0.0"
 dependencies = [
  "env_logger 0.11.5",
  "log",
@@ -4925,7 +4925,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-explorer"
-version = "43.0.0"
+version = "44.0.0"
 dependencies = [
  "capstone",
  "serde",
@@ -4939,7 +4939,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-fiber"
-version = "43.0.0"
+version = "44.0.0"
 dependencies = [
  "backtrace",
  "cc",
@@ -4953,7 +4953,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-debug"
-version = "43.0.0"
+version = "44.0.0"
 dependencies = [
  "cc",
  "object 0.38.1",
@@ -4963,7 +4963,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "43.0.0"
+version = "44.0.0"
 dependencies = [
  "cfg-if",
  "libc",
@@ -4973,7 +4973,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-unwinder"
-version = "43.0.0"
+version = "44.0.0"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -4984,7 +4984,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
-version = "43.0.0"
+version = "44.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4993,7 +4993,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-winch"
-version = "43.0.0"
+version = "44.0.0"
 dependencies = [
  "cranelift-codegen",
  "gimli 0.33.0",
@@ -5008,7 +5008,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-wit-bindgen"
-version = "43.0.0"
+version = "44.0.0"
 dependencies = [
  "anyhow",
  "bitflags 2.9.4",
@@ -5019,7 +5019,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-wmemcheck"
-version = "43.0.0"
+version = "44.0.0"
 
 [[package]]
 name = "wasmtime-test-macros"
@@ -5034,7 +5034,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-test-util"
-version = "43.0.0"
+version = "44.0.0"
 dependencies = [
  "arbitrary",
  "arbtest",
@@ -5057,7 +5057,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "43.0.0"
+version = "44.0.0"
 dependencies = [
  "async-trait",
  "bitflags 2.9.4",
@@ -5091,7 +5091,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-config"
-version = "43.0.0"
+version = "44.0.0"
 dependencies = [
  "test-programs-artifacts",
  "tokio",
@@ -5101,7 +5101,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-http"
-version = "43.0.0"
+version = "44.0.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -5133,7 +5133,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-io"
-version = "43.0.0"
+version = "44.0.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5144,7 +5144,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-keyvalue"
-version = "43.0.0"
+version = "44.0.0"
 dependencies = [
  "test-programs-artifacts",
  "tokio",
@@ -5154,7 +5154,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-nn"
-version = "43.0.0"
+version = "44.0.0"
 dependencies = [
  "cap-std",
  "libtest-mimic",
@@ -5174,7 +5174,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-threads"
-version = "43.0.0"
+version = "44.0.0"
 dependencies = [
  "log",
  "rand 0.8.5",
@@ -5185,7 +5185,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-tls"
-version = "43.0.0"
+version = "44.0.0"
 dependencies = [
  "bytes",
  "futures",
@@ -5200,7 +5200,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-tls-nativetls"
-version = "43.0.0"
+version = "44.0.0"
 dependencies = [
  "futures",
  "native-tls",
@@ -5214,7 +5214,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-tls-openssl"
-version = "43.0.0"
+version = "44.0.0"
 dependencies = [
  "futures",
  "openssl",
@@ -5228,7 +5228,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wast"
-version = "43.0.0"
+version = "44.0.0"
 dependencies = [
  "json-from-wast",
  "log",
@@ -5242,7 +5242,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wizer"
-version = "43.0.0"
+version = "44.0.0"
 dependencies = [
  "clap",
  "criterion",
@@ -5322,7 +5322,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "43.0.0"
+version = "44.0.0"
 dependencies = [
  "bitflags 2.9.4",
  "proptest",
@@ -5338,7 +5338,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "43.0.0"
+version = "44.0.0"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -5350,7 +5350,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "43.0.0"
+version = "44.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5405,7 +5405,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "43.0.0"
+version = "44.0.0"
 dependencies = [
  "cranelift-assembler-x64",
  "cranelift-codegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -187,7 +187,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "43.0.0"
+version = "44.0.0"
 authors = ["The Wasmtime Project Developers"]
 edition = "2024"
 # Wasmtime's current policy is that this number can be no larger than the
@@ -241,20 +241,20 @@ extra_unused_type_parameters = 'warn'
 # tooling but aren't intended to be widely depended on.
 #
 # All of these crates are supported though in the sense that
-wasmtime = { path = "crates/wasmtime", version = "43.0.0", default-features = false }
-wasmtime-cli-flags = { path = "crates/cli-flags", version = "=43.0.0" }
-wasmtime-environ = { path = "crates/environ", version = "=43.0.0" }
-wasmtime-wasi = { path = "crates/wasi", version = "43.0.0", default-features = false }
-wasmtime-wasi-io = { path = "crates/wasi-io", version = "43.0.0", default-features = false }
-wasmtime-wasi-http = { path = "crates/wasi-http", version = "43.0.0", default-features = false }
-wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "43.0.0" }
-wasmtime-wasi-config = { path = "crates/wasi-config", version = "43.0.0" }
-wasmtime-wasi-keyvalue = { path = "crates/wasi-keyvalue", version = "43.0.0" }
-wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "43.0.0" }
-wasmtime-wasi-tls = { path = "crates/wasi-tls", version = "43.0.0" }
-wasmtime-wasi-tls-nativetls = { path = "crates/wasi-tls-nativetls", version = "43.0.0" }
-wasmtime-wasi-tls-openssl = { path = "crates/wasi-tls-openssl", version = "43.0.0" }
-wasmtime-wast = { path = "crates/wast", version = "=43.0.0" }
+wasmtime = { path = "crates/wasmtime", version = "44.0.0", default-features = false }
+wasmtime-cli-flags = { path = "crates/cli-flags", version = "=44.0.0" }
+wasmtime-environ = { path = "crates/environ", version = "=44.0.0" }
+wasmtime-wasi = { path = "crates/wasi", version = "44.0.0", default-features = false }
+wasmtime-wasi-io = { path = "crates/wasi-io", version = "44.0.0", default-features = false }
+wasmtime-wasi-http = { path = "crates/wasi-http", version = "44.0.0", default-features = false }
+wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "44.0.0" }
+wasmtime-wasi-config = { path = "crates/wasi-config", version = "44.0.0" }
+wasmtime-wasi-keyvalue = { path = "crates/wasi-keyvalue", version = "44.0.0" }
+wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "44.0.0" }
+wasmtime-wasi-tls = { path = "crates/wasi-tls", version = "44.0.0" }
+wasmtime-wasi-tls-nativetls = { path = "crates/wasi-tls-nativetls", version = "44.0.0" }
+wasmtime-wasi-tls-openssl = { path = "crates/wasi-tls-openssl", version = "44.0.0" }
+wasmtime-wast = { path = "crates/wast", version = "=44.0.0" }
 
 # Internal Wasmtime-specific crates.
 #
@@ -263,54 +263,54 @@ wasmtime-wast = { path = "crates/wast", version = "=43.0.0" }
 # that these are internal unsupported crates for external use. These exist as
 # part of the project organization of other public crates in Wasmtime and are
 # otherwise not supported in terms of CVEs for example.
-wasmtime-core = { path = "crates/core", version = "=43.0.0", package = 'wasmtime-internal-core' }
-wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=43.0.0", package = 'wasmtime-internal-wmemcheck' }
-wasmtime-c-api-macros = { path = "crates/c-api-macros", version = "=43.0.0", package = 'wasmtime-internal-c-api-macros' }
-wasmtime-cache = { path = "crates/cache", version = "=43.0.0", package = 'wasmtime-internal-cache' }
-wasmtime-cranelift = { path = "crates/cranelift", version = "=43.0.0", package = 'wasmtime-internal-cranelift' }
-wasmtime-winch = { path = "crates/winch", version = "=43.0.0", package = 'wasmtime-internal-winch'  }
-wasmtime-explorer = { path = "crates/explorer", version = "=43.0.0", package = 'wasmtime-internal-explorer'  }
-wasmtime-fiber = { path = "crates/fiber", version = "=43.0.0", package = 'wasmtime-internal-fiber' }
-wasmtime-jit-debug = { path = "crates/jit-debug", version = "=43.0.0", package = 'wasmtime-internal-jit-debug' }
-wasmtime-component-util = { path = "crates/component-util", version = "=43.0.0", package = 'wasmtime-internal-component-util' }
-wasmtime-component-macro = { path = "crates/component-macro", version = "=43.0.0", package = 'wasmtime-internal-component-macro' }
-wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=43.0.0", package = 'wasmtime-internal-versioned-export-macros' }
-wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=43.0.0", package = 'wasmtime-internal-jit-icache-coherence' }
-wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=43.0.0", package = 'wasmtime-internal-wit-bindgen' }
-wasmtime-unwinder = { path = "crates/unwinder", version = "=43.0.0", package = 'wasmtime-internal-unwinder' }
-wasmtime-debugger = { path = "crates/debugger", version = "=43.0.0", package = "wasmtime-internal-debugger" }
-wasmtime-wizer = { path = "crates/wizer", version = "43.0.0" }
+wasmtime-core = { path = "crates/core", version = "=44.0.0", package = 'wasmtime-internal-core' }
+wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=44.0.0", package = 'wasmtime-internal-wmemcheck' }
+wasmtime-c-api-macros = { path = "crates/c-api-macros", version = "=44.0.0", package = 'wasmtime-internal-c-api-macros' }
+wasmtime-cache = { path = "crates/cache", version = "=44.0.0", package = 'wasmtime-internal-cache' }
+wasmtime-cranelift = { path = "crates/cranelift", version = "=44.0.0", package = 'wasmtime-internal-cranelift' }
+wasmtime-winch = { path = "crates/winch", version = "=44.0.0", package = 'wasmtime-internal-winch'  }
+wasmtime-explorer = { path = "crates/explorer", version = "=44.0.0", package = 'wasmtime-internal-explorer'  }
+wasmtime-fiber = { path = "crates/fiber", version = "=44.0.0", package = 'wasmtime-internal-fiber' }
+wasmtime-jit-debug = { path = "crates/jit-debug", version = "=44.0.0", package = 'wasmtime-internal-jit-debug' }
+wasmtime-component-util = { path = "crates/component-util", version = "=44.0.0", package = 'wasmtime-internal-component-util' }
+wasmtime-component-macro = { path = "crates/component-macro", version = "=44.0.0", package = 'wasmtime-internal-component-macro' }
+wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=44.0.0", package = 'wasmtime-internal-versioned-export-macros' }
+wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=44.0.0", package = 'wasmtime-internal-jit-icache-coherence' }
+wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=44.0.0", package = 'wasmtime-internal-wit-bindgen' }
+wasmtime-unwinder = { path = "crates/unwinder", version = "=44.0.0", package = 'wasmtime-internal-unwinder' }
+wasmtime-debugger = { path = "crates/debugger", version = "=44.0.0", package = "wasmtime-internal-debugger" }
+wasmtime-wizer = { path = "crates/wizer", version = "44.0.0" }
 
 # Miscellaneous crates without a `wasmtime-*` prefix in their name but still
 # used in the `wasmtime-*` family of crates depending on various features/etc.
-wiggle = { path = "crates/wiggle", version = "=43.0.0", default-features = false }
-wiggle-macro = { path = "crates/wiggle/macro", version = "=43.0.0" }
-wiggle-generate = { path = "crates/wiggle/generate", version = "=43.0.0" }
-wasi-common = { path = "crates/wasi-common", version = "=43.0.0", default-features = false }
-pulley-interpreter = { path = 'pulley', version = "=43.0.0" }
-pulley-macros = { path = 'pulley/macros', version = "=43.0.0" }
+wiggle = { path = "crates/wiggle", version = "=44.0.0", default-features = false }
+wiggle-macro = { path = "crates/wiggle/macro", version = "=44.0.0" }
+wiggle-generate = { path = "crates/wiggle/generate", version = "=44.0.0" }
+wasi-common = { path = "crates/wasi-common", version = "=44.0.0", default-features = false }
+pulley-interpreter = { path = 'pulley', version = "=44.0.0" }
+pulley-macros = { path = 'pulley/macros', version = "=44.0.0" }
 
 # Cranelift crates in this workspace
-cranelift-assembler-x64 = { path = "cranelift/assembler-x64", version = "0.130.0" }
-cranelift-codegen = { path = "cranelift/codegen", version = "0.130.0", default-features = false, features = ["std", "unwind"] }
-cranelift-frontend = { path = "cranelift/frontend", version = "0.130.0" }
-cranelift-entity = { path = "cranelift/entity", version = "0.130.0" }
-cranelift-native = { path = "cranelift/native", version = "0.130.0" }
-cranelift-module = { path = "cranelift/module", version = "0.130.0" }
-cranelift-interpreter = { path = "cranelift/interpreter", version = "0.130.0" }
-cranelift-reader = { path = "cranelift/reader", version = "0.130.0" }
+cranelift-assembler-x64 = { path = "cranelift/assembler-x64", version = "0.131.0" }
+cranelift-codegen = { path = "cranelift/codegen", version = "0.131.0", default-features = false, features = ["std", "unwind"] }
+cranelift-frontend = { path = "cranelift/frontend", version = "0.131.0" }
+cranelift-entity = { path = "cranelift/entity", version = "0.131.0" }
+cranelift-native = { path = "cranelift/native", version = "0.131.0" }
+cranelift-module = { path = "cranelift/module", version = "0.131.0" }
+cranelift-interpreter = { path = "cranelift/interpreter", version = "0.131.0" }
+cranelift-reader = { path = "cranelift/reader", version = "0.131.0" }
 cranelift-filetests = { path = "cranelift/filetests" }
-cranelift-object = { path = "cranelift/object", version = "0.130.0" }
-cranelift-jit = { path = "cranelift/jit", version = "0.130.0" }
+cranelift-object = { path = "cranelift/object", version = "0.131.0" }
+cranelift-jit = { path = "cranelift/jit", version = "0.131.0" }
 cranelift-fuzzgen = { path = "cranelift/fuzzgen" }
-cranelift-bforest = { path = "cranelift/bforest", version = "0.130.0" }
-cranelift-bitset = { path = "cranelift/bitset", version = "0.130.0" }
-cranelift-control = { path = "cranelift/control", version = "0.130.0", default-features = false }
-cranelift-srcgen = { path = "cranelift/srcgen", version = "0.130.0" }
-cranelift = { path = "cranelift/umbrella", version = "0.130.0" }
+cranelift-bforest = { path = "cranelift/bforest", version = "0.131.0" }
+cranelift-bitset = { path = "cranelift/bitset", version = "0.131.0" }
+cranelift-control = { path = "cranelift/control", version = "0.131.0", default-features = false }
+cranelift-srcgen = { path = "cranelift/srcgen", version = "0.131.0" }
+cranelift = { path = "cranelift/umbrella", version = "0.131.0" }
 
 # Winch crates in this workspace.
-winch-codegen = { path = "winch/codegen", version = "=43.0.0" }
+winch-codegen = { path = "winch/codegen", version = "=44.0.0" }
 
 # Internal crates not published to crates.io used in testing, builds, etc
 wasi-preview1-component-adapter = { path = "crates/wasi-preview1-component-adapter" }

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,4 +1,4 @@
-## 43.0.0
+## 44.0.0
 
 Unreleased.
 
@@ -12,6 +12,7 @@ Release notes for previous releases of Wasmtime can be found on the respective
 release branches of the Wasmtime repository.
 
 <!-- ARCHIVE_START -->
+* [43.0.x](https://github.com/bytecodealliance/wasmtime/blob/release-43.0.0/RELEASES.md)
 * [42.0.x](https://github.com/bytecodealliance/wasmtime/blob/release-42.0.0/RELEASES.md)
 * [41.0.x](https://github.com/bytecodealliance/wasmtime/blob/release-41.0.0/RELEASES.md)
 * [40.0.x](https://github.com/bytecodealliance/wasmtime/blob/release-40.0.0/RELEASES.md)

--- a/cranelift/assembler-x64/Cargo.toml
+++ b/cranelift/assembler-x64/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-assembler-x64"
 description = "A Cranelift-specific x64 assembler"
-version = "0.130.0"
+version = "0.131.0"
 license = "Apache-2.0 WITH LLVM-exception"
 edition.workspace = true
 rust-version.workspace = true
@@ -16,7 +16,7 @@ arbtest = { workspace = true }
 capstone = { workspace = true }
 
 [build-dependencies]
-cranelift-assembler-x64-meta = { path = "meta", version = "0.130.0" }
+cranelift-assembler-x64-meta = { path = "meta", version = "0.131.0" }
 
 [lints]
 workspace = true

--- a/cranelift/assembler-x64/meta/Cargo.toml
+++ b/cranelift/assembler-x64/meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-assembler-x64-meta"
 description = "Generate a Cranelift-specific assembler for x64 instructions"
-version = "0.130.0"
+version = "0.131.0"
 license = "Apache-2.0 WITH LLVM-exception"
 edition.workspace = true
 rust-version.workspace = true

--- a/cranelift/bforest/Cargo.toml
+++ b/cranelift/bforest/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bforest"
-version = "0.130.0"
+version = "0.131.0"
 description = "A forest of B+-trees"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-bforest"

--- a/cranelift/bitset/Cargo.toml
+++ b/cranelift/bitset/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bitset"
-version = "0.130.0"
+version = "0.131.0"
 description = "Various bitset stuff for use inside Cranelift"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-bitset"

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen"
-version = "0.130.0"
+version = "0.131.0"
 description = "Low-level code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-codegen"
@@ -25,7 +25,7 @@ anyhow = { workspace = true, optional = true, features = ['std'] }
 bumpalo = { workspace = true }
 capstone = { workspace = true, optional = true }
 cranelift-assembler-x64 = { workspace = true }
-cranelift-codegen-shared = { path = "./shared", version = "0.130.0" }
+cranelift-codegen-shared = { path = "./shared", version = "0.131.0" }
 cranelift-entity = { workspace = true }
 cranelift-bforest = { workspace = true }
 cranelift-bitset = { workspace = true }
@@ -57,8 +57,8 @@ env_logger = { workspace = true }
 proptest = { workspace = true }
 
 [build-dependencies]
-cranelift-codegen-meta = { path = "meta", version = "0.130.0" }
-cranelift-isle = { path = "../isle/isle", version = "=0.130.0" }
+cranelift-codegen-meta = { path = "meta", version = "0.131.0" }
+cranelift-isle = { path = "../isle/isle", version = "=0.131.0" }
 
 [features]
 default = ["std", "unwind", "host-arch", "timing"]

--- a/cranelift/codegen/meta/Cargo.toml
+++ b/cranelift/codegen/meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-codegen-meta"
 authors = ["The Cranelift Project Developers"]
-version = "0.130.0"
+version = "0.131.0"
 description = "Metaprogram for cranelift-codegen code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
@@ -17,8 +17,8 @@ rustdoc-args = ["--document-private-items"]
 
 [dependencies]
 cranelift-srcgen = { workspace = true }
-cranelift-assembler-x64-meta = { path = "../../assembler-x64/meta", version = "0.130.0" }
-cranelift-codegen-shared = { path = "../shared", version = "0.130.0" }
+cranelift-assembler-x64-meta = { path = "../../assembler-x64/meta", version = "0.131.0" }
+cranelift-codegen-shared = { path = "../shared", version = "0.131.0" }
 pulley-interpreter = { workspace = true, optional = true }
 heck = "0.5.0"
 

--- a/cranelift/codegen/shared/Cargo.toml
+++ b/cranelift/codegen/shared/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen-shared"
-version = "0.130.0"
+version = "0.131.0"
 description = "For code shared between cranelift-codegen-meta and cranelift-codegen"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/control/Cargo.toml
+++ b/cranelift/control/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-control"
-version = "0.130.0"
+version = "0.131.0"
 description = "White-box fuzz testing framework"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/entity/Cargo.toml
+++ b/cranelift/entity/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-entity"
-version = "0.130.0"
+version = "0.131.0"
 description = "Data structures using entity references as mapping keys"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-entity"

--- a/cranelift/frontend/Cargo.toml
+++ b/cranelift/frontend/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-frontend"
-version = "0.130.0"
+version = "0.131.0"
 description = "Cranelift IR builder helper"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-frontend"

--- a/cranelift/interpreter/Cargo.toml
+++ b/cranelift/interpreter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-interpreter"
-version = "0.130.0"
+version = "0.131.0"
 authors = ["The Cranelift Project Developers"]
 description = "Interpret Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/isle/isle/Cargo.toml
+++ b/cranelift/isle/isle/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 name = "cranelift-isle"
 readme = "../README.md"
 repository = "https://github.com/bytecodealliance/wasmtime/tree/main/cranelift/isle"
-version = "0.130.0"
+version = "0.131.0"
 
 [lints]
 workspace = true

--- a/cranelift/jit/Cargo.toml
+++ b/cranelift/jit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-jit"
-version = "0.130.0"
+version = "0.131.0"
 authors = ["The Cranelift Project Developers"]
 description = "A JIT library backed by Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/module/Cargo.toml
+++ b/cranelift/module/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-module"
-version = "0.130.0"
+version = "0.131.0"
 authors = ["The Cranelift Project Developers"]
 description = "Support for linking functions and data with Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/native/Cargo.toml
+++ b/cranelift/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-native"
-version = "0.130.0"
+version = "0.131.0"
 authors = ["The Cranelift Project Developers"]
 description = "Support for targeting the host with Cranelift"
 documentation = "https://docs.rs/cranelift-native"

--- a/cranelift/object/Cargo.toml
+++ b/cranelift/object/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-object"
-version = "0.130.0"
+version = "0.131.0"
 authors = ["The Cranelift Project Developers"]
 description = "Emit Cranelift output to native object files with `object`"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/reader/Cargo.toml
+++ b/cranelift/reader/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-reader"
-version = "0.130.0"
+version = "0.131.0"
 description = "Cranelift textual IR reader"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-reader"

--- a/cranelift/serde/Cargo.toml
+++ b/cranelift/serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-serde"
-version = "0.130.0"
+version = "0.131.0"
 authors = ["The Cranelift Project Developers"]
 description = "Serializer/Deserializer for Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/srcgen/Cargo.toml
+++ b/cranelift/srcgen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-srcgen"
-version = "0.130.0"
+version = "0.131.0"
 authors = ["The Wasmtime Project Developers"]
 description = "Helper functions for generating Rust and ISLE files"
 license = "Apache-2.0 WITH LLVM-exception"

--- a/cranelift/umbrella/Cargo.toml
+++ b/cranelift/umbrella/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift"
-version = "0.130.0"
+version = "0.131.0"
 description = "Umbrella for commonly-used cranelift crates"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift"

--- a/crates/c-api/include/wasmtime.h
+++ b/crates/c-api/include/wasmtime.h
@@ -212,11 +212,11 @@
 /**
  * \brief Wasmtime version string.
  */
-#define WASMTIME_VERSION "43.0.0"
+#define WASMTIME_VERSION "44.0.0"
 /**
  * \brief Wasmtime major version number.
  */
-#define WASMTIME_VERSION_MAJOR 43
+#define WASMTIME_VERSION_MAJOR 44
 /**
  * \brief Wasmtime minor version number.
  */

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -9,6 +9,10 @@ audited_as = "0.127.1"
 version = "0.130.0"
 audited_as = "0.128.3"
 
+[[unpublished.cranelift]]
+version = "0.131.0"
+audited_as = "0.129.1"
+
 [[unpublished.cranelift-assembler-x64]]
 version = "0.129.0"
 audited_as = "0.127.1"
@@ -16,6 +20,10 @@ audited_as = "0.127.1"
 [[unpublished.cranelift-assembler-x64]]
 version = "0.130.0"
 audited_as = "0.128.3"
+
+[[unpublished.cranelift-assembler-x64]]
+version = "0.131.0"
+audited_as = "0.129.1"
 
 [[unpublished.cranelift-assembler-x64-meta]]
 version = "0.129.0"
@@ -25,6 +33,10 @@ audited_as = "0.127.1"
 version = "0.130.0"
 audited_as = "0.128.3"
 
+[[unpublished.cranelift-assembler-x64-meta]]
+version = "0.131.0"
+audited_as = "0.129.1"
+
 [[unpublished.cranelift-bforest]]
 version = "0.129.0"
 audited_as = "0.127.1"
@@ -32,6 +44,10 @@ audited_as = "0.127.1"
 [[unpublished.cranelift-bforest]]
 version = "0.130.0"
 audited_as = "0.128.3"
+
+[[unpublished.cranelift-bforest]]
+version = "0.131.0"
+audited_as = "0.129.1"
 
 [[unpublished.cranelift-bitset]]
 version = "0.129.0"
@@ -41,6 +57,10 @@ audited_as = "0.127.1"
 version = "0.130.0"
 audited_as = "0.128.3"
 
+[[unpublished.cranelift-bitset]]
+version = "0.131.0"
+audited_as = "0.129.1"
+
 [[unpublished.cranelift-codegen]]
 version = "0.129.0"
 audited_as = "0.127.1"
@@ -48,6 +68,10 @@ audited_as = "0.127.1"
 [[unpublished.cranelift-codegen]]
 version = "0.130.0"
 audited_as = "0.128.3"
+
+[[unpublished.cranelift-codegen]]
+version = "0.131.0"
+audited_as = "0.129.1"
 
 [[unpublished.cranelift-codegen-meta]]
 version = "0.129.0"
@@ -57,6 +81,10 @@ audited_as = "0.127.1"
 version = "0.130.0"
 audited_as = "0.128.3"
 
+[[unpublished.cranelift-codegen-meta]]
+version = "0.131.0"
+audited_as = "0.129.1"
+
 [[unpublished.cranelift-codegen-shared]]
 version = "0.129.0"
 audited_as = "0.127.1"
@@ -64,6 +92,10 @@ audited_as = "0.127.1"
 [[unpublished.cranelift-codegen-shared]]
 version = "0.130.0"
 audited_as = "0.128.3"
+
+[[unpublished.cranelift-codegen-shared]]
+version = "0.131.0"
+audited_as = "0.129.1"
 
 [[unpublished.cranelift-control]]
 version = "0.129.0"
@@ -73,6 +105,10 @@ audited_as = "0.127.1"
 version = "0.130.0"
 audited_as = "0.128.3"
 
+[[unpublished.cranelift-control]]
+version = "0.131.0"
+audited_as = "0.129.1"
+
 [[unpublished.cranelift-entity]]
 version = "0.129.0"
 audited_as = "0.127.1"
@@ -80,6 +116,10 @@ audited_as = "0.127.1"
 [[unpublished.cranelift-entity]]
 version = "0.130.0"
 audited_as = "0.128.3"
+
+[[unpublished.cranelift-entity]]
+version = "0.131.0"
+audited_as = "0.129.1"
 
 [[unpublished.cranelift-frontend]]
 version = "0.129.0"
@@ -89,6 +129,10 @@ audited_as = "0.127.1"
 version = "0.130.0"
 audited_as = "0.128.3"
 
+[[unpublished.cranelift-frontend]]
+version = "0.131.0"
+audited_as = "0.129.1"
+
 [[unpublished.cranelift-interpreter]]
 version = "0.129.0"
 audited_as = "0.127.1"
@@ -96,6 +140,10 @@ audited_as = "0.127.1"
 [[unpublished.cranelift-interpreter]]
 version = "0.130.0"
 audited_as = "0.128.3"
+
+[[unpublished.cranelift-interpreter]]
+version = "0.131.0"
+audited_as = "0.129.1"
 
 [[unpublished.cranelift-isle]]
 version = "0.129.0"
@@ -105,6 +153,10 @@ audited_as = "0.127.1"
 version = "0.130.0"
 audited_as = "0.128.3"
 
+[[unpublished.cranelift-isle]]
+version = "0.131.0"
+audited_as = "0.129.1"
+
 [[unpublished.cranelift-jit]]
 version = "0.129.0"
 audited_as = "0.127.1"
@@ -112,6 +164,10 @@ audited_as = "0.127.1"
 [[unpublished.cranelift-jit]]
 version = "0.130.0"
 audited_as = "0.128.3"
+
+[[unpublished.cranelift-jit]]
+version = "0.131.0"
+audited_as = "0.129.1"
 
 [[unpublished.cranelift-module]]
 version = "0.129.0"
@@ -121,6 +177,10 @@ audited_as = "0.127.1"
 version = "0.130.0"
 audited_as = "0.128.3"
 
+[[unpublished.cranelift-module]]
+version = "0.131.0"
+audited_as = "0.129.1"
+
 [[unpublished.cranelift-native]]
 version = "0.129.0"
 audited_as = "0.127.1"
@@ -128,6 +188,10 @@ audited_as = "0.127.1"
 [[unpublished.cranelift-native]]
 version = "0.130.0"
 audited_as = "0.128.3"
+
+[[unpublished.cranelift-native]]
+version = "0.131.0"
+audited_as = "0.129.1"
 
 [[unpublished.cranelift-object]]
 version = "0.129.0"
@@ -137,6 +201,10 @@ audited_as = "0.127.1"
 version = "0.130.0"
 audited_as = "0.128.3"
 
+[[unpublished.cranelift-object]]
+version = "0.131.0"
+audited_as = "0.129.1"
+
 [[unpublished.cranelift-reader]]
 version = "0.129.0"
 audited_as = "0.127.1"
@@ -144,6 +212,10 @@ audited_as = "0.127.1"
 [[unpublished.cranelift-reader]]
 version = "0.130.0"
 audited_as = "0.128.3"
+
+[[unpublished.cranelift-reader]]
+version = "0.131.0"
+audited_as = "0.129.1"
 
 [[unpublished.cranelift-serde]]
 version = "0.129.0"
@@ -153,6 +225,10 @@ audited_as = "0.127.1"
 version = "0.130.0"
 audited_as = "0.128.3"
 
+[[unpublished.cranelift-serde]]
+version = "0.131.0"
+audited_as = "0.129.1"
+
 [[unpublished.cranelift-srcgen]]
 version = "0.129.0"
 audited_as = "0.127.1"
@@ -161,6 +237,10 @@ audited_as = "0.127.1"
 version = "0.130.0"
 audited_as = "0.128.3"
 
+[[unpublished.cranelift-srcgen]]
+version = "0.131.0"
+audited_as = "0.129.1"
+
 [[unpublished.pulley-interpreter]]
 version = "42.0.0"
 audited_as = "40.0.1"
@@ -168,6 +248,10 @@ audited_as = "40.0.1"
 [[unpublished.pulley-interpreter]]
 version = "43.0.0"
 audited_as = "41.0.3"
+
+[[unpublished.pulley-interpreter]]
+version = "44.0.0"
+audited_as = "42.0.1"
 
 [[unpublished.pulley-macros]]
 version = "42.0.0"
@@ -177,6 +261,10 @@ audited_as = "40.0.1"
 version = "43.0.0"
 audited_as = "41.0.3"
 
+[[unpublished.pulley-macros]]
+version = "44.0.0"
+audited_as = "42.0.1"
+
 [[unpublished.wasi-common]]
 version = "42.0.0"
 audited_as = "40.0.1"
@@ -184,6 +272,10 @@ audited_as = "40.0.1"
 [[unpublished.wasi-common]]
 version = "43.0.0"
 audited_as = "41.0.3"
+
+[[unpublished.wasi-common]]
+version = "44.0.0"
+audited_as = "42.0.1"
 
 [[unpublished.wasmtime]]
 version = "42.0.0"
@@ -193,6 +285,10 @@ audited_as = "40.0.1"
 version = "43.0.0"
 audited_as = "41.0.3"
 
+[[unpublished.wasmtime]]
+version = "44.0.0"
+audited_as = "42.0.1"
+
 [[unpublished.wasmtime-cli]]
 version = "42.0.0"
 audited_as = "40.0.1"
@@ -200,6 +296,10 @@ audited_as = "40.0.1"
 [[unpublished.wasmtime-cli]]
 version = "43.0.0"
 audited_as = "41.0.3"
+
+[[unpublished.wasmtime-cli]]
+version = "44.0.0"
+audited_as = "42.0.1"
 
 [[unpublished.wasmtime-cli-flags]]
 version = "42.0.0"
@@ -209,6 +309,10 @@ audited_as = "40.0.1"
 version = "43.0.0"
 audited_as = "41.0.3"
 
+[[unpublished.wasmtime-cli-flags]]
+version = "44.0.0"
+audited_as = "42.0.1"
+
 [[unpublished.wasmtime-environ]]
 version = "42.0.0"
 audited_as = "40.0.1"
@@ -216,6 +320,10 @@ audited_as = "40.0.1"
 [[unpublished.wasmtime-environ]]
 version = "43.0.0"
 audited_as = "41.0.3"
+
+[[unpublished.wasmtime-environ]]
+version = "44.0.0"
+audited_as = "42.0.1"
 
 [[unpublished.wasmtime-internal-c-api-macros]]
 version = "42.0.0"
@@ -225,6 +333,10 @@ audited_as = "40.0.1"
 version = "43.0.0"
 audited_as = "41.0.3"
 
+[[unpublished.wasmtime-internal-c-api-macros]]
+version = "44.0.0"
+audited_as = "42.0.1"
+
 [[unpublished.wasmtime-internal-cache]]
 version = "42.0.0"
 audited_as = "40.0.1"
@@ -232,6 +344,10 @@ audited_as = "40.0.1"
 [[unpublished.wasmtime-internal-cache]]
 version = "43.0.0"
 audited_as = "41.0.3"
+
+[[unpublished.wasmtime-internal-cache]]
+version = "44.0.0"
+audited_as = "42.0.1"
 
 [[unpublished.wasmtime-internal-component-macro]]
 version = "42.0.0"
@@ -241,6 +357,10 @@ audited_as = "40.0.1"
 version = "43.0.0"
 audited_as = "41.0.3"
 
+[[unpublished.wasmtime-internal-component-macro]]
+version = "44.0.0"
+audited_as = "42.0.1"
+
 [[unpublished.wasmtime-internal-component-util]]
 version = "42.0.0"
 audited_as = "40.0.1"
@@ -248,6 +368,10 @@ audited_as = "40.0.1"
 [[unpublished.wasmtime-internal-component-util]]
 version = "43.0.0"
 audited_as = "41.0.3"
+
+[[unpublished.wasmtime-internal-component-util]]
+version = "44.0.0"
+audited_as = "42.0.1"
 
 [[unpublished.wasmtime-internal-core]]
 version = "42.0.0"
@@ -257,6 +381,10 @@ audited_as = "0.0.0"
 version = "43.0.0"
 audited_as = "0.0.0"
 
+[[unpublished.wasmtime-internal-core]]
+version = "44.0.0"
+audited_as = "42.0.1"
+
 [[unpublished.wasmtime-internal-cranelift]]
 version = "42.0.0"
 audited_as = "40.0.1"
@@ -264,6 +392,10 @@ audited_as = "40.0.1"
 [[unpublished.wasmtime-internal-cranelift]]
 version = "43.0.0"
 audited_as = "41.0.3"
+
+[[unpublished.wasmtime-internal-cranelift]]
+version = "44.0.0"
+audited_as = "42.0.1"
 
 [[unpublished.wasmtime-internal-debugger]]
 version = "42.0.0"
@@ -272,6 +404,10 @@ audited_as = "41.0.0"
 [[unpublished.wasmtime-internal-debugger]]
 version = "43.0.0"
 audited_as = "41.0.3"
+
+[[unpublished.wasmtime-internal-debugger]]
+version = "44.0.0"
+audited_as = "42.0.1"
 
 [[unpublished.wasmtime-internal-error]]
 version = "42.0.0"
@@ -285,6 +421,10 @@ audited_as = "40.0.1"
 version = "43.0.0"
 audited_as = "41.0.3"
 
+[[unpublished.wasmtime-internal-explorer]]
+version = "44.0.0"
+audited_as = "42.0.1"
+
 [[unpublished.wasmtime-internal-fiber]]
 version = "42.0.0"
 audited_as = "40.0.1"
@@ -292,6 +432,10 @@ audited_as = "40.0.1"
 [[unpublished.wasmtime-internal-fiber]]
 version = "43.0.0"
 audited_as = "41.0.3"
+
+[[unpublished.wasmtime-internal-fiber]]
+version = "44.0.0"
+audited_as = "42.0.1"
 
 [[unpublished.wasmtime-internal-jit-debug]]
 version = "42.0.0"
@@ -301,6 +445,10 @@ audited_as = "40.0.1"
 version = "43.0.0"
 audited_as = "41.0.3"
 
+[[unpublished.wasmtime-internal-jit-debug]]
+version = "44.0.0"
+audited_as = "42.0.1"
+
 [[unpublished.wasmtime-internal-jit-icache-coherence]]
 version = "42.0.0"
 audited_as = "40.0.1"
@@ -308,6 +456,10 @@ audited_as = "40.0.1"
 [[unpublished.wasmtime-internal-jit-icache-coherence]]
 version = "43.0.0"
 audited_as = "41.0.3"
+
+[[unpublished.wasmtime-internal-jit-icache-coherence]]
+version = "44.0.0"
+audited_as = "42.0.1"
 
 [[unpublished.wasmtime-internal-math]]
 version = "42.0.0"
@@ -325,6 +477,10 @@ audited_as = "40.0.1"
 version = "43.0.0"
 audited_as = "41.0.3"
 
+[[unpublished.wasmtime-internal-unwinder]]
+version = "44.0.0"
+audited_as = "42.0.1"
+
 [[unpublished.wasmtime-internal-versioned-export-macros]]
 version = "42.0.0"
 audited_as = "40.0.1"
@@ -332,6 +488,10 @@ audited_as = "40.0.1"
 [[unpublished.wasmtime-internal-versioned-export-macros]]
 version = "43.0.0"
 audited_as = "41.0.3"
+
+[[unpublished.wasmtime-internal-versioned-export-macros]]
+version = "44.0.0"
+audited_as = "42.0.1"
 
 [[unpublished.wasmtime-internal-winch]]
 version = "42.0.0"
@@ -341,6 +501,10 @@ audited_as = "40.0.1"
 version = "43.0.0"
 audited_as = "41.0.3"
 
+[[unpublished.wasmtime-internal-winch]]
+version = "44.0.0"
+audited_as = "42.0.1"
+
 [[unpublished.wasmtime-internal-wit-bindgen]]
 version = "42.0.0"
 audited_as = "40.0.1"
@@ -348,6 +512,10 @@ audited_as = "40.0.1"
 [[unpublished.wasmtime-internal-wit-bindgen]]
 version = "43.0.0"
 audited_as = "41.0.3"
+
+[[unpublished.wasmtime-internal-wit-bindgen]]
+version = "44.0.0"
+audited_as = "42.0.1"
 
 [[unpublished.wasmtime-internal-wmemcheck]]
 version = "42.0.0"
@@ -357,6 +525,10 @@ audited_as = "40.0.1"
 version = "43.0.0"
 audited_as = "41.0.3"
 
+[[unpublished.wasmtime-internal-wmemcheck]]
+version = "44.0.0"
+audited_as = "42.0.1"
+
 [[unpublished.wasmtime-wasi]]
 version = "42.0.0"
 audited_as = "40.0.1"
@@ -364,6 +536,10 @@ audited_as = "40.0.1"
 [[unpublished.wasmtime-wasi]]
 version = "43.0.0"
 audited_as = "41.0.3"
+
+[[unpublished.wasmtime-wasi]]
+version = "44.0.0"
+audited_as = "42.0.1"
 
 [[unpublished.wasmtime-wasi-config]]
 version = "42.0.0"
@@ -373,6 +549,10 @@ audited_as = "40.0.1"
 version = "43.0.0"
 audited_as = "41.0.3"
 
+[[unpublished.wasmtime-wasi-config]]
+version = "44.0.0"
+audited_as = "42.0.1"
+
 [[unpublished.wasmtime-wasi-http]]
 version = "42.0.0"
 audited_as = "40.0.1"
@@ -380,6 +560,10 @@ audited_as = "40.0.1"
 [[unpublished.wasmtime-wasi-http]]
 version = "43.0.0"
 audited_as = "41.0.3"
+
+[[unpublished.wasmtime-wasi-http]]
+version = "44.0.0"
+audited_as = "42.0.1"
 
 [[unpublished.wasmtime-wasi-io]]
 version = "42.0.0"
@@ -389,6 +573,10 @@ audited_as = "40.0.1"
 version = "43.0.0"
 audited_as = "41.0.3"
 
+[[unpublished.wasmtime-wasi-io]]
+version = "44.0.0"
+audited_as = "42.0.1"
+
 [[unpublished.wasmtime-wasi-keyvalue]]
 version = "42.0.0"
 audited_as = "40.0.1"
@@ -396,6 +584,10 @@ audited_as = "40.0.1"
 [[unpublished.wasmtime-wasi-keyvalue]]
 version = "43.0.0"
 audited_as = "41.0.3"
+
+[[unpublished.wasmtime-wasi-keyvalue]]
+version = "44.0.0"
+audited_as = "42.0.1"
 
 [[unpublished.wasmtime-wasi-nn]]
 version = "42.0.0"
@@ -405,6 +597,10 @@ audited_as = "40.0.1"
 version = "43.0.0"
 audited_as = "41.0.3"
 
+[[unpublished.wasmtime-wasi-nn]]
+version = "44.0.0"
+audited_as = "42.0.1"
+
 [[unpublished.wasmtime-wasi-threads]]
 version = "42.0.0"
 audited_as = "40.0.1"
@@ -412,6 +608,10 @@ audited_as = "40.0.1"
 [[unpublished.wasmtime-wasi-threads]]
 version = "43.0.0"
 audited_as = "41.0.3"
+
+[[unpublished.wasmtime-wasi-threads]]
+version = "44.0.0"
+audited_as = "42.0.1"
 
 [[unpublished.wasmtime-wasi-tls]]
 version = "42.0.0"
@@ -421,6 +621,10 @@ audited_as = "40.0.1"
 version = "43.0.0"
 audited_as = "41.0.3"
 
+[[unpublished.wasmtime-wasi-tls]]
+version = "44.0.0"
+audited_as = "42.0.1"
+
 [[unpublished.wasmtime-wasi-tls-nativetls]]
 version = "42.0.0"
 audited_as = "40.0.1"
@@ -428,6 +632,10 @@ audited_as = "40.0.1"
 [[unpublished.wasmtime-wasi-tls-nativetls]]
 version = "43.0.0"
 audited_as = "41.0.3"
+
+[[unpublished.wasmtime-wasi-tls-nativetls]]
+version = "44.0.0"
+audited_as = "42.0.1"
 
 [[unpublished.wasmtime-wasi-tls-openssl]]
 version = "42.0.0"
@@ -437,6 +645,10 @@ audited_as = "0.0.1"
 version = "43.0.0"
 audited_as = "0.0.1"
 
+[[unpublished.wasmtime-wasi-tls-openssl]]
+version = "44.0.0"
+audited_as = "42.0.1"
+
 [[unpublished.wasmtime-wast]]
 version = "42.0.0"
 audited_as = "40.0.1"
@@ -444,6 +656,10 @@ audited_as = "40.0.1"
 [[unpublished.wasmtime-wast]]
 version = "43.0.0"
 audited_as = "41.0.3"
+
+[[unpublished.wasmtime-wast]]
+version = "44.0.0"
+audited_as = "42.0.1"
 
 [[unpublished.wasmtime-wizer]]
 version = "42.0.0"
@@ -453,6 +669,10 @@ audited_as = "40.0.1"
 version = "43.0.0"
 audited_as = "41.0.3"
 
+[[unpublished.wasmtime-wizer]]
+version = "44.0.0"
+audited_as = "42.0.1"
+
 [[unpublished.wiggle]]
 version = "42.0.0"
 audited_as = "40.0.1"
@@ -460,6 +680,10 @@ audited_as = "40.0.1"
 [[unpublished.wiggle]]
 version = "43.0.0"
 audited_as = "41.0.3"
+
+[[unpublished.wiggle]]
+version = "44.0.0"
+audited_as = "42.0.1"
 
 [[unpublished.wiggle-generate]]
 version = "42.0.0"
@@ -469,6 +693,10 @@ audited_as = "40.0.1"
 version = "43.0.0"
 audited_as = "41.0.3"
 
+[[unpublished.wiggle-generate]]
+version = "44.0.0"
+audited_as = "42.0.1"
+
 [[unpublished.wiggle-macro]]
 version = "42.0.0"
 audited_as = "40.0.1"
@@ -476,6 +704,10 @@ audited_as = "40.0.1"
 [[unpublished.wiggle-macro]]
 version = "43.0.0"
 audited_as = "41.0.3"
+
+[[unpublished.wiggle-macro]]
+version = "44.0.0"
+audited_as = "42.0.1"
 
 [[unpublished.wiggle-test]]
 version = "0.0.0"
@@ -488,6 +720,10 @@ audited_as = "40.0.1"
 [[unpublished.winch-codegen]]
 version = "43.0.0"
 audited_as = "41.0.3"
+
+[[unpublished.winch-codegen]]
+version = "44.0.0"
+audited_as = "42.0.1"
 
 [[publisher.aho-corasick]]
 version = "1.0.2"
@@ -706,103 +942,103 @@ user-login = "jrmuizel"
 user-name = "Jeff Muizelaar"
 
 [[publisher.cranelift]]
-version = "0.128.3"
-when = "2026-02-04"
+version = "0.129.1"
+when = "2026-02-25"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-assembler-x64]]
-version = "0.128.3"
-when = "2026-02-04"
+version = "0.129.1"
+when = "2026-02-25"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-assembler-x64-meta]]
-version = "0.128.3"
-when = "2026-02-04"
+version = "0.129.1"
+when = "2026-02-25"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-bforest]]
-version = "0.128.3"
-when = "2026-02-04"
+version = "0.129.1"
+when = "2026-02-25"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-bitset]]
-version = "0.128.3"
-when = "2026-02-04"
+version = "0.129.1"
+when = "2026-02-25"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-codegen]]
-version = "0.128.3"
-when = "2026-02-04"
+version = "0.129.1"
+when = "2026-02-25"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-codegen-meta]]
-version = "0.128.3"
-when = "2026-02-04"
+version = "0.129.1"
+when = "2026-02-25"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-codegen-shared]]
-version = "0.128.3"
-when = "2026-02-04"
+version = "0.129.1"
+when = "2026-02-25"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-control]]
-version = "0.128.3"
-when = "2026-02-04"
+version = "0.129.1"
+when = "2026-02-25"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-entity]]
-version = "0.128.3"
-when = "2026-02-04"
+version = "0.129.1"
+when = "2026-02-25"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-frontend]]
-version = "0.128.3"
-when = "2026-02-04"
+version = "0.129.1"
+when = "2026-02-25"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-interpreter]]
-version = "0.128.3"
-when = "2026-02-04"
+version = "0.129.1"
+when = "2026-02-25"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-isle]]
-version = "0.128.3"
-when = "2026-02-04"
+version = "0.129.1"
+when = "2026-02-25"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-jit]]
-version = "0.128.3"
-when = "2026-02-04"
+version = "0.129.1"
+when = "2026-02-25"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-module]]
-version = "0.128.3"
-when = "2026-02-04"
+version = "0.129.1"
+when = "2026-02-25"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-native]]
-version = "0.128.3"
-when = "2026-02-04"
+version = "0.129.1"
+when = "2026-02-25"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-object]]
-version = "0.128.3"
-when = "2026-02-04"
+version = "0.129.1"
+when = "2026-02-25"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-reader]]
-version = "0.128.3"
-when = "2026-02-04"
+version = "0.129.1"
+when = "2026-02-25"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-serde]]
-version = "0.128.3"
-when = "2026-02-04"
+version = "0.129.1"
+when = "2026-02-25"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-srcgen]]
-version = "0.128.3"
-when = "2026-02-04"
+version = "0.129.1"
+when = "2026-02-25"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.derive_arbitrary]]
@@ -1095,13 +1331,13 @@ user-login = "dtolnay"
 user-name = "David Tolnay"
 
 [[publisher.pulley-interpreter]]
-version = "41.0.3"
-when = "2026-02-04"
+version = "42.0.1"
+when = "2026-02-25"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.pulley-macros]]
-version = "41.0.3"
-when = "2026-02-04"
+version = "42.0.1"
+when = "2026-02-25"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.quote]]
@@ -1427,8 +1663,8 @@ user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
 [[publisher.wasi-common]]
-version = "41.0.3"
-when = "2026-02-04"
+version = "42.0.1"
+when = "2026-02-25"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasip1]]
@@ -1529,153 +1765,163 @@ when = "2026-02-10"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
 [[publisher.wasmtime]]
-version = "41.0.3"
-when = "2026-02-04"
+version = "42.0.1"
+when = "2026-02-25"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-cli]]
-version = "41.0.3"
-when = "2026-02-04"
+version = "42.0.1"
+when = "2026-02-25"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-cli-flags]]
-version = "41.0.3"
-when = "2026-02-04"
+version = "42.0.1"
+when = "2026-02-25"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-environ]]
-version = "41.0.3"
-when = "2026-02-04"
+version = "42.0.1"
+when = "2026-02-25"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-c-api-macros]]
-version = "41.0.3"
-when = "2026-02-04"
+version = "42.0.1"
+when = "2026-02-25"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-cache]]
-version = "41.0.3"
-when = "2026-02-04"
+version = "42.0.1"
+when = "2026-02-25"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-component-macro]]
-version = "41.0.3"
-when = "2026-02-04"
+version = "42.0.1"
+when = "2026-02-25"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-component-util]]
-version = "41.0.3"
-when = "2026-02-04"
+version = "42.0.1"
+when = "2026-02-25"
+trusted-publisher = "github:bytecodealliance/wasmtime"
+
+[[publisher.wasmtime-internal-core]]
+version = "42.0.1"
+when = "2026-02-25"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-cranelift]]
-version = "41.0.3"
-when = "2026-02-04"
+version = "42.0.1"
+when = "2026-02-25"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-debugger]]
-version = "41.0.3"
-when = "2026-02-04"
+version = "42.0.1"
+when = "2026-02-25"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-explorer]]
-version = "41.0.3"
-when = "2026-02-04"
+version = "42.0.1"
+when = "2026-02-25"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-fiber]]
-version = "41.0.3"
-when = "2026-02-04"
+version = "42.0.1"
+when = "2026-02-25"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-jit-debug]]
-version = "41.0.3"
-when = "2026-02-04"
+version = "42.0.1"
+when = "2026-02-25"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-jit-icache-coherence]]
-version = "41.0.3"
-when = "2026-02-04"
+version = "42.0.1"
+when = "2026-02-25"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-unwinder]]
-version = "41.0.3"
-when = "2026-02-04"
+version = "42.0.1"
+when = "2026-02-25"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-versioned-export-macros]]
-version = "41.0.3"
-when = "2026-02-04"
+version = "42.0.1"
+when = "2026-02-25"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-winch]]
-version = "41.0.3"
-when = "2026-02-04"
+version = "42.0.1"
+when = "2026-02-25"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-wit-bindgen]]
-version = "41.0.3"
-when = "2026-02-04"
+version = "42.0.1"
+when = "2026-02-25"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-wmemcheck]]
-version = "41.0.3"
-when = "2026-02-04"
+version = "42.0.1"
+when = "2026-02-25"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wasi]]
-version = "41.0.3"
-when = "2026-02-04"
+version = "42.0.1"
+when = "2026-02-25"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wasi-config]]
-version = "41.0.3"
-when = "2026-02-04"
+version = "42.0.1"
+when = "2026-02-25"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wasi-http]]
-version = "41.0.3"
-when = "2026-02-04"
+version = "42.0.1"
+when = "2026-02-25"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wasi-io]]
-version = "41.0.3"
-when = "2026-02-04"
+version = "42.0.1"
+when = "2026-02-25"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wasi-keyvalue]]
-version = "41.0.3"
-when = "2026-02-04"
+version = "42.0.1"
+when = "2026-02-25"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wasi-nn]]
-version = "41.0.3"
-when = "2026-02-04"
+version = "42.0.1"
+when = "2026-02-25"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wasi-threads]]
-version = "41.0.3"
-when = "2026-02-04"
+version = "42.0.1"
+when = "2026-02-25"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wasi-tls]]
-version = "41.0.3"
-when = "2026-02-04"
+version = "42.0.1"
+when = "2026-02-25"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wasi-tls-nativetls]]
-version = "41.0.3"
-when = "2026-02-04"
+version = "42.0.1"
+when = "2026-02-25"
+trusted-publisher = "github:bytecodealliance/wasmtime"
+
+[[publisher.wasmtime-wasi-tls-openssl]]
+version = "42.0.1"
+when = "2026-02-25"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wast]]
-version = "41.0.3"
-when = "2026-02-04"
+version = "42.0.1"
+when = "2026-02-25"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wizer]]
-version = "41.0.3"
-when = "2026-02-04"
+version = "42.0.1"
+when = "2026-02-25"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wast]]
@@ -1689,18 +1935,18 @@ when = "2026-02-10"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
 [[publisher.wiggle]]
-version = "41.0.3"
-when = "2026-02-04"
+version = "42.0.1"
+when = "2026-02-25"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wiggle-generate]]
-version = "41.0.3"
-when = "2026-02-04"
+version = "42.0.1"
+when = "2026-02-25"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wiggle-macro]]
-version = "41.0.3"
-when = "2026-02-04"
+version = "42.0.1"
+when = "2026-02-25"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wiggle-test]]
@@ -1718,8 +1964,8 @@ user-login = "BurntSushi"
 user-name = "Andrew Gallant"
 
 [[publisher.winch-codegen]]
-version = "41.0.3"
-when = "2026-02-04"
+version = "42.0.1"
+when = "2026-02-25"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.windows]]


### PR DESCRIPTION
This is an [automated pull request][process] from CI which indicates that the next [`release-43.0.0` branch][branch] has been created and the `main` branch is getting its version number bumped from 43.0.0 to 44.0.0.

Maintainers should take a moment to review the [release notes][RELEASES.md] for 43.0.0 and any updates should be made directly to the [release branch][branch].

Another automated PR will be made in roughly 2 weeks time when for the actual release itself.

If any issues arise on the `main` branch before the release is made then the issue should first be fixed on `main` and then backport to the `release-43.0.0` branch.

[RELEASES.md]: https://github.com/bytecodealliance/wasmtime/blob/release-43.0.0/RELEASES.md
[branch]: https://github.com/bytecodealliance/wasmtime/tree/release-43.0.0
[process]: https://docs.wasmtime.dev/contributing-release-process.html
