### PR TITLE
Fix enabling `cfg(gc_zeal)` during fuzzing

### DIFF
--- a/crates/cranelift/build.rs
+++ b/crates/cranelift/build.rs
@@ -1,5 +1,5 @@
 fn main() {
-    if cfg!(fuzzing) {
+    if std::env::var("CARGO_CFG_FUZZING").is_ok() {
         println!("cargo:rustc-cfg=gc_zeal");
     }
 }

--- a/crates/wasmtime/build.rs
+++ b/crates/wasmtime/build.rs
@@ -34,7 +34,7 @@ fn main() {
     custom_cfg("has_virtual_memory", has_virtual_memory);
     custom_cfg("has_custom_sync", has_custom_sync);
     custom_cfg("has_host_compiler_backend", has_host_compiler_backend);
-    custom_cfg("gc_zeal", cfg!(fuzzing));
+    custom_cfg("gc_zeal", cfg("fuzzing"));
 
     // If this OS isn't supported and no debug-builtins or if Cranelift doesn't support
     // the host or there's no need to build these helpers.


### PR DESCRIPTION
This commit fixes a minor mistake from #13053 where `cfg!(fuzzing)` isn't set for build scripts because `RUSTFLAGS`, where `--cfg fuzzing` is specified, is only passed to target artifacts, not build scripts. This means that the lookup must happen via Cargo's set env vars (e.g. `CARGO_CFG_FUZZING`), not `cfg!(...)`.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
