### PR TITLE
Update `indexmap` and `hashbrown` dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -772,7 +772,7 @@ dependencies = [
  "criterion",
  "env_logger 0.11.5",
  "gimli 0.33.0",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "libm",
  "log",
  "postcard",
@@ -860,7 +860,7 @@ version = "0.132.0"
 dependencies = [
  "cranelift-codegen",
  "env_logger 0.11.5",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "log",
  "similar",
  "smallvec 1.15.1",
@@ -931,7 +931,7 @@ dependencies = [
  "anyhow",
  "cranelift-codegen",
  "cranelift-control",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_derive",
 ]
@@ -1700,7 +1700,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 dependencies = [
  "fallible-iterator",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "stable_deref_trait",
 ]
 
@@ -1712,7 +1712,7 @@ checksum = "0bf7f043f89559805f8c7cacc432749b2fa0d0a0a9ee46ce47164ed5ba7f126c"
 dependencies = [
  "fnv",
  "hashbrown 0.16.1",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "stable_deref_trait",
 ]
 
@@ -1743,7 +1743,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1790,6 +1790,15 @@ dependencies = [
  "foldhash 0.2.0",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+dependencies = [
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -2083,12 +2092,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -2616,7 +2625,7 @@ checksum = "63944c133d03f44e75866bbd160b95af0ec3f6a13d936d69d31c81078cbc5baf"
 dependencies = [
  "crc32fast",
  "hashbrown 0.16.1",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "memchr",
 ]
 
@@ -2829,7 +2838,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
 ]
 
 [[package]]
@@ -3447,7 +3456,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itoa",
  "ryu",
  "serde",
@@ -3977,7 +3986,7 @@ version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0dc8b1fb61449e27716ec0e1bdf0f6b8f3e8f6b05391e8497b8b6d7804ea6d8"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde_core",
  "serde_spanned",
  "toml_datetime",
@@ -4472,7 +4481,7 @@ checksum = "f05a2b3bad87cc1ce45b63425ec09a854cc4cb369231c9fed1fee31538103efb"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "petgraph",
  "smallvec 1.15.1",
@@ -4508,7 +4517,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "wasm-encoder 0.244.0",
  "wasmparser 0.244.0",
 ]
@@ -4520,7 +4529,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e4c2aa916c425dcca61a6887d3e135acdee2c6d0ed51fd61c08d41ddaf62b1"
 dependencies = [
  "anyhow",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "wasm-encoder 0.246.2",
  "wasmparser 0.246.2",
 ]
@@ -4620,7 +4629,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4abf1132c1fdf747d56bbc1bb52152400c70f336870f968b85e89ea422198ae3"
 dependencies = [
  "bitflags 2.9.4",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
 ]
 
 [[package]]
@@ -4631,7 +4640,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags 2.9.4",
  "hashbrown 0.15.2",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "semver",
 ]
 
@@ -4643,7 +4652,7 @@ checksum = "71cde4757396defafd25417cfb36aa3161027d06d865b0c24baaae229aac005d"
 dependencies = [
  "bitflags 2.9.4",
  "hashbrown 0.16.1",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "semver",
  "serde",
 ]
@@ -4870,8 +4879,8 @@ dependencies = [
  "cranelift-entity",
  "env_logger 0.11.5",
  "gimli 0.33.0",
- "hashbrown 0.16.1",
- "indexmap 2.13.0",
+ "hashbrown 0.17.0",
+ "indexmap 2.14.0",
  "log",
  "object 0.39.0",
  "postcard",
@@ -4945,7 +4954,7 @@ dependencies = [
  "cranelift-bitset",
  "env_logger 0.11.5",
  "futures",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "mutatis",
  "rand 0.10.1",
@@ -5034,7 +5043,7 @@ name = "wasmtime-internal-core"
 version = "45.0.0"
 dependencies = [
  "anyhow",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "libm",
  "serde",
 ]
@@ -5187,7 +5196,7 @@ dependencies = [
  "anyhow",
  "bitflags 2.9.4",
  "heck 0.5.0",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "wit-parser 0.246.2",
 ]
 
@@ -5213,7 +5222,7 @@ dependencies = [
  "arbitrary",
  "arbtest",
  "env_logger 0.11.5",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "proc-macro2",
  "quote",
  "rand 0.10.1",
@@ -5867,7 +5876,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "prettyplease",
  "syn 2.0.106",
  "wasm-metadata 0.244.0",
@@ -5883,7 +5892,7 @@ checksum = "920a1c8c0f89397431db4900a7bf7c511b78e1b7068289fe812dc76e993f1491"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "prettyplease",
  "syn 2.0.106",
  "wasm-metadata 0.246.2",
@@ -5930,7 +5939,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags 2.9.4",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -5949,7 +5958,7 @@ checksum = "1936c26cb24b93dc36bf78fb5dc35c55cd37f66ecdc2d2663a717d9fb3ee951e"
 dependencies = [
  "anyhow",
  "bitflags 2.9.4",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -5968,7 +5977,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",
@@ -5987,7 +5996,7 @@ dependencies = [
  "anyhow",
  "hashbrown 0.16.1",
  "id-arena",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,7 +118,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -129,7 +129,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1319,7 +1319,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2166,7 +2166,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2578,7 +2578,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3279,7 +3279,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3574,7 +3574,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3755,7 +3755,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3924,9 +3924,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.52.0"
+version = "1.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a91135f59b1cbf38c91e73cf3386fca9bb77915c45ce2771460c9d92f0f3d776"
+checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
 dependencies = [
  "bytes",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,7 +118,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -129,7 +129,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1319,7 +1319,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2166,7 +2166,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2578,7 +2578,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3279,7 +3279,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3574,7 +3574,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3755,7 +3755,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,11 +4,11 @@ version = 4
 
 [[package]]
 name = "addr2line"
-version = "0.24.1"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5fb1d8e4442bd405fdfd1dacb42792696b0cf9cb15882e5d097b742a676d375"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
 dependencies = [
- "gimli 0.31.1",
+ "gimli 0.32.3",
 ]
 
 [[package]]
@@ -44,6 +44,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -178,17 +187,17 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "backtrace"
-version = "0.3.75"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
 dependencies = [
- "addr2line 0.24.1",
+ "addr2line 0.25.1",
  "cfg-if",
  "libc",
  "miniz_oxide",
- "object 0.36.5",
+ "object 0.37.3",
  "rustc-demangle",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
@@ -215,7 +224,7 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.11.1",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -231,18 +240,18 @@ dependencies = [
 
 [[package]]
 name = "bit-set"
-version = "0.5.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e11e16035ea35e4e5997b393eacbf6f63983188f7a2ad25bfb13465f5ad59de"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
  "bit-vec",
 ]
 
 [[package]]
 name = "bit-vec"
-version = "0.6.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -252,9 +261,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.4"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "block-buffer"
@@ -366,7 +375,7 @@ checksum = "20a158160765c6a7d0d8c072a53d772e4cb243f38b04bfcf6b4939cfbe7482e7"
 dependencies = [
  "cap-primitives",
  "cap-std",
- "rustix 1.0.8",
+ "rustix 1.1.4",
  "smallvec 1.15.1",
 ]
 
@@ -382,7 +391,7 @@ dependencies = [
  "io-lifetimes",
  "ipnet",
  "maybe-owned",
- "rustix 1.0.8",
+ "rustix 1.1.4",
  "rustix-linux-procfs",
  "windows-sys 0.52.0",
  "winx",
@@ -397,7 +406,7 @@ dependencies = [
  "cap-primitives",
  "io-extras",
  "io-lifetimes",
- "rustix 1.0.8",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -410,7 +419,7 @@ dependencies = [
  "cap-primitives",
  "iana-time-zone",
  "once_cell",
- "rustix 1.0.8",
+ "rustix 1.1.4",
  "winx",
 ]
 
@@ -1029,10 +1038,11 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.7.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1c047a62b0cc3e145fa84415a3191f628e980b194c2755aa12300a4e6cbd928"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
 dependencies = [
+ "alloca",
  "anes",
  "cast",
  "ciborium",
@@ -1041,6 +1051,7 @@ dependencies = [
  "itertools 0.13.0",
  "num-traits",
  "oorandom",
+ "page_size",
  "rayon",
  "regex",
  "serde",
@@ -1051,9 +1062,9 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.6.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b1bcc0dc7dfae599d84ad0b1a55f80cde8af3725da8313b528da95ef783e338"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
 dependencies = [
  "cast",
  "itertools 0.13.0",
@@ -1374,7 +1385,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
  "cfg-if",
- "rustix 1.0.8",
+ "rustix 1.1.4",
  "windows-sys 0.52.0",
 ]
 
@@ -1490,7 +1501,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
 dependencies = [
  "io-lifetimes",
- "rustix 1.0.8",
+ "rustix 1.1.4",
  "windows-sys 0.52.0",
 ]
 
@@ -1614,7 +1625,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25234f20a3ec0a962a61770cfe39ecf03cb529a6e474ad8cff025ed497eda557"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.11.1",
  "debugid",
  "rustc-hash",
  "serde",
@@ -1628,7 +1639,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bafc7e33650ab9f05dcc16325f05d56b8d10393114e31a19a353b86fa60cfe7"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.11.1",
  "cfg-if",
  "log",
  "managed",
@@ -1706,6 +1717,12 @@ dependencies = [
 
 [[package]]
 name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+
+[[package]]
+name = "gimli"
 version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf7f043f89559805f8c7cacc432749b2fa0d0a0a9ee46ce47164ed5ba7f126c"
@@ -1733,15 +1750,15 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.4"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "816ec7294445779408f36fe57bc5b7fc1cf59664059096c65f905c1c61f58069"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
 dependencies = [
+ "atomic-waker",
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
- "futures-util",
  "http",
  "indexmap 2.14.0",
  "slab",
@@ -1891,9 +1908,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "1.7.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb3aa54a13a0dfe7fbe3a59e0c76093041720fdc77b110cc0fc260fafb4dc51e"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1906,7 +1923,6 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec 1.15.1",
  "tokio",
  "want",
@@ -2273,9 +2289,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.177"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -2323,9 +2339,9 @@ checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.4"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "listenfd"
@@ -2446,7 +2462,7 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad38eb12aea514a0466ea40a80fd8cc83637065948eb4a426e4aa46261175227"
 dependencies = [
- "rustix 1.0.8",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -2485,9 +2501,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
@@ -2610,9 +2626,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.5"
+version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
  "memchr",
 ]
@@ -2682,7 +2698,7 @@ version = "0.10.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.11.1",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -2773,6 +2789,16 @@ dependencies = [
  "sha2",
  "tar",
  "ureq",
+]
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -2904,22 +2930,21 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "1.0.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0d9cc07f18492d879586c92b485def06bc850da3118075cd45d50e9c95b0e5"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
- "bitflags 1.3.2",
- "byteorder",
- "lazy_static",
+ "bit-vec",
+ "bitflags 2.11.1",
  "num-traits",
- "quick-error 2.0.1",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
  "rand_xorshift",
- "regex-syntax 0.6.25",
+ "regex-syntax 0.8.5",
  "rusty-fork",
  "tempfile",
+ "unarray",
 ]
 
 [[package]]
@@ -2960,12 +2985,6 @@ name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
-
-[[package]]
-name = "quick-error"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
@@ -3060,11 +3079,11 @@ checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
 
 [[package]]
 name = "rand_xorshift"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
- "rand_core 0.6.3",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -3073,7 +3092,7 @@ version = "11.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6df7ab838ed27997ba19a4664507e6f82b41fe6e20be42929332156e5e85146"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -3126,13 +3145,13 @@ dependencies = [
 
 [[package]]
 name = "regalloc2"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "952ddbfc6f9f64d006c3efd8c9851a6ba2f2b944ba94730db255d55006e0ffda"
+checksum = "de2c52737737f8609e94f975dee22854a2d5c125772d4b1cf292120f4d45c186"
 dependencies = [
  "allocator-api2",
  "bumpalo",
- "hashbrown 0.15.2",
+ "hashbrown 0.17.0",
  "log",
  "rustc-hash",
  "serde",
@@ -3179,12 +3198,6 @@ version = "0.1.0"
 dependencies = [
  "regex",
 ]
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
 name = "regex-syntax"
@@ -3249,7 +3262,7 @@ version = "0.38.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a78891ee6bf2340288408954ac787aa063d8e8817e9f53abb37c695c6d834ef6"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys 0.4.14",
@@ -3258,15 +3271,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.8"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.11.1",
  "errno",
  "libc",
- "linux-raw-sys 0.9.4",
- "windows-sys 0.60.2",
+ "linux-raw-sys 0.12.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3276,7 +3289,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fc84bf7e9aa16c4f2c758f27412dc9841341e16aa682d9c7ac308fe3ee12056"
 dependencies = [
  "once_cell",
- "rustix 1.0.8",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -3327,7 +3340,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
 dependencies = [
  "fnv",
- "quick-error 1.2.3",
+ "quick-error",
  "tempfile",
  "wait-timeout",
 ]
@@ -3372,7 +3385,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.11.1",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -3556,12 +3569,12 @@ checksum = "51d44cfb396c3caf6fbfd0ab422af02631b69ddd96d2eff0b0f0724f9024051b"
 
 [[package]]
 name = "socket2"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3688,7 +3701,7 @@ version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc4592f674ce18521c2a81483873a49596655b179f71c5e05d10c1fe66c78745"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.11.1",
  "cap-fs-ext",
  "cap-std",
  "fd-lock",
@@ -3734,14 +3747,14 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.23.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand 2.3.0",
- "getrandom 0.3.1",
+ "getrandom 0.4.2",
  "once_cell",
- "rustix 1.0.8",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -3760,7 +3773,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b8cb979cb11c32ce1603f8137b22262a9d131aaa5c37b5678025f22b8becd0"
 dependencies = [
- "rustix 1.0.8",
+ "rustix 1.1.4",
  "windows-sys 0.60.2",
 ]
 
@@ -3911,9 +3924,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.48.0"
+version = "1.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
+checksum = "a91135f59b1cbf38c91e73cf3386fca9bb77915c45ce2771460c9d92f0f3d776"
 dependencies = [
  "bytes",
  "libc",
@@ -3927,9 +3940,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4114,6 +4127,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4234,7 +4253,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a33ccf9cc537275d7bb848e94f160986164e2ea5138e60166551d115c7ea8f1a"
 dependencies = [
  "bindgen",
- "bitflags 2.9.4",
+ "bitflags 2.11.1",
  "fslock",
  "gzip-header",
  "home",
@@ -4347,7 +4366,7 @@ name = "wasi-common"
 version = "45.0.0"
 dependencies = [
  "async-trait",
- "bitflags 2.9.4",
+ "bitflags 2.11.1",
  "cap-fs-ext",
  "cap-std",
  "cap-time-ext",
@@ -4357,7 +4376,7 @@ dependencies = [
  "libc",
  "log",
  "rand 0.10.1",
- "rustix 1.0.8",
+ "rustix 1.1.4",
  "system-interface",
  "tempfile",
  "test-log",
@@ -4386,7 +4405,7 @@ dependencies = [
 name = "wasi-preview1-component-adapter"
 version = "45.0.0"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.11.1",
  "byte-array-literals",
  "object 0.39.0",
  "wasip1",
@@ -4628,7 +4647,7 @@ version = "0.228.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4abf1132c1fdf747d56bbc1bb52152400c70f336870f968b85e89ea422198ae3"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.11.1",
  "indexmap 2.14.0",
 ]
 
@@ -4638,7 +4657,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.11.1",
  "hashbrown 0.15.2",
  "indexmap 2.14.0",
  "semver",
@@ -4650,7 +4669,7 @@ version = "0.246.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71cde4757396defafd25417cfb36aa3161027d06d865b0c24baaae229aac005d"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.11.1",
  "hashbrown 0.16.1",
  "indexmap 2.14.0",
  "semver",
@@ -4674,7 +4693,7 @@ version = "45.0.0"
 dependencies = [
  "addr2line 0.26.0",
  "async-trait",
- "bitflags 2.9.4",
+ "bitflags 2.11.1",
  "bumpalo",
  "bytes",
  "cc",
@@ -4698,7 +4717,7 @@ dependencies = [
  "pulley-interpreter",
  "rand 0.10.1",
  "rayon",
- "rustix 1.0.8",
+ "rustix 1.1.4",
  "semver",
  "serde",
  "serde_derive",
@@ -4806,7 +4825,7 @@ dependencies = [
  "pulley-interpreter",
  "rand 0.10.1",
  "rayon",
- "rustix 1.0.8",
+ "rustix 1.1.4",
  "serde",
  "serde_derive",
  "serde_json",
@@ -5003,7 +5022,7 @@ dependencies = [
  "filetime",
  "log",
  "postcard",
- "rustix 1.0.8",
+ "rustix 1.1.4",
  "serde",
  "serde_derive",
  "sha2",
@@ -5108,7 +5127,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "libc",
- "rustix 1.0.8",
+ "rustix 1.1.4",
  "wasmtime-environ",
  "wasmtime-internal-versioned-export-macros",
  "windows-sys 0.61.2",
@@ -5140,7 +5159,7 @@ version = "45.0.0"
 dependencies = [
  "cc",
  "object 0.39.0",
- "rustix 1.0.8",
+ "rustix 1.1.4",
  "wasmtime-internal-versioned-export-macros",
 ]
 
@@ -5194,7 +5213,7 @@ name = "wasmtime-internal-wit-bindgen"
 version = "45.0.0"
 dependencies = [
  "anyhow",
- "bitflags 2.9.4",
+ "bitflags 2.11.1",
  "heck 0.5.0",
  "indexmap 2.14.0",
  "wit-parser 0.246.2",
@@ -5243,7 +5262,7 @@ name = "wasmtime-wasi"
 version = "45.0.0"
 dependencies = [
  "async-trait",
- "bitflags 2.9.4",
+ "bitflags 2.11.1",
  "bytes",
  "cap-fs-ext",
  "cap-net-ext",
@@ -5255,7 +5274,7 @@ dependencies = [
  "io-extras",
  "io-lifetimes",
  "rand 0.10.1",
- "rustix 1.0.8",
+ "rustix 1.1.4",
  "system-interface",
  "tempfile",
  "test-log",
@@ -5485,7 +5504,7 @@ dependencies = [
 name = "wiggle"
 version = "45.0.0"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.11.1",
  "proptest",
  "thiserror 2.0.17",
  "tokio",
@@ -5804,7 +5823,7 @@ version = "0.36.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.11.1",
  "windows-sys 0.52.0",
 ]
 
@@ -5814,7 +5833,7 @@ version = "0.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c573471f125075647d03df72e026074b7203790d41351cd6edc96f46bcccd36"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -5832,7 +5851,7 @@ version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7607d30e7e5e8fd5a0695f7cb8b2128829e0bf9dca7a1fe8c4d6ed3ca1058fce"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.11.1",
  "futures",
  "wit-bindgen-rust-macro 0.56.0",
 ]
@@ -5865,7 +5884,7 @@ version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -5938,7 +5957,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.9.4",
+ "bitflags 2.11.1",
  "indexmap 2.14.0",
  "log",
  "serde",
@@ -5957,7 +5976,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1936c26cb24b93dc36bf78fb5dc35c55cd37f66ecdc2d2663a717d9fb3ee951e"
 dependencies = [
  "anyhow",
- "bitflags 2.9.4",
+ "bitflags 2.11.1",
  "indexmap 2.14.0",
  "log",
  "serde",
@@ -6082,7 +6101,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
- "rustix 1.0.8",
+ "rustix 1.1.4",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -412,7 +412,7 @@ tempfile = "3.27.0"
 filecheck = "0.5.0"
 libc = { version = "0.2.185", default-features = true }
 file-per-thread-logger = "0.2.0"
-tokio = { version = "1.52.0", features = [ "rt", "time" ] }
+tokio = { version = "1.51.1", features = [ "rt", "time" ] }
 hyper = "1.9.0"
 http = "1.3.1"
 http-body = "1.0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -385,7 +385,7 @@ env_logger = "0.11.5"
 log = { version = "0.4.28", default-features = false }
 clap = { version = "4.5.48", default-features = false, features = ["std", "derive"] }
 clap_complete = "4.5.58"
-hashbrown = { version = "0.16", default-features = false }
+hashbrown = { version = "0.17", default-features = false }
 capstone = "0.13.0"
 smallvec = { version = "1.15.1", features = ["union"] }
 tracing = { version = "0.1.41", default-features = false }
@@ -419,7 +419,7 @@ http-body = "1.0.1"
 http-body-util = "0.1.3"
 bytes = { version = "1.11.1", default-features = false }
 futures = { version = "0.3.31", default-features = false }
-indexmap = { version = "2.11.4", default-features = false }
+indexmap = { version = "2.14.0", default-features = false }
 syn = "2.0.106"
 quote = "1.0.41"
 proc-macro2 = "1.0.101"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -332,7 +332,7 @@ component-async-tests = { path = "crates/misc/component-async-tests" }
 
 # Bytecode Alliance maintained dependencies:
 # ---------------------------
-regalloc2 = "0.15.0"
+regalloc2 = "0.15.1"
 wasip1 = { version = "1.0.0", default-features = false }
 
 # cap-std family:
@@ -346,7 +346,7 @@ fs-set-times = "0.20.3"
 system-interface = { version = "0.27.3", features = ["cap_std_impls"] }
 io-lifetimes = { version = "2.0.3", default-features = false }
 io-extras = "0.18.4"
-rustix = "1.0.8"
+rustix = "1.1.4"
 # wit-bindgen:
 wit-bindgen = { version = "0.56.0", default-features = false }
 wit-bindgen-rust-macro = { version = "0.56.0", default-features = false }
@@ -371,7 +371,7 @@ wasip2 = "1.0"
 # Non-Bytecode Alliance maintained dependencies:
 # --------------------------
 arbitrary = "1.4.2"
-backtrace = "0.3.75"
+backtrace = "0.3.76"
 bumpalo = "3.20.0"
 mutatis = {version = "0.4.0", features = ["alloc", "derive", "check"] }
 cc = "1.2.41"
@@ -398,7 +398,7 @@ toml = "0.9.8"
 mach2 = "0.4.2"
 memfd = "0.6.5"
 psm = "0.1.11"
-proptest = "1.0.0"
+proptest = "1.11.0"
 rand = { version = "0.10.1", default-features = false }
 # serde and serde_derive must have the same version
 serde = { version = "1.0.228", default-features = false, features = ['alloc'] }
@@ -408,12 +408,12 @@ glob = "0.3.3"
 libfuzzer-sys = "0.4.10"
 walkdir = "2.5.0"
 cfg-if = "1.0"
-tempfile = "3.23.0"
+tempfile = "3.27.0"
 filecheck = "0.5.0"
-libc = { version = "0.2.177", default-features = true }
+libc = { version = "0.2.185", default-features = true }
 file-per-thread-logger = "0.2.0"
-tokio = { version = "1.48.0", features = [ "rt", "time" ] }
-hyper = "1.7.0"
+tokio = { version = "1.52.0", features = [ "rt", "time" ] }
+hyper = "1.9.0"
 http = "1.3.1"
 http-body = "1.0.1"
 http-body-util = "0.1.3"
@@ -427,7 +427,7 @@ test-log = { version = "0.2.18", default-features = false, features = ["trace"] 
 tracing-subscriber = { version = "0.3.20", default-features = false, features = ['fmt', 'env-filter', 'ansi', 'tracing-log'] }
 url = "2.5.7"
 postcard = { version = "1.1.3", default-features = false, features = ['alloc'] }
-criterion = { version = "0.7.0", default-features = false, features = ["html_reports", "rayon"] }
+criterion = { version = "0.8.2", default-features = false, features = ["html_reports", "rayon"] }
 rustc-hash = { version = "2.1.1", default-features = false }
 libtest-mimic = "0.8.1"
 semver = { version = "1.0.27", default-features = false }

--- a/deny.toml
+++ b/deny.toml
@@ -35,29 +35,15 @@ multiple-versions = "deny"
 wildcards = "allow"
 deny = []
 skip = [
-    { name = "cpufeatures", reason = "requires an update to `sha2` which pulls in a lot of other dependencies which doesn't seem worth it" }
+    { name = "cpufeatures", reason = "requires an update to `sha2` which pulls in a lot of other dependencies which doesn't seem worth it" },
+    { name = "hashbrown", reason = "waiting on lots of crates to update" },
+    { name = "gimli", reason = "waiting on a few crates to update" },
+    { name = "linux-raw-sys", reason = "waiting on `system-interface` to update" },
+    { name = "rustix", reason = "waiting on `system-interface` to update" },
 ]
 skip-tree = [
-    # proptest depends on bitflags 1.x.x while other crates depend on 2.x.x so
-    # ignore its dependency tree until it updates.
-    { name = "proptest", depth = 20 },
-
-    # This is maintained externally and we allow it to have duplicate
-    # dependencies relative to Wasmtime's main dependency tree.
-    { name = "witx", depth = 20 },
-
-    # They want to publish version 2.0 to upgrade `hashbrown` so in the meantime
-    # it is duplicated for us.
-    { name = "indexmap", depth = 2 },
-
-    # criterion is on old version, will update on next release.
-    { name = "itertools" },
-
-    # backtrace currently using an older version of gimli/addr2line
-    { name = "backtrace" },
-
-    # right now terminal_size pulls in an older version of io-lifetimes
-    { name = "io-lifetimes" },
-
-    { name = "file-per-thread-logger", reason = "this uses an old version of env-logger; may be unmaintained?" }
+    { name = "rand", reason = "waiting on `proptest` to update" },
+    { name = "witx", depth = 20, reason = "dep will never update again" },
+    { name = "file-per-thread-logger", reason = "unmaintained dep not updating" },
+    { name = "region", reason = "unmaintained dep not updating" },
 ]

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -4330,6 +4330,12 @@ criteria = "safe-to-deploy"
 delta = "0.10.0 -> 0.10.1"
 notes = "Minor logging-based updated fixing a recent advisory for the crate."
 
+[[audits.rand_xorshift]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.3.0 -> 0.4.0"
+notes = "Minor updates for a new `rand` crate version, nothing awry."
+
 [[audits.raw-cpuid]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
@@ -4978,6 +4984,15 @@ who = "Pat Hickey <phickey@fastly.com>"
 criteria = "safe-to-deploy"
 version = "0.2.4"
 notes = "Implements a concurrency primitive with atomics, and is not obviously incorrect"
+
+[[audits.unarray]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+version = "0.1.4"
+notes = """
+Crate is sound, albeit leaky, and not actively malicious. Probably not the best
+crate to use in practice but it's suitable for testing dependencies.
+"""
 
 [[audits.unicase]]
 who = "Alex Crichton <alex@alexcrichton.com>"

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -45,7 +45,7 @@ who = "Saúl Cabrera <saulecabrera@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
 start = "2025-02-20"
-end = "2026-02-20"
+end = "2027-04-14"
 notes = "The Bytecode Alliance is the author of this crate"
 
 [[wildcard-audits.cranelift-assembler-x64-meta]]
@@ -61,7 +61,7 @@ who = "Saúl Cabrera <saulecabrera@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
 start = "2025-02-20"
-end = "2026-02-20"
+end = "2027-04-14"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.cranelift-bforest]]
@@ -85,7 +85,7 @@ who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
 start = "2025-04-21"
-end = "2026-04-21"
+end = "2027-04-14"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.cranelift-bitset]]
@@ -325,7 +325,7 @@ who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
 start = "2025-04-21"
-end = "2026-04-21"
+end = "2027-04-14"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.cranelift-srcgen]]
@@ -811,7 +811,7 @@ who = "Trevor Elliott <telliott@fastly.com>"
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
 start = "2024-02-20"
-end = "2026-01-21"
+end = "2027-04-14"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.wasmtime-c-api-macros]]
@@ -819,7 +819,7 @@ who = "Trevor Elliott <telliott@fastly.com>"
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
 start = "2024-02-20"
-end = "2026-01-21"
+end = "2027-04-14"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.wasmtime-cache]]
@@ -1291,7 +1291,7 @@ who = "Saúl Cabrera <saulecabrera@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
 start = "2025-01-20"
-end = "2026-01-21"
+end = "2027-04-14"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.wasmtime-runtime]]
@@ -1391,7 +1391,7 @@ who = "Saúl Cabrera <saulecabrera@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
 start = "2025-02-20"
-end = "2026-02-20"
+end = "2027-04-14"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.wasmtime-wasi-keyvalue]]
@@ -1455,7 +1455,7 @@ who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish
 start = "2025-04-21"
-end = "2026-04-21"
+end = "2027-04-14"
 notes = "The Bytecode Alliance is the author of this crate."
 
 [[wildcard-audits.wasmtime-wasi-tls]]
@@ -6962,7 +6962,7 @@ end = "2027-02-11"
 criteria = "safe-to-deploy"
 user-id = 539 # Josh Stone (cuviper)
 start = "2020-01-15"
-end = "2026-01-08"
+end = "2027-04-14"
 
 [[trusted.io-extras]]
 criteria = "safe-to-deploy"

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -2221,6 +2221,12 @@ criteria = "safe-to-deploy"
 delta = "2.7.0 -> 2.9.4"
 notes = "Tweaks to the macro, nothing out of order."
 
+[[audits.bitflags]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "2.10.0 -> 2.11.1"
+notes = "Minor updates, nothing awry here."
+
 [[audits.bitmaps]]
 who = "Nick Fitzgerald <fitzgen@gmail.com>"
 criteria = "safe-to-deploy"
@@ -7066,6 +7072,12 @@ user-id = 189 # Andrew Gallant (BurntSushi)
 start = "2019-07-07"
 end = "2026-10-10"
 
+[[trusted.mio]]
+criteria = "safe-to-deploy"
+user-id = 6025 # Thomas de Zeeuw (Thomasdezeeuw)
+start = "2019-12-17"
+end = "2027-04-15"
+
 [[trusted.num_cpus]]
 criteria = "safe-to-deploy"
 user-id = 359 # Sean McArthur (seanmonstar)
@@ -7234,6 +7246,12 @@ user-id = 1 # Alex Crichton (alexcrichton)
 start = "2019-05-06"
 end = "2025-12-05"
 
+[[trusted.socket2]]
+criteria = "safe-to-deploy"
+user-id = 6025 # Thomas de Zeeuw (Thomasdezeeuw)
+start = "2020-09-09"
+end = "2027-04-15"
+
 [[trusted.syn]]
 criteria = "safe-to-deploy"
 user-id = 3618 # David Tolnay (dtolnay)
@@ -7287,6 +7305,12 @@ criteria = "safe-to-deploy"
 user-id = 6741 # Alice Ryhl (Darksonn)
 start = "2020-12-25"
 end = "2026-10-10"
+
+[[trusted.tokio-macros]]
+criteria = "safe-to-deploy"
+user-id = 6741 # Alice Ryhl (Darksonn)
+start = "2020-10-26"
+end = "2027-04-15"
 
 [[trusted.tokio-util]]
 criteria = "safe-to-deploy"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -325,10 +325,6 @@ criteria = "safe-to-deploy"
 version = "2.1.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.im-rc]]
-version = "15.1.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.ipnet]]
 version = "2.5.0"
 criteria = "safe-to-deploy"
@@ -440,10 +436,6 @@ criteria = "safe-to-deploy"
 version = "0.3.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.rand_xoshiro]]
-version = "0.6.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.rawpointer]]
 version = "0.2.1"
 criteria = "safe-to-deploy"
@@ -465,19 +457,11 @@ version = "0.17.14"
 criteria = "safe-to-deploy"
 
 [[exemptions.rustls]]
-version = "0.22.4"
-criteria = "safe-to-deploy"
-
-[[exemptions.rustls]]
 version = "0.23.37"
 criteria = "safe-to-deploy"
 
 [[exemptions.rustls-pki-types]]
 version = "1.3.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.rustls-webpki]]
-version = "0.102.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.rustls-webpki]]
@@ -504,10 +488,6 @@ criteria = "safe-to-deploy"
 version = "1.1.2"
 criteria = "safe-to-deploy"
 
-[[exemptions.sized-chunks]]
-version = "0.6.5"
-criteria = "safe-to-deploy"
-
 [[exemptions.socket2]]
 version = "0.4.9"
 criteria = "safe-to-deploy"
@@ -530,10 +510,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.tokio-macros]]
 version = "2.5.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.tokio-rustls]]
-version = "0.25.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.tokio-rustls]]

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -263,10 +263,6 @@ criteria = "safe-to-deploy"
 version = "0.3.5"
 criteria = "safe-to-run"
 
-[[exemptions.criterion-plot]]
-version = "0.4.4"
-criteria = "safe-to-run"
-
 [[exemptions.crossbeam-deque]]
 version = "0.8.1"
 criteria = "safe-to-deploy"
@@ -413,15 +409,11 @@ version = "0.2.16"
 criteria = "safe-to-deploy"
 
 [[exemptions.proptest]]
-version = "1.0.0"
+version = "1.11.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.quick-error]]
 version = "1.2.3"
-criteria = "safe-to-deploy"
-
-[[exemptions.quick-error]]
-version = "2.0.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.r-efi]]

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -368,10 +368,6 @@ criteria = "safe-to-deploy"
 version = "0.2.3"
 criteria = "safe-to-deploy"
 
-[[exemptions.mio]]
-version = "1.0.3"
-criteria = "safe-to-deploy"
-
 [[exemptions.ndarray]]
 version = "0.15.6"
 criteria = "safe-to-deploy"
@@ -488,10 +484,6 @@ criteria = "safe-to-deploy"
 version = "1.1.2"
 criteria = "safe-to-deploy"
 
-[[exemptions.socket2]]
-version = "0.4.9"
-criteria = "safe-to-deploy"
-
 [[exemptions.souper-ir]]
 version = "2.1.0"
 criteria = "safe-to-deploy"
@@ -506,10 +498,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.time]]
 version = "0.3.36"
-criteria = "safe-to-deploy"
-
-[[exemptions.tokio-macros]]
-version = "2.5.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.tokio-rustls]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -911,13 +911,6 @@ user-login = "BurntSushi"
 user-name = "Andrew Gallant"
 
 [[publisher.regex-syntax]]
-version = "0.6.25"
-when = "2021-05-02"
-user-id = 189
-user-login = "BurntSushi"
-user-name = "Andrew Gallant"
-
-[[publisher.regex-syntax]]
 version = "0.7.4"
 when = "2023-07-11"
 user-id = 189
@@ -1086,8 +1079,8 @@ user-login = "dtolnay"
 user-name = "David Tolnay"
 
 [[publisher.tokio]]
-version = "1.48.0"
-when = "2025-10-14"
+version = "1.51.1"
+when = "2026-04-08"
 user-id = 6741
 user-login = "Darksonn"
 user-name = "Alice Ryhl"
@@ -2184,11 +2177,6 @@ delta = "0.9.1 -> 0.9.2"
 who = "David Cook <dcook@divviup.org>"
 criteria = "safe-to-deploy"
 delta = "0.9.2 -> 0.10.0"
-
-[[audits.isrg.audits.rand_chacha]]
-who = "David Cook <dcook@divviup.org>"
-criteria = "safe-to-deploy"
-version = "0.3.1"
 
 [[audits.isrg.audits.rand_chacha]]
 who = "David Cook <dcook@divviup.org>"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -2,956 +2,236 @@
 # cargo-vet imports lock
 
 [[unpublished.cranelift]]
-version = "0.129.0"
-audited_as = "0.127.1"
-
-[[unpublished.cranelift]]
-version = "0.130.0"
-audited_as = "0.128.3"
-
-[[unpublished.cranelift]]
-version = "0.131.0"
-audited_as = "0.129.1"
-
-[[unpublished.cranelift]]
 version = "0.132.0"
-audited_as = "0.130.0"
-
-[[unpublished.cranelift-assembler-x64]]
-version = "0.129.0"
-audited_as = "0.127.1"
-
-[[unpublished.cranelift-assembler-x64]]
-version = "0.130.0"
-audited_as = "0.128.3"
-
-[[unpublished.cranelift-assembler-x64]]
-version = "0.131.0"
-audited_as = "0.129.1"
+audited_as = "0.130.1"
 
 [[unpublished.cranelift-assembler-x64]]
 version = "0.132.0"
-audited_as = "0.130.0"
-
-[[unpublished.cranelift-assembler-x64-meta]]
-version = "0.129.0"
-audited_as = "0.127.1"
-
-[[unpublished.cranelift-assembler-x64-meta]]
-version = "0.130.0"
-audited_as = "0.128.3"
-
-[[unpublished.cranelift-assembler-x64-meta]]
-version = "0.131.0"
-audited_as = "0.129.1"
+audited_as = "0.130.1"
 
 [[unpublished.cranelift-assembler-x64-meta]]
 version = "0.132.0"
-audited_as = "0.130.0"
-
-[[unpublished.cranelift-bforest]]
-version = "0.129.0"
-audited_as = "0.127.1"
-
-[[unpublished.cranelift-bforest]]
-version = "0.130.0"
-audited_as = "0.128.3"
-
-[[unpublished.cranelift-bforest]]
-version = "0.131.0"
-audited_as = "0.129.1"
+audited_as = "0.130.1"
 
 [[unpublished.cranelift-bforest]]
 version = "0.132.0"
-audited_as = "0.130.0"
-
-[[unpublished.cranelift-bitset]]
-version = "0.129.0"
-audited_as = "0.127.1"
-
-[[unpublished.cranelift-bitset]]
-version = "0.130.0"
-audited_as = "0.128.3"
-
-[[unpublished.cranelift-bitset]]
-version = "0.131.0"
-audited_as = "0.129.1"
+audited_as = "0.130.1"
 
 [[unpublished.cranelift-bitset]]
 version = "0.132.0"
-audited_as = "0.130.0"
-
-[[unpublished.cranelift-codegen]]
-version = "0.129.0"
-audited_as = "0.127.1"
-
-[[unpublished.cranelift-codegen]]
-version = "0.130.0"
-audited_as = "0.128.3"
-
-[[unpublished.cranelift-codegen]]
-version = "0.131.0"
-audited_as = "0.129.1"
+audited_as = "0.130.1"
 
 [[unpublished.cranelift-codegen]]
 version = "0.132.0"
-audited_as = "0.130.0"
-
-[[unpublished.cranelift-codegen-meta]]
-version = "0.129.0"
-audited_as = "0.127.1"
-
-[[unpublished.cranelift-codegen-meta]]
-version = "0.130.0"
-audited_as = "0.128.3"
-
-[[unpublished.cranelift-codegen-meta]]
-version = "0.131.0"
-audited_as = "0.129.1"
+audited_as = "0.130.1"
 
 [[unpublished.cranelift-codegen-meta]]
 version = "0.132.0"
-audited_as = "0.130.0"
-
-[[unpublished.cranelift-codegen-shared]]
-version = "0.129.0"
-audited_as = "0.127.1"
-
-[[unpublished.cranelift-codegen-shared]]
-version = "0.130.0"
-audited_as = "0.128.3"
-
-[[unpublished.cranelift-codegen-shared]]
-version = "0.131.0"
-audited_as = "0.129.1"
+audited_as = "0.130.1"
 
 [[unpublished.cranelift-codegen-shared]]
 version = "0.132.0"
-audited_as = "0.130.0"
-
-[[unpublished.cranelift-control]]
-version = "0.129.0"
-audited_as = "0.127.1"
-
-[[unpublished.cranelift-control]]
-version = "0.130.0"
-audited_as = "0.128.3"
-
-[[unpublished.cranelift-control]]
-version = "0.131.0"
-audited_as = "0.129.1"
+audited_as = "0.130.1"
 
 [[unpublished.cranelift-control]]
 version = "0.132.0"
-audited_as = "0.130.0"
-
-[[unpublished.cranelift-entity]]
-version = "0.129.0"
-audited_as = "0.127.1"
-
-[[unpublished.cranelift-entity]]
-version = "0.130.0"
-audited_as = "0.128.3"
-
-[[unpublished.cranelift-entity]]
-version = "0.131.0"
-audited_as = "0.129.1"
+audited_as = "0.130.1"
 
 [[unpublished.cranelift-entity]]
 version = "0.132.0"
-audited_as = "0.130.0"
-
-[[unpublished.cranelift-frontend]]
-version = "0.129.0"
-audited_as = "0.127.1"
-
-[[unpublished.cranelift-frontend]]
-version = "0.130.0"
-audited_as = "0.128.3"
-
-[[unpublished.cranelift-frontend]]
-version = "0.131.0"
-audited_as = "0.129.1"
+audited_as = "0.130.1"
 
 [[unpublished.cranelift-frontend]]
 version = "0.132.0"
-audited_as = "0.130.0"
-
-[[unpublished.cranelift-interpreter]]
-version = "0.129.0"
-audited_as = "0.127.1"
-
-[[unpublished.cranelift-interpreter]]
-version = "0.130.0"
-audited_as = "0.128.3"
-
-[[unpublished.cranelift-interpreter]]
-version = "0.131.0"
-audited_as = "0.129.1"
+audited_as = "0.130.1"
 
 [[unpublished.cranelift-interpreter]]
 version = "0.132.0"
-audited_as = "0.130.0"
-
-[[unpublished.cranelift-isle]]
-version = "0.129.0"
-audited_as = "0.127.1"
-
-[[unpublished.cranelift-isle]]
-version = "0.130.0"
-audited_as = "0.128.3"
-
-[[unpublished.cranelift-isle]]
-version = "0.131.0"
-audited_as = "0.129.1"
+audited_as = "0.130.1"
 
 [[unpublished.cranelift-isle]]
 version = "0.132.0"
-audited_as = "0.130.0"
-
-[[unpublished.cranelift-jit]]
-version = "0.129.0"
-audited_as = "0.127.1"
-
-[[unpublished.cranelift-jit]]
-version = "0.130.0"
-audited_as = "0.128.3"
-
-[[unpublished.cranelift-jit]]
-version = "0.131.0"
-audited_as = "0.129.1"
+audited_as = "0.130.1"
 
 [[unpublished.cranelift-jit]]
 version = "0.132.0"
-audited_as = "0.130.0"
-
-[[unpublished.cranelift-module]]
-version = "0.129.0"
-audited_as = "0.127.1"
-
-[[unpublished.cranelift-module]]
-version = "0.130.0"
-audited_as = "0.128.3"
-
-[[unpublished.cranelift-module]]
-version = "0.131.0"
-audited_as = "0.129.1"
+audited_as = "0.130.1"
 
 [[unpublished.cranelift-module]]
 version = "0.132.0"
-audited_as = "0.130.0"
-
-[[unpublished.cranelift-native]]
-version = "0.129.0"
-audited_as = "0.127.1"
-
-[[unpublished.cranelift-native]]
-version = "0.130.0"
-audited_as = "0.128.3"
-
-[[unpublished.cranelift-native]]
-version = "0.131.0"
-audited_as = "0.129.1"
+audited_as = "0.130.1"
 
 [[unpublished.cranelift-native]]
 version = "0.132.0"
-audited_as = "0.130.0"
-
-[[unpublished.cranelift-object]]
-version = "0.129.0"
-audited_as = "0.127.1"
-
-[[unpublished.cranelift-object]]
-version = "0.130.0"
-audited_as = "0.128.3"
-
-[[unpublished.cranelift-object]]
-version = "0.131.0"
-audited_as = "0.129.1"
+audited_as = "0.130.1"
 
 [[unpublished.cranelift-object]]
 version = "0.132.0"
-audited_as = "0.130.0"
-
-[[unpublished.cranelift-reader]]
-version = "0.129.0"
-audited_as = "0.127.1"
-
-[[unpublished.cranelift-reader]]
-version = "0.130.0"
-audited_as = "0.128.3"
-
-[[unpublished.cranelift-reader]]
-version = "0.131.0"
-audited_as = "0.129.1"
+audited_as = "0.130.1"
 
 [[unpublished.cranelift-reader]]
 version = "0.132.0"
-audited_as = "0.130.0"
-
-[[unpublished.cranelift-serde]]
-version = "0.129.0"
-audited_as = "0.127.1"
-
-[[unpublished.cranelift-serde]]
-version = "0.130.0"
-audited_as = "0.128.3"
-
-[[unpublished.cranelift-serde]]
-version = "0.131.0"
-audited_as = "0.129.1"
+audited_as = "0.130.1"
 
 [[unpublished.cranelift-serde]]
 version = "0.132.0"
-audited_as = "0.130.0"
-
-[[unpublished.cranelift-srcgen]]
-version = "0.129.0"
-audited_as = "0.127.1"
-
-[[unpublished.cranelift-srcgen]]
-version = "0.130.0"
-audited_as = "0.128.3"
-
-[[unpublished.cranelift-srcgen]]
-version = "0.131.0"
-audited_as = "0.129.1"
+audited_as = "0.130.1"
 
 [[unpublished.cranelift-srcgen]]
 version = "0.132.0"
-audited_as = "0.130.0"
-
-[[unpublished.pulley-interpreter]]
-version = "42.0.0"
-audited_as = "40.0.1"
-
-[[unpublished.pulley-interpreter]]
-version = "43.0.0"
-audited_as = "41.0.3"
-
-[[unpublished.pulley-interpreter]]
-version = "44.0.0"
-audited_as = "42.0.1"
+audited_as = "0.130.1"
 
 [[unpublished.pulley-interpreter]]
 version = "45.0.0"
-audited_as = "43.0.0"
-
-[[unpublished.pulley-macros]]
-version = "42.0.0"
-audited_as = "40.0.1"
-
-[[unpublished.pulley-macros]]
-version = "43.0.0"
-audited_as = "41.0.3"
-
-[[unpublished.pulley-macros]]
-version = "44.0.0"
-audited_as = "42.0.1"
+audited_as = "43.0.1"
 
 [[unpublished.pulley-macros]]
 version = "45.0.0"
-audited_as = "43.0.0"
-
-[[unpublished.wasi-common]]
-version = "42.0.0"
-audited_as = "40.0.1"
-
-[[unpublished.wasi-common]]
-version = "43.0.0"
-audited_as = "41.0.3"
-
-[[unpublished.wasi-common]]
-version = "44.0.0"
-audited_as = "42.0.1"
+audited_as = "43.0.1"
 
 [[unpublished.wasi-common]]
 version = "45.0.0"
-audited_as = "43.0.0"
-
-[[unpublished.wasmtime]]
-version = "42.0.0"
-audited_as = "40.0.1"
-
-[[unpublished.wasmtime]]
-version = "43.0.0"
-audited_as = "41.0.3"
-
-[[unpublished.wasmtime]]
-version = "44.0.0"
-audited_as = "42.0.1"
+audited_as = "43.0.1"
 
 [[unpublished.wasmtime]]
 version = "45.0.0"
-audited_as = "43.0.0"
-
-[[unpublished.wasmtime-cli]]
-version = "42.0.0"
-audited_as = "40.0.1"
-
-[[unpublished.wasmtime-cli]]
-version = "43.0.0"
-audited_as = "41.0.3"
-
-[[unpublished.wasmtime-cli]]
-version = "44.0.0"
-audited_as = "42.0.1"
+audited_as = "43.0.1"
 
 [[unpublished.wasmtime-cli]]
 version = "45.0.0"
-audited_as = "43.0.0"
-
-[[unpublished.wasmtime-cli-flags]]
-version = "42.0.0"
-audited_as = "40.0.1"
-
-[[unpublished.wasmtime-cli-flags]]
-version = "43.0.0"
-audited_as = "41.0.3"
-
-[[unpublished.wasmtime-cli-flags]]
-version = "44.0.0"
-audited_as = "42.0.1"
+audited_as = "43.0.1"
 
 [[unpublished.wasmtime-cli-flags]]
 version = "45.0.0"
-audited_as = "43.0.0"
-
-[[unpublished.wasmtime-environ]]
-version = "42.0.0"
-audited_as = "40.0.1"
-
-[[unpublished.wasmtime-environ]]
-version = "43.0.0"
-audited_as = "41.0.3"
-
-[[unpublished.wasmtime-environ]]
-version = "44.0.0"
-audited_as = "42.0.1"
+audited_as = "43.0.1"
 
 [[unpublished.wasmtime-environ]]
 version = "45.0.0"
-audited_as = "43.0.0"
-
-[[unpublished.wasmtime-internal-c-api-macros]]
-version = "42.0.0"
-audited_as = "40.0.1"
-
-[[unpublished.wasmtime-internal-c-api-macros]]
-version = "43.0.0"
-audited_as = "41.0.3"
-
-[[unpublished.wasmtime-internal-c-api-macros]]
-version = "44.0.0"
-audited_as = "42.0.1"
+audited_as = "43.0.1"
 
 [[unpublished.wasmtime-internal-c-api-macros]]
 version = "45.0.0"
-audited_as = "43.0.0"
-
-[[unpublished.wasmtime-internal-cache]]
-version = "42.0.0"
-audited_as = "40.0.1"
-
-[[unpublished.wasmtime-internal-cache]]
-version = "43.0.0"
-audited_as = "41.0.3"
-
-[[unpublished.wasmtime-internal-cache]]
-version = "44.0.0"
-audited_as = "42.0.1"
+audited_as = "43.0.1"
 
 [[unpublished.wasmtime-internal-cache]]
 version = "45.0.0"
-audited_as = "43.0.0"
-
-[[unpublished.wasmtime-internal-component-macro]]
-version = "42.0.0"
-audited_as = "40.0.1"
-
-[[unpublished.wasmtime-internal-component-macro]]
-version = "43.0.0"
-audited_as = "41.0.3"
-
-[[unpublished.wasmtime-internal-component-macro]]
-version = "44.0.0"
-audited_as = "42.0.1"
+audited_as = "43.0.1"
 
 [[unpublished.wasmtime-internal-component-macro]]
 version = "45.0.0"
-audited_as = "43.0.0"
-
-[[unpublished.wasmtime-internal-component-util]]
-version = "42.0.0"
-audited_as = "40.0.1"
-
-[[unpublished.wasmtime-internal-component-util]]
-version = "43.0.0"
-audited_as = "41.0.3"
-
-[[unpublished.wasmtime-internal-component-util]]
-version = "44.0.0"
-audited_as = "42.0.1"
+audited_as = "43.0.1"
 
 [[unpublished.wasmtime-internal-component-util]]
 version = "45.0.0"
-audited_as = "43.0.0"
-
-[[unpublished.wasmtime-internal-core]]
-version = "42.0.0"
-audited_as = "0.0.0"
-
-[[unpublished.wasmtime-internal-core]]
-version = "43.0.0"
-audited_as = "0.0.0"
-
-[[unpublished.wasmtime-internal-core]]
-version = "44.0.0"
-audited_as = "42.0.1"
+audited_as = "43.0.1"
 
 [[unpublished.wasmtime-internal-core]]
 version = "45.0.0"
-audited_as = "43.0.0"
-
-[[unpublished.wasmtime-internal-cranelift]]
-version = "42.0.0"
-audited_as = "40.0.1"
-
-[[unpublished.wasmtime-internal-cranelift]]
-version = "43.0.0"
-audited_as = "41.0.3"
-
-[[unpublished.wasmtime-internal-cranelift]]
-version = "44.0.0"
-audited_as = "42.0.1"
+audited_as = "43.0.1"
 
 [[unpublished.wasmtime-internal-cranelift]]
 version = "45.0.0"
-audited_as = "43.0.0"
-
-[[unpublished.wasmtime-internal-debugger]]
-version = "42.0.0"
-audited_as = "41.0.0"
-
-[[unpublished.wasmtime-internal-debugger]]
-version = "43.0.0"
-audited_as = "41.0.3"
-
-[[unpublished.wasmtime-internal-debugger]]
-version = "44.0.0"
-audited_as = "42.0.1"
+audited_as = "43.0.1"
 
 [[unpublished.wasmtime-internal-debugger]]
 version = "45.0.0"
-audited_as = "43.0.0"
-
-[[unpublished.wasmtime-internal-error]]
-version = "42.0.0"
-audited_as = "0.0.0"
-
-[[unpublished.wasmtime-internal-explorer]]
-version = "42.0.0"
-audited_as = "40.0.1"
-
-[[unpublished.wasmtime-internal-explorer]]
-version = "43.0.0"
-audited_as = "41.0.3"
-
-[[unpublished.wasmtime-internal-explorer]]
-version = "44.0.0"
-audited_as = "42.0.1"
+audited_as = "43.0.1"
 
 [[unpublished.wasmtime-internal-explorer]]
 version = "45.0.0"
-audited_as = "43.0.0"
-
-[[unpublished.wasmtime-internal-fiber]]
-version = "42.0.0"
-audited_as = "40.0.1"
-
-[[unpublished.wasmtime-internal-fiber]]
-version = "43.0.0"
-audited_as = "41.0.3"
-
-[[unpublished.wasmtime-internal-fiber]]
-version = "44.0.0"
-audited_as = "42.0.1"
+audited_as = "43.0.1"
 
 [[unpublished.wasmtime-internal-fiber]]
 version = "45.0.0"
-audited_as = "43.0.0"
-
-[[unpublished.wasmtime-internal-jit-debug]]
-version = "42.0.0"
-audited_as = "40.0.1"
-
-[[unpublished.wasmtime-internal-jit-debug]]
-version = "43.0.0"
-audited_as = "41.0.3"
-
-[[unpublished.wasmtime-internal-jit-debug]]
-version = "44.0.0"
-audited_as = "42.0.1"
+audited_as = "43.0.1"
 
 [[unpublished.wasmtime-internal-jit-debug]]
 version = "45.0.0"
-audited_as = "43.0.0"
-
-[[unpublished.wasmtime-internal-jit-icache-coherence]]
-version = "42.0.0"
-audited_as = "40.0.1"
-
-[[unpublished.wasmtime-internal-jit-icache-coherence]]
-version = "43.0.0"
-audited_as = "41.0.3"
-
-[[unpublished.wasmtime-internal-jit-icache-coherence]]
-version = "44.0.0"
-audited_as = "42.0.1"
+audited_as = "43.0.1"
 
 [[unpublished.wasmtime-internal-jit-icache-coherence]]
 version = "45.0.0"
-audited_as = "43.0.0"
-
-[[unpublished.wasmtime-internal-math]]
-version = "42.0.0"
-audited_as = "40.0.1"
-
-[[unpublished.wasmtime-internal-slab]]
-version = "42.0.0"
-audited_as = "40.0.1"
-
-[[unpublished.wasmtime-internal-unwinder]]
-version = "42.0.0"
-audited_as = "40.0.1"
-
-[[unpublished.wasmtime-internal-unwinder]]
-version = "43.0.0"
-audited_as = "41.0.3"
-
-[[unpublished.wasmtime-internal-unwinder]]
-version = "44.0.0"
-audited_as = "42.0.1"
+audited_as = "43.0.1"
 
 [[unpublished.wasmtime-internal-unwinder]]
 version = "45.0.0"
-audited_as = "43.0.0"
-
-[[unpublished.wasmtime-internal-versioned-export-macros]]
-version = "42.0.0"
-audited_as = "40.0.1"
-
-[[unpublished.wasmtime-internal-versioned-export-macros]]
-version = "43.0.0"
-audited_as = "41.0.3"
-
-[[unpublished.wasmtime-internal-versioned-export-macros]]
-version = "44.0.0"
-audited_as = "42.0.1"
+audited_as = "43.0.1"
 
 [[unpublished.wasmtime-internal-versioned-export-macros]]
 version = "45.0.0"
-audited_as = "43.0.0"
-
-[[unpublished.wasmtime-internal-winch]]
-version = "42.0.0"
-audited_as = "40.0.1"
-
-[[unpublished.wasmtime-internal-winch]]
-version = "43.0.0"
-audited_as = "41.0.3"
-
-[[unpublished.wasmtime-internal-winch]]
-version = "44.0.0"
-audited_as = "42.0.1"
+audited_as = "43.0.1"
 
 [[unpublished.wasmtime-internal-winch]]
 version = "45.0.0"
-audited_as = "43.0.0"
-
-[[unpublished.wasmtime-internal-wit-bindgen]]
-version = "42.0.0"
-audited_as = "40.0.1"
-
-[[unpublished.wasmtime-internal-wit-bindgen]]
-version = "43.0.0"
-audited_as = "41.0.3"
-
-[[unpublished.wasmtime-internal-wit-bindgen]]
-version = "44.0.0"
-audited_as = "42.0.1"
+audited_as = "43.0.1"
 
 [[unpublished.wasmtime-internal-wit-bindgen]]
 version = "45.0.0"
-audited_as = "43.0.0"
-
-[[unpublished.wasmtime-internal-wmemcheck]]
-version = "42.0.0"
-audited_as = "40.0.1"
-
-[[unpublished.wasmtime-internal-wmemcheck]]
-version = "43.0.0"
-audited_as = "41.0.3"
-
-[[unpublished.wasmtime-internal-wmemcheck]]
-version = "44.0.0"
-audited_as = "42.0.1"
+audited_as = "43.0.1"
 
 [[unpublished.wasmtime-internal-wmemcheck]]
 version = "45.0.0"
-audited_as = "43.0.0"
-
-[[unpublished.wasmtime-wasi]]
-version = "42.0.0"
-audited_as = "40.0.1"
-
-[[unpublished.wasmtime-wasi]]
-version = "43.0.0"
-audited_as = "41.0.3"
-
-[[unpublished.wasmtime-wasi]]
-version = "44.0.0"
-audited_as = "42.0.1"
+audited_as = "43.0.1"
 
 [[unpublished.wasmtime-wasi]]
 version = "45.0.0"
-audited_as = "43.0.0"
-
-[[unpublished.wasmtime-wasi-config]]
-version = "42.0.0"
-audited_as = "40.0.1"
-
-[[unpublished.wasmtime-wasi-config]]
-version = "43.0.0"
-audited_as = "41.0.3"
-
-[[unpublished.wasmtime-wasi-config]]
-version = "44.0.0"
-audited_as = "42.0.1"
+audited_as = "43.0.1"
 
 [[unpublished.wasmtime-wasi-config]]
 version = "45.0.0"
-audited_as = "43.0.0"
-
-[[unpublished.wasmtime-wasi-http]]
-version = "42.0.0"
-audited_as = "40.0.1"
-
-[[unpublished.wasmtime-wasi-http]]
-version = "43.0.0"
-audited_as = "41.0.3"
-
-[[unpublished.wasmtime-wasi-http]]
-version = "44.0.0"
-audited_as = "42.0.1"
+audited_as = "43.0.1"
 
 [[unpublished.wasmtime-wasi-http]]
 version = "45.0.0"
-audited_as = "43.0.0"
-
-[[unpublished.wasmtime-wasi-io]]
-version = "42.0.0"
-audited_as = "40.0.1"
-
-[[unpublished.wasmtime-wasi-io]]
-version = "43.0.0"
-audited_as = "41.0.3"
-
-[[unpublished.wasmtime-wasi-io]]
-version = "44.0.0"
-audited_as = "42.0.1"
+audited_as = "43.0.1"
 
 [[unpublished.wasmtime-wasi-io]]
 version = "45.0.0"
-audited_as = "43.0.0"
-
-[[unpublished.wasmtime-wasi-keyvalue]]
-version = "42.0.0"
-audited_as = "40.0.1"
-
-[[unpublished.wasmtime-wasi-keyvalue]]
-version = "43.0.0"
-audited_as = "41.0.3"
-
-[[unpublished.wasmtime-wasi-keyvalue]]
-version = "44.0.0"
-audited_as = "42.0.1"
+audited_as = "43.0.1"
 
 [[unpublished.wasmtime-wasi-keyvalue]]
 version = "45.0.0"
-audited_as = "43.0.0"
-
-[[unpublished.wasmtime-wasi-nn]]
-version = "42.0.0"
-audited_as = "40.0.1"
-
-[[unpublished.wasmtime-wasi-nn]]
-version = "43.0.0"
-audited_as = "41.0.3"
-
-[[unpublished.wasmtime-wasi-nn]]
-version = "44.0.0"
-audited_as = "42.0.1"
+audited_as = "43.0.1"
 
 [[unpublished.wasmtime-wasi-nn]]
 version = "45.0.0"
-audited_as = "43.0.0"
-
-[[unpublished.wasmtime-wasi-threads]]
-version = "42.0.0"
-audited_as = "40.0.1"
-
-[[unpublished.wasmtime-wasi-threads]]
-version = "43.0.0"
-audited_as = "41.0.3"
-
-[[unpublished.wasmtime-wasi-threads]]
-version = "44.0.0"
-audited_as = "42.0.1"
+audited_as = "43.0.1"
 
 [[unpublished.wasmtime-wasi-threads]]
 version = "45.0.0"
-audited_as = "43.0.0"
-
-[[unpublished.wasmtime-wasi-tls]]
-version = "42.0.0"
-audited_as = "40.0.1"
-
-[[unpublished.wasmtime-wasi-tls]]
-version = "43.0.0"
-audited_as = "41.0.3"
-
-[[unpublished.wasmtime-wasi-tls]]
-version = "44.0.0"
-audited_as = "42.0.1"
+audited_as = "43.0.1"
 
 [[unpublished.wasmtime-wasi-tls]]
 version = "45.0.0"
-audited_as = "43.0.0"
-
-[[unpublished.wasmtime-wasi-tls-nativetls]]
-version = "42.0.0"
-audited_as = "40.0.1"
-
-[[unpublished.wasmtime-wasi-tls-nativetls]]
-version = "43.0.0"
-audited_as = "41.0.3"
-
-[[unpublished.wasmtime-wasi-tls-nativetls]]
-version = "44.0.0"
-audited_as = "42.0.1"
-
-[[unpublished.wasmtime-wasi-tls-openssl]]
-version = "42.0.0"
-audited_as = "0.0.1"
-
-[[unpublished.wasmtime-wasi-tls-openssl]]
-version = "43.0.0"
-audited_as = "0.0.1"
-
-[[unpublished.wasmtime-wasi-tls-openssl]]
-version = "44.0.0"
-audited_as = "42.0.1"
-
-[[unpublished.wasmtime-wast]]
-version = "42.0.0"
-audited_as = "40.0.1"
-
-[[unpublished.wasmtime-wast]]
-version = "43.0.0"
-audited_as = "41.0.3"
-
-[[unpublished.wasmtime-wast]]
-version = "44.0.0"
-audited_as = "42.0.1"
+audited_as = "43.0.1"
 
 [[unpublished.wasmtime-wast]]
 version = "45.0.0"
-audited_as = "43.0.0"
-
-[[unpublished.wasmtime-wizer]]
-version = "42.0.0"
-audited_as = "40.0.1"
-
-[[unpublished.wasmtime-wizer]]
-version = "43.0.0"
-audited_as = "41.0.3"
-
-[[unpublished.wasmtime-wizer]]
-version = "44.0.0"
-audited_as = "42.0.1"
+audited_as = "43.0.1"
 
 [[unpublished.wasmtime-wizer]]
 version = "45.0.0"
-audited_as = "43.0.0"
-
-[[unpublished.wiggle]]
-version = "42.0.0"
-audited_as = "40.0.1"
-
-[[unpublished.wiggle]]
-version = "43.0.0"
-audited_as = "41.0.3"
-
-[[unpublished.wiggle]]
-version = "44.0.0"
-audited_as = "42.0.1"
+audited_as = "43.0.1"
 
 [[unpublished.wiggle]]
 version = "45.0.0"
-audited_as = "43.0.0"
-
-[[unpublished.wiggle-generate]]
-version = "42.0.0"
-audited_as = "40.0.1"
-
-[[unpublished.wiggle-generate]]
-version = "43.0.0"
-audited_as = "41.0.3"
-
-[[unpublished.wiggle-generate]]
-version = "44.0.0"
-audited_as = "42.0.1"
+audited_as = "43.0.1"
 
 [[unpublished.wiggle-generate]]
 version = "45.0.0"
-audited_as = "43.0.0"
-
-[[unpublished.wiggle-macro]]
-version = "42.0.0"
-audited_as = "40.0.1"
-
-[[unpublished.wiggle-macro]]
-version = "43.0.0"
-audited_as = "41.0.3"
-
-[[unpublished.wiggle-macro]]
-version = "44.0.0"
-audited_as = "42.0.1"
+audited_as = "43.0.1"
 
 [[unpublished.wiggle-macro]]
 version = "45.0.0"
-audited_as = "43.0.0"
+audited_as = "43.0.1"
 
 [[unpublished.wiggle-test]]
 version = "0.0.0"
 audited_as = "0.1.0"
 
 [[unpublished.winch-codegen]]
-version = "42.0.0"
-audited_as = "40.0.1"
-
-[[unpublished.winch-codegen]]
-version = "43.0.0"
-audited_as = "41.0.3"
-
-[[unpublished.winch-codegen]]
-version = "44.0.0"
-audited_as = "42.0.1"
-
-[[unpublished.winch-codegen]]
 version = "45.0.0"
-audited_as = "43.0.0"
+audited_as = "43.0.1"
 
 [[publisher.aho-corasick]]
 version = "1.0.2"
@@ -1163,103 +443,103 @@ user-login = "jrmuizel"
 user-name = "Jeff Muizelaar"
 
 [[publisher.cranelift]]
-version = "0.130.0"
-when = "2026-03-20"
+version = "0.130.1"
+when = "2026-04-09"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-assembler-x64]]
-version = "0.130.0"
-when = "2026-03-20"
+version = "0.130.1"
+when = "2026-04-09"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-assembler-x64-meta]]
-version = "0.130.0"
-when = "2026-03-20"
+version = "0.130.1"
+when = "2026-04-09"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-bforest]]
-version = "0.130.0"
-when = "2026-03-20"
+version = "0.130.1"
+when = "2026-04-09"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-bitset]]
-version = "0.130.0"
-when = "2026-03-20"
+version = "0.130.1"
+when = "2026-04-09"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-codegen]]
-version = "0.130.0"
-when = "2026-03-20"
+version = "0.130.1"
+when = "2026-04-09"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-codegen-meta]]
-version = "0.130.0"
-when = "2026-03-20"
+version = "0.130.1"
+when = "2026-04-09"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-codegen-shared]]
-version = "0.130.0"
-when = "2026-03-20"
+version = "0.130.1"
+when = "2026-04-09"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-control]]
-version = "0.130.0"
-when = "2026-03-20"
+version = "0.130.1"
+when = "2026-04-09"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-entity]]
-version = "0.130.0"
-when = "2026-03-20"
+version = "0.130.1"
+when = "2026-04-09"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-frontend]]
-version = "0.130.0"
-when = "2026-03-20"
+version = "0.130.1"
+when = "2026-04-09"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-interpreter]]
-version = "0.130.0"
-when = "2026-03-20"
+version = "0.130.1"
+when = "2026-04-09"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-isle]]
-version = "0.130.0"
-when = "2026-03-20"
+version = "0.130.1"
+when = "2026-04-09"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-jit]]
-version = "0.130.0"
-when = "2026-03-20"
+version = "0.130.1"
+when = "2026-04-09"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-module]]
-version = "0.130.0"
-when = "2026-03-20"
+version = "0.130.1"
+when = "2026-04-09"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-native]]
-version = "0.130.0"
-when = "2026-03-20"
+version = "0.130.1"
+when = "2026-04-09"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-object]]
-version = "0.130.0"
-when = "2026-03-20"
+version = "0.130.1"
+when = "2026-04-09"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-reader]]
-version = "0.130.0"
-when = "2026-03-20"
+version = "0.130.1"
+when = "2026-04-09"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-serde]]
-version = "0.130.0"
-when = "2026-03-20"
+version = "0.130.1"
+when = "2026-04-09"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-srcgen]]
-version = "0.130.0"
-when = "2026-03-20"
+version = "0.130.1"
+when = "2026-04-09"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.derive_arbitrary]]
@@ -1380,6 +660,12 @@ when = "2025-11-20"
 user-id = 55123
 user-login = "rust-lang-owner"
 
