### PR TITLE
Fix nodiscard warnings in C++ tests

### DIFF
--- a/crates/c-api/tests/func.cc
+++ b/crates/c-api/tests/func.cc
@@ -87,13 +87,13 @@ TEST(TypedFunc, Call) {
     FuncType ty({ValKind::ExternRef, ValKind::ExternRef},
                 {ValKind::ExternRef, ValKind::ExternRef});
     Func f(store, ty, [](auto caller, auto params, auto results) {
-      caller.context().gc();
+      caller.context().gc().unwrap();
       EXPECT_TRUE(params[0].externref());
       EXPECT_EQ(std::any_cast<int>(params[0].externref()->data(caller)), 100);
       EXPECT_FALSE(params[1].externref());
       results[0] = ExternRef(caller, int(3));
       results[1] = std::optional<ExternRef>(std::nullopt);
-      caller.context().gc();
+      caller.context().gc().unwrap();
       return std::monostate();
     });
 
@@ -102,7 +102,7 @@ TEST(TypedFunc, Call) {
     auto func = f.typed<ExternRefPair, ExternRefPair>(store).unwrap();
     auto result =
         func.call(store, {ExternRef(store, int(100)), std::nullopt}).unwrap();
-    store.context().gc();
+    store.context().gc().unwrap();
     EXPECT_EQ(std::any_cast<int>(std::get<0>(result)->data(store)), 3);
     EXPECT_EQ(std::get<1>(result), std::nullopt);
   }

--- a/crates/c-api/tests/store.cc
+++ b/crates/c-api/tests/store.cc
@@ -25,7 +25,7 @@ TEST(Store, Smoke) {
 
   store = Store(engine);
   store.limiter(-1, -1, -1, -1, -1);
-  store.context().gc();
+  store.context().gc().unwrap();
   store.context().get_fuel().err();
   store.context().set_fuel(1).err();
   store.context().set_epoch_deadline(1);

--- a/crates/c-api/tests/val.cc
+++ b/crates/c-api/tests/val.cc
@@ -110,11 +110,11 @@ TEST(Val, DropsExternRef) {
     flag = guard.flag();
     ExternRef r(store, std::make_shared<SetOnDrop>(std::move(guard)));
     EXPECT_FALSE(flag->load());
-    store.gc();
+    store.gc().unwrap();
     EXPECT_FALSE(flag->load());
   }
   EXPECT_FALSE(flag->load());
-  store.gc();
+  store.gc().unwrap();
   EXPECT_TRUE(flag->load());
 
   // Test that if a `Val(ExternRef)` is created and dropped it doesn't leak.
@@ -124,11 +124,11 @@ TEST(Val, DropsExternRef) {
     ExternRef r(store, std::make_shared<SetOnDrop>(std::move(guard)));
     Val v(r);
     EXPECT_FALSE(flag->load());
-    store.gc();
+    store.gc().unwrap();
     EXPECT_FALSE(flag->load());
   }
   EXPECT_FALSE(flag->load());
-  store.gc();
+  store.gc().unwrap();
   EXPECT_TRUE(flag->load());
 
   // Similar to above testing a variety of APIs.
@@ -147,10 +147,10 @@ TEST(Val, DropsExternRef) {
     v3 = v2;
     v = std::move(v2);
 
-    store.gc();
+    store.gc().unwrap();
     EXPECT_FALSE(flag->load());
   }
   EXPECT_FALSE(flag->load());
-  store.gc();
+  store.gc().unwrap();
   EXPECT_TRUE(flag->load());
 }


### PR DESCRIPTION
Fixes warnings that cropped up when `gc` was changed to return a result.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
