### PR TITLE
Assert that Mach-O section_flags_mut is 0

### DIFF
--- a/cranelift/object/src/backend.rs
+++ b/cranelift/object/src/backend.rs
@@ -518,6 +518,13 @@ impl Module for ObjectModule {
 
             match self.object.section_flags_mut(section) {
                 SectionFlags::MachO { flags } => {
+                    // There are no default flags for the `SectionKind`s that
+                    // we've specified above, so it's fine to override.
+                    //
+                    // (If we don't want to override, we'll have to be careful
+                    // with how we set these, to ensure we set the section
+                    // type properly).
+                    assert_eq!(*flags, 0);
                     *flags = *macho_flags;
                 }
                 _ => {


### PR DESCRIPTION
To ensure we don't unintentionally overwrite default flags. Discussed in https://github.com/bytecodealliance/wasmtime/pull/13137#discussion_r3113321558.