### PR TITLE
Fix DRC leak when passing same object to Wasm multiple times

### DIFF
--- a/crates/wasmtime/src/runtime/vm/gc/enabled/drc.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/enabled/drc.rs
@@ -930,12 +930,21 @@ unsafe impl GcHeap for DrcHeap {
         let next = (*self.over_approximated_stack_roots)
             .as_ref()
             .map(|r| r.unchecked_copy());
+
         let header = self.index_mut(drc_ref(&gc_ref));
         if header.is_in_over_approximated_stack_roots() {
-            // Already in the over-approximated-stack-roots list, nothing more
-            // to do here.
+            // Already in the over-approximated-stack-roots list. Decrement the
+            // object's ref count because the OASR list can't hold multiple
+            // copies of the same GC reference.
+            let ref_count_is_zero = header.dec_ref();
+            debug_assert!(
+                !ref_count_is_zero,
+                "should not have reached refcount == 0 because the OASR list \
+                 is holding a reference"
+            );
             return;
         }
+
         // Push this object onto the head of the over-approximated-stack-roots
         // list using a single index_mut call.
         header.set_in_over_approximated_stack_roots_bit(true);

--- a/tests/all/gc.rs
+++ b/tests/all/gc.rs
@@ -1,5 +1,6 @@
 use super::ref_types_module;
 use std::sync::Arc;
+use std::sync::atomic::Ordering;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering::SeqCst};
 use wasmtime::*;
 
@@ -1892,6 +1893,39 @@ fn gc_heap_guard_pages_but_no_memory_guard_pages() -> Result<()> {
     // Also exercise the memory access to make sure it works with bounds checks.
     let result = load.call(&mut store, (0,))?;
     assert_eq!(result, 0);
+
+    Ok(())
+}
+
+#[test]
+fn issue_13037_drc_leak_passing_objects_already_in_over_approx_stack_roots_list() -> Result<()> {
+    let _ = env_logger::try_init();
+
+    let mut config = Config::new();
+    config.collector(Collector::DeferredReferenceCounting);
+    let engine = Engine::new(&config)?;
+    let mut store = Store::new(&engine, ());
+
+    let module = Module::new(
+        &engine,
+        r#"(module (func (export "nop") (param externref)))"#,
+    )?;
+
+    let instance = Instance::new(&mut store, &module, &[])?;
+    let nop = instance.get_typed_func::<Option<Rooted<ExternRef>>, ()>(&mut store, "nop")?;
+
+    let dropped = Arc::new(AtomicBool::new(false));
+    {
+        let mut scope = RootScope::new(&mut store);
+        let ext = ExternRef::new(&mut scope, SetFlagOnDrop(dropped.clone()))?;
+
+        nop.call(&mut scope, Some(ext))?;
+        nop.call(&mut scope, Some(ext))?;
+    }
+
+    store.gc(None)?;
+
+    assert!(dropped.load(Ordering::SeqCst));
 
     Ok(())
 }

--- a/tests/all/gc.rs
+++ b/tests/all/gc.rs
@@ -1898,6 +1898,7 @@ fn gc_heap_guard_pages_but_no_memory_guard_pages() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn issue_13037_drc_leak_passing_objects_already_in_over_approx_stack_roots_list() -> Result<()> {
     let _ = env_logger::try_init();
 


### PR DESCRIPTION
The `expose_gc_ref_to_wasm` function takes ownership of a GC reference in the process of exposing it to raw Wasm code. For the DRC collector, this inserts the GC ref into the over-approximated-stack-roots list, as the Wasm stack logically holds a reference to the object. That reference is cleaned up when we scan the stack during GC and consolidate between what is actually still in use on the Wasm stack vs what is only in the OASR list.

However, the OASR list cannot contain duplicates (it is an intrusive linked list in the DRC object header) so if the object was already in the list, then we would not insert it into the list again. But this then causes leaks because `expose_gc_ref_to_wasm` took ownership of the GC reference because the OASR list clean up during GC only decrefs a single time.

The solution is to decref in `expose_gc_ref_to_wasm` when the object is already in the OASR list.

Fixes #13037

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
