### PR TITLE
Refactor how inlining is configured in Wasmtime

### DIFF
--- a/benches/compile_time_builtins.rs
+++ b/benches/compile_time_builtins.rs
@@ -88,7 +88,7 @@ impl ExposedBuf {
 
 fn make_engine() -> Result<Engine, Error> {
     let mut config = Config::new();
-    config.compiler_inlining(true);
+    config.compiler_inlining(wasmtime::Inlining::Yes);
     config.concurrency_support(false);
     unsafe {
         config.cranelift_flag_set("wasmtime_inlining_intra_module", "yes");

--- a/benches/compile_time_builtins.rs
+++ b/benches/compile_time_builtins.rs
@@ -90,9 +90,6 @@ fn make_engine() -> Result<Engine, Error> {
     let mut config = Config::new();
     config.compiler_inlining(wasmtime::Inlining::Yes);
     config.concurrency_support(false);
-    unsafe {
-        config.cranelift_flag_set("wasmtime_inlining_intra_module", "yes");
-    }
     let engine = Engine::new(&config)?;
     Ok(engine)
 }

--- a/crates/cli-flags/src/lib.rs
+++ b/crates/cli-flags/src/lib.rs
@@ -262,7 +262,9 @@ wasmtime_option_group! {
         pub native_unwind_info: Option<bool>,
 
         /// Whether to perform function inlining during compilation.
-        pub inlining: Option<bool>,
+        #[serde(default)]
+        #[serde(deserialize_with = "crate::opt::cli_parse_wrapper")]
+        pub inlining: Option<wasmtime::Inlining>,
 
         #[prefixed = "cranelift"]
         #[serde(default)]

--- a/crates/cli-flags/src/opt.rs
+++ b/crates/cli-flags/src/opt.rs
@@ -590,6 +590,20 @@ impl WasmtimeOptionValue for wasmtime::Enabled {
     }
 }
 
+impl WasmtimeOptionValue for wasmtime::Inlining {
+    const VAL_HELP: &'static str = "[=y|n|gc|inter-module|intrinsics]";
+    fn parse(val: Option<&str>) -> Result<Self> {
+        match val {
+            None => Ok(wasmtime::Inlining::Yes),
+            Some(val) => val.parse(),
+        }
+    }
+
+    fn display(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{self}")
+    }
+}
+
 impl WasmtimeOptionValue for WasiNnGraph {
     const VAL_HELP: &'static str = "=<format>::<dir>";
     fn parse(val: Option<&str>) -> Result<Self> {

--- a/crates/cranelift/src/builder.rs
+++ b/crates/cranelift/src/builder.rs
@@ -87,9 +87,6 @@ impl CompilerBuilder for Builder {
             "wasmtime_linkopt_force_jump_veneer" => {
                 self.linkopts.force_jump_veneers = value.parse()?;
             }
-            "wasmtime_inlining_intra_module" => {
-                self.tunables.as_mut().unwrap().inlining_intra_module = value.parse()?;
-            }
             "wasmtime_inlining_small_callee_size" => {
                 self.tunables.as_mut().unwrap().inlining_small_callee_size = value.parse()?;
             }

--- a/crates/cranelift/src/compiler.rs
+++ b/crates/cranelift/src/compiler.rs
@@ -36,9 +36,10 @@ use wasmtime_environ::obj::{ELF_WASMTIME_EXCEPTIONS, ELF_WASMTIME_FRAMES};
 use wasmtime_environ::{
     Abi, AddressMapSection, BuiltinFunctionIndex, CacheStore, CompileError, CompiledFunctionBody,
     DefinedFuncIndex, FlagValue, FrameInstPos, FrameStackShape, FrameStateSlotBuilder,
-    FrameTableBuilder, FuncKey, FunctionBodyData, FunctionLoc, HostCall, InliningCompiler,
-    ModulePC, ModuleTranslation, ModuleTypesBuilder, PtrSize, StackMapSection, StaticModuleIndex,
-    TrapEncodingBuilder, TrapSentinel, TripleExt, Tunables, WasmFuncType, WasmValType, prelude::*,
+    FrameTableBuilder, FuncKey, FunctionBodyData, FunctionLoc, HostCall, Inlining,
+    InliningCompiler, ModulePC, ModuleTranslation, ModuleTypesBuilder, PtrSize, StackMapSection,
+    StaticModuleIndex, TrapEncodingBuilder, TrapSentinel, TripleExt, Tunables, WasmFuncType,
+    WasmValType, prelude::*,
 };
 use wasmtime_unwinder::ExceptionTableBuilder;
 
@@ -325,7 +326,7 @@ impl wasmtime_environ::Compiler for Compiler {
             &mut func_env,
         )?;
 
-        if self.tunables.inlining {
+        if self.tunables.inlining != Inlining::No {
             compiler
                 .cx
                 .codegen_context

--- a/crates/environ/src/tunables.rs
+++ b/crates/environ/src/tunables.rs
@@ -430,28 +430,26 @@ pub enum Inlining {
     /// This includes inter-module inlining (across modules) as well as
     /// intra-module inlining (within a module).
     ///
-    /// Note that this option does not at this time preserve backtraces in
-    /// WebAssembly traps.
+    /// Note that backtraces may omit inlined stack frames.
     Yes,
 
     /// Inter-module inlining (across modules) is allowed, but intra-module
     /// (within a module) is only allowed when the module is using GC.
     ///
-    /// Note that this option does not at this time preserve backtraces in
-    /// WebAssembly traps.
+    /// Note that backtraces may omit inlined stack frames.
     InterModuleAndIntraGc,
 
     /// Inter-module inlining (across modules) is allowed, but intra-module
     /// (within a module) is not allowed.
     ///
-    /// Note that this option does not at this time preserve backtraces in
-    /// WebAssembly traps.
+    /// Note that backtraces may omit inlined stack frames.
     InterModule,
 
     /// No module inlining is allowed, either inter- or intra-module. Only
     /// inlining Wasmtime's intrinsics are allowed.
     ///
-    /// This option, for example, preserves backtraces of WebAssembly.
+    /// This option, for example, never emits WebAssembly stack frames from
+    /// backtraces.
     Intrinsics,
 
     /// Inlining is disabled entirely.

--- a/crates/environ/src/tunables.rs
+++ b/crates/environ/src/tunables.rs
@@ -133,10 +133,7 @@ define_tunables! {
 
         /// Whether to enable inlining in Wasmtime's compilation orchestration
         /// or not.
-        pub inlining: bool,
-
-        /// Whether to inline calls within the same core Wasm module or not.
-        pub inlining_intra_module: IntraModuleInlining,
+        pub inlining: Inlining,
 
         /// The size of "small callees" that can be inlined regardless of the
         /// caller's size.
@@ -255,8 +252,7 @@ impl Tunables {
             winch_callable: false,
             signals_based_traps: false,
             memory_init_cow: true,
-            inlining: false,
-            inlining_intra_module: IntraModuleInlining::WhenUsingGc,
+            inlining: Inlining::No,
             inlining_small_callee_size: 50,
             inlining_sum_size_threshold: 2000,
             debug_guest: false,
@@ -426,27 +422,68 @@ impl fmt::Display for Collector {
     }
 }
 
-/// Whether to inline function calls within the same module.
+/// Inlining modes supported by Wasmtime.
 #[derive(Clone, Copy, Hash, Serialize, Deserialize, Debug, PartialEq, Eq)]
-#[expect(missing_docs, reason = "self-describing variants")]
-pub enum IntraModuleInlining {
+pub enum Inlining {
+    /// All inlining is enabled wherever possible.
+    ///
+    /// This includes inter-module inlining (across modules) as well as
+    /// intra-module inlining (within a module).
+    ///
+    /// Note that this option does not at this time preserve backtraces in
+    /// WebAssembly traps.
     Yes,
+
+    /// Inter-module inlining (across modules) is allowed, but intra-module
+    /// (within a module) is only allowed when the module is using GC.
+    ///
+    /// Note that this option does not at this time preserve backtraces in
+    /// WebAssembly traps.
+    InterModuleAndIntraGc,
+
+    /// Inter-module inlining (across modules) is allowed, but intra-module
+    /// (within a module) is not allowed.
+    ///
+    /// Note that this option does not at this time preserve backtraces in
+    /// WebAssembly traps.
+    InterModule,
+
+    /// No module inlining is allowed, either inter- or intra-module. Only
+    /// inlining Wasmtime's intrinsics are allowed.
+    ///
+    /// This option, for example, preserves backtraces of WebAssembly.
+    Intrinsics,
+
+    /// Inlining is disabled entirely.
     No,
-    WhenUsingGc,
 }
 
-impl FromStr for IntraModuleInlining {
+impl FromStr for Inlining {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "y" | "yes" | "true" => Ok(Self::Yes),
             "n" | "no" | "false" => Ok(Self::No),
-            "gc" => Ok(Self::WhenUsingGc),
+            "gc" => Ok(Self::InterModuleAndIntraGc),
+            "inter-module" => Ok(Self::InterModuleAndIntraGc),
+            "intrinsics" => Ok(Self::Intrinsics),
             _ => bail!(
                 "invalid intra-module inlining option string: `{s}`, \
-                 only yes,no,gc accepted"
+                 only yes,no,gc,inter-module,intrinsics accepted"
             ),
+        }
+    }
+}
+
+impl fmt::Display for Inlining {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Inlining::Yes => write!(f, "yes"),
+            Inlining::InterModuleAndIntraGc => write!(f, "gc"),
+            Inlining::InterModule => write!(f, "inter-module"),
+            Inlining::Intrinsics => write!(f, "intrinsics"),
+            Inlining::No => write!(f, "no"),
         }
     }
 }

--- a/crates/fuzzing/src/generators/config.rs
+++ b/crates/fuzzing/src/generators/config.rs
@@ -350,7 +350,7 @@ impl Config {
 
         self.wasmtime.codegen.configure(&mut cfg);
 
-        cfg.codegen.inlining = self.wasmtime.inlining;
+        cfg.codegen.inlining = self.wasmtime.inlining.map(|i| i.into());
 
         // If the wasm-smith-generated module use nan canonicalization then we
         // don't need to enable it, but if it doesn't enable it already then we
@@ -360,12 +360,6 @@ impl Config {
         // Only set cranelift specific flags when the Cranelift strategy is
         // chosen.
         if cranelift_strategy {
-            if let Some(option) = self.wasmtime.inlining_intra_module {
-                cfg.codegen.cranelift.push((
-                    "wasmtime_inlining_intra_module".to_string(),
-                    Some(option.to_string()),
-                ));
-            }
             if let Some(size) = self.wasmtime.inlining_small_callee_size {
                 cfg.codegen.cranelift.push((
                     "wasmtime_inlining_small_callee_size".to_string(),
@@ -579,8 +573,7 @@ pub struct WasmtimeConfig {
     force_jump_veneers: bool,
     memory_init_cow: bool,
     memory_guaranteed_dense_image_size: u64,
-    inlining: Option<bool>,
-    inlining_intra_module: Option<IntraModuleInlining>,
+    inlining: Option<Inlining>,
     inlining_small_callee_size: Option<u32>,
     inlining_sum_size_threshold: Option<u32>,
     use_precompiled_cwasm: bool,
@@ -892,18 +885,33 @@ impl RegallocAlgorithm {
 }
 
 #[derive(Arbitrary, Clone, Copy, Debug, PartialEq, Eq, Hash)]
-enum IntraModuleInlining {
+enum Inlining {
     Yes,
+    InterModuleAndIntraGc,
+    InterModule,
+    Intrinsics,
     No,
-    WhenUsingGc,
 }
 
-impl std::fmt::Display for IntraModuleInlining {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            IntraModuleInlining::Yes => write!(f, "yes"),
-            IntraModuleInlining::No => write!(f, "no"),
-            IntraModuleInlining::WhenUsingGc => write!(f, "gc"),
+impl From<Inlining> for wasmtime::Inlining {
+    fn from(i: Inlining) -> Self {
+        let ret = match i {
+            Inlining::Yes => wasmtime::Inlining::Yes,
+            Inlining::InterModuleAndIntraGc => wasmtime::Inlining::InterModuleAndIntraGc,
+            Inlining::InterModule => wasmtime::Inlining::InterModule,
+            Inlining::Intrinsics => wasmtime::Inlining::Intrinsics,
+            Inlining::No => wasmtime::Inlining::No,
+        };
+
+        match ret {
+            wasmtime::Inlining::Yes
+            | wasmtime::Inlining::No
+            | wasmtime::Inlining::InterModuleAndIntraGc
+            | wasmtime::Inlining::InterModule
+            | wasmtime::Inlining::Intrinsics
+            // NOTE: if you add another arm here, be sure to update the
+            // `Inlining` enum above.
+            => ret,
         }
     }
 }

--- a/crates/wasmtime/src/compile.rs
+++ b/crates/wasmtime/src/compile.rs
@@ -30,7 +30,7 @@ use std::{any::Any, borrow::Cow, collections::BTreeMap, mem, ops::Range};
 use wasmtime_environ::{
     Abi, CompiledFunctionBody, CompiledFunctionsTable, CompiledFunctionsTableBuilder,
     CompiledModuleInfo, Compiler, DefinedFuncIndex, FilePos, FinishedObject, FuncKey,
-    FunctionBodyData, InliningCompiler, IntraModuleInlining, ModuleEnvironment, ModuleTranslation,
+    FunctionBodyData, Inlining, InliningCompiler, ModuleEnvironment, ModuleTranslation,
     ModuleTypes, ModuleTypesBuilder, ObjectKind, PrimaryMap, StaticModuleIndex, Tunables,
     graphs::{EntityGraph, Graph as _},
 };
@@ -560,7 +560,7 @@ the use case.
         }
 
         let mut raw_outputs = if let Some(inlining_compiler) = compiler.inlining_compiler() {
-            if engine.tunables().inlining {
+            if engine.tunables().inlining != Inlining::No {
                 self.compile_with_inlining(engine, compiler, inlining_compiler)?
             } else {
                 // Inlining compiler but inlining is disabled: compile each
@@ -803,7 +803,7 @@ the use case.
         );
 
         debug_assert!(
-            tunables.inlining,
+            tunables.inlining != Inlining::No,
             "shouldn't even call this method if we aren't configured for inlining"
         );
         debug_assert_ne!(caller_key, callee_key, "we never inline recursion");
@@ -841,29 +841,30 @@ the use case.
             (
                 FuncKey::DefinedWasmFunction(caller_module, _),
                 FuncKey::DefinedWasmFunction(callee_module, _),
-            ) => {
-                if caller_module == callee_module {
-                    match tunables.inlining_intra_module {
-                        IntraModuleInlining::Yes => {}
+            ) => match tunables.inlining {
+                Inlining::Yes => {}
 
-                        IntraModuleInlining::WhenUsingGc
-                            if caller_needs_gc_heap || callee_needs_gc_heap => {}
-
-                        IntraModuleInlining::WhenUsingGc => {
-                            log::trace!(
-                                "  --> not inlining: intra-module call that does not use GC"
-                            );
-                            return false;
-                        }
-
-                        IntraModuleInlining::No => {
-                            log::trace!("  --> not inlining: intra-module call");
-                            return false;
-                        }
+                Inlining::InterModuleAndIntraGc => {
+                    if caller_module == callee_module && !caller_needs_gc_heap {
+                        log::trace!("  --> not inlining: intra-module call where GC is not used");
+                        return false;
                     }
                 }
-            }
 
+                Inlining::InterModule => {
+                    if caller_module == callee_module {
+                        log::trace!("  --> not inlining: only inter-module calls inlined");
+                        return false;
+                    }
+                }
+
+                Inlining::Intrinsics => {
+                    log::trace!("  --> not inlining: only inlining intrinsics");
+                    return false;
+                }
+
+                Inlining::No => unreachable!(),
+            },
             _ => {}
         }
 

--- a/crates/wasmtime/src/compile/code_builder.rs
+++ b/crates/wasmtime/src/compile/code_builder.rs
@@ -456,7 +456,7 @@ impl<'a> CodeBuilder<'a> {
     /// // Enable function inlining during compilation. If you are using unsafe intrinsics, you
     /// // almost assuredly want them inlined to avoid function call overheads.
     /// let mut config = Config::new();
-    /// config.compiler_inlining(true);
+    /// config.compiler_inlining(wasmtime::Inlining::Yes);
     ///
     /// let engine = Engine::new(&config)?;
     /// let linker = wasmtime::component::Linker::new(&engine);

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -31,6 +31,7 @@ pub use crate::runtime::code_memory::CustomCodeMemory;
 pub use wasmtime_cache::{Cache, CacheConfig};
 #[cfg(all(feature = "incremental-cache", feature = "cranelift"))]
 pub use wasmtime_environ::CacheStore;
+pub use wasmtime_environ::Inlining;
 
 pub(crate) const DEFAULT_WASM_BACKTRACE_MAX_FRAMES: NonZeroUsize = NonZeroUsize::new(20).unwrap();
 
@@ -2262,9 +2263,8 @@ impl Config {
     /// when using a compilation strategy that does not support inlining, like
     /// Winch.
     ///
-    /// Note that inlining is still somewhat experimental at the moment (as of
-    /// the Wasmtime version 36).
-    pub fn compiler_inlining(&mut self, inlining: bool) -> &mut Self {
+    /// The default value for this is `Inlining::No`.
+    pub fn compiler_inlining(&mut self, inlining: Inlining) -> &mut Self {
         self.tunables.inlining = Some(inlining);
         self
     }
@@ -2562,6 +2562,17 @@ impl Config {
         #[cfg(feature = "debug")]
         if self.tunables.debug_guest == Some(true) {
             tunables.signals_based_traps = false;
+        }
+
+        // Inlining currently falls over with the `stack_switch` instruction.
+        #[cfg(any(feature = "cranelift", feature = "winch"))]
+        if features.contains(WasmFeatures::STACK_SWITCHING) {
+            if let Some(inlining) = self.tunables.inlining
+                && inlining != Inlining::No
+            {
+                bail!("cannot enable compiler inlining when stack switching is enabled");
+            }
+            tunables.inlining = Inlining::No;
         }
 
         self.tunables.configure(&mut tunables);

--- a/crates/wasmtime/src/engine/serialization.rs
+++ b/crates/wasmtime/src/engine/serialization.rs
@@ -310,7 +310,6 @@ impl Metadata<'_> {
             signals_based_traps,
             memory_init_cow,
             inlining,
-            inlining_intra_module,
             inlining_small_callee_size,
             inlining_sum_size_threshold,
             concurrency_support,
@@ -395,7 +394,6 @@ impl Metadata<'_> {
             other.memory_init_cow,
             "memory initialization with CoW",
         )?;
-        Self::check_bool(inlining, other.inlining, "function inlining")?;
         Self::check_int(
             inlining_small_callee_size,
             other.inlining_small_callee_size,
@@ -412,7 +410,7 @@ impl Metadata<'_> {
             "concurrency support",
         )?;
         Self::check_bool(recording, other.recording, "RR recording support")?;
-        Self::check_intra_module_inlining(inlining_intra_module, other.inlining_intra_module)?;
+        Self::check_inlining(inlining, other.inlining)?;
         Self::check_int(
             gc_heap_reservation,
             other.gc_heap_reservation,
@@ -464,20 +462,22 @@ impl Metadata<'_> {
         }
     }
 
-    fn check_intra_module_inlining(
-        module: wasmtime_environ::IntraModuleInlining,
-        host: wasmtime_environ::IntraModuleInlining,
+    fn check_inlining(
+        module: wasmtime_environ::Inlining,
+        host: wasmtime_environ::Inlining,
     ) -> Result<()> {
         if module == host {
             return Ok(());
         }
 
         let desc = |cfg| match cfg {
-            wasmtime_environ::IntraModuleInlining::No => "without intra-module inlining",
-            wasmtime_environ::IntraModuleInlining::Yes => "with intra-module inlining",
-            wasmtime_environ::IntraModuleInlining::WhenUsingGc => {
+            wasmtime_environ::Inlining::No => "without intra-module inlining",
+            wasmtime_environ::Inlining::Yes => "with intra-module inlining",
+            wasmtime_environ::Inlining::InterModuleAndIntraGc => {
                 "with intra-module inlining only when using GC"
             }
+            wasmtime_environ::Inlining::Intrinsics => "with intrinsic inlining",
+            wasmtime_environ::Inlining::InterModule => "with inter-module inlining",
         };
 
         let module = desc(module);

--- a/tests/all/debug.rs
+++ b/tests/all/debug.rs
@@ -4,8 +4,8 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use wasmtime::{
     AsContextMut, Caller, Config, DebugEvent, DebugHandler, Engine, Extern, FrameHandle, Func,
-    Global, GlobalType, Instance, Module, ModulePC, Mutability, Store, StoreContextMut, Val,
-    ValType,
+    Global, GlobalType, Inlining, Instance, Module, ModulePC, Mutability, Store, StoreContextMut,
+    Val, ValType,
 };
 
 use crate::async_functions::PollOnce;
@@ -74,7 +74,7 @@ fn test_stack_values<
 fn stack_values_two_frames() -> wasmtime::Result<()> {
     let _ = env_logger::try_init();
 
-    for inlining in [false, true] {
+    for inlining in [Inlining::No, Inlining::Yes] {
         test_stack_values(
             r#"
     (module
@@ -92,11 +92,6 @@ fn stack_values_two_frames() -> wasmtime::Result<()> {
     "#,
             |config| {
                 config.compiler_inlining(inlining);
-                if inlining {
-                    unsafe {
-                        config.cranelift_flag_set("wasmtime_inlining_intra_module", "true");
-                    }
-                }
             },
             |mut caller: Caller<'_, ()>| {
                 let stack = caller.debug_exit_frames().next().unwrap();
@@ -932,10 +927,7 @@ async fn breakpoints_in_inlined_code() -> wasmtime::Result<()> {
     let (module, mut store) = get_module_and_store(
         |config| {
             config.wasm_exceptions(true);
-            config.compiler_inlining(true);
-            unsafe {
-                config.cranelift_flag_set("wasmtime_inlining_intra_module", "true");
-            }
+            config.compiler_inlining(Inlining::Yes);
         },
         r#"
     (module

--- a/tests/all/tags.rs
+++ b/tests/all/tags.rs
@@ -78,3 +78,15 @@ fn wasm_import_tags() -> Result<()> {
 
     return Ok(());
 }
+
+// Tests that enabling inlining with stack switching, for now, returns an error.
+// If the support in Cranelift is fixed to the point that this is fine to
+// enable, then delete this test and the check in `config.rs` as well.
+#[test]
+fn stack_switching_disallows_inlining() -> Result<()> {
+    let mut config = Config::new();
+    config.wasm_stack_switching(true);
+    config.compiler_inlining(wasmtime::Inlining::Yes);
+    assert!(Engine::new(&config).is_err());
+    return Ok(());
+}

--- a/tests/disas/component-model/context-intrinsics.wat
+++ b/tests/disas/component-model/context-intrinsics.wat
@@ -1,6 +1,6 @@
 ;;! target = "x86_64"
 ;;! test = 'compile'
-;;! flags = '-Wcomponent-model-async -Wcomponent-model-threading -Cinlining'
+;;! flags = '-Wcomponent-model-async -Wcomponent-model-threading -Cinlining=intrinsics'
 
 (component
   (core func $context.get0 (canon context.get i32 0))

--- a/tests/disas/component-model/inlining-bug.wat
+++ b/tests/disas/component-model/inlining-bug.wat
@@ -1,7 +1,7 @@
 ;;! target = "x86_64"
 ;;! test = "optimize"
 ;;! filter = "wasm[2]--function"
-;;! flags = "-C inlining=y"
+;;! flags = "-C inlining=inter-module"
 
 (component
   (core module $A

--- a/tests/disas/intra-module-inlining.wat
+++ b/tests/disas/intra-module-inlining.wat
@@ -1,7 +1,7 @@
 ;;! target = "x86_64"
 ;;! test = "optimize"
 ;;! filter = "wasm[0]--function"
-;;! flags = "-C inlining=y -C cranelift-wasmtime_inlining_intra_module=y"
+;;! flags = "-C inlining=y"
 
 (module
   (func (result i32)


### PR DESCRIPTION
Fold the `inlining` boolean and the `inlining_intra_module` options into a single `Inlining` enum option. This option encompasses both and has an additional mode which is "only intrinsics" where inter-module and intra-module calls are never inlined, but intrinsics for Wasmtime are allowed to be inlined. This is inspired from discussion on #13214 and after some performance work and/or confirmations the expectation is to turn the default inlining mode to `Inlining::Intrinsics`.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
