### PR TITLE
[Cranelift] fold bnot+iadd

### DIFF
--- a/cranelift/codegen/src/opts/cprop.isle
+++ b/cranelift/codegen/src/opts/cprop.isle
@@ -457,3 +457,8 @@
 (decl ieee128_constant (Ieee128) Constant)
 (extern constructor ieee128_constant ieee128_constant)
 (extern extractor ieee128_constant ieee128_constant_extractor)
+
+;; a special case of ~a = -a - 1
+;; ~(x + y) = -(x + y) - 1 = (~x) - y = (~x) + (-y)
+;; bnot pushed to the leaf so that it not only canonicalzes the IR but also folds the constant y into -y
+(rule (simplify (bnot (fits_in_64 ty) (iadd ty x (iconst ty y)))) (iadd ty (bnot ty x) (iconst ty (imm64_neg ty y))))

--- a/cranelift/filetests/filetests/egraph/arithmetic.clif
+++ b/cranelift/filetests/filetests/egraph/arithmetic.clif
@@ -439,3 +439,28 @@ block0(v0: i32):
   ; return v6
 }
 
+;; ~(x + y) --> (~x) + (-y)
+function %bnot_iadd_const_i32(i32) -> i32 {
+block0(v0: i32):
+    v1 = iconst.i32 5
+    v2 = iadd v0, v1
+    v3 = bnot v2
+    return v3
+    ; check: v4 = bnot v0
+    ; check: v5 = iconst.i32 -5
+    ; check: v6 = iadd v4, v5
+    ; check: return v6
+}
+
+;; ~(x + y) --> (~x) + (-y)
+function %bnot_iadd_neg_const_i64(i64) -> i64 {
+block0(v0: i64):
+    v1 = iconst.i64 -7
+    v2 = iadd v0, v1
+    v3 = bnot v2
+    return v3
+    ; check: v4 = bnot v0
+    ; check: v5 = iconst.i64 7
+    ; check: v6 = iadd v4, v5
+    ; check: return v6
+}

--- a/cranelift/filetests/filetests/runtests/arithmetic.clif
+++ b/cranelift/filetests/filetests/runtests/arithmetic.clif
@@ -1039,3 +1039,29 @@ block0(v0: i32, v1: i32):
 
 ; run: %test_ugt_x_umax(0, 0) == 0
 ; run: %test_ugt_x_umax(1, 2) == 0
+
+function %fold_bnot_iadd_const_i32_rt(i32) -> i32 fast {
+block0(v0: i32):
+    v1 = iconst.i32 5
+    v2 = iadd v0, v1
+    v3 = bnot v2
+    return v3
+}
+
+; run: %fold_bnot_iadd_const_i32_rt(0) == -6
+; run: %fold_bnot_iadd_const_i32_rt(7) == -13
+; run: %fold_bnot_iadd_const_i32_rt(-5) == -1
+; run: %fold_bnot_iadd_const_i32_rt(0x7fffffff) == 0x7ffffffb
+
+function %fold_bnot_iadd_neg_const_i64_rt(i64) -> i64 fast {
+block0(v0: i64):
+    v1 = iconst.i64 -7
+    v2 = iadd v0, v1
+    v3 = bnot v2
+    return v3
+}
+
+; run: %fold_bnot_iadd_neg_const_i64_rt(0) == 6
+; run: %fold_bnot_iadd_neg_const_i64_rt(7) == -1
+; run: %fold_bnot_iadd_neg_const_i64_rt(-1) == 7
+; run: %fold_bnot_iadd_neg_const_i64_rt(0x80000000_00000000) == 0x80000000_00000006


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->

This folds and canonicalizes `~(x + y)` for a constant y as follows:

```
~(x + y)
= -(x + y) - 1 ;; ~a = -a - 1
= (~x) - y ;; -x - 1 = ~x
= (~x) + (-y)
```
