### PR TITLE
Add `Strategy::Winch` and `RegallocAlgorithm` support to the C and C++ API

### DIFF
--- a/crates/c-api/include/wasmtime/config.h
+++ b/crates/c-api/include/wasmtime/config.h
@@ -94,6 +94,39 @@ enum wasmtime_profiling_strategy_enum { // ProfilingStrategy
   WASMTIME_PROFILING_STRATEGY_PERFMAP,
 };
 
+/**
+ * \brief Different ways Cranelift can allocate registers
+ *
+ * See #wasmtime_regalloc_algorithm_enum for possible values.
+ */
+typedef uint8_t wasmtime_regalloc_algorithm_t;
+
+/**
+ * \brief Different ways to allocate registers.
+ *
+ * The default is #WASMTIME_REGALLOC_BACKTRACKING.
+ */
+enum wasmtime_regalloc_algorithm_enum { // RegallocAlgorithm
+  /// Generates the fastest possible code, but may take longer.
+  ///
+  /// This algorithm performs “backtracking”, which means that it may undo
+  /// its earlier work and retry as it discovers conflicts. This results
+  /// in better register utilization,  producing fewer spills and moves,
+  /// but can cause super-linear compile runtime.
+  WASMTIME_REGALLOC_BACKTRACKING,
+  /// Generates acceptable code very quickly.
+  ///
+  /// This algorithm performs a single pass through the code, guaranteed to work
+  /// in linear time.
+  /// (Note that the rest of Cranelift is not necessarily guaranteed to run in
+  /// linear time, however.)
+  /// It cannot undo earlier decisions, however, and it cannot foresee
+  /// constraints or issues that may
+  /// occur further ahead in the code, so the code may have more spills and
+  /// moves as a result.
+  WASMTIME_REGALLOC_SINGLE_PASS,
+};
+
 #define WASMTIME_CONFIG_PROP(ret, name, ty)                                    \
   WASM_API_EXTERN ret wasmtime_config_##name##_set(wasm_config_t *, ty);
 
@@ -348,6 +381,15 @@ WASMTIME_CONFIG_PROP(void, cranelift_nan_canonicalization, bool)
  * This setting in #WASMTIME_OPT_LEVEL_SPEED by default.
  */
 WASMTIME_CONFIG_PROP(void, cranelift_opt_level, wasmtime_opt_level_t)
+
+/**
+ * \brief Configures the regalloc algorithm used by the Cranelift code
+ * generator.
+ *
+ * This setting in #WASMTIME_REGALLOC_BACKTRACKING by default.
+ */
+WASMTIME_CONFIG_PROP(void, cranelift_regalloc_algorithm,
+                     wasmtime_regalloc_algorithm_t)
 
 #endif // WASMTIME_FEATURE_COMPILER
 

