### PR TITLE
Add `Component::{text,address_map,functions}` methods

### DIFF
--- a/crates/wasmtime/src/lib.rs
+++ b/crates/wasmtime/src/lib.rs
@@ -513,6 +513,7 @@ pub use wasmtime_environ::OperatorCost;
 pub use wasmtime_environ::ToWasmtimeResult;
 #[doc(inline)]
 pub use wasmtime_environ::error;
+pub use wasmtime_environ::{FuncIndex, StaticModuleIndex};
 
 // Only for use in `bindgen!`-generated code.
 #[doc(hidden)]

--- a/crates/wasmtime/src/runtime.rs
+++ b/crates/wasmtime/src/runtime.rs
@@ -99,7 +99,7 @@ pub use instantiate::CompiledModule;
 pub use limits::*;
 pub use linker::*;
 pub use memory::*;
-pub use module::{Module, ModuleExport};
+pub use module::{Module, ModuleExport, ModuleFunction};
 pub use resources::*;
 #[cfg(all(feature = "async", feature = "call-hook"))]
 pub use store::CallHookHandler;

--- a/crates/wasmtime/src/runtime/component/component.rs
+++ b/crates/wasmtime/src/runtime/component/component.rs
@@ -558,6 +558,31 @@ impl Component {
         &self.inner.code
     }
 
+    /// Get this component's code object's `.text` section, containing its
+    /// compiled executable code.
+    pub fn text(&self) -> &[u8] {
+        self.engine_code().text()
+    }
+
+    /// Get information about functions in this component's `.text` section:
+    /// their module index, function index, name, and offset+length.
+    pub fn functions(&self) -> impl Iterator<Item = crate::ModuleFunction> + '_ {
+        self.inner
+            .static_modules
+            .values()
+            .flat_map(|m| m.functions())
+    }
+
+    /// Get the address map for this component's `.text` section.
+    ///
+    /// See [`Module::address_map`] for more details.
+    pub fn address_map(&self) -> Option<impl Iterator<Item = (usize, Option<u32>)> + '_> {
+        Some(
+            wasmtime_environ::iterate_address_map(self.engine_code().address_map_data())?
+                .map(|(offset, file_pos)| (offset as usize, file_pos.file_offset())),
+        )
+    }
+
     /// Same as [`Module::serialize`], except for a component.
     ///
     /// Note that the artifact produced here must be passed to

--- a/crates/wasmtime/src/runtime/module.rs
+++ b/crates/wasmtime/src/runtime/module.rs
@@ -22,7 +22,7 @@ use wasmparser::{Parser, ValidPayload, Validator};
 use wasmtime_environ::FrameTable;
 use wasmtime_environ::{
     CompiledFunctionsTable, CompiledModuleInfo, EntityIndex, HostPtr, ModuleTypes, ObjectKind,
-    TypeTrace, VMOffsets, VMSharedTypeIndex, WasmChecksum,
+    StaticModuleIndex, TypeTrace, VMOffsets, VMSharedTypeIndex, WasmChecksum,
 };
 #[cfg(feature = "gc")]
 use wasmtime_unwinder::ExceptionTable;
@@ -1089,10 +1089,12 @@ impl Module {
     /// Results are yielded in a ModuleFunction struct.
     pub fn functions<'a>(&'a self) -> impl ExactSizeIterator<Item = ModuleFunction> + 'a {
         let module = self.compiled_module();
-        self.env_module().defined_func_indices().map(|idx| {
+        let module_index = self.env_module().module_index;
+        self.env_module().defined_func_indices().map(move |idx| {
             let loc = module.func_loc(idx);
             let idx = module.module().func_index(idx);
             ModuleFunction {
+                module: module_index,
                 index: idx,
                 name: module.func_name(idx).map(|n| n.to_string()),
                 offset: loc.start as usize,
@@ -1213,9 +1215,15 @@ impl Module {
 
 /// Describes a function for a given module.
 pub struct ModuleFunction {
+    /// The static module index this function belongs to.
+    pub module: StaticModuleIndex,
+    /// The function index within the module.
     pub index: wasmtime_environ::FuncIndex,
+    /// The display name of the function, if available.
     pub name: Option<String>,
+    /// The byte offset of this function in the text section.
     pub offset: usize,
+    /// The byte length of this function in the text section.
     pub len: usize,
 }
 


### PR DESCRIPTION
These are similar to the methods with the same names on `Module`.

Also publicly export `ModuleFunction`, since it is returned by `Module::functions` (and now also `Component::functions`).

Also publicly re-export `StaticModuleIndex` and `FuncIndex`, since they appear inside `ModuleFunction`.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
