### PR TITLE
wasmtime-wasi-http: Only inject Host header in the default HTTP/1 send_request path

### DIFF
--- a/crates/wasi-http/src/p2/http_impl.rs
+++ b/crates/wasi-http/src/p2/http_impl.rs
@@ -64,8 +64,6 @@ impl outgoing_handler::Host for WasiHttpCtxView<'_> {
 
         let authority = req.authority.unwrap_or_else(String::new);
 
-        builder = builder.header(hyper::header::HOST, &authority);
-
         let mut uri = http::Uri::builder()
             .scheme(scheme)
             .authority(authority.clone());

--- a/crates/wasi-http/src/p2/mod.rs
+++ b/crates/wasi-http/src/p2/mod.rs
@@ -582,6 +582,14 @@ pub async fn default_send_request_handler(
     use tokio::net::TcpStream;
     use tokio::time::timeout;
 
+    if !request.headers().contains_key(hyper::header::HOST) {
+        if let Some(authority) = request.uri().authority() {
+            if let Ok(value) = hyper::header::HeaderValue::from_str(authority.as_str()) {
+                request.headers_mut().insert(hyper::header::HOST, value);
+            }
+        }
+    }
+
     let authority = if let Some(authority) = request.uri().authority() {
         if authority.port().is_some() {
             authority.to_string()


### PR DESCRIPTION
Currently, `outgoing_handler::handle` unconditionally appends a `Host` header to the hyper::Request before calling `WasiHttpView::send_request`. This is fine for HTTP/1.1, but embedders that override `send_request` to dispatch over HTTP/2 (e.g. via `hyper_util::client::legacy::Client` negotiating h2 through ALPN) end up sending both `:authority` and a `host` header on the wire. Per RFC 9113 §8.3.1, clients generating HTTP/2 requests directly should use `:authority` instead of `Host`, and strict servers such as Google's GFE reject the stream with RST_STREAM PROTOCOL_ERROR when both appear.

This PR moves the `Host` insertion out of `handle` and into `default_send_request_handler`, which is the only code path in this crate that terminates in `hyper::client::conn::http1::handshake`. HTTP/1 dispatch preserves the existing behavior, while custom `send_request` implementations no longer have to strip the header themselves.