### PR TITLE
Add OOM test for component Linker::instantiate_async

### DIFF
--- a/crates/fuzzing/tests/oom/component_linker.rs
+++ b/crates/fuzzing/tests/oom/component_linker.rs
@@ -1,0 +1,43 @@
+#![cfg(arc_try_new)]
+
+use wasmtime::component::{Component, Linker};
+use wasmtime::{Config, Engine, Result, Store};
+use wasmtime_fuzzing::oom::OomTest;
+
+#[tokio::test]
+async fn component_linker_instantiate_async() -> Result<()> {
+    let component_bytes = {
+        let mut config = Config::new();
+        config.concurrency_support(false);
+        let engine = Engine::new(&config)?;
+        Component::new(
+            &engine,
+            r#"
+                (component
+                    (core module $m
+                        (func (export "id") (param i32) (result i32) (local.get 0))
+                    )
+                    (core instance $i (instantiate $m))
+                    (func (export "id") (param "x" s32) (result s32)
+                        (canon lift (core func $i "id"))
+                    )
+                )
+            "#,
+        )?
+        .serialize()?
+    };
+    let mut config = Config::new();
+    config.enable_compiler(false);
+    config.concurrency_support(false);
+    let engine = Engine::new(&config)?;
+    let component = unsafe { Component::deserialize(&engine, &component_bytes)? };
+    let linker = Linker::<()>::new(&engine);
+
+    OomTest::new()
+        .test_async(|| async {
+            let mut store = Store::try_new(&engine, ())?;
+            let _instance = linker.instantiate_async(&mut store, &component).await?;
+            Ok(())
+        })
+        .await
+}

--- a/crates/fuzzing/tests/oom/main.rs
+++ b/crates/fuzzing/tests/oom/main.rs
@@ -6,6 +6,7 @@ mod boxed;
 mod btree_map;
 mod caller;
 mod component_func;
+mod component_linker;
 mod config;
 mod engine;
 mod entity_set;

--- a/crates/wasmtime/src/runtime/component/linker.rs
+++ b/crates/wasmtime/src/runtime/component/linker.rs
@@ -177,7 +177,7 @@ impl<T: 'static> Linker<T> {
             engine: &self.engine,
             types: component.types(),
             strings: &self.strings,
-            imported_resources: Default::default(),
+            imported_resources: try_new::<Arc<_>>(Default::default())?,
         };
 
         // Walk over the component's list of import names and use that to lookup
@@ -267,7 +267,11 @@ impl<T: 'static> Linker<T> {
             assert_eq!(i, idx);
         }
         Ok(unsafe {
-            InstancePre::new_unchecked(component.clone(), Arc::new(imports), imported_resources)
+            InstancePre::new_unchecked(
+                component.clone(),
+                try_new::<Arc<_>>(imports)?,
+                imported_resources,
+            )
         })
     }
 


### PR DESCRIPTION
Use `try_new` for `Arc` allocations in `Linker::typecheck` and `Linker::instantiate_pre` to avoid infallible allocations during OOM testing.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
