### PR TITLE
Fix logic and double-drop UB in `WriteBuffer` impls

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1203,7 +1203,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - crate: "wasmtime"
+          - crate: "wasmtime --features component-model-async-bytes"
           - crate: "wasmtime-cli"
           - crate: "wasmtime-environ --all-features"
           - crate: "pulley-interpreter --all-features"

--- a/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams/buffers.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams/buffers.rs
@@ -256,7 +256,7 @@ unsafe impl WriteBuffer<u8> for SliceBuffer {
         // always be sound.
         fun(unsafe {
             mem::transmute::<&[u8], &[MaybeUninit<u8>]>(
-                &self.buffer[self.offset - count..self.limit],
+                &self.buffer[self.offset - count..self.offset],
             )
         });
     }
@@ -330,7 +330,7 @@ unsafe impl<T: Send + Sync + 'static> WriteBuffer<T> for VecBuffer<T> {
         // ensure that if `fun` panics that the items are still considered
         // transferred.
         self.offset += count;
-        fun(&self.buffer[self.offset - count..]);
+        fun(&self.buffer[self.offset - count..self.offset]);
     }
 }
 
@@ -396,7 +396,7 @@ unsafe impl WriteBuffer<u8> for Cursor<Bytes> {
 
     fn take(&mut self, count: usize, fun: &mut dyn FnMut(&[MaybeUninit<u8>])) {
         assert!(count <= self.remaining().len());
-        fun(unsafe_byte_slice(self.remaining()));
+        fun(unsafe_byte_slice(&self.remaining()[..count]));
         self.skip(count);
     }
 }
@@ -420,7 +420,7 @@ unsafe impl WriteBuffer<u8> for Cursor<BytesMut> {
 
     fn take(&mut self, count: usize, fun: &mut dyn FnMut(&[MaybeUninit<u8>])) {
         assert!(count <= self.remaining().len());
-        fun(unsafe_byte_slice(self.remaining()));
+        fun(unsafe_byte_slice(&self.remaining()[..count]));
         self.skip(count);
     }
 }
@@ -452,4 +452,67 @@ fn unsafe_byte_slice(slice: &[u8]) -> &[MaybeUninit<u8>] {
     // SAFETY: it's always safe to interpret a slice of items as a
     // possibly-initialized slice of items.
     unsafe { mem::transmute::<&[u8], &[MaybeUninit<u8>]>(slice) }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::prelude::*;
+
+    #[test]
+    fn test_vec_buffer_take() {
+        let mut buf = VecBuffer::from(vec!["a".to_string(), "b".to_string(), "c".to_string()]);
+        let mut dst = Vec::new();
+        dst.reserve(1);
+        dst.move_from(&mut buf, 1);
+        assert_eq!(buf.remaining().len(), 2);
+        assert_eq!(dst.len(), 1);
+        None.move_from(&mut buf, 1);
+        assert_eq!(buf.remaining().len(), 1);
+        assert_eq!(dst.len(), 1);
+    }
+
+    #[test]
+    fn test_slice_buffer_take() {
+        let mut buf = SliceBuffer::new(vec![1, 2, 3], 0, 3);
+        let mut dst = Vec::new();
+        dst.reserve(1);
+        dst.move_from(&mut buf, 1);
+        assert_eq!(buf.remaining().len(), 2);
+        assert_eq!(dst.len(), 1);
+    }
+
+    #[test]
+    #[cfg(feature = "component-model-async-bytes")]
+    fn test_cursor_bytes_take() {
+        let mut buf = Cursor::new(Bytes::from(&b"123"[..]));
+        let mut dst = Vec::new();
+        dst.reserve(1);
+        dst.move_from(&mut buf, 1);
+        assert_eq!(buf.remaining().len(), 2);
+        assert_eq!(dst.len(), 1);
+
+        let mut dst = BytesMut::new();
+        dst.reserve(1);
+        dst.move_from(&mut buf, 1);
+        assert_eq!(buf.remaining().len(), 1);
+        assert_eq!(dst.len(), 1);
+    }
+
+    #[test]
+    #[cfg(feature = "component-model-async-bytes")]
+    fn test_cursor_bytes_mut_take() {
+        let mut buf = Cursor::new(BytesMut::from(&b"123"[..]));
+        let mut dst = Vec::new();
+        dst.reserve(1);
+        dst.move_from(&mut buf, 1);
+        assert_eq!(buf.remaining().len(), 2);
+        assert_eq!(dst.len(), 1);
+
+        let mut dst = BytesMut::new();
+        dst.reserve(1);
+        dst.move_from(&mut buf, 1);
+        assert_eq!(buf.remaining().len(), 1);
+        assert_eq!(dst.len(), 1);
+    }
 }


### PR DESCRIPTION
For component-model-async this fixes logic and undefined behavior issues in the implementation of the `WriteBuffer` trait for various types. Notably all types didn't respect the `unsafe` contract of the `WriteBuffer::take` method by limiting the number of results to what was requested. This flawed detail, when coupled with other implementation details, led to both incorrect results and UB in the case that `VecBuffer<T>` was used where `T` had a `Drop` implementation. This is not a security issue because component-model-async is not yet Tier 1 and thus is exempt from the security issue process, but this is nonetheless something needed to be fixed.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
