### PR TITLE
Mach-O: Set `LC_BUILD_VERSION`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3718,9 +3718,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.13.0"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ff4a4048091358129767b8a200d6927f58876c8b5ea16fb7b0222d43b79bfa8"
+checksum = "df7f62577c25e07834649fc3b39fafdc597c0a3527dc1c60129201ccfcbaa50c"
 
 [[package]]
 name = "tch"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -336,7 +336,7 @@ regalloc2 = "0.15.1"
 wasip1 = { version = "1.0.0", default-features = false }
 
 # cap-std family:
-target-lexicon = "0.13.0"
+target-lexicon = "0.13.3"
 cap-std = "3.4.5"
 cap-fs-ext = "3.4.5"
 cap-net-ext = "3.4.5"

--- a/cranelift/codegen/src/isa/aarch64/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/mod.rs
@@ -18,8 +18,6 @@ use alloc::string::String;
 use alloc::{boxed::Box, vec::Vec};
 use core::fmt;
 use cranelift_control::ControlPlane;
-#[cfg(feature = "unwind")]
-use target_lexicon::OperatingSystem;
 use target_lexicon::{Aarch64Architecture, Architecture, Triple};
 
 // New backend:
@@ -151,17 +149,9 @@ impl TargetIsa for AArch64Backend {
 
     #[cfg(feature = "unwind")]
     fn create_systemv_cie(&self) -> Option<gimli::write::CommonInformationEntry> {
-        let is_apple_os = match self.triple.operating_system {
-            OperatingSystem::Darwin(_)
-            | OperatingSystem::IOS(_)
-            | OperatingSystem::MacOSX { .. }
-            | OperatingSystem::TvOS(_) => true,
-            _ => false,
-        };
-
         if self.isa_flags.sign_return_address()
             && self.isa_flags.sign_return_address_with_bkey()
-            && !is_apple_os
+            && !self.triple.operating_system.is_like_darwin()
         {
             unimplemented!(
                 "Specifying that the B key is used with pointer authentication instructions in the CIE is not implemented."
@@ -185,19 +175,12 @@ impl TargetIsa for AArch64Backend {
     }
 
     fn page_size_align_log2(&self) -> u8 {
-        use target_lexicon::*;
-        match self.triple().operating_system {
-            OperatingSystem::MacOSX { .. }
-            | OperatingSystem::Darwin(_)
-            | OperatingSystem::IOS(_)
-            | OperatingSystem::TvOS(_) => {
-                debug_assert_eq!(1 << 14, 0x4000);
-                14
-            }
-            _ => {
-                debug_assert_eq!(1 << 16, 0x10000);
-                16
-            }
+        if self.triple().operating_system.is_like_darwin() {
+            debug_assert_eq!(1 << 14, 0x4000);
+            14
+        } else {
+            debug_assert_eq!(1 << 16, 0x10000);
+            16
         }
     }
 

--- a/cranelift/object/src/backend.rs
+++ b/cranelift/object/src/backend.rs
@@ -10,7 +10,7 @@ use cranelift_module::{
     DataDescription, DataId, FuncId, Init, Linkage, Module, ModuleDeclarations, ModuleError,
     ModuleReloc, ModuleRelocTarget, ModuleResult,
 };
-use log::info;
+use log::{info, warn};
 use object::write::{
     Object, Relocation, SectionId, StandardSection, Symbol, SymbolId, SymbolSection,
 };
@@ -21,7 +21,7 @@ use object::{
 use std::collections::HashMap;
 use std::collections::hash_map::Entry;
 use std::mem;
-use target_lexicon::PointerWidth;
+use target_lexicon::{PointerWidth, Triple};
 
 /// A builder for `ObjectModule`.
 pub struct ObjectBuilder {
@@ -137,6 +137,68 @@ impl ObjectBuilder {
     }
 }
 
+/// See the following for details:
+/// <https://github.com/rust-lang/rust/blob/1.95.0/compiler/rustc_codegen_ssa/src/back/metadata.rs#L408-L425>
+fn macho_build_version(triple: &Triple) -> Option<object::write::MachOBuildVersion> {
+    use target_lexicon::{DeploymentTarget, OperatingSystem::*};
+
+    fn pack_version(v: DeploymentTarget) -> u32 {
+        let (major, minor, patch) = (v.major as u32, v.minor as u32, v.patch as u32);
+        (major << 16) | (minor << 8) | patch
+    }
+
+    match triple.operating_system {
+        Darwin(v) | MacOSX(v) | IOS(v) | TvOS(v) | VisionOS(v) | WatchOS(v) | XROS(v) => {
+            use object::macho::*;
+            use target_lexicon::Environment::*;
+            // Same as https://github.com/rust-lang/rust/blob/1.95.0/compiler/rustc_codegen_ssa/src/back/apple.rs#L36-L50.
+            //
+            // TODO(madsmtm): Properly support simulator after
+            // https://github.com/bytecodealliance/target-lexicon/pull/130
+            let platform = match (triple.operating_system, triple.environment) {
+                (Darwin(_), _) => 0, // PLATFORM_UNKNOWN
+                (MacOSX(_), _) => PLATFORM_MACOS,
+                (_, Macabi) => PLATFORM_MACCATALYST,
+                (IOS(_), Sim) => PLATFORM_IOSSIMULATOR,
+                (IOS(_), _) => PLATFORM_IOS,
+                (TvOS(_), Sim) => PLATFORM_TVOSSIMULATOR,
+                (TvOS(_), _) => PLATFORM_TVOS,
+                (VisionOS(_) | XROS(_), Sim) => PLATFORM_XROSSIMULATOR,
+                (VisionOS(_) | XROS(_), _) => PLATFORM_XROS,
+                (WatchOS(_), Sim) => PLATFORM_WATCHOSSIMULATOR,
+                (WatchOS(_), _) => PLATFORM_WATCHOS,
+                _ => {
+                    warn!("unsupported OS/environment: {triple}");
+                    0
+                }
+            };
+
+            let mut build_version = object::write::MachOBuildVersion::default();
+            build_version.platform = platform;
+
+            build_version.minos = if let Some(v) = v {
+                pack_version(v)
+            } else {
+                // The `minos` in object files is useful for diagnostics, as
+                // it tells the linker whether the file supports a given OS -
+                // if the `minos` is higher than what you're linking against,
+                // that's a signal that something has gone wrong.
+                //
+                // Using `0.0.0` here should be fine if we don't have the data
+                // available.
+                0
+            };
+
+            // Setting a 0 SDK version is fine, it's only relevant for the
+            // final linked binary.
+            build_version.sdk = 0;
+
+            Some(build_version)
+        }
+        _ => None,
+    }
+}
+
 /// An `ObjectModule` implements `Module` and emits ".o" files using the `object` library.
 ///
 /// See the `ObjectBuilder` for a convenient way to construct `ObjectModule` instances.
@@ -162,6 +224,13 @@ impl ObjectModule {
         object.flags = builder.flags;
         object.set_subsections_via_symbols();
         object.add_file_symbol(builder.name);
+        if let Some(info) = macho_build_version(builder.isa.triple()) {
+            // Set LC_BUILD_VERSION.
+            //
+            // Required when linking Apple targets to avoid warning, see:
+            // https://github.com/bytecodealliance/wasmtime/issues/8730
+            object.set_macho_build_version(info);
+        }
         Self {
             isa: builder.isa,
             object,

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1037,8 +1037,8 @@ user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
 [[publisher.target-lexicon]]
-version = "0.13.0"
-when = "2024-12-05"
+version = "0.13.3"
+when = "2025-09-09"
 user-id = 6825
 user-login = "sunfishcode"
 user-name = "Dan Gohman"


### PR DESCRIPTION
Fixes https://github.com/bytecodealliance/wasmtime/issues/8730, the remaining linker warnings are now gone.

See also https://github.com/rust-lang/rustc_codegen_cranelift/pull/1645 which passes the actual version (instead of just specifying `0.0.0`).