### PR TITLE
Fill out GC type reflection in the C API

### DIFF
--- a/crates/c-api/include/wasmtime.h
+++ b/crates/c-api/include/wasmtime.h
@@ -220,8 +220,7 @@
 #include <wasmtime/table.h>
 #include <wasmtime/tag.h>
 #include <wasmtime/trap.h>
-#include <wasmtime/types/arrayref.h>
-#include <wasmtime/types/structref.h>
+#include <wasmtime/types.h>
 #include <wasmtime/val.h>
 #include <wasmtime/wat.h>
 // IWYU pragma: end_exports

--- a/crates/c-api/include/wasmtime/_func_class.hh
+++ b/crates/c-api/include/wasmtime/_func_class.hh
@@ -67,7 +67,7 @@ template <typename T> struct WasmTypeList {
   static T load(Store::Context cx, wasmtime_val_raw_t *storage) {
     return WasmType<T>::load(cx, storage);
   }
-  static std::vector<ValType> types() { return {WasmType<T>::kind}; }
+  static std::vector<ValType> types() { return {WasmType<T>::valtype()}; }
 };
 
 /// A "trait" for what can be returned from closures specified to `Func::wrap`.

--- a/crates/c-api/include/wasmtime/_val_class.hh
+++ b/crates/c-api/include/wasmtime/_val_class.hh
@@ -28,6 +28,18 @@ struct V128 {
   }
 };
 
+enum class ValKind {
+  I32 = WASMTIME_I32,
+  I64 = WASMTIME_I64,
+  F32 = WASMTIME_F32,
+  F64 = WASMTIME_F64,
+  V128 = WASMTIME_V128,
+  FuncRef = WASMTIME_FUNCREF,
+  ExternRef = WASMTIME_EXTERNREF,
+  AnyRef = WASMTIME_ANYREF,
+  ExnRef = WASMTIME_EXNREF,
+};
+
 /**
  * \brief Representation of a generic WebAssembly value.
  *

--- a/crates/c-api/include/wasmtime/externref.hh
+++ b/crates/c-api/include/wasmtime/externref.hh
@@ -17,7 +17,7 @@ namespace wasmtime {
 /// `ExternRef`.
 template <> struct detail::WasmType<std::optional<ExternRef>> {
   static const bool valid = true;
-  static const ValKind kind = ValKind::ExternRef;
+  static ValType valtype() { return ValType::externref(); }
   static void store(Store::Context cx, wasmtime_val_raw_t *p,
                     std::optional<ExternRef> &&ref) {
     if (ref) {

--- a/crates/c-api/include/wasmtime/func.hh
+++ b/crates/c-api/include/wasmtime/func.hh
@@ -18,7 +18,7 @@ namespace detail {
 #define NATIVE_WASM_TYPE(native, valkind, field)                               \
   template <> struct WasmType<native> {                                        \
     static const bool valid = true;                                            \
-    static const ValKind kind = ValKind::valkind;                              \
+    static ValType valtype() { return ValType::valkind(); }                    \
     static void store(Store::Context cx, wasmtime_val_raw_t *p,                \
                       const native &t) {                                       \
       (void)cx;                                                                \
@@ -30,14 +30,40 @@ namespace detail {
     }                                                                          \
   };
 
-NATIVE_WASM_TYPE(int32_t, I32, i32)
-NATIVE_WASM_TYPE(uint32_t, I32, i32)
-NATIVE_WASM_TYPE(int64_t, I64, i64)
-NATIVE_WASM_TYPE(uint64_t, I64, i64)
-NATIVE_WASM_TYPE(float, F32, f32)
-NATIVE_WASM_TYPE(double, F64, f64)
+NATIVE_WASM_TYPE(int32_t, i32, i32)
+NATIVE_WASM_TYPE(uint32_t, i32, i32)
+NATIVE_WASM_TYPE(int64_t, i64, i64)
+NATIVE_WASM_TYPE(uint64_t, i64, i64)
+NATIVE_WASM_TYPE(float, f32, f32)
+NATIVE_WASM_TYPE(double, f64, f64)
 
 #undef NATIVE_WASM_TYPE
+
+/// Definition for the `funcref` native wasm type
+template <> struct WasmType<std::optional<Func>> {
+  /// @private
+  static const bool valid = true;
+  /// @private
+  static ValType valtype() { return ValType::funcref(); }
+  /// @private
+  static void store(Store::Context cx, wasmtime_val_raw_t *p,
+                    const std::optional<Func> func) {
+    if (func) {
+      p->funcref = wasmtime_func_to_raw(cx.capi(), &func->capi());
+    } else {
+      p->funcref = 0;
+    }
+  }
+  /// @private
+  static std::optional<Func> load(Store::Context cx, wasmtime_val_raw_t *p) {
+    if (p->funcref == 0) {
+      return std::nullopt;
+    }
+    wasmtime_func_t ret;
+    wasmtime_func_from_raw(cx.capi(), p->funcref, &ret);
+    return ret;
+  }
+};
 
 /// std::monostate translates to an empty list of types.
 template <> struct WasmTypeList<std::monostate> {
@@ -67,7 +93,7 @@ template <typename... T> struct WasmTypeList<std::tuple<T...>> {
       return false;
     }
     size_t n = 0;
-    return ((WasmType<T>::kind == types.begin()[n++].kind()) && ...);
+    return ((WasmType<T>::valtype() == types.begin()[n++]) && ...);
   }
   static void store(Store::Context cx, wasmtime_val_raw_t *storage,
                     std::tuple<T...> &&t) {
@@ -91,7 +117,7 @@ template <typename... T> struct WasmTypeList<std::tuple<T...>> {
     (void)cx;
     return std::tuple<T...>{WasmType<T>::load(cx, storage++)...}; // NOLINT
   }
-  static std::vector<ValType> types() { return {WasmType<T>::kind...}; }
+  static std::vector<ValType> types() { return {WasmType<T>::valtype()...}; }
 };
 
 /// Host functions can return nothing

--- a/crates/c-api/include/wasmtime/store.hh
+++ b/crates/c-api/include/wasmtime/store.hh
@@ -12,32 +12,6 @@
 
 namespace wasmtime {
 
-/// Definition for the `funcref` native wasm type
-template <> struct detail::WasmType<std::optional<Func>> {
-  /// @private
-  static const bool valid = true;
-  /// @private
-  static const ValKind kind = ValKind::FuncRef;
-  /// @private
-  static void store(Store::Context cx, wasmtime_val_raw_t *p,
-                    const std::optional<Func> func) {
-    if (func) {
-      p->funcref = wasmtime_func_to_raw(cx.capi(), &func->capi());
-    } else {
-      p->funcref = 0;
-    }
-  }
-  /// @private
-  static std::optional<Func> load(Store::Context cx, wasmtime_val_raw_t *p) {
-    if (p->funcref == 0) {
-      return std::nullopt;
-    }
-    wasmtime_func_t ret;
-    wasmtime_func_from_raw(cx.capi(), p->funcref, &ret);
-    return ret;
-  }
-};
-
 inline Store::Context::Context(Caller &caller)
     : Context(wasmtime_caller_context(caller.ptr)) {}
 inline Store::Context::Context(Caller *caller) : Context(*caller) {}

--- a/crates/c-api/include/wasmtime/types.h
+++ b/crates/c-api/include/wasmtime/types.h
@@ -1,0 +1,9 @@
+#ifndef WASMTIME_TYPES_H
+#define WASMTIME_TYPES_H
+
+#include <wasmtime/types/arrayref.h>
+#include <wasmtime/types/exnref.h>
+#include <wasmtime/types/structref.h>
+#include <wasmtime/types/val.h>
+
+#endif // WASMTIME_TYPES_H

--- a/crates/c-api/include/wasmtime/types.hh
+++ b/crates/c-api/include/wasmtime/types.hh
@@ -8,6 +8,7 @@
 #include <wasmtime/types/import.hh>
 #include <wasmtime/types/memory.hh>
 #include <wasmtime/types/table.hh>
+#include <wasmtime/types/exnref.hh>
 #include <wasmtime/types/tag.hh>
 #include <wasmtime/types/val.hh>
 

--- a/crates/c-api/include/wasmtime/types.hh
+++ b/crates/c-api/include/wasmtime/types.hh
@@ -1,6 +1,7 @@
 #ifndef WASMTIME_TYPES_HH
 #define WASMTIME_TYPES_HH
 
+#include <wasmtime/types/exnref.hh>
 #include <wasmtime/types/export.hh>
 #include <wasmtime/types/extern.hh>
 #include <wasmtime/types/func.hh>
@@ -8,7 +9,6 @@
 #include <wasmtime/types/import.hh>
 #include <wasmtime/types/memory.hh>
 #include <wasmtime/types/table.hh>
-#include <wasmtime/types/exnref.hh>
 #include <wasmtime/types/tag.hh>
 #include <wasmtime/types/val.hh>
 

--- a/crates/c-api/include/wasmtime/types/_structref_class.hh
+++ b/crates/c-api/include/wasmtime/types/_structref_class.hh
@@ -1,0 +1,177 @@
+#ifndef WASMTIME_TYPES_STRUCTREF_CLASS_HH
+#define WASMTIME_TYPES_STRUCTREF_CLASS_HH
+
+#include <wasmtime/conf.h>
+
+#ifdef WASMTIME_FEATURE_GC
+
+#include <memory>
+#include <vector>
+#include <wasmtime/engine.hh>
+#include <wasmtime/types/_val_class.hh>
+#include <wasmtime/types/structref.h>
+
+namespace wasmtime {
+
+/// \brief Storage type for a struct field or array element.
+class StorageType {
+  wasmtime_storage_type_t ty;
+
+  StorageType(wasmtime_storage_type_kind_t kind) { ty.kind = kind; }
+
+public:
+  /// Copy constructor.
+  StorageType(const StorageType &other) {
+    wasmtime_storage_type_clone(&other.ty, &ty);
+  }
+  /// Copy assignment operator.
+  StorageType &operator=(const StorageType &other) {
+    wasmtime_storage_type_delete(&ty);
+    wasmtime_storage_type_clone(&other.ty, &ty);
+    return *this;
+  }
+  ~StorageType() { wasmtime_storage_type_delete(&ty); }
+  /// Move constructor
+  StorageType(StorageType &&other) {
+    ty = other.ty;
+    other.ty.kind = WASMTIME_STORAGE_TYPE_KIND_I8;
+  }
+  /// Move assignment operator
+  StorageType &operator=(StorageType &&other) {
+    wasmtime_storage_type_delete(&ty);
+    ty = other.ty;
+    other.ty.kind = WASMTIME_STORAGE_TYPE_KIND_I8;
+    return *this;
+  }
+
+  /// \brief Constructs a storage type from a value type.
+  StorageType(const ValType &ty);
+
+  /// \brief Constructs a storage type for an 8-bit integer.
+  static StorageType i8() { return StorageType(WASMTIME_STORAGE_TYPE_KIND_I8); }
+
+  /// \brief Constructs a storage type for a 16-bit integer.
+  static StorageType i16() {
+    return StorageType(WASMTIME_STORAGE_TYPE_KIND_I16);
+  }
+
+  /// \brief Returns the underlying C API storage type.
+  const wasmtime_storage_type_t *capi() const { return &ty; }
+
+  /// \brief Returns whether this storage type is an 8-bit integer.
+  bool is_i8() const { return ty.kind == WASMTIME_STORAGE_TYPE_KIND_I8; }
+
+  /// \brief Returns whether this storage type is a 16-bit integer.
+  bool is_i16() const { return ty.kind == WASMTIME_STORAGE_TYPE_KIND_I16; }
+
+  /// \brief If this storage type is a value type, returns the underlying value
+  /// type.
+  std::optional<ValType::Ref> as_valtype() const {
+    if (ty.kind == WASMTIME_STORAGE_TYPE_KIND_VALTYPE)
+      return ty.valtype;
+    return std::nullopt;
+  }
+};
+
+/**
+ * \brief Describes the storage type and mutability of a struct field or array
+ * element.
+ */
+class FieldType {
+  wasmtime_field_type_t ty;
+
+public:
+  /// \brief Constructs a field type from a C API field type.
+  FieldType(wasmtime_field_type ty) : ty(ty) {}
+
+  /// Copy constructor.
+  FieldType(const FieldType &other) {
+    wasmtime_field_type_clone(&other.ty, &ty);
+  }
+  /// Copy assignment operator.
+  FieldType &operator=(const FieldType &other) {
+    wasmtime_field_type_delete(&ty);
+    wasmtime_field_type_clone(&other.ty, &ty);
+    return *this;
+  }
+  ~FieldType() { wasmtime_field_type_delete(&ty); }
+  /// Move constructor
+  FieldType(FieldType &&other) {
+    ty = other.ty;
+    other.ty.storage.kind = WASMTIME_STORAGE_TYPE_KIND_I8;
+  }
+  /// Move assignment operator
+  FieldType &operator=(FieldType &&other) {
+    wasmtime_field_type_delete(&ty);
+    ty = other.ty;
+    other.ty.storage.kind = WASMTIME_STORAGE_TYPE_KIND_I8;
+    return *this;
+  }
+
+  /// \brief Constructs a field type with the given mutability and storage type.
+  FieldType(bool is_mutable, const StorageType &ty) {
+    this->ty.mutable_ = is_mutable;
+    wasmtime_storage_type_clone(ty.capi(), &this->ty.storage);
+  }
+
+  /// \brief Constructs a mutable field type with the given storage type.
+  static FieldType mut_(const StorageType &ty) { return FieldType(true, ty); }
+
+  /// \brief Constructs an immutable field type with the given storage type.
+  static FieldType const_(const StorageType &ty) {
+    return FieldType(false, ty);
+  }
+
+  /// \brief Returns whether this field type is mutable.
+  bool is_mutable() const { return ty.mutable_; }
+
+  /// \brief Returns the storage type of this field type.
+  const StorageType &storage_type() const {
+    static_assert(sizeof(StorageType) == sizeof(wasmtime_storage_type_t));
+    return *reinterpret_cast<const StorageType *>(&ty.storage);
+  }
+
+  /// \brief Returns the underlying C API field type.
+  const wasmtime_field_type_t *capi() const { return &ty; }
+};
+
+/**
+ * \brief Owned handle to a WebAssembly struct type definition.
+ *
+ * Create with StructType::create, then use with StructRefPre to allocate
+ * instances.
+ */
+class StructType {
+#define wasmtime_struct_type_clone wasmtime_struct_type_copy
+  WASMTIME_CLONE_WRAPPER(StructType, wasmtime_struct_type)
+#undef wasmtime_struct_type_clone
+
+  /// Create a new struct type with the given fields.
+  StructType(const Engine &engine, const std::vector<FieldType> &fields)
+      : ptr(wasmtime_struct_type_new(
+            engine.capi(),
+            reinterpret_cast<const wasmtime_field_type_t *>(fields.data()),
+            fields.size()))
+
+  {
+    static_assert(sizeof(FieldType) == sizeof(wasmtime_field_type_t));
+  }
+
+  size_t num_fields() const {
+    return wasmtime_struct_type_num_fields(ptr.get());
+  }
+
+  std::optional<FieldType> field(size_t index) const {
+    if (index >= wasmtime_struct_type_num_fields(ptr.get()))
+      return std::nullopt;
+    wasmtime_field_type_t ty;
+    wasmtime_struct_type_field(ptr.get(), index, &ty);
+    return FieldType(ty);
+  }
+};
+
+} // namespace wasmtime
+
+#endif // WASMTIME_FEATURE_GC
+
+#endif // WASMTIME_TYPES_STRUCTREF_CLASS_HH

