### PR TITLE
Always use mmap in cranelift-jit

### DIFF
--- a/cranelift/filetests/Cargo.toml
+++ b/cranelift/filetests/Cargo.toml
@@ -19,7 +19,7 @@ cranelift-frontend = { workspace = true }
 cranelift-interpreter = { workspace = true }
 cranelift-native = { workspace = true }
 cranelift-reader = { workspace = true }
-cranelift-jit = { workspace = true, features = ["selinux-fix", "wasmtime-unwinder"] }
+cranelift-jit = { workspace = true, features = ["wasmtime-unwinder"] }
 cranelift-module = { workspace = true }
 cranelift-control = { workspace = true }
 wasmtime-unwinder = { workspace = true, features = ["cranelift"] }

--- a/cranelift/jit/Cargo.toml
+++ b/cranelift/jit/Cargo.toml
@@ -24,7 +24,7 @@ anyhow = { workspace = true }
 region = "3.0.2"
 libc = { workspace = true }
 target-lexicon = { workspace = true }
-memmap2 = { version = "0.2.1", optional = true }
+memmap2 = "0.2.1"
 log = { workspace = true }
 wasmtime-jit-icache-coherence = { workspace = true }
 
@@ -37,7 +37,6 @@ features = [
 ]
 
 [features]
-selinux-fix = ['memmap2']
 default = []
 
 wasmtime-unwinder = ["dep:wasmtime-unwinder"]

--- a/cranelift/jit/src/memory/system.rs
+++ b/cranelift/jit/src/memory/system.rs
@@ -1,10 +1,8 @@
 use cranelift_module::{ModuleError, ModuleResult};
 
-#[cfg(all(not(target_os = "windows"), feature = "selinux-fix"))]
+#[cfg(not(target_os = "windows"))]
 use memmap2::MmapMut;
 
-#[cfg(not(any(feature = "selinux-fix", windows)))]
-use std::alloc;
 use std::io;
 use std::mem;
 use std::ptr;
