### PR TITLE
Fix souper harvest

### DIFF
--- a/cranelift/codegen/src/souper_harvest.rs
+++ b/cranelift/codegen/src/souper_harvest.rs
@@ -454,8 +454,7 @@ fn harvest_candidate_lhs(
                                 ast::Instruction::Slt { a, b }.into()
                             }
                             ir::condcodes::IntCC::UnsignedLessThanOrEqual => {
-                                // FIXME
-                                ast::Instruction::Sle { a, b }.into()
+                                ast::Instruction::Ule { a, b }.into()
                             }
                             ir::condcodes::IntCC::SignedLessThanOrEqual => {
                                 ast::Instruction::Sle { a, b }.into()

--- a/cranelift/codegen/src/souper_harvest.rs
+++ b/cranelift/codegen/src/souper_harvest.rs
@@ -340,7 +340,8 @@ fn harvest_candidate_lhs(
                         let b = ast::Constant {
                             value: -1,
                             r#type: souper_type_of(&func.dfg, val),
-                        }.into();
+                        }
+                        .into();
                         ast::Instruction::Xor { a, b }.into()
                     }
                     (ir::Opcode::Ishl, _) => {
@@ -443,7 +444,7 @@ fn harvest_candidate_lhs(
                     | (ir::Opcode::IcmpImm, ir::InstructionData::IntCompare { cond, .. }) => {
                         let a = arg(allocs, 0);
                         let b = arg(allocs, 1);
-                        match cond {
+                        let cmp = match cond {
                             ir::condcodes::IntCC::Equal => ast::Instruction::Eq { a, b }.into(),
                             ir::condcodes::IntCC::NotEqual => ast::Instruction::Ne { a, b }.into(),
                             ir::condcodes::IntCC::UnsignedLessThan => {
@@ -453,12 +454,23 @@ fn harvest_candidate_lhs(
                                 ast::Instruction::Slt { a, b }.into()
                             }
                             ir::condcodes::IntCC::UnsignedLessThanOrEqual => {
+                                // FIXME
                                 ast::Instruction::Sle { a, b }.into()
                             }
                             ir::condcodes::IntCC::SignedLessThanOrEqual => {
                                 ast::Instruction::Sle { a, b }.into()
                             }
                             _ => ast::AssignmentRhs::Var,
+                        };
+
+                        match cmp {
+                            ast::AssignmentRhs::Var => ast::AssignmentRhs::Var,
+                            cmp => {
+                                let cmp = lhs
+                                    .assignment(None, Some(ast::Type { width: 1 }), cmp, vec![])
+                                    .into();
+                                ast::Instruction::Zext { a: cmp }.into()
+                            }
                         }
                     }
                     (ir::Opcode::Popcnt, _) => {
@@ -543,15 +555,7 @@ fn souper_type_of(dfg: &ir::DataFlowGraph, val: ir::Value) -> Option<ast::Type> 
     let ty = dfg.value_type(val);
     assert!(ty.is_int());
     assert_eq!(ty.lane_count(), 1);
-    let width = match dfg.value_def(val).inst() {
-        Some(inst)
-            if dfg.insts[inst].opcode() == ir::Opcode::IcmpImm
-                || dfg.insts[inst].opcode() == ir::Opcode::Icmp =>
-        {
-            1
-        }
-        _ => ty.bits().try_into().unwrap(),
-    };
+    let width = ty.bits().try_into().unwrap();
     Some(ast::Type { width })
 }
 

--- a/cranelift/codegen/src/souper_harvest.rs
+++ b/cranelift/codegen/src/souper_harvest.rs
@@ -113,6 +113,7 @@ fn harvest_candidate_lhs(
                 | ir::Opcode::BorImm
                 | ir::Opcode::Bxor
                 | ir::Opcode::BxorImm
+                | ir::Opcode::Bnot
                 | ir::Opcode::Ishl
                 | ir::Opcode::IshlImm
                 | ir::Opcode::Sshr
@@ -332,6 +333,14 @@ fn harvest_candidate_lhs(
                             r#type: souper_type_of(&func.dfg, val),
                         }
                         .into();
+                        ast::Instruction::Xor { a, b }.into()
+                    }
+                    (ir::Opcode::Bnot, _) => {
+                        let a = arg(allocs, 0);
+                        let b = ast::Constant {
+                            value: -1,
+                            r#type: souper_type_of(&func.dfg, val),
+                        }.into();
                         ast::Instruction::Xor { a, b }.into()
                     }
                     (ir::Opcode::Ishl, _) => {

--- a/cranelift/run-souper.sh
+++ b/cranelift/run-souper.sh
@@ -36,6 +36,12 @@ function run_one {
     local rhs="$lhs".result
 
     if [[ -f "$rhs" ]]; then
+        if grep -q "^result " "$rhs"; then
+            echo "success"
+        else
+            echo "warning: existing result file for $lhs has no RHS; counting as failed" >&2
+            echo "failed"
+        fi
         return
     fi
 
@@ -49,9 +55,15 @@ function run_one {
 
     case "$exit_code" in
         "0")
-            # Success! Copy the RHS to its final destination.
-            cp $lhs $rhs
-            cat "$temp" >> "$rhs"
+            if grep -q "^result " "$temp"; then
+                # Success! Copy the RHS to its final destination.
+                cp $lhs $rhs
+                cat "$temp" >> "$rhs"
+                echo "success"
+            else
+                echo "warning: Souper did not infer an RHS for $lhs; skipping" >&2
+                echo "failed"
+            fi
             ;;
 
         # SIGINT. Exit this whole script.
@@ -61,17 +73,23 @@ function run_one {
 
         # Timeout (regular).
         "124")
+            echo "timed out: $lhs" >&2
+            echo "timeout"
             return
             ;;
 
         # Timeout (with SIGKILL).
         "137")
+            echo "timed out: $lhs" >&2
+            echo "timeout"
             return
             ;;
 
         # Something else.
         *)
-            exit 1
+            echo "warning: Souper failed on $lhs with exit code $exit_code; skipping" >&2
+            echo "failed"
+            return
     esac
 
 }
@@ -87,6 +105,9 @@ function main {
     cd "$lhs_dir"
 
     local i=0;
+    local succeeded=0;
+    local timed_out=0;
+    local failed=0;
     for lhs in $(ls -1S $lhs_dir); do
         # Ignore '.result' files.
         if $(echo "$lhs" | grep -q result); then
@@ -99,10 +120,28 @@ function main {
             echo "$i / $lhs_count ($percent%)"
         fi
 
-        run_one "$souper" "$lhs"
+        local result=$(run_one "$souper" "$lhs")
+        case "$result" in
+            "success")
+                succeeded=$(( $succeeded + 1 ))
+                ;;
+            "timeout")
+                timed_out=$(( $timed_out + 1 ))
+                ;;
+            "failed")
+                failed=$(( $failed + 1 ))
+                ;;
+            *)
+                echo "warning: unexpected result from $lhs: $result" >&2
+                failed=$(( $failed + 1 ))
+                ;;
+        esac
     done
 
     echo "Done!"
+    echo "Succeeded: $succeeded / $lhs_count"
+    echo "Timed out: $timed_out / $lhs_count"
+    echo "Failed: $failed / $lhs_count"
 }
 
 # Kick everything off!


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->

