### PR TITLE
Try different apt-get mirrors in CI

### DIFF
--- a/.github/actions/apt-get-install/action.yml
+++ b/.github/actions/apt-get-install/action.yml
@@ -1,0 +1,40 @@
+name: "Run apt-get to install packages"
+description: "Helper to work around some common github actions issues"
+
+inputs:
+  packages:
+    description: "The packages to install with apt-get"
+    required: true
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    # See https://github.com/actions/runner-images/issues/12949 and
+    # https://github.com/actions/runner-images/issues/7048 for some background,
+    # but the default mirrors can sometimes take up to 30+ minutes to install a
+    # package. Seems like the azure mirrors are heavily throttled occasionally.
+    # Ideally something like
+    # https://github.com/marketplace/actions/configure-fast-apt-mirror would be
+    # used to figure out the fastest mirror but in the interest of trying out
+    # something simple we instead just tweak some priorities.
+    #
+    # This is lifted from
+    # https://github.com/servo/servo/blob/main/.github/actions/apt-mirrors/action.yml
+    # which is in turn lifted from
+    # https://github.com/CrowdStrike/glide-core/pull/1113 apparently.
+    - name: Change Mirror Priorities
+      shell: bash
+      run: |
+        sudo sed -i '/archive.ubuntu.com\/ubuntu\/\tpriority/ s/priority:2/priority:0/' /etc/apt/apt-mirrors.txt
+        sudo sed -i '/azure.archive.ubuntu.com\/ubuntu\/\tpriority/ s/priority:0/priority:1/' /etc/apt/apt-mirrors.txt
+        sudo sed -i '/security.ubuntu.com\/ubuntu\/\tpriority/ s/priority:3/priority:2/' /etc/apt/apt-mirrors.txt
+        sudo cat /etc/apt/apt-mirrors.txt
+
+    - name: Update apt-get
+      shell: bash
+      run: sudo apt-get update
+
+    - name: Install packages
+      shell: bash
+      run: sudo apt-get install -y ${{ inputs.packages }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -661,7 +661,9 @@ jobs:
     # Install the OCaml packages necessary for fuzz targets that use the
     # `wasm-spec-interpreter`.
     - run: cargo install cargo-fuzz --vers "^0.11" --locked
-    - run: sudo apt-get update && sudo apt install -y ocaml-nox ocamlbuild ocaml-findlib libzarith-ocaml-dev
+    - uses: ./.github/actions/apt-get-install
+      with:
+        packages: ocaml-nox ocamlbuild ocaml-findlib libzarith-ocaml-dev
     - run: cargo fetch
       working-directory: ./fuzz
     - run: cargo fuzz check --dev

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -616,9 +616,10 @@ jobs:
         curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
         cargo binstall --no-confirm cross
       if: ${{ matrix.cross }}
-    - name: Install apt packages
+    - uses: ./.github/actions/apt-get-install
       if: ${{ matrix.apt_packages }}
-      run: sudo apt-get update && sudo apt-get install -y ${{ matrix.apt_packages }}
+      with:
+        packages: ${{ matrix.apt_packages }}
     - run: ${{ matrix.test }}
       env:
         CARGO_BUILD_TARGET: ${{ matrix.target }}
@@ -796,15 +797,16 @@ jobs:
 
     - run: cargo fetch --locked
 
-    - name: Install cross-compilation tools
+    - uses: ./.github/actions/apt-get-install
+      name: Install cross-compilation tools
+      if: matrix.gcc_package != ''
+      with:
+        packages: ${{ matrix.gcc_package }}
+
+    # Configure Cargo for cross compilation and tell it how it can run
+    # cross executables
+    - name: Configure cross-compilation tools
       run: |
-        set -ex
-
-        sudo apt-get update
-        sudo apt-get install -y ${{ matrix.gcc_package }}
-
-        # Configure Cargo for cross compilation and tell it how it can run
-        # cross executables
         upcase=$(echo ${{ matrix.target }} | awk '{ print toupper($0) }' | sed 's/-/_/g')
         echo CARGO_TARGET_${upcase}_LINKER=${{ matrix.gcc }} >> $GITHUB_ENV
       if: matrix.gcc != ''
@@ -1053,8 +1055,10 @@ jobs:
         curl --retry 5 --retry-all-errors -OL https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-30/wasi-sdk-30.0-x86_64-linux.tar.gz
         tar -xzf wasi-sdk-30.0-x86_64-linux.tar.gz
         mv wasi-sdk-30.0-x86_64-linux wasi-sdk
+    - uses: ./.github/actions/apt-get-install
+      with:
+        packages: gdb lldb-18 llvm
     - run: |
-        sudo apt-get update && sudo apt-get install -y gdb lldb-18 llvm
         # workaround for https://bugs.launchpad.net/ubuntu/+source/llvm-defaults/+bug/1972855
         sudo mkdir -p /usr/lib/local/lib/python3.10/dist-packages/lldb
         sudo ln -s /usr/lib/llvm-15/lib/python3.10/dist-packages/lldb/* /usr/lib/python3/dist-packages/lldb/


### PR DESCRIPTION
Every other run is currently taking 30+ minutes due to apt-get talking to azure's default servers being heavily throttled. Try out different mirrors with configuration I've cribbed from a few other locations.

prtest:full

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
