### PR TITLE
Adjust configuration of reservation-for-growth in fuzzing

### DIFF
--- a/crates/fuzzing/src/generators/config.rs
+++ b/crates/fuzzing/src/generators/config.rs
@@ -795,37 +795,11 @@ impl WasmtimeConfig {
     /// the current state of the engine's development.
     pub(crate) fn make_internally_consistent(&mut self) {
         if !self.signals_based_traps {
-            let cfg = &mut self.memory_config;
             // Spectre-based heap mitigations require signal handlers so
             // this must always be disabled if signals-based traps are
             // disabled.
-            cfg.cranelift_enable_heap_access_spectre_mitigations = None;
-
-            // With configuration settings that match the use of malloc for
-            // linear memories and GC heaps, cap the reservation-for-growth
-            // values to something reasonable to avoid OOM in fuzzing.
-            if !cfg.memory_init_cow
-                && cfg.memory_guard_size == Some(0)
-                && cfg.memory_reservation == Some(0)
-            {
-                let min = 10 << 20; // 10 MiB
-                if let Some(val) = &mut cfg.memory_reservation_for_growth {
-                    *val = (*val).min(min);
-                } else {
-                    cfg.memory_reservation_for_growth = Some(min);
-                }
-            }
-
-            // Similarly cap gc_heap_reservation_for_growth when signals-based
-            // traps are disabled and the GC heap uses malloc-style allocation.
-            if cfg.gc_heap_guard_size == Some(0) && cfg.gc_heap_reservation == Some(0) {
-                let min = 10 << 20; // 10 MiB
-                if let Some(val) = &mut cfg.gc_heap_reservation_for_growth {
-                    *val = (*val).min(min);
-                } else {
-                    cfg.gc_heap_reservation_for_growth = Some(min);
-                }
-            }
+            self.memory_config
+                .cranelift_enable_heap_access_spectre_mitigations = None;
         }
 
         // If malloc-based memory is going to be used, which requires these
@@ -838,7 +812,7 @@ impl WasmtimeConfig {
         let is_pulley = self.compiler_strategy == CompilerStrategy::CraneliftPulley;
         let mcfg = &mut self.memory_config;
         if self.signals_based_traps || is_pulley {
-            if mcfg.memory_guard_size == Some(0)
+            if (mcfg.memory_guard_size == Some(0) || is_pulley)
                 && mcfg.memory_reservation == Some(0)
                 && !mcfg.memory_init_cow
             {
@@ -849,7 +823,9 @@ impl WasmtimeConfig {
                     None => Some(max),
                 };
             }
-            if mcfg.gc_heap_guard_size == Some(0) && mcfg.gc_heap_reservation == Some(0) {
+            if (mcfg.gc_heap_guard_size == Some(0) || is_pulley)
+                && mcfg.gc_heap_reservation == Some(0)
+            {
                 let growth = &mut mcfg.gc_heap_reservation_for_growth;
                 let max = 1 << 20;
                 *growth = match *growth {


### PR DESCRIPTION
This fixes a mistake in #13174 with the translation of clamping logic, and this additionally deduplicates the clamping logic since it looks like it was basically present in the same manner.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
