### PR TITLE
[Cranelift] (x | z) & (y | z) => (x & y) | z (and its dual)

### DIFF
--- a/cranelift/codegen/src/opts/bitops.isle
+++ b/cranelift/codegen/src/opts/bitops.isle
@@ -246,4 +246,24 @@
 (rule (simplify (iadd ty (ineg ty y) (bor ty y x)))
       (band ty x (bnot ty y)))
 
+; (x | z) & (y | z) --> (x & y) | z
+(rule (simplify (band ty (bor ty x z) (bor ty y z))) (bor ty (band ty x y) z))
+(rule (simplify (band ty (bor ty y z) (bor ty x z))) (bor ty (band ty x y) z))
+(rule (simplify (band ty (bor ty x z) (bor ty z y))) (bor ty (band ty x y) z))
+(rule (simplify (band ty (bor ty z y) (bor ty x z))) (bor ty (band ty x y) z))
+(rule (simplify (band ty (bor ty z x) (bor ty y z))) (bor ty (band ty x y) z))
+(rule (simplify (band ty (bor ty y z) (bor ty z x))) (bor ty (band ty x y) z))
+(rule (simplify (band ty (bor ty z x) (bor ty z y))) (bor ty (band ty x y) z))
+(rule (simplify (band ty (bor ty z y) (bor ty z x))) (bor ty (band ty x y) z))
+
+; (x & z) | (y & z) --> (x | y) & z
+(rule (simplify (bor ty (band ty x z) (band ty y z))) (band ty (bor ty x y) z))
+(rule (simplify (bor ty (band ty y z) (band ty x z))) (band ty (bor ty x y) z))
+(rule (simplify (bor ty (band ty x z) (band ty z y))) (band ty (bor ty x y) z))
+(rule (simplify (bor ty (band ty z y) (band ty x z))) (band ty (bor ty x y) z))
+(rule (simplify (bor ty (band ty z x) (band ty y z))) (band ty (bor ty x y) z))
+(rule (simplify (bor ty (band ty y z) (band ty z x))) (band ty (bor ty x y) z))
+(rule (simplify (bor ty (band ty z x) (band ty z y))) (band ty (bor ty x y) z))
+(rule (simplify (bor ty (band ty z y) (band ty z x))) (band ty (bor ty x y) z))
+
 

--- a/cranelift/filetests/filetests/egraph/fold-bitops.clif
+++ b/cranelift/filetests/filetests/egraph/fold-bitops.clif
@@ -107,3 +107,35 @@ block0(v0: i32, v1: i32):
 ;     return v7
 ; }
 
+;; (band ty (bor ty x z) (bor ty y z)) -> (bor ty (band ty x y) z)
+function %test_band_bor_bor(i32, i32, i32) -> i32 fast {
+block0(v0: i32, v1: i32, v2: i32):
+    v3 = bor v0, v2
+    v4 = bor v1, v2
+    v5 = band v3, v4
+    return v5
+}
+
+; function %test_band_bor_bor(i32, i32, i32) -> i32 fast {
+; block0(v0: i32, v1: i32, v2: i32):
+;     v8 = band v1, v0
+;     v9 = bor v8, v2
+;     return v9
+; }
+
+;; (bor ty (band ty x z) (band ty y z)) -> (band ty (bor ty x y) z)
+function %test_bor_band_band(i32, i32, i32) -> i32 fast {
+block0(v0: i32, v1: i32, v2: i32):
+    v3 = band v0, v2
+    v4 = band v1, v2
+    v5 = bor v3, v4
+    return v5
+}
+
+; function %test_bor_band_band(i32, i32, i32) -> i32 fast {
+; block0(v0: i32, v1: i32, v2: i32):
+;     v8 = bor v1, v0
+;     v9 = band v8, v2
+;     return v9
+; }
+

--- a/cranelift/filetests/filetests/runtests/bitops.clif
+++ b/cranelift/filetests/filetests/runtests/bitops.clif
@@ -258,3 +258,29 @@ block0(v0: i32, v1: i32):
 ; run: %test_iadd_bor_ineg(1, 1) == 0
 ; run: %test_iadd_bor_ineg(2, 1) == 2
 ; run: %test_iadd_bor_ineg(0xffffffff, 0) == -1
+
+function %test_band_bor_bor(i32, i32, i32) -> i32 fast {
+block0(v0: i32, v1: i32, v2: i32):
+    v3 = bor v0, v2
+    v4 = bor v1, v2
+    v5 = band v3, v4
+    return v5
+}
+
+; run: %test_band_bor_bor(0, 0, 0) == 0
+; run: %test_band_bor_bor(1, 0, 0) == 0
+; run: %test_band_bor_bor(1, 0, 1) == 1
+
+function %test_bor_band_band(i32, i32, i32) -> i32 fast {
+block0(v0: i32, v1: i32, v2: i32):
+    v3 = band v0, v2
+    v4 = band v1, v2
+    v5 = bor v3, v4
+    return v5
+}
+
+; run: %test_bor_band_band(0, 0, 0) == 0
+; run: %test_bor_band_band(1, 0, 0) == 0
+; run: %test_bor_band_band(1, 0, 1) == 1
+; run: %test_bor_band_band(2, 1, 1) == 1
+; run: %test_bor_band_band(0xf0, 0x0f, 0xaa) == 0xaa


### PR DESCRIPTION
This PR adds a Cranelift bitops simplification rule:

```(x | z) & (y | z) => (x & y) | z```

and its dual:

```(x & z) | (y & z) => (x | y) & z```