### PR TITLE
Disable overflow-checks in Tokio, not debug asserts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -707,7 +707,7 @@ opt-level = 's'
 # then this can be removed. Otherwise this is causing spurious failures on CI at
 # this time.
 [profile.dev.package.tokio]
-debug-assertions = false
+overflow-checks = false
 
 [profile.profiling]
 inherits = "bench"


### PR DESCRIPTION
I didn't let my loop run long enough to test whether #13147 fixed the issue... In any case overflow-checks is what we want, not debug assertions.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
