### PR TITLE
Gate synchronous future/stream read/write separately

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -645,7 +645,7 @@ dependencies = [
  "test-programs-artifacts",
  "tokio",
  "wasm-compose",
- "wasmparser 0.247.0",
+ "wasmparser 0.248.0",
  "wasmtime",
  "wasmtime-wasi",
 ]
@@ -2253,14 +2253,14 @@ dependencies = [
 
 [[package]]
 name = "json-from-wast"
-version = "0.247.0"
+version = "0.248.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368ba37ac86fe3f725a95a4286e5c2c588b6e0e6c5efc2dffa304bbb63e88521"
+checksum = "692e5e6883558fb83746e7ab1da0d94a69b31286f88ecaa9ce6add0f269da0b6"
 dependencies = [
  "anyhow",
  "serde",
  "serde_derive",
- "wast 247.0.0",
+ "wast 248.0.0",
 ]
 
 [[package]]
@@ -3816,7 +3816,7 @@ dependencies = [
  "wasmtime",
  "wasmtime-test-util",
  "wat",
- "wit-component 0.247.0",
+ "wit-component 0.248.0",
 ]
 
 [[package]]
@@ -4286,7 +4286,7 @@ name = "verify-component-adapter"
 version = "45.0.0"
 dependencies = [
  "anyhow",
- "wasmparser 0.247.0",
+ "wasmparser 0.248.0",
  "wat",
 ]
 
@@ -4394,7 +4394,7 @@ dependencies = [
  "byte-array-literals",
  "object 0.39.0",
  "wasip1",
- "wasm-encoder 0.247.0",
+ "wasm-encoder 0.248.0",
  "wit-bindgen-rust-macro 0.57.0",
 ]
 
@@ -4479,9 +4479,9 @@ checksum = "6ee99da9c5ba11bd675621338ef6fa52296b76b83305e9b6e5c77d4c286d6d49"
 
 [[package]]
 name = "wasm-compose"
-version = "0.247.0"
+version = "0.248.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "950aaf4054cf5600325ba8ca008161ab04fcc54295511a2018bead96ebd7a689"
+checksum = "96ba953e2b9b4b4b52a31cf4e3ee1c1374c872b6e012cf2138d1c37cba00bfd6"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -4489,8 +4489,8 @@ dependencies = [
  "log",
  "petgraph",
  "smallvec 1.15.1",
- "wasm-encoder 0.247.0",
- "wasmparser 0.247.0",
+ "wasm-encoder 0.248.0",
+ "wasmparser 0.248.0",
  "wat",
 ]
 
@@ -4512,6 +4512,16 @@ checksum = "30b6733b8b91d010a6ac5b0fb237dc46a19650bc4c67db66857e2e787d437204"
 dependencies = [
  "leb128fmt",
  "wasmparser 0.247.0",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.248.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac92cf547bc18d27ecc521015c08c353b4f18b84ab388bb6d1b6b682c620d9b6"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.248.0",
 ]
 
 [[package]]
@@ -4539,31 +4549,43 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-mutate"
-version = "0.247.0"
+name = "wasm-metadata"
+version = "0.248.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711ddc6a40d65f86bfe5ef4b3764b1231f4f97d26f7ea3f2723a041b13656fe9"
+checksum = "ee4f85f11dcdabc91e805c03eb84ccc7b7ef2282c6610bb83c7a7c853425850c"
+dependencies = [
+ "anyhow",
+ "indexmap 2.14.0",
+ "wasm-encoder 0.248.0",
+ "wasmparser 0.248.0",
+]
+
+[[package]]
+name = "wasm-mutate"
+version = "0.248.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6210f23d92145ecdbc04e27d4b570714148e45c61db913f1f69a38fe80fb61d7"
 dependencies = [
  "egg",
  "log",
  "rand 0.10.1",
  "thiserror 2.0.17",
- "wasm-encoder 0.247.0",
- "wasmparser 0.247.0",
+ "wasm-encoder 0.248.0",
+ "wasmparser 0.248.0",
 ]
 
 [[package]]
 name = "wasm-smith"
-version = "0.247.0"
+version = "0.248.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d73849650a48c574f68c429fedaa363b4acff38dc1c28b213b6f7c8b22ab7ceb"
+checksum = "050b559c1cec6dd6b9a558ae984d91d61e5e7b4c3e47081305a13efe6869eea0"
 dependencies = [
  "anyhow",
  "arbitrary",
  "flagset",
  "serde",
  "serde_derive",
- "wasm-encoder 0.247.0",
+ "wasm-encoder 0.248.0",
  "wat",
 ]
 
@@ -4577,13 +4599,13 @@ dependencies = [
 
 [[package]]
 name = "wasm-wave"
-version = "0.247.0"
+version = "0.248.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a33f92f506694b5dee9a975b8ed380142086344d59981c5a5841d7e9bdc53206"
+checksum = "db8c928a58132ecc6a4daee3795bb3560702436f6516b5f8c5b3086113031e76"
 dependencies = [
  "logos",
  "thiserror 2.0.17",
- "wit-parser 0.247.0",
+ "wit-parser 0.248.0",
 ]
 
 [[package]]
@@ -4658,18 +4680,30 @@ dependencies = [
  "hashbrown 0.17.0",
  "indexmap 2.14.0",
  "semver",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.248.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa4439c5eee9df71ee0c6efb37f63b1fcb1fec38f85f5142c54e7ed05d33091a"
+dependencies = [
+ "bitflags 2.11.1",
+ "hashbrown 0.17.0",
+ "indexmap 2.14.0",
+ "semver",
  "serde",
 ]
 
 [[package]]
 name = "wasmprinter"
-version = "0.247.0"
+version = "0.248.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11b221eaf3943d2f562f022ccee3d8c631e144b41cb7c8850c24b437923ee64e"
+checksum = "30b264a5410b008d4d199a92bf536eae703cbd614482fc1ec53831cf19e1c183"
 dependencies = [
  "anyhow",
  "termcolor",
- "wasmparser 0.247.0",
+ "wasmparser 0.248.0",
 ]
 
 [[package]]
@@ -4712,9 +4746,9 @@ dependencies = [
  "tempfile",
  "tokio",
  "wasm-compose",
- "wasm-encoder 0.247.0",
+ "wasm-encoder 0.248.0",
  "wasm-wave",
- "wasmparser 0.247.0",
+ "wasmparser 0.248.0",
  "wasmtime-environ",
  "wasmtime-internal-cache",
  "wasmtime-internal-component-macro",
@@ -4825,8 +4859,8 @@ dependencies = [
  "tracing",
  "walkdir",
  "wasi-common",
- "wasm-encoder 0.247.0",
- "wasmparser 0.247.0",
+ "wasm-encoder 0.248.0",
+ "wasmparser 0.248.0",
  "wasmprinter",
  "wasmtime",
  "wasmtime-cli-flags",
@@ -4849,10 +4883,10 @@ dependencies = [
  "wasmtime-wasi-tls",
  "wasmtime-wast",
  "wasmtime-wizer",
- "wast 247.0.0",
+ "wast 248.0.0",
  "wat",
  "windows-sys 0.61.2",
- "wit-component 0.247.0",
+ "wit-component 0.248.0",
 ]
 
 [[package]]
@@ -4895,8 +4929,8 @@ dependencies = [
  "sha2",
  "smallvec 1.15.1",
  "target-lexicon",
- "wasm-encoder 0.247.0",
- "wasmparser 0.247.0",
+ "wasm-encoder 0.248.0",
+ "wasmparser 0.248.0",
  "wasmprinter",
  "wasmtime-internal-component-util",
  "wasmtime-internal-core",
@@ -4910,7 +4944,7 @@ dependencies = [
  "arbitrary",
  "env_logger 0.11.5",
  "libfuzzer-sys",
- "wasmparser 0.247.0",
+ "wasmparser 0.248.0",
  "wasmprinter",
  "wasmtime-environ",
  "wasmtime-test-util",
@@ -4942,7 +4976,7 @@ dependencies = [
  "rand 0.10.1",
  "smallvec 1.15.1",
  "target-lexicon",
- "wasmparser 0.247.0",
+ "wasmparser 0.248.0",
  "wasmtime",
  "wasmtime-fuzzing",
  "wasmtime-test-util",
@@ -4969,12 +5003,12 @@ dependencies = [
  "tempfile",
  "tokio",
  "v8",
- "wasm-encoder 0.247.0",
+ "wasm-encoder 0.248.0",
  "wasm-mutate",
  "wasm-smith",
  "wasm-spec-interpreter",
  "wasmi",
- "wasmparser 0.247.0",
+ "wasmparser 0.248.0",
  "wasmprinter",
  "wasmtime",
  "wasmtime-cli-flags",
@@ -5031,7 +5065,7 @@ dependencies = [
  "wasmtime",
  "wasmtime-internal-component-util",
  "wasmtime-internal-wit-bindgen",
- "wit-parser 0.247.0",
+ "wit-parser 0.248.0",
 ]
 
 [[package]]
@@ -5066,7 +5100,7 @@ dependencies = [
  "smallvec 1.15.1",
  "target-lexicon",
  "thiserror 2.0.17",
- "wasmparser 0.247.0",
+ "wasmparser 0.248.0",
  "wasmtime-environ",
  "wasmtime-internal-core",
  "wasmtime-internal-unwinder",
@@ -5183,7 +5217,7 @@ dependencies = [
  "log",
  "object 0.39.0",
  "target-lexicon",
- "wasmparser 0.247.0",
+ "wasmparser 0.248.0",
  "wasmtime-environ",
  "wasmtime-internal-cranelift",
  "winch-codegen",
@@ -5197,7 +5231,7 @@ dependencies = [
  "bitflags 2.11.1",
  "heck 0.5.0",
  "indexmap 2.14.0",
- "wit-parser 0.247.0",
+ "wit-parser 0.248.0",
 ]
 
 [[package]]
@@ -5230,7 +5264,7 @@ dependencies = [
  "serde_derive",
  "target-lexicon",
  "toml",
- "wasmparser 0.247.0",
+ "wasmparser 0.248.0",
  "wasmprinter",
  "wasmtime",
  "wasmtime-environ",
@@ -5396,9 +5430,9 @@ dependencies = [
  "object 0.39.0",
  "serde_json",
  "tokio",
- "wasmparser 0.247.0",
+ "wasmparser 0.248.0",
  "wasmtime",
- "wast 247.0.0",
+ "wast 248.0.0",
 ]
 
 [[package]]
@@ -5412,8 +5446,8 @@ dependencies = [
  "rayon",
  "test-programs-artifacts",
  "tokio",
- "wasm-encoder 0.247.0",
- "wasmparser 0.247.0",
+ "wasm-encoder 0.248.0",
+ "wasmparser 0.248.0",
  "wasmprinter",
  "wasmtime",
  "wasmtime-wasi",
@@ -5431,25 +5465,25 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "247.0.0"
+version = "248.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "579d2d47eb33b0cdf9b14723cb115f1e1b7d6e77aac6f0816e5b7c7aeaa418ff"
+checksum = "acc54622ed5a5cddafcdf152043f9d4aed54d4a653d686b7dfe874809fca99d7"
 dependencies = [
  "bumpalo",
  "gimli 0.32.3",
  "leb128fmt",
  "memchr",
  "unicode-width 0.2.0",
- "wasm-encoder 0.247.0",
+ "wasm-encoder 0.248.0",
 ]
 
 [[package]]
 name = "wat"
-version = "1.247.0"
+version = "1.248.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3f4091c56437e86f2b57fa2fac72c4f528957a605b3f44f7c0b3b19a17ac5ee"
+checksum = "d75cd9e510603909748e6ebab89f27cd04472c1d9d85a3c88a7a6fc51a1a7934"
 dependencies = [
- "wast 247.0.0",
+ "wast 248.0.0",
 ]
 
 [[package]]
@@ -5576,7 +5610,7 @@ dependencies = [
  "smallvec 1.15.1",
  "target-lexicon",
  "thiserror 2.0.17",
- "wasmparser 0.247.0",
+ "wasmparser 0.248.0",
  "wasmtime-environ",
  "wasmtime-internal-core",
  "wasmtime-internal-cranelift",
@@ -5971,6 +6005,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-component"
+version = "0.248.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0012379f0ff47e1d44dd312e76cfa42de2589251f093fb105e9de9db90c89221"
+dependencies = [
+ "anyhow",
+ "bitflags 2.11.1",
+ "indexmap 2.14.0",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder 0.248.0",
+ "wasm-metadata 0.248.0",
+ "wasmparser 0.248.0",
+ "wit-parser 0.248.0",
+]
+
+[[package]]
 name = "wit-parser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6005,6 +6058,25 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser 0.247.0",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.248.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "247ad505da2915a082fe13204c5ba8788425aea1de54f43b284818cf82637856"
+dependencies = [
+ "anyhow",
+ "hashbrown 0.17.0",
+ "id-arena",
+ "indexmap 2.14.0",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.248.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -351,18 +351,18 @@ wit-bindgen = { version = "0.57.0", default-features = false }
 wit-bindgen-rust-macro = { version = "0.57.0", default-features = false }
 
 # wasm-tools family:
-wasmparser = { version = "0.247.0", default-features = false, features = ['simd'] }
-wat = "1.247.0"
-wast = "247.0.0"
-wasmprinter = "0.247.0"
-wasm-encoder = "0.247.0"
-wasm-smith = "0.247.0"
-wasm-mutate = "0.247.0"
-wit-parser = "0.247.0"
-wit-component = "0.247.0"
-wasm-wave = "0.247.0"
-wasm-compose = { version = "0.247.0", default-features = false }
-json-from-wast = "0.247.0"
+wasmparser = { version = "0.248.0", default-features = false, features = ['simd'] }
+wat = "1.248.0"
+wast = "248.0.0"
+wasmprinter = "0.248.0"
+wasm-encoder = "0.248.0"
+wasm-smith = "0.248.0"
+wasm-mutate = "0.248.0"
+wit-parser = "0.248.0"
+wit-component = "0.248.0"
+wasm-wave = "0.248.0"
+wasm-compose = { version = "0.248.0", default-features = false }
+json-from-wast = "0.248.0"
 
 wstd = "0.6.5"
 wasip2 = "1.0"

--- a/ci/miri-provenance-test.sh
+++ b/ci/miri-provenance-test.sh
@@ -19,7 +19,7 @@ compile() {
     -O memory-guard-size=0 \
     -O signals-based-traps=n \
     -D guest-debug=y \
-    -W function-references,component-model-async,component-model-async-stackful,component-model-async-builtins,component-model-error-context
+    -W function-references,component-model-async,component-model-async-stackful,component-model-more-async-builtins,component-model-error-context
 }
 
 compile ./tests/all/pulley_provenance_test.wat

--- a/crates/c-api/include/wasmtime/config.h
+++ b/crates/c-api/include/wasmtime/config.h
@@ -917,9 +917,9 @@ WASMTIME_CONFIG_PROP(void, wasm_component_model_async, bool)
  * component model.
  *
  * For more information see the Rust documentation at
- * https://docs.wasmtime.dev/api/wasmtime/struct.Config.html#method.wasm_component_model_async_builtins.
+ * https://docs.wasmtime.dev/api/wasmtime/struct.Config.html#method.wasm_component_model_more_async_builtins.
  */
-WASMTIME_CONFIG_PROP(void, wasm_component_model_async_builtins, bool)
+WASMTIME_CONFIG_PROP(void, wasm_component_model_more_async_builtins, bool)
 
 /**
  * \brief Configures whether stackful coroutine support is enabled for async

--- a/crates/c-api/include/wasmtime/config.hh
+++ b/crates/c-api/include/wasmtime/config.hh
@@ -697,10 +697,11 @@ public:
    * \brief Configures whether async built-in intrinsics are enabled for the
    * component model.
    *
-   * https://docs.wasmtime.dev/api/wasmtime/struct.Config.html#method.wasm_component_model_async_builtins
+   * https://docs.wasmtime.dev/api/wasmtime/struct.Config.html#method.wasm_component_model_more_async_builtins
    */
-  void wasm_component_model_async_builtins(bool enable) {
-    wasmtime_config_wasm_component_model_async_builtins_set(ptr.get(), enable);
+  void wasm_component_model_more_async_builtins(bool enable) {
+    wasmtime_config_wasm_component_model_more_async_builtins_set(ptr.get(),
+                                                                 enable);
   }
 
   /**

--- a/crates/c-api/src/component/component.rs
+++ b/crates/c-api/src/component/component.rs
@@ -29,11 +29,11 @@ pub extern "C" fn wasmtime_config_wasm_component_model_async_set(
 
 #[unsafe(no_mangle)]
 #[cfg(feature = "component-model-async")]
-pub extern "C" fn wasmtime_config_wasm_component_model_async_builtins_set(
+pub extern "C" fn wasmtime_config_wasm_component_model_more_async_builtins_set(
     c: &mut wasm_config_t,
     enable: bool,
 ) {
-    c.config.wasm_component_model_async_builtins(enable);
+    c.config.wasm_component_model_more_async_builtins(enable);
 }
 
 #[unsafe(no_mangle)]

--- a/crates/c-api/tests/component/async.cc
+++ b/crates/c-api/tests/component/async.cc
@@ -13,9 +13,9 @@ using wasmtime::Store;
 
 TEST(component_async, config) {
   Config config;
-  wasmtime_config_wasm_component_model_async_set(config.capi(), true);
-  wasmtime_config_wasm_component_model_async_builtins_set(config.capi(), true);
-  wasmtime_config_wasm_component_model_async_stackful_set(config.capi(), true);
+  config.wasm_component_model_async(true);
+  config.wasm_component_model_more_async_builtins(true);
+  config.wasm_component_model_async_stackful(true);
   Engine engine(std::move(config));
 }
 

--- a/crates/cli-flags/src/lib.rs
+++ b/crates/cli-flags/src/lib.rs
@@ -417,7 +417,7 @@ wasmtime_option_group! {
         pub component_model_async: Option<bool>,
         /// Component model support for async lifting/lowering: this corresponds
         /// to the 🚝 emoji in the component model specification.
-        pub component_model_async_builtins: Option<bool>,
+        pub component_model_more_async_builtins: Option<bool>,
         /// Component model support for async lifting/lowering: this corresponds
         /// to the 🚟 emoji in the component model specification.
         pub component_model_async_stackful: Option<bool>,
@@ -1202,7 +1202,7 @@ impl CommonOptions {
         handle_conditionally_compiled! {
             ("component-model", component_model, wasm_component_model)
             ("component-model-async", component_model_async, wasm_component_model_async)
-            ("component-model-async", component_model_async_builtins, wasm_component_model_async_builtins)
+            ("component-model-async", component_model_more_async_builtins, wasm_component_model_more_async_builtins)
             ("component-model-async", component_model_async_stackful, wasm_component_model_async_stackful)
             ("component-model-async", component_model_threading, wasm_component_model_threading)
             ("component-model", component_model_error_context, wasm_component_model_error_context)

--- a/crates/environ/src/component/translate.rs
+++ b/crates/environ/src/component/translate.rs
@@ -1127,15 +1127,21 @@ impl<'a, 'data> Translator<'a, 'data> {
                             core_func_index += 1;
                             LocalInitializer::ErrorContextDrop { func }
                         }
-                        wasmparser::CanonicalFunction::ContextGet(i) => {
+                        wasmparser::CanonicalFunction::ContextGet { slot, ty } => {
+                            if ty != wasmparser::ValType::I32 {
+                                bail!("unsupported context.get type: {ty:?}");
+                            }
                             let func = self.core_func_signature(core_func_index)?;
                             core_func_index += 1;
-                            LocalInitializer::ContextGet { i, func }
+                            LocalInitializer::ContextGet { i: slot, func }
                         }
-                        wasmparser::CanonicalFunction::ContextSet(i) => {
+                        wasmparser::CanonicalFunction::ContextSet { slot, ty } => {
+                            if ty != wasmparser::ValType::I32 {
+                                bail!("unsupported context.set type: {ty:?}");
+                            }
                             let func = self.core_func_signature(core_func_index)?;
                             core_func_index += 1;
-                            LocalInitializer::ContextSet { i, func }
+                            LocalInitializer::ContextSet { i: slot, func }
                         }
                         wasmparser::CanonicalFunction::ThreadIndex => {
                             let func = self.core_func_signature(core_func_index)?;

--- a/crates/fuzzing/src/generators/config.rs
+++ b/crates/fuzzing/src/generators/config.rs
@@ -139,7 +139,7 @@ impl Config {
             extended_const,
             wide_arithmetic,
             component_model_async,
-            component_model_async_builtins,
+            component_model_more_async_builtins,
             component_model_async_stackful,
             component_model_threading,
             component_model_error_context,
@@ -163,8 +163,8 @@ impl Config {
         self.module_config.function_references_enabled =
             function_references.or(gc).unwrap_or(false);
         self.module_config.component_model_async = component_model_async.unwrap_or(false);
-        self.module_config.component_model_async_builtins =
-            component_model_async_builtins.unwrap_or(false);
+        self.module_config.component_model_more_async_builtins =
+            component_model_more_async_builtins.unwrap_or(false);
         self.module_config.component_model_async_stackful =
             component_model_async_stackful.unwrap_or(false);
         self.module_config.component_model_threading = component_model_threading.unwrap_or(false);
@@ -304,8 +304,8 @@ impl Config {
         cfg.wasm.async_stack_zeroing = Some(self.wasmtime.async_stack_zeroing);
         cfg.wasm.bulk_memory = Some(self.module_config.config.bulk_memory_enabled);
         cfg.wasm.component_model_async = Some(self.module_config.component_model_async);
-        cfg.wasm.component_model_async_builtins =
-            Some(self.module_config.component_model_async_builtins);
+        cfg.wasm.component_model_more_async_builtins =
+            Some(self.module_config.component_model_more_async_builtins);
         cfg.wasm.component_model_async_stackful =
             Some(self.module_config.component_model_async_stackful);
         cfg.wasm.component_model_threading = Some(self.module_config.component_model_threading);

--- a/crates/fuzzing/src/generators/module.rs
+++ b/crates/fuzzing/src/generators/module.rs
@@ -17,7 +17,7 @@ pub struct ModuleConfig {
     // config-to-`wasmtime::Config` translation.
     pub function_references_enabled: bool,
     pub component_model_async: bool,
-    pub component_model_async_builtins: bool,
+    pub component_model_more_async_builtins: bool,
     pub component_model_async_stackful: bool,
     pub component_model_threading: bool,
     pub component_model_error_context: bool,
@@ -77,7 +77,7 @@ impl<'a> Arbitrary<'a> for ModuleConfig {
 
         Ok(ModuleConfig {
             component_model_async: false,
-            component_model_async_builtins: false,
+            component_model_more_async_builtins: false,
             component_model_async_stackful: false,
             component_model_threading: false,
             component_model_error_context: false,

--- a/crates/misc/component-async-tests/tests/scenario/util.rs
+++ b/crates/misc/component-async-tests/tests/scenario/util.rs
@@ -34,7 +34,7 @@ pub fn config() -> Config {
     }
     config.wasm_component_model(true);
     config.wasm_component_model_async(true);
-    config.wasm_component_model_async_builtins(true);
+    config.wasm_component_model_more_async_builtins(true);
     config.wasm_component_model_async_stackful(true);
     config.wasm_component_model_threading(true);
     config.wasm_component_model_error_context(true);

--- a/crates/test-util/src/wasmtime_wast.rs
+++ b/crates/test-util/src/wasmtime_wast.rs
@@ -40,7 +40,7 @@ pub fn apply_test_config(config: &mut Config, test_config: &wast::TestConfig) {
         extended_const,
         wide_arithmetic,
         component_model_async,
-        component_model_async_builtins,
+        component_model_more_async_builtins,
         component_model_async_stackful,
         component_model_threading,
         component_model_error_context,
@@ -72,7 +72,7 @@ pub fn apply_test_config(config: &mut Config, test_config: &wast::TestConfig) {
     let extended_const = extended_const.unwrap_or(false);
     let wide_arithmetic = wide_arithmetic.unwrap_or(false);
     let component_model_async = component_model_async.unwrap_or(false);
-    let component_model_async_builtins = component_model_async_builtins.unwrap_or(false);
+    let component_model_more_async_builtins = component_model_more_async_builtins.unwrap_or(false);
     let component_model_async_stackful = component_model_async_stackful.unwrap_or(false);
     let component_model_threading = component_model_threading.unwrap_or(false);
     let component_model_error_context = component_model_error_context.unwrap_or(false);
@@ -114,7 +114,7 @@ pub fn apply_test_config(config: &mut Config, test_config: &wast::TestConfig) {
         .wasm_extended_const(extended_const)
         .wasm_wide_arithmetic(wide_arithmetic)
         .wasm_component_model_async(component_model_async)
-        .wasm_component_model_async_builtins(component_model_async_builtins)
+        .wasm_component_model_more_async_builtins(component_model_more_async_builtins)
         .wasm_component_model_async_stackful(component_model_async_stackful)
         .wasm_component_model_threading(component_model_threading)
         .wasm_component_model_error_context(component_model_error_context)

--- a/crates/test-util/src/wast.rs
+++ b/crates/test-util/src/wast.rs
@@ -202,7 +202,7 @@ fn component_test_config(test: &Path) -> TestConfig {
         {
             ret.component_model_async = Some(true);
             ret.component_model_async_stackful = Some(true);
-            ret.component_model_async_builtins = Some(true);
+            ret.component_model_more_async_builtins = Some(true);
             ret.component_model_threading = Some(true);
         }
         if parent.ends_with("wasm-tools") {
@@ -275,7 +275,7 @@ macro_rules! foreach_config_option {
             hogs_memory
             nan_canonicalization
             component_model_async
-            component_model_async_builtins
+            component_model_more_async_builtins
             component_model_async_stackful
             component_model_threading
             component_model_error_context
@@ -467,12 +467,16 @@ impl WastTest {
             return true;
         }
 
-        // These tests in the `component-model` submodule have not yet been
-        // updated to account for the recent threading-related intrinsic
-        // changes
         let unsupported = [
+            // These tests in the `component-model` submodule have not yet been
+            // updated to account for the recent threading-related intrinsic
+            // changes
             "test/async/same-component-stream-future.wast",
             "test/async/trap-if-block-and-sync.wast",
+            // These tests assert different errors and aren't updated for
+            // memory64.
+            "test/wasm-tools/memory64.wast",
+            "test/wasm-tools/resources.wast",
         ];
         if unsupported.iter().any(|part| self.path.ends_with(part)) {
             return true;

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -1236,8 +1236,8 @@ impl Config {
     /// [proposal]:
     ///     https://github.com/WebAssembly/component-model/blob/main/design/mvp/Concurrency.md
     #[cfg(feature = "component-model-async")]
-    pub fn wasm_component_model_async_builtins(&mut self, enable: bool) -> &mut Self {
-        self.wasm_features(WasmFeatures::CM_ASYNC_BUILTINS, enable);
+    pub fn wasm_component_model_more_async_builtins(&mut self, enable: bool) -> &mut Self {
+        self.wasm_features(WasmFeatures::CM_MORE_ASYNC_BUILTINS, enable);
         self
     }
 
@@ -2321,7 +2321,7 @@ impl Config {
             | WasmFeatures::WIDE_ARITHMETIC
             | WasmFeatures::CM_ASYNC
             | WasmFeatures::CM_ASYNC_STACKFUL
-            | WasmFeatures::CM_ASYNC_BUILTINS
+            | WasmFeatures::CM_MORE_ASYNC_BUILTINS
             | WasmFeatures::CM_THREADING
             | WasmFeatures::CM_ERROR_CONTEXT
             | WasmFeatures::CM_GC
@@ -2615,7 +2615,7 @@ impl Config {
 
         // Concurrency support is required for some component model features.
         let requires_concurrency = WasmFeatures::CM_ASYNC
-            | WasmFeatures::CM_ASYNC_BUILTINS
+            | WasmFeatures::CM_MORE_ASYNC_BUILTINS
             | WasmFeatures::CM_ASYNC_STACKFUL
             | WasmFeatures::CM_THREADING
             | WasmFeatures::CM_ERROR_CONTEXT;

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -769,8 +769,8 @@ user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
 [[publisher.json-from-wast]]
-version = "0.247.0"
-when = "2026-04-17"
+version = "0.248.0"
+when = "2026-04-28"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
 [[publisher.libc]]
@@ -1256,8 +1256,8 @@ user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
 [[publisher.wasm-compose]]
-version = "0.247.0"
-when = "2026-04-17"
+version = "0.248.0"
+when = "2026-04-28"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
 [[publisher.wasm-encoder]]
@@ -1268,6 +1268,11 @@ trusted-publisher = "github:bytecodealliance/wasm-tools"
 [[publisher.wasm-encoder]]
 version = "0.247.0"
 when = "2026-04-17"
+trusted-publisher = "github:bytecodealliance/wasm-tools"
+
+[[publisher.wasm-encoder]]
+version = "0.248.0"
+when = "2026-04-28"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
 [[publisher.wasm-metadata]]
@@ -1281,9 +1286,14 @@ version = "0.247.0"
 when = "2026-04-17"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
+[[publisher.wasm-metadata]]
+version = "0.248.0"
+when = "2026-04-28"
+trusted-publisher = "github:bytecodealliance/wasm-tools"
+
 [[publisher.wasm-wave]]
-version = "0.247.0"
-when = "2026-04-17"
+version = "0.248.0"
+when = "2026-04-28"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
 [[publisher.wasmparser]]
@@ -1296,9 +1306,14 @@ version = "0.247.0"
 when = "2026-04-17"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
+[[publisher.wasmparser]]
+version = "0.248.0"
+when = "2026-04-28"
+trusted-publisher = "github:bytecodealliance/wasm-tools"
+
 [[publisher.wasmprinter]]
-version = "0.247.0"
-when = "2026-04-17"
+version = "0.248.0"
+when = "2026-04-28"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
 [[publisher.wasmtime]]
@@ -1457,13 +1472,13 @@ when = "2026-04-09"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wast]]
-version = "247.0.0"
-when = "2026-04-17"
+version = "248.0.0"
+when = "2026-04-28"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
 [[publisher.wat]]
-version = "1.247.0"
-when = "2026-04-17"
+version = "1.248.0"
+when = "2026-04-28"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
 [[publisher.wiggle]]
@@ -1751,6 +1766,11 @@ version = "0.247.0"
 when = "2026-04-17"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
+[[publisher.wit-component]]
+version = "0.248.0"
+when = "2026-04-28"
+trusted-publisher = "github:bytecodealliance/wasm-tools"
+
 [[publisher.wit-parser]]
 version = "0.244.0"
 when = "2026-01-06"
@@ -1759,6 +1779,11 @@ trusted-publisher = "github:bytecodealliance/wasm-tools"
 [[publisher.wit-parser]]
 version = "0.247.0"
 when = "2026-04-17"
+trusted-publisher = "github:bytecodealliance/wasm-tools"
+
+[[publisher.wit-parser]]
+version = "0.248.0"
+when = "2026-04-28"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
 [[publisher.witx]]

--- a/tests/all/component_model/async.rs
+++ b/tests/all/component_model/async.rs
@@ -322,7 +322,7 @@ async fn task_deletion() -> Result<()> {
     config.wasm_component_model_async(true);
     config.wasm_component_model_threading(true);
     config.wasm_component_model_async_stackful(true);
-    config.wasm_component_model_async_builtins(true);
+    config.wasm_component_model_more_async_builtins(true);
     let engine = Engine::new(&config)?;
     let component = Component::new(
         &engine,
@@ -1054,7 +1054,7 @@ async fn stream_cancel_read_async_does_not_corrupt_state() -> Result<()> {
 
     let mut config = Config::new();
     config.wasm_component_model_async(true);
-    config.wasm_component_model_async_builtins(true);
+    config.wasm_component_model_more_async_builtins(true);
     config.wasm_component_model_async_stackful(true);
     let engine = Engine::new(&config)?;
 
@@ -1190,7 +1190,7 @@ async fn concurrent_sync_calls_to_async_host() -> Result<()> {
 
     let mut config = Config::new();
     config.wasm_component_model_async(true);
-    config.wasm_component_model_async_builtins(true);
+    config.wasm_component_model_more_async_builtins(true);
     config.wasm_component_model_async_stackful(true);
     config.wasm_component_model_threading(true);
     let engine = Engine::new(&config)?;

--- a/tests/all/component_model/async_dynamic.rs
+++ b/tests/all/component_model/async_dynamic.rs
@@ -197,7 +197,6 @@ async fn stream_any_smoke() -> Result<()> {
 
     (core module $m
         (import "" "stream.new" (func $stream.new (result i64)))
-        (import "" "stream.write" (func $stream.write (param i32 i32 i32) (result i32)))
         (import "" "task.return" (func $task.return))
         (import "" "waitable-set.new" (func $waitable-set.new (result i32)))
         (import "" "waitable.join" (func $waitable.join (param i32 i32)))
@@ -237,7 +236,6 @@ async fn stream_any_smoke() -> Result<()> {
         (func (export "cb") (param i32 i32 i32) (result i32) unreachable)
     )
     (core func $stream.new (canon stream.new $s))
-    (core func $stream.write (canon stream.write $s (memory $libc "mem")))
     (core func $task.return (canon task.return))
     (core func $waitable-set.new (canon waitable-set.new))
     (core func $waitable.join (canon waitable.join))
@@ -246,7 +244,6 @@ async fn stream_any_smoke() -> Result<()> {
     (core instance $i (instantiate $m
         (with "" (instance
             (export "stream.new" (func $stream.new))
-            (export "stream.write" (func $stream.write))
             (export "task.return" (func $task.return))
             (export "waitable-set.new" (func $waitable-set.new))
             (export "waitable.join" (func $waitable.join))

--- a/tests/all/pulley.rs
+++ b/tests/all/pulley.rs
@@ -84,7 +84,7 @@ fn provenance_test_config() -> Config {
     config.memory_guard_size(0);
     config.signals_based_traps(false);
     config.wasm_component_model_async(true);
-    config.wasm_component_model_async_builtins(true);
+    config.wasm_component_model_more_async_builtins(true);
     config.wasm_component_model_async_stackful(true);
     config.wasm_component_model_threading(true);
     config.wasm_component_model_error_context(true);

--- a/tests/misc_testsuite/component-model-threading/stackful-cancellation.wast
+++ b/tests/misc_testsuite/component-model-threading/stackful-cancellation.wast
@@ -1,6 +1,6 @@
 ;;! component_model_async = true
 ;;! component_model_async_stackful = true
-;;! component_model_async_builtins = true
+;;! component_model_more_async_builtins = true
 ;;! component_model_threading = true
 ;;! reference_types = true
 

--- a/tests/misc_testsuite/component-model/async/async-builtins.wast
+++ b/tests/misc_testsuite/component-model/async/async-builtins.wast
@@ -1,5 +1,5 @@
 ;;! component_model_async = true
-;;! component_model_async_builtins = true
+;;! component_model_more_async_builtins = true
 
 ;; stream.cancel-read
 (component

--- a/tests/misc_testsuite/component-model/async/future-read.wast
+++ b/tests/misc_testsuite/component-model/async/future-read.wast
@@ -1,4 +1,5 @@
 ;;! component_model_async = true
+;;! component_model_more_async_builtins = true
 ;;! reference_types = true
 ;;! gc_types = true
 ;;! multi_memory = true
@@ -35,13 +36,13 @@
     (import "child" (instance $child
       (export "run" (func async (param "x" $future)))
     ))
-             
+
     (core func $new (canon future.new $future))
     (core func $child-run (canon lower (func $child "run")))
     (core module $m
       (import "" "new" (func $new (result i64)))
       (import "" "child-run" (func $child-run (param i32)))
-  
+
       (func (export "run")
         (call $child-run (i32.wrap_i64 (call $new)))
       )
@@ -52,7 +53,7 @@
         (export "child-run" (func $child-run))
       ))
     ))
-  
+
     (func (export "run") async
       (canon lift (core func $i "run")))
   )
@@ -98,11 +99,11 @@
     ))
     (core func $new (canon future.new $future))
     (core func $child-run (canon lower (func $child "run")))
-  
+
     (core module $m
       (import "" "new" (func $new (result i64)))
       (import "" "child-run" (func $child-run (param i32)))
-  
+
       (func (export "run")
         (call $child-run (i32.wrap_i64 (call $new)))
       )
@@ -113,7 +114,7 @@
         (export "child-run" (func $child-run))
       ))
     ))
-  
+
     (func (export "run")
       (canon lift (core func $i "run")))
   )
@@ -162,11 +163,11 @@
     ))
     (core func $new (canon future.new $future))
     (core func $child-run (canon lower (func $child "run")))
-  
+
     (core module $m
       (import "" "new" (func $new (result i64)))
       (import "" "child-run" (func $child-run (param i32)))
-  
+
       (func (export "run")
         (call $child-run (i32.wrap_i64 (call $new)))
       )
@@ -177,7 +178,7 @@
         (export "child-run" (func $child-run))
       ))
     ))
-  
+
     (func (export "run") async
       (canon lift (core func $i "run")))
   )
@@ -231,11 +232,11 @@
     ))
     (core func $new (canon future.new $future))
     (core func $child-run (canon lower (func $child "run")))
-  
+
     (core module $m
       (import "" "new" (func $new (result i64)))
       (import "" "child-run" (func $child-run (param i32)))
-  
+
       (func (export "run")
         (call $child-run (i32.wrap_i64 (call $new)))
       )
@@ -246,7 +247,7 @@
         (export "child-run" (func $child-run))
       ))
     ))
-  
+
     (func (export "run") async
       (canon lift (core func $i "run")))
   )

--- a/tests/misc_testsuite/component-model/async/futures.wast
+++ b/tests/misc_testsuite/component-model/async/futures.wast
@@ -1,5 +1,5 @@
 ;;! component_model_async = true
-;;! component_model_async_builtins = true
+;;! component_model_more_async_builtins = true
 
 ;; future.new
 (component

--- a/tests/misc_testsuite/component-model/async/intra-futures.wast
+++ b/tests/misc_testsuite/component-model/async/intra-futures.wast
@@ -1,5 +1,5 @@
 ;;! component_model_async = true
-;;! component_model_async_builtins = true
+;;! component_model_more_async_builtins = true
 
 (component
   (core module $libc

--- a/tests/misc_testsuite/component-model/async/intra-streams.wast
+++ b/tests/misc_testsuite/component-model/async/intra-streams.wast
@@ -1,5 +1,5 @@
 ;;! component_model_async = true
-;;! component_model_async_builtins = true
+;;! component_model_more_async_builtins = true
 ;;! multi_memory = true
 
 (component

--- a/tests/misc_testsuite/component-model/async/streams-massive-send.wast
+++ b/tests/misc_testsuite/component-model/async/streams-massive-send.wast
@@ -1,4 +1,5 @@
 ;;! component_model_async = true
+;;! component_model_more_async_builtins = true
 ;;! reference_types = true
 
 ;; This test exercises corner cases where extremely large values are sent

--- a/tests/misc_testsuite/component-model/async/sync-streams.wast
+++ b/tests/misc_testsuite/component-model/async/sync-streams.wast
@@ -1,4 +1,5 @@
 ;;! component_model_async = true
+;;! component_model_more_async_builtins = true
 ;;! reference_types = true
 ;;! gc_types = true
 

--- a/tests/misc_testsuite/component-model/async/task-builtins.wast
+++ b/tests/misc_testsuite/component-model/async/task-builtins.wast
@@ -1,4 +1,5 @@
 ;;! component_model_async = true
+;;! component_model_more_async_builtins = true
 ;;! multi_memory = true
 ;;! reference_types = true
 
@@ -537,14 +538,14 @@
 
       (global $future-completed (mut i32) (i32.const 0))
       (global $stream-completed (mut i32) (i32.const 0))
-      
+
       ;; Callback invoked when a subtask completes. Since we joined both subtasks to the
       ;; same waitable set, this will be called once for each completion. We track which
       ;; subtasks have completed and only return when both are done.
       (func (export "run-cb") (param $event_code i32) (param $index i32) (param $payload i32) (result i32)
         (if (i32.ne (local.get $event_code) (i32.const 1 (; SUBTASK ;))) (then (unreachable)))
         (if (i32.ne (local.get $payload) (i32.const 2 (; RETURNED ;))) (then (unreachable)))
-        
+
         ;; Track which subtask completed
         (if (i32.eq (local.get $index) (global.get $future-subtask))
           (then
@@ -553,18 +554,18 @@
           (else
             (if (i32.eq (local.get $index) (global.get $stream-subtask))
               (then
-              (if (i32.ne (i32.load (global.get $stream-retp)) (i32.const 42)) (then (unreachable))) 
+              (if (i32.ne (i32.load (global.get $stream-retp)) (i32.const 42)) (then (unreachable)))
                 (global.set $stream-completed (i32.const 1)))
               (else unreachable))))
-        
+
         ;; If both completed, exit; otherwise keep waiting
-        (if (result i32) 
+        (if (result i32)
           (i32.and (i32.eq (global.get $future-completed) (i32.const 1))
                    (i32.eq (global.get $stream-completed) (i32.const 1)))
             (then
               (call $task.return (i32.const 42))
               (i32.const 0 (; EXIT ;)))
-            (else 
+            (else
               (i32.or (i32.const 2 (; WAIT ;)) (i32.shl (global.get $ws) (i32.const 4)))))
       )
 
@@ -618,7 +619,7 @@
         i32.const 400
         i32.ne
         if unreachable end
-        
+
         i32.const 500
         call $context.set
 
@@ -671,7 +672,7 @@
         (local.set $ret (call $future.read (local.get $fr) (i32.const 40)))
         (if (i32.ne (i32.const 0 (; COMPLETED ;)) (local.get $ret)) (then (unreachable)))
         (if (i32.ne (call $context.get) (i32.const 500)) (then (unreachable)))
-  
+
         (call $task.return (i32.const 42))
         (i32.const 0 (; EXIT ;))
       )
@@ -684,7 +685,7 @@
         (local.set $ret (call $stream.read (local.get $sr) (i32.const 40) (i32.const 1)))
         (if (i32.ne (i32.const 0x10 (; COMPLETED | 1<<4 ;)) (local.get $ret)) (then (unreachable)))
         (if (i32.ne (call $context.get) (i32.const 500)) (then (unreachable)))
-        
+
         (call $task.return (i32.const 42))
         (i32.const 0 (; EXIT ;))
       )

--- a/tests/misc_testsuite/component-model/async/trap-if-done.wast
+++ b/tests/misc_testsuite/component-model/async/trap-if-done.wast
@@ -1,4 +1,5 @@
 ;;! component_model_async = true
+;;! component_model_more_async_builtins = true
 ;;! reference_types = true
 
 ;; This test has two components $C and $D, where $D imports and calls $C.


### PR DESCRIPTION
This commit renames the previous `wasm_component_model_async_builtins` feature to `wasm_component_model_more_async_builtins` and then moves synchronous future/stream reads/writes behind this feature. This is inspired by bytecodealliance/wasmtime#13212 and corresponds to WebAssembly/component-model#641 plus bytecodealliance/wasm-tools#2507.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
