### PR TITLE
Allow running Wasm GC programs in the bench API

### DIFF
--- a/crates/bench-api/Cargo.toml
+++ b/crates/bench-api/Cargo.toml
@@ -24,6 +24,7 @@ target-lexicon = { workspace = true }
 wasmtime = { workspace = true, default-features = true, features = ["winch", "pulley"] }
 wasmtime-cli-flags = { workspace = true, default-features = true, features = [
     "cranelift",
+    "gc",
 ] }
 wasmtime-wasi = { workspace = true, features = ['p1'] }
 wasmtime-wasi-nn = { workspace = true, optional = true }


### PR DESCRIPTION
We need to be able to parse `-Wgc` from Sightglass.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
