### PR TITLE
[Cranelift] Add arithmetic simplification rules

### DIFF
--- a/cranelift/codegen/src/opts/arithmetic.isle
+++ b/cranelift/codegen/src/opts/arithmetic.isle
@@ -324,3 +324,67 @@
 
 (rule (simplify (iadd $I128 (bnot $I128 x) x)) (sextend $I128 (iconst_s $I64 -1)))
 (rule (simplify (iadd $I128 x (bnot $I128 x))) (sextend $I128 (iconst_s $I64 -1)))
+
+;; ((x + y) - (x + z)) --> (y - z)
+(rule (simplify (isub ty (iadd ty x y) (iadd ty x z))) (isub ty y z))
+(rule (simplify (isub ty (iadd ty x y) (iadd ty z x))) (isub ty y z))
+(rule (simplify (isub ty (iadd ty y x) (iadd ty x z))) (isub ty y z))
+(rule (simplify (isub ty (iadd ty y x) (iadd ty z x))) (isub ty y z))
+
+;; ((x - z) - (y - z)) --> (x - y)
+(rule (simplify (isub ty (isub ty x z) (isub ty y z))) (isub ty x y))
+
+;; ((x - y) - (x - z)) --> (z - y)
+(rule (simplify (isub ty (isub ty x y) (isub ty x z))) (isub ty z y))
+
+;; umin(x, y) + umax(x, y) --> x + y
+(rule (simplify (iadd ty (umin ty x y) (umax ty x y))) (iadd ty x y))
+(rule (simplify (iadd ty (umax ty x y) (umin ty x y))) (iadd ty x y))
+(rule (simplify (iadd ty (umin ty x y) (umax ty y x))) (iadd ty x y))
+(rule (simplify (iadd ty (umax ty y x) (umin ty x y))) (iadd ty x y))
+(rule (simplify (iadd ty (umin ty y x) (umax ty x y))) (iadd ty x y))
+(rule (simplify (iadd ty (umax ty x y) (umin ty y x))) (iadd ty x y))
+(rule (simplify (iadd ty (umin ty y x) (umax ty y x))) (iadd ty x y))
+(rule (simplify (iadd ty (umax ty y x) (umin ty y x))) (iadd ty x y))
+
+;; smin(x, y) + smax(x, y) --> x + y
+(rule (simplify (iadd ty (smin ty x y) (smax ty x y))) (iadd ty x y))
+(rule (simplify (iadd ty (smax ty x y) (smin ty x y))) (iadd ty x y))
+(rule (simplify (iadd ty (smin ty x y) (smax ty y x))) (iadd ty x y))
+(rule (simplify (iadd ty (smax ty y x) (smin ty x y))) (iadd ty x y))
+(rule (simplify (iadd ty (smin ty y x) (smax ty x y))) (iadd ty x y))
+(rule (simplify (iadd ty (smax ty x y) (smin ty y x))) (iadd ty x y))
+(rule (simplify (iadd ty (smin ty y x) (smax ty y x))) (iadd ty x y))
+(rule (simplify (iadd ty (smax ty y x) (smin ty y x))) (iadd ty x y))
+
+;; ((x + z) - (y + z)) --> (x - y)
+(rule (simplify (isub ty (iadd ty x z) (iadd ty y z))) (isub ty x y))
+(rule (simplify (isub ty (iadd ty x z) (iadd ty z y))) (isub ty x y))
+(rule (simplify (isub ty (iadd ty z x) (iadd ty y z))) (isub ty x y))
+(rule (simplify (isub ty (iadd ty z x) (iadd ty z y))) (isub ty x y))
+
+;; ((x - y) + (y + z)) --> (x + z)
+(rule (simplify (iadd ty (isub ty x y) (iadd ty y z))) (iadd ty x z))
+(rule (simplify (iadd ty (iadd ty y z) (isub ty x y))) (iadd ty x z))
+(rule (simplify (iadd ty (isub ty x y) (iadd ty z y))) (iadd ty x z))
+(rule (simplify (iadd ty (iadd ty z y) (isub ty x y))) (iadd ty x z))
+
+;; (x - (x + y)) --> -y
+(rule (simplify (isub ty x (iadd ty x y))) (ineg ty y))
+(rule (simplify (isub ty x (iadd ty y x))) (ineg ty y))
+
+;; (x + (y + (z - x))) --> (y + z)
+(rule (simplify (iadd ty x (iadd ty y (isub ty z x)))) (iadd ty y z))
+(rule (simplify (iadd ty (iadd ty y (isub ty z x)) x)) (iadd ty y z))
+(rule (simplify (iadd ty x (iadd ty (isub ty z x) y))) (iadd ty y z))
+(rule (simplify (iadd ty (iadd ty (isub ty z x) y) x)) (iadd ty y z))
+
+;; (x + y) == (y + x) --> true
+(rule (simplify (eq ty (iadd cty x y) (iadd cty y x))) (iconst_u ty 1))
+(rule (simplify (eq ty (iadd cty y x) (iadd cty x y))) (iconst_u ty 1))
+(rule (simplify (eq ty (iadd cty x y) (iadd cty x y))) (iconst_u ty 1))
+(rule (simplify (eq ty (iadd cty y x) (iadd cty y x))) (iconst_u ty 1))
+
+;; (x - y) != x --> y != 0
+(rule (simplify (ne cty (isub ty x y) x)) (ne cty y (iconst_u ty 0)))
+(rule (simplify (ne cty x (isub ty x y))) (ne cty y (iconst_u ty 0)))

