### PR TITLE
refactor: clarify error msg. for de-allocated `ResourceAny`

### DIFF
--- a/crates/wasmtime/src/runtime/component/resources/host_tables.rs
+++ b/crates/wasmtime/src/runtime/component/resources/host_tables.rs
@@ -177,7 +177,7 @@ impl<'a> HostResourceTables<'a> {
         // precise error, such as a lift operation.
         if let Some(actual) = actual {
             if actual.generation != idx.generation() {
-                bail!("host-owned resource is being used with the wrong type");
+                bail!("host-owned resource was already de-allocated");
             }
         }
 

--- a/tests/all/component_model/resources.rs
+++ b/tests/all/component_model/resources.rs
@@ -187,7 +187,7 @@ fn resource_any() -> Result<()> {
         // reuse of `t` should fail, despite it pointing to a valid resource
         assert_eq!(
             t_dtor.call(&mut store, (t,)).unwrap_err().to_string(),
-            "host-owned resource is being used with the wrong type"
+            "host-owned resource was already de-allocated"
         );
     }
 
@@ -207,7 +207,7 @@ fn resource_any() -> Result<()> {
         // reuse of `t0` should fail, despite it pointing to a valid resource
         assert_eq!(
             t_dtor.call(&mut store, (t0,)).unwrap_err().to_string(),
-            "host-owned resource is being used with the wrong type"
+            "host-owned resource was already de-allocated"
         );
     }
 


### PR DESCRIPTION
The error message used to state that this happens because the type of the resource changed, but actually this can also happen with the very same type if the resource was already de-allocated. Clarifying the error message might safe some `wasmtime` users some long debugging sessions.

See #12465.