### PR TITLE
Remove the explicit gc feature from the wasmtime dependency in the c-api crate

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -409,6 +409,7 @@ jobs:
               -p wasmtime-c-api --no-default-features
               -p wasmtime-c-api --no-default-features --features wat
               -p wasmtime-c-api --no-default-features --features wasi
+              -p wasmtime-c-api --no-default-features --features gc
 
           - name: wasmtime-wasi-http
             checks: |

--- a/crates/c-api/Cargo.toml
+++ b/crates/c-api/Cargo.toml
@@ -21,7 +21,7 @@ doctest = false
 
 [dependencies]
 env_logger = { workspace = true, optional = true }
-wasmtime = { workspace = true, features = ['runtime', 'gc', 'std'] }
+wasmtime = { workspace = true, features = ['runtime', 'std'] }
 wasmtime-c-api-macros = { workspace = true }
 log = { workspace = true }
 tracing = { workspace = true }


### PR DESCRIPTION
The `c-api` crate currently enables the `gc` feature on its `wasmtime` dependency, even though it exposes a `gc` feature to control this behaviour. This prevents downstream users from disabling `gc`, since `Cargo.toml` doesn't allow overriding it.

### Changes
1. Removes the explicitly set `gc` feature for the `wasmtime` dependency in `c-api`, thus enabling downstream users to specify this behaviour.
2. Adds ci job for building the `c-api` crate without default features, and with the `gc` feature

### Note
This introduces a breaking change for downstream users who may not have explicitly enabled the `gc` feature on the `c-api` crate but rely on it.

Closes https://github.com/bytecodealliance/wasmtime/issues/12783