### PR TITLE
Generate psuedorandom `gc_zeal_alloc_counter` values for fuzzing

### DIFF
--- a/crates/cli-flags/src/lib.rs
+++ b/crates/cli-flags/src/lib.rs
@@ -4,6 +4,7 @@ use clap::Parser;
 use serde::Deserialize;
 use std::{
     fmt, fs,
+    num::NonZeroU32,
     path::{Path, PathBuf},
     time::Duration,
 };
@@ -198,6 +199,10 @@ wasmtime_option_group! {
         #[serde(default)]
         #[serde(deserialize_with = "crate::opt::cli_parse_wrapper")]
         pub pooling_pagemap_scan: Option<wasmtime::Enabled>,
+
+        /// XXX: For internal fuzzing and debugging use only!
+        #[doc(hidden)]
+        pub gc_zeal_alloc_counter: Option<NonZeroU32>,
     }
 
     enum Optimize {
@@ -893,6 +898,10 @@ impl CommonOptions {
         }
         if let Some(enable) = self.opts.table_lazy_init {
             config.table_lazy_init(enable);
+        }
+
+        if let Some(n) = self.opts.gc_zeal_alloc_counter {
+            config.gc_zeal_alloc_counter(Some(n))?;
         }
 
         // If fuel has been configured, set the `consume fuel` flag on the config.

--- a/crates/cli-flags/src/lib.rs
+++ b/crates/cli-flags/src/lib.rs
@@ -900,7 +900,9 @@ impl CommonOptions {
             config.table_lazy_init(enable);
         }
 
-        if let Some(n) = self.opts.gc_zeal_alloc_counter {
+        if let Some(n) = self.opts.gc_zeal_alloc_counter
+            && (cfg!(gc_zeal) || cfg!(fuzzing))
+        {
             config.gc_zeal_alloc_counter(Some(n))?;
         }
 

--- a/crates/cli-flags/src/opt.rs
+++ b/crates/cli-flags/src/opt.rs
@@ -9,11 +9,12 @@ use crate::{KeyValuePair, WasiNnGraph};
 use clap::builder::{StringValueParser, TypedValueParser, ValueParserFactory};
 use clap::error::{Error, ErrorKind};
 use serde::de::{self, Visitor};
+use std::num::NonZeroU32;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::time::Duration;
 use std::{fmt, marker};
-use wasmtime::{Result, bail};
+use wasmtime::{Result, bail, format_err};
 
 /// Characters which can be safely ignored while parsing numeric options to wasmtime
 const IGNORED_NUMBER_CHARS: [char; 1] = ['_'];
@@ -368,6 +369,19 @@ impl WasmtimeOptionValue for u32 {
             Some(hex) => Ok(u32::from_str_radix(hex, 16)?),
             None => Ok(val.parse()?),
         }
+    }
+
+    fn display(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{self}")
+    }
+}
+
+impl WasmtimeOptionValue for NonZeroU32 {
+    const VAL_HELP: &'static str = "=N";
+
+    fn parse(val: Option<&str>) -> Result<Self> {
+        let n = <u32 as WasmtimeOptionValue>::parse(val)?;
+        NonZeroU32::new(n).ok_or_else(|| format_err!("value must be non-zero"))
     }
 
     fn display(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/crates/fuzzing/Cargo.toml
+++ b/crates/fuzzing/Cargo.toml
@@ -59,6 +59,7 @@ features = [
   'pulley',
   'threads',
   'parallel-compilation',
+  'stack-switching',
 ]
 
 # We rely on precompiled v8 binaries, but rusty-v8 doesn't have a precompiled

--- a/crates/fuzzing/src/generators/config.rs
+++ b/crates/fuzzing/src/generators/config.rs
@@ -3,6 +3,7 @@
 use super::{AsyncConfig, CodegenSettings, InstanceAllocationStrategy, MemoryConfig, ModuleConfig};
 use crate::oracles::{StoreLimits, Timeout};
 use arbitrary::{Arbitrary, Unstructured};
+use std::num::NonZeroU32;
 use std::time::Duration;
 use wasmtime::Result;
 use wasmtime::{Enabled, Engine, Module, Store};
@@ -285,6 +286,10 @@ impl Config {
             16 << 20,
             self.wasmtime.memory_guaranteed_dense_image_size,
         ));
+        cfg.opts.gc_zeal_alloc_counter = self
+            .wasmtime
+            .gc_zeal_alloc_counter
+            .map(|c| c.clamp(NonZeroU32::new(1).unwrap(), NonZeroU32::new(1024).unwrap()));
         cfg.wasm.async_stack_zeroing = Some(self.wasmtime.async_stack_zeroing);
         cfg.wasm.bulk_memory = Some(self.module_config.config.bulk_memory_enabled);
         cfg.wasm.component_model_async = Some(self.module_config.component_model_async);
@@ -596,6 +601,7 @@ pub struct WasmtimeConfig {
     /// Configuration for the compiler to use.
     pub compiler_strategy: CompilerStrategy,
     collector: Collector,
+    gc_zeal_alloc_counter: Option<NonZeroU32>,
     table_lazy_init: bool,
 
     /// Configuration for whether wasm is invoked in an async fashion and how

--- a/crates/fuzzing/src/generators/config.rs
+++ b/crates/fuzzing/src/generators/config.rs
@@ -152,7 +152,7 @@ impl Config {
             hogs_memory: _,
             nan_canonicalization: _,
             gc_types: _,
-            stack_switching: _,
+            stack_switching,
             spec_test: _,
         } = test.config;
 
@@ -172,6 +172,7 @@ impl Config {
         self.module_config.component_model_map = component_model_map.unwrap_or(false);
         self.module_config.component_model_fixed_length_lists =
             component_model_fixed_length_lists.unwrap_or(false);
+        self.module_config.stack_switching = stack_switching.unwrap_or(false);
 
         // Enable/disable proposals that wasm-smith has knobs for which will be
         // read when creating `wasmtime::Config`.


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