+[[publisher.hashbrown]]
+version = "0.17.0"
+when = "2026-04-09"
+user-id = 55123
+user-login = "rust-lang-owner"
+
 [[publisher.http]]
 version = "1.3.1"
 when = "2025-03-11"
@@ -1423,8 +709,8 @@ user-login = "fitzgen"
 user-name = "Nick Fitzgerald"
 
 [[publisher.indexmap]]
-version = "2.13.0"
-when = "2026-01-07"
+version = "2.14.0"
+when = "2026-04-09"
 user-id = 539
 user-login = "cuviper"
 user-name = "Josh Stone"
@@ -1573,13 +859,13 @@ user-login = "dtolnay"
 user-name = "David Tolnay"
 
 [[publisher.pulley-interpreter]]
-version = "43.0.0"
-when = "2026-03-20"
+version = "43.0.1"
+when = "2026-04-09"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.pulley-macros]]
-version = "43.0.0"
-when = "2026-03-20"
+version = "43.0.1"
+when = "2026-04-09"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.quote]]
@@ -1707,13 +993,6 @@ when = "2025-10-09"
 user-id = 6743
 user-login = "epage"
 user-name = "Ed Page"
-
-[[publisher.serde_yaml]]
-version = "0.9.34+deprecated"
-when = "2024-03-25"
-user-id = 3618
-user-login = "dtolnay"
-user-name = "David Tolnay"
 
 [[publisher.slab]]
 version = "0.4.11"
