### PR TITLE
[Cranelift] fix e-graph rewrite depth limit

### DIFF
--- a/cranelift/codegen/src/egraph/mod.rs
+++ b/cranelift/codegen/src/egraph/mod.rs
@@ -302,7 +302,7 @@ where
         // infinite or problematic recursion, we bound the rewrite
         // depth to a small constant here.
         const REWRITE_LIMIT: usize = 5;
-        if ctx.rewrite_depth > REWRITE_LIMIT {
+        if ctx.rewrite_depth >= REWRITE_LIMIT {
             ctx.stats.rewrite_depth_limit += 1;
             return orig_value;
         }

--- a/cranelift/filetests/filetests/egraph/cprop.clif
+++ b/cranelift/filetests/filetests/egraph/cprop.clif
@@ -349,10 +349,10 @@ block0(v0: i32, v1: i32):
     return v7
 }
 
-; check: v15 = iconst.i32 333
-; check: v19 = iadd v1, v15
-; check: v20 = icmp eq v0, v19
-; nextln: return v20
+; check: v16 = iconst.i32 333
+; check: v18 = iadd v1, v16
+; check: v19 = icmp eq v0, v18
+; nextln: return v19
 
 function %icmp_subs_const_addends(i32, i32) -> i8 {
 block0(v0: i32, v1: i32):
@@ -364,10 +364,10 @@ block0(v0: i32, v1: i32):
     return v7
 }
 
-; check: v47 = iconst.i32 333
-; check: v49 = iadd v0, v47
-; check: v50 = icmp eq v1, v49
-; nextln: return v50
+; check: v40 = iconst.i32 333
+; check: v44 = iadd v0, v40
+; check: v45 = icmp eq v1, v44
+; nextln: return v45
 
 function %ireduce_iconst() -> i8 {
 block0:

--- a/cranelift/filetests/filetests/egraph/i128-opts.clif
+++ b/cranelift/filetests/filetests/egraph/i128-opts.clif
@@ -95,8 +95,8 @@ block0:
     v4 = bor v1, v3
     return v4
     ; check: v6 = iconst.i32 13
-    ; check: v12 = uextend.i128 v6  ; v6 = 13
-    ; check: return v12
+    ; check: v11 = uextend.i128 v6  ; v6 = 13
+    ; check: return v11
 }
 
 ;; These are big enough that they overflow u64, so should not be collapsed

--- a/cranelift/filetests/filetests/egraph/remat.clif
+++ b/cranelift/filetests/filetests/egraph/remat.clif
@@ -23,8 +23,8 @@ block2:
 ; check:      brif v2, block1, block2
 ; check:   block1:
 ; check:      v6 = iconst.i32 126
-; check:      v12 = iadd.i32 v0, v6
-; check:      return v12
+; check:      v11 = iadd.i32 v0, v6
+; check:      return v11
 ; check:   block2:
-; check:      v14 = iadd.i32 v0, v1
-; check:      return v14
+; check:      v13 = iadd.i32 v0, v1
+; check:      return v13

--- a/cranelift/filetests/filetests/egraph/shifts.clif
+++ b/cranelift/filetests/filetests/egraph/shifts.clif
@@ -652,8 +652,8 @@ block0(v0: i8):
 }
 
 ; check: v6 = iconst.i8 2
-; check: v12 = rotr v0, v6  ; v6 = 2
-; check: return v12
+; check: v11 = rotr v0, v6  ; v6 = 2
+; check: return v11
 
 function %rotr_rotr_add(i8, i8, i8) -> i8 {
 block0(v0: i8, v1: i8, v2: i8):
@@ -676,8 +676,8 @@ block0(v0: i8):
 }
 
 ; check: v6 = iconst.i8 2
-; check: v12 = rotl v0, v6  ; v6 = 2
-; check: return v12
+; check: v11 = rotl v0, v6  ; v6 = 2
+; check: return v11
 
 function %rotl_rotl_add(i8, i8, i8) -> i8 {
 block0(v0: i8, v1: i8, v2: i8):
@@ -701,8 +701,8 @@ block0(v0: i8):
 }
 
 ; check: v2 = iconst.i8 1
-; check: v15 = rotr v0, v2  ; v2 = 1
-; check: return v15
+; check: v14 = rotr v0, v2  ; v2 = 1
+; check: return v14
 
 function %rotl_rotr_add(i8, i8, i8) -> i8 {
 block0(v0: i8, v1: i8, v2: i8):
@@ -725,8 +725,8 @@ block0(v0: i8):
 }
 
 ; check: v2 = iconst.i8 1
