### PR TITLE
Use traps when checking initial table/memory bounds

### DIFF
--- a/crates/wasmtime/src/runtime/vm/instance/allocator.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator.rs
@@ -517,7 +517,7 @@ fn check_table_init_bounds(
                 // Initializer is in bounds
             }
             _ => {
-                bail!("table out of bounds: elements segment does not fit")
+                bail!(Trap::TableOutOfBounds);
             }
         }
     }
@@ -627,7 +627,7 @@ fn check_memory_init_bounds(
                 // Initializer is in bounds
             }
             _ => {
-                bail!("memory out of bounds: data segment does not fit")
+                bail!(Trap::MemoryOutOfBounds);
             }
         }
     }


### PR DESCRIPTION
Instead of using a custom error string this enables fuzzing to, for example, see that a `Trap` was returned and consider the fuzz test case a normal failure. These code paths are only executed when `bulk_memory` is disabled which is pretty rare, and also explains why it's come up in fuzzing only just now after #12883.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
