### PR TITLE
Enable the `gc-copying` cargo feature by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -506,6 +506,7 @@ default = [
   "component-model-async",
   "threads",
   "gc",
+  "gc-copying",
   "gc-drc",
   "gc-null",
   "stack-switching",

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -134,6 +134,7 @@ default = [
   'backtrace',
   'cache',
   'gc',
+  'gc-copying',
   'gc-drc',
   'gc-null',
   'wat',


### PR DESCRIPTION
Now that it isn't just a skeleton.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
