### PR TITLE
chore: remove unnecessary clone when deriving output path

### DIFF
--- a/src/commands/explore.rs
+++ b/src/commands/explore.rs
@@ -41,7 +41,6 @@ impl ExploreCommand {
 
         let output = self
             .output
-            .clone()
             .unwrap_or_else(|| self.module.with_extension("explore.html"));
         let output_file = std::fs::File::create(&output)
             .with_context(|| format!("failed to create file: {}", output.display()))?;


### PR DESCRIPTION
Removes an unnecessary .clone() when deriving the default output path in the explore command. self.output is not used after this point, so moving it directly avoids an extra allocation without changing behavior.