### PR TITLE
Remove `system-interface` from `wasmtime-wasi`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5268,6 +5268,7 @@ dependencies = [
  "cap-net-ext",
  "cap-std",
  "cap-time-ext",
+ "cfg-if",
  "env_logger 0.11.5",
  "fs-set-times",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5275,7 +5275,6 @@ dependencies = [
  "io-lifetimes",
  "rand 0.10.1",
  "rustix 1.1.4",
- "system-interface",
  "tempfile",
  "test-log",
  "test-programs-artifacts",

--- a/crates/test-programs/src/bin/p1_file_write.rs
+++ b/crates/test-programs/src/bin/p1_file_write.rs
@@ -106,7 +106,9 @@ unsafe fn test_file_long_write(dir_fd: wasip1::Fd, filename: &str) {
         }],
     );
     assert!(
-        res == Err(wasip1::ERRNO_BADF) || res == Err(wasip1::ERRNO_PERM),
+        res == Err(wasip1::ERRNO_BADF)
+            || res == Err(wasip1::ERRNO_PERM)
+            || res == Err(wasip1::ERRNO_ACCES),
         "bad result {res:?}"
     )
 }

--- a/crates/test-programs/src/bin/p1_path_open_read_write.rs
+++ b/crates/test-programs/src/bin/p1_path_open_read_write.rs
@@ -40,7 +40,8 @@ unsafe fn test_path_open_read_write(dir_fd: wasip1::Fd) {
             .err()
             .expect("read of writeonly fails"),
         wasip1::ERRNO_PERM,
-        wasip1::ERRNO_BADF
+        wasip1::ERRNO_BADF,
+        wasip1::ERRNO_ACCES
     );
 
     wasip1::fd_close(f_readonly).expect("close readonly");
@@ -69,7 +70,8 @@ unsafe fn test_path_open_read_write(dir_fd: wasip1::Fd) {
             .err()
             .expect("read of writeonly fails"),
         wasip1::ERRNO_PERM,
-        wasip1::ERRNO_BADF
+        wasip1::ERRNO_BADF,
+        wasip1::ERRNO_ACCES
     );
     let bytes_written = wasip1::fd_write(f_writeonly, &[ciovec]).expect("write to writeonly");
     assert_eq!(bytes_written, write_buffer.len());

