### PR TITLE
Use some APIs first available in Rust 1.93

### DIFF
--- a/crates/environ/src/graphs/entity_graph.rs
+++ b/crates/environ/src/graphs/entity_graph.rs
@@ -24,22 +24,18 @@ where
     Node: EntityRef + Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        struct Edges<'a, Node: EntityRef + Debug>(&'a EntityGraph<Node>);
-
-        impl<'a, Node: EntityRef + Debug> Debug for Edges<'a, Node> {
-            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                f.debug_map()
-                    .entries(
-                        self.0
-                            .nodes()
-                            .map(|n| (n, self.0.successors(n).collect::<Box<[_]>>())),
-                    )
-                    .finish()
-            }
-        }
-
         f.debug_struct("Graph")
-            .field("edges", &Edges(self))
+            .field(
+                "edges",
+                &fmt::from_fn(|f| {
+                    f.debug_map()
+                        .entries(
+                            self.nodes()
+                                .map(|n| (n, self.successors(n).collect::<Box<[_]>>())),
+                        )
+                        .finish()
+                }),
+            )
             .finish()
     }
 }

--- a/crates/fiber/src/stackswitch/aarch64.rs
+++ b/crates/fiber/src/stackswitch/aarch64.rs
@@ -17,7 +17,7 @@ pub(crate) unsafe extern "C" fn wasmtime_fiber_switch(top_of_stack: *mut u8) {
 
 #[unsafe(naked)]
 unsafe extern "C" fn wasmtime_fiber_switch_(top_of_stack: *mut u8 /* x0 */) {
-    naked_asm!(concat!(
+    naked_asm!(
         "
             .cfi_startproc
             // Save all callee-saved registers on the stack since we're
@@ -57,7 +57,7 @@ unsafe extern "C" fn wasmtime_fiber_switch_(top_of_stack: *mut u8 /* x0 */) {
             ret
             .cfi_endproc
         ",
-    ));
+    );
 }
 
 pub(crate) unsafe fn wasmtime_fiber_init(

--- a/crates/wasmtime/src/compile/stratify.rs
+++ b/crates/wasmtime/src/compile/stratify.rs
@@ -68,20 +68,17 @@ pub struct Strata<Node> {
 
 impl<Node: Debug> Debug for Strata<Node> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        struct Layers<'a, Node>(&'a Strata<Node>);
-
-        impl<'a, Node: Debug> Debug for Layers<'a, Node> {
-            fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                let mut f = f.debug_list();
-                for layer in self.0.layers() {
-                    f.entry(&layer);
-                }
-                f.finish()
-            }
-        }
-
         f.debug_struct("Strata")
-            .field("layers", &Layers(self))
+            .field(
+                "layers",
+                &core::fmt::from_fn(|f| {
+                    let mut f = f.debug_list();
+                    for layer in self.layers() {
+                        f.entry(&layer);
+                    }
+                    f.finish()
+                }),
+            )
             .finish()
     }
 }

