### PR TITLE
Allow using `demangle` feature in `no_std` builds.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -552,7 +552,7 @@ jobs:
           os: ubuntu-latest
           test: >
             cargo check -p wasmtime --no-default-features --features runtime,component-model &&
-            cargo check -p wasmtime --no-default-features --features runtime,gc,component-model,async,debug-builtins &&
+            cargo check -p wasmtime --no-default-features --features runtime,gc,component-model,pulley,async,debug,debug-builtins,demangle,anyhow &&
             cargo check -p cranelift-control --no-default-features &&
             cargo check -p cranelift-assembler-x64 --lib &&
             cargo check -p pulley-interpreter --features encode,decode,disas,interp &&

--- a/crates/environ/Cargo.toml
+++ b/crates/environ/Cargo.toml
@@ -20,7 +20,7 @@ all-features = true
 [dependencies]
 anyhow = { workspace = true }
 postcard = { workspace = true }
-cpp_demangle = { version = "0.4.3", optional = true }
+cpp_demangle = { version = "0.4.3", default-features = false, features = ['alloc'], optional = true }
 cranelift-entity = { workspace = true, features = ['enable-serde'] }
 cranelift-bitset = { workspace = true, features = ['enable-serde'] }
 cranelift-bforest = { workspace = true }
@@ -32,7 +32,7 @@ serde_derive = { workspace = true }
 log = { workspace = true }
 gimli = { workspace = true }
 object = { workspace = true }
-rustc-demangle = { version = "0.1.16", optional = true }
+rustc-demangle = { version = "0.1.16", default-features = false, optional = true }
 target-lexicon = { workspace = true }
 wasm-encoder = { workspace = true, optional = true }
 wasmprinter = { workspace = true, optional = true }
@@ -70,7 +70,7 @@ component-model = [
   "dep:semver",
   "wasmparser/component-model",
 ]
-demangle = ['std', 'dep:rustc-demangle', 'dep:cpp_demangle']
+demangle = ['dep:rustc-demangle', 'dep:cpp_demangle']
 gc = []
 gc-drc = ["gc"]
 gc-null = ["gc"]
@@ -90,6 +90,8 @@ std = [
   'wasmparser/std',
   'indexmap/std',
   'wasmtime-core/std',
+  'cpp_demangle?/std',
+  'rustc-demangle?/std',
 ]
 rr = [
   "component-model"

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -249,7 +249,7 @@ trace-log = ["wasmtime-cranelift?/trace-log"]
 
 # Enables support for demangling WebAssembly function names at runtime in
 # errors such as backtraces.
-demangle = ["wasmtime-environ/demangle", "std"]
+demangle = ["wasmtime-environ/demangle"]
 
 # Enable support for generating core dumps on traps.
 coredump = ["dep:wasm-encoder", "runtime", "std"]

--- a/docs/stability-platform-support.md
+++ b/docs/stability-platform-support.md
@@ -83,6 +83,11 @@ Cargo features are:
 * `gc`
 * `component-model`
 * `pulley`
+* `async`
+* `debug`
+* `debug-builtins`
+* `demangle`
+* `anyhow`
 
 This notably does not include the `default` feature which means that when
 depending on Wasmtime you'll need to specify `default-features = false`. This


### PR DESCRIPTION
While there, add `async`, `debug`, `debug-builtins` and `anyhow` to
the list of features supporting `#![no_std]`, and update the CI job
to include those features.