--- a/crates/c-api/include/wasmtime/types/_val_class.hh
+++ b/crates/c-api/include/wasmtime/types/_val_class.hh
@@ -1,0 +1,199 @@
+#ifndef WASMTIME_TYPES_VAL_CLASS_HH
+#define WASMTIME_TYPES_VAL_CLASS_HH
+
+#include <memory>
+#include <wasm.h>
+#include <wasmtime/engine.hh>
+#include <wasmtime/types/val.h>
+#include <wasmtime/val.h>
+
+namespace wasmtime {
+
+class RefType;
+
+/**
+ * \brief Type information about a WebAssembly value.
+ *
+ * Currently mostly just contains the `ValKind`.
+ */
+class ValType {
+  friend class TableType;
+  friend class GlobalType;
+  friend class FuncType;
+  struct deleter {
+    void operator()(wasm_valtype_t *p) const { wasm_valtype_delete(p); }
+  };
+
+  std::unique_ptr<wasm_valtype_t, deleter> ptr;
+
+public:
+  /// \brief Non-owning reference to a `ValType`, must not be used after the
+  /// original `ValType` is deleted.
+  class Ref {
+    friend class ValType;
+
+    const wasm_valtype_t *ptr;
+
+  public:
+    /// \brief Instantiates from the raw C API representation.
+    Ref(const wasm_valtype_t *ptr) : ptr(ptr) {}
+    /// Copy constructor
+    Ref(const ValType &ty) : Ref(ty.ptr.get()) {}
+
+    /// \brief Tests if this type is equal to another.
+    bool operator==(const Ref &other) const {
+      return wasmtime_wasm_valtype_equal(ptr, other.ptr);
+    }
+  };
+
+  /// \brief Non-owning reference to a list of `ValType` instances. Must not be
+  /// used after the original owner is deleted.
+  class ListRef {
+    const wasm_valtype_vec_t *list;
+
+  public:
+    /// Creates a list from the raw underlying C API.
+    ListRef(const wasm_valtype_vec_t *list) : list(list) {}
+
+    /// This list iterates over a list of `ValType::Ref` instances.
+    typedef const Ref *iterator;
+
+    /// Pointer to the beginning of iteration
+    iterator begin() const {
+      return reinterpret_cast<Ref *>(&list->data[0]); // NOLINT
+    }
+
+    /// Pointer to the end of iteration
+    iterator end() const {
+      return reinterpret_cast<Ref *>(&list->data[list->size]); // NOLINT
+    }
+
+    /// Returns how many types are in this list.
+    size_t size() const { return list->size; }
+  };
+
+private:
+  Ref ref;
+  wasmtime_valtype_t wasmtime_ty;
+  ValType(wasm_valtype_t *ptr) : ptr(ptr), ref(ptr) {
+    wasmtime_valtype_new(ptr, &wasmtime_ty);
+  }
+  ValType(wasmtime_valtype_t *ty)
+      : ptr(wasmtime_valtype_to_wasm(nullptr, ty)), ref(nullptr),
+        wasmtime_ty(*ty) {
+    ref = ptr.get();
+  }
+
+public:
+  /// Copies a `Ref` to a new owned value.
+  ValType(Ref other) : ValType(wasm_valtype_copy(other.ptr)) {}
+  /// Copies one type to a new one.
+  ValType(const ValType &other) : ValType(wasm_valtype_copy(other.ptr.get())) {}
+  /// Copies the contents of another type into this one.
+  ValType &operator=(const ValType &other) {
+    ptr.reset(wasm_valtype_copy(other.ptr.get()));
+    ref = ptr.get();
+    wasmtime_valtype_delete(&wasmtime_ty);
+    wasmtime_valtype_clone(&other.wasmtime_ty, &wasmtime_ty);
+    return *this;
+  }
+  ~ValType() { wasmtime_valtype_delete(&wasmtime_ty); }
+  /// Moves the memory owned by another value type into this one.
+  ValType(ValType &&other) : ptr(std::move(other.ptr)), ref(ptr.get()) {
+    wasmtime_ty = other.wasmtime_ty;
+    other.ref = nullptr;
+    other.wasmtime_ty.kind = WASMTIME_VALTYPE_KIND_I32;
+  }
+  /// Moves the memory owned by another value type into this one.
+  ValType &operator=(ValType &&other) {
+    ptr = std::move(other.ptr);
+    ref = ptr.get();
+    wasmtime_ty = other.wasmtime_ty;
+    other.ref = nullptr;
+    other.wasmtime_ty.kind = WASMTIME_VALTYPE_KIND_I32;
+    return *this;
+  }
+
+  /// Convenience constructor for the `i32` value type.
+  static ValType i32() { return ValType(wasm_valtype_new(WASM_I32)); }
+
+  /// Convenience constructor for the `i64` value type.
+  static ValType i64() { return ValType(wasm_valtype_new(WASM_I64)); }
+
+  /// Convenience constructor for the `f32` value type.
+  static ValType f32() { return ValType(wasm_valtype_new(WASM_F32)); }
+
+  /// Convenience constructor for the `f64` value type.
+  static ValType f64() { return ValType(wasm_valtype_new(WASM_F64)); }
+
+  /// Convenience constructor for the `v128` value type.
+  static ValType v128() {
+    wasmtime_valtype_t ty;
+    ty.kind = WASMTIME_VALTYPE_KIND_V128;
+    return ValType(&ty);
+  }
+
+  /// Convenience constructor for the `funcref` value type.
+  static ValType funcref() { return ValType(wasm_valtype_new(WASM_FUNCREF)); }
+
+  /// Convenience constructor for the `externref` value type.
+  static ValType externref() {
+    return ValType(wasm_valtype_new(WASM_EXTERNREF));
+  }
+
+  /// Convenience constructor for the `anyref` value type.
+  static ValType anyref();
+
+  /// Convenience constructor for the `exnref` value type.
+  static ValType exnref();
+
+  /// Convenience constructor for reference types.
+  ValType(const Engine &engine, const RefType &ref_type);
+
+  /// \brief Returns the underlying `Ref`, a non-owning reference pointing to
+  /// this instance.
+  Ref *operator->() { return &ref; }
+  /// \brief Returns the underlying `Ref`, a non-owning reference pointing to
+  /// this instance.
+  Ref *operator*() { return &ref; }
+
+  /// \brief Equality operator, compares the underlying types for equality.
+  bool operator==(const Ref &other) const {
+    return wasmtime_wasm_valtype_equal(ptr.get(), other.ptr);
+  }
+
+  /// \brief Equality operator, compares the underlying types for equality.
+  bool operator==(const ValType &other) const {
+    return wasmtime_wasm_valtype_equal(ptr.get(), other.ptr.get());
+  }
+
+  /// \brief Returns the underlying C API representation of this type.
+  const wasmtime_valtype_t *wasmtime_capi() const { return &wasmtime_ty; }
+
+  /// \brief Returns the underlying C API representation of this type.
+  const wasm_valtype_t *capi() const { return ptr.get(); }
+
+  /// \brief Returns if this is the `i32` wasm type.
+  bool is_i32() const { return wasmtime_ty.kind == WASMTIME_VALTYPE_KIND_I32; }
+
+  /// \brief Returns if this is the `i64` wasm type.
+  bool is_i64() const { return wasmtime_ty.kind == WASMTIME_VALTYPE_KIND_I64; }
+
+  /// \brief Returns if this is the `f32` wasm type.
+  bool is_f32() const { return wasmtime_ty.kind == WASMTIME_VALTYPE_KIND_F32; }
+
+  /// \brief Returns if this is the `f64` wasm type.
+  bool is_f64() const { return wasmtime_ty.kind == WASMTIME_VALTYPE_KIND_F64; }
+
+  /// \brief Returns if this is the `v128` wasm type.
+  bool is_v128() const {
+    return wasmtime_ty.kind == WASMTIME_VALTYPE_KIND_V128;
+  }
+
+  /// \brief Returns if this is a reference type.
+  const RefType *as_ref() const;
+};
+
+}; // namespace wasmtime
+
+#endif // WASMTIME_TYPES_VAL_CLASS_HH

--- a/crates/c-api/include/wasmtime/types/arrayref.h
+++ b/crates/c-api/include/wasmtime/types/arrayref.h
@@ -41,9 +41,20 @@ wasmtime_array_type_new(const wasm_engine_t *engine,
                         const wasmtime_field_type_t *field);
 
 /**
+ * \brief Clone an array type.
+ */
+WASM_API_EXTERN wasmtime_array_type_t *
+wasmtime_array_type_copy(const wasmtime_array_type_t *ty);
+
+/**
  * \brief Delete an array type.
  */
 WASM_API_EXTERN void wasmtime_array_type_delete(wasmtime_array_type_t *ty);
+
+/// \brief Get the element type of an array type.
+WASM_API_EXTERN void
+wasmtime_array_type_element(const wasmtime_array_type_t *ty,
+                            wasmtime_field_type_t *out);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/crates/c-api/include/wasmtime/types/arrayref.h
+++ b/crates/c-api/include/wasmtime/types/arrayref.h
@@ -7,10 +7,6 @@
 #ifndef WASMTIME_TYPES_ARRAYREF_H
 #define WASMTIME_TYPES_ARRAYREF_H
 
-#include <wasmtime/conf.h>
-
-#ifdef WASMTIME_FEATURE_GC
-
 #include <wasm.h>
 #include <wasmtime/types/structref.h>
 
@@ -59,7 +55,5 @@ wasmtime_array_type_element(const wasmtime_array_type_t *ty,
 #ifdef __cplusplus
 } // extern "C"
 #endif
-
-#endif // WASMTIME_FEATURE_GC
 
 #endif // WASMTIME_TYPES_ARRAYREF_H

--- a/crates/c-api/include/wasmtime/types/arrayref.hh
+++ b/crates/c-api/include/wasmtime/types/arrayref.hh
@@ -5,10 +5,6 @@
 #ifndef WASMTIME_TYPES_ARRAYREF_HH
 #define WASMTIME_TYPES_ARRAYREF_HH
 
-#include <wasmtime/conf.h>
-
-#ifdef WASMTIME_FEATURE_GC
-
 #include <memory>
 #include <wasmtime/engine.hh>
 #include <wasmtime/types/arrayref.h>
@@ -37,7 +33,5 @@ class ArrayType {
 };
 
 } // namespace wasmtime
-
-#endif // WASMTIME_FEATURE_GC
 
 #endif // WASMTIME_TYPES_ARRAYREF_HH

