### PR TITLE
Flag the single-pass regalloc as "not buggy"

### DIFF
--- a/crates/fuzzing/src/generators/config.rs
+++ b/crates/fuzzing/src/generators/config.rs
@@ -880,8 +880,7 @@ impl RegallocAlgorithm {
         match self {
             RegallocAlgorithm::Backtracking => wasmtime::RegallocAlgorithm::Backtracking,
             RegallocAlgorithm::SinglePass => {
-                // FIXME(#11850)
-                const SINGLE_PASS_KNOWN_BUGGY_AT_THIS_TIME: bool = true;
+                const SINGLE_PASS_KNOWN_BUGGY_AT_THIS_TIME: bool = false;
                 if SINGLE_PASS_KNOWN_BUGGY_AT_THIS_TIME {
                     wasmtime::RegallocAlgorithm::Backtracking
                 } else {


### PR DESCRIPTION
The referenced issue was closed some time ago and we've since updated regalloc2, so re-enable fuzzing for the single-pass regalloc.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
