### PR TITLE
Fix some comparison-related clif optimization rules

### DIFF
--- a/cranelift/codegen/src/opts/bitops.isle
+++ b/cranelift/codegen/src/opts/bitops.isle
@@ -222,8 +222,8 @@
 (rule (simplify (bor ty (bnot ty x) (band ty x y))) (bor ty y (bnot ty x)))
 
 ; (z & x) ^ (z & y) => z & (x ^ y)
-(rule (simplify 
-  (bxor ty (band ty z x) (band ty z y))) 
+(rule (simplify
+  (bxor ty (band ty z x) (band ty z y)))
 	(band ty z (bxor ty x y)))
 
 ; (x & y) | ~(x ^ y) => ~(x ^ y)
@@ -669,13 +669,13 @@
 (rule (simplify (eq rty (bnot cty y) (band cty x (bnot cty y)))) (eq rty (bor cty y x) (iconst_s cty -1)))
 
 ;; x >=_u (x & y), and (x & y) <=_u x, are always true.
-(rule (simplify (uge ty x (band ty x y))) (iconst_u ty 1))
-(rule (simplify (uge ty x (band ty y x))) (iconst_u ty 1))
-(rule (simplify (ule ty (band ty x y) x)) (iconst_u ty 1))
-(rule (simplify (ule ty (band ty y x) x)) (iconst_u ty 1))
+(rule (simplify (uge ty x (band ty x y))) (cmp_true ty))
+(rule (simplify (uge ty x (band ty y x))) (cmp_true ty))
+(rule (simplify (ule ty (band ty x y) x)) (cmp_true ty))
+(rule (simplify (ule ty (band ty y x) x)) (cmp_true ty))
 
 ;; (x | y) >=_u x, and x <=_u (x | y), are always true.
-(rule (simplify (uge ty (bor ty x y) x)) (iconst_u ty 1))
-(rule (simplify (uge ty (bor ty y x) x)) (iconst_u ty 1))
-(rule (simplify (ule ty x (bor ty x y))) (iconst_u ty 1))
-(rule (simplify (ule ty x (bor ty y x))) (iconst_u ty 1))
+(rule (simplify (uge ty (bor ty x y) x)) (cmp_true ty))
+(rule (simplify (uge ty (bor ty y x) x)) (cmp_true ty))
+(rule (simplify (ule ty x (bor ty x y))) (cmp_true ty))
+(rule (simplify (ule ty x (bor ty y x))) (cmp_true ty))

--- a/cranelift/filetests/filetests/runtests/vec-cmp-true-opts.clif
+++ b/cranelift/filetests/filetests/runtests/vec-cmp-true-opts.clif
@@ -1,6 +1,7 @@
 test interpret
 test run
 set opt_level=speed
+set enable_multi_ret_implicit_sret
 target aarch64
 target s390x
 target x86_64

--- a/cranelift/filetests/filetests/runtests/vec-cmp-true-opts.clif
+++ b/cranelift/filetests/filetests/runtests/vec-cmp-true-opts.clif
@@ -1,0 +1,78 @@
+test interpret
+test run
+set opt_level=speed
+target aarch64
+target s390x
+target x86_64
+target x86_64 skylake
+target riscv64 has_v
+target riscv64 has_v has_c has_zcb
+target pulley32
+target pulley32be
+target pulley64
+target pulley64be
+
+function %uge_band_i32x4(i32x4, i32x4) -> i32x4 {
+block0(v0: i32x4, v1: i32x4):
+    v2 = band v0, v1
+    v3 = icmp uge v0, v2
+    return v3
+}
+; run: %uge_band_i32x4([1 2 3 4], [5 6 7 8]) == [-1 -1 -1 -1]
+; run: %uge_band_i32x4([0 0 0 0], [0xFFFFFFFF 0xFFFFFFFF 0xFFFFFFFF 0xFFFFFFFF]) == [-1 -1 -1 -1]
+
+function %uge_band_commuted_i32x4(i32x4, i32x4) -> i32x4 {
+block0(v0: i32x4, v1: i32x4):
+    v2 = band v1, v0
+    v3 = icmp uge v0, v2
+    return v3
+}
+; run: %uge_band_commuted_i32x4([1 2 3 4], [5 6 7 8]) == [-1 -1 -1 -1]
+
+function %ule_band_i32x4(i32x4, i32x4) -> i32x4 {
+block0(v0: i32x4, v1: i32x4):
+    v2 = band v0, v1
+    v3 = icmp ule v2, v0
+    return v3
+}
+; run: %ule_band_i32x4([1 2 3 4], [5 6 7 8]) == [-1 -1 -1 -1]
+
+function %ule_bor_i32x4(i32x4, i32x4) -> i32x4 {
+block0(v0: i32x4, v1: i32x4):
+    v2 = bor v0, v1
+    v3 = icmp ule v0, v2
+    return v3
+}
+; run: %ule_bor_i32x4([1 2 3 4], [5 6 7 8]) == [-1 -1 -1 -1]
+
+function %uge_bor_i32x4(i32x4, i32x4) -> i32x4 {
+block0(v0: i32x4, v1: i32x4):
+    v2 = bor v0, v1
+    v3 = icmp uge v2, v0
+    return v3
+}
+; run: %uge_bor_i32x4([1 2 3 4], [5 6 7 8]) == [-1 -1 -1 -1]
+
+function %uge_band_i16x8(i16x8, i16x8) -> i16x8 {
+block0(v0: i16x8, v1: i16x8):
+    v2 = band v0, v1
+    v3 = icmp uge v0, v2
+    return v3
+}
+; run: %uge_band_i16x8([1 2 3 4 5 6 7 8], [9 10 11 12 13 14 15 16]) == [-1 -1 -1 -1 -1 -1 -1 -1]
+
+function %uge_band_i8x16(i8x16, i8x16) -> i8x16 {
+block0(v0: i8x16, v1: i8x16):
+    v2 = band v0, v1
+    v3 = icmp uge v0, v2
+    return v3
+}
+; run: %uge_band_i8x16([1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16], [17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32]) == [-1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1]
+
+function %uge_band_i64x2(i64x2, i64x2) -> i64x2 {
+block0(v0: i64x2, v1: i64x2):
+    v2 = band v0, v1
+    v3 = icmp uge v0, v2
+    return v3
+}
+; run: %uge_band_i64x2([1 2], [3 4]) == [-1 -1]


### PR DESCRIPTION
The fix in #13063 failed to take into account some extra rules in `bitops.isle` which now works for vector types and didn't correctly use the `cmp_true` helper to create a "true" value for the destination type.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
