### PR TITLE
Fix panic optimizing vector expressions

### DIFF
--- a/cranelift/codegen/src/opts/arithmetic.isle
+++ b/cranelift/codegen/src/opts/arithmetic.isle
@@ -380,10 +380,10 @@
 (rule (simplify (iadd ty (iadd ty (isub ty z x) y) x)) (iadd ty y z))
 
 ;; (x + y) == (y + x) --> true
-(rule (simplify (eq ty (iadd cty x y) (iadd cty y x))) (iconst_u ty 1))
-(rule (simplify (eq ty (iadd cty y x) (iadd cty x y))) (iconst_u ty 1))
-(rule (simplify (eq ty (iadd cty x y) (iadd cty x y))) (iconst_u ty 1))
-(rule (simplify (eq ty (iadd cty y x) (iadd cty y x))) (iconst_u ty 1))
+(rule (simplify (eq (ty_int ty) (iadd cty x y) (iadd cty y x))) (iconst_u ty 1))
+(rule (simplify (eq (ty_int ty) (iadd cty y x) (iadd cty x y))) (iconst_u ty 1))
+(rule (simplify (eq (ty_int ty) (iadd cty x y) (iadd cty x y))) (iconst_u ty 1))
+(rule (simplify (eq (ty_int ty) (iadd cty y x) (iadd cty y x))) (iconst_u ty 1))
 
 ;; (x - y) != x --> y != 0
 (rule (simplify (ne cty (isub ty x y) x)) (ne cty y (iconst_u ty 0)))

--- a/cranelift/filetests/filetests/egraph/arithmetic-precise.clif
+++ b/cranelift/filetests/filetests/egraph/arithmetic-precise.clif
@@ -234,6 +234,21 @@ block0(v0: i32, v1: i32):
 ;     return v5  ; v5 = 1
 ; }
 
+;; (eq ty (iadd cty x y) (iadd cty y x)) -> 1
+function %simplify_vector_icmp_eq_iadd_commute(i32x4, i32x4) -> i32x4 fast {
+block0(v0: i32x4, v1: i32x4):
+    v2 = iadd v0, v1
+    v3 = iadd v1, v0
+    v4 = icmp eq v2, v3
+    return v4
+}
+
+; function %simplify_vector_icmp_eq_iadd_commute(i32x4, i32x4) -> i32x4 fast {
+; block0(v0: i32x4, v1: i32x4):
+;     v5 = icmp eq v0, v0
+;     return v5
+; }
+
 ;; (x - y) != x --> y != 0
 function %simplify_icmp_ne_isub_x(i32, i32) -> i8 fast {
 block0(v0: i32, v1: i32):


### PR DESCRIPTION
This commit fixes an accidental regression from #12926 where `iconst_u` was called with vector types which caused a panic. The fix is is to disallow vector types in these ISLE rules and defer vector optimizations to a future commit.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