--- a/cranelift/filetests/filetests/egraph/arithmetic-precise.clif
+++ b/cranelift/filetests/filetests/egraph/arithmetic-precise.clif
@@ -84,3 +84,167 @@ block0(v0: i128):
 ;     v4 = sextend.i128 v3  ; v3 = -1
 ;     return v4
 ; }
+
+;; ((x + y) - (x + z)) --> (y - z)
+function %test_isub_iadd_iadd_cancel(i32, i32, i32) -> i32 fast {
+block0(v0: i32, v1: i32, v2: i32):
+    v3 = iadd v0, v1
+    v4 = iadd v0, v2
+    v5 = isub v3, v4
+    return v5
+}
+
+; function %test_isub_iadd_iadd_cancel(i32, i32, i32) -> i32 fast {
+; block0(v0: i32, v1: i32, v2: i32):
+;     v6 = isub v1, v2
+;     return v6
+; }
+
+;; ((x - z) - (y - z)) --> (x - y)
+function %test_isub_isub_isub_cancel(i32, i32, i32) -> i32 fast {
+block0(v0: i32, v1: i32, v2: i32):
+    v3 = isub v0, v2
+    v4 = isub v1, v2
+    v5 = isub v3, v4
+    return v5
+}
+
+; function %test_isub_isub_isub_cancel(i32, i32, i32) -> i32 fast {
+; block0(v0: i32, v1: i32, v2: i32):
+;     v6 = isub v0, v1
+;     return v6
+; }
+
+;; ((x - y) - (x - z)) --> (z - y)
+function %test_isub_isub_isub_swap_cancel(i32, i32, i32) -> i32 fast {
+block0(v0: i32, v1: i32, v2: i32):
+    v3 = isub v0, v1
+    v4 = isub v0, v2
+    v5 = isub v3, v4
+    return v5
+}
+
+; function %test_isub_isub_isub_swap_cancel(i32, i32, i32) -> i32 fast {
+; block0(v0: i32, v1: i32, v2: i32):
+;     v6 = isub v2, v1
+;     return v6
+; }
+
+;; umin(x, y) + umax(x, y) --> x + y
+function %test_iadd_umin_umax(i32, i32) -> i32 fast {
+block0(v0: i32, v1: i32):
+    v2 = umin v0, v1
+    v3 = umax v0, v1
+    v4 = iadd v2, v3
+    return v4
+}
+
+; function %test_iadd_umin_umax(i32, i32) -> i32 fast {
+; block0(v0: i32, v1: i32):
+;     v6 = iadd v1, v0
+;     return v6
+; }
+
+;; smin(x, y) + smax(x, y) --> x + y
+function %test_iadd_smin_smax(i32, i32) -> i32 fast {
+block0(v0: i32, v1: i32):
+    v2 = smin v0, v1
+    v3 = smax v0, v1
+    v4 = iadd v2, v3
+    return v4
+}
+
+; function %test_iadd_smin_smax(i32, i32) -> i32 fast {
+; block0(v0: i32, v1: i32):
+;     v6 = iadd v1, v0
+;     return v6
+; }
+
+;; ((x + z) - (y + z)) --> (x - y)
+function %test_isub_iadd_iadd_common_rhs(i32, i32, i32) -> i32 fast {
+block0(v0: i32, v1: i32, v2: i32):
+    v3 = iadd v0, v2
+    v4 = iadd v1, v2
+    v5 = isub v3, v4
+    return v5
+}
+
+; function %test_isub_iadd_iadd_common_rhs(i32, i32, i32) -> i32 fast {
+; block0(v0: i32, v1: i32, v2: i32):
+;     v6 = isub v0, v1
+;     return v6
+; }
+
+;; ((x - y) + (y + z)) --> (x + z)
+function %test_iadd_isub_iadd_cancel(i32, i32, i32) -> i32 fast {
+block0(v0: i32, v1: i32, v2: i32):
+    v3 = isub v0, v1
+    v4 = iadd v1, v2
+    v5 = iadd v3, v4
+    return v5
+}
+
+; function %test_iadd_isub_iadd_cancel(i32, i32, i32) -> i32 fast {
+; block0(v0: i32, v1: i32, v2: i32):
+;     v6 = iadd v0, v2
+;     return v6
+; }
+
+;; (x - (x + y)) --> -y
+function %test_isub_iadd_to_ineg(i32, i32) -> i32 fast {
+block0(v0: i32, v1: i32):
+    v2 = iadd v0, v1
+    v3 = isub v0, v2
+    return v3
+}
+
+; function %test_isub_iadd_to_ineg(i32, i32) -> i32 fast {
+; block0(v0: i32, v1: i32):
+;     v4 = ineg v1
+;     return v4
+; }
+
+;; (x + (y + (z - x))) --> (y + z)
+function %test_iadd_iadd_isub_cancel(i32, i32, i32) -> i32 fast {
+block0(v0: i32, v1: i32, v2: i32):
+    v3 = isub v2, v0
+    v4 = iadd v1, v3
+    v5 = iadd v0, v4
+    return v5
+}
+
+; function %test_iadd_iadd_isub_cancel(i32, i32, i32) -> i32 fast {
+; block0(v0: i32, v1: i32, v2: i32):
+;     v6 = iadd v1, v2
+;     return v6
+; }
+
+;; (eq ty (iadd cty x y) (iadd cty y x)) -> 1
+function %simplify_icmp_eq_iadd_commute(i32, i32) -> i8 fast {
+block0(v0: i32, v1: i32):
+    v2 = iadd v0, v1
+    v3 = iadd v1, v0
+    v4 = icmp eq v2, v3
+    return v4
+}
+
+; function %simplify_icmp_eq_iadd_commute(i32, i32) -> i8 fast {
+; block0(v0: i32, v1: i32):
+;     v5 = iconst.i8 1
+;     return v5  ; v5 = 1
+; }
+
+;; (x - y) != x --> y != 0
+function %simplify_icmp_ne_isub_x(i32, i32) -> i8 fast {
+block0(v0: i32, v1: i32):
+    v2 = isub v0, v1
+    v3 = icmp ne v2, v0
+    return v3
+}
+
+; function %simplify_icmp_ne_isub_x(i32, i32) -> i8 fast {
+; block0(v0: i32, v1: i32):
+;     v4 = iconst.i32 0
+;     v5 = icmp ne v1, v4  ; v4 = 0
+;     return v5
+; }

