### PR TITLE
[Cranelift] add arithmetic simplification rules

### DIFF
--- a/cranelift/codegen/src/opts/arithmetic.isle
+++ b/cranelift/codegen/src/opts/arithmetic.isle
@@ -291,3 +291,32 @@
   (if-let 0 (u64_checked_rem z x))
   (if-let 1 (u64_rem x 2))
   (eq ty y (iconst ty1 (imm64 (u64_div z x)))))
+
+;; (x + y) + (-y) ==> x
+;; and equivalent operand-order variants.
+(rule (simplify (iadd ty (iadd ty x y) (ineg ty y))) x)
+(rule (simplify (iadd ty (ineg ty y) (iadd ty x y))) x)
+(rule (simplify (iadd ty (iadd ty y x) (ineg ty y))) x)
+(rule (simplify (iadd ty (ineg ty y) (iadd ty y x))) x)
+
+;; (x | y) - (x & y)  ==>  (x ^ y)
+(rule (simplify (isub ty (bor ty x y) (band ty x y))) (bxor ty x y))
+(rule (simplify (isub ty (bor ty x y) (band ty y x))) (bxor ty x y))
+(rule (simplify (isub ty (bor ty y x) (band ty x y))) (bxor ty x y))
+(rule (simplify (isub ty (bor ty y x) (band ty y x))) (bxor ty x y))
+
+;; (x + y) - (x & y)  ==>  (x | y)
+(rule (simplify (isub ty (iadd ty x y) (band ty x y))) (bor ty x y))
+(rule (simplify (isub ty (iadd ty x y) (band ty y x))) (bor ty x y))
+(rule (simplify (isub ty (iadd ty y x) (band ty x y))) (bor ty x y))
+(rule (simplify (isub ty (iadd ty y x) (band ty y x))) (bor ty x y))
+
+;; (x | y) - (x ^ y)  ==>  (x & y)
+(rule (simplify (isub ty (bor ty x y) (bxor ty x y))) (band ty x y))
+(rule (simplify (isub ty (bor ty x y) (bxor ty y x))) (band ty x y))
+(rule (simplify (isub ty (bor ty y x) (bxor ty x y))) (band ty x y))
+(rule (simplify (isub ty (bor ty y x) (bxor ty y x))) (band ty x y))
+
+;; (~x) + x == -1
+(rule (simplify (iadd ty (bnot ty x) x)) (iconst_s ty -1))
+(rule (simplify (iadd ty x (bnot ty x))) (iconst_s ty -1))

--- a/cranelift/filetests/filetests/egraph/arithmetic-precise.clif
+++ b/cranelift/filetests/filetests/egraph/arithmetic-precise.clif
@@ -1,0 +1,73 @@
+test optimize precise-output
+set opt_level=speed
+target x86_64
+
+function %fold_iadd_iadd_ineg_i32(i32, i32) -> i32 {
+block0(v0: i32, v1: i32):
+    v2 = iadd v0, v1
+    v3 = ineg v1
+    v4 = iadd v2, v3
+    return v4
+}
+
+; function %fold_iadd_iadd_ineg_i32(i32, i32) -> i32 fast {
+; block0(v0: i32, v1: i32):
+;     return v0
+; }
+
+;; (x | y) - (x & y)  ==>  (x ^ y)
+function %test_isub_bor_band_to_bxor(i32, i32) -> i32 fast {
+block0(v0: i32, v1: i32):
+    v2 = bor v0, v1
+    v3 = band v0, v1
+    v4 = isub v2, v3
+    return v4
+}
+
+; function %test_isub_bor_band_to_bxor(i32, i32) -> i32 fast {
+; block0(v0: i32, v1: i32):
+;     v6 = bxor v1, v0
+;     return v6
+; }
+
+function %fold_isub_iadd_band_to_bor_i32(i32, i32) -> i32 {
+block0(v0: i32, v1: i32):
+    v2 = iadd v0, v1
+    v3 = band v0, v1
+    v4 = isub v2, v3
+    return v4
+}
+
+; function %fold_isub_iadd_band_to_bor_i32(i32, i32) -> i32 fast {
+; block0(v0: i32, v1: i32):
+;     v6 = bor v1, v0
+;     return v6
+; }
+
+function %fold_isub_bor_bxor_to_band_i32(i32, i32) -> i32 {
+block0(v0: i32, v1: i32):
+    v2 = bor v0, v1
+    v3 = bxor v0, v1
+    v4 = isub v2, v3
+    return v4
+}
+
+; function %fold_isub_bor_bxor_to_band_i32(i32, i32) -> i32 fast {
+; block0(v0: i32, v1: i32):
+;     v6 = band v1, v0
+;     return v6
+; }
+
+function %fold_iadd_bnot_x_to_allones_i32(i32) -> i32 {
+block0(v0: i32):
+    v1 = bnot v0
+    v2 = iadd v1, v0
+    return v2
+}
+
+; function %fold_iadd_bnot_x_to_allones_i32(i32) -> i32 fast {
+; block0(v0: i32):
+;     v3 = iconst.i32 -1
+;     return v3  ; v3 = -1
+; }
+

