### PR TITLE
pulley: fix XDiv32U opcode in xdiv32_u divide-by-zero trap

### DIFF
--- a/pulley/src/interp.rs
+++ b/pulley/src/interp.rs
@@ -2193,7 +2193,7 @@ impl OpVisitor for Interpreter<'_> {
                 self.state[operands.dst].set_u32(result);
                 ControlFlow::Continue(())
             }
-            None => self.done_trap_kind::<crate::XDiv64U>(Some(TrapKind::DivideByZero)),
+            None => self.done_trap_kind::<crate::XDiv32U>(Some(TrapKind::DivideByZero)),
         }
     }
 


### PR DESCRIPTION
## Summary

Fix a copy-paste bug in the Pulley interpreter: `xdiv32_u` reported divide-by-zero traps with the wrong opcode type parameter (`XDiv64U` instead of `XDiv32U`).

## Testing

- Change is a one-line opcode fix aligned with `xdiv64_u` and other 32-bit ops; no behavioral change to trapping itself beyond correct trap metadata.