--- a/crates/c-api/include/wasmtime/types/arrayref.hh
+++ b/crates/c-api/include/wasmtime/types/arrayref.hh
@@ -20,14 +20,19 @@ namespace wasmtime {
  * \brief Owned handle to a WebAssembly array type definition.
  */
 class ArrayType {
-  WASMTIME_OWN_WRAPPER(ArrayType, wasmtime_array_type)
+/// Bridge the various naming conventions here.
+#define wasmtime_array_type_clone wasmtime_array_type_copy
+  WASMTIME_CLONE_WRAPPER(ArrayType, wasmtime_array_type)
+#undef wasmtime_array_type_clone
 
   /// Create a new array type with the given element type.
-  static ArrayType create(const Engine &engine, const FieldType &field) {
-    static_assert(sizeof(FieldType) == sizeof(wasmtime_field_type_t));
-    auto *raw = wasmtime_array_type_new(
-        engine.capi(), reinterpret_cast<const wasmtime_field_type_t *>(&field));
-    return ArrayType(raw);
+  ArrayType(const Engine &engine, const FieldType &field)
+      : ArrayType(wasmtime_array_type_new(engine.capi(), field.capi())) {}
+
+  FieldType element_type() const {
+    wasmtime_field_type_t ty;
+    wasmtime_array_type_element(capi(), &ty);
+    return FieldType(ty);
   }
 };
 

--- a/crates/c-api/include/wasmtime/types/exnref.h
+++ b/crates/c-api/include/wasmtime/types/exnref.h
@@ -1,0 +1,43 @@
+/**
+ * \file wasmtime/types/exnref.h
+ */
+
+#ifndef WASMTIME_TYPES_EXNREF_H
+#define WASMTIME_TYPES_EXNREF_H
+
+#include <wasm.h>
+#include <wasmtime/error.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/// \brief A type of a WebAssembly exception.
+typedef struct wasmtime_exn_type wasmtime_exn_type_t;
+
+/// \brief Creates a new exception type with the given parameter types.
+///
+/// Fills in `out` on success and returns `NULL`. Otherwise returns an
+/// error and does not modify `out`.
+WASM_API_EXTERN wasmtime_error_t *
+wasmtime_exn_type_new(const wasm_engine_t *engine,
+                      const wasm_valtype_vec_t *params,
+                      wasmtime_exn_type_t **out);
+
+/// \brief Deletes an exception type.
+WASM_API_EXTERN void wasmtime_exn_type_delete(wasmtime_exn_type_t *ty);
+
+/// \brief Clones `ty`, returning a pointer that must be deleted with
+/// `wasmtime_exn_type_delete`.
+WASM_API_EXTERN wasmtime_exn_type_t *
+wasmtime_exn_type_copy(const wasmtime_exn_type_t *ty);
+
+/// \brief Returns tag type associated with this exception type.
+WASM_API_EXTERN wasm_tagtype_t *
+wasmtime_exn_type_tag_type(const wasmtime_exn_type_t *ty);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif // WASMTIME_TYPES_EXNREF_H

--- a/crates/c-api/include/wasmtime/types/exnref.hh
+++ b/crates/c-api/include/wasmtime/types/exnref.hh
@@ -1,0 +1,54 @@
+/**
+ * \file wasmtime/types/exnref.hh
+ */
+
+#ifndef WASMTIME_TYPES_EXNREF_HH
+#define WASMTIME_TYPES_EXNREF_HH
+
+#include <initializer_list>
+#include <memory>
+#include <wasmtime/engine.hh>
+#include <wasmtime/types/_val_class.hh>
+#include <wasmtime/types/exnref.h>
+#include <wasmtime/types/tag.hh>
+#include <wasmtime/error.hh>
+
+namespace wasmtime {
+
+/**
+ * \brief Owned handle to a WebAssembly exception type definition.
+ */
+class ExnType {
+#define wasmtime_exn_type_clone wasmtime_exn_type_copy
+  WASMTIME_CLONE_WRAPPER(ExnType, wasmtime_exn_type)
+#undef wasmtime_exn_type_clone
+
+public:
+
+  /// Creates a new exception type with the given parameter types.
+  static Result<ExnType> create(const Engine &engine, const std::initializer_list<ValType> &params) {
+    std::vector<const wasm_valtype_t*> tmp;
+    for (const auto &param : params)
+      tmp.push_back(param.capi());
+    wasm_valtype_vec_t params_vec;
+    params_vec.data = const_cast<wasm_valtype_t **>(tmp.data());
+    params_vec.size = tmp.size();
+    wasmtime_exn_type_t *result = nullptr;
+    auto error = wasmtime_exn_type_new(engine.capi(), &params_vec, &result);
+    if (error)
+      return Error(error);
+    return ExnType(result);
+  }
+
+  /// Returns the tag type associated with this exception type.
+  TagType tag_type() const {
+    wasm_tagtype_t *raw = wasmtime_exn_type_tag_type(capi());
+    auto result = TagType(TagType::Ref(raw));
+    wasm_tagtype_delete(raw);
+    return result;
+  }
+};
+
+} // namespace wasmtime
+
+#endif // WASMTIME_TYPES_EXNREF_HH

--- a/crates/c-api/include/wasmtime/types/exnref.hh
+++ b/crates/c-api/include/wasmtime/types/exnref.hh
@@ -8,10 +8,10 @@
 #include <initializer_list>
 #include <memory>
 #include <wasmtime/engine.hh>
+#include <wasmtime/error.hh>
 #include <wasmtime/types/_val_class.hh>
 #include <wasmtime/types/exnref.h>
 #include <wasmtime/types/tag.hh>
-#include <wasmtime/error.hh>
 
 namespace wasmtime {
 
@@ -24,10 +24,10 @@ class ExnType {
 #undef wasmtime_exn_type_clone
 
 public:
-
   /// Creates a new exception type with the given parameter types.
-  static Result<ExnType> create(const Engine &engine, const std::initializer_list<ValType> &params) {
-    std::vector<const wasm_valtype_t*> tmp;
+  static Result<ExnType> create(const Engine &engine,
+                                const std::initializer_list<ValType> &params) {
+    std::vector<const wasm_valtype_t *> tmp;
     for (const auto &param : params)
       tmp.push_back(param.capi());
     wasm_valtype_vec_t params_vec;

--- a/crates/c-api/include/wasmtime/types/exnref.hh
+++ b/crates/c-api/include/wasmtime/types/exnref.hh
@@ -7,6 +7,7 @@
 
 #include <initializer_list>
 #include <memory>
+#include <vector>
 #include <wasmtime/engine.hh>
 #include <wasmtime/error.hh>
 #include <wasmtime/types/_val_class.hh>

--- a/crates/c-api/include/wasmtime/types/exnref.hh
+++ b/crates/c-api/include/wasmtime/types/exnref.hh
@@ -20,6 +20,7 @@ namespace wasmtime {
  * \brief Owned handle to a WebAssembly exception type definition.
  */
 class ExnType {
+/// Workaround for slightly different naming conventions
 #define wasmtime_exn_type_clone wasmtime_exn_type_copy
   WASMTIME_CLONE_WRAPPER(ExnType, wasmtime_exn_type)
 #undef wasmtime_exn_type_clone

--- a/crates/c-api/include/wasmtime/types/func.hh
+++ b/crates/c-api/include/wasmtime/types/func.hh
@@ -5,7 +5,7 @@
 #ifndef WASMTIME_TYPES_FUNC_HH
 #define WASMTIME_TYPES_FUNC_HH
 
-#include <wasmtime/types/val.hh>
+#include <wasmtime/types/_val_class.hh>
 
 namespace wasmtime {
 
@@ -97,6 +97,14 @@ public:
   /// \brief Returns the underlying `Ref`, a non-owning reference pointing to
   /// this instance.
   Ref *operator*() { return &ref; }
+
+  /**
+   * \brief Releases the underlying C API pointer.
+   */
+  wasm_functype_t *capi_release() {
+    ref = nullptr;
+    return ptr.release();
+  }
 };
 
 }; // namespace wasmtime

--- a/crates/c-api/include/wasmtime/types/structref.h
+++ b/crates/c-api/include/wasmtime/types/structref.h
@@ -19,16 +19,36 @@ extern "C" {
 
 /**
  * \brief Discriminant for storage types in struct/array field types.
- *
- * Extends #wasmtime_valkind_t with packed storage types
- * #WASMTIME_STORAGE_KIND_I8 and #WASMTIME_STORAGE_KIND_I16.
  */
-typedef uint8_t wasmtime_storage_kind_t;
+typedef uint8_t wasmtime_storage_type_kind_t;
 
-/// \brief An 8-bit packed integer (only valid inside struct/array fields).
-#define WASMTIME_STORAGE_KIND_I8 9
-/// \brief A 16-bit packed integer (only valid inside struct/array fields).
-#define WASMTIME_STORAGE_KIND_I16 10
+/// \brief An 8-bit packed integer
+#define WASMTIME_STORAGE_TYPE_KIND_I8 0
+/// \brief A 16-bit packed integer
+#define WASMTIME_STORAGE_TYPE_KIND_I16 1
+/// \brief A regular value type (i32, f64, funcref, etc).
+#define WASMTIME_STORAGE_TYPE_KIND_VALTYPE 2
+
+/// \brief A storage type descriptor for struct/array fields.
+typedef struct wasmtime_storage_type {
+  /// The kind of storage type this is.
+  wasmtime_storage_type_kind_t kind;
+  /// if `kind` is `WASMTIME_STORAGE_TYPE_KIND_VALTYPE`, then this is
+  /// set.
+  wasm_valtype_t *valtype;
+} wasmtime_storage_type_t;
+
+/// \brief Clone a storage type into `out`.
+WASM_API_EXTERN void
+wasmtime_storage_type_clone(const wasmtime_storage_type_t *storage,
+                            wasmtime_storage_type_t *out);
+
+/// \brief Delete a storage type.
+///
+/// Only necessary for `WASMTIME_STORAGE_TYPE_KIND_VALTYPE` when the value
+/// type is a concrete reference type.
+WASM_API_EXTERN void
+wasmtime_storage_type_delete(wasmtime_storage_type_t *storage);
 
 /**
  * \typedef wasmtime_field_type_t
@@ -38,14 +58,20 @@ typedef uint8_t wasmtime_storage_kind_t;
  * \brief Describes the type and mutability of a struct field or array element.
  */
 typedef struct wasmtime_field_type {
-  /// The storage type of this field. Use #WASMTIME_I32, #WASMTIME_I64,
-  /// #WASMTIME_F32, etc. for value types, or #WASMTIME_STORAGE_KIND_I8 /
-  /// #WASMTIME_STORAGE_KIND_I16 for packed types.
-  wasmtime_storage_kind_t kind;
   /// Whether this field is mutable. `true` for mutable, `false` for
   /// immutable.
   bool mutable_;
+  /// The type stored in this field.
+  wasmtime_storage_type_t storage;
 } wasmtime_field_type_t;
+
+/// \brief Clone a field type into `out`.
+WASM_API_EXTERN void
+wasmtime_field_type_clone(const wasmtime_field_type_t *field,
+                          wasmtime_field_type_t *out);
+
+/// \brief Delete a field type.
+WASM_API_EXTERN void wasmtime_field_type_delete(wasmtime_field_type_t *field);
 
 /**
  * \brief An opaque handle to a WebAssembly struct type definition.
@@ -72,9 +98,27 @@ wasmtime_struct_type_new(const wasm_engine_t *engine,
                          const wasmtime_field_type_t *fields, size_t nfields);
 
 /**
+ * \brief Clone a struct type.
+ */
+WASM_API_EXTERN wasmtime_struct_type_t *
+wasmtime_struct_type_copy(const wasmtime_struct_type_t *ty);
+
+/**
  * \brief Delete a struct type.
  */
 WASM_API_EXTERN void wasmtime_struct_type_delete(wasmtime_struct_type_t *ty);
+
+/// \brief Get the number of fields in a struct type.
+WASM_API_EXTERN size_t
+wasmtime_struct_type_num_fields(const wasmtime_struct_type_t *ty);
+
+/// \brief Get the field type of a struct type's field by index.
+///
+/// Returns `true` if `index` is in-bounds and `out` is filled in. Returns
+/// `false` if `index` is out-of-bounds and `out` is not modified.
+WASM_API_EXTERN bool
+wasmtime_struct_type_field(const wasmtime_struct_type_t *ty, size_t index,
+                           wasmtime_field_type_t *out);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/crates/c-api/include/wasmtime/types/structref.h
+++ b/crates/c-api/include/wasmtime/types/structref.h
@@ -7,10 +7,6 @@
 #ifndef WASMTIME_TYPES_STRUCTREF_H
 #define WASMTIME_TYPES_STRUCTREF_H
 
-#include <wasmtime/conf.h>
-
-#ifdef WASMTIME_FEATURE_GC
-
 #include <wasm.h>
 
 #ifdef __cplusplus
@@ -123,7 +119,5 @@ wasmtime_struct_type_field(const wasmtime_struct_type_t *ty, size_t index,
 #ifdef __cplusplus
 } // extern "C"
 #endif
-
-#endif // WASMTIME_FEATURE_GC
 
 #endif // WASMTIME_TYPES_STRUCTREF_H

--- a/crates/c-api/include/wasmtime/types/structref.hh
+++ b/crates/c-api/include/wasmtime/types/structref.hh
@@ -9,49 +9,15 @@
 
 #ifdef WASMTIME_FEATURE_GC
 
-#include <memory>
-#include <vector>
-#include <wasmtime/engine.hh>
-#include <wasmtime/types/structref.h>
+#include <wasmtime/types/_structref_class.hh>
+#include <wasmtime/types/_val_class.hh>
 
 namespace wasmtime {
 
-/**
- * \brief Describes the storage type and mutability of a struct field or array
- * element.
- */
-struct FieldType {
-  /// The field's storage kind.
-  wasmtime_storage_kind_t kind;
-  /// Whether the field is mutable or not.
-  bool mutable_;
-
-  /// Create a mutable field type.
-  static FieldType mut_(wasmtime_storage_kind_t k) { return {k, true}; }
-  /// Create an immutable field type.
-  static FieldType const_(wasmtime_storage_kind_t k) { return {k, false}; }
-};
-
-/**
- * \brief Owned handle to a WebAssembly struct type definition.
- *
- * Create with StructType::create, then use with StructRefPre to allocate
- * instances.
- */
-class StructType {
-  WASMTIME_OWN_WRAPPER(StructType, wasmtime_struct_type)
-
-  /// Create a new struct type with the given fields.
-  static StructType create(const Engine &engine,
-                           const std::vector<FieldType> &fields) {
-    static_assert(sizeof(FieldType) == sizeof(wasmtime_field_type_t));
-    auto *raw = wasmtime_struct_type_new(
-        engine.capi(),
-        reinterpret_cast<const wasmtime_field_type_t *>(fields.data()),
-        fields.size());
-    return StructType(raw);
-  }
-};
+inline StorageType::StorageType(const ValType &ty) {
+  this->ty.kind = WASMTIME_STORAGE_TYPE_KIND_VALTYPE;
+  this->ty.valtype = wasm_valtype_copy(ty.capi());
+}
 
 } // namespace wasmtime
 

--- a/crates/c-api/include/wasmtime/types/structref.hh
+++ b/crates/c-api/include/wasmtime/types/structref.hh
@@ -5,10 +5,6 @@
 #ifndef WASMTIME_TYPES_STRUCTREF_HH
 #define WASMTIME_TYPES_STRUCTREF_HH
 
-#include <wasmtime/conf.h>
-
-#ifdef WASMTIME_FEATURE_GC
-
 #include <wasmtime/types/_structref_class.hh>
 #include <wasmtime/types/_val_class.hh>
 
@@ -20,7 +16,5 @@ inline StorageType::StorageType(const ValType &ty) {
 }
 
 } // namespace wasmtime
-
-#endif // WASMTIME_FEATURE_GC
 
 #endif // WASMTIME_TYPES_STRUCTREF_HH

--- a/crates/c-api/include/wasmtime/types/val.h
+++ b/crates/c-api/include/wasmtime/types/val.h
@@ -1,0 +1,163 @@
+/**
+ * \file wasmtime/types/val.h
+ *
+ * Wasmtime-specific extensions for `wasm_valtype_t` and structures for working
+ * with the full breadth of value types in the wasm type system.
+ */
+
+#ifndef WASMTIME_TYPES_VAL_H
+#define WASMTIME_TYPES_VAL_H
+
+#include <wasm.h>
+#include <wasmtime/types/arrayref.h>
+#include <wasmtime/types/exnref.h>
+#include <wasmtime/types/structref.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/// \brief Returns a new value type representing the wasm `v128` type.
+WASM_API_EXTERN wasm_valtype_t *wasmtime_wasm_valtype_v128(void);
+
+/// \brief Returns whether `a` is logically equal to `b`.
+WASM_API_EXTERN bool wasmtime_wasm_valtype_equal(const wasm_valtype_t *a,
+                                                 const wasm_valtype_t *b);
+
+/// \brief Discriminant located in `wasmtime_heaptype_t.kind`
+typedef uint8_t wasmtime_heaptype_kind_t;
+
+/// \brief Heap type for the abstract `extern` type.
+#define WASMTIME_HEAPTYPE_KIND_EXTERN 0
+/// \brief Heap type for the abstract `noextern` type.
+#define WASMTIME_HEAPTYPE_KIND_NOEXTERN 1
+/// \brief Heap type for the abstract `func` type.
+#define WASMTIME_HEAPTYPE_KIND_FUNC 2
+/// \brief Heap type for a concrete function type.
+#define WASMTIME_HEAPTYPE_KIND_CONCRETE_FUNC 3
+/// \brief Heap type for the abstract `nofunc` type.
+#define WASMTIME_HEAPTYPE_KIND_NOFUNC 4
+/// \brief Heap type for the abstract `any` type.
+#define WASMTIME_HEAPTYPE_KIND_ANY 5
+/// \brief Heap type for the abstract `none` type.
+#define WASMTIME_HEAPTYPE_KIND_NONE 6
+/// \brief Heap type for the abstract `eq` type.
+#define WASMTIME_HEAPTYPE_KIND_EQ 7
+/// \brief Heap type for the abstract `i31` type.
+#define WASMTIME_HEAPTYPE_KIND_I31 8
+/// \brief Heap type for the abstract `array` type.
+#define WASMTIME_HEAPTYPE_KIND_ARRAY 9
+/// \brief Heap type for a concrete array type.
+#define WASMTIME_HEAPTYPE_KIND_CONCRETE_ARRAY 10
+/// \brief Heap type for the abstract `struct` type.
+#define WASMTIME_HEAPTYPE_KIND_STRUCT 11
+/// \brief Heap type for a concrete struct type.
+#define WASMTIME_HEAPTYPE_KIND_CONCRETE_STRUCT 12
+/// \brief Heap type for the abstract `exn` type.
+#define WASMTIME_HEAPTYPE_KIND_EXN 13
+/// \brief Heap type for a concrete exception type.
+#define WASMTIME_HEAPTYPE_KIND_CONCRETE_EXN 14
+/// \brief Heap type for the abstract `noexn` type.
+#define WASMTIME_HEAPTYPE_KIND_NOEXN 15
+
+/// \brief Payload of the `wasmtime_heaptype_t` union.
+typedef union wasmtime_heaptype_union {
+  /// \brief Used with `WASMTIME_HEAPTYPE_KIND_CONCRETE_FUNC`.
+  wasm_functype_t *concrete_func;
+  /// \brief Used with `WASMTIME_HEAPTYPE_KIND_CONCRETE_ARRAY`.
+  wasmtime_array_type_t *concrete_array;
+  /// \brief Used with `WASMTIME_HEAPTYPE_KIND_CONCRETE_STRUCT`.
+  wasmtime_struct_type_t *concrete_struct;
+  /// \brief Used with `WASMTIME_HEAPTYPE_KIND_CONCRETE_EXN`.
+  wasmtime_exn_type_t *concrete_exn;
+} wasmtime_heaptype_union_t;
+
+/// \brief A WebAssembly heap type.
+typedef struct wasmtime_heaptype {
+  /// \brief Discriminant of which heap type this is, and may indicate fields of
+  /// `of` to use.
+  wasmtime_heaptype_kind_t kind;
+  /// \brief Payload of this heap type, with fields indicated by `kind`.
+  wasmtime_heaptype_union_t of;
+} wasmtime_heaptype_t;
+
+/// \brief Clones `ty` into `out`.
+WASM_API_EXTERN void wasmtime_heaptype_clone(const wasmtime_heaptype_t *ty,
+                                             wasmtime_heaptype_t *out);
+
+/// \brief Deletes any payload of `ty`, if applicable.
+///
+/// Only necessary to call for concrete types.
+WASM_API_EXTERN void wasmtime_heaptype_delete(wasmtime_heaptype_t *ty);
+
+/// \brief A WebAssembly reference type.
+typedef struct wasmtime_reftype {
+  /// \brief Whether this reference type is nullable.
+  bool nullable;
+  /// \brief The heap type of this reference type.
+  wasmtime_heaptype_t heaptype;
+} wasmtime_reftype_t;
+
+/// \brief Clones `ty` into `out`.
+WASM_API_EXTERN void wasmtime_reftype_clone(const wasmtime_reftype_t *ty,
+                                            wasmtime_reftype_t *out);
+
+/// \brief Deletes any payload of `ty`, if applicable.
+///
+/// Only necessary if `ty->heaptype` is concrete.
+WASM_API_EXTERN void wasmtime_reftype_delete(wasmtime_reftype_t *ty);
+
+/// \brief Discriminant located in `wasmtime_valtype_t.kind`
+typedef uint8_t wasmtime_valtype_kind_t;
+
+/// \brief The WebAssembly `i32` type.
+#define WASMTIME_VALTYPE_KIND_I32 0
+/// \brief The WebAssembly `i64` type.
+#define WASMTIME_VALTYPE_KIND_I64 1
+/// \brief The WebAssembly `f32` type.
+#define WASMTIME_VALTYPE_KIND_F32 2
+/// \brief The WebAssembly `f64` type.
+#define WASMTIME_VALTYPE_KIND_F64 3
+/// \brief The WebAssembly `v128` type.
+#define WASMTIME_VALTYPE_KIND_V128 4
+/// \brief A WebAssembly reference type.
+#define WASMTIME_VALTYPE_KIND_REF 5
+
+/// \brief A WebAssembly value type.
+///
+/// Note that this is a parallel representation to `wasm_valtype_t` which
+/// is intended to support the entire breadth of WebAssembly that wasmtime
+/// supports.
+typedef struct wasmtime_valtype {
+  /// \brief Discriminant of which value type this is.
+  wasmtime_valtype_kind_t kind;
+  /// \brief Payload of this value type, only used with
+  /// `WASMTIME_VALTYPE_KIND_REF`.
+  wasmtime_reftype_t reftype;
+} wasmtime_valtype_t;
+
+/// \brief Creates a new type in `out` from the type in `ty`.
+WASM_API_EXTERN void wasmtime_valtype_new(const wasm_valtype_t *ty,
+                                          wasmtime_valtype_t *out);
+
+/// \brief Clones `ty` into `out`.
+WASM_API_EXTERN void wasmtime_valtype_clone(const wasmtime_valtype_t *ty,
+                                            wasmtime_valtype_t *out);
+
+/// \brief Deletes any payload of `ty`, if applicable.
+///
+/// Only necessary when `ty` is a concrete reference type.
+WASM_API_EXTERN void wasmtime_valtype_delete(wasmtime_valtype_t *ty);
+
+/// \brief Converts `ty` into a `wasm_valtype_t` and returns a pointer to it.
+///
+/// The caller must deallocate the returned value.
+WASM_API_EXTERN wasm_valtype_t *
+wasmtime_valtype_to_wasm(const wasm_engine_t *engine,
+                         const wasmtime_valtype_t *ty);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif // WASMTIME_TYPES_VAL_H

--- a/crates/c-api/include/wasmtime/types/val.hh
+++ b/crates/c-api/include/wasmtime/types/val.hh
@@ -22,7 +22,7 @@ namespace wasmtime {
 class HeapType {
   wasmtime_heaptype_t ty;
 
-  constexpr HeapType(wasmtime_heaptype_kind_t ty) { this->ty.kind = ty; }
+  HeapType(wasmtime_heaptype_kind_t ty) { this->ty.kind = ty; }
 
 public:
   /// Copy constructor.

--- a/crates/c-api/include/wasmtime/types/val.hh
+++ b/crates/c-api/include/wasmtime/types/val.hh
@@ -8,172 +8,413 @@
 #include <memory>
 #include <ostream>
 #include <wasm.h>
+#include <wasmtime/types/_structref_class.hh>
+#include <wasmtime/types/_val_class.hh>
+#include <wasmtime/types/arrayref.hh>
+#include <wasmtime/types/exnref.hh>
+#include <wasmtime/types/func.hh>
+#include <wasmtime/types/val.h>
 #include <wasmtime/val.h>
 
 namespace wasmtime {
 
-/// Different kinds of types accepted by Wasmtime.
-enum class ValKind {
-  /// WebAssembly's `i32` type
-  I32,
-  /// WebAssembly's `i64` type
-  I64,
-  /// WebAssembly's `f32` type
-  F32,
-  /// WebAssembly's `f64` type
-  F64,
-  /// WebAssembly's `v128` type from the simd proposal
-  V128,
-  /// WebAssembly's `externref` type from the reference types
-  ExternRef,
-  /// WebAssembly's `funcref` type from the reference types
-  FuncRef,
-  /// WebAssembly's `anyref` type
-  AnyRef,
-  /// WebAssembly's `exnref` type
-  ExnRef,
+/// Representation of a heap type in WebAssembly.
+class HeapType {
+  wasmtime_heaptype_t ty;
+
+  constexpr HeapType(wasmtime_heaptype_kind_t ty) { this->ty.kind = ty; }
+
+public:
+  /// Copy constructor.
+  HeapType(const HeapType &other) { wasmtime_heaptype_clone(&other.ty, &ty); }
+  /// Copy assignment operator.
+  HeapType &operator=(const HeapType &other) {
+    wasmtime_heaptype_delete(&ty);
+    wasmtime_heaptype_clone(&other.ty, &ty);
+    return *this;
+  }
+  ~HeapType() {
+    if (is_concrete())
+      wasmtime_heaptype_delete(&ty);
+  }
+  /// Move constructor
+  HeapType(HeapType &&other) {
+    ty = other.ty;
+    other.ty.kind = WASMTIME_HEAPTYPE_KIND_NONE;
+  }
+  /// Move assignment operator
+  HeapType &operator=(HeapType &&other) {
+    wasmtime_heaptype_delete(&ty);
+    ty = other.ty;
+    other.ty.kind = WASMTIME_HEAPTYPE_KIND_NONE;
+    return *this;
+  }
+
+  /// \brief Constructor for the `extern` heap type
+  static HeapType extern_() { return HeapType(WASMTIME_HEAPTYPE_KIND_EXTERN); }
+
+  /// \brief Constructor for the `noextern` heap type
+  static HeapType noextern() {
+    return HeapType(WASMTIME_HEAPTYPE_KIND_NOEXTERN);
+  }
+
+  /// \brief Constructor for the `func` heap type
+  static HeapType func() { return HeapType(WASMTIME_HEAPTYPE_KIND_FUNC); }
+
+  /// \brief Constructor for a concrete function heap type.
+  HeapType(const FuncType &ty) {
+    this->ty.kind = WASMTIME_HEAPTYPE_KIND_CONCRETE_FUNC;
+    this->ty.of.concrete_func = FuncType(ty).capi_release();
+  }
+
+  /// \brief Constructor for the `nofunc` heap type
+  static HeapType nofunc() { return HeapType(WASMTIME_HEAPTYPE_KIND_NOFUNC); }
+
+  /// \brief Constructor for the `any` heap type
+  static HeapType any() { return HeapType(WASMTIME_HEAPTYPE_KIND_ANY); }
+
+  /// \brief Constructor for the `none` heap type
+  static HeapType none() { return HeapType(WASMTIME_HEAPTYPE_KIND_NONE); }
+
+  /// \brief Constructor for the `eq` heap type
+  static HeapType eq() { return HeapType(WASMTIME_HEAPTYPE_KIND_EQ); }
+
+  /// \brief Constructor for the `i31` heap type
+  static HeapType i31() { return HeapType(WASMTIME_HEAPTYPE_KIND_I31); }
+
+  /// \brief Constructor for the `array` heap type
+  static HeapType array() { return HeapType(WASMTIME_HEAPTYPE_KIND_ARRAY); }
+
+  /// \brief Constructor for a concrete array heap type.
+  HeapType(const ArrayType &ty) {
+    this->ty.kind = WASMTIME_HEAPTYPE_KIND_CONCRETE_ARRAY;
+    this->ty.of.concrete_array = ArrayType(ty).capi_release();
+  }
+
+  /// \brief Constructor for the `struct` heap type
+  static HeapType struct_() { return HeapType(WASMTIME_HEAPTYPE_KIND_STRUCT); }
+
+  /// \brief Constructor for a concrete struct heap type.
+  HeapType(const StructType &ty) {
+    this->ty.kind = WASMTIME_HEAPTYPE_KIND_CONCRETE_STRUCT;
+    this->ty.of.concrete_struct = StructType(ty).capi_release();
+  }
+
+  /// \brief Constructor for the `exn` heap type
+  static HeapType exn() { return HeapType(WASMTIME_HEAPTYPE_KIND_EXN); }
+
+  /// \brief Constructor for a concrete exception heap type.
+  HeapType(const ExnType &ty) {
+    this->ty.kind = WASMTIME_HEAPTYPE_KIND_CONCRETE_EXN;
+    this->ty.of.concrete_exn = ExnType(ty).capi_release();
+  }
+
+  /// \brief Constructor for the `noexn` heap type
+  static HeapType noexn() { return HeapType(WASMTIME_HEAPTYPE_KIND_NOEXN); }
+
+  /// \brief Is this a concrete heap type?
+  bool is_concrete() const {
+    switch (ty.kind) {
+    case WASMTIME_HEAPTYPE_KIND_CONCRETE_FUNC:
+    case WASMTIME_HEAPTYPE_KIND_CONCRETE_ARRAY:
+    case WASMTIME_HEAPTYPE_KIND_CONCRETE_STRUCT:
+    case WASMTIME_HEAPTYPE_KIND_CONCRETE_EXN:
+      return true;
+    default:
+      return false;
+    }
+  }
+
+  /// \brief Is this the abstract `extern` heap type?
+  bool is_extern() const { return ty.kind == WASMTIME_HEAPTYPE_KIND_EXTERN; }
+
+  /// \brief Is this the abstract `noextern` heap type?
+  bool is_noextern() const {
+    return ty.kind == WASMTIME_HEAPTYPE_KIND_NOEXTERN;
+  }
+
+  /// \brief Is this the abstract `func` heap type?
+  bool is_func() const { return ty.kind == WASMTIME_HEAPTYPE_KIND_FUNC; }
+
+  /// \brief If this is a concrete function type, returns the underlying
+  /// function type.
+  std::optional<FuncType::Ref> as_concrete_func() const {
+    if (ty.kind == WASMTIME_HEAPTYPE_KIND_CONCRETE_FUNC) {
+      return FuncType::Ref(ty.of.concrete_func);
+    }
+    return std::nullopt;
+  }
+
+  /// \brief Is this the abstract `nofunc` heap type?
+  bool is_nofunc() const { return ty.kind == WASMTIME_HEAPTYPE_KIND_NOFUNC; }
+
+  /// \brief Is this the abstract `any` heap type?
+  bool is_any() const { return ty.kind == WASMTIME_HEAPTYPE_KIND_ANY; }
+
+  /// \brief Is this the abstract `none` heap type?
+  bool is_none() const { return ty.kind == WASMTIME_HEAPTYPE_KIND_NONE; }
+
+  /// \brief Is this the abstract `eq` heap type?
+  bool is_eq() const { return ty.kind == WASMTIME_HEAPTYPE_KIND_EQ; }
+
+  /// \brief Is this the abstract `i31` heap type?
+  bool is_i31() const { return ty.kind == WASMTIME_HEAPTYPE_KIND_I31; }
+
+  /// \brief Is this the abstract `array` heap type?
+  bool is_array() const { return ty.kind == WASMTIME_HEAPTYPE_KIND_ARRAY; }
+
+  /// \brief If this is a concrete array type, returns the underlying
+  /// array type.
+  const ArrayType *as_concrete_array() const {
+    static_assert(sizeof(ArrayType) == sizeof(wasmtime_array_type_t *));
+    if (ty.kind == WASMTIME_HEAPTYPE_KIND_CONCRETE_ARRAY) {
+      return reinterpret_cast<const ArrayType *>(&ty.of.concrete_array);
+    }
+    return nullptr;
+  }
+
+  /// \brief Is this the abstract `struct` heap type?
+  bool is_struct() const { return ty.kind == WASMTIME_HEAPTYPE_KIND_STRUCT; }
+
+  /// \brief If this is a concrete struct type, returns the underlying
+  /// struct type.
+  const StructType *as_concrete_struct() const {
+    static_assert(sizeof(StructType) == sizeof(wasmtime_struct_type_t *));
+    if (ty.kind == WASMTIME_HEAPTYPE_KIND_CONCRETE_STRUCT) {
+      return reinterpret_cast<const StructType *>(&ty.of.concrete_struct);
+    }
+    return nullptr;
+  }
+
+  /// \brief Is this the abstract `exn` heap type?
+  bool is_exn() const { return ty.kind == WASMTIME_HEAPTYPE_KIND_EXN; }
+
+  /// \brief If this is a concrete exception type, returns the underlying
+  /// exception type.
+  const ExnType *as_concrete_exn() const {
+    static_assert(sizeof(ExnType) == sizeof(wasmtime_exn_type_t *));
+    if (ty.kind == WASMTIME_HEAPTYPE_KIND_CONCRETE_EXN) {
+      return reinterpret_cast<const ExnType *>(&ty.of.concrete_exn);
+    }
+    return nullptr;
+  }
+
+  /// \brief Is this the abstract `noexn` heap type?
+  bool is_noexn() const { return ty.kind == WASMTIME_HEAPTYPE_KIND_NOEXN; }
+
+  /// \brief Returns the underlying C API heap type.
+  const wasmtime_heaptype_t *capi() const { return &ty; }
 };
 
-/// Helper X macro to construct statement for each enumerator in `ValKind`.
-/// X(enumerator in `ValKind`, name string, enumerator in `wasm_valkind_t`)
-#define WASMTIME_FOR_EACH_VAL_KIND(X)                                          \
-  X(I32, "i32", WASM_I32)                                                      \
-  X(I64, "i64", WASM_I64)                                                      \
-  X(F32, "f32", WASM_F32)                                                      \
-  X(F64, "f64", WASM_F64)                                                      \
-  X(ExternRef, "externref", WASM_EXTERNREF)                                    \
-  X(FuncRef, "funcref", WASM_FUNCREF)                                          \
-  X(AnyRef, "anyref", WASMTIME_ANYREF)                                         \
-  X(ExnRef, "exnref", WASMTIME_EXNREF)                                         \
-  X(V128, "v128", WASMTIME_V128)
+/// Representation of a reference type in WebAssembly.
+class RefType {
+  wasmtime_reftype_t ty;
 
-/// \brief Used to print a ValKind.
-inline std::ostream &operator<<(std::ostream &os, const ValKind &e) {
-  switch (e) {
-#define CASE_KIND_PRINT_NAME(kind, name, ignore)                               \
-  case ValKind::kind:                                                          \
-    os << name;                                                                \
+public:
+  /// Copy constructor.
+  RefType(const RefType &other) { wasmtime_reftype_clone(&other.ty, &ty); }
+  /// Copy assignment operator.
+  RefType &operator=(const RefType &other) {
+    wasmtime_reftype_delete(&ty);
+    wasmtime_reftype_clone(&other.ty, &ty);
+    return *this;
+  }
+  ~RefType() { wasmtime_reftype_delete(&ty); }
+  /// Move constructor
+  RefType(RefType &&other) {
+    ty = other.ty;
+    other.ty.heaptype.kind = WASMTIME_HEAPTYPE_KIND_NONE;
+  }
+  /// Move assignment operator
+  RefType &operator=(RefType &&other) {
+    wasmtime_reftype_delete(&ty);
+    ty = other.ty;
+    other.ty.heaptype.kind = WASMTIME_HEAPTYPE_KIND_NONE;
+    return *this;
+  }
+
+  /// \brief Constructs a reference type with the given nullability and heap
+  /// type.
+  RefType(bool nullable, const HeapType &heaptype) {
+    ty.nullable = nullable;
+    wasmtime_heaptype_clone(heaptype.capi(), &ty.heaptype);
+  }
+
+  /// \brief Returns whether this reference type is nullable.
+  bool nullable() const { return ty.nullable; }
+
+  /// \brief Returns the heap type of this reference type.
+  const HeapType &heaptype() const {
+    static_assert(sizeof(HeapType) == sizeof(wasmtime_heaptype_t));
+    return *reinterpret_cast<const HeapType *>(&ty.heaptype);
+  }
+
+  /// \brief Convenience constructor for the wasm `externref` type.
+  static RefType externref() { return RefType(true, HeapType::extern_()); }
+
+  /// \brief Convenience constructor for the wasm `nullexternref` type.
+  static RefType nullexternref() { return RefType(true, HeapType::noextern()); }
+
+  /// \brief Convenience constructor for the wasm `funcref` type.
+  static RefType funcref() { return RefType(true, HeapType::func()); }
+
+  /// \brief Convenience constructor for the wasm `nullfuncref` type.
+  static RefType nullfuncref() { return RefType(true, HeapType::nofunc()); }
+
+  /// \brief Convenience constructor for the wasm `anyref` type.
+  static RefType anyref() { return RefType(true, HeapType::any()); }
+
+  /// \brief Convenience constructor for the wasm `eqref` type.
+  static RefType eqref() { return RefType(true, HeapType::eq()); }
+
+  /// \brief Convenience constructor for the wasm `i31ref` type.
+  static RefType i31ref() { return RefType(true, HeapType::i31()); }
+
+  /// \brief Convenience constructor for the wasm `arrayref` type.
+  static RefType arrayref() { return RefType(true, HeapType::array()); }
+
+  /// \brief Convenience constructor for the wasm `structref` type.
+  static RefType structref() { return RefType(true, HeapType::struct_()); }
+
+  /// \brief Convenience constructor for the wasm `nullref` type.
+  static RefType nullref() { return RefType(true, HeapType::none()); }
+
+  /// \brief Convenience constructor for the wasm `exnref` type.
+  static RefType exnref() { return RefType(true, HeapType::exn()); }
+
+  /// \brief Convenience constructor for the wasm `nullexnref` type.
+  static RefType nullexnref() { return RefType(true, HeapType::noexn()); }
+
+  /// \brief Returns the underlying C API reference type.
+  const wasmtime_reftype_t *capi() const { return &ty; }
+};
+
+inline const RefType *ValType::as_ref() const {
+  static_assert(sizeof(RefType) == sizeof(wasmtime_reftype_t));
+  if (wasmtime_ty.kind == WASMTIME_VALTYPE_KIND_REF) {
+    return reinterpret_cast<const RefType *>(&wasmtime_ty.reftype);
+  }
+  return nullptr;
+}
+
+inline ValType::ValType(const Engine &engine, const RefType &ty)
+    : ref(nullptr) {
+  wasmtime_ty.kind = WASMTIME_VALTYPE_KIND_REF;
+  wasmtime_reftype_clone(ty.capi(), &wasmtime_ty.reftype);
+  ptr.reset(wasmtime_valtype_to_wasm(engine.capi(), &wasmtime_ty));
+  ref = ptr.get();
+}
+
+inline ValType ValType::anyref() {
+  wasmtime_valtype_t ty;
+  ty.kind = WASMTIME_VALTYPE_KIND_REF;
+  ty.reftype.nullable = true;
+  ty.reftype.heaptype.kind = WASMTIME_HEAPTYPE_KIND_ANY;
+  return ValType(&ty);
+}
+
+inline ValType ValType::exnref() {
+  wasmtime_valtype_t ty;
+  ty.kind = WASMTIME_VALTYPE_KIND_REF;
+  ty.reftype.nullable = true;
+  ty.reftype.heaptype.kind = WASMTIME_HEAPTYPE_KIND_EXN;
+  return ValType(&ty);
+}
+
+/// \brief Used to print a HeapType.
+inline std::ostream &operator<<(std::ostream &os, const HeapType &e) {
+  const wasmtime_heaptype_t *ty = e.capi();
+  switch (ty->kind) {
+  case WASMTIME_HEAPTYPE_KIND_EXTERN:
+    os << "extern";
     break;
-    WASMTIME_FOR_EACH_VAL_KIND(CASE_KIND_PRINT_NAME)
-#undef CASE_KIND_PRINT_NAME
+  case WASMTIME_HEAPTYPE_KIND_NOEXTERN:
+    os << "noextern";
+    break;
+  case WASMTIME_HEAPTYPE_KIND_FUNC:
+    os << "func";
+    break;
+  case WASMTIME_HEAPTYPE_KIND_CONCRETE_FUNC:
+    os << "$func";
+    break;
+  case WASMTIME_HEAPTYPE_KIND_NOFUNC:
+    os << "nofunc";
+    break;
+  case WASMTIME_HEAPTYPE_KIND_ANY:
+    os << "any";
+    break;
+  case WASMTIME_HEAPTYPE_KIND_NONE:
+    os << "none";
+    break;
+  case WASMTIME_HEAPTYPE_KIND_EQ:
+    os << "eq";
+    break;
+  case WASMTIME_HEAPTYPE_KIND_I31:
+    os << "i31";
+    break;
+  case WASMTIME_HEAPTYPE_KIND_ARRAY:
+    os << "array";
+    break;
+  case WASMTIME_HEAPTYPE_KIND_CONCRETE_ARRAY:
+    os << "$array";
+    break;
+  case WASMTIME_HEAPTYPE_KIND_STRUCT:
+    os << "struct";
+    break;
+  case WASMTIME_HEAPTYPE_KIND_CONCRETE_STRUCT:
+    os << "$struct";
+    break;
+  case WASMTIME_HEAPTYPE_KIND_EXN:
+    os << "exn";
+    break;
+  case WASMTIME_HEAPTYPE_KIND_NOEXN:
+    os << "noexn";
+    break;
   default:
-    abort();
+    os << "unknown";
+    break;
   }
   return os;
 }
 
-/**
- * \brief Type information about a WebAssembly value.
- *
- * Currently mostly just contains the `ValKind`.
- */
-class ValType {
-  friend class TableType;
-  friend class GlobalType;
-  friend class FuncType;
-  struct deleter {
-    void operator()(wasm_valtype_t *p) const { wasm_valtype_delete(p); }
-  };
+/// \brief Used to print a RefType.
+inline std::ostream &operator<<(std::ostream &os, const RefType &e) {
+  os << "(ref ";
+  if (e.nullable())
+    os << "null ";
+  os << e.heaptype();
+  os << ")";
+  return os;
+}
 
-  std::unique_ptr<wasm_valtype_t, deleter> ptr;
-
-  static wasm_valkind_t kind_to_c(ValKind kind) {
-    switch (kind) {
-#define CASE_KIND_TO_C(kind, ignore, ckind)                                    \
-  case ValKind::kind:                                                          \
-    return ckind;
-      WASMTIME_FOR_EACH_VAL_KIND(CASE_KIND_TO_C)
-#undef CASE_KIND_TO_C
-    default:
-      abort();
-    }
+/// \brief Used to print a ValType.
+inline std::ostream &operator<<(std::ostream &os, const ValType &e) {
+  const wasmtime_valtype_t *ty = e.wasmtime_capi();
+  switch (ty->kind) {
+  case WASMTIME_VALTYPE_KIND_I32:
+    os << "i32";
+    break;
+  case WASMTIME_VALTYPE_KIND_I64:
+    os << "i64";
+    break;
+  case WASMTIME_VALTYPE_KIND_F32:
+    os << "f32";
+    break;
+  case WASMTIME_VALTYPE_KIND_F64:
+    os << "f64";
+    break;
+  case WASMTIME_VALTYPE_KIND_V128:
+    os << "v128";
+    break;
+  case WASMTIME_VALTYPE_KIND_REF:
+    os << *e.as_ref();
+    break;
+  default:
+    os << "unknown";
+    break;
   }
-
-public:
-  /// \brief Non-owning reference to a `ValType`, must not be used after the
-  /// original `ValType` is deleted.
-  class Ref {
-    friend class ValType;
-
-    const wasm_valtype_t *ptr;
-
-  public:
-    /// \brief Instantiates from the raw C API representation.
-    Ref(const wasm_valtype_t *ptr) : ptr(ptr) {}
-    /// Copy constructor
-    Ref(const ValType &ty) : Ref(ty.ptr.get()) {}
-
-    /// \brief Returns the corresponding "kind" for this type.
-    ValKind kind() const {
-      switch (wasm_valtype_kind(ptr)) {
-#define CASE_C_TO_KIND(kind, ignore, ckind)                                    \
-  case ckind:                                                                  \
-    return ValKind::kind;
-        WASMTIME_FOR_EACH_VAL_KIND(CASE_C_TO_KIND)
-#undef CASE_C_TO_KIND
-      }
-      std::abort();
-    }
-  };
-
-  /// \brief Non-owning reference to a list of `ValType` instances. Must not be
-  /// used after the original owner is deleted.
-  class ListRef {
-    const wasm_valtype_vec_t *list;
-
-  public:
-    /// Creates a list from the raw underlying C API.
-    ListRef(const wasm_valtype_vec_t *list) : list(list) {}
-
-    /// This list iterates over a list of `ValType::Ref` instances.
-    typedef const Ref *iterator;
-
-    /// Pointer to the beginning of iteration
-    iterator begin() const {
-      return reinterpret_cast<Ref *>(&list->data[0]); // NOLINT
-    }
-
-    /// Pointer to the end of iteration
-    iterator end() const {
-      return reinterpret_cast<Ref *>(&list->data[list->size]); // NOLINT
-    }
-
-    /// Returns how many types are in this list.
-    size_t size() const { return list->size; }
-  };
-
-private:
-  Ref ref;
-  ValType(wasm_valtype_t *ptr) : ptr(ptr), ref(ptr) {}
-
-public:
-  /// Creates a new type from its kind.
-  ValType(ValKind kind) : ValType(wasm_valtype_new(kind_to_c(kind))) {}
-  /// Copies a `Ref` to a new owned value.
-  ValType(Ref other) : ValType(wasm_valtype_copy(other.ptr)) {}
-  /// Copies one type to a new one.
-  ValType(const ValType &other) : ValType(wasm_valtype_copy(other.ptr.get())) {}
-  /// Copies the contents of another type into this one.
-  ValType &operator=(const ValType &other) {
-    ptr.reset(wasm_valtype_copy(other.ptr.get()));
-    ref = other.ref;
-    return *this;
-  }
-  ~ValType() = default;
-  /// Moves the memory owned by another value type into this one.
-  ValType(ValType &&other) = default;
-  /// Moves the memory owned by another value type into this one.
-  ValType &operator=(ValType &&other) = default;
-
-  /// \brief Returns the underlying `Ref`, a non-owning reference pointing to
-  /// this instance.
-  Ref *operator->() { return &ref; }
-  /// \brief Returns the underlying `Ref`, a non-owning reference pointing to
-  /// this instance.
-  Ref *operator*() { return &ref; }
-};
-
-#undef WASMTIME_FOR_EACH_VAL_KIND
+  return os;
+}
 
 }; // namespace wasmtime
 

--- a/crates/c-api/include/wasmtime/val.hh
+++ b/crates/c-api/include/wasmtime/val.hh
@@ -88,7 +88,7 @@ inline std::optional<ExternRef> Val::externref() const {
 /// Type information for the `V128` host value used as a wasm value.
 template <> struct detail::WasmType<V128> {
   static const bool valid = true;
-  static const ValKind kind = ValKind::V128;
+  static ValType valtype() { return ValType::v128(); }
   static void store(Store::Context cx, wasmtime_val_raw_t *p, const V128 &t) {
     (void)cx;
     memcpy(&p->v128[0], &t.v128[0], sizeof(wasmtime_v128));

--- a/crates/c-api/src/tag.rs
+++ b/crates/c-api/src/tag.rs
@@ -11,7 +11,7 @@ pub unsafe extern "C" fn wasmtime_tag_new(
     tt: &wasm_tagtype_t,
     ret: &mut MaybeUninit<Tag>,
 ) -> Option<Box<wasmtime_error_t>> {
-    let tag_type = tt.to_tag_type(store.engine());
+    let tag_type = tt.ty(store.engine());
     handle_result(Tag::new(&mut store, &tag_type), |tag| {
         ret.write(tag);
     })
@@ -24,7 +24,7 @@ pub extern "C" fn wasmtime_tag_type(
     tag: &Tag,
 ) -> Box<wasm_tagtype_t> {
     let ty = tag.ty(store);
-    Box::new(wasm_tagtype_t::from_tag_type(ty))
+    Box::new(wasm_tagtype_t::new(ty))
 }
 
 /// Tests whether two tags are the same (identity equality).

--- a/crates/c-api/src/types.rs
+++ b/crates/c-api/src/types.rs
@@ -37,8 +37,12 @@ pub use self::val::*;
 #[cfg(feature = "gc")]
 mod arrayref;
 #[cfg(feature = "gc")]
+mod exn;
+#[cfg(feature = "gc")]
 mod structref;
 #[cfg(feature = "gc")]
 pub use self::arrayref::*;
+#[cfg(feature = "gc")]
+pub use self::exn::*;
 #[cfg(feature = "gc")]
 pub use self::structref::*;

--- a/crates/c-api/src/types.rs
+++ b/crates/c-api/src/types.rs
@@ -15,34 +15,27 @@ impl wasm_limits_t {
     }
 }
 
+mod arrayref;
+mod exn;
 mod export;
 mod r#extern;
 mod func;
 mod global;
 mod import;
 mod memory;
+mod structref;
 mod table;
 mod tag;
 mod val;
+pub use self::arrayref::*;
+pub use self::exn::*;
 pub use self::export::*;
 pub use self::r#extern::*;
 pub use self::func::*;
 pub use self::global::*;
 pub use self::import::*;
 pub use self::memory::*;
+pub use self::structref::*;
 pub use self::table::*;
 pub use self::tag::*;
 pub use self::val::*;
-
-#[cfg(feature = "gc")]
-mod arrayref;
-#[cfg(feature = "gc")]
-mod exn;
-#[cfg(feature = "gc")]
-mod structref;
-#[cfg(feature = "gc")]
-pub use self::arrayref::*;
-#[cfg(feature = "gc")]
-pub use self::exn::*;
-#[cfg(feature = "gc")]
-pub use self::structref::*;

--- a/crates/c-api/src/types/arrayref.rs
+++ b/crates/c-api/src/types/arrayref.rs
@@ -1,10 +1,12 @@
 use crate::wasmtime_field_type_t;
+use std::mem::MaybeUninit;
 use wasmtime::ArrayType;
 
+#[derive(Clone)]
 pub struct wasmtime_array_type_t {
     pub(crate) ty: ArrayType,
 }
-wasmtime_c_api_macros::declare_own!(wasmtime_array_type_t);
+wasmtime_c_api_macros::declare_ty!(wasmtime_array_type_t);
 
 #[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_array_type_new(
@@ -14,4 +16,12 @@ pub extern "C" fn wasmtime_array_type_new(
     let ft = field.to_wasmtime();
     let ty = ArrayType::new(&engine.engine, ft);
     Box::new(wasmtime_array_type_t { ty })
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn wasmtime_array_type_element(
+    ty: &wasmtime_array_type_t,
+    out: &mut MaybeUninit<wasmtime_field_type_t>,
+) {
+    out.write(ty.ty.field_type().into());
 }

--- a/crates/c-api/src/types/exn.rs
+++ b/crates/c-api/src/types/exn.rs
@@ -1,0 +1,34 @@
+use crate::{wasm_tagtype_t, wasm_valtype_vec_t, wasmtime_error_t};
+use std::mem::MaybeUninit;
+use wasmtime::ExnType;
+
+#[derive(Clone)]
+pub struct wasmtime_exn_type_t {
+    pub(crate) ty: ExnType,
+}
+wasmtime_c_api_macros::declare_ty!(wasmtime_exn_type_t);
+
+#[unsafe(no_mangle)]
+pub extern "C" fn wasmtime_exn_type_new(
+    engine: &crate::wasm_engine_t,
+    params: &wasm_valtype_vec_t,
+    out: &mut MaybeUninit<Box<wasmtime_exn_type_t>>,
+) -> Option<Box<wasmtime_error_t>> {
+    crate::handle_result(
+        ExnType::new(
+            &engine.engine,
+            params
+                .as_slice()
+                .iter()
+                .map(|t| (**t.as_ref().unwrap()).clone()),
+        ),
+        |ty| {
+            out.write(Box::new(wasmtime_exn_type_t { ty }));
+        },
+    )
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn wasmtime_exn_type_tag_type(ty: &wasmtime_exn_type_t) -> Box<wasm_tagtype_t> {
+    Box::new(wasm_tagtype_t::new(ty.ty.tag_type()))
+}

--- a/crates/c-api/src/types/func.rs
+++ b/crates/c-api/src/types/func.rs
@@ -1,4 +1,4 @@
-use crate::{CExternType, wasm_externtype_t, wasm_valtype_t, wasm_valtype_vec_t};
+use crate::{CExternType, wasm_externtype_t, wasm_valtype_vec_t};
 use std::cell::OnceCell;
 use std::{
     mem,
@@ -102,12 +102,6 @@ impl wasm_functype_t {
         }
     }
 
-    pub(crate) fn from_cfunc(ty: CFuncType) -> wasm_functype_t {
-        wasm_functype_t {
-            ext: wasm_externtype_t::from_cextern_type(CExternType::Func(ty)),
-        }
-    }
-
     pub(crate) fn try_from(e: &wasm_externtype_t) -> Option<&wasm_functype_t> {
         match &e.which {
             CExternType::Func(_) => Some(unsafe { &*(e as *const _ as *const _) }),
@@ -154,12 +148,12 @@ pub extern "C" fn wasm_functype_new(
     let params = params
         .take()
         .into_iter()
-        .map(|vt| vt.unwrap().ty.clone())
+        .map(|vt| (*vt.unwrap()).clone())
         .collect();
     let results = results
         .take()
         .into_iter()
-        .map(|vt| vt.unwrap().ty.clone())
+        .map(|vt| (*vt.unwrap()).clone())
         .collect();
     Box::new(wasm_functype_t::lazy(params, results))
 }
@@ -170,7 +164,7 @@ pub extern "C" fn wasm_functype_params(ft: &wasm_functype_t) -> &wasm_valtype_ve
     ft.params_cache.get_or_init(|| {
         let ty = ft.ty.lock().unwrap();
         ty.params()
-            .map(|p| Some(Box::new(wasm_valtype_t { ty: p.clone() })))
+            .map(|p| Some(Box::new(p.clone())))
             .collect::<Vec<_>>()
             .into()
     })
@@ -182,7 +176,7 @@ pub extern "C" fn wasm_functype_results(ft: &wasm_functype_t) -> &wasm_valtype_v
     ft.returns_cache.get_or_init(|| {
         let ty = ft.ty.lock().unwrap();
         ty.results()
-            .map(|p| Some(Box::new(wasm_valtype_t { ty: p.clone() })))
+            .map(|p| Some(Box::new(p.clone())))
             .collect::<Vec<_>>()
             .into()
     })

--- a/crates/c-api/src/types/global.rs
+++ b/crates/c-api/src/types/global.rs
@@ -1,5 +1,4 @@
 use crate::{CExternType, wasm_externtype_t, wasm_valtype_t};
-use std::cell::OnceCell;
 use wasmtime::GlobalType;
 
 pub type wasm_mutability_t = u8;
@@ -18,7 +17,6 @@ wasmtime_c_api_macros::declare_ty!(wasm_globaltype_t);
 #[derive(Clone)]
 pub(crate) struct CGlobalType {
     pub(crate) ty: GlobalType,
-    content_cache: OnceCell<wasm_valtype_t>,
 }
 
 impl wasm_globaltype_t {
@@ -45,10 +43,7 @@ impl wasm_globaltype_t {
 
 impl CGlobalType {
     pub(crate) fn new(ty: GlobalType) -> CGlobalType {
-        CGlobalType {
-            ty,
-            content_cache: OnceCell::new(),
-        }
+        CGlobalType { ty }
     }
 }
 
@@ -63,16 +58,13 @@ pub extern "C" fn wasm_globaltype_new(
         WASM_VAR => Var,
         _ => return None,
     };
-    let ty = GlobalType::new(ty.ty.clone(), mutability);
+    let ty = GlobalType::new((*ty).clone(), mutability);
     Some(Box::new(wasm_globaltype_t::new(ty)))
 }
 
 #[unsafe(no_mangle)]
 pub extern "C" fn wasm_globaltype_content(gt: &wasm_globaltype_t) -> &wasm_valtype_t {
-    let gt = gt.ty();
-    gt.content_cache.get_or_init(|| wasm_valtype_t {
-        ty: gt.ty.content().clone(),
-    })
+    gt.ty().ty.content()
 }
 
 #[unsafe(no_mangle)]

--- a/crates/c-api/src/types/structref.rs
+++ b/crates/c-api/src/types/structref.rs
@@ -1,13 +1,57 @@
-use wasmtime::{FieldType, Mutability, StorageType, StructType, ValType};
+use crate::wasm_valtype_t;
+use std::mem::{ManuallyDrop, MaybeUninit};
+use wasmtime::{FieldType, Mutability, StorageType, StructType};
 
-pub type wasmtime_storage_kind_t = u8;
-pub const WASMTIME_STORAGE_KIND_I8: wasmtime_storage_kind_t = 9;
-pub const WASMTIME_STORAGE_KIND_I16: wasmtime_storage_kind_t = 10;
+#[repr(C, u8)]
+#[derive(Clone)]
+pub enum wasmtime_storage_type_t {
+    I8,
+    I16,
+    Val(Box<wasm_valtype_t>),
+}
+
+impl From<StorageType> for wasmtime_storage_type_t {
+    fn from(ty: StorageType) -> Self {
+        match ty {
+            StorageType::I8 => Self::I8,
+            StorageType::I16 => Self::I16,
+            StorageType::ValType(ty) => Self::Val(Box::new(ty.into())),
+        }
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn wasmtime_storage_type_clone(
+    storage: &wasmtime_storage_type_t,
+    out: &mut MaybeUninit<wasmtime_storage_type_t>,
+) {
+    out.write(storage.clone());
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn wasmtime_storage_type_delete(
+    out: Option<&mut ManuallyDrop<wasmtime_storage_type_t>>,
+) {
+    if let Some(out) = out {
+        unsafe {
+            ManuallyDrop::drop(out);
+        }
+    }
+}
 
 #[repr(C)]
+#[derive(Clone)]
 pub struct wasmtime_field_type_t {
-    pub kind: wasmtime_storage_kind_t,
     pub mutable_: bool,
+    pub storage: wasmtime_storage_type_t,
+}
+
+impl From<FieldType> for wasmtime_field_type_t {
+    fn from(field: FieldType) -> Self {
+        let mutable_ = field.mutability() == Mutability::Var;
+        let storage = field.element_type().clone().into();
+        Self { mutable_, storage }
+    }
 }
 
 impl wasmtime_field_type_t {
@@ -17,28 +61,39 @@ impl wasmtime_field_type_t {
         } else {
             Mutability::Const
         };
-        let storage = match self.kind {
-            WASMTIME_STORAGE_KIND_I8 => StorageType::I8,
-            WASMTIME_STORAGE_KIND_I16 => StorageType::I16,
-            crate::WASMTIME_I32 => StorageType::ValType(ValType::I32),
-            crate::WASMTIME_I64 => StorageType::ValType(ValType::I64),
-            crate::WASMTIME_F32 => StorageType::ValType(ValType::F32),
-            crate::WASMTIME_F64 => StorageType::ValType(ValType::F64),
-            crate::WASMTIME_V128 => StorageType::ValType(ValType::V128),
-            crate::WASMTIME_FUNCREF => StorageType::ValType(ValType::FUNCREF),
-            crate::WASMTIME_EXTERNREF => StorageType::ValType(ValType::EXTERNREF),
-            crate::WASMTIME_ANYREF => StorageType::ValType(ValType::ANYREF),
-            crate::WASMTIME_EXNREF => StorageType::ValType(ValType::EXNREF),
-            other => panic!("unknown wasmtime_storage_kind_t: {other}"),
+        let storage = match &self.storage {
+            wasmtime_storage_type_t::I8 => StorageType::I8,
+            wasmtime_storage_type_t::I16 => StorageType::I16,
+            wasmtime_storage_type_t::Val(ty) => StorageType::ValType((**ty).clone()),
         };
         FieldType::new(mutability, storage)
     }
 }
 
+#[unsafe(no_mangle)]
+pub extern "C" fn wasmtime_field_type_clone(
+    field: &wasmtime_field_type_t,
+    out: &mut MaybeUninit<wasmtime_field_type_t>,
+) {
+    out.write(field.clone());
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn wasmtime_field_type_delete(
+    out: Option<&mut ManuallyDrop<wasmtime_field_type_t>>,
+) {
+    if let Some(out) = out {
+        unsafe {
+            ManuallyDrop::drop(out);
+        }
+    }
+}
+
+#[derive(Clone)]
 pub struct wasmtime_struct_type_t {
     pub(crate) ty: StructType,
 }
-wasmtime_c_api_macros::declare_own!(wasmtime_struct_type_t);
+wasmtime_c_api_macros::declare_ty!(wasmtime_struct_type_t);
 
 #[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_struct_type_new(
@@ -50,4 +105,24 @@ pub extern "C" fn wasmtime_struct_type_new(
     let field_types: Vec<FieldType> = fields.iter().map(|f| f.to_wasmtime()).collect();
     let ty = StructType::new(&engine.engine, field_types).expect("failed to create struct type");
     Box::new(wasmtime_struct_type_t { ty })
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn wasmtime_struct_type_num_fields(ty: &wasmtime_struct_type_t) -> usize {
+    ty.ty.fields().len()
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn wasmtime_struct_type_field(
+    ty: &wasmtime_struct_type_t,
+    index: usize,
+    out: &mut MaybeUninit<wasmtime_field_type_t>,
+) -> bool {
+    match ty.ty.field(index) {
+        Some(field) => {
+            out.write(field.into());
+            true
+        }
+        None => false,
+    }
 }

--- a/crates/c-api/src/types/structref.rs
+++ b/crates/c-api/src/types/structref.rs
@@ -15,7 +15,7 @@ impl From<StorageType> for wasmtime_storage_type_t {
         match ty {
             StorageType::I8 => Self::I8,
             StorageType::I16 => Self::I16,
-            StorageType::ValType(ty) => Self::Val(Box::new(ty.into())),
+            StorageType::ValType(ty) => Self::Val(Box::new(ty)),
         }
     }
 }

--- a/crates/c-api/src/types/table.rs
+++ b/crates/c-api/src/types/table.rs
@@ -54,7 +54,7 @@ pub extern "C" fn wasm_tabletype_new(
     ty: Box<wasm_valtype_t>,
     limits: &wasm_limits_t,
 ) -> Option<Box<wasm_tabletype_t>> {
-    let ty = ty.ty.as_ref()?.clone();
+    let ty = (*ty).as_ref()?.clone();
     Some(Box::new(wasm_tabletype_t::new(TableType::new(
         ty,
         limits.min,
@@ -65,9 +65,8 @@ pub extern "C" fn wasm_tabletype_new(
 #[unsafe(no_mangle)]
 pub extern "C" fn wasm_tabletype_element(tt: &wasm_tabletype_t) -> &wasm_valtype_t {
     let tt = tt.ty();
-    tt.element_cache.get_or_init(|| wasm_valtype_t {
-        ty: ValType::Ref(tt.ty.element().clone()),
-    })
+    tt.element_cache
+        .get_or_init(|| ValType::Ref(tt.ty.element().clone()))
 }
 
 #[unsafe(no_mangle)]

--- a/crates/c-api/src/types/tag.rs
+++ b/crates/c-api/src/types/tag.rs
@@ -1,4 +1,4 @@
-use crate::{CExternType, CFuncType, wasm_externtype_t, wasm_functype_t};
+use crate::{CExternType, wasm_externtype_t, wasm_functype_t};
 use std::cell::OnceCell;
 use wasmtime::{Engine, TagType};
 
@@ -12,27 +12,42 @@ wasmtime_c_api_macros::declare_ty!(wasm_tagtype_t);
 
 #[derive(Clone)]
 pub(crate) struct CTagType {
-    ty: CFuncType,
+    ty: LazyTagType,
+    tagtype_cache: OnceCell<TagType>,
     functype_cache: OnceCell<Box<wasm_functype_t>>,
+}
+
+#[derive(Clone)]
+enum LazyTagType {
+    TagType(TagType),
+    Lazy(Box<wasm_functype_t>),
 }
 
 impl CTagType {
     pub(crate) fn new(ty: TagType) -> CTagType {
         CTagType {
-            ty: CFuncType::new(ty.ty().clone()),
+            ty: LazyTagType::TagType(ty),
+            tagtype_cache: OnceCell::new(),
             functype_cache: OnceCell::new(),
         }
     }
 
-    fn from_cfunc(ty: CFuncType) -> CTagType {
+    fn lazy(functype: Box<wasm_functype_t>) -> CTagType {
         CTagType {
-            ty,
+            ty: LazyTagType::Lazy(functype),
+            tagtype_cache: OnceCell::new(),
             functype_cache: OnceCell::new(),
         }
     }
 }
 
 impl wasm_tagtype_t {
+    pub(crate) fn new(ty: TagType) -> wasm_tagtype_t {
+        wasm_tagtype_t {
+            ext: wasm_externtype_t::from_extern_type(ty.into()),
+        }
+    }
+
     pub(crate) fn try_from(e: &wasm_externtype_t) -> Option<&wasm_tagtype_t> {
         match &e.which {
             CExternType::Tag(_) => Some(unsafe { &*(e as *const _ as *const _) }),
@@ -47,16 +62,13 @@ impl wasm_tagtype_t {
         }
     }
 
-    /// Converts this C tag type into a Wasmtime `TagType`.
-    pub(crate) fn to_tag_type(&self, engine: &Engine) -> TagType {
-        let func_type = self.cty().ty.ty(engine);
-        TagType::new(func_type)
-    }
-
-    /// Creates a `wasm_tagtype_t` from a Wasmtime `TagType`.
-    pub(crate) fn from_tag_type(ty: TagType) -> wasm_tagtype_t {
-        wasm_tagtype_t {
-            ext: wasm_externtype_t::from_cextern_type(CExternType::Tag(CTagType::new(ty))),
+    pub(crate) fn ty(&self, engine: &Engine) -> &TagType {
+        let cty = self.cty();
+        match &cty.ty {
+            LazyTagType::TagType(ty) => ty,
+            LazyTagType::Lazy(f) => cty
+                .tagtype_cache
+                .get_or_init(|| TagType::new(f.ty().ty(engine))),
         }
     }
 }
@@ -65,9 +77,8 @@ impl wasm_tagtype_t {
 /// Takes ownership of `functype`.
 #[unsafe(no_mangle)]
 pub extern "C" fn wasm_tagtype_new(functype: Box<wasm_functype_t>) -> Box<wasm_tagtype_t> {
-    let cfunc = functype.ty().clone();
     Box::new(wasm_tagtype_t {
-        ext: wasm_externtype_t::from_cextern_type(CExternType::Tag(CTagType::from_cfunc(cfunc))),
+        ext: wasm_externtype_t::from_cextern_type(CExternType::Tag(CTagType::lazy(functype))),
     })
 }
 
@@ -75,8 +86,12 @@ pub extern "C" fn wasm_tagtype_new(functype: Box<wasm_functype_t>) -> Box<wasm_t
 #[unsafe(no_mangle)]
 pub extern "C" fn wasm_tagtype_functype(tt: &wasm_tagtype_t) -> &wasm_functype_t {
     let cty = tt.cty();
-    cty.functype_cache
-        .get_or_init(|| Box::new(wasm_functype_t::from_cfunc(cty.ty.clone())))
+    match &cty.ty {
+        LazyTagType::TagType(ty) => cty
+            .functype_cache
+            .get_or_init(|| Box::new(wasm_functype_t::new(ty.ty().clone()))),
+        LazyTagType::Lazy(f) => f,
+    }
 }
 
 /// Converts a `wasm_tagtype_t` to a `wasm_externtype_t` (borrowed).

--- a/crates/c-api/src/types/val.rs
+++ b/crates/c-api/src/types/val.rs
@@ -1,10 +1,11 @@
-use wasmtime::{HeapType, ValType};
+use crate::{
+    wasm_engine_t, wasm_functype_t, wasmtime_array_type_t, wasmtime_exn_type_t,
+    wasmtime_struct_type_t,
+};
+use std::mem::{ManuallyDrop, MaybeUninit};
+use wasmtime::{HeapType, RefType, ValType};
 
-#[repr(C)]
-#[derive(Clone)]
-pub struct wasm_valtype_t {
-    pub(crate) ty: ValType,
-}
+pub type wasm_valtype_t = ValType;
 
 wasmtime_c_api_macros::declare_ty!(wasm_valtype_t);
 
@@ -18,51 +19,231 @@ pub const WASM_FUNCREF: wasm_valkind_t = 129;
 
 #[unsafe(no_mangle)]
 pub extern "C" fn wasm_valtype_new(kind: wasm_valkind_t) -> Box<wasm_valtype_t> {
-    Box::new(wasm_valtype_t {
-        ty: into_valtype(kind),
-    })
-}
-
-#[unsafe(no_mangle)]
-pub extern "C" fn wasm_valtype_kind(vt: &wasm_valtype_t) -> wasm_valkind_t {
-    from_valtype(&vt.ty)
-}
-
-pub(crate) fn into_valtype(kind: wasm_valkind_t) -> ValType {
-    match kind {
+    Box::new(match kind {
         WASM_I32 => ValType::I32,
         WASM_I64 => ValType::I64,
         WASM_F32 => ValType::F32,
         WASM_F64 => ValType::F64,
         WASM_EXTERNREF => ValType::EXTERNREF,
         WASM_FUNCREF => ValType::FUNCREF,
-        WASMTIME_V128 => ValType::V128,
-        _ => panic!("unexpected kind: {kind}"),
-    }
+        _ => crate::abort("unexpected value type kind"),
+    })
 }
 
-pub(crate) fn from_valtype(ty: &ValType) -> wasm_valkind_t {
-    match ty {
+#[unsafe(no_mangle)]
+pub extern "C" fn wasm_valtype_kind(vt: &wasm_valtype_t) -> wasm_valkind_t {
+    match vt {
         ValType::I32 => WASM_I32,
         ValType::I64 => WASM_I64,
         ValType::F32 => WASM_F32,
         ValType::F64 => WASM_F64,
-        ValType::V128 => WASMTIME_V128,
+        // TODO
+        ValType::V128 => crate::abort("support for v128 "),
         ValType::Ref(r) => match (r.is_nullable(), r.heap_type()) {
             (true, HeapType::Extern) => WASM_EXTERNREF,
             (true, HeapType::Func) => WASM_FUNCREF,
+            // TODO
             _ => crate::abort("support for non-externref and non-funcref references"),
         },
     }
 }
 
-pub type wasmtime_valkind_t = u8;
-pub const WASMTIME_I32: wasmtime_valkind_t = 0;
-pub const WASMTIME_I64: wasmtime_valkind_t = 1;
-pub const WASMTIME_F32: wasmtime_valkind_t = 2;
-pub const WASMTIME_F64: wasmtime_valkind_t = 3;
-pub const WASMTIME_V128: wasmtime_valkind_t = 4;
-pub const WASMTIME_FUNCREF: wasmtime_valkind_t = 5;
-pub const WASMTIME_EXTERNREF: wasmtime_valkind_t = 6;
-pub const WASMTIME_ANYREF: wasmtime_valkind_t = 7;
-pub const WASMTIME_EXNREF: wasmtime_valkind_t = 8;
+#[unsafe(no_mangle)]
+pub extern "C" fn wasmtime_wasm_valtype_v128() -> Box<wasm_valtype_t> {
+    Box::new(ValType::V128)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn wasmtime_wasm_valtype_equal(a: &wasm_valtype_t, b: &wasm_valtype_t) -> bool {
+    ValType::eq(a, b)
+}
+
+#[repr(C, u8)]
+#[derive(Clone)]
+pub enum wasmtime_valtype_t {
+    I32,
+    I64,
+    F32,
+    F64,
+    V128,
+    Ref(wasmtime_reftype_t),
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn wasmtime_valtype_new(
+    ty: &wasm_valtype_t,
+    ret: &mut MaybeUninit<wasmtime_valtype_t>,
+) {
+    ret.write(match ty {
+        ValType::I32 => wasmtime_valtype_t::I32,
+        ValType::I64 => wasmtime_valtype_t::I64,
+        ValType::F32 => wasmtime_valtype_t::F32,
+        ValType::F64 => wasmtime_valtype_t::F64,
+        ValType::V128 => wasmtime_valtype_t::V128,
+        ValType::Ref(r) => wasmtime_valtype_t::Ref(wasmtime_reftype_t::from(r)),
+    });
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn wasmtime_valtype_clone(
+    ty: &wasmtime_valtype_t,
+    ret: &mut MaybeUninit<wasmtime_valtype_t>,
+) {
+    ret.write(ty.clone());
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn wasmtime_valtype_delete(
+    ret: Option<&mut ManuallyDrop<wasmtime_valtype_t>>,
+) {
+    if let Some(ret) = ret {
+        unsafe {
+            ManuallyDrop::drop(ret);
+        };
+    }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn wasmtime_valtype_to_wasm(
+    engine: Option<&wasm_engine_t>,
+    r: &wasmtime_valtype_t,
+) -> Box<wasm_valtype_t> {
+    let r = match r {
+        wasmtime_valtype_t::I32 => return Box::new(ValType::I32),
+        wasmtime_valtype_t::I64 => return Box::new(ValType::I64),
+        wasmtime_valtype_t::F32 => return Box::new(ValType::F32),
+        wasmtime_valtype_t::F64 => return Box::new(ValType::F64),
+        wasmtime_valtype_t::V128 => return Box::new(ValType::V128),
+        wasmtime_valtype_t::Ref(r) => r,
+    };
+    let heap_type = match &r.hty {
+        wasmtime_heaptype_t::Extern => HeapType::Extern,
+        wasmtime_heaptype_t::NoExtern => HeapType::NoExtern,
+        wasmtime_heaptype_t::Func => HeapType::Func,
+        wasmtime_heaptype_t::ConcreteFunc(f) => {
+            HeapType::ConcreteFunc(f.ty().ty(&engine.unwrap().engine).clone())
+        }
+        wasmtime_heaptype_t::NoFunc => HeapType::NoFunc,
+        wasmtime_heaptype_t::Any => HeapType::Any,
+        wasmtime_heaptype_t::None => HeapType::None,
+        wasmtime_heaptype_t::Eq => HeapType::Eq,
+        wasmtime_heaptype_t::I31 => HeapType::I31,
+        wasmtime_heaptype_t::Array => HeapType::Array,
+        wasmtime_heaptype_t::ConcreteArray(a) => HeapType::ConcreteArray(a.ty.clone()),
+        wasmtime_heaptype_t::Struct => HeapType::Struct,
+        wasmtime_heaptype_t::ConcreteStruct(s) => HeapType::ConcreteStruct(s.ty.clone()),
+        wasmtime_heaptype_t::Exn => HeapType::Exn,
+        wasmtime_heaptype_t::ConcreteExn(e) => HeapType::ConcreteExn(e.ty.clone()),
+        wasmtime_heaptype_t::NoExn => HeapType::NoExn,
+    };
+    Box::new(ValType::Ref(RefType::new(r.nullable, heap_type)))
+}
+
+#[repr(C, u8)]
+#[derive(Clone)]
+pub enum wasmtime_heaptype_t {
+    Extern,
+    NoExtern,
+    Func,
+    ConcreteFunc(Box<wasm_functype_t>),
+    NoFunc,
+    Any,
+    None,
+    Eq,
+    I31,
+    Array,
+    ConcreteArray(Box<wasmtime_array_type_t>),
+    Struct,
+    ConcreteStruct(Box<wasmtime_struct_type_t>),
+    Exn,
+    ConcreteExn(Box<wasmtime_exn_type_t>),
+    NoExn,
+}
+
+impl From<&HeapType> for wasmtime_heaptype_t {
+    fn from(r: &HeapType) -> Self {
+        match r {
+            HeapType::Extern => Self::Extern,
+            HeapType::NoExtern => Self::NoExtern,
+            HeapType::Func => Self::Func,
+            HeapType::ConcreteFunc(f) => {
+                Self::ConcreteFunc(Box::new(wasm_functype_t::new(f.clone())))
+            }
+            HeapType::NoFunc => Self::NoFunc,
+            HeapType::Any => Self::Any,
+            HeapType::None => Self::None,
+            HeapType::Eq => Self::Eq,
+            HeapType::I31 => Self::I31,
+            HeapType::Array => Self::Array,
+            HeapType::ConcreteArray(a) => {
+                Self::ConcreteArray(Box::new(wasmtime_array_type_t { ty: a.clone() }))
+            }
+            HeapType::Struct => Self::Struct,
+            HeapType::ConcreteStruct(s) => {
+                Self::ConcreteStruct(Box::new(wasmtime_struct_type_t { ty: s.clone() }))
+            }
+            HeapType::Exn => Self::Exn,
+            HeapType::ConcreteExn(e) => {
+                Self::ConcreteExn(Box::new(wasmtime_exn_type_t { ty: e.clone() }))
+            }
+            HeapType::NoExn => Self::NoExn,
+            HeapType::Cont | HeapType::ConcreteCont(_) | HeapType::NoCont => {
+                crate::abort("missing support for contref")
+            }
+        }
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn wasmtime_heaptype_clone(
+    ty: &wasmtime_heaptype_t,
+    ret: &mut MaybeUninit<wasmtime_heaptype_t>,
+) {
+    ret.write(ty.clone());
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn wasmtime_heaptype_delete(
+    ret: Option<&mut ManuallyDrop<wasmtime_heaptype_t>>,
+) {
+    if let Some(ret) = ret {
+        unsafe {
+            ManuallyDrop::drop(ret);
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Clone)]
+pub struct wasmtime_reftype_t {
+    pub nullable: bool,
+    pub hty: wasmtime_heaptype_t,
+}
+
+impl From<&RefType> for wasmtime_reftype_t {
+    fn from(r: &RefType) -> Self {
+        Self {
+            nullable: r.is_nullable(),
+            hty: r.heap_type().into(),
+        }
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn wasmtime_reftype_clone(
+    ty: &wasmtime_reftype_t,
+    ret: &mut MaybeUninit<wasmtime_reftype_t>,
+) {
+    ret.write(ty.clone());
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn wasmtime_reftype_delete(
+    ret: Option<&mut ManuallyDrop<wasmtime_reftype_t>>,
+) {
+    if let Some(ret) = ret {
+        unsafe {
+            ManuallyDrop::drop(ret);
+        }
+    }
+}

--- a/crates/c-api/src/val.rs
+++ b/crates/c-api/src/val.rs
@@ -1,8 +1,11 @@
 #[cfg(feature = "gc")]
 use crate::r#ref::ref_to_val;
-use crate::{WASM_EXTERNREF, WASM_F32, WASM_F64, WASM_FUNCREF, WASM_I32, WASM_I64, wasm_valkind_t};
 #[cfg(feature = "gc")]
-use crate::{wasm_ref_t, wasmtime_anyref_t, wasmtime_exnref_t, wasmtime_externref_t};
+use crate::{
+    WASM_EXTERNREF, WASM_FUNCREF, wasm_ref_t, wasmtime_anyref_t, wasmtime_exnref_t,
+    wasmtime_externref_t,
+};
+use crate::{WASM_F32, WASM_F64, WASM_I32, WASM_I64, wasm_valkind_t};
 use std::mem::{ManuallyDrop, MaybeUninit};
 use std::ptr;
 use wasmtime::{AsContextMut, Func, Val};

--- a/crates/c-api/src/val.rs
+++ b/crates/c-api/src/val.rs
@@ -1,13 +1,13 @@
 #[cfg(feature = "gc")]
 use crate::r#ref::ref_to_val;
-use crate::{WASM_I32, from_valtype, into_valtype, wasm_valkind_t, wasmtime_valkind_t};
+use crate::{WASM_EXTERNREF, WASM_F32, WASM_F64, WASM_FUNCREF, WASM_I32, WASM_I64, wasm_valkind_t};
 #[cfg(feature = "gc")]
 use crate::{wasm_ref_t, wasmtime_anyref_t, wasmtime_exnref_t, wasmtime_externref_t};
 use std::mem::{ManuallyDrop, MaybeUninit};
 use std::ptr;
-use wasmtime::{AsContextMut, Func, Val, ValType};
+use wasmtime::{AsContextMut, Func, Val};
 #[cfg(feature = "gc")]
-use wasmtime::{HeapType, Ref, RootScope};
+use wasmtime::{Ref, RootScope};
 
 #[repr(C)]
 pub struct wasm_val_t {
@@ -31,8 +31,8 @@ pub union wasm_val_union {
 #[cfg(feature = "gc")]
 impl Drop for wasm_val_t {
     fn drop(&mut self) {
-        match into_valtype(self.kind) {
-            ValType::Ref(_) => unsafe {
+        match self.kind {
+            WASM_FUNCREF | WASM_EXTERNREF => unsafe {
                 if !self.of.ref_.is_null() {
                     drop(Box::from_raw(self.of.ref_));
                 }
@@ -55,8 +55,8 @@ impl Clone for wasm_val_t {
 
         #[cfg(feature = "gc")]
         unsafe {
-            match into_valtype(self.kind) {
-                ValType::Ref(_) if !self.of.ref_.is_null() => {
+            match self.kind {
+                WASM_FUNCREF | WASM_EXTERNREF if !self.of.ref_.is_null() => {
                     ret.of.ref_ = Box::into_raw(Box::new((*self.of.ref_).clone()));
                 }
                 _ => {}
@@ -80,24 +80,24 @@ impl wasm_val_t {
     pub fn from_val(val: Val) -> wasm_val_t {
         match val {
             Val::I32(i) => wasm_val_t {
-                kind: from_valtype(&ValType::I32),
+                kind: WASM_I32,
                 of: wasm_val_union { i32: i },
             },
             Val::I64(i) => wasm_val_t {
-                kind: from_valtype(&ValType::I64),
+                kind: WASM_I64,
                 of: wasm_val_union { i64: i },
             },
             Val::F32(f) => wasm_val_t {
-                kind: from_valtype(&ValType::F32),
+                kind: WASM_F32,
                 of: wasm_val_union { u32: f },
             },
             Val::F64(f) => wasm_val_t {
-                kind: from_valtype(&ValType::F64),
+                kind: WASM_F64,
                 of: wasm_val_union { u64: f },
             },
             #[cfg(feature = "gc")]
             Val::FuncRef(f) => wasm_val_t {
-                kind: from_valtype(&ValType::FUNCREF),
+                kind: WASM_FUNCREF,
                 of: wasm_val_union {
                     ref_: f.map_or(ptr::null_mut(), |f| {
                         Box::into_raw(Box::new(wasm_ref_t {
@@ -117,26 +117,20 @@ impl wasm_val_t {
     }
 
     pub fn val(&self) -> Val {
-        match into_valtype(self.kind) {
-            ValType::I32 => Val::from(unsafe { self.of.i32 }),
-            ValType::I64 => Val::from(unsafe { self.of.i64 }),
-            ValType::F32 => Val::from(unsafe { self.of.f32 }),
-            ValType::F64 => Val::from(unsafe { self.of.f64 }),
+        match self.kind {
+            WASM_I32 => Val::from(unsafe { self.of.i32 }),
+            WASM_I64 => Val::from(unsafe { self.of.i64 }),
+            WASM_F32 => Val::from(unsafe { self.of.f32 }),
+            WASM_F64 => Val::from(unsafe { self.of.f64 }),
             #[cfg(feature = "gc")]
-            ValType::Ref(r) => match r.heap_type() {
-                HeapType::Func => unsafe {
-                    if self.of.ref_.is_null() {
-                        assert!(r.is_nullable());
-                        Val::FuncRef(None)
-                    } else {
-                        ref_to_val(&*self.of.ref_)
-                    }
-                },
-                _ => unreachable!("wasm_val_t cannot contain non-function reference values"),
+            WASM_FUNCREF => unsafe {
+                if self.of.ref_.is_null() {
+                    Val::FuncRef(None)
+                } else {
+                    ref_to_val(&*self.of.ref_)
+                }
             },
-            #[cfg(not(feature = "gc"))]
-            ValType::Ref(_) => unimplemented!("wasm_val_t: reference types require gc feature"),
-            ValType::V128 => unimplemented!("wasm_val_t: v128"),
+            _ => crate::abort("unsupported val discriminant"),
         }
     }
 }
@@ -156,6 +150,17 @@ pub struct wasmtime_val_t {
     pub kind: wasmtime_valkind_t,
     pub of: wasmtime_val_union,
 }
+
+pub type wasmtime_valkind_t = u8;
+pub const WASMTIME_I32: wasmtime_valkind_t = 0;
+pub const WASMTIME_I64: wasmtime_valkind_t = 1;
+pub const WASMTIME_F32: wasmtime_valkind_t = 2;
+pub const WASMTIME_F64: wasmtime_valkind_t = 3;
+pub const WASMTIME_V128: wasmtime_valkind_t = 4;
+pub const WASMTIME_FUNCREF: wasmtime_valkind_t = 5;
+pub const WASMTIME_EXTERNREF: wasmtime_valkind_t = 6;
+pub const WASMTIME_ANYREF: wasmtime_valkind_t = 7;
+pub const WASMTIME_EXNREF: wasmtime_valkind_t = 8;
 
 #[repr(C)]
 pub union wasmtime_val_union {

--- a/crates/c-api/tests/component/types.cc
+++ b/crates/c-api/tests/component/types.cc
@@ -144,7 +144,7 @@ TEST(types, module_type) {
   EXPECT_EQ(export_ty->ref().name(), "x");
   auto export_item_ty = ExternType::from_export(export_ty->ref());
   auto global_ty = std::get<wasmtime::GlobalType::Ref>(export_item_ty);
-  EXPECT_EQ(global_ty.content().kind(), wasmtime::ValKind::I32);
+  EXPECT_EQ(global_ty.content(), wasmtime::ValType::i32());
   EXPECT_TRUE(global_ty.is_mutable());
 }
 

--- a/crates/c-api/tests/exception.cc
+++ b/crates/c-api/tests/exception.cc
@@ -15,7 +15,7 @@ TEST(Exception, ConstructAndExamine) {
   auto cx = store.context();
 
   // Create a tag type with (i32, i64) payload.
-  FuncType ft({ValKind::I32, ValKind::I64}, {});
+  FuncType ft({ValType::i32(), ValType::i64()}, {});
   TagType tt(ft);
 
   // Create a tag instance.
@@ -61,7 +61,7 @@ TEST(Exception, TagFromModule) {
   auto tt = tag.type(cx);
   auto func = tt->functype();
   EXPECT_EQ(func->params().size(), 1u);
-  EXPECT_EQ(func->params().begin()->kind(), ValKind::I32);
+  EXPECT_EQ(*func->params().begin(), ValType::i32());
 }
 
 TEST(Exception, HostThrowWasmCatch) {
@@ -69,7 +69,7 @@ TEST(Exception, HostThrowWasmCatch) {
   Store store(engine);
   auto cx = store.context();
 
-  FuncType tag_ft({ValKind::I32}, {});
+  FuncType tag_ft({ValType::i32()}, {});
   TagType tt(tag_ft);
   auto tag = Tag::create(cx, tt).unwrap();
 

--- a/crates/c-api/tests/export_type.cc
+++ b/crates/c-api/tests/export_type.cc
@@ -20,7 +20,7 @@ TEST(ExportType, Smoke) {
   auto e = *exports.begin();
   EXPECT_EQ(e.name(), "x");
   auto export_ty = std::get<GlobalType::Ref>(ExternType::from_export(e));
-  EXPECT_EQ(export_ty.content().kind(), ValKind::I32);
+  EXPECT_EQ(export_ty.content(), ValType::i32());
   EXPECT_FALSE(export_ty.is_mutable());
 
   for (auto &exp : exports) {

--- a/crates/c-api/tests/extern_type.cc
+++ b/crates/c-api/tests/extern_type.cc
@@ -26,6 +26,6 @@ TEST(ExternType, Smoke) {
   EXPECT_EQ(exports.size(), 1);
   auto e = *exports.begin();
   auto export_ty = std::get<GlobalType::Ref>(ExternType::from_export(e));
-  EXPECT_EQ(export_ty.content().kind(), ValKind::I32);
+  EXPECT_EQ(export_ty.content(), ValType::i32());
   EXPECT_FALSE(export_ty.is_mutable());
 }

--- a/crates/c-api/tests/func.cc
+++ b/crates/c-api/tests/func.cc
@@ -19,7 +19,7 @@ TEST(TypedFunc, Smoke) {
   EXPECT_TRUE((thunk.typed<empty_t, empty_t>(store)));
 
   Func pi32(
-      store, FuncType({ValKind::I32}, {}),
+      store, FuncType({ValType::i32()}, {}),
       [](auto caller, auto params, auto results) { return std::monostate(); });
 
   EXPECT_FALSE((pi32.typed<float, empty_t>(store)));
@@ -29,7 +29,7 @@ TEST(TypedFunc, Smoke) {
   EXPECT_TRUE((pi32.typed<uint32_t, empty_t>(store)));
 
   Func rets(
-      store, FuncType({}, {ValKind::F32, ValKind::F64}),
+      store, FuncType({}, {ValType::f32(), ValType::f64()}),
       [](auto caller, auto params, auto results) { return std::monostate(); });
 
   EXPECT_FALSE((rets.typed<empty_t, std::tuple<int, int>>(store)));
@@ -51,7 +51,7 @@ TEST(TypedFunc, Call) {
   }
 
   {
-    Func f(store, FuncType({ValKind::I32}, {}),
+    Func f(store, FuncType({ValType::i32()}, {}),
            [](auto caller, auto params, auto results) {
              EXPECT_EQ(params[0].i32(), 1);
              return std::monostate();
@@ -65,7 +65,8 @@ TEST(TypedFunc, Call) {
   }
   {
     Func f(store,
-           FuncType({ValKind::F32, ValKind::I64}, {ValKind::I32, ValKind::F64}),
+           FuncType({ValType::f32(), ValType::i64()},
+                    {ValType::i32(), ValType::f64()}),
            [](auto caller, auto params, auto results) {
              EXPECT_EQ(params[0].f32(), 1);
              EXPECT_EQ(params[1].i64(), 2);
@@ -84,8 +85,8 @@ TEST(TypedFunc, Call) {
   }
 
   {
-    FuncType ty({ValKind::ExternRef, ValKind::ExternRef},
-                {ValKind::ExternRef, ValKind::ExternRef});
+    FuncType ty({ValType::externref(), ValType::externref()},
+                {ValType::externref(), ValType::externref()});
     Func f(store, ty, [](auto caller, auto params, auto results) {
       caller.context().gc().unwrap();
       EXPECT_TRUE(params[0].externref());
@@ -113,8 +114,8 @@ TEST(TypedFunc, Call) {
               return std::monostate();
             });
 
-    FuncType ty({ValKind::FuncRef, ValKind::FuncRef},
-                {ValKind::FuncRef, ValKind::FuncRef});
+    FuncType ty({ValType::funcref(), ValType::funcref()},
+                {ValType::funcref(), ValType::funcref()});
 
     Func f(store, ty, [&](auto caller, auto params, auto results) {
       EXPECT_TRUE(params[0].funcref());
@@ -142,7 +143,7 @@ TEST(TypedFunc, Call) {
   }
 
   {
-    FuncType ty({ValKind::V128}, {ValKind::V128});
+    FuncType ty({ValType::v128()}, {ValType::v128()});
 
     Func f(store, ty, [&](auto caller, auto params, auto results) {
       V128 ret;
@@ -167,18 +168,18 @@ TEST(TypedFunc, Call) {
 }
 
 void assert_types_eq(ValType::ListRef actual,
-                     std::initializer_list<ValKind> expected) {
+                     std::initializer_list<ValType> expected) {
   EXPECT_EQ(expected.size(), actual.size());
-  std::vector<ValKind> actual_vec;
+  std::vector<ValType> actual_vec;
   for (auto ty : actual) {
-    actual_vec.push_back(ty.kind());
+    actual_vec.push_back(ty);
   }
-  std::vector<ValKind> expected_vec(expected);
+  std::vector<ValType> expected_vec(expected);
   EXPECT_EQ(actual_vec, expected_vec);
 }
 
-void assert_func_type(FuncType actual, std::initializer_list<ValKind> params,
-                      std::initializer_list<ValKind> results) {
+void assert_func_type(FuncType actual, std::initializer_list<ValType> params,
+                      std::initializer_list<ValType> results) {
   assert_types_eq(actual->params(), params);
   assert_types_eq(actual->results(), results);
 }
@@ -189,53 +190,53 @@ TEST(TypedFunc, WrapAndTypes) {
   Func f = Func::wrap(store, []() {});
   assert_func_type(f.type(store), {}, {});
   f = Func::wrap(store, []() { return int32_t(1); });
-  assert_func_type(f.type(store), {}, {ValKind::I32});
+  assert_func_type(f.type(store), {}, {ValType::i32()});
   f = Func::wrap(store, []() { return int64_t(1); });
-  assert_func_type(f.type(store), {}, {ValKind::I64});
+  assert_func_type(f.type(store), {}, {ValType::i64()});
   f = Func::wrap(store, []() { return float(1); });
-  assert_func_type(f.type(store), {}, {ValKind::F32});
+  assert_func_type(f.type(store), {}, {ValType::f32()});
   f = Func::wrap(store, []() { return double(1); });
-  assert_func_type(f.type(store), {}, {ValKind::F64});
+  assert_func_type(f.type(store), {}, {ValType::f64()});
   f = Func::wrap(store, []() { return V128(); });
-  assert_func_type(f.type(store), {}, {ValKind::V128});
+  assert_func_type(f.type(store), {}, {ValType::v128()});
   f = Func::wrap(store,
                  []() { return std::make_tuple(int32_t(1), int32_t(2)); });
-  assert_func_type(f.type(store), {}, {ValKind::I32, ValKind::I32});
+  assert_func_type(f.type(store), {}, {ValType::i32(), ValType::i32()});
   f = Func::wrap(store, []() { return std::optional<Func>(std::nullopt); });
-  assert_func_type(f.type(store), {}, {ValKind::FuncRef});
+  assert_func_type(f.type(store), {}, {ValType::funcref()});
   f = Func::wrap(store,
                  []() { return std::optional<ExternRef>(std::nullopt); });
-  assert_func_type(f.type(store), {}, {ValKind::ExternRef});
+  assert_func_type(f.type(store), {}, {ValType::externref()});
   f = Func::wrap(
       store, []() { return Result<std::monostate, Trap>(std::monostate()); });
   assert_func_type(f.type(store), {}, {});
   f = Func::wrap(store, []() { return Result<int32_t, Trap>(1); });
-  assert_func_type(f.type(store), {}, {ValKind::I32});
+  assert_func_type(f.type(store), {}, {ValType::i32()});
   f = Func::wrap(store, []() { return Result<float, Trap>(1); });
-  assert_func_type(f.type(store), {}, {ValKind::F32});
+  assert_func_type(f.type(store), {}, {ValType::f32()});
   f = Func::wrap(store, []() {
     return Result<std::tuple<int32_t, int32_t>, Trap>({1, 2});
   });
-  assert_func_type(f.type(store), {}, {ValKind::I32, ValKind::I32});
+  assert_func_type(f.type(store), {}, {ValType::i32(), ValType::i32()});
 
   f = Func::wrap(store, [](int32_t a) {});
-  assert_func_type(f.type(store), {ValKind::I32}, {});
+  assert_func_type(f.type(store), {ValType::i32()}, {});
   f = Func::wrap(store, [](int64_t a) {});
-  assert_func_type(f.type(store), {ValKind::I64}, {});
+  assert_func_type(f.type(store), {ValType::i64()}, {});
   f = Func::wrap(store, [](float a) {});
-  assert_func_type(f.type(store), {ValKind::F32}, {});
+  assert_func_type(f.type(store), {ValType::f32()}, {});
   f = Func::wrap(store, [](double a) {});
-  assert_func_type(f.type(store), {ValKind::F64}, {});
+  assert_func_type(f.type(store), {ValType::f64()}, {});
   f = Func::wrap(store, [](V128 a) {});
-  assert_func_type(f.type(store), {ValKind::V128}, {});
+  assert_func_type(f.type(store), {ValType::v128()}, {});
   f = Func::wrap(store, [](std::optional<Func> a) {});
-  assert_func_type(f.type(store), {ValKind::FuncRef}, {});
+  assert_func_type(f.type(store), {ValType::funcref()}, {});
   f = Func::wrap(store, [](std::optional<ExternRef> a) {});
-  assert_func_type(f.type(store), {ValKind::ExternRef}, {});
+  assert_func_type(f.type(store), {ValType::externref()}, {});
   f = Func::wrap(store, [](Caller a) {});
   assert_func_type(f.type(store), {}, {});
   f = Func::wrap(store, [](Caller a, int32_t b) {});
-  assert_func_type(f.type(store), {ValKind::I32}, {});
+  assert_func_type(f.type(store), {ValType::i32()}, {});
 }
 
 TEST(TypedFunc, WrapRuntime) {

--- a/crates/c-api/tests/func_type.cc
+++ b/crates/c-api/tests/func_type.cc
@@ -12,13 +12,13 @@ TEST(FuncType, Smoke) {
   auto other = t;
   other = t;
 
-  FuncType t2({ValKind::I32}, {ValKind::I64});
+  FuncType t2({ValType::i32()}, {ValType::i64()});
   EXPECT_EQ(t2->params().size(), 1);
   for (auto ty : t2->params()) {
-    EXPECT_EQ(ty.kind(), ValKind::I32);
+    EXPECT_EQ(ty, ValType::i32());
   }
   EXPECT_EQ(t2->results().size(), 1);
   for (auto ty : t2->results()) {
-    EXPECT_EQ(ty.kind(), ValKind::I64);
+    EXPECT_EQ(ty, ValType::i64());
   }
 }

--- a/crates/c-api/tests/gc.cc
+++ b/crates/c-api/tests/gc.cc
@@ -97,10 +97,10 @@ TEST(StructRef, CreateAndReadFields) {
   auto cx = store.context();
 
   // Create a struct type with two mutable i32 fields.
-  auto ty = StructType::create(engine, {
-                                           FieldType::mut_(WASMTIME_I32),
-                                           FieldType::mut_(WASMTIME_I32),
-                                       });
+  auto ty = StructType(engine, {
+                                   FieldType::mut_(ValType::i32()),
+                                   FieldType::mut_(ValType::i32()),
+                               });
   auto pre = StructRefPre::create(cx, ty);
 
   // Allocate a struct with field values 10 and 20.
@@ -134,9 +134,9 @@ TEST(StructRef, UpcastAndDowncast) {
   Store store(engine);
   auto cx = store.context();
 
-  auto ty = StructType::create(engine, {
-                                           FieldType::const_(WASMTIME_I32),
-                                       });
+  auto ty = StructType(engine, {
+                                   FieldType::const_(ValType::i32()),
+                               });
   auto pre = StructRefPre::create(cx, ty);
 
   auto result = StructRef::create(cx, pre, {Val(int32_t(99))});
@@ -169,7 +169,7 @@ TEST(ArrayRef, CreateAndReadElements) {
   auto cx = store.context();
 
   // Create an array type with mutable i32 elements.
-  auto ty = ArrayType::create(engine, FieldType::mut_(WASMTIME_I32));
+  ArrayType ty(engine, FieldType::mut_(ValType::i32()));
   auto pre = ArrayRefPre::create(cx, ty);
 
   // Allocate an array of 5 elements, all initialized to 7.
@@ -205,7 +205,7 @@ TEST(ArrayRef, UpcastAndDowncast) {
   Store store(engine);
   auto cx = store.context();
 
-  auto ty = ArrayType::create(engine, FieldType::const_(WASMTIME_I32));
+  ArrayType ty(engine, FieldType::const_(ValType::i32()));
   auto pre = ArrayRefPre::create(cx, ty);
 
   auto result = ArrayRef::create(cx, pre, Val(int32_t(99)), 3);
@@ -265,7 +265,7 @@ TEST(AnyRef, DowncastStruct) {
   Store store(engine);
   auto cx = store.context();
 
-  auto ty = StructType::create(engine, {FieldType::const_(WASMTIME_I32)});
+  auto ty = StructType(engine, {FieldType::const_(ValType::i32())});
   auto pre = StructRefPre::create(cx, ty);
   auto result = StructRef::create(cx, pre, {Val(int32_t(77))});
   ASSERT_TRUE(result);
@@ -293,7 +293,7 @@ TEST(AnyRef, DowncastArray) {
   Store store(engine);
   auto cx = store.context();
 
-  auto ty = ArrayType::create(engine, FieldType::const_(WASMTIME_I32));
+  auto ty = ArrayType(engine, FieldType::const_(ValType::i32()));
   auto pre = ArrayRefPre::create(cx, ty);
   auto result = ArrayRef::create(cx, pre, Val(int32_t(55)), 2);
   ASSERT_TRUE(result);

--- a/crates/c-api/tests/global.cc
+++ b/crates/c-api/tests/global.cc
@@ -8,17 +8,18 @@ using namespace wasmtime;
 TEST(Global, Smoke) {
   Engine engine;
   Store store(engine);
-  Global::create(store, GlobalType(ValKind::I32, true), 3.0).err();
-  Global::create(store, GlobalType(ValKind::I32, true), 3).unwrap();
-  Global::create(store, GlobalType(ValKind::I32, false), 3).unwrap();
+  Global::create(store, GlobalType(ValType::i32(), true), 3.0).err();
+  Global::create(store, GlobalType(ValType::i32(), true), 3).unwrap();
+  Global::create(store, GlobalType(ValType::i32(), false), 3).unwrap();
 
-  Global g = Global::create(store, GlobalType(ValKind::I32, true), 4).unwrap();
+  Global g =
+      Global::create(store, GlobalType(ValType::i32(), true), 4).unwrap();
   EXPECT_EQ(g.get(store).i32(), 4);
   g.set(store, 10).unwrap();
   EXPECT_EQ(g.get(store).i32(), 10);
   g.set(store, 10.23).err();
   EXPECT_EQ(g.get(store).i32(), 10);
 
-  EXPECT_EQ(g.type(store)->content().kind(), ValKind::I32);
+  EXPECT_EQ(g.type(store)->content(), ValType::i32());
   EXPECT_TRUE(g.type(store)->is_mutable());
 }

--- a/crates/c-api/tests/global_type.cc
+++ b/crates/c-api/tests/global_type.cc
@@ -5,11 +5,11 @@
 using namespace wasmtime;
 
 TEST(GlobalType, Simple) {
-  GlobalType ty(ValKind::I32, false);
+  GlobalType ty(ValType::i32(), false);
   EXPECT_FALSE(ty->is_mutable());
-  EXPECT_EQ(ty->content().kind(), ValKind::I32);
+  EXPECT_EQ(ty->content(), ValType::i32());
 
-  ty = GlobalType(ValKind::V128, true);
+  ty = GlobalType(ValType::v128(), true);
   EXPECT_TRUE(ty->is_mutable());
-  EXPECT_EQ(ty->content().kind(), ValKind::V128);
+  EXPECT_EQ(ty->content(), ValType::v128());
 }

--- a/crates/c-api/tests/instance.cc
+++ b/crates/c-api/tests/instance.cc
@@ -8,8 +8,9 @@ TEST(Instance, Smoke) {
   Engine engine;
   Store store(engine);
   Memory m = Memory::create(store, MemoryType(1)).unwrap();
-  Global g = Global::create(store, GlobalType(ValKind::I32, false), 1).unwrap();
-  Table t = Table::create(store, TableType(ValKind::FuncRef, 1),
+  Global g =
+      Global::create(store, GlobalType(ValType::i32(), false), 1).unwrap();
+  Table t = Table::create(store, TableType(ValType::funcref(), 1),
                           std::optional<Func>())
                 .unwrap();
   Func f(store, FuncType({}, {}),

--- a/crates/c-api/tests/linker.cc
+++ b/crates/c-api/tests/linker.cc
@@ -9,7 +9,8 @@ TEST(Linker, Smoke) {
   Linker linker(engine);
   Store store(engine);
   linker.allow_shadowing(false);
-  Global g = Global::create(store, GlobalType(ValKind::I32, false), 1).unwrap();
+  Global g =
+      Global::create(store, GlobalType(ValType::i32(), false), 1).unwrap();
   linker.define(store, "a", "g", g).unwrap();
   linker.define_wasi().unwrap();
   linker

--- a/crates/c-api/tests/table.cc
+++ b/crates/c-api/tests/table.cc
@@ -8,10 +8,11 @@ using namespace wasmtime;
 TEST(Table, Smoke) {
   Engine engine;
   Store store(engine);
-  Table::create(store, TableType(ValKind::FuncRef, 1), 3.0).err();
+  Table::create(store, TableType(ValType::funcref(), 1), 3.0).err();
 
   Val null = std::optional<Func>();
-  Table t = Table::create(store, TableType(ValKind::FuncRef, 1), null).unwrap();
+  Table t =
+      Table::create(store, TableType(ValType::funcref(), 1), null).unwrap();
   EXPECT_FALSE(t.get(store, 1));
   EXPECT_TRUE(t.get(store, 0));
   Val val = *t.get(store, 0);
@@ -21,5 +22,5 @@ TEST(Table, Smoke) {
   t.set(store, 3, null).unwrap();
   t.set(store, 3, 3).err();
   EXPECT_EQ(t.size(store), 5);
-  EXPECT_EQ(t.type(store)->element().kind(), ValKind::FuncRef);
+  EXPECT_EQ(t.type(store)->element(), ValType::funcref());
 }

--- a/crates/c-api/tests/table_type.cc
+++ b/crates/c-api/tests/table_type.cc
@@ -5,13 +5,13 @@
 using namespace wasmtime;
 
 TEST(TableType, Simple) {
-  TableType ty(ValKind::FuncRef, 1);
+  TableType ty(ValType::funcref(), 1);
   EXPECT_EQ(ty->min(), 1);
   EXPECT_EQ(ty->max(), std::nullopt);
-  EXPECT_EQ(ty->element().kind(), ValKind::FuncRef);
+  EXPECT_EQ(ty->element(), ValType::funcref());
 
-  ty = TableType(ValKind::ExternRef, 2, 3);
+  ty = TableType(ValType::externref(), 2, 3);
   EXPECT_EQ(ty->min(), 2);
   EXPECT_EQ(ty->max(), 3);
-  EXPECT_EQ(ty->element().kind(), ValKind::ExternRef);
+  EXPECT_EQ(ty->element(), ValType::externref());
 }

--- a/crates/c-api/tests/tag_type.cc
+++ b/crates/c-api/tests/tag_type.cc
@@ -18,15 +18,15 @@ TEST(TagType, Simple) {
   EXPECT_EQ(empty_func->params().size(), 0u);
 
   // Tag with i32 and i64 payload types.
-  FuncType ft({ValKind::I32, ValKind::I64}, {});
+  FuncType ft({ValType::i32(), ValType::i64()}, {});
   TagType t(ft);
   auto func = t->functype();
   auto params = func->params();
   EXPECT_EQ(params.size(), 2u);
   auto it = params.begin();
-  EXPECT_EQ(it->kind(), ValKind::I32);
+  EXPECT_EQ(*it, ValType::i32());
   ++it;
-  EXPECT_EQ(it->kind(), ValKind::I64);
+  EXPECT_EQ(*it, ValType::i64());
 
   // Copy.
   auto t2 = t;
@@ -61,7 +61,7 @@ TEST(TagType, ModuleExportEnumeration) {
   auto func = tag_ref.functype();
   auto params = func->params();
   ASSERT_EQ(params.size(), 1u);
-  EXPECT_EQ(params.begin()->kind(), ValKind::I32);
+  EXPECT_EQ(*params.begin(), ValType::i32());
 }
 
 // Verify that wasm_externtype_kind returns WASM_EXTERN_TAG for tag exports

--- a/crates/c-api/tests/types.cc
+++ b/crates/c-api/tests/types.cc
@@ -12,17 +12,19 @@ template <typename T, typename E> T unwrap(Result<T, E> result) {
 }
 
 TEST(ValType, Smoke) {
-  EXPECT_EQ(ValType(ValKind::I32)->kind(), ValKind::I32);
-  EXPECT_EQ(ValType(ValKind::I64)->kind(), ValKind::I64);
-  EXPECT_EQ(ValType(ValKind::F32)->kind(), ValKind::F32);
-  EXPECT_EQ(ValType(ValKind::F64)->kind(), ValKind::F64);
-  EXPECT_EQ(ValType(ValKind::V128)->kind(), ValKind::V128);
-  EXPECT_EQ(ValType(ValKind::FuncRef)->kind(), ValKind::FuncRef);
-  EXPECT_EQ(ValType(ValKind::ExternRef)->kind(), ValKind::ExternRef);
+  EXPECT_EQ(ValType::i32(), ValType::i32());
+  EXPECT_EQ(ValType::i64(), ValType::i64());
+  EXPECT_EQ(ValType::f32(), ValType::f32());
+  EXPECT_EQ(ValType::f64(), ValType::f64());
+  EXPECT_EQ(ValType::v128(), ValType::v128());
+  EXPECT_EQ(ValType::funcref(), ValType::funcref());
+  EXPECT_EQ(ValType::externref(), ValType::externref());
+  EXPECT_EQ(ValType::exnref(), ValType::exnref());
+  EXPECT_EQ(ValType::anyref(), ValType::anyref());
 
-  ValType t(ValKind::I32);
-  t = ValKind::I64;
-  ValType t2(ValKind::F32);
+  ValType t(ValType::i32());
+  t = ValType::i64();
+  ValType t2(ValType::f32());
   t = t2;
   ValType t3(t2);
 
@@ -40,20 +42,20 @@ TEST(MemoryType, Smoke) {
 }
 
 TEST(TableType, Smoke) {
-  TableType t(ValKind::FuncRef, 1);
+  TableType t(ValType::funcref(), 1);
 
   EXPECT_EQ(t->min(), 1);
   EXPECT_EQ(t->max(), std::nullopt);
-  EXPECT_EQ(t->element().kind(), ValKind::FuncRef);
+  EXPECT_EQ(t->element(), ValType::funcref());
 
   TableType t2 = t;
   t2 = t;
 }
 
 TEST(GlobalType, Smoke) {
-  GlobalType t(ValKind::FuncRef, true);
+  GlobalType t(ValType::funcref(), true);
 
-  EXPECT_EQ(t->content().kind(), ValKind::FuncRef);
+  EXPECT_EQ(t->content(), ValType::funcref());
   EXPECT_TRUE(t->is_mutable());
 
   GlobalType t2 = t;
@@ -89,7 +91,7 @@ TEST(ModuleType, Smoke) {
   auto e = *exports.begin();
   EXPECT_EQ(e.name(), "x");
   auto export_ty = std::get<GlobalType::Ref>(ExternType::from_export(e));
-  EXPECT_EQ(export_ty.content().kind(), ValKind::I32);
+  EXPECT_EQ(export_ty.content(), ValType::i32());
   EXPECT_FALSE(export_ty.is_mutable());
 
   for (auto &exp : exports) {

--- a/crates/c-api/tests/val_type.cc
+++ b/crates/c-api/tests/val_type.cc
@@ -6,26 +6,118 @@
 using namespace wasmtime;
 
 TEST(ValType, Simple) {
-  ValType ty(ValKind::I32);
-  EXPECT_EQ(ty->kind(), ValKind::I32);
-  ty = ValKind::I64;
-  EXPECT_EQ(ty->kind(), ValKind::I64);
-  ty = ValKind::F32;
-  EXPECT_EQ(ty->kind(), ValKind::F32);
-  ty = ValKind::F64;
-  EXPECT_EQ(ty->kind(), ValKind::F64);
-  ty = ValKind::ExternRef;
-  EXPECT_EQ(ty->kind(), ValKind::ExternRef);
-  ty = ValKind::FuncRef;
-  EXPECT_EQ(ty->kind(), ValKind::FuncRef);
-  ty = ValKind::V128;
-  EXPECT_EQ(ty->kind(), ValKind::V128);
+  ValType ty = ValType::i32();
+  EXPECT_EQ(ty, ValType::i32());
+  ty = ValType::i64();
+  EXPECT_EQ(ty, ValType::i64());
+  ty = ValType::f32();
+  EXPECT_EQ(ty, ValType::f32());
+  ty = ValType::f64();
+  EXPECT_EQ(ty, ValType::f64());
+  ty = ValType::externref();
+  EXPECT_EQ(ty, ValType::externref());
+  ty = ValType::funcref();
+  EXPECT_EQ(ty, ValType::funcref());
+  ty = ValType::v128();
+  EXPECT_EQ(ty, ValType::v128());
 }
 
 TEST(ValKind, String) {
   std::stringstream x;
-  x << ValKind::I32;
+  x << ValType::i32();
   EXPECT_EQ(x.str(), "i32");
-  x << ValKind::F32;
+  x << ValType::f32();
   EXPECT_EQ(x.str(), "i32f32");
+}
+
+TEST(HeapType, Smoke) {
+  EXPECT_TRUE(HeapType::extern_().is_extern());
+  EXPECT_TRUE(HeapType::noextern().is_noextern());
+  EXPECT_TRUE(HeapType::func().is_func());
+  EXPECT_TRUE(HeapType(FuncType({}, {})).as_concrete_func());
+  EXPECT_TRUE(HeapType::nofunc().is_nofunc());
+  EXPECT_TRUE(HeapType::any().is_any());
+  EXPECT_TRUE(HeapType::none().is_none());
+  EXPECT_TRUE(HeapType::eq().is_eq());
+  EXPECT_TRUE(HeapType::i31().is_i31());
+  EXPECT_TRUE(HeapType::array().is_array());
+  EXPECT_TRUE(HeapType::struct_().is_struct());
+  EXPECT_TRUE(HeapType::exn().is_exn());
+  EXPECT_TRUE(HeapType::noexn().is_noexn());
+
+  HeapType hty(FuncType({ValType::i32()}, {ValType::i64()}));
+  auto func_ty = hty.as_concrete_func();
+  EXPECT_TRUE(func_ty);
+  EXPECT_EQ(func_ty->params().size(), 1);
+  EXPECT_EQ(*func_ty->params().begin(), ValType::i32());
+  EXPECT_EQ(func_ty->results().size(), 1);
+  EXPECT_EQ(*func_ty->results().begin(), ValType::i64());
+
+  EXPECT_TRUE(!HeapType::extern_().is_concrete());
+  EXPECT_TRUE(HeapType(FuncType({}, {})).is_concrete());
+}
+
+TEST(ArrayType, Smoke) {
+  Engine engine;
+  ArrayType aty(engine, FieldType::mut_(ValType::i32()));
+  HeapType hty(aty);
+  auto array_ty = hty.as_concrete_array();
+  ASSERT_NE(array_ty, nullptr);
+  EXPECT_TRUE(array_ty->element_type().is_mutable());
+
+  StorageType sty = array_ty->element_type().storage_type();
+  EXPECT_TRUE(sty.as_valtype());
+  EXPECT_EQ(*sty.as_valtype(), ValType::i32());
+
+  RefType rty(true, hty);
+  rty = RefType(false, hty);
+  rty = RefType(false, aty);
+  ValType vty(engine, rty);
+}
+
+TEST(ExnType, Smoke) {
+  Engine engine;
+  ExnType ety = ExnType::create(engine, {ValType::i32(), ValType::i64()}).unwrap();
+  HeapType hty(ety);
+  auto exn_ty = hty.as_concrete_exn();
+  ASSERT_NE(exn_ty, nullptr);
+  EXPECT_TRUE(hty.is_concrete());
+  EXPECT_FALSE(HeapType::exn().is_concrete());
+
+  TagType tt = exn_ty->tag_type();
+  auto ft = tt->functype();
+  EXPECT_EQ(ft->params().size(), 2);
+  EXPECT_EQ(*ft->params().begin(), ValType::i32());
+
+  RefType rty(true, hty);
+  rty = RefType(false, hty);
+  rty = RefType(false, ety);
+  ValType vty(engine, rty);
+
+  ety = ExnType::create(engine, {}).unwrap();
+  HeapType hty2(ety);
+  auto exn_ty2 = hty2.as_concrete_exn();
+  ASSERT_NE(exn_ty2, nullptr);
+  EXPECT_EQ(exn_ty2->tag_type()->functype()->params().size(), 0);
+}
+
+TEST(StructType, Smoke) {
+  Engine engine;
+  StructType sty(engine, {});
+  HeapType hty(sty);
+  auto struct_ty = hty.as_concrete_struct();
+  ASSERT_NE(struct_ty, nullptr);
+  EXPECT_EQ(struct_ty->field(0), std::nullopt);
+  EXPECT_EQ(struct_ty->num_fields(), 0);
+
+  RefType rty(true, hty);
+  rty = RefType(false, hty);
+  rty = RefType(false, sty);
+  ValType vty(engine, rty);
+
+  sty = StructType(engine, {FieldType::mut_(StorageType::i8())});
+  EXPECT_EQ(sty.field(0)->is_mutable(), true);
+  EXPECT_TRUE(sty.field(0)->storage_type().is_i8());
+  EXPECT_FALSE(sty.field(0)->storage_type().as_valtype());
+  EXPECT_EQ(sty.num_fields(), 1);
 }

--- a/crates/c-api/tests/val_type.cc
+++ b/crates/c-api/tests/val_type.cc
@@ -77,7 +77,8 @@ TEST(ArrayType, Smoke) {
 
 TEST(ExnType, Smoke) {
   Engine engine;
-  ExnType ety = ExnType::create(engine, {ValType::i32(), ValType::i64()}).unwrap();
+  ExnType ety =
+      ExnType::create(engine, {ValType::i32(), ValType::i64()}).unwrap();
   HeapType hty(ety);
   auto exn_ty = hty.as_concrete_exn();
   ASSERT_NE(exn_ty, nullptr);


### PR DESCRIPTION
This commit fills out APIs necessary to reflect on value types to get the full type hierarchy of WebAssembly. Currently types in the C API are primarily inherited from `wasm.h` which notably doesn't handle proposals such as simd or GC or typed function references. This puts us in a bit of an awkward position where much of our API relies on `wasm.h`, but there's obvious holes in `wasm.h` that would otherwise require modifications.

This commit takes the route of adding a parallel `wasmtime_valtype_t` definition fully tailored for Wasmtime's use case. Conversions are then provided between `wasmtime_valtype_t` and `wasm_valtype_t`. The Wasmtime version notably has a different representation which enables, for example, constructing primitive types without function calls.

This then fills out the corresponding C++ APIs and fills gaps in the preexisting types. For example `FieldType` is much different from before and now follows C++ idioms and semantics. Additionally it now has the ability to express the full breadth of all wasm types in fields and they can both be constructed and read.

This is all necessary for some implementation work to fill out the GC proposal in the `wasmtime-py` bindings where the lack of type information was otherwise leading to a pretty awkward API relative to the rest of the package.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
