### PR TITLE
Allow passing Mach-O flags to `set_segment_section`

### DIFF
--- a/cranelift/module/src/data_context.rs
+++ b/cranelift/module/src/data_context.rs
@@ -60,8 +60,8 @@ pub struct DataDescription {
     pub function_relocs: Vec<(CodeOffset, ir::FuncRef)>,
     /// Data addresses to write at specified offsets.
     pub data_relocs: Vec<(CodeOffset, ir::GlobalValue, Addend)>,
-    /// Object file section
-    pub custom_segment_section: Option<(String, String)>,
+    /// Object file segment, section and Mach-O flags.
+    pub custom_segment_section: Option<(String, String, u32)>,
     /// Alignment in bytes. `None` means that the default alignment of the
     /// respective module should be used.
     pub align: Option<u64>,
@@ -112,8 +112,8 @@ impl DataDescription {
     }
 
     /// Override the segment/section for data, only supported on Object backend
-    pub fn set_segment_section(&mut self, seg: &str, sec: &str) {
-        self.custom_segment_section = Some((seg.to_owned(), sec.to_owned()))
+    pub fn set_segment_section(&mut self, seg: &str, sec: &str, macho_flags: u32) {
+        self.custom_segment_section = Some((seg.to_owned(), sec.to_owned(), macho_flags))
     }
 
     /// Set the alignment for data. The alignment must be a power of two.

--- a/cranelift/object/src/backend.rs
+++ b/cranelift/object/src/backend.rs
@@ -434,8 +434,8 @@ impl Module for ObjectModule {
                     "Custom section not supported for TLS"
                 )));
             }
-            let (seg, sec) = &custom_segment_section.as_ref().unwrap();
-            self.object.add_section(
+            let (seg, sec, macho_flags) = &custom_segment_section.as_ref().unwrap();
+            let section = self.object.add_section(
                 seg.clone().into_bytes(),
                 sec.clone().into_bytes(),
                 if decl.writable {
@@ -445,7 +445,22 @@ impl Module for ObjectModule {
                 } else {
                     SectionKind::ReadOnlyDataWithRel
                 },
-            )
+            );
+
+            match self.object.section_flags_mut(section) {
+                SectionFlags::MachO { flags } => {
+                    *flags = *macho_flags;
+                }
+                _ => {
+                    if *macho_flags != 0 {
+                        return Err(cranelift_module::ModuleError::Backend(anyhow::anyhow!(
+                            "unsupported Mach-O flags for this platform: {macho_flags:?}"
+                        )));
+                    }
+                }
+            }
+
+            section
         };
 
         if used {


### PR DESCRIPTION
This enables `rustc_codegen_cranelift` to control these, see https://github.com/rust-lang/rustc_codegen_cranelift/pull/1648.