### PR TITLE
Fix `EntitySet` debug formatting

### DIFF
--- a/cranelift/entity/src/set.rs
+++ b/cranelift/entity/src/set.rs
@@ -29,7 +29,7 @@ where
     K: fmt::Debug + EntityRef,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_set().entries(self.keys()).finish()
+        f.debug_set().entries(self.iter()).finish()
     }
 }
 
@@ -199,7 +199,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloc::vec::Vec;
+    use alloc::{format, vec::Vec};
     use core::u32;
 
     // `EntityRef` impl for testing.
@@ -306,5 +306,14 @@ mod tests {
         }
 
         assert!(m.is_empty());
+    }
+
+    #[test]
+    fn fmt_debug() {
+        let mut s = EntitySet::new();
+        s.insert(E(2));
+        s.insert(E(4));
+        // The `Debug` formatting should only show the elements within the set.
+        assert_eq!(format!("{s:?}"), "{E(2), E(4)}");
     }
 }


### PR DESCRIPTION
It was printing all keys up to the max key in the set instead of the entities actually in the set.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