Currently, `clif-util souper-harvest` has limitations where:
1. It does not translate `bnot` instruction to Souper IR, and
2. It does not correctly infer types of instructions that use an `icmp` instruction.

The fix for the first one is straightforward. I added a translation from `bnot x` (in CLIF) to `xor x, -1` (in Souper IR).

The second problem arises when an instruction uses a value produced by an `icmp` instruction.
In Cranelift, `icmp` produces an `i8` value; therefore, its users usually also are of `i8` type too.
However, in Souper/LLVM, `icmp` produces an `i1` value; therefore, its users, without casting, users must be of `i1` type.
The current problem of the harvest is that, when determining the type of an Souper value, it directly copies the type of that of CLIF side. For example,

```clif
function %test_bor_slt_eq(i32, i32) -> i8 fast {
block0(v0: i32, v1: i32):
    v2 = icmp slt v0, v1
    v3 = icmp eq v0, v1
    v4 = bor v2, v3
    return v4
}
```

is translated to

```souper
...
%0:i32 = var
%1:i32 = var
%2:i1 = slt %0, %1
%3:i1 = eq %0, %1
%4:i8 = or %2, %3
infer %4
```

which causes type mismatch, preventing Souper from running properly. (Notice that `or` is  `i8`!)

I fixed this by carrying Souper-side type information with new `SouperValue` struct, while such a type information is produced in `souper_type_of` function. Initial type informations are only produced for constants (`iconst`), variables, and type-casts.

However, I didn't yet implement type unification. A proper implementation would require a larger refactor to make operand types mutable and propagate inferred types back to other values. The current change is intentionally narrower to keep this simple.

### Test Results

```
cargo run -- souper-harvest --target x86_64 cranelift/filetests/filetests/egraph/bitops.clif -o /tmp/souper/
./run-souper.sh souper-check /tmp/souper/
```

* **Before**: Produced 57 left-hand sides. 17 souper-check inference successes. 34 timed out.
  - Fails on the example case above.
* **After**: Processing 72 left-hand sides. 21 souper-check inference succeesses. 50 timed out.