@@ -1869,13 +1148,6 @@ user-id = 1139
 user-login = "Manishearth"
 user-name = "Manish Goregaokar"
 
-[[publisher.unsafe-libyaml]]
-version = "0.2.11"
-when = "2024-03-17"
-user-id = 3618
-user-login = "dtolnay"
-user-name = "David Tolnay"
-
 [[publisher.utf8_iter]]
 version = "1.0.4"
 when = "2023-12-01"
@@ -1905,8 +1177,8 @@ user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
 [[publisher.wasi-common]]
-version = "43.0.0"
-when = "2026-03-20"
+version = "43.0.1"
+when = "2026-04-09"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasip1]]
@@ -2012,153 +1284,153 @@ when = "2026-04-03"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
 [[publisher.wasmtime]]
-version = "43.0.0"
-when = "2026-03-20"
+version = "43.0.1"
+when = "2026-04-09"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-cli]]
-version = "43.0.0"
-when = "2026-03-20"
+version = "43.0.1"
+when = "2026-04-09"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-cli-flags]]
-version = "43.0.0"
-when = "2026-03-20"
+version = "43.0.1"
+when = "2026-04-09"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-environ]]
-version = "43.0.0"
-when = "2026-03-20"
+version = "43.0.1"
+when = "2026-04-09"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-c-api-macros]]
-version = "43.0.0"
-when = "2026-03-20"
+version = "43.0.1"
+when = "2026-04-09"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-cache]]
-version = "43.0.0"
-when = "2026-03-20"
+version = "43.0.1"
+when = "2026-04-09"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-component-macro]]
-version = "43.0.0"
-when = "2026-03-20"
+version = "43.0.1"
+when = "2026-04-09"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-component-util]]
-version = "43.0.0"
-when = "2026-03-20"
+version = "43.0.1"
+when = "2026-04-09"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-core]]
-version = "43.0.0"
-when = "2026-03-20"
+version = "43.0.1"
+when = "2026-04-09"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-cranelift]]
-version = "43.0.0"
-when = "2026-03-20"
+version = "43.0.1"
+when = "2026-04-09"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-debugger]]
-version = "43.0.0"
-when = "2026-03-20"
+version = "43.0.1"
+when = "2026-04-09"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-explorer]]
-version = "43.0.0"
-when = "2026-03-20"
+version = "43.0.1"
+when = "2026-04-09"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-fiber]]
-version = "43.0.0"
-when = "2026-03-20"
+version = "43.0.1"
+when = "2026-04-09"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-jit-debug]]
-version = "43.0.0"
-when = "2026-03-20"
+version = "43.0.1"
+when = "2026-04-09"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-jit-icache-coherence]]
-version = "43.0.0"
-when = "2026-03-20"
+version = "43.0.1"
+when = "2026-04-09"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-unwinder]]
-version = "43.0.0"
-when = "2026-03-20"
+version = "43.0.1"
+when = "2026-04-09"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-versioned-export-macros]]
-version = "43.0.0"
-when = "2026-03-20"
+version = "43.0.1"
+when = "2026-04-09"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-winch]]
-version = "43.0.0"
-when = "2026-03-20"
+version = "43.0.1"
+when = "2026-04-09"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-wit-bindgen]]
-version = "43.0.0"
-when = "2026-03-20"
+version = "43.0.1"
+when = "2026-04-09"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-wmemcheck]]
-version = "43.0.0"
-when = "2026-03-20"
+version = "43.0.1"
+when = "2026-04-09"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wasi]]
-version = "43.0.0"
-when = "2026-03-20"
+version = "43.0.1"
+when = "2026-04-09"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wasi-config]]
-version = "43.0.0"
-when = "2026-03-20"
+version = "43.0.1"
+when = "2026-04-09"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wasi-http]]
-version = "43.0.0"
-when = "2026-03-20"
+version = "43.0.1"
+when = "2026-04-09"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wasi-io]]
-version = "43.0.0"
-when = "2026-03-20"
+version = "43.0.1"
+when = "2026-04-09"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wasi-keyvalue]]
-version = "43.0.0"
-when = "2026-03-20"
+version = "43.0.1"
+when = "2026-04-09"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wasi-nn]]
-version = "43.0.0"
-when = "2026-03-20"
+version = "43.0.1"
+when = "2026-04-09"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wasi-threads]]
-version = "43.0.0"
-when = "2026-03-20"
+version = "43.0.1"
+when = "2026-04-09"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wasi-tls]]
-version = "43.0.0"
-when = "2026-03-20"
+version = "43.0.1"
+when = "2026-04-09"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wast]]
-version = "43.0.0"
-when = "2026-03-20"
+version = "43.0.1"
+when = "2026-04-09"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wizer]]
-version = "43.0.0"
-when = "2026-03-20"
+version = "43.0.1"
+when = "2026-04-09"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wast]]
@@ -2172,18 +1444,18 @@ when = "2026-04-03"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
 [[publisher.wiggle]]
