### PR TITLE
Plumb stack-switching config more in fuzzing

### DIFF
--- a/crates/fuzzing/src/generators/config.rs
+++ b/crates/fuzzing/src/generators/config.rs
@@ -317,6 +317,7 @@ impl Config {
             Some(self.module_config.config.shared_everything_threads_enabled);
         cfg.wasm.wide_arithmetic = Some(self.module_config.config.wide_arithmetic_enabled);
         cfg.wasm.exceptions = Some(self.module_config.config.exceptions_enabled);
+        cfg.wasm.stack_switching = Some(self.module_config.stack_switching);
         cfg.wasm.shared_memory = Some(self.module_config.shared_memory);
         if !self.module_config.config.simd_enabled {
             cfg.wasm.relaxed_simd = Some(false);
@@ -665,6 +666,7 @@ impl WasmtimeConfig {
                 config.config.reference_types_enabled = false;
                 config.config.exceptions_enabled = false;
                 config.function_references_enabled = false;
+                config.stack_switching = false;
 
                 // Winch's SIMD implementations require AVX and AVX2.
                 if self

--- a/crates/fuzzing/src/generators/module.rs
+++ b/crates/fuzzing/src/generators/module.rs
@@ -26,6 +26,7 @@ pub struct ModuleConfig {
     pub component_model_fixed_length_lists: bool,
     pub legacy_exceptions: bool,
     pub shared_memory: bool,
+    pub stack_switching: bool,
 }
 
 impl<'a> Arbitrary<'a> for ModuleConfig {
@@ -85,6 +86,7 @@ impl<'a> Arbitrary<'a> for ModuleConfig {
             component_model_fixed_length_lists: false,
             legacy_exceptions: false,
             shared_memory: false,
+            stack_switching: false,
             function_references_enabled: config.gc_enabled,
             config,
         })


### PR DESCRIPTION
Fixes a fuzz bug trying to work with #12967 since the fuzzer otherwise isn't aware of the `stack-switching` config option and how it's required for this test.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
