### PR TITLE
Fix reading registers on aarch64 FreeBSD

### DIFF
--- a/crates/wasmtime/src/runtime/vm/sys/unix/signals.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/unix/signals.rs
@@ -308,10 +308,10 @@ unsafe fn get_trap_registers(cx: *mut libc::c_void, _signum: libc::c_int) -> Tra
                 fp: cx.uc_mcontext.__gregs[libc::REG_S0] as usize,
             }
         } else if #[cfg(all(target_os = "freebsd", target_arch = "aarch64"))] {
-            let cx = unsafe { &*(cx as *const libc::mcontext_t) };
+            let cx = unsafe { &*(cx as *const libc::ucontext_t) };
             TrapRegisters {
-                pc: cx.mc_gpregs.gp_elr as usize,
-                fp: cx.mc_gpregs.gp_x[29] as usize,
+                pc: cx.uc_mcontext.mc_gpregs.gp_elr as usize,
+                fp: cx.uc_mcontext.mc_gpregs.gp_x[29] as usize,
             }
         } else if #[cfg(all(target_os = "openbsd", target_arch = "x86_64"))] {
             let cx = unsafe { &*(cx as *const libc::ucontext_t) };
@@ -384,12 +384,12 @@ unsafe fn store_handler_in_ucontext(cx: *mut libc::c_void, handler: &Handler) {
             cx.uc_mcontext.mc_rax = 0;
             cx.uc_mcontext.mc_rdx = 0;
         } else if #[cfg(all(target_os = "freebsd", target_arch = "aarch64"))] {
-            let cx = unsafe { cx.cast::<libc::mcontext_t>().as_mut().unwrap() };
-            cx.mc_gpregs.gp_elr = handler.pc as _;
-            cx.mc_gpregs.gp_sp = handler.sp as _;
-            cx.mc_gpregs.gp_x[29] = handler.fp as _;
-            cx.mc_gpregs.gp_x[0] = 0;
-            cx.mc_gpregs.gp_x[1] = 0;
+            let cx = unsafe { cx.cast::<libc::ucontext_t>().as_mut().unwrap() };
+            cx.uc_mcontext.mc_gpregs.gp_elr = handler.pc as _;
+            cx.uc_mcontext.mc_gpregs.gp_sp = handler.sp as _;
+            cx.uc_mcontext.mc_gpregs.gp_x[29] = handler.fp as _;
+            cx.uc_mcontext.mc_gpregs.gp_x[0] = 0;
+            cx.uc_mcontext.mc_gpregs.gp_x[1] = 0;
         } else if #[cfg(all(target_os = "openbsd", target_arch = "x86_64"))] {
             let cx = unsafe { cx.cast::<libc::ucontext_t>().as_mut().unwrap() };
             cx.sc_rip = handler.pc as _;


### PR DESCRIPTION
The previous iteration of the code had a typo using `mcontext_t` instead of `ucontext_t` as the input pointer.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
