### PR TITLE
Add `Send` to `p2::WasiHttpHooks` trait

### DIFF
--- a/crates/wasi-http/src/p2/mod.rs
+++ b/crates/wasi-http/src/p2/mod.rs
@@ -282,7 +282,7 @@ pub use self::error::*;
 ///     }
 /// }
 /// ```
-pub trait WasiHttpHooks {
+pub trait WasiHttpHooks: Send {
     /// Send an outgoing request.
     #[cfg(feature = "default-send-request")]
     fn send_request(


### PR DESCRIPTION
This means that the trait object `&mut dyn p2::WasiHttpHooks` is itself `Send` which is generally necessary for `async` operation.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
