### PR TITLE
Fix another panic optimizing vector expressions

### DIFF
--- a/cranelift/codegen/src/opts/arithmetic.isle
+++ b/cranelift/codegen/src/opts/arithmetic.isle
@@ -386,5 +386,5 @@
 (rule (simplify (eq (ty_int ty) (iadd cty y x) (iadd cty y x))) (iconst_u ty 1))
 
 ;; (x - y) != x --> y != 0
-(rule (simplify (ne cty (isub ty x y) x)) (ne cty y (iconst_u ty 0)))
-(rule (simplify (ne cty x (isub ty x y))) (ne cty y (iconst_u ty 0)))
+(rule (simplify (ne cty (isub (ty_int ty) x y) x)) (ne cty y (iconst_u ty 0)))
+(rule (simplify (ne cty x (isub (ty_int ty) x y))) (ne cty y (iconst_u ty 0)))

--- a/cranelift/filetests/filetests/egraph/arithmetic-precise.clif
+++ b/cranelift/filetests/filetests/egraph/arithmetic-precise.clif
@@ -263,3 +263,18 @@ block0(v0: i32, v1: i32):
 ;     v5 = icmp ne v1, v4  ; v4 = 0
 ;     return v5
 ; }
+
+;; (x - y) != x --> y != 0 (vector)
+function %simplify_vector_icmp_ne_isub_x(i32x4, i32x4) -> i32x4 fast {
+block0(v0: i32x4, v1: i32x4):
+    v2 = isub v0, v1
+    v3 = icmp ne v2, v0
+    return v3
+}
+
+; function %simplify_vector_icmp_ne_isub_x(i32x4, i32x4) -> i32x4 fast {
+; block0(v0: i32x4, v1: i32x4):
+;     v2 = isub v0, v1
+;     v3 = icmp ne v2, v0
+;     return v3
+; }


### PR DESCRIPTION
#12957 fixed the `iadd` rules introduced by #12926, but not the `isub` ones.