### PR TITLE
[Cranelift] add select simplification rules

### DIFF
--- a/cranelift/codegen/src/opts/selects.isle
+++ b/cranelift/codegen/src/opts/selects.isle
@@ -181,12 +181,12 @@
 (rule (simplify (select ty x (iconst_u ty 1) (bor ty x y))) (select ty x (iconst_u ty 1) y))
 (rule (simplify (select ty x (iconst_u ty 1) (bor ty y x))) (select ty x (iconst_u ty 1) y))
 
-;; if x == 1 then (y - 1) else (y - x)  ==>  (y - x)
-;; and equivalent operand-order variants.
+;; if x == n then (y - n) else (y - x)  ==>  (y - x)
+;; and equivalent predicate/operand-order variants.
 (rule (simplify (select ty (eq cty x (iconst_u ty n)) (isub ty y (iconst_u ty n)) (isub ty y x))) (isub ty y x))
-(rule (simplify (select ty (ne cty x (iconst_u ty 1)) (isub ty y x) (isub ty y (iconst_u ty 1)))) (isub ty y x))
-(rule (simplify (select ty (eq cty (iconst_u ty 1) x) (isub ty y (iconst_u ty 1)) (isub ty y x))) (isub ty y x))
-(rule (simplify (select ty (ne cty (iconst_u ty 1) x) (isub ty y x) (isub ty y (iconst_u ty 1)))) (isub ty y x))
+(rule (simplify (select ty (ne cty x (iconst_u ty n)) (isub ty y x) (isub ty y (iconst_u ty n)))) (isub ty y x))
+(rule (simplify (select ty (eq cty (iconst_u ty n) x) (isub ty y (iconst_u ty n)) (isub ty y x))) (isub ty y x))
+(rule (simplify (select ty (ne cty (iconst_u ty n) x) (isub ty y x) (isub ty y (iconst_u ty n)))) (isub ty y x))
 
 ;; select(cond, eq(z, y), eq(p, y))  ==>  eq(y, select(cond, z, p))
 (rule (simplify (select ty x (eq ty z y) (eq ty (iconst_u cty p) y))) (eq ty y (select cty x z (iconst_u cty p))))

--- a/cranelift/filetests/filetests/egraph/selects.clif
+++ b/cranelift/filetests/filetests/egraph/selects.clif
@@ -193,10 +193,10 @@ block0(v0: i8, v1: i8):
 ;     return v5
 ; }
 
-;; if x == 1 then (y - 1) else (y - x)  ==>  (y - x)
-function %select_eq_x1_yminus1_yminusx_to_yminusx(i32, i32) -> i32 fast {
+;; if x == n then (y - n) else (y - x)  ==>  (y - x)
+function %select_eq_xn_yminusn_yminusx_to_yminusx(i32, i32) -> i32 fast {
 block0(v0: i32, v1: i32):
-    v2 = iconst.i32 1
+    v2 = iconst.i32 7
     v3 = icmp eq v0, v2
     v4 = isub v1, v2
     v5 = isub v1, v0
@@ -204,7 +204,7 @@ block0(v0: i32, v1: i32):
     return v6
 }
 
-; function %select_eq_x1_yminus1_yminusx_to_yminusx(i32, i32) -> i32 fast {
+; function %select_eq_xn_yminusn_yminusx_to_yminusx(i32, i32) -> i32 fast {
 ; block0(v0: i32, v1: i32):
 ;     v5 = isub v1, v0
 ;     return v5

--- a/cranelift/filetests/filetests/runtests/select.clif
+++ b/cranelift/filetests/filetests/runtests/select.clif
@@ -539,18 +539,18 @@ block0(v0: i8, v1: i8):
 ; run: %select_x_one_borxy_to_select_x_one_y_rt(1, 5) == 1
 ; run: %select_x_one_borxy_to_select_x_one_y_rt(2, 5) == 1
 
-function %select_eq_x1_yminus1_yminusx_to_yminusx_rt(i32, i32) -> i32 fast {
+function %select_eq_xn_yminusn_yminusx_to_yminusx_rt(i32, i32) -> i32 fast {
 block0(v0: i32, v1: i32):
-  v2 = iconst.i32 1
+  v2 = iconst.i32 7
   v3 = icmp eq v0, v2
   v4 = isub v1, v2
   v5 = isub v1, v0
   v6 = select v3, v4, v5
   return v6
 }
-; run: %select_eq_x1_yminus1_yminusx_to_yminusx_rt(1, 10) == 9
-; run: %select_eq_x1_yminus1_yminusx_to_yminusx_rt(3, 10) == 7
-; run: %select_eq_x1_yminus1_yminusx_to_yminusx_rt(0, 10) == 10
+; run: %select_eq_xn_yminusn_yminusx_to_yminusx_rt(7, 10) == 3
+; run: %select_eq_xn_yminusn_yminusx_to_yminusx_rt(3, 10) == 7
+; run: %select_eq_xn_yminusn_yminusx_to_yminusx_rt(0, 10) == 10
 
 function %select_eq_eq_to_eq_select_rt(i8, i32, i32) -> i8 fast {
 block0(v0: i8, v1: i32, v2: i32):


### PR DESCRIPTION
This PR adds a batch of select simplification rules.

Added rewrites:

1. `(x == y) ? x : y => y`
2. `(x | (y != z)) ? y : z => y`
3. `(x == y) ? x : (x | y) => (x | y)`
4. `(x != y) ? (x & y) : y => (x & y)`
5. `(x <_u y) ? 1 : (x == y) => (x <=_u y)`
6. `(x < y) ? 1 : (x > y) => (x != y)`
7. `(x ? 1 : (x | y)) => (x ? 1 : y)`
8. `if x == 1 then (y - 1) else (y - x) => (y - x)`
9. `select(cond, eq(z, y), eq(p, y)) => eq(y, select(cond, z, p))`

These rewrites come from a synthesis project with @bongjunj (details: #10979 ).

I grouped these into one PR to reduce overhead from many small PRs. 
If you'd prefer splitting by rule family, I'm happy to do that.

cc @bongjunj