-; check: v15 = rotl v0, v2  ; v2 = 1
-; check: return v15
+; check: v14 = rotl v0, v2  ; v2 = 1
+; check: return v14
 
 function %rotl_rotr_add(i8, i8, i8) -> i8 {
 block0(v0: i8, v1: i8, v2: i8):

--- a/cranelift/filetests/filetests/egraph/skeleton.clif
+++ b/cranelift/filetests/filetests/egraph/skeleton.clif
@@ -90,9 +90,9 @@ block0:
 
 ; function %cprop_udiv() -> i32 fast {
 ; block0:
-;     v18 = iconst.i32 1
-;     v2 -> v18
-;     return v18  ; v18 = 1
+;     v16 = iconst.i32 1
+;     v2 -> v16
+;     return v16  ; v16 = 1
 ; }
 
 function %cprop_urem() -> i32 {
@@ -105,9 +105,9 @@ block0:
 
 ; function %cprop_urem() -> i32 fast {
 ; block0:
-;     v37 = iconst.i32 6
-;     v2 -> v37
-;     return v37  ; v37 = 6
+;     v33 = iconst.i32 6
+;     v2 -> v33
+;     return v33  ; v33 = 6
 ; }
 
 function %cprop_sdiv() -> i32 {
@@ -181,11 +181,10 @@ block0:
 
 ; function %cprop_srem() -> i32 fast {
 ; block0:
-;     v28 = iconst.i32 -3
-;     v2 -> v28
-;     return v28  ; v28 = -3
+;     v26 = iconst.i32 -3
+;     v2 -> v26
+;     return v26  ; v26 = -3
 ; }
-
 
 function %udiv_by_one(i32) -> i32 {
 block0(v0: i32):

--- a/tests/disas/component-model/direct-adapter-calls-inlining.wat
+++ b/tests/disas/component-model/direct-adapter-calls-inlining.wat
@@ -102,9 +102,9 @@
 ;;                                     v24 = iconst.i32 -2
 ;;                                     v25 = band v23, v24  ; v24 = -2
 ;;                                     store notrap aligned table v25, v22
-;;                                     v56 = iconst.i32 1
-;;                                     v57 = bor v23, v56  ; v56 = 1
-;;                                     store notrap aligned table v57, v22
+;;                                     v55 = iconst.i32 1
+;;                                     v56 = bor v23, v55  ; v55 = 1
+;;                                     store notrap aligned table v56, v22
 ;;                                     jump block6
 ;;
 ;;                                 block6:
@@ -115,12 +115,12 @@
 ;;
 ;;                                 block8:
 ;;                                     v36 = load.i32 notrap aligned table v12
-;;                                     v58 = iconst.i32 -2
-;;                                     v59 = band v36, v58  ; v58 = -2
-;;                                     store notrap aligned table v59, v12
-;;                                     v60 = iconst.i32 1
-;;                                     v61 = bor v36, v60  ; v60 = 1
-;;                                     store notrap aligned table v61, v12
+;;                                     v57 = iconst.i32 -2
+;;                                     v58 = band v36, v57  ; v57 = -2
+;;                                     store notrap aligned table v58, v12
+;;                                     v59 = iconst.i32 1
+;;                                     v60 = bor v36, v59  ; v59 = 1
+;;                                     store notrap aligned table v60, v12
 ;;                                     jump block3
 ;;
 ;;                                 block3:

--- a/tests/disas/component-model/inlining-fuzz-bug.wat
+++ b/tests/disas/component-model/inlining-fuzz-bug.wat
@@ -90,6 +90,6 @@
 ;; @00c6                               jump block1
 ;;
 ;;                                 block1:
-;;                                     v26 = iconst.i32 301
-;; @00c6                               return v26  ; v26 = 301
+;;                                     v25 = iconst.i32 301
+;; @00c6                               return v25  ; v25 = 301
 ;; }

--- a/tests/disas/gc/drc/array-new-fixed-of-gc-refs.wat
+++ b/tests/disas/gc/drc/array-new-fixed-of-gc-refs.wat
@@ -34,9 +34,9 @@
 ;; @0025                               v14 = iconst.i32 -1476395008
 ;; @0025                               v16 = load.i64 notrap aligned readonly can_move v0+40
 ;; @0025                               v17 = load.i32 notrap aligned readonly can_move v16
-;;                                     v150 = iconst.i32 40
+;;                                     v149 = iconst.i32 40
 ;; @0025                               v18 = iconst.i32 8
-;; @0025                               v19 = call fn0(v0, v14, v17, v150, v18), stack_map=[i32 @ ss2+0, i32 @ ss1+0, i32 @ ss0+0]  ; v14 = -1476395008, v150 = 40, v18 = 8
+;; @0025                               v19 = call fn0(v0, v14, v17, v149, v18), stack_map=[i32 @ ss2+0, i32 @ ss1+0, i32 @ ss0+0]  ; v14 = -1476395008, v149 = 40, v18 = 8
 ;; @0025                               v6 = iconst.i32 3
 ;; @0025                               v131 = load.i64 notrap aligned readonly can_move v0+8
 ;; @0025                               v20 = load.i64 notrap aligned readonly can_move v131+32
@@ -57,8 +57,8 @@
 ;;                                 block2:
 ;; @0025                               v32 = uextend.i64 v93
 ;; @0025                               v34 = iadd.i64 v20, v32
-;;                                     v168 = iconst.i64 8
-;; @0025                               v36 = iadd v34, v168  ; v168 = 8
+;;                                     v165 = iconst.i64 8
+;; @0025                               v36 = iadd v34, v165  ; v165 = 8
 ;; @0025                               v37 = load.i64 notrap aligned v36
 ;;                                     v98 = iconst.i64 1
 ;; @0025                               v38 = iadd v37, v98  ; v98 = 1
@@ -67,59 +67,59 @@
 ;;
 ;;                                 block3:
 ;;                                     v89 = load.i32 notrap v137
-;;                                     v152 = iconst.i64 28
-;;                                     v158 = iadd.i64 v22, v152  ; v152 = 28
-;; @0025                               store notrap aligned little v89, v158
+;;                                     v151 = iconst.i64 28
+;;                                     v156 = iadd.i64 v22, v151  ; v151 = 28
+;; @0025                               store notrap aligned little v89, v156
 ;;                                     v88 = load.i32 notrap v136
-;;                                     v258 = iconst.i32 1
-;;                                     v259 = band v88, v258  ; v258 = 1
-;;                                     v260 = iconst.i32 0
-;;                                     v261 = icmp eq v88, v260  ; v260 = 0
-;; @0025                               v47 = uextend.i32 v261
-;; @0025                               v48 = bor v259, v47
+;;                                     v243 = iconst.i32 1
+;;                                     v244 = band v88, v243  ; v243 = 1
+;;                                     v245 = iconst.i32 0
+;;                                     v246 = icmp eq v88, v245  ; v245 = 0
+;; @0025                               v47 = uextend.i32 v246
+;; @0025                               v48 = bor v244, v47
 ;; @0025                               brif v48, block5, block4
 ;;
 ;;                                 block4:
 ;; @0025                               v49 = uextend.i64 v88
 ;; @0025                               v51 = iadd.i64 v20, v49
-;;                                     v262 = iconst.i64 8
-;; @0025                               v53 = iadd v51, v262  ; v262 = 8
+;;                                     v247 = iconst.i64 8
+;; @0025                               v53 = iadd v51, v247  ; v247 = 8
 ;; @0025                               v54 = load.i64 notrap aligned v53
-;;                                     v263 = iconst.i64 1
-;; @0025                               v55 = iadd v54, v263  ; v263 = 1
+;;                                     v248 = iconst.i64 1
+;; @0025                               v55 = iadd v54, v248  ; v248 = 1
 ;; @0025                               store notrap aligned v55, v53
 ;; @0025                               jump block5
 ;;
 ;;                                 block5:
 ;;                                     v84 = load.i32 notrap v136
 ;;                                     v133 = iconst.i64 32
-;;                                     v166 = iadd.i64 v22, v133  ; v133 = 32
-;; @0025                               store notrap aligned little v84, v166
+;;                                     v163 = iadd.i64 v22, v133  ; v133 = 32
+;; @0025                               store notrap aligned little v84, v163
 ;;                                     v83 = load.i32 notrap v135
-;;                                     v264 = iconst.i32 1
-;;                                     v265 = band v83, v264  ; v264 = 1
-;;                                     v266 = iconst.i32 0
-;;                                     v267 = icmp eq v83, v266  ; v266 = 0
-;; @0025                               v64 = uextend.i32 v267
-;; @0025                               v65 = bor v265, v64
+;;                                     v249 = iconst.i32 1
+;;                                     v250 = band v83, v249  ; v249 = 1
+;;                                     v251 = iconst.i32 0
+;;                                     v252 = icmp eq v83, v251  ; v251 = 0
+;; @0025                               v64 = uextend.i32 v252
+;; @0025                               v65 = bor v250, v64
 ;; @0025                               brif v65, block7, block6
 ;;
 ;;                                 block6:
 ;; @0025                               v66 = uextend.i64 v83
 ;; @0025                               v68 = iadd.i64 v20, v66
-;;                                     v268 = iconst.i64 8
-;; @0025                               v70 = iadd v68, v268  ; v268 = 8
+;;                                     v253 = iconst.i64 8
+;; @0025                               v70 = iadd v68, v253  ; v253 = 8
 ;; @0025                               v71 = load.i64 notrap aligned v70
-;;                                     v269 = iconst.i64 1
-;; @0025                               v72 = iadd v71, v269  ; v269 = 1
+;;                                     v254 = iconst.i64 1
+;; @0025                               v72 = iadd v71, v254  ; v254 = 1
 ;; @0025                               store notrap aligned v72, v70
 ;; @0025                               jump block7
 ;;
 ;;                                 block7:
 ;;                                     v79 = load.i32 notrap v135
-;;                                     v184 = iconst.i64 36
-;;                                     v190 = iadd.i64 v22, v184  ; v184 = 36
-;; @0025                               store notrap aligned little v79, v190
+;;                                     v179 = iconst.i64 36
+;;                                     v184 = iadd.i64 v22, v179  ; v179 = 36
+;; @0025                               store notrap aligned little v79, v184
 ;; @0029                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/drc/array-new-fixed.wat
+++ b/tests/disas/gc/drc/array-new-fixed.wat
@@ -24,9 +24,9 @@
 ;; @0025                               v14 = iconst.i32 -1476395008
 ;; @0025                               v16 = load.i64 notrap aligned readonly can_move v0+40
 ;; @0025                               v17 = load.i32 notrap aligned readonly can_move v16
-;;                                     v47 = iconst.i32 56
+;;                                     v46 = iconst.i32 56
 ;; @0025                               v18 = iconst.i32 8
-;; @0025                               v19 = call fn0(v0, v14, v17, v47, v18)  ; v14 = -1476395008, v47 = 56, v18 = 8
+;; @0025                               v19 = call fn0(v0, v14, v17, v46, v18)  ; v14 = -1476395008, v46 = 56, v18 = 8
 ;; @0025                               v6 = iconst.i32 3
 ;; @0025                               v32 = load.i64 notrap aligned readonly can_move v0+8
 ;; @0025                               v20 = load.i64 notrap aligned readonly can_move v32+32
@@ -36,14 +36,14 @@
 ;; @0025                               v23 = iadd v22, v37  ; v37 = 24
 ;; @0025                               store notrap aligned v6, v23  ; v6 = 3
 ;;                                     v34 = iconst.i64 32
-;;                                     v54 = iadd v22, v34  ; v34 = 32
-;; @0025                               store notrap aligned little v2, v54
-;;                                     v57 = iconst.i64 40
-;;                                     v63 = iadd v22, v57  ; v57 = 40
-;; @0025                               store notrap aligned little v3, v63
-;;                                     v81 = iconst.i64 48
-;;                                     v87 = iadd v22, v81  ; v81 = 48
-;; @0025                               store notrap aligned little v4, v87
+;;                                     v52 = iadd v22, v34  ; v34 = 32
+;; @0025                               store notrap aligned little v2, v52
+;;                                     v55 = iconst.i64 40
+;;                                     v60 = iadd v22, v55  ; v55 = 40
+;; @0025                               store notrap aligned little v3, v60
+;;                                     v76 = iconst.i64 48
+;;                                     v81 = iadd v22, v76  ; v76 = 48
+;; @0025                               store notrap aligned little v4, v81
 ;; @0029                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/drc/array-new.wat
+++ b/tests/disas/gc/drc/array-new.wat
@@ -43,11 +43,11 @@
 ;;                                     v32 = iconst.i64 24
 ;; @0022                               v21 = iadd v20, v32  ; v32 = 24
 ;; @0022                               store notrap aligned v3, v21
-;;                                     v54 = iadd v20, v35  ; v35 = 32
+;;                                     v53 = iadd v20, v35  ; v35 = 32
 ;; @0022                               v27 = uextend.i64 v10
 ;; @0022                               v28 = iadd v20, v27
 ;;                                     v36 = iconst.i64 8
-;; @0022                               jump block2(v54)
+;; @0022                               jump block2(v53)
 ;;
 ;;                                 block2(v29: i64):
 ;; @0022                               v30 = icmp eq v29, v28
@@ -55,9 +55,9 @@
 ;;
 ;;                                 block3:
 ;; @0022                               store.i64 notrap aligned little v2, v29
-;;                                     v59 = iconst.i64 8
-;;                                     v60 = iadd.i64 v29, v59  ; v59 = 8
-;; @0022                               jump block2(v60)
+;;                                     v58 = iconst.i64 8
+;;                                     v59 = iadd.i64 v29, v58  ; v58 = 8
+;; @0022                               jump block2(v59)
 ;;
 ;;                                 block4:
 ;; @0025                               jump block1

--- a/tests/disas/gc/drc/externref-globals.wat
+++ b/tests/disas/gc/drc/externref-globals.wat
@@ -101,8 +101,8 @@
 ;; @003b                               v29 = iconst.i64 8
 ;; @003b                               v14 = iadd v12, v29  ; v29 = 8
 ;; @003b                               v15 = load.i64 notrap aligned v14
-;;                                     v64 = iconst.i64 1
-;; @003b                               v16 = iadd v15, v64  ; v64 = 1
+;;                                     v63 = iconst.i64 1
+;; @003b                               v16 = iadd v15, v63  ; v63 = 1
 ;; @003b                               store notrap aligned v16, v14
 ;; @003b                               jump block3
 ;;

--- a/tests/disas/gc/drc/struct-new-default.wat
+++ b/tests/disas/gc/drc/struct-new-default.wat
@@ -55,10 +55,10 @@
 ;; @0021                               jump block3
 ;;
 ;;                                 block3:
-;;                                     v68 = iconst.i32 0
+;;                                     v65 = iconst.i32 0
 ;;                                     v43 = iconst.i64 32
 ;; @0021                               v19 = iadd.i64 v16, v43  ; v43 = 32
-;; @0021                               store notrap aligned little v68, v19  ; v68 = 0
+;; @0021                               store notrap aligned little v65, v19  ; v65 = 0
 ;; @0024                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/drc/struct-set.wat
+++ b/tests/disas/gc/drc/struct-set.wat
@@ -104,8 +104,8 @@
 ;; @004a                               v33 = iconst.i64 8
 ;; @004a                               v18 = iadd v16, v33  ; v33 = 8
 ;; @004a                               v19 = load.i64 notrap aligned v18
-;;                                     v69 = iconst.i64 1
-;; @004a                               v20 = iadd v19, v69  ; v69 = 1
+;;                                     v68 = iconst.i64 1
+;; @004a                               v20 = iadd v19, v68  ; v68 = 1
 ;; @004a                               store notrap aligned v20, v18
 ;; @004a                               jump block3
 ;;

--- a/tests/disas/gc/null/array-new-fixed-of-gc-refs.wat
+++ b/tests/disas/gc/null/array-new-fixed-of-gc-refs.wat
@@ -33,12 +33,12 @@
 ;;                                     store notrap v4, v60
 ;; @0025                               v17 = load.i64 notrap aligned readonly v0+32
 ;; @0025                               v18 = load.i32 notrap aligned v17
-;;                                     v82 = iconst.i32 7
-;; @0025                               v21 = uadd_overflow_trap v18, v82, user17  ; v82 = 7
-;;                                     v89 = iconst.i32 -8
-;; @0025                               v23 = band v21, v89  ; v89 = -8
-;;                                     v74 = iconst.i32 24
-;; @0025                               v24 = uadd_overflow_trap v23, v74, user17  ; v74 = 24
+;;                                     v80 = iconst.i32 7
+;; @0025                               v21 = uadd_overflow_trap v18, v80, user17  ; v80 = 7
+;;                                     v86 = iconst.i32 -8
+;; @0025                               v23 = band v21, v86  ; v86 = -8
+;;                                     v73 = iconst.i32 24
+;; @0025                               v24 = uadd_overflow_trap v23, v73, user17  ; v73 = 24
 ;; @0025                               v56 = load.i64 notrap aligned readonly can_move v0+8
 ;; @0025                               v26 = load.i64 notrap aligned v56+40
 ;; @0025                               v25 = uextend.i64 v24
@@ -46,12 +46,12 @@
 ;; @0025                               brif v27, block2, block3
 ;;
 ;;                                 block2:
-;;                                     v90 = iconst.i32 -1476394984
+;;                                     v87 = iconst.i32 -1476394984
 ;; @0025                               v31 = load.i64 notrap aligned readonly can_move v56+32
-;;                                     v175 = band.i32 v21, v89  ; v89 = -8
-;;                                     v176 = uextend.i64 v175
-;; @0025                               v33 = iadd v31, v176
-;; @0025                               store notrap aligned v90, v33  ; v90 = -1476394984
+;;                                     v162 = band.i32 v21, v86  ; v86 = -8
+;;                                     v163 = uextend.i64 v162
+;; @0025                               v33 = iadd v31, v163
+;; @0025                               store notrap aligned v87, v33  ; v87 = -1476394984
 ;; @0025                               v37 = load.i64 notrap aligned readonly can_move v0+40
 ;; @0025                               v38 = load.i32 notrap aligned readonly can_move v37
 ;; @0025                               store notrap aligned v38, v33+4
@@ -62,16 +62,16 @@
 ;; @0025                               store notrap aligned v6, v39  ; v6 = 3
 ;;                                     v49 = load.i32 notrap v62
 ;;                                     v64 = iconst.i64 12
-;;                                     v103 = iadd v33, v64  ; v64 = 12
-;; @0025                               store notrap aligned little v49, v103
+;;                                     v98 = iadd v33, v64  ; v64 = 12
+;; @0025                               store notrap aligned little v49, v98
 ;;                                     v48 = load.i32 notrap v61
-;;                                     v106 = iconst.i64 16
-;;                                     v112 = iadd v33, v106  ; v106 = 16
-;; @0025                               store notrap aligned little v48, v112
+;;                                     v101 = iconst.i64 16
+;;                                     v106 = iadd v33, v101  ; v101 = 16
+;; @0025                               store notrap aligned little v48, v106
 ;;                                     v47 = load.i32 notrap v60
-;;                                     v129 = iconst.i64 20
-;;                                     v135 = iadd v33, v129  ; v129 = 20
-;; @0025                               store notrap aligned little v47, v135
+;;                                     v121 = iconst.i64 20
+;;                                     v126 = iadd v33, v121  ; v121 = 20
+;; @0025                               store notrap aligned little v47, v126
 ;; @0029                               jump block1
 ;;
 ;;                                 block3 cold:
@@ -80,6 +80,6 @@
 ;; @0025                               jump block2
 ;;
 ;;                                 block1:
-;;                                     v177 = band.i32 v21, v89  ; v89 = -8
-;; @0029                               return v177
+;;                                     v164 = band.i32 v21, v86  ; v86 = -8
+;; @0029                               return v164
 ;; }

--- a/tests/disas/gc/null/array-new-fixed.wat
+++ b/tests/disas/gc/null/array-new-fixed.wat
@@ -24,12 +24,12 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64):
 ;; @0025                               v17 = load.i64 notrap aligned readonly v0+32
 ;; @0025                               v18 = load.i32 notrap aligned v17
-;;                                     v73 = iconst.i32 7
-;; @0025                               v21 = uadd_overflow_trap v18, v73, user17  ; v73 = 7
-;;                                     v80 = iconst.i32 -8
-;; @0025                               v23 = band v21, v80  ; v80 = -8
-;;                                     v65 = iconst.i32 40
-;; @0025                               v24 = uadd_overflow_trap v23, v65, user17  ; v65 = 40
+;;                                     v71 = iconst.i32 7
+;; @0025                               v21 = uadd_overflow_trap v18, v71, user17  ; v71 = 7
+;;                                     v77 = iconst.i32 -8
+;; @0025                               v23 = band v21, v77  ; v77 = -8
+;;                                     v64 = iconst.i32 40
+;; @0025                               v24 = uadd_overflow_trap v23, v64, user17  ; v64 = 40
 ;; @0025                               v50 = load.i64 notrap aligned readonly can_move v0+8
 ;; @0025                               v26 = load.i64 notrap aligned v50+40
 ;; @0025                               v25 = uextend.i64 v24
@@ -37,12 +37,12 @@
 ;; @0025                               brif v27, block2, block3
 ;;
 ;;                                 block2:
-;;                                     v81 = iconst.i32 -1476394968
+;;                                     v78 = iconst.i32 -1476394968
 ;; @0025                               v31 = load.i64 notrap aligned readonly can_move v50+32
-;;                                     v150 = band.i32 v21, v80  ; v80 = -8
-;;                                     v151 = uextend.i64 v150
-;; @0025                               v33 = iadd v31, v151
-;; @0025                               store notrap aligned v81, v33  ; v81 = -1476394968
+;;                                     v140 = band.i32 v21, v77  ; v77 = -8
+;;                                     v141 = uextend.i64 v140
+;; @0025                               v33 = iadd v31, v141
+;; @0025                               store notrap aligned v78, v33  ; v78 = -1476394968
 ;; @0025                               v37 = load.i64 notrap aligned readonly can_move v0+40
 ;; @0025                               v38 = load.i32 notrap aligned readonly can_move v37
 ;; @0025                               store notrap aligned v38, v33+4
@@ -51,15 +51,15 @@
 ;;                                     v53 = iconst.i64 8
 ;; @0025                               v39 = iadd v33, v53  ; v53 = 8
 ;; @0025                               store notrap aligned v6, v39  ; v6 = 3
-;;                                     v89 = iconst.i64 16
-;;                                     v95 = iadd v33, v89  ; v89 = 16
-;; @0025                               store.i64 notrap aligned little v2, v95
+;;                                     v85 = iconst.i64 16
+;;                                     v90 = iadd v33, v85  ; v85 = 16
+;; @0025                               store.i64 notrap aligned little v2, v90
 ;;                                     v55 = iconst.i64 24
-;;                                     v103 = iadd v33, v55  ; v55 = 24
-;; @0025                               store.i64 notrap aligned little v3, v103
+;;                                     v97 = iadd v33, v55  ; v55 = 24
+;; @0025                               store.i64 notrap aligned little v3, v97
 ;;                                     v52 = iconst.i64 32
-;;                                     v114 = iadd v33, v52  ; v52 = 32
-;; @0025                               store.i64 notrap aligned little v4, v114
+;;                                     v107 = iadd v33, v52  ; v52 = 32
+;; @0025                               store.i64 notrap aligned little v4, v107
 ;; @0029                               jump block1
 ;;
 ;;                                 block3 cold:
@@ -68,6 +68,6 @@
 ;; @0025                               jump block2
 ;;
 ;;                                 block1:
-;;                                     v152 = band.i32 v21, v80  ; v80 = -8
-;; @0029                               return v152
+;;                                     v142 = band.i32 v21, v77  ; v77 = -8
+;; @0029                               return v142
 ;; }

