### PR TITLE
Add inherit_network and allow_ip_name_lookup to C API

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,55 @@
   </h3>
 </div>
 
+## How to build and use
+You'll need rust and cargo to build most of the crates, and you'll need cmake and c++ compiler, to build c-api.
+Official building documentation is [here|https://docs.wasmtime.dev/contributing-building.html]
+
+### Rust part
+First, update git submodules
+```console
+git submodule update --init
+```
+
+Build everything, except c-api:
+```console
+cargo build --release
+```
+
+The built executable will be located at `target/release/wasmtime.`
+
+### C-API
+Make sure that you have c++ compiler and cmake in your system.
+On Windows I used MSYS2 with clang64 toolchain.
+On Linux and macOS either gcc or clang should be sufficient.
+
+From the root of the Wasmtime repository, run the following commands:
+
+```shell-session
+$ cmake -S crates/c-api -B target/c-api --install-prefix "$(pwd)/artifacts"
+$ cmake --build target/c-api
+$ cmake --install target/c-api
+```
+
+These commands will produce the following files:
+
+* `artifacts/lib/libwasmtime.{a,lib}`: Static Wasmtime library. Exact extension
+  depends on your operating system.
+
+* `artifacts/lib/libwasmtime.{so,dylib,dll}`: Dynamic Wasmtime library. Exact
+  extension depends on your operating system.
+
+* `artifacts/include/**.{h,hh}`: Header files for working with Wasmtime.
+
+On Windows MSYS2+CLANG64 will produce `wasmtime.dll`, `wasmtime.lib` and `wasmtime.dll.lib`.
+If you then will use clang toolchain to link with these libraries, it may not work, because
+clang linker follows linux naming convention when searching for libraries. In my case, following actions helped
+
+```bash
+cp artifacts/lib/wasmtime.dll.lib artifacts/lib/libwasmtime.dll.a
+PATH="$(pwd)/artifacts/lib:$PATH"
+```
+
 ## Installation
 
 The Wasmtime CLI can be installed on Linux and macOS (locally) with a small install

--- a/README.md
+++ b/README.md
@@ -26,55 +26,6 @@
   </h3>
 </div>
 
-## How to build and use
-You'll need rust and cargo to build most of the crates, and you'll need cmake and c++ compiler, to build c-api.
-Official building documentation is [here|https://docs.wasmtime.dev/contributing-building.html]
-
-### Rust part
-First, update git submodules
-```console
-git submodule update --init
-```
-
-Build everything, except c-api:
-```console
-cargo build --release
-```
-
-The built executable will be located at `target/release/wasmtime.`
-
-### C-API
-Make sure that you have c++ compiler and cmake in your system.
-On Windows I used MSYS2 with clang64 toolchain.
-On Linux and macOS either gcc or clang should be sufficient.
-
-From the root of the Wasmtime repository, run the following commands:
-
-```shell-session
-$ cmake -S crates/c-api -B target/c-api --install-prefix "$(pwd)/artifacts"
-$ cmake --build target/c-api
-$ cmake --install target/c-api
-```
-
-These commands will produce the following files:
-
-* `artifacts/lib/libwasmtime.{a,lib}`: Static Wasmtime library. Exact extension
-  depends on your operating system.
-
-* `artifacts/lib/libwasmtime.{so,dylib,dll}`: Dynamic Wasmtime library. Exact
-  extension depends on your operating system.
-
-* `artifacts/include/**.{h,hh}`: Header files for working with Wasmtime.
-
-On Windows MSYS2+CLANG64 will produce `wasmtime.dll`, `wasmtime.lib` and `wasmtime.dll.lib`.
-If you then will use clang toolchain to link with these libraries, it may not work, because
-clang linker follows linux naming convention when searching for libraries. In my case, following actions helped
-
-```bash
-cp artifacts/lib/wasmtime.dll.lib artifacts/lib/libwasmtime.dll.a
-PATH="$(pwd)/artifacts/lib:$PATH"
-```
-
 ## Installation
 
 The Wasmtime CLI can be installed on Linux and macOS (locally) with a small install

--- a/crates/c-api/include/wasi.h
+++ b/crates/c-api/include/wasi.h
@@ -51,6 +51,22 @@ WASI_DECLARE_OWN(config)
 WASI_API_EXTERN own wasi_config_t *wasi_config_new();
 
 /**
+ * \brief Allow all network addresses accessible to the host.
+ *
+ * This method will inherit all network addresses meaning that any address
+ * can be bound by the guest or connected to by the guest using any
+ * protocol.
+ */
+WASI_API_EXTERN void wasi_config_inherit_network(wasi_config_t *config);
+
+/**
+ * \brief Allow usage of `wasi:sockets/ip-name-lookup`
+ *
+ * By default this is disabled.
+ */
+WASI_API_EXTERN void wasi_config_allow_ip_name_lookup(wasi_config_t *config, bool enable);
+
+/**
  * \brief Sets the argv list for this configuration object.
  *
  * By default WASI programs have an empty argv list, but this can be used to

--- a/crates/c-api/include/wasi.h
+++ b/crates/c-api/include/wasi.h
@@ -64,7 +64,8 @@ WASI_API_EXTERN void wasi_config_inherit_network(wasi_config_t *config);
  *
  * By default this is disabled.
  */
-WASI_API_EXTERN void wasi_config_allow_ip_name_lookup(wasi_config_t *config, bool enable);
+WASI_API_EXTERN void wasi_config_allow_ip_name_lookup(wasi_config_t *config,
+                                                      bool enable);
 
 /**
  * \brief Sets the argv list for this configuration object.

--- a/crates/c-api/src/wasi.rs
+++ b/crates/c-api/src/wasi.rs
@@ -51,6 +51,16 @@ pub extern "C" fn wasi_config_new() -> Box<wasi_config_t> {
 }
 
 #[unsafe(no_mangle)]
+pub unsafe extern "C" fn wasi_config_inherit_network(config: &mut wasi_config_t) {
+    config.builder.inherit_network();
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn wasi_config_allow_ip_name_lookup(config: &mut wasi_config_t, enable: bool) {
+    config.builder.allow_ip_name_lookup(enable);
+}
+
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn wasi_config_set_argv(
     config: &mut wasi_config_t,
     argc: usize,

--- a/crates/c-api/src/wasi.rs
+++ b/crates/c-api/src/wasi.rs
@@ -56,7 +56,10 @@ pub unsafe extern "C" fn wasi_config_inherit_network(config: &mut wasi_config_t)
 }
 
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn wasi_config_allow_ip_name_lookup(config: &mut wasi_config_t, enable: bool) {
+pub unsafe extern "C" fn wasi_config_allow_ip_name_lookup(
+    config: &mut wasi_config_t,
+    enable: bool,
+) {
     config.builder.allow_ip_name_lookup(enable);
 }
 

--- a/crates/jit-debug/gdbjit.c
+++ b/crates/jit-debug/gdbjit.c
@@ -17,7 +17,7 @@ __declspec(dllexport)
 // `asm` statement.
 __attribute__((weak, noinline))
 #endif
-    void __jit_debug_register_code() {
+void __jit_debug_register_code() {
 #ifndef CFG_TARGET_OS_windows
   __asm__("");
 #endif


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
Discussed in issue #13130 

Without these changes there is no way to C API users to allow network access and DNS resolution for wasm components.

Resolves #13130