### PR TITLE
Track whether there are any async tasks in a store

### DIFF
--- a/crates/test-programs/src/bin/p3_cli_serve_post_return.rs
+++ b/crates/test-programs/src/bin/p3_cli_serve_post_return.rs
@@ -1,0 +1,26 @@
+use test_programs::p3::wasi::http::types::{ErrorCode, Fields, Request, Response};
+use test_programs::p3::{service, wit_future};
+
+struct T;
+
+service::export!(T);
+
+impl service::exports::wasi::http::handler::Guest for T {
+    async fn handle(_request: Request) -> Result<Response, ErrorCode> {
+        let (body_result_tx, body_result_rx) = wit_future::new(|| Ok(None));
+        let (response, _future_result) = Response::new(Fields::new(), None, body_result_rx);
+        drop(body_result_tx);
+
+        wit_bindgen::spawn(async move {
+            for _ in 0..10 {
+                wit_bindgen::yield_async().await;
+            }
+            println!("please see me");
+        });
+        Ok(response)
+    }
+}
+
+fn main() {
+    unreachable!()
+}

--- a/crates/wasi-http/src/handler.rs
+++ b/crates/wasi-http/src/handler.rs
@@ -3,7 +3,7 @@
 
 #[cfg(feature = "p3")]
 use crate::p3;
-use futures::stream::{FuturesUnordered, StreamExt};
+use futures::stream::{FuturesUnordered, Stream};
 use std::collections::VecDeque;
 use std::collections::btree_map::{BTreeMap, Entry};
 use std::future;
@@ -350,101 +350,166 @@ where
                 accept_task(task, &mut futures, &mut reuse_count);
             }
 
+            // This is the main driver loop for this worker. This is modeled as
+            // a `poll_fn` which internally loops around the possible events.
+            // Events are sourced from the locals here, pinned outside of the
+            // `poll_fn` closure.
+            let mut futures = pin!(futures);
+            let mut idle_timeout_set = false;
+            let mut idle_timeout = pin!(tokio::time::sleep(Duration::MAX));
             let handler = self.handler.clone();