--- a/tests/disas/gc/null/array-new.wat
+++ b/tests/disas/gc/null/array-new.wat
@@ -39,8 +39,8 @@
 ;; @0022                               v16 = load.i32 notrap aligned v15
 ;;                                     v66 = iconst.i32 7
 ;; @0022                               v19 = uadd_overflow_trap v16, v66, user17  ; v66 = 7
-;;                                     v73 = iconst.i32 -8
-;; @0022                               v21 = band v19, v73  ; v73 = -8
+;;                                     v72 = iconst.i32 -8
+;; @0022                               v21 = band v19, v72  ; v72 = -8
 ;; @0022                               v22 = uadd_overflow_trap v21, v10, user17
 ;; @0022                               v51 = load.i64 notrap aligned readonly can_move v0+8
 ;; @0022                               v24 = load.i64 notrap aligned v51+40
@@ -50,12 +50,12 @@
 ;;
 ;;                                 block2:
 ;; @0022                               v32 = iconst.i32 -1476395008
-;;                                     v74 = bor.i32 v10, v32  ; v32 = -1476395008
+;;                                     v73 = bor.i32 v10, v32  ; v32 = -1476395008
 ;; @0022                               v29 = load.i64 notrap aligned readonly can_move v51+32
-;;                                     v88 = band.i32 v19, v73  ; v73 = -8
-;;                                     v89 = uextend.i64 v88
-;; @0022                               v31 = iadd v29, v89
-;; @0022                               store notrap aligned v74, v31
+;;                                     v86 = band.i32 v19, v72  ; v72 = -8
+;;                                     v87 = uextend.i64 v86
+;; @0022                               v31 = iadd v29, v87
+;; @0022                               store notrap aligned v73, v31
 ;; @0022                               v35 = load.i64 notrap aligned readonly can_move v0+40
 ;; @0022                               v36 = load.i32 notrap aligned readonly can_move v35
 ;; @0022                               store notrap aligned v36, v31+4
