### PR TITLE
[Cranelift] allow bitop optimizations for vectors

### DIFF
--- a/cranelift/codegen/src/opts/arithmetic.isle
+++ b/cranelift/codegen/src/opts/arithmetic.isle
@@ -340,7 +340,10 @@
 
 ;; Helper to create a "true" value for a comparison. For scalar integers this is
 ;; a value of 1 but for vectors this is -1 since each lane is filled with all
-;; 1s.
+;; 1s. We use `(iconst_u ty 0)` for falses for both integers and vector. This is
+;; because of the Cranelift semantics:
+;; When comparing scalars, the result is 1 if the condition holds, or 0 otherwise.
+;; When comparing vectors, the result is -1 (all-ones) if the condition holds, or 0 otherwise.
 (decl cmp_true (Type) Value)
 (rule 0 (cmp_true (ty_int ty)) (iconst_u ty 1))
 (rule 1 (cmp_true (ty_vec128 ty)) (iconst_s ty -1))

--- a/cranelift/codegen/src/opts/bitops.isle
+++ b/cranelift/codegen/src/opts/bitops.isle
@@ -20,10 +20,10 @@
 
 ;; x ^ not(x) == not(x) ^ x == x | not(x) == not(x) | x == -1.
 ;; This identity also holds for non-integer types, vectors, and wider types.
-(rule (simplify (bxor (ty_int ty) x (bnot ty x))) (subsume (iconst_s ty -1)))
-(rule (simplify (bxor (ty_int ty) (bnot ty x) x)) (subsume (iconst_s ty -1)))
-(rule (simplify (bor (ty_int ty) x (bnot ty x))) (subsume (iconst_s ty -1)))
-(rule (simplify (bor (ty_int ty) (bnot ty x) x)) (subsume (iconst_s ty -1)))
+(rule (simplify (bxor ty x (bnot ty x))) (subsume (iconst_s ty -1)))
+(rule (simplify (bxor ty (bnot ty x) x)) (subsume (iconst_s ty -1)))
+(rule (simplify (bor ty x (bnot ty x))) (subsume (iconst_s ty -1)))
+(rule (simplify (bor ty (bnot ty x) x)) (subsume (iconst_s ty -1)))
 
 ;; x & x == x & -1 == x.
 (rule (simplify (band ty x x)) (subsume x))
@@ -32,8 +32,8 @@
 
 ;; x & 0 == x & not(x) == not(x) & x == 0.
 (rule (simplify (band ty _ zero @ (iconst_u ty 0))) (subsume zero))
-(rule (simplify (band (ty_int ty) x (bnot ty x))) (subsume (iconst_u ty 0)))
-(rule (simplify (band (ty_int ty) (bnot ty x) x)) (subsume (iconst_u ty 0)))
+(rule (simplify (band ty x (bnot ty x))) (subsume (iconst_u ty 0)))
+(rule (simplify (band ty (bnot ty x) x)) (subsume (iconst_u ty 0)))
 
 ;; (x & y) ^ (x ^ y) == x | y
 (rule (simplify (bxor ty (band ty X Y) (bxor ty X Y))) (bor ty X Y))

--- a/cranelift/codegen/src/opts/icmp.isle
+++ b/cranelift/codegen/src/opts/icmp.isle
@@ -101,7 +101,7 @@
 
 ;; Comparisons against largest/smallest signed/unsigned values:
 ;; ult(x, 0) == false.
-(rule (simplify (ult (fits_in_64 (ty_int bty)) x zero @ (iconst_u _ 0)))
+(rule (simplify (ult bty x zero @ (iconst_u _ 0)))
       (subsume (iconst_u bty 0)))
 
 ;; ule(x, 0) == eq(x, 0)
@@ -113,8 +113,8 @@
       (ne bty x zero))
 
 ;; uge(x, 0) == true.
