### PR TITLE
Always set `RUST_BACKTRACE=1` env variable in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,6 +34,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}2
   cancel-in-progress: true
 
+env:
+  # Always collect backtraces on panics to help with debugging CI failures,
+  # especially intermittent ones.
+  RUST_BACKTRACE: 1
+
 jobs:
   # Check Code style quickly by running `rustfmt` over all code
   rustfmt:


### PR DESCRIPTION
Should help with debugging CI failures in general, but also intermittent failures in particular.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
