### PR TITLE
Bump Wasmtime to 45.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -287,7 +287,7 @@ dependencies = [
 
 [[package]]
 name = "byte-array-literals"
-version = "44.0.0"
+version = "45.0.0"
 
 [[package]]
 name = "byteorder"
@@ -690,7 +690,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift"
-version = "0.131.0"
+version = "0.132.0"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.131.0"
+version = "0.132.0"
 dependencies = [
  "arbitrary",
  "arbtest",
@@ -721,14 +721,14 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.131.0"
+version = "0.132.0"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.131.0"
+version = "0.132.0"
 dependencies = [
  "cranelift-entity",
  "wasmtime-internal-core",
@@ -736,7 +736,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.131.0"
+version = "0.132.0"
 dependencies = [
  "arbitrary",
  "serde",
@@ -746,7 +746,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.131.0"
+version = "0.132.0"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -782,7 +782,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.131.0"
+version = "0.132.0"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -793,18 +793,18 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.131.0"
+version = "0.132.0"
 
 [[package]]
 name = "cranelift-control"
-version = "0.131.0"
+version = "0.132.0"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.131.0"
+version = "0.132.0"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -846,7 +846,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.131.0"
+version = "0.132.0"
 dependencies = [
  "cranelift-codegen",
  "env_logger 0.11.5",
@@ -871,7 +871,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-interpreter"
-version = "0.131.0"
+version = "0.132.0"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.131.0"
+version = "0.132.0"
 dependencies = [
  "codespan-reporting",
  "log",
@@ -894,7 +894,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-jit"
-version = "0.131.0"
+version = "0.132.0"
 dependencies = [
  "anyhow",
  "cranelift",
@@ -916,7 +916,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-module"
-version = "0.131.0"
+version = "0.132.0"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -928,7 +928,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.131.0"
+version = "0.132.0"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -937,7 +937,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-object"
-version = "0.131.0"
+version = "0.132.0"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -952,7 +952,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-reader"
-version = "0.131.0"
+version = "0.132.0"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-serde"
-version = "0.131.0"
+version = "0.132.0"
 dependencies = [
  "clap",
  "cranelift-codegen",
@@ -972,7 +972,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.131.0"
+version = "0.132.0"
 
 [[package]]
 name = "cranelift-tools"
@@ -1232,7 +1232,7 @@ checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "embedding"
-version = "44.0.0"
+version = "45.0.0"
 dependencies = [
  "dlmalloc",
  "raw-cpuid",
@@ -2416,7 +2416,7 @@ dependencies = [
 
 [[package]]
 name = "min-platform-host"
-version = "44.0.0"
+version = "45.0.0"
 dependencies = [
  "libloading",
  "object 0.39.0",
@@ -2880,7 +2880,7 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "44.0.0"
+version = "45.0.0"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -2904,7 +2904,7 @@ dependencies = [
 
 [[package]]
 name = "pulley-macros"
-version = "44.0.0"
+version = "45.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4211,7 +4211,7 @@ version = "0.1.0"
 
 [[package]]
 name = "verify-component-adapter"
-version = "44.0.0"
+version = "45.0.0"
 dependencies = [
  "anyhow",
  "wasmparser 0.246.1",
@@ -4276,7 +4276,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-common"
-version = "44.0.0"
+version = "45.0.0"
 dependencies = [
  "async-trait",
  "bitflags 2.9.4",
@@ -4316,7 +4316,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-preview1-component-adapter"
-version = "44.0.0"
+version = "45.0.0"
 dependencies = [
  "bitflags 2.9.4",
  "byte-array-literals",
@@ -4593,7 +4593,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "44.0.0"
+version = "45.0.0"
 dependencies = [
  "addr2line 0.26.0",
  "async-trait",
@@ -4654,7 +4654,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-bench-api"
-version = "44.0.0"
+version = "45.0.0"
 dependencies = [
  "cap-std",
  "clap",
@@ -4669,14 +4669,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-c-api"
-version = "44.0.0"
+version = "45.0.0"
 dependencies = [
  "wasmtime-c-api-impl",
 ]
 
 [[package]]
 name = "wasmtime-c-api-impl"
-version = "44.0.0"
+version = "45.0.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4696,7 +4696,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli"
-version = "44.0.0"
+version = "45.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4775,7 +4775,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli-flags"
-version = "44.0.0"
+version = "45.0.0"
 dependencies = [
  "clap",
  "file-per-thread-logger",
@@ -4789,7 +4789,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "44.0.0"
+version = "45.0.0"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -4910,7 +4910,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-c-api-macros"
-version = "44.0.0"
+version = "45.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4918,7 +4918,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cache"
-version = "44.0.0"
+version = "45.0.0"
 dependencies = [
  "base64",
  "directories-next",
@@ -4939,7 +4939,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-macro"
-version = "44.0.0"
+version = "45.0.0"
 dependencies = [
  "anyhow",
  "component-macro-test-helpers",
@@ -4959,11 +4959,11 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-util"
-version = "44.0.0"
+version = "45.0.0"
 
 [[package]]
 name = "wasmtime-internal-core"
-version = "44.0.0"
+version = "45.0.0"
 dependencies = [
  "anyhow",
  "hashbrown 0.16.1",
@@ -4973,7 +4973,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "44.0.0"
+version = "45.0.0"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -4998,7 +4998,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-debugger"
-version = "44.0.0"
+version = "45.0.0"
 dependencies = [
  "async-trait",
  "env_logger 0.11.5",
@@ -5011,7 +5011,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-explorer"
-version = "44.0.0"
+version = "45.0.0"
 dependencies = [
  "capstone",
  "serde",
@@ -5025,7 +5025,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-fiber"
-version = "44.0.0"
+version = "45.0.0"
 dependencies = [
  "backtrace",
  "cc",
@@ -5039,7 +5039,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-gdbstub-component"
-version = "44.0.0"
+version = "45.0.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -5055,11 +5055,11 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-gdbstub-component-artifact"
-version = "44.0.0"
+version = "45.0.0"
 
 [[package]]
 name = "wasmtime-internal-jit-debug"
-version = "44.0.0"
+version = "45.0.0"
 dependencies = [
  "cc",
  "object 0.39.0",
@@ -5069,7 +5069,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "44.0.0"
+version = "45.0.0"
 dependencies = [
  "cfg-if",
  "libc",
@@ -5079,7 +5079,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-unwinder"
-version = "44.0.0"
+version = "45.0.0"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -5090,7 +5090,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
-version = "44.0.0"
+version = "45.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5099,7 +5099,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-winch"
-version = "44.0.0"
+version = "45.0.0"
 dependencies = [
  "cranelift-codegen",
  "gimli 0.33.0",
@@ -5114,7 +5114,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-wit-bindgen"
-version = "44.0.0"
+version = "45.0.0"
 dependencies = [
  "anyhow",
  "bitflags 2.9.4",
@@ -5125,7 +5125,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-wmemcheck"
-version = "44.0.0"
+version = "45.0.0"
 
 [[package]]
 name = "wasmtime-test-macros"
@@ -5140,7 +5140,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-test-util"
-version = "44.0.0"
+version = "45.0.0"
 dependencies = [
  "arbitrary",
  "arbtest",
@@ -5163,7 +5163,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "44.0.0"
+version = "45.0.0"
 dependencies = [
  "async-trait",
  "bitflags 2.9.4",
@@ -5197,7 +5197,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-config"
-version = "44.0.0"
+version = "45.0.0"
 dependencies = [
  "test-programs-artifacts",
  "tokio",
@@ -5207,7 +5207,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-http"
-version = "44.0.0"
+version = "45.0.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -5239,7 +5239,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-io"
-version = "44.0.0"
+version = "45.0.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5250,7 +5250,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-keyvalue"
-version = "44.0.0"
+version = "45.0.0"
 dependencies = [
  "test-programs-artifacts",
  "tokio",
@@ -5260,7 +5260,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-nn"
-version = "44.0.0"
+version = "45.0.0"
 dependencies = [
  "cap-std",
  "libtest-mimic",
@@ -5280,7 +5280,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-threads"
-version = "44.0.0"
+version = "45.0.0"
 dependencies = [
  "log",
  "rand 0.8.5",
@@ -5291,7 +5291,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-tls"
-version = "44.0.0"
+version = "45.0.0"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -5312,7 +5312,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wast"
-version = "44.0.0"
+version = "45.0.0"
 dependencies = [
  "json-from-wast",
  "log",
@@ -5326,7 +5326,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wizer"
-version = "44.0.0"
+version = "45.0.0"
 dependencies = [
  "clap",
  "criterion",
@@ -5406,7 +5406,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "44.0.0"
+version = "45.0.0"
 dependencies = [
  "bitflags 2.9.4",
  "proptest",
@@ -5422,7 +5422,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "44.0.0"
+version = "45.0.0"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -5434,7 +5434,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "44.0.0"
+version = "45.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5489,7 +5489,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "44.0.0"
+version = "45.0.0"
 dependencies = [
  "cranelift-assembler-x64",
  "cranelift-codegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -189,7 +189,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "44.0.0"
+version = "45.0.0"
 authors = ["The Wasmtime Project Developers"]
 edition = "2024"
 # Wasmtime's current policy is that this number can be no larger than the
@@ -247,18 +247,18 @@ extra_unused_type_parameters = 'warn'
 # tooling but aren't intended to be widely depended on.
 #
 # All of these crates are supported though in the sense that
-wasmtime = { path = "crates/wasmtime", version = "44.0.0", default-features = false }
-wasmtime-cli-flags = { path = "crates/cli-flags", version = "=44.0.0" }
-wasmtime-environ = { path = "crates/environ", version = "=44.0.0" }
-wasmtime-wasi = { path = "crates/wasi", version = "44.0.0", default-features = false }
-wasmtime-wasi-io = { path = "crates/wasi-io", version = "44.0.0", default-features = false }
-wasmtime-wasi-http = { path = "crates/wasi-http", version = "44.0.0", default-features = false }
-wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "44.0.0" }
-wasmtime-wasi-config = { path = "crates/wasi-config", version = "44.0.0" }
-wasmtime-wasi-keyvalue = { path = "crates/wasi-keyvalue", version = "44.0.0" }
-wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "44.0.0" }
-wasmtime-wasi-tls = { path = "crates/wasi-tls", version = "44.0.0" }
-wasmtime-wast = { path = "crates/wast", version = "=44.0.0" }
+wasmtime = { path = "crates/wasmtime", version = "45.0.0", default-features = false }
+wasmtime-cli-flags = { path = "crates/cli-flags", version = "=45.0.0" }
+wasmtime-environ = { path = "crates/environ", version = "=45.0.0" }
+wasmtime-wasi = { path = "crates/wasi", version = "45.0.0", default-features = false }
+wasmtime-wasi-io = { path = "crates/wasi-io", version = "45.0.0", default-features = false }
+wasmtime-wasi-http = { path = "crates/wasi-http", version = "45.0.0", default-features = false }
+wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "45.0.0" }
+wasmtime-wasi-config = { path = "crates/wasi-config", version = "45.0.0" }
+wasmtime-wasi-keyvalue = { path = "crates/wasi-keyvalue", version = "45.0.0" }
+wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "45.0.0" }
+wasmtime-wasi-tls = { path = "crates/wasi-tls", version = "45.0.0" }
+wasmtime-wast = { path = "crates/wast", version = "=45.0.0" }
 
 # Internal Wasmtime-specific crates.
 #
@@ -267,55 +267,55 @@ wasmtime-wast = { path = "crates/wast", version = "=44.0.0" }
 # that these are internal unsupported crates for external use. These exist as
 # part of the project organization of other public crates in Wasmtime and are
 # otherwise not supported in terms of CVEs for example.
-wasmtime-core = { path = "crates/core", version = "=44.0.0", package = 'wasmtime-internal-core' }
-wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=44.0.0", package = 'wasmtime-internal-wmemcheck' }
-wasmtime-c-api-macros = { path = "crates/c-api-macros", version = "=44.0.0", package = 'wasmtime-internal-c-api-macros' }
-wasmtime-cache = { path = "crates/cache", version = "=44.0.0", package = 'wasmtime-internal-cache' }
-wasmtime-cranelift = { path = "crates/cranelift", version = "=44.0.0", package = 'wasmtime-internal-cranelift' }
-wasmtime-winch = { path = "crates/winch", version = "=44.0.0", package = 'wasmtime-internal-winch'  }
-wasmtime-explorer = { path = "crates/explorer", version = "=44.0.0", package = 'wasmtime-internal-explorer'  }
-wasmtime-fiber = { path = "crates/fiber", version = "=44.0.0", package = 'wasmtime-internal-fiber' }
-wasmtime-jit-debug = { path = "crates/jit-debug", version = "=44.0.0", package = 'wasmtime-internal-jit-debug' }
-wasmtime-component-util = { path = "crates/component-util", version = "=44.0.0", package = 'wasmtime-internal-component-util' }
-wasmtime-component-macro = { path = "crates/component-macro", version = "=44.0.0", package = 'wasmtime-internal-component-macro' }
-wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=44.0.0", package = 'wasmtime-internal-versioned-export-macros' }
-wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=44.0.0", package = 'wasmtime-internal-jit-icache-coherence' }
-wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=44.0.0", package = 'wasmtime-internal-wit-bindgen' }
-wasmtime-unwinder = { path = "crates/unwinder", version = "=44.0.0", package = 'wasmtime-internal-unwinder' }
-wasmtime-debugger = { path = "crates/debugger", version = "=44.0.0", package = "wasmtime-internal-debugger" }
-gdbstub-component-artifact = { path = "crates/gdbstub-component/artifact", version = "=44.0.0", package = "wasmtime-internal-gdbstub-component-artifact" }
-wasmtime-wizer = { path = "crates/wizer", version = "44.0.0" }
+wasmtime-core = { path = "crates/core", version = "=45.0.0", package = 'wasmtime-internal-core' }
+wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=45.0.0", package = 'wasmtime-internal-wmemcheck' }
+wasmtime-c-api-macros = { path = "crates/c-api-macros", version = "=45.0.0", package = 'wasmtime-internal-c-api-macros' }
+wasmtime-cache = { path = "crates/cache", version = "=45.0.0", package = 'wasmtime-internal-cache' }
+wasmtime-cranelift = { path = "crates/cranelift", version = "=45.0.0", package = 'wasmtime-internal-cranelift' }
+wasmtime-winch = { path = "crates/winch", version = "=45.0.0", package = 'wasmtime-internal-winch'  }
+wasmtime-explorer = { path = "crates/explorer", version = "=45.0.0", package = 'wasmtime-internal-explorer'  }
+wasmtime-fiber = { path = "crates/fiber", version = "=45.0.0", package = 'wasmtime-internal-fiber' }
+wasmtime-jit-debug = { path = "crates/jit-debug", version = "=45.0.0", package = 'wasmtime-internal-jit-debug' }
+wasmtime-component-util = { path = "crates/component-util", version = "=45.0.0", package = 'wasmtime-internal-component-util' }
+wasmtime-component-macro = { path = "crates/component-macro", version = "=45.0.0", package = 'wasmtime-internal-component-macro' }
+wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=45.0.0", package = 'wasmtime-internal-versioned-export-macros' }
+wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=45.0.0", package = 'wasmtime-internal-jit-icache-coherence' }
+wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=45.0.0", package = 'wasmtime-internal-wit-bindgen' }
+wasmtime-unwinder = { path = "crates/unwinder", version = "=45.0.0", package = 'wasmtime-internal-unwinder' }
+wasmtime-debugger = { path = "crates/debugger", version = "=45.0.0", package = "wasmtime-internal-debugger" }
+gdbstub-component-artifact = { path = "crates/gdbstub-component/artifact", version = "=45.0.0", package = "wasmtime-internal-gdbstub-component-artifact" }
+wasmtime-wizer = { path = "crates/wizer", version = "45.0.0" }
 
 # Miscellaneous crates without a `wasmtime-*` prefix in their name but still
 # used in the `wasmtime-*` family of crates depending on various features/etc.
-wiggle = { path = "crates/wiggle", version = "=44.0.0", default-features = false }
-wiggle-macro = { path = "crates/wiggle/macro", version = "=44.0.0" }
-wiggle-generate = { path = "crates/wiggle/generate", version = "=44.0.0" }
-wasi-common = { path = "crates/wasi-common", version = "=44.0.0", default-features = false }
-pulley-interpreter = { path = 'pulley', version = "=44.0.0" }
-pulley-macros = { path = 'pulley/macros', version = "=44.0.0" }
+wiggle = { path = "crates/wiggle", version = "=45.0.0", default-features = false }
+wiggle-macro = { path = "crates/wiggle/macro", version = "=45.0.0" }
+wiggle-generate = { path = "crates/wiggle/generate", version = "=45.0.0" }
+wasi-common = { path = "crates/wasi-common", version = "=45.0.0", default-features = false }
+pulley-interpreter = { path = 'pulley', version = "=45.0.0" }
+pulley-macros = { path = 'pulley/macros', version = "=45.0.0" }
 
 # Cranelift crates in this workspace
-cranelift-assembler-x64 = { path = "cranelift/assembler-x64", version = "0.131.0" }
-cranelift-codegen = { path = "cranelift/codegen", version = "0.131.0", default-features = false, features = ["std", "unwind"] }
-cranelift-frontend = { path = "cranelift/frontend", version = "0.131.0" }
-cranelift-entity = { path = "cranelift/entity", version = "0.131.0" }
-cranelift-native = { path = "cranelift/native", version = "0.131.0" }
-cranelift-module = { path = "cranelift/module", version = "0.131.0" }
-cranelift-interpreter = { path = "cranelift/interpreter", version = "0.131.0" }
-cranelift-reader = { path = "cranelift/reader", version = "0.131.0" }
+cranelift-assembler-x64 = { path = "cranelift/assembler-x64", version = "0.132.0" }
+cranelift-codegen = { path = "cranelift/codegen", version = "0.132.0", default-features = false, features = ["std", "unwind"] }
+cranelift-frontend = { path = "cranelift/frontend", version = "0.132.0" }
+cranelift-entity = { path = "cranelift/entity", version = "0.132.0" }
+cranelift-native = { path = "cranelift/native", version = "0.132.0" }
+cranelift-module = { path = "cranelift/module", version = "0.132.0" }
+cranelift-interpreter = { path = "cranelift/interpreter", version = "0.132.0" }
+cranelift-reader = { path = "cranelift/reader", version = "0.132.0" }
 cranelift-filetests = { path = "cranelift/filetests" }
-cranelift-object = { path = "cranelift/object", version = "0.131.0" }
-cranelift-jit = { path = "cranelift/jit", version = "0.131.0" }
+cranelift-object = { path = "cranelift/object", version = "0.132.0" }
+cranelift-jit = { path = "cranelift/jit", version = "0.132.0" }
 cranelift-fuzzgen = { path = "cranelift/fuzzgen" }
-cranelift-bforest = { path = "cranelift/bforest", version = "0.131.0" }
-cranelift-bitset = { path = "cranelift/bitset", version = "0.131.0" }
-cranelift-control = { path = "cranelift/control", version = "0.131.0", default-features = false }
-cranelift-srcgen = { path = "cranelift/srcgen", version = "0.131.0" }
-cranelift = { path = "cranelift/umbrella", version = "0.131.0" }
+cranelift-bforest = { path = "cranelift/bforest", version = "0.132.0" }
+cranelift-bitset = { path = "cranelift/bitset", version = "0.132.0" }
+cranelift-control = { path = "cranelift/control", version = "0.132.0", default-features = false }
+cranelift-srcgen = { path = "cranelift/srcgen", version = "0.132.0" }
+cranelift = { path = "cranelift/umbrella", version = "0.132.0" }
 
 # Winch crates in this workspace.
-winch-codegen = { path = "winch/codegen", version = "=44.0.0" }
+winch-codegen = { path = "winch/codegen", version = "=45.0.0" }
 
 # Internal crates not published to crates.io used in testing, builds, etc
 wasi-preview1-component-adapter = { path = "crates/wasi-preview1-component-adapter" }

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,4 +1,4 @@
-## 44.0.0
+## 45.0.0
 
 Unreleased.
 
@@ -12,6 +12,7 @@ Release notes for previous releases of Wasmtime can be found on the respective
 release branches of the Wasmtime repository.
 
 <!-- ARCHIVE_START -->
+* [44.0.x](https://github.com/bytecodealliance/wasmtime/blob/release-44.0.0/RELEASES.md)
 * [43.0.x](https://github.com/bytecodealliance/wasmtime/blob/release-43.0.0/RELEASES.md)
 * [42.0.x](https://github.com/bytecodealliance/wasmtime/blob/release-42.0.0/RELEASES.md)
 * [41.0.x](https://github.com/bytecodealliance/wasmtime/blob/release-41.0.0/RELEASES.md)

--- a/cranelift/assembler-x64/Cargo.toml
+++ b/cranelift/assembler-x64/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-assembler-x64"
 description = "A Cranelift-specific x64 assembler"
-version = "0.131.0"
+version = "0.132.0"
 license = "Apache-2.0 WITH LLVM-exception"
 edition.workspace = true
 rust-version.workspace = true
@@ -16,7 +16,7 @@ arbtest = { workspace = true }
 capstone = { workspace = true }
 
 [build-dependencies]
-cranelift-assembler-x64-meta = { path = "meta", version = "0.131.0" }
+cranelift-assembler-x64-meta = { path = "meta", version = "0.132.0" }
 
 [lints]
 workspace = true

--- a/cranelift/assembler-x64/meta/Cargo.toml
+++ b/cranelift/assembler-x64/meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-assembler-x64-meta"
 description = "Generate a Cranelift-specific assembler for x64 instructions"
-version = "0.131.0"
+version = "0.132.0"
 license = "Apache-2.0 WITH LLVM-exception"
 edition.workspace = true
 rust-version.workspace = true

--- a/cranelift/bforest/Cargo.toml
+++ b/cranelift/bforest/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bforest"
-version = "0.131.0"
+version = "0.132.0"
 description = "A forest of B+-trees"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-bforest"

--- a/cranelift/bitset/Cargo.toml
+++ b/cranelift/bitset/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bitset"
-version = "0.131.0"
+version = "0.132.0"
 description = "Various bitset stuff for use inside Cranelift"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-bitset"

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen"
-version = "0.131.0"
+version = "0.132.0"
 description = "Low-level code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-codegen"
@@ -25,7 +25,7 @@ anyhow = { workspace = true, optional = true, features = ['std'] }
 bumpalo = { workspace = true }
 capstone = { workspace = true, optional = true }
 cranelift-assembler-x64 = { workspace = true }
-cranelift-codegen-shared = { path = "./shared", version = "0.131.0" }
+cranelift-codegen-shared = { path = "./shared", version = "0.132.0" }
 cranelift-entity = { workspace = true }
 cranelift-bforest = { workspace = true }
 cranelift-bitset = { workspace = true }
@@ -57,8 +57,8 @@ env_logger = { workspace = true }
 proptest = { workspace = true }
 
 [build-dependencies]
-cranelift-codegen-meta = { path = "meta", version = "0.131.0" }
-cranelift-isle = { path = "../isle/isle", version = "=0.131.0" }
+cranelift-codegen-meta = { path = "meta", version = "0.132.0" }
+cranelift-isle = { path = "../isle/isle", version = "=0.132.0" }
 
 [features]
 default = ["std", "unwind", "host-arch", "timing"]

--- a/cranelift/codegen/meta/Cargo.toml
+++ b/cranelift/codegen/meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-codegen-meta"
 authors = ["The Cranelift Project Developers"]
-version = "0.131.0"
+version = "0.132.0"
 description = "Metaprogram for cranelift-codegen code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
@@ -17,8 +17,8 @@ rustdoc-args = ["--document-private-items"]
 
 [dependencies]
 cranelift-srcgen = { workspace = true }
-cranelift-assembler-x64-meta = { path = "../../assembler-x64/meta", version = "0.131.0" }
-cranelift-codegen-shared = { path = "../shared", version = "0.131.0" }
+cranelift-assembler-x64-meta = { path = "../../assembler-x64/meta", version = "0.132.0" }
+cranelift-codegen-shared = { path = "../shared", version = "0.132.0" }
 pulley-interpreter = { workspace = true, optional = true }
 heck = "0.5.0"
 

--- a/cranelift/codegen/shared/Cargo.toml
+++ b/cranelift/codegen/shared/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen-shared"
-version = "0.131.0"
+version = "0.132.0"
 description = "For code shared between cranelift-codegen-meta and cranelift-codegen"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/control/Cargo.toml
+++ b/cranelift/control/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-control"
-version = "0.131.0"
+version = "0.132.0"
 description = "White-box fuzz testing framework"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/entity/Cargo.toml
+++ b/cranelift/entity/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-entity"
-version = "0.131.0"
+version = "0.132.0"
 description = "Data structures using entity references as mapping keys"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-entity"

--- a/cranelift/frontend/Cargo.toml
+++ b/cranelift/frontend/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-frontend"
-version = "0.131.0"
+version = "0.132.0"
 description = "Cranelift IR builder helper"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-frontend"

--- a/cranelift/interpreter/Cargo.toml
+++ b/cranelift/interpreter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-interpreter"
-version = "0.131.0"
+version = "0.132.0"
 authors = ["The Cranelift Project Developers"]
 description = "Interpret Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/isle/isle/Cargo.toml
+++ b/cranelift/isle/isle/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 name = "cranelift-isle"
 readme = "../README.md"
 repository = "https://github.com/bytecodealliance/wasmtime/tree/main/cranelift/isle"
-version = "0.131.0"
+version = "0.132.0"
 
 [lints]
 workspace = true

--- a/cranelift/jit/Cargo.toml
+++ b/cranelift/jit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-jit"
-version = "0.131.0"
+version = "0.132.0"
 authors = ["The Cranelift Project Developers"]
 description = "A JIT library backed by Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/module/Cargo.toml
+++ b/cranelift/module/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-module"
-version = "0.131.0"
+version = "0.132.0"
 authors = ["The Cranelift Project Developers"]
 description = "Support for linking functions and data with Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/native/Cargo.toml
+++ b/cranelift/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-native"
-version = "0.131.0"
+version = "0.132.0"
 authors = ["The Cranelift Project Developers"]
 description = "Support for targeting the host with Cranelift"
 documentation = "https://docs.rs/cranelift-native"

--- a/cranelift/object/Cargo.toml
+++ b/cranelift/object/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-object"
-version = "0.131.0"
+version = "0.132.0"
 authors = ["The Cranelift Project Developers"]
 description = "Emit Cranelift output to native object files with `object`"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/reader/Cargo.toml
+++ b/cranelift/reader/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-reader"
-version = "0.131.0"
+version = "0.132.0"
 description = "Cranelift textual IR reader"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-reader"

--- a/cranelift/serde/Cargo.toml
+++ b/cranelift/serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-serde"
-version = "0.131.0"
+version = "0.132.0"
 authors = ["The Cranelift Project Developers"]
 description = "Serializer/Deserializer for Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/srcgen/Cargo.toml
+++ b/cranelift/srcgen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-srcgen"
-version = "0.131.0"
+version = "0.132.0"
 authors = ["The Wasmtime Project Developers"]
 description = "Helper functions for generating Rust and ISLE files"
 license = "Apache-2.0 WITH LLVM-exception"

--- a/cranelift/umbrella/Cargo.toml
+++ b/cranelift/umbrella/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift"
-version = "0.131.0"
+version = "0.132.0"
 description = "Umbrella for commonly-used cranelift crates"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift"

--- a/crates/c-api/include/wasmtime.h
+++ b/crates/c-api/include/wasmtime.h
@@ -215,11 +215,11 @@
 /**
  * \brief Wasmtime version string.
  */
-#define WASMTIME_VERSION "44.0.0"
+#define WASMTIME_VERSION "45.0.0"
 /**
  * \brief Wasmtime major version number.
  */
-#define WASMTIME_VERSION_MAJOR 44
+#define WASMTIME_VERSION_MAJOR 45
 /**
  * \brief Wasmtime minor version number.
  */

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -13,6 +13,10 @@ audited_as = "0.128.3"
 version = "0.131.0"
 audited_as = "0.129.1"
 
+[[unpublished.cranelift]]
+version = "0.132.0"
+audited_as = "0.130.0"
+
 [[unpublished.cranelift-assembler-x64]]
 version = "0.129.0"
 audited_as = "0.127.1"
@@ -24,6 +28,10 @@ audited_as = "0.128.3"
 [[unpublished.cranelift-assembler-x64]]
 version = "0.131.0"
 audited_as = "0.129.1"
+
+[[unpublished.cranelift-assembler-x64]]
+version = "0.132.0"
+audited_as = "0.130.0"
 
 [[unpublished.cranelift-assembler-x64-meta]]
 version = "0.129.0"
@@ -37,6 +45,10 @@ audited_as = "0.128.3"
 version = "0.131.0"
 audited_as = "0.129.1"
 
+[[unpublished.cranelift-assembler-x64-meta]]
+version = "0.132.0"
+audited_as = "0.130.0"
+
 [[unpublished.cranelift-bforest]]
 version = "0.129.0"
 audited_as = "0.127.1"
@@ -48,6 +60,10 @@ audited_as = "0.128.3"
 [[unpublished.cranelift-bforest]]
 version = "0.131.0"
 audited_as = "0.129.1"
+
+[[unpublished.cranelift-bforest]]
+version = "0.132.0"
+audited_as = "0.130.0"
 
 [[unpublished.cranelift-bitset]]
 version = "0.129.0"
@@ -61,6 +77,10 @@ audited_as = "0.128.3"
 version = "0.131.0"
 audited_as = "0.129.1"
 
+[[unpublished.cranelift-bitset]]
+version = "0.132.0"
+audited_as = "0.130.0"
+
 [[unpublished.cranelift-codegen]]
 version = "0.129.0"
 audited_as = "0.127.1"
@@ -72,6 +92,10 @@ audited_as = "0.128.3"
 [[unpublished.cranelift-codegen]]
 version = "0.131.0"
 audited_as = "0.129.1"
+
+[[unpublished.cranelift-codegen]]
+version = "0.132.0"
+audited_as = "0.130.0"
 
 [[unpublished.cranelift-codegen-meta]]
 version = "0.129.0"
@@ -85,6 +109,10 @@ audited_as = "0.128.3"
 version = "0.131.0"
 audited_as = "0.129.1"
 
+[[unpublished.cranelift-codegen-meta]]
+version = "0.132.0"
+audited_as = "0.130.0"
+
 [[unpublished.cranelift-codegen-shared]]
 version = "0.129.0"
 audited_as = "0.127.1"
@@ -96,6 +124,10 @@ audited_as = "0.128.3"
 [[unpublished.cranelift-codegen-shared]]
 version = "0.131.0"
 audited_as = "0.129.1"
+
+[[unpublished.cranelift-codegen-shared]]
+version = "0.132.0"
+audited_as = "0.130.0"
 
 [[unpublished.cranelift-control]]
 version = "0.129.0"
@@ -109,6 +141,10 @@ audited_as = "0.128.3"
 version = "0.131.0"
 audited_as = "0.129.1"
 
+[[unpublished.cranelift-control]]
+version = "0.132.0"
+audited_as = "0.130.0"
+
 [[unpublished.cranelift-entity]]
 version = "0.129.0"
 audited_as = "0.127.1"
@@ -120,6 +156,10 @@ audited_as = "0.128.3"
 [[unpublished.cranelift-entity]]
 version = "0.131.0"
 audited_as = "0.129.1"
+
+[[unpublished.cranelift-entity]]
+version = "0.132.0"
+audited_as = "0.130.0"
 
 [[unpublished.cranelift-frontend]]
 version = "0.129.0"
@@ -133,6 +173,10 @@ audited_as = "0.128.3"
 version = "0.131.0"
 audited_as = "0.129.1"
 
+[[unpublished.cranelift-frontend]]
+version = "0.132.0"
+audited_as = "0.130.0"
+
 [[unpublished.cranelift-interpreter]]
 version = "0.129.0"
 audited_as = "0.127.1"
@@ -144,6 +188,10 @@ audited_as = "0.128.3"
 [[unpublished.cranelift-interpreter]]
 version = "0.131.0"
 audited_as = "0.129.1"
+
+[[unpublished.cranelift-interpreter]]
+version = "0.132.0"
+audited_as = "0.130.0"
 
 [[unpublished.cranelift-isle]]
 version = "0.129.0"
@@ -157,6 +205,10 @@ audited_as = "0.128.3"
 version = "0.131.0"
 audited_as = "0.129.1"
 
+[[unpublished.cranelift-isle]]
+version = "0.132.0"
+audited_as = "0.130.0"
+
 [[unpublished.cranelift-jit]]
 version = "0.129.0"
 audited_as = "0.127.1"
@@ -168,6 +220,10 @@ audited_as = "0.128.3"
 [[unpublished.cranelift-jit]]
 version = "0.131.0"
 audited_as = "0.129.1"
+
+[[unpublished.cranelift-jit]]
+version = "0.132.0"
+audited_as = "0.130.0"
 
 [[unpublished.cranelift-module]]
 version = "0.129.0"
@@ -181,6 +237,10 @@ audited_as = "0.128.3"
 version = "0.131.0"
 audited_as = "0.129.1"
 
+[[unpublished.cranelift-module]]
+version = "0.132.0"
+audited_as = "0.130.0"
+
 [[unpublished.cranelift-native]]
 version = "0.129.0"
 audited_as = "0.127.1"
@@ -192,6 +252,10 @@ audited_as = "0.128.3"
 [[unpublished.cranelift-native]]
 version = "0.131.0"
 audited_as = "0.129.1"
+
+[[unpublished.cranelift-native]]
+version = "0.132.0"
+audited_as = "0.130.0"
 
 [[unpublished.cranelift-object]]
 version = "0.129.0"
@@ -205,6 +269,10 @@ audited_as = "0.128.3"
 version = "0.131.0"
 audited_as = "0.129.1"
 
+[[unpublished.cranelift-object]]
+version = "0.132.0"
+audited_as = "0.130.0"
+
 [[unpublished.cranelift-reader]]
 version = "0.129.0"
 audited_as = "0.127.1"
@@ -216,6 +284,10 @@ audited_as = "0.128.3"
 [[unpublished.cranelift-reader]]
 version = "0.131.0"
 audited_as = "0.129.1"
+
+[[unpublished.cranelift-reader]]
+version = "0.132.0"
+audited_as = "0.130.0"
 
 [[unpublished.cranelift-serde]]
 version = "0.129.0"
@@ -229,6 +301,10 @@ audited_as = "0.128.3"
 version = "0.131.0"
 audited_as = "0.129.1"
 
+[[unpublished.cranelift-serde]]
+version = "0.132.0"
+audited_as = "0.130.0"
+
 [[unpublished.cranelift-srcgen]]
 version = "0.129.0"
 audited_as = "0.127.1"
@@ -241,6 +317,10 @@ audited_as = "0.128.3"
 version = "0.131.0"
 audited_as = "0.129.1"
 
+[[unpublished.cranelift-srcgen]]
+version = "0.132.0"
+audited_as = "0.130.0"
+
 [[unpublished.pulley-interpreter]]
 version = "42.0.0"
 audited_as = "40.0.1"
@@ -252,6 +332,10 @@ audited_as = "41.0.3"
 [[unpublished.pulley-interpreter]]
 version = "44.0.0"
 audited_as = "42.0.1"
+
+[[unpublished.pulley-interpreter]]
+version = "45.0.0"
+audited_as = "43.0.0"
 
 [[unpublished.pulley-macros]]
 version = "42.0.0"
@@ -265,6 +349,10 @@ audited_as = "41.0.3"
 version = "44.0.0"
 audited_as = "42.0.1"
 
+[[unpublished.pulley-macros]]
+version = "45.0.0"
+audited_as = "43.0.0"
+
 [[unpublished.wasi-common]]
 version = "42.0.0"
 audited_as = "40.0.1"
@@ -276,6 +364,10 @@ audited_as = "41.0.3"
 [[unpublished.wasi-common]]
 version = "44.0.0"
 audited_as = "42.0.1"
+
+[[unpublished.wasi-common]]
+version = "45.0.0"
+audited_as = "43.0.0"
 
 [[unpublished.wasmtime]]
 version = "42.0.0"
@@ -289,6 +381,10 @@ audited_as = "41.0.3"
 version = "44.0.0"
 audited_as = "42.0.1"
 
+[[unpublished.wasmtime]]
+version = "45.0.0"
+audited_as = "43.0.0"
+
 [[unpublished.wasmtime-cli]]
 version = "42.0.0"
 audited_as = "40.0.1"
@@ -300,6 +396,10 @@ audited_as = "41.0.3"
 [[unpublished.wasmtime-cli]]
 version = "44.0.0"
 audited_as = "42.0.1"
+
+[[unpublished.wasmtime-cli]]
+version = "45.0.0"
+audited_as = "43.0.0"
 
 [[unpublished.wasmtime-cli-flags]]
 version = "42.0.0"
@@ -313,6 +413,10 @@ audited_as = "41.0.3"
 version = "44.0.0"
 audited_as = "42.0.1"
 
+[[unpublished.wasmtime-cli-flags]]
+version = "45.0.0"
+audited_as = "43.0.0"
+
 [[unpublished.wasmtime-environ]]
 version = "42.0.0"
 audited_as = "40.0.1"
@@ -324,6 +428,10 @@ audited_as = "41.0.3"
 [[unpublished.wasmtime-environ]]
 version = "44.0.0"
 audited_as = "42.0.1"
+
+[[unpublished.wasmtime-environ]]
+version = "45.0.0"
+audited_as = "43.0.0"
 
 [[unpublished.wasmtime-internal-c-api-macros]]
 version = "42.0.0"
@@ -337,6 +445,10 @@ audited_as = "41.0.3"
 version = "44.0.0"
 audited_as = "42.0.1"
 
+[[unpublished.wasmtime-internal-c-api-macros]]
+version = "45.0.0"
+audited_as = "43.0.0"
+
 [[unpublished.wasmtime-internal-cache]]
 version = "42.0.0"
 audited_as = "40.0.1"
@@ -348,6 +460,10 @@ audited_as = "41.0.3"
 [[unpublished.wasmtime-internal-cache]]
 version = "44.0.0"
 audited_as = "42.0.1"
+
+[[unpublished.wasmtime-internal-cache]]
+version = "45.0.0"
+audited_as = "43.0.0"
 
 [[unpublished.wasmtime-internal-component-macro]]
 version = "42.0.0"
@@ -361,6 +477,10 @@ audited_as = "41.0.3"
 version = "44.0.0"
 audited_as = "42.0.1"
 
+[[unpublished.wasmtime-internal-component-macro]]
+version = "45.0.0"
+audited_as = "43.0.0"
+
 [[unpublished.wasmtime-internal-component-util]]
 version = "42.0.0"
 audited_as = "40.0.1"
@@ -372,6 +492,10 @@ audited_as = "41.0.3"
 [[unpublished.wasmtime-internal-component-util]]
 version = "44.0.0"
 audited_as = "42.0.1"
+
+[[unpublished.wasmtime-internal-component-util]]
+version = "45.0.0"
+audited_as = "43.0.0"
 
 [[unpublished.wasmtime-internal-core]]
 version = "42.0.0"
@@ -385,6 +509,10 @@ audited_as = "0.0.0"
 version = "44.0.0"
 audited_as = "42.0.1"
 
+[[unpublished.wasmtime-internal-core]]
+version = "45.0.0"
+audited_as = "43.0.0"
+
 [[unpublished.wasmtime-internal-cranelift]]
 version = "42.0.0"
 audited_as = "40.0.1"
@@ -396,6 +524,10 @@ audited_as = "41.0.3"
 [[unpublished.wasmtime-internal-cranelift]]
 version = "44.0.0"
 audited_as = "42.0.1"
+
+[[unpublished.wasmtime-internal-cranelift]]
+version = "45.0.0"
+audited_as = "43.0.0"
 
 [[unpublished.wasmtime-internal-debugger]]
 version = "42.0.0"
@@ -408,6 +540,10 @@ audited_as = "41.0.3"
 [[unpublished.wasmtime-internal-debugger]]
 version = "44.0.0"
 audited_as = "42.0.1"
+
+[[unpublished.wasmtime-internal-debugger]]
+version = "45.0.0"
+audited_as = "43.0.0"
 
 [[unpublished.wasmtime-internal-error]]
 version = "42.0.0"
@@ -425,6 +561,10 @@ audited_as = "41.0.3"
 version = "44.0.0"
 audited_as = "42.0.1"
 
+[[unpublished.wasmtime-internal-explorer]]
+version = "45.0.0"
+audited_as = "43.0.0"
+
 [[unpublished.wasmtime-internal-fiber]]
 version = "42.0.0"
 audited_as = "40.0.1"
@@ -436,6 +576,10 @@ audited_as = "41.0.3"
 [[unpublished.wasmtime-internal-fiber]]
 version = "44.0.0"
 audited_as = "42.0.1"
+
+[[unpublished.wasmtime-internal-fiber]]
+version = "45.0.0"
+audited_as = "43.0.0"
 
 [[unpublished.wasmtime-internal-jit-debug]]
 version = "42.0.0"
@@ -449,6 +593,10 @@ audited_as = "41.0.3"
 version = "44.0.0"
 audited_as = "42.0.1"
 
+[[unpublished.wasmtime-internal-jit-debug]]
+version = "45.0.0"
+audited_as = "43.0.0"
+
 [[unpublished.wasmtime-internal-jit-icache-coherence]]
 version = "42.0.0"
 audited_as = "40.0.1"
@@ -460,6 +608,10 @@ audited_as = "41.0.3"
 [[unpublished.wasmtime-internal-jit-icache-coherence]]
 version = "44.0.0"
 audited_as = "42.0.1"
+
+[[unpublished.wasmtime-internal-jit-icache-coherence]]
+version = "45.0.0"
+audited_as = "43.0.0"
 
 [[unpublished.wasmtime-internal-math]]
 version = "42.0.0"
@@ -481,6 +633,10 @@ audited_as = "41.0.3"
 version = "44.0.0"
 audited_as = "42.0.1"
 
+[[unpublished.wasmtime-internal-unwinder]]
+version = "45.0.0"
+audited_as = "43.0.0"
+
 [[unpublished.wasmtime-internal-versioned-export-macros]]
 version = "42.0.0"
 audited_as = "40.0.1"
@@ -492,6 +648,10 @@ audited_as = "41.0.3"
 [[unpublished.wasmtime-internal-versioned-export-macros]]
 version = "44.0.0"
 audited_as = "42.0.1"
+
+[[unpublished.wasmtime-internal-versioned-export-macros]]
+version = "45.0.0"
+audited_as = "43.0.0"
 
 [[unpublished.wasmtime-internal-winch]]
 version = "42.0.0"
@@ -505,6 +665,10 @@ audited_as = "41.0.3"
 version = "44.0.0"
 audited_as = "42.0.1"
 
+[[unpublished.wasmtime-internal-winch]]
+version = "45.0.0"
+audited_as = "43.0.0"
+
 [[unpublished.wasmtime-internal-wit-bindgen]]
 version = "42.0.0"
 audited_as = "40.0.1"
@@ -516,6 +680,10 @@ audited_as = "41.0.3"
 [[unpublished.wasmtime-internal-wit-bindgen]]
 version = "44.0.0"
 audited_as = "42.0.1"
+
+[[unpublished.wasmtime-internal-wit-bindgen]]
+version = "45.0.0"
+audited_as = "43.0.0"
 
 [[unpublished.wasmtime-internal-wmemcheck]]
 version = "42.0.0"
@@ -529,6 +697,10 @@ audited_as = "41.0.3"
 version = "44.0.0"
 audited_as = "42.0.1"
 
+[[unpublished.wasmtime-internal-wmemcheck]]
+version = "45.0.0"
+audited_as = "43.0.0"
+
 [[unpublished.wasmtime-wasi]]
 version = "42.0.0"
 audited_as = "40.0.1"
@@ -540,6 +712,10 @@ audited_as = "41.0.3"
 [[unpublished.wasmtime-wasi]]
 version = "44.0.0"
 audited_as = "42.0.1"
+
+[[unpublished.wasmtime-wasi]]
+version = "45.0.0"
+audited_as = "43.0.0"
 
 [[unpublished.wasmtime-wasi-config]]
 version = "42.0.0"
@@ -553,6 +729,10 @@ audited_as = "41.0.3"
 version = "44.0.0"
 audited_as = "42.0.1"
 
+[[unpublished.wasmtime-wasi-config]]
+version = "45.0.0"
+audited_as = "43.0.0"
+
 [[unpublished.wasmtime-wasi-http]]
 version = "42.0.0"
 audited_as = "40.0.1"
@@ -564,6 +744,10 @@ audited_as = "41.0.3"
 [[unpublished.wasmtime-wasi-http]]
 version = "44.0.0"
 audited_as = "42.0.1"
+
+[[unpublished.wasmtime-wasi-http]]
+version = "45.0.0"
+audited_as = "43.0.0"
 
 [[unpublished.wasmtime-wasi-io]]
 version = "42.0.0"
@@ -577,6 +761,10 @@ audited_as = "41.0.3"
 version = "44.0.0"
 audited_as = "42.0.1"
 
+[[unpublished.wasmtime-wasi-io]]
+version = "45.0.0"
+audited_as = "43.0.0"
+
 [[unpublished.wasmtime-wasi-keyvalue]]
 version = "42.0.0"
 audited_as = "40.0.1"
@@ -588,6 +776,10 @@ audited_as = "41.0.3"
 [[unpublished.wasmtime-wasi-keyvalue]]
 version = "44.0.0"
 audited_as = "42.0.1"
+
+[[unpublished.wasmtime-wasi-keyvalue]]
+version = "45.0.0"
+audited_as = "43.0.0"
 
 [[unpublished.wasmtime-wasi-nn]]
 version = "42.0.0"
@@ -601,6 +793,10 @@ audited_as = "41.0.3"
 version = "44.0.0"
 audited_as = "42.0.1"
 
+[[unpublished.wasmtime-wasi-nn]]
+version = "45.0.0"
+audited_as = "43.0.0"
+
 [[unpublished.wasmtime-wasi-threads]]
 version = "42.0.0"
 audited_as = "40.0.1"
@@ -613,6 +809,10 @@ audited_as = "41.0.3"
 version = "44.0.0"
 audited_as = "42.0.1"
 
+[[unpublished.wasmtime-wasi-threads]]
+version = "45.0.0"
+audited_as = "43.0.0"
+
 [[unpublished.wasmtime-wasi-tls]]
 version = "42.0.0"
 audited_as = "40.0.1"
@@ -624,6 +824,10 @@ audited_as = "41.0.3"
 [[unpublished.wasmtime-wasi-tls]]
 version = "44.0.0"
 audited_as = "42.0.1"
+
+[[unpublished.wasmtime-wasi-tls]]
+version = "45.0.0"
+audited_as = "43.0.0"
 
 [[unpublished.wasmtime-wasi-tls-nativetls]]
 version = "42.0.0"
@@ -661,6 +865,10 @@ audited_as = "41.0.3"
 version = "44.0.0"
 audited_as = "42.0.1"
 
+[[unpublished.wasmtime-wast]]
+version = "45.0.0"
+audited_as = "43.0.0"
+
 [[unpublished.wasmtime-wizer]]
 version = "42.0.0"
 audited_as = "40.0.1"
@@ -672,6 +880,10 @@ audited_as = "41.0.3"
 [[unpublished.wasmtime-wizer]]
 version = "44.0.0"
 audited_as = "42.0.1"
+
+[[unpublished.wasmtime-wizer]]
+version = "45.0.0"
+audited_as = "43.0.0"
 
 [[unpublished.wiggle]]
 version = "42.0.0"
@@ -685,6 +897,10 @@ audited_as = "41.0.3"
 version = "44.0.0"
 audited_as = "42.0.1"
 
+[[unpublished.wiggle]]
+version = "45.0.0"
+audited_as = "43.0.0"
+
 [[unpublished.wiggle-generate]]
 version = "42.0.0"
 audited_as = "40.0.1"
@@ -697,6 +913,10 @@ audited_as = "41.0.3"
 version = "44.0.0"
 audited_as = "42.0.1"
 
+[[unpublished.wiggle-generate]]
+version = "45.0.0"
+audited_as = "43.0.0"
+
 [[unpublished.wiggle-macro]]
 version = "42.0.0"
 audited_as = "40.0.1"
@@ -708,6 +928,10 @@ audited_as = "41.0.3"
 [[unpublished.wiggle-macro]]
 version = "44.0.0"
 audited_as = "42.0.1"
+
+[[unpublished.wiggle-macro]]
+version = "45.0.0"
+audited_as = "43.0.0"
 
 [[unpublished.wiggle-test]]
 version = "0.0.0"
@@ -724,6 +948,10 @@ audited_as = "41.0.3"
 [[unpublished.winch-codegen]]
 version = "44.0.0"
 audited_as = "42.0.1"
+
+[[unpublished.winch-codegen]]
+version = "45.0.0"
+audited_as = "43.0.0"
 
 [[publisher.aho-corasick]]
 version = "1.0.2"
@@ -942,103 +1170,103 @@ user-login = "jrmuizel"
 user-name = "Jeff Muizelaar"
 
 [[publisher.cranelift]]
-version = "0.129.1"
-when = "2026-02-25"
+version = "0.130.0"
+when = "2026-03-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-assembler-x64]]
-version = "0.129.1"
-when = "2026-02-25"
+version = "0.130.0"
+when = "2026-03-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-assembler-x64-meta]]
-version = "0.129.1"
-when = "2026-02-25"
+version = "0.130.0"
+when = "2026-03-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-bforest]]
-version = "0.129.1"
-when = "2026-02-25"
+version = "0.130.0"
+when = "2026-03-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-bitset]]
-version = "0.129.1"
-when = "2026-02-25"
+version = "0.130.0"
+when = "2026-03-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-codegen]]
-version = "0.129.1"
-when = "2026-02-25"
+version = "0.130.0"
+when = "2026-03-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-codegen-meta]]
-version = "0.129.1"
-when = "2026-02-25"
+version = "0.130.0"
+when = "2026-03-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-codegen-shared]]
-version = "0.129.1"
-when = "2026-02-25"
+version = "0.130.0"
+when = "2026-03-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-control]]
-version = "0.129.1"
-when = "2026-02-25"
+version = "0.130.0"
+when = "2026-03-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-entity]]
-version = "0.129.1"
-when = "2026-02-25"
+version = "0.130.0"
+when = "2026-03-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-frontend]]
-version = "0.129.1"
-when = "2026-02-25"
+version = "0.130.0"
+when = "2026-03-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-interpreter]]
-version = "0.129.1"
-when = "2026-02-25"
+version = "0.130.0"
+when = "2026-03-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-isle]]
-version = "0.129.1"
-when = "2026-02-25"
+version = "0.130.0"
+when = "2026-03-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-jit]]
-version = "0.129.1"
-when = "2026-02-25"
+version = "0.130.0"
+when = "2026-03-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-module]]
-version = "0.129.1"
-when = "2026-02-25"
+version = "0.130.0"
+when = "2026-03-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-native]]
-version = "0.129.1"
-when = "2026-02-25"
+version = "0.130.0"
+when = "2026-03-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-object]]
-version = "0.129.1"
-when = "2026-02-25"
+version = "0.130.0"
+when = "2026-03-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-reader]]
-version = "0.129.1"
-when = "2026-02-25"
+version = "0.130.0"
+when = "2026-03-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-serde]]
-version = "0.129.1"
-when = "2026-02-25"
+version = "0.130.0"
+when = "2026-03-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-srcgen]]
-version = "0.129.1"
-when = "2026-02-25"
+version = "0.130.0"
+when = "2026-03-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.derive_arbitrary]]
@@ -1345,13 +1573,13 @@ user-login = "dtolnay"
 user-name = "David Tolnay"
 
 [[publisher.pulley-interpreter]]
-version = "42.0.1"
-when = "2026-02-25"
+version = "43.0.0"
+when = "2026-03-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.pulley-macros]]
-version = "42.0.1"
-when = "2026-02-25"
+version = "43.0.0"
+when = "2026-03-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.quote]]
@@ -1677,8 +1905,8 @@ user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
 [[publisher.wasi-common]]
-version = "42.0.1"
-when = "2026-02-25"
+version = "43.0.0"
+when = "2026-03-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasip1]]
@@ -1776,153 +2004,153 @@ when = "2026-03-31"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
 [[publisher.wasmtime]]
-version = "42.0.1"
-when = "2026-02-25"
+version = "43.0.0"
+when = "2026-03-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-cli]]
-version = "42.0.1"
-when = "2026-02-25"
+version = "43.0.0"
+when = "2026-03-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-cli-flags]]
-version = "42.0.1"
-when = "2026-02-25"
+version = "43.0.0"
+when = "2026-03-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-environ]]
-version = "42.0.1"
-when = "2026-02-25"
+version = "43.0.0"
+when = "2026-03-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-c-api-macros]]
-version = "42.0.1"
-when = "2026-02-25"
+version = "43.0.0"
+when = "2026-03-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-cache]]
-version = "42.0.1"
-when = "2026-02-25"
+version = "43.0.0"
+when = "2026-03-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-component-macro]]
-version = "42.0.1"
-when = "2026-02-25"
+version = "43.0.0"
+when = "2026-03-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-component-util]]
-version = "42.0.1"
-when = "2026-02-25"
+version = "43.0.0"
+when = "2026-03-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-core]]
-version = "42.0.1"
-when = "2026-02-25"
+version = "43.0.0"
+when = "2026-03-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-cranelift]]
-version = "42.0.1"
-when = "2026-02-25"
+version = "43.0.0"
+when = "2026-03-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-debugger]]
-version = "42.0.1"
-when = "2026-02-25"
+version = "43.0.0"
+when = "2026-03-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-explorer]]
-version = "42.0.1"
-when = "2026-02-25"
+version = "43.0.0"
+when = "2026-03-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-fiber]]
-version = "42.0.1"
-when = "2026-02-25"
+version = "43.0.0"
+when = "2026-03-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-jit-debug]]
-version = "42.0.1"
-when = "2026-02-25"
+version = "43.0.0"
+when = "2026-03-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-jit-icache-coherence]]
-version = "42.0.1"
-when = "2026-02-25"
+version = "43.0.0"
+when = "2026-03-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-unwinder]]
-version = "42.0.1"
-when = "2026-02-25"
+version = "43.0.0"
+when = "2026-03-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-versioned-export-macros]]
-version = "42.0.1"
-when = "2026-02-25"
+version = "43.0.0"
+when = "2026-03-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-winch]]
-version = "42.0.1"
-when = "2026-02-25"
+version = "43.0.0"
+when = "2026-03-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-wit-bindgen]]
-version = "42.0.1"
-when = "2026-02-25"
+version = "43.0.0"
+when = "2026-03-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-wmemcheck]]
-version = "42.0.1"
-when = "2026-02-25"
+version = "43.0.0"
+when = "2026-03-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wasi]]
-version = "42.0.1"
-when = "2026-02-25"
+version = "43.0.0"
+when = "2026-03-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wasi-config]]
-version = "42.0.1"
-when = "2026-02-25"
+version = "43.0.0"
+when = "2026-03-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wasi-http]]
-version = "42.0.1"
-when = "2026-02-25"
+version = "43.0.0"
+when = "2026-03-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wasi-io]]
-version = "42.0.1"
-when = "2026-02-25"
+version = "43.0.0"
+when = "2026-03-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wasi-keyvalue]]
-version = "42.0.1"
-when = "2026-02-25"
+version = "43.0.0"
+when = "2026-03-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wasi-nn]]
-version = "42.0.1"
-when = "2026-02-25"
+version = "43.0.0"
+when = "2026-03-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wasi-threads]]
-version = "42.0.1"
-when = "2026-02-25"
+version = "43.0.0"
+when = "2026-03-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wasi-tls]]
-version = "42.0.1"
-when = "2026-02-25"
+version = "43.0.0"
+when = "2026-03-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wast]]
-version = "42.0.1"
-when = "2026-02-25"
+version = "43.0.0"
+when = "2026-03-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wizer]]
-version = "42.0.1"
-when = "2026-02-25"
+version = "43.0.0"
+when = "2026-03-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wast]]
@@ -1936,18 +2164,18 @@ when = "2026-03-31"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
 [[publisher.wiggle]]
-version = "42.0.1"
-when = "2026-02-25"
+version = "43.0.0"
+when = "2026-03-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wiggle-generate]]
-version = "42.0.1"
-when = "2026-02-25"
+version = "43.0.0"
+when = "2026-03-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wiggle-macro]]
-version = "42.0.1"
-when = "2026-02-25"
+version = "43.0.0"
+when = "2026-03-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wiggle-test]]
@@ -1965,8 +2193,8 @@ user-login = "BurntSushi"
 user-name = "Andrew Gallant"
 
 [[publisher.winch-codegen]]
-version = "42.0.1"
-when = "2026-02-25"
+version = "43.0.0"
+when = "2026-03-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.windows]]


### PR DESCRIPTION
This is an [automated pull request][process] from CI which indicates that the next [`release-44.0.0` branch][branch] has been created and the `main` branch is getting its version number bumped from 44.0.0 to 45.0.0.

Maintainers should take a moment to review the [release notes][RELEASES.md] for 44.0.0 and any updates should be made directly to the [release branch][branch].

Another automated PR will be made in roughly 2 weeks time when for the actual release itself.

If any issues arise on the `main` branch before the release is made then the issue should first be fixed on `main` and then backport to the `release-44.0.0` branch.

[RELEASES.md]: https://github.com/bytecodealliance/wasmtime/blob/release-44.0.0/RELEASES.md
[branch]: https://github.com/bytecodealliance/wasmtime/tree/release-44.0.0
[process]: https://docs.wasmtime.dev/contributing-release-process.html
