### PR TITLE
x64: Refactor `x64_load` helper

### DIFF
--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -1355,33 +1355,14 @@
 
 ;;;; Helpers for Emitting Loads ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;; Load a value into a register.
-(decl x64_load (Type SyntheticAmode ExtKind) Reg)
-
-(rule 1 (x64_load (fits_in_32 ty) addr (ExtKind.SignExtend))
-      (x64_movsx (ext_mode (ty_bytes ty) 8)
-             addr))
-
-(rule 2 (x64_load $I64 addr _ext_kind)
-      (x64_movq_rm addr))
-
-(rule 2 (x64_load $F32 addr _ext_kind)
-      (x64_movss_load addr))
-
-(rule 2 (x64_load $F64 addr _ext_kind)
-      (x64_movsd_load addr))
-
-(rule 2 (x64_load $F128 addr _ext_kind)
-      (x64_movdqu_load addr))
-
-(rule 2 (x64_load $F32X4 addr _ext_kind)
-      (x64_movups_load addr))
-
-(rule 2 (x64_load $F64X2 addr _ext_kind)
-      (x64_movupd_load addr))
-
-(rule 0 (x64_load (multi_lane _bits _lanes) addr _ext_kind)
-      (x64_movdqu_load addr))
+;; Load a value into an XMM register.
+(decl x64_load_xmm (Type SyntheticAmode) Xmm)
+(rule 1 (x64_load_xmm $F32 addr) (x64_movss_load addr))
+(rule 1 (x64_load_xmm $F64 addr) (x64_movsd_load addr))
+(rule 1 (x64_load_xmm $F128 addr) (x64_movdqu_load addr))
+(rule 1 (x64_load_xmm $F32X4 addr) (x64_movups_load addr))
+(rule 1 (x64_load_xmm $F64X2 addr) (x64_movupd_load addr))
+(rule 0 (x64_load_xmm (multi_lane _bits _lanes) addr) (x64_movdqu_load addr))
 
 (decl x64_mov (SyntheticAmode) Reg)
 (spec (x64_mov addr)
@@ -1521,7 +1502,7 @@
 ;; Load a constant into an XMM register.
 (decl x64_xmm_load_const (Type VCodeConstant) Xmm)
 (rule (x64_xmm_load_const ty const)
-      (x64_load ty (const_to_synthetic_amode const) (ExtKind.None)))
+      (x64_load_xmm ty (const_to_synthetic_amode const)))
 
 
 ;;;; Flag Helpers ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -623,7 +623,7 @@
             ;; the mask below.
             (unmasked Xmm (x64_psllw src (mov_rmi_to_xmm masked_amt)))
             (mask_addr SyntheticAmode (ishl_i8x16_mask masked_amt))
-            (mask Reg (x64_load $I8X16 mask_addr (ExtKind.None))))
+            (mask Reg (x64_movdqu_load mask_addr)))
         (sse_and $I8X16 unmasked (RegMem.Reg mask))))
 
 ;; Get the address of the mask to use when fixing up the lanes that weren't
@@ -656,7 +656,7 @@
                               (mem_flags_trusted))))
 
 (rule (ishl_i8x16_mask (RegMemImm.Mem amt))
-      (ishl_i8x16_mask (RegMemImm.Reg (x64_load $I64 amt (ExtKind.None)))))
+      (ishl_i8x16_mask (RegMemImm.Reg (x64_movq_rm amt))))
 
 ;; 16x8, 32x4, and 64x2 shifts can each use a single instruction, once the shift amount is masked.
 
@@ -762,7 +762,7 @@
                               (mem_flags_trusted))))
 
 (rule (ushr_i8x16_mask (RegMemImm.Mem amt))
-      (ushr_i8x16_mask (RegMemImm.Reg (x64_load $I64 amt (ExtKind.None)))))
+      (ushr_i8x16_mask (RegMemImm.Reg (x64_movq_rm amt))))
 
 ;; 16x8, 32x4, and 64x2 shifts can each use a single instruction, once the shift amount is masked.
 
@@ -3624,9 +3624,7 @@
       (x64_rsp))
 
 (rule (lower (get_return_address _))
-      (x64_load $I64
-                (Amode.ImmReg 8 (x64_rbp) (mem_flags_trusted))
-                (ExtKind.None)))
+      (x64_movq_rm (Amode.ImmReg 8 (x64_rbp) (mem_flags_trusted))))
 
 ;; Rules for `jump` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -4355,7 +4353,7 @@
         )
         (x64_movlhps result a1)))
 (rule (x64_round ty (RegMem.Mem addr) imm)
-      (x64_round ty (RegMem.Reg (x64_load ty addr (ExtKind.ZeroExtend))) imm))
+      (x64_round ty (RegMem.Reg (x64_load_xmm ty addr)) imm))
 
 (decl round_libcall (Type RoundImm) LibCall)
 (rule (round_libcall $F32 (RoundImm.RoundUp)) (LibCall.CeilF32))


### PR DESCRIPTION
It's mostly unused nowadays so whittle it down to exactly what's necessary, which is to say:

* Loading 64-bits is "const propagated" to `x64_movq_rm`
* The helper itself is now `x64_load_xmm` and returns a typed `Xmm` register which handles only XMM-related types.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