-version = "43.0.0"
-when = "2026-03-20"
+version = "43.0.1"
+when = "2026-04-09"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wiggle-generate]]
-version = "43.0.0"
-when = "2026-03-20"
+version = "43.0.1"
+when = "2026-04-09"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wiggle-macro]]
-version = "43.0.0"
-when = "2026-03-20"
+version = "43.0.1"
+when = "2026-04-09"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wiggle-test]]
@@ -2201,8 +1473,8 @@ user-login = "BurntSushi"
 user-name = "Andrew Gallant"
 
 [[publisher.winch-codegen]]
-version = "43.0.0"
-when = "2026-03-20"
+version = "43.0.1"
+when = "2026-04-09"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.windows]]
@@ -2521,12 +1793,6 @@ criteria = "safe-to-deploy"
 version = "0.1.0"
 notes = "No unsafe usage or ambient capabilities, sane build script"
 
-[[audits.embark-studios.audits.vec_map]]
-who = "Johan Andersson <opensource@embark-studios.com>"
-criteria = "safe-to-deploy"
-version = "0.8.2"
-notes = "No unsafe usage or ambient capabilities"
-
 [[audits.google.audits.addr2line]]
 who = "George Burgess IV <gbiv@google.com>"
 criteria = "safe-to-run"
@@ -2618,12 +1884,6 @@ delta = "0.2.9 -> 0.2.13"
 notes = "Audited at https://fxrev.dev/946396"
 aggregated-from = "https://fuchsia.googlesource.com/fuchsia/+/refs/heads/main/third_party/rust_crates/supply-chain/audits.toml?format=TEXT"
 
