### PR TITLE
winch: Fix spectre-related table indexing comparison size

### DIFF
--- a/tests/disas/winch/aarch64/call_indirect/call_indirect.wat
+++ b/tests/disas/winch/aarch64/call_indirect/call_indirect.wat
@@ -73,7 +73,7 @@
 ;;       ldur    x2, [x2, #0x30]
 ;;       mov     x4, x2
 ;;       add     x2, x2, x16, uxtx
-;;       cmp     w1, w3, uxtx
+;;       cmp     x1, x3, uxtx
 ;;       csel    x2, x4, x2, hs
 ;;       ldur    x0, [x2]
 ;;       tst     x0, x0
@@ -139,7 +139,7 @@
 ;;       ldur    x2, [x2, #0x30]
 ;;       mov     x4, x2
 ;;       add     x2, x2, x16, uxtx
-;;       cmp     w1, w3, uxtx
+;;       cmp     x1, x3, uxtx
 ;;       csel    x2, x4, x2, hs
 ;;       ldur    x0, [x2]
 ;;       tst     x0, x0

--- a/tests/disas/winch/aarch64/call_indirect/local_arg.wat
+++ b/tests/disas/winch/aarch64/call_indirect/local_arg.wat
@@ -79,7 +79,7 @@
 ;;       ldur    x2, [x2, #0x30]
 ;;       mov     x4, x2
 ;;       add     x2, x2, x16, uxtx
-;;       cmp     w1, w3, uxtx
+;;       cmp     x1, x3, uxtx
 ;;       csel    x2, x4, x2, hs
 ;;       ldur    x0, [x2]
 ;;       tst     x0, x0

--- a/tests/disas/winch/x64/call_indirect/call_indirect.wat
+++ b/tests/disas/winch/x64/call_indirect/call_indirect.wat
@@ -37,7 +37,7 @@
 ;;       movq    0x18(%r11), %r11
 ;;       addq    $0x30, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x229
+;;       ja      0x22b
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
@@ -50,7 +50,7 @@
 ;;       testl   %eax, %eax
 ;;       je      0x55
 ;;   4b: movl    $1, %eax
-;;       jmp     0x220
+;;       jmp     0x222
 ;;   55: movl    0xc(%rsp), %eax
 ;;       subl    $2, %eax
 ;;       subq    $4, %rsp
@@ -59,37 +59,37 @@
 ;;       movq    %r14, %rdx
 ;;       movq    0x38(%rdx), %rbx
 ;;       cmpq    %rbx, %rcx
-;;       jae     0x22b
+;;       jae     0x22d
 ;;   7d: movq    %rcx, %r11
 ;;       imulq   $8, %r11, %r11
 ;;       movq    0x30(%rdx), %rdx
 ;;       movq    %rdx, %rsi
 ;;       addq    %r11, %rdx
-;;       cmpl    %ebx, %ecx
+;;       cmpq    %rbx, %rcx
 ;;       cmovaeq %rsi, %rdx
 ;;       movq    (%rdx), %rax
 ;;       testq   %rax, %rax
-;;       jne     0xdd
-;;   a3: subq    $4, %rsp
+;;       jne     0xde
+;;   a4: subq    $4, %rsp
 ;;       movl    %ecx, (%rsp)
 ;;       subq    $8, %rsp
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
 ;;       movl    8(%rsp), %edx
-;;       callq   0x334
+;;       callq   0x336
 ;;       addq    $8, %rsp
 ;;       addq    $4, %rsp
 ;;       movq    0x1c(%rsp), %r14
-;;       jmp     0xe3
-;;   dd: andq    $0xfffffffffffffffe, %rax
+;;       jmp     0xe4
+;;   de: andq    $0xfffffffffffffffe, %rax
 ;;       testq   %rax, %rax
-;;       je      0x22d
-;;   ec: movq    0x28(%r14), %r11
+;;       je      0x22f
+;;   ed: movq    0x28(%r14), %r11
 ;;       movl    (%r11), %ecx
 ;;       movl    0x10(%rax), %edx
 ;;       cmpl    %edx, %ecx
-;;       jne     0x22f
-;;   fe: pushq   %rax
+;;       jne     0x231
+;;   ff: pushq   %rax
 ;;       popq    %rcx
 ;;       movq    0x18(%rcx), %r8
 ;;       movq    8(%rcx), %rbx
@@ -111,37 +111,37 @@
 ;;       movq    %r14, %rdx
 ;;       movq    0x38(%rdx), %rbx
 ;;       cmpq    %rbx, %rcx
-;;       jae     0x231
-;;  161: movq    %rcx, %r11
+;;       jae     0x233
+;;  162: movq    %rcx, %r11
 ;;       imulq   $8, %r11, %r11
 ;;       movq    0x30(%rdx), %rdx
 ;;       movq    %rdx, %rsi
 ;;       addq    %r11, %rdx
-;;       cmpl    %ebx, %ecx
+;;       cmpq    %rbx, %rcx
 ;;       cmovaeq %rsi, %rdx
 ;;       movq    (%rdx), %rax
 ;;       testq   %rax, %rax
-;;       jne     0x1c1
-;;  187: subq    $4, %rsp
+;;       jne     0x1c3
+;;  189: subq    $4, %rsp
 ;;       movl    %ecx, (%rsp)
 ;;       subq    $4, %rsp
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
 ;;       movl    4(%rsp), %edx
-;;       callq   0x334
+;;       callq   0x336
 ;;       addq    $4, %rsp
 ;;       addq    $4, %rsp
 ;;       movq    0x20(%rsp), %r14
-;;       jmp     0x1c7
-;;  1c1: andq    $0xfffffffffffffffe, %rax
+;;       jmp     0x1c9
+;;  1c3: andq    $0xfffffffffffffffe, %rax
 ;;       testq   %rax, %rax
-;;       je      0x233
-;;  1d0: movq    0x28(%r14), %r11
+;;       je      0x235
+;;  1d2: movq    0x28(%r14), %r11
 ;;       movl    (%r11), %ecx
 ;;       movl    0x10(%rax), %edx
 ;;       cmpl    %edx, %ecx
-;;       jne     0x235
-;;  1e2: pushq   %rax
+;;       jne     0x237
+;;  1e4: pushq   %rax
 ;;       popq    %rcx
 ;;       movq    0x18(%rcx), %r8
 ;;       movq    8(%rcx), %rbx
@@ -160,10 +160,10 @@
 ;;       addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;  229: ud2
 ;;  22b: ud2
 ;;  22d: ud2
 ;;  22f: ud2
 ;;  231: ud2
 ;;  233: ud2
 ;;  235: ud2
+;;  237: ud2

--- a/tests/disas/winch/x64/call_indirect/local_arg.wat
+++ b/tests/disas/winch/x64/call_indirect/local_arg.wat
@@ -42,7 +42,7 @@
 ;;       movq    0x18(%r11), %r11
 ;;       addq    $0x30, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x156
+;;       ja      0x157
 ;;   5c: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
@@ -55,37 +55,37 @@
 ;;       movq    %r14, %rdx
 ;;       movq    0x38(%rdx), %rbx
 ;;       cmpq    %rbx, %rcx
-;;       jae     0x158
+;;       jae     0x159
 ;;   9e: movq    %rcx, %r11
 ;;       imulq   $8, %r11, %r11
 ;;       movq    0x30(%rdx), %rdx
 ;;       movq    %rdx, %rsi
 ;;       addq    %r11, %rdx
-;;       cmpl    %ebx, %ecx
+;;       cmpq    %rbx, %rcx
 ;;       cmovaeq %rsi, %rdx
 ;;       movq    (%rdx), %rax
 ;;       testq   %rax, %rax
-;;       jne     0xfe
-;;   c4: subq    $4, %rsp
+;;       jne     0xff
+;;   c5: subq    $4, %rsp
 ;;       movl    %ecx, (%rsp)
 ;;       subq    $8, %rsp
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
 ;;       movl    8(%rsp), %edx
-;;       callq   0x31d
+;;       callq   0x31e
 ;;       addq    $8, %rsp
 ;;       addq    $4, %rsp
 ;;       movq    0x1c(%rsp), %r14
-;;       jmp     0x104
-;;   fe: andq    $0xfffffffffffffffe, %rax
+;;       jmp     0x105
+;;   ff: andq    $0xfffffffffffffffe, %rax
 ;;       testq   %rax, %rax
-;;       je      0x15a
-;;  10d: movq    0x28(%r14), %r11
+;;       je      0x15b
+;;  10e: movq    0x28(%r14), %r11
 ;;       movl    (%r11), %ecx
 ;;       movl    0x10(%rax), %edx
 ;;       cmpl    %edx, %ecx
-;;       jne     0x15c
-;;  11f: movq    0x18(%rax), %rbx
+;;       jne     0x15d
+;;  120: movq    0x18(%rax), %rbx
 ;;       movq    8(%rax), %rcx
 ;;       subq    $0xc, %rsp
 ;;       movq    %rbx, %rdi
@@ -98,7 +98,7 @@
 ;;       addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;  156: ud2
-;;  158: ud2
-;;  15a: ud2
-;;  15c: ud2
+;;  157: ud2
+;;  159: ud2
+;;  15b: ud2
+;;  15d: ud2

--- a/tests/disas/winch/x64/table/fill.wat
+++ b/tests/disas/winch/x64/table/fill.wat
@@ -78,7 +78,7 @@
 ;;       movq    0x18(%r11), %r11
 ;;       addq    $0x40, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x1f9
+;;       ja      0x1fa
 ;;   dc: movq    %rdi, %r14
 ;;       subq    $0x30, %rsp
 ;;       movq    %rdi, 0x28(%rsp)
@@ -96,29 +96,29 @@
 ;;       movq    %r14, %rdx
 ;;       movq    0x38(%rdx), %rbx
 ;;       cmpq    %rbx, %rcx
-;;       jae     0x1fb
+;;       jae     0x1fc
 ;;  138: movq    %rcx, %r11
 ;;       imulq   $8, %r11, %r11
 ;;       movq    0x30(%rdx), %rdx
 ;;       movq    %rdx, %rsi
 ;;       addq    %r11, %rdx
-;;       cmpl    %ebx, %ecx
+;;       cmpq    %rbx, %rcx
 ;;       cmovaeq %rsi, %rdx
 ;;       movq    (%rdx), %rax
 ;;       testq   %rax, %rax
-;;       jne     0x198
-;;  15e: subq    $4, %rsp
+;;       jne     0x199
+;;  15f: subq    $4, %rsp
 ;;       movl    %ecx, (%rsp)
 ;;       subq    $0xc, %rsp
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
 ;;       movl    0xc(%rsp), %edx
-;;       callq   0x4e6
+;;       callq   0x4e7
 ;;       addq    $0xc, %rsp
 ;;       addq    $4, %rsp
 ;;       movq    0x28(%rsp), %r14
-;;       jmp     0x19e
-;;  198: andq    $0xfffffffffffffffe, %rax
+;;       jmp     0x19f
+;;  199: andq    $0xfffffffffffffffe, %rax
 ;;       movq    %rax, 0xc(%rsp)
 ;;       movl    0x1c(%rsp), %r11d
 ;;       subq    $4, %rsp
@@ -133,11 +133,11 @@
 ;;       movl    0xc(%rsp), %edx
 ;;       movq    4(%rsp), %rcx
 ;;       movl    (%rsp), %r8d
-;;       callq   0x511
+;;       callq   0x512
 ;;       addq    $0x10, %rsp
 ;;       movq    0x28(%rsp), %r14
 ;;       addq    $0x30, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;  1f9: ud2
-;;  1fb: ud2
+;;  1fa: ud2
+;;  1fc: ud2

--- a/tests/disas/winch/x64/table/get.wat
+++ b/tests/disas/winch/x64/table/get.wat
@@ -34,7 +34,7 @@
 ;;       movq    0x18(%r11), %r11
 ;;       addq    $0x30, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x10d
+;;       ja      0x10e
 ;;   5c: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
@@ -48,31 +48,31 @@
 ;;       movq    %r14, %rdx
 ;;       movq    0x38(%rdx), %rbx
 ;;       cmpq    %rbx, %rcx
-;;       jae     0x10f
+;;       jae     0x110
 ;;   9e: movq    %rcx, %r11
 ;;       imulq   $8, %r11, %r11
 ;;       movq    0x30(%rdx), %rdx
 ;;       movq    %rdx, %rsi
 ;;       addq    %r11, %rdx
-;;       cmpl    %ebx, %ecx
+;;       cmpq    %rbx, %rcx
 ;;       cmovaeq %rsi, %rdx
 ;;       movq    (%rdx), %rax
 ;;       testq   %rax, %rax
-;;       jne     0xfe
-;;   c4: subq    $4, %rsp
+;;       jne     0xff
+;;   c5: subq    $4, %rsp
 ;;       movl    %ecx, (%rsp)
 ;;       subq    $0xc, %rsp
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
 ;;       movl    0xc(%rsp), %edx
-;;       callq   0x2e5
+;;       callq   0x2e6
 ;;       addq    $0xc, %rsp
 ;;       addq    $4, %rsp
 ;;       movq    0x18(%rsp), %r14
-;;       jmp     0x104
-;;   fe: andq    $0xfffffffffffffffe, %rax
+;;       jmp     0x105
+;;   ff: andq    $0xfffffffffffffffe, %rax
 ;;       addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;  10d: ud2
-;;  10f: ud2
+;;  10e: ud2
+;;  110: ud2

--- a/tests/disas/winch/x64/table/init_copy_drop.wat
+++ b/tests/disas/winch/x64/table/init_copy_drop.wat
@@ -142,11 +142,11 @@
 ;;       movl    $7, %ecx
 ;;       movl    $0, %r8d
 ;;       movl    $4, %r9d
-;;       callq   0x939
+;;       callq   0x93a
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $1, %esi
-;;       callq   0x984
+;;       callq   0x985
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
@@ -154,11 +154,11 @@
 ;;       movl    $0xf, %ecx
 ;;       movl    $1, %r8d
 ;;       movl    $3, %r9d
-;;       callq   0x939
+;;       callq   0x93a
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $3, %esi
-;;       callq   0x984
+;;       callq   0x985
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
@@ -166,7 +166,7 @@
 ;;       movl    $0x14, %ecx
 ;;       movl    $0xf, %r8d
 ;;       movl    $5, %r9d
-;;       callq   0x8ee
+;;       callq   0x8ef
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
@@ -174,7 +174,7 @@
 ;;       movl    $0x15, %ecx
 ;;       movl    $0x1d, %r8d
 ;;       movl    $1, %r9d
-;;       callq   0x8ee
+;;       callq   0x8ef
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
@@ -182,7 +182,7 @@
 ;;       movl    $0x18, %ecx
 ;;       movl    $0xa, %r8d
 ;;       movl    $1, %r9d
-;;       callq   0x8ee
+;;       callq   0x8ef
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
@@ -190,7 +190,7 @@
 ;;       movl    $0xd, %ecx
 ;;       movl    $0xb, %r8d
 ;;       movl    $4, %r9d
-;;       callq   0x8ee
+;;       callq   0x8ef
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
@@ -198,7 +198,7 @@
 ;;       movl    $0x13, %ecx
 ;;       movl    $0x14, %r8d
 ;;       movl    $5, %r9d
-;;       callq   0x8ee
+;;       callq   0x8ef
 ;;       movq    8(%rsp), %r14
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
@@ -212,7 +212,7 @@
 ;;       movq    0x18(%r11), %r11
 ;;       addq    $0x30, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x3c5
+;;       ja      0x3c6
 ;;  2dc: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
@@ -226,37 +226,37 @@
 ;;       movq    %r14, %rdx
 ;;       movq    0xb0(%rdx), %rbx
 ;;       cmpq    %rbx, %rcx
-;;       jae     0x3c7
+;;       jae     0x3c8
 ;;  321: movq    %rcx, %r11
 ;;       imulq   $8, %r11, %r11
 ;;       movq    0xa8(%rdx), %rdx
 ;;       movq    %rdx, %rsi
 ;;       addq    %r11, %rdx
-;;       cmpl    %ebx, %ecx
+;;       cmpq    %rbx, %rcx
 ;;       cmovaeq %rsi, %rdx
 ;;       movq    (%rdx), %rax
 ;;       testq   %rax, %rax
-;;       jne     0x384
-;;  34a: subq    $4, %rsp
+;;       jne     0x385
+;;  34b: subq    $4, %rsp
 ;;       movl    %ecx, (%rsp)
 ;;       subq    $0xc, %rsp
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
 ;;       movl    0xc(%rsp), %edx
-;;       callq   0x9cc
+;;       callq   0x9cd
 ;;       addq    $0xc, %rsp
 ;;       addq    $4, %rsp
 ;;       movq    0x18(%rsp), %r14
-;;       jmp     0x38a
-;;  384: andq    $0xfffffffffffffffe, %rax
+;;       jmp     0x38b
+;;  385: andq    $0xfffffffffffffffe, %rax
 ;;       testq   %rax, %rax
-;;       je      0x3c9
-;;  393: movq    0x28(%r14), %r11
+;;       je      0x3ca
+;;  394: movq    0x28(%r14), %r11
 ;;       movl    (%r11), %ecx
 ;;       movl    0x10(%rax), %edx
 ;;       cmpl    %edx, %ecx
-;;       jne     0x3cb
-;;  3a5: pushq   %rax
+;;       jne     0x3cc
+;;  3a6: pushq   %rax
 ;;       popq    %rcx
 ;;       movq    0x18(%rcx), %rbx
 ;;       movq    8(%rcx), %rdx
@@ -267,7 +267,7 @@
 ;;       addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;  3c5: ud2
-;;  3c7: ud2
-;;  3c9: ud2
-;;  3cb: ud2
+;;  3c6: ud2
+;;  3c8: ud2
+;;  3ca: ud2
+;;  3cc: ud2

--- a/tests/disas/winch/x64/table/set.wat
+++ b/tests/disas/winch/x64/table/set.wat
@@ -39,7 +39,7 @@
 ;;       movq    0x18(%r11), %r11
 ;;       addq    $0x20, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0xbc
+;;       ja      0xbd
 ;;   5c: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
@@ -51,21 +51,21 @@
 ;;       movq    %r14, %rdx
 ;;       movq    0x38(%rdx), %rbx
 ;;       cmpq    %rbx, %rcx
-;;       jae     0xbe
+;;       jae     0xbf
 ;;   90: movq    %rcx, %r11
 ;;       imulq   $8, %r11, %r11
 ;;       movq    0x30(%rdx), %rdx
 ;;       movq    %rdx, %rsi
 ;;       addq    %r11, %rdx
-;;       cmpl    %ebx, %ecx
+;;       cmpq    %rbx, %rcx
 ;;       cmovaeq %rsi, %rdx
 ;;       orq     $1, %rax
 ;;       movq    %rax, (%rdx)
 ;;       addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   bc: ud2
-;;   be: ud2
+;;   bd: ud2
+;;   bf: ud2
 ;;
 ;; wasm[0]::function[2]:
 ;;       pushq   %rbp
@@ -74,8 +74,8 @@
 ;;       movq    0x18(%r11), %r11
 ;;       addq    $0x30, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x1de
-;;   dc: movq    %rdi, %r14
+;;       ja      0x1f0
+;;   ec: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
 ;;       movq    %rsi, 0x10(%rsp)
@@ -92,47 +92,47 @@
 ;;       movq    %r14, %rdx
 ;;       movq    0x38(%rdx), %rbx
 ;;       cmpq    %rbx, %rcx
-;;       jae     0x1e0
-;;  132: movq    %rcx, %r11
+;;       jae     0x1f2
+;;  142: movq    %rcx, %r11
 ;;       imulq   $8, %r11, %r11
 ;;       movq    0x30(%rdx), %rdx
 ;;       movq    %rdx, %rsi
 ;;       addq    %r11, %rdx
-;;       cmpl    %ebx, %ecx
+;;       cmpq    %rbx, %rcx
 ;;       cmovaeq %rsi, %rdx
 ;;       movq    (%rdx), %rax
 ;;       testq   %rax, %rax
-;;       jne     0x192
-;;  158: subq    $4, %rsp
+;;       jne     0x1a3
+;;  169: subq    $4, %rsp
 ;;       movl    %ecx, (%rsp)
 ;;       subq    $8, %rsp
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
 ;;       movl    8(%rsp), %edx
-;;       callq   0x4a5
+;;       callq   0x4b7
 ;;       addq    $8, %rsp
 ;;       addq    $4, %rsp
 ;;       movq    0x1c(%rsp), %r14
-;;       jmp     0x198
-;;  192: andq    $0xfffffffffffffffe, %rax
+;;       jmp     0x1a9
+;;  1a3: andq    $0xfffffffffffffffe, %rax
 ;;       movl    (%rsp), %ecx
 ;;       addq    $4, %rsp
 ;;       movq    %r14, %rdx
 ;;       movq    0x38(%rdx), %rbx
 ;;       cmpq    %rbx, %rcx
-;;       jae     0x1e2
-;;  1b2: movq    %rcx, %r11
+;;       jae     0x1f4
+;;  1c3: movq    %rcx, %r11
 ;;       imulq   $8, %r11, %r11
 ;;       movq    0x30(%rdx), %rdx
 ;;       movq    %rdx, %rsi
 ;;       addq    %r11, %rdx
-;;       cmpl    %ebx, %ecx
+;;       cmpq    %rbx, %rcx
 ;;       cmovaeq %rsi, %rdx
 ;;       orq     $1, %rax
 ;;       movq    %rax, (%rdx)
 ;;       addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;  1de: ud2
-;;  1e0: ud2
-;;  1e2: ud2
+;;  1f0: ud2
+;;  1f2: ud2
+;;  1f4: ud2

--- a/winch/codegen/src/codegen/mod.rs
+++ b/winch/codegen/src/codegen/mod.rs
@@ -1047,7 +1047,7 @@ where
         if self.env.table_access_spectre_mitigation() {
             // Perform a bounds check and override the value of the
             // table element address in case the index is out of bounds.
-            self.masm.cmp(index, bound.into(), OperandSize::S32)?;
+            self.masm.cmp(index, bound.into(), bound_size)?;
             self.masm
                 .cmov(writable!(base), tmp, IntCmpKind::GeU, ptr_size)?;
         }


### PR DESCRIPTION
This commit fixes a minor issue in the Winch backend when loading a value from a table when spectre mitigations are enabled. In this situation an extra comparison and conditional move is executed after the original bounds check and load to specifically handle the speculation case and ensure that out-of-bounds values can't be speculated on. The comparison performed on this path, however, was an incorrect one where it unconditionally used a 32-bit comparison. The comparison instead needs to use `bound_size` to handle platform/table differences. This matches the actual bounds check, for example, which occurs prior to the spectre-related mitigation.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
