### PR TITLE
Implement RiscvPCRelHi20 relocation in cranelift-object

### DIFF
--- a/cranelift/object/src/backend.rs
+++ b/cranelift/object/src/backend.rs
@@ -1030,6 +1030,16 @@ impl ObjectModule {
                     r_type: object::elf::R_RISCV_GOT_HI20,
                 }
             }
+            Reloc::RiscvPCRelHi20 => {
+                assert_eq!(
+                    self.object.format(),
+                    object::BinaryFormat::Elf,
+                    "RiscvPCRelHi20 is not supported for this file format"
+                );
+                RelocationFlags::Elf {
+                    r_type: object::elf::R_RISCV_PCREL_HI20,
+                }
+            }
             // FIXME
             reloc => unimplemented!("{:?}", reloc),
         };


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->

Tested this with a project I'm working on. This prevented me from cross compiling from aarch64 to riscv64.