### PR TITLE
Fix `ExtendedOpcode::MAX` for Pulley

### DIFF
--- a/pulley/src/interp/tail_loop.rs
+++ b/pulley/src/interp/tail_loop.rs
@@ -128,9 +128,7 @@ static OPCODE_HANDLER_TABLE: [Handler; Opcode::MAX as usize + 1] = {
     for_each_op!(define_opcode_handler_table)
 };
 
-// same as above, but without a +1 for handling of extended ops as this is the
-// extended ops.
-static EXTENDED_OPCODE_HANDLER_TABLE: [Handler; ExtendedOpcode::MAX as usize] = {
+static EXTENDED_OPCODE_HANDLER_TABLE: [Handler; ExtendedOpcode::MAX as usize + 1] = {
     macro_rules! define_extended_opcode_handler_table {
         ($(
             $( #[$attr:meta] )*

--- a/pulley/src/opcode.rs
+++ b/pulley/src/opcode.rs
@@ -76,7 +76,7 @@ macro_rules! define_extended_opcode {
             /// The value of the maximum defined extended opcode.
             pub const MAX: u16 = $(
                 if true { 1 } else { ExtendedOpcode::$name as u16 } +
-            )* 0;
+            )* 0 - 1;
         }
     };
 }
@@ -102,5 +102,18 @@ impl ExtendedOpcode {
     pub unsafe fn unchecked_new(byte: u16) -> Self {
         debug_assert!(byte <= Self::MAX);
         unsafe { core::mem::transmute(byte) }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn max_values() {
+        assert!(Opcode::new(Opcode::MAX).is_some());
+        assert!(Opcode::new(Opcode::MAX + 1).is_none());
+        assert!(ExtendedOpcode::new(ExtendedOpcode::MAX).is_some());
+        assert!(ExtendedOpcode::new(ExtendedOpcode::MAX + 1).is_none());
     }
 }


### PR DESCRIPTION
This was off-by-one which could lead to possible undefined behavior in Miri and at runtime when disassembling invalid opcodes. This isn't reachable from Wasmtime itself since Cranelift only generates valid opcodes, but it's nonetheless reachable via `wasmtime objdump` and still good to fix.

Closes #12813

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
