### PR TITLE
Implement the semi-space copying garbage collector

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,7 +97,7 @@ rustix = { workspace = true, features = ["mm", "process"] }
 
 [dev-dependencies]
 # depend again on wasmtime to activate its default features for tests
-wasmtime = { workspace = true, features = ['default', 'anyhow', 'winch', 'pulley', 'all-arch', 'call-hook', 'memory-protection-keys', 'component-model-async', 'component-model-async-bytes'] }
+wasmtime = { workspace = true, features = ['default', 'anyhow', 'winch', 'pulley', 'all-arch', 'call-hook', 'memory-protection-keys', 'component-model-async', 'component-model-async-bytes', 'gc-copying'] }
 env_logger = { workspace = true }
 log = { workspace = true }
 filecheck = { workspace = true }

--- a/crates/cranelift/src/func_environ/gc/enabled.rs
+++ b/crates/cranelift/src/func_environ/gc/enabled.rs
@@ -106,10 +106,7 @@ fn unbarriered_store_gc_ref(
 }
 
 /// Emit CLIF to call the `gc_raw_alloc` libcall.
-#[cfg_attr(
-    not(any(feature = "gc-drc", feature = "gc-copying")),
-    expect(dead_code, reason = "easier to define")
-)]
+#[cfg(any(feature = "gc-drc", feature = "gc-copying"))]
 fn emit_gc_raw_alloc(
     func_env: &mut FuncEnvironment<'_>,
     builder: &mut FunctionBuilder<'_>,

--- a/crates/cranelift/src/func_environ/gc/enabled.rs
+++ b/crates/cranelift/src/func_environ/gc/enabled.rs
@@ -72,7 +72,7 @@ pub fn gc_compiler(func_env: &mut FuncEnvironment<'_>) -> WasmResult<Box<dyn GcC
 }
 
 #[cfg_attr(
-    not(feature = "gc-drc"),
+    not(any(feature = "gc-drc", feature = "gc-copying")),
     expect(dead_code, reason = "easier to define")
 )]
 fn unbarriered_load_gc_ref(
@@ -90,7 +90,7 @@ fn unbarriered_load_gc_ref(
 }
 
 #[cfg_attr(
-    not(any(feature = "gc-drc", feature = "gc-null")),
+    not(any(feature = "gc-drc", feature = "gc-null", feature = "gc-copying")),
     expect(dead_code, reason = "easier to define")
 )]
 fn unbarriered_store_gc_ref(
@@ -103,6 +103,40 @@ fn unbarriered_store_gc_ref(
     debug_assert!(ty.is_vmgcref_type());
     builder.ins().store(flags, gc_ref, dst, 0);
     Ok(())
+}
+
+/// Emit CLIF to call the `gc_raw_alloc` libcall.
+#[cfg_attr(
+    not(any(feature = "gc-drc", feature = "gc-copying")),
+    expect(dead_code, reason = "easier to define")
+)]
+fn emit_gc_raw_alloc(
+    func_env: &mut FuncEnvironment<'_>,
+    builder: &mut FunctionBuilder<'_>,
+    kind: VMGcKind,
+    ty: ModuleInternedTypeIndex,
+    size: ir::Value,
+    align: u32,
+) -> ir::Value {
+    let gc_alloc_raw_builtin = func_env.builtin_functions.gc_alloc_raw(builder.func);
+    let vmctx = func_env.vmctx_val(&mut builder.cursor());
+
+    let kind = builder
+        .ins()
+        .iconst(ir::types::I32, i64::from(kind.as_u32()));
+
+    let ty = func_env.module_interned_to_shared_ty(&mut builder.cursor(), ty);
+
+    assert!(align.is_power_of_two());
+    let align = builder.ins().iconst(ir::types::I32, i64::from(align));
+
+    let call_inst = builder
+        .ins()
+        .call(gc_alloc_raw_builtin, &[vmctx, kind, ty, size, align]);
+
+    let gc_ref = builder.func.dfg.first_result(call_inst);
+    builder.declare_value_needs_stack_map(gc_ref);
+    gc_ref
 }
 
 /// Emit inline CLIF code that asserts an object's `VMGcKind` matches the
@@ -645,7 +679,7 @@ pub fn translate_array_new_fixed(
 impl ArrayInit<'_> {
     /// Get the length (as an `i32`-typed `ir::Value`) of these array elements.
     #[cfg_attr(
-        not(any(feature = "gc-drc", feature = "gc-null")),
+        not(any(feature = "gc-drc", feature = "gc-null", feature = "gc-copying")),
         expect(dead_code, reason = "easier to define")
     )]
     fn len(self, pos: &mut FuncCursor) -> ir::Value {
@@ -660,7 +694,7 @@ impl ArrayInit<'_> {
 
     /// Initialize a newly-allocated array's elements.
     #[cfg_attr(
-        not(any(feature = "gc-drc", feature = "gc-null")),
+        not(any(feature = "gc-drc", feature = "gc-null", feature = "gc-copying")),
         expect(dead_code, reason = "easier to define")
     )]
     fn initialize(
@@ -1333,7 +1367,7 @@ fn uextend_i32_to_pointer_type(
 ///
 /// Traps if the size overflows.
 #[cfg_attr(
-    not(any(feature = "gc-drc", feature = "gc-null")),
+    not(any(feature = "gc-drc", feature = "gc-null", feature = "gc-copying")),
     expect(dead_code, reason = "easier to define")
 )]
 fn emit_array_size(
@@ -1381,7 +1415,7 @@ fn emit_array_size(
 /// Common helper for struct-field initialization that can be reused across
 /// collectors.
 #[cfg_attr(
-    not(any(feature = "gc-drc", feature = "gc-null")),
+    not(any(feature = "gc-drc", feature = "gc-null", feature = "gc-copying")),
     expect(dead_code, reason = "easier to define")
 )]
 fn initialize_struct_fields(
@@ -1483,7 +1517,7 @@ impl FuncEnvironment<'_> {
     }
 
     /// Get the GC heap's base.
-    #[cfg(any(feature = "gc-null", feature = "gc-drc"))]
+    #[cfg(any(feature = "gc-null", feature = "gc-drc", feature = "gc-copying"))]
     fn get_gc_heap_base(&mut self, builder: &mut FunctionBuilder) -> ir::Value {
         let global = self.get_gc_heap_base_global(&mut builder.func);
         builder.ins().global_value(self.pointer_type(), global)

--- a/crates/cranelift/src/func_environ/gc/enabled/copying.rs
+++ b/crates/cranelift/src/func_environ/gc/enabled/copying.rs
@@ -1,20 +1,69 @@
-//! Compiler for the copying collector.
+//! Compiler for the copying (semi-space/Cheney) collector.
 //!
-//! This is a skeleton implementation that is not yet functional. All methods
-//! return `WasmError::Unsupported` errors.
+//! Allocation is performed via the `gc_alloc_raw` libcall (not inlined) for
+//! now. Read and write barriers are unnecessary (e.g. no reference counting and
+//! no concurrent mutation during collection) but we do need stack maps so the
+//! collector can find and update roots when it relocates objects.
 
 use super::*;
+use crate::TRAP_INTERNAL_ASSERT;
 use crate::func_environ::FuncEnvironment;
-use cranelift_codegen::ir;
+use crate::translate::TargetEnvironment;
+use cranelift_codegen::ir::{self, InstBuilder};
 use cranelift_frontend::FunctionBuilder;
+use smallvec::SmallVec;
+use wasmtime_environ::copying::{EXCEPTION_TAG_DEFINED_OFFSET, EXCEPTION_TAG_INSTANCE_OFFSET};
 use wasmtime_environ::{
-    GcTypeLayouts, TypeIndex, WasmRefType, WasmResult, copying::CopyingTypeLayouts,
-    wasm_unsupported,
+    GcTypeLayouts, TypeIndex, VMGcKind, WasmHeapTopType, WasmHeapType, WasmRefType, WasmResult,
+    WasmStorageType, WasmValType, copying::CopyingTypeLayouts,
 };
 
 #[derive(Default)]
 pub struct CopyingCompiler {
     layouts: CopyingTypeLayouts,
+}
+
+impl CopyingCompiler {
+    fn init_field(
+        &mut self,
+        func_env: &mut FuncEnvironment<'_>,
+        builder: &mut FunctionBuilder<'_>,
+        field_addr: ir::Value,
+        ty: WasmStorageType,
+        val: ir::Value,
+    ) -> WasmResult<()> {
+        // Data inside GC objects is always little endian.
+        let flags = ir::MemFlags::trusted().with_endianness(ir::Endianness::Little);
+
+        match ty {
+            WasmStorageType::Val(WasmValType::Ref(r)) => match r.heap_type.top() {
+                WasmHeapTopType::Func => {
+                    write_func_ref_at_addr(func_env, builder, r, flags, field_addr, val)?
+                }
+                WasmHeapTopType::Extern | WasmHeapTopType::Any | WasmHeapTopType::Exn => {
+                    // No init barrier needed for the copying collector; just
+                    // store the reference directly.
+                    unbarriered_store_gc_ref(builder, r.heap_type, field_addr, val, flags)?;
+                }
+                WasmHeapTopType::Cont => return super::stack_switching_unsupported(),
+            },
+            WasmStorageType::I8 => {
+                assert_eq!(builder.func.dfg.value_type(val), ir::types::I32);
+                builder.ins().istore8(flags, val, field_addr, 0);
+            }
+            WasmStorageType::I16 => {
+                assert_eq!(builder.func.dfg.value_type(val), ir::types::I32);
+                builder.ins().istore16(flags, val, field_addr, 0);
+            }
+            WasmStorageType::Val(_) => {
+                let size_of_access = wasmtime_environ::byte_size_of_wasm_ty_in_gc_heap(&ty);
+                assert_eq!(builder.func.dfg.value_type(val).bytes(), size_of_access);
+                builder.ins().store(flags, val, field_addr, 0);
+            }
+        }
+
+        Ok(())
+    }
 }
 
 impl GcCompiler for CopyingCompiler {
@@ -24,66 +73,225 @@ impl GcCompiler for CopyingCompiler {
 
     fn alloc_array(
         &mut self,
-        _func_env: &mut FuncEnvironment<'_>,
-        _builder: &mut FunctionBuilder<'_>,
-        _array_type_index: TypeIndex,
-        _init: super::ArrayInit<'_>,
+        func_env: &mut FuncEnvironment<'_>,
+        builder: &mut FunctionBuilder<'_>,
+        array_type_index: TypeIndex,
+        init: super::ArrayInit<'_>,
     ) -> WasmResult<ir::Value> {
-        Err(wasm_unsupported!(
-            "copying collector is not yet implemented"
-        ))
+        let interned_type_index =
+            func_env.module.types[array_type_index].unwrap_module_type_index();
+        let ptr_ty = func_env.pointer_type();
+
+        let len_offset = gc_compiler(func_env)?.layouts().array_length_field_offset();
+        let array_layout = func_env.array_layout(interned_type_index).clone();
+        let base_size = array_layout.base_size;
+        let align = array_layout.align;
+        let len_to_elems_delta = base_size.checked_sub(len_offset).unwrap();
+
+        // First, compute the array's total size.
+        let len = init.len(&mut builder.cursor());
+        let size = emit_array_size(func_env, builder, &array_layout, len);
+
+        // Allocate via libcall.
+        let array_ref = emit_gc_raw_alloc(
+            func_env,
+            builder,
+            VMGcKind::ArrayRef,
+            interned_type_index,
+            size,
+            align,
+        );
+
+        // Write the array's length.
+        let base = func_env.get_gc_heap_base(builder);
+        let extended_array_ref =
+            uextend_i32_to_pointer_type(builder, func_env.pointer_type(), array_ref);
+        let object_addr = builder.ins().iadd(base, extended_array_ref);
+        let len_addr = builder.ins().iadd_imm(object_addr, i64::from(len_offset));
+        let len = init.len(&mut builder.cursor());
+        builder
+            .ins()
+            .store(ir::MemFlags::trusted(), len, len_addr, 0);
+
+        // Initialize elements.
+        let len_to_elems_delta = builder.ins().iconst(ptr_ty, i64::from(len_to_elems_delta));
+        let elems_addr = builder.ins().iadd(len_addr, len_to_elems_delta);
+        init.initialize(
+            func_env,
+            builder,
+            interned_type_index,
+            base_size,
+            size,
+            elems_addr,
+            |func_env, builder, elem_ty, elem_addr, val| {
+                self.init_field(func_env, builder, elem_addr, elem_ty, val)
+            },
+        )?;
+        Ok(array_ref)
     }
 
     fn alloc_struct(
         &mut self,
-        _func_env: &mut FuncEnvironment<'_>,
-        _builder: &mut FunctionBuilder<'_>,
-        _struct_type_index: TypeIndex,
-        _field_vals: &[ir::Value],
+        func_env: &mut FuncEnvironment<'_>,
+        builder: &mut FunctionBuilder<'_>,
+        struct_type_index: TypeIndex,
+        field_vals: &[ir::Value],
     ) -> WasmResult<ir::Value> {
-        Err(wasm_unsupported!(
-            "copying collector is not yet implemented"
-        ))
+        let interned_type_index =
+            func_env.module.types[struct_type_index].unwrap_module_type_index();
+        let struct_layout = func_env.struct_or_exn_layout(interned_type_index);
+
+        let struct_size = struct_layout.size;
+        let struct_align = struct_layout.align;
+        let field_offsets: SmallVec<[_; 8]> = struct_layout.fields.iter().copied().collect();
+        assert_eq!(field_vals.len(), field_offsets.len());
+
+        let struct_size_val = builder.ins().iconst(ir::types::I32, i64::from(struct_size));
+
+        let struct_ref = emit_gc_raw_alloc(
+            func_env,
+            builder,
+            VMGcKind::StructRef,
+            interned_type_index,
+            struct_size_val,
+            struct_align,
+        );
+
+        // Initialize fields.
+        let base = func_env.get_gc_heap_base(builder);
+        let extended_struct_ref =
+            uextend_i32_to_pointer_type(builder, func_env.pointer_type(), struct_ref);
+        let raw_ptr_to_struct = builder.ins().iadd(base, extended_struct_ref);
+        initialize_struct_fields(
+            func_env,
+            builder,
+            interned_type_index,
+            raw_ptr_to_struct,
+            field_vals,
+            |func_env, builder, ty, field_addr, val| {
+                self.init_field(func_env, builder, field_addr, ty, val)
+            },
+        )?;
+
+        Ok(struct_ref)
     }
 
     fn alloc_exn(
         &mut self,
-        _func_env: &mut FuncEnvironment<'_>,
-        _builder: &mut FunctionBuilder<'_>,
-        _tag_index: TagIndex,
-        _field_vals: &[ir::Value],
-        _instance_id: ir::Value,
-        _tag: ir::Value,
+        func_env: &mut FuncEnvironment<'_>,
+        builder: &mut FunctionBuilder<'_>,
+        tag_index: TagIndex,
+        field_vals: &[ir::Value],
+        instance_id: ir::Value,
+        tag: ir::Value,
     ) -> WasmResult<ir::Value> {
-        Err(wasm_unsupported!(
-            "copying collector is not yet implemented"
-        ))
+        let interned_type_index = func_env.module.tags[tag_index]
+            .exception
+            .unwrap_module_type_index();
+        let exn_layout = func_env.struct_or_exn_layout(interned_type_index);
+
+        let exn_size = exn_layout.size;
+        let exn_align = exn_layout.align;
+        let field_offsets: SmallVec<[_; 8]> = exn_layout.fields.iter().copied().collect();
+        assert_eq!(field_vals.len(), field_offsets.len());
+
+        let exn_size_val = builder.ins().iconst(ir::types::I32, i64::from(exn_size));
+
+        let exn_ref = emit_gc_raw_alloc(
+            func_env,
+            builder,
+            VMGcKind::ExnRef,
+            interned_type_index,
+            exn_size_val,
+            exn_align,
+        );
+
+        // Initialize fields.
+        let base = func_env.get_gc_heap_base(builder);
+        let extended_exn_ref =
+            uextend_i32_to_pointer_type(builder, func_env.pointer_type(), exn_ref);
+        let raw_ptr_to_exn = builder.ins().iadd(base, extended_exn_ref);
+        initialize_struct_fields(
+            func_env,
+            builder,
+            interned_type_index,
+            raw_ptr_to_exn,
+            field_vals,
+            |func_env, builder, ty, field_addr, val| {
+                self.init_field(func_env, builder, field_addr, ty, val)
+            },
+        )?;
+
+        // Initialize tag fields.
+        let instance_id_addr = builder
+            .ins()
+            .iadd_imm(raw_ptr_to_exn, i64::from(EXCEPTION_TAG_INSTANCE_OFFSET));
+        self.init_field(
+            func_env,
+            builder,
+            instance_id_addr,
+            WasmStorageType::Val(WasmValType::I32),
+            instance_id,
+        )?;
+        let tag_addr = builder
+            .ins()
+            .iadd_imm(raw_ptr_to_exn, i64::from(EXCEPTION_TAG_DEFINED_OFFSET));
+        self.init_field(
+            func_env,
+            builder,
+            tag_addr,
+            WasmStorageType::Val(WasmValType::I32),
+            tag,
+        )?;
+
+        Ok(exn_ref)
     }
 
     fn translate_read_gc_reference(
         &mut self,
-        _func_env: &mut FuncEnvironment<'_>,
-        _builder: &mut FunctionBuilder,
-        _ty: WasmRefType,
-        _src: ir::Value,
-        _flags: ir::MemFlags,
+        func_env: &mut FuncEnvironment<'_>,
+        builder: &mut FunctionBuilder,
+        ty: WasmRefType,
+        src: ir::Value,
+        flags: ir::MemFlags,
     ) -> WasmResult<ir::Value> {
-        Err(wasm_unsupported!(
-            "copying collector is not yet implemented"
-        ))
+        assert!(ty.is_vmgcref_type());
+
+        let (reference_type, _) = func_env.reference_type(ty.heap_type);
+
+        // Special case for references to uninhabited bottom types.
+        if let WasmHeapType::None = ty.heap_type {
+            let null = builder.ins().iconst(reference_type, 0);
+            if flags.trap_code().is_some() {
+                let _ = builder.ins().load(reference_type, flags, src, 0);
+            }
+            if !ty.nullable {
+                let zero = builder.ins().iconst(ir::types::I32, 0);
+                builder.ins().trapz(zero, TRAP_INTERNAL_ASSERT);
+            }
+            return Ok(null);
+        };
+
+        // Special case for `i31` references: they don't need stack maps.
+        if let WasmHeapType::I31 = ty.heap_type {
+            return unbarriered_load_gc_ref(builder, ty.heap_type, src, flags);
+        }
+
+        // No read barrier needed for the copying collector, but we do need
+        // stack maps so the collector can find and relocate roots.
+        unbarriered_load_gc_ref(builder, ty.heap_type, src, flags)
     }
 
     fn translate_write_gc_reference(
         &mut self,
         _func_env: &mut FuncEnvironment<'_>,
-        _builder: &mut FunctionBuilder,
-        _ty: WasmRefType,
-        _dst: ir::Value,
-        _new_val: ir::Value,
-        _flags: ir::MemFlags,
+        builder: &mut FunctionBuilder,
+        ty: WasmRefType,
+        dst: ir::Value,
+        new_val: ir::Value,
+        flags: ir::MemFlags,
     ) -> WasmResult<()> {
-        Err(wasm_unsupported!(
-            "copying collector is not yet implemented"
-        ))
+        // No write barrier needed for the copying collector.
+        unbarriered_store_gc_ref(builder, ty.heap_type, dst, new_val, flags)
     }
 }

--- a/crates/cranelift/src/func_environ/gc/enabled/drc.rs
+++ b/crates/cranelift/src/func_environ/gc/enabled/drc.rs
@@ -11,8 +11,8 @@ use cranelift_frontend::FunctionBuilder;
 use smallvec::SmallVec;
 use wasmtime_environ::drc::{EXCEPTION_TAG_DEFINED_OFFSET, EXCEPTION_TAG_INSTANCE_OFFSET};
 use wasmtime_environ::{
-    GcTypeLayouts, ModuleInternedTypeIndex, PtrSize, TypeIndex, VMGcKind, WasmHeapTopType,
-    WasmHeapType, WasmRefType, WasmResult, WasmStorageType, WasmValType, drc::DrcTypeLayouts,
+    GcTypeLayouts, PtrSize, TypeIndex, VMGcKind, WasmHeapTopType, WasmHeapType, WasmRefType,
+    WasmResult, WasmStorageType, WasmValType, drc::DrcTypeLayouts,
 };
 
 #[derive(Default)]
@@ -346,36 +346,6 @@ impl DrcCompiler {
 
         Ok(())
     }
-}
-
-/// Emit CLIF to call the `gc_raw_alloc` libcall.
-fn emit_gc_raw_alloc(
-    func_env: &mut FuncEnvironment<'_>,
-    builder: &mut FunctionBuilder<'_>,
-    kind: VMGcKind,
-    ty: ModuleInternedTypeIndex,
-    size: ir::Value,
-    align: u32,
-) -> ir::Value {
-    let gc_alloc_raw_builtin = func_env.builtin_functions.gc_alloc_raw(builder.func);
-    let vmctx = func_env.vmctx_val(&mut builder.cursor());
-
-    let kind = builder
-        .ins()
-        .iconst(ir::types::I32, i64::from(kind.as_u32()));
-
-    let ty = func_env.module_interned_to_shared_ty(&mut builder.cursor(), ty);
-
-    assert!(align.is_power_of_two());
-    let align = builder.ins().iconst(ir::types::I32, i64::from(align));
-
-    let call_inst = builder
-        .ins()
-        .call(gc_alloc_raw_builtin, &[vmctx, kind, ty, size, align]);
-
-    let gc_ref = builder.func.dfg.first_result(call_inst);
-    builder.declare_value_needs_stack_map(gc_ref);
-    gc_ref
 }
 
 impl GcCompiler for DrcCompiler {

--- a/crates/environ/src/builtin.rs
+++ b/crates/environ/src/builtin.rs
@@ -82,7 +82,7 @@ macro_rules! foreach_builtin_function {
 
             // Allocate a new, uninitialized GC object and return a reference to
             // it.
-            #[cfg(feature = "gc-drc")]
+            #[cfg(any(feature = "gc-drc", feature = "gc-copying"))]
             gc_alloc_raw(
                 vmctx: vmctx,
                 kind: u32,

--- a/crates/environ/src/gc/copying.rs
+++ b/crates/environ/src/gc/copying.rs
@@ -1,12 +1,19 @@
 //! Layout of Wasm GC objects in the copying garbage collector.
 
 use super::*;
+use core::mem;
 
 /// The size of the `VMCopyingHeader` header for GC objects.
-pub const HEADER_SIZE: u32 = 8;
+///
+/// Note: This is 16 (not 12) because `VMGcHeader` has `align(8)`, so the
+/// `repr(C)` struct has 4 bytes of trailing padding after the `object_size`
+/// field.
+pub const HEADER_SIZE: u32 = 16;
 
-/// The align of the `VMCopyingHeader` header for GC objects.
-pub const HEADER_ALIGN: u32 = 8;
+/// The alignment of all GC objects in the copying collector.
+///
+/// All objects and all layouts must be a multiple of this alignment.
+pub const ALIGN: u32 = 16;
 
 /// The offset of the length field in a `VMCopyingArrayHeader`.
 pub const ARRAY_LENGTH_OFFSET: u32 = HEADER_SIZE;
@@ -16,6 +23,25 @@ pub const EXCEPTION_TAG_INSTANCE_OFFSET: u32 = HEADER_SIZE;
 
 /// The offset of the tag-defined-index field in an exception header.
 pub const EXCEPTION_TAG_DEFINED_OFFSET: u32 = HEADER_SIZE + 4;
+
+/// The bit within a `VMCopyingHeader`'s reserved bits that represents whether,
+/// during a collection, the object has already been copied into the new
+/// semi-space.
+pub const HEADER_COPIED_BIT: u32 = 1 << 0;
+
+/// The offset within this GC object, which must have the `HEADER_COPIED_BIT`
+/// set and must reside within the old semi-space, where the new copy of this
+/// object is located within the new semi-space.
+pub const FORWARDING_REF_OFFSET: u32 = HEADER_SIZE;
+
+/// The minimum object size: every object must have enough room for the
+/// forwarding reference that the copying collector writes during collection.
+pub const MIN_OBJECT_SIZE: u32 = FORWARDING_REF_OFFSET + mem::size_of::<u32>() as u32;
+
+/// Round `size` up to a multiple of `ALIGN`.
+fn align_up(size: u32) -> u32 {
+    (size + ALIGN - 1) & !(ALIGN - 1)
+}
 
 /// The layout of Wasm GC objects in the copying collector.
 #[derive(Default)]
@@ -35,14 +61,33 @@ impl GcTypeLayouts for CopyingTypeLayouts {
     }
 
     fn array_layout(&self, ty: &WasmArrayType) -> GcArrayLayout {
-        common_array_layout(ty, HEADER_SIZE, HEADER_ALIGN, ARRAY_LENGTH_OFFSET)
+        let mut layout = common_array_layout(ty, HEADER_SIZE, ALIGN, ARRAY_LENGTH_OFFSET);
+        debug_assert!(layout.align <= ALIGN);
+        layout.align = ALIGN;
+        debug_assert!(layout.base_size >= MIN_OBJECT_SIZE);
+        layout
     }
 
     fn struct_layout(&self, ty: &WasmStructType) -> GcStructLayout {
-        common_struct_layout(ty, HEADER_SIZE, HEADER_ALIGN)
+        let mut layout = common_struct_layout(ty, HEADER_SIZE, ALIGN);
+        // Ensure there is always space for the forwarding reference, even if
+        // the struct has no fields.
+        if layout.size < MIN_OBJECT_SIZE {
+            layout.size = MIN_OBJECT_SIZE;
+        }
+        layout.size = align_up(layout.size);
+        debug_assert!(layout.align <= ALIGN);
+        layout.align = ALIGN;
+        debug_assert!(layout.size >= MIN_OBJECT_SIZE);
+        layout
     }
 
     fn exn_layout(&self, ty: &WasmExnType) -> GcStructLayout {
-        common_exn_layout(ty, HEADER_SIZE, HEADER_ALIGN)
+        let mut layout = common_exn_layout(ty, HEADER_SIZE, ALIGN);
+        layout.size = align_up(layout.size);
+        debug_assert!(layout.align <= ALIGN);
+        layout.align = ALIGN;
+        debug_assert!(layout.size >= MIN_OBJECT_SIZE);
+        layout
     }
 }

--- a/crates/environ/src/gc/copying.rs
+++ b/crates/environ/src/gc/copying.rs
@@ -38,11 +38,6 @@ pub const FORWARDING_REF_OFFSET: u32 = HEADER_SIZE;
 /// forwarding reference that the copying collector writes during collection.
 pub const MIN_OBJECT_SIZE: u32 = FORWARDING_REF_OFFSET + mem::size_of::<u32>() as u32;
 
-/// Round `size` up to a multiple of `ALIGN`.
-fn align_up(size: u32) -> u32 {
-    (size + ALIGN - 1) & !(ALIGN - 1)
-}
-
 /// The layout of Wasm GC objects in the copying collector.
 #[derive(Default)]
 pub struct CopyingTypeLayouts;
@@ -75,7 +70,7 @@ impl GcTypeLayouts for CopyingTypeLayouts {
         if layout.size < MIN_OBJECT_SIZE {
             layout.size = MIN_OBJECT_SIZE;
         }
-        layout.size = align_up(layout.size);
+        layout.size = layout.size.next_multiple_of(ALIGN);
         debug_assert!(layout.align <= ALIGN);
         layout.align = ALIGN;
         debug_assert!(layout.size >= MIN_OBJECT_SIZE);
@@ -84,7 +79,7 @@ impl GcTypeLayouts for CopyingTypeLayouts {
 
     fn exn_layout(&self, ty: &WasmExnType) -> GcStructLayout {
         let mut layout = common_exn_layout(ty, HEADER_SIZE, ALIGN);
-        layout.size = align_up(layout.size);
+        layout.size = layout.size.next_multiple_of(ALIGN);
         debug_assert!(layout.align <= ALIGN);
         layout.align = ALIGN;
         debug_assert!(layout.size >= MIN_OBJECT_SIZE);

--- a/crates/fuzzing/Cargo.toml
+++ b/crates/fuzzing/Cargo.toml
@@ -28,7 +28,7 @@ tempfile = "3.3.0"
 wasmparser = { workspace = true }
 wasmprinter = { workspace = true }
 wasmtime-wast = { workspace = true, features = ['component-model'] }
-wasmtime = { workspace = true, features = ['default', 'winch'] }
+wasmtime = { workspace = true, features = ['default', 'winch', 'gc-copying'] }
 wasmtime-core = { workspace = true, features = ['backtrace', 'serde'] }
 wasm-encoder = { workspace = true }
 wasm-smith = { workspace = true, features = ['serde'] }

--- a/crates/fuzzing/src/generators/config.rs
+++ b/crates/fuzzing/src/generators/config.rs
@@ -256,6 +256,7 @@ impl Config {
                 Collector::DeferredReferenceCounting => {
                     wasmtime_test_util::wast::Collector::DeferredReferenceCounting
                 }
+                Collector::Copying => wasmtime_test_util::wast::Collector::Copying,
             },
             pooling: matches!(
                 self.wasmtime.strategy,
@@ -975,6 +976,7 @@ impl Arbitrary<'_> for CompilerStrategy {
 pub enum Collector {
     DeferredReferenceCounting,
     Null,
+    Copying,
 }
 
 impl Collector {
@@ -982,6 +984,7 @@ impl Collector {
         match self {
             Collector::DeferredReferenceCounting => wasmtime::Collector::DeferredReferenceCounting,
             Collector::Null => wasmtime::Collector::Null,
+            Collector::Copying => wasmtime::Collector::Copying,
         }
     }
 }

--- a/crates/fuzzing/src/generators/config.rs
+++ b/crates/fuzzing/src/generators/config.rs
@@ -261,6 +261,7 @@ impl Config {
                 Collector::DeferredReferenceCounting => {
                     wasmtime_test_util::wast::Collector::DeferredReferenceCounting
                 }
+                Collector::Copying => wasmtime_test_util::wast::Collector::Copying,
             },
             pooling: matches!(
                 self.wasmtime.strategy,
@@ -953,6 +954,7 @@ impl Arbitrary<'_> for CompilerStrategy {
 pub enum Collector {
     DeferredReferenceCounting,
     Null,
+    Copying,
 }
 
 impl Collector {
@@ -960,6 +962,7 @@ impl Collector {
         match self {
             Collector::DeferredReferenceCounting => wasmtime::Collector::DeferredReferenceCounting,
             Collector::Null => wasmtime::Collector::Null,
+            Collector::Copying => wasmtime::Collector::Copying,
         }
     }
 }

--- a/crates/wasmtime/src/engine.rs
+++ b/crates/wasmtime/src/engine.rs
@@ -1003,7 +1003,7 @@ impl Engine {
 }
 
 /// A weak reference to an [`Engine`].
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct EngineWeak {
     inner: alloc::sync::Weak<EngineInner>,
 }

--- a/crates/wasmtime/src/engine.rs
+++ b/crates/wasmtime/src/engine.rs
@@ -1007,7 +1007,7 @@ impl Engine {
 }
 
 /// A weak reference to an [`Engine`].
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct EngineWeak {
     inner: alloc::sync::Weak<EngineInner>,
 }

--- a/crates/wasmtime/src/runtime/store.rs
+++ b/crates/wasmtime/src/runtime/store.rs
@@ -2084,7 +2084,7 @@ impl StoreOpaque {
 
     /// Returns a mutable reference to the GC store if it has been allocated.
     #[inline]
-    #[cfg(feature = "gc-drc")]
+    #[cfg(any(feature = "gc-drc", feature = "gc-copying"))]
     pub(crate) fn try_gc_store_mut(&mut self) -> Option<&mut GcStore> {
         self.gc_store.as_mut()
     }

--- a/crates/wasmtime/src/runtime/store.rs
+++ b/crates/wasmtime/src/runtime/store.rs
@@ -2103,7 +2103,7 @@ impl StoreOpaque {
 
     /// Returns a mutable reference to the GC store if it has been allocated.
     #[inline]
-    #[cfg(feature = "gc-drc")]
+    #[cfg(any(feature = "gc-drc", feature = "gc-copying"))]
     pub(crate) fn try_gc_store_mut(&mut self) -> Option<&mut GcStore> {
         self.gc_store.as_mut()
     }

--- a/crates/wasmtime/src/runtime/store/gc.rs
+++ b/crates/wasmtime/src/runtime/store/gc.rs
@@ -69,7 +69,7 @@ impl StoreOpaque {
                     u64::try_from(gc.last_post_gc_allocated_bytes.unwrap_or(0)).unwrap()
                 }))
         {
-            let _ = self.grow_gc_heap(limiter, n).await;
+            let _ = self.grow_gc_heap(limiter, n, asyncness).await;
         }
     }
 
@@ -80,9 +80,27 @@ impl StoreOpaque {
         &mut self,
         limiter: Option<&mut StoreResourceLimiter<'_>>,
         bytes_needed: u64,
+        asyncness: Asyncness,
     ) -> Result<()> {
         log::trace!("Attempting to grow the GC heap by {bytes_needed} bytes");
         assert!(bytes_needed > 0);
+
+        // If the GC heap needs a collection before growth (e.g. the copying
+        // collector's active space is the second half), do a GC first.
+        if self
+            .gc_store
+            .as_ref()
+            .map_or(false, |gc| gc.gc_heap.needs_gc_before_next_growth())
+        {
+            self.do_gc(asyncness).await;
+            debug_assert!(
+                !self
+                    .gc_store
+                    .as_ref()
+                    .map_or(false, |gc| gc.gc_heap.needs_gc_before_next_growth()),
+                "needs_gc_before_next_growth should return false after a GC"
+            );
+        }
 
         let page_size = self.engine().tunables().gc_heap_memory_type().page_size();
 
@@ -222,7 +240,8 @@ impl StoreOpaque {
                                     // from `alloc_func` below if
                                     // growth failed and failure to
                                     // grow was fatal.
-                                    let _ = self.grow_gc_heap(limiter, bytes_needed).await;
+                                    let _ =
+                                        self.grow_gc_heap(limiter, bytes_needed, asyncness).await;
                                     alloc_func(self, value)
                                 }
                                 Err(e) => Err(e),
@@ -234,7 +253,7 @@ impl StoreOpaque {
                         // Ignore error; we'll get one from
                         // `alloc_func` below if growth failed and
                         // failure to grow was fatal.
-                        let _ = self.grow_gc_heap(limiter, bytes_needed).await;
+                        let _ = self.grow_gc_heap(limiter, bytes_needed, asyncness).await;
                         alloc_func(self, value)
                     }
                 }

--- a/crates/wasmtime/src/runtime/store/gc.rs
+++ b/crates/wasmtime/src/runtime/store/gc.rs
@@ -69,7 +69,7 @@ impl StoreOpaque {
                     u64::try_from(gc.last_post_gc_allocated_bytes.unwrap_or(0)).unwrap()
                 }))
         {
-            let _ = self.grow_gc_heap(limiter, n).await;
+            let _ = self.grow_gc_heap(limiter, n, asyncness).await;
         }
     }
 
@@ -80,10 +80,28 @@ impl StoreOpaque {
         &mut self,
         limiter: Option<&mut StoreResourceLimiter<'_>>,
         bytes_needed: u64,
+        asyncness: Asyncness,
     ) -> Result<()> {
         log::trace!("Attempting to grow the GC heap by {bytes_needed} bytes");
         if bytes_needed == 0 {
             return Ok(());
+        }
+
+        // If the GC heap needs a collection before growth (e.g. the copying
+        // collector's active space is the second half), do a GC first.
+        if self
+            .gc_store
+            .as_ref()
+            .map_or(false, |gc| gc.gc_heap.needs_gc_before_next_growth())
+        {
+            self.do_gc(asyncness).await;
+            debug_assert!(
+                !self
+                    .gc_store
+                    .as_ref()
+                    .map_or(false, |gc| gc.gc_heap.needs_gc_before_next_growth()),
+                "needs_gc_before_next_growth should return false after a GC"
+            );
         }
 
         let page_size = self.engine().tunables().gc_heap_memory_type().page_size();
@@ -230,7 +248,8 @@ impl StoreOpaque {
                                     // from `alloc_func` below if
                                     // growth failed and failure to
                                     // grow was fatal.
-                                    let _ = self.grow_gc_heap(limiter, bytes_needed).await;
+                                    let _ =
+                                        self.grow_gc_heap(limiter, bytes_needed, asyncness).await;
                                     alloc_func(self, value)
                                 }
                                 Err(e) => Err(e),
@@ -242,7 +261,7 @@ impl StoreOpaque {
                         // Ignore error; we'll get one from
                         // `alloc_func` below if growth failed and
                         // failure to grow was fatal.
-                        let _ = self.grow_gc_heap(limiter, bytes_needed).await;
+                        let _ = self.grow_gc_heap(limiter, bytes_needed, asyncness).await;
                         alloc_func(self, value)
                     }
                 }

--- a/crates/wasmtime/src/runtime/store/gc.rs
+++ b/crates/wasmtime/src/runtime/store/gc.rs
@@ -60,9 +60,6 @@ impl StoreOpaque {
         log::trace!("collect_and_maybe_grow_gc_heap(bytes_needed = {bytes_needed:#x?})");
         self.do_gc(asyncness).await;
         if let Some(n) = bytes_needed
-            // The gc_zeal's allocation counter will pass `bytes_needed == 0` to
-            // signify that we shouldn't grow the GC heap, just do a collection.
-            && n > 0
             && n > u64::try_from(self.gc_heap_capacity())
                 .unwrap()
                 .saturating_sub(self.gc_store.as_ref().map_or(0, |gc| {
@@ -83,6 +80,7 @@ impl StoreOpaque {
         asyncness: Asyncness,
     ) -> Result<()> {
         log::trace!("Attempting to grow the GC heap by {bytes_needed} bytes");
+
         if bytes_needed == 0 {
             return Ok(());
         }
@@ -194,6 +192,12 @@ impl StoreOpaque {
         }
     }
 
+    fn reset_gc_zeal_alloc_counter(&mut self) {
+        if let Some(gc_store) = &mut self.gc_store {
+            gc_store.reset_gc_zeal_alloc_counter();
+        }
+    }
+
     /// Attempt an allocation, if it fails due to GC OOM, apply the
     /// grow-or-collect heuristic and retry.
     ///
@@ -213,6 +217,7 @@ impl StoreOpaque {
         T: Send + Sync + 'static,
     {
         self.ensure_gc_store(limiter.as_deref_mut()).await?;
+
         match alloc_func(self, value) {
             Ok(x) => Ok(x),
             Err(e) => match e.downcast::<crate::GcHeapOutOfMemory<T>>() {
@@ -222,21 +227,22 @@ impl StoreOpaque {
                     let (value, oom) = oom.take_inner();
                     let bytes_needed = oom.bytes_needed();
 
-                    // Determine whether to collect or grow first.
-                    let should_collect_first =
-                        // The gc zeal infrastructure will use `bytes_needed =
-                        // 0` to trigger extra collections.
-                        bytes_needed == 0
-                        || self.gc_store.as_ref().map_or(false, |gc_store| {
-                            let capacity = gc_store.gc_heap_capacity();
-                            let last_usage = gc_store.last_post_gc_allocated_bytes.unwrap_or(0);
-                            last_usage < capacity / 2
-                        });
+                    let gc_heap_capacity = self
+                        .gc_store
+                        .as_ref()
+                        .map_or(0, |gc_store| gc_store.gc_heap_capacity());
+                    let last_gc_heap_usage = self.gc_store.as_ref().map_or(0, |gc_store| {
+                        gc_store.last_post_gc_allocated_bytes.unwrap_or(0)
+                    });
 
-                    if should_collect_first {
-                        // Collect first, then retry.
+                    if should_collect_first(bytes_needed, gc_heap_capacity, last_gc_heap_usage) {
+                        log::trace!(
+                            "Collecting first, then retrying; growing GC heap if collecting didn't \
+                             free up enough space, then retrying again"
+                        );
                         self.gc(limiter.as_deref_mut(), None, None, asyncness).await;
 
+                        self.reset_gc_zeal_alloc_counter();
                         match alloc_func(self, value) {
                             Ok(x) => Ok(x),
                             Err(e) => match e.downcast::<crate::GcHeapOutOfMemory<T>>() {
@@ -244,29 +250,138 @@ impl StoreOpaque {
                                     // Collection wasn't enough; grow and try
                                     // one final time.
                                     let (value, _) = oom2.take_inner();
-                                    // Ignore error; we'll get one
-                                    // from `alloc_func` below if
-                                    // growth failed and failure to
-                                    // grow was fatal.
+                                    // Ignore error; we'll get one from
+                                    // `alloc_func` below if growth failed and
+                                    // failure to grow was fatal.
                                     let _ =
                                         self.grow_gc_heap(limiter, bytes_needed, asyncness).await;
+
+                                    self.reset_gc_zeal_alloc_counter();
                                     alloc_func(self, value)
                                 }
                                 Err(e) => Err(e),
                             },
                         }
                     } else {
-                        // Grow first and retry.
-                        //
-                        // Ignore error; we'll get one from
-                        // `alloc_func` below if growth failed and
-                        // failure to grow was fatal.
-                        let _ = self.grow_gc_heap(limiter, bytes_needed, asyncness).await;
+                        log::trace!(
+                            "Grow GC heap first, collecting if growth failed, then retrying"
+                        );
+
+                        if let Err(e) = self
+                            .grow_gc_heap(limiter.as_deref_mut(), bytes_needed.max(1), asyncness)
+                            .await
+                        {
+                            log::trace!("growing GC heap failed: {e}");
+                            self.gc(limiter, None, None, asyncness).await;
+                        }
+
+                        self.reset_gc_zeal_alloc_counter();
                         alloc_func(self, value)
                     }
                 }
                 Err(e) => Err(e),
             },
         }
+    }
+}
+
+/// Given that we've hit a `GcHeapOutOfMemory` error, should we try freeing up
+/// space by collecting first or by growing the GC heap first?
+///
+/// * `bytes_needed`: the number of bytes the mutator wants to allocate
+///
+/// * `gc_heap_capacity`: The current size of the GC heap.
+///
+/// * `last_gc_heap_usage`: The precise GC heap usage after the last collection.
+#[track_caller]
+fn should_collect_first(
+    bytes_needed: u64,
+    gc_heap_capacity: usize,
+    last_gc_heap_usage: usize,
+) -> bool {
+    debug_assert!(last_gc_heap_usage <= gc_heap_capacity);
+
+    // If we haven't allocated the GC heap yet, there's nothing to collect.
+    //
+    // Make sure to grow in this scenario even when the GC zeal infrastructure
+    // passes `bytes_needed = 0`. This way our retry-after-gc logic doesn't
+    // auto-fail on its second attempt, which would be bad because it doesn't
+    // necessarily retry more than once.
+    if gc_heap_capacity == 0 {
+        return false;
+    }
+
+    // The GC zeal infrastructure will use `bytes_needed = 0` to trigger extra
+    // collections.
+    if bytes_needed == 0 {
+        return true;
+    }
+
+    let Ok(bytes_needed) = usize::try_from(bytes_needed) else {
+        // No point wasting time on collection if we will never be able to
+        // satisfy the allocation.
+        return false;
+    };
+
+    if bytes_needed > isize::MAX.cast_unsigned() {
+        // Similarly, no allocation can be larger than `isize::MAX` in Rust (or
+        // LLVM), so don't bother wasting time on collection if we will never be
+        // able to satisfy the allocation.
+        return false;
+    }
+
+    let Some(predicted_usage) = last_gc_heap_usage.checked_add(bytes_needed) else {
+        // If we can't represent our predicted usage as a `usize`, we won't be
+        // able to grow the GC heap to that size, so try collecting first to
+        // free up space.
+        return true;
+    };
+
+    // Common case: to balance collection frequency (and its time overhead) with
+    // GC heap growth (and its space overhead), only prefer growing first if the
+    // predicted GC heap utilization is greater than half the GC heap's
+    // capacity.
+    predicted_usage < gc_heap_capacity / 2
+}
+
+#[cfg(test)]
+mod tests {
+    use super::should_collect_first;
+
+    #[test]
+    fn test_should_collect_first() {
+        // No GC heap yet special case.
+        for bytes_needed in 0..256 {
+            assert_eq!(should_collect_first(bytes_needed, 0, 0), false);
+        }
+
+        // GC zeal special case.
+        for cap in 1..256 {
+            for usage in 0..=cap {
+                assert_eq!(should_collect_first(0, cap, usage), true);
+            }
+        }
+
+        let max_alloc_usize = isize::MAX.cast_unsigned();
+        let max_alloc_u64 = u64::try_from(max_alloc_usize).unwrap();
+
+        // Allocation size larger than `isize::MAX` --> will never succeed, do
+        // not bother collecting.
+        assert_eq!(
+            should_collect_first(max_alloc_u64 + 1, max_alloc_usize, 0),
+            false,
+        );
+
+        // Predicted usage overflow --> growth will likely fail, collect first.
+        assert_eq!(should_collect_first(1, usize::MAX, usize::MAX), true);
+
+        // Common case: predicted usage is low --> we likely have more than
+        // enough space already, so collect first.
+        assert_eq!(should_collect_first(16, 1024, 64), true);
+
+        // Common case: predicted usage is high --> plausible we may not have
+        // enough space, and we want to amortize the cost of collections, so
+        // grow first.
+        assert_eq!(should_collect_first(16, 1024, 512), false);
     }
 }

--- a/crates/wasmtime/src/runtime/vm/gc.rs
+++ b/crates/wasmtime/src/runtime/vm/gc.rs
@@ -377,4 +377,11 @@ impl GcStore {
     pub fn dealloc_uninit_exn(&mut self, exnref: VMExnRef) {
         self.gc_heap.dealloc_uninit_struct_or_exn(exnref.into());
     }
+
+    pub(crate) fn reset_gc_zeal_alloc_counter(&mut self) {
+        #[cfg(gc_zeal)]
+        {
+            self.gc_zeal_alloc_counter = self.gc_zeal_alloc_counter_init;
+        }
+    }
 }

--- a/crates/wasmtime/src/runtime/vm/gc.rs
+++ b/crates/wasmtime/src/runtime/vm/gc.rs
@@ -378,6 +378,7 @@ impl GcStore {
         self.gc_heap.dealloc_uninit_struct_or_exn(exnref.into());
     }
 
+    #[cfg(feature = "gc")]
     pub(crate) fn reset_gc_zeal_alloc_counter(&mut self) {
         #[cfg(gc_zeal)]
         {

--- a/crates/wasmtime/src/runtime/vm/gc/enabled.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/enabled.rs
@@ -7,6 +7,8 @@ mod externref;
 #[cfg(feature = "gc-drc")]
 mod free_list;
 mod structref;
+#[cfg(any(feature = "gc-drc", feature = "gc-copying"))]
+mod trace_info;
 
 pub use arrayref::*;
 pub use data::*;

--- a/crates/wasmtime/src/runtime/vm/gc/enabled/copying.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/enabled/copying.rs
@@ -270,11 +270,21 @@ impl CopyingHeap {
 
     /// Initialize the semi-spaces for a heap of the given capacity.
     fn initialize_semi_spaces(&mut self, capacity: u32) {
+        // Round capacity down to an even number, so our semi-spaces are
+        // equal-sized.
+        let capacity = capacity & !1;
+
         let halfway = capacity / 2;
         self.active_space_start = 0;
         self.active_space_end = halfway;
         self.idle_space_start = halfway;
         self.idle_space_end = capacity;
+
+        debug_assert_eq!(
+            self.active_space_end - self.active_space_start,
+            self.idle_space_end - self.idle_space_start,
+            "the active and idle spaces should be the same size"
+        );
 
         // VMGcRef uses NonZeroU32, so index 0 is reserved. Start the bump
         // pointer at `ALIGN` to skip past zero while keeping it aligned.
@@ -318,19 +328,28 @@ impl CopyingHeap {
 
     /// Swap the active and idle semi-spaces.
     fn flip(&mut self) {
+        debug_assert_eq!(
+            self.active_space_end - self.active_space_start,
+            self.idle_space_end - self.idle_space_start,
+            "the active and idle spaces should be the same size"
+        );
+
         mem::swap(&mut self.active_space_start, &mut self.idle_space_start);
         mem::swap(&mut self.active_space_end, &mut self.idle_space_end);
-        self.bump_ptr = self.active_space_start;
+
         // VMGcRef uses NonZeroU32, so index 0 is reserved. Skip past it
         // with proper alignment so allocations never return index 0.
+        self.bump_ptr = self.active_space_start;
         if self.bump_ptr == 0 && self.active_space_end > ALIGN {
             self.bump_ptr = ALIGN;
         }
+
         // Swap the externref linked lists along with the semi-spaces.
         mem::swap(
             &mut self.active_extern_ref_set_head,
             &mut self.idle_extern_ref_set_head,
         );
+
         // Clear the active list since we're starting fresh in the new space.
         self.active_extern_ref_set_head = None;
     }
@@ -898,52 +917,61 @@ enum CopyingCollectionPhase {
 impl CopyingCollection<'_> {
     /// Forward all GC roots from the idle space to the active space.
     fn process_roots(&mut self) {
-        let heap = &mut *self.heap;
-        let mut roots = self.roots.take().unwrap();
-        for mut root in &mut roots {
+        log::trace!("Begin processing GC roots");
+        let roots = self.roots.take().unwrap();
+        for mut root in roots {
             let gc_ref = root.get();
             if gc_ref.is_i31() {
                 continue;
             }
             let old_index = gc_ref.as_heap_index().unwrap().get();
-            debug_assert!(heap.is_in_idle_space(old_index));
-            let new_ref = heap.forward(&gc_ref);
+            debug_assert!(self.heap.is_in_idle_space(old_index));
+            let new_ref = self.heap.forward(&gc_ref);
             root.set(new_ref);
         }
-        drop(roots);
+        log::trace!("End processing GC roots");
     }
 
     /// Scan all grey objects until the worklist is empty.
     fn process_worklist(&mut self) {
-        let heap = &mut *self.heap;
-        let trace_infos = mem::take(&mut heap.trace_infos);
-        while let Some(gc_ref) = heap.worklist_pop() {
-            debug_assert!(heap.is_in_active_space(gc_ref.as_heap_index().unwrap().get()));
-            heap.scan(&gc_ref, &trace_infos);
+        log::trace!("Begin processing worklist");
+        let trace_infos = mem::take(&mut self.heap.trace_infos);
+        while let Some(gc_ref) = self.heap.worklist_pop() {
+            debug_assert!(
+                self.heap
+                    .is_in_active_space(gc_ref.as_heap_index().unwrap().get())
+            );
+            self.heap.scan(&gc_ref, &trace_infos);
         }
-        heap.trace_infos = trace_infos;
+        self.heap.trace_infos = trace_infos;
+        log::trace!("End processing worklist");
     }
 
     /// Clean up dead externrefs by iterating the idle semi-space's externref
     /// linked list and deallocating host data for any that were not forwarded.
     fn sweep_extern_refs(&mut self) {
-        let heap = &mut *self.heap;
-        let mut link = heap.idle_extern_ref_set_head.take();
+        log::trace!("Begin sweeping `externref`s");
+        let mut link = self.heap.idle_extern_ref_set_head.take();
         while let Some(externref) = link {
             let gc_ref = externref.as_gc_ref();
-            debug_assert!(heap.is_in_idle_space(gc_ref.as_heap_index().unwrap().get()));
-            let header = heap.index(copying_ref(gc_ref));
+            debug_assert!(
+                self.heap
+                    .is_in_idle_space(gc_ref.as_heap_index().unwrap().get())
+            );
+            let header = self.heap.index(copying_ref(gc_ref));
             if !header.copied() {
                 let typed: &TypedGcRef<VMCopyingExternRef> = gc_ref.as_typed_unchecked();
-                let host_data_id = heap.index(typed).host_data;
+                let host_data_id = self.heap.index(typed).host_data;
                 self.host_data_table.dealloc(host_data_id);
             }
-            link = heap
+            link = self
+                .heap
                 .index::<VMCopyingExternRef>(gc_ref.as_typed_unchecked())
                 .next_extern_ref
                 .as_ref()
                 .map(|e| e.unchecked_copy());
         }
+        log::trace!("End sweeping `externref`s");
     }
 }
 
@@ -953,58 +981,69 @@ impl GarbageCollection<'_> for CopyingCollection<'_> {
             CopyingCollectionPhase::Collect => {
                 log::trace!("Begin copying collection");
 
-                let heap = &mut *self.heap;
-
-                assert!(heap.active_space_start <= heap.bump_ptr);
-                assert!(heap.bump_ptr <= heap.active_space_end);
-                assert!(heap.idle_space_start <= heap.idle_space_end);
+                assert!(self.heap.active_space_start <= self.heap.bump_ptr);
+                assert!(self.heap.bump_ptr <= self.heap.active_space_end);
+                assert!(self.heap.idle_space_start <= self.heap.idle_space_end);
                 assert!(
-                    heap.active_space_end <= heap.idle_space_start
-                        || heap.idle_space_end <= heap.active_space_start
+                    self.heap.active_space_end <= self.heap.idle_space_start
+                        || self.heap.idle_space_end <= self.heap.active_space_start
                 );
 
                 // Flip the semi-spaces.
-                heap.flip();
-                heap.initialize_worklist();
+                self.heap.flip();
+                self.heap.initialize_worklist();
 
                 self.process_roots();
                 self.process_worklist();
 
-                let heap = &mut *self.heap;
-                assert!(heap.active_space_start <= heap.bump_ptr);
-                assert!(heap.bump_ptr <= heap.active_space_end);
-                assert!(heap.idle_space_start <= heap.idle_space_end);
+                assert!(self.heap.active_space_start <= self.heap.bump_ptr);
+                assert!(self.heap.bump_ptr <= self.heap.active_space_end);
+                assert!(self.heap.idle_space_start <= self.heap.idle_space_end);
                 assert!(
-                    heap.active_space_end <= heap.idle_space_start
-                        || heap.idle_space_end <= heap.active_space_start
+                    self.heap.active_space_end <= self.heap.idle_space_start
+                        || self.heap.idle_space_end <= self.heap.active_space_start
                 );
 
                 self.sweep_extern_refs();
 
                 // Adjust semi-space regions for any new capacity if the active
                 // space is the first half.
-                let heap = &mut *self.heap;
-                if heap.active_space_start < heap.idle_space_start {
+                if self.heap.active_space_start < self.heap.idle_space_start {
                     let mem_len =
-                        u32::try_from(heap.vmmemory.as_ref().unwrap().current_length()).unwrap();
-                    assert!(heap.idle_space_end <= mem_len);
-                    heap.idle_space_end = mem_len;
+                        u32::try_from(self.heap.vmmemory.as_ref().unwrap().current_length())
+                            .unwrap();
+                    // Round `mem_len` down to an even number, so our
+                    // semi-spaces are equal-sized.
+                    let mem_len = mem_len & !1;
+                    assert!(self.heap.idle_space_end <= mem_len);
+                    self.heap.idle_space_end = mem_len;
 
                     let halfway = mem_len / 2;
-                    assert!(heap.bump_ptr <= halfway);
+                    assert!(self.heap.bump_ptr <= halfway);
 
-                    assert!(heap.idle_space_start <= halfway);
-                    heap.idle_space_start = halfway;
+                    assert!(self.heap.idle_space_start <= halfway);
+                    self.heap.idle_space_start = halfway;
 
-                    assert!(heap.active_space_end <= halfway);
-                    heap.active_space_end = halfway;
+                    assert!(self.heap.active_space_end <= halfway);
+                    self.heap.active_space_end = halfway;
+                } else {
+                    // NB: Cannot adjust semi-space regions when the active
+                    // space is the second half of the GC heap because resizing
+                    // them would require moving objects which, in turn, would
+                    // require updating GC edges.
                 }
+
+                debug_assert_eq!(
+                    self.heap.active_space_end - self.heap.active_space_start,
+                    self.heap.idle_space_end - self.heap.idle_space_start,
+                    "the active and idle spaces should be the same size"
+                );
 
                 // Poison the idle space so stale accesses are detectable.
                 if cfg!(gc_zeal) {
-                    let idle_start = usize::try_from(heap.idle_space_start).unwrap();
-                    let idle_end = usize::try_from(heap.idle_space_end).unwrap();
-                    heap.heap_slice_mut()[idle_start..idle_end].fill(POISON);
+                    let idle_start = usize::try_from(self.heap.idle_space_start).unwrap();
+                    let idle_end = usize::try_from(self.heap.idle_space_end).unwrap();
+                    self.heap.heap_slice_mut()[idle_start..idle_end].fill(POISON);
                 }
 
                 log::trace!("End copying collection");

--- a/crates/wasmtime/src/runtime/vm/gc/enabled/copying.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/enabled/copying.rs
@@ -1,10 +1,35 @@
-//! The copying collector.
+//! The copying (semi-space) garbage collector.
 //!
-//! This is a skeleton implementation that is not yet functional. All methods
-//! bail with "not yet implemented" errors.
+//! This implements a Cheney-style semi-space copying collector. The GC heap is
+//! divided into two halves: the "active" semi-space where new objects are
+//! allocated, and the "idle" semi-space. During collection, live objects are
+//! copied from the idle space (which was the previous active space) to the new
+//! active space, and all roots are updated to point to the new locations.
+//!
+//! Allocation is a simple bump pointer within the active semi-space.
+//!
+//! This collector does not require any read or write barriers.
 
-use crate::{Engine, prelude::*, vm::GcRuntime};
-use wasmtime_environ::{GcTypeLayouts, copying::CopyingTypeLayouts};
+use super::VMArrayRef;
+use super::trace_info::{TraceInfo, TraceInfos};
+use crate::runtime::vm::{
+    ExternRefHostDataId, ExternRefHostDataTable, GarbageCollection, GcHeap, GcHeapObject,
+    GcProgress, GcRootsIter, GcRuntime, TypedGcRef, VMExternRef, VMGcHeader, VMGcRef,
+};
+use crate::vm::VMMemoryDefinition;
+use crate::{Engine, prelude::*};
+use core::mem::MaybeUninit;
+use core::sync::atomic::AtomicUsize;
+use core::{alloc::Layout, any::Any, mem, num::NonZeroU32, ptr::NonNull};
+use wasmtime_environ::copying::{
+    ALIGN, ARRAY_LENGTH_OFFSET, CopyingTypeLayouts, HEADER_COPIED_BIT,
+};
+use wasmtime_environ::{
+    GcArrayLayout, GcStructLayout, GcTypeLayouts, POISON, VMGcKind, VMSharedTypeIndex, gc_assert,
+};
+
+#[expect(clippy::cast_possible_truncation, reason = "known to not overflow")]
+const GC_REF_ARRAY_ELEMS_OFFSET: u32 = ARRAY_LENGTH_OFFSET + (mem::size_of::<u32>() as u32);
 
 /// The copying collector.
 #[derive(Default)]
@@ -17,7 +42,1032 @@ unsafe impl GcRuntime for CopyingCollector {
         &self.layouts
     }
 
-    fn new_gc_heap(&self, _: &Engine) -> Result<Box<dyn crate::vm::GcHeap>> {
-        bail!("copying collector is not yet implemented")
+    fn new_gc_heap(&self, engine: &Engine) -> Result<Box<dyn GcHeap>> {
+        let heap = CopyingHeap::new(engine)?;
+        Ok(Box::new(heap) as _)
+    }
+}
+
+/// The common header for all objects in the copying collector.
+#[repr(C)]
+struct VMCopyingHeader {
+    header: VMGcHeader,
+    object_size: u32,
+}
+
+// Safety: All copying collector objects have a `VMCopyingHeader`.
+unsafe impl GcHeapObject for VMCopyingHeader {
+    #[inline]
+    fn is(_header: &VMGcHeader) -> bool {
+        true
+    }
+}
+
+impl VMCopyingHeader {
+    /// Get the size of this object in the GC heap.
+    #[inline]
+    fn object_size(&self) -> u32 {
+        self.object_size
+    }
+
+    /// Check whether this object has been copied to the new semi-space during
+    /// a collection.
+    #[inline]
+    fn copied(&self) -> bool {
+        self.header.reserved_u26() & HEADER_COPIED_BIT != 0
+    }
+
+    /// Mark this object as having been copied to the new semi-space.
+    #[inline]
+    fn set_copied(&mut self) {
+        let reserved = self.header.reserved_u26();
+        self.header.set_reserved_u26(reserved | HEADER_COPIED_BIT);
+    }
+}
+
+/// A copying collector header together with a forwarding reference.
+///
+/// During collection, after an object has been copied to the new semi-space,
+/// its old location is overwritten with the forwarding reference pointing to
+/// the new location.
+#[repr(C)]
+struct VMCopyingHeaderAndForwardingRef {
+    header: VMCopyingHeader,
+    forwarding_ref: Option<VMGcRef>,
+}
+
+// Safety: All copying collector objects have a `VMCopyingHeader` and space for
+// the forwarding reference.
+unsafe impl GcHeapObject for VMCopyingHeaderAndForwardingRef {
+    #[inline]
+    fn is(_header: &VMGcHeader) -> bool {
+        true
+    }
+}
+
+impl VMCopyingHeaderAndForwardingRef {
+    /// Get the forwarding reference for this object, if it has been copied
+    /// during the current collection.
+    fn forwarding_ref(&self) -> Option<VMGcRef> {
+        debug_assert!(
+            self.header.object_size()
+                >= u32::try_from(mem::size_of::<VMCopyingHeaderAndForwardingRef>()).unwrap()
+        );
+        if self.header.copied() {
+            Some(
+                self.forwarding_ref
+                    .as_ref()
+                    .expect("should always have a forwarding ref if the copied bit is set")
+                    .unchecked_copy(),
+            )
+        } else {
+            None
+        }
+    }
+
+    /// Set the forwarding reference for this object and mark it as copied.
+    fn set_forwarding_ref(&mut self, forwarding_ref: VMGcRef) {
+        debug_assert!(!self.header.copied());
+        debug_assert!(
+            self.header.object_size()
+                >= u32::try_from(mem::size_of::<VMCopyingHeaderAndForwardingRef>()).unwrap()
+        );
+        self.header.set_copied();
+        self.forwarding_ref = Some(forwarding_ref);
+    }
+}
+
+/// The header for an array in the copying collector.
+#[repr(C)]
+struct VMCopyingArrayHeader {
+    header: VMCopyingHeader,
+    length: u32,
+}
+
+unsafe impl GcHeapObject for VMCopyingArrayHeader {
+    #[inline]
+    fn is(header: &VMGcHeader) -> bool {
+        header.kind() == VMGcKind::ArrayRef
+    }
+}
+
+/// The representation of an `externref` in the copying collector.
+#[repr(C)]
+struct VMCopyingExternRef {
+    header: VMCopyingHeader,
+
+    /// Padding so that our other fields aren't overwritten by the forwarding
+    /// location.
+    _forwarding_ref_padding: MaybeUninit<Option<VMGcRef>>,
+
+    /// The ID of this ref's data in the `ExternRefHostDataTable`.
+    host_data: ExternRefHostDataId,
+
+    /// Link to the next `externref` in this semi-space.
+    next_extern_ref: Option<VMExternRef>,
+}
+
+unsafe impl GcHeapObject for VMCopyingExternRef {
+    #[inline]
+    fn is(header: &VMGcHeader) -> bool {
+        header.kind() == VMGcKind::ExternRef
+    }
+}
+
+/// Get a typed reference to a copying-collector object from a raw `VMGcRef`.
+fn copying_ref(gc_ref: &VMGcRef) -> &TypedGcRef<VMCopyingHeader> {
+    debug_assert!(!gc_ref.is_i31());
+    gc_ref.as_typed_unchecked()
+}
+
+/// Get a typed reference to a forwarding-ref header from a raw `VMGcRef`.
+fn header_and_forwarding_ref(gc_ref: &VMGcRef) -> &TypedGcRef<VMCopyingHeaderAndForwardingRef> {
+    debug_assert!(!gc_ref.is_i31());
+    gc_ref.as_typed_unchecked()
+}
+
+fn externref_to_copying(externref: &VMExternRef) -> &TypedGcRef<VMCopyingExternRef> {
+    let gc_ref = externref.as_gc_ref();
+    debug_assert!(!gc_ref.is_i31());
+    gc_ref.as_typed_unchecked()
+}
+
+/// A copying (semi-space) heap.
+struct CopyingHeap {
+    /// For every type that we have allocated in this heap, how do we trace it?
+    trace_infos: TraceInfos,
+
+    /// Count of how many no-gc scopes we are currently within.
+    no_gc_count: u64,
+
+    /// The storage for the GC heap itself.
+    memory: Option<crate::vm::Memory>,
+
+    /// The cached `VMMemoryDefinition` for `self.memory` so that we don't have
+    /// to make indirect calls through a `dyn RuntimeLinearMemory` object.
+    ///
+    /// Must be updated and kept in sync with `self.memory`, cleared when the
+    /// memory is taken and updated when the memory is replaced.
+    vmmemory: Option<VMMemoryDefinition>,
+
+    /// The bump "pointer" (really an index) for allocating new objects.
+    ///
+    /// This is always within the active semi-space.
+    bump_ptr: u32,
+
+    /// The start of the active semi-space.
+    active_space_start: u32,
+
+    /// The end of the active semi-space.
+    active_space_end: u32,
+
+    /// The start of the idle semi-space.
+    idle_space_start: u32,
+
+    /// The end of the idle semi-space.
+    idle_space_end: u32,
+
+    /// "Pointer" (really an index) to the start of the worklist.
+    ///
+    /// This is always within the active semi-space and is always less than or
+    /// equal to `bump_ptr`.
+    ///
+    /// This is used to implement a Cheney-style worklist: grey objects (the set
+    /// of objects that have been copied to the new semi-space but have not yet
+    /// been scanned) are always within `worklist_ptr..bump_ptr`. The worklist
+    /// is empty when `worklist_ptr == bump_ptr` and we can pop from the
+    /// worklist by advancing `worklist_ptr`.
+    worklist_ptr: u32,
+
+    /// The set of `externref`s in the active semi-space.
+    ///
+    /// The set is implemented as an intrusive linked-list, and this is the
+    /// head of the list.
+    active_extern_ref_set_head: Option<VMExternRef>,
+
+    /// Like `active_extern_ref_set_head` but for the idle semi-space.
+    idle_extern_ref_set_head: Option<VMExternRef>,
+}
+
+impl CopyingHeap {
+    fn new(engine: &Engine) -> Result<Self> {
+        log::trace!("allocating new copying heap");
+        Ok(Self {
+            trace_infos: TraceInfos::new(engine, GC_REF_ARRAY_ELEMS_OFFSET),
+            no_gc_count: 0,
+            memory: None,
+            vmmemory: None,
+            bump_ptr: 0,
+            active_space_start: 0,
+            active_space_end: 0,
+            idle_space_start: 0,
+            idle_space_end: 0,
+            worklist_ptr: 0,
+            active_extern_ref_set_head: None,
+            idle_extern_ref_set_head: None,
+        })
+    }
+
+    /// Initialize the semi-spaces for a heap of the given capacity.
+    fn initialize_semi_spaces(&mut self, capacity: u32) {
+        let halfway = capacity / 2;
+        self.active_space_start = 0;
+        self.active_space_end = halfway;
+        self.idle_space_start = halfway;
+        self.idle_space_end = capacity;
+
+        // VMGcRef uses NonZeroU32, so index 0 is reserved. Start the bump
+        // pointer at `ALIGN` to skip past zero while keeping it aligned.
+        debug_assert!(capacity == 0 || capacity > ALIGN);
+        self.bump_ptr = if capacity > 0 { ALIGN } else { 0 };
+    }
+
+    /// Ensure that we have tracing information for the given type.
+    fn ensure_trace_info(&mut self, ty: VMSharedTypeIndex) {
+        self.trace_infos.ensure(ty);
+    }
+
+    /// Allocate `size` bytes from the active semi-space bump pointer.
+    ///
+    /// Returns `None` if there isn't enough room.
+    fn allocate(&mut self, size: u32) -> Option<u32> {
+        debug_assert!(self.bump_ptr >= self.active_space_start);
+        debug_assert!(self.bump_ptr <= self.active_space_end);
+
+        let result = self.bump_ptr;
+        let new_bump_ptr = result.checked_add(size)?;
+        if new_bump_ptr > self.active_space_end {
+            return None;
+        }
+        self.bump_ptr = new_bump_ptr;
+
+        debug_assert!(self.bump_ptr >= self.active_space_start);
+        debug_assert!(self.bump_ptr <= self.active_space_end);
+        Some(result)
+    }
+
+    /// Check whether an index is within the active semi-space.
+    fn is_in_active_space(&self, index: u32) -> bool {
+        index >= self.active_space_start && index < self.active_space_end
+    }
+
+    /// Check whether an index is within the idle semi-space.
+    fn is_in_idle_space(&self, index: u32) -> bool {
+        index >= self.idle_space_start && index < self.idle_space_end
+    }
+
+    /// Swap the active and idle semi-spaces.
+    fn flip(&mut self) {
+        mem::swap(&mut self.active_space_start, &mut self.idle_space_start);
+        mem::swap(&mut self.active_space_end, &mut self.idle_space_end);
+        self.bump_ptr = self.active_space_start;
+        // VMGcRef uses NonZeroU32, so index 0 is reserved. Skip past it
+        // with proper alignment so allocations never return index 0.
+        if self.bump_ptr == 0 && self.active_space_end > ALIGN {
+            self.bump_ptr = ALIGN;
+        }
+        // Swap the externref linked lists along with the semi-spaces.
+        mem::swap(
+            &mut self.active_extern_ref_set_head,
+            &mut self.idle_extern_ref_set_head,
+        );
+        // Clear the active list since we're starting fresh in the new space.
+        self.active_extern_ref_set_head = None;
+    }
+
+    /// Initialize the worklist at the start of a collection.
+    fn initialize_worklist(&mut self) {
+        self.worklist_ptr = self.bump_ptr;
+    }
+
+    /// Pop the next item off the worklist, or return `None` if the worklist is
+    /// empty.
+    fn worklist_pop(&mut self) -> Option<VMGcRef> {
+        debug_assert!(
+            self.is_in_active_space(self.worklist_ptr)
+                || self.worklist_ptr == self.active_space_end
+        );
+        debug_assert!(
+            self.is_in_active_space(self.bump_ptr) || self.bump_ptr == self.active_space_end
+        );
+        debug_assert!(self.worklist_ptr <= self.bump_ptr);
+
+        if self.worklist_ptr == self.bump_ptr {
+            return None;
+        }
+
+        let result = self.worklist_ptr;
+        let result = NonZeroU32::new(result).unwrap();
+        let result = VMGcRef::from_heap_index(result).unwrap();
+
+        let obj_size = self.index(copying_ref(&result)).object_size();
+
+        self.worklist_ptr += obj_size;
+        debug_assert!(self.worklist_ptr <= self.bump_ptr);
+
+        Some(result)
+    }
+
+    /// Insert `gc_ref`, which points to a grey object, into the worklist.
+    fn worklist_insert(&self, gc_ref: &VMGcRef) {
+        // This is a no-op: insertion happens implicitly in `copy` when
+        // allocating space for the copied object and advancing the
+        // `bump_ptr`. But we still define and call this method just for the
+        // debug assertions.
+        if !cfg!(debug_assertions) {
+            return;
+        }
+
+        let index = gc_ref.as_heap_index().unwrap().get();
+        debug_assert!(self.is_in_active_space(index));
+        let obj_size = self.index(copying_ref(gc_ref)).object_size();
+        debug_assert_eq!(index + obj_size, self.bump_ptr);
+        debug_assert!(self.worklist_ptr <= index);
+    }
+
+    /// Get-or-create the location of this idle-space ref in the new active
+    /// semi-space.
+    fn forward(&mut self, from_ref: &VMGcRef) -> VMGcRef {
+        debug_assert!(!from_ref.is_i31());
+        debug_assert!(self.is_in_idle_space(from_ref.as_heap_index().unwrap().get()));
+
+        if let Some(to_ref) = self
+            .index(header_and_forwarding_ref(from_ref))
+            .forwarding_ref()
+        {
+            return to_ref;
+        }
+        self.copy(from_ref)
+    }
+
+    /// Copy this idle-space ref into the new active semi-space and return its
+    /// new location.
+    fn copy(&mut self, from_ref: &VMGcRef) -> VMGcRef {
+        debug_assert!(!from_ref.is_i31());
+        let from_index = from_ref.as_heap_index().unwrap().get();
+        debug_assert!(self.is_in_idle_space(from_index));
+        debug_assert!(!self.index(copying_ref(from_ref)).copied());
+
+        let size = self.index(copying_ref(from_ref)).object_size();
+        let to_index = self.allocate(size).expect(
+            "there should always be enough room in the active semi-space for objects that \
+             survived collection, since the active space is the same size as the idle space",
+        );
+        debug_assert!(self.is_in_active_space(to_index));
+
+        let to_ref =
+            VMGcRef::from_heap_index(NonZeroU32::new(to_index).unwrap()).expect("valid heap index");
+
+        // Copy the object bytes.
+        let from_start = usize::try_from(from_index).unwrap();
+        let to_start = usize::try_from(to_index).unwrap();
+        let size_usize = usize::try_from(size).unwrap();
+        let [from, to] = self
+            .heap_slice_mut()
+            .get_disjoint_mut([
+                from_start..from_start + size_usize,
+                to_start..to_start + size_usize,
+            ])
+            .expect("semi-spaces do not overlap");
+        to.copy_from_slice(from);
+
+        // Set the forwarding ref in the old (idle-space) object.
+        self.index_mut(header_and_forwarding_ref(from_ref))
+            .set_forwarding_ref(to_ref.unchecked_copy());
+
+        // If this is an externref, insert it into the active externref list.
+        if self
+            .index(copying_ref(&to_ref))
+            .header
+            .kind()
+            .matches(VMGcKind::ExternRef)
+        {
+            let old_head = self.active_extern_ref_set_head.take();
+            self.index_mut::<VMCopyingExternRef>(to_ref.as_typed_unchecked())
+                .next_extern_ref = old_head;
+            self.active_extern_ref_set_head =
+                Some(to_ref.unchecked_copy().into_externref_unchecked());
+        }
+
+        self.worklist_insert(&to_ref);
+        to_ref
+    }
+
+    /// Trace a grey object's outgoing edges, copying their referents into the
+    /// new semi-space if necessary, and updating the object's references with
+    /// their forwarded locations in the new semi-space.
+    fn scan(&mut self, gc_ref: &VMGcRef, trace_infos: &TraceInfos) {
+        debug_assert!(!gc_ref.is_i31());
+        let index = gc_ref.as_heap_index().unwrap().get();
+        debug_assert!(self.is_in_active_space(index));
+
+        let ty = self.index(copying_ref(gc_ref)).header.ty();
+
+        // `externref`s have no GC edges.
+        let Some(ty) = ty else {
+            return;
+        };
+
+        match trace_infos.trace_info(&ty) {
+            TraceInfo::Struct { gc_ref_offsets } => {
+                let object_start = usize::try_from(index).unwrap();
+
+                for &offset in gc_ref_offsets {
+                    let offset_usize = usize::try_from(offset).unwrap();
+                    let field_start = object_start + offset_usize;
+                    let field_end = field_start + mem::size_of::<u32>();
+
+                    let raw: [u8; 4] = self.heap_slice()[field_start..field_end]
+                        .try_into()
+                        .unwrap();
+                    let raw = u32::from_le_bytes(raw);
+
+                    if let Some(child) = VMGcRef::from_raw_u32(raw)
+                        && !child.is_i31()
+                    {
+                        debug_assert!(self.is_in_idle_space(child.as_heap_index().unwrap().get()));
+                        let new_ref = self.forward(&child);
+                        debug_assert!(
+                            self.is_in_active_space(new_ref.as_heap_index().unwrap().get())
+                        );
+                        // Write the new reference back.
+                        let new_raw = new_ref.as_raw_u32().to_le_bytes();
+                        self.heap_slice_mut()[field_start..field_end].copy_from_slice(&new_raw);
+                    }
+                }
+            }
+            TraceInfo::Array { gc_ref_elems } => {
+                if *gc_ref_elems {
+                    let array_ref = gc_ref.as_arrayref_unchecked();
+                    let len = self.array_len(array_ref);
+                    let object_start = usize::try_from(index).unwrap();
+
+                    for i in 0..len {
+                        let elem_offset = GC_REF_ARRAY_ELEMS_OFFSET
+                            + i * u32::try_from(mem::size_of::<u32>()).unwrap();
+                        let offset_usize = usize::try_from(elem_offset).unwrap();
+                        let field_start = object_start + offset_usize;
+                        let field_end = field_start + mem::size_of::<u32>();
+
+                        let raw: [u8; 4] = self.heap_slice()[field_start..field_end]
+                            .try_into()
+                            .unwrap();
+                        let raw = u32::from_le_bytes(raw);
+
+                        if let Some(child) = VMGcRef::from_raw_u32(raw)
+                            && !child.is_i31()
+                        {
+                            debug_assert!(
+                                self.is_in_idle_space(child.as_heap_index().unwrap().get())
+                            );
+                            let new_ref = self.forward(&child);
+                            debug_assert!(
+                                self.is_in_active_space(new_ref.as_heap_index().unwrap().get())
+                            );
+                            let new_raw = new_ref.as_raw_u32().to_le_bytes();
+                            self.heap_slice_mut()[field_start..field_end].copy_from_slice(&new_raw);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+unsafe impl GcHeap for CopyingHeap {
+    fn is_attached(&self) -> bool {
+        debug_assert_eq!(self.memory.is_some(), self.vmmemory.is_some());
+        self.memory.is_some()
+    }
+
+    fn attach(&mut self, memory: crate::vm::Memory) {
+        assert!(!self.is_attached());
+        assert!(!memory.is_shared_memory());
+        let len = memory.vmmemory().current_length();
+        let capacity = u32::try_from(len).unwrap();
+        self.initialize_semi_spaces(capacity);
+        self.vmmemory = Some(memory.vmmemory());
+        self.memory = Some(memory);
+
+        if cfg!(gc_zeal) {
+            self.heap_slice_mut().fill(POISON);
+        }
+    }
+
+    fn detach(&mut self) -> crate::vm::Memory {
+        assert!(self.is_attached());
+
+        let CopyingHeap {
+            no_gc_count,
+            memory,
+            vmmemory,
+            bump_ptr,
+            active_space_start,
+            active_space_end,
+            idle_space_start,
+            idle_space_end,
+            worklist_ptr,
+            active_extern_ref_set_head,
+            idle_extern_ref_set_head,
+            // NB: we will only ever be reused with the same engine, so no need
+            // to clear out our tracing info just to fill it back in with the
+            // same exact stuff.
+            trace_infos: _,
+        } = self;
+
+        *no_gc_count = 0;
+        *vmmemory = None;
+        *bump_ptr = 0;
+        *active_space_start = 0;
+        *active_space_end = 0;
+        *idle_space_start = 0;
+        *idle_space_end = 0;
+        *worklist_ptr = 0;
+        *active_extern_ref_set_head = None;
+        *idle_extern_ref_set_head = None;
+
+        memory.take().unwrap()
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self as _
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self as _
+    }
+
+    fn enter_no_gc_scope(&mut self) {
+        self.no_gc_count += 1;
+    }
+
+    fn exit_no_gc_scope(&mut self) {
+        self.no_gc_count -= 1;
+    }
+
+    fn clone_gc_ref(&mut self, gc_ref: &VMGcRef) -> VMGcRef {
+        // The copying collector doesn't use reference counting; cloning is a
+        // simple copy.
+        gc_ref.unchecked_copy()
+    }
+
+    fn write_gc_ref(
+        &mut self,
+        _host_data_table: &mut ExternRefHostDataTable,
+        destination: &mut Option<VMGcRef>,
+        source: Option<&VMGcRef>,
+    ) {
+        // The copying collector doesn't use reference counting; writes are
+        // simple overwrites.
+        *destination = source.map(|s| s.unchecked_copy());
+    }
+
+    fn expose_gc_ref_to_wasm(&mut self, _gc_ref: VMGcRef) {
+        // The copying collector doesn't need any special handling when exposing
+        // a GC ref to Wasm. There is no over-approximated-stack-roots list.
+    }
+
+    fn alloc_externref(
+        &mut self,
+        host_data: ExternRefHostDataId,
+    ) -> Result<Result<VMExternRef, u64>> {
+        let align = usize::try_from(ALIGN).unwrap();
+        let size = core::mem::size_of::<VMCopyingExternRef>();
+        let size = (size + align - 1) & !(align - 1);
+        let gc_ref = match self.alloc_raw(
+            VMGcHeader::externref(),
+            Layout::from_size_align(size, align).unwrap(),
+        )? {
+            Err(n) => return Ok(Err(n)),
+            Ok(gc_ref) => gc_ref,
+        };
+        // Take the old list head before borrowing self mutably through index_mut.
+        let old_head = self.active_extern_ref_set_head.take();
+        let externref_obj = self.index_mut::<VMCopyingExternRef>(gc_ref.as_typed_unchecked());
+        externref_obj.host_data = host_data;
+        externref_obj.next_extern_ref = old_head;
+        let externref = gc_ref.into_externref_unchecked();
+        self.active_extern_ref_set_head = Some(externref.unchecked_copy());
+        Ok(Ok(externref))
+    }
+
+    fn externref_host_data(&self, externref: &VMExternRef) -> ExternRefHostDataId {
+        let typed_ref = externref_to_copying(externref);
+        self.index(typed_ref).host_data
+    }
+
+    fn header(&self, gc_ref: &VMGcRef) -> &VMGcHeader {
+        let header: &VMGcHeader = self.index(gc_ref.as_typed_unchecked());
+
+        debug_assert!(
+            VMGcKind::try_from_u32(header.kind().as_u32()).is_some(),
+            "header: invalid VMGcKind {:#010x} at gc_ref {gc_ref:#p}",
+            header.kind().as_u32(),
+        );
+
+        header
+    }
+
+    fn header_mut(&mut self, gc_ref: &VMGcRef) -> &mut VMGcHeader {
+        let header: &mut VMGcHeader = self.index_mut(gc_ref.as_typed_unchecked());
+
+        debug_assert!(
+            VMGcKind::try_from_u32(header.kind().as_u32()).is_some(),
+            "header_mut: invalid VMGcKind {:#010x} at gc_ref {gc_ref:#p}",
+            header.kind().as_u32(),
+        );
+
+        header
+    }
+
+    fn object_size(&self, gc_ref: &VMGcRef) -> usize {
+        usize::try_from(self.index(copying_ref(gc_ref)).object_size()).unwrap()
+    }
+
+    fn alloc_raw(&mut self, header: VMGcHeader, layout: Layout) -> Result<Result<VMGcRef, u64>> {
+        let align = u32::try_from(layout.align()).unwrap();
+        ensure!(
+            align == ALIGN,
+            "copying collector requires all allocations to have alignment {ALIGN}, \
+             but got alignment {align}",
+        );
+
+        debug_assert!(layout.size() >= core::mem::size_of::<VMCopyingHeader>());
+        debug_assert_eq!(self.bump_ptr % ALIGN, 0, "bump_ptr is not aligned to ALIGN");
+        debug_assert_eq!(header.reserved_u26(), 0);
+
+        // We must have trace info for every GC type that we allocate in this
+        // heap.
+        if let Some(ty) = header.ty() {
+            self.ensure_trace_info(ty);
+        } else {
+            debug_assert_eq!(header.kind(), VMGcKind::ExternRef);
+        }
+
+        let size = u32::try_from(layout.size()).unwrap();
+        // Round up the allocation size to ALIGN so that the next bump-pointer
+        // allocation is also aligned.
+        let size = (size + ALIGN - 1) & !(ALIGN - 1);
+
+        let gc_ref = match self.allocate(size) {
+            None => return Ok(Err(u64::try_from(layout.size()).unwrap())),
+            Some(index) => {
+                debug_assert_ne!(index, 0, "index 0 is reserved; bump_ptr should skip it");
+                VMGcRef::from_heap_index(NonZeroU32::new(index).unwrap()).unwrap()
+            }
+        };
+
+        // Assert that the newly-allocated memory is still filled with the
+        // poison pattern.
+        if cfg!(gc_zeal) {
+            let start = usize::try_from(gc_ref.as_heap_index().unwrap().get()).unwrap();
+            let slice = &self.heap_slice()[start..][..layout.size()];
+            gc_assert!(
+                slice.iter().all(|&b| b == POISON),
+                "newly allocated GC object at index {start} is not fully poisoned; \
+                 freed memory was corrupted",
+            );
+        }
+
+        let object_size = size;
+        *self.index_mut(copying_ref(&gc_ref)) = VMCopyingHeader {
+            header,
+            object_size,
+        };
+        Ok(Ok(gc_ref))
+    }
+
+    fn alloc_uninit_struct_or_exn(
+        &mut self,
+        ty: VMSharedTypeIndex,
+        layout: &GcStructLayout,
+    ) -> Result<Result<VMGcRef, u64>> {
+        let kind = if layout.is_exception {
+            VMGcKind::ExnRef
+        } else {
+            VMGcKind::StructRef
+        };
+        let gc_ref =
+            match self.alloc_raw(VMGcHeader::from_kind_and_index(kind, ty), layout.layout())? {
+                Err(n) => return Ok(Err(n)),
+                Ok(gc_ref) => gc_ref,
+            };
+
+        Ok(Ok(gc_ref))
+    }
+
+    fn dealloc_uninit_struct_or_exn(&mut self, _gcref: VMGcRef) {
+        // The copying collector doesn't support individual deallocation; memory
+        // is reclaimed during collection.
+    }
+
+    fn alloc_uninit_array(
+        &mut self,
+        ty: VMSharedTypeIndex,
+        length: u32,
+        layout: &GcArrayLayout,
+    ) -> Result<Result<VMArrayRef, u64>> {
+        let gc_ref = match self.alloc_raw(
+            VMGcHeader::from_kind_and_index(VMGcKind::ArrayRef, ty),
+            layout.layout(length),
+        )? {
+            Err(n) => return Ok(Err(n)),
+            Ok(gc_ref) => gc_ref,
+        };
+
+        self.index_mut(gc_ref.as_typed_unchecked::<VMCopyingArrayHeader>())
+            .length = length;
+
+        Ok(Ok(gc_ref.into_arrayref_unchecked()))
+    }
+
+    fn dealloc_uninit_array(&mut self, _arrayref: VMArrayRef) {
+        // The copying collector doesn't support individual deallocation; memory
+        // is reclaimed during collection.
+    }
+
+    fn array_len(&self, arrayref: &VMArrayRef) -> u32 {
+        debug_assert!(arrayref.as_gc_ref().is_typed::<VMCopyingArrayHeader>(self));
+        self.index::<VMCopyingArrayHeader>(arrayref.as_gc_ref().as_typed_unchecked())
+            .length
+    }
+
+    fn allocated_bytes(&self) -> usize {
+        usize::try_from(self.bump_ptr - self.active_space_start).unwrap()
+    }
+
+    fn gc<'a>(
+        &'a mut self,
+        roots: GcRootsIter<'a>,
+        host_data_table: &'a mut ExternRefHostDataTable,
+    ) -> Box<dyn GarbageCollection<'a> + 'a> {
+        assert_eq!(self.no_gc_count, 0, "Cannot GC inside a no-GC scope!");
+        Box::new(CopyingCollection {
+            roots: Some(roots),
+            host_data_table,
+            heap: self,
+            phase: CopyingCollectionPhase::Collect,
+        })
+    }
+
+    unsafe fn vmctx_gc_heap_data(&self) -> NonNull<u8> {
+        // The copying collector doesn't currently have vmctx GC heap
+        // data. Return a dangling pointer.
+        NonNull::dangling()
+    }
+
+    fn take_memory(&mut self) -> crate::vm::Memory {
+        debug_assert!(self.is_attached());
+        self.vmmemory.take();
+        self.memory.take().unwrap()
+    }
+
+    fn needs_gc_before_next_growth(&self) -> bool {
+        // We need a GC before growth when the active space is the second half
+        // of the GC heap, because we cannot safely extend the active space in
+        // that configuration without making it larger than the idle space.
+        self.active_space_start >= self.idle_space_start && self.active_space_end > 0
+    }
+
+    unsafe fn replace_memory(&mut self, memory: crate::vm::Memory, _delta_bytes_grown: u64) {
+        debug_assert!(self.memory.is_none());
+        debug_assert!(!memory.is_shared_memory());
+        self.vmmemory = Some(memory.vmmemory());
+        self.memory = Some(memory);
+
+        let new_len = u32::try_from(self.vmmemory.as_ref().unwrap().current_length()).unwrap();
+
+        // If the heap was previously empty (all zeroes), reinitialize the
+        // semi-spaces from scratch.
+        if self.active_space_end == 0 && self.idle_space_end == 0 {
+            self.initialize_semi_spaces(new_len);
+            return;
+        }
+
+        // Only adjust the semi-space regions for new capacity if the active
+        // semi-space is the first half of the GC heap. Otherwise, wait until
+        // the next collection to update the regions.
+        if self.active_space_start < self.idle_space_start {
+            let halfway = new_len / 2;
+            debug_assert!(self.bump_ptr <= halfway);
+            debug_assert!(self.idle_space_start <= halfway);
+            debug_assert!(self.active_space_end <= halfway);
+
+            self.active_space_end = halfway;
+            self.idle_space_start = halfway;
+            self.idle_space_end = new_len;
+        }
+
+        // Poison the newly-grown region.
+        if cfg!(gc_zeal) {
+            // The idle space has grown, poison any new bytes.
+            let idle_end = usize::try_from(self.idle_space_end).unwrap();
+            let slice = self.heap_slice_mut();
+            if idle_end <= slice.len() {
+                // Poison from the old idle_space_end to the new length.
+                // But we need to know the old idle_space_end. For simplicity
+                // just let collection handle reclamation.
+            }
+        }
+    }
+
+    #[inline]
+    fn vmmemory(&self) -> VMMemoryDefinition {
+        debug_assert!(self.is_attached());
+        debug_assert!(!self.memory.as_ref().unwrap().is_shared_memory());
+        let vmmemory = self.vmmemory.as_ref().unwrap();
+        VMMemoryDefinition {
+            base: vmmemory.base,
+            current_length: AtomicUsize::new(vmmemory.current_length()),
+        }
+    }
+}
+
+struct CopyingCollection<'a> {
+    roots: Option<GcRootsIter<'a>>,
+    host_data_table: &'a mut ExternRefHostDataTable,
+    heap: &'a mut CopyingHeap,
+    phase: CopyingCollectionPhase,
+}
+
+enum CopyingCollectionPhase {
+    Collect,
+    Done,
+}
+
+impl CopyingCollection<'_> {
+    /// Forward all GC roots from the idle space to the active space.
+    fn process_roots(&mut self) {
+        let heap = &mut *self.heap;
+        let mut roots = self.roots.take().unwrap();
+        for mut root in &mut roots {
+            let gc_ref = root.get();
+            if gc_ref.is_i31() {
+                continue;
+            }
+            let old_index = gc_ref.as_heap_index().unwrap().get();
+            debug_assert!(heap.is_in_idle_space(old_index));
+            let new_ref = heap.forward(&gc_ref);
+            root.set(new_ref);
+        }
+        drop(roots);
+    }
+
+    /// Scan all grey objects until the worklist is empty.
+    fn process_worklist(&mut self) {
+        let heap = &mut *self.heap;
+        let trace_infos = mem::take(&mut heap.trace_infos);
+        while let Some(gc_ref) = heap.worklist_pop() {
+            debug_assert!(heap.is_in_active_space(gc_ref.as_heap_index().unwrap().get()));
+            heap.scan(&gc_ref, &trace_infos);
+        }
+        heap.trace_infos = trace_infos;
+    }
+
+    /// Clean up dead externrefs by iterating the idle semi-space's externref
+    /// linked list and deallocating host data for any that were not forwarded.
+    fn sweep_extern_refs(&mut self) {
+        let heap = &mut *self.heap;
+        let mut link = heap.idle_extern_ref_set_head.take();
+        while let Some(externref) = link {
+            let gc_ref = externref.as_gc_ref();
+            debug_assert!(heap.is_in_idle_space(gc_ref.as_heap_index().unwrap().get()));
+            let header = heap.index(copying_ref(gc_ref));
+            if !header.copied() {
+                let typed: &TypedGcRef<VMCopyingExternRef> = gc_ref.as_typed_unchecked();
+                let host_data_id = heap.index(typed).host_data;
+                self.host_data_table.dealloc(host_data_id);
+            }
+            link = heap
+                .index::<VMCopyingExternRef>(gc_ref.as_typed_unchecked())
+                .next_extern_ref
+                .as_ref()
+                .map(|e| e.unchecked_copy());
+        }
+    }
+}
+
+impl GarbageCollection<'_> for CopyingCollection<'_> {
+    fn collect_increment(&mut self) -> GcProgress {
+        match self.phase {
+            CopyingCollectionPhase::Collect => {
+                log::trace!("Begin copying collection");
+
+                let heap = &mut *self.heap;
+
+                assert!(heap.active_space_start <= heap.bump_ptr);
+                assert!(heap.bump_ptr <= heap.active_space_end);
+                assert!(heap.idle_space_start <= heap.idle_space_end);
+                assert!(
+                    heap.active_space_end <= heap.idle_space_start
+                        || heap.idle_space_end <= heap.active_space_start
+                );
+
+                // Flip the semi-spaces.
+                heap.flip();
+                heap.initialize_worklist();
+
+                self.process_roots();
+                self.process_worklist();
+
+                let heap = &mut *self.heap;
+                assert!(heap.active_space_start <= heap.bump_ptr);
+                assert!(heap.bump_ptr <= heap.active_space_end);
+                assert!(heap.idle_space_start <= heap.idle_space_end);
+                assert!(
+                    heap.active_space_end <= heap.idle_space_start
+                        || heap.idle_space_end <= heap.active_space_start
+                );
+
+                self.sweep_extern_refs();
+
+                // Adjust semi-space regions for any new capacity if the active
+                // space is the first half.
+                let heap = &mut *self.heap;
+                if heap.active_space_start < heap.idle_space_start {
+                    let mem_len =
+                        u32::try_from(heap.vmmemory.as_ref().unwrap().current_length()).unwrap();
+                    assert!(heap.idle_space_end <= mem_len);
+                    heap.idle_space_end = mem_len;
+
+                    let halfway = mem_len / 2;
+                    assert!(heap.bump_ptr <= halfway);
+
+                    assert!(heap.idle_space_start <= halfway);
+                    heap.idle_space_start = halfway;
+
+                    assert!(heap.active_space_end <= halfway);
+                    heap.active_space_end = halfway;
+                }
+
+                // Poison the idle space so stale accesses are detectable.
+                if cfg!(gc_zeal) {
+                    let idle_start = usize::try_from(heap.idle_space_start).unwrap();
+                    let idle_end = usize::try_from(heap.idle_space_end).unwrap();
+                    heap.heap_slice_mut()[idle_start..idle_end].fill(POISON);
+                }
+
+                log::trace!("End copying collection");
+                self.phase = CopyingCollectionPhase::Done;
+                GcProgress::Complete
+            }
+            CopyingCollectionPhase::Done => GcProgress::Complete,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wasmtime_environ::HostPtr;
+
+    #[test]
+    fn vm_copying_header_size_align() {
+        assert_eq!(
+            wasmtime_environ::copying::HEADER_SIZE as usize,
+            core::mem::size_of::<VMCopyingHeader>(),
+        );
+        // The struct's natural alignment must not exceed ALIGN, which is
+        // enforced by the bump allocator.
+        assert!(
+            core::mem::align_of::<VMCopyingHeader>() <= wasmtime_environ::copying::ALIGN as usize,
+        );
+    }
+
+    #[test]
+    fn vm_copying_array_header_length_offset() {
+        assert_eq!(
+            wasmtime_environ::copying::ARRAY_LENGTH_OFFSET,
+            u32::try_from(core::mem::offset_of!(VMCopyingArrayHeader, length)).unwrap(),
+        );
+    }
+
+    #[test]
+    fn vm_copying_header_object_size_offset() {
+        assert_eq!(
+            // object_size comes right after the VMGcHeader
+            wasmtime_environ::VM_GC_HEADER_SIZE,
+            u32::try_from(core::mem::offset_of!(VMCopyingHeader, object_size)).unwrap(),
+        );
+    }
+
+    #[test]
+    fn vm_copying_forwarding_ref_offset() {
+        assert_eq!(
+            wasmtime_environ::copying::FORWARDING_REF_OFFSET as usize,
+            core::mem::offset_of!(VMCopyingHeaderAndForwardingRef, forwarding_ref),
+        );
+    }
+
+    #[test]
+    fn vm_copying_header_and_forwarding_ref_size() {
+        // The forwarding ref data (at FORWARDING_REF_OFFSET) plus its size
+        // must fit within MIN_OBJECT_SIZE, so every object has room for
+        // the forwarding pointer during collection.
+        assert!(
+            wasmtime_environ::copying::FORWARDING_REF_OFFSET as usize
+                + core::mem::size_of::<Option<VMGcRef>>()
+                <= wasmtime_environ::copying::MIN_OBJECT_SIZE as usize,
+        );
     }
 }

--- a/crates/wasmtime/src/runtime/vm/gc/enabled/copying.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/enabled/copying.rs
@@ -863,21 +863,24 @@ unsafe impl GcHeap for CopyingHeap {
         // semi-spaces from scratch.
         if self.active_space_end == 0 && self.idle_space_end == 0 {
             self.initialize_semi_spaces(new_len);
-            return;
-        }
+        } else {
+            // Otherwise the memory was grown.
+            //
+            // We only adjust the semi-space regions for new memory capacity if
+            // the active semi-space is the first half of the GC heap. Else,
+            // when the the second half of the GC heap is the active semi-space,
+            // wait until the next collection to automatically update the
+            // regions.
+            if self.active_space_start < self.idle_space_start {
+                let halfway = new_len / 2;
+                debug_assert!(self.bump_ptr <= halfway);
+                debug_assert!(self.idle_space_start <= halfway);
+                debug_assert!(self.active_space_end <= halfway);
 
-        // Only adjust the semi-space regions for new capacity if the active
-        // semi-space is the first half of the GC heap. Otherwise, wait until
-        // the next collection to update the regions.
-        if self.active_space_start < self.idle_space_start {
-            let halfway = new_len / 2;
-            debug_assert!(self.bump_ptr <= halfway);
-            debug_assert!(self.idle_space_start <= halfway);
-            debug_assert!(self.active_space_end <= halfway);
-
-            self.active_space_end = halfway;
-            self.idle_space_start = halfway;
-            self.idle_space_end = new_len;
+                self.active_space_end = halfway;
+                self.idle_space_start = halfway;
+                self.idle_space_end = new_len;
+            }
         }
 
         // Poison the newly-grown region.

--- a/crates/wasmtime/src/runtime/vm/gc/enabled/copying.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/enabled/copying.rs
@@ -857,7 +857,7 @@ unsafe impl GcHeap for CopyingHeap {
         self.idle_space_start < self.active_space_start
     }
 
-    unsafe fn replace_memory(&mut self, memory: crate::vm::Memory, _delta_bytes_grown: u64) {
+    unsafe fn replace_memory(&mut self, memory: crate::vm::Memory, delta_bytes_grown: u64) {
         debug_assert!(self.memory.is_none());
         debug_assert!(!memory.is_shared_memory());
         self.vmmemory = Some(memory.vmmemory());
@@ -874,15 +874,11 @@ unsafe impl GcHeap for CopyingHeap {
         }
 
         // Poison the newly-grown region.
-        if cfg!(gc_zeal) {
-            // The idle space has grown, poison any new bytes.
-            let idle_end = usize::try_from(self.idle_space_end).unwrap();
+        if cfg!(gc_zeal) && delta_bytes_grown > 0 {
             let slice = self.heap_slice_mut();
-            if idle_end <= slice.len() {
-                // Poison from the old idle_space_end to the new length.
-                // But we need to know the old idle_space_end. For simplicity
-                // just let collection handle reclamation.
-            }
+            let len = slice.len();
+            let delta_bytes_grown = usize::try_from(delta_bytes_grown).unwrap();
+            slice[len - delta_bytes_grown..].fill(POISON);
         }
     }
 

--- a/crates/wasmtime/src/runtime/vm/gc/enabled/copying.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/enabled/copying.rs
@@ -1064,7 +1064,6 @@ impl GarbageCollection<'_> for CopyingCollection<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use wasmtime_environ::HostPtr;
 
     #[test]
     fn vm_copying_header_size_align() {

--- a/crates/wasmtime/src/runtime/vm/gc/enabled/copying.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/enabled/copying.rs
@@ -288,7 +288,7 @@ impl CopyingHeap {
 
         // VMGcRef uses NonZeroU32, so index 0 is reserved. Start the bump
         // pointer at `ALIGN` to skip past zero while keeping it aligned.
-        debug_assert!(capacity == 0 || capacity > ALIGN);
+        debug_assert!(capacity == 0 || capacity > 2 * ALIGN);
         self.bump_ptr = if capacity > 0 { ALIGN } else { 0 };
     }
 
@@ -337,11 +337,14 @@ impl CopyingHeap {
         mem::swap(&mut self.active_space_start, &mut self.idle_space_start);
         mem::swap(&mut self.active_space_end, &mut self.idle_space_end);
 
-        // VMGcRef uses NonZeroU32, so index 0 is reserved. Skip past it
-        // with proper alignment so allocations never return index 0.
+        // VMGcRef uses NonZeroU32, so index 0 is reserved. Skip past it with
+        // proper alignment so allocations never return index 0. Also skip past
+        // the first ALIGN bytes in the second half of the GC heap so that the
+        // usable size of both semi-spaces is the same (which we require when
+        // copying live objects across semi-spaces during collection).
         self.bump_ptr = self.active_space_start;
-        if self.bump_ptr == 0 && self.active_space_end > ALIGN {
-            self.bump_ptr = ALIGN;
+        if self.active_space_end - self.active_space_start >= ALIGN {
+            self.bump_ptr += ALIGN;
         }
 
         // Swap the externref linked lists along with the semi-spaces.

--- a/crates/wasmtime/src/runtime/vm/gc/enabled/copying.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/enabled/copying.rs
@@ -18,7 +18,6 @@ use crate::runtime::vm::{
 };
 use crate::vm::VMMemoryDefinition;
 use crate::{Engine, prelude::*};
-use core::mem::MaybeUninit;
 use core::sync::atomic::AtomicUsize;
 use core::{alloc::Layout, any::Any, mem, num::NonZeroU32, ptr::NonNull};
 use wasmtime_environ::copying::{
@@ -154,11 +153,9 @@ unsafe impl GcHeapObject for VMCopyingArrayHeader {
 /// The representation of an `externref` in the copying collector.
 #[repr(C)]
 struct VMCopyingExternRef {
-    header: VMCopyingHeader,
-
-    /// Padding so that our other fields aren't overwritten by the forwarding
-    /// location.
-    _forwarding_ref_padding: MaybeUninit<Option<VMGcRef>>,
+    /// NB: Explicitly leave room for the forwarding ref so that our other
+    /// fields aren't overwritten after copying to the new semi-space.
+    header: VMCopyingHeaderAndForwardingRef,
 
     /// The ID of this ref's data in the `ExternRefHostDataTable`.
     host_data: ExternRefHostDataId,
@@ -268,14 +265,49 @@ impl CopyingHeap {
         })
     }
 
-    /// Initialize the semi-spaces for a heap of the given capacity.
-    fn initialize_semi_spaces(&mut self, capacity: u32) {
-        // Round capacity down to an even number, so our semi-spaces are
+    fn capacity(&self) -> u32 {
+        let len = self.vmmemory.as_ref().unwrap().current_length();
+        let len = u32::try_from(len).unwrap_or(u32::MAX);
+        // Round down to a multiple of `ALIGN` so our semi-spaces are
         // equal-sized.
-        let capacity = capacity & !1;
+        let len = len & !(ALIGN - 1);
+        len
+    }
 
+    /// Initialize the semi-spaces for a heap of the given capacity.
+    fn initialize_semi_spaces(&mut self) {
+        debug_assert_eq!(self.active_space_start, 0);
+        debug_assert_eq!(self.active_space_end, 0);
+        debug_assert_eq!(self.idle_space_start, 0);
+        debug_assert_eq!(self.idle_space_end, 0);
+        debug_assert_eq!(self.bump_ptr, 0);
+
+        self.resize_semi_spaces();
+        self.reset_bump_ptr();
+    }
+
+    fn resize_semi_spaces(&mut self) {
+        debug_assert_eq!(
+            self.active_space_end - self.active_space_start,
+            self.idle_space_end - self.idle_space_start,
+            "the active and idle spaces should be the same size"
+        );
+
+        // We only adjust the semi-space regions for new memory capacity if the
+        // active semi-space is the first half of the GC heap. Else, when the
+        // the second half of the GC heap is the active semi-space, wait until
+        // the next collection to automatically update the regions.
+        if self.idle_space_start < self.active_space_start {
+            return;
+        }
+
+        let capacity = self.capacity();
         let halfway = capacity / 2;
-        self.active_space_start = 0;
+
+        debug_assert!(self.bump_ptr <= halfway);
+        debug_assert!(self.idle_space_start <= halfway);
+        debug_assert!(self.active_space_end <= halfway);
+
         self.active_space_end = halfway;
         self.idle_space_start = halfway;
         self.idle_space_end = capacity;
@@ -285,11 +317,23 @@ impl CopyingHeap {
             self.idle_space_end - self.idle_space_start,
             "the active and idle spaces should be the same size"
         );
+    }
 
-        // VMGcRef uses NonZeroU32, so index 0 is reserved. Start the bump
-        // pointer at `ALIGN` to skip past zero while keeping it aligned.
-        debug_assert!(capacity == 0 || capacity > 2 * ALIGN);
-        self.bump_ptr = if capacity > 0 { ALIGN } else { 0 };
+    fn reset_bump_ptr(&mut self) {
+        // We always need to keep `bump_ptr` aligned to `ALIGN`.
+        //
+        // When the active space is the first half of the GC heap, we need to
+        // skip past index 0, since `VMGcRef` is a `NonZeroU32`.
+        //
+        // When the active space is the second half of the GC heap, we *also*
+        // skip the first `ALIGN` bytes. This ensures that the active and idle
+        // spaces are always equally sized, which is required to guarantee that
+        // evacuating objects from one to the other will succeed.
+        self.bump_ptr = self.active_space_start;
+        if self.active_space_end - self.active_space_start >= ALIGN {
+            self.bump_ptr += ALIGN;
+        }
+        debug_assert!(self.bump_ptr.is_multiple_of(ALIGN));
     }
 
     /// Ensure that we have tracing information for the given type.
@@ -301,6 +345,8 @@ impl CopyingHeap {
     ///
     /// Returns `None` if there isn't enough room.
     fn allocate(&mut self, size: u32) -> Option<u32> {
+        debug_assert!(size.is_multiple_of(ALIGN));
+        debug_assert!(self.bump_ptr.is_multiple_of(ALIGN));
         debug_assert!(self.bump_ptr >= self.active_space_start);
         debug_assert!(self.bump_ptr <= self.active_space_end);
 
@@ -309,10 +355,12 @@ impl CopyingHeap {
         if new_bump_ptr > self.active_space_end {
             return None;
         }
-        self.bump_ptr = new_bump_ptr;
 
+        self.bump_ptr = new_bump_ptr;
+        debug_assert!(self.bump_ptr.is_multiple_of(ALIGN));
         debug_assert!(self.bump_ptr >= self.active_space_start);
         debug_assert!(self.bump_ptr <= self.active_space_end);
+
         Some(result)
     }
 
@@ -336,25 +384,11 @@ impl CopyingHeap {
 
         mem::swap(&mut self.active_space_start, &mut self.idle_space_start);
         mem::swap(&mut self.active_space_end, &mut self.idle_space_end);
+        self.reset_bump_ptr();
 
-        // VMGcRef uses NonZeroU32, so index 0 is reserved. Skip past it with
-        // proper alignment so allocations never return index 0. Also skip past
-        // the first ALIGN bytes in the second half of the GC heap so that the
-        // usable size of both semi-spaces is the same (which we require when
-        // copying live objects across semi-spaces during collection).
-        self.bump_ptr = self.active_space_start;
-        if self.active_space_end - self.active_space_start >= ALIGN {
-            self.bump_ptr += ALIGN;
-        }
-
-        // Swap the externref linked lists along with the semi-spaces.
-        mem::swap(
-            &mut self.active_extern_ref_set_head,
-            &mut self.idle_extern_ref_set_head,
-        );
-
-        // Clear the active list since we're starting fresh in the new space.
-        self.active_extern_ref_set_head = None;
+        // The active idle list becomes the old active list; the active list is
+        // cleared because we are starting fresh in the new space.
+        self.idle_extern_ref_set_head = self.active_extern_ref_set_head.take();
     }
 
     /// Initialize the worklist at the start of a collection.
@@ -444,14 +478,8 @@ impl CopyingHeap {
         let from_start = usize::try_from(from_index).unwrap();
         let to_start = usize::try_from(to_index).unwrap();
         let size_usize = usize::try_from(size).unwrap();
-        let [from, to] = self
-            .heap_slice_mut()
-            .get_disjoint_mut([
-                from_start..from_start + size_usize,
-                to_start..to_start + size_usize,
-            ])
-            .expect("semi-spaces do not overlap");
-        to.copy_from_slice(from);
+        self.heap_slice_mut()
+            .copy_within(from_start..from_start + size_usize, to_start);
 
         // Set the forwarding ref in the old (idle-space) object.
         self.index_mut(header_and_forwarding_ref(from_ref))
@@ -490,68 +518,48 @@ impl CopyingHeap {
             return;
         };
 
+        let object_start = usize::try_from(index).unwrap();
         match trace_infos.trace_info(&ty) {
             TraceInfo::Struct { gc_ref_offsets } => {
-                let object_start = usize::try_from(index).unwrap();
-
                 for &offset in gc_ref_offsets {
-                    let offset_usize = usize::try_from(offset).unwrap();
-                    let field_start = object_start + offset_usize;
-                    let field_end = field_start + mem::size_of::<u32>();
-
-                    let raw: [u8; 4] = self.heap_slice()[field_start..field_end]
-                        .try_into()
-                        .unwrap();
-                    let raw = u32::from_le_bytes(raw);
-
-                    if let Some(child) = VMGcRef::from_raw_u32(raw)
-                        && !child.is_i31()
-                    {
-                        debug_assert!(self.is_in_idle_space(child.as_heap_index().unwrap().get()));
-                        let new_ref = self.forward(&child);
-                        debug_assert!(
-                            self.is_in_active_space(new_ref.as_heap_index().unwrap().get())
-                        );
-                        // Write the new reference back.
-                        let new_raw = new_ref.as_raw_u32().to_le_bytes();
-                        self.heap_slice_mut()[field_start..field_end].copy_from_slice(&new_raw);
-                    }
+                    self.scan_field(object_start, offset);
                 }
             }
             TraceInfo::Array { gc_ref_elems } => {
                 if *gc_ref_elems {
                     let array_ref = gc_ref.as_arrayref_unchecked();
                     let len = self.array_len(array_ref);
-                    let object_start = usize::try_from(index).unwrap();
 
                     for i in 0..len {
                         let elem_offset = GC_REF_ARRAY_ELEMS_OFFSET
                             + i * u32::try_from(mem::size_of::<u32>()).unwrap();
-                        let offset_usize = usize::try_from(elem_offset).unwrap();
-                        let field_start = object_start + offset_usize;
-                        let field_end = field_start + mem::size_of::<u32>();
-
-                        let raw: [u8; 4] = self.heap_slice()[field_start..field_end]
-                            .try_into()
-                            .unwrap();
-                        let raw = u32::from_le_bytes(raw);
-
-                        if let Some(child) = VMGcRef::from_raw_u32(raw)
-                            && !child.is_i31()
-                        {
-                            debug_assert!(
-                                self.is_in_idle_space(child.as_heap_index().unwrap().get())
-                            );
-                            let new_ref = self.forward(&child);
-                            debug_assert!(
-                                self.is_in_active_space(new_ref.as_heap_index().unwrap().get())
-                            );
-                            let new_raw = new_ref.as_raw_u32().to_le_bytes();
-                            self.heap_slice_mut()[field_start..field_end].copy_from_slice(&new_raw);
-                        }
+                        self.scan_field(object_start, elem_offset);
                     }
                 }
             }
+        }
+    }
+
+    #[inline]
+    fn scan_field(&mut self, object_start: usize, offset: u32) {
+        let offset = usize::try_from(offset).unwrap();
+        let field_start = object_start + offset;
+        let field_end = field_start + mem::size_of::<u32>();
+
+        let raw: [u8; 4] = self.heap_slice()[field_start..field_end]
+            .try_into()
+            .unwrap();
+        let raw = u32::from_le_bytes(raw);
+
+        if let Some(child) = VMGcRef::from_raw_u32(raw)
+            && !child.is_i31()
+        {
+            debug_assert!(self.is_in_idle_space(child.as_heap_index().unwrap().get()));
+            let new_ref = self.forward(&child);
+            debug_assert!(self.is_in_active_space(new_ref.as_heap_index().unwrap().get()));
+            // Write the new reference back.
+            let new_raw = new_ref.as_raw_u32().to_le_bytes();
+            self.heap_slice_mut()[field_start..field_end].copy_from_slice(&new_raw);
         }
     }
 }
@@ -565,11 +573,9 @@ unsafe impl GcHeap for CopyingHeap {
     fn attach(&mut self, memory: crate::vm::Memory) {
         assert!(!self.is_attached());
         assert!(!memory.is_shared_memory());
-        let len = memory.vmmemory().current_length();
-        let capacity = u32::try_from(len).unwrap();
-        self.initialize_semi_spaces(capacity);
         self.vmmemory = Some(memory.vmmemory());
         self.memory = Some(memory);
+        self.initialize_semi_spaces();
 
         if cfg!(gc_zeal) {
             self.heap_slice_mut().fill(POISON);
@@ -848,7 +854,7 @@ unsafe impl GcHeap for CopyingHeap {
         // We need a GC before growth when the active space is the second half
         // of the GC heap, because we cannot safely extend the active space in
         // that configuration without making it larger than the idle space.
-        self.active_space_start >= self.idle_space_start && self.active_space_end > 0
+        self.idle_space_start < self.active_space_start
     }
 
     unsafe fn replace_memory(&mut self, memory: crate::vm::Memory, _delta_bytes_grown: u64) {
@@ -857,30 +863,14 @@ unsafe impl GcHeap for CopyingHeap {
         self.vmmemory = Some(memory.vmmemory());
         self.memory = Some(memory);
 
-        let new_len = u32::try_from(self.vmmemory.as_ref().unwrap().current_length()).unwrap();
-
-        // If the heap was previously empty (all zeroes), reinitialize the
-        // semi-spaces from scratch.
+        // If the heap was previously empty, reinitialize the semi-spaces from
+        // scratch.
         if self.active_space_end == 0 && self.idle_space_end == 0 {
-            self.initialize_semi_spaces(new_len);
+            self.initialize_semi_spaces();
         } else {
-            // Otherwise the memory was grown.
-            //
-            // We only adjust the semi-space regions for new memory capacity if
-            // the active semi-space is the first half of the GC heap. Else,
-            // when the the second half of the GC heap is the active semi-space,
-            // wait until the next collection to automatically update the
-            // regions.
-            if self.active_space_start < self.idle_space_start {
-                let halfway = new_len / 2;
-                debug_assert!(self.bump_ptr <= halfway);
-                debug_assert!(self.idle_space_start <= halfway);
-                debug_assert!(self.active_space_end <= halfway);
-
-                self.active_space_end = halfway;
-                self.idle_space_start = halfway;
-                self.idle_space_end = new_len;
-            }
+            // Otherwise the memory was grown: try to resize the semi-spaces
+            // accordingly.
+            self.resize_semi_spaces();
         }
 
         // Poison the newly-grown region.
@@ -1011,33 +1001,7 @@ impl GarbageCollection<'_> for CopyingCollection<'_> {
                 );
 
                 self.sweep_extern_refs();
-
-                // Adjust semi-space regions for any new capacity if the active
-                // space is the first half.
-                if self.heap.active_space_start < self.heap.idle_space_start {
-                    let mem_len =
-                        u32::try_from(self.heap.vmmemory.as_ref().unwrap().current_length())
-                            .unwrap();
-                    // Round `mem_len` down to an even number, so our
-                    // semi-spaces are equal-sized.
-                    let mem_len = mem_len & !1;
-                    assert!(self.heap.idle_space_end <= mem_len);
-                    self.heap.idle_space_end = mem_len;
-
-                    let halfway = mem_len / 2;
-                    assert!(self.heap.bump_ptr <= halfway);
-
-                    assert!(self.heap.idle_space_start <= halfway);
-                    self.heap.idle_space_start = halfway;
-
-                    assert!(self.heap.active_space_end <= halfway);
-                    self.heap.active_space_end = halfway;
-                } else {
-                    // NB: Cannot adjust semi-space regions when the active
-                    // space is the second half of the GC heap because resizing
-                    // them would require moving objects which, in turn, would
-                    // require updating GC edges.
-                }
+                self.heap.resize_semi_spaces();
 
                 debug_assert_eq!(
                     self.heap.active_space_end - self.heap.active_space_start,

--- a/crates/wasmtime/src/runtime/vm/gc/enabled/copying.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/enabled/copying.rs
@@ -15,8 +15,8 @@ use super::trace_info::{TraceInfo, TraceInfos};
 use crate::runtime::vm::{
     ExternRefHostDataId, ExternRefHostDataTable, GarbageCollection, GcHeap, GcHeapObject,
     GcProgress, GcRootsIter, GcRuntime, TypedGcRef, VMExternRef, VMGcHeader, VMGcRef,
+    VMMemoryDefinition,
 };
-use crate::vm::VMMemoryDefinition;
 use crate::{Engine, prelude::*};
 use core::sync::atomic::AtomicUsize;
 use core::{alloc::Layout, any::Any, mem, num::NonZeroU32, ptr::NonNull};
@@ -730,7 +730,9 @@ unsafe impl GcHeap for CopyingHeap {
         let size = u32::try_from(layout.size()).unwrap();
         // Round up the allocation size to ALIGN so that the next bump-pointer
         // allocation is also aligned.
-        let size = (size + ALIGN - 1) & !(ALIGN - 1);
+        let size = size
+            .checked_next_multiple_of(ALIGN)
+            .ok_or_else(|| crate::Trap::AllocationTooLarge)?;
 
         let gc_ref = match self.allocate(size) {
             None => return Ok(Err(u64::try_from(layout.size()).unwrap())),

--- a/crates/wasmtime/src/runtime/vm/gc/enabled/copying.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/enabled/copying.rs
@@ -1059,7 +1059,6 @@ impl GarbageCollection<'_> for CopyingCollection<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use wasmtime_environ::HostPtr;
 
     #[test]
     fn vm_copying_header_size_align() {

--- a/crates/wasmtime/src/runtime/vm/gc/enabled/copying.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/enabled/copying.rs
@@ -792,9 +792,13 @@ unsafe impl GcHeap for CopyingHeap {
         length: u32,
         layout: &GcArrayLayout,
     ) -> Result<Result<VMArrayRef, u64>> {
+        let layout = layout
+            .layout(length)
+            .ok_or_else(|| crate::Trap::AllocationTooLarge)?;
+
         let gc_ref = match self.alloc_raw(
             VMGcHeader::from_kind_and_index(VMGcKind::ArrayRef, ty),
-            layout.layout(length),
+            layout,
         )? {
             Err(n) => return Ok(Err(n)),
             Ok(gc_ref) => gc_ref,

--- a/crates/wasmtime/src/runtime/vm/gc/enabled/copying.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/enabled/copying.rs
@@ -852,7 +852,7 @@ unsafe impl GcHeap for CopyingHeap {
         self.idle_space_start < self.active_space_start
     }
 
-    unsafe fn replace_memory(&mut self, memory: crate::vm::Memory, _delta_bytes_grown: u64) {
+    unsafe fn replace_memory(&mut self, memory: crate::vm::Memory, delta_bytes_grown: u64) {
         debug_assert!(self.memory.is_none());
         debug_assert!(!memory.is_shared_memory());
         self.vmmemory = Some(memory.vmmemory());
@@ -869,15 +869,11 @@ unsafe impl GcHeap for CopyingHeap {
         }
 
         // Poison the newly-grown region.
-        if cfg!(gc_zeal) {
-            // The idle space has grown, poison any new bytes.
-            let idle_end = usize::try_from(self.idle_space_end).unwrap();
+        if cfg!(gc_zeal) && delta_bytes_grown > 0 {
             let slice = self.heap_slice_mut();
-            if idle_end <= slice.len() {
-                // Poison from the old idle_space_end to the new length.
-                // But we need to know the old idle_space_end. For simplicity
-                // just let collection handle reclamation.
-            }
+            let len = slice.len();
+            let delta_bytes_grown = usize::try_from(delta_bytes_grown).unwrap();
+            slice[len - delta_bytes_grown..].fill(POISON);
         }
     }
 

--- a/crates/wasmtime/src/runtime/vm/gc/enabled/copying.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/enabled/copying.rs
@@ -18,7 +18,6 @@ use crate::runtime::vm::{
 };
 use crate::vm::VMMemoryDefinition;
 use crate::{Engine, prelude::*};
-use core::mem::MaybeUninit;
 use core::sync::atomic::AtomicUsize;
 use core::{alloc::Layout, any::Any, mem, num::NonZeroU32, ptr::NonNull};
 use wasmtime_environ::copying::{
@@ -154,11 +153,9 @@ unsafe impl GcHeapObject for VMCopyingArrayHeader {
 /// The representation of an `externref` in the copying collector.
 #[repr(C)]
 struct VMCopyingExternRef {
-    header: VMCopyingHeader,
-
-    /// Padding so that our other fields aren't overwritten by the forwarding
-    /// location.
-    _forwarding_ref_padding: MaybeUninit<Option<VMGcRef>>,
+    /// NB: Explicitly leave room for the forwarding ref so that our other
+    /// fields aren't overwritten after copying to the new semi-space.
+    header: VMCopyingHeaderAndForwardingRef,
 
     /// The ID of this ref's data in the `ExternRefHostDataTable`.
     host_data: ExternRefHostDataId,
@@ -268,14 +265,49 @@ impl CopyingHeap {
         })
     }
 
-    /// Initialize the semi-spaces for a heap of the given capacity.
-    fn initialize_semi_spaces(&mut self, capacity: u32) {
-        // Round capacity down to an even number, so our semi-spaces are
+    fn capacity(&self) -> u32 {
+        let len = self.vmmemory.as_ref().unwrap().current_length();
+        let len = u32::try_from(len).unwrap_or(u32::MAX);
+        // Round down to a multiple of `ALIGN` so our semi-spaces are
         // equal-sized.
-        let capacity = capacity & !1;
+        let len = len & !(ALIGN - 1);
+        len
+    }
 
+    /// Initialize the semi-spaces for a heap of the given capacity.
+    fn initialize_semi_spaces(&mut self) {
+        debug_assert_eq!(self.active_space_start, 0);
+        debug_assert_eq!(self.active_space_end, 0);
+        debug_assert_eq!(self.idle_space_start, 0);
+        debug_assert_eq!(self.idle_space_end, 0);
+        debug_assert_eq!(self.bump_ptr, 0);
+
+        self.resize_semi_spaces();
+        self.reset_bump_ptr();
+    }
+
+    fn resize_semi_spaces(&mut self) {
+        debug_assert_eq!(
+            self.active_space_end - self.active_space_start,
+            self.idle_space_end - self.idle_space_start,
+            "the active and idle spaces should be the same size"
+        );
+
+        // We only adjust the semi-space regions for new memory capacity if the
+        // active semi-space is the first half of the GC heap. Else, when the
+        // the second half of the GC heap is the active semi-space, wait until
+        // the next collection to automatically update the regions.
+        if self.idle_space_start < self.active_space_start {
+            return;
+        }
+
+        let capacity = self.capacity();
         let halfway = capacity / 2;
-        self.active_space_start = 0;
+
+        debug_assert!(self.bump_ptr <= halfway);
+        debug_assert!(self.idle_space_start <= halfway);
+        debug_assert!(self.active_space_end <= halfway);
+
         self.active_space_end = halfway;
         self.idle_space_start = halfway;
         self.idle_space_end = capacity;
@@ -285,17 +317,31 @@ impl CopyingHeap {
             self.idle_space_end - self.idle_space_start,
             "the active and idle spaces should be the same size"
         );
+    }
 
-        // VMGcRef uses NonZeroU32, so index 0 is reserved. Start the bump
-        // pointer at `ALIGN` to skip past zero while keeping it aligned.
-        debug_assert!(capacity == 0 || capacity > 2 * ALIGN);
-        self.bump_ptr = if capacity > 0 { ALIGN } else { 0 };
+    fn reset_bump_ptr(&mut self) {
+        // We always need to keep `bump_ptr` aligned to `ALIGN`.
+        //
+        // When the active space is the first half of the GC heap, we need to
+        // skip past index 0, since `VMGcRef` is a `NonZeroU32`.
+        //
+        // When the active space is the second half of the GC heap, we *also*
+        // skip the first `ALIGN` bytes. This ensures that the active and idle
+        // spaces are always equally sized, which is required to guarantee that
+        // evacuating objects from one to the other will succeed.
+        self.bump_ptr = self.active_space_start;
+        if self.active_space_end - self.active_space_start >= ALIGN {
+            self.bump_ptr += ALIGN;
+        }
+        debug_assert!(self.bump_ptr.is_multiple_of(ALIGN));
     }
 
     /// Allocate `size` bytes from the active semi-space bump pointer.
     ///
     /// Returns `None` if there isn't enough room.
     fn allocate(&mut self, size: u32) -> Option<u32> {
+        debug_assert!(size.is_multiple_of(ALIGN));
+        debug_assert!(self.bump_ptr.is_multiple_of(ALIGN));
         debug_assert!(self.bump_ptr >= self.active_space_start);
         debug_assert!(self.bump_ptr <= self.active_space_end);
 
@@ -304,10 +350,12 @@ impl CopyingHeap {
         if new_bump_ptr > self.active_space_end {
             return None;
         }
-        self.bump_ptr = new_bump_ptr;
 
+        self.bump_ptr = new_bump_ptr;
+        debug_assert!(self.bump_ptr.is_multiple_of(ALIGN));
         debug_assert!(self.bump_ptr >= self.active_space_start);
         debug_assert!(self.bump_ptr <= self.active_space_end);
+
         Some(result)
     }
 
@@ -331,25 +379,11 @@ impl CopyingHeap {
 
         mem::swap(&mut self.active_space_start, &mut self.idle_space_start);
         mem::swap(&mut self.active_space_end, &mut self.idle_space_end);
+        self.reset_bump_ptr();
 
-        // VMGcRef uses NonZeroU32, so index 0 is reserved. Skip past it with
-        // proper alignment so allocations never return index 0. Also skip past
-        // the first ALIGN bytes in the second half of the GC heap so that the
-        // usable size of both semi-spaces is the same (which we require when
-        // copying live objects across semi-spaces during collection).
-        self.bump_ptr = self.active_space_start;
-        if self.active_space_end - self.active_space_start >= ALIGN {
-            self.bump_ptr += ALIGN;
-        }
-
-        // Swap the externref linked lists along with the semi-spaces.
-        mem::swap(
-            &mut self.active_extern_ref_set_head,
-            &mut self.idle_extern_ref_set_head,
-        );
-
-        // Clear the active list since we're starting fresh in the new space.
-        self.active_extern_ref_set_head = None;
+        // The active idle list becomes the old active list; the active list is
+        // cleared because we are starting fresh in the new space.
+        self.idle_extern_ref_set_head = self.active_extern_ref_set_head.take();
     }
 
     /// Initialize the worklist at the start of a collection.
@@ -439,14 +473,8 @@ impl CopyingHeap {
         let from_start = usize::try_from(from_index).unwrap();
         let to_start = usize::try_from(to_index).unwrap();
         let size_usize = usize::try_from(size).unwrap();
-        let [from, to] = self
-            .heap_slice_mut()
-            .get_disjoint_mut([
-                from_start..from_start + size_usize,
-                to_start..to_start + size_usize,
-            ])
-            .expect("semi-spaces do not overlap");
-        to.copy_from_slice(from);
+        self.heap_slice_mut()
+            .copy_within(from_start..from_start + size_usize, to_start);
 
         // Set the forwarding ref in the old (idle-space) object.
         self.index_mut(header_and_forwarding_ref(from_ref))
@@ -485,68 +513,48 @@ impl CopyingHeap {
             return;
         };
 
+        let object_start = usize::try_from(index).unwrap();
         match trace_infos.trace_info(&ty) {
             TraceInfo::Struct { gc_ref_offsets } => {
-                let object_start = usize::try_from(index).unwrap();
-
                 for &offset in gc_ref_offsets {
-                    let offset_usize = usize::try_from(offset).unwrap();
-                    let field_start = object_start + offset_usize;
-                    let field_end = field_start + mem::size_of::<u32>();
-
-                    let raw: [u8; 4] = self.heap_slice()[field_start..field_end]
-                        .try_into()
-                        .unwrap();
-                    let raw = u32::from_le_bytes(raw);
-
-                    if let Some(child) = VMGcRef::from_raw_u32(raw)
-                        && !child.is_i31()
-                    {
-                        debug_assert!(self.is_in_idle_space(child.as_heap_index().unwrap().get()));
-                        let new_ref = self.forward(&child);
-                        debug_assert!(
-                            self.is_in_active_space(new_ref.as_heap_index().unwrap().get())
-                        );
-                        // Write the new reference back.
-                        let new_raw = new_ref.as_raw_u32().to_le_bytes();
-                        self.heap_slice_mut()[field_start..field_end].copy_from_slice(&new_raw);
-                    }
+                    self.scan_field(object_start, offset);
                 }
             }
             TraceInfo::Array { gc_ref_elems } => {
                 if *gc_ref_elems {
                     let array_ref = gc_ref.as_arrayref_unchecked();
                     let len = self.array_len(array_ref);
-                    let object_start = usize::try_from(index).unwrap();
 
                     for i in 0..len {
                         let elem_offset = GC_REF_ARRAY_ELEMS_OFFSET
                             + i * u32::try_from(mem::size_of::<u32>()).unwrap();
-                        let offset_usize = usize::try_from(elem_offset).unwrap();
-                        let field_start = object_start + offset_usize;
-                        let field_end = field_start + mem::size_of::<u32>();
-
-                        let raw: [u8; 4] = self.heap_slice()[field_start..field_end]
-                            .try_into()
-                            .unwrap();
-                        let raw = u32::from_le_bytes(raw);
-
-                        if let Some(child) = VMGcRef::from_raw_u32(raw)
-                            && !child.is_i31()
-                        {
-                            debug_assert!(
-                                self.is_in_idle_space(child.as_heap_index().unwrap().get())
-                            );
-                            let new_ref = self.forward(&child);
-                            debug_assert!(
-                                self.is_in_active_space(new_ref.as_heap_index().unwrap().get())
-                            );
-                            let new_raw = new_ref.as_raw_u32().to_le_bytes();
-                            self.heap_slice_mut()[field_start..field_end].copy_from_slice(&new_raw);
-                        }
+                        self.scan_field(object_start, elem_offset);
                     }
                 }
             }
+        }
+    }
+
+    #[inline]
+    fn scan_field(&mut self, object_start: usize, offset: u32) {
+        let offset = usize::try_from(offset).unwrap();
+        let field_start = object_start + offset;
+        let field_end = field_start + mem::size_of::<u32>();
+
+        let raw: [u8; 4] = self.heap_slice()[field_start..field_end]
+            .try_into()
+            .unwrap();
+        let raw = u32::from_le_bytes(raw);
+
+        if let Some(child) = VMGcRef::from_raw_u32(raw)
+            && !child.is_i31()
+        {
+            debug_assert!(self.is_in_idle_space(child.as_heap_index().unwrap().get()));
+            let new_ref = self.forward(&child);
+            debug_assert!(self.is_in_active_space(new_ref.as_heap_index().unwrap().get()));
+            // Write the new reference back.
+            let new_raw = new_ref.as_raw_u32().to_le_bytes();
+            self.heap_slice_mut()[field_start..field_end].copy_from_slice(&new_raw);
         }
     }
 }
@@ -560,11 +568,9 @@ unsafe impl GcHeap for CopyingHeap {
     fn attach(&mut self, memory: crate::vm::Memory) {
         assert!(!self.is_attached());
         assert!(!memory.is_shared_memory());
-        let len = memory.vmmemory().current_length();
-        let capacity = u32::try_from(len).unwrap();
-        self.initialize_semi_spaces(capacity);
         self.vmmemory = Some(memory.vmmemory());
         self.memory = Some(memory);
+        self.initialize_semi_spaces();
 
         if cfg!(gc_zeal) {
             self.heap_slice_mut().fill(POISON);
@@ -843,7 +849,7 @@ unsafe impl GcHeap for CopyingHeap {
         // We need a GC before growth when the active space is the second half
         // of the GC heap, because we cannot safely extend the active space in
         // that configuration without making it larger than the idle space.
-        self.active_space_start >= self.idle_space_start && self.active_space_end > 0
+        self.idle_space_start < self.active_space_start
     }
 
     unsafe fn replace_memory(&mut self, memory: crate::vm::Memory, _delta_bytes_grown: u64) {
@@ -852,30 +858,14 @@ unsafe impl GcHeap for CopyingHeap {
         self.vmmemory = Some(memory.vmmemory());
         self.memory = Some(memory);
 
-        let new_len = u32::try_from(self.vmmemory.as_ref().unwrap().current_length()).unwrap();
-
-        // If the heap was previously empty (all zeroes), reinitialize the
-        // semi-spaces from scratch.
+        // If the heap was previously empty, reinitialize the semi-spaces from
+        // scratch.
         if self.active_space_end == 0 && self.idle_space_end == 0 {
-            self.initialize_semi_spaces(new_len);
+            self.initialize_semi_spaces();
         } else {
-            // Otherwise the memory was grown.
-            //
-            // We only adjust the semi-space regions for new memory capacity if
-            // the active semi-space is the first half of the GC heap. Else,
-            // when the the second half of the GC heap is the active semi-space,
-            // wait until the next collection to automatically update the
-            // regions.
-            if self.active_space_start < self.idle_space_start {
-                let halfway = new_len / 2;
-                debug_assert!(self.bump_ptr <= halfway);
-                debug_assert!(self.idle_space_start <= halfway);
-                debug_assert!(self.active_space_end <= halfway);
-
-                self.active_space_end = halfway;
-                self.idle_space_start = halfway;
-                self.idle_space_end = new_len;
-            }
+            // Otherwise the memory was grown: try to resize the semi-spaces
+            // accordingly.
+            self.resize_semi_spaces();
         }
 
         // Poison the newly-grown region.
@@ -1006,33 +996,7 @@ impl GarbageCollection<'_> for CopyingCollection<'_> {
                 );
 
                 self.sweep_extern_refs();
-
-                // Adjust semi-space regions for any new capacity if the active
-                // space is the first half.
-                if self.heap.active_space_start < self.heap.idle_space_start {
-                    let mem_len =
-                        u32::try_from(self.heap.vmmemory.as_ref().unwrap().current_length())
-                            .unwrap();
-                    // Round `mem_len` down to an even number, so our
-                    // semi-spaces are equal-sized.
-                    let mem_len = mem_len & !1;
-                    assert!(self.heap.idle_space_end <= mem_len);
-                    self.heap.idle_space_end = mem_len;
-
-                    let halfway = mem_len / 2;
-                    assert!(self.heap.bump_ptr <= halfway);
-
-                    assert!(self.heap.idle_space_start <= halfway);
-                    self.heap.idle_space_start = halfway;
-
-                    assert!(self.heap.active_space_end <= halfway);
-                    self.heap.active_space_end = halfway;
-                } else {
-                    // NB: Cannot adjust semi-space regions when the active
-                    // space is the second half of the GC heap because resizing
-                    // them would require moving objects which, in turn, would
-                    // require updating GC edges.
-                }
+                self.heap.resize_semi_spaces();
 
                 debug_assert_eq!(
                     self.heap.active_space_end - self.heap.active_space_start,

--- a/crates/wasmtime/src/runtime/vm/gc/enabled/copying.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/enabled/copying.rs
@@ -270,11 +270,21 @@ impl CopyingHeap {
 
     /// Initialize the semi-spaces for a heap of the given capacity.
     fn initialize_semi_spaces(&mut self, capacity: u32) {
+        // Round capacity down to an even number, so our semi-spaces are
+        // equal-sized.
+        let capacity = capacity & !1;
+
         let halfway = capacity / 2;
         self.active_space_start = 0;
         self.active_space_end = halfway;
         self.idle_space_start = halfway;
         self.idle_space_end = capacity;
+
+        debug_assert_eq!(
+            self.active_space_end - self.active_space_start,
+            self.idle_space_end - self.idle_space_start,
+            "the active and idle spaces should be the same size"
+        );
 
         // VMGcRef uses NonZeroU32, so index 0 is reserved. Start the bump
         // pointer at `ALIGN` to skip past zero while keeping it aligned.
@@ -313,19 +323,28 @@ impl CopyingHeap {
 
     /// Swap the active and idle semi-spaces.
     fn flip(&mut self) {
+        debug_assert_eq!(
+            self.active_space_end - self.active_space_start,
+            self.idle_space_end - self.idle_space_start,
+            "the active and idle spaces should be the same size"
+        );
+
         mem::swap(&mut self.active_space_start, &mut self.idle_space_start);
         mem::swap(&mut self.active_space_end, &mut self.idle_space_end);
-        self.bump_ptr = self.active_space_start;
+
         // VMGcRef uses NonZeroU32, so index 0 is reserved. Skip past it
         // with proper alignment so allocations never return index 0.
+        self.bump_ptr = self.active_space_start;
         if self.bump_ptr == 0 && self.active_space_end > ALIGN {
             self.bump_ptr = ALIGN;
         }
+
         // Swap the externref linked lists along with the semi-spaces.
         mem::swap(
             &mut self.active_extern_ref_set_head,
             &mut self.idle_extern_ref_set_head,
         );
+
         // Clear the active list since we're starting fresh in the new space.
         self.active_extern_ref_set_head = None;
     }
@@ -893,52 +912,61 @@ enum CopyingCollectionPhase {
 impl CopyingCollection<'_> {
     /// Forward all GC roots from the idle space to the active space.
     fn process_roots(&mut self) {
-        let heap = &mut *self.heap;
-        let mut roots = self.roots.take().unwrap();
-        for mut root in &mut roots {
+        log::trace!("Begin processing GC roots");
+        let roots = self.roots.take().unwrap();
+        for mut root in roots {
             let gc_ref = root.get();
             if gc_ref.is_i31() {
                 continue;
             }
             let old_index = gc_ref.as_heap_index().unwrap().get();
-            debug_assert!(heap.is_in_idle_space(old_index));
-            let new_ref = heap.forward(&gc_ref);
+            debug_assert!(self.heap.is_in_idle_space(old_index));
+            let new_ref = self.heap.forward(&gc_ref);
             root.set(new_ref);
         }
-        drop(roots);
+        log::trace!("End processing GC roots");
     }
 
     /// Scan all grey objects until the worklist is empty.
     fn process_worklist(&mut self) {
-        let heap = &mut *self.heap;
-        let trace_infos = mem::take(&mut heap.trace_infos);
-        while let Some(gc_ref) = heap.worklist_pop() {
-            debug_assert!(heap.is_in_active_space(gc_ref.as_heap_index().unwrap().get()));
-            heap.scan(&gc_ref, &trace_infos);
+        log::trace!("Begin processing worklist");
+        let trace_infos = mem::take(&mut self.heap.trace_infos);
+        while let Some(gc_ref) = self.heap.worklist_pop() {
+            debug_assert!(
+                self.heap
+                    .is_in_active_space(gc_ref.as_heap_index().unwrap().get())
+            );
+            self.heap.scan(&gc_ref, &trace_infos);
         }
-        heap.trace_infos = trace_infos;
+        self.heap.trace_infos = trace_infos;
+        log::trace!("End processing worklist");
     }
 
     /// Clean up dead externrefs by iterating the idle semi-space's externref
     /// linked list and deallocating host data for any that were not forwarded.
     fn sweep_extern_refs(&mut self) {
-        let heap = &mut *self.heap;
-        let mut link = heap.idle_extern_ref_set_head.take();
+        log::trace!("Begin sweeping `externref`s");
+        let mut link = self.heap.idle_extern_ref_set_head.take();
         while let Some(externref) = link {
             let gc_ref = externref.as_gc_ref();
-            debug_assert!(heap.is_in_idle_space(gc_ref.as_heap_index().unwrap().get()));
-            let header = heap.index(copying_ref(gc_ref));
+            debug_assert!(
+                self.heap
+                    .is_in_idle_space(gc_ref.as_heap_index().unwrap().get())
+            );
+            let header = self.heap.index(copying_ref(gc_ref));
             if !header.copied() {
                 let typed: &TypedGcRef<VMCopyingExternRef> = gc_ref.as_typed_unchecked();
-                let host_data_id = heap.index(typed).host_data;
+                let host_data_id = self.heap.index(typed).host_data;
                 self.host_data_table.dealloc(host_data_id);
             }
-            link = heap
+            link = self
+                .heap
                 .index::<VMCopyingExternRef>(gc_ref.as_typed_unchecked())
                 .next_extern_ref
                 .as_ref()
                 .map(|e| e.unchecked_copy());
         }
+        log::trace!("End sweeping `externref`s");
     }
 }
 
@@ -948,58 +976,69 @@ impl GarbageCollection<'_> for CopyingCollection<'_> {
             CopyingCollectionPhase::Collect => {
                 log::trace!("Begin copying collection");
 
-                let heap = &mut *self.heap;
-
-                assert!(heap.active_space_start <= heap.bump_ptr);
-                assert!(heap.bump_ptr <= heap.active_space_end);
-                assert!(heap.idle_space_start <= heap.idle_space_end);
+                assert!(self.heap.active_space_start <= self.heap.bump_ptr);
+                assert!(self.heap.bump_ptr <= self.heap.active_space_end);
+                assert!(self.heap.idle_space_start <= self.heap.idle_space_end);
                 assert!(
-                    heap.active_space_end <= heap.idle_space_start
-                        || heap.idle_space_end <= heap.active_space_start
+                    self.heap.active_space_end <= self.heap.idle_space_start
+                        || self.heap.idle_space_end <= self.heap.active_space_start
                 );
 
                 // Flip the semi-spaces.
-                heap.flip();
-                heap.initialize_worklist();
+                self.heap.flip();
+                self.heap.initialize_worklist();
 
                 self.process_roots();
                 self.process_worklist();
 
-                let heap = &mut *self.heap;
-                assert!(heap.active_space_start <= heap.bump_ptr);
-                assert!(heap.bump_ptr <= heap.active_space_end);
-                assert!(heap.idle_space_start <= heap.idle_space_end);
+                assert!(self.heap.active_space_start <= self.heap.bump_ptr);
+                assert!(self.heap.bump_ptr <= self.heap.active_space_end);
+                assert!(self.heap.idle_space_start <= self.heap.idle_space_end);
                 assert!(
-                    heap.active_space_end <= heap.idle_space_start
-                        || heap.idle_space_end <= heap.active_space_start
+                    self.heap.active_space_end <= self.heap.idle_space_start
+                        || self.heap.idle_space_end <= self.heap.active_space_start
                 );
 
                 self.sweep_extern_refs();
 
                 // Adjust semi-space regions for any new capacity if the active
                 // space is the first half.
-                let heap = &mut *self.heap;
-                if heap.active_space_start < heap.idle_space_start {
+                if self.heap.active_space_start < self.heap.idle_space_start {
                     let mem_len =
-                        u32::try_from(heap.vmmemory.as_ref().unwrap().current_length()).unwrap();
-                    assert!(heap.idle_space_end <= mem_len);
-                    heap.idle_space_end = mem_len;
+                        u32::try_from(self.heap.vmmemory.as_ref().unwrap().current_length())
+                            .unwrap();
+                    // Round `mem_len` down to an even number, so our
+                    // semi-spaces are equal-sized.
+                    let mem_len = mem_len & !1;
+                    assert!(self.heap.idle_space_end <= mem_len);
+                    self.heap.idle_space_end = mem_len;
 
                     let halfway = mem_len / 2;
-                    assert!(heap.bump_ptr <= halfway);
+                    assert!(self.heap.bump_ptr <= halfway);
 
-                    assert!(heap.idle_space_start <= halfway);
-                    heap.idle_space_start = halfway;
+                    assert!(self.heap.idle_space_start <= halfway);
+                    self.heap.idle_space_start = halfway;
 
-                    assert!(heap.active_space_end <= halfway);
-                    heap.active_space_end = halfway;
+                    assert!(self.heap.active_space_end <= halfway);
+                    self.heap.active_space_end = halfway;
+                } else {
+                    // NB: Cannot adjust semi-space regions when the active
+                    // space is the second half of the GC heap because resizing
+                    // them would require moving objects which, in turn, would
+                    // require updating GC edges.
                 }
+
+                debug_assert_eq!(
+                    self.heap.active_space_end - self.heap.active_space_start,
+                    self.heap.idle_space_end - self.heap.idle_space_start,
+                    "the active and idle spaces should be the same size"
+                );
 
                 // Poison the idle space so stale accesses are detectable.
                 if cfg!(gc_zeal) {
-                    let idle_start = usize::try_from(heap.idle_space_start).unwrap();
-                    let idle_end = usize::try_from(heap.idle_space_end).unwrap();
-                    heap.heap_slice_mut()[idle_start..idle_end].fill(POISON);
+                    let idle_start = usize::try_from(self.heap.idle_space_start).unwrap();
+                    let idle_end = usize::try_from(self.heap.idle_space_end).unwrap();
+                    self.heap.heap_slice_mut()[idle_start..idle_end].fill(POISON);
                 }
 
                 log::trace!("End copying collection");

--- a/crates/wasmtime/src/runtime/vm/gc/enabled/copying.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/enabled/copying.rs
@@ -858,21 +858,24 @@ unsafe impl GcHeap for CopyingHeap {
         // semi-spaces from scratch.
         if self.active_space_end == 0 && self.idle_space_end == 0 {
             self.initialize_semi_spaces(new_len);
-            return;
-        }
+        } else {
+            // Otherwise the memory was grown.
+            //
+            // We only adjust the semi-space regions for new memory capacity if
+            // the active semi-space is the first half of the GC heap. Else,
+            // when the the second half of the GC heap is the active semi-space,
+            // wait until the next collection to automatically update the
+            // regions.
+            if self.active_space_start < self.idle_space_start {
+                let halfway = new_len / 2;
+                debug_assert!(self.bump_ptr <= halfway);
+                debug_assert!(self.idle_space_start <= halfway);
+                debug_assert!(self.active_space_end <= halfway);
 
-        // Only adjust the semi-space regions for new capacity if the active
-        // semi-space is the first half of the GC heap. Otherwise, wait until
-        // the next collection to update the regions.
-        if self.active_space_start < self.idle_space_start {
-            let halfway = new_len / 2;
-            debug_assert!(self.bump_ptr <= halfway);
-            debug_assert!(self.idle_space_start <= halfway);
-            debug_assert!(self.active_space_end <= halfway);
-
-            self.active_space_end = halfway;
-            self.idle_space_start = halfway;
-            self.idle_space_end = new_len;
+                self.active_space_end = halfway;
+                self.idle_space_start = halfway;
+                self.idle_space_end = new_len;
+            }
         }
 
         // Poison the newly-grown region.

--- a/crates/wasmtime/src/runtime/vm/gc/enabled/copying.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/enabled/copying.rs
@@ -288,7 +288,7 @@ impl CopyingHeap {
 
         // VMGcRef uses NonZeroU32, so index 0 is reserved. Start the bump
         // pointer at `ALIGN` to skip past zero while keeping it aligned.
-        debug_assert!(capacity == 0 || capacity > ALIGN);
+        debug_assert!(capacity == 0 || capacity > 2 * ALIGN);
         self.bump_ptr = if capacity > 0 { ALIGN } else { 0 };
     }
 
@@ -332,11 +332,14 @@ impl CopyingHeap {
         mem::swap(&mut self.active_space_start, &mut self.idle_space_start);
         mem::swap(&mut self.active_space_end, &mut self.idle_space_end);
 
-        // VMGcRef uses NonZeroU32, so index 0 is reserved. Skip past it
-        // with proper alignment so allocations never return index 0.
+        // VMGcRef uses NonZeroU32, so index 0 is reserved. Skip past it with
+        // proper alignment so allocations never return index 0. Also skip past
+        // the first ALIGN bytes in the second half of the GC heap so that the
+        // usable size of both semi-spaces is the same (which we require when
+        // copying live objects across semi-spaces during collection).
         self.bump_ptr = self.active_space_start;
-        if self.bump_ptr == 0 && self.active_space_end > ALIGN {
-            self.bump_ptr = ALIGN;
+        if self.active_space_end - self.active_space_start >= ALIGN {
+            self.bump_ptr += ALIGN;
         }
 
         // Swap the externref linked lists along with the semi-spaces.

--- a/crates/wasmtime/src/runtime/vm/gc/enabled/copying.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/enabled/copying.rs
@@ -1,10 +1,35 @@
-//! The copying collector.
+//! The copying (semi-space) garbage collector.
 //!
-//! This is a skeleton implementation that is not yet functional. All methods
-//! bail with "not yet implemented" errors.
+//! This implements a Cheney-style semi-space copying collector. The GC heap is
+//! divided into two halves: the "active" semi-space where new objects are
+//! allocated, and the "idle" semi-space. During collection, live objects are
+//! copied from the idle space (which was the previous active space) to the new
+//! active space, and all roots are updated to point to the new locations.
+//!
+//! Allocation is a simple bump pointer within the active semi-space.
+//!
+//! This collector does not require any read or write barriers.
 
-use crate::{Engine, prelude::*, vm::GcRuntime};
-use wasmtime_environ::{GcTypeLayouts, copying::CopyingTypeLayouts};
+use super::VMArrayRef;
+use super::trace_info::{TraceInfo, TraceInfos};
+use crate::runtime::vm::{
+    ExternRefHostDataId, ExternRefHostDataTable, GarbageCollection, GcHeap, GcHeapObject,
+    GcProgress, GcRootsIter, GcRuntime, TypedGcRef, VMExternRef, VMGcHeader, VMGcRef,
+};
+use crate::vm::VMMemoryDefinition;
+use crate::{Engine, prelude::*};
+use core::mem::MaybeUninit;
+use core::sync::atomic::AtomicUsize;
+use core::{alloc::Layout, any::Any, mem, num::NonZeroU32, ptr::NonNull};
+use wasmtime_environ::copying::{
+    ALIGN, ARRAY_LENGTH_OFFSET, CopyingTypeLayouts, HEADER_COPIED_BIT,
+};
+use wasmtime_environ::{
+    GcArrayLayout, GcStructLayout, GcTypeLayouts, POISON, VMGcKind, VMSharedTypeIndex, gc_assert,
+};
+
+#[expect(clippy::cast_possible_truncation, reason = "known to not overflow")]
+const GC_REF_ARRAY_ELEMS_OFFSET: u32 = ARRAY_LENGTH_OFFSET + (mem::size_of::<u32>() as u32);
 
 /// The copying collector.
 #[derive(Default)]
@@ -17,7 +42,1027 @@ unsafe impl GcRuntime for CopyingCollector {
         &self.layouts
     }
 
-    fn new_gc_heap(&self, _: &Engine) -> Result<Box<dyn crate::vm::GcHeap>> {
-        bail!("copying collector is not yet implemented")
+    fn new_gc_heap(&self, engine: &Engine) -> Result<Box<dyn GcHeap>> {
+        let heap = CopyingHeap::new(engine)?;
+        Ok(Box::new(heap) as _)
+    }
+}
+
+/// The common header for all objects in the copying collector.
+#[repr(C)]
+struct VMCopyingHeader {
+    header: VMGcHeader,
+    object_size: u32,
+}
+
+// Safety: All copying collector objects have a `VMCopyingHeader`.
+unsafe impl GcHeapObject for VMCopyingHeader {
+    #[inline]
+    fn is(_header: &VMGcHeader) -> bool {
+        true
+    }
+}
+
+impl VMCopyingHeader {
+    /// Get the size of this object in the GC heap.
+    #[inline]
+    fn object_size(&self) -> u32 {
+        self.object_size
+    }
+
+    /// Check whether this object has been copied to the new semi-space during
+    /// a collection.
+    #[inline]
+    fn copied(&self) -> bool {
+        self.header.reserved_u26() & HEADER_COPIED_BIT != 0
+    }
+
+    /// Mark this object as having been copied to the new semi-space.
+    #[inline]
+    fn set_copied(&mut self) {
+        let reserved = self.header.reserved_u26();
+        self.header.set_reserved_u26(reserved | HEADER_COPIED_BIT);
+    }
+}
+
+/// A copying collector header together with a forwarding reference.
+///
+/// During collection, after an object has been copied to the new semi-space,
+/// its old location is overwritten with the forwarding reference pointing to
+/// the new location.
+#[repr(C)]
+struct VMCopyingHeaderAndForwardingRef {
+    header: VMCopyingHeader,
+    forwarding_ref: Option<VMGcRef>,
+}
+
+// Safety: All copying collector objects have a `VMCopyingHeader` and space for
+// the forwarding reference.
+unsafe impl GcHeapObject for VMCopyingHeaderAndForwardingRef {
+    #[inline]
+    fn is(_header: &VMGcHeader) -> bool {
+        true
+    }
+}
+
+impl VMCopyingHeaderAndForwardingRef {
+    /// Get the forwarding reference for this object, if it has been copied
+    /// during the current collection.
+    fn forwarding_ref(&self) -> Option<VMGcRef> {
+        debug_assert!(
+            self.header.object_size()
+                >= u32::try_from(mem::size_of::<VMCopyingHeaderAndForwardingRef>()).unwrap()
+        );
+        if self.header.copied() {
+            Some(
+                self.forwarding_ref
+                    .as_ref()
+                    .expect("should always have a forwarding ref if the copied bit is set")
+                    .unchecked_copy(),
+            )
+        } else {
+            None
+        }
+    }
+
+    /// Set the forwarding reference for this object and mark it as copied.
+    fn set_forwarding_ref(&mut self, forwarding_ref: VMGcRef) {
+        debug_assert!(!self.header.copied());
+        debug_assert!(
+            self.header.object_size()
+                >= u32::try_from(mem::size_of::<VMCopyingHeaderAndForwardingRef>()).unwrap()
+        );
+        self.header.set_copied();
+        self.forwarding_ref = Some(forwarding_ref);
+    }
+}
+
+/// The header for an array in the copying collector.
+#[repr(C)]
+struct VMCopyingArrayHeader {
+    header: VMCopyingHeader,
+    length: u32,
+}
+
+unsafe impl GcHeapObject for VMCopyingArrayHeader {
+    #[inline]
+    fn is(header: &VMGcHeader) -> bool {
+        header.kind() == VMGcKind::ArrayRef
+    }
+}
+
+/// The representation of an `externref` in the copying collector.
+#[repr(C)]
+struct VMCopyingExternRef {
+    header: VMCopyingHeader,
+
+    /// Padding so that our other fields aren't overwritten by the forwarding
+    /// location.
+    _forwarding_ref_padding: MaybeUninit<Option<VMGcRef>>,
+
+    /// The ID of this ref's data in the `ExternRefHostDataTable`.
+    host_data: ExternRefHostDataId,
+
+    /// Link to the next `externref` in this semi-space.
+    next_extern_ref: Option<VMExternRef>,
+}
+
+unsafe impl GcHeapObject for VMCopyingExternRef {
+    #[inline]
+    fn is(header: &VMGcHeader) -> bool {
+        header.kind() == VMGcKind::ExternRef
+    }
+}
+
+/// Get a typed reference to a copying-collector object from a raw `VMGcRef`.
+fn copying_ref(gc_ref: &VMGcRef) -> &TypedGcRef<VMCopyingHeader> {
+    debug_assert!(!gc_ref.is_i31());
+    gc_ref.as_typed_unchecked()
+}
+
+/// Get a typed reference to a forwarding-ref header from a raw `VMGcRef`.
+fn header_and_forwarding_ref(gc_ref: &VMGcRef) -> &TypedGcRef<VMCopyingHeaderAndForwardingRef> {
+    debug_assert!(!gc_ref.is_i31());
+    gc_ref.as_typed_unchecked()
+}
+
+fn externref_to_copying(externref: &VMExternRef) -> &TypedGcRef<VMCopyingExternRef> {
+    let gc_ref = externref.as_gc_ref();
+    debug_assert!(!gc_ref.is_i31());
+    gc_ref.as_typed_unchecked()
+}
+
+/// A copying (semi-space) heap.
+struct CopyingHeap {
+    /// For every type that we have allocated in this heap, how do we trace it?
+    trace_infos: TraceInfos,
+
+    /// Count of how many no-gc scopes we are currently within.
+    no_gc_count: u64,
+
+    /// The storage for the GC heap itself.
+    memory: Option<crate::vm::Memory>,
+
+    /// The cached `VMMemoryDefinition` for `self.memory` so that we don't have
+    /// to make indirect calls through a `dyn RuntimeLinearMemory` object.
+    ///
+    /// Must be updated and kept in sync with `self.memory`, cleared when the
+    /// memory is taken and updated when the memory is replaced.
+    vmmemory: Option<VMMemoryDefinition>,
+
+    /// The bump "pointer" (really an index) for allocating new objects.
+    ///
+    /// This is always within the active semi-space.
+    bump_ptr: u32,
+
+    /// The start of the active semi-space.
+    active_space_start: u32,
+
+    /// The end of the active semi-space.
+    active_space_end: u32,
+
+    /// The start of the idle semi-space.
+    idle_space_start: u32,
+
+    /// The end of the idle semi-space.
+    idle_space_end: u32,
+
+    /// "Pointer" (really an index) to the start of the worklist.
+    ///
+    /// This is always within the active semi-space and is always less than or
+    /// equal to `bump_ptr`.
+    ///
+    /// This is used to implement a Cheney-style worklist: grey objects (the set
+    /// of objects that have been copied to the new semi-space but have not yet
+    /// been scanned) are always within `worklist_ptr..bump_ptr`. The worklist
+    /// is empty when `worklist_ptr == bump_ptr` and we can pop from the
+    /// worklist by advancing `worklist_ptr`.
+    worklist_ptr: u32,
+
+    /// The set of `externref`s in the active semi-space.
+    ///
+    /// The set is implemented as an intrusive linked-list, and this is the
+    /// head of the list.
+    active_extern_ref_set_head: Option<VMExternRef>,
+
+    /// Like `active_extern_ref_set_head` but for the idle semi-space.
+    idle_extern_ref_set_head: Option<VMExternRef>,
+}
+
+impl CopyingHeap {
+    fn new(engine: &Engine) -> Result<Self> {
+        log::trace!("allocating new copying heap");
+        Ok(Self {
+            trace_infos: TraceInfos::new(engine, GC_REF_ARRAY_ELEMS_OFFSET),
+            no_gc_count: 0,
+            memory: None,
+            vmmemory: None,
+            bump_ptr: 0,
+            active_space_start: 0,
+            active_space_end: 0,
+            idle_space_start: 0,
+            idle_space_end: 0,
+            worklist_ptr: 0,
+            active_extern_ref_set_head: None,
+            idle_extern_ref_set_head: None,
+        })
+    }
+
+    /// Initialize the semi-spaces for a heap of the given capacity.
+    fn initialize_semi_spaces(&mut self, capacity: u32) {
+        let halfway = capacity / 2;
+        self.active_space_start = 0;
+        self.active_space_end = halfway;
+        self.idle_space_start = halfway;
+        self.idle_space_end = capacity;
+
+        // VMGcRef uses NonZeroU32, so index 0 is reserved. Start the bump
+        // pointer at `ALIGN` to skip past zero while keeping it aligned.
+        debug_assert!(capacity == 0 || capacity > ALIGN);
+        self.bump_ptr = if capacity > 0 { ALIGN } else { 0 };
+    }
+
+    /// Allocate `size` bytes from the active semi-space bump pointer.
+    ///
+    /// Returns `None` if there isn't enough room.
+    fn allocate(&mut self, size: u32) -> Option<u32> {
+        debug_assert!(self.bump_ptr >= self.active_space_start);
+        debug_assert!(self.bump_ptr <= self.active_space_end);
+
+        let result = self.bump_ptr;
+        let new_bump_ptr = result.checked_add(size)?;
+        if new_bump_ptr > self.active_space_end {
+            return None;
+        }
+        self.bump_ptr = new_bump_ptr;
+
+        debug_assert!(self.bump_ptr >= self.active_space_start);
+        debug_assert!(self.bump_ptr <= self.active_space_end);
+        Some(result)
+    }
+
+    /// Check whether an index is within the active semi-space.
+    fn is_in_active_space(&self, index: u32) -> bool {
+        index >= self.active_space_start && index < self.active_space_end
+    }
+
+    /// Check whether an index is within the idle semi-space.
+    fn is_in_idle_space(&self, index: u32) -> bool {
+        index >= self.idle_space_start && index < self.idle_space_end
+    }
+
+    /// Swap the active and idle semi-spaces.
+    fn flip(&mut self) {
+        mem::swap(&mut self.active_space_start, &mut self.idle_space_start);
+        mem::swap(&mut self.active_space_end, &mut self.idle_space_end);
+        self.bump_ptr = self.active_space_start;
+        // VMGcRef uses NonZeroU32, so index 0 is reserved. Skip past it
+        // with proper alignment so allocations never return index 0.
+        if self.bump_ptr == 0 && self.active_space_end > ALIGN {
+            self.bump_ptr = ALIGN;
+        }
+        // Swap the externref linked lists along with the semi-spaces.
+        mem::swap(
+            &mut self.active_extern_ref_set_head,
+            &mut self.idle_extern_ref_set_head,
+        );
+        // Clear the active list since we're starting fresh in the new space.
+        self.active_extern_ref_set_head = None;
+    }
+
+    /// Initialize the worklist at the start of a collection.
+    fn initialize_worklist(&mut self) {
+        self.worklist_ptr = self.bump_ptr;
+    }
+
+    /// Pop the next item off the worklist, or return `None` if the worklist is
+    /// empty.
+    fn worklist_pop(&mut self) -> Option<VMGcRef> {
+        debug_assert!(
+            self.is_in_active_space(self.worklist_ptr)
+                || self.worklist_ptr == self.active_space_end
+        );
+        debug_assert!(
+            self.is_in_active_space(self.bump_ptr) || self.bump_ptr == self.active_space_end
+        );
+        debug_assert!(self.worklist_ptr <= self.bump_ptr);
+
+        if self.worklist_ptr == self.bump_ptr {
+            return None;
+        }
+
+        let result = self.worklist_ptr;
+        let result = NonZeroU32::new(result).unwrap();
+        let result = VMGcRef::from_heap_index(result).unwrap();
+
+        let obj_size = self.index(copying_ref(&result)).object_size();
+
+        self.worklist_ptr += obj_size;
+        debug_assert!(self.worklist_ptr <= self.bump_ptr);
+
+        Some(result)
+    }
+
+    /// Insert `gc_ref`, which points to a grey object, into the worklist.
+    fn worklist_insert(&self, gc_ref: &VMGcRef) {
+        // This is a no-op: insertion happens implicitly in `copy` when
+        // allocating space for the copied object and advancing the
+        // `bump_ptr`. But we still define and call this method just for the
+        // debug assertions.
+        if !cfg!(debug_assertions) {
+            return;
+        }
+
+        let index = gc_ref.as_heap_index().unwrap().get();
+        debug_assert!(self.is_in_active_space(index));
+        let obj_size = self.index(copying_ref(gc_ref)).object_size();
+        debug_assert_eq!(index + obj_size, self.bump_ptr);
+        debug_assert!(self.worklist_ptr <= index);
+    }
+
+    /// Get-or-create the location of this idle-space ref in the new active
+    /// semi-space.
+    fn forward(&mut self, from_ref: &VMGcRef) -> VMGcRef {
+        debug_assert!(!from_ref.is_i31());
+        debug_assert!(self.is_in_idle_space(from_ref.as_heap_index().unwrap().get()));
+
+        if let Some(to_ref) = self
+            .index(header_and_forwarding_ref(from_ref))
+            .forwarding_ref()
+        {
+            return to_ref;
+        }
+        self.copy(from_ref)
+    }
+
+    /// Copy this idle-space ref into the new active semi-space and return its
+    /// new location.
+    fn copy(&mut self, from_ref: &VMGcRef) -> VMGcRef {
+        debug_assert!(!from_ref.is_i31());
+        let from_index = from_ref.as_heap_index().unwrap().get();
+        debug_assert!(self.is_in_idle_space(from_index));
+        debug_assert!(!self.index(copying_ref(from_ref)).copied());
+
+        let size = self.index(copying_ref(from_ref)).object_size();
+        let to_index = self.allocate(size).expect(
+            "there should always be enough room in the active semi-space for objects that \
+             survived collection, since the active space is the same size as the idle space",
+        );
+        debug_assert!(self.is_in_active_space(to_index));
+
+        let to_ref =
+            VMGcRef::from_heap_index(NonZeroU32::new(to_index).unwrap()).expect("valid heap index");
+
+        // Copy the object bytes.
+        let from_start = usize::try_from(from_index).unwrap();
+        let to_start = usize::try_from(to_index).unwrap();
+        let size_usize = usize::try_from(size).unwrap();
+        let [from, to] = self
+            .heap_slice_mut()
+            .get_disjoint_mut([
+                from_start..from_start + size_usize,
+                to_start..to_start + size_usize,
+            ])
+            .expect("semi-spaces do not overlap");
+        to.copy_from_slice(from);
+
+        // Set the forwarding ref in the old (idle-space) object.
+        self.index_mut(header_and_forwarding_ref(from_ref))
+            .set_forwarding_ref(to_ref.unchecked_copy());
+
+        // If this is an externref, insert it into the active externref list.
+        if self
+            .index(copying_ref(&to_ref))
+            .header
+            .kind()
+            .matches(VMGcKind::ExternRef)
+        {
+            let old_head = self.active_extern_ref_set_head.take();
+            self.index_mut::<VMCopyingExternRef>(to_ref.as_typed_unchecked())
+                .next_extern_ref = old_head;
+            self.active_extern_ref_set_head =
+                Some(to_ref.unchecked_copy().into_externref_unchecked());
+        }
+
+        self.worklist_insert(&to_ref);
+        to_ref
+    }
+
+    /// Trace a grey object's outgoing edges, copying their referents into the
+    /// new semi-space if necessary, and updating the object's references with
+    /// their forwarded locations in the new semi-space.
+    fn scan(&mut self, gc_ref: &VMGcRef, trace_infos: &TraceInfos) {
+        debug_assert!(!gc_ref.is_i31());
+        let index = gc_ref.as_heap_index().unwrap().get();
+        debug_assert!(self.is_in_active_space(index));
+
+        let ty = self.index(copying_ref(gc_ref)).header.ty();
+
+        // `externref`s have no GC edges.
+        let Some(ty) = ty else {
+            return;
+        };
+
+        match trace_infos.trace_info(&ty) {
+            TraceInfo::Struct { gc_ref_offsets } => {
+                let object_start = usize::try_from(index).unwrap();
+
+                for &offset in gc_ref_offsets {
+                    let offset_usize = usize::try_from(offset).unwrap();
+                    let field_start = object_start + offset_usize;
+                    let field_end = field_start + mem::size_of::<u32>();
+
+                    let raw: [u8; 4] = self.heap_slice()[field_start..field_end]
+                        .try_into()
+                        .unwrap();
+                    let raw = u32::from_le_bytes(raw);
+
+                    if let Some(child) = VMGcRef::from_raw_u32(raw)
+                        && !child.is_i31()
+                    {
+                        debug_assert!(self.is_in_idle_space(child.as_heap_index().unwrap().get()));
+                        let new_ref = self.forward(&child);
+                        debug_assert!(
+                            self.is_in_active_space(new_ref.as_heap_index().unwrap().get())
+                        );
+                        // Write the new reference back.
+                        let new_raw = new_ref.as_raw_u32().to_le_bytes();
+                        self.heap_slice_mut()[field_start..field_end].copy_from_slice(&new_raw);
+                    }
+                }
+            }
+            TraceInfo::Array { gc_ref_elems } => {
+                if *gc_ref_elems {
+                    let array_ref = gc_ref.as_arrayref_unchecked();
+                    let len = self.array_len(array_ref);
+                    let object_start = usize::try_from(index).unwrap();
+
+                    for i in 0..len {
+                        let elem_offset = GC_REF_ARRAY_ELEMS_OFFSET
+                            + i * u32::try_from(mem::size_of::<u32>()).unwrap();
+                        let offset_usize = usize::try_from(elem_offset).unwrap();
+                        let field_start = object_start + offset_usize;
+                        let field_end = field_start + mem::size_of::<u32>();
+
+                        let raw: [u8; 4] = self.heap_slice()[field_start..field_end]
+                            .try_into()
+                            .unwrap();
+                        let raw = u32::from_le_bytes(raw);
+
+                        if let Some(child) = VMGcRef::from_raw_u32(raw)
+                            && !child.is_i31()
+                        {
+                            debug_assert!(
+                                self.is_in_idle_space(child.as_heap_index().unwrap().get())
+                            );
+                            let new_ref = self.forward(&child);
+                            debug_assert!(
+                                self.is_in_active_space(new_ref.as_heap_index().unwrap().get())
+                            );
+                            let new_raw = new_ref.as_raw_u32().to_le_bytes();
+                            self.heap_slice_mut()[field_start..field_end].copy_from_slice(&new_raw);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+unsafe impl GcHeap for CopyingHeap {
+    fn is_attached(&self) -> bool {
+        debug_assert_eq!(self.memory.is_some(), self.vmmemory.is_some());
+        self.memory.is_some()
+    }
+
+    fn attach(&mut self, memory: crate::vm::Memory) {
+        assert!(!self.is_attached());
+        assert!(!memory.is_shared_memory());
+        let len = memory.vmmemory().current_length();
+        let capacity = u32::try_from(len).unwrap();
+        self.initialize_semi_spaces(capacity);
+        self.vmmemory = Some(memory.vmmemory());
+        self.memory = Some(memory);
+
+        if cfg!(gc_zeal) {
+            self.heap_slice_mut().fill(POISON);
+        }
+    }
+
+    fn detach(&mut self) -> crate::vm::Memory {
+        assert!(self.is_attached());
+
+        let CopyingHeap {
+            no_gc_count,
+            memory,
+            vmmemory,
+            bump_ptr,
+            active_space_start,
+            active_space_end,
+            idle_space_start,
+            idle_space_end,
+            worklist_ptr,
+            active_extern_ref_set_head,
+            idle_extern_ref_set_head,
+            // NB: we will only ever be reused with the same engine, so no need
+            // to clear out our tracing info just to fill it back in with the
+            // same exact stuff.
+            trace_infos: _,
+        } = self;
+
+        *no_gc_count = 0;
+        *vmmemory = None;
+        *bump_ptr = 0;
+        *active_space_start = 0;
+        *active_space_end = 0;
+        *idle_space_start = 0;
+        *idle_space_end = 0;
+        *worklist_ptr = 0;
+        *active_extern_ref_set_head = None;
+        *idle_extern_ref_set_head = None;
+
+        memory.take().unwrap()
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self as _
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self as _
+    }
+
+    fn enter_no_gc_scope(&mut self) {
+        self.no_gc_count += 1;
+    }
+
+    fn exit_no_gc_scope(&mut self) {
+        self.no_gc_count -= 1;
+    }
+
+    fn clone_gc_ref(&mut self, gc_ref: &VMGcRef) -> VMGcRef {
+        // The copying collector doesn't use reference counting; cloning is a
+        // simple copy.
+        gc_ref.unchecked_copy()
+    }
+
+    fn write_gc_ref(
+        &mut self,
+        _host_data_table: &mut ExternRefHostDataTable,
+        destination: &mut Option<VMGcRef>,
+        source: Option<&VMGcRef>,
+    ) {
+        // The copying collector doesn't use reference counting; writes are
+        // simple overwrites.
+        *destination = source.map(|s| s.unchecked_copy());
+    }
+
+    fn expose_gc_ref_to_wasm(&mut self, _gc_ref: VMGcRef) {
+        // The copying collector doesn't need any special handling when exposing
+        // a GC ref to Wasm. There is no over-approximated-stack-roots list.
+    }
+
+    fn alloc_externref(
+        &mut self,
+        host_data: ExternRefHostDataId,
+    ) -> Result<Result<VMExternRef, u64>> {
+        let align = usize::try_from(ALIGN).unwrap();
+        let size = core::mem::size_of::<VMCopyingExternRef>();
+        let size = (size + align - 1) & !(align - 1);
+        let gc_ref = match self.alloc_raw(
+            VMGcHeader::externref(),
+            Layout::from_size_align(size, align).unwrap(),
+        )? {
+            Err(n) => return Ok(Err(n)),
+            Ok(gc_ref) => gc_ref,
+        };
+        // Take the old list head before borrowing self mutably through index_mut.
+        let old_head = self.active_extern_ref_set_head.take();
+        let externref_obj = self.index_mut::<VMCopyingExternRef>(gc_ref.as_typed_unchecked());
+        externref_obj.host_data = host_data;
+        externref_obj.next_extern_ref = old_head;
+        let externref = gc_ref.into_externref_unchecked();
+        self.active_extern_ref_set_head = Some(externref.unchecked_copy());
+        Ok(Ok(externref))
+    }
+
+    fn externref_host_data(&self, externref: &VMExternRef) -> ExternRefHostDataId {
+        let typed_ref = externref_to_copying(externref);
+        self.index(typed_ref).host_data
+    }
+
+    fn header(&self, gc_ref: &VMGcRef) -> &VMGcHeader {
+        let header: &VMGcHeader = self.index(gc_ref.as_typed_unchecked());
+
+        debug_assert!(
+            VMGcKind::try_from_u32(header.kind().as_u32()).is_some(),
+            "header: invalid VMGcKind {:#010x} at gc_ref {gc_ref:#p}",
+            header.kind().as_u32(),
+        );
+
+        header
+    }
+
+    fn header_mut(&mut self, gc_ref: &VMGcRef) -> &mut VMGcHeader {
+        let header: &mut VMGcHeader = self.index_mut(gc_ref.as_typed_unchecked());
+
+        debug_assert!(
+            VMGcKind::try_from_u32(header.kind().as_u32()).is_some(),
+            "header_mut: invalid VMGcKind {:#010x} at gc_ref {gc_ref:#p}",
+            header.kind().as_u32(),
+        );
+
+        header
+    }
+
+    fn object_size(&self, gc_ref: &VMGcRef) -> usize {
+        usize::try_from(self.index(copying_ref(gc_ref)).object_size()).unwrap()
+    }
+
+    fn alloc_raw(&mut self, header: VMGcHeader, layout: Layout) -> Result<Result<VMGcRef, u64>> {
+        let align = u32::try_from(layout.align()).unwrap();
+        ensure!(
+            align == ALIGN,
+            "copying collector requires all allocations to have alignment {ALIGN}, \
+             but got alignment {align}",
+        );
+
+        debug_assert!(layout.size() >= core::mem::size_of::<VMCopyingHeader>());
+        debug_assert_eq!(self.bump_ptr % ALIGN, 0, "bump_ptr is not aligned to ALIGN");
+        debug_assert_eq!(header.reserved_u26(), 0);
+
+        // We must have trace info for every GC type that we allocate in this
+        // heap.
+        if let Some(ty) = header.ty() {
+            self.trace_infos.ensure(ty);
+        } else {
+            debug_assert_eq!(header.kind(), VMGcKind::ExternRef);
+        }
+
+        let size = u32::try_from(layout.size()).unwrap();
+        // Round up the allocation size to ALIGN so that the next bump-pointer
+        // allocation is also aligned.
+        let size = (size + ALIGN - 1) & !(ALIGN - 1);
+
+        let gc_ref = match self.allocate(size) {
+            None => return Ok(Err(u64::try_from(layout.size()).unwrap())),
+            Some(index) => {
+                debug_assert_ne!(index, 0, "index 0 is reserved; bump_ptr should skip it");
+                VMGcRef::from_heap_index(NonZeroU32::new(index).unwrap()).unwrap()
+            }
+        };
+
+        // Assert that the newly-allocated memory is still filled with the
+        // poison pattern.
+        if cfg!(gc_zeal) {
+            let start = usize::try_from(gc_ref.as_heap_index().unwrap().get()).unwrap();
+            let slice = &self.heap_slice()[start..][..layout.size()];
+            gc_assert!(
+                slice.iter().all(|&b| b == POISON),
+                "newly allocated GC object at index {start} is not fully poisoned; \
+                 freed memory was corrupted",
+            );
+        }
+
+        let object_size = size;
+        *self.index_mut(copying_ref(&gc_ref)) = VMCopyingHeader {
+            header,
+            object_size,
+        };
+        Ok(Ok(gc_ref))
+    }
+
+    fn alloc_uninit_struct_or_exn(
+        &mut self,
+        ty: VMSharedTypeIndex,
+        layout: &GcStructLayout,
+    ) -> Result<Result<VMGcRef, u64>> {
+        let kind = if layout.is_exception {
+            VMGcKind::ExnRef
+        } else {
+            VMGcKind::StructRef
+        };
+        let gc_ref =
+            match self.alloc_raw(VMGcHeader::from_kind_and_index(kind, ty), layout.layout())? {
+                Err(n) => return Ok(Err(n)),
+                Ok(gc_ref) => gc_ref,
+            };
+
+        Ok(Ok(gc_ref))
+    }
+
+    fn dealloc_uninit_struct_or_exn(&mut self, _gcref: VMGcRef) {
+        // The copying collector doesn't support individual deallocation; memory
+        // is reclaimed during collection.
+    }
+
+    fn alloc_uninit_array(
+        &mut self,
+        ty: VMSharedTypeIndex,
+        length: u32,
+        layout: &GcArrayLayout,
+    ) -> Result<Result<VMArrayRef, u64>> {
+        let gc_ref = match self.alloc_raw(
+            VMGcHeader::from_kind_and_index(VMGcKind::ArrayRef, ty),
+            layout.layout(length),
+        )? {
+            Err(n) => return Ok(Err(n)),
+            Ok(gc_ref) => gc_ref,
+        };
+
+        self.index_mut(gc_ref.as_typed_unchecked::<VMCopyingArrayHeader>())
+            .length = length;
+
+        Ok(Ok(gc_ref.into_arrayref_unchecked()))
+    }
+
+    fn dealloc_uninit_array(&mut self, _arrayref: VMArrayRef) {
+        // The copying collector doesn't support individual deallocation; memory
+        // is reclaimed during collection.
+    }
+
+    fn array_len(&self, arrayref: &VMArrayRef) -> u32 {
+        debug_assert!(arrayref.as_gc_ref().is_typed::<VMCopyingArrayHeader>(self));
+        self.index::<VMCopyingArrayHeader>(arrayref.as_gc_ref().as_typed_unchecked())
+            .length
+    }
+
+    fn allocated_bytes(&self) -> usize {
+        usize::try_from(self.bump_ptr - self.active_space_start).unwrap()
+    }
+
+    fn gc<'a>(
+        &'a mut self,
+        roots: GcRootsIter<'a>,
+        host_data_table: &'a mut ExternRefHostDataTable,
+    ) -> Box<dyn GarbageCollection<'a> + 'a> {
+        assert_eq!(self.no_gc_count, 0, "Cannot GC inside a no-GC scope!");
+        Box::new(CopyingCollection {
+            roots: Some(roots),
+            host_data_table,
+            heap: self,
+            phase: CopyingCollectionPhase::Collect,
+        })
+    }
+
+    unsafe fn vmctx_gc_heap_data(&self) -> NonNull<u8> {
+        // The copying collector doesn't currently have vmctx GC heap
+        // data. Return a dangling pointer.
+        NonNull::dangling()
+    }
+
+    fn take_memory(&mut self) -> crate::vm::Memory {
+        debug_assert!(self.is_attached());
+        self.vmmemory.take();
+        self.memory.take().unwrap()
+    }
+
+    fn needs_gc_before_next_growth(&self) -> bool {
+        // We need a GC before growth when the active space is the second half
+        // of the GC heap, because we cannot safely extend the active space in
+        // that configuration without making it larger than the idle space.
+        self.active_space_start >= self.idle_space_start && self.active_space_end > 0
+    }
+
+    unsafe fn replace_memory(&mut self, memory: crate::vm::Memory, _delta_bytes_grown: u64) {
+        debug_assert!(self.memory.is_none());
+        debug_assert!(!memory.is_shared_memory());
+        self.vmmemory = Some(memory.vmmemory());
+        self.memory = Some(memory);
+
+        let new_len = u32::try_from(self.vmmemory.as_ref().unwrap().current_length()).unwrap();
+
+        // If the heap was previously empty (all zeroes), reinitialize the
+        // semi-spaces from scratch.
+        if self.active_space_end == 0 && self.idle_space_end == 0 {
+            self.initialize_semi_spaces(new_len);
+            return;
+        }
+
+        // Only adjust the semi-space regions for new capacity if the active
+        // semi-space is the first half of the GC heap. Otherwise, wait until
+        // the next collection to update the regions.
+        if self.active_space_start < self.idle_space_start {
+            let halfway = new_len / 2;
+            debug_assert!(self.bump_ptr <= halfway);
+            debug_assert!(self.idle_space_start <= halfway);
+            debug_assert!(self.active_space_end <= halfway);
+
+            self.active_space_end = halfway;
+            self.idle_space_start = halfway;
+            self.idle_space_end = new_len;
+        }
+
+        // Poison the newly-grown region.
+        if cfg!(gc_zeal) {
+            // The idle space has grown, poison any new bytes.
+            let idle_end = usize::try_from(self.idle_space_end).unwrap();
+            let slice = self.heap_slice_mut();
+            if idle_end <= slice.len() {
+                // Poison from the old idle_space_end to the new length.
+                // But we need to know the old idle_space_end. For simplicity
+                // just let collection handle reclamation.
+            }
+        }
+    }
+
+    #[inline]
+    fn vmmemory(&self) -> VMMemoryDefinition {
+        debug_assert!(self.is_attached());
+        debug_assert!(!self.memory.as_ref().unwrap().is_shared_memory());
+        let vmmemory = self.vmmemory.as_ref().unwrap();
+        VMMemoryDefinition {
+            base: vmmemory.base,
+            current_length: AtomicUsize::new(vmmemory.current_length()),
+        }
+    }
+}
+
+struct CopyingCollection<'a> {
+    roots: Option<GcRootsIter<'a>>,
+    host_data_table: &'a mut ExternRefHostDataTable,
+    heap: &'a mut CopyingHeap,
+    phase: CopyingCollectionPhase,
+}
+
+enum CopyingCollectionPhase {
+    Collect,
+    Done,
+}
+
+impl CopyingCollection<'_> {
+    /// Forward all GC roots from the idle space to the active space.
+    fn process_roots(&mut self) {
+        let heap = &mut *self.heap;
+        let mut roots = self.roots.take().unwrap();
+        for mut root in &mut roots {
+            let gc_ref = root.get();
+            if gc_ref.is_i31() {
+                continue;
+            }
+            let old_index = gc_ref.as_heap_index().unwrap().get();
+            debug_assert!(heap.is_in_idle_space(old_index));
+            let new_ref = heap.forward(&gc_ref);
+            root.set(new_ref);
+        }
+        drop(roots);
+    }
+
+    /// Scan all grey objects until the worklist is empty.
+    fn process_worklist(&mut self) {
+        let heap = &mut *self.heap;
+        let trace_infos = mem::take(&mut heap.trace_infos);
+        while let Some(gc_ref) = heap.worklist_pop() {
+            debug_assert!(heap.is_in_active_space(gc_ref.as_heap_index().unwrap().get()));
+            heap.scan(&gc_ref, &trace_infos);
+        }
+        heap.trace_infos = trace_infos;
+    }
+
+    /// Clean up dead externrefs by iterating the idle semi-space's externref
+    /// linked list and deallocating host data for any that were not forwarded.
+    fn sweep_extern_refs(&mut self) {
+        let heap = &mut *self.heap;
+        let mut link = heap.idle_extern_ref_set_head.take();
+        while let Some(externref) = link {
+            let gc_ref = externref.as_gc_ref();
+            debug_assert!(heap.is_in_idle_space(gc_ref.as_heap_index().unwrap().get()));
+            let header = heap.index(copying_ref(gc_ref));
+            if !header.copied() {
+                let typed: &TypedGcRef<VMCopyingExternRef> = gc_ref.as_typed_unchecked();
+                let host_data_id = heap.index(typed).host_data;
+                self.host_data_table.dealloc(host_data_id);
+            }
+            link = heap
+                .index::<VMCopyingExternRef>(gc_ref.as_typed_unchecked())
+                .next_extern_ref
+                .as_ref()
+                .map(|e| e.unchecked_copy());
+        }
+    }
+}
+
+impl GarbageCollection<'_> for CopyingCollection<'_> {
+    fn collect_increment(&mut self) -> GcProgress {
+        match self.phase {
+            CopyingCollectionPhase::Collect => {
+                log::trace!("Begin copying collection");
+
+                let heap = &mut *self.heap;
+
+                assert!(heap.active_space_start <= heap.bump_ptr);
+                assert!(heap.bump_ptr <= heap.active_space_end);
+                assert!(heap.idle_space_start <= heap.idle_space_end);
+                assert!(
+                    heap.active_space_end <= heap.idle_space_start
+                        || heap.idle_space_end <= heap.active_space_start
+                );
+
+                // Flip the semi-spaces.
+                heap.flip();
+                heap.initialize_worklist();
+
+                self.process_roots();
+                self.process_worklist();
+
+                let heap = &mut *self.heap;
+                assert!(heap.active_space_start <= heap.bump_ptr);
+                assert!(heap.bump_ptr <= heap.active_space_end);
+                assert!(heap.idle_space_start <= heap.idle_space_end);
+                assert!(
+                    heap.active_space_end <= heap.idle_space_start
+                        || heap.idle_space_end <= heap.active_space_start
+                );
+
+                self.sweep_extern_refs();
+
+                // Adjust semi-space regions for any new capacity if the active
+                // space is the first half.
+                let heap = &mut *self.heap;
+                if heap.active_space_start < heap.idle_space_start {
+                    let mem_len =
+                        u32::try_from(heap.vmmemory.as_ref().unwrap().current_length()).unwrap();
+                    assert!(heap.idle_space_end <= mem_len);
+                    heap.idle_space_end = mem_len;
+
+                    let halfway = mem_len / 2;
+                    assert!(heap.bump_ptr <= halfway);
+
+                    assert!(heap.idle_space_start <= halfway);
+                    heap.idle_space_start = halfway;
+
+                    assert!(heap.active_space_end <= halfway);
+                    heap.active_space_end = halfway;
+                }
+
+                // Poison the idle space so stale accesses are detectable.
+                if cfg!(gc_zeal) {
+                    let idle_start = usize::try_from(heap.idle_space_start).unwrap();
+                    let idle_end = usize::try_from(heap.idle_space_end).unwrap();
+                    heap.heap_slice_mut()[idle_start..idle_end].fill(POISON);
+                }
+
+                log::trace!("End copying collection");
+                self.phase = CopyingCollectionPhase::Done;
+                GcProgress::Complete
+            }
+            CopyingCollectionPhase::Done => GcProgress::Complete,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wasmtime_environ::HostPtr;
+
+    #[test]
+    fn vm_copying_header_size_align() {
+        assert_eq!(
+            wasmtime_environ::copying::HEADER_SIZE as usize,
+            core::mem::size_of::<VMCopyingHeader>(),
+        );
+        // The struct's natural alignment must not exceed ALIGN, which is
+        // enforced by the bump allocator.
+        assert!(
+            core::mem::align_of::<VMCopyingHeader>() <= wasmtime_environ::copying::ALIGN as usize,
+        );
+    }
+
+    #[test]
+    fn vm_copying_array_header_length_offset() {
+        assert_eq!(
+            wasmtime_environ::copying::ARRAY_LENGTH_OFFSET,
+            u32::try_from(core::mem::offset_of!(VMCopyingArrayHeader, length)).unwrap(),
+        );
+    }
+
+    #[test]
+    fn vm_copying_header_object_size_offset() {
+        assert_eq!(
+            // object_size comes right after the VMGcHeader
+            wasmtime_environ::VM_GC_HEADER_SIZE,
+            u32::try_from(core::mem::offset_of!(VMCopyingHeader, object_size)).unwrap(),
+        );
+    }
+
+    #[test]
+    fn vm_copying_forwarding_ref_offset() {
+        assert_eq!(
+            wasmtime_environ::copying::FORWARDING_REF_OFFSET as usize,
+            core::mem::offset_of!(VMCopyingHeaderAndForwardingRef, forwarding_ref),
+        );
+    }
+
+    #[test]
+    fn vm_copying_header_and_forwarding_ref_size() {
+        // The forwarding ref data (at FORWARDING_REF_OFFSET) plus its size
+        // must fit within MIN_OBJECT_SIZE, so every object has room for
+        // the forwarding pointer during collection.
+        assert!(
+            wasmtime_environ::copying::FORWARDING_REF_OFFSET as usize
+                + core::mem::size_of::<Option<VMGcRef>>()
+                <= wasmtime_environ::copying::MIN_OBJECT_SIZE as usize,
+        );
     }
 }

--- a/crates/wasmtime/src/runtime/vm/gc/enabled/drc.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/enabled/drc.rs
@@ -46,15 +46,14 @@
 
 use super::VMArrayRef;
 use super::free_list::FreeList;
-use crate::hash_map::HashMap;
+use super::trace_info::{TraceInfo, TraceInfos};
 use crate::hash_set::HashSet;
 use crate::runtime::vm::{
     ExternRefHostDataId, ExternRefHostDataTable, GarbageCollection, GcHeap, GcHeapObject,
     GcProgress, GcRootsIter, GcRuntime, TypedGcRef, VMExternRef, VMGcHeader, VMGcRef,
 };
 use crate::vm::VMMemoryDefinition;
-use crate::{Engine, EngineWeak, prelude::*};
-use core::hash::BuildHasher;
+use crate::{Engine, prelude::*};
 use core::sync::atomic::AtomicUsize;
 use core::{
     alloc::Layout,
@@ -65,8 +64,7 @@ use core::{
 };
 use wasmtime_environ::drc::{ARRAY_LENGTH_OFFSET, DrcTypeLayouts};
 use wasmtime_environ::{
-    GcArrayLayout, GcLayout, GcStructLayout, GcTypeLayouts, POISON, VMGcKind, VMSharedTypeIndex,
-    gc_assert,
+    GcArrayLayout, GcStructLayout, GcTypeLayouts, POISON, VMGcKind, VMSharedTypeIndex, gc_assert,
 };
 
 #[expect(clippy::cast_possible_truncation, reason = "known to not overflow")]
@@ -95,83 +93,10 @@ unsafe impl GcRuntime for DrcCollector {
     }
 }
 
-/// How to trace a GC object.
-enum TraceInfo {
-    /// How to trace an array.
-    Array {
-        /// Whether this array type's elements are GC references, and need
-        /// tracing.
-        gc_ref_elems: bool,
-    },
-
-    /// How to trace a struct.
-    Struct {
-        /// The offsets of each GC reference field that needs tracing in
-        /// instances of this struct type.
-        gc_ref_offsets: Box<[u32]>,
-    },
-}
-
-/// A hasher that doesn't hash, for use in the trace-info hash map, where we are
-/// just using scalar keys and aren't overly concerned with collision-based DoS.
-#[derive(Default)]
-struct NopHasher(u64);
-
-impl BuildHasher for NopHasher {
-    type Hasher = Self;
-
-    #[inline]
-    fn build_hasher(&self) -> Self::Hasher {
-        NopHasher::default()
-    }
-}
-
-impl core::hash::Hasher for NopHasher {
-    #[inline]
-    fn finish(&self) -> u64 {
-        self.0
-    }
-
-    #[inline]
-    fn write(&mut self, bytes: &[u8]) {
-        let mut hash = self.0.to_ne_bytes();
-        let n = hash.len().min(bytes.len());
-        hash[..n].copy_from_slice(bytes);
-        self.0 = u64::from_ne_bytes(hash);
-    }
-
-    #[inline]
-    fn write_u8(&mut self, i: u8) {
-        self.write_u64(i.into());
-    }
-
-    #[inline]
-    fn write_u16(&mut self, i: u16) {
-        self.write_u64(i.into())
-    }
-
-    #[inline]
-    fn write_u32(&mut self, i: u32) {
-        self.write_u64(i.into())
-    }
-
-    #[inline]
-    fn write_u64(&mut self, i: u64) {
-        self.0 = i;
-    }
-
-    #[inline]
-    fn write_usize(&mut self, i: usize) {
-        self.write_u64(i.try_into().unwrap());
-    }
-}
-
 /// A deferred reference-counting (DRC) heap.
 struct DrcHeap {
-    engine: EngineWeak,
-
     /// For every type that we have allocated in this heap, how do we trace it?
-    trace_infos: HashMap<VMSharedTypeIndex, TraceInfo, NopHasher>,
+    trace_infos: TraceInfos,
 
     /// Count of how many no-gc scopes we are currently within.
     no_gc_count: u64,
@@ -216,11 +141,8 @@ impl DrcHeap {
     /// Construct a new, default DRC heap.
     fn new(engine: &Engine) -> Result<Self> {
         log::trace!("allocating new DRC heap");
-        let mut trace_infos = HashMap::default();
-        trace_infos.reserve(1);
         Ok(Self {
-            engine: engine.weak(),
-            trace_infos,
+            trace_infos: TraceInfos::new(engine, GC_REF_ARRAY_ELEMS_OFFSET),
             no_gc_count: 0,
             over_approximated_stack_roots: Box::new(None),
             memory: None,
@@ -229,10 +151,6 @@ impl DrcHeap {
             dec_ref_stack: Some(Vec::with_capacity(1)),
             allocated_bytes: 0,
         })
-    }
-
-    fn engine(&self) -> Engine {
-        self.engine.upgrade().unwrap()
     }
 
     fn dealloc(&mut self, gc_ref: VMGcRef) {
@@ -306,7 +224,7 @@ impl DrcHeap {
 
             // Trace: enqueue child GC refs for dec-ref'ing.
             if let Some(ty) = ty {
-                match &self.trace_infos[&ty] {
+                match self.trace_infos.trace_info(&ty) {
                     TraceInfo::Struct { gc_ref_offsets } => {
                         stack.reserve(gc_ref_offsets.len());
 
@@ -395,42 +313,7 @@ impl DrcHeap {
 
     /// Ensure that we have tracing information for the given type.
     fn ensure_trace_info(&mut self, ty: VMSharedTypeIndex) {
-        if self.trace_infos.contains_key(&ty) {
-            return;
-        }
-
-        self.insert_new_trace_info(ty);
-    }
-
-    fn insert_new_trace_info(&mut self, ty: VMSharedTypeIndex) {
-        debug_assert!(!self.trace_infos.contains_key(&ty));
-
-        let engine = self.engine();
-        let gc_layout = engine
-            .signatures()
-            .layout(ty)
-            .unwrap_or_else(|| panic!("should have a GC layout for {ty:?}"));
-
-        let info = match gc_layout {
-            GcLayout::Array(l) => {
-                if l.elems_are_gc_refs {
-                    debug_assert_eq!(l.elem_offset(0), GC_REF_ARRAY_ELEMS_OFFSET,);
-                }
-                TraceInfo::Array {
-                    gc_ref_elems: l.elems_are_gc_refs,
-                }
-            }
-            GcLayout::Struct(l) => TraceInfo::Struct {
-                gc_ref_offsets: l
-                    .fields
-                    .iter()
-                    .filter_map(|f| if f.is_gc_ref { Some(f.offset) } else { None })
-                    .collect(),
-            },
-        };
-
-        let old_entry = self.trace_infos.insert(ty, info);
-        debug_assert!(old_entry.is_none());
+        self.trace_infos.ensure(ty);
     }
 
     /// Iterate over the over-approximated-stack-roots list.
@@ -858,7 +741,6 @@ unsafe impl GcHeap for DrcHeap {
         assert!(self.is_attached());
 
         let DrcHeap {
-            engine: _,
             no_gc_count,
             over_approximated_stack_roots,
             free_list,

--- a/crates/wasmtime/src/runtime/vm/gc/enabled/drc.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/enabled/drc.rs
@@ -45,16 +45,15 @@
 //! <https://openresearch-repository.anu.edu.au/bitstream/1885/42030/2/hon-thesis.pdf>
 
 use super::free_list::FreeList;
+use super::trace_info::{TraceInfo, TraceInfos};
 use super::{VMArrayRef, VMGcObjectData};
-use crate::hash_map::HashMap;
 use crate::hash_set::HashSet;
 use crate::runtime::vm::{
     ExternRefHostDataId, ExternRefHostDataTable, GarbageCollection, GcHeap, GcHeapObject,
     GcProgress, GcRootsIter, GcRuntime, TypedGcRef, VMExternRef, VMGcHeader, VMGcRef,
 };
 use crate::vm::VMMemoryDefinition;
-use crate::{Engine, EngineWeak, prelude::*};
-use core::hash::BuildHasher;
+use crate::{Engine, prelude::*};
 use core::sync::atomic::AtomicUsize;
 use core::{
     alloc::Layout,
@@ -65,8 +64,7 @@ use core::{
 };
 use wasmtime_environ::drc::{ARRAY_LENGTH_OFFSET, DrcTypeLayouts};
 use wasmtime_environ::{
-    GcArrayLayout, GcLayout, GcStructLayout, GcTypeLayouts, POISON, VMGcKind, VMSharedTypeIndex,
-    gc_assert,
+    GcArrayLayout, GcStructLayout, GcTypeLayouts, POISON, VMGcKind, VMSharedTypeIndex, gc_assert,
 };
 
 #[expect(clippy::cast_possible_truncation, reason = "known to not overflow")]
@@ -97,83 +95,10 @@ unsafe impl GcRuntime for DrcCollector {
     }
 }
 
-/// How to trace a GC object.
-enum TraceInfo {
-    /// How to trace an array.
-    Array {
-        /// Whether this array type's elements are GC references, and need
-        /// tracing.
-        gc_ref_elems: bool,
-    },
-
-    /// How to trace a struct.
-    Struct {
-        /// The offsets of each GC reference field that needs tracing in
-        /// instances of this struct type.
-        gc_ref_offsets: Box<[u32]>,
-    },
-}
-
-/// A hasher that doesn't hash, for use in the trace-info hash map, where we are
-/// just using scalar keys and aren't overly concerned with collision-based DoS.
-#[derive(Default)]
-struct NopHasher(u64);
-
-impl BuildHasher for NopHasher {
-    type Hasher = Self;
-
-    #[inline]
-    fn build_hasher(&self) -> Self::Hasher {
-        NopHasher::default()
-    }
-}
-
-impl core::hash::Hasher for NopHasher {
-    #[inline]
-    fn finish(&self) -> u64 {
-        self.0
-    }
-
-    #[inline]
-    fn write(&mut self, bytes: &[u8]) {
-        let mut hash = self.0.to_ne_bytes();
-        let n = hash.len().min(bytes.len());
-        hash[..n].copy_from_slice(bytes);
-        self.0 = u64::from_ne_bytes(hash);
-    }
-
-    #[inline]
-    fn write_u8(&mut self, i: u8) {
-        self.write_u64(i.into());
-    }
-
-    #[inline]
-    fn write_u16(&mut self, i: u16) {
-        self.write_u64(i.into())
-    }
-
-    #[inline]
-    fn write_u32(&mut self, i: u32) {
-        self.write_u64(i.into())
-    }
-
-    #[inline]
-    fn write_u64(&mut self, i: u64) {
-        self.0 = i;
-    }
-
-    #[inline]
-    fn write_usize(&mut self, i: usize) {
-        self.write_u64(i.try_into().unwrap());
-    }
-}
-
 /// A deferred reference-counting (DRC) heap.
 struct DrcHeap {
-    engine: EngineWeak,
-
     /// For every type that we have allocated in this heap, how do we trace it?
-    trace_infos: HashMap<VMSharedTypeIndex, TraceInfo, NopHasher>,
+    trace_infos: TraceInfos,
 
     /// Count of how many no-gc scopes we are currently within.
     no_gc_count: u64,
@@ -226,11 +151,8 @@ impl DrcHeap {
     /// Construct a new, default DRC heap.
     fn new(engine: &Engine) -> Result<Self> {
         log::trace!("allocating new DRC heap");
-        let mut trace_infos = HashMap::default();
-        trace_infos.reserve(1);
         Ok(Self {
-            engine: engine.weak(),
-            trace_infos,
+            trace_infos: TraceInfos::new(engine, GC_REF_ARRAY_ELEMS_OFFSET),
             no_gc_count: 0,
             over_approximated_stack_roots: Box::new(None),
             memory: None,
@@ -241,10 +163,6 @@ impl DrcHeap {
             to_dealloc: Some(Vec::with_capacity(1)),
             allocated_bytes: 0,
         })
-    }
-
-    fn engine(&self) -> Engine {
-        self.engine.upgrade().unwrap()
     }
 
     fn dealloc(&mut self, gc_ref: VMGcRef) {
@@ -324,7 +242,7 @@ impl DrcHeap {
 
                 // Trace: enqueue child GC refs for dec-ref'ing.
                 if let Some(ty) = ty {
-                    match &self.trace_infos[&ty] {
+                    match self.trace_infos.trace_info(&ty) {
                         TraceInfo::Struct { gc_ref_offsets } => {
                             stack.reserve(gc_ref_offsets.len());
                             let data = self.gc_object_data(&gc_ref);
@@ -431,46 +349,6 @@ impl DrcHeap {
         {
             stack.push(gc_ref);
         }
-    }
-
-    /// Ensure that we have tracing information for the given type.
-    fn ensure_trace_info(&mut self, ty: VMSharedTypeIndex) {
-        if self.trace_infos.contains_key(&ty) {
-            return;
-        }
-
-        self.insert_new_trace_info(ty);
-    }
-
-    fn insert_new_trace_info(&mut self, ty: VMSharedTypeIndex) {
-        debug_assert!(!self.trace_infos.contains_key(&ty));
-
-        let engine = self.engine();
-        let gc_layout = engine
-            .signatures()
-            .layout(ty)
-            .unwrap_or_else(|| panic!("should have a GC layout for {ty:?}"));
-
-        let info = match gc_layout {
-            GcLayout::Array(l) => {
-                if l.elems_are_gc_refs {
-                    debug_assert_eq!(l.elem_offset(0), Some(GC_REF_ARRAY_ELEMS_OFFSET));
-                }
-                TraceInfo::Array {
-                    gc_ref_elems: l.elems_are_gc_refs,
-                }
-            }
-            GcLayout::Struct(l) => TraceInfo::Struct {
-                gc_ref_offsets: l
-                    .fields
-                    .iter()
-                    .filter_map(|f| if f.is_gc_ref { Some(f.offset) } else { None })
-                    .collect(),
-            },
-        };
-
-        let old_entry = self.trace_infos.insert(ty, info);
-        debug_assert!(old_entry.is_none());
     }
 
     /// Iterate over the over-approximated-stack-roots list.
@@ -898,7 +776,6 @@ unsafe impl GcHeap for DrcHeap {
         assert!(self.is_attached());
 
         let DrcHeap {
-            engine: _,
             no_gc_count,
             over_approximated_stack_roots,
             free_list,
@@ -1058,7 +935,7 @@ unsafe impl GcHeap for DrcHeap {
         // associated `VMSharedTypeIndex` are `externref`s, and they don't have
         // any GC edges.
         if let Some(ty) = header.ty() {
-            self.ensure_trace_info(ty);
+            self.trace_infos.ensure(ty);
         } else {
             debug_assert_eq!(header.kind(), VMGcKind::ExternRef);
         }

--- a/crates/wasmtime/src/runtime/vm/gc/enabled/trace_info.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/enabled/trace_info.rs
@@ -106,12 +106,6 @@ impl TraceInfos {
         self.engine.upgrade().unwrap()
     }
 
-    /// Get the trace info for the given type, if we have it.
-    #[allow(dead_code)]
-    pub fn get(&self, ty: &VMSharedTypeIndex) -> Option<&TraceInfo> {
-        self.map.get(ty)
-    }
-
     /// Index into the trace infos, panicking if the type is not present.
     pub fn trace_info(&self, ty: &VMSharedTypeIndex) -> &TraceInfo {
         &self.map[ty]

--- a/crates/wasmtime/src/runtime/vm/gc/enabled/trace_info.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/enabled/trace_info.rs
@@ -1,0 +1,158 @@
+//! Shared tracing information for GC collectors.
+//!
+//! Both the DRC and copying collectors need to know how to trace GC objects to
+//! find outgoing GC-reference edges. This module provides a shared `TraceInfos`
+//! type that both collectors use.
+
+use crate::hash_map::HashMap;
+use crate::{Engine, EngineWeak};
+use alloc::boxed::Box;
+use core::hash::BuildHasher;
+use wasmtime_environ::{GcLayout, VMSharedTypeIndex};
+
+/// How to trace a GC object.
+pub(super) enum TraceInfo {
+    /// How to trace an array.
+    Array {
+        /// Whether this array type's elements are GC references, and need
+        /// tracing.
+        gc_ref_elems: bool,
+    },
+
+    /// How to trace a struct.
+    Struct {
+        /// The offsets of each GC reference field that needs tracing in
+        /// instances of this struct type.
+        gc_ref_offsets: Box<[u32]>,
+    },
+}
+
+/// A hasher that doesn't hash, for use in the trace-info hash map, where we are
+/// just using scalar keys and aren't overly concerned with collision-based DoS.
+#[derive(Default)]
+struct NopHasher(u64);
+
+impl BuildHasher for NopHasher {
+    type Hasher = Self;
+
+    #[inline]
+    fn build_hasher(&self) -> Self::Hasher {
+        NopHasher::default()
+    }
+}
+
+impl core::hash::Hasher for NopHasher {
+    #[inline]
+    fn finish(&self) -> u64 {
+        self.0
+    }
+
+    #[inline]
+    fn write(&mut self, bytes: &[u8]) {
+        let mut hash = self.0.to_ne_bytes();
+        let n = hash.len().min(bytes.len());
+        hash[..n].copy_from_slice(bytes);
+        self.0 = u64::from_ne_bytes(hash);
+    }
+
+    #[inline]
+    fn write_u8(&mut self, i: u8) {
+        self.write_u64(i.into());
+    }
+
+    #[inline]
+    fn write_u16(&mut self, i: u16) {
+        self.write_u64(i.into())
+    }
+
+    #[inline]
+    fn write_u32(&mut self, i: u32) {
+        self.write_u64(i.into())
+    }
+
+    #[inline]
+    fn write_u64(&mut self, i: u64) {
+        self.0 = i;
+    }
+
+    #[inline]
+    fn write_usize(&mut self, i: usize) {
+        self.write_u64(i.try_into().unwrap());
+    }
+}
+
+/// A map from GC type indices to their tracing information.
+#[derive(Default)]
+pub(super) struct TraceInfos {
+    engine: EngineWeak,
+    map: HashMap<VMSharedTypeIndex, TraceInfo, NopHasher>,
+    gc_ref_array_elems_offset: u32,
+}
+
+impl TraceInfos {
+    /// Create a new `TraceInfos` with the given engine and expected array
+    /// element offset for GC-ref arrays.
+    pub fn new(engine: &Engine, gc_ref_array_elems_offset: u32) -> Self {
+        let mut map = HashMap::default();
+        map.reserve(1);
+        Self {
+            engine: engine.weak(),
+            map,
+            gc_ref_array_elems_offset,
+        }
+    }
+
+    fn engine(&self) -> Engine {
+        self.engine.upgrade().unwrap()
+    }
+
+    /// Get the trace info for the given type, if we have it.
+    #[allow(dead_code)]
+    pub fn get(&self, ty: &VMSharedTypeIndex) -> Option<&TraceInfo> {
+        self.map.get(ty)
+    }
+
+    /// Index into the trace infos, panicking if the type is not present.
+    pub fn trace_info(&self, ty: &VMSharedTypeIndex) -> &TraceInfo {
+        &self.map[ty]
+    }
+
+    /// Ensure that we have tracing information for the given type.
+    pub fn ensure(&mut self, ty: VMSharedTypeIndex) {
+        if self.map.contains_key(&ty) {
+            return;
+        }
+        self.insert_new(ty);
+    }
+
+    fn insert_new(&mut self, ty: VMSharedTypeIndex) {
+        debug_assert!(!self.map.contains_key(&ty));
+
+        let engine = self.engine();
+        let gc_layout = engine
+            .signatures()
+            .layout(ty)
+            .unwrap_or_else(|| panic!("should have a GC layout for {ty:?}"));
+
+        let info = match gc_layout {
+            GcLayout::Array(l) => {
+                if l.elems_are_gc_refs {
+                    debug_assert_eq!(l.elem_offset(0), self.gc_ref_array_elems_offset);
+                }
+                TraceInfo::Array {
+                    gc_ref_elems: l.elems_are_gc_refs,
+                }
+            }
+            GcLayout::Struct(l) => TraceInfo::Struct {
+                gc_ref_offsets: l
+                    .fields
+                    .iter()
+                    .filter_map(|f| if f.is_gc_ref { Some(f.offset) } else { None })
+                    .collect(),
+            },
+        };
+
+        let old_entry = self.map.insert(ty, info);
+        debug_assert!(old_entry.is_none());
+    }
+}

--- a/crates/wasmtime/src/runtime/vm/gc/enabled/trace_info.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/enabled/trace_info.rs
@@ -131,7 +131,7 @@ impl TraceInfos {
         let info = match gc_layout {
             GcLayout::Array(l) => {
                 if l.elems_are_gc_refs {
-                    debug_assert_eq!(l.elem_offset(0), self.gc_ref_array_elems_offset);
+                    debug_assert_eq!(l.elem_offset(0), Some(self.gc_ref_array_elems_offset));
                 }
                 TraceInfo::Array {
                     gc_ref_elems: l.elems_are_gc_refs,

--- a/crates/wasmtime/src/runtime/vm/gc/gc_runtime.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/gc_runtime.rs
@@ -348,6 +348,17 @@ pub unsafe trait GcHeap: 'static + Send + Sync {
     /// This is distinct from the heap capacity.
     fn allocated_bytes(&self) -> usize;
 
+    /// Whether a GC should be performed before the next heap growth.
+    ///
+    /// Some collectors (e.g. the copying collector) need to perform a GC before
+    /// growing the heap in certain states, to ensure that the semi-spaces remain
+    /// properly balanced.
+    ///
+    /// Defaults to `false`.
+    fn needs_gc_before_next_growth(&self) -> bool {
+        false
+    }
+
     /// Start a new garbage collection process.
     ///
     /// The given `roots` are GC roots and should not be collected (nor anything

--- a/crates/wasmtime/src/runtime/vm/libcalls.rs
+++ b/crates/wasmtime/src/runtime/vm/libcalls.rs
@@ -642,10 +642,12 @@ fn grow_gc_heap(store: &mut dyn VMStore, _instance: InstanceId, bytes_needed: u6
     .unwrap();
 
     let (mut limiter, store) = store.resource_limiter_and_store_opaque();
-    block_on!(store, async |store, _asyncness| {
+    block_on!(store, async |store, asyncness| {
         // We error below if there's still not enough space; swallow
         // any growth failures here.
-        let _ = store.grow_gc_heap(limiter.as_mut(), bytes_needed).await;
+        let _ = store
+            .grow_gc_heap(limiter.as_mut(), bytes_needed, asyncness)
+            .await;
     })?;
 
     // JIT code relies on the memory having grown by `bytes_needed` bytes if
@@ -671,7 +673,7 @@ fn grow_gc_heap(store: &mut dyn VMStore, _instance: InstanceId, bytes_needed: u6
 /// Allocate a raw, unininitialized GC object for Wasm code.
 ///
 /// The Wasm code is responsible for initializing the object.
-#[cfg(feature = "gc-drc")]
+#[cfg(any(feature = "gc-drc", feature = "gc-copying"))]
 fn gc_alloc_raw(
     store: &mut dyn VMStore,
     _instance: InstanceId,

--- a/crates/wasmtime/src/runtime/vm/libcalls.rs
+++ b/crates/wasmtime/src/runtime/vm/libcalls.rs
@@ -643,10 +643,12 @@ fn grow_gc_heap(store: &mut dyn VMStore, _instance: InstanceId, bytes_needed: u6
     .unwrap();
 
     let (mut limiter, store) = store.resource_limiter_and_store_opaque();
-    block_on!(store, async |store, _asyncness| {
+    block_on!(store, async |store, asyncness| {
         // We error below if there's still not enough space; swallow
         // any growth failures here.
-        let _ = store.grow_gc_heap(limiter.as_mut(), bytes_needed).await;
+        let _ = store
+            .grow_gc_heap(limiter.as_mut(), bytes_needed, asyncness)
+            .await;
     })?;
 
     // JIT code relies on the memory having grown by `bytes_needed` bytes if
@@ -672,7 +674,7 @@ fn grow_gc_heap(store: &mut dyn VMStore, _instance: InstanceId, bytes_needed: u6
 /// Allocate a raw, unininitialized GC object for Wasm code.
 ///
 /// The Wasm code is responsible for initializing the object.
-#[cfg(feature = "gc-drc")]
+#[cfg(any(feature = "gc-drc", feature = "gc-copying"))]
 fn gc_alloc_raw(
     store: &mut dyn VMStore,
     _instance: InstanceId,

--- a/tests/all/gc.rs
+++ b/tests/all/gc.rs
@@ -2272,6 +2272,8 @@ fn copying_collector_gc_zeal_counter_stress() -> Result<()> {
     // GC timing.
     for counter in [2, 3, 5, 7, 10] {
         let (mut store, engine) = copying_store_with_gc_zeal(counter)?;
+        log::debug!("Testing with gc_zeal_alloc_counter = {counter}");
+
         let module = Module::new(
             &engine,
             r#"

--- a/tests/all/gc.rs
+++ b/tests/all/gc.rs
@@ -1,4 +1,5 @@
 use super::ref_types_module;
+use std::num::NonZeroU32;
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering::SeqCst};
@@ -2026,7 +2027,59 @@ fn issue_13037_drc_leak_passing_objects_already_in_over_approx_stack_roots_list(
     store.gc(None)?;
 
     assert!(dropped.load(Ordering::SeqCst));
+    Ok(())
+}
 
+fn copying_store_with_gc_zeal(counter: u32) -> Result<(Store<()>, Engine)> {
+    let _ = env_logger::try_init();
+    let mut config = Config::new();
+    config.wasm_gc(true);
+    config.wasm_function_references(true);
+    config.collector(Collector::Copying);
+    let _ = config.gc_zeal_alloc_counter(NonZeroU32::new(counter));
+    let engine = Engine::new(&config)?;
+    let store = Store::new(&engine, ());
+    Ok((store, engine))
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn copying_collector_externref_survives_gc() -> Result<()> {
+    let (mut store, engine) = copying_store_with_gc_zeal(1)?;
+    let module = Module::new(
+        &engine,
+        r#"
+        (module
+            (import "" "gc" (func $gc))
+            (func (export "roundtrip") (param externref) (result externref)
+                (call $gc)
+                (local.get 0)
+            )
+        )
+        "#,
+    )?;
+    let gc_func = Func::wrap(&mut store, |mut caller: Caller<'_, ()>| -> Result<()> {
+        caller.gc(None)
+    });
+    let instance = Instance::new(&mut store, &module, &[gc_func.into()])?;
+    let roundtrip = instance
+        .get_typed_func::<Option<Rooted<ExternRef>>, Option<Rooted<ExternRef>>>(
+            &mut store,
+            "roundtrip",
+        )?;
+
+    {
+        let val = ExternRef::new(&mut store, 42u32)?;
+        let result = roundtrip.call(&mut store, Some(val))?;
+        let result = result.unwrap();
+        let data = result
+            .data(&store)?
+            .expect("should have data")
+            .downcast_ref::<u32>()
+            .copied()
+            .unwrap();
+        assert_eq!(data, 42u32);
+    }
     Ok(())
 }
 
@@ -2081,6 +2134,71 @@ fn issue_13173_gc_heap_uses_gc_tunables_no_signals() -> Result<()> {
     let run = instance.get_typed_func::<(), i32>(&mut store, "run")?;
     let result = run.call(&mut store, ())?;
     assert_eq!(result, 1000);
+
+    Ok(())
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn copying_collector_many_externrefs() -> Result<()> {
+    let (mut store, engine) = copying_store_with_gc_zeal(2)?;
+    let module = Module::new(
+        &engine,
+        r#"
+        (module
+            (import "" "gc" (func $gc))
+            (import "" "make" (func $make (param i32) (result externref)))
+            (import "" "check" (func $check (param externref i32)))
+
+            (func (export "test")
+                (local $a externref)
+                (local $b externref)
+                (local $c externref)
+
+                (local.set $a (call $make (i32.const 100)))
+                (local.set $b (call $make (i32.const 200)))
+                (local.set $c (call $make (i32.const 300)))
+
+                (call $gc)
+
+                (call $check (local.get $a) (i32.const 100))
+                (call $check (local.get $b) (i32.const 200))
+                (call $check (local.get $c) (i32.const 300))
+            )
+        )
+        "#,
+    )?;
+
+    let gc_func = Func::wrap(&mut store, |mut caller: Caller<'_, ()>| -> Result<()> {
+        caller.gc(None)
+    });
+    let make = Func::wrap(
+        &mut store,
+        |mut caller: Caller<'_, ()>, val: i32| -> Result<Option<Rooted<ExternRef>>> {
+            Ok(Some(ExternRef::new(&mut caller, val)?))
+        },
+    );
+    let check = Func::wrap(
+        &mut store,
+        |caller: Caller<'_, ()>, ext: Option<Rooted<ExternRef>>, expected: i32| -> Result<()> {
+            let ext = ext.unwrap();
+            let val = *ext
+                .data(&caller)?
+                .expect("data")
+                .downcast_ref::<i32>()
+                .unwrap();
+            assert_eq!(val, expected, "externref value mismatch after GC");
+            Ok(())
+        },
+    );
+
+    let instance = Instance::new(
+        &mut store,
+        &module,
+        &[gc_func.into(), make.into(), check.into()],
+    )?;
+    let test = instance.get_typed_func::<(), ()>(&mut store, "test")?;
+    test.call(&mut store, ())?;
     Ok(())
 }
 
@@ -2143,5 +2261,49 @@ fn issue_13173_gc_heap_uses_gc_tunables_guard_size_mismatch() -> Result<()> {
     let run = instance.get_typed_func::<(), i32>(&mut store, "run")?;
     let result = run.call(&mut store, ())?;
     assert_eq!(result, 1000);
+
+    Ok(())
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn copying_collector_gc_zeal_counter_stress() -> Result<()> {
+    // Many allocations with different `gc_zeal_alloc_counter` values to stress
+    // GC timing.
+    for counter in [2, 3, 5, 7, 10] {
+        let (mut store, engine) = copying_store_with_gc_zeal(counter)?;
+        let module = Module::new(
+            &engine,
+            r#"
+            (module
+                (type $box (struct (field i32)))
+
+                (func (export "test") (result i32)
+                    (local $keep (ref null $box))
+                    (local $i i32)
+
+                    (local.set $keep (struct.new $box (i32.const 12345)))
+
+                    (local.set $i (i32.const 0))
+                    (block $done
+                        (loop $loop
+                            (br_if $done (i32.ge_u (local.get $i) (i32.const 30)))
+                            (drop (struct.new $box (local.get $i)))
+                            (local.set $i (i32.add (local.get $i) (i32.const 1)))
+                            (br $loop)
+                        )
+                    )
+
+                    (struct.get $box 0 (local.get $keep))
+                )
+            )
+            "#,
+        )?;
+        let instance = Instance::new(&mut store, &module, &[])?;
+        let test = instance.get_typed_func::<(), i32>(&mut store, "test")?;
+        let result = test.call(&mut store, ())?;
+        assert_eq!(result, 12345, "failed with gc_zeal_counter={counter}");
+    }
+
     Ok(())
 }

--- a/tests/disas/gc/copying/array-fill.wat
+++ b/tests/disas/gc/copying/array-fill.wat
@@ -1,0 +1,72 @@
+;;! target = "x86_64"
+;;! flags = "-W function-references,gc -C collector=copying"
+;;! test = "optimize"
+(module
+  (type $ty (array (mut i64)))
+
+  (func (param (ref $ty) i32 i64 i32)
+    (array.fill $ty (local.get 0) (local.get 1) (local.get 2) (local.get 3))
+  )
+)
+;; function u0:0(i64 vmctx, i64, i32, i32, i64, i32) tail {
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv3 = vmctx
+;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
+;;     gv6 = load.i64 notrap aligned gv4+40
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i64, v5: i32):
+;; @0027                               trapz v2, user15
+;; @0027                               v41 = load.i64 notrap aligned readonly can_move v0+8
+;; @0027                               v7 = load.i64 notrap aligned readonly can_move v41+32
+;; @0027                               v6 = uextend.i64 v2
+;; @0027                               v8 = iadd v7, v6
+;; @0027                               v9 = iconst.i64 16
+;; @0027                               v10 = iadd v8, v9  ; v9 = 16
+;; @0027                               v11 = load.i32 notrap aligned readonly v10
+;; @0027                               v12 = uadd_overflow_trap v3, v5, user16
+;; @0027                               v13 = icmp ugt v12, v11
+;; @0027                               trapnz v13, user16
+;; @0027                               v15 = uextend.i64 v11
+;;                                     v43 = iconst.i64 3
+;;                                     v44 = ishl v15, v43  ; v43 = 3
+;;                                     v40 = iconst.i64 32
+;; @0027                               v17 = ushr v44, v40  ; v40 = 32
+;; @0027                               trapnz v17, user1
+;;                                     v53 = iconst.i32 3
+;;                                     v54 = ishl v11, v53  ; v53 = 3
+;; @0027                               v19 = iconst.i32 24
+;; @0027                               v20 = uadd_overflow_trap v54, v19, user1  ; v19 = 24
+;; @0027                               v24 = uadd_overflow_trap v2, v20, user1
+;; @0027                               v25 = uextend.i64 v24
+;; @0027                               v27 = iadd v7, v25
+;;                                     v60 = ishl v3, v53  ; v53 = 3
+;;                                     v62 = iadd v60, v19  ; v19 = 24
+;; @0027                               v28 = isub v20, v62
+;; @0027                               v29 = uextend.i64 v28
+;; @0027                               v30 = isub v27, v29
+;;                                     v64 = ishl v5, v53  ; v53 = 3
+;; @0027                               v32 = uextend.i64 v64
+;; @0027                               v33 = iadd v30, v32
+;; @0027                               v14 = iconst.i64 8
+;; @0027                               jump block2(v30)
+;;
+;;                                 block2(v35: i64):
+;; @0027                               v36 = icmp eq v35, v33
+;; @0027                               brif v36, block4, block3
+;;
+;;                                 block3:
+;; @0027                               store.i64 notrap aligned little v4, v35
+;;                                     v66 = iconst.i64 8
+;;                                     v67 = iadd.i64 v35, v66  ; v66 = 8
+;; @0027                               jump block2(v67)
+;;
+;;                                 block4:
+;; @002a                               jump block1
+;;
+;;                                 block1:
+;; @002a                               return
+;; }

--- a/tests/disas/gc/copying/array-get-s.wat
+++ b/tests/disas/gc/copying/array-get-s.wat
@@ -1,0 +1,51 @@
+;;! target = "x86_64"
+;;! flags = "-W function-references,gc -C collector=copying"
+;;! test = "optimize"
+(module
+  (type $ty (array (mut i8)))
+
+  (func (param (ref $ty) i32) (result i32)
+    (array.get_s $ty (local.get 0) (local.get 1))
+  )
+)
+;; function u0:0(i64 vmctx, i64, i32, i32) -> i32 tail {
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv3 = vmctx
+;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
+;;     gv6 = load.i64 notrap aligned gv4+40
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
+;; @0022                               trapz v2, user15
+;; @0022                               v34 = load.i64 notrap aligned readonly can_move v0+8
+;; @0022                               v6 = load.i64 notrap aligned readonly can_move v34+32
+;; @0022                               v5 = uextend.i64 v2
+;; @0022                               v7 = iadd v6, v5
+;; @0022                               v8 = iconst.i64 16
+;; @0022                               v9 = iadd v7, v8  ; v8 = 16
+;; @0022                               v10 = load.i32 notrap aligned readonly v9
+;; @0022                               v11 = icmp ult v3, v10
+;; @0022                               trapz v11, user16
+;; @0022                               v13 = uextend.i64 v10
+;;                                     v33 = iconst.i64 32
+;; @0022                               v15 = ushr v13, v33  ; v33 = 32
+;; @0022                               trapnz v15, user1
+;; @0022                               v17 = iconst.i32 20
+;; @0022                               v18 = uadd_overflow_trap v10, v17, user1  ; v17 = 20
+;; @0022                               v22 = uadd_overflow_trap v2, v18, user1
+;; @0022                               v23 = uextend.i64 v22
+;; @0022                               v25 = iadd v6, v23
+;; @0022                               v21 = iadd v3, v17  ; v17 = 20
+;; @0022                               v26 = isub v18, v21
+;; @0022                               v27 = uextend.i64 v26
+;; @0022                               v28 = isub v25, v27
+;; @0022                               v29 = load.i8 notrap aligned little v28
+;; @0025                               jump block1
+;;
+;;                                 block1:
+;; @0022                               v30 = sextend.i32 v29
+;; @0025                               return v30
+;; }

--- a/tests/disas/gc/copying/array-get-u.wat
+++ b/tests/disas/gc/copying/array-get-u.wat
@@ -1,0 +1,51 @@
+;;! target = "x86_64"
+;;! flags = "-W function-references,gc -C collector=copying"
+;;! test = "optimize"
+(module
+  (type $ty (array (mut i8)))
+
+  (func (param (ref $ty) i32) (result i32)
+    (array.get_u $ty (local.get 0) (local.get 1))
+  )
+)
+;; function u0:0(i64 vmctx, i64, i32, i32) -> i32 tail {
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv3 = vmctx
+;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
+;;     gv6 = load.i64 notrap aligned gv4+40
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
+;; @0022                               trapz v2, user15
+;; @0022                               v34 = load.i64 notrap aligned readonly can_move v0+8
+;; @0022                               v6 = load.i64 notrap aligned readonly can_move v34+32
+;; @0022                               v5 = uextend.i64 v2
+;; @0022                               v7 = iadd v6, v5
+;; @0022                               v8 = iconst.i64 16
+;; @0022                               v9 = iadd v7, v8  ; v8 = 16
+;; @0022                               v10 = load.i32 notrap aligned readonly v9
+;; @0022                               v11 = icmp ult v3, v10
+;; @0022                               trapz v11, user16
+;; @0022                               v13 = uextend.i64 v10
+;;                                     v33 = iconst.i64 32
+;; @0022                               v15 = ushr v13, v33  ; v33 = 32
+;; @0022                               trapnz v15, user1
+;; @0022                               v17 = iconst.i32 20
+;; @0022                               v18 = uadd_overflow_trap v10, v17, user1  ; v17 = 20
+;; @0022                               v22 = uadd_overflow_trap v2, v18, user1
+;; @0022                               v23 = uextend.i64 v22
+;; @0022                               v25 = iadd v6, v23
+;; @0022                               v21 = iadd v3, v17  ; v17 = 20
+;; @0022                               v26 = isub v18, v21
+;; @0022                               v27 = uextend.i64 v26
+;; @0022                               v28 = isub v25, v27
+;; @0022                               v29 = load.i8 notrap aligned little v28
+;; @0025                               jump block1
+;;
+;;                                 block1:
+;; @0022                               v30 = uextend.i32 v29
+;; @0025                               return v30
+;; }

--- a/tests/disas/gc/copying/array-get.wat
+++ b/tests/disas/gc/copying/array-get.wat
@@ -1,0 +1,55 @@
+;;! target = "x86_64"
+;;! flags = "-W function-references,gc -C collector=copying"
+;;! test = "optimize"
+(module
+  (type $ty (array (mut i64)))
+
+  (func (param (ref $ty) i32) (result i64)
+    (array.get $ty (local.get 0) (local.get 1))
+  )
+)
+;; function u0:0(i64 vmctx, i64, i32, i32) -> i64 tail {
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv3 = vmctx
+;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
+;;     gv6 = load.i64 notrap aligned gv4+40
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
+;; @0022                               trapz v2, user15
+;; @0022                               v33 = load.i64 notrap aligned readonly can_move v0+8
+;; @0022                               v6 = load.i64 notrap aligned readonly can_move v33+32
+;; @0022                               v5 = uextend.i64 v2
+;; @0022                               v7 = iadd v6, v5
+;; @0022                               v8 = iconst.i64 16
+;; @0022                               v9 = iadd v7, v8  ; v8 = 16
+;; @0022                               v10 = load.i32 notrap aligned readonly v9
+;; @0022                               v11 = icmp ult v3, v10
+;; @0022                               trapz v11, user16
+;; @0022                               v13 = uextend.i64 v10
+;;                                     v35 = iconst.i64 3
+;;                                     v36 = ishl v13, v35  ; v35 = 3
+;;                                     v32 = iconst.i64 32
+;; @0022                               v15 = ushr v36, v32  ; v32 = 32
+;; @0022                               trapnz v15, user1
+;;                                     v45 = iconst.i32 3
+;;                                     v46 = ishl v10, v45  ; v45 = 3
+;; @0022                               v17 = iconst.i32 24
+;; @0022                               v18 = uadd_overflow_trap v46, v17, user1  ; v17 = 24
+;; @0022                               v22 = uadd_overflow_trap v2, v18, user1
+;; @0022                               v23 = uextend.i64 v22
+;; @0022                               v25 = iadd v6, v23
+;;                                     v52 = ishl v3, v45  ; v45 = 3
+;; @0022                               v21 = iadd v52, v17  ; v17 = 24
+;; @0022                               v26 = isub v18, v21
+;; @0022                               v27 = uextend.i64 v26
+;; @0022                               v28 = isub v25, v27
+;; @0022                               v29 = load.i64 notrap aligned little v28
+;; @0025                               jump block1
+;;
+;;                                 block1:
+;; @0025                               return v29
+;; }

--- a/tests/disas/gc/copying/array-len.wat
+++ b/tests/disas/gc/copying/array-len.wat
@@ -1,0 +1,34 @@
+;;! target = "x86_64"
+;;! flags = "-W function-references,gc -C collector=copying"
+;;! test = "optimize"
+(module
+  (type $ty (array (mut i64)))
+
+  (func (param (ref $ty)) (result i32)
+    (array.len (local.get 0))
+  )
+)
+;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv3 = vmctx
+;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
+;;     gv6 = load.i64 notrap aligned gv4+40
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64, v2: i32):
+;; @001f                               trapz v2, user15
+;; @001f                               v10 = load.i64 notrap aligned readonly can_move v0+8
+;; @001f                               v5 = load.i64 notrap aligned readonly can_move v10+32
+;; @001f                               v4 = uextend.i64 v2
+;; @001f                               v6 = iadd v5, v4
+;; @001f                               v7 = iconst.i64 16
+;; @001f                               v8 = iadd v6, v7  ; v7 = 16
+;; @001f                               v9 = load.i32 notrap aligned readonly v8
+;; @0021                               jump block1
+;;
+;;                                 block1:
+;; @0021                               return v9
+;; }

--- a/tests/disas/gc/copying/array-new-fixed-of-gc-refs.wat
+++ b/tests/disas/gc/copying/array-new-fixed-of-gc-refs.wat
@@ -1,0 +1,62 @@
+;;! target = "x86_64"
+;;! flags = "-W function-references,gc -C collector=copying"
+;;! test = "optimize"
+(module
+  (type $ty (array (mut anyref)))
+
+  (func (param anyref anyref anyref) (result (ref $ty))
+    (array.new_fixed $ty 3 (local.get 0) (local.get 1) (local.get 2))
+  )
+)
+;; function u0:0(i64 vmctx, i64, i32, i32, i32) -> i32 tail {
+;;     ss0 = explicit_slot 4, align = 4
+;;     ss1 = explicit_slot 4, align = 4
+;;     ss2 = explicit_slot 4, align = 4
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv3 = vmctx
+;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
+;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
+;;     fn0 = colocated u805306368:27 sig0
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
+;;                                     v44 = stack_addr.i64 ss2
+;;                                     store notrap v2, v44
+;;                                     v43 = stack_addr.i64 ss1
+;;                                     store notrap v3, v43
+;;                                     v42 = stack_addr.i64 ss0
+;;                                     store notrap v4, v42
+;; @0025                               v14 = iconst.i32 -1476395008
+;; @0025                               v16 = load.i64 notrap aligned readonly can_move v0+40
+;; @0025                               v17 = load.i32 notrap aligned readonly can_move v16
+;;                                     v57 = iconst.i32 32
+;; @0025                               v18 = iconst.i32 16
+;; @0025                               v19 = call fn0(v0, v14, v17, v57, v18), stack_map=[i32 @ ss2+0, i32 @ ss1+0, i32 @ ss0+0]  ; v14 = -1476395008, v57 = 32, v18 = 16
+;; @0025                               v6 = iconst.i32 3
+;; @0025                               v38 = load.i64 notrap aligned readonly can_move v0+8
+;; @0025                               v20 = load.i64 notrap aligned readonly can_move v38+32
+;; @0025                               v21 = uextend.i64 v19
+;; @0025                               v22 = iadd v20, v21
+;;                                     v37 = iconst.i64 16
+;; @0025                               v23 = iadd v22, v37  ; v37 = 16
+;; @0025                               store notrap aligned v6, v23  ; v6 = 3
+;;                                     v33 = load.i32 notrap v44
+;;                                     v59 = iconst.i64 20
+;;                                     v65 = iadd v22, v59  ; v59 = 20
+;; @0025                               store notrap aligned little v33, v65
+;;                                     v32 = load.i32 notrap v43
+;;                                     v68 = iconst.i64 24
+;;                                     v74 = iadd v22, v68  ; v68 = 24
+;; @0025                               store notrap aligned little v32, v74
+;;                                     v31 = load.i32 notrap v42
+;;                                     v92 = iconst.i64 28
+;;                                     v98 = iadd v22, v92  ; v92 = 28
+;; @0025                               store notrap aligned little v31, v98
+;; @0029                               jump block1
+;;
+;;                                 block1:
+;; @0029                               return v19
+;; }

--- a/tests/disas/gc/copying/array-new-fixed-of-gc-refs.wat
+++ b/tests/disas/gc/copying/array-new-fixed-of-gc-refs.wat
@@ -32,9 +32,9 @@
 ;; @0025                               v14 = iconst.i32 -1476395008
 ;; @0025                               v16 = load.i64 notrap aligned readonly can_move v0+40
 ;; @0025                               v17 = load.i32 notrap aligned readonly can_move v16
-;;                                     v57 = iconst.i32 32
+;;                                     v56 = iconst.i32 32
 ;; @0025                               v18 = iconst.i32 16
-;; @0025                               v19 = call fn0(v0, v14, v17, v57, v18), stack_map=[i32 @ ss2+0, i32 @ ss1+0, i32 @ ss0+0]  ; v14 = -1476395008, v57 = 32, v18 = 16
+;; @0025                               v19 = call fn0(v0, v14, v17, v56, v18), stack_map=[i32 @ ss2+0, i32 @ ss1+0, i32 @ ss0+0]  ; v14 = -1476395008, v56 = 32, v18 = 16
 ;; @0025                               v6 = iconst.i32 3
 ;; @0025                               v38 = load.i64 notrap aligned readonly can_move v0+8
 ;; @0025                               v20 = load.i64 notrap aligned readonly can_move v38+32
@@ -44,17 +44,17 @@
 ;; @0025                               v23 = iadd v22, v37  ; v37 = 16
 ;; @0025                               store notrap aligned v6, v23  ; v6 = 3
 ;;                                     v33 = load.i32 notrap v44
-;;                                     v59 = iconst.i64 20
-;;                                     v65 = iadd v22, v59  ; v59 = 20
-;; @0025                               store notrap aligned little v33, v65
+;;                                     v58 = iconst.i64 20
+;;                                     v63 = iadd v22, v58  ; v58 = 20
+;; @0025                               store notrap aligned little v33, v63
 ;;                                     v32 = load.i32 notrap v43
-;;                                     v68 = iconst.i64 24
-;;                                     v74 = iadd v22, v68  ; v68 = 24
-;; @0025                               store notrap aligned little v32, v74
+;;                                     v66 = iconst.i64 24
+;;                                     v71 = iadd v22, v66  ; v66 = 24
+;; @0025                               store notrap aligned little v32, v71
 ;;                                     v31 = load.i32 notrap v42
-;;                                     v92 = iconst.i64 28
-;;                                     v98 = iadd v22, v92  ; v92 = 28
-;; @0025                               store notrap aligned little v31, v98
+;;                                     v87 = iconst.i64 28
+;;                                     v92 = iadd v22, v87  ; v87 = 28
+;; @0025                               store notrap aligned little v31, v92
 ;; @0029                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/copying/array-new-fixed.wat
+++ b/tests/disas/gc/copying/array-new-fixed.wat
@@ -1,0 +1,50 @@
+;;! target = "x86_64"
+;;! flags = "-W function-references,gc -C collector=copying"
+;;! test = "optimize"
+(module
+  (type $ty (array (mut i64)))
+
+  (func (param i64 i64 i64) (result (ref $ty))
+    (array.new_fixed $ty 3 (local.get 0) (local.get 1) (local.get 2))
+  )
+)
+;; function u0:0(i64 vmctx, i64, i64, i64, i64) -> i32 tail {
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv3 = vmctx
+;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
+;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
+;;     fn0 = colocated u805306368:27 sig0
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64):
+;; @0025                               v14 = iconst.i32 -1476395008
+;; @0025                               v16 = load.i64 notrap aligned readonly can_move v0+40
+;; @0025                               v17 = load.i32 notrap aligned readonly can_move v16
+;;                                     v46 = iconst.i32 48
+;; @0025                               v18 = iconst.i32 16
+;; @0025                               v19 = call fn0(v0, v14, v17, v46, v18)  ; v14 = -1476395008, v46 = 48, v18 = 16
+;; @0025                               v6 = iconst.i32 3
+;; @0025                               v32 = load.i64 notrap aligned readonly can_move v0+8
+;; @0025                               v20 = load.i64 notrap aligned readonly can_move v32+32
+;; @0025                               v21 = uextend.i64 v19
+;; @0025                               v22 = iadd v20, v21
+;;                                     v31 = iconst.i64 16
+;; @0025                               v23 = iadd v22, v31  ; v31 = 16
+;; @0025                               store notrap aligned v6, v23  ; v6 = 3
+;;                                     v37 = iconst.i64 24
+;;                                     v53 = iadd v22, v37  ; v37 = 24
+;; @0025                               store notrap aligned little v2, v53
+;;                                     v34 = iconst.i64 32
+;;                                     v61 = iadd v22, v34  ; v34 = 32
+;; @0025                               store notrap aligned little v3, v61
+;;                                     v78 = iconst.i64 40
+;;                                     v84 = iadd v22, v78  ; v78 = 40
+;; @0025                               store notrap aligned little v4, v84
+;; @0029                               jump block1
+;;
+;;                                 block1:
+;; @0029                               return v19
+;; }

--- a/tests/disas/gc/copying/array-new-fixed.wat
+++ b/tests/disas/gc/copying/array-new-fixed.wat
@@ -23,9 +23,9 @@
 ;; @0025                               v14 = iconst.i32 -1476395008
 ;; @0025                               v16 = load.i64 notrap aligned readonly can_move v0+40
 ;; @0025                               v17 = load.i32 notrap aligned readonly can_move v16
-;;                                     v46 = iconst.i32 48
+;;                                     v45 = iconst.i32 48
 ;; @0025                               v18 = iconst.i32 16
-;; @0025                               v19 = call fn0(v0, v14, v17, v46, v18)  ; v14 = -1476395008, v46 = 48, v18 = 16
+;; @0025                               v19 = call fn0(v0, v14, v17, v45, v18)  ; v14 = -1476395008, v45 = 48, v18 = 16
 ;; @0025                               v6 = iconst.i32 3
 ;; @0025                               v32 = load.i64 notrap aligned readonly can_move v0+8
 ;; @0025                               v20 = load.i64 notrap aligned readonly can_move v32+32
@@ -35,14 +35,14 @@
 ;; @0025                               v23 = iadd v22, v31  ; v31 = 16
 ;; @0025                               store notrap aligned v6, v23  ; v6 = 3
 ;;                                     v37 = iconst.i64 24
-;;                                     v53 = iadd v22, v37  ; v37 = 24
-;; @0025                               store notrap aligned little v2, v53
+;;                                     v51 = iadd v22, v37  ; v37 = 24
+;; @0025                               store notrap aligned little v2, v51
 ;;                                     v34 = iconst.i64 32
-;;                                     v61 = iadd v22, v34  ; v34 = 32
-;; @0025                               store notrap aligned little v3, v61
-;;                                     v78 = iconst.i64 40
-;;                                     v84 = iadd v22, v78  ; v78 = 40
-;; @0025                               store notrap aligned little v4, v84
+;;                                     v58 = iadd v22, v34  ; v34 = 32
+;; @0025                               store notrap aligned little v3, v58
+;;                                     v73 = iconst.i64 40
+;;                                     v78 = iadd v22, v73  ; v73 = 40
+;; @0025                               store notrap aligned little v4, v78
 ;; @0029                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/copying/array-new.wat
+++ b/tests/disas/gc/copying/array-new.wat
@@ -1,0 +1,67 @@
+;;! target = "x86_64"
+;;! flags = "-W function-references,gc -C collector=copying"
+;;! test = "optimize"
+(module
+  (type $ty (array (mut i64)))
+
+  (func (param i64 i32) (result (ref $ty))
+    (array.new $ty (local.get 0) (local.get 1))
+  )
+)
+;; function u0:0(i64 vmctx, i64, i64, i32) -> i32 tail {
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv3 = vmctx
+;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
+;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
+;;     fn0 = colocated u805306368:27 sig0
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
+;; @0022                               v6 = uextend.i64 v3
+;;                                     v37 = iconst.i64 3
+;;                                     v38 = ishl v6, v37  ; v37 = 3
+;;                                     v35 = iconst.i64 32
+;; @0022                               v8 = ushr v38, v35  ; v35 = 32
+;; @0022                               trapnz v8, user17
+;; @0022                               v5 = iconst.i32 24
+;;                                     v44 = iconst.i32 3
+;;                                     v45 = ishl v3, v44  ; v44 = 3
+;; @0022                               v10 = uadd_overflow_trap v5, v45, user17  ; v5 = 24
+;; @0022                               v12 = iconst.i32 -1476395008
+;; @0022                               v14 = load.i64 notrap aligned readonly can_move v0+40
+;; @0022                               v15 = load.i32 notrap aligned readonly can_move v14
+;; @0022                               v16 = iconst.i32 16
+;; @0022                               v17 = call fn0(v0, v12, v15, v10, v16)  ; v12 = -1476395008, v16 = 16
+;; @0022                               v33 = load.i64 notrap aligned readonly can_move v0+8
+;; @0022                               v18 = load.i64 notrap aligned readonly can_move v33+32
+;; @0022                               v19 = uextend.i64 v17
+;; @0022                               v20 = iadd v18, v19
+;;                                     v32 = iconst.i64 16
+;; @0022                               v21 = iadd v20, v32  ; v32 = 16
+;; @0022                               store notrap aligned v3, v21
+;;                                     v49 = iconst.i64 24
+;;                                     v55 = iadd v20, v49  ; v49 = 24
+;; @0022                               v27 = uextend.i64 v10
+;; @0022                               v28 = iadd v20, v27
+;;                                     v36 = iconst.i64 8
+;; @0022                               jump block2(v55)
+;;
+;;                                 block2(v29: i64):
+;; @0022                               v30 = icmp eq v29, v28
+;; @0022                               brif v30, block4, block3
+;;
+;;                                 block3:
+;; @0022                               store.i64 notrap aligned little v2, v29
+;;                                     v60 = iconst.i64 8
+;;                                     v61 = iadd.i64 v29, v60  ; v60 = 8
+;; @0022                               jump block2(v61)
+;;
+;;                                 block4:
+;; @0025                               jump block1
+;;
+;;                                 block1:
+;; @0025                               return v17
+;; }

--- a/tests/disas/gc/copying/array-new.wat
+++ b/tests/disas/gc/copying/array-new.wat
@@ -43,11 +43,11 @@
 ;; @0022                               v21 = iadd v20, v32  ; v32 = 16
 ;; @0022                               store notrap aligned v3, v21
 ;;                                     v49 = iconst.i64 24
-;;                                     v55 = iadd v20, v49  ; v49 = 24
+;;                                     v54 = iadd v20, v49  ; v49 = 24
 ;; @0022                               v27 = uextend.i64 v10
 ;; @0022                               v28 = iadd v20, v27
 ;;                                     v36 = iconst.i64 8
-;; @0022                               jump block2(v55)
+;; @0022                               jump block2(v54)
 ;;
 ;;                                 block2(v29: i64):
 ;; @0022                               v30 = icmp eq v29, v28
@@ -55,9 +55,9 @@
 ;;
 ;;                                 block3:
 ;; @0022                               store.i64 notrap aligned little v2, v29
-;;                                     v60 = iconst.i64 8
-;;                                     v61 = iadd.i64 v29, v60  ; v60 = 8
-;; @0022                               jump block2(v61)
+;;                                     v59 = iconst.i64 8
+;;                                     v60 = iadd.i64 v29, v59  ; v59 = 8
+;; @0022                               jump block2(v60)
 ;;
 ;;                                 block4:
 ;; @0025                               jump block1

--- a/tests/disas/gc/copying/array-set.wat
+++ b/tests/disas/gc/copying/array-set.wat
@@ -1,0 +1,55 @@
+;;! target = "x86_64"
+;;! flags = "-W function-references,gc -C collector=copying"
+;;! test = "optimize"
+(module
+  (type $ty (array (mut i64)))
+
+  (func (param (ref $ty) i32 i64)
+    (array.set $ty (local.get 0) (local.get 1) (local.get 2))
+  )
+)
+;; function u0:0(i64 vmctx, i64, i32, i32, i64) tail {
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv3 = vmctx
+;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
+;;     gv6 = load.i64 notrap aligned gv4+40
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i64):
+;; @0024                               trapz v2, user15
+;; @0024                               v32 = load.i64 notrap aligned readonly can_move v0+8
+;; @0024                               v6 = load.i64 notrap aligned readonly can_move v32+32
+;; @0024                               v5 = uextend.i64 v2
+;; @0024                               v7 = iadd v6, v5
+;; @0024                               v8 = iconst.i64 16
+;; @0024                               v9 = iadd v7, v8  ; v8 = 16
+;; @0024                               v10 = load.i32 notrap aligned readonly v9
+;; @0024                               v11 = icmp ult v3, v10
+;; @0024                               trapz v11, user16
+;; @0024                               v13 = uextend.i64 v10
+;;                                     v34 = iconst.i64 3
+;;                                     v35 = ishl v13, v34  ; v34 = 3
+;;                                     v31 = iconst.i64 32
+;; @0024                               v15 = ushr v35, v31  ; v31 = 32
+;; @0024                               trapnz v15, user1
+;;                                     v44 = iconst.i32 3
+;;                                     v45 = ishl v10, v44  ; v44 = 3
+;; @0024                               v17 = iconst.i32 24
+;; @0024                               v18 = uadd_overflow_trap v45, v17, user1  ; v17 = 24
+;; @0024                               v22 = uadd_overflow_trap v2, v18, user1
+;; @0024                               v23 = uextend.i64 v22
+;; @0024                               v25 = iadd v6, v23
+;;                                     v51 = ishl v3, v44  ; v44 = 3
+;; @0024                               v21 = iadd v51, v17  ; v17 = 24
+;; @0024                               v26 = isub v18, v21
+;; @0024                               v27 = uextend.i64 v26
+;; @0024                               v28 = isub v25, v27
+;; @0024                               store notrap aligned little v4, v28
+;; @0027                               jump block1
+;;
+;;                                 block1:
+;; @0027                               return
+;; }

--- a/tests/disas/gc/copying/br-on-cast-fail.wat
+++ b/tests/disas/gc/copying/br-on-cast-fail.wat
@@ -1,0 +1,82 @@
+;;! target = "x86_64"
+;;! flags = "-W function-references,gc -C collector=copying"
+;;! test = "optimize"
+(module
+  (type $s (struct))
+  (import "" "f" (func $f))
+  (import "" "g" (func $g))
+  (func (param anyref)
+    block (result anyref)
+      (br_on_cast_fail 0 anyref (ref $s) (local.get 0))
+      (call $f)
+      return
+    end
+    (call $g)
+    return
+  )
+)
+;; function u0:0(i64 vmctx, i64, i32) tail {
+;;     ss0 = explicit_slot 4, align = 4
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv3 = vmctx
+;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
+;;     gv6 = load.i64 notrap aligned gv4+40
+;;     sig0 = (i64 vmctx, i32, i32) -> i32 tail
+;;     sig1 = (i64 vmctx, i64) tail
+;;     fn0 = colocated u805306368:35 sig0
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64, v2: i32):
+;;                                     v42 = stack_addr.i64 ss0
+;;                                     store notrap v2, v42
+;;                                     v40 = iconst.i32 0
+;; @002e                               v4 = icmp eq v2, v40  ; v40 = 0
+;; @002e                               v5 = uextend.i32 v4
+;; @002e                               brif v5, block5(v40), block3  ; v40 = 0
+;;
+;;                                 block3:
+;; @002e                               v7 = iconst.i32 1
+;; @002e                               v8 = band.i32 v2, v7  ; v7 = 1
+;;                                     v43 = iconst.i32 0
+;; @002e                               brif v8, block5(v43), block4  ; v43 = 0
+;;
+;;                                 block4:
+;; @002e                               v36 = load.i64 notrap aligned readonly can_move v0+8
+;; @002e                               v14 = load.i64 notrap aligned readonly can_move v36+32
+;; @002e                               v13 = uextend.i64 v2
+;; @002e                               v15 = iadd v14, v13
+;; @002e                               v16 = iconst.i64 4
+;; @002e                               v17 = iadd v15, v16  ; v16 = 4
+;; @002e                               v18 = load.i32 notrap aligned readonly v17
+;; @002e                               v11 = load.i64 notrap aligned readonly can_move v0+40
+;; @002e                               v12 = load.i32 notrap aligned readonly can_move v11
+;; @002e                               v19 = icmp eq v18, v12
+;; @002e                               v20 = uextend.i32 v19
+;; @002e                               brif v20, block7(v20), block6
+;;
+;;                                 block6:
+;; @002e                               v22 = call fn0(v0, v18, v12), stack_map=[i32 @ ss0+0]
+;; @002e                               jump block7(v22)
+;;
+;;                                 block7(v23: i32):
+;; @002e                               jump block5(v23)
+;;
+;;                                 block5(v24: i32):
+;;                                     v31 = load.i32 notrap v42
+;; @002e                               brif v24, block8, block2
+;;
+;;                                 block8:
+;; @0034                               v27 = load.i64 notrap aligned readonly can_move v0+48
+;; @0034                               v26 = load.i64 notrap aligned readonly can_move v0+64
+;; @0034                               call_indirect sig1, v27(v26, v0)
+;; @0036                               return
+;;
+;;                                 block2:
+;; @0038                               v30 = load.i64 notrap aligned readonly can_move v0+72
+;; @0038                               v29 = load.i64 notrap aligned readonly can_move v0+88
+;; @0038                               call_indirect sig1, v30(v29, v0)
+;; @003a                               return
+;; }

--- a/tests/disas/gc/copying/br-on-cast-fail.wat
+++ b/tests/disas/gc/copying/br-on-cast-fail.wat
@@ -69,14 +69,14 @@
 ;; @002e                               brif v24, block8, block2
 ;;
 ;;                                 block8:
-;; @0034                               v27 = load.i64 notrap aligned readonly can_move v0+48
-;; @0034                               v26 = load.i64 notrap aligned readonly can_move v0+64
+;; @0034                               v27 = load.i64 notrap aligned readonly can_move v0+56
+;; @0034                               v26 = load.i64 notrap aligned readonly can_move v0+72
 ;; @0034                               call_indirect sig1, v27(v26, v0)
 ;; @0036                               return
 ;;
 ;;                                 block2:
-;; @0038                               v30 = load.i64 notrap aligned readonly can_move v0+72
-;; @0038                               v29 = load.i64 notrap aligned readonly can_move v0+88
+;; @0038                               v30 = load.i64 notrap aligned readonly can_move v0+88
+;; @0038                               v29 = load.i64 notrap aligned readonly can_move v0+104
 ;; @0038                               call_indirect sig1, v30(v29, v0)
 ;; @003a                               return
 ;; }

--- a/tests/disas/gc/copying/br-on-cast.wat
+++ b/tests/disas/gc/copying/br-on-cast.wat
@@ -1,0 +1,82 @@
+;;! target = "x86_64"
+;;! flags = "-W function-references,gc -C collector=copying"
+;;! test = "optimize"
+(module
+  (type $s (struct))
+  (import "" "f" (func $f))
+  (import "" "g" (func $g))
+  (func (param anyref)
+    block (result (ref $s))
+      (br_on_cast 0 anyref (ref $s) (local.get 0))
+      (call $f)
+      return
+    end
+    (call $g)
+    return
+  )
+)
+;; function u0:0(i64 vmctx, i64, i32) tail {
+;;     ss0 = explicit_slot 4, align = 4
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv3 = vmctx
+;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
+;;     gv6 = load.i64 notrap aligned gv4+40
+;;     sig0 = (i64 vmctx, i32, i32) -> i32 tail
+;;     sig1 = (i64 vmctx, i64) tail
+;;     fn0 = colocated u805306368:35 sig0
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64, v2: i32):
+;;                                     v42 = stack_addr.i64 ss0
+;;                                     store notrap v2, v42
+;;                                     v40 = iconst.i32 0
+;; @002f                               v4 = icmp eq v2, v40  ; v40 = 0
+;; @002f                               v5 = uextend.i32 v4
+;; @002f                               brif v5, block5(v40), block3  ; v40 = 0
+;;
+;;                                 block3:
+;; @002f                               v7 = iconst.i32 1
+;; @002f                               v8 = band.i32 v2, v7  ; v7 = 1
+;;                                     v43 = iconst.i32 0
+;; @002f                               brif v8, block5(v43), block4  ; v43 = 0
+;;
+;;                                 block4:
+;; @002f                               v36 = load.i64 notrap aligned readonly can_move v0+8
+;; @002f                               v14 = load.i64 notrap aligned readonly can_move v36+32
+;; @002f                               v13 = uextend.i64 v2
+;; @002f                               v15 = iadd v14, v13
+;; @002f                               v16 = iconst.i64 4
+;; @002f                               v17 = iadd v15, v16  ; v16 = 4
+;; @002f                               v18 = load.i32 notrap aligned readonly v17
+;; @002f                               v11 = load.i64 notrap aligned readonly can_move v0+40
+;; @002f                               v12 = load.i32 notrap aligned readonly can_move v11
+;; @002f                               v19 = icmp eq v18, v12
+;; @002f                               v20 = uextend.i32 v19
+;; @002f                               brif v20, block7(v20), block6
+;;
+;;                                 block6:
+;; @002f                               v22 = call fn0(v0, v18, v12), stack_map=[i32 @ ss0+0]
+;; @002f                               jump block7(v22)
+;;
+;;                                 block7(v23: i32):
+;; @002f                               jump block5(v23)
+;;
+;;                                 block5(v24: i32):
+;;                                     v31 = load.i32 notrap v42
+;; @002f                               brif v24, block2, block8
+;;
+;;                                 block8:
+;; @0035                               v27 = load.i64 notrap aligned readonly can_move v0+48
+;; @0035                               v26 = load.i64 notrap aligned readonly can_move v0+64
+;; @0035                               call_indirect sig1, v27(v26, v0)
+;; @0037                               return
+;;
+;;                                 block2:
+;; @0039                               v30 = load.i64 notrap aligned readonly can_move v0+72
+;; @0039                               v29 = load.i64 notrap aligned readonly can_move v0+88
+;; @0039                               call_indirect sig1, v30(v29, v0)
+;; @003b                               return
+;; }

--- a/tests/disas/gc/copying/br-on-cast.wat
+++ b/tests/disas/gc/copying/br-on-cast.wat
@@ -69,14 +69,14 @@
 ;; @002f                               brif v24, block2, block8
 ;;
 ;;                                 block8:
-;; @0035                               v27 = load.i64 notrap aligned readonly can_move v0+48
-;; @0035                               v26 = load.i64 notrap aligned readonly can_move v0+64
+;; @0035                               v27 = load.i64 notrap aligned readonly can_move v0+56
+;; @0035                               v26 = load.i64 notrap aligned readonly can_move v0+72
 ;; @0035                               call_indirect sig1, v27(v26, v0)
 ;; @0037                               return
 ;;
 ;;                                 block2:
-;; @0039                               v30 = load.i64 notrap aligned readonly can_move v0+72
-;; @0039                               v29 = load.i64 notrap aligned readonly can_move v0+88
+;; @0039                               v30 = load.i64 notrap aligned readonly can_move v0+88
+;; @0039                               v29 = load.i64 notrap aligned readonly can_move v0+104
 ;; @0039                               call_indirect sig1, v30(v29, v0)
 ;; @003b                               return
 ;; }

--- a/tests/disas/gc/copying/call-indirect-and-subtyping.wat
+++ b/tests/disas/gc/copying/call-indirect-and-subtyping.wat
@@ -1,0 +1,72 @@
+;;! target = "x86_64"
+;;! flags = "-W function-references,gc -C collector=copying"
+;;! test = "optimize"
+(module
+  (type $t1 (sub (func)))
+  (type $t2 (sub $t1 (func)))
+  (type $t3 (sub $t2 (func)))
+
+  (import "" "f2" (func $f2 (type $t2)))
+  (import "" "f3" (func $f3 (type $t3)))
+
+  (table (ref null $t2) (elem $f2 $f3))
+
+  (func (export "run") (param i32)
+    (call_indirect (type $t1) (local.get 0))
+  )
+)
+;; function u0:0(i64 vmctx, i64, i32) tail {
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv3 = vmctx
+;;     gv4 = load.i64 notrap aligned readonly can_move gv3+96
+;;     sig0 = (i64 vmctx, i64) tail
+;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
+;;     sig2 = (i64 vmctx, i32, i32) -> i32 tail
+;;     fn0 = colocated u805306368:9 sig1
+;;     fn1 = colocated u805306368:35 sig2
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64, v2: i32):
+;; @005c                               v3 = iconst.i32 2
+;; @005c                               v4 = icmp uge v2, v3  ; v3 = 2
+;; @005c                               v9 = iconst.i64 0
+;; @005c                               v6 = load.i64 notrap aligned readonly can_move v0+96
+;; @005c                               v5 = uextend.i64 v2
+;;                                     v30 = iconst.i64 3
+;; @005c                               v7 = ishl v5, v30  ; v30 = 3
+;; @005c                               v8 = iadd v6, v7
+;; @005c                               v10 = select_spectre_guard v4, v9, v8  ; v9 = 0
+;; @005c                               v11 = load.i64 user5 aligned table v10
+;;                                     v29 = iconst.i64 -2
+;; @005c                               v12 = band v11, v29  ; v29 = -2
+;; @005c                               brif v11, block3(v12), block2
+;;
+;;                                 block2 cold:
+;; @005c                               v14 = iconst.i32 0
+;; @005c                               v17 = call fn0(v0, v14, v5)  ; v14 = 0
+;; @005c                               jump block3(v17)
+;;
+;;                                 block3(v13: i64):
+;; @005c                               v21 = load.i32 user6 aligned readonly v13+16
+;; @005c                               v19 = load.i64 notrap aligned readonly can_move v0+40
+;; @005c                               v20 = load.i32 notrap aligned readonly can_move v19
+;; @005c                               v22 = icmp eq v21, v20
+;; @005c                               v23 = uextend.i32 v22
+;; @005c                               brif v23, block5(v23), block4
+;;
+;;                                 block4:
+;; @005c                               v25 = call fn1(v0, v21, v20)
+;; @005c                               jump block5(v25)
+;;
+;;                                 block5(v26: i32):
+;; @005c                               trapz v26, user7
+;; @005c                               v27 = load.i64 notrap aligned readonly v13+8
+;; @005c                               v28 = load.i64 notrap aligned readonly v13+24
+;; @005c                               call_indirect sig0, v27(v28, v0)
+;; @005f                               jump block1
+;;
+;;                                 block1:
+;; @005f                               return
+;; }

--- a/tests/disas/gc/copying/call-indirect-and-subtyping.wat
+++ b/tests/disas/gc/copying/call-indirect-and-subtyping.wat
@@ -20,7 +20,7 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+96
+;;     gv4 = load.i64 notrap aligned readonly can_move gv3+112
 ;;     sig0 = (i64 vmctx, i64) tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
 ;;     sig2 = (i64 vmctx, i32, i32) -> i32 tail
@@ -32,7 +32,7 @@
 ;; @005c                               v3 = iconst.i32 2
 ;; @005c                               v4 = icmp uge v2, v3  ; v3 = 2
 ;; @005c                               v9 = iconst.i64 0
-;; @005c                               v6 = load.i64 notrap aligned readonly can_move v0+96
+;; @005c                               v6 = load.i64 notrap aligned readonly can_move v0+112
 ;; @005c                               v5 = uextend.i64 v2
 ;;                                     v30 = iconst.i64 3
 ;; @005c                               v7 = ishl v5, v30  ; v30 = 3

--- a/tests/disas/gc/copying/externref-globals.wat
+++ b/tests/disas/gc/copying/externref-globals.wat
@@ -1,0 +1,45 @@
+;;! target = "x86_64"
+;;! flags = "-W function-references,gc -C collector=copying"
+;;! test = "optimize"
+(module
+  (global $x (mut externref) (ref.null extern))
+  (func (export "get") (result externref)
+    (global.get $x)
+  )
+  (func (export "set") (param externref)
+    (global.set $x (local.get 0))
+  )
+)
+;; function u0:0(i64 vmctx, i64) -> i32 tail {
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv3 = vmctx
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64):
+;;                                     v6 = iconst.i64 48
+;; @0034                               v4 = iadd v0, v6  ; v6 = 48
+;; @0034                               v5 = load.i32 notrap aligned v4
+;; @0036                               jump block1
+;;
+;;                                 block1:
+;; @0036                               return v5
+;; }
+;;
+;; function u0:1(i64 vmctx, i64, i32) tail {
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv3 = vmctx
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64, v2: i32):
+;;                                     v5 = iconst.i64 48
+;; @003b                               v4 = iadd v0, v5  ; v5 = 48
+;; @003b                               store notrap aligned v2, v4
+;; @003d                               jump block1
+;;
+;;                                 block1:
+;; @003d                               return
+;; }

--- a/tests/disas/gc/copying/funcref-in-gc-heap-get.wat
+++ b/tests/disas/gc/copying/funcref-in-gc-heap-get.wat
@@ -1,0 +1,38 @@
+;;! target = "x86_64"
+;;! flags = "-W function-references,gc -C collector=copying"
+;;! test = "optimize"
+(module
+  (type $ty (struct (field (mut funcref))))
+
+  (func (param (ref $ty)) (result funcref)
+    (struct.get $ty 0 (local.get 0))
+  )
+)
+;; function u0:0(i64 vmctx, i64, i32) -> i64 tail {
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv3 = vmctx
+;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
+;;     gv6 = load.i64 notrap aligned gv4+40
+;;     sig0 = (i64 vmctx, i32, i32) -> i64 tail
+;;     fn0 = colocated u805306368:29 sig0
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64, v2: i32):
+;; @0020                               trapz v2, user15
+;; @0020                               v13 = load.i64 notrap aligned readonly can_move v0+8
+;; @0020                               v5 = load.i64 notrap aligned readonly can_move v13+32
+;; @0020                               v4 = uextend.i64 v2
+;; @0020                               v6 = iadd v5, v4
+;; @0020                               v7 = iconst.i64 16
+;; @0020                               v8 = iadd v6, v7  ; v7 = 16
+;; @0020                               v11 = load.i32 notrap aligned little v8
+;; @0020                               v9 = iconst.i32 -1
+;; @0020                               v12 = call fn0(v0, v11, v9)  ; v9 = -1
+;; @0024                               jump block1
+;;
+;;                                 block1:
+;; @0024                               return v12
+;; }

--- a/tests/disas/gc/copying/funcref-in-gc-heap-new.wat
+++ b/tests/disas/gc/copying/funcref-in-gc-heap-new.wat
@@ -1,0 +1,48 @@
+;;! target = "x86_64"
+;;! flags = "-W function-references,gc -C collector=copying"
+;;! test = "optimize"
+(module
+  (type $ty (struct (field (mut funcref))))
+
+  (func (param funcref) (result (ref $ty))
+    (struct.new $ty (local.get 0))
+  )
+)
+;; function u0:0(i64 vmctx, i64, i64) -> i32 tail {
+;;     ss0 = explicit_slot 4, align = 4
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv3 = vmctx
+;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
+;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
+;;     sig1 = (i64 vmctx, i64) -> i64 tail
+;;     fn0 = colocated u805306368:27 sig0
+;;     fn1 = colocated u805306368:28 sig1
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64, v2: i64):
+;; @0020                               v6 = iconst.i32 -1342177280
+;; @0020                               v8 = load.i64 notrap aligned readonly can_move v0+40
+;; @0020                               v9 = load.i32 notrap aligned readonly can_move v8
+;; @0020                               v4 = iconst.i32 32
+;; @0020                               v10 = iconst.i32 16
+;; @0020                               v11 = call fn0(v0, v6, v9, v4, v10)  ; v6 = -1342177280, v4 = 32, v10 = 16
+;;                                     v26 = stack_addr.i64 ss0
+;;                                     store notrap v11, v26
+;; @0020                               v17 = call fn1(v0, v2), stack_map=[i32 @ ss0+0]
+;; @0020                               v18 = ireduce.i32 v17
+;; @0020                               v24 = load.i64 notrap aligned readonly can_move v0+8
+;; @0020                               v12 = load.i64 notrap aligned readonly can_move v24+32
+;; @0020                               v13 = uextend.i64 v11
+;; @0020                               v14 = iadd v12, v13
+;;                                     v22 = iconst.i64 16
+;; @0020                               v15 = iadd v14, v22  ; v22 = 16
+;; @0020                               store notrap aligned little v18, v15
+;;                                     v19 = load.i32 notrap v26
+;; @0023                               jump block1
+;;
+;;                                 block1:
+;; @0023                               return v19
+;; }

--- a/tests/disas/gc/copying/funcref-in-gc-heap-set.wat
+++ b/tests/disas/gc/copying/funcref-in-gc-heap-set.wat
@@ -1,0 +1,38 @@
+;;! target = "x86_64"
+;;! flags = "-W function-references,gc -C collector=copying"
+;;! test = "optimize"
+(module
+  (type $ty (struct (field (mut funcref))))
+
+  (func (param (ref $ty) funcref)
+    (struct.set $ty 0 (local.get 0) (local.get 1))
+  )
+)
+;; function u0:0(i64 vmctx, i64, i32, i64) tail {
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv3 = vmctx
+;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
+;;     gv6 = load.i64 notrap aligned gv4+40
+;;     sig0 = (i64 vmctx, i64) -> i64 tail
+;;     fn0 = colocated u805306368:28 sig0
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i64):
+;; @0022                               trapz v2, user15
+;; @0022                               v10 = call fn0(v0, v3)
+;; @0022                               v11 = ireduce.i32 v10
+;; @0022                               v12 = load.i64 notrap aligned readonly can_move v0+8
+;; @0022                               v5 = load.i64 notrap aligned readonly can_move v12+32
+;; @0022                               v4 = uextend.i64 v2
+;; @0022                               v6 = iadd v5, v4
+;; @0022                               v7 = iconst.i64 16
+;; @0022                               v8 = iadd v6, v7  ; v7 = 16
+;; @0022                               store notrap aligned little v11, v8
+;; @0026                               jump block1
+;;
+;;                                 block1:
+;; @0026                               return
+;; }

--- a/tests/disas/gc/copying/i31ref-globals.wat
+++ b/tests/disas/gc/copying/i31ref-globals.wat
@@ -1,0 +1,45 @@
+;;! target = "x86_64"
+;;! flags = "-W function-references,gc -C collector=copying"
+;;! test = "optimize"
+(module
+  (global $x (mut i31ref) (ref.i31 (i32.const 42)))
+  (func (export "get") (result i31ref)
+    (global.get $x)
+  )
+  (func (export "set") (param i31ref)
+    (global.set $x (local.get 0))
+  )
+)
+;; function u0:0(i64 vmctx, i64) -> i32 tail {
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv3 = vmctx
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64):
+;;                                     v6 = iconst.i64 48
+;; @0036                               v4 = iadd v0, v6  ; v6 = 48
+;; @0036                               v5 = load.i32 notrap aligned v4
+;; @0038                               jump block1
+;;
+;;                                 block1:
+;; @0038                               return v5
+;; }
+;;
+;; function u0:1(i64 vmctx, i64, i32) tail {
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv3 = vmctx
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64, v2: i32):
+;;                                     v5 = iconst.i64 48
+;; @003d                               v4 = iadd v0, v5  ; v5 = 48
+;; @003d                               store notrap aligned v2, v4
+;; @003f                               jump block1
+;;
+;;                                 block1:
+;; @003f                               return
+;; }

--- a/tests/disas/gc/copying/multiple-array-get.wat
+++ b/tests/disas/gc/copying/multiple-array-get.wat
@@ -1,0 +1,64 @@
+;;! target = "x86_64"
+;;! flags = "-W function-references,gc -C collector=copying"
+;;! test = "optimize"
+(module
+  (type $ty (array (mut i64)))
+
+  (func (param (ref $ty) i32 i32) (result i64 i64)
+    (array.get $ty (local.get 0) (local.get 1))
+    (array.get $ty (local.get 0) (local.get 2))
+  )
+)
+;; function u0:0(i64 vmctx, i64, i32, i32, i32) -> i64, i64 tail {
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv3 = vmctx
+;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
+;;     gv6 = load.i64 notrap aligned gv4+40
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
+;; @0024                               trapz v2, user15
+;; @0024                               v65 = load.i64 notrap aligned readonly can_move v0+8
+;; @0024                               v8 = load.i64 notrap aligned readonly can_move v65+32
+;; @0024                               v7 = uextend.i64 v2
+;; @0024                               v9 = iadd v8, v7
+;; @0024                               v10 = iconst.i64 16
+;; @0024                               v11 = iadd v9, v10  ; v10 = 16
+;; @0024                               v12 = load.i32 notrap aligned readonly v11
+;; @0024                               v13 = icmp ult v3, v12
+;; @0024                               trapz v13, user16
+;; @0024                               v15 = uextend.i64 v12
+;;                                     v67 = iconst.i64 3
+;;                                     v68 = ishl v15, v67  ; v67 = 3
+;;                                     v64 = iconst.i64 32
+;; @0024                               v17 = ushr v68, v64  ; v64 = 32
+;; @0024                               trapnz v17, user1
+;;                                     v77 = iconst.i32 3
+;;                                     v78 = ishl v12, v77  ; v77 = 3
+;; @0024                               v19 = iconst.i32 24
+;; @0024                               v20 = uadd_overflow_trap v78, v19, user1  ; v19 = 24
+;; @0024                               v24 = uadd_overflow_trap v2, v20, user1
+;; @0024                               v25 = uextend.i64 v24
+;; @0024                               v27 = iadd v8, v25
+;;                                     v84 = ishl v3, v77  ; v77 = 3
+;; @0024                               v23 = iadd v84, v19  ; v19 = 24
+;; @0024                               v28 = isub v20, v23
+;; @0024                               v29 = uextend.i64 v28
+;; @0024                               v30 = isub v27, v29
+;; @0024                               v31 = load.i64 notrap aligned little v30
+;; @002b                               v38 = icmp ult v4, v12
+;; @002b                               trapz v38, user16
+;;                                     v86 = ishl v4, v77  ; v77 = 3
+;; @002b                               v48 = iadd v86, v19  ; v19 = 24
+;; @002b                               v53 = isub v20, v48
+;; @002b                               v54 = uextend.i64 v53
+;; @002b                               v55 = isub v27, v54
+;; @002b                               v56 = load.i64 notrap aligned little v55
+;; @002e                               jump block1
+;;
+;;                                 block1:
+;; @002e                               return v31, v56
+;; }

--- a/tests/disas/gc/copying/multiple-struct-get.wat
+++ b/tests/disas/gc/copying/multiple-struct-get.wat
@@ -1,0 +1,40 @@
+;;! target = "x86_64"
+;;! flags = "-W function-references,gc -C collector=copying"
+;;! test = "optimize"
+(module
+  (type $ty (struct (field (mut f32))
+                    (field (mut i8))))
+
+  (func (param (ref null $ty)) (result f32 i32)
+    (struct.get $ty 0 (local.get 0))
+    (struct.get_s $ty 1 (local.get 0))
+  )
+)
+;; function u0:0(i64 vmctx, i64, i32) -> f32, i32 tail {
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv3 = vmctx
+;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
+;;     gv6 = load.i64 notrap aligned gv4+40
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64, v2: i32):
+;; @0023                               trapz v2, user15
+;; @0023                               v20 = load.i64 notrap aligned readonly can_move v0+8
+;; @0023                               v6 = load.i64 notrap aligned readonly can_move v20+32
+;; @0023                               v5 = uextend.i64 v2
+;; @0023                               v7 = iadd v6, v5
+;; @0023                               v8 = iconst.i64 16
+;; @0023                               v9 = iadd v7, v8  ; v8 = 16
+;; @0023                               v10 = load.f32 notrap aligned little v9
+;; @0029                               v14 = iconst.i64 20
+;; @0029                               v15 = iadd v7, v14  ; v14 = 20
+;; @0029                               v16 = load.i8 notrap aligned little v15
+;; @002d                               jump block1
+;;
+;;                                 block1:
+;; @0029                               v17 = sextend.i32 v16
+;; @002d                               return v10, v17
+;; }

--- a/tests/disas/gc/copying/ref-cast.wat
+++ b/tests/disas/gc/copying/ref-cast.wat
@@ -1,0 +1,65 @@
+;;! target = "x86_64"
+;;! flags = "-W function-references,gc -C collector=copying"
+;;! test = "optimize"
+(module
+  (type $s (struct))
+  (func (param anyref) (result (ref $s))
+    (ref.cast (ref $s) (local.get 0))
+  )
+)
+;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
+;;     ss0 = explicit_slot 4, align = 4
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv3 = vmctx
+;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
+;;     gv6 = load.i64 notrap aligned gv4+40
+;;     sig0 = (i64 vmctx, i32, i32) -> i32 tail
+;;     fn0 = colocated u805306368:35 sig0
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64, v2: i32):
+;;                                     v36 = stack_addr.i64 ss0
+;;                                     store notrap v2, v36
+;;                                     v34 = iconst.i32 0
+;; @001e                               v4 = icmp eq v2, v34  ; v34 = 0
+;; @001e                               v5 = uextend.i32 v4
+;; @001e                               brif v5, block4(v34), block2  ; v34 = 0
+;;
+;;                                 block2:
+;; @001e                               v7 = iconst.i32 1
+;; @001e                               v8 = band.i32 v2, v7  ; v7 = 1
+;;                                     v37 = iconst.i32 0
+;; @001e                               brif v8, block4(v37), block3  ; v37 = 0
+;;
+;;                                 block3:
+;; @001e                               v30 = load.i64 notrap aligned readonly can_move v0+8
+;; @001e                               v14 = load.i64 notrap aligned readonly can_move v30+32
+;; @001e                               v13 = uextend.i64 v2
+;; @001e                               v15 = iadd v14, v13
+;; @001e                               v16 = iconst.i64 4
+;; @001e                               v17 = iadd v15, v16  ; v16 = 4
+;; @001e                               v18 = load.i32 notrap aligned readonly v17
+;; @001e                               v11 = load.i64 notrap aligned readonly can_move v0+40
+;; @001e                               v12 = load.i32 notrap aligned readonly can_move v11
+;; @001e                               v19 = icmp eq v18, v12
+;; @001e                               v20 = uextend.i32 v19
+;; @001e                               brif v20, block6(v20), block5
+;;
+;;                                 block5:
+;; @001e                               v22 = call fn0(v0, v18, v12), stack_map=[i32 @ ss0+0]
+;; @001e                               jump block6(v22)
+;;
+;;                                 block6(v23: i32):
+;; @001e                               jump block4(v23)
+;;
+;;                                 block4(v24: i32):
+;; @001e                               trapz v24, user18
+;;                                     v25 = load.i32 notrap v36
+;; @0021                               jump block1
+;;
+;;                                 block1:
+;; @0021                               return v25
+;; }

--- a/tests/disas/gc/copying/ref-is-null.wat
+++ b/tests/disas/gc/copying/ref-is-null.wat
@@ -1,0 +1,40 @@
+;;! target = "x86_64"
+;;! flags = "-W function-references,gc -C collector=copying"
+;;! test = "optimize"
+(module
+  (func (param anyref) (result i32)
+    (ref.is_null (local.get 0))
+  )
+  (func (param (ref any)) (result i32)
+    (ref.is_null (local.get 0))
+  )
+)
+;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv2 = load.i64 notrap aligned gv1+24
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64, v2: i32):
+;; @0023                               jump block1
+;;
+;;                                 block1:
+;;                                     v6 = iconst.i32 0
+;;                                     v4 = icmp.i32 eq v2, v6  ; v6 = 0
+;;                                     v5 = uextend.i32 v4
+;; @0023                               return v5
+;; }
+;;
+;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv2 = load.i64 notrap aligned gv1+24
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64, v2: i32):
+;; @0029                               jump block1
+;;
+;;                                 block1:
+;;                                     v4 = iconst.i32 0
+;; @0029                               return v4  ; v4 = 0
+;; }

--- a/tests/disas/gc/copying/ref-test-any.wat
+++ b/tests/disas/gc/copying/ref-test-any.wat
@@ -1,0 +1,40 @@
+;;! target = "x86_64"
+;;! flags = "-W function-references,gc -C collector=copying"
+;;! test = "optimize"
+(module
+  (func (param anyref) (result i32)
+    (ref.test (ref any) (local.get 0))
+  )
+  (func (param (ref any)) (result i32)
+    (ref.test (ref any) (local.get 0))
+  )
+)
+;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv2 = load.i64 notrap aligned gv1+24
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64, v2: i32):
+;; @0025                               jump block1
+;;
+;;                                 block1:
+;; @0022                               v7 = iconst.i32 1
+;;                                     v9 = iconst.i32 0
+;;                                     v14 = select v2, v7, v9  ; v7 = 1, v9 = 0
+;; @0025                               return v14
+;; }
+;;
+;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv2 = load.i64 notrap aligned gv1+24
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64, v2: i32):
+;; @002d                               jump block1
+;;
+;;                                 block1:
+;; @002a                               v6 = iconst.i32 1
+;; @002d                               return v6  ; v6 = 1
+;; }

--- a/tests/disas/gc/copying/ref-test-array.wat
+++ b/tests/disas/gc/copying/ref-test-array.wat
@@ -1,0 +1,48 @@
+;;! target = "x86_64"
+;;! flags = "-W function-references,gc -C collector=copying"
+;;! test = "optimize"
+(module
+  (func (param anyref) (result i32)
+    (ref.test (ref array) (local.get 0))
+  )
+)
+;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv3 = vmctx
+;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
+;;     gv6 = load.i64 notrap aligned gv4+40
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64, v2: i32):
+;;                                     v23 = iconst.i32 0
+;; @001b                               v4 = icmp eq v2, v23  ; v23 = 0
+;; @001b                               v5 = uextend.i32 v4
+;; @001b                               brif v5, block4(v23), block2  ; v23 = 0
+;;
+;;                                 block2:
+;; @001b                               v7 = iconst.i32 1
+;; @001b                               v8 = band.i32 v2, v7  ; v7 = 1
+;;                                     v24 = iconst.i32 0
+;; @001b                               brif v8, block4(v24), block3  ; v24 = 0
+;;
+;;                                 block3:
+;; @001b                               v21 = load.i64 notrap aligned readonly can_move v0+8
+;; @001b                               v11 = load.i64 notrap aligned readonly can_move v21+32
+;; @001b                               v10 = uextend.i64 v2
+;; @001b                               v12 = iadd v11, v10
+;; @001b                               v15 = load.i32 notrap aligned readonly v12
+;; @001b                               v16 = iconst.i32 -1476395008
+;; @001b                               v17 = band v15, v16  ; v16 = -1476395008
+;; @001b                               v18 = icmp eq v17, v16  ; v16 = -1476395008
+;; @001b                               v19 = uextend.i32 v18
+;; @001b                               jump block4(v19)
+;;
+;;                                 block4(v20: i32):
+;; @001e                               jump block1(v20)
+;;
+;;                                 block1(v3: i32):
+;; @001e                               return v3
+;; }

--- a/tests/disas/gc/copying/ref-test-concrete-func-type.wat
+++ b/tests/disas/gc/copying/ref-test-concrete-func-type.wat
@@ -1,0 +1,49 @@
+;;! target = "x86_64"
+;;! flags = "-W function-references,gc -C collector=copying"
+;;! test = "optimize"
+(module
+  (type $f (func (param i32) (result i32)))
+  (func (param funcref) (result i32)
+    (ref.test (ref $f) (local.get 0))
+  )
+)
+;; function u0:0(i64 vmctx, i64, i64) -> i32 tail {
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv3 = vmctx
+;;     sig0 = (i64 vmctx, i32, i32) -> i32 tail
+;;     fn0 = colocated u805306368:35 sig0
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64, v2: i64):
+;;                                     v17 = iconst.i64 0
+;; @0020                               v4 = icmp eq v2, v17  ; v17 = 0
+;; @0020                               v5 = uextend.i32 v4
+;; @0020                               v6 = iconst.i32 0
+;; @0020                               brif v5, block4(v6), block2  ; v6 = 0
+;;
+;;                                 block2:
+;; @0020                               jump block3
+;;
+;;                                 block3:
+;; @0020                               v10 = load.i32 notrap aligned readonly v2+16
+;; @0020                               v8 = load.i64 notrap aligned readonly can_move v0+40
+;; @0020                               v9 = load.i32 notrap aligned readonly can_move v8
+;; @0020                               v11 = icmp eq v10, v9
+;; @0020                               v12 = uextend.i32 v11
+;; @0020                               brif v12, block6(v12), block5
+;;
+;;                                 block5:
+;; @0020                               v14 = call fn0(v0, v10, v9)
+;; @0020                               jump block6(v14)
+;;
+;;                                 block6(v15: i32):
+;; @0020                               jump block4(v15)
+;;
+;;                                 block4(v16: i32):
+;; @0023                               jump block1(v16)
+;;
+;;                                 block1(v3: i32):
+;; @0023                               return v3
+;; }

--- a/tests/disas/gc/copying/ref-test-concrete-type.wat
+++ b/tests/disas/gc/copying/ref-test-concrete-type.wat
@@ -1,0 +1,60 @@
+;;! target = "x86_64"
+;;! flags = "-W function-references,gc -C collector=copying"
+;;! test = "optimize"
+(module
+  (type $s (struct))
+  (func (param anyref) (result i32)
+    (ref.test (ref $s) (local.get 0))
+  )
+)
+;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv3 = vmctx
+;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
+;;     gv6 = load.i64 notrap aligned gv4+40
+;;     sig0 = (i64 vmctx, i32, i32) -> i32 tail
+;;     fn0 = colocated u805306368:35 sig0
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64, v2: i32):
+;;                                     v27 = iconst.i32 0
+;; @001d                               v4 = icmp eq v2, v27  ; v27 = 0
+;; @001d                               v5 = uextend.i32 v4
+;; @001d                               brif v5, block4(v27), block2  ; v27 = 0
+;;
+;;                                 block2:
+;; @001d                               v7 = iconst.i32 1
+;; @001d                               v8 = band.i32 v2, v7  ; v7 = 1
+;;                                     v28 = iconst.i32 0
+;; @001d                               brif v8, block4(v28), block3  ; v28 = 0
+;;
+;;                                 block3:
+;; @001d                               v25 = load.i64 notrap aligned readonly can_move v0+8
+;; @001d                               v14 = load.i64 notrap aligned readonly can_move v25+32
+;; @001d                               v13 = uextend.i64 v2
+;; @001d                               v15 = iadd v14, v13
+;; @001d                               v16 = iconst.i64 4
+;; @001d                               v17 = iadd v15, v16  ; v16 = 4
+;; @001d                               v18 = load.i32 notrap aligned readonly v17
+;; @001d                               v11 = load.i64 notrap aligned readonly can_move v0+40
+;; @001d                               v12 = load.i32 notrap aligned readonly can_move v11
+;; @001d                               v19 = icmp eq v18, v12
+;; @001d                               v20 = uextend.i32 v19
+;; @001d                               brif v20, block6(v20), block5
+;;
+;;                                 block5:
+;; @001d                               v22 = call fn0(v0, v18, v12)
+;; @001d                               jump block6(v22)
+;;
+;;                                 block6(v23: i32):
+;; @001d                               jump block4(v23)
+;;
+;;                                 block4(v24: i32):
+;; @0020                               jump block1(v24)
+;;
+;;                                 block1(v3: i32):
+;; @0020                               return v3
+;; }

--- a/tests/disas/gc/copying/ref-test-eq.wat
+++ b/tests/disas/gc/copying/ref-test-eq.wat
@@ -1,0 +1,47 @@
+;;! target = "x86_64"
+;;! flags = "-W function-references,gc -C collector=copying"
+;;! test = "optimize"
+(module
+  (func (param anyref) (result i32)
+    (ref.test (ref eq) (local.get 0))
+  )
+)
+;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv3 = vmctx
+;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
+;;     gv6 = load.i64 notrap aligned gv4+40
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64, v2: i32):
+;;                                     v23 = iconst.i32 0
+;; @001b                               v4 = icmp eq v2, v23  ; v23 = 0
+;; @001b                               v5 = uextend.i32 v4
+;; @001b                               brif v5, block4(v23), block2  ; v23 = 0
+;;
+;;                                 block2:
+;; @001b                               v7 = iconst.i32 1
+;; @001b                               v8 = band.i32 v2, v7  ; v7 = 1
+;; @001b                               brif v8, block4(v7), block3  ; v7 = 1
+;;
+;;                                 block3:
+;; @001b                               v21 = load.i64 notrap aligned readonly can_move v0+8
+;; @001b                               v11 = load.i64 notrap aligned readonly can_move v21+32
+;; @001b                               v10 = uextend.i64 v2
+;; @001b                               v12 = iadd v11, v10
+;; @001b                               v15 = load.i32 notrap aligned readonly v12
+;; @001b                               v16 = iconst.i32 -1610612736
+;; @001b                               v17 = band v15, v16  ; v16 = -1610612736
+;; @001b                               v18 = icmp eq v17, v16  ; v16 = -1610612736
+;; @001b                               v19 = uextend.i32 v18
+;; @001b                               jump block4(v19)
+;;
+;;                                 block4(v20: i32):
+;; @001e                               jump block1(v20)
+;;
+;;                                 block1(v3: i32):
+;; @001e                               return v3
+;; }

--- a/tests/disas/gc/copying/ref-test-i31.wat
+++ b/tests/disas/gc/copying/ref-test-i31.wat
@@ -1,0 +1,22 @@
+;;! target = "x86_64"
+;;! flags = "-W function-references,gc -C collector=copying"
+;;! test = "optimize"
+(module
+  (func (param anyref) (result i32)
+    (ref.test (ref i31) (local.get 0))
+  )
+)
+;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv2 = load.i64 notrap aligned gv1+24
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64, v2: i32):
+;; @001e                               jump block1
+;;
+;;                                 block1:
+;; @001b                               v4 = iconst.i32 1
+;; @001b                               v5 = band.i32 v2, v4  ; v4 = 1
+;; @001e                               return v5
+;; }

--- a/tests/disas/gc/copying/ref-test-none.wat
+++ b/tests/disas/gc/copying/ref-test-none.wat
@@ -1,0 +1,40 @@
+;;! target = "x86_64"
+;;! flags = "-W function-references,gc -C collector=copying"
+;;! test = "optimize"
+(module
+  (func (param anyref) (result i32)
+    (ref.test (ref none) (local.get 0))
+  )
+  (func (param anyref) (result i32)
+    (ref.test (ref null none) (local.get 0))
+  )
+)
+;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv2 = load.i64 notrap aligned gv1+24
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64, v2: i32):
+;; @001f                               jump block1
+;;
+;;                                 block1:
+;; @001c                               v4 = iconst.i32 0
+;; @001f                               return v4  ; v4 = 0
+;; }
+;;
+;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv2 = load.i64 notrap aligned gv1+24
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64, v2: i32):
+;; @0027                               jump block1
+;;
+;;                                 block1:
+;;                                     v6 = iconst.i32 0
+;; @0024                               v4 = icmp.i32 eq v2, v6  ; v6 = 0
+;; @0024                               v5 = uextend.i32 v4
+;; @0027                               return v5
+;; }

--- a/tests/disas/gc/copying/ref-test-struct.wat
+++ b/tests/disas/gc/copying/ref-test-struct.wat
@@ -1,0 +1,48 @@
+;;! target = "x86_64"
+;;! flags = "-W function-references,gc -C collector=copying"
+;;! test = "optimize"
+(module
+  (func (param anyref) (result i32)
+    (ref.test (ref struct) (local.get 0))
+  )
+)
+;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv3 = vmctx
+;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
+;;     gv6 = load.i64 notrap aligned gv4+40
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64, v2: i32):
+;;                                     v23 = iconst.i32 0
+;; @001b                               v4 = icmp eq v2, v23  ; v23 = 0
+;; @001b                               v5 = uextend.i32 v4
+;; @001b                               brif v5, block4(v23), block2  ; v23 = 0
+;;
+;;                                 block2:
+;; @001b                               v7 = iconst.i32 1
+;; @001b                               v8 = band.i32 v2, v7  ; v7 = 1
+;;                                     v24 = iconst.i32 0
+;; @001b                               brif v8, block4(v24), block3  ; v24 = 0
+;;
+;;                                 block3:
+;; @001b                               v21 = load.i64 notrap aligned readonly can_move v0+8
+;; @001b                               v11 = load.i64 notrap aligned readonly can_move v21+32
+;; @001b                               v10 = uextend.i64 v2
+;; @001b                               v12 = iadd v11, v10
+;; @001b                               v15 = load.i32 notrap aligned readonly v12
+;; @001b                               v16 = iconst.i32 -1342177280
+;; @001b                               v17 = band v15, v16  ; v16 = -1342177280
+;; @001b                               v18 = icmp eq v17, v16  ; v16 = -1342177280
+;; @001b                               v19 = uextend.i32 v18
+;; @001b                               jump block4(v19)
+;;
+;;                                 block4(v20: i32):
+;; @001e                               jump block1(v20)
+;;
+;;                                 block1(v3: i32):
+;; @001e                               return v3
+;; }

--- a/tests/disas/gc/copying/struct-get.wat
+++ b/tests/disas/gc/copying/struct-get.wat
@@ -1,0 +1,125 @@
+;;! target = "x86_64"
+;;! flags = "-W function-references,gc -C collector=copying"
+;;! test = "optimize"
+(module
+  (type $ty (struct (field (mut f32))
+                    (field (mut i8))
+                    (field (mut anyref))))
+
+  (func (param (ref null $ty)) (result f32)
+    (struct.get $ty 0 (local.get 0))
+  )
+
+  (func (param (ref null $ty)) (result i32)
+    (struct.get_s $ty 1 (local.get 0))
+  )
+
+  (func (param (ref null $ty)) (result i32)
+    (struct.get_u $ty 1 (local.get 0))
+  )
+
+  (func (param (ref null $ty)) (result anyref)
+    (struct.get $ty 2 (local.get 0))
+  )
+)
+;; function u0:0(i64 vmctx, i64, i32) -> f32 tail {
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv3 = vmctx
+;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
+;;     gv6 = load.i64 notrap aligned gv4+40
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64, v2: i32):
+;; @0033                               trapz v2, user15
+;; @0033                               v10 = load.i64 notrap aligned readonly can_move v0+8
+;; @0033                               v5 = load.i64 notrap aligned readonly can_move v10+32
+;; @0033                               v4 = uextend.i64 v2
+;; @0033                               v6 = iadd v5, v4
+;; @0033                               v7 = iconst.i64 16
+;; @0033                               v8 = iadd v6, v7  ; v7 = 16
+;; @0033                               v9 = load.f32 notrap aligned little v8
+;; @0037                               jump block1
+;;
+;;                                 block1:
+;; @0037                               return v9
+;; }
+;;
+;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv3 = vmctx
+;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
+;;     gv6 = load.i64 notrap aligned gv4+40
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64, v2: i32):
+;; @003c                               trapz v2, user15
+;; @003c                               v11 = load.i64 notrap aligned readonly can_move v0+8
+;; @003c                               v5 = load.i64 notrap aligned readonly can_move v11+32
+;; @003c                               v4 = uextend.i64 v2
+;; @003c                               v6 = iadd v5, v4
+;; @003c                               v7 = iconst.i64 20
+;; @003c                               v8 = iadd v6, v7  ; v7 = 20
+;; @003c                               v9 = load.i8 notrap aligned little v8
+;; @0040                               jump block1
+;;
+;;                                 block1:
+;; @003c                               v10 = sextend.i32 v9
+;; @0040                               return v10
+;; }
+;;
+;; function u0:2(i64 vmctx, i64, i32) -> i32 tail {
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv3 = vmctx
+;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
+;;     gv6 = load.i64 notrap aligned gv4+40
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64, v2: i32):
+;; @0045                               trapz v2, user15
+;; @0045                               v11 = load.i64 notrap aligned readonly can_move v0+8
+;; @0045                               v5 = load.i64 notrap aligned readonly can_move v11+32
+;; @0045                               v4 = uextend.i64 v2
+;; @0045                               v6 = iadd v5, v4
+;; @0045                               v7 = iconst.i64 20
+;; @0045                               v8 = iadd v6, v7  ; v7 = 20
+;; @0045                               v9 = load.i8 notrap aligned little v8
+;; @0049                               jump block1
+;;
+;;                                 block1:
+;; @0045                               v10 = uextend.i32 v9
+;; @0049                               return v10
+;; }
+;;
+;; function u0:3(i64 vmctx, i64, i32) -> i32 tail {
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv3 = vmctx
+;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
+;;     gv6 = load.i64 notrap aligned gv4+40
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64, v2: i32):
+;; @004e                               trapz v2, user15
+;; @004e                               v10 = load.i64 notrap aligned readonly can_move v0+8
+;; @004e                               v5 = load.i64 notrap aligned readonly can_move v10+32
+;; @004e                               v4 = uextend.i64 v2
+;; @004e                               v6 = iadd v5, v4
+;; @004e                               v7 = iconst.i64 24
+;; @004e                               v8 = iadd v6, v7  ; v7 = 24
+;; @004e                               v9 = load.i32 notrap aligned little v8
+;; @0052                               jump block1
+;;
+;;                                 block1:
+;; @0052                               return v9
+;; }

--- a/tests/disas/gc/copying/struct-new-default.wat
+++ b/tests/disas/gc/copying/struct-new-default.wat
@@ -1,0 +1,50 @@
+;;! target = "x86_64"
+;;! flags = "-W function-references,gc -C collector=copying"
+;;! test = "optimize"
+(module
+  (type $ty (struct (field (mut f32))
+                    (field (mut i8))
+                    (field (mut anyref))))
+
+  (func (result (ref $ty))
+    (struct.new_default $ty)
+  )
+)
+;; function u0:0(i64 vmctx, i64) -> i32 tail {
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv3 = vmctx
+;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
+;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
+;;     fn0 = colocated u805306368:27 sig0
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64):
+;; @0021                               v8 = iconst.i32 -1342177280
+;; @0021                               v10 = load.i64 notrap aligned readonly can_move v0+40
+;; @0021                               v11 = load.i32 notrap aligned readonly can_move v10
+;; @0021                               v6 = iconst.i32 32
+;; @0021                               v12 = iconst.i32 16
+;; @0021                               v13 = call fn0(v0, v8, v11, v6, v12)  ; v8 = -1342177280, v6 = 32, v12 = 16
+;; @0021                               v3 = f32const 0.0
+;; @0021                               v23 = load.i64 notrap aligned readonly can_move v0+8
+;; @0021                               v14 = load.i64 notrap aligned readonly can_move v23+32
+;; @0021                               v15 = uextend.i64 v13
+;; @0021                               v16 = iadd v14, v15
+;;                                     v22 = iconst.i64 16
+;; @0021                               v17 = iadd v16, v22  ; v22 = 16
+;; @0021                               store notrap aligned little v3, v17  ; v3 = 0.0
+;; @0021                               v4 = iconst.i32 0
+;;                                     v21 = iconst.i64 20
+;; @0021                               v18 = iadd v16, v21  ; v21 = 20
+;; @0021                               istore8 notrap aligned little v4, v18  ; v4 = 0
+;;                                     v20 = iconst.i64 24
+;; @0021                               v19 = iadd v16, v20  ; v20 = 24
+;; @0021                               store notrap aligned little v4, v19  ; v4 = 0
+;; @0024                               jump block1
+;;
+;;                                 block1:
+;; @0024                               return v13
+;; }

--- a/tests/disas/gc/copying/struct-new.wat
+++ b/tests/disas/gc/copying/struct-new.wat
@@ -1,0 +1,52 @@
+;;! target = "x86_64"
+;;! flags = "-W function-references,gc -C collector=copying"
+;;! test = "optimize"
+(module
+  (type $ty (struct (field (mut f32))
+                    (field (mut i8))
+                    (field (mut anyref))))
+
+  (func (param f32 i32 anyref) (result (ref $ty))
+    (struct.new $ty (local.get 0) (local.get 1) (local.get 2))
+  )
+)
+;; function u0:0(i64 vmctx, i64, f32, i32, i32) -> i32 tail {
+;;     ss0 = explicit_slot 4, align = 4
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv3 = vmctx
+;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
+;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
+;;     fn0 = colocated u805306368:27 sig0
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64, v2: f32, v3: i32, v4: i32):
+;;                                     v27 = stack_addr.i64 ss0
+;;                                     store notrap v4, v27
+;; @002a                               v8 = iconst.i32 -1342177280
+;; @002a                               v10 = load.i64 notrap aligned readonly can_move v0+40
+;; @002a                               v11 = load.i32 notrap aligned readonly can_move v10
+;; @002a                               v6 = iconst.i32 32
+;; @002a                               v12 = iconst.i32 16
+;; @002a                               v13 = call fn0(v0, v8, v11, v6, v12), stack_map=[i32 @ ss0+0]  ; v8 = -1342177280, v6 = 32, v12 = 16
+;; @002a                               v25 = load.i64 notrap aligned readonly can_move v0+8
+;; @002a                               v14 = load.i64 notrap aligned readonly can_move v25+32
+;; @002a                               v15 = uextend.i64 v13
+;; @002a                               v16 = iadd v14, v15
+;;                                     v24 = iconst.i64 16
+;; @002a                               v17 = iadd v16, v24  ; v24 = 16
+;; @002a                               store notrap aligned little v2, v17
+;;                                     v23 = iconst.i64 20
+;; @002a                               v18 = iadd v16, v23  ; v23 = 20
+;; @002a                               istore8 notrap aligned little v3, v18
+;;                                     v20 = load.i32 notrap v27
+;;                                     v22 = iconst.i64 24
+;; @002a                               v19 = iadd v16, v22  ; v22 = 24
+;; @002a                               store notrap aligned little v20, v19
+;; @002d                               jump block1
+;;
+;;                                 block1:
+;; @002d                               return v13
+;; }

--- a/tests/disas/gc/copying/struct-set.wat
+++ b/tests/disas/gc/copying/struct-set.wat
@@ -1,0 +1,94 @@
+;;! target = "x86_64"
+;;! flags = "-W function-references,gc -C collector=copying"
+;;! test = "optimize"
+(module
+  (type $ty (struct (field (mut f32))
+                    (field (mut i8))
+                    (field (mut anyref))))
+
+  (func (param (ref null $ty) f32)
+    (struct.set $ty 0 (local.get 0) (local.get 1))
+  )
+
+  (func (param (ref null $ty) i32)
+    (struct.set $ty 1 (local.get 0) (local.get 1))
+  )
+
+  (func (param (ref null $ty) anyref)
+    (struct.set $ty 2 (local.get 0) (local.get 1))
+  )
+)
+;; function u0:0(i64 vmctx, i64, i32, f32) tail {
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv3 = vmctx
+;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
+;;     gv6 = load.i64 notrap aligned gv4+40
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64, v2: i32, v3: f32):
+;; @0034                               trapz v2, user15
+;; @0034                               v9 = load.i64 notrap aligned readonly can_move v0+8
+;; @0034                               v5 = load.i64 notrap aligned readonly can_move v9+32
+;; @0034                               v4 = uextend.i64 v2
+;; @0034                               v6 = iadd v5, v4
+;; @0034                               v7 = iconst.i64 16
+;; @0034                               v8 = iadd v6, v7  ; v7 = 16
+;; @0034                               store notrap aligned little v3, v8
+;; @0038                               jump block1
+;;
+;;                                 block1:
+;; @0038                               return
+;; }
+;;
+;; function u0:1(i64 vmctx, i64, i32, i32) tail {
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv3 = vmctx
+;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
+;;     gv6 = load.i64 notrap aligned gv4+40
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
+;; @003f                               trapz v2, user15
+;; @003f                               v9 = load.i64 notrap aligned readonly can_move v0+8
+;; @003f                               v5 = load.i64 notrap aligned readonly can_move v9+32
+;; @003f                               v4 = uextend.i64 v2
+;; @003f                               v6 = iadd v5, v4
+;; @003f                               v7 = iconst.i64 20
+;; @003f                               v8 = iadd v6, v7  ; v7 = 20
+;; @003f                               istore8 notrap aligned little v3, v8
+;; @0043                               jump block1
+;;
+;;                                 block1:
+;; @0043                               return
+;; }
+;;
+;; function u0:2(i64 vmctx, i64, i32, i32) tail {
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv3 = vmctx
+;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
+;;     gv6 = load.i64 notrap aligned gv4+40
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
+;; @004a                               trapz v2, user15
+;; @004a                               v9 = load.i64 notrap aligned readonly can_move v0+8
+;; @004a                               v5 = load.i64 notrap aligned readonly can_move v9+32
+;; @004a                               v4 = uextend.i64 v2
+;; @004a                               v6 = iadd v5, v4
+;; @004a                               v7 = iconst.i64 24
+;; @004a                               v8 = iadd v6, v7  ; v7 = 24
+;; @004a                               store notrap aligned little v3, v8
+;; @004e                               jump block1
+;;
+;;                                 block1:
+;; @004e                               return
+;; }

--- a/tests/disas/gc/copying/v128-fields.wat
+++ b/tests/disas/gc/copying/v128-fields.wat
@@ -1,0 +1,37 @@
+;;! target = "x86_64"
+;;! flags = "-W function-references,gc -C collector=copying"
+;;! test = "optimize"
+(module
+  (type $ty (struct (field (mut v128))
+                    (field (mut v128))))
+
+  (func (param (ref $ty)) (result v128)
+    (v128.xor (struct.get $ty 0 (local.get 0))
+              (struct.get $ty 0 (local.get 0)))
+  )
+)
+;; function u0:0(i64 vmctx, i64, i32) -> i8x16 tail {
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv3 = vmctx
+;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
+;;     gv6 = load.i64 notrap aligned gv4+40
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64, v2: i32):
+;; @0022                               trapz v2, user15
+;; @0022                               v19 = load.i64 notrap aligned readonly can_move v0+8
+;; @0022                               v5 = load.i64 notrap aligned readonly can_move v19+32
+;; @0022                               v4 = uextend.i64 v2
+;; @0022                               v6 = iadd v5, v4
+;; @0022                               v7 = iconst.i64 16
+;; @0022                               v8 = iadd v6, v7  ; v7 = 16
+;; @0022                               v9 = load.i8x16 notrap aligned little v8
+;; @002e                               jump block1
+;;
+;;                                 block1:
+;; @002c                               v16 = bxor.i8x16 v9, v9
+;; @002e                               return v16
+;; }

--- a/tests/misc_testsuite/gc/array-copy-gc-refs.wast
+++ b/tests/misc_testsuite/gc/array-copy-gc-refs.wast
@@ -1,0 +1,31 @@
+;;! gc = true
+
+(module
+  (import "wasmtime" "gc" (func $gc))
+  (type $box (struct (field i32)))
+  (type $arr (array (mut (ref null $box))))
+
+  (func (export "test") (result i32)
+    (local $src (ref null $arr))
+    (local $dst (ref null $arr))
+    ;; Create source array
+    (local.set $src (array.new_fixed $arr 3
+      (struct.new $box (i32.const 10))
+      (struct.new $box (i32.const 20))
+      (struct.new $box (i32.const 30))
+    ))
+    ;; Create dest array of nulls
+    (local.set $dst (array.new $arr (ref.null $box) (i32.const 3)))
+    ;; Copy src[0..3] to dst[0..3]
+    (array.copy $arr $arr (local.get $dst) (i32.const 0) (local.get $src) (i32.const 0) (i32.const 3))
+    ;; Trigger GC
+    (call $gc)
+    ;; Read from dst
+    (i32.add
+      (struct.get $box 0 (array.get $arr (local.get $dst) (i32.const 0)))
+      (struct.get $box 0 (array.get $arr (local.get $dst) (i32.const 2)))
+    )
+  )
+)
+
+(assert_return (invoke "test") (i32.const 40))

--- a/tests/misc_testsuite/gc/array-fill-gc-refs.wast
+++ b/tests/misc_testsuite/gc/array-fill-gc-refs.wast
@@ -1,0 +1,24 @@
+;;! gc = true
+
+(module
+  (import "wasmtime" "gc" (func $gc))
+  (type $box (struct (field i32)))
+  (type $arr (array (mut (ref null $box))))
+
+  (func (export "test") (result i32)
+    (local $a (ref null $arr))
+    (local $b (ref null $box))
+    ;; Create box with value 77
+    (local.set $b (struct.new $box (i32.const 77)))
+    ;; Create array of 5 nulls
+    (local.set $a (array.new $arr (ref.null $box) (i32.const 5)))
+    ;; Fill all elements with the box
+    (array.fill $arr (local.get $a) (i32.const 0) (local.get $b) (i32.const 5))
+    ;; Trigger GC
+    (call $gc)
+    ;; Read element 3
+    (struct.get $box 0 (array.get $arr (local.get $a) (i32.const 3)))
+  )
+)
+
+(assert_return (invoke "test") (i32.const 77))

--- a/tests/misc_testsuite/gc/array-gc-refs.wast
+++ b/tests/misc_testsuite/gc/array-gc-refs.wast
@@ -1,0 +1,38 @@
+;;! gc = true
+
+(module
+  (type $box (struct (field i32)))
+  (type $arr (array (ref null $box)))
+
+  (import "wasmtime" "gc" (func $gc))
+
+  (func (export "test") (result i32)
+    (local $a (ref null $arr))
+    (local.set $a
+      (array.new_fixed $arr 3
+        (block (result (ref $box))
+          (struct.new $box (i32.const 10))
+          (call $gc)
+        )
+        (block (result (ref $box))
+          (struct.new $box (i32.const 20))
+          (call $gc)
+        )
+        (block (result (ref $box))
+          (struct.new $box (i32.const 30))
+          (call $gc)
+        )
+      )
+    )
+    (call $gc)
+    (i32.add
+      (i32.add
+        (struct.get $box 0 (array.get $arr (local.get $a) (i32.const 0)))
+        (struct.get $box 0 (array.get $arr (local.get $a) (i32.const 1)))
+      )
+      (struct.get $box 0 (array.get $arr (local.get $a) (i32.const 2)))
+    )
+  )
+)
+
+(assert_return (invoke "test") (i32.const 60))

--- a/tests/misc_testsuite/gc/big-array-overflow.wast
+++ b/tests/misc_testsuite/gc/big-array-overflow.wast
@@ -1,0 +1,18 @@
+;;! gc = true
+
+(module
+  (type $arr (array (mut i8)))
+  (func (export "test")
+    ;; With the copying collector, this allocation has
+    ;;
+    ;;     base_size=20,
+    ;;     elem_size=1,
+    ;;     length=4294967275
+    ;;     total size = 20 + 4294967275 = 4294967295 = u32::MAX
+    ;;
+    ;; In alloc_raw, the rounding (size + 15) & !15 overflows u32
+    (drop (array.new_default $arr (i32.const -21)))
+  )
+)
+
+(assert_trap (invoke "test") "allocation size too large")

--- a/tests/misc_testsuite/gc/binary-tree.wast
+++ b/tests/misc_testsuite/gc/binary-tree.wast
@@ -1,0 +1,64 @@
+;;! gc = true
+
+(module
+  (type $tree (struct
+    (field (ref null $tree))  ;; left
+    (field (ref null $tree))  ;; right
+    (field i32)               ;; value
+  ))
+
+  (import "wasmtime" "gc" (func $gc))
+
+  ;; Build a complete binary tree of depth n, with values 1..2^n-1
+  (func $build (param $depth i32) (param $val i32) (result (ref null $tree))
+    (local $left (ref null $tree))
+    (local $right (ref null $tree))
+    (if (result (ref null $tree)) (i32.le_s (local.get $depth) (i32.const 0))
+      (then (ref.null $tree))
+      (else
+        (local.set $left
+          (call $build
+            (i32.sub (local.get $depth) (i32.const 1))
+            (i32.mul (local.get $val) (i32.const 2))
+          )
+        )
+        (local.set $right
+          (call $build
+            (i32.sub (local.get $depth) (i32.const 1))
+            (i32.add (i32.mul (local.get $val) (i32.const 2)) (i32.const 1))
+          )
+        )
+        (struct.new $tree
+          (local.get $left)
+          (local.get $right)
+          (local.get $val)
+        )
+        (call $gc)
+      )
+    )
+  )
+
+  ;; Sum all values in the tree
+  (func $sum (param $t (ref null $tree)) (result i32)
+    (if (result i32) (ref.is_null (local.get $t))
+      (then (i32.const 0))
+      (else
+        (i32.add
+          (struct.get $tree 2 (local.get $t))
+          (i32.add
+            (call $sum (struct.get $tree 0 (local.get $t)))
+            (call $sum (struct.get $tree 1 (local.get $t)))
+          )
+        )
+      )
+    )
+  )
+
+  ;; Build tree of depth 5 (31 nodes), sum all values
+  ;; Values: 1,2,3,...,31 -> sum = 31*32/2 = 496
+  (func (export "test") (result i32)
+    (call $sum (call $build (i32.const 5) (i32.const 1)))
+  )
+)
+
+(assert_return (invoke "test") (i32.const 496))

--- a/tests/misc_testsuite/gc/deeply-nested-struct-survives-gc.wast
+++ b/tests/misc_testsuite/gc/deeply-nested-struct-survives-gc.wast
@@ -1,0 +1,33 @@
+;;! gc = true
+
+(module
+  (import "wasmtime" "gc" (func $gc))
+  (type $node (struct (field i32) (field (mut (ref null $node)))))
+
+  (func (export "test") (result i32)
+    (local $n1 (ref null $node))
+    (local $n2 (ref null $node))
+    (local $n3 (ref null $node))
+    (local $n4 (ref null $node))
+    ;; Build chain: n4 -> n3 -> n2 -> n1
+    (local.set $n1 (struct.new $node (i32.const 1) (ref.null $node)))
+    (local.set $n2 (struct.new $node (i32.const 2) (local.get $n1)))
+    (call $gc)
+    (local.set $n3 (struct.new $node (i32.const 3) (local.get $n2)))
+    (call $gc)
+    (local.set $n4 (struct.new $node (i32.const 4) (local.get $n3)))
+    (call $gc)
+    ;; Traverse: n4.next.next.next.val should be 1
+    (struct.get $node 0
+      (struct.get $node 1
+        (struct.get $node 1
+          (struct.get $node 1
+            (local.get $n4)
+          )
+        )
+      )
+    )
+  )
+)
+
+(assert_return (invoke "test") (i32.const 1))

--- a/tests/misc_testsuite/gc/empty-struct.wast
+++ b/tests/misc_testsuite/gc/empty-struct.wast
@@ -1,0 +1,22 @@
+;;! gc = true
+
+(module
+  (import "wasmtime" "gc" (func $gc))
+  (type $empty (struct))
+  (type $holder (struct (field (ref null $empty)) (field i32)))
+
+  (func (export "test") (result i32)
+    (local $e (ref null $empty))
+    (local $h (ref null $holder))
+    (local.set $e (struct.new_default $empty))
+    (local.set $h (struct.new $holder (local.get $e) (i32.const 42)))
+    (call $gc)
+    ;; Check that the empty struct ref is still valid
+    (if (ref.is_null (struct.get $holder 0 (local.get $h)))
+      (then (return (i32.const -1)))
+    )
+    (struct.get $holder 1 (local.get $h))
+  )
+)
+
+(assert_return (invoke "test") (i32.const 42))

--- a/tests/misc_testsuite/gc/funcref-field.wast
+++ b/tests/misc_testsuite/gc/funcref-field.wast
@@ -1,0 +1,21 @@
+;;! gc = true
+;;! bulk_memory = true
+
+(module
+  (type $ft (func (result i32)))
+  (type $fbox (struct (field (ref null $ft))))
+
+  (import "wasmtime" "gc" (func $gc))
+
+  (func $f (type $ft) (i32.const 77))
+  (elem declare func $f)
+
+  (func (export "test") (result i32)
+    (local $b (ref null $fbox))
+    (local.set $b (struct.new $fbox (ref.func $f)))
+    (call $gc)
+    (call_ref $ft (struct.get $fbox 0 (local.get $b)))
+  )
+)
+
+(assert_return (invoke "test") (i32.const 77))

--- a/tests/misc_testsuite/gc/gc-pressure.wast
+++ b/tests/misc_testsuite/gc/gc-pressure.wast
@@ -1,0 +1,32 @@
+;;! gc = true
+
+(module
+  (type $box (struct (field i32)))
+
+  (import "wasmtime" "gc" (func $gc))
+
+  (func (export "test") (result i32)
+    (local $keep (ref null $box))
+    (local $i i32)
+
+    ;; Create the value we want to keep
+    (local.set $keep (struct.new $box (i32.const 999)))
+
+    ;; Allocate and discard 100 objects, forcing many GC cycles
+    (local.set $i (i32.const 0))
+    (block $done
+      (loop $loop
+        (br_if $done (i32.ge_u (local.get $i) (i32.const 100)))
+        (call $gc)
+        (drop (struct.new $box (local.get $i)))
+        (local.set $i (i32.add (local.get $i) (i32.const 1)))
+        (br $loop)
+      )
+    )
+
+    ;; Read back the kept value
+    (struct.get $box 0 (local.get $keep))
+  )
+)
+
+(assert_return (invoke "test") (i32.const 999))

--- a/tests/misc_testsuite/gc/gc-ref-array-pressure.wast
+++ b/tests/misc_testsuite/gc/gc-ref-array-pressure.wast
@@ -1,0 +1,54 @@
+;;! gc = true
+
+(module
+  (type $box (struct (field i32)))
+  (type $arr (array (ref null $box)))
+
+  (import "wasmtime" "gc" (func $gc))
+
+  (global $g (mut (ref null $arr)) (ref.null $arr))
+
+  (func (export "test") (result i32)
+    (local $a (ref null $arr))
+    (local $i i32)
+    (local $total i32)
+
+    ;; Create array of 10 refs
+    (local.set $a
+      (array.new_fixed $arr 5
+        (struct.new $box (i32.const 1))
+        (struct.new $box (i32.const 2))
+        (struct.new $box (i32.const 3))
+        (struct.new $box (i32.const 4))
+        (struct.new $box (i32.const 5))
+      )
+    )
+
+    ;; GC and allocate to cause heap-growth pressure.
+    (call $gc)
+    (global.set $g
+      (array.new_default $arr (i32.const 10000))
+    )
+    (call $gc)
+
+    ;; Read back from the array
+    (local.set $i (i32.const 0))
+    (block $done2
+      (loop $loop2
+        (br_if $done2 (i32.ge_u (local.get $i) (i32.const 5)))
+        (local.set $total
+          (i32.add
+            (local.get $total)
+            (struct.get $box 0 (array.get $arr (local.get $a) (local.get $i)))
+          )
+        )
+        (local.set $i (i32.add (local.get $i) (i32.const 1)))
+        (br $loop2)
+      )
+    )
+    (local.get $total)
+  )
+)
+
+;; 1+2+3+4+5=15
+(assert_return (invoke "test") (i32.const 15))

--- a/tests/misc_testsuite/gc/i31ref-in-struct.wast
+++ b/tests/misc_testsuite/gc/i31ref-in-struct.wast
@@ -1,0 +1,17 @@
+;;! gc = true
+
+(module
+  (import "wasmtime" "gc" (func $gc))
+  (type $box (struct (field (mut anyref))))
+
+  (func (export "test") (result i32)
+    (local $b (ref null $box))
+    ;; Store an i31ref in the anyref field
+    (local.set $b (struct.new $box (ref.i31 (i32.const 42))))
+    (call $gc)
+    ;; Read it back
+    (i31.get_s (ref.cast (ref i31) (struct.get $box 0 (local.get $b))))
+  )
+)
+
+(assert_return (invoke "test") (i32.const 42))

--- a/tests/misc_testsuite/gc/linked-list.wast
+++ b/tests/misc_testsuite/gc/linked-list.wast
@@ -1,0 +1,61 @@
+;;! gc = true
+
+;; Test: Many allocations forcing many GC cycles and heap growths.
+;;
+;; The copying collector must properly handle repeated flip/copy/resize cycles.
+
+(module
+  (type $node (struct (field (ref null $node)) (field i32)))
+
+  (import "wasmtime" "gc" (func $gc))
+
+  ;; Build a linked list of n nodes, each storing its index
+  (func $build (param $n i32) (result (ref null $node))
+    (local $head (ref null $node))
+    (local $i i32)
+    (local.set $i (i32.const 0))
+    (block $done
+      (loop $loop
+        (br_if $done (i32.ge_u (local.get $i) (local.get $n)))
+        (local.set $head
+          (struct.new $node (local.get $head) (local.get $i))
+        )
+        (call $gc)
+        (local.set $i (i32.add (local.get $i) (i32.const 1)))
+        (br $loop)
+      )
+    )
+    (local.get $head)
+  )
+
+  ;; Sum all values in the linked list
+  (func $sum (param $head (ref null $node)) (result i32)
+    (local $total i32)
+    (local $cur (ref null $node))
+    (local.set $cur (local.get $head))
+    (block $done
+      (loop $loop
+        (br_if $done (ref.is_null (local.get $cur)))
+        (local.set $total
+          (i32.add (local.get $total)
+                   (struct.get $node 1 (local.get $cur)))
+        )
+        (local.set $cur (struct.get $node 0 (local.get $cur)))
+        (br $loop)
+      )
+    )
+    (local.get $total)
+  )
+
+  ;; Build a list of 20 nodes, force GC, then sum. Expected: 0+1+...+19 = 190
+  (func (export "test-linked-list") (result i32)
+    (local $list (ref null $node))
+    (local.set $list (call $build (i32.const 50)))
+    (call $gc)
+    (call $sum (local.get $list))
+  )
+)
+
+(assert_return (invoke "test-linked-list")
+               ;; 0+1+2+...+49 = 49*50/2 = 1225
+               (i32.const 1225))

--- a/tests/misc_testsuite/gc/packed-struct-fields.wast
+++ b/tests/misc_testsuite/gc/packed-struct-fields.wast
@@ -1,0 +1,48 @@
+;;! gc = true
+
+(module
+  (type $packed (struct
+    (field i8)
+    (field i16)
+    (field i32)
+    (field i64)
+    (field f32)
+    (field f64)
+  ))
+
+  (import "wasmtime" "gc" (func $gc))
+
+  (func (export "test") (result i32)
+    (local $s (ref null $packed))
+    (local.set $s
+      (struct.new $packed
+        (i32.const 1)
+        (i32.const 2)
+        (i32.const 3)
+        (i64.const 4)
+        (f32.const 5.0)
+        (f64.const 6.0)
+      )
+    )
+    (call $gc)
+    ;; Read back all fields and sum the fields
+    (i32.add
+      (i32.add
+        (i32.add
+          (struct.get_u $packed 0 (local.get $s))
+          (struct.get_u $packed 1 (local.get $s))
+        )
+        (i32.add
+          (struct.get $packed 2 (local.get $s))
+          (i32.wrap_i64 (struct.get $packed 3 (local.get $s)))
+        )
+      )
+      (i32.add
+        (i32.trunc_f32_u (struct.get $packed 4 (local.get $s)))
+        (i32.trunc_f64_u (struct.get $packed 5 (local.get $s)))
+      )
+    )
+  )
+)
+
+(assert_return (invoke "test") (i32.const 21))

--- a/tests/misc_testsuite/gc/semispace-capacity.wast
+++ b/tests/misc_testsuite/gc/semispace-capacity.wast
@@ -1,0 +1,38 @@
+;;! gc = true
+
+(module
+  (type $big (struct
+    (field i64) (field i64) (field i64) (field i64)
+    (field i64) (field i64) (field i64) (field i64)
+  ))
+
+  (import "wasmtime" "gc" (func $gc))
+
+  ;; Keep a reference alive across GC so objects must survive collection.
+  (global $keep (mut (ref null $big)) (ref.null $big))
+
+  (func (export "run")
+    ;; Allocate a struct, keep it alive, and force GC repeatedly.
+    (global.set $keep (struct.new $big
+      (i64.const 1) (i64.const 2) (i64.const 3) (i64.const 4)
+      (i64.const 5) (i64.const 6) (i64.const 7) (i64.const 8)
+    ))
+    call $gc
+    (global.set $keep (struct.new $big
+      (i64.const 1) (i64.const 2) (i64.const 3) (i64.const 4)
+      (i64.const 5) (i64.const 6) (i64.const 7) (i64.const 8)
+    ))
+    call $gc
+    (global.set $keep (struct.new $big
+      (i64.const 1) (i64.const 2) (i64.const 3) (i64.const 4)
+      (i64.const 5) (i64.const 6) (i64.const 7) (i64.const 8)
+    ))
+    call $gc
+    ;; Verify the last struct is still correct.
+    (if (i64.ne (struct.get $big 0 (global.get $keep)) (i64.const 1))
+      (then unreachable)
+    )
+  )
+)
+
+(assert_return (invoke "run"))

--- a/tests/misc_testsuite/gc/struct-mixed-fields.wast
+++ b/tests/misc_testsuite/gc/struct-mixed-fields.wast
@@ -1,0 +1,42 @@
+;;! gc = true
+
+(module
+  (type $inner (struct (field i32)))
+  (type $mixed (struct
+    (field i8)
+    (field i16)
+    (field (ref null $inner))
+    (field i64)
+  ))
+
+  (import "wasmtime" "gc" (func $gc))
+
+  (func (export "test") (result i32)
+    (local $i (ref null $inner))
+    (local $m (ref null $mixed))
+    (local.set $i (struct.new $inner (i32.const 99)))
+    (call $gc)
+    (local.set $m
+      (struct.new $mixed
+        (i32.const 1)
+        (i32.const 2)
+        (local.get $i)
+        (i64.const 3)
+      )
+    )
+    (call $gc)
+    (i32.add
+      (i32.add
+        (struct.get_u $mixed 0 (local.get $m))
+        (struct.get_u $mixed 1 (local.get $m))
+      )
+      (i32.add
+        (struct.get $inner 0 (struct.get $mixed 2 (local.get $m)))
+        (i32.wrap_i64 (struct.get $mixed 3 (local.get $m)))
+      )
+    )
+  )
+)
+
+;; 1+2+99+3=105
+(assert_return (invoke "test") (i32.const 105))

--- a/tests/misc_testsuite/gc/struct-refs-survive-gc.wast
+++ b/tests/misc_testsuite/gc/struct-refs-survive-gc.wast
@@ -1,0 +1,35 @@
+;;! gc = true
+
+;; Structs with GC reference fields survive GC correctly.
+
+(module
+  (type $inner (struct (field i32)))
+  (type $outer (struct (field (ref null $inner)) (field i32)))
+
+  (import "wasmtime" "gc" (func $gc))
+
+  (func (export "test") (result i32)
+    (local $a (ref null $inner))
+    (local $b (ref null $outer))
+
+    ;; Create inner struct with value 42
+    (local.set $a (struct.new $inner (i32.const 42)))
+
+    ;; Force GC - $a should be relocated
+    (call $gc)
+
+    ;; Create outer struct referencing inner, with value 100
+    (local.set $b (struct.new $outer (local.get $a) (i32.const 100)))
+
+    ;; Force GC - both $a and $b should be relocated
+    (call $gc)
+
+    ;; Read inner.field through outer.field_0
+    (i32.add
+      (struct.get $inner 0 (struct.get $outer 0 (local.get $b)))
+      (struct.get $outer 1 (local.get $b))
+    )
+  )
+)
+
+(assert_return (invoke "test") (i32.const 142))

--- a/tests/misc_testsuite/gc/struct-set-gc-ref.wast
+++ b/tests/misc_testsuite/gc/struct-set-gc-ref.wast
@@ -1,0 +1,27 @@
+;;! gc = true
+
+(module
+  (type $inner (struct (field i32)))
+  (type $outer (struct (field (mut (ref null $inner)))))
+
+  (import "wasmtime" "gc" (func $gc))
+
+  (func (export "test") (result i32)
+    (local $o (ref null $outer))
+    (local $i (ref null $inner))
+    ;; Create outer with null inner
+    (local.set $o (struct.new $outer (ref.null $inner)))
+    (call $gc)
+    ;; Create inner
+    (local.set $i (struct.new $inner (i32.const 999)))
+    (call $gc)
+    ;; Set the field
+    (struct.set $outer 0 (local.get $o) (local.get $i))
+    ;; Trigger GC
+    (call $gc)
+    ;; Read the field
+    (struct.get $inner 0 (struct.get $outer 0 (local.get $o)))
+  )
+)
+
+(assert_return (invoke "test") (i32.const 999))

--- a/tests/misc_testsuite/gc/struct-with-v128.wast
+++ b/tests/misc_testsuite/gc/struct-with-v128.wast
@@ -1,0 +1,26 @@
+;;! gc = true
+;;! simd = true
+
+(module
+  (type $v (struct (field (mut v128)) (field (mut v128))))
+
+  (import "wasmtime" "gc" (func $gc))
+
+  (func (export "test") (result i32)
+    (local $s (ref null $v))
+    (local.set $s
+      (struct.new $v
+        (v128.const i32x4 1 2 3 4)
+        (v128.const i32x4 10 20 30 40)
+      )
+    )
+    (call $gc)
+    ;; Extract and add lanes from both fields
+    (i32.add
+      (i32x4.extract_lane 0 (struct.get $v 0 (local.get $s)))
+      (i32x4.extract_lane 0 (struct.get $v 1 (local.get $s)))
+    )
+  )
+)
+
+(assert_return (invoke "test") (i32.const 11))

--- a/tests/misc_testsuite/gc/v128-with-gc-ref.wast
+++ b/tests/misc_testsuite/gc/v128-with-gc-ref.wast
@@ -1,0 +1,29 @@
+;;! gc = true
+;;! simd = true
+
+(module
+  (type $inner (struct (field i32)))
+  (type $outer (struct (field v128) (field (ref null $inner))))
+
+  (import "wasmtime" "gc" (func $gc))
+
+  (func (export "test") (result i32)
+    (local $i (ref null $inner))
+    (local $o (ref null $outer))
+    (local.set $i (struct.new $inner (i32.const 42)))
+    (call $gc)
+    (local.set $o
+      (struct.new $outer
+        (v128.const i32x4 100 200 300 400)
+        (local.get $i)
+      )
+    )
+    (call $gc)
+    (i32.add
+      (i32x4.extract_lane 0 (struct.get $outer 0 (local.get $o)))
+      (struct.get $inner 0 (struct.get $outer 1 (local.get $o)))
+    )
+  )
+)
+
+(assert_return (invoke "test") (i32.const 142))

--- a/tests/wast.rs
+++ b/tests/wast.rs
@@ -118,7 +118,6 @@ fn main() {
                 },
             );
 
-            #[cfg(feature = "gc-copying")]
             add_trial(
                 &test,
                 WastConfig {

--- a/tests/wast.rs
+++ b/tests/wast.rs
@@ -117,6 +117,16 @@ fn main() {
                     collector: Collector::Null,
                 },
             );
+
+            #[cfg(feature = "gc-copying")]
+            add_trial(
+                &test,
+                WastConfig {
+                    compiler,
+                    pooling: false,
+                    collector: Collector::Copying,
+                },
+            );
         }
     }
 


### PR DESCRIPTION
This is a classic semi-space copying collector that uses bump allocation and Cheney-style worklists to avoid an explicit stack for grey (relocated but not yet scanned) objects outside the GC heap. Forwarding "pointers" (really `VMGcRef` indices) are stored inline in objects in the old semi-space, which again avoids explicit data structures outside of the GC heap. Furthermore, an intrusive linked-list of all `externref`s is maintained to allow for efficiently sweeping their associated host data after collection (and, once again, avoiding additional data structures outside the GC heap).

Allocation in compiled Wasm code always happens by calling out to the `gc_alloc_raw` libcall currently. This is expected to become inline bump allocation, very similar to the null collector, in a follow-up commit shortly after this one. It is delayed to make review easier.

Collection is not incremental (in the Wasmtime sense, not the GC literature sense) yet and the `CopyingCollection::collect_increment` implementation only has a single increment. This is delayed to make review easier and is also expected to come shortly in follow-up commits.

I've also added new disas tests for the copying collector and also enabled running wast tests which need a GC heap with the copying collector.

Finally, fuzz config generation can now generate configurations that enable the copying collector.

Fixes https://github.com/bytecodealliance/wasmtime/issues/10329

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
