### PR TITLE
Cranelift: add bitops simplification rules

### DIFF
--- a/cranelift/codegen/src/opts/bitops.isle
+++ b/cranelift/codegen/src/opts/bitops.isle
@@ -251,3 +251,41 @@
 (rule (simplify (band ty x (bor ty x y))) x)
 (rule (simplify (band ty (bor ty y x) x)) x)
 (rule (simplify (band ty x (bor ty y x))) x)
+
+; (x | z) & (y | z) --> (x & y) | z
+(rule (simplify (band ty (bor ty x z) (bor ty y z))) (bor ty (band ty x y) z))
+(rule (simplify (band ty (bor ty y z) (bor ty x z))) (bor ty (band ty x y) z))
+(rule (simplify (band ty (bor ty x z) (bor ty z y))) (bor ty (band ty x y) z))
+(rule (simplify (band ty (bor ty z y) (bor ty x z))) (bor ty (band ty x y) z))
+(rule (simplify (band ty (bor ty z x) (bor ty y z))) (bor ty (band ty x y) z))
+(rule (simplify (band ty (bor ty y z) (bor ty z x))) (bor ty (band ty x y) z))
+(rule (simplify (band ty (bor ty z x) (bor ty z y))) (bor ty (band ty x y) z))
+(rule (simplify (band ty (bor ty z y) (bor ty z x))) (bor ty (band ty x y) z))
+
+; (x & z) | (y & z) --> (x | y) & z
+(rule (simplify (bor ty (band ty x z) (band ty y z))) (band ty (bor ty x y) z))
+(rule (simplify (bor ty (band ty y z) (band ty x z))) (band ty (bor ty x y) z))
+(rule (simplify (bor ty (band ty x z) (band ty z y))) (band ty (bor ty x y) z))
+(rule (simplify (bor ty (band ty z y) (band ty x z))) (band ty (bor ty x y) z))
+(rule (simplify (bor ty (band ty z x) (band ty y z))) (band ty (bor ty x y) z))
+(rule (simplify (bor ty (band ty y z) (band ty z x))) (band ty (bor ty x y) z))
+(rule (simplify (bor ty (band ty z x) (band ty z y))) (band ty (bor ty x y) z))
+(rule (simplify (bor ty (band ty z y) (band ty z x))) (band ty (bor ty x y) z))
+
+; (x | y) ^ (x | ~y) --> ~x
+(rule (simplify (bxor ty (bor ty x y) (bor ty x (bnot ty y)))) (bnot ty x))
+(rule (simplify (bxor ty (bor ty x (bnot ty y)) (bor ty x y))) (bnot ty x))
+(rule (simplify (bxor ty (bor ty x y) (bor ty (bnot ty y) x))) (bnot ty x))
+(rule (simplify (bxor ty (bor ty (bnot ty y) x) (bor ty x y))) (bnot ty x))
+(rule (simplify (bxor ty (bor ty y x) (bor ty x (bnot ty y)))) (bnot ty x))
+(rule (simplify (bxor ty (bor ty x (bnot ty y)) (bor ty y x))) (bnot ty x))
+(rule (simplify (bxor ty (bor ty y x) (bor ty (bnot ty y) x))) (bnot ty x))
+(rule (simplify (bxor ty (bor ty (bnot ty y) x) (bor ty y x))) (bnot ty x))
+
+; (~x) & (~y) --> ~(x | y)
+(rule (simplify (band ty (bnot ty x) (bnot ty y))) (bnot ty (bor ty x y)))
+(rule (simplify (band ty (bnot ty y) (bnot ty x))) (bnot ty (bor ty x y)))
+
+; (~x) | (~y) --> ~(x & y)
+(rule (simplify (bor ty (bnot ty x) (bnot ty y))) (bnot ty (band ty x y)))
+(rule (simplify (bor ty (bnot ty y) (bnot ty x))) (bnot ty (band ty x y)))

--- a/cranelift/filetests/filetests/egraph/fold-bitops.clif
+++ b/cranelift/filetests/filetests/egraph/fold-bitops.clif
@@ -119,3 +119,84 @@ block0(v0: i32, v1: i32):
 ; block0(v0: i32, v1: i32):
 ;     return v0
 ; }