--- a/crates/c-api/include/wasmtime/config.h
+++ b/crates/c-api/include/wasmtime/config.h
@@ -34,6 +34,13 @@ enum wasmtime_strategy_enum { // Strategy
   /// Indicates that Wasmtime will unconditionally use Cranelift to compile
   /// WebAssembly code.
   WASMTIME_STRATEGY_CRANELIFT,
+
+  /// Indicates that Wasmtime will unconditionally use Winch to compile
+  /// WebAssembly code.
+  //
+  /// For more details regarding ISA support and Wasm proposals support
+  /// see <https://docs.wasmtime.dev/stability-tiers.html#current-tier-status>
+  WASMTIME_STRATEGY_WINCH,
 };
 
 /**

--- a/crates/c-api/include/wasmtime/config.hh
+++ b/crates/c-api/include/wasmtime/config.hh
@@ -45,6 +45,30 @@ enum class ProfilingStrategy {
   Perfmap = WASMTIME_PROFILING_STRATEGY_PERFMAP,
 };
 
+/// \brief Values passed to `Config::cranelift_regalloc_algorithm`
+enum RegallocAlgorithm {
+  /// Generates the fastest possible code, but may take longer.
+  ///
+  /// This algorithm performs “backtracking”, which means that it may undo its
+  /// earlier work
+  /// and retry as it discovers conflicts. This results in better register
+  /// utilization,
+  /// producing fewer spills and moves, but can cause super-linear compile
+  /// runtime.
+  Backtracking = WASMTIME_REGALLOC_BACKTRACKING,
+  /// Generates acceptable code very quickly.
+  ///
+  /// This algorithm performs a single pass through the code, guaranteed to work
+  /// in linear time.
+  /// (Note that the rest of Cranelift is not necessarily guaranteed to run in
+  /// linear time, however.)
+  /// It cannot undo earlier decisions, however, and it cannot foresee
+  /// constraints or issues that may
+  /// occur further ahead in the code, so the code may have more spills and
+  /// moves as a result.
+  SinglePass = WASMTIME_REGALLOC_SINGLE_PASS,
+};
+
 #ifdef WASMTIME_FEATURE_POOLING_ALLOCATOR
 /**
  * \brief Pool allocation configuration for Wasmtime.
@@ -478,6 +502,14 @@ class Config {
   /// https://docs.wasmtime.dev/api/wasmtime/struct.Config.html#method.cranelift_flag_set
   void cranelift_flag_set(const std::string &flag, const std::string &value) {
     wasmtime_config_cranelift_flag_set(ptr.get(), flag.c_str(), value.c_str());
+  }
+
+  /// \brief Configures cranelift's register allocation mode
+  ///
+  /// https://docs.wasmtime.dev/api/wasmtime/struct.Config.html#method.cranelift_regalloc_algorithm
+  void cranelift_regalloc_algorithm(RegallocAlgorithm algo) {
+    wasmtime_config_cranelift_regalloc_algorithm_set(
+        ptr.get(), static_cast<wasmtime_regalloc_algorithm_t>(algo));
   }
 #endif // WASMTIME_FEATURE_COMPILER
 

--- a/crates/c-api/include/wasmtime/config.hh
+++ b/crates/c-api/include/wasmtime/config.hh
@@ -19,6 +19,8 @@ enum class Strategy {
   Auto = WASMTIME_STRATEGY_AUTO,
   /// Requires Cranelift to be used for compilation
   Cranelift = WASMTIME_STRATEGY_CRANELIFT,
+  /// Use winch for compilation
+  Winch = WASMTIME_STRATEGY_WINCH,
 };
 
 /// \brief Values passed to `Config::cranelift_opt_level`

--- a/crates/c-api/src/config.rs
+++ b/crates/c-api/src/config.rs
@@ -8,7 +8,7 @@ use std::ptr;
 use std::{ffi::CStr, sync::Arc};
 use wasmtime::{
     Config, InstanceAllocationStrategy, LinearMemory, MemoryCreator, OptLevel, ProfilingStrategy,
-    Result, Strategy,
+    RegallocAlgorithm, Result, Strategy,
 };
 
 #[cfg(feature = "pooling-allocator")]
@@ -45,6 +45,13 @@ pub enum wasmtime_profiling_strategy_t {
     WASMTIME_PROFILING_STRATEGY_JITDUMP,
     WASMTIME_PROFILING_STRATEGY_VTUNE,
     WASMTIME_PROFILING_STRATEGY_PERFMAP,
+}
+
+#[repr(u8)]
+#[derive(Clone)]
+pub enum wasmtime_regalloc_algorithm_t {
+    WASMTIME_REGALLOC_BACKTRACKING,
+    WASMTIME_REGALLOC_SINGLE_PASS,
 }
 
 #[unsafe(no_mangle)]
@@ -208,6 +215,19 @@ pub extern "C" fn wasmtime_config_cranelift_opt_level_set(
         WASMTIME_OPT_LEVEL_NONE => OptLevel::None,
         WASMTIME_OPT_LEVEL_SPEED => OptLevel::Speed,
         WASMTIME_OPT_LEVEL_SPEED_AND_SIZE => OptLevel::SpeedAndSize,
+    });
+}
+
+#[unsafe(no_mangle)]
+#[cfg(any(feature = "cranelift", feature = "winch"))]
+pub extern "C" fn wasmtime_config_cranelift_regalloc_algorithm_set(
+    c: &mut wasm_config_t,
+    algo: wasmtime_regalloc_algorithm_t,
+) {
+    use wasmtime_regalloc_algorithm_t::*;
+    c.config.cranelift_regalloc_algorithm(match algo {
+        WASMTIME_REGALLOC_BACKTRACKING => RegallocAlgorithm::Backtracking,
+        WASMTIME_REGALLOC_SINGLE_PASS => RegallocAlgorithm::SinglePass,
     });
 }
 

--- a/crates/c-api/src/config.rs
+++ b/crates/c-api/src/config.rs
@@ -27,6 +27,7 @@ wasmtime_c_api_macros::declare_own!(wasm_config_t);
 pub enum wasmtime_strategy_t {
     WASMTIME_STRATEGY_AUTO,
     WASMTIME_STRATEGY_CRANELIFT,
+    WASMTIME_STRATEGY_WINCH,
 }
 
 #[repr(u8)]
@@ -168,6 +169,7 @@ pub extern "C" fn wasmtime_config_strategy_set(
     c.config.strategy(match strategy {
         WASMTIME_STRATEGY_AUTO => Strategy::Auto,
         WASMTIME_STRATEGY_CRANELIFT => Strategy::Cranelift,
+        WASMTIME_STRATEGY_WINCH => Strategy::Winch,
     });
 }
 

--- a/crates/c-api/tests/config.cc
+++ b/crates/c-api/tests/config.cc
@@ -56,6 +56,7 @@ TEST(Config, Smoke) {
   config.strategy(Strategy::Auto);
   config.cranelift_debug_verifier(false);
   config.cranelift_opt_level(OptLevel::Speed);
+  config.cranelift_regalloc_algorithm(RegallocAlgorithm::Backtracking);
   config.cranelift_nan_canonicalization(false);
   config.profiler(ProfilingStrategy::None);
   config.memory_reservation(0);


### PR DESCRIPTION
Hi all!

This is a very small PR that just ensures that `Strategy::Winch` has been added to the C and C++ side of things.

It also adds support for setting `cranelift_regalloc_algorithm`, via the C and C++ APIs so it adds the needed bits for that (that being support for setting it via the C and C++ APIs and the new enum defs on that side of the FFI fence)

I did give a quick canvas around and didn't find anything super directly related to these changes in the existing PR list, but I could have missed something!