@@ -63,11 +63,11 @@
 ;;                                     v54 = iconst.i64 8
 ;; @0022                               v37 = iadd v31, v54  ; v54 = 8
 ;; @0022                               store.i32 notrap aligned v3, v37
-;;                                     v77 = iconst.i64 16
-;;                                     v83 = iadd v31, v77  ; v77 = 16
+;;                                     v76 = iconst.i64 16
+;;                                     v81 = iadd v31, v76  ; v76 = 16
 ;; @0022                               v43 = uextend.i64 v10
 ;; @0022                               v44 = iadd v31, v43
-;; @0022                               jump block4(v83)
+;; @0022                               jump block4(v81)
 ;;
 ;;                                 block4(v45: i64):
 ;; @0022                               v46 = icmp eq v45, v44
@@ -75,9 +75,9 @@
 ;;
 ;;                                 block5:
 ;; @0022                               store.i64 notrap aligned little v2, v45
-;;                                     v90 = iconst.i64 8
-;;                                     v91 = iadd.i64 v45, v90  ; v90 = 8
-;; @0022                               jump block4(v91)
+;;                                     v88 = iconst.i64 8
+;;                                     v89 = iadd.i64 v45, v88  ; v88 = 8
+;; @0022                               jump block4(v89)
 ;;
 ;;                                 block6:
 ;; @0025                               jump block1
