### PR TITLE
Don't create a pool of GC heaps if it's disabled

### DIFF
--- a/crates/wasmtime/src/runtime/vm/instance/allocator/pooling.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/pooling.rs
@@ -319,7 +319,7 @@ pub struct PoolingInstanceAllocator {
     live_tables: AtomicUsize,
 
     #[cfg(feature = "gc")]
-    gc_heaps: GcHeapPool,
+    gc_heaps: Option<GcHeapPool>,
     #[cfg(feature = "gc")]
     live_gc_heaps: AtomicUsize,
 
@@ -356,8 +356,8 @@ impl Drop for PoolingInstanceAllocator {
         debug_assert!(self.tables.is_empty());
 
         #[cfg(feature = "gc")]
-        {
-            debug_assert!(self.gc_heaps.is_empty());
+        if let Some(gc_heaps) = &self.gc_heaps {
+            debug_assert!(gc_heaps.is_empty());
             debug_assert_eq!(self.live_gc_heaps.load(Ordering::Acquire), 0);
         }
 
@@ -383,7 +383,11 @@ impl PoolingInstanceAllocator {
             tables: TablePool::new(config)?,
             live_tables: AtomicUsize::new(0),
             #[cfg(feature = "gc")]
-            gc_heaps: GcHeapPool::new(config, tunables)?,
+            gc_heaps: if tunables.collector.is_some() {
+                Some(GcHeapPool::new(config, tunables)?)
+            } else {
+                None
+            },
             #[cfg(feature = "gc")]
             live_gc_heaps: AtomicUsize::new(0),
             #[cfg(feature = "async")]
@@ -882,9 +886,12 @@ unsafe impl InstanceAllocator for PoolingInstanceAllocator {
         memory_alloc_index: MemoryAllocationIndex,
         memory: Memory,
     ) -> Result<(GcHeapAllocationIndex, Box<dyn GcHeap>)> {
-        let ret = self
-            .gc_heaps
-            .allocate(engine, gc_runtime, memory_alloc_index, memory)?;
+        let ret = self.gc_heaps.as_ref().unwrap().allocate(
+            engine,
+            gc_runtime,
+            memory_alloc_index,
+            memory,
+        )?;
         self.live_gc_heaps.fetch_add(1, Ordering::Relaxed);
         Ok(ret)
     }
@@ -895,8 +902,9 @@ unsafe impl InstanceAllocator for PoolingInstanceAllocator {
         allocation_index: GcHeapAllocationIndex,
         gc_heap: Box<dyn GcHeap>,
     ) -> (MemoryAllocationIndex, Memory) {
+        let gc_heaps = self.gc_heaps.as_ref().unwrap();
         self.live_gc_heaps.fetch_sub(1, Ordering::Relaxed);
-        self.gc_heaps.deallocate(allocation_index, gc_heap)
+        gc_heaps.deallocate(allocation_index, gc_heap)
     }
 
     fn as_pooling(&self) -> Option<&PoolingInstanceAllocator> {


### PR DESCRIPTION
A fuzz test case is failing right now on `main` where the validation in `Config` only checks tunables if a collector is enabled, but the GC pool creation unconditionally check the tunables. This also felt a bit odd creating a GC heap pool when the GC itself is disabled, so the code is refactored to avoid creating a GC heap pool at all when a collector is disabled.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
