### PR TITLE
Make `resources` substitution table optional in type-checking

### DIFF
--- a/crates/wasmtime/src/runtime/component/component.rs
+++ b/crates/wasmtime/src/runtime/component/component.rs
@@ -388,10 +388,9 @@ impl Component {
     }
 
     fn with_uninstantiated_instance_type<R>(&self, f: impl FnOnce(&InstanceType<'_>) -> R) -> R {
-        let resources = Arc::new(TryPrimaryMap::new());
         f(&InstanceType {
             types: self.types(),
-            resources: &resources,
+            resources: None,
         })
     }
 

--- a/crates/wasmtime/src/runtime/component/instance.rs
+++ b/crates/wasmtime/src/runtime/component/instance.rs
@@ -1149,7 +1149,7 @@ impl<T: 'static> InstancePre<T> {
     pub fn instance_type(&self) -> InstanceType<'_> {
         InstanceType {
             types: &self.component.types(),
-            resources: &self.resource_types,
+            resources: Some(&self.resource_types),
         }
     }
 

--- a/crates/wasmtime/src/runtime/component/linker.rs
+++ b/crates/wasmtime/src/runtime/component/linker.rs
@@ -192,7 +192,7 @@ impl<T: 'static> Linker<T> {
             component.ty(),
             &InstanceType {
                 types: cx.types,
-                resources: &cx.imported_resources,
+                resources: Some(&cx.imported_resources),
             },
         ))
     }

--- a/crates/wasmtime/src/runtime/component/matching.rs
+++ b/crates/wasmtime/src/runtime/component/matching.rs
@@ -26,7 +26,13 @@ pub struct TypeChecker<'a> {
 #[doc(hidden)]
 pub struct InstanceType<'a> {
     pub types: &'a Arc<ComponentTypes>,
-    pub resources: &'a Arc<TryPrimaryMap<ResourceIndex, ResourceType>>,
+    /// Resource type substitutions for resources within `ComponentTypes`, if
+    /// any.
+    ///
+    /// If this isn't present then resource types are considered "abstract" and
+    /// un-intantiated. This doesn't refer to a concrete instantiated component,
+    /// but rather an abstract component type.
+    pub resources: Option<&'a Arc<TryPrimaryMap<ResourceIndex, ResourceType>>>,
 }
 
 impl TypeChecker<'_> {
@@ -170,7 +176,7 @@ impl TypeChecker<'_> {
     fn func(&self, expected: TypeFuncIndex, actual: &HostFunc) -> Result<()> {
         let instance_type = InstanceType {
             types: self.types,
-            resources: &self.imported_resources,
+            resources: Some(&self.imported_resources),
         };
         actual.typecheck(expected, &instance_type)
     }
