### PR TITLE
wasip3: Limit random number generation by default

### DIFF
--- a/crates/test-programs/src/bin/p3_cli_random_limits.rs
+++ b/crates/test-programs/src/bin/p3_cli_random_limits.rs
@@ -1,0 +1,26 @@
+use test_programs::p3::wasi::random;
+
+struct Component;
+
+test_programs::p3::export!(Component);
+
+impl test_programs::p3::exports::wasi::cli::run::Guest for Component {
+    async fn run() -> Result<(), ()> {
+        let args = std::env::args().collect::<Vec<_>>();
+        let args = args.iter().map(|s| s.as_str()).collect::<Vec<_>>();
+        match &args[1..] {
+            ["random", n] => {
+                random::random::get_random_bytes(n.parse().unwrap());
+            }
+            ["insecure", n] => {
+                random::insecure::get_insecure_random_bytes(n.parse().unwrap());
+            }
+            other => {
+                panic!("unexpected args: {other:?}");
+            }
+        }
+        Ok(())
+    }
+}
+
+fn main() {}

--- a/crates/wasi/src/p3/random/host.rs
+++ b/crates/wasi/src/p3/random/host.rs
@@ -1,11 +1,14 @@
-use cap_rand::Rng;
-use cap_rand::distributions::Standard;
-
 use crate::p3::bindings::random::{insecure, insecure_seed, random};
 use crate::random::WasiRandomCtx;
+use cap_rand::Rng;
+use cap_rand::distributions::Standard;
+use wasmtime::bail;
 
 impl random::Host for WasiRandomCtx {
     fn get_random_bytes(&mut self, len: u64) -> wasmtime::Result<Vec<u8>> {
+        if len > self.max_size {
+            bail!("requested len {len:?} exceeds limit {}", self.max_size);
+        }
         Ok((&mut self.random)
             .sample_iter(Standard)
             .take(len as usize)
@@ -19,6 +22,9 @@ impl random::Host for WasiRandomCtx {
 
 impl insecure::Host for WasiRandomCtx {
     fn get_insecure_random_bytes(&mut self, len: u64) -> wasmtime::Result<Vec<u8>> {
+        if len > self.max_size {
+            bail!("requested len {len:?} exceeds limit {}", self.max_size);
+        }
         Ok((&mut self.insecure_random)
             .sample_iter(Standard)
             .take(len as usize)

--- a/tests/all/cli_tests.rs
+++ b/tests/all/cli_tests.rs
@@ -2757,6 +2757,29 @@ start a print 1234
         }
         Ok(())
     }
+
+    #[test]
+    fn p3_cli_random_limits() -> Result<()> {
+        let c = P3_CLI_RANDOM_LIMITS_COMPONENT;
+
+        for rand in ["random", "insecure"] {
+            run_wasmtime(&["run", "-Sp3", "-Wcomponent-model-async", c, rand, "256"])?;
+            assert!(
+                run_wasmtime(&[
+                    "run",
+                    "-Sp3",
+                    "-Wcomponent-model-async",
+                    "-Smax-random-size=255",
+                    c,
+                    rand,
+                    "256"
+                ])
+                .is_err()
+            );
+        }
+
+        Ok(())
+    }
 }
 
 #[test]


### PR DESCRIPTION
This commit extends the random-related fixes of #12652 to WASIp3's implementation of randomness-related interfaces.

cc #12674

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