-[[audits.google.audits.proc-macro-error-attr]]
-who = "George Burgess IV <gbiv@google.com>"
-criteria = "safe-to-deploy"
-version = "1.0.4"
-aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
-
 [[audits.google.audits.rand]]
 who = "Lukasz Anforowicz <lukasza@chromium.org>"
 criteria = "safe-to-deploy"
@@ -2632,12 +1892,6 @@ notes = """
 For more detailed unsafe review notes please see https://crrev.com/c/6362797
 """
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.rand_chacha]]
-who = "Android Legacy"
-criteria = "safe-to-run"
-version = "0.3.1"
-aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
 
 [[audits.google.audits.rand_core]]
 who = "Lukasz Anforowicz <lukasza@chromium.org>"
@@ -2882,11 +2136,6 @@ delta = "0.9.2 -> 0.10.0"
 who = "David Cook <dcook@divviup.org>"
 criteria = "safe-to-deploy"
 version = "0.3.1"
-
-[[audits.isrg.audits.rand_chacha]]
-who = "David Cook <dcook@divviup.org>"
-criteria = "safe-to-deploy"
-delta = "0.3.1 -> 0.9.0"
 
 [[audits.isrg.audits.rand_core]]
 who = "David Cook <dcook@divviup.org>"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -297,8 +297,8 @@ user-login = "dtolnay"
 user-name = "David Tolnay"
 
 [[publisher.backtrace]]
