### PR TITLE
fix `preview2_stdin` test on Asahi Linux

### DIFF
--- a/tests/all/cli_tests.rs
+++ b/tests/all/cli_tests.rs
@@ -1044,7 +1044,10 @@ fn preview2_stdin() -> Result<()> {
     // helper thread depends on how much the OS buffers for us. For now give
     // some some slop and assume that OSes are unlikely to buffer more than
     // that.
-    let slop = 256 * 1024;
+    //
+    // Note that 256 * 1024 is _one_ byte too small on Asahi Linux (possibly
+    // related to 16K page sizes?), hence the `+ 1` here:
+    let slop = 256 * 1024 + 1;
     for amt in [0, 100, 100_000] {
         let written = count_up_to(amt)?;
         assert!(written < slop + amt, "wrote too much {written}");


### PR DESCRIPTION
This has test has been failing on my Asahi Ubuntu Linux (ARM64) machine since the first time I ran it, but I never got around to actually addressing it until now.  Seems that the `slop` factor in this test was just _one_ byte too small.

Not sure why this never broke on CI; might be specific to Apple hardware, e.g. 16K page sizes.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
