### PR TITLE
wasip3: Limit randomness instead of trapping

### DIFF
--- a/crates/wasi/src/p3/random/host.rs
+++ b/crates/wasi/src/p3/random/host.rs
@@ -2,16 +2,12 @@ use crate::p3::bindings::random::{insecure, insecure_seed, random};
 use crate::random::WasiRandomCtx;
 use cap_rand::Rng;
 use cap_rand::distributions::Standard;
-use wasmtime::bail;
 
 impl random::Host for WasiRandomCtx {
     fn get_random_bytes(&mut self, len: u64) -> wasmtime::Result<Vec<u8>> {
-        if len > self.max_size {
-            bail!("requested len {len:?} exceeds limit {}", self.max_size);
-        }
         Ok((&mut self.random)
             .sample_iter(Standard)
-            .take(len as usize)
+            .take(len.min(self.max_size) as usize)
             .collect())
     }
 
@@ -22,12 +18,9 @@ impl random::Host for WasiRandomCtx {
 
 impl insecure::Host for WasiRandomCtx {
     fn get_insecure_random_bytes(&mut self, len: u64) -> wasmtime::Result<Vec<u8>> {
-        if len > self.max_size {
-            bail!("requested len {len:?} exceeds limit {}", self.max_size);
-        }
         Ok((&mut self.insecure_random)
             .sample_iter(Standard)
-            .take(len as usize)
+            .take(len.min(self.max_size) as usize)
             .collect())
     }
 

--- a/tests/all/cli_tests.rs
+++ b/tests/all/cli_tests.rs
@@ -2844,18 +2844,15 @@ start a print 1234
 
         for rand in ["random", "insecure"] {
             run_wasmtime(&["run", "-Sp3", "-Wcomponent-model-async", c, rand, "256"])?;
-            assert!(
-                run_wasmtime(&[
-                    "run",
-                    "-Sp3",
-                    "-Wcomponent-model-async",
-                    "-Smax-random-size=255",
-                    c,
-                    rand,
-                    "256"
-                ])
-                .is_err()
-            );
+            run_wasmtime(&[
+                "run",
+                "-Sp3",
+                "-Wcomponent-model-async",
+                "-Smax-random-size=255",
+                c,
+                rand,
+                "256",
+            ])?;
         }
 
         Ok(())


### PR DESCRIPTION
This updates the behavior of the randomness-generating interfaces in WASIp3 to account for recent spec changes, notably the ability for the guest to receive less random bytes than requested to limit allocations the host is forced to do.

cc WebAssembly/WASI#901

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
