### PR TITLE
Cranelift: riscv64: fix zero-extension in trapif + icmp folding.

### DIFF
--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -2125,7 +2125,10 @@
 
 ; fold icmp + trapz
 (rule 2 (lower (trapz (icmp _ cc x @ (value_type (fits_in_64 _)) y) code))
-  (gen_trapif (intcc_complement cc) x y code))
+  (gen_trapif (intcc_complement cc)
+    (put_value_in_reg_for_icmp cc x)
+    (put_value_in_reg_for_icmp cc y)
+    code))
 
 ;;;;;  Rules for `trapnz`;;;;;;;;;
 (rule
@@ -2138,7 +2141,10 @@
 
 ; fold icmp + trapnz
 (rule 2 (lower (trapnz (icmp _ cc x @ (value_type (fits_in_64 _)) y) code))
-  (gen_trapif cc x y code))
+  (gen_trapif cc
+    (put_value_in_reg_for_icmp cc x)
+    (put_value_in_reg_for_icmp cc y)
+    code))
 
 ;;;;;  Rules for `uload8`;;;;;;;;;
 (rule (lower (uload8 _ (little_or_native_endian flags) addr offset))

--- a/cranelift/filetests/filetests/isa/riscv64/trapz-sign-extend-load32.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/trapz-sign-extend-load32.clif
@@ -13,12 +13,20 @@ block0(v0: i64, v1: i64):
 ; VCode:
 ; block0:
 ;   lw a0,0(a0)
+;   slli a0,a0,32
+;   srli a0,a0,32
+;   slli a1,a1,32
+;   srli a1,a1,32
 ;   trap_if user15##(a0 uge a1)
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   lw a0, 0(a0)
+;   slli a0, a0, 0x20
+;   srli a0, a0, 0x20
+;   slli a1, a1, 0x20
+;   srli a1, a1, 0x20
 ;   bltu a0, a1, 8
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: user15
 ;   ret


### PR DESCRIPTION
The riscv64 backend has an instruction lowering for `trapif` of an `icmp` that emits a compare-and-branch instruction. When the `icmp` has an unsigned comparison mode and operates on narrower-than-64-bit values (e.g. `I32`s), the compare-and-branch requires that the values be zero-extended, since ordinarily registers have undefined bits above the contained type's width.

Unfortunately the lowering didn't do this, so when the bits are actually nonzero, the comparison result is incorrect. For example, a 32-bit load (`lw`) on riscv64 sign-extends the loaded value; if we make use of this, then we get an incorrect comparison result. The included test-case reproduces this issue.

The fix is to use our existing helper to normalize the value (sign- or zero-extend as needed) for the comparison. (I had hoped to fold this logic into `gen_trapif` to make it a little harder to skip, but at that level we're already dealing with `XReg`s rather than `Value`s so we've lost the type information and thus can't extend properly.)