### PR TITLE
Adjust depth calculation of `map<K, V>` type

### DIFF
--- a/crates/environ/src/component/types_builder.rs
+++ b/crates/environ/src/component/types_builder.rs
@@ -1228,8 +1228,8 @@ impl TypeInformation {
         *self = TypeInformation::string();
         let key_info = types.type_information(&ty.key);
         let value_info = types.type_information(&ty.value);
-        // Depth is max of key/value depths, plus 1 for tuple, plus 1 for list
-        self.depth = key_info.depth.max(value_info.depth) + 2;
+        // Depth is max of key/value depths, plus 1 for the extra map layer.
+        self.depth = key_info.depth.max(value_info.depth) + 1;
         self.has_borrow = key_info.has_borrow || value_info.has_borrow;
     }
 }


### PR DESCRIPTION
Previously it added 2 but this meant that it was out-of-sync with the fuzz test case generator which only accounted for 1 for each level of map. There's no need to have an extra layer for maps, so adjust the depth to add 1 instead of 2 which fixes the fuzz test case in question.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