+
+;; (band ty (bor ty x z) (bor ty y z)) -> (bor ty (band ty x y) z)
+function %test_band_bor_bor(i32, i32, i32) -> i32 fast {
+block0(v0: i32, v1: i32, v2: i32):
+    v3 = bor v0, v2
+    v4 = bor v1, v2
+    v5 = band v3, v4
+    return v5
+}
+
+; function %test_band_bor_bor(i32, i32, i32) -> i32 fast {
+; block0(v0: i32, v1: i32, v2: i32):
+;     v8 = band v1, v0
+;     v9 = bor v8, v2
+;     return v9
+; }
+
+;; (bor ty (band ty x z) (band ty y z)) -> (band ty (bor ty x y) z)
+function %test_bor_band_band(i32, i32, i32) -> i32 fast {
+block0(v0: i32, v1: i32, v2: i32):
+    v3 = band v0, v2
+    v4 = band v1, v2
+    v5 = bor v3, v4
+    return v5
+}
+
+; function %test_bor_band_band(i32, i32, i32) -> i32 fast {
+; block0(v0: i32, v1: i32, v2: i32):
+;     v8 = bor v1, v0
+;     v9 = band v8, v2
+;     return v9
+; }
+
+;; (bxor ty (bor ty x y) (bor ty x (bnot ty y))) -> (bnot ty x)
+function %test_bxor_bor_bor_bnot(i32, i32) -> i32 fast {
+block0(v0: i32, v1: i32):
+    v2 = bor v0, v1
+    v3 = bnot v1
+    v4 = bor v0, v3
+    v5 = bxor v2, v4
+    return v5
+}
+
+; function %test_bxor_bor_bor_bnot(i32, i32) -> i32 fast {
+; block0(v0: i32, v1: i32):
+;     v6 = bnot v0
+;     return v6
+; }
+
+;; (band ty (bnot ty x) (bnot ty y)) -> (bnot ty (bor ty x y))
+function %test_band_bnot_bnot(i32, i32) -> i32 fast {
+block0(v0: i32, v1: i32):
+    v2 = bnot v0
+    v3 = bnot v1
+    v4 = band v2, v3
+    return v4
+}
+
+; function %test_band_bnot_bnot(i32, i32) -> i32 fast {
+; block0(v0: i32, v1: i32):
+;     v7 = bor v1, v0
+;     v8 = bnot v7
+;     return v8
+; }
+
+;; (bor ty (bnot ty x) (bnot ty y)) -> (bnot ty (band ty x y))
+function %test_bor_bnot_bnot(i32, i32) -> i32 fast {
+block0(v0: i32, v1: i32):
+    v2 = bnot v0
+    v3 = bnot v1
+    v4 = bor v2, v3
+    return v4
+}
+
+; function %test_bor_bnot_bnot(i32, i32) -> i32 fast {
+; block0(v0: i32, v1: i32):
+;     v7 = band v1, v0
+;     v8 = bnot v7
+;     return v8
+; }
+

--- a/cranelift/filetests/filetests/runtests/bitops.clif
+++ b/cranelift/filetests/filetests/runtests/bitops.clif
@@ -271,3 +271,69 @@ block0(v0: i32, v1: i32):
 ; run: %test_band_bor_absorb_x(1, 1) == 1
 ; run: %test_band_bor_absorb_x(2, 1) == 2
 ; run: %test_band_bor_absorb_x(0xf0f0f0f0, 0x0f0f0f0f) == 0xf0f0f0f0
+
+function %test_band_bor_bor(i32, i32, i32) -> i32 fast {
+block0(v0: i32, v1: i32, v2: i32):
+    v3 = bor v0, v2
+    v4 = bor v1, v2
+    v5 = band v3, v4
+    return v5
+}
+
+; run: %test_band_bor_bor(0, 0, 0) == 0
+; run: %test_band_bor_bor(1, 0, 0) == 0
+; run: %test_band_bor_bor(1, 0, 1) == 1
+
+function %test_bor_band_band(i32, i32, i32) -> i32 fast {
+block0(v0: i32, v1: i32, v2: i32):
+    v3 = band v0, v2
+    v4 = band v1, v2
+    v5 = bor v3, v4
+    return v5
+}
+
+; run: %test_bor_band_band(0, 0, 0) == 0
+; run: %test_bor_band_band(1, 0, 0) == 0
+; run: %test_bor_band_band(1, 0, 1) == 1
+; run: %test_bor_band_band(2, 1, 1) == 1
+; run: %test_bor_band_band(0xf0, 0x0f, 0xaa) == 0xaa
+
+function %test_bxor_bor_bor_bnot(i32, i32) -> i32 fast {
+block0(v0: i32, v1: i32):
+    v2 = bor v0, v1
+    v3 = bnot v1
+    v4 = bor v0, v3
+    v5 = bxor v2, v4
+    return v5
+}
+
+; run: %test_bxor_bor_bor_bnot(0, 0) == 0xffffffff
+; run: %test_bxor_bor_bor_bnot(1, 0) == 0xfffffffe
+; run: %test_bxor_bor_bor_bnot(1, 1) == 0xfffffffe
+; run: %test_bxor_bor_bor_bnot(0x12345678, 0x9abcdef0) == 0xedcba987
+; run: %test_bxor_bor_bor_bnot(0xffffffff, 0) == 0
+
+
+function %test_band_bnot_bnot(i32, i32) -> i32 fast {
+block0(v0: i32, v1: i32):
+    v2 = bnot v0
+    v3 = bnot v1
+    v4 = band v2, v3
+    return v4
+}
+
+; run: %test_band_bnot_bnot(0, 0) == 0xffffffff
+; run: %test_band_bnot_bnot(1, 0) == 0xfffffffe
+; run: %test_band_bnot_bnot(1, 1) == 0xfffffffe
+
+function %test_bor_bnot_bnot(i32, i32) -> i32 fast {
+block0(v0: i32, v1: i32):
+    v2 = bnot v0
+    v3 = bnot v1
+    v4 = bor v2, v3
+    return v4
+}
+
+; run: %test_bor_bnot_bnot(0, 0) == 0xffffffff
+; run: %test_bor_bnot_bnot(1, 0) == 0xffffffff
+; run: %test_bor_bnot_bnot(1, 1) == 0xfffffffe


### PR DESCRIPTION
This PR consolidates the changes from the following earlier PRs into a single branch:

- #12730
- #12732
- #12734

Those PRs developed overlap and conflicts as more bitops rules were added to the same file. To make review and merging easier, this PR supersedes them and contains the combined, up-to-date version of the changes.

Supersedes #12730, #12732, #12734.

#12730 adds the following rule:

`(x | z) & (y | z) => (x & y) | z`

and its dual: `(x & z) | (y & z) => (x | y) & z`

#12732 adds the following rule:

`(x | y) ^ (x | ~y) => ~x`

#12734 adds the following rule:

`(~x) & (~y) -> ~(x | y)`

and its dual: `(~x) | (~y) -> ~(x & y)`

Apologies for the inconvenience.

cc @bongjunj 