### PR TITLE
Fix: asyncReadStream worker never exits after EOF

### DIFF
--- a/crates/wasi/src/p2/pipe.rs
+++ b/crates/wasi/src/p2/pipe.rs
@@ -164,17 +164,34 @@ impl AsyncReadStream {
             loop {
                 use tokio::io::AsyncReadExt;
                 let mut buf = bytes::BytesMut::with_capacity(crate::MAX_READ_SIZE_ALLOC);
-                let sent = match reader.read_buf(&mut buf).await {
-                    Ok(nbytes) if nbytes == 0 => sender.send(Err(StreamError::Closed)).await,
-                    Ok(_) => sender.send(Ok(buf.freeze())).await,
+                let eof = match reader.read_buf(&mut buf).await {
+                    Ok(nbytes) if nbytes == 0 => {
+                        if sender.send(Err(StreamError::Closed)).await.is_err() {
+                            // no more receiver - stop trying to read
+                            break;
+                        }
+                        true
+                    }
+                    Ok(_) => {
+                        if sender.send(Ok(buf.freeze())).await.is_err() {
+                            // no more receiver - stop trying to read
+                            break;
+                        }
+                        false
+                    }
                     Err(e) => {
-                        sender
+                        if sender
                             .send(Err(StreamError::LastOperationFailed(e.into())))
                             .await
+                            .is_err()
+                        {
+                            // no more receiver - stop trying to read
+                            break;
+                        }
+                        false
                     }
                 };
-                if sent.is_err() {
-                    // no more receiver - stop trying to read
+                if eof {
                     break;
                 }
             }


### PR DESCRIPTION
SUMMARY
`AsyncReadStream::new` keeps its background read task alive after the wrapped reader reaches EOF, so closed streams continue looping instead of terminating the worker.

PROVENANCE
This exploration and report were automatically generated by the Swival Security Scanner (https://swival.dev).

PRECONDITIONS
- An `AsyncReadStream` is created around an `AsyncRead` that can reach EOF; this is the intended use of `AsyncReadStream` and is exercised by `tokio::io::empty()` and finite readers in `crates/wasi/src/p2/pipe.rs`.
- The stream remains alive after EOF, so the worker task is not cancelled by dropping the handle.

PROOF
1. `AsyncReadStream::new` spawns a background task that loops forever around `reader.read_buf(&mut buf).await` in `crates/wasi/src/p2/pipe.rs:162`.
2. When the wrapped reader reaches EOF, the `Ok(nbytes) if nbytes == 0` arm sends `Err(StreamError::Closed)` through the channel in `crates/wasi/src/p2/pipe.rs:168`.
3. After that send succeeds, execution falls through to the loop tail. The only terminating condition is `if sent.is_err() { break; }` in `crates/wasi/src/p2/pipe.rs:176`, which does not fire when the receiver is still alive.
4. The next iteration reads EOF again and repeats the same send, so the task never terminates on its own.
5. This is reachable today because the test helpers instantiate `AsyncReadStream` with EOF-producing readers such as `tokio::io::empty()` and finite pipe readers in `crates/wasi/src/p2/pipe.rs:380` and `crates/wasi/src/p2/pipe.rs:435`.

WHY THIS IS A REAL BUG
The worker is documented and structured as the asynchronous bridge for a single stream. Once EOF is observed, the stream is permanently closed, so continuing to poll the underlying reader and resignal closure is incorrect behavior, not a stylistic choice.

PATCH RATIONALE
The patch makes EOF a terminal condition by breaking the loop after a successful closed notification, while preserving existing behavior for normal data delivery, receiver shutdown, and I/O errors. It is local to the loop that mishandles EOF and does not change unrelated stream semantics.

RESIDUAL RISK
None
