### PR TITLE
Fix some minor C API mistakes

### DIFF
--- a/crates/c-api/include/wasmtime/val.h
+++ b/crates/c-api/include/wasmtime/val.h
@@ -16,7 +16,6 @@ extern "C" {
 #endif
 
 #ifdef WASMTIME_FEATURE_GC
-struct wasmtime_eqref;
 /// Convenience alias for #wasmtime_eqref
 typedef struct wasmtime_eqref wasmtime_eqref_t;
 
@@ -81,19 +80,6 @@ static inline bool wasmtime_anyref_is_null(const wasmtime_anyref_t *ref) {
  */
 WASM_API_EXTERN void wasmtime_anyref_clone(const wasmtime_anyref_t *anyref,
                                            wasmtime_anyref_t *out);
-
-/**
- * \brief Downcast an `anyref` to an `eqyref`.
- *
- * Returns `true` if the downcast succeeded, and `out` is initialized. Returns
- * `false` if the downcast failed, and `out` is left uninitialized.
- *
- * The original `anyref` is not consumed; `out` receives a new cloned root
- * pointing to the same GC object as `anyref`.
- */
-WASM_API_EXTERN bool wasmtime_anyref_to_eqref(wasmtime_context_t *context,
-                                              const wasmtime_anyref_t *anyref,
-                                              wasmtime_eqref_t *out);
 
 /**
  * \brief Unroots the `ref` provided within the `context`.

--- a/crates/c-api/src/vec.rs
+++ b/crates/c-api/src/vec.rs
@@ -1,7 +1,7 @@
 use crate::{
     wasm_exporttype_t, wasm_extern_t, wasm_externtype_t, wasm_frame_t, wasm_functype_t,
-    wasm_globaltype_t, wasm_importtype_t, wasm_memorytype_t, wasm_tabletype_t, wasm_val_t,
-    wasm_valtype_t,
+    wasm_globaltype_t, wasm_importtype_t, wasm_memorytype_t, wasm_tabletype_t, wasm_tagtype_t,
+    wasm_val_t, wasm_valtype_t,
 };
 use std::mem;
 use std::mem::MaybeUninit;
@@ -259,5 +259,14 @@ declare_vecs! {
         uninit: wasm_extern_vec_new_uninitialized,
         copy: wasm_extern_vec_copy,
         delete: wasm_extern_vec_delete,
+    )
+    (
+        name: wasm_tagtype_vec_t,
+        ty: Option<Box<wasm_tagtype_t>>,
+        new: wasm_tagtype_vec_new,
+        empty: wasm_tagtype_vec_new_empty,
+        uninit: wasm_tagtype_vec_new_uninitialized,
+        copy: wasm_tagtype_vec_copy,
+        delete: wasm_tagtype_vec_delete,
     )
 }


### PR DESCRIPTION
* Remove stray `struct wasmtime_eqref`
* Remove header definition for `wasmtime_anyref_to_eqref` as it doesn't exist. The function is actually `wasmtime_anyref_as_eqref` which has tests and such.
* Define `wasm_tagtype_vec_*` functions.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