--- a/crates/wasmtime/src/runtime/component/func/typed.rs
+++ b/crates/wasmtime/src/runtime/component/func/typed.rs
@@ -1157,7 +1157,7 @@ macro_rules! integers {
             fn linear_lift_from_memory(_cx: &mut LiftContext<'_>, ty: InterfaceType, bytes: &[u8]) -> Result<Self> {
                 debug_assert!(matches!(ty, InterfaceType::$ty));
                 debug_assert!((bytes.as_ptr() as usize) % Self::SIZE32 == 0);
-                Ok($primitive::from_le_bytes(bytes.try_into().unwrap()))
+                Ok($primitive::from_le_bytes(*bytes.as_array().unwrap()))
             }
 
             fn linear_lift_into_from_memory(
@@ -1257,8 +1257,9 @@ macro_rules! floats {
                 // into a memcpy on little-endian platforms.
                 // TODO use `as_chunks` when https://github.com/rust-lang/rust/issues/74985
                 // is stabilized
-                for (dst, src) in iter::zip(dst.chunks_exact_mut(Self::SIZE32), items) {
-                    let dst: &mut [u8; Self::SIZE32] = dst.try_into().unwrap();
+                let (dst, rest) = dst.as_chunks_mut::<{Self::SIZE32}>();
+                debug_assert!(rest.is_empty());
+                for (dst, src) in iter::zip(dst, items) {
                     *dst = src.to_le_bytes();
                 }
                 Ok(())
@@ -1276,7 +1277,7 @@ macro_rules! floats {
             fn linear_lift_from_memory(_cx: &mut LiftContext<'_>, ty: InterfaceType, bytes: &[u8]) -> Result<Self> {
                 debug_assert!(matches!(ty, InterfaceType::$ty));
                 debug_assert!((bytes.as_ptr() as usize) % Self::SIZE32 == 0);
-                Ok($float::from_le_bytes(bytes.try_into().unwrap()))
+                Ok($float::from_le_bytes(*bytes.as_array().unwrap()))
             }
 
             fn linear_lift_list_from_memory(cx: &mut LiftContext<'_>, list: &WasmList<Self>) -> Result<Vec<Self>> where Self: Sized {
@@ -1295,7 +1296,7 @@ macro_rules! floats {
                 Ok(
                     bytes
                         .chunks_exact(Self::SIZE32)
-                        .map(|i| $float::from_le_bytes(i.try_into().unwrap()))
+                        .map(|i| $float::from_le_bytes(*i.as_array().unwrap()))
                         .collect()
                 )
             }
@@ -1435,7 +1436,7 @@ unsafe impl Lift for char {
     ) -> Result<Self> {
         debug_assert!(matches!(ty, InterfaceType::Char));
         debug_assert!((bytes.as_ptr() as usize) % Self::SIZE32 == 0);
-        let bits = u32::from_le_bytes(bytes.try_into().unwrap());
+        let bits = u32::from_le_bytes(*bytes.as_array().unwrap());
         Ok(char::try_from(bits)?)
     }
 }
@@ -1454,8 +1455,8 @@ fn lift_pointer_pair_from_flat(
 fn lift_pointer_pair_from_memory(cx: &mut LiftContext<'_>, bytes: &[u8]) -> Result<(usize, usize)> {
     // FIXME(#4311): needs memory64 treatment
     let _ = cx; // this will be needed for memory64 in the future
-    let ptr = u32::from_le_bytes(bytes[..4].try_into().unwrap());
-    let len = u32::from_le_bytes(bytes[4..].try_into().unwrap());
+    let ptr = u32::from_le_bytes(*bytes[..4].as_array().unwrap());
+    let len = u32::from_le_bytes(*bytes[4..].as_array().unwrap());
     Ok((usize::try_from(ptr)?, usize::try_from(len)?))
 }
 
@@ -1769,14 +1770,13 @@ impl WasmStr {
 
     fn decode_utf16<'a>(&self, memory: &'a [u8], len: usize) -> Result<Cow<'a, str>> {
         // See notes in `decode_utf8` for why this is panicking indexing.
-        let memory = &memory[self.ptr..][..len * 2];
-        Ok(core::char::decode_utf16(
-            memory
-                .chunks(2)
-                .map(|chunk| u16::from_le_bytes(chunk.try_into().unwrap())),
+        let (chunks, rest) = &memory[self.ptr..][..len * 2].as_chunks::<2>();
+        debug_assert!(rest.is_empty());
+        Ok(
+            core::char::decode_utf16(chunks.iter().map(|chunk| u16::from_le_bytes(*chunk)))
+                .collect::<Result<String, _>>()?
+                .into(),
         )
-        .collect::<Result<String, _>>()?
-        .into())
     }
 
     fn decode_latin1<'a>(&self, memory: &'a [u8]) -> Result<Cow<'a, str>> {

--- a/crates/wasmtime/src/runtime/component/values.rs
+++ b/crates/wasmtime/src/runtime/component/values.rs
@@ -947,8 +947,8 @@ fn lift_flat_pointer_pair(
 }
 
 fn load_flat_pointer_pair(bytes: &[u8]) -> (usize, usize) {
-    let ptr = u32::from_le_bytes(bytes[..4].try_into().unwrap()) as usize;
-    let len = u32::from_le_bytes(bytes[4..].try_into().unwrap()) as usize;
+    let ptr = u32::from_le_bytes(*bytes[..4].as_array().unwrap()) as usize;
+    let len = u32::from_le_bytes(*bytes[4..].as_array().unwrap()) as usize;
     (ptr, len)
 }
 

--- a/crates/wasmtime/src/runtime/vm/gc/enabled/data.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/enabled/data.rs
@@ -135,7 +135,7 @@ impl VMGcObjectData {
         let offset = usize::try_from(offset).unwrap();
         let end = offset.checked_add(N).unwrap();
         let bytes = self.data.get(offset..end).expect("out of bounds field");
-        T::read_le(bytes.try_into().unwrap())
+        T::read_le(bytes.as_array().unwrap())
     }
 
     /// Read a POD field out of this object.
@@ -159,7 +159,7 @@ impl VMGcObjectData {
                 self.data.as_mut().len(),
             ),
         };
-        val.write_le(into.try_into().unwrap());
+        val.write_le(into.as_mut_array().unwrap());
     }
 
     /// Get a slice of this object's data.

--- a/crates/wasmtime/src/runtime/vm/gc/enabled/drc.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/enabled/drc.rs
@@ -324,7 +324,7 @@ impl DrcHeap {
                             debug_assert!(
                                 field_end <= object_start + usize::try_from(object_size).unwrap()
                             );
-                            let raw: [u8; 4] = heap[field_start..field_end].try_into().unwrap();
+                            let raw = *heap[field_start..field_end].as_array().unwrap();
                             let raw = u32::from_le_bytes(raw);
 
                             if let Some(child) = VMGcRef::from_raw_u32(raw)


### PR DESCRIPTION
Some minor clean-ups/adjustments in a few location using niceties added in 1.93.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
