### PR TITLE
Add `-Dmax-backtrace=N` to the CLI

### DIFF
--- a/crates/cli-flags/src/lib.rs
+++ b/crates/cli-flags/src/lib.rs
@@ -2,13 +2,14 @@
 
 use clap::Parser;
 use serde::Deserialize;
+use std::num::NonZeroUsize;
 use std::{
     fmt, fs,
     num::NonZeroU32,
     path::{Path, PathBuf},
     time::Duration,
 };
-use wasmtime::{Config, Result, bail, error::Context as _};
+use wasmtime::{Config, Result, WasmBacktraceDetails, bail, error::Context as _};
 
 pub mod opt;
 
@@ -307,6 +308,8 @@ wasmtime_option_group! {
         /// Allow the debugger component to inherit stderr. Off by
         /// default.
         pub inherit_stderr: Option<bool>,
+        /// Maximum number of frames to capture in backtraces.
+        pub max_backtrace: Option<usize>,
     }
 
     enum Debug {
@@ -944,6 +947,16 @@ impl CommonOptions {
         }
         if let Some(enable) = self.debug.address_map {
             config.generate_address_map(enable);
+        }
+        if let Some(frames) = self.debug.max_backtrace {
+            match NonZeroUsize::new(frames) {
+                None => {
+                    config.wasm_backtrace_details(WasmBacktraceDetails::Disable);
+                }
+                Some(amt) => {
+                    config.wasm_backtrace_max_frames(Some(amt));
+                }
+            }
         }
         if let Some(enable) = self.opts.memory_init_cow {
             config.memory_init_cow(enable);


### PR DESCRIPTION
This enables customizing the number of frames captured in a backtrace should it exceed 20. Setting this to 0 additionally enables a mechanism to disable backtraces.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