-(rule (simplify (uge (fits_in_64 (ty_int bty)) x zero @ (iconst_u _ 0)))
-      (subsume (iconst_u bty 1)))
+(rule (simplify (uge bty x zero @ (iconst_u _ 0)))
+      (subsume (cmp_true bty)))
 
 ;; ult(x, UMAX) == ne(x, UMAX).
 (rule (simplify (ult (fits_in_64 (ty_int bty)) x umax @ (iconst_u cty y)))
@@ -317,10 +317,10 @@
 (rule (simplify (bxor ty (ult ty x y) (ult ty y x))) (ne ty x y))
 
 ;; a < b && a > b = false
-(rule (simplify (band (fits_in_64 ty) (sgt ty x y) (slt ty x y))) (iconst_u ty 0))
-(rule (simplify (band (fits_in_64 ty) (slt ty x y) (sgt ty x y))) (iconst_u ty 0))
-(rule (simplify (band (fits_in_64 ty) (ugt ty x y) (ult ty x y))) (iconst_u ty 0))
-(rule (simplify (band (fits_in_64 ty) (ult ty x y) (ugt ty x y))) (iconst_u ty 0))
+(rule (simplify (band ty (sgt ty x y) (slt ty x y))) (iconst_u ty 0))
+(rule (simplify (band ty (slt ty x y) (sgt ty x y))) (iconst_u ty 0))
+(rule (simplify (band ty (ugt ty x y) (ult ty x y))) (iconst_u ty 0))
+(rule (simplify (band ty (ult ty x y) (ugt ty x y))) (iconst_u ty 0))
 (rule
   (simplify (band ty (sgt ty x (iconst_s _ y)) (ult ty x (iconst_s _ y))))
   (if-let true (i64_gt_eq y 0))

--- a/cranelift/filetests/filetests/egraph/bitops.clif
+++ b/cranelift/filetests/filetests/egraph/bitops.clif
@@ -138,6 +138,72 @@ block0(v1: i64):
 ; check: v5 = bnot v1
 ; check: return v5
 
+function %vector_bxor_x_bnot_x(i32x4) -> i32x4 {
+block0(v0: i32x4):
+    v1 = bnot v0
+    v2 = bxor v0, v1
+    return v2
+}
+
+; check: const0 = 0xffffffffffffffffffffffffffffffff
+; check: v5 = vconst.i32x4 const0
+; check: return v5
+
+function %vector_bxor_bnot_x_x(i32x4) -> i32x4 {
+block0(v0: i32x4):
+    v1 = bnot v0
+    v2 = bxor v1, v0
+    return v2
+}
+
+; check: const0 = 0xffffffffffffffffffffffffffffffff
+; check: v5 = vconst.i32x4 const0
+; check: return v5
+
+function %vector_bor_x_bnot_x(i32x4) -> i32x4 {
+block0(v0: i32x4):
+    v1 = bnot v0
+    v2 = bor v0, v1
+    return v2
+}
+
+; check: const0 = 0xffffffffffffffffffffffffffffffff
+; check: v5 = vconst.i32x4 const0
+; check: return v5
+
+function %vector_bor_bnot_x_x(i32x4) -> i32x4 {
+block0(v0: i32x4):
+    v1 = bnot v0
+    v2 = bor v1, v0
+    return v2
+}
+
+; check: const0 = 0xffffffffffffffffffffffffffffffff
+; check: v5 = vconst.i32x4 const0
+; check: return v5
+
+function %vector_band_x_bnot_x(i32x4) -> i32x4 {
+block0(v0: i32x4):
+    v1 = bnot v0
+    v2 = band v0, v1
+    return v2
+}
+
+; check: const0 = 0x00000000000000000000000000000000
+; check: v5 = vconst.i32x4 const0
+; check: return v5
+
+function %vector_band_bnot_x_x(i32x4) -> i32x4 {
+block0(v0: i32x4):
+    v1 = bnot v0
+    v2 = band v1, v0
+    return v2
+}
+
+; check: const0 = 0x00000000000000000000000000000000
+; check: v5 = vconst.i32x4 const0
+; check: return v5
+
 function %bitops_bmask(i64) -> i64 {
 block0(v0: i64):
     v1 = bnot v0

--- a/cranelift/filetests/filetests/egraph/icmp.clif
+++ b/cranelift/filetests/filetests/egraph/icmp.clif
@@ -214,12 +214,12 @@ block0():
 
 ; function %issue_10929_no_crash_on_icmp_vectors() -> i32x4 fast {
 ;     const0 = 0x40ad3fb47cb16076c8cb1fdd8189d40f
+;     const1 = 0xffffffffffffffffffffffffffffffff
 ;
 ; block0:
 ;     v1 = vconst.i32x4 const0
-;     v4 = bnot v1  ; v1 = const0
-;     v2 = bxor v1, v4  ; v1 = const0
-;     v3 = icmp ne v1, v2  ; v1 = const0
+;     v7 = vconst.i32x4 const1
+;     v3 = icmp ne v1, v7  ; v1 = const0, v7 = const1
 ;     return v3
 ; }
 
@@ -420,4 +420,3 @@ block0(v0: i32, v1: i32):
 ;     v6 = icmp ult v0, v1
 ;     return v6
 ; }
-

--- a/cranelift/filetests/filetests/egraph/issue-12328.clif
+++ b/cranelift/filetests/filetests/egraph/issue-12328.clif
@@ -8,6 +8,9 @@ block0(v0: i32x4, v1: i32x4):
     v3 = icmp slt v0, v1
     v4 = band v2, v3
     return v4
+    ; check: const0 = 0x00000000000000000000000000000000
+    ; check: v7 = vconst.i32x4 const0
+    ; check: return v7  ; v7 = const0
 }
 
 function %slt_sgt_i32x4(i32x4, i32x4) -> i32x4 {
@@ -16,6 +19,9 @@ block0(v0: i32x4, v1: i32x4):
     v3 = icmp sgt v0, v1
     v4 = band v2, v3
     return v4
+    ; check: const0 = 0x00000000000000000000000000000000
+    ; check: v7 = vconst.i32x4 const0
+    ; check: return v7  ; v7 = const0
 }
 
 function %ugt_ult_i32x4(i32x4, i32x4) -> i32x4 {
@@ -24,6 +30,9 @@ block0(v0: i32x4, v1: i32x4):
     v3 = icmp ult v0, v1
     v4 = band v2, v3
     return v4
+    ; check: const0 = 0x00000000000000000000000000000000
+    ; check: v7 = vconst.i32x4 const0
+    ; check: return v7  ; v7 = const0
 }
 
 function %ult_ugt_i32x4(i32x4, i32x4) -> i32x4 {
@@ -32,6 +41,9 @@ block0(v0: i32x4, v1: i32x4):
     v3 = icmp ugt v0, v1
     v4 = band v2, v3
     return v4
+    ; check: const0 = 0x00000000000000000000000000000000
+    ; check: v7 = vconst.i32x4 const0
+    ; check: return v7  ; v7 = const0
 }
 
 function %sgt_slt_i64x2(i64x2, i64x2) -> i64x2 {
@@ -40,6 +52,9 @@ block0(v0: i64x2, v1: i64x2):
     v3 = icmp slt v0, v1
     v4 = band v2, v3
     return v4
+    ; check: const0 = 0x00000000000000000000000000000000
+    ; check: v7 = vconst.i64x2 const0
+    ; check: return v7  ; v7 = const0
 }
 
 function %slt_sgt_i16x8(i16x8, i16x8) -> i16x8 {
@@ -48,6 +63,9 @@ block0(v0: i16x8, v1: i16x8):
     v3 = icmp sgt v0, v1
     v4 = band v2, v3
     return v4
+    ; check: const0 = 0x00000000000000000000000000000000
+    ; check: v7 = vconst.i16x8 const0
+    ; check: return v7  ; v7 = const0
 }
 
 function %ugt_ult_i8x16(i8x16, i8x16) -> i8x16 {
@@ -56,4 +74,7 @@ block0(v0: i8x16, v1: i8x16):
     v3 = icmp ult v0, v1
     v4 = band v2, v3
     return v4
+    ; check: const0 = 0x00000000000000000000000000000000
+    ; check: v7 = vconst.i8x16 const0
+    ; check: return v7  ; v7 = const0
 }

--- a/tests/disas/issue-10929-v128-icmp-egraphs.wat
+++ b/tests/disas/issue-10929-v128-icmp-egraphs.wat
@@ -14,14 +14,14 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
+;;     const0 = 0xffffffffffffffffffffffffffffffff
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i8x16):
 ;; @0025                               jump block1
 ;;
 ;;                                 block1:
-;; @001f                               v4 = bnot.i8x16 v2
-;; @0021                               v5 = bxor.i8x16 v2, v4
-;; @0023                               v6 = icmp.i8x16 ne v2, v5
+;;                                     v9 = vconst.i8x16 const0
+;; @0023                               v6 = icmp.i8x16 ne v2, v9  ; v9 = const0
 ;; @0025                               return v6
 ;; }


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->


https://github.com/bytecodealliance/wasmtime/pull/13063 made it safe to use `iconst_u` for vector values. Therefore the rules changed in this PR should now also be enabled for optimizing vector types too.