-            while !(futures.is_empty() && reuse_count >= max_instance_reuse_count) {
-                let new_task = {
-                    let future_count = futures.len();
-                    let mut next_future = pin!(async {
-                        if futures.is_empty() {
-                            future::pending().await
-                        } else {
-                            futures.next().await.unwrap()
-                        }
-                    });
-                    let mut next_task = pin!(tokio::time::timeout(
-                        if future_count == 0 {
-                            idle_instance_timeout
-                        } else {
-                            Duration::MAX
-                        },
-                        handler.0.task_queue.pop()
-                    ));
-                    // Poll any existing tasks, and if they're all `Pending`
-                    // _and_ we haven't reached any reuse limits yet, poll for a
-                    // new task from the queue.
-                    //
-                    // Note the the order of operations here is important.  By
-                    // polling `next_future` first, we'll discover any tasks that
-                    // may have timed out, at which point we'll stop accepting
-                    // new tasks altogether (see below for details).  This is
-                    // especially important in the case where the task was
-                    // blocked on a synchronous call to a host function which
-                    // has exclusive access to the `Store`; once that call
-                    // finishes, the first think we need to do is time out the
-                    // task.  If we were to poll for a new task first, then we'd
-                    // have to wait for _that_ task to finish or time out before
-                    // we could kill the instance.
-                    future::poll_fn(|cx| match next_future.as_mut().poll(cx) {
-                        Poll::Pending => {
-                            // Note that `Pending` here doesn't necessarily mean
-                            // all tasks are blocked on I/O.  They might simply
-                            // be waiting for some deferred work to be done by
-                            // the next turn of the
-                            // `StoreContextMut::run_concurrent` event loop.
-                            // Therefore, we check `accept_concurrent` here and
-                            // only advertise we have capacity for another task
-                            // if either we have no tasks at all or all our
-                            // tasks really are blocked on I/O.
-                            self.set_available(
-                                reuse_count < max_instance_reuse_count
-                                    && future_count < max_instance_concurrent_reuse_count
-                                    && (future_count == 0 || accept_concurrent.load(Relaxed)),
-                            );
+            let mut incoming_tasks = pin!(futures::stream::unfold(
+                &handler.0.task_queue,
+                |queue| async move {
+                    let task = queue.pop().await;
+                    Some((task, queue))
+                }
+            ));
+            future::poll_fn(|cx| {
+                // See docs about the idle timeout handling at the very bottom
+                // for what this is doing.
+                let prev_idle_timeout_set = idle_timeout_set;
+                idle_timeout_set = false;
 
-                            if self.available {
-                                next_task.as_mut().poll(cx).map(Some)
-                            } else {
-                                Poll::Pending
-                            }
-                        }
-                        Poll::Ready(Ok(start_time)) => {
-                            // Task completed; carry on!
+                loop {
+                    // First, and crucially first , poll `futures` first. This
+                    // way we'll discover any tasks that may have timed out, at
+                    // which point we'll stop accepting new tasks altogether
+                    // (see below for details). This is especially important in
+                    // the case where the task was blocked on a synchronous call
+                    // to a host function which has exclusive access to the
+                    // `Store`; once that call finishes, the first thing we need
+                    // to do is time out the task. If we were to poll for a new
+                    // task first, then we'd have to wait for _that_ task to
+                    // finish or time out before we could kill the instance.
+                    match futures.as_mut().poll_next(cx) {
+                        // Task completed; carry on!
+                        Poll::Ready(Some(Ok(start_time))) => {
                             if let Some(start_time) = start_time {
                                 task_start_times.lock().unwrap().remove(start_time);
                             }
-                            Poll::Ready(None)
                         }
-                        Poll::Ready(Err(_)) => {
-                            // Task timed out; stop accepting new tasks, but
-                            // continue polling until any other, in-progress
-                            // tasks until they have either finished or timed
-                            // out.  This effectively kicks off a "graceful
-                            // shutdown" of the worker, allowing any other
-                            // concurrent tasks time to finish before we drop
-                            // the instance.
-                            //
-                            // TODO: We should also send a cancel request to the
-                            // timed-out task to give it a chance to shut down
-                            // gracefully (and delay dropping the instance for a
-                            // reasonable amount of time), but as of this
-                            // writing Wasmtime does not yet provide an API for
-                            // doing that.  See issue #11833.
+
+                        // Task timed out; stop accepting new tasks, but
+                        // continue polling until any other, in-progress tasks
+                        // until they have either finished or timed out. This
+                        // effectively kicks off a "graceful shutdown" of the
+                        // worker, allowing any other concurrent tasks time to
+                        // finish before we drop the instance.
+                        //
+                        // TODO: We should also send a cancel request to the
+                        // timed-out task to give it a chance to shut down
+                        // gracefully (and delay dropping the instance for a
+                        // reasonable amount of time), but as of this writing
+                        // Wasmtime does not yet provide an API for doing that.
+                        // See issue #11833.
+                        Poll::Ready(Some(Err(_))) => {
                             timed_out = true;
                             reuse_count = max_instance_reuse_count;
-                            Poll::Ready(None)
                         }
-                    })
-                    .await
-                };
 
-                match new_task {
-                    Some(Ok(task)) => {
-                        accept_task(task, &mut futures, &mut reuse_count);
+                        Poll::Ready(None) | Poll::Pending => {}
                     }
-                    Some(Err(_)) => break,
-                    None => {}
+
+                    // At this point `futures` is either empty or it's `Pending`
+                    // meaning nothing is ready. Note that `Pending` here
+                    // doesn't necessarily mean all tasks are blocked on I/O.
+                    // They might simply be waiting for some deferred work to be
+                    // done by the next turn of the
+                    // `StoreContextMut::run_concurrent` event loop.  Therefore,
+                    // we check `accept_concurrent` here and only advertise we
+                    // have capacity for another task if either we have no tasks
+                    // at all or all our tasks really are blocked on I/O.
+                    self.set_available(
+                        reuse_count < max_instance_reuse_count
+                            && futures.len() < max_instance_concurrent_reuse_count
+                            && (futures.is_empty() || accept_concurrent.load(Relaxed)),
+                    );
+
+                    // If we're available for accepting more requests after the
+                    // deduction above, then try to accept a new task. If that's
+                    // successful then push it into `futures` and turn this loop
+                    // again to see where we're at next time around.
+                    if self.available
+                        && let Poll::Ready(Some(task)) = incoming_tasks.as_mut().poll_next(cx)
+                    {
+                        accept_task(task, &mut futures, &mut reuse_count);
+                        continue;
+                    }
+
+                    // If, at this point, we still have some requests that are
+                    // being processed then go ahead and bail out of this
+                    // singular call to `poll` by saying we're not ready yet.
+                    // This means we unconditionally wait for events within
+                    // `futures` and we're also registered, optionally, for
+                    // listening for incoming connections. That's all the events
+                    // we're interested in, so this iteration of `poll` is complete.
+                    if !futures.is_empty() {
+                        break Poll::Pending;
+                    }
+
+                    // At this point `futures` is empty, and we haven't gotten
+                    // any incoming tasks. Check the store we're using to see if
+                    // there are any "interesting" tasks around. These are tasks
+                    // which act as effectively strong references to this worker
+                    // to keep it running. If there are still interesting tasks,
+                    // then we're done with this iteration of `poll`. We'll get
+                    // woken up when anything changes, but otherwise it's time
+                    // to let something else happen.
+                    //
+                    // This is all skipped if something has timed out though. In
+                    // that situation we're basically no longer interested in
+                    // this store so we're no longer cooperatively trying to let
+                    // it keep going.
+                    if !timed_out && !accessor.poll_no_interesting_tasks(cx).is_ready() {
+                        break Poll::Pending;
+                    }
+
+                    // And now at this point we (a) have no `futures`, (b) no
+                    // new connections came in, and (c) the store is completely
+                    // devoid of interesting work. In this situation if we're
+                    // not actually capable of accepting any more work, then
+                    // we're completely done and it's time to exit this worker.
+                    if !self.available {
+                        break Poll::Ready(());
+                    }
+
+                    // And now, finally, we wait for a timeout. Here we're just
+                    // like above except that we're candidate for accepting more
+                    // work in the future. If this is our first time here then
+                    // reset the idle timeout to `idle_instance_timeout` from
+                    // now, but othrewise just go take a look at `idle_timeout`
+                    // and see if it's elapsed yet.
+                    //
+                    // Note that the way that this entire loop is structured is
+                    // that we've already polled all the interesting sources of
+                    // events we're interested in at this point, for example
+                    // `futures`, `accessor`, and `incoming_tasks`. Here we add
+                    // `idle_timeout` to that set and once anything is ready and
+                    // fires then this entire loop will restart and we'll check
+                    // everything again.
+                    //
+                    // Also note that the idle timeout is supposed to start when
+                    // the store is itself entirely idle. The way this loop is
+                    // structured is that when we entire this `poll` closure the
+                    // `idle_timeout_set` variable is unconditionally set to
+                    // `false`. That way if we exit out for some other reason,
+                    // such as getting work, then the idle timeout will get
+                    // reset next time we fall down here. Otherwise though if we
+                    // fell down this far we actually want to preserve
+                    // `idle_timeout_set` from when we first started, so that's
+                    // restored here.
+                    idle_timeout_set = prev_idle_timeout_set;
+                    if !idle_timeout_set {
+                        idle_timeout
+                            .as_mut()
+                            .reset(tokio::time::Instant::now() + idle_instance_timeout);
+                        idle_timeout_set = true;
+                    }
+                    break idle_timeout.as_mut().poll(cx);
                 }
-            }
+            })
+            .await;
 
             accessor.with(|mut access| write_profile(access.as_context_mut()));
 

--- a/crates/wasmtime/src/runtime/component/concurrent.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent.rs
@@ -524,6 +524,54 @@ where
             get_data: self.get_data,
         }
     }
+
+    /// Polls to see if this store contains any "interesting" tasks still within
+    /// it.
+    ///
+    /// Returns `Poll::Ready(())` if there are no more interesting tasks, and
+    /// otherwise returns `Poll::Pending`. If pending is returned then whenever
+    /// the last remaining "interesting" task has exited the provided context's
+    /// waker will be notified. Note that only the waker passed to the last call
+    /// to `poll_no_interesting_tasks` will be notified, so this is only
+    /// appropriate to use one-at-a-time.
+    ///
+    /// The component model specification, as of this current date, does not
+    /// have a distinction between "interesting" tasks and not. The current
+    /// intention is that in a future revision of the component model this will
+    /// be distinguished at the component ABI level where tasks will be able to
+    /// flag themselves as "interesting" optionally. Additionally extra work can
+    /// be opted-in to being "interesting".
+    ///
+    /// For now what this means is that all component model tasks within this
+    /// store are considered interesting. This specifically includes the entire
+    /// duration of a task, so even all of the time after a task has returned
+    /// but before it has exited. This means that this function is, today,
+    /// effectively a proxy for "are there any more tasks still running in this
+    /// store". This can be used by embedders to determine whether there's any
+    /// more work going on, even in the background, for a particular guest.
+    /// Hosts can use this as a signal that the guest wants to stay alive a
+    /// little longer, even after a task has returned.
+    ///
+    /// In the future this predicate won't include all tasks in this store. Some
+    /// tasks will be able to flag themselves as not interesting, meaning that
+    /// when this returns ready it'd be possible that there are still tasks
+    /// remaining in the store.
+    ///
+    /// Note that at this time spawned threads within a task are always
+    /// considered uninteresting. If this function returns ready, then spawned
+    /// threads may still be in the store.
+    pub fn poll_no_interesting_tasks(&self, cx: &mut Context<'_>) -> Poll<()> {
+        self.with(|mut access| {
+            let store = access.as_context_mut().0;
+            let state = store.concurrent_state_mut();
+            if state.interesting_tasks == 0 {
+                Poll::Ready(())
+            } else {
+                state.interesting_tasks_empty_waker = Some(cx.waker().clone());
+                Poll::Pending
+            }
+        })
+    }
 }
 
 /// Represents a task which may be provided to `Accessor::spawn`,
@@ -1508,7 +1556,8 @@ impl StoreOpaque {
         if guest_caller.is_some() {
             debug_assert_eq!(instance, guest_caller);
         }
-        let task = GuestTask::new(
+        let guest_thread = GuestTask::new(
+            state,
             Box::new(move |_, _| bail_bug!("cannot lower params in sync call")),
             LiftResult {
                 lift: Box::new(move |_, _| bail_bug!("cannot lift result in sync call")),
@@ -1530,22 +1579,12 @@ impl StoreOpaque {
             callee_async,
         )?;
 
-        let guest_task = state.push(task)?;
-        let new_thread = GuestThread::new_implicit(state, guest_task)?;
-        let guest_thread = state.push(new_thread)?;
         Instance::from_wasmtime(self, callee.instance).add_guest_thread_to_instance_table(
-            guest_thread,
+            guest_thread.thread,
             self,
             callee.index,
         )?;
-
-        let state = self.concurrent_state_mut();
-        state.get_mut(guest_task)?.threads.insert(guest_thread);
-
-        self.set_thread(QualifiedThreadId {
-            task: guest_task,
-            thread: guest_thread,
-        })?;
+        self.set_thread(guest_thread)?;
 
         Ok(())
     }
@@ -1559,27 +1598,18 @@ impl StoreOpaque {
             Some(t) => *t,
             None => bail_bug!("expected task when exiting"),
         };
-        let instance = self.concurrent_state_mut().get_mut(thread.task)?.instance;
-        log::trace!("exit sync call {instance:?}");
-        Instance::from_wasmtime(self, instance.instance).cleanup_thread(
-            self,
-            thread,
-            instance.index,
-        )?;
-
-        let state = self.concurrent_state_mut();
-        let task = state.get_mut(thread.task)?;
+        let task = self.concurrent_state_mut().get_mut(thread.task)?;
+        let instance = task.instance;
         let caller = match &task.caller {
             &Caller::Guest { thread } => thread.into(),
             &Caller::Host { caller, .. } => caller,
         };
+        task.lift_result = None;
+        task.exited = true;
         self.set_thread(caller)?;
 
-        let state = self.concurrent_state_mut();
-        let task = state.get_mut(thread.task)?;
-        if task.ready_to_delete() {
-            state.delete(thread.task)?;
-        }
+        log::trace!("exit sync call {instance:?}");
+        self.cleanup_thread(thread, instance, CleanupTask::Yes)?;
 
         Ok(())
     }
@@ -1967,6 +1997,144 @@ impl StoreOpaque {
         let state = self.concurrent_state_mut();
         waitable.join(state, old_set)
     }
+
+    /// Cleans up the data structures backing the `guest_thread` specified,
+    /// removing it from the internal tables of `runtime_instance` as well.
+    ///
+    /// This function is used whenever a guest thread has fully exited and
+    /// completed. This'll clean up the associated `GuestThread` structure and
+    /// related resources it contains.
+    ///
+    /// Other functionality that this implements is:
+    ///
+    /// * This will perform conditional cleanup of the `GuestTask` that owns
+    ///   this thread if `cleanup_task` is `CleanupTask::Yes`.
+    /// * If there are no more threads in the `GuestTask` that this thread is
+    ///   associated with, and if the task hasn't produced a result (e.g. it's not
+    ///   returned or cancelled), then a trap will be raised that a result
+    ///   wasn't ever produced.
+    /// * If this task is finished, meaning the top-level thread exited and
+    ///   additionally it's been returned or cancelled, then this will handle
+    ///   management of the store's "active interesting tasks" counter.
+    ///
+    /// Effectively this is intended to be a "narrow waist" through which many
+    /// destruction operations are funneled through.
+    fn cleanup_thread(
+        &mut self,
+        guest_thread: QualifiedThreadId,
+        runtime_instance: RuntimeInstance,
+        cleanup_task: CleanupTask,
+    ) -> Result<()> {
+        let state = self.concurrent_state_mut();
+        let thread_data = state.get_mut(guest_thread.thread)?;
+        let sync_call_set = thread_data.sync_call_set;
+        if let Some(guest_id) = thread_data.instance_rep {
+            self.instance_state(runtime_instance)
+                .thread_handle_table()
+                .guest_thread_remove(guest_id)?;
+        }
+        let state = self.concurrent_state_mut();
+
+        // Clean up any pending subtasks in the sync_call_set
+        for waitable in mem::take(&mut state.get_mut(sync_call_set)?.ready) {
+            if let Some(Event::Subtask {
+                status: Status::Returned | Status::ReturnCancelled,
+            }) = waitable.common(state)?.event
+            {
+                waitable.delete_from(state)?;
+            }
+        }
+
+        state.delete(guest_thread.thread)?;
+        state.delete(sync_call_set)?;
+        let task = state.get_mut(guest_thread.task)?;
+        task.threads.remove(&guest_thread.thread);
+
+        if task.threads.is_empty() && !task.returned_or_cancelled() {
+            bail!(Trap::NoAsyncResult);
+        }
+        let ready_to_delete = task.ready_to_delete();
+
+        if !task.decremented_interesting_task_count && task.exited && task.returned_or_cancelled() {
+            task.decremented_interesting_task_count = true;
+
+            debug_assert!(state.interesting_tasks > 0);
+            state.interesting_tasks -= 1;
+            if state.interesting_tasks == 0
+                && let Some(waker) = state.interesting_tasks_empty_waker.take()
+            {
+                waker.wake();
+            }
+        }
+
+        match cleanup_task {
+            CleanupTask::Yes => {
+                if ready_to_delete {
+                    Waitable::Guest(guest_thread.task).delete_from(state)?;
+                }
+            }
+            CleanupTask::No => {}
+        }
+
+        Ok(())
+    }
+
+    /// Performs cancellation of the `guest_task` specified with the
+    /// precondition that the task hasn't lowered its parameters.
+    ///
+    /// In this situation the task hasn't ever been started meaning it hasn't
+    /// actually run any wasm code yet. This requires cleaning up metadata such
+    /// as thread information attached to the task.
+    ///
+    /// The main two entrypoints for this function are:
+    ///
+    /// * Task cancellation via `subtask.cancel`, the intrinsic.
+    /// * Dropping a host `call_async` future which needs to cancel the task
+    ///   because it cannot reference its parameters any more.
+    fn cancel_guest_subtask_without_lowered_parameters(
+        &mut self,
+        caller_instance: RuntimeInstance,
+        guest_task: TableId<GuestTask>,
+    ) -> Result<()> {
+        let concurrent_state = self.concurrent_state_mut();
+        let task = concurrent_state.get_mut(guest_task)?;
+        assert!(!task.already_lowered_parameters());
+        // The task is in a `starting` state, meaning it hasn't run at
+        // all yet.  Here we update its fields to indicate that it is
+        // ready to delete immediately once `subtask.drop` is called.
+        task.lower_params = None;
+        task.lift_result = None;
+        task.exited = true;
+        let instance = task.instance;
+
+        // Clean up the thread within this task as it's now never going
+        // to run.
+        assert_eq!(1, task.threads.len());
+        let thread = *task.threads.iter().next().unwrap();
+        self.cleanup_thread(
+            QualifiedThreadId {
+                task: guest_task,
+                thread,
+            },
+            caller_instance,
+            CleanupTask::No,
+        )?;
+
+        // Not yet started; cancel and remove from pending
+        let pending = &mut self.instance_state(instance).concurrent_state().pending;
+        let pending_count = pending.len();
+        pending.retain(|thread, _| thread.task != guest_task);
+        // If there were no pending threads for this task, we're in an error state
+        if pending.len() == pending_count {
+            bail!(Trap::SubtaskCancelAfterTerminal);
+        }
+        Ok(())
+    }
+}
+
+enum CleanupTask {
+    Yes,
+    No,
 }
 
 impl Instance {
@@ -2039,10 +2207,7 @@ impl Instance {
 
         let get_set = |store: &mut StoreOpaque, handle| -> Result<_> {
             let set = store
-                .instance_state(RuntimeInstance {
-                    instance: self.id().instance(),
-                    index: runtime_instance,
-                })
+                .instance_state(self.runtime_instance(runtime_instance))
                 .handle_table()
                 .waitable_set_rep(handle)?;
 
@@ -2052,18 +2217,14 @@ impl Instance {
         Ok(match code {
             callback_code::EXIT => {
                 log::trace!("implicit thread {guest_thread:?} completed");
-                self.cleanup_thread(store, guest_thread, runtime_instance)?;
                 let task = store.concurrent_state_mut().get_mut(guest_thread.task)?;
-                if task.threads.is_empty() && !task.returned_or_cancelled() {
-                    bail!(Trap::NoAsyncResult);
-                }
-                if let Caller::Guest { .. } = task.caller {
-                    task.exited = true;
-                    task.callback = None;
-                }
-                if task.ready_to_delete() {
-                    Waitable::Guest(guest_thread.task).delete_from(store.concurrent_state_mut())?;
-                }
+                task.exited = true;
+                task.callback = None;
+                store.cleanup_thread(
+                    guest_thread,
+                    self.runtime_instance(runtime_instance),
+                    CleanupTask::Yes,
+                )?;
                 None
             }
             callback_code::YIELD => {
@@ -2145,43 +2306,6 @@ impl Instance {
             }
             _ => bail!(Trap::UnsupportedCallbackCode),
         })
-    }
-
-    fn cleanup_thread(
-        self,
-        store: &mut StoreOpaque,
-        guest_thread: QualifiedThreadId,
-        runtime_instance: RuntimeComponentInstanceIndex,
-    ) -> Result<()> {
-        let state = store.concurrent_state_mut();
-        let thread_data = state.get_mut(guest_thread.thread)?;
-        let sync_call_set = thread_data.sync_call_set;
-        if let Some(guest_id) = thread_data.instance_rep {
-            store
-                .instance_state(RuntimeInstance {
-                    instance: self.id().instance(),
-                    index: runtime_instance,
-                })
-                .thread_handle_table()
-                .guest_thread_remove(guest_id)?;
-        }
-        let state = store.concurrent_state_mut();
-
-        // Clean up any pending subtasks in the sync_call_set
-        for waitable in mem::take(&mut state.get_mut(sync_call_set)?.ready) {
-            if let Some(Event::Subtask {
-                status: Status::Returned | Status::ReturnCancelled,
-            }) = waitable.common(state)?.event
-            {
-                waitable.delete_from(state)?;
-            }
-        }
-
-        state.delete(guest_thread.thread)?;
-        state.delete(sync_call_set)?;
-        let task = state.get_mut(guest_thread.task)?;
-        task.threads.remove(&guest_thread.thread);
-        Ok(())
     }
 
     /// Add the specified guest call to the "high priority" work item queue, to
@@ -2350,12 +2474,7 @@ impl Instance {
                 // over must be valid.
                 let storage = call(store)?;
 
-                if async_ {
-                    let task = store.concurrent_state_mut().get_mut(guest_thread.task)?;
-                    if task.threads.len() == 1 && !task.returned_or_cancelled() {
-                        bail!(Trap::NoAsyncResult);
-                    }
-                } else {
+                if !async_ {
                     // This is a sync-lifted export, so now is when we lift the
                     // result, optionally call the post-return function, if any,
                     // and finally notify any current or future waiters that the
@@ -2405,23 +2524,13 @@ impl Instance {
 
                 store.set_thread(old_thread)?;
 
+                store
+                    .concurrent_state_mut()
+                    .get_mut(guest_thread.task)?
+                    .exited = true;
+
                 // This is a callback-less call, so the implicit thread has now completed
-                self.cleanup_thread(store, guest_thread, callee_instance.index)?;
-
-                let state = store.concurrent_state_mut();
-                let task = state.get_mut(guest_thread.task)?;
-
-                match &task.caller {
-                    Caller::Host { .. } => {
-                        if task.ready_to_delete() {
-                            Waitable::Guest(guest_thread.task).delete_from(state)?;
-                        }
-                    }
-                    Caller::Guest { .. } => {
-                        task.exited = true;
-                    }
-                }
-
+                store.cleanup_thread(guest_thread, callee_instance, CleanupTask::Yes)?;
                 Ok(None)
             })
         };
@@ -2517,13 +2626,11 @@ impl Instance {
 
         debug_assert_eq!(
             state.get_mut(old_thread.task)?.instance,
-            RuntimeInstance {
-                instance: self.id().instance(),
-                index: caller_instance,
-            }
+            self.runtime_instance(caller_instance)
         );
 
-        let new_task = GuestTask::new(
+        let guest_thread = GuestTask::new(
+            state,
             Box::new(move |store, dst| {
                 let mut store = token.as_context_mut(store);
                 assert!(dst.len() <= MAX_FLAT_PARAMS);
@@ -2633,27 +2740,14 @@ impl Instance {
             },
             Caller::Guest { thread: old_thread },
             None,
-            RuntimeInstance {
-                instance: self.id().instance(),
-                index: callee_instance,
-            },
+            self.runtime_instance(callee_instance),
             callee_async,
         )?;
 
-        let guest_task = state.push(new_task)?;
-        let new_thread = GuestThread::new_implicit(state, guest_task)?;
-        let guest_thread = state.push(new_thread)?;
-        state.get_mut(guest_task)?.threads.insert(guest_thread);
-
         // Make the new thread the current one so that `Self::start_call` knows
         // which one to start.
-        store.0.set_thread(QualifiedThreadId {
-            task: guest_task,
-            thread: guest_thread,
-        })?;
-        log::trace!(
-            "pushed {guest_task:?}:{guest_thread:?} as current thread; old thread was {old_thread:?}"
-        );
+        store.0.set_thread(guest_thread)?;
+        log::trace!("pushed {guest_thread:?} as current thread; old thread was {old_thread:?}");
 
         Ok(())
     }
@@ -3110,10 +3204,7 @@ impl Instance {
     ) -> Result<u32> {
         let set = store.concurrent_state_mut().push(WaitableSet::default())?;
         let handle = store
-            .instance_state(RuntimeInstance {
-                instance: self.id().instance(),
-                index: caller_instance,
-            })
+            .instance_state(self.runtime_instance(caller_instance))
             .handle_table()
             .waitable_set_insert(set.rep())?;
         log::trace!("new waitable set {set:?} (handle {handle})");
@@ -3128,10 +3219,7 @@ impl Instance {
         set: u32,
     ) -> Result<()> {
         let rep = store
-            .instance_state(RuntimeInstance {
-                instance: self.id().instance(),
-                index: caller_instance,
-            })
+            .instance_state(self.runtime_instance(caller_instance))
             .handle_table()
             .waitable_set_remove(set)?;
 
@@ -3195,10 +3283,7 @@ impl Instance {
         self.waitable_join(store, caller_instance, task_id, 0)?;
 
         let (rep, is_host) = store
-            .instance_state(RuntimeInstance {
-                instance: self.id().instance(),
-                index: caller_instance,
-            })
+            .instance_state(self.runtime_instance(caller_instance))
             .handle_table()
             .subtask_remove(task_id)?;
 
@@ -3263,10 +3348,7 @@ impl Instance {
             ..
         } = &self.id().get(store).component().env_component().options[options];
         let rep = store
-            .instance_state(RuntimeInstance {
-                instance: self.id().instance(),
-                index: caller_instance,
-            })
+            .instance_state(self.runtime_instance(caller_instance))
             .handle_table()
             .waitable_set_rep(set)?;
 
@@ -3296,10 +3378,7 @@ impl Instance {
             ..
         } = &self.id().get(store).component().env_component().options[options];
         let rep = store
-            .instance_state(RuntimeInstance {
-                instance: self.id().instance(),
-                index: caller_instance,
-            })
+            .instance_state(self.runtime_instance(caller_instance))
             .handle_table()
             .waitable_set_rep(set)?;
 
@@ -3365,19 +3444,15 @@ impl Instance {
 
                 store.0.set_thread(old_thread)?;
 
-                self.cleanup_thread(store.0, guest_thread, runtime_instance)?;
+                store.0.cleanup_thread(
+                    guest_thread,
+                    self.runtime_instance(runtime_instance),
+                    CleanupTask::Yes,
+                )?;
                 log::trace!("explicit thread {guest_thread:?} completed");
-                let state = store.0.concurrent_state_mut();
-                let task = state.get_mut(guest_thread.task)?;
-                if task.threads.is_empty() && !task.returned_or_cancelled() {
-                    bail!(Trap::NoAsyncResult);
-                }
                 let state = store.0.concurrent_state_mut();
                 if let Some(t) = old_thread.guest() {
                     state.get_mut(t.thread)?.state = GuestThreadState::Running;
-                }
-                if state.get_mut(guest_thread.task)?.ready_to_delete() {
-                    Waitable::Guest(guest_thread.task).delete_from(state)?;
                 }
                 log::trace!("thread start: restored {old_thread:?} as current thread");
 
@@ -3456,10 +3531,7 @@ impl Instance {
         runtime_instance: RuntimeComponentInstanceIndex,
     ) -> Result<u32> {
         let guest_id = store
-            .instance_state(RuntimeInstance {
-                instance: self.id().instance(),
-                index: runtime_instance,
-            })
+            .instance_state(self.runtime_instance(runtime_instance))
             .thread_handle_table()
             .guest_thread_insert(thread_id.rep())?;
         store
@@ -3648,10 +3720,7 @@ impl Instance {
         }
 
         let (rep, is_host) = store
-            .instance_state(RuntimeInstance {
-                instance: self.id().instance(),
-                index: caller_instance,
-            })
+            .instance_state(self.runtime_instance(caller_instance))
             .handle_table()
             .subtask_rep(task_id)?;
         let waitable = if is_host {
@@ -3697,39 +3766,13 @@ impl Instance {
                 }
             }
         } else {
-            let caller = concurrent_state.current_guest_thread()?;
             let guest_task = TableId::<GuestTask>::new(rep);
             let task = concurrent_state.get_mut(guest_task)?;
             if !task.already_lowered_parameters() {
-                // The task is in a `starting` state, meaning it hasn't run at
-                // all yet.  Here we update its fields to indicate that it is
-                // ready to delete immediately once `subtask.drop` is called.
-                task.lower_params = None;
-                task.lift_result = None;
-                task.exited = true;
-                let instance = task.instance;
-
-                // Clean up the thread within this task as it's now never going
-                // to run.
-                assert_eq!(1, task.threads.len());
-                let thread = *task.threads.iter().next().unwrap();
-                self.cleanup_thread(
-                    store,
-                    QualifiedThreadId {
-                        task: guest_task,
-                        thread,
-                    },
-                    caller_instance,
+                store.cancel_guest_subtask_without_lowered_parameters(
+                    self.runtime_instance(caller_instance),
+                    guest_task,
                 )?;
-
-                // Not yet started; cancel and remove from pending
-                let pending = &mut store.instance_state(instance).concurrent_state().pending;
-                let pending_count = pending.len();
-                pending.retain(|thread, _| thread.task != guest_task);
-                // If there were no pending threads for this task, we're in an error state
-                if pending.len() == pending_count {
-                    bail!(Trap::SubtaskCancelAfterTerminal);
-                }
                 return Ok(Status::StartCancelled as u32);
             } else if !task.returned_or_cancelled() {
                 // Started, but not yet returned or cancelled; send the
@@ -3767,6 +3810,7 @@ impl Instance {
                         };
                         concurrent_state.push_high_priority(item);
 
+                        let caller = concurrent_state.current_guest_thread()?;
                         store.suspend(SuspendReason::Yielding {
                             thread: caller,
                             // `subtask.cancel` is not allowed to be called in a
@@ -4569,6 +4613,8 @@ pub(crate) struct GuestTask {
     /// Indicates whether this task was created for a call to an async-lifted
     /// export.
     async_function: bool,
+
+    decremented_interesting_task_count: bool,
 }
 
 impl GuestTask {
@@ -4606,13 +4652,14 @@ impl GuestTask {
     }
 
     fn new(
+        state: &mut ConcurrentState,
         lower_params: RawLower,
         lift_result: LiftResult,
         caller: Caller,
         callback: Option<CallbackFn>,
         instance: RuntimeInstance,
         async_function: bool,
-    ) -> Result<Self> {
+    ) -> Result<QualifiedThreadId> {
         let host_future_state = match &caller {
             Caller::Guest { .. } => HostFutureState::NotApplicable,
             Caller::Host {
@@ -4626,7 +4673,7 @@ impl GuestTask {
                 }
             }
         };
-        Ok(Self {
+        let task = state.push(Self {
             common: WaitableCommon::default(),
             lower_params: Some(lower_params),
             lift_result: Some(lift_result),
@@ -4643,7 +4690,13 @@ impl GuestTask {
             threads: HashSet::new(),
             host_future_state,
             async_function,
-        })
+            decremented_interesting_task_count: false,
+        })?;
+        let new_thread = GuestThread::new_implicit(state, task)?;
+        let thread = state.push(new_thread)?;
+        state.get_mut(task)?.threads.insert(thread);
+        state.interesting_tasks += 1;
+        Ok(QualifiedThreadId { task, thread })
     }
 }
 
@@ -4805,7 +4858,15 @@ impl Waitable {
             }
             Self::Guest(task) => {
                 log::trace!("delete guest task {task:?}");
-                state.delete(*task)?;
+                let task = state.delete(*task)?;
+
+                // When a guest task is created it increments the
+                // `ConcurrentState::interesting_tasks` counter, and that needs
+                // to be paired with a decrement. There are a few situations in
+                // which the decrement needs to happen which don't all funnel
+                // through here, so in lieu of that at least try to catch issues
+                // where we forgot to do a decrement.
+                debug_assert!(task.decremented_interesting_task_count);
             }
             Self::Transmit(task) => {
                 state.delete(*task)?;
@@ -4957,6 +5018,25 @@ pub struct ConcurrentState {
     /// as a `TableId<ErrorContextState>`.
     global_error_context_ref_counts:
         BTreeMap<TypeComponentGlobalErrorContextTableIndex, GlobalErrorContextRefCount>,
+
+    /// The number of "interesting tasks" currently executing in the store.
+    ///
+    /// This tracks the concept of a component instance lifetime as defined in
+    /// https://github.com/WebAssembly/component-model/pull/643. Specifically
+    /// all tasks currently increment this counter which then gets decremented
+    /// when they exit. In the future some tasks might not increment this
+    /// counter, but for now all do.
+    ///
+    /// This is used to implement `Accessor::poll_no_interesting_tasks` to
+    /// inform the embedder when all tasks have completed. This is then
+    /// used in wasmtime-wasi-http, for example, to know when an instance is
+    /// idle.
+    interesting_tasks: usize,
+
+    /// Single waker to notify when `interesting_tasks` reaches 0.
+    ///
+    /// Used in the implementation of `Accessor::poll_no_interesting_tasks`.
+    interesting_tasks_empty_waker: Option<Waker>,
 }
 
 impl Default for ConcurrentState {
@@ -4971,6 +5051,8 @@ impl Default for ConcurrentState {
             worker: None,
             worker_item: None,
             global_error_context_ref_counts: BTreeMap::new(),
+            interesting_tasks: 0,
+            interesting_tasks_empty_waker: None,
         }
     }
 }
@@ -5321,6 +5403,8 @@ pub(crate) struct PreparedCall<R> {
     /// The `oneshot::Receiver` to which the result of the call will be
     /// delivered when it is available.
     rx: oneshot::Receiver<LiftedResult>,
+    /// The instance that this call is prepared for.
+    runtime_instance: RuntimeInstance,
     _phantom: PhantomData<R>,
 }
 
@@ -5329,6 +5413,7 @@ impl<R> PreparedCall<R> {
     pub(crate) fn task_id(&self) -> TaskId {
         TaskId {
             task: self.thread.task,
+            runtime_instance: self.runtime_instance,
         }
     }
 }
@@ -5336,6 +5421,7 @@ impl<R> PreparedCall<R> {
 /// Represents a task created by `prepare_call`.
 pub(crate) struct TaskId {
     task: TableId<GuestTask>,
+    runtime_instance: RuntimeInstance,
 }
 
 impl TaskId {
@@ -5344,16 +5430,20 @@ impl TaskId {
     /// we delete the task eagerly. Otherwise, there may be running threads, or ones that are suspended
     /// and can be resumed by other tasks for this component, so we mark the future as dropped
     /// and delete the task when all threads are done.
-    pub(crate) fn host_future_dropped<T>(&self, store: StoreContextMut<T>) -> Result<()> {
-        let task = store.0.concurrent_state_mut().get_mut(self.task)?;
+    pub(crate) fn host_future_dropped(&self, store: &mut StoreOpaque) -> Result<()> {
+        let task = store.concurrent_state_mut().get_mut(self.task)?;
         let delete = if !task.already_lowered_parameters() {
+            store.cancel_guest_subtask_without_lowered_parameters(
+                self.runtime_instance,
+                self.task,
+            )?;
             true
         } else {
             task.host_future_state = HostFutureState::Dropped;
             task.ready_to_delete()
         };
         if delete {
-            Waitable::Guest(self.task).delete_from(store.0.concurrent_state_mut())?
+            Waitable::Guest(self.task).delete_from(store.concurrent_state_mut())?
         }
         Ok(())
     }
@@ -5397,12 +5487,10 @@ pub(crate) fn prepare_call<T, R>(
 
     let (tx, rx) = oneshot::channel();
 
-    let instance = RuntimeInstance {
-        instance: handle.instance().id().instance(),
-        index: component_instance,
-    };
+    let instance = handle.instance().runtime_instance(component_instance);
     let caller = state.current_thread;
-    let task = GuestTask::new(
+    let thread = GuestTask::new(
+        state,
         Box::new(for_any_lower(move |store, params| {
             lower_params(handle, token.as_context_mut(store), params)
         })),
@@ -5433,19 +5521,15 @@ pub(crate) fn prepare_call<T, R>(
         async_function,
     )?;
 
-    let task = state.push(task)?;
-    let new_thread = GuestThread::new_implicit(state, task)?;
-    let thread = state.push(new_thread)?;
-    state.get_mut(task)?.threads.insert(thread);
-
     if !store.0.may_enter(instance)? {
         bail!(Trap::CannotEnterComponent);
     }
 
     Ok(PreparedCall {
         handle,
-        thread: QualifiedThreadId { task, thread },
+        thread,
         param_count,
+        runtime_instance: instance,
         rx,
         _phantom: PhantomData,
     })

--- a/crates/wasmtime/src/runtime/component/func.rs
+++ b/crates/wasmtime/src/runtime/component/func.rs
@@ -1,4 +1,3 @@
-use crate::component::RuntimeInstance;
 use crate::component::instance::Instance;
 use crate::component::matching::InstanceType;
 use crate::component::storage::storage_as_slice;
@@ -605,10 +604,7 @@ impl Func {
     {
         let export = self.lifted_core_func(store.0);
         let (_options, _flags, _ty, raw_options) = self.abi_info(store.0);
-        let instance = RuntimeInstance {
-            instance: self.instance.id().instance(),
-            index: raw_options.instance,
-        };
+        let instance = self.instance.runtime_instance(raw_options.instance);
 
         if !store.0.may_enter(instance)? {
             bail!(crate::Trap::CannotEnterComponent);

--- a/crates/wasmtime/src/runtime/component/func/typed.rs
+++ b/crates/wasmtime/src/runtime/component/func/typed.rs
@@ -214,9 +214,7 @@ where
 
             impl<'a, T> Drop for SignalOnDrop<'a, T> {
                 fn drop(&mut self) {
-                    self.task
-                        .host_future_dropped(self.store.as_context_mut())
-                        .unwrap();
+                    self.task.host_future_dropped(self.store.0).unwrap();
                 }
             }
 

--- a/crates/wasmtime/src/runtime/component/instance.rs
+++ b/crates/wasmtime/src/runtime/component/instance.rs
@@ -569,6 +569,13 @@ impl Instance {
             (&*component, store)
         }
     }
+
+    pub(crate) fn runtime_instance(&self, index: RuntimeComponentInstanceIndex) -> RuntimeInstance {
+        RuntimeInstance {
+            instance: self.id.instance(),
+            index,
+        }
+    }
 }
 
 /// Translates a `CoreDef`, a definition of a core wasm item, to an

--- a/crates/wasmtime/src/runtime/vm/component/libcalls.rs
+++ b/crates/wasmtime/src/runtime/vm/component/libcalls.rs
@@ -4,7 +4,6 @@ use crate::component::Instance;
 #[cfg(feature = "component-model-async")]
 use crate::component::concurrent::WaitResult;
 use crate::prelude::*;
-use crate::runtime::component::RuntimeInstance;
 #[cfg(feature = "component-model-async")]
 use crate::runtime::component::concurrent::{ResourcePair, SuspensionTarget};
 use crate::runtime::vm::component::{ComponentInstance, VMComponentContext};
@@ -681,15 +680,9 @@ fn enter_sync_call(
     callee_instance: u32,
 ) -> Result<()> {
     store.enter_guest_sync_call(
-        Some(RuntimeInstance {
-            instance: instance.id().instance(),
-            index: RuntimeComponentInstanceIndex::from_u32(caller_instance),
-        }),
+        Some(instance.runtime_instance(RuntimeComponentInstanceIndex::from_u32(caller_instance))),
         callee_async != 0,
-        RuntimeInstance {
-            instance: instance.id().instance(),
-            index: RuntimeComponentInstanceIndex::from_u32(callee_instance),
-        },
+        instance.runtime_instance(RuntimeComponentInstanceIndex::from_u32(callee_instance)),
     )
 }
 
@@ -708,10 +701,7 @@ fn backpressure_modify(
     increment: u8,
 ) -> Result<()> {
     store.backpressure_modify(
-        RuntimeInstance {
-            instance: instance.id().instance(),
-            index: RuntimeComponentInstanceIndex::from_u32(caller_instance),
-        },
+        instance.runtime_instance(RuntimeComponentInstanceIndex::from_u32(caller_instance)),
         |old| {
             if increment != 0 {
                 old.checked_add(1)

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -666,6 +666,9 @@ impl ServeCommand {
                 component,
                 max_instance_reuse_count,
                 max_instance_concurrent_reuse_count,
+                // Give one shutdown guard to this handler which will track the
+                // full lifetime of any instances spawned.
+                _shutdown_guard: Box::new(shutdown.clone().increment()),
             },
             instance,
         );
@@ -688,6 +691,10 @@ impl ServeCommand {
 
             let stream = TokioIo::new(stream);
             let h = handler.clone();
+
+            // In addition to the shutdown guard given to the handler above,
+            // also give one to the tokio tasks doing HTTP I/O as well to ensure
+            // it keeps them alive too.
             let shutdown_guard = shutdown.clone().increment();
             tokio::task::spawn(async move {
                 if let Err(e) = http1::Builder::new()
@@ -738,6 +745,8 @@ impl ServeCommand {
             });
         }
 
+        drop(handler);
+
         // Upon exiting the loop we'll no longer process any more incoming
         // connections but there may still be outstanding connections
         // processing in child tasks. If there are wait for those to complete
@@ -762,6 +771,7 @@ struct HostHandlerState {
     component: Component,
     max_instance_reuse_count: usize,
     max_instance_concurrent_reuse_count: usize,
+    _shutdown_guard: Box<dyn std::any::Any + Send + Sync>,
 }
 
 impl HandlerState for HostHandlerState {
@@ -818,7 +828,7 @@ struct GracefulShutdownState {
 
 impl GracefulShutdown {
     /// Increments the number of active tasks and returns a guard indicating
-    fn increment(self: Arc<Self>) -> impl Drop {
+    fn increment(self: Arc<Self>) -> impl Drop + Send + Sync {
         struct Guard(Arc<GracefulShutdown>);
 
         let mut state = self.state.lock().unwrap();

--- a/tests/all/cli_tests.rs
+++ b/tests/all/cli_tests.rs
@@ -2881,6 +2881,32 @@ start a print 1234
 
         Ok(())
     }
+
+    #[tokio::test]
+    async fn p3_cli_serve_post_return() -> Result<()> {
+        let server = WasmtimeServe::new(P3_CLI_SERVE_POST_RETURN_COMPONENT, move |cmd| {
+            cmd.arg("-Wcomponent-model-async");
+            cmd.arg("-Sp3,cli");
+            cmd.arg("--max-instance-reuse-count=1");
+        })?;
+        let resp = server
+            .send_request(
+                hyper::Request::builder()
+                    .uri("http://localhost/")
+                    .body(String::new())
+                    .context("failed to make request")?,
+            )
+            .await?;
+        assert!(resp.status().is_success());
+        assert!(resp.body().is_empty());
+
+        let (stdout, stderr) = server.finish()?;
+        println!("stdout: {stdout}");
+        println!("stderr: {stderr}");
+
+        assert!(stdout.contains("please see me"));
+        Ok(())
+    }
 }
 
 #[test]

--- a/tests/misc_testsuite/component-model/async/callback-yield-then-exit.wast
+++ b/tests/misc_testsuite/component-model/async/callback-yield-then-exit.wast
@@ -1,0 +1,51 @@
+;;! component_model_async = true
+;;! reference_types = true
+
+;; An example component where a sync lower calls an async lift. The async lift
+;; is an early-return but then keeps going afterwards for a late exit.
+
+(component
+  (component $A
+    (core module $m
+      (import "" "task.return" (func $task.return (param i32)))
+      (func (export "callback") (param i32 i32 i32) (result i32)
+        i32.const 0 ;; EXIT
+      )
+      (func (export "foo") (param i32) (result i32)
+        (call $task.return (local.get 0))
+        i32.const 1 ;; YIELD
+      )
+    )
+    (core func $task.return (canon task.return (result u32)))
+    (core instance $i (instantiate $m
+      (with "" (instance (export "task.return" (func $task.return))))
+    ))
+
+    (func (export "foo") (param "p1" u32) (result u32)
+      (canon lift (core func $i "foo") async (callback (func $i "callback")))
+    )
+  )
+
+  (component $B
+    (import "a" (func $foo (param "p1" u32) (result u32)))
+    (core func $foo (canon lower (func $foo)))
+    (core module $m
+      (import "" "foo" (func $foo (param i32) (result i32)))
+      (func (export "run")
+        (i32.ne (call $foo (i32.const 42)) (i32.const 42))
+        if unreachable end
+      )
+    )
+    (core instance $i (instantiate $m
+      (with "" (instance (export "foo" (func $foo))))
+    ))
+    (func (export "run") (canon lift (core func $i "run")))
+  )
+
+  (instance $A (instantiate $A))
+  (instance $B (instantiate $B (with "a" (func $A "foo"))))
+  (func (export "run") (alias export $B "run"))
+)
+
+(assert_return (invoke "run"))
+(assert_return (invoke "run"))


### PR DESCRIPTION
This commit adds a new API to `Accessor` to learn whether there are any async tasks that are "interesting" in a store. This is borne out of many discussions over the past few weeks amongst a number of folks where the basic problem is that for WASIp3 HTTP guests there's no way right now to send a signal of "keep me alive after I send my response" because that's post-return-style work. In WASIp2 this was modeled where the outparam that was passed in was set, and then work was done before returning. With WASIp3, however, a response is sent by returning which means that this is no longer possible.

The general idea is that Wasmtime will now consider all tasks which have not yet exited as "interesting". These tasks in theory mean that the store should be kept alive as the guest still has work to complete. Note that tasks first return, and then exit, and they're still considered interesting after returning before they exit. In the future it's expected that the component model might have an ABI option to say "this task, by default, isn't interesting" with an opt-in method at runtime of saying "ok wait but yes this is interesting". In this manner it's expected that not all tasks for all of time will be considered interesting, only those that are intentionally opted-in to being interesting (and today that just so happens to be all of them).

The API itself on `Accessor` is a `poll_*`-style function which enables both checking to see if there are no more tasks remaining as well as registering a callback to get notified when there are actually no more tasks remaining. In this manner HTTP servers can await this as one of the events that concludes when a guest is finished processing.

The implementation of this API required some refactoring of `concurrent.rs`. Namely I wanted to have a relatively "narrow waist" through which increments/decrements of this internal counter happened to ensure that nothing was forgot. This is a bit non-trivial because there are a number of situations which means that a task is "exited", such as:

* A synchronously lifted function returns.
* An asynchronously lifted function returns `CALLBACK_CODE_EXIT`.
* An asynchronously lifted function is stuck in the `STARTING` state, and then gets cancelled.
* A task is running, is then cancelled, acknowledges the cancellation, and then exits.
* A task with threads exits without actually returning, and then one of its threads returns for it.

For now the logic of "are interesting tasks done" is now hooked into `cleanup_thread`. This will likely require adjusting in the future for threads because in this last bullet the `task.return` invocation is the point where all conditions are met (main thread exited, task returned) as opposed to when the thread itself exits. For now though this is intended to be as close an approximation as possible.

Throughout this implementation I've performed a number of refactorings to reduce duplication, shuffle where methods are implemented, reduce some verbosity, etc. There are debug assertions in place for if this predicate ever goes wrong, which is intended to assist during development.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
