### PR TITLE
Fix funcref downcasts across import boundaries

### DIFF
--- a/crates/environ/src/vmoffsets.rs
+++ b/crates/environ/src/vmoffsets.rs
@@ -716,28 +716,34 @@ impl<P: PtrSize> From<VMOffsetsFields<P>> for VMOffsets<P> {
 }
 
 impl<P: PtrSize> VMOffsets<P> {
-    /// The offset of the `wasm_call` field.
+    /// The offset of the `VMFunctionImport::array_call` field.
     #[inline]
-    pub fn vmfunction_import_wasm_call(&self) -> u8 {
+    pub fn vmfunction_import_array_call(&self) -> u8 {
         0 * self.pointer_size()
     }
 
-    /// The offset of the `array_call` field.
+    /// The offset of the `VMFunctionImport::wasm_call` field.
     #[inline]
-    pub fn vmfunction_import_array_call(&self) -> u8 {
+    pub fn vmfunction_import_wasm_call(&self) -> u8 {
         1 * self.pointer_size()
     }
 
-    /// The offset of the `vmctx` field.
+    /// The offset of the `VMFunctionImport::type_index` field.
+    #[inline]
+    pub fn vmfunction_import_type_index(&self) -> u8 {
+        2 * self.pointer_size()
+    }
+
+    /// The offset of the `VMFunctionImport::vmctx` field.
     #[inline]
     pub fn vmfunction_import_vmctx(&self) -> u8 {
-        2 * self.pointer_size()
+        3 * self.pointer_size()
     }
 
     /// Return the size of `VMFunctionImport`.
     #[inline]
     pub fn size_of_vmfunction_import(&self) -> u8 {
-        3 * self.pointer_size()
+        4 * self.pointer_size()
     }
 }
 

--- a/crates/wasmtime/src/runtime/func.rs
+++ b/crates/wasmtime/src/runtime/func.rs
@@ -1197,38 +1197,35 @@ impl Func {
     }
 
     pub(crate) fn vmimport(&self, store: &StoreOpaque) -> VMFunctionImport {
-        unsafe {
-            let f = self.vm_func_ref(store);
-            VMFunctionImport {
-                // Note that this is a load-bearing `unwrap` here, but is
-                // never expected to trip at runtime. The general problem is
-                // that host functions do not have a `wasm_call` function so
-                // the `VMFuncRef` type has an optional pointer there. This is
-                // only able to be filled out when a function is "paired" with
-                // a module where trampolines are present to fill out
-                // `wasm_call` pointers.
-                //
-                // This pairing of modules doesn't happen explicitly but is
-                // instead managed lazily throughout Wasmtime. Specifically the
-                // way this works is one of:
-                //
-                // * When a host function is created the store's list of
-                //   modules are searched for a wasm trampoline. If not found
-                //   the `wasm_call` field is left blank.
-                //
-                // * When a module instantiation happens, which uses this
-                //   function, the module will be used to fill any outstanding
-                //   holes that it has trampolines for.
-                //
-                // This means that by the time we get to this point any
-                // relevant holes should be filled out. Thus if this panic
-                // actually triggers then it's indicative of a missing `fill`
-                // call somewhere else.
-                wasm_call: f.as_ref().wasm_call.unwrap(),
-                array_call: f.as_ref().array_call,
-                vmctx: f.as_ref().vmctx,
-            }
-        }
+        // Safety: it should be fine to dereference the funcref pointer while we
+        // borrow the store.
+        let func_ref = unsafe { self.vm_func_ref(store).as_ref() };
+
+        // Note that this is a load-bearing `unwrap` here, but is never expected
+        // to trip at runtime. The general problem is that host functions do not
+        // have a `wasm_call` function so the `VMFuncRef` type has an optional
+        // pointer there. This is only able to be filled out when a function is
+        // "paired" with a module where trampolines are present to fill out
+        // `wasm_call` pointers.
+        //
+        // This pairing of modules doesn't happen explicitly but is instead
+        // managed lazily throughout Wasmtime. Specifically the way this works
+        // is one of:
+        //
+        // * When a host function is created the store's list of modules are
+        //   searched for a wasm trampoline. If not found the `wasm_call` field
+        //   is left blank.
+        //
+        // * When a module instantiation happens, which uses this function, the
+        //   module will be used to fill any outstanding holes that it has
+        //   trampolines for.
+        //
+        // This means that by the time we get to this point any relevant holes
+        // should be filled out. Thus if this panic actually triggers then it's
+        // indicative of a missing `fill` call somewhere else.
+        let func_import = func_ref.as_vm_function_import().unwrap();
+
+        func_import.clone()
     }
 
     pub(crate) fn comes_from_same_store(&self, store: &StoreOpaque) -> bool {

--- a/crates/wasmtime/src/runtime/instance.rs
+++ b/crates/wasmtime/src/runtime/instance.rs
@@ -734,14 +734,7 @@ impl OwnedImports {
     ) -> Result<(), OutOfMemory> {
         match item {
             crate::runtime::vm::Export::Function(f) => {
-                // SAFETY: the funcref associated with a `Func` is valid to use
-                // under the `store` that owns the function.
-                let f = unsafe { f.vm_func_ref(store).as_ref() };
-                self.functions.push(VMFunctionImport {
-                    wasm_call: f.wasm_call.unwrap(),
-                    array_call: f.array_call,
-                    vmctx: f.vmctx,
-                })?;
+                self.functions.push(f.vmimport(store))?;
             }
             crate::runtime::vm::Export::Global(g) => {
                 self.globals.push(g.vmimport(store))?;

--- a/crates/wasmtime/src/runtime/vm/instance.rs
+++ b/crates/wasmtime/src/runtime/vm/instance.rs
@@ -808,73 +808,6 @@ impl Instance {
         unsafe { self.vmctx_plus_offset_raw(self.offsets().ptr.vmctx_type_ids_array()) }
     }
 
-    /// Construct a new VMFuncRef for the given function
-    /// (imported or defined in this module) and store into the given
-    /// location. Used during lazy initialization.
-    ///
-    /// Note that our current lazy-init scheme actually calls this every
-    /// time the funcref pointer is fetched; this turns out to be better
-    /// than tracking state related to whether it's been initialized
-    /// before, because resetting that state on (re)instantiation is
-    /// very expensive if there are many funcrefs.
-    ///
-    /// # Safety
-    ///
-    /// This functions requires that `into` is a valid pointer.
-    unsafe fn construct_func_ref(
-        self: Pin<&mut Self>,
-        registry: &ModuleRegistry,
-        index: FuncIndex,
-        type_index: VMSharedTypeIndex,
-        into: *mut VMFuncRef,
-    ) {
-        let module_with_code = ModuleWithCode::in_store(
-            registry,
-            self.runtime_module()
-                .expect("funcref impossible in fake module"),
-        )
-        .expect("module not in store");
-
-        let func_ref = if let Some(def_index) = self.env_module().defined_func_index(index) {
-            VMFuncRef {
-                array_call: NonNull::from(
-                    module_with_code
-                        .array_to_wasm_trampoline(def_index)
-                        .expect("should have array-to-Wasm trampoline for escaping function"),
-                )
-                .cast()
-                .into(),
-                wasm_call: Some(
-                    NonNull::new(
-                        module_with_code
-                            .finished_function(def_index)
-                            .as_ptr()
-                            .cast::<VMWasmCallFunction>()
-                            .cast_mut(),
-                    )
-                    .unwrap()
-                    .into(),
-                ),
-                vmctx: VMOpaqueContext::from_vmcontext(self.vmctx()).into(),
-                type_index,
-            }
-        } else {
-            let import = self.imported_function(index);
-            VMFuncRef {
-                array_call: import.array_call,
-                wasm_call: Some(import.wasm_call),
-                vmctx: import.vmctx,
-                type_index,
-            }
-        };
-
-        // SAFETY: the unsafe contract here is forwarded to callers of this
-        // function.
-        unsafe {
-            ptr::write(into, func_ref);
-        }
-    }
-
     /// Get a `&VMFuncRef` for the given `FuncIndex`.
     ///
     /// Returns `None` if the index is the reserved index value.
@@ -890,46 +823,82 @@ impl Instance {
             return None;
         }
 
-        // For now, we eagerly initialize an funcref struct in-place
-        // whenever asked for a reference to it. This is mostly
-        // fine, because in practice each funcref is unlikely to be
-        // requested more than a few times: once-ish for funcref
-        // tables used for call_indirect (the usual compilation
-        // strategy places each function in the table at most once),
-        // and once or a few times when fetching exports via API.
-        // Note that for any case driven by table accesses, the lazy
-        // table init behaves like a higher-level cache layer that
-        // protects this initialization from happening multiple
-        // times, via that particular table at least.
+        let Some(def_index) = self.env_module().defined_func_index(index) else {
+            debug_assert!(self.env_module().is_imported_function(index));
+            return Some(self.imported_function(index).as_func_ref().into());
+        };
+
+        // For now, we eagerly initialize an funcref struct in-place whenever
+        // asked for a reference to it. This is mostly fine, because in practice
+        // each funcref is unlikely to be requested more than a few times:
+        // once-ish for funcref tables used for call_indirect (the usual
+        // compilation strategy places each function in the table at most once),
+        // and once or a few times when fetching exports via API.  Note that for
+        // any case driven by table accesses, the lazy table init behaves like a
+        // higher-level cache layer that protects this initialization from
+        // happening multiple times, via that particular table at least.
         //
-        // When `ref.func` becomes more commonly used or if we
-        // otherwise see a use-case where this becomes a hotpath,
-        // we can reconsider by using some state to track
-        // "uninitialized" explicitly, for example by zeroing the
-        // funcrefs (perhaps together with other
-        // zeroed-at-instantiate-time state) or using a separate
-        // is-initialized bitmap.
+        // When `ref.func` becomes more commonly used or if we otherwise see a
+        // use-case where this becomes a hotpath, we can reconsider by using
+        // some state to track "uninitialized" explicitly, for example by
+        // zeroing the funcrefs (perhaps together with other
+        // zeroed-at-instantiate-time state) or using a separate is-initialized
+        // bitmap.
         //
-        // We arrived at this design because zeroing memory is
-        // expensive, so it's better for instantiation performance
-        // if we don't have to track "is-initialized" state at
-        // all!
+        // We arrived at this design because zeroing memory is expensive, so
+        // it's better for instantiation performance if we don't have to track
+        // "is-initialized" state at all!
+
         let func = &self.env_module().functions[index];
-        let sig = func.signature.unwrap_engine_type_index();
+        let type_index = func.signature.unwrap_engine_type_index();
+
+        let module_with_code = ModuleWithCode::in_store(
+            registry,
+            self.runtime_module()
+                .expect("funcref impossible in fake module"),
+        )
+        .expect("module not in store");
+
+        let array_call = VmPtr::from(
+            NonNull::from(
+                module_with_code
+                    .array_to_wasm_trampoline(def_index)
+                    .expect("should have array-to-Wasm trampoline for escaping function"),
+            )
+            .cast(),
+        );
+
+        let wasm_call = Some(VmPtr::from(
+            NonNull::new(
+                module_with_code
+                    .finished_function(def_index)
+                    .as_ptr()
+                    .cast::<VMWasmCallFunction>()
+                    .cast_mut(),
+            )
+            .unwrap(),
+        ));
+
+        let vmctx = VMOpaqueContext::from_vmcontext(self.vmctx()).into();
 
         // SAFETY: the offset calculated here should be correct with
         // `self.offsets`
-        let func_ref = unsafe {
+        let func_ref_ptr = unsafe {
             self.vmctx_plus_offset_raw::<VMFuncRef>(self.offsets().vmctx_func_ref(func.func_ref))
         };
 
-        // SAFETY: the `func_ref` ptr should be valid as it's within our
+        // SAFETY: the `func_ref_ptr` should be valid as it's within our
         // `VMContext` area.
         unsafe {
-            self.construct_func_ref(registry, index, sig, func_ref.as_ptr());
+            func_ref_ptr.write(VMFuncRef {
+                array_call,
+                wasm_call,
+                vmctx,
+                type_index,
+            });
         }
 
-        Some(func_ref)
+        Some(func_ref_ptr)
     }
 
     /// Get the passive elements segment at the given index.

--- a/crates/wasmtime/src/runtime/vm/provenance.rs
+++ b/crates/wasmtime/src/runtime/vm/provenance.rs
@@ -138,6 +138,13 @@ impl<T> fmt::Debug for VmPtr<T> {
     }
 }
 
+// Constructor from `&T`.
+impl<T> From<&T> for VmPtr<T> {
+    fn from(p: &T) -> Self {
+        NonNull::from(p).into()
+    }
+}
+
 // Constructor from `NonNull<T>`
 impl<T> From<NonNull<T>> for VmPtr<T> {
     fn from(ptr: NonNull<T>) -> VmPtr<T> {

--- a/crates/wasmtime/src/runtime/vm/vmcontext.rs
+++ b/crates/wasmtime/src/runtime/vm/vmcontext.rs
@@ -116,7 +116,7 @@ impl VMFunctionImport {
 
 #[cfg(test)]
 mod test_vmfunction_import {
-    use super::VMFunctionImport;
+    use super::{VMFuncRef, VMFunctionImport};
     use core::mem::offset_of;
     use std::mem::size_of;
     use wasmtime_environ::{HostPtr, Module, StaticModuleIndex, VMOffsets};

--- a/crates/wasmtime/src/runtime/vm/vmcontext.rs
+++ b/crates/wasmtime/src/runtime/vm/vmcontext.rs
@@ -68,27 +68,51 @@ pub struct VMArrayCallFunction(VMFunctionBody);
 pub struct VMWasmCallFunction(VMFunctionBody);
 
 /// An imported function.
-#[derive(Debug, Copy, Clone)]
+///
+/// Basically the same as `VMFuncRef`, except that `wasm_call` is not optional.
+#[derive(Debug, Clone)]
 #[repr(C)]
 pub struct VMFunctionImport {
-    /// Function pointer to use when calling this imported function from Wasm.
-    pub wasm_call: VmPtr<VMWasmCallFunction>,
-
-    /// Function pointer to use when calling this imported function with the
-    /// "array" calling convention that `Func::new` et al use.
+    /// Same as `VMFuncRef::array_call`.
     pub array_call: VmPtr<VMArrayCallFunction>,
 
-    /// The VM state associated with this function.
+    /// Same as `VMFuncRef::wasm_call`, except always non-null. Must be filled
+    /// in by the time Wasm is importing this function!
+    pub wasm_call: VmPtr<VMWasmCallFunction>,
+
+    /// Function signature's _actual_ type id.
     ///
-    /// For Wasm functions defined by core wasm instances this will be `*mut
-    /// VMContext`, but for lifted/lowered component model functions this will
-    /// be a `VMComponentContext`, and for a host function it will be a
-    /// `VMHostFuncContext`, etc.
+    /// This is the type that the function was defined with, not the type that
+    /// it was imported as. These two can be different in the face of subtyping
+    /// and we need the former for to correctly implement dynamic downcasts.
+    pub type_index: VMSharedTypeIndex,
+
+    /// Same as `VMFuncRef::vmctx`.
     pub vmctx: VmPtr<VMOpaqueContext>,
+    // If more elements are added here, remember to add offset_of tests below!
 }
 
 // SAFETY: the above structure is repr(C) and only contains `VmSafe` fields.
 unsafe impl VmSafe for VMFunctionImport {}
+
+impl VMFunctionImport {
+    /// Convert `&VMFunctionImport` into `&VMFuncRef`.
+    pub fn as_func_ref(&self) -> &VMFuncRef {
+        // Safety: `VMFunctionImport` and `VMFuncRef` have the same
+        // representation.
+        unsafe { Self::as_non_null_func_ref(NonNull::from(self)).as_ref() }
+    }
+
+    /// Convert `NonNull<VMFunctionImport>` into `NonNull<VMFuncRef>`.
+    pub fn as_non_null_func_ref(p: NonNull<VMFunctionImport>) -> NonNull<VMFuncRef> {
+        p.cast()
+    }
+
+    /// Convert `*mut VMFunctionImport` into `*mut VMFuncRef`.
+    pub fn as_func_ref_ptr(p: *mut VMFunctionImport) -> *mut VMFuncRef {
+        p.cast()
+    }
+}
 
 #[cfg(test)]
 mod test_vmfunction_import {
@@ -106,16 +130,41 @@ mod test_vmfunction_import {
             usize::from(offsets.size_of_vmfunction_import())
         );
         assert_eq!(
-            offset_of!(VMFunctionImport, wasm_call),
-            usize::from(offsets.vmfunction_import_wasm_call())
-        );
-        assert_eq!(
             offset_of!(VMFunctionImport, array_call),
             usize::from(offsets.vmfunction_import_array_call())
         );
         assert_eq!(
+            offset_of!(VMFunctionImport, wasm_call),
+            usize::from(offsets.vmfunction_import_wasm_call())
+        );
+        assert_eq!(
+            offset_of!(VMFunctionImport, type_index),
+            usize::from(offsets.vmfunction_import_type_index())
+        );
+        assert_eq!(
             offset_of!(VMFunctionImport, vmctx),
             usize::from(offsets.vmfunction_import_vmctx())
+        );
+    }
+
+    #[test]
+    fn vmfunction_import_and_vmfunc_ref_have_same_layout() {
+        assert_eq!(size_of::<VMFunctionImport>(), size_of::<VMFuncRef>());
+        assert_eq!(
+            offset_of!(VMFunctionImport, array_call),
+            offset_of!(VMFuncRef, array_call),
+        );
+        assert_eq!(
+            offset_of!(VMFunctionImport, wasm_call),
+            offset_of!(VMFuncRef, wasm_call),
+        );
+        assert_eq!(
+            offset_of!(VMFunctionImport, type_index),
+            offset_of!(VMFuncRef, type_index),
+        );
+        assert_eq!(
+            offset_of!(VMFunctionImport, vmctx),
+            offset_of!(VMFuncRef, vmctx),
         );
     }
 }
@@ -966,6 +1015,16 @@ impl VMFuncRef {
                 args_and_results.cast(),
                 args_and_results.len(),
             )
+        }
+    }
+
+    pub(crate) fn as_vm_function_import(&self) -> Option<&VMFunctionImport> {
+        if self.wasm_call.is_some() {
+            // Safety: `VMFuncRef` and `VMFunctionImport` have the same layout
+            // and `wasm_call` is non-null.
+            Some(unsafe { NonNull::from(self).cast::<VMFunctionImport>().as_ref() })
+        } else {
+            None
         }
     }
 }

--- a/tests/disas/component-model/direct-adapter-calls-inlining.wat
+++ b/tests/disas/component-model/direct-adapter-calls-inlining.wat
@@ -63,8 +63,8 @@
 ;;     gv5 = load.i64 notrap aligned readonly gv4+8
 ;;     gv6 = load.i64 notrap aligned gv5+24
 ;;     gv7 = vmctx
-;;     gv8 = load.i64 notrap aligned readonly can_move gv7+120
-;;     gv9 = load.i64 notrap aligned readonly can_move gv7+96
+;;     gv8 = load.i64 notrap aligned readonly can_move gv7+136
+;;     gv9 = load.i64 notrap aligned readonly can_move gv7+112
 ;;     gv10 = vmctx
 ;;     gv11 = load.i64 notrap aligned readonly gv10+8
 ;;     gv12 = load.i64 notrap aligned gv11+24
@@ -79,8 +79,8 @@
 ;; @00ee                               jump block2
 ;;
 ;;                                 block2:
-;; @00ee                               v5 = load.i64 notrap aligned readonly can_move v0+64
-;;                                     v12 = load.i64 notrap aligned readonly can_move v5+120
+;; @00ee                               v5 = load.i64 notrap aligned readonly can_move v0+72
+;;                                     v12 = load.i64 notrap aligned readonly can_move v5+136
 ;;                                     v13 = load.i32 notrap aligned table v12
 ;;                                     v14 = iconst.i32 1
 ;;                                     v15 = band v13, v14  ; v14 = 1
@@ -90,14 +90,14 @@
 ;;                                     brif v18, block4, block5
 ;;
 ;;                                 block4:
-;;                                     v21 = load.i64 notrap aligned readonly can_move v5+72
-;;                                     v20 = load.i64 notrap aligned readonly can_move v5+88
+;;                                     v21 = load.i64 notrap aligned readonly can_move v5+88
+;;                                     v20 = load.i64 notrap aligned readonly can_move v5+104
 ;;                                     v19 = iconst.i32 23
 ;;                                     call_indirect sig1, v21(v20, v5, v19)  ; v19 = 23
 ;;                                     trap user11
 ;;
 ;;                                 block5:
-;;                                     v22 = load.i64 notrap aligned readonly can_move v5+96
+;;                                     v22 = load.i64 notrap aligned readonly can_move v5+112
 ;;                                     v23 = load.i32 notrap aligned table v22
 ;;                                     v24 = iconst.i32 -2
 ;;                                     v25 = band v23, v24  ; v24 = -2

--- a/tests/disas/component-model/direct-adapter-calls-x64.wat
+++ b/tests/disas/component-model/direct-adapter-calls-x64.wat
@@ -72,7 +72,7 @@
 ;;       cmpq    %rsp, %r10
 ;;       ja      0x4f
 ;;   39: movq    %rdi, %rsi
-;;       movq    0x40(%rdi), %rdi
+;;       movq    0x48(%rdi), %rdi
 ;;       movl    $0x4d2, %edx
 ;;       callq   0x60
 ;;       movq    %rbp, %rsp
@@ -87,14 +87,14 @@
 ;;       movq    0x18(%r10), %r10
 ;;       addq    $0x20, %r10
 ;;       cmpq    %rsp, %r10
-;;       ja      0xe4
+;;       ja      0xe7
 ;;   79: subq    $0x10, %rsp
 ;;       movq    %rbx, (%rsp)
-;;       movq    0x78(%rdi), %rbx
+;;       movq    0x88(%rdi), %rbx
 ;;       movl    (%rbx), %eax
 ;;       testl   $1, %eax
-;;       je      0xd0
-;;   92: movq    0x60(%rdi), %rax
+;;       je      0xd3
+;;   95: movq    0x70(%rdi), %rax
 ;;       movl    (%rax), %ecx
 ;;       movq    %rcx, %rsi
 ;;       andl    $0xfffffffe, %esi
@@ -102,7 +102,7 @@
 ;;       orl     $1, %ecx
 ;;       movl    %ecx, (%rax)
 ;;       movq    %rdi, %rax
-;;       movq    0x40(%rax), %rdi
+;;       movq    0x48(%rax), %rdi
 ;;       movq    %rax, %rsi
 ;;       callq   0
 ;;       movl    (%rbx), %ecx
@@ -116,10 +116,10 @@
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   d0: movq    %rdi, %rsi
-;;   d3: movq    0x48(%rsi), %rax
-;;   d7: movq    0x58(%rsi), %rdi
-;;   db: movl    $0x17, %edx
-;;   e0: callq   *%rax
-;;   e2: ud2
-;;   e4: ud2
+;;   d3: movq    %rdi, %rsi
+;;   d6: movq    0x58(%rsi), %rax
+;;   da: movq    0x68(%rsi), %rdi
+;;   de: movl    $0x17, %edx
+;;   e3: callq   *%rax
+;;   e5: ud2
+;;   e7: ud2

--- a/tests/disas/component-model/direct-adapter-calls.wat
+++ b/tests/disas/component-model/direct-adapter-calls.wat
@@ -82,7 +82,7 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @00ee                               v5 = load.i64 notrap aligned readonly can_move v0+64
+;; @00ee                               v5 = load.i64 notrap aligned readonly can_move v0+72
 ;; @00eb                               v3 = iconst.i32 1234
 ;; @00ee                               v6 = call fn0(v5, v0, v3)  ; v3 = 1234
 ;; @00f0                               jump block1
@@ -96,15 +96,15 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+120
-;;     gv5 = load.i64 notrap aligned readonly can_move gv3+96
+;;     gv4 = load.i64 notrap aligned readonly can_move gv3+136
+;;     gv5 = load.i64 notrap aligned readonly can_move gv3+112
 ;;     sig0 = (i64 vmctx, i64, i32) tail
 ;;     sig1 = (i64 vmctx, i64, i32) -> i32 tail
 ;;     fn0 = colocated u0:0 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @0077                               v5 = load.i64 notrap aligned readonly can_move v0+120
+;; @0077                               v5 = load.i64 notrap aligned readonly can_move v0+136
 ;; @0077                               v6 = load.i32 notrap aligned table v5
 ;; @0079                               v7 = iconst.i32 1
 ;; @007b                               v8 = band v6, v7  ; v7 = 1
@@ -114,14 +114,14 @@
 ;; @007d                               brif v10, block2, block3
 ;;
 ;;                                 block2:
-;; @0081                               v14 = load.i64 notrap aligned readonly can_move v0+72
-;; @0081                               v13 = load.i64 notrap aligned readonly can_move v0+88
+;; @0081                               v14 = load.i64 notrap aligned readonly can_move v0+88
+;; @0081                               v13 = load.i64 notrap aligned readonly can_move v0+104
 ;; @007f                               v11 = iconst.i32 23
 ;; @0081                               call_indirect sig0, v14(v13, v0, v11)  ; v11 = 23
 ;; @0083                               trap user11
 ;;
 ;;                                 block3:
-;; @0085                               v15 = load.i64 notrap aligned readonly can_move v0+96
+;; @0085                               v15 = load.i64 notrap aligned readonly can_move v0+112
 ;; @0085                               v16 = load.i32 notrap aligned table v15
 ;; @0087                               v17 = iconst.i32 -2
 ;; @0089                               v18 = band v16, v17  ; v17 = -2
@@ -129,7 +129,7 @@
 ;;                                     v52 = iconst.i32 1
 ;;                                     v53 = bor v16, v52  ; v52 = 1
 ;; @0093                               store notrap aligned table v53, v15
-;; @0095                               v26 = load.i64 notrap aligned readonly can_move v0+64
+;; @0095                               v26 = load.i64 notrap aligned readonly can_move v0+72
 ;; @0095                               v27 = call fn0(v26, v0, v2)
 ;; @0099                               v29 = load.i32 notrap aligned table v5
 ;; @009d                               v31 = band v29, v17  ; v17 = -2

--- a/tests/disas/component-model/exported-module-makes-adapters-indirect.wat
+++ b/tests/disas/component-model/exported-module-makes-adapters-indirect.wat
@@ -67,8 +67,8 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @00ee                               v6 = load.i64 notrap aligned readonly can_move v0+48
-;; @00ee                               v5 = load.i64 notrap aligned readonly can_move v0+64
+;; @00ee                               v6 = load.i64 notrap aligned readonly can_move v0+56
+;; @00ee                               v5 = load.i64 notrap aligned readonly can_move v0+72
 ;; @00eb                               v3 = iconst.i32 1234
 ;; @00ee                               v7 = call_indirect sig0, v6(v5, v0, v3)  ; v3 = 1234
 ;; @00f0                               jump block1

--- a/tests/disas/component-model/inlining-and-unsafe-intrinsics.wat
+++ b/tests/disas/component-model/inlining-and-unsafe-intrinsics.wat
@@ -65,7 +65,7 @@
 ;; @0155                               jump block4
 ;;
 ;;                                 block4:
-;; @0153                               v4 = load.i64 notrap aligned readonly can_move v0+64
+;; @0153                               v4 = load.i64 notrap aligned readonly can_move v0+72
 ;;                                     v17 = load.i64 notrap aligned readonly can_move vmctx v4+16
 ;;                                     v18 = load.i64 notrap aligned readonly can_move vmctx v17+104
 ;;                                     v20 = load.i8 notrap aligned v18

--- a/tests/disas/component-model/inlining-bug.wat
+++ b/tests/disas/component-model/inlining-bug.wat
@@ -61,8 +61,8 @@
 ;;                                     jump block4
 ;;
 ;;                                 block4:
-;; @00d4                               v4 = load.i64 notrap aligned readonly can_move v0+64
-;;                                     v10 = load.i64 notrap aligned readonly can_move v4+88
+;; @00d4                               v4 = load.i64 notrap aligned readonly can_move v0+72
+;;                                     v10 = load.i64 notrap aligned readonly can_move v4+104
 ;;                                     call fn2(v10, v10)
 ;;                                     jump block5
 ;;

--- a/tests/disas/component-model/issue-11458.wat
+++ b/tests/disas/component-model/issue-11458.wat
@@ -37,7 +37,7 @@
 ;; @006f                               jump block2
 ;;
 ;;                                 block2:
-;; @006f                               v6 = load.i64 notrap aligned readonly can_move v0+64
+;; @006f                               v6 = load.i64 notrap aligned readonly can_move v0+72
 ;;                                     v10 = iconst.i32 1
 ;;                                     v12 = call fn1(v6, v6, v10)  ; v10 = 1
 ;;                                     jump block4

--- a/tests/disas/component-model/multiple-instantiations-makes-adapters-indirect.wat
+++ b/tests/disas/component-model/multiple-instantiations-makes-adapters-indirect.wat
@@ -73,8 +73,8 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @00ee                               v6 = load.i64 notrap aligned readonly can_move v0+48
-;; @00ee                               v5 = load.i64 notrap aligned readonly can_move v0+64
+;; @00ee                               v6 = load.i64 notrap aligned readonly can_move v0+56
+;; @00ee                               v5 = load.i64 notrap aligned readonly can_move v0+72
 ;; @00eb                               v3 = iconst.i32 1234
 ;; @00ee                               v7 = call_indirect sig0, v6(v5, v0, v3)  ; v3 = 1234
 ;; @00f0                               jump block1

--- a/tests/disas/debug-exceptions.wat
+++ b/tests/disas/debug-exceptions.wat
@@ -115,8 +115,8 @@
 ;;       ├─╼ debug frame state (after previous inst): func key DefinedWasmFunction(StaticModuleIndex(0), DefinedFuncIndex(0)), wasm PC 0x48, slot at FP-0xc0, locals , stack I32 @ slot+0x8
 ;;       ╰─╼ breakpoint patch: wasm PC 0x48, patch bytes [234, 0, 0, 148]
 ;;       ldur    x1, [sp, #0x10]
-;;       ldr     x0, [x1, #0x30]
-;;       ldr     x2, [x1, #0x40]
+;;       ldr     x0, [x1, #0x38]
+;;       ldr     x2, [x1, #0x48]
 ;;       ldur    x3, [sp, #0x10]
 ;;       blr     x0
 ;;       ╰─╼ debug frame state (after previous inst): func key DefinedWasmFunction(StaticModuleIndex(0), DefinedFuncIndex(0)), wasm PC 0x4a, slot at FP-0xc0, locals , stack I32 @ slot+0x8

--- a/tests/disas/gc/drc/br-on-cast-fail.wat
+++ b/tests/disas/gc/drc/br-on-cast-fail.wat
@@ -70,14 +70,14 @@
 ;; @002e                               brif v24, block8, block2
 ;;
 ;;                                 block8:
-;; @0034                               v27 = load.i64 notrap aligned readonly can_move v0+48
-;; @0034                               v26 = load.i64 notrap aligned readonly can_move v0+64
+;; @0034                               v27 = load.i64 notrap aligned readonly can_move v0+56
+;; @0034                               v26 = load.i64 notrap aligned readonly can_move v0+72
 ;; @0034                               call_indirect sig1, v27(v26, v0)
 ;; @0036                               return
 ;;
 ;;                                 block2:
-;; @0038                               v30 = load.i64 notrap aligned readonly can_move v0+72
-;; @0038                               v29 = load.i64 notrap aligned readonly can_move v0+88
+;; @0038                               v30 = load.i64 notrap aligned readonly can_move v0+88
+;; @0038                               v29 = load.i64 notrap aligned readonly can_move v0+104
 ;; @0038                               call_indirect sig1, v30(v29, v0)
 ;; @003a                               return
 ;; }

--- a/tests/disas/gc/drc/br-on-cast.wat
+++ b/tests/disas/gc/drc/br-on-cast.wat
@@ -70,14 +70,14 @@
 ;; @002f                               brif v24, block2, block8
 ;;
 ;;                                 block8:
-;; @0035                               v27 = load.i64 notrap aligned readonly can_move v0+48
-;; @0035                               v26 = load.i64 notrap aligned readonly can_move v0+64
+;; @0035                               v27 = load.i64 notrap aligned readonly can_move v0+56
+;; @0035                               v26 = load.i64 notrap aligned readonly can_move v0+72
 ;; @0035                               call_indirect sig1, v27(v26, v0)
 ;; @0037                               return
 ;;
 ;;                                 block2:
-;; @0039                               v30 = load.i64 notrap aligned readonly can_move v0+72
-;; @0039                               v29 = load.i64 notrap aligned readonly can_move v0+88
+;; @0039                               v30 = load.i64 notrap aligned readonly can_move v0+88
+;; @0039                               v29 = load.i64 notrap aligned readonly can_move v0+104
 ;; @0039                               call_indirect sig1, v30(v29, v0)
 ;; @003b                               return
 ;; }

--- a/tests/disas/gc/drc/call-indirect-and-subtyping.wat
+++ b/tests/disas/gc/drc/call-indirect-and-subtyping.wat
@@ -21,7 +21,7 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+96
+;;     gv4 = load.i64 notrap aligned readonly can_move gv3+112
 ;;     sig0 = (i64 vmctx, i64) tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
 ;;     sig2 = (i64 vmctx, i32, i32) -> i32 tail
@@ -33,7 +33,7 @@
 ;; @005c                               v3 = iconst.i32 2
 ;; @005c                               v4 = icmp uge v2, v3  ; v3 = 2
 ;; @005c                               v9 = iconst.i64 0
-;; @005c                               v6 = load.i64 notrap aligned readonly can_move v0+96
+;; @005c                               v6 = load.i64 notrap aligned readonly can_move v0+112
 ;; @005c                               v5 = uextend.i64 v2
 ;;                                     v30 = iconst.i64 3
 ;; @005c                               v7 = ishl v5, v30  ; v30 = 3

--- a/tests/disas/gc/issue-11753.wat
+++ b/tests/disas/gc/issue-11753.wat
@@ -51,8 +51,8 @@
 ;;       movl    %eax, %eax
 ;;       movl    $0x2a, 0x18(%rcx, %rax)
 ;;       movq    %rcx, 0x10(%rsp)
-;;       movq    0x30(%rbx), %rax
-;;       movq    0x40(%rbx), %rdi
+;;       movq    0x38(%rbx), %rax
+;;       movq    0x48(%rbx), %rdi
 ;;       movq    %rbx, %rsi
 ;;       movq    %rbx, 8(%rsp)
 ;;       callq   *%rax

--- a/tests/disas/gc/null/br-on-cast-fail.wat
+++ b/tests/disas/gc/null/br-on-cast-fail.wat
@@ -70,14 +70,14 @@
 ;; @002e                               brif v24, block8, block2
 ;;
 ;;                                 block8:
-;; @0034                               v27 = load.i64 notrap aligned readonly can_move v0+48
-;; @0034                               v26 = load.i64 notrap aligned readonly can_move v0+64
+;; @0034                               v27 = load.i64 notrap aligned readonly can_move v0+56
+;; @0034                               v26 = load.i64 notrap aligned readonly can_move v0+72
 ;; @0034                               call_indirect sig1, v27(v26, v0)
 ;; @0036                               return
 ;;
 ;;                                 block2:
-;; @0038                               v30 = load.i64 notrap aligned readonly can_move v0+72
-;; @0038                               v29 = load.i64 notrap aligned readonly can_move v0+88
+;; @0038                               v30 = load.i64 notrap aligned readonly can_move v0+88
+;; @0038                               v29 = load.i64 notrap aligned readonly can_move v0+104
 ;; @0038                               call_indirect sig1, v30(v29, v0)
 ;; @003a                               return
 ;; }

--- a/tests/disas/gc/null/br-on-cast.wat
+++ b/tests/disas/gc/null/br-on-cast.wat
@@ -70,14 +70,14 @@
 ;; @002f                               brif v24, block2, block8
 ;;
 ;;                                 block8:
-;; @0035                               v27 = load.i64 notrap aligned readonly can_move v0+48
-;; @0035                               v26 = load.i64 notrap aligned readonly can_move v0+64
+;; @0035                               v27 = load.i64 notrap aligned readonly can_move v0+56
+;; @0035                               v26 = load.i64 notrap aligned readonly can_move v0+72
 ;; @0035                               call_indirect sig1, v27(v26, v0)
 ;; @0037                               return
 ;;
 ;;                                 block2:
-;; @0039                               v30 = load.i64 notrap aligned readonly can_move v0+72
-;; @0039                               v29 = load.i64 notrap aligned readonly can_move v0+88
+;; @0039                               v30 = load.i64 notrap aligned readonly can_move v0+88
+;; @0039                               v29 = load.i64 notrap aligned readonly can_move v0+104
 ;; @0039                               call_indirect sig1, v30(v29, v0)
 ;; @003b                               return
 ;; }

--- a/tests/disas/gc/null/call-indirect-and-subtyping.wat
+++ b/tests/disas/gc/null/call-indirect-and-subtyping.wat
@@ -21,7 +21,7 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     gv4 = load.i64 notrap aligned readonly can_move gv3+96
+;;     gv4 = load.i64 notrap aligned readonly can_move gv3+112
 ;;     sig0 = (i64 vmctx, i64) tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
 ;;     sig2 = (i64 vmctx, i32, i32) -> i32 tail
@@ -33,7 +33,7 @@
 ;; @005c                               v3 = iconst.i32 2
 ;; @005c                               v4 = icmp uge v2, v3  ; v3 = 2
 ;; @005c                               v9 = iconst.i64 0
-;; @005c                               v6 = load.i64 notrap aligned readonly can_move v0+96
+;; @005c                               v6 = load.i64 notrap aligned readonly can_move v0+112
 ;; @005c                               v5 = uextend.i64 v2
 ;;                                     v30 = iconst.i64 3
 ;; @005c                               v7 = ishl v5, v30  ; v30 = 3

--- a/tests/disas/gc/typed-select-and-stack-maps.wat
+++ b/tests/disas/gc/typed-select-and-stack-maps.wat
@@ -53,12 +53,12 @@
 ;; @0049                               v5 = select v4, v2, v3
 ;;                                     v14 = stack_addr.i64 ss0
 ;;                                     store notrap v5, v14
-;; @004c                               v8 = load.i64 notrap aligned readonly can_move v0+72
-;; @004c                               v7 = load.i64 notrap aligned readonly can_move v0+88
+;; @004c                               v8 = load.i64 notrap aligned readonly can_move v0+88
+;; @004c                               v7 = load.i64 notrap aligned readonly can_move v0+104
 ;; @004c                               call_indirect sig0, v8(v7, v0), stack_map=[i32 @ ss0+0]
 ;;                                     v12 = load.i32 notrap v14
-;; @004e                               v11 = load.i64 notrap aligned readonly can_move v0+48
-;; @004e                               v10 = load.i64 notrap aligned readonly can_move v0+64
+;; @004e                               v11 = load.i64 notrap aligned readonly can_move v0+56
+;; @004e                               v10 = load.i64 notrap aligned readonly can_move v0+72
 ;; @004e                               call_indirect sig1, v11(v10, v0, v12)
 ;; @0050                               jump block1
 ;;
@@ -76,11 +76,11 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
-;; @005c                               v8 = load.i64 notrap aligned readonly can_move v0+72
-;; @005c                               v7 = load.i64 notrap aligned readonly can_move v0+88
+;; @005c                               v8 = load.i64 notrap aligned readonly can_move v0+88
+;; @005c                               v7 = load.i64 notrap aligned readonly can_move v0+104
 ;; @005c                               call_indirect sig0, v8(v7, v0)
-;; @005e                               v11 = load.i64 notrap aligned readonly can_move v0+48
-;; @005e                               v10 = load.i64 notrap aligned readonly can_move v0+64
+;; @005e                               v11 = load.i64 notrap aligned readonly can_move v0+56
+;; @005e                               v10 = load.i64 notrap aligned readonly can_move v0+72
 ;; @0059                               v5 = select v4, v2, v3
 ;; @005e                               call_indirect sig1, v11(v10, v0, v5)
 ;; @0060                               jump block1

--- a/tests/disas/memory-min-max-same.wat
+++ b/tests/disas/memory-min-max-same.wat
@@ -45,8 +45,8 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @0028                               v3 = iconst.i32 0
-;; @0030                               v7 = load.i64 notrap aligned readonly can_move v0+72
-;; @0030                               v6 = load.i64 notrap aligned readonly can_move v0+88
+;; @0030                               v7 = load.i64 notrap aligned readonly can_move v0+80
+;; @0030                               v6 = load.i64 notrap aligned readonly can_move v0+96
 ;; @0039                               v13 = iconst.i64 0x0001_0000
 ;; @0039                               v17 = iconst.i64 0
 ;; @0039                               v15 = load.i64 notrap aligned readonly can_move v0+56

--- a/tests/disas/pulley/call.wat
+++ b/tests/disas/pulley/call.wat
@@ -7,9 +7,9 @@
 )
 ;; wasm[0]::function[1]:
 ;;       push_frame
-;;       xload32le_o32 x3, x0, 24
+;;       xload32le_o32 x3, x0, 28
 ;;       xmov x6, x0
-;;       xload32le_o32 x0, x6, 32
+;;       xload32le_o32 x0, x6, 36
 ;;       xmov x1, x6
 ;;       call_indirect x3
 ;;       pop_frame

--- a/tests/disas/winch/x64/fuel/call.wat
+++ b/tests/disas/winch/x64/fuel/call.wat
@@ -34,8 +34,8 @@
 ;;       movq    (%rax), %r11
 ;;       addq    $1, %r11
 ;;       movq    %r11, (%rax)
-;;       movq    0x40(%r14), %rcx
-;;       movq    0x30(%r14), %rax
+;;       movq    0x48(%r14), %rcx
+;;       movq    0x38(%r14), %rax
 ;;       movq    %rcx, %rdi
 ;;       movq    %r14, %rsi
 ;;       callq   *%rax

--- a/tests/disas/winch/x64/table/init_copy_drop.wat
+++ b/tests/disas/winch/x64/table/init_copy_drop.wat
@@ -224,12 +224,12 @@
 ;;       movl    (%rsp), %ecx
 ;;       addq    $4, %rsp
 ;;       movq    %r14, %rdx
-;;       movq    0xb0(%rdx), %rbx
+;;       movq    0xd8(%rdx), %rbx
 ;;       cmpq    %rbx, %rcx
 ;;       jae     0x3c8
 ;;  321: movq    %rcx, %r11
 ;;       imulq   $8, %r11, %r11
-;;       movq    0xa8(%rdx), %rdx
+;;       movq    0xd0(%rdx), %rdx
 ;;       movq    %rdx, %rsi
 ;;       addq    %r11, %rdx
 ;;       cmpq    %rbx, %rcx

--- a/tests/misc_testsuite/gc/issue-13095.wast
+++ b/tests/misc_testsuite/gc/issue-13095.wast
@@ -1,0 +1,33 @@
+;;! gc = true
+;;! bulk_memory = true
+
+(module $A
+  (type $super (sub (func (param i32) (result i32))))
+  (type $sub (sub $super (func (param i32) (result i32))))
+  (func (export "f") (type $sub) (param i32) (result i32) (local.get 0))
+)
+(register "A" $A)
+
+(module $B
+  (type $super (sub (func (param i32) (result i32))))
+  (type $sub (sub $super (func (param i32) (result i32))))
+
+  ;; Valid covariant import: $sub <: $super
+  (import "A" "f" (func $f (type $super)))
+
+  (table 10 funcref)
+  (elem declare func $f)
+
+  (func (export "test_super") (result i32)
+    (table.set (i32.const 0) (ref.func $f))
+    (i32.const 99) (i32.const 0)
+    (call_indirect (type $super)))
+
+  (func (export "test_sub") (result i32)
+    (table.set (i32.const 0) (ref.func $f))
+    (i32.const 99) (i32.const 0)
+    (call_indirect (type $sub)))
+)
+
+(assert_return (invoke "test_super") (i32.const 99))
+(assert_return (invoke "test_sub")   (i32.const 99))


### PR DESCRIPTION
This commit adds a type index to `VMFunctionImport`, basically making it a refinement of `VMFuncRef` that requires the `wasm_call` field be non-null.

Fixes #13095

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
