### PR TITLE
Fix fmin f16 cprop rule using $F32 instead of $F16

### DIFF
--- a/cranelift/codegen/src/opts/cprop.isle
+++ b/cranelift/codegen/src/opts/cprop.isle
@@ -403,7 +403,7 @@
 
 (rule (simplify (fmin $F16 (f16const $F16 n) (f16const $F16 m)))
       (if-let r (f16_min n m))
-      (subsume (f16const $F32 r)))
+      (subsume (f16const $F16 r)))
 (rule (simplify (fmin $F32 (f32const $F32 n) (f32const $F32 m)))
       (if-let r (f32_min n m))
       (subsume (f32const $F32 r)))

--- a/cranelift/filetests/filetests/egraph/cprop.clif
+++ b/cranelift/filetests/filetests/egraph/cprop.clif
@@ -484,6 +484,19 @@ block0:
 ; check: v4 = f16const -0.0
 ; check: return v4  ; v4 = -0.0
 
+function %f16_fmin_promotes_correctly() -> f64 {
+block0:
+    v1 = f16const 0x1.0p0
+    v2 = f16const 0x1.0p1
+    v3 = fmin v1, v2
+    v4 = fpromote.f64 v3
+    return v4
+}
+
+; check: v5 = f16const 0x1.000p0
+; check: v4 = fpromote.f64 v5  ; v5 = 0x1.000p0
+; check: return v4
+
 function %f16_fmax() -> f16 {
 block0:
     v1 = f16const -0x1.5p6


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->

Typo in the `fmin` f16 constant propagation rule causes the folded constant to be typed as F32 instead of F16. This means the 16-bit float bit pattern gets reinterpreted as a 32-bit float in any subsequent type-dependent operation (e.g., `fpromote`) producing incorrect values.

https://github.com/bytecodealliance/wasmtime/blob/c7d25dfd8cf0adaab2629166b80141a58c2329d9/cranelift/codegen/src/opts/cprop.isle#L406

The adjacent `fmax` f16 rule has the correct typing.

https://github.com/bytecodealliance/wasmtime/blob/c7d25dfd8cf0adaab2629166b80141a58c2329d9/cranelift/codegen/src/opts/cprop.isle#L419

This PR fixes the typo and adds a regression test that folds `fmin` on two f16 constants and promotes the result, verifying the fix.