### PR TITLE
[Cranelift] (x | y) & x -> x

### DIFF
--- a/cranelift/codegen/src/opts/bitops.isle
+++ b/cranelift/codegen/src/opts/bitops.isle
@@ -246,4 +246,8 @@
 (rule (simplify (iadd ty (ineg ty y) (bor ty y x)))
       (band ty x (bnot ty y)))
 
-
+; x & (x | y) --> x
+(rule (simplify (band ty (bor ty x y) x)) x)
+(rule (simplify (band ty x (bor ty x y))) x)
+(rule (simplify (band ty (bor ty y x) x)) x)
+(rule (simplify (band ty x (bor ty y x))) x)

--- a/cranelift/filetests/filetests/egraph/fold-bitops.clif
+++ b/cranelift/filetests/filetests/egraph/fold-bitops.clif
@@ -107,3 +107,15 @@ block0(v0: i32, v1: i32):
 ;     return v7
 ; }
 
+;; (band ty (bor ty x y) x) -> x
+function %test_band_bor_absorb_x(i32, i32) -> i32 fast {
+block0(v0: i32, v1: i32):
+    v2 = bor v0, v1
+    v3 = band v2, v0
+    return v3
+}
+
+; function %test_band_bor_absorb_x(i32, i32) -> i32 fast {
+; block0(v0: i32, v1: i32):
+;     return v0
+; }

--- a/cranelift/filetests/filetests/runtests/bitops.clif
+++ b/cranelift/filetests/filetests/runtests/bitops.clif
@@ -258,3 +258,16 @@ block0(v0: i32, v1: i32):
 ; run: %test_iadd_bor_ineg(1, 1) == 0
 ; run: %test_iadd_bor_ineg(2, 1) == 2
 ; run: %test_iadd_bor_ineg(0xffffffff, 0) == -1
+
+function %test_band_bor_absorb_x(i32, i32) -> i32 fast {
+block0(v0: i32, v1: i32):
+    v2 = bor v0, v1
+    v3 = band v2, v0
+    return v3
+}
+
+; run: %test_band_bor_absorb_x(0, 0) == 0
+; run: %test_band_bor_absorb_x(1, 0) == 1
+; run: %test_band_bor_absorb_x(1, 1) == 1
+; run: %test_band_bor_absorb_x(2, 1) == 2
+; run: %test_band_bor_absorb_x(0xf0f0f0f0, 0x0f0f0f0f) == 0xf0f0f0f0


### PR DESCRIPTION
This PR adds the dual of a previously implemented simplification rule(: `(x & y) | x -> x`):

```(x | y) & x -> x```


