### PR TITLE
Add another `make_internally_consistent` during fuzzing

### DIFF
--- a/crates/fuzzing/src/generators/config.rs
+++ b/crates/fuzzing/src/generators/config.rs
@@ -99,6 +99,8 @@ impl Config {
         // These instructions are explicitly not expected to be exactly the same
         // across engines. Don't fuzz them.
         config.relaxed_simd_enabled = false;
+
+        self.wasmtime.make_internally_consistent();
     }
 
     /// Uses this configuration and the supplied source of data to generate


### PR DESCRIPTION
Resolves a fuzz bug in `differential` testing where otherwise this was causing a failure to create a `Config`.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
