### PR TITLE
Add special `"wasmtime"` imports to the `wasmtime wast` subcommand

### DIFF
--- a/src/commands/wast.rs
+++ b/src/commands/wast.rs
@@ -78,6 +78,7 @@ impl WastCommand {
                 suppress_prints: false,
             })
             .expect("error instantiating \"spectest\"");
+        wast_context.register_wasmtime()?;
 
         if let Some(path) = &self.precompile_save {
             wast_context.precompile_save(path);


### PR DESCRIPTION
Allows running tests that use these imports via the CLI.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
