### PR TITLE
aarch64: Fix `splat(ireduce(iconst(...)))`

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/lower.isle
+++ b/cranelift/codegen/src/isa/aarch64/lower.isle
@@ -2313,9 +2313,6 @@
 (rule (lower (has_type ty (splat _ (iconst _ (u64_from_imm64 n)))))
       (splat_const n (vector_size ty)))
 
-(rule (lower (has_type ty (splat _ (ireduce _ (iconst _ (u64_from_imm64 n))))))
-      (splat_const n (vector_size ty)))
-
 (rule (lower (has_type ty (splat _ x @ (load _ flags _ _))))
       (if-let mem_op (is_sinkable_inst x))
       (let ((addr Reg (sink_load_into_addr (lane_type ty) mem_op)))

--- a/cranelift/filetests/filetests/isa/aarch64/simd.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/simd.clif
@@ -33,14 +33,14 @@ block0:
 
 ; VCode:
 ; block0:
-;   movz x0, #42679
-;   dup v0.8h, w0
+;   movz w1, #42679
+;   dup v0.8h, w1
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   mov x0, #0xa6b7
-;   dup v0.8h, w0
+;   mov w1, #0xa6b7
+;   dup v0.8h, w1
 ;   ret
 
 function %f4(i32, i8x16, i8x16) -> i8x16 {

--- a/cranelift/filetests/filetests/runtests/simd-splat.clif
+++ b/cranelift/filetests/filetests/runtests/simd-splat.clif
@@ -212,3 +212,13 @@ block0(v0: f64):
 ; run: %load_splat_f64x2(0x0.0) == [0x0.0 0x0.0]
 ; run: %load_splat_f64x2(0x2.0) == [0x2.0 0x2.0]
 ; run: %load_splat_f64x2(NaN) == [NaN NaN]
+
+function %splat_ireduce() -> i32 {
+block0:
+    v0 = iconst.i64 0x000000FF_00FFFF00
+    v1 = ireduce.i32 v0
+    v2 = splat.i32x4 v1
+    v3 = extractlane v2, 1
+    return v3
+}
+; run: %splat_ireduce() == 0x00ffff00


### PR DESCRIPTION
This commit fixes a lowering rule in the aarch64 Cranelift backend. Specifically a combined `splat(ireduce(_))` combo would pass an immediate to the `splat_const` helper which had higher bits set since the `ireduce` wasn't const-propagated. The fix applied here is to delete the `ireduce`-related rule and rely on mid-end optimizations to trigger to fold the `ireduce(iconst(...))` appropriately. This ensures that the `u64` values passed into the `splat_const` rule is indeed the exact value that's being splatted.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
