### PR TITLE
Support vector types in `iconst_{u,s}`

### DIFF
--- a/cranelift/codegen/src/opts/arithmetic.isle
+++ b/cranelift/codegen/src/opts/arithmetic.isle
@@ -47,7 +47,7 @@
       (subsume inner))
 
 ;; x-x == 0.
-(rule (simplify (isub (ty_int ty) x x)) (subsume (iconst_u ty 0)))
+(rule (simplify (isub ty x x)) (subsume (iconst_u ty 0)))
 
 ;; x*1 == x.
 (rule (simplify (imul ty
@@ -318,12 +318,8 @@
 (rule (simplify (isub ty (bor ty y x) (bxor ty y x))) (band ty x y))
 
 ;; (~x) + x == -1
-;; Keep the generic fold for <=64-bit types, and handle i128 explicitly.
-(rule (simplify (iadd (fits_in_64 ty) (bnot ty x) x)) (iconst_s ty -1))
-(rule (simplify (iadd (fits_in_64 ty) x (bnot ty x))) (iconst_s ty -1))
-
-(rule (simplify (iadd $I128 (bnot $I128 x) x)) (sextend $I128 (iconst_s $I64 -1)))
-(rule (simplify (iadd $I128 x (bnot $I128 x))) (sextend $I128 (iconst_s $I64 -1)))
+(rule (simplify (iadd ty (bnot ty x) x)) (iconst_s ty -1))
+(rule (simplify (iadd ty x (bnot ty x))) (iconst_s ty -1))
 
 ;; ((x + y) - (x + z)) --> (y - z)
 (rule (simplify (isub ty (iadd ty x y) (iadd ty x z))) (isub ty y z))
@@ -379,11 +375,18 @@
 (rule (simplify (iadd ty x (iadd ty (isub ty z x) y))) (iadd ty y z))
 (rule (simplify (iadd ty (iadd ty (isub ty z x) y) x)) (iadd ty y z))
 
+;; Helper to create a "true" value for a comparison. For scalar integers this is
+;; a value of 1 but for vectors this is -1 since each lane is filled with all
+;; 1s.
+(decl cmp_true (Type) Value)
+(rule 0 (cmp_true (ty_int ty)) (iconst_u ty 1))
+(rule 1 (cmp_true (ty_vec128 ty)) (iconst_s ty -1))
+
 ;; (x + y) == (y + x) --> true
-(rule (simplify (eq (ty_int ty) (iadd cty x y) (iadd cty y x))) (iconst_u ty 1))
-(rule (simplify (eq (ty_int ty) (iadd cty y x) (iadd cty x y))) (iconst_u ty 1))
-(rule (simplify (eq (ty_int ty) (iadd cty x y) (iadd cty x y))) (iconst_u ty 1))
-(rule (simplify (eq (ty_int ty) (iadd cty y x) (iadd cty y x))) (iconst_u ty 1))
+(rule (simplify (eq ty (iadd cty x y) (iadd cty y x))) (cmp_true ty))
+(rule (simplify (eq ty (iadd cty y x) (iadd cty x y))) (cmp_true ty))
+(rule (simplify (eq ty (iadd cty x y) (iadd cty x y))) (cmp_true ty))
+(rule (simplify (eq ty (iadd cty y x) (iadd cty y x))) (cmp_true ty))
 
 ;; (x - y) != x --> y != 0
 (rule (simplify (ne cty (isub ty x y) x)) (ne cty y (iconst_u ty 0)))
@@ -407,24 +410,24 @@
 (rule (simplify (ineg ty (imul ty x (ineg ty y)))) (imul ty x y))
 
 ;; max(x, y) >= x
-(rule (simplify (sge ty (smax ty x y) x)) (iconst_u ty 1))
-(rule (simplify (sge ty (smax ty y x) x)) (iconst_u ty 1))
-(rule (simplify (sle ty x (smax ty x y))) (iconst_u ty 1))
-(rule (simplify (sle ty x (smax ty y x))) (iconst_u ty 1))
-(rule (simplify (uge ty (umax ty x y) x)) (iconst_u ty 1))
-(rule (simplify (uge ty (umax ty y x) x)) (iconst_u ty 1))
-(rule (simplify (ule ty x (umax ty x y))) (iconst_u ty 1))
-(rule (simplify (ule ty x (umax ty y x))) (iconst_u ty 1))
+(rule (simplify (sge ty (smax ty x y) x)) (cmp_true ty))
+(rule (simplify (sge ty (smax ty y x) x)) (cmp_true ty))
+(rule (simplify (sle ty x (smax ty x y))) (cmp_true ty))
+(rule (simplify (sle ty x (smax ty y x))) (cmp_true ty))
+(rule (simplify (uge ty (umax ty x y) x)) (cmp_true ty))
+(rule (simplify (uge ty (umax ty y x) x)) (cmp_true ty))
+(rule (simplify (ule ty x (umax ty x y))) (cmp_true ty))
+(rule (simplify (ule ty x (umax ty y x))) (cmp_true ty))
 
 ;; x >= min(x, y)
-(rule (simplify (sge ty x (smin ty x y))) (iconst_u ty 1))
-(rule (simplify (sge ty x (smin ty y x))) (iconst_u ty 1))
-(rule (simplify (sle ty (smin ty x y) x)) (iconst_u ty 1))
-(rule (simplify (sle ty (smin ty y x) x)) (iconst_u ty 1))
-(rule (simplify (uge ty x (umin ty x y))) (iconst_u ty 1))
-(rule (simplify (uge ty x (umin ty y x))) (iconst_u ty 1))
-(rule (simplify (ule ty (umin ty x y) x)) (iconst_u ty 1))
-(rule (simplify (ule ty (umin ty y x) x)) (iconst_u ty 1))
+(rule (simplify (sge ty x (smin ty x y))) (cmp_true ty))
+(rule (simplify (sge ty x (smin ty y x))) (cmp_true ty))
+(rule (simplify (sle ty (smin ty x y) x)) (cmp_true ty))
+(rule (simplify (sle ty (smin ty y x) x)) (cmp_true ty))
+(rule (simplify (uge ty x (umin ty x y))) (cmp_true ty))
+(rule (simplify (uge ty x (umin ty y x))) (cmp_true ty))
+(rule (simplify (ule ty (umin ty x y) x)) (cmp_true ty))
+(rule (simplify (ule ty (umin ty y x) x)) (cmp_true ty))
 
 ;; min/max(x,x) --> x
 (rule (simplify (umin ty x x)) x)

--- a/cranelift/codegen/src/prelude_opt.isle
+++ b/cranelift/codegen/src/prelude_opt.isle
@@ -125,38 +125,51 @@
 (decl iconst_sextend_etor (Type i64) TypeAndInstructionData)
 (extern extractor iconst_sextend_etor iconst_sextend_etor)
 
-;; Construct an `iconst` from an `i64` or Extract an `i64` from an `iconst`
-;; by treating the constant as signed.
+;; Create a constant value represented by the `i64` provided which has the
+;; `Type` provided.
+;;
+;; For 8 to 64-bit scalar integers this will construct an `iconst` from an `i64`
+;; or Extract an `i64` from an `iconst` by treating the constant as signed.
 ;; When extracting, smaller types get their value sign-extended to 64-bits,
 ;; so that `iconst.i8 255` will give you a `-1_i64`.
+;;
+;; For 128-bit integer types this rule will create a 64-bit `iconst` and then
+;; `sextend` it to 128-bit bits.
+;;
+;; For vector types this will create a constant for the lane type and then splat
+;; that to all lanes of the vector type.
+;;
 ;; When constructing, the rule will fail if the value cannot be represented in
 ;; the target type.  If it fits, it'll be masked accordingly in the constant.
 ;;
-;; Recursion: may recurse at most once to reduce reduce 128-bit to 64-bit.
+;; Recursion: may recurse at most once to reduce reduce 128-bit to 64-bit or
+;; to create a scalar constant to splat into a vector type.
 (decl rec iconst_s (Type i64) Value)
 (extractor (iconst_s ty c) (inst_data_value_tupled (iconst_sextend_etor ty c)))
-(rule 0 (iconst_s ty c)
+(rule 0 (iconst_s (ty_int (fits_in_64 ty)) c)
     (if-let c_masked (u64_and (i64_cast_unsigned c)
                               (ty_umax ty)))
     (if-let c_reextended (i64_sextend_u64 ty c_masked))
     (if-let true (i64_eq c c_reextended))
     (iconst ty (imm64 c_masked)))
 (rule 1 (iconst_s $I128 c) (sextend $I128 (iconst_s $I64 c)))
+(rule 2 (iconst_s (ty_vec128 ty) c) (splat ty (iconst_s (lane_type ty) c)))
 
-;; Construct an `iconst` from a `u64` or Extract a `u64` from an `iconst`
-;; by treating the constant as unsigned.
+;; Same as `iconst_s`, but used for zero-extending constant values.
+;;
 ;; When extracting, smaller types get their value zero-extended to 64-bits,
 ;; so that `iconst.i8 255` will give you a `255_u64`.
 ;; When constructing, the rule will fail if the value cannot be represented in
 ;; the target type.
 ;;
-;; Recursion: may recurse at most once to reduce reduce 128-bit to 64-bit.
+;; Recursion: same as `iconst_s`, once for 128-bit integers or vectors.
 (decl rec iconst_u (Type u64) Value)
 (extractor (iconst_u ty c) (iconst ty (u64_from_imm64 c)))
-(rule 0 (iconst_u ty c)
+(rule 0 (iconst_u (ty_int (fits_in_64 ty)) c)
     (if-let true (u64_lt_eq c (ty_umax ty)))
     (iconst ty (imm64 c)))
 (rule 1 (iconst_u $I128 c) (uextend $I128 (iconst_u $I64 c)))
+(rule 2 (iconst_u (ty_vec128 ty) c) (splat ty (iconst_u (lane_type ty) c)))
 
 ;; These take `Value`, rather than going through `inst_data_value_tupled`,
 ;; because most of the time they want to return the original `Value`, and it

--- a/cranelift/filetests/filetests/egraph/arithmetic-precise.clif
+++ b/cranelift/filetests/filetests/egraph/arithmetic-precise.clif
@@ -244,9 +244,11 @@ block0(v0: i32x4, v1: i32x4):
 }
 
 ; function %simplify_vector_icmp_eq_iadd_commute(i32x4, i32x4) -> i32x4 fast {
+;     const0 = 0xffffffffffffffffffffffffffffffff
+;
 ; block0(v0: i32x4, v1: i32x4):
-;     v5 = icmp eq v0, v0
-;     return v5
+;     v9 = icmp eq v0, v0
+;     return v9
 ; }
 
 ;; (x - y) != x --> y != 0

--- a/tests/disas/x64-optimize-vector-types.wat
+++ b/tests/disas/x64-optimize-vector-types.wat
@@ -1,0 +1,281 @@
+;;! target = "x86_64"
+;;! test = "compile"
+
+(module
+  (memory 1)
+
+  (func (export "i32x4_sge_smax") (param v128 v128) (result v128)
+    local.get 0
+    local.get 1
+    i32x4.max_s
+    local.get 0
+    i32x4.ge_s
+  )
+
+  (func (export "i32x4_sle_smax") (param v128 v128) (result v128)
+    local.get 0
+    local.get 0
+    local.get 1
+    i32x4.max_s
+    i32x4.le_s
+  )
+
+  (func (export "i32x4_sge_smin") (param v128 v128) (result v128)
+    local.get 0
+    local.get 0
+    local.get 1
+    i32x4.min_s
+    i32x4.ge_s
+  )
+
+  (func (export "i32x4_sle_smin") (param v128 v128) (result v128)
+    local.get 0
+    local.get 1
+    i32x4.min_s
+    local.get 0
+    i32x4.le_s
+  )
+
+  (func (export "i16x8_uge_umax") (param v128 v128) (result v128)
+    local.get 0
+    local.get 1
+    i16x8.max_u
+    local.get 0
+    i16x8.ge_u
+  )
+
+  (func (export "i8x16_ule_umin") (param v128 v128) (result v128)
+    local.get 0
+    local.get 1
+    i8x16.min_u
+    local.get 0
+    i8x16.le_u
+  )
+
+  (func (export "i32x4_sgt_smax") (param v128 v128) (result v128)
+    local.get 0
+    local.get 0
+    local.get 1
+    i32x4.max_s
+    i32x4.gt_s
+  )
+
+  (func (export "i64x2_ugt_umax") (param v128 v128) (result v128)
+    local.get 0
+    local.get 0
+    local.get 1
+    i32x4.max_u
+    i32x4.gt_u
+  )
+
+  (func (export "v128_band_bnot_eq") (param v128 v128) (result v128)
+    local.get 0
+    local.get 1
+    v128.not
+    v128.and
+    local.get 1
+    v128.not
+    i8x16.eq
+  )
+
+  (func (export "ne_isub_i32x4") (param v128 v128) (result v128)
+    local.get 0
+    local.get 1
+    i32x4.sub
+    local.get 0
+    i32x4.ne
+  )
+
+  (func (export "eq_isub_i32x4") (param v128 v128) (result v128)
+    local.get 0
+    local.get 1
+    i32x4.sub
+    local.get 0
+    i32x4.eq
+  )
+
+  (func (export "eq_iadd_i32x4") (param v128 v128) (result v128)
+    local.get 0
+    local.get 1
+    i32x4.add
+    local.get 1
+    i32x4.eq
+  )
+
+  (func (export "ne_isub_i16x8") (param v128 v128) (result v128)
+    local.get 0
+    local.get 1
+    i16x8.sub
+    local.get 0
+    i16x8.ne
+  )
+
+  (func (export "eq_iadd_i8x16") (param v128 v128) (result v128)
+    local.get 0
+    local.get 1
+    i8x16.add
+    local.get 1
+    i8x16.eq
+  )
+
+  (func (export "eq_isub_rev") (param v128 v128) (result v128)
+    local.get 0
+    local.get 0
+    local.get 1
+    i32x4.sub
+    i32x4.eq
+  )
+
+  (func (export "eq_iadd_rev") (param v128 v128) (result v128)
+    local.get 1
+    local.get 0
+    local.get 1
+    i32x4.add
+    i32x4.eq
+  )
+)
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       pcmpeqd %xmm0, %xmm0
+;;       movq    %rbp, %rsp
+;;       popq    %rbp
+;;       retq
+;;
+;; wasm[0]::function[1]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       pcmpeqd %xmm0, %xmm0
+;;       movq    %rbp, %rsp
+;;       popq    %rbp
+;;       retq
+;;
+;; wasm[0]::function[2]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       pcmpeqd %xmm0, %xmm0
+;;       movq    %rbp, %rsp
+;;       popq    %rbp
+;;       retq
+;;
+;; wasm[0]::function[3]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       pcmpeqd %xmm0, %xmm0
+;;       movq    %rbp, %rsp
+;;       popq    %rbp
+;;       retq
+;;
+;; wasm[0]::function[4]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       pcmpeqd %xmm0, %xmm0
+;;       movq    %rbp, %rsp
+;;       popq    %rbp
+;;       retq
+;;
+;; wasm[0]::function[5]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       pcmpeqd %xmm0, %xmm0
+;;       movq    %rbp, %rsp
+;;       popq    %rbp
+;;       retq
+;;
+;; wasm[0]::function[6]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       pxor    %xmm0, %xmm0
+;;       movq    %rbp, %rsp
+;;       popq    %rbp
+;;       retq
+;;
+;; wasm[0]::function[7]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       pxor    %xmm0, %xmm0
+;;       movq    %rbp, %rsp
+;;       popq    %rbp
+;;       retq
+;;
+;; wasm[0]::function[8]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       por     %xmm0, %xmm1
+;;       pcmpeqd %xmm7, %xmm7
+;;       movdqa  %xmm1, %xmm0
+;;       pcmpeqb %xmm7, %xmm0
+;;       movq    %rbp, %rsp
+;;       popq    %rbp
+;;       retq
+;;
+;; wasm[0]::function[9]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       pxor    %xmm0, %xmm0
+;;       pcmpeqd %xmm0, %xmm1
+;;       pcmpeqd %xmm2, %xmm2
+;;       movdqa  %xmm1, %xmm0
+;;       pxor    %xmm2, %xmm0
+;;       movq    %rbp, %rsp
+;;       popq    %rbp
+;;       retq
+;;
+;; wasm[0]::function[10]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       pxor    %xmm5, %xmm5
+;;       movdqa  %xmm1, %xmm0
+;;       pcmpeqd %xmm5, %xmm0
+;;       movq    %rbp, %rsp
+;;       popq    %rbp
+;;       retq
+;;
+;; wasm[0]::function[11]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       pxor    %xmm5, %xmm5
+;;       pcmpeqd %xmm5, %xmm0
+;;       movq    %rbp, %rsp
+;;       popq    %rbp
+;;       retq
+;;
+;; wasm[0]::function[12]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       pxor    %xmm0, %xmm0
+;;       pcmpeqw %xmm0, %xmm1
+;;       pcmpeqd %xmm2, %xmm2
+;;       movdqa  %xmm1, %xmm0
+;;       pxor    %xmm2, %xmm0
+;;       movq    %rbp, %rsp
+;;       popq    %rbp
+;;       retq
+;;
+;; wasm[0]::function[13]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       paddb   %xmm1, %xmm0
+;;       pcmpeqb %xmm1, %xmm0
+;;       movq    %rbp, %rsp
+;;       popq    %rbp
+;;       retq
+;;
+;; wasm[0]::function[14]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       pxor    %xmm5, %xmm5
+;;       movdqa  %xmm1, %xmm0
+;;       pcmpeqd %xmm5, %xmm0
+;;       movq    %rbp, %rsp
+;;       popq    %rbp
+;;       retq
+;;
+;; wasm[0]::function[15]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       pxor    %xmm5, %xmm5
+;;       pcmpeqd %xmm5, %xmm0
+;;       movq    %rbp, %rsp
+;;       popq    %rbp
+;;       retq


### PR DESCRIPTION
This commit updates the `iconst_{u,s}` helpers to support vector types where previously they did not support them. The meaning of `iconst_*` with a vector type is to insert the specified constant value into all lanes of the vector type. This gets a large number of optimization rules that currently panic on vector types to "just work" and my hope is that these sorts of bugs will be less common as vector ops will be both optimizable and applicable to existing rules.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
