### PR TITLE
Add `bulk_memory` to wast configuration

### DIFF
--- a/crates/fuzzing/src/generators/config.rs
+++ b/crates/fuzzing/src/generators/config.rs
@@ -122,6 +122,7 @@ impl Config {
     /// to execute all tests.
     pub fn make_wast_test_compliant(&mut self, test: &WastTest) -> WastConfig {
         let wasmtime_test_util::wast::TestConfig {
+            bulk_memory,
             memory64,
             custom_page_sizes,
             multi_memory,
@@ -174,7 +175,7 @@ impl Config {
         // Enable/disable proposals that wasm-smith has knobs for which will be
         // read when creating `wasmtime::Config`.
         let config = &mut self.module_config.config;
-        config.bulk_memory_enabled = true;
+        config.bulk_memory_enabled = bulk_memory.unwrap_or(false);
         config.multi_value_enabled = true;
         config.wide_arithmetic_enabled = wide_arithmetic.unwrap_or(false);
         config.memory64_enabled = memory64.unwrap_or(false);
@@ -285,7 +286,7 @@ impl Config {
             self.wasmtime.memory_guaranteed_dense_image_size,
         ));
         cfg.wasm.async_stack_zeroing = Some(self.wasmtime.async_stack_zeroing);
-        cfg.wasm.bulk_memory = Some(true);
+        cfg.wasm.bulk_memory = Some(self.module_config.config.bulk_memory_enabled);
         cfg.wasm.component_model_async = Some(self.module_config.component_model_async);
         cfg.wasm.component_model_async_builtins =
             Some(self.module_config.component_model_async_builtins);

--- a/crates/fuzzing/src/oracles/component_api.rs
+++ b/crates/fuzzing/src/oracles/component_api.rs
@@ -142,6 +142,7 @@ fn store<T>(input: &mut Unstructured<'_>, val: T) -> arbitrary::Result<Store<T>>
     let mut config = input.arbitrary::<generators::Config>()?;
     config.enable_async(input)?;
     config.module_config.config.multi_value_enabled = true;
+    config.module_config.config.bulk_memory_enabled = true;
     config.module_config.config.reference_types_enabled = true;
     config.module_config.config.max_memories = 2;
     config.module_config.component_model_async = true;

--- a/crates/test-util/src/wasmtime_wast.rs
+++ b/crates/test-util/src/wasmtime_wast.rs
@@ -25,6 +25,7 @@ pub fn apply_wast_config(config: &mut Config, wast_config: &wast::WastConfig) {
 /// Helper method to apply `test_config` to `config`.
 pub fn apply_test_config(config: &mut Config, test_config: &wast::TestConfig) {
     let wast::TestConfig {
+        bulk_memory,
         memory64,
         custom_page_sizes,
         multi_memory,
@@ -59,6 +60,7 @@ pub fn apply_test_config(config: &mut Config, test_config: &wast::TestConfig) {
     // Note that all of these proposals/features are currently default-off to
     // ensure that we annotate all tests accurately with what features they
     // need, even in the future when features are stabilized.
+    let bulk_memory = bulk_memory.unwrap_or(false);
     let memory64 = memory64.unwrap_or(false);
     let custom_page_sizes = custom_page_sizes.unwrap_or(false);
     let multi_memory = multi_memory.unwrap_or(false);
@@ -96,6 +98,7 @@ pub fn apply_test_config(config: &mut Config, test_config: &wast::TestConfig) {
     let _custom_descriptors = custom_descriptors.unwrap_or(false);
 
     config
+        .wasm_bulk_memory(bulk_memory)
         .wasm_multi_memory(multi_memory)
         .wasm_threads(threads)
         .wasm_shared_everything_threads(shared_everything_threads)

--- a/crates/test-util/src/wast.rs
+++ b/crates/test-util/src/wast.rs
@@ -112,6 +112,7 @@ fn add_tests(tests: &mut Vec<WastTest>, path: &Path, config: &FindConfig) -> Res
 fn spec_test_config(test: &Path) -> TestConfig {
     let mut ret = TestConfig::default();
     ret.spec_test = Some(true);
+    ret.bulk_memory = Some(true);
     match spec_proposal_from_path(test) {
         Some("wide-arithmetic") => {
             ret.wide_arithmetic = Some(true);
@@ -248,6 +249,7 @@ impl fmt::Debug for WastTest {
 macro_rules! foreach_config_option {
     ($m:ident) => {
         $m! {
+            bulk_memory
             memory64
             custom_page_sizes
             multi_memory

--- a/tests/all/fuel.rs
+++ b/tests/all/fuel.rs
@@ -57,7 +57,7 @@ fn fuel_consumed(config: &Config, wasm: &[u8]) -> Result<u64> {
     Ok(u64::MAX - store.get_fuel()?)
 }
 
-#[wasmtime_test(wasm_features(gc, function_references))]
+#[wasmtime_test(wasm_features(gc, function_references, bulk_memory))]
 #[cfg_attr(miri, ignore)]
 fn iloop(config: &mut Config) -> Result<()> {
     config.consume_fuel(true);

--- a/tests/all/func.rs
+++ b/tests/all/func.rs
@@ -1425,7 +1425,7 @@ fn wrap_multiple_results(config: &mut Config) -> wasmtime::Result<()> {
     }
 }
 
-#[wasmtime_test(wasm_features(reference_types, gc_types))]
+#[wasmtime_test(wasm_features(reference_types, gc_types, bulk_memory))]
 #[cfg_attr(miri, ignore)]
 fn trampoline_for_declared_elem(config: &mut Config) -> wasmtime::Result<()> {
     let engine = Engine::new(&config)?;
@@ -1675,7 +1675,7 @@ fn calls_with_funcref_and_externref(config: &mut Config) -> wasmtime::Result<()>
     Ok(())
 }
 
-#[wasmtime_test(wasm_features(function_references))]
+#[wasmtime_test(wasm_features(function_references, bulk_memory))]
 #[cfg_attr(miri, ignore)]
 fn typed_concrete_param(config: &mut Config) -> wasmtime::Result<()> {
     let engine = Engine::new(&config)?;
@@ -1748,7 +1748,7 @@ fn typed_concrete_param(config: &mut Config) -> wasmtime::Result<()> {
     Ok(())
 }
 
-#[wasmtime_test(wasm_features(function_references))]
+#[wasmtime_test(wasm_features(function_references, bulk_memory))]
 #[cfg_attr(miri, ignore)]
 fn typed_concrete_result(config: &mut Config) -> wasmtime::Result<()> {
     let engine = Engine::new(&config)?;
@@ -1924,7 +1924,7 @@ fn call_wasm_passing_subtype_func_param(config: &mut Config) -> wasmtime::Result
     Ok(())
 }
 
-#[wasmtime_test(wasm_features(gc, function_references))]
+#[wasmtime_test(wasm_features(gc, function_references, bulk_memory))]
 #[cfg_attr(miri, ignore)]
 fn call_wasm_getting_subtype_func_return(config: &mut Config) -> wasmtime::Result<()> {
     let engine = Engine::new(&config)?;

--- a/tests/misc_testsuite/component-model/async/many-params-with-retptr.wast
+++ b/tests/misc_testsuite/component-model/async/many-params-with-retptr.wast
@@ -2,6 +2,7 @@
 ;;! reference_types = true
 ;;! gc_types = true
 ;;! multi_memory = true
+;;! bulk_memory = true
 
 ;; This test (which was generated during fuzzing) composes a sync lower with an
 ;; async lift such that the maximum number of flat parameters _and_ a return

--- a/tests/misc_testsuite/custom-page-sizes/custom-page-sizes.wast
+++ b/tests/misc_testsuite/custom-page-sizes/custom-page-sizes.wast
@@ -1,5 +1,6 @@
 ;;! custom_page_sizes = true
 ;;! multi_memory = true
+;;! bulk_memory = true
 
 ;; Check all the valid custom page sizes.
 (module (memory 1 (pagesize 1)))

--- a/tests/misc_testsuite/elem-ref-null.wast
+++ b/tests/misc_testsuite/elem-ref-null.wast
@@ -1,4 +1,5 @@
 ;;! reference_types = true
+;;! bulk_memory = true
 
 (module
   (elem funcref (ref.null func)))

--- a/tests/misc_testsuite/elem_drop.wast
+++ b/tests/misc_testsuite/elem_drop.wast
@@ -1,4 +1,5 @@
 ;;! reference_types = true
+;;! bulk_memory = true
 
 (module
   (table 1 1 funcref)

--- a/tests/misc_testsuite/externref-table-dropped-segment-issue-8281.wast
+++ b/tests/misc_testsuite/externref-table-dropped-segment-issue-8281.wast
@@ -1,4 +1,5 @@
 ;;! reference_types = true
+;;! bulk_memory = true
 
 (module
   (table $t 0 0 externref)

--- a/tests/misc_testsuite/function-references/instance.wast
+++ b/tests/misc_testsuite/function-references/instance.wast
@@ -1,5 +1,6 @@
 ;;! gc = true
 ;;! multi_memory = true
+;;! bulk_memory = true
 
 ;; Instantiation is generative
 

--- a/tests/misc_testsuite/function-references/table_grow.wast
+++ b/tests/misc_testsuite/function-references/table_grow.wast
@@ -1,4 +1,5 @@
 ;;! gc = true
+;;! bulk_memory = true
 
 (module
   (table $t 0 externref)

--- a/tests/misc_testsuite/gc/array-init-data.wast
+++ b/tests/misc_testsuite/gc/array-init-data.wast
@@ -1,4 +1,5 @@
 ;;! gc = true
+;;! bulk_memory = true
 
 (module
   (type $arr (array (mut i8)))

--- a/tests/misc_testsuite/gc/array-new-data.wast
+++ b/tests/misc_testsuite/gc/array-new-data.wast
@@ -1,4 +1,5 @@
 ;;! gc = true
+;;! bulk_memory = true
 
 (module
   (type $arr (array (mut i8)))

--- a/tests/misc_testsuite/gc/array-new-elem.wast
+++ b/tests/misc_testsuite/gc/array-new-elem.wast
@@ -1,4 +1,5 @@
 ;;! gc = true
+;;! bulk_memory = true
 
 (module
   (type $arr (array i31ref))

--- a/tests/misc_testsuite/gc/arrays-of-different-types.wast
+++ b/tests/misc_testsuite/gc/arrays-of-different-types.wast
@@ -1,5 +1,6 @@
 ;;! gc = true
 ;;! simd = true
+;;! bulk_memory = true
 
 (module
   (type $func_ty (func))

--- a/tests/misc_testsuite/gc/func-refs-in-gc-heap.wast
+++ b/tests/misc_testsuite/gc/func-refs-in-gc-heap.wast
@@ -1,4 +1,5 @@
 ;;! gc = true
+;;! bulk_memory = true
 
 (module
   (type $f0 (func (result i32)))

--- a/tests/misc_testsuite/gc/i31ref-tables.wast
+++ b/tests/misc_testsuite/gc/i31ref-tables.wast
@@ -1,4 +1,5 @@
 ;;! gc = true
+;;! bulk_memory = true
 
 (module $tables_of_i31ref
   (table $table 3 10 i31ref)

--- a/tests/misc_testsuite/gc/issue-10397.wast
+++ b/tests/misc_testsuite/gc/issue-10397.wast
@@ -1,4 +1,5 @@
 ;;! gc = true
+;;! bulk_memory = true
 
 (module
   (type $func (func))

--- a/tests/misc_testsuite/gc/issue-10459.wast
+++ b/tests/misc_testsuite/gc/issue-10459.wast
@@ -1,4 +1,5 @@
 ;;! gc = true
+;;! bulk_memory = true
 
 (module
   (type $func (func))

--- a/tests/misc_testsuite/imported-memory-copy.wast
+++ b/tests/misc_testsuite/imported-memory-copy.wast
@@ -1,3 +1,5 @@
+;;! bulk_memory = true
+
 (module $foreign
   (memory (export "mem") 1 1)
   (data 0 (i32.const 1000) "hello")

--- a/tests/misc_testsuite/memory-copy.wast
+++ b/tests/misc_testsuite/memory-copy.wast
@@ -1,3 +1,5 @@
+;;! bulk_memory = true
+
 (module
   (memory 1 1)
   (data 0 (i32.const 1000) "hello")

--- a/tests/misc_testsuite/memory64/bounds.wast
+++ b/tests/misc_testsuite/memory64/bounds.wast
@@ -1,4 +1,5 @@
 ;;! memory64 = true
+;;! bulk_memory = true
 
 (assert_unlinkable
   (module

--- a/tests/misc_testsuite/memory64/codegen.wast
+++ b/tests/misc_testsuite/memory64/codegen.wast
@@ -1,4 +1,5 @@
 ;;! memory64 = true
+;;! bulk_memory = true
 
 ;; make sure everything codegens correctly and has no cranelift verifier errors
 (module

--- a/tests/misc_testsuite/memory64/multi-memory.wast
+++ b/tests/misc_testsuite/memory64/multi-memory.wast
@@ -1,5 +1,6 @@
 ;;! memory64 = true
 ;;! multi_memory = true
+;;! bulk_memory = true
 
 ;; 64 => 64
 (module

--- a/tests/misc_testsuite/multi-memory/simple.wast
+++ b/tests/misc_testsuite/multi-memory/simple.wast
@@ -1,4 +1,5 @@
 ;;! multi_memory = true
+;;! bulk_memory = true
 
 (module
   (memory $m1 1)

--- a/tests/misc_testsuite/partial-init-memory-segment.wast
+++ b/tests/misc_testsuite/partial-init-memory-segment.wast
@@ -1,3 +1,5 @@
+;;! bulk_memory = true
+
 (module $m
   (memory (export "mem") 1)
 

--- a/tests/misc_testsuite/partial-init-table-segment.wast
+++ b/tests/misc_testsuite/partial-init-table-segment.wast
@@ -1,3 +1,5 @@
+;;! bulk_memory = true
+
 (module $m
   (table (export "table") funcref (elem $zero $zero $zero $zero $zero $zero $zero $zero $zero $zero))
 

--- a/tests/misc_testsuite/simd/spillslot-size-fuzzbug.wast
+++ b/tests/misc_testsuite/simd/spillslot-size-fuzzbug.wast
@@ -1,4 +1,5 @@
 ;;! simd = true
+;;! bulk_memory = true
 
 (module
   (func (export "test") (result f32 f32)

--- a/tests/misc_testsuite/table_copy.wast
+++ b/tests/misc_testsuite/table_copy.wast
@@ -1,3 +1,5 @@
+;;! bulk_memory = true
+
 (module
   (func $f (param i32 i32 i32) (result i32) (local.get 0))
   (func $g (param i32 i32 i32) (result i32) (local.get 1))

--- a/tests/misc_testsuite/table_copy_on_imported_tables.wast
+++ b/tests/misc_testsuite/table_copy_on_imported_tables.wast
@@ -1,4 +1,5 @@
 ;;! reference_types = true
+;;! bulk_memory = true
 
 (module $m
   (func $f (param i32 i32 i32 i32 i32 i32) (result i32) (local.get 0))

--- a/tests/misc_testsuite/winch/issue-424666628.wast
+++ b/tests/misc_testsuite/winch/issue-424666628.wast
@@ -1,3 +1,5 @@
+;;! bulk_memory = true
+
 (module
   (type (;0;) (func (param f32 f32) (result i32 f64 i32 f32 f32)))
   (type (;1;) (func (result f64 i32 f32 f32)))


### PR DESCRIPTION
Allows enabling/disabling this wasm proposal on a per-test basis.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