-version = "0.3.75"
-when = "2025-05-06"
+version = "0.3.76"
+when = "2025-09-26"
 user-id = 55123
 user-login = "rust-lang-owner"
 
@@ -641,8 +641,8 @@ user-login = "philipc"
 user-name = "Philip Craig"
 
 [[publisher.h2]]
-version = "0.4.4"
-when = "2024-04-03"
+version = "0.4.13"
+when = "2026-01-05"
 user-id = 359
 user-login = "seanmonstar"
 user-name = "Sean McArthur"
@@ -695,8 +695,8 @@ user-login = "seanmonstar"
 user-name = "Sean McArthur"
 
 [[publisher.hyper]]
-version = "1.7.0"
-when = "2025-08-18"
+version = "1.9.0"
+when = "2026-03-31"
 user-id = 359
 user-login = "seanmonstar"
 user-name = "Sean McArthur"
@@ -770,8 +770,8 @@ when = "2026-04-03"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
 [[publisher.libc]]
-version = "0.2.177"
-when = "2025-10-09"
+version = "0.2.185"
+when = "2026-04-13"
 user-id = 55123
 user-login = "rust-lang-owner"
 
@@ -789,8 +789,8 @@ user-login = "sunfishcode"
 user-name = "Dan Gohman"
 
 [[publisher.linux-raw-sys]]
