### PR TITLE
Cranelift: perform aggressive splitting of generated ISLE function bodies in debug builds.

### DIFF
--- a/cranelift/codegen/build.rs
+++ b/cranelift/codegen/build.rs
@@ -216,12 +216,26 @@ fn run_compilation(compilation: &IsleCompilation) -> Result<(), Errors> {
         // the generated code to help debug rule matching.
         options.emit_logging = std::env::var("CARGO_FEATURE_TRACE_LOG").is_ok();
 
-        // Enable optional match-arm splitting in iterator terms for faster compile times.
-        options.split_match_arms = std::env::var("CARGO_FEATURE_ISLE_SPLIT_MATCH").is_ok();
-        if let Ok(value) = std::env::var("ISLE_SPLIT_MATCH_THRESHOLD") {
-            options.match_arm_split_threshold = Some(value.parse().unwrap_or_else(|err| {
-                panic!("invalid ISLE_SPLIT_MATCH_THRESHOLD value '{value}': {err}");
-            }));
+        // Enable optional match-arm splitting in iterator terms for
+        // faster compile times in release builds.
+        //
+        // In debug builds, *always* split with an aggressive
+        // threshold, because we cannot rely on rustc doing regalloc
+        // on all of the local bindings to shrink the stack frame to a
+        // reasonable size.
+        #[cfg(not(debug_assertions))]
+        {
+            options.split_match_arms = std::env::var("CARGO_FEATURE_ISLE_SPLIT_MATCH").is_ok();
+            if let Ok(value) = std::env::var("ISLE_SPLIT_MATCH_THRESHOLD") {
+                options.match_arm_split_threshold = Some(value.parse().unwrap_or_else(|err| {
+                    panic!("invalid ISLE_SPLIT_MATCH_THRESHOLD value '{value}': {err}");
+                }));
+            }
+        }
+        #[cfg(debug_assertions)]
+        {
+            options.split_match_arms = true;
+            options.match_arm_split_threshold = Some(4);
         }
 
         if let Ok(out_dir) = std::env::var("OUT_DIR") {


### PR DESCRIPTION
As investigated in #12821, ISLE-generated Rust code with many locals in one large function body results in unreasonably-large stack frames when rustc's optimizations (and therefore LLVM's mem2reg) are disabled. In `constructor_simplify`, a single function body generated from all mid-end rewrite rules, I was seeing a stack-frame size of `0x44000` bytes (272 KiB) on x86-64 (while in an opt build it is `0x1000` bytes (4 KiB)). With a recursion depth of 5 (the default limit) for rewrites of RHS-created nodes, this has the potential to overrun a 1 MiB stack; and is generally quite wasteful.

In [another branch] I attempted to make `islec` do manual regalloc of a sort just for multi-extractor iterators; but soon realized that the problem has to do with *all* locals (which become `alloca`s in LLVM IR), not just the iterators. We could do the equivalent thing to share all locals but this would become grossly un-idiomatic for e.g. LHSes of destructuring in Rust.

Instead, this PR leverages previous work in #12303 (thanks Bongjun!) that splits function bodies in the generated Rust code from ISLE with a configurable threshold. This PR enables that feature and makes the threshold quite low in debug builds. This has the natural effect of splitting locals among many smaller stack frames, which are dynamically pushed only when matching enters a particular subtree; so stack usage more closely mirrors the actual live-set of values bound during matching.

With this change, the stack frame for the top-level `constructor_simplify` is < 4 KiB on x86-64 in a debug build.

Fixes #12821.

[another branch]: https://github.com/cfallin/wasmtime/tree/isle-iterator-reuse

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
