### PR TITLE
Update exception-handling status in Wasmtime docs: now has C API.

### DIFF
--- a/docs/stability-wasm-proposals.md
+++ b/docs/stability-wasm-proposals.md
@@ -47,7 +47,7 @@ The emoji legend is:
 |  Proposal                | Phase 4 | Tests | Finished | Fuzzed | API | C API  |
 |--------------------------|---------|-------|----------|--------|-----|--------|
 | [`custom-page-sizes`]    | ❌      | ✅    | ✅       | ✅     | ✅  | ✅     |
-| [`exception-handling`]   | ✅      | ✅    | ✅       | 🚧[^9] | ✅  | 🚧[^10]|
+| [`exception-handling`]   | ✅      | ✅    | ✅       | 🚧[^9] | ✅  | ✅     |
 | [`function-references`]  | ✅      | ✅    | ✅       | 🚧     | ✅  | ❌     |
 | [`gc`] [^5]              | ✅      | ✅    | 🚧[^6]   | 🚧[^7] | ✅  | ❌     |
 | [`threads`]              | ✅      | ✅    | 🚧[^8]   | ❌[^4] | ✅  | ✅     |
@@ -74,9 +74,6 @@ The emoji legend is:
 [^9]: The exception-handling proposal is fuzzed by our whole-module fuzzer,
       but we do not have an exception-specific fuzzer that attempts to create
       interesting throw/catch patterns or payloads.
-[^10]: The exception-handling proposal can be enabled for exceptions in the guest
-       via the C API, but exception objects have no C API to examine, clone,
-       rethrow, or drop exceptions that propagate to the host.
 
 [cm-capi-gaps]: https://github.com/bytecodealliance/wasmtime/issues?q=is%3Aissue%20state%3Aopen%20label%3Awasm-proposal%3Acomponent-model%20label%3Awasmtime%3Ac-api
 


### PR DESCRIPTION
After #12861 lands, we have full C/C++ API support for creating, inspecting, throwing and catching exceptions.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