--- a/cranelift/filetests/filetests/runtests/arithmetic.clif
+++ b/cranelift/filetests/filetests/runtests/arithmetic.clif
@@ -687,3 +687,138 @@ block0(v0: i32):
 ; run: %fold_iadd_bnot_x_to_allones_i32_rt(1) == -1
 ; run: %fold_iadd_bnot_x_to_allones_i32_rt(0x12345678) == -1
 
+function %test_isub_iadd_iadd_cancel_rt(i32, i32, i32) -> i32 fast {
+block0(v0: i32, v1: i32, v2: i32):
+    v3 = iadd v0, v1
+    v4 = iadd v0, v2
+    v5 = isub v3, v4
+    return v5
+}
+
+; run: %test_isub_iadd_iadd_cancel_rt(0, 0, 0) == 0
+; run: %test_isub_iadd_iadd_cancel_rt(5, 7, 3) == 4
+; run: %test_isub_iadd_iadd_cancel_rt(10, 1, 9) == -8
+
+function %test_isub_isub_isub_cancel_rt(i32, i32, i32) -> i32 fast {
+block0(v0: i32, v1: i32, v2: i32):
+    v3 = isub v0, v2
+    v4 = isub v1, v2
+    v5 = isub v3, v4
+    return v5
+}
+
+; run: %test_isub_isub_isub_cancel_rt(0, 0, 0) == 0
+; run: %test_isub_isub_isub_cancel_rt(7, 3, 1) == 4
+; run: %test_isub_isub_isub_cancel_rt(3, 7, 1) == -4
+
+function %test_isub_isub_isub_swap_cancel_rt(i32, i32, i32) -> i32 fast {
+block0(v0: i32, v1: i32, v2: i32):
+    v3 = isub v0, v1
+    v4 = isub v0, v2
+    v5 = isub v3, v4
+    return v5
+}
+
+; run: %test_isub_isub_isub_swap_cancel_rt(0, 0, 0) == 0
+; run: %test_isub_isub_isub_swap_cancel_rt(7, 3, 1) == -2
+; run: %test_isub_isub_isub_swap_cancel_rt(7, 1, 3) == 2
+
+function %test_iadd_umin_umax(i32, i32) -> i32 fast {
+block0(v0: i32, v1: i32):
+    v2 = umin v0, v1
+    v3 = umax v0, v1
+    v4 = iadd v2, v3
+    return v4
+}
+
+; run: %test_iadd_umin_umax(1, 2) == 3
+; run: %test_iadd_umin_umax(2, 1) == 3
+; run: %test_iadd_umin_umax(7, 7) == 14
+; run: %test_iadd_umin_umax(-1, 1) == 0
+
+function %test_iadd_smin_smax(i32, i32) -> i32 fast {
+block0(v0: i32, v1: i32):
+    v2 = smin v0, v1
+    v3 = smax v0, v1
+    v4 = iadd v2, v3
+    return v4
+}
+
+; run: %test_iadd_smin_smax(1, 2) == 3
+; run: %test_iadd_smin_smax(2, 1) == 3
+; run: %test_iadd_smin_smax(7, 7) == 14
+; run: %test_iadd_smin_smax(-1, 1) == 0
+
+function %test_isub_iadd_iadd_common_rhs_rt(i32, i32, i32) -> i32 fast {
+block0(v0: i32, v1: i32, v2: i32):
+    v3 = iadd v0, v2
+    v4 = iadd v1, v2
+    v5 = isub v3, v4
+    return v5
+}
+
+; run: %test_isub_iadd_iadd_common_rhs_rt(0, 0, 0) == 0
+; run: %test_isub_iadd_iadd_common_rhs_rt(7, 3, 1) == 4
+; run: %test_isub_iadd_iadd_common_rhs_rt(3, 7, 1) == -4
+
+function %test_iadd_isub_iadd_cancel_rt(i32, i32, i32) -> i32 fast {
+block0(v0: i32, v1: i32, v2: i32):
+    v3 = isub v0, v1
+    v4 = iadd v1, v2
+    v5 = iadd v3, v4
+    return v5
+}
+
+; run: %test_iadd_isub_iadd_cancel_rt(0, 0, 0) == 0
+; run: %test_iadd_isub_iadd_cancel_rt(7, 3, 1) == 8
+; run: %test_iadd_isub_iadd_cancel_rt(7, 1, 3) == 10
+
+function %test_isub_iadd_to_ineg_rt(i32, i32) -> i32 fast {
+block0(v0: i32, v1: i32):
+    v2 = iadd v0, v1
+    v3 = isub v0, v2
+    return v3
+}
+
+; run: %test_isub_iadd_to_ineg_rt(0, 0) == 0
+; run: %test_isub_iadd_to_ineg_rt(7, 3) == -3
+; run: %test_isub_iadd_to_ineg_rt(7, -3) == 3
+
+function %test_iadd_iadd_isub_cancel_rt(i32, i32, i32) -> i32 fast {
+block0(v0: i32, v1: i32, v2: i32):
+    v3 = isub v2, v0
+    v4 = iadd v1, v3
+    v5 = iadd v0, v4
+    return v5
+}
+
+; run: %test_iadd_iadd_isub_cancel_rt(0, 0, 0) == 0
+; run: %test_iadd_iadd_isub_cancel_rt(7, 3, 1) == 4
+; run: %test_iadd_iadd_isub_cancel_rt(7, 1, 3) == 4
+; run: %test_iadd_iadd_isub_cancel_rt(-4, 6, 2) == 8
+; run: %test_iadd_iadd_isub_cancel_rt(0x1234, 0x34, 0x10) == 0x44
+
+;; (eq ty (iadd cty x y) (iadd cty y x)) -> 1
+function %simplify_icmp_eq_iadd_commute(i32, i32) -> i8 fast {
+block0(v0: i32, v1: i32):
+    v2 = iadd v0, v1
+    v3 = iadd v1, v0
+    v4 = icmp eq v2, v3
+    return v4
+}
+
+; run: %simplify_icmp_eq_iadd_commute(0, 0) == 1
+; run: %simplify_icmp_eq_iadd_commute(1, 2) == 1
+; run: %simplify_icmp_eq_iadd_commute(-1, 1) == 1
+
+;; (x - y) != x --> y != 0
+function %simplify_icmp_ne_isub_x(i32, i32) -> i8 fast {
+block0(v0: i32, v1: i32):
+    v2 = isub v0, v1
+    v3 = icmp ne v2, v0
+    return v3
+}
+
+; run: %simplify_icmp_ne_isub_x(0, 0) == 0
+; run: %simplify_icmp_ne_isub_x(1, 0) == 0
+; run: %simplify_icmp_ne_isub_x(1, 1) == 1


### PR DESCRIPTION
This PR adds several arithmetic simplification rules:


- `((x + y) - (x + z)) --> (y - z)`
- `((x - z) - (y - z)) --> (x - y)`
- `((x - y) - (x - z)) --> (z - y)`
- `min(x, y) + max(x, y) --> x + y`
- `((x - y) + (y + z)) --> (x + z)`
- `(x - (x + y)) --> -y`
- `(x + (y + (z - x))) --> (y + z)`
- `(x + y) == (y + x) --> true`
- `(x - y) != x --> y != 0`