### PR TITLE
Change how ninja is installed on github actions

### DIFF
--- a/.github/actions/install-ninja/action.yml
+++ b/.github/actions/install-ninja/action.yml
@@ -13,6 +13,7 @@ runs:
       if: runner.os == 'Windows'
       shell: bash
     - name: Install ninja (Linux)
-      run: sudo apt-get update && sudo apt-get install -y ninja-build
       if: runner.os == 'Linux'
-      shell: bash
+      uses: ./.github/actions/apt-get-install
+      with:
+        packages: ninja-build


### PR DESCRIPTION
Use the helper `apt-get install` action which handles adjusting mirror priorities the same way all other apt-get packages are installed on CI.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
