### PR TITLE
wasmtime-wasi: handle host fifos

### DIFF
--- a/crates/wasi/src/filesystem.rs
+++ b/crates/wasi/src/filesystem.rs
@@ -254,6 +254,8 @@ pub(crate) enum DescriptorType {
     SymbolicLink,
     /// The descriptor refers to a regular file inode.
     RegularFile,
+    /// The descriptor refers to a FIFO
+    Fifo,
 }
 
 impl From<cap_std::fs::FileType> for DescriptorType {
@@ -268,6 +270,8 @@ impl From<cap_std::fs::FileType> for DescriptorType {
             DescriptorType::CharacterDevice
         } else if ft.is_file() {
             DescriptorType::RegularFile
+        } else if ft.is_fifo() {
+            DescriptorType::Fifo
         } else {
             DescriptorType::Unknown
         }

--- a/crates/wasi/src/p0.rs
+++ b/crates/wasi/src/p0.rs
@@ -31,7 +31,7 @@ wiggle::from_witx!({
             fd_filestat_set_times, fd_read, fd_pread, fd_seek, fd_sync, fd_readdir, fd_write,
             fd_pwrite, poll_oneoff, path_create_directory, path_filestat_get,
             path_filestat_set_times, path_link, path_open, path_readlink, path_remove_directory,
-            path_rename, path_symlink, path_unlink_file
+            path_rename, path_symlink, path_unlink_file, fd_tell,
         }
     },
     errors: { errno => trappable Error },
@@ -50,7 +50,7 @@ mod sync {
                 fd_filestat_set_times, fd_read, fd_pread, fd_seek, fd_sync, fd_readdir, fd_write,
                 fd_pwrite, poll_oneoff, path_create_directory, path_filestat_get,
                 path_filestat_set_times, path_link, path_open, path_readlink, path_remove_directory,
-                path_rename, path_symlink, path_unlink_file
+                path_rename, path_symlink, path_unlink_file, fd_tell,
             }
         },
         errors: { errno => trappable Error },
@@ -325,12 +325,12 @@ impl<T: Snapshot1 + Send> wasi_unstable::WasiUnstable for T {
         Ok(())
     }
 
