### PR TITLE
Fix configuring a missing limit in wast fuzzing

### DIFF
--- a/crates/fuzzing/src/generators/config.rs
+++ b/crates/fuzzing/src/generators/config.rs
@@ -228,6 +228,9 @@ impl Config {
             pooling.total_tables = pooling.total_tables.max(limits::TABLES);
             pooling.max_tables_per_module =
                 pooling.max_tables_per_module.max(limits::TABLES_PER_MODULE);
+            pooling.max_tables_per_component = pooling
+                .max_tables_per_component
+                .max(limits::TABLES_PER_MODULE);
             pooling.max_memories_per_module = pooling
                 .max_memories_per_module
                 .max(limits::MEMORIES_PER_MODULE);


### PR DESCRIPTION
Need to set items-per-component the same way items-per-module is set. This configures tables in the same manner that memories are already configured.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
