### PR TITLE
[Cranelift] resolves #13306, delete extend/reduce rule

### DIFF
--- a/cranelift/codegen/src/opts/arithmetic.isle
+++ b/cranelift/codegen/src/opts/arithmetic.isle
@@ -406,18 +406,6 @@
 (rule (simplify (ineg ty (imul ty (ineg ty y) x))) (imul ty x y))
 (rule (simplify (ineg ty (imul ty x (ineg ty y)))) (imul ty x y))
 
-;; ireduce(xext(a) + xext(b)) --> a + b
-(rule (simplify (ireduce ty (iadd cty (sextend cty x) (sextend cty y)))) (iadd ty x y))
-(rule (simplify (ireduce ty (iadd cty (sextend cty x) (uextend cty y)))) (iadd ty x y))
-(rule (simplify (ireduce ty (iadd cty (uextend cty x) (sextend cty y)))) (iadd ty x y))
-(rule (simplify (ireduce ty (iadd cty (uextend cty x) (uextend cty y)))) (iadd ty x y))
-
-;; ireduce(xext(a) - xext(b)) --> a - b
-(rule (simplify (ireduce ty (isub cty (sextend cty x) (sextend cty y)))) (isub ty x y))
-(rule (simplify (ireduce ty (isub cty (sextend cty x) (uextend cty y)))) (isub ty x y))
-(rule (simplify (ireduce ty (isub cty (uextend cty x) (sextend cty y)))) (isub ty x y))
-(rule (simplify (ireduce ty (isub cty (uextend cty x) (uextend cty y)))) (isub ty x y))
-
 ;; max(x, y) >= x
 (rule (simplify (sge ty (smax ty x y) x)) (iconst_u ty 1))
 (rule (simplify (sge ty (smax ty y x) x)) (iconst_u ty 1))

--- a/cranelift/filetests/filetests/egraph/arithmetic-precise.clif
+++ b/cranelift/filetests/filetests/egraph/arithmetic-precise.clif
@@ -340,38 +340,6 @@ block0(v0: i32, v1: i32):
 ;     return v5
 ; }
 
-;; ireduce(sextend(x) + uextend(y)) --> x + y
-function %test_ireduce_iadd_extends(i8, i8) -> i8 fast {
-block0(v0: i8, v1: i8):
-    v2 = sextend.i16 v0
-    v3 = uextend.i16 v1
-    v4 = iadd v2, v3
-    v5 = ireduce.i8 v4
-    return v5
-}
-
-; function %test_ireduce_iadd_extends(i8, i8) -> i8 fast {
-; block0(v0: i8, v1: i8):
-;     v6 = iadd v0, v1
-;     return v6
-; }
-
-;; ireduce(sextend(x) - uextend(y)) --> x - y
-function %test_ireduce_isub_extends(i8, i8) -> i8 fast {
-block0(v0: i8, v1: i8):
-    v2 = sextend.i16 v0
-    v3 = uextend.i16 v1
-    v4 = isub v2, v3
-    v5 = ireduce.i8 v4
-    return v5
-}
-
-; function %test_ireduce_isub_extends(i8, i8) -> i8 fast {
-; block0(v0: i8, v1: i8):
-;     v6 = isub v0, v1
-;     return v6
-; }
-
 ;; smax(x, y) >= x --> true
 function %test_sge_smax_x(i32, i32) -> i8 fast {
 block0(v0: i32, v1: i32):

--- a/cranelift/filetests/filetests/egraph/arithmetic.clif
+++ b/cranelift/filetests/filetests/egraph/arithmetic.clif
@@ -363,8 +363,8 @@ block0(v0: i16, v1: i16, v2: i16):
     return v8
 }
 
-; check: v10 = iadd v0, v1
-; check: v15 = iadd v10, v2
+; check: v12 = iadd v0, v1
+; check: v15 = iadd v12, v2
 ; check: return v15
 
 ;; or(x, C) + (-C)  -->  and(x, ~C)

--- a/cranelift/filetests/filetests/egraph/extends.clif
+++ b/cranelift/filetests/filetests/egraph/extends.clif
@@ -179,8 +179,8 @@ block0(v0: i16, v1: i16):
     return v5
 }
 
-; check: v6 = iadd v0, v1
-; check: return v6
+; check: v8 = iadd v0, v1
+; check: return v8
 
 function %extend_bxor_reduce(i64, i64) -> i64 {
 block0(v0: i64, v1: i64):

--- a/cranelift/filetests/filetests/runtests/arithmetic.clif
+++ b/cranelift/filetests/filetests/runtests/arithmetic.clif
@@ -881,33 +881,6 @@ block0(v0: i32, v1: i32):
 ; run: %test_ineg_imul_ineg_rhs(0, 0) == 0
 ; run: %test_ineg_imul_ineg_rhs(1, 2) == 2
 
-function %test_ireduce_iadd_extends(i8, i8) -> i8 fast {
-block0(v0: i8, v1: i8):
-    v2 = sextend.i16 v0
-    v3 = uextend.i16 v1
-    v4 = iadd v2, v3
-    v5 = ireduce.i8 v4
-    return v5
-}
-
-; run: %test_ireduce_iadd_extends(0, 0) == 0
-; run: %test_ireduce_iadd_extends(1, 2) == 3
-
-function %test_ireduce_isub_extends(i8, i8) -> i8 fast {
-block0(v0: i8, v1: i8):
-    v2 = sextend.i16 v0
-    v3 = uextend.i16 v1
-    v4 = isub v2, v3
-    v5 = ireduce.i8 v4
-    return v5
-}
-
-; run: %test_ireduce_isub_extends(0, 0) == 0
-; run: %test_ireduce_isub_extends(5, 2) == 3
-; run: %test_ireduce_isub_extends(0, 1) == -1
-; run: %test_ireduce_isub_extends(-1, 1) == -2
-; run: %test_ireduce_isub_extends(-128, 1) == 127
-
 function %test_sge_smax_x(i32, i32) -> i8 fast {
 block0(v0: i32, v1: i32):
     v2 = smax v0, v1


### PR DESCRIPTION
## Cause

This regression was caused by the `ireduce(xext(a) +/- xext(b)) -> a +/- b` simplification rules added in `cranelift/codegen/src/opts/arithmetic.isle`.

These rewrites only check that both operands are extended to the same wide type (`cty`). They do not verify that the original operand types match the final reduced type (`ty`), or even match each other.

For example, a pattern such as:

- `ireduce.i32 (iadd.i64 (sextend.i64 x:i16) (uextend.i64 y:i32))`

can be rewritten into:

- `iadd.i32 x, y`

which is ill-typed, because `x` is still `i16` while the new instruction expects both operands to be `i32`.
This matches the verifier failure we observed.

## Resolution

We decided to remove these rules for now.

Thanks for reporting this issue.