### PR TITLE
Fix a `stacks` fuzzer regression

### DIFF
--- a/crates/fuzzing/src/oracles/stacks.rs
+++ b/crates/fuzzing/src/oracles/stacks.rs
@@ -78,7 +78,13 @@ pub fn check_stacks(stacks: Stacks) -> usize {
                 .get_memory(&mut store, "memory")
                 .expect("should have `memory` export");
 
-            let host_trace = trap.downcast_ref::<WasmBacktrace>().unwrap().frames();
+            let host_trace = match trap.downcast_ref::<WasmBacktrace>() {
+                Some(bt) => bt.frames(),
+                None => {
+                    assert!(stacks.limit.is_none());
+                    continue;
+                }
+            };
             let trap = trap.downcast_ref::<Trap>().unwrap();
             max_stack_depth = max_stack_depth.max(host_trace.len());
             assert_stack_matches(


### PR DESCRIPTION
This commit fixes an accidental mistake from #12542 where when the `limit` of stack frames for the fuzzer to capture is `None` then it meant that backtraces were never captured. This updates the assertion logic to handle a missing `WasmBacktrace` and the case that `stacks.limit` is `None`.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
