### PR TITLE
Enable inlining by default

### DIFF
--- a/crates/environ/src/tunables.rs
+++ b/crates/environ/src/tunables.rs
@@ -255,7 +255,7 @@ impl Tunables {
             winch_callable: false,
             signals_based_traps: false,
             memory_init_cow: true,
-            inlining: false,
+            inlining: true,
             inlining_intra_module: IntraModuleInlining::WhenUsingGc,
             inlining_small_callee_size: 50,
             inlining_sum_size_threshold: 2000,

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -2564,6 +2564,15 @@ impl Config {
             tunables.signals_based_traps = false;
         }
 
+        // Inlining currently falls over with the `stack_switch` instruction.
+        #[cfg(any(feature = "cranelift", feature = "winch"))]
+        if features.contains(WasmFeatures::STACK_SWITCHING) {
+            if self.tunables.inlining == Some(true) {
+                bail!("cannot enable compiler inlining when stack switching is enabled");
+            }
+            tunables.inlining = false;
+        }
+
         self.tunables.configure(&mut tunables);
 
         // If no GC heap tunables are explicitly configured, copy the memory

--- a/tests/all/component_model/import.rs
+++ b/tests/all/component_model/import.rs
@@ -337,7 +337,9 @@ fn attempt_to_leave_during_malloc() -> Result<()> {
 )
     "#;
 
-    let engine = super::engine();
+    let mut config = Config::new();
+    config.compiler_inlining(false);
+    let engine = Engine::new(&config)?;
     let mut linker = Linker::new(&engine);
     linker.root().func_wrap("thunk", |_, _: ()| -> Result<()> {
         panic!("should not get here")


### PR DESCRIPTION
This commit switches the default configuration of Wasmtime to enable cross-module inlining by default. This means that components with multiple modules will, by default, inline small functions across these modules. Additionally modules which use the GC proposal will have inlining performed by default. Intra-module inlining without GC, however, will continue to not happen.

This required two minor updates in tests. One is to disable inlining when the exact call stack is expected and another is to disable inlining when the stack-switching proposal is enabled because it currently falls over in Cranelift on the `stack_switch` instruction.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
