### PR TITLE
Shuffle around adjusting tunables in fuzzing

### DIFF
--- a/crates/fuzzing/src/generators/config.rs
+++ b/crates/fuzzing/src/generators/config.rs
@@ -825,18 +825,6 @@ impl WasmtimeConfig {
     /// these sorts of configurations. For now though it's intended to reflect
     /// the current state of the engine's development.
     pub(crate) fn make_internally_consistent(&mut self) {
-        // When using the pooling allocator, GC heap tunables must match memory
-        // tunables.
-        if let InstanceAllocationStrategy::Pooling(_) = &self.strategy {
-            self.memory_config.gc_heap_reservation = self.memory_config.memory_reservation;
-            self.memory_config.gc_heap_guard_size = self.memory_config.memory_guard_size;
-            self.memory_config.gc_heap_reservation_for_growth =
-                self.memory_config.memory_reservation_for_growth;
-            // memory_may_move is not in MemoryConfig, but gc_heap_may_move
-            // must not conflict. Set it to None so the default matches.
-            self.memory_config.gc_heap_may_move = None;
-        }
-
         if !self.signals_based_traps {
             let cfg = &mut self.memory_config;
             // Spectre-based heap mitigations require signal handlers so
@@ -869,6 +857,18 @@ impl WasmtimeConfig {
                     cfg.gc_heap_reservation_for_growth = Some(min);
                 }
             }
+        }
+
+        // When using the pooling allocator, GC heap tunables must match memory
+        // tunables.
+        if let InstanceAllocationStrategy::Pooling(_) = &self.strategy {
+            self.memory_config.gc_heap_reservation = self.memory_config.memory_reservation;
+            self.memory_config.gc_heap_guard_size = self.memory_config.memory_guard_size;
+            self.memory_config.gc_heap_reservation_for_growth =
+                self.memory_config.memory_reservation_for_growth;
+            // memory_may_move is not in MemoryConfig, but gc_heap_may_move
+            // must not conflict. Set it to None so the default matches.
+            self.memory_config.gc_heap_may_move = None;
         }
     }
 }


### PR DESCRIPTION
Fixes a test case where the pooling/gc options got out of sync.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
