### PR TITLE
Remove erroneous debug assertions about parent tasks

### DIFF
--- a/crates/wasmtime/src/runtime/component/concurrent.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent.rs
@@ -3124,7 +3124,7 @@ impl Instance {
             .subtask_remove(task_id)?;
 
         let concurrent_state = store.concurrent_state_mut();
-        let (waitable, expected_caller, delete) = if is_host {
+        let (waitable, delete) = if is_host {
             let id = TableId::<HostTask>::new(rep);
             let task = concurrent_state.get_mut(id)?;
             match &task.state {
@@ -3134,22 +3134,17 @@ impl Instance {
                     bail_bug!("invalid state for callee in `subtask.drop`")
                 }
             }
-            (Waitable::Host(id), task.caller, true)
+            (Waitable::Host(id), true)
         } else {
             let id = TableId::<GuestTask>::new(rep);
             let task = concurrent_state.get_mut(id)?;
             if task.lift_result.is_some() {
                 bail!(Trap::SubtaskDropNotResolved);
             }
-            if let Caller::Guest { thread } = task.caller {
-                (
-                    Waitable::Guest(id),
-                    thread,
-                    concurrent_state.get_mut(id)?.ready_to_delete(),
-                )
-            } else {
-                bail_bug!("expected guest caller for `subtask.drop`")
-            }
+            (
+                Waitable::Guest(id),
+                concurrent_state.get_mut(id)?.ready_to_delete(),
+            )
         };
 
         waitable.common(concurrent_state)?.handle = None;
@@ -3164,10 +3159,6 @@ impl Instance {
             waitable.delete_from(concurrent_state)?;
         }
 
-        // Since waitables can neither be passed between instances nor forged,
-        // this should never fail unless there's a bug in Wasmtime, but we check
-        // here to be sure:
-        debug_assert_eq!(expected_caller, concurrent_state.current_guest_thread()?);
         log::trace!("subtask_drop {waitable:?} (handle {task_id})");
         Ok(())
     }
@@ -3583,25 +3574,12 @@ impl Instance {
             })
             .handle_table()
             .subtask_rep(task_id)?;
-        let (waitable, expected_caller) = if is_host {
-            let id = TableId::<HostTask>::new(rep);
-            (
-                Waitable::Host(id),
-                store.concurrent_state_mut().get_mut(id)?.caller,
-            )
+        let waitable = if is_host {
+            Waitable::Host(TableId::<HostTask>::new(rep))
         } else {
-            let id = TableId::<GuestTask>::new(rep);
-            if let Caller::Guest { thread } = store.concurrent_state_mut().get_mut(id)?.caller {
-                (Waitable::Guest(id), thread)
-            } else {
-                bail_bug!("expected guest caller for `subtask.cancel`")
-            }
+            Waitable::Guest(TableId::<GuestTask>::new(rep))
         };
-        // Since waitables can neither be passed between instances nor forged,
-        // this should never fail unless there's a bug in Wasmtime, but we check
-        // here to be sure:
         let concurrent_state = store.concurrent_state_mut();
-        debug_assert_eq!(expected_caller, concurrent_state.current_guest_thread()?);
 
         log::trace!("subtask_cancel {waitable:?} (handle {task_id})");
 

--- a/tests/misc_testsuite/component-model/async/cancel-sibling-subtask.wast
+++ b/tests/misc_testsuite/component-model/async/cancel-sibling-subtask.wast
@@ -37,12 +37,15 @@
       (import "" "f" (func $f (result i32)))
       (import "" "cancel" (func $cancel (param i32) (result i32)))
       (import "" "drop" (func $drop (param i32)))
+      (import "" "future.new" (func $future.new (result i64)))
       (global $subtask (mut i32) (i32.const 0))
 
       ;; This export starts a call to `$f` in the above component but doesn't
       ;; await it or complete it. Instead this task exits.
       (func (export "a") (param $cancel i32)
         (local $ret i32)
+
+        (drop (call $future.new))
 
         ;; start the subtask
         (local.set $ret (call $f))
@@ -81,29 +84,67 @@
     (core func $f (canon lower (func $f) async))
     (core func $cancel (canon subtask.cancel))
     (core func $drop (canon subtask.drop))
+    (type $ft (future))
+    (core func $future.new (canon future.new $ft))
     (core instance $i (instantiate $m
       (with "" (instance
         (export "f" (func $f))
         (export "cancel" (func $cancel))
         (export "drop" (func $drop))
+        (export "future.new" (func $future.new))
       ))
     ))
     (func (export "a") async (param "cancel" bool) (canon lift (core func $i "a")))
     (func (export "b") async (param "cancel" bool) (canon lift (core func $i "b")))
   )
 
+  (component $c
+    (import "b" (instance $b
+      (export "a" (func async (param "cancel" bool)))
+      (export "b" (func async (param "cancel" bool)))
+    ))
+    (core module $m
+      (import "" "a" (func $a (param i32)))
+      (import "" "b" (func $b (param i32)))
+      (import "" "future.new" (func $future.new (result i64)))
+
+      (func (export "run") (param i32 i32)
+        (call $a (local.get 0))
+
+        ;; push things into the handle table to ensure that b's task is
+        ;; different from a's.
+        (drop (call $future.new))
+
+        (call $b (local.get 1))
+      )
+    )
+    (core func $a (canon lower (func $b "a")))
+    (core func $b (canon lower (func $b "b")))
+    (type $ft (future))
+    (core func $future.new (canon future.new $ft))
+    (core instance $i (instantiate $m
+      (with "" (instance
+        (export "a" (func $a))
+        (export "b" (func $b))
+        (export "future.new" (func $future.new))
+      ))
+    ))
+
+    (func (export "run") async (param "a" bool) (param "b" bool)
+      (canon lift (core func $i "run"))
+    )
+  )
+
   (instance $a (instantiate $a))
   (instance $b (instantiate $b (with "f" (func $a "f"))))
-  (export "a" (func $b "a"))
-  (export "b" (func $b "b"))
+  (instance $c (instantiate $c (with "b" (instance $b))))
+  (export "run" (func $c "run"))
 )
 
 ;; start subtask in "a", cancel/drop it in "b"
 (component instance $A $A)
-(assert_return (invoke "a" (bool.const false)))
-(assert_return (invoke "b" (bool.const true)))
+(assert_return (invoke "run" (bool.const false) (bool.const true)))
 
 ;; start/cancel subtask in "a", drop it in "b"
 (component instance $A $A)
-(assert_return (invoke "a" (bool.const true)))
-(assert_return (invoke "b" (bool.const false)))
+(assert_return (invoke "run" (bool.const true) (bool.const false)))


### PR DESCRIPTION
The fix in #12570 forgot to remove some stray debug assertions about the parent of a subtask when it's cancelled/dropped. Due to index reuse the assertions happened to pass with the test added in #12570, so the test was updated to "spray" the table a bit to prevent reuse which triggers the assertions. The fix here is then to just remove the assertions as they're no longer necessary.

Closes #13024

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
