### PR TITLE
Add missing missing stack map declaration for `array.new_data`

### DIFF
--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -2742,7 +2742,9 @@ impl FuncEnvironment<'_> {
             libcall,
             &[vmctx, interned_type_index, data_index, data_offset, len],
         );
-        Ok(builder.func.dfg.first_result(call_inst))
+        let array_ref = builder.func.dfg.first_result(call_inst);
+        builder.declare_value_needs_stack_map(array_ref);
+        Ok(array_ref)
     }
 
     pub fn translate_array_new_elem(

--- a/tests/misc_testsuite/gc/array-new-data-missing-stack-map.wast
+++ b/tests/misc_testsuite/gc/array-new-data-missing-stack-map.wast
@@ -1,0 +1,20 @@
+;;! gc = true
+;;! bulk_memory = true
+
+(module
+  (type $arr (array i8))
+  (data $d "hello world")
+
+  (import "wasmtime" "gc" (func $gc))
+
+  (func (export "test") (result i32)
+    (array.new_data $arr $d (i32.const 0) (i32.const 5))
+
+    (call $gc)
+    (drop (array.new $arr (i32.const 0) (i32.const 5)))
+
+    (array.get_u $arr (i32.const 0))
+  )
+)
+
+(assert_return (invoke "test") (i32.const 104)) ;; 'h'


### PR DESCRIPTION
`translate_array_new_data` created a GC reference (array ref) via a libcall but
did not call `builder.declare_value_needs_stack_map()` on the result. This meant
that the reference was not included in stack maps at subsequent safepoints, so
if a GC occurred, the reference became stale (leading to use-after-free bugs
inside the GC heap sandbox).

Depends on https://github.com/bytecodealliance/wasmtime/pull/12934