### PR TITLE
Fix error message for out-of-bounds variant discriminants

### DIFF
--- a/crates/wasmtime/src/runtime/component/values.rs
+++ b/crates/wasmtime/src/runtime/component/values.rs
@@ -1045,13 +1045,10 @@ fn load_variant(
             u32::linear_lift_from_memory(cx, InterfaceType::U32, &bytes[..4])?
         }
     };
-    let case_ty = types.nth(discriminant as usize).ok_or_else(|| {
-        format_err!(
-            "discriminant {} out of range [0..{})",
-            discriminant,
-            types.len()
-        )
-    })?;
+    let len = types.len();
+    let case_ty = types
+        .nth(discriminant as usize)
+        .ok_or_else(|| format_err!("discriminant {discriminant} out of range [0..{len})"))?;
     let value = match case_ty {
         Some(case_ty) => {
             let payload_offset = usize::try_from(info.payload_offset32).unwrap();

--- a/tests/misc_testsuite/component-model/types.wast
+++ b/tests/misc_testsuite/component-model/types.wast
@@ -353,3 +353,26 @@
     (export "t" (instance $t (type $t')))
   ))
 )
+
+(component definition $A
+  (type $t' (variant (case "a" u32) (case "b")))
+  (export $t "t" (type $t'))
+
+  (core module $m
+    (memory (export "m") 1)
+    (func (export "f") (param i32) (result i32)
+      (i32.store8
+        (i32.const 0)
+        (local.get 0))
+      i32.const 0)
+  )
+  (core instance $m (instantiate $m))
+  (func (export "f") (param "a" u32) (result $t)
+    (canon lift (core func $m "f") (memory $m "m"))
+  )
+)
+
+(component instance $A $A)
+(assert_return (invoke "f" (u32.const 0)) (variant.const "a" (u32.const 0)))
+(assert_return (invoke "f" (u32.const 1)) (variant.const "b"))
+(assert_trap (invoke "f" (u32.const 2)) "discriminant 2 out of range [0..2)")


### PR DESCRIPTION
Fixes a minor mistake when loading a `Val` from memory with an out-of-bounds discriminant.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
