### PR TITLE
Fix intra-component stream/futures copies with multi-memory

### DIFF
--- a/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams.rs
@@ -3295,7 +3295,9 @@ impl Instance {
 
                     assert_eq!(read_length_in_bytes, write_length_in_bytes);
 
-                    if write_caller_instance == read_caller_instance {
+                    if self.options_memory(store_opaque, read_options).as_ptr()
+                        == self.options_memory(store_opaque, write_options).as_ptr()
+                    {
                         let memory = self.options_memory_mut(store_opaque, read_options);
                         memory.copy_within(
                             write_address..write_address + write_length_in_bytes,
@@ -3313,9 +3315,9 @@ impl Instance {
                         // above to be valid pointers as they're derived from
                         // slices that have the desired length with the desired
                         // read/write permission. The `unsafe` bit here is that
-                        // the memories are disjoint (present in different
-                        // instances) and there's no easy way to borrow both
-                        // simultaneously from the store. Different instances
+                        // the memories are disjoint (different base pointers)
+                        // and there's no easy way to borrow both
+                        // simultaneously from the store. Different memories
                         // are guaranteed to be disjoint, however, so the
                         // `unsafe` here should be ok.
                         unsafe {

--- a/tests/misc_testsuite/component-model/async/intra-streams.wast
+++ b/tests/misc_testsuite/component-model/async/intra-streams.wast
@@ -1,5 +1,6 @@
 ;;! component_model_async = true
 ;;! component_model_async_builtins = true
+;;! multi_memory = true
 
 (component
   (core module $libc
@@ -53,3 +54,186 @@
 )
 
 (assert_trap (invoke "run") "cannot read from and write to intra-component future/stream with non-numeric payload")
+
+;; intra-component u64 works
+(component
+  (core module $libc
+     (memory (export "m") 1)
+  )
+  (core instance $libc (instantiate $libc))
+
+  (type $s (stream u64))
+  (core func $stream.new (canon stream.new $s))
+  (core func $stream.read (canon stream.read $s async (memory $libc "m")))
+  (core func $stream.write (canon stream.write $s async (memory $libc "m")))
+
+  (core module $m
+    (import "" "m" (memory 1))
+    (import "" "stream.new" (func $stream.new (result i64)))
+    (import "" "stream.read" (func $stream.read (param i32 i32 i32) (result i32)))
+    (import "" "stream.write" (func $stream.write (param i32 i32 i32) (result i32)))
+
+    (func (export "run")
+      (local $tmp i64)
+      (local $r i32)
+      (local $w i32)
+      (local.set $tmp (call $stream.new))
+
+      (local.set $r (i32.wrap_i64 (local.get $tmp)))
+      (local.set $w (i32.wrap_i64 (i64.shr_u (local.get $tmp) (i64.const 32))))
+
+      (call $stream.read (local.get $r) (i32.const 0) (i32.const 1))
+      i32.const -1 ;; BLOCKED
+      i32.ne
+      if unreachable end
+
+      (i64.store (i32.const 8) (i64.const 100))
+      (call $stream.write (local.get $w) (i32.const 8) (i32.const 1))
+      i32.const 0x10 ;; (1 << 4) | COMPLETED
+      i32.ne
+      if unreachable end
+
+      (i64.load (i32.const 0))
+      i64.const 100
+      i64.ne
+      if unreachable end
+    )
+  )
+
+  (core instance $i (instantiate $m
+    (with "" (instance
+      (export "m" (memory $libc "m"))
+      (export "stream.new" (func $stream.new))
+      (export "stream.read" (func $stream.read))
+      (export "stream.write" (func $stream.write))
+    ))
+  ))
+
+  (func (export "run") (canon lift (core func $i "run")))
+)
+
+(assert_return (invoke "run"))
+
+;; intra-component u64 works, even across different linear memories.
+(component
+  (core module $libc
+     (memory (export "m1") 1)
+     (memory (export "m2") 2)
+  )
+  (core instance $libc (instantiate $libc))
+
+  (type $s (stream u64))
+  (core func $stream.new (canon stream.new $s))
+  (core func $stream.read (canon stream.read $s async (memory $libc "m1")))
+  (core func $stream.write (canon stream.write $s async (memory $libc "m2")))
+
+  (core module $m
+    (import "libc" "m1" (memory $m1 1))
+    (import "libc" "m2" (memory $m2 2))
+    (import "" "stream.new" (func $stream.new (result i64)))
+    (import "" "stream.read" (func $stream.read (param i32 i32 i32) (result i32)))
+    (import "" "stream.write" (func $stream.write (param i32 i32 i32) (result i32)))
+
+    (func (export "run")
+      (local $tmp i64)
+      (local $r i32)
+      (local $w i32)
+      (local.set $tmp (call $stream.new))
+
+      (local.set $r (i32.wrap_i64 (local.get $tmp)))
+      (local.set $w (i32.wrap_i64 (i64.shr_u (local.get $tmp) (i64.const 32))))
+
+      (call $stream.read (local.get $r) (i32.const 0) (i32.const 1))
+      i32.const -1 ;; BLOCKED
+      i32.ne
+      if unreachable end
+
+      (i64.store $m2 (i32.const 65536) (i64.const 100))
+      (call $stream.write (local.get $w) (i32.const 65536) (i32.const 1))
+      i32.const 0x10 ;; (1 << 4) | COMPLETED
+      i32.ne
+      if unreachable end
+
+      (i64.load $m1 (i32.const 0))
+      i64.const 100
+      i64.ne
+      if unreachable end
+    )
+  )
+
+  (core instance $i (instantiate $m
+    (with "libc" (instance $libc))
+    (with "" (instance
+      (export "stream.new" (func $stream.new))
+      (export "stream.read" (func $stream.read))
+      (export "stream.write" (func $stream.write))
+    ))
+  ))
+
+  (func (export "run") (canon lift (core func $i "run")))
+)
+
+(assert_return (invoke "run"))
+
+;; intrinsics should pick the correct memory
+(component
+  (core module $libc
+     (memory (export "m1") 1)
+     (memory (export "m2") 2)
+  )
+  (core instance $libc (instantiate $libc))
+
+  (type $s (stream u64))
+  (core func $stream.new (canon stream.new $s))
+  (core func $stream.read (canon stream.read $s async (memory $libc "m1")))
+  (core func $stream.write (canon stream.write $s async (memory $libc "m2")))
+
+  (core module $m
+    (import "libc" "m1" (memory $m1 1))
+    (import "libc" "m2" (memory $m2 2))
+    (import "" "stream.new" (func $stream.new (result i64)))
+    (import "" "stream.read" (func $stream.read (param i32 i32 i32) (result i32)))
+    (import "" "stream.write" (func $stream.write (param i32 i32 i32) (result i32)))
+
+    (func (export "run")
+      (local $tmp i64)
+      (local $r i32)
+      (local $w i32)
+      (local.set $tmp (call $stream.new))
+
+      (local.set $r (i32.wrap_i64 (local.get $tmp)))
+      (local.set $w (i32.wrap_i64 (i64.shr_u (local.get $tmp) (i64.const 32))))
+
+      (call $stream.read (local.get $r) (i32.const 0) (i32.const 1))
+      i32.const -1 ;; BLOCKED
+      i32.ne
+      if unreachable end
+
+      (i64.store $m1 (i32.const 8) (i64.const 101))
+      (i64.store $m2 (i32.const 8) (i64.const 102))
+
+      (call $stream.write (local.get $w) (i32.const 8) (i32.const 1))
+      i32.const 0x10 ;; (1 << 4) | COMPLETED
+      i32.ne
+      if unreachable end
+
+      (i64.load $m1 (i32.const 0))
+      i64.const 102
+      i64.ne
+      if unreachable end
+    )
+  )
+
+  (core instance $i (instantiate $m
+    (with "libc" (instance $libc))
+    (with "" (instance
+      (export "stream.new" (func $stream.new))
+      (export "stream.read" (func $stream.read))
+      (export "stream.write" (func $stream.write))
+    ))
+  ))
+
+  (func (export "run") (canon lift (core func $i "run")))
+)
+
+(assert_return (invoke "run"))


### PR DESCRIPTION
This commit fixes a mistake from #12872 where an intra-component copy of a stream/future payload incorrectly use a `copy_within` when different memories were in use. Previously instance identity was used to test whether `copy_within` can be used but the correct check is to use memory identity. This handles the case where a single component instance has multiple memories in use, for example.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