-version = "0.9.4"
-when = "2025-04-09"
+version = "0.12.1"
+when = "2025-12-23"
 user-id = 6825
 user-login = "sunfishcode"
 user-name = "Dan Gohman"
@@ -808,6 +808,13 @@ when = "2025-09-25"
 user-id = 189
 user-login = "BurntSushi"
 user-name = "Andrew Gallant"
+
+[[publisher.mio]]
+version = "1.2.0"
+when = "2026-03-27"
+user-id = 6025
+user-login = "Thomasdezeeuw"
+user-name = "Thomas de Zeeuw"
 
 [[publisher.num_cpus]]
 version = "1.17.0"
@@ -876,8 +883,8 @@ user-login = "dtolnay"
 user-name = "David Tolnay"
 
 [[publisher.regalloc2]]
-version = "0.15.0"
-when = "2026-02-17"
+version = "0.15.1"
+when = "2026-04-15"
 user-id = 3726
 user-login = "cfallin"
 user-name = "Chris Fallin"
@@ -932,8 +939,8 @@ user-login = "sunfishcode"
 user-name = "Dan Gohman"
 
 [[publisher.rustix]]
-version = "1.0.8"
-when = "2025-07-15"
+version = "1.1.4"
+when = "2026-02-22"
 user-id = 6825
 user-login = "sunfishcode"
 user-name = "Dan Gohman"
