### PR TITLE
Fix a list length calculation in FACT-generated adapters

### DIFF
--- a/crates/environ/src/fact/trampoline.rs
+++ b/crates/environ/src/fact/trampoline.rs
@@ -2564,7 +2564,7 @@ impl<'a, 'b> Compiler<'a, 'b> {
         } else if src_mem_opts.ptr() == dst_mem_opts.ptr() {
             self.calculate_list_byte_len(dst_mem_opts, src_len.idx, dst_element_size)
         } else {
-            self.convert_src_len_to_dst(src_byte_len.idx, src_mem_opts.ptr(), dst_mem_opts.ptr());
+            self.convert_src_len_to_dst(src_len.idx, src_mem_opts.ptr(), dst_mem_opts.ptr());
             let tmp = self.local_set_new_tmp(dst_mem_opts.ptr());
             let ret = self.calculate_list_byte_len(dst_mem_opts, tmp.idx, dst_element_size);
             self.free_temp_local(tmp);


### PR DESCRIPTION
This fixes a calculation when the source memory and destination memory have different pointer sizes. A typo meant that the destination byte length used the source byte length by accident instead of the source length. This isn't actually reachable at all in wasm today because memory64 isn't available at this time for components. FACT was originally written with memory64 support, however, to be a bit more future-proof and the component model may be getting memory64 support soon. For now though there's no test for this, just a minor update.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
