### PR TITLE
Use `if cfg!(...)` instead of `#[cfg]`

### DIFF
--- a/cranelift/codegen/build.rs
+++ b/cranelift/codegen/build.rs
@@ -223,19 +223,16 @@ fn run_compilation(compilation: &IsleCompilation) -> Result<(), Errors> {
         // threshold, because we cannot rely on rustc doing regalloc
         // on all of the local bindings to shrink the stack frame to a
         // reasonable size.
-        #[cfg(not(debug_assertions))]
-        {
+        if cfg!(debug_assertions) {
+            options.split_match_arms = true;
+            options.match_arm_split_threshold = Some(4);
+        } else {
             options.split_match_arms = std::env::var("CARGO_FEATURE_ISLE_SPLIT_MATCH").is_ok();
             if let Ok(value) = std::env::var("ISLE_SPLIT_MATCH_THRESHOLD") {
                 options.match_arm_split_threshold = Some(value.parse().unwrap_or_else(|err| {
                     panic!("invalid ISLE_SPLIT_MATCH_THRESHOLD value '{value}': {err}");
                 }));
             }
-        }
-        #[cfg(debug_assertions)]
-        {
-            options.split_match_arms = true;
-            options.match_arm_split_threshold = Some(4);
         }
 
         if let Ok(out_dir) = std::env::var("OUT_DIR") {


### PR DESCRIPTION
Minor style follow-up from #12841

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
