### PR TITLE
Add `OutOfMemory` to `wasmtime_environ::prelude`

### DIFF
--- a/crates/environ/src/prelude.rs
+++ b/crates/environ/src/prelude.rs
@@ -24,7 +24,7 @@ pub use crate::collections::{
     TryHashSet, TryIndexMap, TryNew, TryPrimaryMap, TrySecondaryMap, TryString, TryToOwned, TryVec,
     try_new, try_vec,
 };
-pub use crate::error::{Context, Error, Result, bail, ensure, format_err};
+pub use crate::error::{Context, Error, OutOfMemory, Result, bail, ensure, format_err};
 pub use alloc::borrow::ToOwned;
 pub use alloc::boxed::Box;
 pub use alloc::format;


### PR DESCRIPTION
No need to keep manually importing this, when it is pretty core to the runtime at this point, and also has little risk of conflicting with another item.