@@ -13,7 +11,7 @@ use super::{BranchProtection, JITMemoryKind, JITMemoryProvider};
 
 /// A simple struct consisting of a pointer and length.
 struct PtrLen {
-    #[cfg(all(not(target_os = "windows"), feature = "selinux-fix"))]
+    #[cfg(not(target_os = "windows"))]
     map: Option<MmapMut>,
 
     ptr: *mut u8,
@@ -24,7 +22,7 @@ impl PtrLen {
     /// Create a new empty `PtrLen`.
     fn new() -> Self {
         Self {
-            #[cfg(all(not(target_os = "windows"), feature = "selinux-fix"))]
+            #[cfg(not(target_os = "windows"))]
             map: None,
 
             ptr: ptr::null_mut(),
@@ -34,7 +32,7 @@ impl PtrLen {
 
     /// Create a new `PtrLen` pointing to at least `size` bytes of memory,
     /// suitably sized and aligned for memory protection.
-    #[cfg(all(not(target_os = "windows"), feature = "selinux-fix"))]
+    #[cfg(not(target_os = "windows"))]
     fn with_size(size: usize) -> io::Result<Self> {
         let alloc_size = region::page::ceil(size as *const ()) as usize;
         MmapMut::map_anon(alloc_size).map(|mut mmap| {
@@ -46,25 +44,6 @@ impl PtrLen {
                 len: alloc_size,
             }
         })
-    }
-
-    #[cfg(all(not(target_os = "windows"), not(feature = "selinux-fix")))]
-    fn with_size(size: usize) -> io::Result<Self> {
-        assert_ne!(size, 0);
-        let page_size = region::page::size();
-        let alloc_size = region::page::ceil(size as *const ()) as usize;
-        let layout = alloc::Layout::from_size_align(alloc_size, page_size).unwrap();
-        // Safety: We assert that the size is non-zero above.
-        let ptr = unsafe { alloc::alloc(layout) };
-
-        if !ptr.is_null() {
-            Ok(Self {
-                ptr,
-                len: alloc_size,
-            })
-        } else {
-            Err(io::Error::from(io::ErrorKind::OutOfMemory))
-        }
     }
 
     #[cfg(target_os = "windows")]
@@ -89,22 +68,6 @@ impl PtrLen {
             })
         } else {
             Err(io::Error::last_os_error())
-        }
-    }
-}
-
-// `MMapMut` from `cfg(feature = "selinux-fix")` already deallocates properly.
-#[cfg(all(not(target_os = "windows"), not(feature = "selinux-fix")))]
-impl Drop for PtrLen {
-    fn drop(&mut self) {
-        if !self.ptr.is_null() {
-            let page_size = region::page::size();
-            let layout = alloc::Layout::from_size_align(self.len, page_size).unwrap();
-            unsafe {
-                region::protect(self.ptr, self.len, region::Protection::READ_WRITE)
-                    .expect("unable to unprotect memory");
-                alloc::dealloc(self.ptr, layout)
-            }
         }
     }
 }
@@ -203,10 +166,10 @@ impl Memory {
     fn non_protected_allocations_iter(&self) -> impl Iterator<Item = &PtrLen> {
         let iter = self.allocations[self.already_protected..].iter();
 
-        #[cfg(all(not(target_os = "windows"), feature = "selinux-fix"))]
+        #[cfg(not(target_os = "windows"))]
         return iter.filter(|&PtrLen { map, len, .. }| *len != 0 && map.is_some());
 
-        #[cfg(any(target_os = "windows", not(feature = "selinux-fix")))]
+        #[cfg(target_os = "windows")]
         return iter.filter(|&PtrLen { len, .. }| *len != 0);
     }
 

--- a/cranelift/jit/src/memory/system.rs
+++ b/cranelift/jit/src/memory/system.rs
@@ -1,19 +1,15 @@
-use cranelift_module::{ModuleError, ModuleResult};
-
-#[cfg(not(target_os = "windows"))]
-use memmap2::MmapMut;
-
 use std::io;
 use std::mem;
 use std::ptr;
+
+use cranelift_module::{ModuleError, ModuleResult};
+use memmap2::MmapMut;
 
 use super::{BranchProtection, JITMemoryKind, JITMemoryProvider};
 
 /// A simple struct consisting of a pointer and length.
 struct PtrLen {
-    #[cfg(not(target_os = "windows"))]
     map: Option<MmapMut>,
-
     ptr: *mut u8,
     len: usize,
 }
@@ -22,9 +18,7 @@ impl PtrLen {
     /// Create a new empty `PtrLen`.
     fn new() -> Self {
         Self {
-            #[cfg(not(target_os = "windows"))]
             map: None,
-
             ptr: ptr::null_mut(),
             len: 0,
         }
@@ -32,7 +26,6 @@ impl PtrLen {
 
     /// Create a new `PtrLen` pointing to at least `size` bytes of memory,
     /// suitably sized and aligned for memory protection.
-    #[cfg(not(target_os = "windows"))]
     fn with_size(size: usize) -> io::Result<Self> {
         let alloc_size = region::page::ceil(size as *const ()) as usize;
         MmapMut::map_anon(alloc_size).map(|mut mmap| {
@@ -45,34 +38,7 @@ impl PtrLen {
             }
         })
     }
-
-    #[cfg(target_os = "windows")]
-    fn with_size(size: usize) -> io::Result<Self> {
-        use windows_sys::Win32::System::Memory::{
-            MEM_COMMIT, MEM_RESERVE, PAGE_READWRITE, VirtualAlloc,
-        };
-
-        // VirtualAlloc always rounds up to the next multiple of the page size
-        let ptr = unsafe {
-            VirtualAlloc(
-                ptr::null_mut(),
-                size,
-                MEM_COMMIT | MEM_RESERVE,
-                PAGE_READWRITE,
-            )
-        };
-        if !ptr.is_null() {
-            Ok(Self {
-                ptr: ptr as *mut u8,
-                len: region::page::ceil(size as *const ()) as usize,
-            })
-        } else {
-            Err(io::Error::last_os_error())
-        }
-    }
 }
-
-// TODO: add a `Drop` impl for `cfg(target_os = "windows")`
 
 /// JIT memory manager. This manages pages of suitably aligned and
 /// accessible memory. Memory will be leaked by default to have
@@ -164,13 +130,9 @@ impl Memory {
 
     /// Iterates non protected memory allocations that are of not zero bytes in size.
     fn non_protected_allocations_iter(&self) -> impl Iterator<Item = &PtrLen> {
-        let iter = self.allocations[self.already_protected..].iter();
-
-        #[cfg(not(target_os = "windows"))]
-        return iter.filter(|&PtrLen { map, len, .. }| *len != 0 && map.is_some());
-
-        #[cfg(target_os = "windows")]
-        return iter.filter(|&PtrLen { len, .. }| *len != 0);
+        self.allocations[self.already_protected..]
+            .iter()
+            .filter(|&PtrLen { map, len, .. }| *len != 0 && map.is_some())
     }
 
     /// Frees all allocated memory regions that would be leaked otherwise.


### PR DESCRIPTION
This was previously not done with the theory that using the regular heap allocator could be faster. We now have an arena memory provider and using mmap is necessary anyway when SELinux is enabled. I don't think the benefits outweight the code complexity cost. Also use memmap2 on Windows too in cranelift-jit.

Fixes https://github.com/bytecodealliance/wasmtime/issues/4986