### PR TITLE
wizer: improve message on debug assertion

### DIFF
--- a/crates/wizer/src/component.rs
+++ b/crates/wizer/src/component.rs
@@ -26,7 +26,7 @@ impl Wizer {
 
         let mut cx = parse::parse(wasm)?;
         let instrumented_wasm = instrument::instrument(&mut cx)?;
-        self.debug_assert_valid_wasm(&instrumented_wasm);
+        self.debug_assert_valid_wasm(&instrumented_wasm, "instrumented component");
 
         Ok((cx, instrumented_wasm))
     }
@@ -43,7 +43,7 @@ impl Wizer {
 
         let snapshot = snapshot::snapshot(&cx, instance).await;
         let rewritten_wasm = self.rewrite_component(&mut cx, &snapshot);
-        self.debug_assert_valid_wasm(&rewritten_wasm);
+        self.debug_assert_valid_wasm(&rewritten_wasm, "rewritten component");
 
         Ok(rewritten_wasm)
     }

--- a/crates/wizer/src/lib.rs
+++ b/crates/wizer/src/lib.rs
@@ -215,7 +215,7 @@ impl Wizer {
         }
 
         let instrumented_wasm = instrument::instrument(&mut cx);
-        self.debug_assert_valid_wasm(&instrumented_wasm);
+        self.debug_assert_valid_wasm(&instrumented_wasm, "instrumented module");
 
         Ok((cx, instrumented_wasm))
     }
@@ -237,22 +237,29 @@ impl Wizer {
         let snapshot = snapshot::snapshot(&cx, instance).await;
         let rewritten_wasm = self.rewrite(&mut cx, &snapshot, &renames, true);
 
-        self.debug_assert_valid_wasm(&rewritten_wasm);
+        self.debug_assert_valid_wasm(&rewritten_wasm, "rewritten module");
 
         Ok(rewritten_wasm)
     }
 
-    fn debug_assert_valid_wasm(&self, wasm: &[u8]) {
+    fn debug_assert_valid_wasm(&self, wasm: &[u8], context: &str) {
         if !cfg!(debug_assertions) {
             return;
         }
         if let Err(error) = self.wasm_validate(&wasm) {
             #[cfg(feature = "wasmprinter")]
             let wat = wasmprinter::print_bytes(&wasm)
-                .unwrap_or_else(|e| format!("Disassembling to WAT failed: {}", e));
+                .unwrap_or_else(|e| format!("Disassembling to WAT failed: {e}"));
             #[cfg(not(feature = "wasmprinter"))]
             let wat = "`wasmprinter` cargo feature is not enabled".to_string();
-            panic!("instrumented Wasm is not valid: {error:?}\n\nWAT:\n{wat}");
+
+            let wat = if wat.len() > 16 * 1024 {
+                std::fs::write("invalid.wat", wat).expect("writing to invalid.wat");
+                "written to invalid.wat"
+            } else {
+                &wat
+            };
+            panic!("{context} is not valid wasm: {error:?}\n\nWAT:\n{wat}");
         }
     }
 

--- a/crates/wizer/tests/all/component.rs
+++ b/crates/wizer/tests/all/component.rs
@@ -691,7 +691,7 @@ async fn rust_regex() -> Result<()> {
     // `keep_init_func(true)` is not set.
     let mut store = store()?;
     let wizened_component = Wizer::new()
-        .keep_init_func(true)
+        .keep_init_func(false)
         .run_component(&mut store, component, instantiate)
         .await
         .context("Wizer::run_component")?;

--- a/crates/wizer/tests/all/component.rs
+++ b/crates/wizer/tests/all/component.rs
@@ -691,7 +691,7 @@ async fn rust_regex() -> Result<()> {
     // `keep_init_func(true)` is not set.
     let mut store = store()?;
     let wizened_component = Wizer::new()
-        .keep_init_func(false)
+        .keep_init_func(true)
         .run_component(&mut store, component, instantiate)
         .await
         .context("Wizer::run_component")?;


### PR DESCRIPTION
Improve the panic message that occurs when encountering a wizer bug such as #13168.

* Instead of printing the wat of a very large component to stderr, write it to a file if above an arbitrary threshold (16k).
* Include context about the assertion in the panic message, rather than relying on the backtrace.