### PR TITLE
Update `rand` crate dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.7",
 ]
 
 [[package]]
@@ -389,16 +389,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cap-rand"
-version = "3.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8144c22e24bbcf26ade86cb6501a0916c46b7e4787abdb0045a467eb1645a1d"
-dependencies = [
- "ambient-authority",
- "rand 0.8.5",
-]
-
-[[package]]
 name = "cap-std"
 version = "3.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -499,6 +489,17 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.0",
+]
 
 [[package]]
 name = "ciborium"
@@ -689,6 +690,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "cranelift"
 version = "0.132.0"
 dependencies = [
@@ -865,7 +875,7 @@ dependencies = [
  "arbitrary",
  "cranelift",
  "cranelift-native",
- "rand 0.9.2",
+ "rand 0.10.1",
  "target-lexicon",
 ]
 
@@ -1667,6 +1677,20 @@ dependencies = [
  "libc",
  "wasi 0.13.3+wasi-0.2.2",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "rand_core 0.10.0",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -2944,6 +2968,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2962,6 +2992,17 @@ checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.0",
 ]
 
 [[package]]
@@ -3001,6 +3042,12 @@ checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.1",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
 
 [[package]]
 name = "rand_xorshift"
@@ -3414,7 +3461,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.7",
  "digest",
 ]
 
@@ -3425,7 +3472,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55deaec60f81eefe3cce0dc50bda92d6d8e88f2a27df7c5033b42afeb1ed2676"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.7",
  "digest",
 ]
 
@@ -3761,7 +3808,7 @@ dependencies = [
  "wasmtime",
  "wasmtime-test-util",
  "wat",
- "wit-component",
+ "wit-component 0.246.2",
 ]
 
 [[package]]