@@ -88,6 +88,6 @@
 ;; @0022                               jump block2
 ;;
 ;;                                 block1:
-;;                                     v92 = band.i32 v19, v73  ; v73 = -8
-;; @0025                               return v92
+;;                                     v90 = band.i32 v19, v72  ; v72 = -8
+;; @0025                               return v90
 ;; }

--- a/tests/disas/gc/null/funcref-in-gc-heap-new.wat
+++ b/tests/disas/gc/null/funcref-in-gc-heap-new.wat
@@ -26,10 +26,10 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i64):
 ;; @0020                               v9 = load.i64 notrap aligned readonly v0+32
 ;; @0020                               v10 = load.i32 notrap aligned v9
-;;                                     v47 = iconst.i32 7
-;; @0020                               v13 = uadd_overflow_trap v10, v47, user17  ; v47 = 7
-;;                                     v54 = iconst.i32 -8
-;; @0020                               v15 = band v13, v54  ; v54 = -8
+;;                                     v46 = iconst.i32 7
+;; @0020                               v13 = uadd_overflow_trap v10, v46, user17  ; v46 = 7
+;;                                     v52 = iconst.i32 -8
+;; @0020                               v15 = band v13, v52  ; v52 = -8
 ;; @0020                               v4 = iconst.i32 16
 ;; @0020                               v16 = uadd_overflow_trap v15, v4, user17  ; v4 = 16
 ;; @0020                               v38 = load.i64 notrap aligned readonly can_move v0+8
