### PR TITLE
[Cranelift] (~x) & (~y) -> ~(x | y) and its dual

### DIFF
--- a/cranelift/codegen/src/opts/bitops.isle
+++ b/cranelift/codegen/src/opts/bitops.isle
@@ -246,4 +246,10 @@
 (rule (simplify (iadd ty (ineg ty y) (bor ty y x)))
       (band ty x (bnot ty y)))
 
+; (~x) & (~y) --> ~(x | y)
+(rule (simplify (band ty (bnot ty x) (bnot ty y))) (bnot ty (bor ty x y)))
+(rule (simplify (band ty (bnot ty y) (bnot ty x))) (bnot ty (bor ty x y)))
 
+; (~x) | (~y) --> ~(x & y)
+(rule (simplify (bor ty (bnot ty x) (bnot ty y))) (bnot ty (band ty x y)))
+(rule (simplify (bor ty (bnot ty y) (bnot ty x))) (bnot ty (band ty x y)))

--- a/cranelift/filetests/filetests/egraph/fold-bitops.clif
+++ b/cranelift/filetests/filetests/egraph/fold-bitops.clif
@@ -107,3 +107,35 @@ block0(v0: i32, v1: i32):
 ;     return v7
 ; }
 
+;; (band ty (bnot ty x) (bnot ty y)) -> (bnot ty (bor ty x y))
+function %test_band_bnot_bnot(i32, i32) -> i32 fast {
+block0(v0: i32, v1: i32):
+    v2 = bnot v0
+    v3 = bnot v1
+    v4 = band v2, v3
+    return v4
+}
+
+; function %test_band_bnot_bnot(i32, i32) -> i32 fast {
+; block0(v0: i32, v1: i32):
+;     v7 = bor v1, v0
+;     v8 = bnot v7
+;     return v8
+; }
+
+;; (bor ty (bnot ty x) (bnot ty y)) -> (bnot ty (band ty x y))
+function %test_bor_bnot_bnot(i32, i32) -> i32 fast {
+block0(v0: i32, v1: i32):
+    v2 = bnot v0
+    v3 = bnot v1
+    v4 = bor v2, v3
+    return v4
+}
+
+; function %test_bor_bnot_bnot(i32, i32) -> i32 fast {
+; block0(v0: i32, v1: i32):
+;     v7 = band v1, v0
+;     v8 = bnot v7
+;     return v8
+; }
+

--- a/cranelift/filetests/filetests/runtests/bitops.clif
+++ b/cranelift/filetests/filetests/runtests/bitops.clif
@@ -258,3 +258,27 @@ block0(v0: i32, v1: i32):
 ; run: %test_iadd_bor_ineg(1, 1) == 0
 ; run: %test_iadd_bor_ineg(2, 1) == 2
 ; run: %test_iadd_bor_ineg(0xffffffff, 0) == -1
+
+function %test_band_bnot_bnot(i32, i32) -> i32 fast {
+block0(v0: i32, v1: i32):
+    v2 = bnot v0
+    v3 = bnot v1
+    v4 = band v2, v3
+    return v4
+}
+
+; run: %test_band_bnot_bnot(0, 0) == 0xffffffff
+; run: %test_band_bnot_bnot(1, 0) == 0xfffffffe
+; run: %test_band_bnot_bnot(1, 1) == 0xfffffffe
+
+function %test_bor_bnot_bnot(i32, i32) -> i32 fast {
+block0(v0: i32, v1: i32):
+    v2 = bnot v0
+    v3 = bnot v1
+    v4 = bor v2, v3
+    return v4
+}
+
+; run: %test_bor_bnot_bnot(0, 0) == 0xffffffff
+; run: %test_bor_bnot_bnot(1, 0) == 0xffffffff
+; run: %test_bor_bnot_bnot(1, 1) == 0xfffffffe


### PR DESCRIPTION
This PR adds a Cranelift bitops simplification rule:

```(~x) & (~y) -> ~(x | y)```

and its dual:

```(~x) | (~y) -> ~(x & y)```

cc @bongjunj 

