### PR TITLE
Fix two off-by-one correctness issues in string transcoding

### DIFF
--- a/crates/environ/src/fact/trampoline.rs
+++ b/crates/environ/src/fact/trampoline.rs
@@ -40,7 +40,7 @@ use wasmtime_component_util::{DiscriminantSize, FlagsSize};
 
 use super::DataModel;
 
-const MAX_STRING_BYTE_LENGTH: u32 = 1 << 31;
+const MAX_STRING_BYTE_LENGTH: u32 = (1 << 31) - 1;
 const UTF16_TAG: u32 = 1 << 31;
 
 /// This value is arbitrarily chosen and should be fine to change at any time,
@@ -2403,7 +2403,7 @@ impl<'a, 'b> Compiler<'a, 'b> {
         self.instruction(LocalGet(s.len.idx));
         let max = MAX_STRING_BYTE_LENGTH / u32::from(dst);
         self.ptr_uconst(mem_opts, max);
-        self.ptr_ge_u(mem_opts);
+        self.ptr_gt_u(mem_opts);
         self.instruction(If(BlockType::Empty));
         self.trap(Trap::StringOutOfBounds);
         self.instruction(End);
@@ -4004,11 +4004,11 @@ impl<'a, 'b> Compiler<'a, 'b> {
         }
     }
 
-    fn ptr_ge_u(&mut self, opts: &LinearMemoryOptions) {
+    fn ptr_gt_u(&mut self, opts: &LinearMemoryOptions) {
         if opts.memory64 {
-            self.instruction(I64GeU);
+            self.instruction(I64GtU);
         } else {
-            self.instruction(I32GeU);
+            self.instruction(I32GtU);
         }
     }
 
@@ -4040,7 +4040,7 @@ impl<'a, 'b> Compiler<'a, 'b> {
         if opts.memory64 {
             self.instruction(I64Const(val.into()));
         } else {
-            self.instruction(I32Const(val as i32));
+            self.instruction(I32Const(val.cast_signed()));
         }
     }
 

--- a/tests/misc_testsuite/component-model/big-strings.wast
+++ b/tests/misc_testsuite/component-model/big-strings.wast
@@ -1,0 +1,66 @@
+;;! multi_memory = true
+;;! hogs_memory = true
+
+;; Sending a massive string
+(component definition $A
+  (component $A
+    (core module $m
+      (memory (export "m") 1)
+      (func (export "f") (param i32 i32) unreachable)
+      (func (export "realloc") (param i32 i32 i32 i32) (result i32) unreachable)
+    )
+    (core instance $i (instantiate $m))
+    (func (export "f") (param "x" string)
+      (canon lift
+        (core func $i "f")
+        (memory $i "m")
+        (realloc (func $i "realloc"))
+      )
+    )
+  )
+  (instance $a (instantiate $A))
+
+  (component $B
+    (import "f" (func $f (param "x" string)))
+    (core module $libc (memory (export "mem") 1))
+    (core instance $libc (instantiate $libc))
+    (core func $f (canon lower (func $f) (memory $libc "mem")))
+    (core module $m
+      (import "" "f" (func $f (param i32 i32)))
+      (import "" "mem" (memory 1))
+
+      (func (export "run") (param i32)
+        (call $f (i32.const 0) (local.get 0)))
+
+      (func (export "grow") (param i32) (result i32)
+        (memory.grow (local.get 0)))
+    )
+    (core instance $i (instantiate $m
+      (with "" (instance
+        (export "f" (func $f))
+        (export "mem" (memory $libc "mem"))
+      ))
+    ))
+    (func (export "run") (param "x" u32) (canon lift (core func $i "run")))
+    (func (export "grow") (param "x" u32) (result s32)
+      (canon lift (core func $i "grow")))
+  )
+  (instance $b (instantiate $B (with "f" (func $a "f"))))
+  (export "run" (func $b "run"))
+  (export "grow" (func $b "grow"))
+)
+
+;; Wildly out of bounds is just rejected
+(component instance $A $A)
+(assert_trap (invoke "run" (u32.const 0x8000_0000)) "string content out-of-bounds")
+
+;; In-bounds, and just under the limit. Should hit the `unreachable` in the
+;; `realloc`.
+(component instance $A $A)
+(assert_return (invoke "grow" (u32.const 65530)) (s32.const 1))
+(assert_trap (invoke "run" (u32.const 0x7fff_ffff)) "unreachable")
+
+;; Size exceeds `(1<<31)-1`
+(component instance $A $A)
+(assert_return (invoke "grow" (u32.const 65530)) (s32.const 1))
+(assert_trap (invoke "run" (u32.const 0x8000_0000)) "string content out-of-bounds")


### PR DESCRIPTION
The first issue fixes here is that the maximum string byte length was one byte larger than the spec defines (`1<<31` instead of `(1<<31)-1`). The second issue is that in the comparison against the maximum byte length `>=` was used where `>` should have been used. A test has been added which exercises these two cases.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
