### PR TITLE
Debug-assert tables are compatible when copying

### DIFF
--- a/crates/wasmtime/src/runtime/vm/table.rs
+++ b/crates/wasmtime/src/runtime/vm/table.rs
@@ -1055,8 +1055,9 @@ impl Table {
         match ty {
             TableElementType::Func => {
                 // `funcref` are `Copy`, so just do a mempcy
-                let (dst_funcrefs, _lazy_init) = dst_table.funcrefs_mut();
-                let (src_funcrefs, _lazy_init) = src_table.funcrefs();
+                let (dst_funcrefs, dst_lazy_init) = dst_table.funcrefs_mut();
+                let (src_funcrefs, src_lazy_init) = src_table.funcrefs();
+                debug_assert_eq!(dst_lazy_init, src_lazy_init);
                 dst_funcrefs[dst_range].copy_from_slice(&src_funcrefs[src_range]);
             }
             TableElementType::GcRef => {


### PR DESCRIPTION
This shouldn't ever trip but there's also no need to ignore these flags.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
