### PR TITLE
Remove incorrect noop in unix stack pool management

### DIFF
--- a/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/unix_stack_pool.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/pooling/unix_stack_pool.rs
@@ -2,7 +2,6 @@
 
 use super::index_allocator::{SimpleIndexAllocator, SlotId};
 use crate::prelude::*;
-use crate::runtime::vm::sys::vm::commit_pages;
 use crate::runtime::vm::{
     HostAlignedByteCount, Mmap, PoolingInstanceAllocatorConfig, mmap::AlignedLength,
 };
@@ -120,8 +119,6 @@ impl StackPool {
                 .as_ptr()
                 .add(self.stack_size.unchecked_mul(index).byte_count())
                 .cast_mut();
-
-            commit_pages(bottom_of_stack, size_without_guard.byte_count())?;
 
             let stack = wasmtime_fiber::FiberStack::from_raw_parts(
                 bottom_of_stack,


### PR DESCRIPTION
This commit removes a call to `commit_pages` in the `unix_stack_pool.rs` file. This function is a noop on unix and the parameters passed in for this call were also incorrect if it actually needed to do something anyway. This is otherwise just distracting, so remove it.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
