### PR TITLE
Adjust error matching predicate during fuzzing

### DIFF
--- a/crates/fuzzing/src/oracles/diff_wasmtime.rs
+++ b/crates/fuzzing/src/oracles/diff_wasmtime.rs
@@ -65,10 +65,7 @@ impl DiffEngine for WasmtimeEngine {
     }
 
     fn is_non_deterministic_error(&self, err: &Error) -> bool {
-        match err.downcast_ref::<Trap>() {
-            Some(trap) => super::wasmtime_trap_is_non_deterministic(trap),
-            None => false,
-        }
+        super::wasmtime_error_is_non_deterministic(err)
     }
 }
 


### PR DESCRIPTION
Fuzzing over the weekend found a failure where a wasmtime "rhs" failed with a trap and a wasmtime "lhs" failed with "gc heap not big enough". This is expected to be effectively equivalent but the method of testing whether a Wasmtime error is "non deterministic", which running out of GC heap space basically is, differed slightly with some other code which led to this differential failure.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
