### PR TITLE
Temporarily disable debug-assertions in Tokio

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -703,6 +703,12 @@ debug-assertions = false
 overflow-checks = false
 opt-level = 's'
 
+# FIXME(tokio-rs/tokio#8062): once that gets merged, published, and updated here
+# then this can be removed. Otherwise this is causing spurious failures on CI at
+# this time.
+[profile.dev.package.tokio]
+debug-assertions = false
+
 [profile.profiling]
 inherits = "bench"
 debug = "line-tables-only"


### PR DESCRIPTION
This is to work around tokio-rs/tokio#8061 while the fix is not yet merged/published.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
