### PR TITLE
Add an extra assert to internal buffers in futures/streams

### DIFF
--- a/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams/buffers.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams/buffers.rs
@@ -223,6 +223,7 @@ pub struct SliceBuffer {
 
 impl SliceBuffer {
     pub fn new(buffer: Vec<u8>, offset: usize, limit: usize) -> Self {
+        assert!(offset <= limit);
         assert!(limit <= buffer.len());
         Self {
             buffer,


### PR DESCRIPTION
This is effectively already implied by the rest of the implementation but by making this a first-class assert it makes it easier to verify the subsequent `unsafe` code is correct.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
