### PR TITLE
Add `miri-wast` directory to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ testcase*.wasm
 testcase*.dna
 testcase*.json
 perf.data*
+miri-wast/


### PR DESCRIPTION
This is a temporary directory created by the `ci/miri-wast.sh` script.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
