### PR TITLE
Type-guard bitop optimization rules (#13229)

### DIFF
--- a/cranelift/codegen/src/isle_prelude.rs
+++ b/cranelift/codegen/src/isle_prelude.rs
@@ -545,7 +545,7 @@ macro_rules! isle_common_prelude_methods {
         }
 
         #[inline]
-        fn ty_iconst(&mut self, ty: Type) -> Option<Type> {
+        fn ty_int_vec128(&mut self, ty: Type) -> Option<Type> {
             if ty.is_int() || (ty.is_vector() && ty.bits() == 128 && ty.lane_type().is_int()) {
                 Some(ty)
             } else {

--- a/cranelift/codegen/src/isle_prelude.rs
+++ b/cranelift/codegen/src/isle_prelude.rs
@@ -545,6 +545,15 @@ macro_rules! isle_common_prelude_methods {
         }
 
         #[inline]
+        fn ty_iconst(&mut self, ty: Type) -> Option<Type> {
+            if ty.is_int() || (ty.is_vector() && ty.bits() == 128 && ty.lane_type().is_int()) {
+                Some(ty)
+            } else {
+                None
+            }
+        }
+
+        #[inline]
         fn ty_scalar(&mut self, ty: Type) -> Option<Type> {
             if ty.lane_count() == 1 { Some(ty) } else { None }
         }

--- a/cranelift/codegen/src/opts/bitops.isle
+++ b/cranelift/codegen/src/opts/bitops.isle
@@ -20,10 +20,10 @@
 
 ;; x ^ not(x) == not(x) ^ x == x | not(x) == not(x) | x == -1.
 ;; This identity also holds for non-integer types, vectors, and wider types.
-(rule (simplify (bxor ty x (bnot ty x))) (subsume (iconst_s ty -1)))
-(rule (simplify (bxor ty (bnot ty x) x)) (subsume (iconst_s ty -1)))
-(rule (simplify (bor ty x (bnot ty x))) (subsume (iconst_s ty -1)))
-(rule (simplify (bor ty (bnot ty x) x)) (subsume (iconst_s ty -1)))
+(rule (simplify (bxor (ty_iconst ty) x (bnot ty x))) (subsume (iconst_s ty -1)))
+(rule (simplify (bxor (ty_iconst ty) (bnot ty x) x)) (subsume (iconst_s ty -1)))
+(rule (simplify (bor (ty_iconst ty) x (bnot ty x))) (subsume (iconst_s ty -1)))
+(rule (simplify (bor (ty_iconst ty) (bnot ty x) x)) (subsume (iconst_s ty -1)))
 
 ;; x & x == x & -1 == x.
 (rule (simplify (band ty x x)) (subsume x))
@@ -31,9 +31,9 @@
       (subsume x))
 
 ;; x & 0 == x & not(x) == not(x) & x == 0.
-(rule (simplify (band ty _ zero @ (iconst_u ty 0))) (subsume zero))
-(rule (simplify (band ty x (bnot ty x))) (subsume (iconst_u ty 0)))
-(rule (simplify (band ty (bnot ty x) x)) (subsume (iconst_u ty 0)))
+(rule (simplify (band (ty_iconst ty) _ zero @ (iconst_u ty 0))) (subsume zero))
+(rule (simplify (band (ty_iconst ty) x (bnot ty x))) (subsume (iconst_u ty 0)))
+(rule (simplify (band (ty_iconst ty) (bnot ty x) x)) (subsume (iconst_u ty 0)))
 
 ;; (x & y) ^ (x ^ y) == x | y
 (rule (simplify (bxor ty (band ty X Y) (bxor ty X Y))) (bor ty X Y))

--- a/cranelift/codegen/src/opts/bitops.isle
+++ b/cranelift/codegen/src/opts/bitops.isle
@@ -20,10 +20,10 @@
 
 ;; x ^ not(x) == not(x) ^ x == x | not(x) == not(x) | x == -1.
 ;; This identity also holds for non-integer types, vectors, and wider types.
-(rule (simplify (bxor (ty_iconst ty) x (bnot ty x))) (subsume (iconst_s ty -1)))
-(rule (simplify (bxor (ty_iconst ty) (bnot ty x) x)) (subsume (iconst_s ty -1)))
-(rule (simplify (bor (ty_iconst ty) x (bnot ty x))) (subsume (iconst_s ty -1)))
-(rule (simplify (bor (ty_iconst ty) (bnot ty x) x)) (subsume (iconst_s ty -1)))
+(rule (simplify (bxor (ty_int_vec128 ty) x (bnot ty x))) (subsume (iconst_s ty -1)))
+(rule (simplify (bxor (ty_int_vec128 ty) (bnot ty x) x)) (subsume (iconst_s ty -1)))
+(rule (simplify (bor (ty_int_vec128 ty) x (bnot ty x))) (subsume (iconst_s ty -1)))
+(rule (simplify (bor (ty_int_vec128 ty) (bnot ty x) x)) (subsume (iconst_s ty -1)))
 
 ;; x & x == x & -1 == x.
 (rule (simplify (band ty x x)) (subsume x))
@@ -31,9 +31,9 @@
       (subsume x))
 
 ;; x & 0 == x & not(x) == not(x) & x == 0.
-(rule (simplify (band (ty_iconst ty) _ zero @ (iconst_u ty 0))) (subsume zero))
-(rule (simplify (band (ty_iconst ty) x (bnot ty x))) (subsume (iconst_u ty 0)))
-(rule (simplify (band (ty_iconst ty) (bnot ty x) x)) (subsume (iconst_u ty 0)))
+(rule (simplify (band (ty_int_vec128 ty) _ zero @ (iconst_u ty 0))) (subsume zero))
+(rule (simplify (band (ty_int_vec128 ty) x (bnot ty x))) (subsume (iconst_u ty 0)))
+(rule (simplify (band (ty_int_vec128 ty) (bnot ty x) x)) (subsume (iconst_u ty 0)))
 
 ;; (x & y) ^ (x ^ y) == x | y
 (rule (simplify (bxor ty (band ty X Y) (bxor ty X Y))) (bor ty X Y))

--- a/cranelift/codegen/src/opts/icmp.isle
+++ b/cranelift/codegen/src/opts/icmp.isle
@@ -317,10 +317,10 @@
 (rule (simplify (bxor ty (ult ty x y) (ult ty y x))) (ne ty x y))
 
 ;; a < b && a > b = false
-(rule (simplify (band (ty_iconst ty) (sgt ty x y) (slt ty x y))) (iconst_u ty 0))
-(rule (simplify (band (ty_iconst ty) (slt ty x y) (sgt ty x y))) (iconst_u ty 0))
-(rule (simplify (band (ty_iconst ty) (ugt ty x y) (ult ty x y))) (iconst_u ty 0))
-(rule (simplify (band (ty_iconst ty) (ult ty x y) (ugt ty x y))) (iconst_u ty 0))
+(rule (simplify (band (ty_int_vec128 ty) (sgt ty x y) (slt ty x y))) (iconst_u ty 0))
+(rule (simplify (band (ty_int_vec128 ty) (slt ty x y) (sgt ty x y))) (iconst_u ty 0))
+(rule (simplify (band (ty_int_vec128 ty) (ugt ty x y) (ult ty x y))) (iconst_u ty 0))
+(rule (simplify (band (ty_int_vec128 ty) (ult ty x y) (ugt ty x y))) (iconst_u ty 0))
 (rule
   (simplify (band ty (sgt ty x (iconst_s _ y)) (ult ty x (iconst_s _ y))))
   (if-let true (i64_gt_eq y 0))

--- a/cranelift/codegen/src/opts/icmp.isle
+++ b/cranelift/codegen/src/opts/icmp.isle
@@ -317,10 +317,10 @@
 (rule (simplify (bxor ty (ult ty x y) (ult ty y x))) (ne ty x y))
 
 ;; a < b && a > b = false
-(rule (simplify (band ty (sgt ty x y) (slt ty x y))) (iconst_u ty 0))
-(rule (simplify (band ty (slt ty x y) (sgt ty x y))) (iconst_u ty 0))
-(rule (simplify (band ty (ugt ty x y) (ult ty x y))) (iconst_u ty 0))
-(rule (simplify (band ty (ult ty x y) (ugt ty x y))) (iconst_u ty 0))
+(rule (simplify (band (ty_iconst ty) (sgt ty x y) (slt ty x y))) (iconst_u ty 0))
+(rule (simplify (band (ty_iconst ty) (slt ty x y) (sgt ty x y))) (iconst_u ty 0))
+(rule (simplify (band (ty_iconst ty) (ugt ty x y) (ult ty x y))) (iconst_u ty 0))
+(rule (simplify (band (ty_iconst ty) (ult ty x y) (ugt ty x y))) (iconst_u ty 0))
 (rule
   (simplify (band ty (sgt ty x (iconst_s _ y)) (ult ty x (iconst_s _ y))))
   (if-let true (i64_gt_eq y 0))

--- a/cranelift/codegen/src/prelude.isle
+++ b/cranelift/codegen/src/prelude.isle
@@ -516,6 +516,10 @@
 (decl ty_vec128 (Type) Type)
 (extern extractor ty_vec128 ty_vec128)
 
+;; An extractor that matches types that support iconst_s/iconst_u construction.
+(decl ty_iconst (Type) Type)
+(extern extractor ty_iconst ty_iconst)
+
 ;; An extractor that only matches dynamic vector types with a 64-bit
 ;; base type.
 (decl ty_dyn_vec64 (Type) Type)

--- a/cranelift/codegen/src/prelude.isle
+++ b/cranelift/codegen/src/prelude.isle
@@ -517,8 +517,8 @@
 (extern extractor ty_vec128 ty_vec128)
 
 ;; An extractor that matches types that support iconst_s/iconst_u construction.
-(decl ty_iconst (Type) Type)
-(extern extractor ty_iconst ty_iconst)
+(decl ty_int_vec128 (Type) Type)
+(extern extractor ty_int_vec128 ty_int_vec128)
 
 ;; An extractor that only matches dynamic vector types with a 64-bit
 ;; base type.

--- a/cranelift/filetests/filetests/egraph/bitops.clif
+++ b/cranelift/filetests/filetests/egraph/bitops.clif
@@ -204,6 +204,14 @@ block0(v0: i32x4):
 ; check: v5 = vconst.i32x4 const0
 ; check: return v5
 
+function %issue_13229_band_not_f64(f64) {
+block0(v0: f64):
+    v1 = band_not v0, v0
+    return
+}
+
+; check: return
+
 function %bitops_bmask(i64) -> i64 {
 block0(v0: i64):
     v1 = bnot v0


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->

This resolves #13229 

### Cause 1

bitops such as `band`, `bor`, ... are not constrained to receive only integer inputs like `iadd`, `isub`, and `icmp`.
The IR builder shows this fact: 
* https://docs.rs/cranelift-codegen/latest/cranelift_codegen/ir/trait.InstBuilder.html#method.band
* https://docs.rs/cranelift-codegen/latest/cranelift_codegen/ir/trait.InstBuilder.html#method.iadd

Note that there is no float input for `iadd`, whereas `band` can take float inputs.

### Cause 2

`iconst_s` and `iconst_u` provide convenient ways to construct constants on RHS, but they are the main contract breaker of ISLE type system. They are declared as non-partial terms, while their definition is not total. They only work for integer and vec128 types and this is why we need type guards to use them. This fact is not explicitly encoded in the declaration of the terms. I guess this is not a proper way to use ISLE, since we cannot trust the ISLE compiler and the ISLE ruleset in this way... But, to fix this, I guess we need more discussions that could easily go out of the scope of fix, so I want to leave this as a future work.


### Fix

* I added `ty_iconst` partial extractor which rules constructing terms with `iconst_s` and `iconst_u` can safely use.
* The widened rules with bitops in #13199 are now guarded with `ty_iconst`.
* The reported regression case is added, which tests a float input for `band` term.