--- a/cranelift/filetests/filetests/runtests/arithmetic.clif
+++ b/cranelift/filetests/filetests/runtests/arithmetic.clif
@@ -632,3 +632,58 @@ block0(v0: i32):
 
 ; run: %ne_mul_odd(6) == 0
 ; run: %ne_mul_odd(7) == 1
+
+function %fold_iadd_iadd_ineg_i32_rt(i32, i32) -> i32 {
+block0(v0: i32, v1: i32):
+    v2 = iadd v0, v1
+    v3 = ineg v1
+    v4 = iadd v2, v3
+    return v4
+}
+; run: %fold_iadd_iadd_ineg_i32_rt(42, 5) == 42
+; run: %fold_iadd_iadd_ineg_i32_rt(-7, 9) == -7
+; run: %fold_iadd_iadd_ineg_i32_rt(0x7fffffff, 0x80000000) == 0x7fffffff
+
+function %test_isub_bor_band_to_bxor_rt(i32, i32) -> i32 fast {
+block0(v0: i32, v1: i32):
+    v2 = bor v0, v1
+    v3 = band v0, v1
+    v4 = isub v2, v3
+    return v4
+}
+; run: %test_isub_bor_band_to_bxor_rt(4, 5) == 1
+; run: %test_isub_bor_band_to_bxor_rt(7, 7) == 0
+; run: %test_isub_bor_band_to_bxor_rt(-1, 1) == -2
+
+function %fold_isub_iadd_band_to_bor_i32_rt(i32, i32) -> i32 {
+block0(v0: i32, v1: i32):
+    v2 = iadd v0, v1
+    v3 = band v0, v1
+    v4 = isub v2, v3
+    return v4
+}
+; run: %fold_isub_iadd_band_to_bor_i32_rt(4, 5) == 5
+; run: %fold_isub_iadd_band_to_bor_i32_rt(7, 7) == 7
+; run: %fold_isub_iadd_band_to_bor_i32_rt(-1, 1) == -1
+
+function %fold_isub_bor_bxor_to_band_i32_rt(i32, i32) -> i32 {
+block0(v0: i32, v1: i32):
+    v2 = bor v0, v1
+    v3 = bxor v0, v1
+    v4 = isub v2, v3
+    return v4
+}
+; run: %fold_isub_bor_bxor_to_band_i32_rt(4, 5) == 4
+; run: %fold_isub_bor_bxor_to_band_i32_rt(7, 7) == 7
+; run: %fold_isub_bor_bxor_to_band_i32_rt(-1, 1) == 1
+
+function %fold_iadd_bnot_x_to_allones_i32_rt(i32) -> i32 {
+block0(v0: i32):
+    v1 = bnot v0
+    v2 = iadd v1, v0
+    return v2
+}
+; run: %fold_iadd_bnot_x_to_allones_i32_rt(0) == -1
+; run: %fold_iadd_bnot_x_to_allones_i32_rt(1) == -1
+; run: %fold_iadd_bnot_x_to_allones_i32_rt(0x12345678) == -1
+


### PR DESCRIPTION
This PR adds several arithmetic/bitwise simplification rules to Cranelift:

1. `(x + y) + (-y) ==> x`
2. `(x | y) - (x & y)  ==>  (x ^ y)`
3. `(x + y) - (x & y)  ==>  (x | y)`
4. `(x | y) - (x ^ y)  ==>  (x & y)`
5. `(~x) + x ==> -1`

cc @bongjunj 