### PR TITLE
Allow using wasmtime wast builtins on the CLI

### DIFF
--- a/src/commands/wast.rs
+++ b/src/commands/wast.rs
@@ -37,6 +37,11 @@ pub struct WastCommand {
     /// Wasmtime itself.
     #[arg(long = "async", require_equals = true, value_name = "true|false")]
     async_: Option<Option<bool>>,
+
+    /// Whether or not to enable wasmtime's builtin functions for the `*.wast`
+    /// to import.
+    #[arg(long = "wasmtime-builtins")]
+    wasmtime_builtins: bool,
 }
 
 impl WastCommand {
@@ -79,6 +84,10 @@ impl WastCommand {
         }
         if let Some(path) = &self.precompile_load {
             wast_context.precompile_load(path);
+        }
+
+        if self.wasmtime_builtins {
+            wast_context.register_wasmtime()?;
         }
 
         for script in self.scripts.iter() {


### PR DESCRIPTION
Add a flag that hooks them up to help share reproducible test cases.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