-    fn fd_tell(
+    async fn fd_tell(
         &mut self,
         memory: &mut GuestMemory<'_>,
         fd: types::Fd,
     ) -> Result<types::Filesize, Error> {
-        Ok(Snapshot1::fd_tell(self, memory, fd.into())?)
+        Ok(Snapshot1::fd_tell(self, memory, fd.into()).await?)
     }
 
     async fn fd_readdir(

--- a/crates/wasi/src/p1.rs
+++ b/crates/wasi/src/p1.rs
@@ -532,10 +532,18 @@ impl Transaction<'_> {
     /// # Errors
     ///
     /// Returns [`types::Errno::Spipe`] if the descriptor corresponds to stdio
-    fn get_seekable(&self, fd: types::Fd) -> Result<&File> {
+    async fn get_seekable(&mut self, fd: types::Fd) -> Result<&File> {
         let fd = fd.into();
         match self.descriptors.used.get(&fd) {
-            Some(Descriptor::File(file)) => Ok(file),
+            Some(Descriptor::File(file)) => {
+                if matches!(
+                    self.view.filesystem().get_type(file.fd.borrowed()).await?,
+                    filesystem::DescriptorType::CharacterDevice | filesystem::DescriptorType::Fifo
+                ) {
+                    return Err(types::Errno::Spipe.into());
+                }
+                Ok(file)
+            }
             Some(
                 Descriptor::Stdin { .. } | Descriptor::Stdout { .. } | Descriptor::Stderr { .. },
             ) => {
@@ -863,7 +871,7 @@ wiggle::from_witx!({
             fd_filestat_set_times, fd_read, fd_pread, fd_seek, fd_sync, fd_readdir, fd_write,
             fd_pwrite, poll_oneoff, path_create_directory, path_filestat_get,
             path_filestat_set_times, path_link, path_open, path_readlink, path_remove_directory,
-            path_rename, path_symlink, path_unlink_file
+            path_rename, path_symlink, path_unlink_file, fd_tell,
         }
     },
     errors: { errno => trappable Error },
@@ -882,7 +890,7 @@ pub(crate) mod sync {
                 fd_filestat_set_times, fd_read, fd_pread, fd_seek, fd_sync, fd_readdir, fd_write,
                 fd_pwrite, poll_oneoff, path_create_directory, path_filestat_get,
                 path_filestat_set_times, path_link, path_open, path_readlink, path_remove_directory,
-                path_rename, path_symlink, path_unlink_file
+                path_rename, path_symlink, path_unlink_file, fd_tell,
             }
         },
         errors: { errno => trappable Error },
@@ -1888,8 +1896,8 @@ impl wasi_snapshot_preview1::WasiSnapshotPreview1 for WasiP1Ctx {
         offset: types::Filedelta,
         whence: types::Whence,
     ) -> Result<types::Filesize, types::Error> {
-        let t = self.transact()?;
-        let File { fd, position, .. } = t.get_seekable(fd)?;
+        let mut t = self.transact()?;
+        let File { fd, position, .. } = t.get_seekable(fd).await?;
         let fd = fd.borrowed();
         let position = position.clone();
         drop(t);
@@ -1927,7 +1935,7 @@ impl wasi_snapshot_preview1::WasiSnapshotPreview1 for WasiP1Ctx {
     /// Return the current offset of a file descriptor.
     /// NOTE: This is similar to `lseek(fd, 0, SEEK_CUR)` in POSIX.
     #[instrument(skip(self, _memory))]
-    fn fd_tell(
+    async fn fd_tell(
         &mut self,
         _memory: &mut GuestMemory<'_>,
         fd: types::Fd,
@@ -1935,6 +1943,7 @@ impl wasi_snapshot_preview1::WasiSnapshotPreview1 for WasiP1Ctx {
         let pos = self
             .transact()?
             .get_seekable(fd)
+            .await
             .map(|File { position, .. }| position.load(Ordering::Relaxed))?;
         Ok(pos)
     }

--- a/crates/wasi/src/p1.rs
+++ b/crates/wasi/src/p1.rs
@@ -536,8 +536,9 @@ impl Transaction<'_> {
         let fd = fd.into();
         match self.descriptors.used.get(&fd) {
             Some(Descriptor::File(file)) => {
+                let descriptor_type = self.view.filesystem().get_type(file.fd.borrowed()).await?;
                 if matches!(
-                    self.view.filesystem().get_type(file.fd.borrowed()).await?,
+                    descriptor_type,
                     filesystem::DescriptorType::CharacterDevice | filesystem::DescriptorType::Fifo
                 ) {
                     return Err(types::Errno::Spipe.into());

--- a/crates/wasi/src/p2/host/filesystem.rs
+++ b/crates/wasi/src/p2/host/filesystem.rs
@@ -616,6 +616,7 @@ impl From<crate::filesystem::DescriptorType> for types::DescriptorType {
             crate::filesystem::DescriptorType::Directory => Self::Directory,
             crate::filesystem::DescriptorType::SymbolicLink => Self::SymbolicLink,
             crate::filesystem::DescriptorType::RegularFile => Self::RegularFile,
+            crate::filesystem::DescriptorType::Fifo => Self::Fifo,
         }
     }
 }

--- a/crates/wasi/src/p3/filesystem/mod.rs
+++ b/crates/wasi/src/p3/filesystem/mod.rs
@@ -261,6 +261,7 @@ impl From<crate::filesystem::DescriptorType> for types::DescriptorType {
             crate::filesystem::DescriptorType::Directory => Self::Directory,
             crate::filesystem::DescriptorType::SymbolicLink => Self::SymbolicLink,
             crate::filesystem::DescriptorType::RegularFile => Self::RegularFile,
+            crate::filesystem::DescriptorType::Fifo => Self::Fifo,
         }
     }
 }
@@ -278,6 +279,8 @@ impl From<cap_std::fs::FileType> for types::DescriptorType {
             Self::CharacterDevice
         } else if ft.is_file() {
             Self::RegularFile
+        } else if ft.is_fifo() {
+            Self::Fifo
         } else {
             Self::Other(None)
         }


### PR DESCRIPTION
* in p1, get_seekable fails with Errno SPIPE for Fifo. Fixes https://github.com/bytecodealliance/wasmtime/issues/12913
* in p2 and p3, plumb through cap_std::fs::FileTypeExt::is_fifo to DescriptorType::Fifo

TODO: tests

Related: #515 #10713
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
