### PR TITLE
[Cranelift] generate rotate ops

### DIFF
--- a/cranelift/codegen/meta/src/gen_isle.rs
+++ b/cranelift/codegen/meta/src/gen_isle.rs
@@ -785,6 +785,16 @@ impl NumericOp<'_> {
                 body: r#"a.checked_shr(b).unwrap_or_else(|| panic!("shr overflow: {a} >> {b}"))"#,
                 ..shift.clone()
             },
+            NumericOp {
+                name: "rotl",
+                body: "a.rotate_left(b)",
+                ..shift.clone()
+            },
+            NumericOp {
+                name: "rotr",
+                body: "a.rotate_right(b)",
+                ..shift.clone()
+            },
             // Predicates.
             //
             // We generate both pure constructors and a variety of extractors


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->

The ISLE generator currently does not produce `rotate_left` and `rotate_right` operations.
To allow further rewrite rules in ISLE, we need these operations.