@@ -191,7 +197,7 @@ impl<'a> InstanceType<'a> {
     pub fn new(instance: &'a ComponentInstance) -> InstanceType<'a> {
         InstanceType {
             types: instance.component().types(),
-            resources: instance.resource_types(),
+            resources: Some(instance.resource_types()),
         }
     }
 
@@ -199,8 +205,7 @@ impl<'a> InstanceType<'a> {
         match self.types[index] {
             TypeResourceTable::Concrete { ty, .. } => self
                 .resources
-                .get(ty)
-                .copied()
+                .map(|t| t[ty])
                 .unwrap_or_else(|| ResourceType::uninstantiated(&self.types, ty)),
             TypeResourceTable::Abstract(ty) => ResourceType::abstract_(&self.types, ty),
         }

--- a/crates/wasmtime/src/runtime/component/types.rs
+++ b/crates/wasmtime/src/runtime/component/types.rs
@@ -35,12 +35,13 @@ pub use crate::component::resources::ResourceType;
 ///   component with different resources produces different instance types but
 ///   the same underlying component type, so this field serves the purpose to
 ///   distinguish instance types from one another. This is runtime state created
-///   during instantiation and threaded through here.
+///   during instantiation and threaded through here. Note that if this field
+///   is `None` then this represents an abstract uninstantiated component type.
 #[derive(Clone)]
 struct Handle<T> {
     index: T,
     types: Arc<ComponentTypes>,
-    resources: Arc<TryPrimaryMap<ResourceIndex, ResourceType>>,
+    resources: Option<Arc<TryPrimaryMap<ResourceIndex, ResourceType>>>,
 }
 
 impl<T> Handle<T> {
@@ -48,14 +49,14 @@ impl<T> Handle<T> {
         Handle {
             index,
             types: ty.types.clone(),
-            resources: ty.resources.clone(),
+            resources: ty.resources.cloned(),
         }
     }
 
     fn instance(&self) -> InstanceType<'_> {
         InstanceType {
             types: &self.types,
-            resources: &self.resources,
+            resources: self.resources.as_ref(),
         }
     }
 
@@ -69,13 +70,17 @@ impl<T> Handle<T> {
     {
         (self.index == other.index
             && Arc::ptr_eq(&self.types, &other.types)
-            && Arc::ptr_eq(&self.resources, &other.resources))
+            && match (&self.resources, &other.resources) {
+                (Some(a), Some(b)) => Arc::ptr_eq(a, b),
+                (None, None) => true,
+                _ => false,
+            })
             || type_check(
                 &TypeChecker {
                     a_types: &self.types,
                     b_types: &other.types,
-                    a_resource: &self.resources,
-                    b_resource: &other.resources,
+                    a_resource: self.resources.as_deref(),
+                    b_resource: other.resources.as_deref(),
                 },
                 self.index,
                 other.index,
@@ -94,9 +99,9 @@ impl<T: fmt::Debug> fmt::Debug for Handle<T> {
 /// Type checker between two `Handle`s
 struct TypeChecker<'a> {
     a_types: &'a ComponentTypes,
-    a_resource: &'a TryPrimaryMap<ResourceIndex, ResourceType>,
+    a_resource: Option<&'a TryPrimaryMap<ResourceIndex, ResourceType>>,
     b_types: &'a ComponentTypes,
-    b_resource: &'a TryPrimaryMap<ResourceIndex, ResourceType>,
+    b_resource: Option<&'a TryPrimaryMap<ResourceIndex, ResourceType>>,
 }
 
 impl TypeChecker<'_> {
@@ -184,7 +189,7 @@ impl TypeChecker<'_> {
             (
                 TypeResourceTable::Concrete { ty: a, .. },
                 TypeResourceTable::Concrete { ty: b, .. },
-            ) => self.a_resource[*a] == self.b_resource[*b],
+            ) => self.a_resource.unwrap()[*a] == self.b_resource.unwrap()[*b],
             (TypeResourceTable::Concrete { .. }, _) => false,
 
             // Abstract resource types are only the same if they have the same
@@ -615,9 +620,9 @@ impl FutureType {
         match (my_payload, payload) {
             (Some(a), Some(b)) => TypeChecker {
                 a_types: &self.0.types,
-                a_resource: &self.0.resources,
+                a_resource: self.0.resources.as_deref(),
                 b_types: ty.types,
-                b_resource: ty.resources,
+                b_resource: ty.resources.map(|p| &**p),
             }
             .interface_types_equal(*a, *b),
             (None, None) => true,
@@ -672,9 +677,9 @@ impl StreamType {
         match (my_payload, payload) {
             (Some(a), Some(b)) => TypeChecker {
                 a_types: &self.0.types,
-                a_resource: &self.0.resources,
+                a_resource: self.0.resources.as_deref(),
                 b_types: ty.types,
-                b_resource: ty.resources,
+                b_resource: ty.resources.map(|p| &**p),
             }
             .interface_types_equal(*a, *b),
             (None, None) => true,
@@ -1071,7 +1076,7 @@ impl Component {
     pub fn instance_type(&self) -> InstanceType<'_> {
         InstanceType {
             types: &self.0.types,
-            resources: &self.0.resources,
+            resources: self.0.resources.as_ref(),
         }
     }
 }
@@ -1152,7 +1157,7 @@ impl ComponentItem {
                 TypeResourceTable::Concrete {
                     ty: resource_index, ..
                 } => {
-                    let ty = match ty.resources.get(resource_index) {
+                    let ty = match ty.resources.and_then(|t| t.get(resource_index)) {
                         // This resource type was substituted by a linker for
                         // example so it's replaced here.
                         Some(ty) => *ty,


### PR DESCRIPTION
There's already a few locations that test for a fallible lookup in this table and those are effectively better handled with a first-class `Option` type of whether the table is present at all. This additionally removes the need to allocate in this method along with the need for #13090.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
