### PR TITLE
Allow another error in `p3_sockets_tcp_streams` test

### DIFF
--- a/crates/test-programs/src/bin/p3_sockets_tcp_streams.rs
+++ b/crates/test-programs/src/bin/p3_sockets_tcp_streams.rs
@@ -103,7 +103,10 @@ async fn test_tcp_send_drops_stream_when_remote_shutdown(family: IpAddressFamily
 
         let result = client.send_result.await;
         assert!(
-            matches!(result, Err(ErrorCode::ConnectionBroken)),
+            matches!(
+                result,
+                Err(ErrorCode::ConnectionBroken | ErrorCode::ConnectionReset)
+            ),
             "unexpected error {result:?}",
         );
     })


### PR DESCRIPTION
Captured in a failure in #12924

Closes #12924

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
