### PR TITLE
Add missing stack map declaration for `array.new_elem`

### DIFF
--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -2766,7 +2766,9 @@ impl FuncEnvironment<'_> {
             libcall,
             &[vmctx, interned_type_index, elem_index, elem_offset, len],
         );
-        Ok(builder.func.dfg.first_result(call_inst))
+        let array_ref = builder.func.dfg.first_result(call_inst);
+        builder.declare_value_needs_stack_map(array_ref);
+        Ok(array_ref)
     }
 
     pub fn translate_array_copy(

--- a/tests/misc_testsuite/gc/array-new-elem-missing-stack-map.wast
+++ b/tests/misc_testsuite/gc/array-new-elem-missing-stack-map.wast
@@ -1,0 +1,26 @@
+;;! gc = true
+;;! bulk_memory = true
+
+(module
+  (type $s (struct (field (mut i32))))
+  (type $arr (array (ref null $s)))
+
+  (elem $e (ref null $s) (struct.new $s (i32.const 42)))
+
+  (import "wasmtime" "gc" (func $gc))
+
+  (func (export "test") (result i32)
+    (array.new_elem $arr $e (i32.const 0) (i32.const 1))
+
+    (call $gc)
+    (drop (struct.new $s (i32.const 0)))
+    (drop (struct.new $s (i32.const 0)))
+    (drop (struct.new $s (i32.const 0)))
+    (drop (struct.new $s (i32.const 0)))
+    (drop (struct.new $s (i32.const 0)))
+
+    (struct.get $s 0 (array.get $arr (i32.const 0)))
+  )
+)
+
+(assert_return (invoke "test") (i32.const 42))


### PR DESCRIPTION
`translate_array_new_elem` created a GC reference (array ref) via a libcall but
did not call `builder.declare_value_needs_stack_map()` on the result. This meant
the reference was not included in stack maps at subsequent safepoints, so if a
GC occurred, the reference became stale (leading to use-after-free within the GC
heap sandbox).

Depends on https://github.com/bytecodealliance/wasmtime/pull/12935