### PR TITLE
Remove some more panics in `concurrent.rs`

### DIFF
--- a/crates/wasmtime/src/runtime/component/concurrent.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent.rs
@@ -5150,27 +5150,27 @@ impl ConcurrentState {
     ///
     /// The `task` is bit-packed as returned by `current_call_context_scope_id`
     /// below.
-    pub fn call_context(&mut self, task: u32) -> &mut CallContext {
+    pub fn call_context(&mut self, task: u32) -> Result<&mut CallContext> {
         let (task, is_host) = (task >> 1, task & 1 == 1);
         if is_host {
             let task: TableId<HostTask> = TableId::new(task);
-            &mut self.get_mut(task).unwrap().call_context
+            Ok(&mut self.get_mut(task)?.call_context)
         } else {
             let task: TableId<GuestTask> = TableId::new(task);
-            &mut self.get_mut(task).unwrap().call_context
+            Ok(&mut self.get_mut(task)?.call_context)
         }
     }
 
     /// Used by `ResourceTables` to record the scope of a borrow to get undone
     /// in the future.
-    pub fn current_call_context_scope_id(&self) -> u32 {
+    pub fn current_call_context_scope_id(&self) -> Result<u32> {
         let (bits, is_host) = match self.current_thread {
             CurrentThread::Guest(id) => (id.task.rep(), false),
             CurrentThread::Host(id) => (id.rep(), true),
-            CurrentThread::None => unreachable!(),
+            CurrentThread::None => bail_bug!("current thread is not set"),
         };
         assert_eq!((bits << 1) >> 1, bits);
-        (bits << 1) | u32::from(is_host)
+        Ok((bits << 1) | u32::from(is_host))
     }
 
     fn current_guest_thread(&self) -> Result<QualifiedThreadId> {

--- a/crates/wasmtime/src/runtime/component/concurrent_disabled.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent_disabled.rs
@@ -11,11 +11,11 @@ use wasmtime_environ::component::{CanonicalAbiInfo, InterfaceType};
 pub enum ConcurrentState {}
 
 impl ConcurrentState {
-    pub fn call_context(&mut self, _: u32) -> &mut CallContext {
+    pub fn call_context(&mut self, _: u32) -> Result<&mut CallContext> {
         match *self {}
     }
 
-    pub fn current_call_context_scope_id(&self) -> u32 {
+    pub fn current_call_context_scope_id(&self) -> Result<u32> {
         match *self {}
     }
 }

--- a/crates/wasmtime/src/runtime/component/store.rs
+++ b/crates/wasmtime/src/runtime/component/store.rs
@@ -503,18 +503,16 @@ pub struct ComponentTasksNotConcurrent {
 }
 
 impl ComponentTaskState {
-    pub fn call_context(&mut self, id: u32) -> &mut CallContext {
+    pub fn call_context(&mut self, id: u32) -> Result<&mut CallContext> {
         match self {
-            ComponentTaskState::NotConcurrent(state) => &mut state.scopes[id as usize],
+            ComponentTaskState::NotConcurrent(state) => Ok(&mut state.scopes[id as usize]),
             ComponentTaskState::Concurrent(state) => state.call_context(id),
         }
     }
 
-    pub fn current_call_context_scope_id(&self) -> u32 {
+    pub fn current_call_context_scope_id(&self) -> Result<u32> {
         match self {
-            ComponentTaskState::NotConcurrent(state) => {
-                u32::try_from(state.scopes.len() - 1).unwrap()
-            }
+            ComponentTaskState::NotConcurrent(state) => Ok(u32::try_from(state.scopes.len() - 1)?),
             ComponentTaskState::Concurrent(state) => state.current_call_context_scope_id(),
         }
     }

--- a/crates/wasmtime/src/runtime/vm/component/resources.rs
+++ b/crates/wasmtime/src/runtime/vm/component/resources.rs
@@ -226,7 +226,7 @@ impl ResourceTables<'_> {
         match self.table_for_index(&index).remove_resource(index)? {
             RemovedResource::Own { rep } => Ok(Some(rep)),
             RemovedResource::Borrow { scope } => {
-                self.task_state.call_context(scope).borrow_count -= 1;
+                self.task_state.call_context(scope)?.borrow_count -= 1;
                 Ok(None)
             }
         }
@@ -273,8 +273,8 @@ impl ResourceTables<'_> {
     pub fn resource_lift_borrow(&mut self, index: TypedResourceIndex) -> Result<u32> {
         let (rep, is_own) = self.table_for_index(&index).resource_lend(index)?;
         if is_own {
-            let scope = self.task_state.current_call_context_scope_id();
-            self.task_state.call_context(scope).lenders.push(index);
+            let scope = self.task_state.current_call_context_scope_id()?;
+            self.task_state.call_context(scope)?.lenders.push(index);
         }
         Ok(rep)
     }
@@ -292,8 +292,8 @@ impl ResourceTables<'_> {
     /// `VMComponentContext` which handles the special case of avoiding borrow
     /// tracking entirely.
     pub fn resource_lower_borrow(&mut self, resource: TypedResource) -> Result<u32> {
-        let scope = self.task_state.current_call_context_scope_id();
-        let cx = self.task_state.call_context(scope);
+        let scope = self.task_state.current_call_context_scope_id()?;
+        let cx = self.task_state.call_context(scope)?;
         cx.borrow_count = cx.borrow_count.checked_add(1).unwrap();
         self.table_for_resource(&resource)
             .resource_borrow_insert(resource, scope)
@@ -306,8 +306,8 @@ impl ResourceTables<'_> {
     /// resources that were originally passed in.
     #[inline]
     pub fn validate_scope_exit(&mut self) -> Result<()> {
-        let current = self.task_state.current_call_context_scope_id();
-        let cx = self.task_state.call_context(current);
+        let current = self.task_state.current_call_context_scope_id()?;
+        let cx = self.task_state.call_context(current)?;
         if cx.borrow_count > 0 {
             bail!("borrow handles still remain at the end of the call")
         }


### PR DESCRIPTION
Downgrade some panics to `bail_bug!` or `?` where appropriate by propagating `Result<T>` in a few more locations.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
