### PR TITLE
Add support for more `*.wast` syntax

### DIFF
--- a/crates/wast/src/wast.rs
+++ b/crates/wast/src/wast.rs
@@ -19,7 +19,7 @@ pub struct WastContext {
     /// recently defined.
     current: Option<InstanceKind>,
     core_linker: Linker<()>,
-    modules: HashMap<String, ModuleKind>,
+    modules: HashMap<Option<String>, ModuleKind>,
     #[cfg(feature = "component-model")]
     component_linker: component::Linker<()>,
 
@@ -645,18 +645,16 @@ impl WastContext {
                 line: _,
             } => {
                 let module = self.module_definition(&file)?;
-                if let Some(name) = name {
-                    self.modules.insert(name.to_string(), module);
-                }
+                self.modules.insert(name.map(|s| s.to_string()), module);
             }
             ModuleInstance {
                 instance,
                 module,
                 line: _,
             } => {
-                let module = module
-                    .as_deref()
-                    .and_then(|n| self.modules.get(n))
+                let module = self
+                    .modules
+                    .get(&module.as_ref().map(|s| s.to_string()))
                     .cloned()
                     .ok_or_else(|| format_err!("no module named {module:?}"))?;
                 self.module(instance.as_deref(), &module)?;

--- a/tests/misc_testsuite/wast-syntax.wast
+++ b/tests/misc_testsuite/wast-syntax.wast
@@ -1,0 +1,5 @@
+(module definition (func (export "f")))
+(module instance)
+
+(invoke "f")
+(assert_return (invoke "f"))


### PR DESCRIPTION
This is used in Wizard, for example, and is easy to support as well.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
