### PR TITLE
Turn the `GC_ZEAL_ALLOC_COUNTER` env var into a `Tunable` field

### DIFF
--- a/crates/environ/src/tunables.rs
+++ b/crates/environ/src/tunables.rs
@@ -1,5 +1,6 @@
 use crate::prelude::*;
 use crate::{IndexType, Limits, Memory, TripleExt};
+use core::num::NonZeroU32;
 use core::{fmt, str::FromStr};
 use serde_derive::{Deserialize, Serialize};
 use target_lexicon::{PointerWidth, Triple};
@@ -152,6 +153,13 @@ define_tunables! {
         /// Whether recording in RR is enabled or not. This is used primarily
         /// to signal checksum computation for compiled artifacts.
         pub recording: bool,
+
+        /// An allocation counter that triggers GC when it reaches zero.
+        ///
+        /// Decremented on every allocation and when it hits zero, a GC is
+        /// forced and the counter is reset. Only effective when
+        /// `cfg(gc_zeal)` is enabled.
+        pub gc_zeal_alloc_counter: Option<NonZeroU32>,
     }
 
     pub struct ConfigTunables {
@@ -230,6 +238,7 @@ impl Tunables {
             debug_guest: false,
             concurrency_support: true,
             recording: false,
+            gc_zeal_alloc_counter: None,
         }
     }
 

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -2,7 +2,7 @@ use crate::prelude::*;
 use alloc::sync::Arc;
 use bitflags::Flags;
 use core::fmt;
-use core::num::NonZeroUsize;
+use core::num::{NonZeroU32, NonZeroUsize};
 use core::str::FromStr;
 #[cfg(any(feature = "cranelift", feature = "winch"))]
 use std::path::Path;
@@ -726,6 +726,24 @@ impl Config {
     pub fn epoch_interruption(&mut self, enable: bool) -> &mut Self {
         self.tunables.epoch_interruption = Some(enable);
         self
+    }
+
+    /// XXX: For internal fuzzing and debugging use only!
+    #[doc(hidden)]
+    pub fn gc_zeal_alloc_counter(&mut self, counter: Option<NonZeroU32>) -> Result<&mut Self> {
+        #[cfg(not(gc_zeal))]
+        {
+            let _ = counter;
+            bail!(
+                "cannot set `gc_zeal_alloc_counter` because Wasmtime was not built with `cfg(gc_zeal)`"
+            );
+        }
+
+        #[cfg(gc_zeal)]
+        {
+            self.tunables.gc_zeal_alloc_counter = Some(counter);
+            Ok(self)
+        }
     }
 
     /// Configures the maximum amount of stack space available for

--- a/crates/wasmtime/src/engine/serialization.rs
+++ b/crates/wasmtime/src/engine/serialization.rs
@@ -327,6 +327,9 @@ impl Metadata<'_> {
 
             // Just a debugging aid, doesn't affect functionality at all.
             debug_adapter_modules: _,
+
+            // This is a runtime GC debugging setting, doesn't affect compilation.
+            gc_zeal_alloc_counter: _,
         } = self.tunables;
 
         Self::check_collector(collector, other.collector)?;

--- a/crates/wasmtime/src/runtime/store.rs
+++ b/crates/wasmtime/src/runtime/store.rs
@@ -1978,7 +1978,11 @@ impl StoreOpaque {
                     .allocator()
                     .allocate_gc_heap(engine, &**gc_runtime, mem_alloc_index, mem)?;
 
-            Ok(GcStore::new(index, heap))
+            Ok(GcStore::new(
+                index,
+                heap,
+                engine.tunables().gc_zeal_alloc_counter,
+            ))
         }
 
         #[cfg(not(feature = "gc"))]

--- a/crates/wasmtime/src/runtime/vm/gc.rs
+++ b/crates/wasmtime/src/runtime/vm/gc.rs
@@ -56,35 +56,27 @@ pub struct GcStore {
 
     /// An allocation counter that triggers GC when it reaches zero.
     ///
-    /// Initialized from the `WASMTIME_GC_ZEAL_ALLOC_COUNTER` environment
-    /// variable. Decremented on every allocation and when it hits zero, a GC is
+    /// Decremented on every allocation and when it hits zero, a GC is
     /// forced and the counter is reset.
-    #[cfg(all(gc_zeal, feature = "std"))]
+    #[cfg(gc_zeal)]
     gc_zeal_alloc_counter: Option<NonZeroU32>,
 
     /// The initial value to reset the counter to after it triggers.
-    #[cfg(all(gc_zeal, feature = "std"))]
+    #[cfg(gc_zeal)]
     gc_zeal_alloc_counter_init: Option<NonZeroU32>,
 }
 
 impl GcStore {
     /// Create a new `GcStore`.
-    pub fn new(allocation_index: GcHeapAllocationIndex, gc_heap: Box<dyn GcHeap>) -> Self {
+    pub fn new(
+        allocation_index: GcHeapAllocationIndex,
+        gc_heap: Box<dyn GcHeap>,
+        gc_zeal_alloc_counter: Option<NonZeroU32>,
+    ) -> Self {
         let host_data_table = ExternRefHostDataTable::default();
         let func_ref_table = FuncRefTable::default();
 
-        #[cfg(all(gc_zeal, feature = "std"))]
-        let gc_zeal_alloc_counter_init =
-            std::env::var("WASMTIME_GC_ZEAL_ALLOC_COUNTER")
-                .ok()
-                .map(|v| {
-                    v.parse::<NonZeroU32>().unwrap_or_else(|_| {
-                        panic!(
-                            "`WASMTIME_GC_ZEAL_ALLOC_COUNTER` must be a non-zero \
-                             `u32` value, got: {v}"
-                        )
-                    })
-                });
+        let _ = &gc_zeal_alloc_counter;
 
         Self {
             allocation_index,
@@ -92,10 +84,10 @@ impl GcStore {
             host_data_table,
             func_ref_table,
             last_post_gc_allocated_bytes: None,
-            #[cfg(all(gc_zeal, feature = "std"))]
-            gc_zeal_alloc_counter: gc_zeal_alloc_counter_init,
-            #[cfg(all(gc_zeal, feature = "std"))]
-            gc_zeal_alloc_counter_init,
+            #[cfg(gc_zeal)]
+            gc_zeal_alloc_counter,
+            #[cfg(gc_zeal)]
+            gc_zeal_alloc_counter_init: gc_zeal_alloc_counter,
         }
     }
 
@@ -279,7 +271,7 @@ impl GcStore {
     ) -> Result<Result<VMGcRef, u64>> {
         // When gc_zeal is enabled with an allocation counter, decrement it and
         // force a GC cycle when it reaches zero by returning a fake OOM.
-        #[cfg(all(gc_zeal, feature = "std"))]
+        #[cfg(gc_zeal)]
         if let Some(counter) = self.gc_zeal_alloc_counter.take() {
             match NonZeroU32::new(counter.get() - 1) {
                 Some(c) => self.gc_zeal_alloc_counter = Some(c),


### PR DESCRIPTION
Replace the `WASMTIME_GC_ZEAL_ALLOC_COUNTER` environment variable with a `gc_zeal_alloc_counter` field on `Tunables` and a corresponding `Config::gc_zeal_alloc_counter` method.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