--- a/crates/test-programs/src/bin/p3_filesystem_file_read_write.rs
+++ b/crates/test-programs/src/bin/p3_filesystem_file_read_write.rs
@@ -11,42 +11,44 @@ impl test_programs::p3::exports::wasi::cli::run::Guest for Component {
         let preopens = wasi::filesystem::preopens::get_directories();
         let (dir, _) = &preopens[0];
 
-        let filename = "test.txt";
-        let file = dir
-            .open_at(
-                PathFlags::empty(),
-                filename.to_string(),
-                OpenFlags::CREATE,
-                DescriptorFlags::READ | DescriptorFlags::WRITE,
-            )
-            .await
-            .unwrap();
-        let (mut data_tx, data_rx) = wit_stream::new();
-        join!(
-            async {
-                file.write_via_stream(data_rx, 5).await.unwrap();
-            },
-            async {
-                let remaining = data_tx.write_all(b"Hello, ".to_vec()).await;
-                assert!(remaining.is_empty());
-                let remaining = data_tx.write_all(b"World!".to_vec()).await;
-                assert!(remaining.is_empty());
-                drop(data_tx);
-            },
-        );
-        let (data_rx, data_fut) = file.read_via_stream(0);
-        let contents = data_rx.collect().await;
-        data_fut.await.unwrap();
-        assert_eq!(
-            String::from_utf8_lossy(&contents),
-            "\0\0\0\0\0Hello, World!"
-        );
+        {
+            let filename = "test.txt";
+            let file = dir
+                .open_at(
+                    PathFlags::empty(),
+                    filename.to_string(),
+                    OpenFlags::CREATE,
+                    DescriptorFlags::READ | DescriptorFlags::WRITE,
+                )
+                .await
+                .unwrap();
+            let (mut data_tx, data_rx) = wit_stream::new();
+            join!(
+                async {
+                    file.write_via_stream(data_rx, 5).await.unwrap();
+                },
+                async {
+                    let remaining = data_tx.write_all(b"Hello, ".to_vec()).await;
+                    assert!(remaining.is_empty());
+                    let remaining = data_tx.write_all(b"World!".to_vec()).await;
+                    assert!(remaining.is_empty());
+                    drop(data_tx);
+                },
+            );
+            let (data_rx, data_fut) = file.read_via_stream(0);
+            let contents = data_rx.collect().await;
+            data_fut.await.unwrap();
+            assert_eq!(
+                String::from_utf8_lossy(&contents),
+                "\0\0\0\0\0Hello, World!"
+            );
 
-        // Test that file read streams behave like other read streams.
-        let (data_rx, data_fut) = file.read_via_stream(5);
-        let contents = data_rx.collect().await;
-        data_fut.await.unwrap();
-        assert_eq!(String::from_utf8_lossy(&contents), "Hello, World!");
+            // Test that file read streams behave like other read streams.
+            let (data_rx, data_fut) = file.read_via_stream(5);
+            let contents = data_rx.collect().await;
+            data_fut.await.unwrap();
+            assert_eq!(String::from_utf8_lossy(&contents), "Hello, World!");
+        }
 
         dir.unlink_file_at(filename.to_string()).await.unwrap();
         Ok(())

--- a/crates/test-programs/src/bin/p3_filesystem_file_read_write.rs
+++ b/crates/test-programs/src/bin/p3_filesystem_file_read_write.rs
@@ -11,8 +11,8 @@ impl test_programs::p3::exports::wasi::cli::run::Guest for Component {
         let preopens = wasi::filesystem::preopens::get_directories();
         let (dir, _) = &preopens[0];
 
+        let filename = "test.txt";
         {
-            let filename = "test.txt";
             let file = dir
                 .open_at(
                     PathFlags::empty(),

--- a/crates/wasi/Cargo.toml
+++ b/crates/wasi/Cargo.toml
@@ -34,7 +34,6 @@ io-lifetimes = { workspace = true }
 fs-set-times = { workspace = true }
 bitflags = { workspace = true }
 async-trait = { workspace = true }
-system-interface = { workspace = true}
 futures = { workspace = true }
 url = { workspace = true }
 rand = { workspace = true, features = ['std_rng', 'thread_rng'] }
@@ -54,8 +53,16 @@ rustix = { workspace = true, features = ["event", "fs", "net"] }
 
 [target.'cfg(windows)'.dependencies]
 io-extras = { workspace = true }
-windows-sys = { workspace = true }
 rustix = { workspace = true, features = ["event", "net"] }
+
+[target.'cfg(windows)'.dependencies.windows-sys]
+workspace = true
+features = [
+  "Wdk_Storage_FileSystem",
+  "Win32_Foundation",
+  "Win32_Storage_FileSystem",
+  "Win32_System_IO",
+]
 
 [features]
 default = ["p1", "p2"]

--- a/crates/wasi/Cargo.toml
+++ b/crates/wasi/Cargo.toml
@@ -37,6 +37,7 @@ async-trait = { workspace = true }
 futures = { workspace = true }
 url = { workspace = true }
 rand = { workspace = true, features = ['std_rng', 'thread_rng'] }
+cfg-if = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["time", "sync", "io-std", "io-util", "rt", "rt-multi-thread", "net", "macros", "fs"] }

--- a/crates/wasi/src/filesystem.rs
+++ b/crates/wasi/src/filesystem.rs
@@ -8,6 +8,15 @@ use tracing::debug;
 use wasmtime::component::{HasData, Resource, ResourceTable};
 use wasmtime::error::Context as _;
 
+#[cfg(unix)]
+pub(crate) mod unix;
+#[cfg(unix)]
+pub(crate) use unix as sys;
+#[cfg(windows)]
+pub(crate) mod windows;
+#[cfg(windows)]
+pub(crate) use windows as sys;
+
 /// A helper struct which implements [`HasData`] for the `wasi:filesystem` APIs.
 ///
 /// This can be useful when directly calling `add_to_linker` functions directly,
@@ -350,6 +359,16 @@ impl From<&cap_std::fs::Metadata> for MetadataHashValue {
     }
 }
 
+#[derive(Copy, Clone, Debug)]
+pub(crate) enum Advice {
+    Normal,
+    Sequential,
+    Random,
+    WillNeed,
+    DontNeed,
+    NoReuse,
+}
+
 #[cfg(unix)]
 fn from_raw_os_error(err: Option<i32>) -> Option<ErrorCode> {
     use rustix::io::Errno as RustixErrno;
@@ -509,25 +528,9 @@ impl Descriptor {
     }
 
     pub(crate) async fn get_flags(&self) -> Result<DescriptorFlags, ErrorCode> {
-        use system_interface::fs::{FdFlags, GetSetFdFlags};
-
-        fn get_from_fdflags(flags: FdFlags) -> DescriptorFlags {
-            let mut out = DescriptorFlags::empty();
-            if flags.contains(FdFlags::DSYNC) {
-                out |= DescriptorFlags::REQUESTED_WRITE_SYNC;
-            }
-            if flags.contains(FdFlags::RSYNC) {
-                out |= DescriptorFlags::DATA_INTEGRITY_SYNC;
-            }
-            if flags.contains(FdFlags::SYNC) {
-                out |= DescriptorFlags::FILE_INTEGRITY_SYNC;
-            }
-            out
-        }
         match self {
             Self::File(f) => {
-                let flags = f.run_blocking(|f| f.get_fd_flags()).await?;
-                let mut flags = get_from_fdflags(flags);
+                let mut flags = f.run_blocking(|f| sys::get_flags(f)).await?;
                 if f.open_mode.contains(OpenMode::READ) {
                     flags |= DescriptorFlags::READ;
                 }
@@ -537,8 +540,7 @@ impl Descriptor {
                 Ok(flags)
             }
             Self::Dir(d) => {
-                let flags = d.run_blocking(|d| d.get_fd_flags()).await?;
-                let mut flags = get_from_fdflags(flags);
+                let mut flags = d.run_blocking(|d| sys::get_flags(d)).await?;
                 if d.open_mode.contains(OpenMode::READ) {
                     flags |= DescriptorFlags::READ;
                 }
@@ -747,10 +749,9 @@ impl File {
         &self,
         offset: u64,
         len: u64,
-        advice: system_interface::fs::Advice,
+        advice: Advice,
     ) -> Result<(), ErrorCode> {
-        use system_interface::fs::FileIoExt as _;
-        self.run_blocking(move |f| f.advise(offset, len, advice))
+        self.run_blocking(move |f| sys::advise(f, offset, len, advice))
             .await?;
         Ok(())
     }
@@ -930,7 +931,6 @@ impl Dir {
         allow_blocking_current_thread: bool,
     ) -> Result<Descriptor, ErrorCode> {
         use cap_fs_ext::{FollowSymlinks, OpenOptionsFollowExt, OpenOptionsMaybeDirExt};
-        use system_interface::fs::{FdFlags, GetSetFdFlags};
 
         if !self.perms.contains(DirPerms::READ) {
             return Err(ErrorCode::NotPermitted);
@@ -1023,7 +1023,7 @@ impl Dir {
 
         let opened = self
             .run_blocking::<_, std::io::Result<OpenResult>>(move |d| {
-                let mut opened = d.open_with(&path, &opts)?;
+                let opened = d.open_with(&path, &opts)?;
                 if opened.metadata()?.is_dir() {
                     Ok(OpenResult::Dir(cap_std::fs::Dir::from_std_file(
                         opened.into_std(),
@@ -1031,10 +1031,6 @@ impl Dir {
                 } else if oflags.contains(OpenFlags::DIRECTORY) {
                     Ok(OpenResult::NotDir)
                 } else {
-                    // FIXME cap-std needs a nonblocking open option so that files reads and writes
-                    // are nonblocking. Instead we set it after opening here:
-                    let set_fd_flags = opened.new_set_fd_flags(FdFlags::NONBLOCK)?;
-                    opened.set_fd_flags(set_fd_flags)?;
                     Ok(OpenResult::File(opened))
                 }
             })

--- a/crates/wasi/src/filesystem/unix.rs
+++ b/crates/wasi/src/filesystem/unix.rs
@@ -4,7 +4,6 @@ use rustix::fs::{OFlags, fcntl_getfl, fcntl_setfl};
 use rustix::io::write;
 use std::fs::File;
 use std::io;
-use std::num::NonZeroU64;
 use std::os::fd::AsFd;
 use std::os::unix::fs::FileExt;
 
@@ -19,6 +18,7 @@ pub(crate) fn get_flags(file: impl AsFd) -> io::Result<DescriptorFlags> {
         DescriptorFlags::FILE_INTEGRITY_SYNC,
         flags.contains(OFlags::SYNC),
     );
+    #[cfg(not(any(target_vendor = "apple", target_os = "freebsd")))]
     ret.set(
         DescriptorFlags::DATA_INTEGRITY_SYNC,
         flags.contains(OFlags::RSYNC),
@@ -27,15 +27,33 @@ pub(crate) fn get_flags(file: impl AsFd) -> io::Result<DescriptorFlags> {
 }
 
 pub(crate) fn advise(file: impl AsFd, offset: u64, len: u64, advice: Advice) -> io::Result<()> {
-    let advice = match advice {
-        Advice::Normal => rustix::fs::Advice::Normal,
-        Advice::Sequential => rustix::fs::Advice::Sequential,
-        Advice::Random => rustix::fs::Advice::Random,
-        Advice::WillNeed => rustix::fs::Advice::WillNeed,
-        Advice::DontNeed => rustix::fs::Advice::DontNeed,
-        Advice::NoReuse => rustix::fs::Advice::NoReuse,
-    };
-    rustix::fs::fadvise(file, offset, NonZeroU64::new(len), advice)?;
+    cfg_if::cfg_if! {
+        if #[cfg(target_vendor = "apple")] {
+            match advice {
+                Advice::WillNeed => {
+                    rustix::fs::fcntl_rdadvise(file, offset, len)?;
+                }
+                Advice::Normal |
+                Advice::Sequential |
+                Advice::Random |
+                Advice::DontNeed |
+                Advice::NoReuse => {}
+            }
+        } else if #[cfg(target_os = "linux")] {
+            use std::num::NonZeroU64;
+            let advice = match advice {
+                Advice::Normal => rustix::fs::Advice::Normal,
+                Advice::Sequential => rustix::fs::Advice::Sequential,
+                Advice::Random => rustix::fs::Advice::Random,
+                Advice::WillNeed => rustix::fs::Advice::WillNeed,
+                Advice::DontNeed => rustix::fs::Advice::DontNeed,
+                Advice::NoReuse => rustix::fs::Advice::NoReuse,
+            };
+            rustix::fs::fadvise(file, offset, NonZeroU64::new(len), advice)?;
+        } else {
+            // noop on other platforms
+        }
+    }
     Ok(())
 }
 

--- a/crates/wasi/src/filesystem/unix.rs
+++ b/crates/wasi/src/filesystem/unix.rs
@@ -60,7 +60,7 @@ pub(crate) fn advise(file: impl AsFd, offset: u64, len: u64, advice: Advice) -> 
 
 pub(crate) fn append_cursor_unspecified(file: impl AsFd, data: &[u8]) -> io::Result<usize> {
     // On Linux, use `pwritev2`.
-    #[cfg(any(target_os = "android", target_os = "linux"))]
+    #[cfg(target_os = "linux")]
     {
         use rustix::io::{Errno, ReadWriteFlags, pwritev2};
         use std::io::IoSlice;

--- a/crates/wasi/src/filesystem/unix.rs
+++ b/crates/wasi/src/filesystem/unix.rs
@@ -1,0 +1,81 @@
+use crate::filesystem::{Advice, DescriptorFlags};
+use io_lifetimes::AsFilelike;
+use rustix::fs::{OFlags, fcntl_getfl, fcntl_setfl};
+use rustix::io::write;
+use std::fs::File;
+use std::io;
+use std::num::NonZeroU64;
+use std::os::fd::AsFd;
+use std::os::unix::fs::FileExt;
+
+pub(crate) fn get_flags(file: impl AsFd) -> io::Result<DescriptorFlags> {
+    let flags = fcntl_getfl(file)?;
+    let mut ret = DescriptorFlags::empty();
+    ret.set(
+        DescriptorFlags::REQUESTED_WRITE_SYNC,
+        flags.contains(OFlags::DSYNC),
+    );
+    ret.set(
+        DescriptorFlags::FILE_INTEGRITY_SYNC,
+        flags.contains(OFlags::SYNC),
+    );
+    ret.set(
+        DescriptorFlags::DATA_INTEGRITY_SYNC,
+        flags.contains(OFlags::RSYNC),
+    );
+    Ok(ret)
+}
+
+pub(crate) fn advise(file: impl AsFd, offset: u64, len: u64, advice: Advice) -> io::Result<()> {
+    let advice = match advice {
+        Advice::Normal => rustix::fs::Advice::Normal,
+        Advice::Sequential => rustix::fs::Advice::Sequential,
+        Advice::Random => rustix::fs::Advice::Random,
+        Advice::WillNeed => rustix::fs::Advice::WillNeed,
+        Advice::DontNeed => rustix::fs::Advice::DontNeed,
+        Advice::NoReuse => rustix::fs::Advice::NoReuse,
+    };
+    rustix::fs::fadvise(file, offset, NonZeroU64::new(len), advice)?;
+    Ok(())
+}
+
+pub(crate) fn append_cursor_unspecified(file: impl AsFd, data: &[u8]) -> io::Result<usize> {
+    // On Linux, use `pwritev2`.
+    #[cfg(any(target_os = "android", target_os = "linux"))]
+    {
+        use rustix::io::{Errno, ReadWriteFlags, pwritev2};
+        use std::io::IoSlice;
+
+        let iovs = [IoSlice::new(data)];
+        match pwritev2(&file, &iovs, 0, ReadWriteFlags::APPEND) {
+            Err(Errno::NOSYS) | Err(Errno::NOTSUP) => {}
+            otherwise => return Ok(otherwise?),
+        }
+    }
+
+    // Otherwise use `F_SETFL` to switch the file description to append
+    // mode, do the write, and switch back. This is not atomic with
+    // respect to other users of the file description, but WASI isn't fully
+    // threaded right now anyway.
+    let old_flags = fcntl_getfl(&file)?;
+    fcntl_setfl(&file, old_flags | OFlags::APPEND)?;
+    let result = write(&file, data);
+    fcntl_setfl(&file, old_flags).unwrap();
+    Ok(result?)
+}
+
+pub(crate) fn write_at_cursor_unspecified(
+    file: impl AsFd,
+    data: &[u8],
+    pos: u64,
+) -> io::Result<usize> {
+    file.as_filelike_view::<File>().write_at(data, pos)
+}
+
+pub(crate) fn read_at_cursor_unspecified(
+    file: impl AsFd,
+    buf: &mut [u8],
+    pos: u64,
+) -> io::Result<usize> {
+    file.as_filelike_view::<File>().read_at(buf, pos)
+}

--- a/crates/wasi/src/filesystem/unix.rs
+++ b/crates/wasi/src/filesystem/unix.rs
@@ -39,7 +39,7 @@ pub(crate) fn advise(file: impl AsFd, offset: u64, len: u64, advice: Advice) -> 
                 Advice::DontNeed |
                 Advice::NoReuse => {}
             }
-        } else if #[cfg(target_os = "linux")] {
+        } else if #[cfg(any(target_os = "linux", target_os = "android"))] {
             use std::num::NonZeroU64;
             let advice = match advice {
                 Advice::Normal => rustix::fs::Advice::Normal,
@@ -52,6 +52,7 @@ pub(crate) fn advise(file: impl AsFd, offset: u64, len: u64, advice: Advice) -> 
             rustix::fs::fadvise(file, offset, NonZeroU64::new(len), advice)?;
         } else {
             // noop on other platforms
+            let _ = (file, offset, len, advice);
         }
     }
     Ok(())

--- a/crates/wasi/src/filesystem/windows.rs
+++ b/crates/wasi/src/filesystem/windows.rs
@@ -1,0 +1,127 @@
+use crate::filesystem::{Advice, DescriptorFlags};
+use io_lifetimes::AsFilelike;
+use std::fs::File;
+use std::io::{self, Write};
+use std::mem::{self, MaybeUninit};
+use std::os::windows::fs::FileExt;
+use std::os::windows::io::*;
+use windows_sys::Wdk::Storage::FileSystem::*;
+use windows_sys::Win32::Foundation::*;
+use windows_sys::Win32::Storage::FileSystem::*;
+use windows_sys::Win32::System::IO::*;
+
+pub(crate) fn get_flags(file: impl AsHandle) -> io::Result<DescriptorFlags> {
+    let file = file.as_handle();
+    let mode = query_mode_information(file)?;
+    let mut ret = DescriptorFlags::empty();
+    ret.set(
+        DescriptorFlags::REQUESTED_WRITE_SYNC,
+        mode & FILE_WRITE_THROUGH != 0,
+    );
+    Ok(ret)
+}
+
+pub(crate) fn advise(file: impl AsHandle, offset: u64, len: u64, advice: Advice) -> io::Result<()> {
+    let _ = (file, offset, len, advice);
+
+    // ... noop for now ...
+
+    Ok(())
+}
+
+pub(crate) fn append_cursor_unspecified(file: impl AsHandle, data: &[u8]) -> io::Result<usize> {
+    let file = file.as_handle();
+    let access = query_access_information(file)?;
+
+    // If this file doesn't allow writing then it can't be appended to.
+    if access & (FILE_WRITE_DATA | FILE_APPEND_DATA) == 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "file not opened with write or append access",
+        ));
+    }
+
+    // Reopen the file with append
+    reopen_file(
+        file,
+        FILE_GENERIC_WRITE & !FILE_WRITE_DATA,
+        // Files on Windows are opened with DELETE, READ, and WRITE share mode
+        // by default (see OpenOptions in stdlib) This keeps the same share mode
+        // when reopening the file handle
+        FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+        0,
+    )?
+    .write(data)
+}
+
+pub(crate) fn write_at_cursor_unspecified(
+    file: impl AsHandle,
+    data: &[u8],
+    pos: u64,
+) -> io::Result<usize> {
+    file.as_filelike_view::<File>().seek_write(data, pos)
+}
+
+pub(crate) fn read_at_cursor_unspecified(
+    file: impl AsHandle,
+    buf: &mut [u8],
+    pos: u64,
+) -> io::Result<usize> {
+    file.as_filelike_view::<File>().seek_read(buf, pos)
+}
+
+fn query_access_information(handle: BorrowedHandle<'_>) -> io::Result<u32> {
+    unsafe {
+        Ok(
+            nt_query_information_file::<FILE_ACCESS_INFORMATION>(handle, FileAccessInformation)?
+                .AccessFlags,
+        )
+    }
+}
+
+fn reopen_file(
+    handle: BorrowedHandle<'_>,
+    access_mode: u32,
+    share_mode: u32,
+    flags: u32,
+) -> io::Result<File> {
+    let new_handle = unsafe { ReOpenFile(handle.as_raw_handle(), access_mode, share_mode, flags) };
+
+    if new_handle == INVALID_HANDLE_VALUE {
+        return Err(io::Error::last_os_error());
+    }
+
+    Ok(unsafe { File::from_raw_handle(new_handle) })
+}
+
+fn query_mode_information(handle: BorrowedHandle<'_>) -> io::Result<u32> {
+    unsafe {
+        Ok(nt_query_information_file::<FILE_MODE_INFORMATION>(handle, FileModeInformation)?.Mode)
+    }
+}
+
+unsafe fn nt_query_information_file<T>(
+    handle: BorrowedHandle<'_>,
+    info: FILE_INFORMATION_CLASS,
+) -> io::Result<T> {
+    unsafe {
+        let mut io_status_block = mem::zeroed::<IO_STATUS_BLOCK>();
+        let mut payload = MaybeUninit::<T>::uninit();
+
+        let status = NtQueryInformationFile(
+            handle.as_raw_handle(),
+            &mut io_status_block,
+            payload.as_mut_ptr().cast(),
+            mem::size_of_val(&payload).try_into().unwrap(),
+            info,
+        );
+
+        if status != STATUS_SUCCESS {
+            return Err(io::Error::from_raw_os_error(
+                RtlNtStatusToDosError(status) as i32
+            ));
+        }
+
+        Ok(payload.assume_init())
+    }
+}

--- a/crates/wasi/src/p1.rs
+++ b/crates/wasi/src/p1.rs
@@ -64,6 +64,7 @@
 use crate::cli::WasiCliView as _;
 use crate::clocks::WasiClocksView as _;
 use crate::filesystem::WasiFilesystemView as _;
+use crate::filesystem::sys;
 use crate::p2::bindings::{
     cli::{
         stderr::Host as _, stdin::Host as _, stdout::Host as _, terminal_input, terminal_output,
@@ -79,7 +80,6 @@ use std::mem::{self, size_of, size_of_val};
 use std::slice;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
-use system_interface::fs::FileIoExt;
 use wasmtime::component::Resource;
 use wasmtime::{bail, error::Context as _};
 use wasmtime_wasi_io::{
@@ -657,9 +657,9 @@ impl WasiP1Ctx {
                     // Note that this is implementing Linux semantics of
                     // `pwrite` where the offset is ignored if the file was
                     // opened in append mode.
-                    (true, _) => f.append(&buf),
-                    (false, FdWrite::At(pos)) => f.write_at(&buf, pos),
-                    (false, FdWrite::AtCur) => f.write_at(&buf, pos),
+                    (true, _) => sys::append_cursor_unspecified(f, &buf),
+                    (false, FdWrite::At(pos)) => sys::write_at_cursor_unspecified(f, &buf, pos),
+                    (false, FdWrite::AtCur) => sys::write_at_cursor_unspecified(f, &buf, pos),
                 };
 
                 let nwritten = match f.as_blocking_file() {
@@ -1690,9 +1690,10 @@ impl wasi_snapshot_preview1::WasiSnapshotPreview1 for WasiP1Ctx {
                     // Try to read directly into wasm memory where possible
                     // when the current thread can block and additionally wasm
                     // memory isn't shared.
-                    (Some(file), Some(mut buf)) => file
-                        .read_at(&mut buf, pos)
-                        .map_err(|e| StreamError::LastOperationFailed(e.into()))?,
+                    (Some(file), Some(mut buf)) => {
+                        sys::read_at_cursor_unspecified(file, &mut buf, pos)
+                            .map_err(|e| StreamError::LastOperationFailed(e.into()))?
+                    }
                     // ... otherwise fall back to performing the read on a
                     // blocking thread and which copies the data back into wasm
                     // memory.
@@ -1701,9 +1702,9 @@ impl wasi_snapshot_preview1::WasiSnapshotPreview1 for WasiP1Ctx {
                         let mut buf = vec![0; iov.len() as usize];
                         let buf = file
                             .run_blocking(move |file| -> Result<_, types::Error> {
-                                let bytes_read = file
-                                    .read_at(&mut buf, pos)
-                                    .map_err(|e| StreamError::LastOperationFailed(e.into()))?;
+                                let bytes_read =
+                                    sys::read_at_cursor_unspecified(file, &mut buf, pos)
+                                        .map_err(|e| StreamError::LastOperationFailed(e.into()))?;
                                 buf.truncate(bytes_read);
                                 Ok(buf)
                             })

--- a/crates/wasi/src/p2/filesystem.rs
+++ b/crates/wasi/src/p2/filesystem.rs
@@ -1,5 +1,6 @@
 use crate::TrappableError;
 use crate::filesystem::File;
+use crate::filesystem::sys;
 use crate::p2::bindings::filesystem::types;
 use crate::p2::{InputStream, OutputStream, Pollable, StreamError, StreamResult};
 use crate::runtime::AbortOnDropJoinHandle;
@@ -84,11 +85,9 @@ impl FileInputStream {
     }
 
     fn blocking_read(file: &cap_std::fs::File, offset: u64, size: usize) -> ReadState {
-        use system_interface::fs::FileIoExt;
-
         let mut buf = BytesMut::zeroed(size.min(crate::MAX_READ_SIZE_ALLOC));
         loop {
-            match file.read_at(&mut buf, offset) {
+            match sys::read_at_cursor_unspecified(file, &mut buf, offset) {
                 Ok(0) => return ReadState::Closed,
                 Ok(n) => {
                     buf.truncate(n);
@@ -243,13 +242,11 @@ impl FileOutputStream {
         mut buf: Bytes,
         mode: FileOutputMode,
     ) -> io::Result<usize> {
-        use system_interface::fs::FileIoExt;
-
         match mode {
             FileOutputMode::Position(mut p) => {
                 let mut total = 0;
                 loop {
-                    let nwritten = file.write_at(buf.as_ref(), p)?;
+                    let nwritten = sys::write_at_cursor_unspecified(file, buf.as_ref(), p)?;
                     // afterwards buf contains [nwritten, len):
                     let _ = buf.split_to(nwritten);
                     p += nwritten as u64;
@@ -263,7 +260,7 @@ impl FileOutputStream {
             FileOutputMode::Append => {
                 let mut total = 0;
                 loop {
-                    let nwritten = file.append(buf.as_ref())?;
+                    let nwritten = sys::append_cursor_unspecified(file, buf.as_ref())?;
                     let _ = buf.split_to(nwritten);
                     total += nwritten;
                     if buf.is_empty() {

--- a/crates/wasi/src/p2/host/filesystem.rs
+++ b/crates/wasi/src/p2/host/filesystem.rs
@@ -1,3 +1,4 @@
+use crate::filesystem::sys;
 use crate::filesystem::{Descriptor, WasiFilesystemCtxView};
 use crate::p2::bindings::clocks::wall_clock;
 use crate::p2::bindings::filesystem::preopens;
@@ -105,9 +106,6 @@ impl HostDescriptor for WasiFilesystemCtxView<'_> {
         len: types::Filesize,
         offset: types::Filesize,
     ) -> FsResult<(Vec<u8>, bool)> {
-        use std::io::IoSliceMut;
-        use system_interface::fs::FileIoExt;
-
         let f = self.table.get(&fd)?.file()?;
         if !f.perms.contains(FilePerms::READ) {
             return Err(ErrorCode::NotPermitted.into());
@@ -121,7 +119,7 @@ impl HostDescriptor for WasiFilesystemCtxView<'_> {
                         .unwrap_or(usize::MAX)
                         .min(crate::MAX_READ_SIZE_ALLOC)
                 ];
-                let r = f.read_vectored_at(&mut [IoSliceMut::new(&mut buffer)], offset);
+                let r = sys::read_at_cursor_unspecified(f, &mut buffer, offset);
                 (buffer, r)
             })
             .await;
@@ -142,16 +140,13 @@ impl HostDescriptor for WasiFilesystemCtxView<'_> {
         buf: Vec<u8>,
         offset: types::Filesize,
     ) -> FsResult<types::Filesize> {
-        use std::io::IoSlice;
-        use system_interface::fs::FileIoExt;
-
         let f = self.table.get(&fd)?.file()?;
         if !f.perms.contains(FilePerms::WRITE) {
             return Err(ErrorCode::NotPermitted.into());
         }
 
         let bytes_written = f
-            .run_blocking(move |f| f.write_vectored_at(&[IoSlice::new(&buf)], offset))
+            .run_blocking(move |f| sys::write_at_cursor_unspecified(f, &buf, offset))
             .await?;
 
         Ok(types::Filesize::try_from(bytes_written).expect("usize fits in Filesize"))
@@ -481,7 +476,7 @@ impl HostDirectoryEntryStream for WasiFilesystemCtxView<'_> {
     }
 }
 
-impl From<types::Advice> for system_interface::fs::Advice {
+impl From<types::Advice> for crate::filesystem::Advice {
     fn from(advice: types::Advice) -> Self {
         match advice {
             types::Advice::Normal => Self::Normal,

--- a/crates/wasi/src/p3/filesystem/host.rs
+++ b/crates/wasi/src/p3/filesystem/host.rs
@@ -1,3 +1,4 @@
+use crate::filesystem::sys;
 use crate::filesystem::{Descriptor, Dir, File, WasiFilesystem, WasiFilesystemCtxView};
 use crate::p3::bindings::clocks::system_clock;
 use crate::p3::bindings::filesystem::types::{
@@ -13,7 +14,6 @@ use core::task::{Context, Poll, ready};
 use core::{iter, mem};
 use std::io::{self, Cursor};
 use std::sync::Arc;
-use system_interface::fs::FileIoExt as _;
 use tokio::sync::{mpsc, oneshot};
 use tokio::task::{JoinHandle, spawn_blocking};
 use wasmtime::StoreContextMut;
@@ -179,7 +179,7 @@ impl<D> StreamProducer<D> for ReadStreamProducer {
             if buf.is_empty() {
                 return Poll::Ready(Ok(StreamResult::Completed));
             }
-            return match file.read_at(buf, self.offset) {
+            return match sys::read_at_cursor_unspecified(file, buf, self.offset) {
                 Ok(0) => {
                     self.close(Ok(()));
                     Poll::Ready(Ok(StreamResult::Dropped))
@@ -203,7 +203,7 @@ impl<D> StreamProducer<D> for ReadStreamProducer {
             let file = Arc::clone(me.file.as_file());
             let offset = me.offset;
             spawn_blocking(move || {
-                file.read_at(&mut buf, offset).map(|n| {
+                sys::read_at_cursor_unspecified(file, &mut buf, offset).map(|n| {
                     buf.truncate(n);
                     buf
                 })
@@ -420,8 +420,8 @@ impl WriteStreamConsumer {
 impl WriteLocation {
     fn write(&self, file: &cap_std::fs::File, bytes: &[u8]) -> io::Result<usize> {
         match *self {
-            WriteLocation::End => file.append(bytes),
-            WriteLocation::Offset(at) => file.write_at(bytes, at),
+            WriteLocation::End => sys::append_cursor_unspecified(file, bytes),
+            WriteLocation::Offset(at) => sys::write_at_cursor_unspecified(file, bytes, at),
         }
     }
 }

--- a/crates/wasi/src/p3/filesystem/mod.rs
+++ b/crates/wasi/src/p3/filesystem/mod.rs
@@ -130,7 +130,7 @@ impl From<wasmtime::component::ResourceTableError> for FilesystemError {
     }
 }
 
-impl From<types::Advice> for system_interface::fs::Advice {
+impl From<types::Advice> for crate::filesystem::Advice {
     fn from(advice: types::Advice) -> Self {
         match advice {
             types::Advice::Normal => Self::Normal,


### PR DESCRIPTION
This commit removes the `system-interface` dependency from `wasmtime-wasi`, reimplementing necessary functionality within the crate itself as appropriate. The goal of this commit is to trim our dependency tree. The `system-interface` crate has not received an update in over a year and continues to pull in an older `rustix` dependency for example. Additionally I've personally found it confusing and surprising in the past to trace through all the layers of abstractions from `wasmtime-wasi` to the OS, and I'd like to start slimming this down to be more local within Wasmtime rather than depending on a tree of crates.

The `system-interface` crate is a relatively thin wrapper around `cap-std`-style crates providing a platform-agnostic API. This sometimes fits what WASI wants, and sometimes doesn't. For example all reads/writes to files within WASI currently require that Wasmtime maintains a file cursor itself meaning that the underlying OS file cursor doesn't actually matter. Reads and writes through the `system-interface` abstraction, however, keep the cursor up-to-date to have the same semantics across Unix and Windows which differ in the behavior of the underlying syscalls. This is unnecessarily adds overhead to Wasmtime's implementation of these APIs where they're otherwise not required.

Effectively `system-interface` is not receiving much maintenance (old dependency on `rustix` has persisted for ~1 year), its an extra layer of abstraction to debug when issues arise, and its abstractions are not always the best fit for WASI's semantics meaning that it can add performance overhead. The replacement of inlining implementations within Wasmtime is not too too costly and, personally, I view as worth it.

I'll note that this doesn't delete the `system-interface` crate entirely. That would require removing it from `wasi-common` as well, which is the subject of #13108.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
