### PR TITLE
Add max_core_instances_aggregate_size_per_component limit to pooling allocator

### DIFF
--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -3700,6 +3700,25 @@ impl PoolingAllocationConfig {
         self
     }
 
+    /// The maximum aggregate memory size, in bytes, of all core module instances
+    /// that a single component may transitively contain (default is unlimited).
+    ///
+    /// This method allows you to cap the total memory overhead of all core
+    /// modules within a single component, regardless of how many core modules
+    /// the component contains. This protects against malicious components that
+    /// might attempt to allocate excessive metadata by instantiating many core
+    /// modules, even if each individual module is within the
+    /// [`PoolingAllocationConfig::max_core_instance_size`] limit.
+    ///
+    /// If a component's aggregate core instance size exceeds this limit, the
+    /// component will fail to instantiate.
+    pub fn max_core_instances_aggregate_size_per_component(&mut self, size: usize) -> &mut Self {
+        self.config
+            .limits
+            .max_core_instances_aggregate_size_per_component = size;
+        self
+    }
+
     /// The maximum number of Wasm linear memories that a single component may
     /// transitively contain (default is unlimited).
     ///

--- a/crates/wasmtime/src/runtime/vm/instance/allocator/pooling.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/pooling.rs
@@ -112,6 +112,10 @@ pub struct InstanceLimits {
     /// transitively contain.
     pub max_core_instances_per_component: u32,
 
+    /// The maximum aggregate memory size, in bytes, of all core module instances
+    /// that a single component may transitively contain.
+    pub max_core_instances_aggregate_size_per_component: usize,
+
     /// The maximum number of Wasm linear memories that a component may
     /// transitively contain.
     pub max_memories_per_component: u32,
@@ -168,6 +172,7 @@ impl Default for InstanceLimits {
             component_instance_size: 1 << 20, // 1 MiB
             total_core_instances: total,
             max_core_instances_per_component: u32::MAX,
+            max_core_instances_aggregate_size_per_component: usize::MAX,
             max_memories_per_component: u32::MAX,
             max_tables_per_component: u32::MAX,
             total_memories: total,
@@ -565,6 +570,7 @@ unsafe impl InstanceAllocator for PoolingInstanceAllocator {
         let mut num_core_instances = 0;
         let mut num_memories = 0;
         let mut num_tables = 0;
+        let mut core_instances_aggregate_size: usize = 0;
         for init in &component.initializers {
             use wasmtime_environ::component::GlobalInitializer::*;
             use wasmtime_environ::component::InstantiateModule;
@@ -577,10 +583,12 @@ unsafe impl InstanceAllocator for PoolingInstanceAllocator {
                 InstantiateModule(InstantiateModule::Static(static_module_index, _), _) => {
                     let module = get_module(*static_module_index);
                     let offsets = VMOffsets::new(HostPtr, &module);
+                    let layout = Instance::alloc_layout(&offsets);
                     self.validate_module(module, &offsets)?;
                     num_core_instances += 1;
                     num_memories += module.num_defined_memories();
                     num_tables += module.num_defined_tables();
+                    core_instances_aggregate_size += layout.size();
                 }
                 LowerImport { .. }
                 | ExtractMemory(_)
@@ -615,6 +623,16 @@ unsafe impl InstanceAllocator for PoolingInstanceAllocator {
                 "The component transitively contains {num_tables} tables, which exceeds the \
                  configured maximum of {} in the pooling allocator",
                 self.limits.max_tables_per_component
+            );
+        }
+
+        if core_instances_aggregate_size
+            > self.limits.max_core_instances_aggregate_size_per_component
+        {
+            bail!(
+                "The component's aggregate core instances size is {core_instances_aggregate_size} \
+                 bytes, which exceeds the configured maximum of {} bytes in the pooling allocator",
+                self.limits.max_core_instances_aggregate_size_per_component
             );
         }
 

--- a/tests/all/pooling_allocator.rs
+++ b/tests/all/pooling_allocator.rs
@@ -1121,6 +1121,41 @@ fn component_tables_limit() -> Result<()> {
 }
 
 #[test]
+#[cfg(feature = "component-model")]
+fn component_core_instances_aggregate_size() -> Result<()> {
+    let mut pool = crate::small_pool_config();
+    pool.max_core_instances_per_component(10)
+        .max_core_instance_size(100000)
+        .total_core_instances(10)
+        .total_memories(5)
+        .max_core_instances_aggregate_size_per_component(1); // Very low limit to ensure failure
+
+    let mut config = Config::new();
+    config.wasm_component_model(true);
+    config.allocation_strategy(pool);
+    let engine = Engine::new(&config)?;
+
+    // Even a single instance should exceed a 1-byte limit
+    match wasmtime::component::Component::new(
+        &engine,
+        r#"
+            (component
+                (core module $m)
+                (core instance $a (instantiate $m))
+            )
+        "#,
+    ) {
+        Ok(_) => panic!("should have hit aggregate size limit"),
+        Err(e) => {
+            e.assert_contains("aggregate core instances size is");
+            e.assert_contains("exceeds the configured maximum");
+        }
+    }
+
+    Ok(())
+}
+
+#[test]
 #[cfg_attr(miri, ignore)]
 fn total_memories_limit() -> Result<()> {
     const TOTAL_MEMORIES: u32 = 5;


### PR DESCRIPTION
There exist several knobs for limiting the memory that might be consumed for metadata for components.  For core module instances within a component, the two that previously existed to control metadata allocations have been:
- A: max_core_instances_per_component
- B: component_instance_size

These allow for an embedder to set an upper bound on memory used by a component's instances to A * B.  This value could be quite large for some systems and it would be nice to be able to set a cap on the total memory that might be used for metadata across all instances while still allowing for a greater number of instances with the potential for a subset of those instances to be relatively large.

To accommodate this, we add a new limit that tracks this aggregate measure.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