@@ -39,12 +39,12 @@
 ;; @0020                               brif v19, block2, block3
 ;;
 ;;                                 block2:
-;;                                     v55 = iconst.i32 -1342177264
+;;                                     v53 = iconst.i32 -1342177264
 ;; @0020                               v23 = load.i64 notrap aligned readonly can_move v38+32
-;;                                     v62 = band.i32 v13, v54  ; v54 = -8
-;;                                     v63 = uextend.i64 v62
-;; @0020                               v25 = iadd v23, v63
-;; @0020                               store notrap aligned v55, v25  ; v55 = -1342177264
+;;                                     v59 = band.i32 v13, v52  ; v52 = -8
+;;                                     v60 = uextend.i64 v59
+;; @0020                               v25 = iadd v23, v60
+;; @0020                               store notrap aligned v53, v25  ; v53 = -1342177264
 ;; @0020                               v29 = load.i64 notrap aligned readonly can_move v0+40
 ;; @0020                               v30 = load.i32 notrap aligned readonly can_move v29
 ;; @0020                               store notrap aligned v30, v25+4
@@ -62,6 +62,6 @@
 ;; @0020                               jump block2
 ;;
 ;;                                 block1:
-;;                                     v64 = band.i32 v13, v54  ; v54 = -8
-;; @0023                               return v64
+;;                                     v61 = band.i32 v13, v52  ; v52 = -8
+;; @0023                               return v61
 ;; }

--- a/tests/disas/gc/null/struct-new-default.wat
+++ b/tests/disas/gc/null/struct-new-default.wat
@@ -26,10 +26,10 @@
 ;;                                 block0(v0: i64, v1: i64):
 ;; @0021                               v11 = load.i64 notrap aligned readonly v0+32
 ;; @0021                               v12 = load.i32 notrap aligned v11
-;;                                     v49 = iconst.i32 7
-;; @0021                               v15 = uadd_overflow_trap v12, v49, user17  ; v49 = 7
-;;                                     v56 = iconst.i32 -8
-;; @0021                               v17 = band v15, v56  ; v56 = -8
+;;                                     v48 = iconst.i32 7
+;; @0021                               v15 = uadd_overflow_trap v12, v48, user17  ; v48 = 7
+;;                                     v54 = iconst.i32 -8
+;; @0021                               v17 = band v15, v54  ; v54 = -8
 ;; @0021                               v6 = iconst.i32 24
 ;; @0021                               v18 = uadd_overflow_trap v17, v6, user17  ; v6 = 24
 ;; @0021                               v41 = load.i64 notrap aligned readonly can_move v0+8
@@ -39,12 +39,12 @@
 ;; @0021                               brif v21, block2, block3
 ;;
 ;;                                 block2:
-;;                                     v57 = iconst.i32 -1342177256
+;;                                     v55 = iconst.i32 -1342177256
 ;; @0021                               v25 = load.i64 notrap aligned readonly can_move v41+32
-;;                                     v64 = band.i32 v15, v56  ; v56 = -8
-;;                                     v65 = uextend.i64 v64
-;; @0021                               v27 = iadd v25, v65
-;; @0021                               store notrap aligned v57, v27  ; v57 = -1342177256
+;;                                     v61 = band.i32 v15, v54  ; v54 = -8
+;;                                     v62 = uextend.i64 v61
+;; @0021                               v27 = iadd v25, v62
+;; @0021                               store notrap aligned v55, v27  ; v55 = -1342177256
 ;; @0021                               v31 = load.i64 notrap aligned readonly can_move v0+40
 ;; @0021                               v32 = load.i32 notrap aligned readonly can_move v31
 ;; @0021                               store notrap aligned v32, v27+4
@@ -68,6 +68,6 @@
 ;; @0021                               jump block2
 ;;
 ;;                                 block1:
-;;                                     v66 = band.i32 v15, v56  ; v56 = -8
-;; @0024                               return v66
+;;                                     v63 = band.i32 v15, v54  ; v54 = -8
+;; @0024                               return v63
 ;; }

--- a/tests/disas/gc/null/struct-new.wat
+++ b/tests/disas/gc/null/struct-new.wat
@@ -29,10 +29,10 @@
 ;;                                     store notrap v4, v45
 ;; @002a                               v11 = load.i64 notrap aligned readonly v0+32
 ;; @002a                               v12 = load.i32 notrap aligned v11
-;;                                     v53 = iconst.i32 7
-;; @002a                               v15 = uadd_overflow_trap v12, v53, user17  ; v53 = 7
-;;                                     v60 = iconst.i32 -8
-;; @002a                               v17 = band v15, v60  ; v60 = -8
+;;                                     v52 = iconst.i32 7
+;; @002a                               v15 = uadd_overflow_trap v12, v52, user17  ; v52 = 7
+;;                                     v58 = iconst.i32 -8
+;; @002a                               v17 = band v15, v58  ; v58 = -8
 ;; @002a                               v6 = iconst.i32 24
 ;; @002a                               v18 = uadd_overflow_trap v17, v6, user17  ; v6 = 24
 ;; @002a                               v43 = load.i64 notrap aligned readonly can_move v0+8