@@ -4292,7 +4339,6 @@ dependencies = [
  "async-trait",
  "bitflags 2.9.4",
  "cap-fs-ext",
- "cap-rand",
  "cap-std",
  "cap-time-ext",
  "fs-set-times",
@@ -4300,6 +4346,7 @@ dependencies = [
  "io-lifetimes",
  "libc",
  "log",
+ "rand 0.10.1",
  "rustix 1.0.8",
  "system-interface",
  "tempfile",
@@ -4333,8 +4380,8 @@ dependencies = [
  "byte-array-literals",
  "object 0.39.0",
  "wasip1",
- "wasm-encoder",
- "wit-bindgen-rust-macro",
+ "wasm-encoder 0.246.2",
+ "wit-bindgen-rust-macro 0.55.0",
 ]
 
 [[package]]
@@ -4350,6 +4397,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03fa2761397e5bd52002cd7e73110c71af2109aca4e521a9f40473fe685b0a24"
 dependencies = [
  "wit-bindgen 0.45.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -4419,9 +4475,19 @@ dependencies = [
  "log",
  "petgraph",
  "smallvec 1.15.1",
- "wasm-encoder",
+ "wasm-encoder 0.246.2",
  "wasmparser 0.246.2",
  "wat",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.244.0",
 ]
 
 [[package]]
@@ -4436,13 +4502,25 @@ dependencies = [
 
 [[package]]
 name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap 2.13.0",
+ "wasm-encoder 0.244.0",
+ "wasmparser 0.244.0",
+]
+
+[[package]]
+name = "wasm-metadata"
 version = "0.246.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e4c2aa916c425dcca61a6887d3e135acdee2c6d0ed51fd61c08d41ddaf62b1"
 dependencies = [
  "anyhow",
  "indexmap 2.13.0",
- "wasm-encoder",
+ "wasm-encoder 0.246.2",
  "wasmparser 0.246.2",
 ]
 
@@ -4456,7 +4534,7 @@ dependencies = [
  "log",
  "rand 0.9.2",
  "thiserror 2.0.17",
- "wasm-encoder",
+ "wasm-encoder 0.246.2",
  "wasmparser 0.246.2",
 ]
 
@@ -4471,7 +4549,7 @@ dependencies = [
  "flagset",
  "serde",
  "serde_derive",
- "wasm-encoder",
+ "wasm-encoder 0.246.2",
  "wat",
 ]
 
@@ -4491,7 +4569,7 @@ checksum = "b42a5e3a45e10af58cb460ea4b77d8738b0923ad84131b74aeec4fa853059845"
 dependencies = [
  "logos",
  "thiserror 2.0.17",
- "wit-parser",
+ "wit-parser 0.246.2",
 ]
 
 [[package]]
@@ -4546,6 +4624,18 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.9.4",
+ "hashbrown 0.15.2",
+ "indexmap 2.13.0",
+ "semver",
+]
+
+[[package]]
+name = "wasmparser"
 version = "0.246.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71cde4757396defafd25417cfb36aa3161027d06d865b0c24baaae229aac005d"
@@ -4596,7 +4686,7 @@ dependencies = [
  "postcard",
  "proptest",
  "pulley-interpreter",
- "rand 0.9.2",
+ "rand 0.10.1",
  "rayon",
  "rustix 1.0.8",
  "semver",
@@ -4608,7 +4698,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "wasm-compose",
- "wasm-encoder",
+ "wasm-encoder 0.246.2",
  "wasm-wave",
  "wasmparser 0.246.2",
  "wasmtime-environ",
@@ -4704,7 +4794,7 @@ dependencies = [
  "num_cpus",
  "object 0.39.0",
  "pulley-interpreter",
- "rand 0.9.2",
+ "rand 0.10.1",
  "rayon",
  "rustix 1.0.8",
  "serde",
@@ -4721,7 +4811,7 @@ dependencies = [
  "tracing",
  "walkdir",
  "wasi-common",
- "wasm-encoder",
+ "wasm-encoder 0.246.2",
  "wasmparser 0.246.2",
  "wasmtime",
  "wasmtime-cli-flags",
@@ -4747,7 +4837,7 @@ dependencies = [
  "wast 246.0.2",
  "wat",
  "windows-sys 0.61.2",
- "wit-component",
+ "wit-component 0.246.2",
 ]
 
 [[package]]
@@ -4790,7 +4880,7 @@ dependencies = [
  "sha2",
  "smallvec 1.15.1",
  "target-lexicon",
- "wasm-encoder",
+ "wasm-encoder 0.246.2",
  "wasmparser 0.246.2",
  "wasmprinter",
  "wasmtime-internal-component-util",
@@ -4834,8 +4924,7 @@ dependencies = [
  "proc-macro2",
  "pulley-interpreter-fuzz",
  "quote",
- "rand 0.8.5",
- "rand 0.9.2",
+ "rand 0.10.1",
  "smallvec 1.15.1",
  "target-lexicon",
  "wasmparser 0.246.2",
@@ -4857,7 +4946,7 @@ dependencies = [
  "indexmap 2.13.0",
  "log",
  "mutatis",
- "rand 0.8.5",
+ "rand 0.10.1",
  "rayon",
  "serde",
  "serde_json",
@@ -4868,7 +4957,7 @@ dependencies = [
  "tokio",
  "v8",
  "wasm-compose",
- "wasm-encoder",
+ "wasm-encoder 0.246.2",
  "wasm-mutate",
  "wasm-smith",
  "wasm-spec-interpreter",
@@ -4931,7 +5020,7 @@ dependencies = [
  "wasmtime",
  "wasmtime-internal-component-util",
  "wasmtime-internal-wit-bindgen",
- "wit-parser",
+ "wit-parser 0.246.2",
 ]
 
 [[package]]
@@ -5097,7 +5186,7 @@ dependencies = [
  "bitflags 2.9.4",
  "heck 0.5.0",
  "indexmap 2.13.0",
- "wit-parser",
+ "wit-parser 0.246.2",
 ]
 
 [[package]]
@@ -5125,7 +5214,7 @@ dependencies = [
  "indexmap 2.13.0",
  "proc-macro2",
  "quote",
- "rand 0.9.2",
+ "rand 0.10.1",
  "serde",
  "serde_derive",
  "target-lexicon",
@@ -5147,7 +5236,6 @@ dependencies = [
  "bytes",
  "cap-fs-ext",
  "cap-net-ext",
- "cap-rand",
  "cap-std",
  "cap-time-ext",
  "env_logger 0.11.5",
@@ -5155,6 +5243,7 @@ dependencies = [
  "futures",
  "io-extras",
  "io-lifetimes",
+ "rand 0.10.1",
  "rustix 1.0.8",
  "system-interface",
  "tempfile",
@@ -5260,7 +5349,7 @@ name = "wasmtime-wasi-threads"
 version = "45.0.0"
 dependencies = [
  "log",
- "rand 0.8.5",
+ "rand 0.10.1",
  "wasi-common",
  "wasmtime",
  "wasmtime-wasi",
@@ -5311,7 +5400,7 @@ dependencies = [
  "log",
  "rayon",
  "tokio",
- "wasm-encoder",
+ "wasm-encoder 0.246.2",
  "wasmparser 0.246.2",
  "wasmprinter",
  "wasmtime",
@@ -5339,7 +5428,7 @@ dependencies = [
  "leb128fmt",
  "memchr",
  "unicode-width 0.2.0",
- "wasm-encoder",
+ "wasm-encoder 0.246.2",
 ]
 
 [[package]]
@@ -5719,13 +5808,33 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro 0.51.0",
+]
+
+[[package]]
+name = "wit-bindgen"
 version = "0.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6870386de1813a61406d88749d5897484e2f6fe90a39408a6a94e160d8c72378"
 dependencies = [
  "bitflags 2.9.4",
  "futures",
- "wit-bindgen-rust-macro",
+ "wit-bindgen-rust-macro 0.55.0",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "wit-parser 0.244.0",
 ]
 
 [[package]]
@@ -5736,7 +5845,7 @@ checksum = "4779c97d3b9dda56600c3404355d404f8c6567fae0c4d8dfeb92f6e9b2c4c8c3"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
- "wit-parser",
+ "wit-parser 0.246.2",
 ]
 
 [[package]]
@@ -5750,6 +5859,22 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "indexmap 2.13.0",
+ "prettyplease",
+ "syn 2.0.106",
+ "wasm-metadata 0.244.0",
+ "wit-bindgen-core 0.51.0",
+ "wit-component 0.244.0",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
 version = "0.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a89a98e0efe034f47f5cf86fa8aeb5d6d7175bade32bbba476aeba29541fed9"
@@ -5759,9 +5884,24 @@ dependencies = [
  "indexmap 2.13.0",
  "prettyplease",
  "syn 2.0.106",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
+ "wasm-metadata 0.246.2",
+ "wit-bindgen-core 0.55.0",
+ "wit-component 0.246.2",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+ "wit-bindgen-core 0.51.0",
+ "wit-bindgen-rust 0.51.0",
 ]
 
 [[package]]
@@ -5776,8 +5916,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
- "wit-bindgen-core",
- "wit-bindgen-rust",
+ "wit-bindgen-core 0.55.0",
+ "wit-bindgen-rust 0.55.0",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.9.4",
+ "indexmap 2.13.0",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder 0.244.0",
+ "wasm-metadata 0.244.0",
+ "wasmparser 0.244.0",
+ "wit-parser 0.244.0",
 ]
 
 [[package]]
@@ -5793,10 +5952,28 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "wasm-encoder",
- "wasm-metadata",
+ "wasm-encoder 0.246.2",
+ "wasm-metadata 0.246.2",
  "wasmparser 0.246.2",
- "wit-parser",
+ "wit-parser 0.246.2",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.13.0",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.244.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -337,7 +337,6 @@ wasip1 = { version = "1.0.0", default-features = false }
 # cap-std family:
 target-lexicon = "0.13.0"
 cap-std = "3.4.5"
-cap-rand = { version = "3.4.5", features = ["small_rng"] }
 cap-fs-ext = "3.4.5"
 cap-net-ext = "3.4.5"
 cap-time-ext = "3.4.5"
@@ -399,7 +398,7 @@ mach2 = "0.4.2"
 memfd = "0.6.5"
 psm = "0.1.11"
 proptest = "1.0.0"
-rand = { version = "0.9.2", features = ["small_rng"] }
+rand = { version = "0.10.1", default-features = false }
 # serde and serde_derive must have the same version
 serde = { version = "1.0.228", default-features = false, features = ['alloc'] }
 serde_derive = "1.0.228"

--- a/benches/compile_time_builtins.rs
+++ b/benches/compile_time_builtins.rs
@@ -474,7 +474,7 @@ mod inc_list {
 
 mod inc_random {
     use super::*;
-    use rand::{Rng, SeedableRng as _};
+    use rand::{RngExt, SeedableRng as _};
 
     pub fn bench(c: &mut Criterion) {
         let mut g = c.benchmark_group("increment-random-byte-in-buf");

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -41,7 +41,7 @@ gimli = { workspace = true, features = ["write"], optional = true }
 smallvec = { workspace = true }
 regalloc2 = { workspace = true, features = ["checker"] }
 souper-ir = { version = "2.1.0", optional = true }
-sha2 = { version = "0.10.2", optional = true }
+sha2 = { workspace = true, optional = true }
 rustc-hash = { workspace = true }
 wasmtime-core = { workspace = true }
 libm = { workspace = true }

--- a/cranelift/fuzzgen/src/lib.rs
+++ b/cranelift/fuzzgen/src/lib.rs
@@ -13,7 +13,7 @@ use cranelift::prelude::settings::SettingKind;
 use cranelift::prelude::*;
 use cranelift_arbitrary::CraneliftArbitrary;
 use cranelift_native::builder_with_options;
-use rand::{Rng, SeedableRng, rngs::SmallRng};
+use rand::{RngExt, SeedableRng, rngs::SmallRng};
 use target_isa_extras::TargetIsaExtras;
 use target_lexicon::Architecture;
 

--- a/crates/cache/Cargo.toml
+++ b/crates/cache/Cargo.toml
@@ -19,7 +19,7 @@ directories-next = "2.0"
 log = { workspace = true }
 serde = { workspace = true }
 serde_derive = { workspace = true }
-sha2 = { workspace = true, features = ['std'] }
+sha2 = { workspace = true }
 toml = { workspace = true }
 zstd = { version = "0.13.0", default-features = false }
 wasmtime-environ = { workspace = true }

--- a/crates/fuzzing/Cargo.toml
+++ b/crates/fuzzing/Cargo.toml
@@ -70,7 +70,7 @@ v8 = "139.0.0"
 
 [dev-dependencies]
 wat = { workspace = true }
-rand = { version = "0.8.0", features = ["small_rng"] }
+rand = { workspace = true }
 wasmtime-environ = { workspace = true }
 cranelift-bforest = { workspace = true }
 cranelift-bitset = { workspace = true }

--- a/crates/fuzzing/src/generators/gc_ops/tests.rs
+++ b/crates/fuzzing/src/generators/gc_ops/tests.rs
@@ -5,7 +5,7 @@ use crate::generators::gc_ops::{
 };
 use mutatis;
 use rand::rngs::StdRng;
-use rand::{Rng, SeedableRng};
+use rand::{RngExt, SeedableRng};
 use wasmparser;
 use wasmprinter;
 
@@ -101,7 +101,7 @@ fn test_ops(num_params: u32, num_globals: u32, table_size: u32) -> GcOps {
     let mut rng = StdRng::seed_from_u64(0xC0FFEE);
     if t.limits.max_rec_groups > 0 {
         for i in 0..t.limits.max_types {
-            let gid = RecGroupId(rng.gen_range(0..t.limits.max_rec_groups));
+            let gid = RecGroupId(rng.random_range(0..t.limits.max_rec_groups));
             let is_final = false;
             let supertype = None;
             t.types

--- a/crates/fuzzing/src/single_module_fuzzer.rs
+++ b/crates/fuzzing/src/single_module_fuzzer.rs
@@ -274,7 +274,7 @@ fn extract_fuzz_input(data: &[u8]) -> wasmtime::Result<FuzzInput<'_>> {
 mod tests {
     use super::*;
     use rand::rngs::SmallRng;
-    use rand::{RngCore, SeedableRng};
+    use rand::{Rng, SeedableRng};
 
     #[test]
     fn changing_configuration_does_not_change_module() {

--- a/crates/test-programs/Cargo.toml
+++ b/crates/test-programs/Cargo.toml
@@ -17,7 +17,7 @@ wit-bindgen = { workspace = true, features = ['default', 'async-spawn', 'inter-t
 libc = { workspace = true }
 futures = { workspace = true, default-features = false, features = ['alloc', 'async-await'] }
 url = { workspace = true }
-sha2 = { workspace = true, features = ['std'] }
+sha2 = { workspace = true }
 base64 = { workspace = true }
 wasip1 = { version = "1.0.0", default-features = true }
 wasip2 = "1.0.0"

--- a/crates/wasi-common/Cargo.toml
+++ b/crates/wasi-common/Cargo.toml
@@ -20,9 +20,9 @@ thiserror = { workspace = true }
 wiggle = { workspace = true }
 tracing = { workspace = true }
 cap-std = { workspace = true }
-cap-rand = { workspace = true }
 bitflags = { workspace = true }
 log = { workspace = true }
+rand = { workspace = true, features = ['std_rng', 'thread_rng'] }
 async-trait = { workspace = true }
 wasmtime-environ = { workspace = true }
 

--- a/crates/wasi-common/src/ctx.rs
+++ b/crates/wasi-common/src/ctx.rs
@@ -5,7 +5,7 @@ use crate::sched::WasiSched;
 use crate::string_array::StringArray;
 use crate::table::Table;
 use crate::{Error, StringArrayError};
-use cap_rand::RngCore;
+use rand::Rng;
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
@@ -24,7 +24,7 @@ pub struct WasiCtxInner {
     // TODO: this mutex should not be necessary, it forces threads to serialize
     // their access to randomness unnecessarily
     // (https://github.com/bytecodealliance/wasmtime/issues/5660).
-    pub random: Mutex<Box<dyn RngCore + Send + Sync>>,
+    pub random: Mutex<Box<dyn Rng + Send + Sync>>,
     pub clocks: WasiClocks,
     pub sched: Box<dyn WasiSched>,
     pub table: Table,
@@ -32,7 +32,7 @@ pub struct WasiCtxInner {
 
 impl WasiCtx {
     pub fn new(
-        random: Box<dyn RngCore + Send + Sync>,
+        random: Box<dyn Rng + Send + Sync>,
         clocks: WasiClocks,
         sched: Box<dyn WasiSched>,
         table: Table,

--- a/crates/wasi-common/src/lib.rs
+++ b/crates/wasi-common/src/lib.rs
@@ -88,12 +88,12 @@ pub mod table;
 #[cfg(feature = "tokio")]
 pub mod tokio;
 
-pub use cap_rand::RngCore;
 pub use clocks::{SystemTimeSpec, WasiClocks, WasiMonotonicClock, WasiSystemClock};
 pub use ctx::WasiCtx;
 pub use dir::WasiDir;
 pub use error::{Error, ErrorExt, I32Exit};
 pub use file::WasiFile;
+pub use rand::TryRng;
 pub use sched::{Poll, WasiSched};
 pub use string_array::{StringArray, StringArrayError};
 pub use table::Table;

--- a/crates/wasi-common/src/random.rs
+++ b/crates/wasi-common/src/random.rs
@@ -1,4 +1,5 @@
-use cap_rand::RngCore;
+use core::convert::Infallible;
+use rand::{Rng, TryRng};
 
 /// Implement `WasiRandom` using a deterministic cycle of bytes.
 pub struct Deterministic {
@@ -13,26 +14,24 @@ impl Deterministic {
     }
 }
 
-impl RngCore for Deterministic {
-    fn next_u32(&mut self) -> u32 {
+impl TryRng for Deterministic {
+    type Error = Infallible;
+    fn try_next_u32(&mut self) -> Result<u32, Infallible> {
         let b0 = self.cycle.next().expect("infinite sequence");
         let b1 = self.cycle.next().expect("infinite sequence");
         let b2 = self.cycle.next().expect("infinite sequence");
         let b3 = self.cycle.next().expect("infinite sequence");
-        ((b0 as u32) << 24) + ((b1 as u32) << 16) + ((b2 as u32) << 8) + (b3 as u32)
+        Ok(((b0 as u32) << 24) + ((b1 as u32) << 16) + ((b2 as u32) << 8) + (b3 as u32))
     }
-    fn next_u64(&mut self) -> u64 {
+    fn try_next_u64(&mut self) -> Result<u64, Infallible> {
         let w0 = self.next_u32();
         let w1 = self.next_u32();
-        ((w0 as u64) << 32) + (w1 as u64)
+        Ok(((w0 as u64) << 32) + (w1 as u64))
     }
-    fn fill_bytes(&mut self, buf: &mut [u8]) {
+    fn try_fill_bytes(&mut self, buf: &mut [u8]) -> Result<(), Infallible> {
         for b in buf.iter_mut() {
             *b = self.cycle.next().expect("infinite sequence");
         }
-    }
-    fn try_fill_bytes(&mut self, buf: &mut [u8]) -> Result<(), cap_rand::Error> {
-        self.fill_bytes(buf);
         Ok(())
     }
 }

--- a/crates/wasi-common/src/snapshots/preview_1.rs
+++ b/crates/wasi-common/src/snapshots/preview_1.rs
@@ -1170,7 +1170,7 @@ impl wasi_snapshot_preview1::WasiSnapshotPreview1 for WasiCtx {
             while copied < buf.len() {
                 let len = (buf.len() - copied).min(MAX_SHARED_BUFFER_SIZE as u32);
                 let mut tmp = vec![0; len as usize];
-                self.random.lock().unwrap().try_fill_bytes(&mut tmp)?;
+                self.random.lock().unwrap().fill_bytes(&mut tmp);
                 let dest = buf.get_range(copied..copied + len).unwrap();
                 memory.copy_from_slice(&tmp, dest)?;
                 copied += len;
@@ -1179,7 +1179,7 @@ impl wasi_snapshot_preview1::WasiSnapshotPreview1 for WasiCtx {
             // If the Wasm memory is non-shared, copy directly into the linear
             // memory.
             let mem = &mut memory.as_slice_mut(buf)?.unwrap();
-            self.random.lock().unwrap().try_fill_bytes(mem)?;
+            self.random.lock().unwrap().fill_bytes(mem);
         }
         Ok(())
     }

--- a/crates/wasi-common/src/snapshots/preview_1/error.rs
+++ b/crates/wasi-common/src/snapshots/preview_1/error.rs
@@ -225,13 +225,6 @@ impl From<std::io::Error> for Error {
     }
 }
 
-impl From<cap_rand::Error> for Error {
-    fn from(err: cap_rand::Error) -> Error {
-        // I picked Error::Io as a 'reasonable default', FIXME dan is this ok?
-        from_raw_os_error(err.raw_os_error()).unwrap_or_else(|| Error::from(Errno::Io))
-    }
-}
-
 impl From<wiggle::GuestError> for Error {
     fn from(err: wiggle::GuestError) -> Error {
         use wiggle::GuestError::*;

--- a/crates/wasi-common/src/sync/mod.rs
+++ b/crates/wasi-common/src/sync/mod.rs
@@ -29,7 +29,7 @@ pub use sched::sched_ctx;
 
 use self::net::Socket;
 use crate::{Error, WasiCtx, WasiFile, file::FileAccessMode, table::Table};
-use cap_rand::{Rng, RngCore, SeedableRng};
+use rand::{Rng, SeedableRng};
 use std::mem;
 use std::path::Path;
 
@@ -129,9 +129,8 @@ impl WasiCtxBuilder {
     }
 }
 
-pub fn random_ctx() -> Box<dyn RngCore + Send + Sync> {
-    let mut rng = cap_rand::thread_rng(cap_rand::ambient_authority());
-    Box::new(cap_rand::rngs::StdRng::from_seed(rng.r#gen()))
+pub fn random_ctx() -> Box<dyn Rng + Send + Sync> {
+    Box::new(rand::rngs::StdRng::from_seed(rand::random()))
 }
 
 #[cfg(feature = "wasmtime")]

--- a/crates/wasi-http/Cargo.toml
+++ b/crates/wasi-http/Cargo.toml
@@ -51,7 +51,7 @@ tracing-subscriber = { workspace = true }
 wasmtime = { workspace = true, features = ['default', 'anyhow'] }
 tokio = { workspace = true, features = ['fs', 'macros'] }
 futures = { workspace = true, default-features = false, features = ['alloc', 'async-await'] }
-sha2 = { workspace = true, features = ['std'] }
+sha2 = { workspace = true }
 base64 = { workspace = true }
 flate2 = { workspace = true }
 wasm-compose = { workspace = true }

--- a/crates/wasi-threads/Cargo.toml
+++ b/crates/wasi-threads/Cargo.toml
@@ -17,7 +17,7 @@ workspace = true
 
 [dependencies]
 log = { workspace = true }
-rand = "0.8"
+rand = { workspace = true }
 wasi-common = { workspace = true, features = ["exit"]}
 wasmtime = { workspace = true, features = ['threads'] }
 wasmtime-wasi = { workspace = true }

--- a/crates/wasi/Cargo.toml
+++ b/crates/wasi/Cargo.toml
@@ -27,7 +27,6 @@ bytes = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true, features = ["std", "attributes"] }
 cap-std = { workspace = true }
-cap-rand = { workspace = true }
 cap-fs-ext = { workspace = true }
 cap-net-ext = { workspace = true }
 cap-time-ext = { workspace = true }
@@ -38,6 +37,7 @@ async-trait = { workspace = true }
 system-interface = { workspace = true}
 futures = { workspace = true }
 url = { workspace = true }
+rand = { workspace = true, features = ['std_rng', 'thread_rng'] }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["time", "sync", "io-std", "io-util", "rt", "rt-multi-thread", "net", "macros", "fs"] }

--- a/crates/wasi/src/ctx.rs
+++ b/crates/wasi/src/ctx.rs
@@ -4,8 +4,8 @@ use crate::filesystem::{Dir, WasiFilesystemCtx};
 use crate::random::WasiRandomCtx;
 use crate::sockets::{SocketAddrCheck, SocketAddrUse, WasiSocketsCtx};
 use crate::{DirPerms, FilePerms, OpenMode};
-use cap_rand::RngCore;
 use cap_std::ambient_authority;
+use rand::Rng;
 use std::future::Future;
 use std::mem;
 use std::net::SocketAddr;
@@ -326,7 +326,7 @@ impl WasiCtxBuilder {
     /// unpredictable random data in order to maintain its security invariants,
     /// and ideally should use the insecure random API otherwise, so using any
     /// prerecorded or otherwise predictable data may compromise security.
-    pub fn secure_random(&mut self, random: impl RngCore + Send + 'static) -> &mut Self {
+    pub fn secure_random(&mut self, random: impl Rng + Send + 'static) -> &mut Self {
         self.random.random = Box::new(random);
         self
     }
@@ -335,7 +335,7 @@ impl WasiCtxBuilder {
     ///
     /// The `insecure_random` generator provided will be used for all randomness
     /// requested by the `wasi:random/insecure` interface.
-    pub fn insecure_random(&mut self, insecure_random: impl RngCore + Send + 'static) -> &mut Self {
+    pub fn insecure_random(&mut self, insecure_random: impl Rng + Send + 'static) -> &mut Self {
         self.random.insecure_random = Box::new(insecure_random);
         self
     }

--- a/crates/wasi/src/lib.rs
+++ b/crates/wasi/src/lib.rs
@@ -61,6 +61,6 @@ pub use async_trait::async_trait;
 #[doc(no_inline)]
 pub use cap_fs_ext::SystemTimeSpec;
 #[doc(no_inline)]
-pub use cap_rand::RngCore;
+pub use rand::Rng;
 #[doc(no_inline)]
 pub use wasmtime::component::{ResourceTable, ResourceTableError};

--- a/crates/wasi/src/p2/host/filesystem.rs
+++ b/crates/wasi/src/p2/host/filesystem.rs
@@ -716,13 +716,6 @@ impl<'a> From<&'a std::io::Error> for ErrorCode {
     }
 }
 
-impl From<cap_rand::Error> for ErrorCode {
-    fn from(err: cap_rand::Error) -> ErrorCode {
-        // I picked Error::Io as a 'reasonable default', FIXME dan is this ok?
-        from_raw_os_error(err.raw_os_error()).unwrap_or(ErrorCode::Io)
-    }
-}
-
 impl From<std::num::TryFromIntError> for ErrorCode {
     fn from(_err: std::num::TryFromIntError) -> ErrorCode {
         ErrorCode::Overflow

--- a/crates/wasi/src/p2/host/random.rs
+++ b/crates/wasi/src/p2/host/random.rs
@@ -1,6 +1,6 @@
 use crate::p2::bindings::random::{insecure, insecure_seed, random};
 use crate::random::WasiRandomCtx;
-use cap_rand::{Rng, distributions::Standard};
+use rand::RngExt;
 use wasmtime::bail;
 
 impl random::Host for WasiRandomCtx {
@@ -9,13 +9,13 @@ impl random::Host for WasiRandomCtx {
             bail!("requested len {len:?} exceeds limit {}", self.max_size);
         }
         Ok((&mut self.random)
-            .sample_iter(Standard)
+            .random_iter()
             .take(len as usize)
             .collect())
     }
 
     fn get_random_u64(&mut self) -> wasmtime::Result<u64> {
-        Ok(self.random.sample(Standard))
+        Ok(self.random.random())
     }
 }
 
@@ -25,13 +25,13 @@ impl insecure::Host for WasiRandomCtx {
             bail!("requested len {len:?} exceeds limit {}", self.max_size);
         }
         Ok((&mut self.insecure_random)
-            .sample_iter(Standard)
+            .random_iter()
             .take(len as usize)
             .collect())
     }
 
     fn get_insecure_random_u64(&mut self) -> wasmtime::Result<u64> {
-        Ok(self.insecure_random.sample(Standard))
+        Ok(self.insecure_random.random())
     }
 }
 

--- a/crates/wasi/src/p3/random/host.rs
+++ b/crates/wasi/src/p3/random/host.rs
@@ -1,31 +1,30 @@
 use crate::p3::bindings::random::{insecure, insecure_seed, random};
 use crate::random::WasiRandomCtx;
-use cap_rand::Rng;
-use cap_rand::distributions::Standard;
+use rand::RngExt;
 
 impl random::Host for WasiRandomCtx {
     fn get_random_bytes(&mut self, len: u64) -> wasmtime::Result<Vec<u8>> {
         Ok((&mut self.random)
-            .sample_iter(Standard)
+            .random_iter()
             .take(len.min(self.max_size) as usize)
             .collect())
     }
 
     fn get_random_u64(&mut self) -> wasmtime::Result<u64> {
-        Ok(self.random.sample(Standard))
+        Ok(self.random.random())
     }
 }
 
 impl insecure::Host for WasiRandomCtx {
     fn get_insecure_random_bytes(&mut self, len: u64) -> wasmtime::Result<Vec<u8>> {
         Ok((&mut self.insecure_random)
-            .sample_iter(Standard)
+            .random_iter()
             .take(len.min(self.max_size) as usize)
             .collect())
     }
 
     fn get_insecure_random_u64(&mut self) -> wasmtime::Result<u64> {
-        Ok(self.insecure_random.sample(Standard))
+        Ok(self.insecure_random.random())
     }
 }
 

--- a/crates/wasi/src/random.rs
+++ b/crates/wasi/src/random.rs
@@ -1,4 +1,5 @@
-use cap_rand::{Rng as _, RngCore, SeedableRng as _};
+use rand::{Rng, SeedableRng as _, TryRng};
+use std::convert::Infallible;
 use wasmtime::component::HasData;
 
 /// A helper struct which implements [`HasData`] for the `wasi:random` APIs.
@@ -47,8 +48,8 @@ impl HasData for WasiRandom {
 pub const DEFAULT_MAX_SIZE: u64 = 64 << 20;
 
 pub struct WasiRandomCtx {
-    pub(crate) random: Box<dyn RngCore + Send>,
-    pub(crate) insecure_random: Box<dyn RngCore + Send>,
+    pub(crate) random: Box<dyn Rng + Send>,
+    pub(crate) insecure_random: Box<dyn Rng + Send>,
     pub(crate) insecure_random_seed: u128,
     pub(crate) max_size: u64,
 }
@@ -57,15 +58,11 @@ impl Default for WasiRandomCtx {
     fn default() -> Self {
         // For the insecure random API, use `SmallRng`, which is fast. It's
         // also insecure, but that's the deal here.
-        let insecure_random = Box::new(
-            cap_rand::rngs::SmallRng::from_rng(cap_rand::thread_rng(cap_rand::ambient_authority()))
-                .unwrap(),
-        );
+        let insecure_random = Box::new(rand::rngs::SmallRng::from_rng(&mut rand::rng()));
         // For the insecure random seed, use a `u128` generated from
-        // `thread_rng()`, so that it's not guessable from the insecure_random
-        // API.
-        let insecure_random_seed =
-            cap_rand::thread_rng(cap_rand::ambient_authority()).r#gen::<u128>();
+        // `rand::random()`, so that it's not guessable from the
+        // insecure_random API.
+        let insecure_random_seed = rand::random::<u128>();
         let max_size = DEFAULT_MAX_SIZE;
         Self {
             random: thread_rng(),
@@ -99,26 +96,24 @@ impl Deterministic {
     }
 }
 
-impl RngCore for Deterministic {
-    fn next_u32(&mut self) -> u32 {
+impl TryRng for Deterministic {
+    type Error = Infallible;
+    fn try_next_u32(&mut self) -> Result<u32, Infallible> {
         let b0 = self.cycle.next().expect("infinite sequence");
         let b1 = self.cycle.next().expect("infinite sequence");
         let b2 = self.cycle.next().expect("infinite sequence");
         let b3 = self.cycle.next().expect("infinite sequence");
-        ((b0 as u32) << 24) + ((b1 as u32) << 16) + ((b2 as u32) << 8) + (b3 as u32)
+        Ok(((b0 as u32) << 24) + ((b1 as u32) << 16) + ((b2 as u32) << 8) + (b3 as u32))
     }
-    fn next_u64(&mut self) -> u64 {
+    fn try_next_u64(&mut self) -> Result<u64, Infallible> {
         let w0 = self.next_u32();
         let w1 = self.next_u32();
-        ((w0 as u64) << 32) + (w1 as u64)
+        Ok(((w0 as u64) << 32) + (w1 as u64))
     }
-    fn fill_bytes(&mut self, buf: &mut [u8]) {
+    fn try_fill_bytes(&mut self, buf: &mut [u8]) -> Result<(), Infallible> {
         for b in buf.iter_mut() {
             *b = self.cycle.next().expect("infinite sequence");
         }
-    }
-    fn try_fill_bytes(&mut self, buf: &mut [u8]) -> Result<(), cap_rand::Error> {
-        self.fill_bytes(buf);
         Ok(())
     }
 }
@@ -137,8 +132,7 @@ mod test {
     }
 }
 
-pub fn thread_rng() -> Box<dyn RngCore + Send> {
-    use cap_rand::{Rng, SeedableRng};
-    let mut rng = cap_rand::thread_rng(cap_rand::ambient_authority());
-    Box::new(cap_rand::rngs::StdRng::from_seed(rng.r#gen()))
+pub fn thread_rng() -> Box<dyn Rng + Send> {
+    let mut rng = rand::rng();
+    Box::new(rand::rngs::StdRng::from_rng(&mut rng))
 }

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -95,7 +95,7 @@ rustix = { workspace = true, optional = true, features = ["mm", "param"] }
 [dev-dependencies]
 env_logger = { workspace = true }
 proptest = { workspace = true }
-rand = { workspace = true }
+rand = { workspace = true, features = ['thread_rng'] }
 tempfile = { workspace = true }
 libtest-mimic = { workspace = true }
 cranelift-native = { workspace = true }

--- a/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/index_allocator.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/index_allocator.rs
@@ -535,6 +535,7 @@ impl List {
 #[cfg(test)]
 mod test {
     use super::*;
+    use rand::RngExt;
     use wasmtime_environ::EntityRef;
 
     #[test]
@@ -637,7 +638,6 @@ mod test {
 
     #[test]
     fn test_affinity_allocation_strategy_random() {
-        use rand::Rng;
         let mut rng = rand::rng();
 
         let ids = std::iter::repeat_with(|| {

--- a/deny.toml
+++ b/deny.toml
@@ -18,7 +18,6 @@ allow = [
     "ISC",
     "MIT",
     "MPL-2.0",
-    "Unicode-DFS-2016",
     "Zlib",
     "Unicode-3.0",
 ]
@@ -36,7 +35,7 @@ multiple-versions = "deny"
 wildcards = "allow"
 deny = []
 skip = [
-    { name = "heck", reason = "wasm-compose uses an old version of `heck` and was updated in https://github.com/bytecodealliance/wasm-tools/pull/2359, but that hasn't released yet" },
+    { name = "cpufeatures", reason = "requires an update to `sha2` which pulls in a lot of other dependencies which doesn't seem worth it" }
 ]
 skip-tree = [
     # proptest depends on bitflags 1.x.x while other crates depend on 2.x.x so

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -41,7 +41,7 @@ anyhow = { workspace = true }
 [build-dependencies]
 proc-macro2 = { workspace = true }
 arbitrary = { workspace = true, features = ["derive"] }
-rand = { version = "0.8.0" }
+rand = { workspace = true, features = ['std_rng', 'thread_rng'] }
 quote = { workspace = true }
 wasmtime = { workspace = true }
 wasmtime-test-util = { workspace = true, features = ['component-fuzz'] }

--- a/fuzz/build.rs
+++ b/fuzz/build.rs
@@ -9,7 +9,7 @@ mod component {
     use proc_macro2::TokenStream;
     use quote::quote;
     use rand::rngs::StdRng;
-    use rand::{Rng, SeedableRng};
+    use rand::{RngExt, SeedableRng};
     use std::collections::HashMap;
     use std::env;
     use std::fmt::Write;
@@ -43,7 +43,7 @@ mod component {
             seed.parse::<u64>()
                 .with_context(|| format_err!("expected u64 in WASMTIME_FUZZ_SEED"))?
         } else {
-            StdRng::from_entropy().r#gen()
+            rand::random()
         };
 
         eprintln!(
@@ -184,8 +184,8 @@ mod component {
     ) -> Result<T> {
         let mut bytes = Vec::new();
         loop {
-            let count = rng.gen_range(1000..2000);
-            bytes.extend(iter::repeat_with(|| rng.r#gen::<u8>()).take(count));
+            let count = rng.random_range(1000..2000);
+            bytes.extend(iter::repeat_with(|| rng.random::<u8>()).take(count));
 
             match f(&mut Unstructured::new(&bytes)) {
                 Ok(ret) => break Ok(ret),

--- a/fuzz/fuzz_targets/exception_ops.rs
+++ b/fuzz/fuzz_targets/exception_ops.rs
@@ -4,7 +4,7 @@ use libfuzzer_sys::arbitrary::{Arbitrary, Unstructured};
 use libfuzzer_sys::{fuzz_mutator, fuzz_target, fuzzer_mutate};
 use mutatis::Session;
 use postcard::{from_bytes, to_slice};
-use rand::{Rng, SeedableRng};
+use rand::{RngExt, SeedableRng};
 use wasmtime_fuzzing::generators::ExceptionOps;
 use wasmtime_fuzzing::oracles::exception_ops;
 

--- a/fuzz/fuzz_targets/gc_ops.rs
+++ b/fuzz/fuzz_targets/gc_ops.rs
@@ -4,7 +4,7 @@ use libfuzzer_sys::arbitrary::{Arbitrary, Unstructured};
 use libfuzzer_sys::{fuzz_mutator, fuzz_target, fuzzer_mutate};
 use mutatis::Session;
 use postcard::{from_bytes, to_slice};
-use rand::{Rng, SeedableRng};
+use rand::{RngExt, SeedableRng};
 use wasmtime_fuzzing::generators::GcOps;
 use wasmtime_fuzzing::oracles::gc_ops;
 

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -2737,6 +2737,12 @@ This is a minor update that looks to add some more detected CPU features and
 various other minor portability fixes such as MIRI support.
 """
 
+[[audits.cpufeatures]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.2.8 -> 0.2.14"
+notes = "Minor updates, nothing awry. Mostly portability updates."
+
 [[audits.criterion]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-run"
@@ -3179,6 +3185,12 @@ version = "0.7.10"
 who = "Chris Fallin <chris@cfallin.org>"
 criteria = "safe-to-deploy"
 version = "0.3.3"
+
+[[audits.getrandom]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.4.1 -> 0.4.2"
+notes = "Nothing awry in this update, standard updates for some platforms and other misc things."
 
 [[audits.gimli]]
 who = "Alex Crichton <alex@alexcrichton.com>"
@@ -4305,6 +4317,12 @@ looks to be receiving new assistance for maintainership as well.
 who = "Pat Hickey <phickey@fastly.com>"
 criteria = "safe-to-deploy"
 delta = "1.0.23 -> 1.0.27"
+
+[[audits.rand]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.10.0 -> 0.10.1"
+notes = "Minor logging-based updated fixing a recent advisory for the crate."
 
 [[audits.raw-cpuid]]
 who = "Alex Crichton <alex@alexcrichton.com>"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -432,6 +432,10 @@ criteria = "safe-to-deploy"
 version = "2.0.1"
 criteria = "safe-to-deploy"
 
+[[exemptions.r-efi]]
+version = "6.0.0"
+criteria = "safe-to-deploy"
+
 [[exemptions.rand_xorshift]]
 version = "0.3.0"
 criteria = "safe-to-deploy"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1085,13 +1085,6 @@ user-id = 6825
 user-login = "sunfishcode"
 user-name = "Dan Gohman"
 
-[[publisher.cap-rand]]
-version = "3.2.0"
-when = "2024-07-08"
-user-id = 6825
-user-login = "sunfishcode"
-user-name = "Dan Gohman"
-
 [[publisher.cap-std]]
 version = "3.2.0"
 when = "2024-07-08"
@@ -1930,6 +1923,13 @@ user-id = 1
 user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
+[[publisher.wasip3]]
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+when = "2026-01-15"
+user-id = 1
+user-login = "alexcrichton"
+user-name = "Alex Crichton"
+
 [[publisher.wasm-bindgen]]
 version = "0.2.97"
 when = "2024-11-30"
@@ -1971,8 +1971,8 @@ when = "2026-04-03"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
 [[publisher.wasm-encoder]]
-version = "0.245.0"
-when = "2026-02-10"
+version = "0.244.0"
+when = "2026-01-06"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
 [[publisher.wasm-encoder]]
@@ -1981,9 +1981,10 @@ when = "2026-04-03"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
 [[publisher.wasm-metadata]]
-version = "0.245.0"
-when = "2026-02-10"
-trusted-publisher = "github:bytecodealliance/wasm-tools"
+version = "0.236.0"
+when = "2025-07-28"
+user-id = 73222
+user-login = "wasmtime-publish"
 
 [[publisher.wasm-metadata]]
 version = "0.246.2"
@@ -1996,8 +1997,8 @@ when = "2026-04-03"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
 [[publisher.wasmparser]]
-version = "0.245.0"
-when = "2026-02-10"
+version = "0.244.0"
+when = "2026-01-06"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
 [[publisher.wasmparser]]
@@ -2400,8 +2401,18 @@ user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wit-bindgen]]
+version = "0.51.0"
+when = "2026-01-12"
+trusted-publisher = "github:bytecodealliance/wit-bindgen"
+
+[[publisher.wit-bindgen]]
 version = "0.55.0"
 when = "2026-04-03"
+trusted-publisher = "github:bytecodealliance/wit-bindgen"
+
+[[publisher.wit-bindgen-core]]
+version = "0.51.0"
+when = "2026-01-12"
 trusted-publisher = "github:bytecodealliance/wit-bindgen"
 
 [[publisher.wit-bindgen-core]]
@@ -2416,8 +2427,18 @@ user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wit-bindgen-rust]]
+version = "0.51.0"
+when = "2026-01-12"
+trusted-publisher = "github:bytecodealliance/wit-bindgen"
+
+[[publisher.wit-bindgen-rust]]
 version = "0.55.0"
 when = "2026-04-03"
+trusted-publisher = "github:bytecodealliance/wit-bindgen"
+
+[[publisher.wit-bindgen-rust-macro]]
+version = "0.51.0"
+when = "2026-01-12"
 trusted-publisher = "github:bytecodealliance/wit-bindgen"
 
 [[publisher.wit-bindgen-rust-macro]]
@@ -2426,8 +2447,8 @@ when = "2026-04-03"
 trusted-publisher = "github:bytecodealliance/wit-bindgen"
 
 [[publisher.wit-component]]
-version = "0.245.0"
-when = "2026-02-10"
+version = "0.244.0"
+when = "2026-01-06"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
 [[publisher.wit-component]]
@@ -2436,8 +2457,8 @@ when = "2026-04-03"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
 [[publisher.wit-parser]]
-version = "0.245.0"
-when = "2026-02-10"
+version = "0.244.0"
+when = "2026-01-06"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
 [[publisher.wit-parser]]
@@ -2619,10 +2640,13 @@ version = "0.3.1"
 aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
 
 [[audits.google.audits.rand_core]]
-who = "Android Legacy"
-criteria = "safe-to-run"
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
 version = "0.6.4"
-aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+notes = """
+For more detailed unsafe review notes please see https://crrev.com/c/6362797
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
 [[audits.google.audits.sha1]]
 who = "David Koloski <dkoloski@google.com>"
@@ -2706,6 +2730,31 @@ who = "David Cook <dcook@divviup.org>"
 criteria = "safe-to-deploy"
 version = "0.9.0"
 
+[[audits.isrg.audits.chacha20]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+version = "0.10.0"
+
+[[audits.isrg.audits.cpufeatures]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "0.2.14 -> 0.2.15"
+
+[[audits.isrg.audits.cpufeatures]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "0.2.15 -> 0.2.16"
+
+[[audits.isrg.audits.cpufeatures]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "0.2.16 -> 0.2.17"
+
+[[audits.isrg.audits.cpufeatures]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "0.2.17 -> 0.3.0"
+
 [[audits.isrg.audits.criterion]]
 who = "Brandon Pitman <bran@bran.land>"
 criteria = "safe-to-run"
@@ -2768,6 +2817,21 @@ who = "David Cook <dcook@divviup.org>"
 criteria = "safe-to-deploy"
 delta = "0.2.14 -> 0.2.15"
 
+[[audits.isrg.audits.getrandom]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "0.3.3 -> 0.3.4"
+
+[[audits.isrg.audits.getrandom]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "0.3.4 -> 0.4.0"
+
+[[audits.isrg.audits.getrandom]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "0.4.0 -> 0.4.1"
+
 [[audits.isrg.audits.hmac]]
 who = "David Cook <dcook@divviup.org>"
 criteria = "safe-to-deploy"
@@ -2809,6 +2873,11 @@ who = "Tim Geoghegan <timg@divviup.org>"
 criteria = "safe-to-deploy"
 delta = "0.9.1 -> 0.9.2"
 
+[[audits.isrg.audits.rand]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "0.9.2 -> 0.10.0"
+
 [[audits.isrg.audits.rand_chacha]]
 who = "David Cook <dcook@divviup.org>"
 criteria = "safe-to-deploy"
@@ -2828,6 +2897,16 @@ version = "0.6.3"
 who = "David Cook <dcook@divviup.org>"
 criteria = "safe-to-deploy"
 delta = "0.6.4 -> 0.9.3"
+
+[[audits.isrg.audits.rand_core]]
+who = "J.C. Jones <jc@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "0.9.3 -> 0.9.5"
+
+[[audits.isrg.audits.rand_core]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "0.9.5 -> 0.10.0"
 
 [[audits.isrg.audits.rayon-core]]
 who = "Brandon Pitman <bran@bran.land>"
@@ -3024,6 +3103,13 @@ delta = "0.9.3 -> 0.9.4"
 notes = "I've reviewed every source contribution that was neither authored nor reviewed by Mozilla."
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
+[[audits.mozilla.audits.cpufeatures]]
+who = "Gabriele Svelto <gsvelto@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.2.7 -> 0.2.8"
+notes = "This release contains a single fix for an issue that affected Firefox"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
 [[audits.mozilla.audits.crossbeam-utils]]
 who = "Mike Hommey <mh+mozilla@glandium.org>"
 criteria = "safe-to-deploy"
@@ -3210,6 +3296,20 @@ notes = """
 I've looked over all unsafe code, and it appears to be safe, fully initializing the rng buffers.
 In addition, I've checked Linux, Windows, Mac, and Android more thoroughly against API
 documentation.
+"""
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.getrandom]]
+who = "Emilio Cobos Álvarez <emilio@crisal.io>"
+criteria = "safe-to-deploy"
+delta = "0.3.1 -> 0.3.3"
+notes = """
+Biggest non-trivial change is a new UEFI back-end, which looks reasonable to
+the best of my ability: There's some trickiness on initialization but doesn't
+look unsafe, at worse it leaks, and it might not if the relevant pointers are
+static/non-owning. Other changes also look reasonable too: some tweaks to
+inlining and a syscall-based linux back-end, whose relevant unsafe code looks
+reasonable.
 """
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 


### PR DESCRIPTION
Purge rand 0.8 and 0.9 from our dependency tree, unify on rand 0.10, and update to versions that fix known documented issues with the prior versions we were using. This additionally removes the `cap-rand` crate since that's not updated yet and I don't think the crate is doing much over the `rand` crate itself.

Closes #13057
Closes #13058

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