@@ -1000,6 +1007,13 @@ when = "2025-08-08"
 user-id = 6741
 user-login = "Darksonn"
 user-name = "Alice Ryhl"
+
+[[publisher.socket2]]
+version = "0.6.3"
+when = "2026-03-06"
+user-id = 6025
+user-login = "Thomasdezeeuw"
+user-name = "Thomas de Zeeuw"
 
 [[publisher.syn]]
 version = "1.0.92"
@@ -1074,6 +1088,13 @@ user-name = "David Tolnay"
 [[publisher.tokio]]
 version = "1.48.0"
 when = "2025-10-14"
+user-id = 6741
+user-login = "Darksonn"
+user-name = "Alice Ryhl"
+
+[[publisher.tokio-macros]]
+version = "2.7.0"
+when = "2026-04-03"
 user-id = 6741
 user-login = "Darksonn"
 user-name = "Alice Ryhl"
@@ -1893,6 +1914,15 @@ For more detailed unsafe review notes please see https://crrev.com/c/6362797
 """
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
+[[audits.google.audits.rand_chacha]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+version = "0.3.1"
+notes = """
+For more detailed unsafe review notes please see https://crrev.com/c/6362797
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
 [[audits.google.audits.rand_core]]
 who = "Lukasz Anforowicz <lukasza@chromium.org>"
 criteria = "safe-to-deploy"
@@ -1927,13 +1957,6 @@ criteria = "safe-to-deploy"
 version = "1.13.2"
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
-[[audits.google.audits.socket2]]
-who = "David Koloski <dkoloski@google.com>"
-criteria = "safe-to-deploy"
-delta = "0.4.4 -> 0.5.5"
-notes = "Reviewed at https://fxrev.dev/946307"
-aggregated-from = "https://fuchsia.googlesource.com/fuchsia/+/refs/heads/main/third_party/rust_crates/supply-chain/audits.toml?format=TEXT"
-
 [[audits.google.audits.stable_deref_trait]]
 who = "Manish Goregaokar <manishearth@google.com>"
 criteria = "safe-to-deploy"
@@ -1963,6 +1986,11 @@ who = "George Burgess IV <gbiv@google.com>"
 criteria = "safe-to-deploy"
 version = "0.9.4"
 aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.isrg.audits.alloca]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-run"
+version = "0.4.0"
 
 [[audits.isrg.audits.base64]]
 who = "Tim Geoghegan <timg@letsencrypt.org>"
@@ -2025,10 +2053,30 @@ who = "David Cook <dcook@divviup.org>"
 criteria = "safe-to-run"
 delta = "0.6.0 -> 0.7.0"
 
-[[audits.isrg.audits.criterion-plot]]
+[[audits.isrg.audits.criterion]]
 who = "David Cook <dcook@divviup.org>"
 criteria = "safe-to-run"
-delta = "0.5.0 -> 0.6.0"
+delta = "0.7.0 -> 0.8.0"
+
+[[audits.isrg.audits.criterion]]
+who = "J.C. Jones <jc@divviup.org>"
+criteria = "safe-to-run"
+delta = "0.8.0 -> 0.8.1"
+
+[[audits.isrg.audits.criterion]]
+who = "J.C. Jones <jc@divviup.org>"
+criteria = "safe-to-run"
+delta = "0.8.1 -> 0.8.2"
+
+[[audits.isrg.audits.criterion-plot]]
+who = "J.C. Jones <jc@divviup.org>"
+criteria = "safe-to-run"
+version = "0.8.1"
+
+[[audits.isrg.audits.criterion-plot]]
+who = "J.C. Jones <jc@divviup.org>"
+criteria = "safe-to-run"
+delta = "0.8.1 -> 0.8.2"
 
 [[audits.isrg.audits.crunchy]]
 who = "David Cook <dcook@divviup.org>"
@@ -2117,6 +2165,11 @@ who = "Brandon Pitman <bran@bran.land>"
 criteria = "safe-to-deploy"
 delta = "1.18.0 -> 1.19.0"
 
+[[audits.isrg.audits.page_size]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-run"
+version = "0.6.0"
+
 [[audits.isrg.audits.rand]]
 who = "David Cook <dcook@divviup.org>"
 criteria = "safe-to-deploy"
@@ -2136,6 +2189,11 @@ delta = "0.9.2 -> 0.10.0"
 who = "David Cook <dcook@divviup.org>"
 criteria = "safe-to-deploy"
 version = "0.3.1"
+
+[[audits.isrg.audits.rand_chacha]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "0.3.1 -> 0.9.0"
 
 [[audits.isrg.audits.rand_core]]
 who = "David Cook <dcook@divviup.org>"
@@ -2267,11 +2325,41 @@ version = "0.5.2"
 notes = "Another crate I own via contain-rs that is ancient and maintenance mode, no known issues."
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
+[[audits.mozilla.audits.bit-set]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "0.5.2 -> 0.5.3"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.bit-set]]
+who = "Teodor Tanasoaia <ttanasoaia@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.5.3 -> 0.6.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.bit-set]]
+who = "Jim Blandy <jimb@red-bean.com>"
+criteria = "safe-to-deploy"
+delta = "0.6.0 -> 0.8.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
 [[audits.mozilla.audits.bit-vec]]
 who = "Aria Beingessner <a.beingessner@gmail.com>"
 criteria = "safe-to-deploy"
 version = "0.6.3"
 notes = "Another crate I own via contain-rs that is ancient and in maintenance mode but otherwise perfectly fine."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.bit-vec]]
+who = "Teodor Tanasoaia <ttanasoaia@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.6.3 -> 0.7.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.bit-vec]]
+who = "Jim Blandy <jimb@red-bean.com>"
+criteria = "safe-to-deploy"
+delta = "0.7.0 -> 0.8.0"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.bitflags]]
@@ -2313,6 +2401,12 @@ who = [
 ]
 criteria = "safe-to-deploy"
 delta = "2.6.0 -> 2.7.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.bitflags]]
+who = "Benjamin VanderSloot <bvandersloot@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "2.9.4 -> 2.10.0"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.cc]]
@@ -2990,12 +3084,6 @@ criteria = "safe-to-deploy"
 delta = "1.14.0 -> 1.15.1"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
-[[audits.mozilla.audits.socket2]]
-who = "Kershaw Chang <kershaw@mozilla.com>"
-criteria = "safe-to-deploy"
-delta = "0.5.5 -> 0.5.7"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
 [[audits.mozilla.audits.strsim]]
 who = "Ben Dean-Kawamura <bdk@mozilla.com>"
 criteria = "safe-to-deploy"
@@ -3058,10 +3146,10 @@ notes = "Big change, but nothing unsafe and lots of it is documentation and conv
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.tempfile]]
-who = "Nika Layzell <nika@thelayzells.com>"
+who = "Jim Blandy <jimb@red-bean.com>"
 criteria = "safe-to-deploy"
-delta = "3.19.1 -> 3.20.0"
-aggregated-from = "https://raw.githubusercontent.com/mozilla/cargo-vet/main/supply-chain/audits.toml"
+delta = "3.16.0 -> 3.27.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.time-core]]
 who = "Kershaw Chang <kershaw@mozilla.com>"


### PR DESCRIPTION
Dual of bytecodealliance/wasm-tools#2487, but for Wasmtime.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