@@ -42,12 +42,12 @@
 ;; @002a                               brif v21, block2, block3
 ;;
 ;;                                 block2:
-;;                                     v61 = iconst.i32 -1342177256
+;;                                     v59 = iconst.i32 -1342177256
 ;; @002a                               v25 = load.i64 notrap aligned readonly can_move v43+32
-;;                                     v68 = band.i32 v15, v60  ; v60 = -8
-;;                                     v69 = uextend.i64 v68
-;; @002a                               v27 = iadd v25, v69
-;; @002a                               store notrap aligned v61, v27  ; v61 = -1342177256
+;;                                     v65 = band.i32 v15, v58  ; v58 = -8
+;;                                     v66 = uextend.i64 v65
+;; @002a                               v27 = iadd v25, v66
+;; @002a                               store notrap aligned v59, v27  ; v59 = -1342177256
 ;; @002a                               v31 = load.i64 notrap aligned readonly can_move v0+40
 ;; @002a                               v32 = load.i32 notrap aligned readonly can_move v31
 ;; @002a                               store notrap aligned v32, v27+4
@@ -70,6 +70,6 @@
 ;; @002a                               jump block2
 ;;
 ;;                                 block1:
-;;                                     v70 = band.i32 v15, v60  ; v60 = -8
-;; @002d                               return v70
+;;                                     v67 = band.i32 v15, v58  ; v58 = -8
+;; @002d                               return v67
 ;; }

--- a/tests/disas/gc/struct-new-default.wat
+++ b/tests/disas/gc/struct-new-default.wat
@@ -57,10 +57,10 @@
 ;; @0023                               jump block3
 ;;
 ;;                                 block3:
-;;                                     v71 = iconst.i32 0
+;;                                     v68 = iconst.i32 0
 ;;                                     v46 = iconst.i64 32
 ;; @0023                               v20 = iadd.i64 v17, v46  ; v46 = 32
-;; @0023                               store notrap aligned little v71, v20  ; v71 = 0
+;; @0023                               store notrap aligned little v68, v20  ; v68 = 0
 ;; @0023                               v6 = vconst.i8x16 const0
 ;;                                     v38 = iconst.i64 48
 ;; @0023                               v37 = iadd.i64 v17, v38  ; v38 = 48

--- a/tests/disas/icall-loop.wat
+++ b/tests/disas/icall-loop.wat
@@ -83,26 +83,26 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64):
 ;; @0038                               v6 = load.i64 notrap aligned readonly can_move v0+48
-;;                                     v37 = iconst.i64 8
-;; @0038                               v8 = iadd v6, v37  ; v37 = 8
+;;                                     v36 = iconst.i64 8
+;; @0038                               v8 = iadd v6, v36  ; v36 = 8
 ;;                                     v26 = iconst.i64 -2
 ;; @0038                               v14 = iconst.i32 0
-;;                                     v36 = iconst.i64 1
+;;                                     v35 = iconst.i64 1
 ;; @0038                               v19 = load.i64 notrap aligned readonly can_move v0+40
 ;; @0038                               v20 = load.i32 notrap aligned readonly can_move v19
 ;; @0034                               jump block2
 ;;
 ;;                                 block2:
-;;                                     v38 = iadd.i64 v6, v37  ; v37 = 8
-;; @0038                               v11 = load.i64 user5 aligned table v38
-;;                                     v39 = iconst.i64 -2
-;;                                     v40 = band v11, v39  ; v39 = -2
-;; @0038                               brif v11, block5(v40), block4
+;;                                     v37 = iadd.i64 v6, v36  ; v36 = 8
+;; @0038                               v11 = load.i64 user5 aligned table v37
+;;                                     v38 = iconst.i64 -2
+;;                                     v39 = band v11, v38  ; v38 = -2
+;; @0038                               brif v11, block5(v39), block4
 ;;
 ;;                                 block4 cold:
-;;                                     v41 = iconst.i32 0
-;;                                     v42 = iconst.i64 1
-;; @0038                               v17 = call fn0(v0, v41, v42)  ; v41 = 0, v42 = 1
+;;                                     v40 = iconst.i32 0
+;;                                     v41 = iconst.i64 1
+;; @0038                               v17 = call fn0(v0, v40, v41)  ; v40 = 0, v41 = 1
 ;; @0038                               jump block5(v17)
 ;;
 ;;                                 block5(v13: i64):

--- a/tests/disas/typed-funcrefs-eager-init.wat
+++ b/tests/disas/typed-funcrefs-eager-init.wat
@@ -137,14 +137,14 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
 ;; @0048                               v12 = load.i64 notrap aligned readonly can_move v0+48
-;;                                     v48 = iconst.i64 8
-;; @0048                               v14 = iadd v12, v48  ; v48 = 8
+;;                                     v47 = iconst.i64 8
+;; @0048                               v14 = iadd v12, v47  ; v47 = 8
 ;; @0048                               v17 = load.i64 user5 aligned table v14
 ;; @004a                               v18 = load.i64 user15 aligned readonly v17+8
 ;; @004a                               v19 = load.i64 notrap aligned readonly v17+24
 ;; @004a                               v20 = call_indirect sig0, v18(v19, v0, v2, v3, v4, v5)
-;;                                     v56 = iconst.i64 16
-;; @005b                               v28 = iadd v12, v56  ; v56 = 16
+;;                                     v54 = iconst.i64 16
+;; @005b                               v28 = iadd v12, v54  ; v54 = 16
 ;; @005b                               v31 = load.i64 user5 aligned table v28
 ;; @005d                               v32 = load.i64 user15 aligned readonly v31+8
 ;; @005d                               v33 = load.i64 notrap aligned readonly v31+24
@@ -167,14 +167,14 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
 ;; @0075                               v12 = load.i64 notrap aligned readonly can_move v0+48
-;;                                     v48 = iconst.i64 8
-;; @0075                               v14 = iadd v12, v48  ; v48 = 8
+;;                                     v47 = iconst.i64 8
+;; @0075                               v14 = iadd v12, v47  ; v47 = 8
 ;; @0075                               v17 = load.i64 user5 aligned table v14
 ;; @0075                               v18 = load.i64 user6 aligned readonly v17+8
 ;; @0075                               v19 = load.i64 notrap aligned readonly v17+24
 ;; @0075                               v20 = call_indirect sig0, v18(v19, v0, v2, v3, v4, v5)
