### PR TITLE
x64: Shrink size of `x64_not` in `icmp` peephole optimization

### DIFF
--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -1978,11 +1978,11 @@
 
 ;; Peephole optimization for `0 <= x`, when x is a signed 32 bit value
 (rule 2 (lower (has_type $I8 (icmp _ (IntCC.SignedLessThanOrEqual) (u64_from_iconst 0) x @ (value_type $I32))))
-      (x64_shrl_mi (x64_not $I64 x) 31))
+      (x64_shrl_mi (x64_not $I32 x) 31))
 
 ;; Peephole optimization for `x >= 0`, when x is a signed 32 bit value
 (rule 2 (lower (has_type $I8 (icmp _ (IntCC.SignedGreaterThanOrEqual) x @ (value_type $I32) (u64_from_iconst 0))))
-      (x64_shrl_mi (x64_not $I64 x) 31))
+      (x64_shrl_mi (x64_not $I32 x) 31))
 
 ;; For XMM-held values, we lower to `PCMP*` instructions, sometimes more than
 ;; one. To note: what is different here about the output values is that each

--- a/cranelift/filetests/filetests/isa/x64/conditional-values.clif
+++ b/cranelift/filetests/filetests/isa/x64/conditional-values.clif
@@ -377,7 +377,7 @@ block0(v0: i32):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block0:
-;   notq %rdi
+;   notl %edi
 ;   movq %rdi, %rax
 ;   shrl $0x1f, %eax
 ;   movq %rbp, %rsp
@@ -389,7 +389,7 @@ block0(v0: i32):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   notq %rdi
+;   notl %edi
 ;   movq %rdi, %rax
 ;   shrl $0x1f, %eax
 ;   movq %rbp, %rsp
@@ -437,7 +437,7 @@ block0(v0: i32):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block0:
-;   notq %rdi
+;   notl %edi
 ;   movq %rdi, %rax
 ;   shrl $0x1f, %eax
 ;   movq %rbp, %rsp
@@ -449,7 +449,7 @@ block0(v0: i32):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   notq %rdi
+;   notl %edi
 ;   movq %rdi, %rax
 ;   shrl $0x1f, %eax
 ;   movq %rbp, %rsp


### PR DESCRIPTION
This commit fixes a minor issue where a `not` instruction was translated with a 64-bit width when the input was a 32-bit value. This didn't end up actually affecting the semantics of the instruction itself but it's not necessary to have a full 64-bit negation, so this commit updates it to a 32-bit negation which was the original intention here.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
