### PR TITLE
Make serde an optional dependency in wasmtime-core

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -13,7 +13,7 @@ version.workspace = true
 anyhow = { workspace = true, optional = true }
 hashbrown = { workspace = true, features = ["default-hasher"] }
 libm = { workspace = true }
-serde = { workspace = true }
+serde = { workspace = true, optional = true }
 
 [lints]
 workspace = true
@@ -26,3 +26,4 @@ backtrace = ["std"]
 # Enable the `From<Error> for anyhow::Error` implementation and
 # `Error::from_anyhow` constructor.
 anyhow = ["dep:anyhow"]
+serde = ["dep:serde"]

--- a/crates/core/src/alloc/string.rs
+++ b/crates/core/src/alloc/string.rs
@@ -67,6 +67,7 @@ impl From<inner::String> for TryString {
     }
 }
 
+#[cfg(feature = "serde")]
 impl serde::ser::Serialize for TryString {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -76,6 +77,7 @@ impl serde::ser::Serialize for TryString {
     }
 }
 
+#[cfg(feature = "serde")]
 impl<'de> serde::de::Deserialize<'de> for TryString {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/crates/core/src/alloc/vec.rs
+++ b/crates/core/src/alloc/vec.rs
@@ -3,13 +3,12 @@ use crate::error::OutOfMemory;
 use core::borrow::Borrow;
 use core::{
     cmp::Ordering,
-    fmt,
-    marker::PhantomData,
-    mem,
+    fmt, mem,
     num::NonZeroUsize,
     ops::{Deref, DerefMut, Index, IndexMut},
     slice::SliceIndex,
 };
+#[cfg(feature = "serde")]
 use serde::ser::SerializeSeq;
 use std_alloc::alloc::Layout;
 use std_alloc::boxed::Box;
@@ -389,6 +388,7 @@ impl<T> From<Box<[T]>> for TryVec<T> {
     }
 }
 
+#[cfg(feature = "serde")]
 impl<T> serde::ser::Serialize for TryVec<T>
 where
     T: serde::ser::Serialize,
@@ -405,6 +405,7 @@ where
     }
 }
 
+#[cfg(feature = "serde")]
 impl<'de, T> serde::de::Deserialize<'de> for TryVec<T>
 where
     T: serde::de::Deserialize<'de>,
@@ -413,6 +414,8 @@ where
     where
         D: serde::Deserializer<'de>,
     {
+        use core::marker::PhantomData;
+
         struct Visitor<T>(PhantomData<fn() -> TryVec<T>>);
 
         impl<'de, T> serde::de::Visitor<'de> for Visitor<T>

--- a/crates/environ/Cargo.toml
+++ b/crates/environ/Cargo.toml
@@ -37,7 +37,7 @@ target-lexicon = { workspace = true }
 wasm-encoder = { workspace = true, optional = true }
 wasmprinter = { workspace = true, optional = true }
 wasmtime-component-util = { workspace = true, optional = true }
-wasmtime-core = { workspace = true }
+wasmtime-core = { workspace = true, features = ['serde'] }
 semver = { workspace = true, optional = true, features = ['serde'] }
 smallvec = { workspace = true, features = ['serde'] }
 sha2 = { workspace = true }

--- a/crates/fuzzing/Cargo.toml
+++ b/crates/fuzzing/Cargo.toml
@@ -28,7 +28,7 @@ wasmparser = { workspace = true }
 wasmprinter = { workspace = true }
 wasmtime-wast = { workspace = true, features = ['component-model'] }
 wasmtime = { workspace = true, features = ['default', 'winch'] }
-wasmtime-core = { workspace = true, features = ['backtrace'] }
+wasmtime-core = { workspace = true, features = ['backtrace', 'serde'] }
 wasm-encoder = { workspace = true }
 wasm-smith = { workspace = true, features = ['serde'] }
 wasm-mutate = { workspace = true }

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -29,7 +29,7 @@ wasmtime-component-macro = { workspace = true, optional = true }
 wasmtime-component-util = { workspace = true, optional = true }
 wasmtime-versioned-export-macros = { workspace = true }
 wasmtime-wmemcheck = { workspace = true, optional = true }
-wasmtime-core = { workspace = true }
+wasmtime-core = { workspace = true, features = ['serde'] }
 pulley-interpreter = { workspace = true }
 target-lexicon = { workspace = true }
 wasmparser = { workspace = true }


### PR DESCRIPTION
cg_clif does not need serde, yet it was previously pulled in by Cranelift through the dependency on wasmtime-core.

Fixes https://github.com/bytecodealliance/wasmtime/issues/12733