### PR TITLE
Implement `DoubleEndedIterator` for `TryBTreeMap`'s range iterator

### DIFF
--- a/crates/environ/src/collections/btree_map.rs
+++ b/crates/environ/src/collections/btree_map.rs
@@ -409,6 +409,16 @@ where
     }
 }
 
+impl<'a, K, V> DoubleEndedIterator for BTreeMapRange<'a, K, V>
+where
+    K: Copy + Ord,
+{
+    fn next_back(&mut self) -> Option<Self::Item> {
+        let (key, id) = self.inner.next_back()?;
+        Some((key, &self.values[id]))
+    }
+}
+
 /// A range iterator of `(K, &'a V)` items returned by [`TryBTreeMap::range`].
 pub struct BTreeMapRangeMut<'a, K, V>
 where


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