-;;                                     v56 = iconst.i64 16
-;; @0087                               v28 = iadd v12, v56  ; v56 = 16
+;;                                     v54 = iconst.i64 16
+;; @0087                               v28 = iadd v12, v54  ; v54 = 16
 ;; @0087                               v31 = load.i64 user5 aligned table v28
 ;; @0087                               v32 = load.i64 user6 aligned readonly v31+8
 ;; @0087                               v33 = load.i64 notrap aligned readonly v31+24

--- a/tests/disas/typed-funcrefs.wat
+++ b/tests/disas/typed-funcrefs.wat
@@ -139,8 +139,8 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
 ;; @0048                               v12 = load.i64 notrap aligned readonly can_move v0+48
-;;                                     v68 = iconst.i64 8
-;; @0048                               v14 = iadd v12, v68  ; v68 = 8
+;;                                     v67 = iconst.i64 8
+;; @0048                               v14 = iadd v12, v67  ; v67 = 8
 ;; @0048                               v17 = load.i64 user5 aligned table v14
 ;;                                     v57 = iconst.i64 -2
 ;; @0048                               v18 = band v17, v57  ; v57 = -2
@@ -148,25 +148,25 @@
 ;;
 ;;                                 block2 cold:
 ;; @003c                               v7 = iconst.i32 0
-;;                                     v67 = iconst.i64 1
-;; @0048                               v23 = call fn0(v0, v7, v67)  ; v7 = 0, v67 = 1
+;;                                     v66 = iconst.i64 1
+;; @0048                               v23 = call fn0(v0, v7, v66)  ; v7 = 0, v66 = 1
 ;; @0048                               jump block3(v23)
 ;;
 ;;                                 block3(v19: i64):
 ;; @004a                               v24 = load.i64 user15 aligned readonly v19+8
 ;; @004a                               v25 = load.i64 notrap aligned readonly v19+24
 ;; @004a                               v26 = call_indirect sig1, v24(v25, v0, v2, v3, v4, v5)
-;;                                     v76 = iconst.i64 16
-;; @005b                               v39 = iadd.i64 v12, v76  ; v76 = 16
+;;                                     v74 = iconst.i64 16
+;; @005b                               v39 = iadd.i64 v12, v74  ; v74 = 16
 ;; @005b                               v42 = load.i64 user5 aligned table v39
-;;                                     v77 = iconst.i64 -2
-;;                                     v78 = band v42, v77  ; v77 = -2
-;; @005b                               brif v42, block5(v78), block4
+;;                                     v75 = iconst.i64 -2
+;;                                     v76 = band v42, v75  ; v75 = -2
+;; @005b                               brif v42, block5(v76), block4
 ;;
 ;;                                 block4 cold:
-;;                                     v79 = iconst.i32 0
-;;                                     v75 = iconst.i64 2
-;; @005b                               v48 = call fn0(v0, v79, v75)  ; v79 = 0, v75 = 2
+;;                                     v77 = iconst.i32 0
+;;                                     v73 = iconst.i64 2
+;; @005b                               v48 = call fn0(v0, v77, v73)  ; v77 = 0, v73 = 2
 ;; @005b                               jump block5(v48)
 ;;
 ;;                                 block5(v44: i64):
@@ -193,8 +193,8 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
 ;; @0075                               v12 = load.i64 notrap aligned readonly can_move v0+48
-;;                                     v68 = iconst.i64 8
-;; @0075                               v14 = iadd v12, v68  ; v68 = 8
+;;                                     v67 = iconst.i64 8
+;; @0075                               v14 = iadd v12, v67  ; v67 = 8
 ;; @0075                               v17 = load.i64 user5 aligned table v14
 ;;                                     v57 = iconst.i64 -2
 ;; @0075                               v18 = band v17, v57  ; v57 = -2
@@ -202,25 +202,25 @@
 ;;
 ;;                                 block2 cold:
 ;; @0069                               v7 = iconst.i32 0
-;;                                     v67 = iconst.i64 1
-;; @0075                               v23 = call fn0(v0, v7, v67)  ; v7 = 0, v67 = 1
+;;                                     v66 = iconst.i64 1
+;; @0075                               v23 = call fn0(v0, v7, v66)  ; v7 = 0, v66 = 1
 ;; @0075                               jump block3(v23)
 ;;
 ;;                                 block3(v19: i64):
 ;; @0075                               v24 = load.i64 user6 aligned readonly v19+8
 ;; @0075                               v25 = load.i64 notrap aligned readonly v19+24
 ;; @0075                               v26 = call_indirect sig0, v24(v25, v0, v2, v3, v4, v5)
-;;                                     v76 = iconst.i64 16
-;; @0087                               v39 = iadd.i64 v12, v76  ; v76 = 16
+;;                                     v74 = iconst.i64 16
+;; @0087                               v39 = iadd.i64 v12, v74  ; v74 = 16
 ;; @0087                               v42 = load.i64 user5 aligned table v39
-;;                                     v77 = iconst.i64 -2
-;;                                     v78 = band v42, v77  ; v77 = -2
-;; @0087                               brif v42, block5(v78), block4
+;;                                     v75 = iconst.i64 -2
+;;                                     v76 = band v42, v75  ; v75 = -2
+;; @0087                               brif v42, block5(v76), block4
 ;;
 ;;                                 block4 cold:
-;;                                     v79 = iconst.i32 0
-;;                                     v75 = iconst.i64 2
-;; @0087                               v48 = call fn0(v0, v79, v75)  ; v79 = 0, v75 = 2
+;;                                     v77 = iconst.i32 0
+;;                                     v73 = iconst.i64 2
+;; @0087                               v48 = call fn0(v0, v77, v73)  ; v77 = 0, v73 = 2
 ;; @0087                               jump block5(v48)
 ;;
 ;;                                 block5(v44: i64):


### PR DESCRIPTION
Fix an off-by-one in the e-graph rewrite depth limit.

`REWRITE_LIMIT` is set to 5. Current check uses `rewrite_depth > REWRITE_LIMIT` before incrementing the depth. Since
`rewrite_depth` starts at 0, this allows rewrites to run at effective depth 6.

If the intended maximum rewrite depth is 5, this changes the check to `rewrite_depth >= REWRITE_LIMIT`.

Noticed while investigating #13204.