### PR TITLE
fix: correct various typos

### DIFF
--- a/cranelift/assembler-x64/meta/src/generate/format.rs
+++ b/cranelift/assembler-x64/meta/src/generate/format.rs
@@ -25,7 +25,7 @@ enum ModRmStyle {
     },
 
     /// Same as `RegMem` above except that this is also used for VEX-encoded
-    /// instructios with "/is4" which indicates that the 4th register operand
+    /// instructions with "/is4" which indicates that the 4th register operand
     /// is encoded in a byte after the ModR/M byte.
     RegMemIs4 {
         reg: ModRmReg,

--- a/cranelift/bforest/src/map.rs
+++ b/cranelift/bforest/src/map.rs
@@ -239,7 +239,7 @@ where
         }
     }
 
-    /// Iterate over the enties within the given range.
+    /// Iterate over the entries within the given range.
     pub fn range<'a, R, C>(
         &'a self,
         range: R,

--- a/cranelift/bforest/src/set.rs
+++ b/cranelift/bforest/src/set.rs
@@ -544,7 +544,7 @@ mod tests {
     // Level 1: 1 root
     // Level 2: 8 inner
     // Level 3: 64 inner
-    // Level 4: 512 leafs, up to 7680 elements
+    // Level 4: 512 leaves, up to 7680 elements
     //
     // A 3-level tree can hold at most 960 elements.
     fn dense4l(f: &mut SetForest<i32>) -> Set<i32> {

--- a/cranelift/codegen/src/egraph/mod.rs
+++ b/cranelift/codegen/src/egraph/mod.rs
@@ -1057,7 +1057,7 @@ impl<'a> EgraphPass<'a> {
 /// Implementation of external-context equality and hashing on
 /// InstructionData. This allows us to deduplicate instructions given
 /// some context that lets us see its value lists, so we don't need to
-/// store arguments inline in the `InstuctionData` (or alongside it in
+/// store arguments inline in the `InstructionData` (or alongside it in
 /// some newly-defined key type) in all cases.
 struct GVNContext<'a> {
     value_lists: &'a ValueListPool,

--- a/cranelift/codegen/src/inline.rs
+++ b/cranelift/codegen/src/inline.rs
@@ -7,7 +7,7 @@
 //! have been marked the equivalent of `#[inline(never)]`, etc... Only the
 //! Cranelift user can understand these aspects of the full compilation
 //! pipeline, and these things can be very different between (say) Wasmtime and
-//! `cg_clif`. Therefore, this module does not attempt to define hueristics for
+//! `cg_clif`. Therefore, this module does not attempt to define heuristics for
 //! when inlining a particular call is likely beneficial. This module only
 //! provides hooks for the Cranelift user to define whether a given call should
 //! be inlined or not, and the mechanics to inline a callee into a particular
@@ -60,7 +60,7 @@ pub trait Inline {
     /// A hook invoked for each direct call instruction in a function, whose
     /// result determines whether Cranelift should inline a given call.
     ///
-    /// The Cranelift user is responsible for defining their own hueristics and
+    /// The Cranelift user is responsible for defining their own heuristics and
     /// deciding whether inlining the call is beneficial.
     ///
     /// When returning a function and directing Cranelift to inline its body

--- a/cranelift/codegen/src/isa/aarch64/inst/imms.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/imms.rs
@@ -602,7 +602,7 @@ impl MoveWideConst {
         None
     }
 
-    /// Create a `MoveWideCosnt` from a given shift, if possible.
+    /// Create a `MoveWideConst` from a given shift, if possible.
     pub fn maybe_with_shift(imm: u16, shift: u8) -> Option<MoveWideConst> {
         let shift_enc = shift / 16;
         if shift_enc > 3 {

--- a/cranelift/codegen/src/isa/pulley_shared/abi.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/abi.rs
@@ -165,7 +165,7 @@ where
 
     fn gen_load_stack(mem: StackAMode, into_reg: Writable<Reg>, ty: Type) -> Self::I {
         let mut flags = MemFlags::trusted();
-        // Stack loads/stores of vectors always use little-endianess to avoid
+        // Stack loads/stores of vectors always use little-endianness to avoid
         // implementing a byte-swap of vectors on big-endian platforms.
         if ty.is_vector() {
             flags.set_endianness(ir::Endianness::Little);
@@ -175,7 +175,7 @@ where
 
     fn gen_store_stack(mem: StackAMode, from_reg: Reg, ty: Type) -> Self::I {
         let mut flags = MemFlags::trusted();
-        // Stack loads/stores of vectors always use little-endianess to avoid
+        // Stack loads/stores of vectors always use little-endianness to avoid
         // implementing a byte-swap of vectors on big-endian platforms.
         if ty.is_vector() {
             flags.set_endianness(ir::Endianness::Little);

--- a/cranelift/codegen/src/isa/pulley_shared/inst.isle
+++ b/cranelift/codegen/src/isa/pulley_shared/inst.isle
@@ -356,7 +356,7 @@
   ;; Next see if the `oob` and `raw_addr` combination match. This will attempt
   ;; extract a full bounds check from these values. If everything succeeds the
   ;; final step is then to extract an 8-bit offset of the load/store operation,
-  ;; if appplicable, assuming that the constants used in various places all line
+  ;; if applicable, assuming that the constants used in various places all line
   ;; up just right.
   (if-let (OobSelect.All base bound wasm_addr access_size_plus_offset)
     (wasm_oob_select oob host_addr))

--- a/cranelift/codegen/src/isa/pulley_shared/inst/emit.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/inst/emit.rs
@@ -125,7 +125,7 @@ fn pulley_emit<P>(
     P: PulleyTargetKind,
 {
     match inst {
-        // Pseduo-instructions that don't actually encode to anything.
+        // Pseudo-instructions that don't actually encode to anything.
         Inst::Args { .. } | Inst::Rets { .. } | Inst::DummyUse { .. } => {}
 
         Inst::TrapIf { cond, code } => {

--- a/cranelift/codegen/src/isa/riscv64/inst_vector.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst_vector.isle
@@ -1735,7 +1735,7 @@
 ;; Builds a vector mask corresponding to the FloatCC operation.
 ;;
 ;; Recursion: recursive rules implement some condition codes in terms of a
-;; smaller set of primtives, which recursive rules would not apply to twice.
+;; smaller set of primitives, which recursive rules would not apply to twice.
 (decl rec gen_fcmp_mask (Type FloatCC Value Value) VReg)
 
 ;; FloatCC.Equal

--- a/cranelift/codegen/src/isa/s390x/inst.isle
+++ b/cranelift/codegen/src/isa/s390x/inst.isle
@@ -1401,14 +1401,14 @@
     (UCmpHi128)
 ))
 
-;; An integer vector element comparion operation.
+;; An integer vector element comparison operation.
 (type VecIntEltCmpOp
   (enum
     (SCmp128)
     (UCmp128)
 ));
 
-;; A floatint-point vector comparison operation.
+;; A floating-point vector comparison operation.
 (type VecFloatCmpOp
   (enum
     (CmpEq32x4)

--- a/cranelift/codegen/src/isa/s390x/lower.isle
+++ b/cranelift/codegen/src/isa/s390x/lower.isle
@@ -711,7 +711,7 @@
             ;; This checks that y == -y, by using Not-Xor for bitwise
             ;; equality, producing all 0b1's (-1u128) when y == -y.
             ;; Then it uses band to include the x == -1 check as well.
-            ;; using (band x (bnot (bxor y neg_divison))) vaiant of vec eval
+            ;; using (band x (bnot (bxor y neg_division))) variant of vec eval
             (neg_divisor Reg (vec_neg $I128 y))
             (reg Reg (vec_eval $I128 0b00001001 x y neg_divisor))
             ;; finally, we check that the combination of x & y == -y is -1

--- a/cranelift/codegen/src/isa/s390x/lower/isle.rs
+++ b/cranelift/codegen/src/isa/s390x/lower/isle.rs
@@ -106,7 +106,7 @@ impl generated_code::Context for IsleContext<'_, '_, MInst, S390xBackend> {
     }
 
     // Adjust the stack before performing a tail call.  The actual stack
-    // adjustment is defered to the call instruction itself, but we create
+    // adjustment is deferred to the call instruction itself, but we create
     // a temporary backchain copy in the proper place here, if necessary
     // for unwinding.
     fn abi_emit_return_call_adjust_stack(&mut self, abi: Sig) -> Unit {

--- a/cranelift/codegen/src/isa/x64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit.rs
@@ -1908,7 +1908,7 @@ fn emit_return_call_common_sequence<T>(
     }
 }
 
-/// Conveniene trait to have an `emit` method on all `asm::inst::*` variants.
+/// Convenience trait to have an `emit` method on all `asm::inst::*` variants.
 trait ExternalEmit {
     fn emit(self, sink: &mut MachBuffer<Inst>, info: &EmitInfo, state: &mut EmitState);
 }

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -156,7 +156,7 @@ impl Inst {
         Inst::External { inst }
     }
 
-    /// Writes the `simm64` immedaite into `dst`.
+    /// Writes the `simm64` immediate into `dst`.
     ///
     /// Note that if `dst_size` is less than 64-bits then the upper bits of
     /// `simm64` will be converted to zero.

--- a/cranelift/codegen/src/machinst/buffer.rs
+++ b/cranelift/codegen/src/machinst/buffer.rs
@@ -378,7 +378,7 @@ pub struct MachBufferFinalized<T: CompilePhase> {
     pub(crate) traps: SmallVec<[MachTrap; 16]>,
     /// Any call site records referring to this code.
     pub(crate) call_sites: SmallVec<[MachCallSite; 16]>,
-    /// Any patchable call site locations refering to this code.
+    /// Any patchable call site locations referring to this code.
     pub(crate) patchable_call_sites: SmallVec<[MachPatchableCallSite; 16]>,
     /// Any exception-handler records referred to at call sites.
     pub(crate) exception_handlers: SmallVec<[FinalizedMachExceptionHandler; 16]>,
@@ -1865,7 +1865,7 @@ impl<T: CompilePhase> MachBufferFinalized<T> {
         &self.user_stack_maps
     }
 
-    /// Take this buffer's user strack map metadata.
+    /// Take this buffer's user stack map metadata.
     pub fn take_user_stack_maps(&mut self) -> SmallVec<[(CodeOffset, u32, ir::UserStackMap); 8]> {
         mem::take(&mut self.user_stack_maps)
     }

--- a/cranelift/codegen/src/prelude_opt.isle
+++ b/cranelift/codegen/src/prelude_opt.isle
@@ -216,7 +216,7 @@
 (decl sge (Type Value Value) Value)
 (extractor (sge ty x y) (icmp ty (IntCC.SignedGreaterThanOrEqual) x y))
 
-;;;;;; Divison-By-Constant Helpers ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;; Division-By-Constant Helpers ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (decl pure i64_is_negative_power_of_two (i64) bool)
 (rule (i64_is_negative_power_of_two x)

--- a/cranelift/filetests/filetests/verifier/exceptions.clif
+++ b/cranelift/filetests/filetests/verifier/exceptions.clif
@@ -150,7 +150,7 @@ function %f5() windows_fastcall {
         return
 }
 
-;; Out-of-bounds `exnN` paylaod
+;; Out-of-bounds `exnN` payload
 function %f5() {
     sig0 = () tail
     fn0 = %g() tail

--- a/cranelift/isle/isle/src/codegen.rs
+++ b/cranelift/isle/isle/src/codegen.rs
@@ -20,7 +20,7 @@ pub struct CodegenOptions {
     /// source. Useful if it must be include!()'d elsewhere.
     pub exclude_global_allow_pragmas: bool,
 
-    /// Prefixes to remove when printing file names in generaed files. This
+    /// Prefixes to remove when printing file names in generated files. This
     /// helps keep codegen deterministic.
     pub prefixes: Vec<Prefix>,
 

--- a/cranelift/isle/veri/veri_engine/examples/broken/broken_fits_in_16_with_imm_rotl_to_rotr.isle
+++ b/cranelift/isle/veri/veri_engine/examples/broken/broken_fits_in_16_with_imm_rotl_to_rotr.isle
@@ -96,7 +96,7 @@
 ;;     ImmShift::maybe_from_u64(imm_value)
 ;; }
 
-;; Add an assertion that the value fits, using the constand with 56 1's then 6 0's (~63)
+;; Add an assertion that the value fits, using the constant with 56 1's then 6 0's (~63)
 (spec (imm_shift_from_imm64 ty x)
       (provide (= result (extract 5 0 (bvand x (bvsub (int2bv 64 ty) #x0000000000000001)))))
       (require (bvult (bvand x (bvsub (int2bv 64 ty)  #x0000000000000001)) #x0000000000000040)))

--- a/cranelift/isle/veri/veri_engine/examples/x86/amode_add_shl.isle
+++ b/cranelift/isle/veri/veri_engine/examples/x86/amode_add_shl.isle
@@ -57,7 +57,7 @@
 (extern constructor gpr_new gpr_new)
 (convert Reg Gpr gpr_new)
 
-;; To make this case study specific to Wasm, contrain to 32 or 64
+;; To make this case study specific to Wasm, constrain to 32 or 64
 (spec (uextend arg) 
   (provide (= result (zero_ext (widthof result) arg)))
   (require 

--- a/cranelift/isle/veri/veri_engine/examples/x86/amode_add_uextend_shl.isle
+++ b/cranelift/isle/veri/veri_engine/examples/x86/amode_add_uextend_shl.isle
@@ -61,7 +61,7 @@
 (extern constructor gpr_new gpr_new)
 (convert Reg Gpr gpr_new)
 
-;; To make this case study specific to Wasm, contrain the widths of
+;; To make this case study specific to Wasm, constrain the widths of
 ;; the argument and returned value to 32 or 64
 (spec (uextend arg) 
   (provide (= result (zero_ext (widthof result) arg)))

--- a/cranelift/isle/veri/veri_engine/src/solver.rs
+++ b/cranelift/isle/veri/veri_engine/src/solver.rs
@@ -1180,7 +1180,7 @@ impl SolverCtx {
                     load_ret
                 } else {
                     if self.rhs_load_args.is_some() {
-                        panic!("Only one load on the RHS currently supported, found miltiple.")
+                        panic!("Only one load on the RHS currently supported, found multiple.")
                     }
                     self.rhs_load_args = Some(vec![ex, ey, ez]);
                     self.load_return.unwrap()
@@ -1784,7 +1784,7 @@ fn resolve_dynamic_widths(
             }
 
             // Otherwise, try again, but adding the assertion that some width is
-            // different than our current assigment
+            // different than our current assignment
             let not_equals = width_resolutions.iter().map(|(s, w)| {
                 ctx.smt.not(
                     ctx.smt

--- a/crates/c-api/doxygen.conf.in
+++ b/crates/c-api/doxygen.conf.in
@@ -466,7 +466,7 @@ LOOKUP_CACHE_SIZE      = 0
 # than 0 to get more control over the balance between CPU load and processing
 # speed. At this moment only the input processing can be done using multiple
 # threads. Since this is still an experimental feature the default is set to 1,
-# which efficively disables parallel processing. Please report any issues you
+# which effectively disables parallel processing. Please report any issues you
 # encounter. Generating dot graphs in parallel is controlled by the
 # DOT_NUM_THREADS setting.
 # Minimum value: 0, maximum value: 32, default value: 1.

--- a/crates/c-api/include/wasmtime/component/linker.h
+++ b/crates/c-api/include/wasmtime/component/linker.h
@@ -175,7 +175,7 @@ typedef wasmtime_error_t *(*wasmtime_component_resource_destructor_t)(
  *
  * This can be used to define a new resource type that the guest will be able
  * to import. Here the `resource` is a type, often a host-defined type, which
- * can be used to distinguish and definie different types of resources. A
+ * can be used to distinguish and definite different types of resources. A
  * destruction callback is also specified via `destructor` which has private
  * data `data` along with an optional `finalizer` for the `data` too.
  *

--- a/crates/c-api/include/wasmtime/component/val.hh
+++ b/crates/c-api/include/wasmtime/component/val.hh
@@ -33,7 +33,7 @@ inline const Val *val_from_capi(const wasmtime_component_val_t *capi) {
 
 } // namespace detail
 
-/// Internal helper macro to define ownership-semanitcs for C++ types based on
+/// Internal helper macro to define ownership-semantics for C++ types based on
 /// a C type as a single member where operations are defined in terms of
 /// `transfer`, `copy`, and `destroy` functions.
 #define VAL_REPR(name, raw_type)                                               \

--- a/crates/cli-flags/src/lib.rs
+++ b/crates/cli-flags/src/lib.rs
@@ -613,7 +613,7 @@ pub struct CommonOptions {
     ///
     /// Generates a serialized trace of the Wasm module execution that captures all
     /// non-determinism observable by the module. This trace can subsequently be
-    /// re-executed in a determinstic, embedding-agnostic manner (see the `wasmtime replay` command).
+    /// re-executed in a deterministic, embedding-agnostic manner (see the `wasmtime replay` command).
     ///
     /// Note: Minimal configuration options for deterministic Wasm semantics will be
     /// enforced during recording by default (NaN canonicalization, deterministic relaxed SIMD).
@@ -658,7 +658,7 @@ pub struct CommonOptions {
 
     /// Use the specified TOML configuration file.
     /// This TOML configuration file can provide same configuration options as the
-    /// `--optimize`, `--codgen`, `--debug`, `--wasm`, `--wasi` CLI options, with a couple exceptions.
+    /// `--optimize`, `--codegen`, `--debug`, `--wasm`, `--wasi` CLI options, with a couple exceptions.
     ///
     /// Additional options specified on the command line will take precedent over options loaded from
     /// this TOML file.

--- a/crates/core/src/alloc/boxed.rs
+++ b/crates/core/src/alloc/boxed.rs
@@ -114,7 +114,7 @@ use boxed_slice_builder::BoxedSliceBuilder;
 mod boxed_slice_builder {
     use super::*;
 
-    /// Builder for constructing and initalizing a boxed slice.
+    /// Builder for constructing and initializing a boxed slice.
     ///
     /// Also acts as an RAII guard to handle dropping the already-initialized
     /// elements when we get too few items or an iterator panics during

--- a/crates/core/src/alloc/try_collect.rs
+++ b/crates/core/src/alloc/try_collect.rs
@@ -21,9 +21,9 @@ impl<I: Iterator> TryCollect for I {}
 /// Analogue of [`FromIterator`] in the standard library, but used with
 /// [`TryCollect::try_collect`] instead.
 pub trait TryFromIterator<T, E>: Sized {
-    /// Creates an intance of this collection from the `iter` provided.
+    /// Creates an instance of this collection from the `iter` provided.
     ///
-    /// Does not abort on OOM but insteads return an error.
+    /// Does not abort on OOM but instead returns an error.
     fn try_from_iter<I>(iter: I) -> Result<Self, E>
     where
         I: Iterator<Item = T>;

--- a/crates/core/src/error/error.rs
+++ b/crates/core/src/error/error.rs
@@ -591,7 +591,7 @@ impl Error {
     {
         if TypeId::of::<E>() == TypeId::of::<OutOfMemory>() {
             // Although we know that `E == OutOfMemory` in this block, the
-            // compiler doesn't understand that, and we have to do this litle
+            // compiler doesn't understand that, and we have to do this little
             // dance.
             union ToOom<T> {
                 oom: OutOfMemory,

--- a/crates/debugger/src/lib.rs
+++ b/crates/debugger/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! This crate builds on top of the core Wasmtime crate's
 //! guest-debugger APIs to present an environment where a debugger
-//! runs as a "co-running process" and sees the debugee as a a
+//! runs as a "co-running process" and sees the debuggee as a a
 //! provider of a stream of events, on which actions can be taken
 //! between each event.
 //!
@@ -187,7 +187,7 @@ impl<T: Send + 'static> DebugHandler for Handler<T> {
             DebugEvent::EpochYield => {
                 // Only pause on epoch yields that were requested via
                 // interrupt(). Other epoch ticks simply yield to the
-                // event loop (funcionality already implemented in
+                // event loop (functionality already implemented in
                 // core Wasmtime; no need to do that yield here in the
                 // debug handler).
                 if !self.0.interrupt_pending.swap(false, Ordering::SeqCst) {

--- a/crates/environ/src/component/translate/inline.rs
+++ b/crates/environ/src/component/translate/inline.rs
@@ -535,7 +535,7 @@ impl<'a> Inliner<'a> {
                         dfg::CoreDef::Trampoline(index)
                     }
 
-                    // Lowering a lifted functio means that a "fused adapter"
+                    // Lowering a lifted function means that a "fused adapter"
                     // was just identified.
                     //
                     // Metadata about this fused adapter is recorded in the

--- a/crates/environ/src/graphs/scc.rs
+++ b/crates/environ/src/graphs/scc.rs
@@ -187,7 +187,7 @@ where
         &self.component_nodes[start..end]
     }
 
-    /// Iterate over each strongly-connnected component and the `Node`s that are
+    /// Iterate over each strongly-connected component and the `Node`s that are
     /// members of it.
     ///
     /// Iteration happens in reverse-topological order (successors are visited
@@ -275,7 +275,7 @@ where
     /// ```
     ///
     /// Note that a graph's condensation is always acyclic, because the
-    /// strongly-conneted components encapsulate and hide any cycles from the
+    /// strongly-connected components encapsulate and hide any cycles from the
     /// input graph.
     ///
     /// I am not aware of an existing name for the reverse (or transpose)

--- a/crates/fiber/src/unix.rs
+++ b/crates/fiber/src/unix.rs
@@ -80,7 +80,7 @@ fn host_page_size() -> usize {
 impl FiberStack {
     pub fn new(size: usize, zeroed: bool) -> io::Result<Self> {
         let page_size = host_page_size();
-        // The anonymous `mmap`s we use for `FiberStackStorage` are alawys
+        // The anonymous `mmap`s we use for `FiberStackStorage` are always
         // zeroed.
         let _ = zeroed;
 

--- a/crates/fuzzing/src/generators/gc_ops/types.rs
+++ b/crates/fuzzing/src/generators/gc_ops/types.rs
@@ -23,7 +23,7 @@ pub struct StructType {
     // Empty for now; fields will come in a future PR.
 }
 
-/// CompsiteType definition.
+/// CompositeType definition.
 #[derive(Debug, Serialize, Deserialize)]
 pub enum CompositeType {
     /// Struct Type definition.

--- a/crates/fuzzing/src/oom.rs
+++ b/crates/fuzzing/src/oom.rs
@@ -178,7 +178,7 @@ unsafe impl GlobalAlloc for OomTestAllocator {
 /// use wasmtime_fuzzing::oom::{OomTest, OomTestAllocator};
 ///
 /// #[global_allocator]
-/// static GLOBAL_ALOCATOR: OomTestAllocator = OomTestAllocator::new();
+/// static GLOBAL_ALLOCATOR: OomTestAllocator = OomTestAllocator::new();
 ///
 /// #[test]
 /// fn my_oom_test() -> Result<()> {

--- a/crates/test-macros/src/wasmtime_test.rs
+++ b/crates/test-macros/src/wasmtime_test.rs
@@ -228,7 +228,7 @@ fn expand(test_config: &TestConfig, func: Fn) -> Result<TokenStream> {
         let func_name = &func.sig.ident;
         match &func.sig.output {
             ReturnType::Default => {
-                return Err(syn::Error::new(func_name.span(), "Expected `Restult<()>`"));
+                return Err(syn::Error::new(func_name.span(), "Expected `Result<()>`"));
             }
             ReturnType::Type(..) => {}
         };

--- a/crates/test-programs/src/bin/async_cancel_caller.rs
+++ b/crates/test-programs/src/bin/async_cancel_caller.rs
@@ -139,7 +139,7 @@ unsafe extern "C" fn callback_run(event0: u32, event1: u32, event2: u32) -> u32 
             } => {
                 assert_eq!(event0, EVENT_NONE);
 
-                // First, call and cancel `yield_with_options::yield_tiems`
+                // First, call and cancel `yield_with_options::yield_times`
                 // with backpressure enabled.  Cancelling should not block since
                 // the call will not even have started.
 

--- a/crates/test-util/src/component_fuzz.rs
+++ b/crates/test-util/src/component_fuzz.rs
@@ -930,7 +930,7 @@ fn make_import_and_export(
     wat.push_str("))\n");
 
     // If the export is async, generate `task.return` as an import as well
-    // which is necesary to communicate the results.
+    // which is necessary to communicate the results.
     if export_results_loc.is_none() {
         wat.push_str(&format!("(type $task.return (func"));
         push_params(&mut wat, &result_lowered, MAX_FLAT_PARAMS);

--- a/crates/wasi-http/src/handler.rs
+++ b/crates/wasi-http/src/handler.rs
@@ -374,10 +374,10 @@ where
                     // new task from the queue.
                     //
                     // Note the the order of operations here is important.  By
-                    // polling `next_future` first, we'll disover any tasks that
+                    // polling `next_future` first, we'll discover any tasks that
                     // may have timed out, at which point we'll stop accepting
                     // new tasks altogether (see below for details).  This is
-                    // especially imporant in the case where the task was
+                    // especially important in the case where the task was
                     // blocked on a synchronous call to a host function which
                     // has exclusive access to the `Store`; once that call
                     // finishes, the first think we need to do is time out the

--- a/crates/wasi-io/src/impls.rs
+++ b/crates/wasi-io/src/impls.rs
@@ -46,10 +46,10 @@ impl poll::Host for ResourceTable {
             fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
                 let mut any_ready = false;
                 let mut results = Vec::new();
-                for (fut, readylist_indicies) in self.futures.iter_mut() {
+                for (fut, readylist_indices) in self.futures.iter_mut() {
                     match fut.as_mut().poll(cx) {
                         Poll::Ready(()) => {
-                            results.extend_from_slice(readylist_indicies);
+                            results.extend_from_slice(readylist_indices);
                             any_ready = true;
                         }
                         Poll::Pending => {}

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -3015,7 +3015,7 @@ impl Config {
     /// The WebAssembly threads proposal, configured by [`Config::wasm_threads`]
     /// is on-by-default but there are enough deficiencies in Wasmtime's
     /// implementation and API integration that creation of a shared memory is
-    /// disabled by default. This cofiguration knob can be used to enable this.
+    /// disabled by default. This configuration knob can be used to enable this.
     ///
     /// When enabling this method be aware that wasm threads are, at this time,
     /// a [tier 2

--- a/crates/wasmtime/src/runtime/code_memory.rs
+++ b/crates/wasmtime/src/runtime/code_memory.rs
@@ -564,7 +564,7 @@ impl CodeMemory {
     pub fn text_mut(&mut self) -> &mut [u8] {
         assert!(!self.published);
         // SAFETY: we assert !published, which means we either have
-        // not yet applied readonly + execute permissinos, or we have
+        // not yet applied readonly + execute permissions, or we have
         // undone that and flipped back to read-write via unpublish.
         unsafe { &mut self.mmap.as_mut_slice()[self.text.clone()] }
     }

--- a/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams.rs
@@ -2118,7 +2118,7 @@ struct TransmitState {
     write: WriteState,
     /// See `ReadState`
     read: ReadState,
-    /// Whether futher values may be transmitted via this stream or future.
+    /// Whether further values may be transmitted via this stream or future.
     done: bool,
     /// The original creator of this stream, used for type-checking with
     /// `{Future,Stream}Any`.
@@ -2784,7 +2784,7 @@ impl<T> StoreContextMut<'_, T> {
                             &WriteState::GuestReady { count, .. } => count,
                             WriteState::HostReady { .. } => match host_buffer_remaining_before {
                                 Some(n) => n,
-                                None => bail_bug!("host_buffer_remaining_before shoudl be set"),
+                                None => bail_bug!("host_buffer_remaining_before should be set"),
                             },
                             _ => bail_bug!("invalid write state"),
                         },

--- a/crates/wasmtime/src/runtime/debug.rs
+++ b/crates/wasmtime/src/runtime/debug.rs
@@ -54,7 +54,7 @@ impl<T> Store<T> {
     /// purposes.
     ///
     /// Guest debugging must be enabled for this accessor to return
-    /// any instances. If it is not, an empty vector is returend.
+    /// any instances. If it is not, an empty vector is returned.
     pub fn debug_all_instances(&mut self) -> Vec<Instance> {
         self.as_store_opaque().debug_all_instances()
     }
@@ -63,7 +63,7 @@ impl<T> Store<T> {
     /// purposes.
     ///
     /// Guest debugging must be enabled for this accessor to return
-    /// any modules. If it is not, an empty vector is returend.
+    /// any modules. If it is not, an empty vector is returned.
     pub fn debug_all_modules(&mut self) -> Vec<Module> {
         self.as_store_opaque().debug_all_modules()
     }

--- a/crates/wasmtime/src/runtime/externals/table.rs
+++ b/crates/wasmtime/src/runtime/externals/table.rs
@@ -346,7 +346,7 @@ impl Table {
     ///
     /// # Panics
     ///
-    /// This function will panic when if the store doens't own the table.
+    /// This function will panic when if the store doesn't own the table.
     #[cfg(feature = "async")]
     pub async fn grow_async(
         &self,

--- a/crates/wasmtime/src/runtime/store.rs
+++ b/crates/wasmtime/src/runtime/store.rs
@@ -1536,7 +1536,7 @@ impl<T> StoreInner<T> {
         // noop shim so code can assume this always exists.
     }
 
-    /// Splits this `StoreInner<T>` into a `limiter`/`StoerOpaque` borrow while
+    /// Splits this `StoreInner<T>` into a `limiter`/`StoreOpaque` borrow while
     /// validating that an async limiter is not configured.
     ///
     /// This is used for sync entrypoints which need to fail if an async limiter

--- a/crates/wasmtime/src/runtime/vm/instance.rs
+++ b/crates/wasmtime/src/runtime/vm/instance.rs
@@ -1714,7 +1714,7 @@ pub struct OwnedVMContext<T> {
     /// The long version of why this field exists is that the rules that MIRI
     /// uses to ensure pointers are used correctly have various conditions on
     /// them depend on how pointers are used. More specifically if `*mut T` is
-    /// derived from `&mut T`, then that invalidates all prior pointers drived
+    /// derived from `&mut T`, then that invalidates all prior pointers derived
     /// from the `&mut T`. This means that while we liberally want to re-acquire
     /// a `*mut VMContext` throughout the implementation of `Instance` the
     /// trivial way, a function `fn vmctx(Pin<&mut Instance>) -> *mut VMContext`

--- a/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/memory_pool.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/memory_pool.rs
@@ -167,7 +167,7 @@ enum ImageSlot {
     ///
     /// Future use of this slot will use `MemoryImageSlot` to continue to
     /// re-instantiate and reuse images and such. This state is entered after
-    /// and allocated slot is successfully deallcoated.
+    /// and allocated slot is successfully deallocated.
     PreviouslyUsed(MemoryImageSlot),
 }
 

--- a/crates/wasmtime/src/runtime/vm/stack_switching.rs
+++ b/crates/wasmtime/src/runtime/vm/stack_switching.rs
@@ -182,7 +182,7 @@ impl<T> VMHostArray<T> {
 pub type VMPayloads = VMHostArray<u128>;
 
 /// Type for a list of handlers, represented by the handled tag. Thus, the
-/// stored data is actually `*mut VMTagDefinition`, but we don't havr access to
+/// stored data is actually `*mut VMTagDefinition`, but we don't have access to
 /// that here.
 pub type VMHandlerList = VMHostArray<*mut u8>;
 

--- a/crates/wiggle/tests/wasi.rs
+++ b/crates/wiggle/tests/wasi.rs
@@ -132,7 +132,7 @@ impl<'a> crate::wasi_snapshot_preview1::WasiSnapshotPreview1 for WasiCtx<'a> {
         _memory: &mut GuestMemory<'_>,
         _fd: types::Fd,
         _fs_rights_base: types::Rights,
-        _fs_rights_inherting: types::Rights,
+        _fs_rights_inheriting: types::Rights,
     ) -> Result<()> {
         unimplemented!("fd_fdstat_set_rights")
     }
@@ -315,7 +315,7 @@ impl<'a> crate::wasi_snapshot_preview1::WasiSnapshotPreview1 for WasiCtx<'a> {
         _path: GuestPtr<str>,
         _oflags: types::Oflags,
         _fs_rights_base: types::Rights,
-        _fs_rights_inherting: types::Rights,
+        _fs_rights_inheriting: types::Rights,
         _fdflags: types::Fdflags,
     ) -> Result<types::Fd> {
         unimplemented!("path_open")

--- a/crates/wizer/README.md
+++ b/crates/wizer/README.md
@@ -131,7 +131,7 @@ initialization function. Then we record the Wasm instance's state:
 * What are the values of its globals?
 * What regions of memory are non-zero?
 
-Then we rewrite the Wasm binary by intializing its globals directly to their
+Then we rewrite the Wasm binary by initializing its globals directly to their
 recorded state, and removing the module's old data segments and replacing them
 with data segments for each of the non-zero regions of memory we recorded.
 

--- a/crates/wizer/src/component/wasmtime.rs
+++ b/crates/wizer/src/component/wasmtime.rs
@@ -75,7 +75,7 @@ impl Wizer {
     }
 }
 
-/// Impementation of [`ComponentInstanceState`] backed by Wasmtime.
+/// Implementation of [`ComponentInstanceState`] backed by Wasmtime.
 pub struct WasmtimeWizerComponent<'a, T: 'static> {
     /// The Wasmtime-based store that owns the `instance` field.
     pub store: &'a mut Store<T>,

--- a/crates/wizer/src/wasmtime.rs
+++ b/crates/wizer/src/wasmtime.rs
@@ -86,7 +86,7 @@ impl Wizer {
     }
 }
 
-/// Impementation of [`InstanceState`] backed by Wasmtime.
+/// Implementation of [`InstanceState`] backed by Wasmtime.
 pub struct WasmtimeWizer<'a, T: 'static> {
     /// The Wasmtime-based store that owns the `instance` field.
     pub store: &'a mut Store<T>,

--- a/pulley/src/disas.rs
+++ b/pulley/src/disas.rs
@@ -321,7 +321,7 @@ macro_rules! impl_disas {
         )*
     };
 
-    // Diassembling `br_table` is a bit special as it has trailing byte after
+    // Disassembling `br_table` is a bit special as it has trailing byte after
     // the opcode of the branch table itself.
     (
         @one br_table32 = BrTable32 $( {

--- a/pulley/src/interp.rs
+++ b/pulley/src/interp.rs
@@ -137,7 +137,7 @@ impl Vm {
         mem::replace(&mut self.state.lr, HOST_RETURN_ADDR)
     }
 
-    /// Peforms the internal part of [`Vm::call`] where bytecode is actually
+    /// Performs the internal part of [`Vm::call`] where bytecode is actually
     /// executed.
     ///
     /// # Unsafety
@@ -156,7 +156,7 @@ impl Vm {
         self.state.done_decode(done)
     }
 
-    /// Peforms the tail end of [`Vm::call`] by returning the values as
+    /// Performs the tail end of [`Vm::call`] by returning the values as
     /// determined by `rets` according to Pulley's ABI.
     ///
     /// The `old_ret` value should have been provided from `call_start`

--- a/pulley/src/regs.rs
+++ b/pulley/src/regs.rs
@@ -332,7 +332,7 @@ impl<'a, R: Reg> arbitrary::Arbitrary<'a> for UpperRegSet<R> {
     }
 }
 
-/// Immediate used for the "o32" addresing mode.
+/// Immediate used for the "o32" addressing mode.
 ///
 /// This addressing mode represents a host address stored in `self.addr` which
 /// is byte-offset by `self.offset`.
@@ -347,7 +347,7 @@ pub struct AddrO32 {
     pub offset: i32,
 }
 
-/// Immediate used for the "z" addresing mode.
+/// Immediate used for the "z" addressing mode.
 ///
 /// This addressing mode represents a host address stored in `self.addr` which
 /// is byte-offset by `self.offset`.

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -82,7 +82,7 @@ impl RunCommand {
     /// the debugger component environment.
     ///
     /// This also adjusts the guest options as needed to enable
-    /// debugging (e.g., implictly set `-D guest-debug=y`).
+    /// debugging (e.g., implicitly set `-D guest-debug=y`).
     #[cfg(feature = "debug")]
     pub(crate) fn debugger_run(&mut self) -> Result<Option<RunCommand>> {
         fn set_implicit_option(

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -3899,7 +3899,7 @@ notes = "one use of unsafe to call windows specific api to get console handle."
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
 delta = "0.46.0 -> 0.50.1"
-notes = "Lots of stylistic/rust-related chanegs, plus new features, but nothing out of the ordrinary."
+notes = "Lots of stylistic/rust-related changes, plus new features, but nothing out of the ordrinary."
 
 [[audits.nu-ansi-term]]
 who = "Alex Crichton <alex@alexcrichton.com>"

--- a/tests/all/iloop.rs
+++ b/tests/all/iloop.rs
@@ -3,7 +3,7 @@
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering::SeqCst};
 use wasmtime::*;
 
-fn interruptable_store() -> Store<()> {
+fn interruptible_store() -> Store<()> {
     let engine = Engine::new(Config::new().epoch_interruption(true)).unwrap();
     let mut store = Store::new(&engine, ());
     store.set_epoch_deadline(1);
@@ -27,8 +27,8 @@ fn hugely_recursive_module(engine: &Engine) -> wasmtime::Result<Module> {
 }
 
 #[test]
-fn loops_interruptable() -> wasmtime::Result<()> {
-    let mut store = interruptable_store();
+fn loops_interruptible() -> wasmtime::Result<()> {
+    let mut store = interruptible_store();
     let module = Module::new(store.engine(), r#"(func (export "loop") (loop br 0))"#)?;
     let instance = Instance::new(&mut store, &module, &[])?;
     let iloop = instance.get_typed_func::<(), ()>(&mut store, "loop")?;
@@ -39,8 +39,8 @@ fn loops_interruptable() -> wasmtime::Result<()> {
 }
 
 #[test]
-fn functions_interruptable() -> wasmtime::Result<()> {
-    let mut store = interruptable_store();
+fn functions_interruptible() -> wasmtime::Result<()> {
+    let mut store = interruptible_store();
     let module = hugely_recursive_module(store.engine())?;
     let func = Func::wrap(&mut store, || {});
     let instance = Instance::new(&mut store, &module, &[func.into()])?;
@@ -60,7 +60,7 @@ fn loop_interrupt_from_afar() -> wasmtime::Result<()> {
     // far.
     static HITS: AtomicUsize = AtomicUsize::new(0);
     static STOP: AtomicBool = AtomicBool::new(false);
-    let mut store = interruptable_store();
+    let mut store = interruptible_store();
     let module = Module::new(
         store.engine(),
         r#"
@@ -108,7 +108,7 @@ fn function_interrupt_from_afar() -> wasmtime::Result<()> {
     static HITS: AtomicUsize = AtomicUsize::new(0);
     static STOP: AtomicBool = AtomicBool::new(false);
 
-    let mut store = interruptable_store();
+    let mut store = interruptible_store();
     let module = hugely_recursive_module(store.engine())?;
     let func = Func::wrap(&mut store, || {
         HITS.fetch_add(1, SeqCst);

--- a/tests/disas/stack-switching/resume-suspend-data-passing.wat
+++ b/tests/disas/stack-switching/resume-suspend-data-passing.wat
@@ -11,7 +11,7 @@
     (local $i i32)
     (local.set $i (i32.const 10))
     (loop $loop
-      ;; suspend and pass countdown to our cosnumer
+      ;; suspend and pass countdown to our consumer
       (suspend $t (local.get $i))
       ;; decrement i; break if we're at 0
       (local.tee $i (i32.sub (local.get $i) (i32.const 1)))

--- a/tests/misc_testsuite/issue1809.wast
+++ b/tests/misc_testsuite/issue1809.wast
@@ -479,7 +479,7 @@
         (i32.store
           (i32.const 1048576)
           (global.get $__data_efd)))))
-  (memory $memroy (export "memroy") 17)
+  (memory $memory (export "memroy") 17)
   (global $g0 (mut i32) (i32.const 1048576))
   (global $__data_efd (export "__data_efd") i32 (i32.const 1048580))
   (global $__heap_bare (export "__heap_bare") i32 (i32.const 1048580)))

--- a/winch/README.md
+++ b/winch/README.md
@@ -22,7 +22,7 @@
 Winch is a WebAssembly "baseline" or single-pass compiler designed for Wasmtime.
 
 Winch's primary goal is compilation performance, therefore only certain, very
-limited peephole optimations are applied.
+limited peephole optimizations are applied.
 
 For more details on the original motivation and goals, refer to the [Bytecode
 Alliance RFC for Baseline Compilation in Wasmtime.][rfc].

--- a/winch/codegen/src/isa/aarch64/masm.rs
+++ b/winch/codegen/src/isa/aarch64/masm.rs
@@ -1571,7 +1571,7 @@ impl MacroAssembler {
         self.asm.mov_rr(sp, writable!(shadow_sp), OperandSize::S64);
     }
 
-    /// Heloper to add an immediate to a register.
+    /// Helper to add an immediate to a register.
     fn add_ir(&mut self, dst: WritableReg, lhs: Reg, rhs: I, size: OperandSize) -> Result<()> {
         let imm = rhs.unwrap_as_u64();
         match Imm12::maybe_from_u64(imm) {


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->

Hello, this PR just corrects many typos like below:

- `addresing` -> `addressing`
- `alawys` -> `always`
- `alocator` -> `allocator`
- `appplicable` -> `applicable`
- `assigment` -> `assignment`
- `chanegs` -> `changes`
- `codgen` -> `codegen`
- `cofiguration` -> `configuration`
- `comparion` -> `comparison`
- `compsite` -> `composite`
- `conneted` -> `connected`
- `connnected` -> `connected`
- `constand` -> `constant`
- `contrain` -> `constrain`
- `conveniene` -> `convenience`
- `cosnt` -> `const`
- `cosnumer` -> `consumer`
- `deallcoated` -> `deallocated`
- `debugee` -> `debuggee`
- `defered` -> `deferred`
- `definie` -> `definite`
- `determinstic` -> `deterministic`
- `diassembling` -> `disassembling`
- `disover` -> `discover`
- `divison` -> `division`
- `doens` -> `doesn`
- `drived` -> `derived`
- `efficively` -> `effectively`
- `endianess` -> `endianness`
- `enties` -> `entries`
- `floatint` -> `floating`
- `funcionality` -> `functionality`
- `functio` -> `function`
- `futher` -> `further`
- `generaed` -> `generated`
- `havr` -> `have`
- `heloper` -> `helper`
- `hueristics` -> `heuristics`
- `immedaite` -> `immediate`
- `impementation` -> `implementation`
- `implictly` -> `implicitly`
- `imporant` -> `important`
- `indicies` -> `indices`
- `inherting` -> `inheriting`
- `initalizing` -> `initializing`
- `instructios` -> `instructions`
- `instuction` -> `instruction`
- `intance` -> `instance`
- `interruptable` -> `interruptible`
- `intializing` -> `initializing`
- `leafs` -> `leaves`
- `litle` -> `little`
- `memroy` -> `memory`
- `miltiple` -> `multiple`
- `necesary` -> `necessary`
- `optimations` -> `optimizations`
- `paylaod` -> `payload`
- `peforms` -> `performs`
- `permissinos` -> `permissions`
- `primtives` -> `primitives`
- `pseduo` -> `pseudo`
- `refering` -> `referring`
- `restult` -> `result`
- `returend` -> `returned`
- `semanitcs` -> `semantics`
- `shoudl` -> `should`
- `stoer` -> `store`
- `strack` -> `stack`
- `tiems` -> `times`
- `vaiant` -> `variant`
