### PR TITLE
Fix current instance count on failure during component instantiation

### DIFF
--- a/crates/fuzzing/tests/oom/component_instance.rs
+++ b/crates/fuzzing/tests/oom/component_instance.rs
@@ -1,0 +1,42 @@
+#![cfg(arc_try_new)]
+
+use wasmtime::component::{Component, Linker};
+use wasmtime::{Config, Engine, PoolingAllocationConfig, Result, Store};
+use wasmtime_fuzzing::oom::OomTest;
+
+#[test]
+fn instantiate() -> Result<()> {
+    let mut config = Config::new();
+    config.concurrency_support(false);
+    let engine = Engine::new(&config)?;
+    let component = Component::new(&engine, "(component)")?;
+    let linker = Linker::<()>::new(&engine);
+    let instance_pre = linker.instantiate_pre(&component)?;
+
+    OomTest::new().test(|| {
+        let mut store = Store::try_new(&engine, ())?;
+        let _instance = instance_pre.instantiate(&mut store)?;
+        Ok(())
+    })
+}
+
+#[test]
+fn instantiate_in_pooling_allocator() -> Result<()> {
+    let mut pool_config = PoolingAllocationConfig::default();
+    pool_config.total_component_instances(1);
+
+    let mut config = Config::new();
+    config.concurrency_support(false);
+    config.allocation_strategy(pool_config);
+
+    let engine = Engine::new(&config)?;
+    let component = Component::new(&engine, "(component)")?;
+    let linker = Linker::<()>::new(&engine);
+    let instance_pre = linker.instantiate_pre(&component)?;
+
+    OomTest::new().test(|| {
+        let mut store = Store::try_new(&engine, ())?;
+        let _instance = instance_pre.instantiate(&mut store)?;
+        Ok(())
+    })
+}

--- a/crates/fuzzing/tests/oom/main.rs
+++ b/crates/fuzzing/tests/oom/main.rs
@@ -6,6 +6,7 @@ mod boxed;
 mod btree_map;
 mod caller;
 mod component_func;
+mod component_instance;
 mod component_linker;
 mod component_resource;
 mod config;

--- a/crates/wasmtime/src/runtime/component/instance.rs
+++ b/crates/wasmtime/src/runtime/component/instance.rs
@@ -1187,23 +1187,46 @@ impl<T: 'static> InstancePre<T> {
         mut store: impl AsContextMut<Data = T>,
         asyncness: Asyncness,
     ) -> Result<Instance> {
-        let mut store = store.as_context_mut();
+        let store = store.as_context_mut();
         store.0.set_async_required(self.asyncness);
         store
             .engine()
             .allocator()
             .increment_component_instance_count()?;
-        let mut instantiator = Instantiator::new(&self.component, store.0, &self.imports)?;
-        instantiator.run(&mut store, asyncness).await.map_err(|e| {
-            store
-                .engine()
-                .allocator()
-                .decrement_component_instance_count();
-            e
-        })?;
 
-        let instance = Instance::from_wasmtime(store.0, instantiator.id);
-        store.0.push_component_instance(instance);
-        Ok(instance)
+        // Helper structure to pair the above increment with a decrement should
+        // anything fail below.
+        let mut decrement = DecrementComponentInstanceCountOnDrop {
+            store,
+            enabled: true,
+        };
+
+        let mut instantiator =
+            Instantiator::new(&self.component, decrement.store.0, &self.imports)?;
+        instantiator.run(&mut decrement.store, asyncness).await?;
+
+        let instance = Instance::from_wasmtime(decrement.store.0, instantiator.id);
+        decrement.store.0.push_component_instance(instance);
+
+        // Everything has passed, don't decrement the instance count and let the
+        // destructor for the `Store` handle that at this point.
+        decrement.enabled = false;
+        return Ok(instance);
+
+        struct DecrementComponentInstanceCountOnDrop<'a, T: 'static> {
+            store: StoreContextMut<'a, T>,
+            enabled: bool,
+        }
+
+        impl<T> Drop for DecrementComponentInstanceCountOnDrop<'_, T> {
+            fn drop(&mut self) {
+                if self.enabled {
+                    self.store
+                        .engine()
+                        .allocator()
+                        .decrement_component_instance_count();
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
This commit fixes an issue during component instantiation where if instantiation failed during creation of the `Instantiator` due to OOM or if the `async` future was dropped the concurrent instance count in the pooling allocator would get corrupted (off-by-one). The fix here is to switch a `map_err` with a manual decrement to using a value that has a
  destructor to ensure that it handles both of these cases.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
