### PR TITLE
Implement idempotent-store elimination

### DIFF
--- a/cranelift/codegen/src/alias_analysis.rs
+++ b/cranelift/codegen/src/alias_analysis.rs
@@ -349,6 +349,16 @@ impl<'a> AliasAnalysis<'a> {
                     mem_loc
                 );
 
+                // Is there a Value already known to be stored
+                // at this specific memory location?  If so,
+                // we can alias the load result to this
+                // already-known Value.
+                //
+                // Check if the definition dominates this
+                // location; it might not, if it comes from a
+                // load (stores will always dominate though if
+                // their `last_store` survives through
+                // meet-points to this use-site).
                 let aliased =
                     if let Some((def_inst, value)) = self.mem_values.get(&mem_loc).cloned() {
                         trace!(
@@ -370,6 +380,8 @@ impl<'a> AliasAnalysis<'a> {
                         None
                     };
 
+                // Otherwise, we can keep *this* load around
+                // as a new equivalent value.
                 if aliased.is_none() {
                     trace!(
                         " -> inserting load result v{} at loc {:?}",

--- a/cranelift/codegen/src/alias_analysis.rs
+++ b/cranelift/codegen/src/alias_analysis.rs
@@ -173,6 +173,16 @@ struct MemoryLoc {
     extending_opcode: Option<Opcode>,
 }
 
+/// The result of processing an instruction through alias analysis.
+pub enum OptResult {
+    /// No optimization applied.
+    None,
+    /// A redundant load; alias its result to this value.
+    AliasedLoad(Value),
+    /// An idempotent store; remove it.
+    IdempotentStore,
+}
+
 /// An alias-analysis pass.
 pub struct AliasAnalysis<'a> {
     /// The domtree for the function.
@@ -260,14 +270,12 @@ impl<'a> AliasAnalysis<'a> {
     /// Process one instruction. Meant to be invoked in program order
     /// within a block, and ideally in RPO or at least some domtree
     /// preorder for maximal reuse.
-    ///
-    /// Returns `true` if instruction was removed.
     pub fn process_inst(
         &mut self,
         func: &mut Function,
         state: &mut LastStores,
         inst: Inst,
-    ) -> Option<Value> {
+    ) -> OptResult {
         trace!(
             "alias analysis: scanning at inst{} with state {:?} ({:?})",
             inst.index(),
@@ -275,14 +283,39 @@ impl<'a> AliasAnalysis<'a> {
             func.dfg.insts[inst],
         );
 
-        let replacing_value = if let Some((address, offset, ty)) = inst_addr_offset_type(func, inst)
-        {
+        let result = if let Some((address, offset, ty)) = inst_addr_offset_type(func, inst) {
             let address = func.dfg.resolve_aliases(address);
             let opcode = func.dfg.insts[inst].opcode();
 
             if opcode.can_store() {
                 let store_data = inst_store_data(func, inst).unwrap();
                 let store_data = func.dfg.resolve_aliases(store_data);
+
+                // Check for idempotent stores, where we are storing the exact
+                // same value back to a location that already has that value.
+                let last_store = state.get_last_store(func, inst);
+                let check_loc = MemoryLoc {
+                    last_store,
+                    address,
+                    offset,
+                    ty,
+                    extending_opcode: get_ext_opcode(opcode),
+                };
+                if let Some((def_inst, known_value)) = self.mem_values.get(&check_loc).cloned() {
+                    if known_value == store_data
+                        && self.domtree.dominates(def_inst, inst, &func.layout)
+                    {
+                        trace!(
+                            "alias analysis: at inst{}: idempotent store of v{} to loc {:?}",
+                            inst.index(),
+                            store_data.index(),
+                            check_loc
+                        );
+                        return OptResult::IdempotentStore;
+                    }
+                }
+
+                // Otherwise, update our state to reflect this store.
                 let mem_loc = MemoryLoc {
                     last_store: inst.into(),
                     address,
@@ -298,7 +331,7 @@ impl<'a> AliasAnalysis<'a> {
                 );
                 self.mem_values.insert(mem_loc, (inst, store_data));
 
-                None
+                OptResult::None
             } else if opcode.can_load() {
                 let last_store = state.get_last_store(func, inst);
                 let load_result = func.dfg.inst_results(inst)[0];
@@ -316,16 +349,6 @@ impl<'a> AliasAnalysis<'a> {
                     mem_loc
                 );
 
-                // Is there a Value already known to be stored
-                // at this specific memory location?  If so,
-                // we can alias the load result to this
-                // already-known Value.
-                //
-                // Check if the definition dominates this
-                // location; it might not, if it comes from a
-                // load (stores will always dominate though if
-                // their `last_store` survives through
-                // meet-points to this use-site).
                 let aliased =
                     if let Some((def_inst, value)) = self.mem_values.get(&mem_loc).cloned() {
                         trace!(
@@ -347,8 +370,6 @@ impl<'a> AliasAnalysis<'a> {
                         None
                     };
 
-                // Otherwise, we can keep *this* load around
-                // as a new equivalent value.
                 if aliased.is_none() {
                     trace!(
                         " -> inserting load result v{} at loc {:?}",
@@ -358,17 +379,20 @@ impl<'a> AliasAnalysis<'a> {
                     self.mem_values.insert(mem_loc, (inst, load_result));
                 }
 
-                aliased
+                match aliased {
+                    Some(value) => OptResult::AliasedLoad(value),
+                    None => OptResult::None,
+                }
             } else {
-                None
+                OptResult::None
             }
         } else {
-            None
+            OptResult::None
         };
 
         state.update(func, inst);
 
-        replacing_value
+        result
     }
 
     /// Make a pass and update known-redundant loads to aliased
@@ -382,11 +406,17 @@ impl<'a> AliasAnalysis<'a> {
         while let Some(block) = pos.next_block() {
             let mut state = self.block_starting_state(block);
             while let Some(inst) = pos.next_inst() {
-                if let Some(replaced_result) = self.process_inst(pos.func, &mut state, inst) {
-                    let result = pos.func.dfg.inst_results(inst)[0];
-                    pos.func.dfg.clear_results(inst);
-                    pos.func.dfg.change_to_alias(result, replaced_result);
-                    pos.remove_inst_and_step_back();
+                match self.process_inst(pos.func, &mut state, inst) {
+                    OptResult::None => {}
+                    OptResult::AliasedLoad(replaced_result) => {
+                        let result = pos.func.dfg.inst_results(inst)[0];
+                        pos.func.dfg.clear_results(inst);
+                        pos.func.dfg.change_to_alias(result, replaced_result);
+                        pos.remove_inst_and_step_back();
+                    }
+                    OptResult::IdempotentStore => {
+                        pos.remove_inst_and_step_back();
+                    }
                 }
             }
         }

--- a/cranelift/codegen/src/egraph/mod.rs
+++ b/cranelift/codegen/src/egraph/mod.rs
@@ -487,7 +487,7 @@ where
                 .process_inst(self.func, self.alias_analysis_state, inst)
             {
                 OptResult::AliasedLoad(new_result) => {
-                    self.stats.alias_analysis_removed += 1;
+                    self.stats.alias_analysis_removed_load += 1;
                     let result = self.func.dfg.first_result(inst);
                     trace!(
                         " -> inst {} has result {} replaced with {}",
@@ -498,7 +498,7 @@ where
                     Some(SkeletonInstSimplification::Remove)
                 }
                 OptResult::IdempotentStore => {
-                    self.stats.alias_analysis_removed += 1;
+                    self.stats.alias_analysis_removed_store += 1;
                     Some(SkeletonInstSimplification::Remove)
                 }
                 OptResult::None => {
@@ -1067,7 +1067,8 @@ pub(crate) struct Stats {
     pub(crate) skeleton_inst: u64,
     pub(crate) skeleton_inst_simplified: u64,
     pub(crate) skeleton_inst_gvn: u64,
-    pub(crate) alias_analysis_removed: u64,
+    pub(crate) alias_analysis_removed_load: u64,
+    pub(crate) alias_analysis_removed_store: u64,
     pub(crate) new_inst: u64,
     pub(crate) union: u64,
     pub(crate) subsume: u64,

--- a/cranelift/codegen/src/egraph/mod.rs
+++ b/cranelift/codegen/src/egraph/mod.rs
@@ -1,7 +1,7 @@
 //! Support for egraphs represented in the DataFlowGraph.
 
 use crate::FxHashSet;
-use crate::alias_analysis::{AliasAnalysis, LastStores};
+use crate::alias_analysis::{AliasAnalysis, LastStores, OptResult};
 use crate::ctxhash::{CtxEq, CtxHash, NullCtx};
 use crate::cursor::{Cursor, CursorPosition, FuncCursor};
 use crate::dominator_tree::DominatorTree;
@@ -480,31 +480,37 @@ where
         }
         // Otherwise, if a load or store, process it with the alias
         // analysis to see if we can optimize it (rewrite in terms of
-        // an earlier load or stored value).
-        else if let Some(new_result) =
-            self.alias_analysis
-                .process_inst(self.func, self.alias_analysis_state, inst)
-        {
-            self.stats.alias_analysis_removed += 1;
-            let result = self.func.dfg.first_result(inst);
-            trace!(
-                " -> inst {} has result {} replaced with {}",
-                inst, result, new_result
-            );
-            self.value_to_opt_value[result] = new_result;
-            self.available_block[result] = self.available_block[new_result];
-            Some(SkeletonInstSimplification::Remove)
-        }
-        // Otherwise, generic side-effecting op -- always keep it, and
-        // set its results to identity-map to original values.
+        // an earlier load or stored value, or remove an idempotent store).
         else {
-            // Set all results to identity-map to themselves
-            // in the value-to-opt-value map.
-            for &result in self.func.dfg.inst_results(inst) {
-                self.value_to_opt_value[result] = result;
-                self.available_block[result] = block;
+            match self
+                .alias_analysis
+                .process_inst(self.func, self.alias_analysis_state, inst)
+            {
+                OptResult::AliasedLoad(new_result) => {
+                    self.stats.alias_analysis_removed += 1;
+                    let result = self.func.dfg.first_result(inst);
+                    trace!(
+                        " -> inst {} has result {} replaced with {}",
+                        inst, result, new_result
+                    );
+                    self.value_to_opt_value[result] = new_result;
+                    self.available_block[result] = self.available_block[new_result];
+                    Some(SkeletonInstSimplification::Remove)
+                }
+                OptResult::IdempotentStore => {
+                    self.stats.alias_analysis_removed += 1;
+                    Some(SkeletonInstSimplification::Remove)
+                }
+                OptResult::None => {
+                    // Generic side-effecting op -- always keep it, and
+                    // set its results to identity-map to original values.
+                    for &result in self.func.dfg.inst_results(inst) {
+                        self.value_to_opt_value[result] = result;
+                        self.available_block[result] = block;
+                    }
+                    None
+                }
             }
-            None
         }
     }
 

--- a/cranelift/filetests/filetests/alias/idempotent-store.clif
+++ b/cranelift/filetests/filetests/alias/idempotent-store.clif
@@ -65,38 +65,39 @@ block1:
 ;     return
 ; }
 
-;; Cross block: store in a block NOT dominated by the load should NOT be
-;; removed. block0 branches to block1 (which loads) and block2 (which stores).
-;; block2 is not dominated by block1, so the store must be kept.
+;; Cross block: store in a block that has another in-edge besides the block with
+;; the original store should NOT be removed. block2 stores and branches to
+;; block4, but block4 also has an in-edge from block3, so the store in block4 is
+;; not dominated by the store in block2 and must be kept.
 function %cross_block_not_dominated(i64, i32) {
 block0(v0: i64, v1: i32):
-    brif v1, block1, block2
-
-block1:
-    v2 = load.i32 heap v0+8
-    jump block3
+    brif v1, block2, block3
 
 block2:
     store.i32 heap v1, v0+8
-    jump block3
+    jump block4
 
 block3:
+    jump block4
+
+block4:
+    store.i32 heap v1, v0+8
     return
 }
 
 ; function %cross_block_not_dominated(i64, i32) fast {
 ; block0(v0: i64, v1: i32):
-;     brif v1, block1, block2
-;
-; block1:
-;     v2 = load.i32 heap v0+8
-;     jump block3
+;     brif v1, block2, block3
 ;
 ; block2:
 ;     store.i32 heap v1, v0+8
-;     jump block3
+;     jump block4
 ;
 ; block3:
+;     jump block4
+;
+; block4:
+;     store.i32 heap v1, v0+8
 ;     return
 ; }
 

--- a/cranelift/filetests/filetests/alias/idempotent-store.clif
+++ b/cranelift/filetests/filetests/alias/idempotent-store.clif
@@ -1,0 +1,138 @@
+test optimize precise-output
+set opt_level=speed
+target x86_64
+
+;; Same block: idempotent store after load should be removed.
+function %idempotent_store_after_load(i64) {
+block0(v0: i64):
+    v1 = load.i32 heap v0+8
+    store.i32 heap v1, v0+8
+    return
+}
+
+; function %idempotent_store_after_load(i64) fast {
+; block0(v0: i64):
+;     v1 = load.i32 heap v0+8
+;     return
+; }
+
+;; Same block: idempotent store after store should be removed.
+function %idempotent_store_after_store(i64, i32) {
+block0(v0: i64, v1: i32):
+    store.i32 heap v1, v0+8
+    store.i32 heap v1, v0+8
+    return
+}
+
+; function %idempotent_store_after_store(i64, i32) fast {
+; block0(v0: i64, v1: i32):
+;     store heap v1, v0+8
+;     return
+; }
+
+;; Same block: non-idempotent store (different value) should NOT be removed.
+function %non_idempotent_store(i64, i32, i32) {
+block0(v0: i64, v1: i32, v2: i32):
+    store.i32 heap v1, v0+8
+    store.i32 heap v2, v0+8
+    return
+}
+
+; function %non_idempotent_store(i64, i32, i32) fast {
+; block0(v0: i64, v1: i32, v2: i32):
+;     store heap v1, v0+8
+;     store heap v2, v0+8
+;     return
+; }
+
+;; Cross block: idempotent store in dominated block should be removed.
+function %cross_block_dominated(i64) {
+block0(v0: i64):
+    v1 = load.i32 heap v0+8
+    jump block1
+
+block1:
+    store.i32 heap v1, v0+8
+    return
+}
+
+; function %cross_block_dominated(i64) fast {
+; block0(v0: i64):
+;     v1 = load.i32 heap v0+8
+;     jump block1
+;
+; block1:
+;     return
+; }
+
+;; Cross block: store in a block NOT dominated by the load should NOT be
+;; removed. block0 branches to block1 (which loads) and block2 (which stores).
+;; block2 is not dominated by block1, so the store must be kept.
+function %cross_block_not_dominated(i64, i32) {
+block0(v0: i64, v1: i32):
+    brif v1, block1, block2
+
+block1:
+    v2 = load.i32 heap v0+8
+    jump block3
+
+block2:
+    store.i32 heap v1, v0+8
+    jump block3
+
+block3:
+    return
+}
+
+; function %cross_block_not_dominated(i64, i32) fast {
+; block0(v0: i64, v1: i32):
+;     brif v1, block1, block2
+;
+; block1:
+;     v2 = load.i32 heap v0+8
+;     jump block3
+;
+; block2:
+;     store.i32 heap v1, v0+8
+;     jump block3
+;
+; block3:
+;     return
+; }
+
+;; Function call between load and store breaks the optimization.
+function %call_barrier(i64) {
+    fn0 = %g(i64)
+block0(v0: i64):
+    v1 = load.i32 heap v0+8
+    call fn0(v0)
+    store.i32 heap v1, v0+8
+    return
+}
+
+; function %call_barrier(i64) fast {
+;     sig0 = (i64) fast
+;     fn0 = %g sig0
+;
+; block0(v0: i64):
+;     v1 = load.i32 heap v0+8
+;     call fn0(v0)
+;     store heap v1, v0+8
+;     return
+; }
+
+;; Removing an idempotent store should preserve RLE for subsequent loads.
+function %idempotent_store_then_load(i64) -> i32 {
+block0(v0: i64):
+    v1 = load.i32 heap v0+8
+    store.i32 heap v1, v0+8
+    v2 = load.i32 heap v0+8
+    return v2
+}
+
+; function %idempotent_store_then_load(i64) -> i32 fast {
+; block0(v0: i64):
+;     v1 = load.i32 heap v0+8
+;     return v1
+; }
+

--- a/cranelift/filetests/filetests/isa/riscv64/issue-12811.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/issue-12811.clif
@@ -3420,10 +3420,6 @@ block2:
 ;   sd zero,0(a0)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
 ;   li a2,4
 ;   sd a2,0(a0)
 ;   sd zero,0(a0)
@@ -3433,40 +3429,21 @@ block2:
 ;   li a1,1
 ;   sd a1,0(a0)
 ;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   sw zero,0(a0)
 ;   sd a1,0(a0)
-;   sw zero,0(a0)
 ;   sw zero,0(a0)
 ;   sd a2,0(a0)
 ;   sd a1,0(a0)
 ;   li a4,1
 ;   sw a4,0(a0)
 ;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
 ;   sw zero,0(a0)
-;   sw zero,0(a0)
+;   sd zero,0(a0)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
 ;   sw zero,0(a0)
@@ -3474,27 +3451,15 @@ block2:
 ;   sd a2,0(a0)
 ;   sd zero,0(a0)
 ;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   sd a1,0(a0)
 ;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
 ;   sd zero,0(a0)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   sw zero,0(a0)
 ;   li a3,9
 ;   sd a3,0(a0)
 ;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   sw zero,0(a0)
 ;   sd a3,0(a0)
 ;   li a3,13
@@ -3504,41 +3469,25 @@ block2:
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
 ;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
 ;   sd zero,0(a0)
 ;   sd a2,0(a0)
 ;   sd a1,0(a0)
 ;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
 ;   sd zero,0(a0)
 ;   sd a1,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   sw zero,0(a0)
 ;   sw a4,0(a0)
 ;   sw zero,0(a0)
 ;   sw a4,0(a0)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
 ;   sd a1,0(a0)
 ;   sd a2,0(a0)
 ;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
 ;   sd zero,0(a0)
 ;   sw zero,0(a0)
-;   sd zero,0(a0)
 ;   sd zero,0(a0)
 ;   li a3,8
 ;   sd a3,0(a0)
@@ -3550,22 +3499,13 @@ block2:
 ;   sd a1,0(a0)
 ;   sw a4,0(a0)
 ;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
 ;   sw a4,0(a0)
 ;   sd a1,0(a0)
-;   sd a1,0(a0)
 ;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
 ;   sw zero,0(a0)
 ;   sw a4,0(a0)
 ;   sd zero,0(a0)
@@ -3574,7 +3514,6 @@ block2:
 ;   sw zero,0(a0)
 ;   sd a1,0(a0)
 ;   sw zero,0(a0)
-;   sw a4,0(a0)
 ;   sw a4,0(a0)
 ;   sd zero,0(a0)
 ;   sw a4,0(a0)
@@ -3588,11 +3527,9 @@ block2:
 ;   sd zero,0(a0)
 ;   sd a3,0(a0)
 ;   sd zero,0(a0)
-;   sd zero,0(a0)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
 ;   sw zero,0(a0)
-;   sd a1,0(a0)
 ;   sd a1,0(a0)
 ;   sw zero,0(a0)
 ;   sd a1,0(a0)
@@ -3618,104 +3555,52 @@ block2:
 ;   sd a1,0(a0)
 ;   sd zero,0(a0)
 ;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   li a5,8
 ;   sw a5,0(a0)
 ;   sw zero,0(a0)
 ;   sd a3,0(a0)
 ;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   sw a4,0(a0)
 ;   sd zero,0(a0)
 ;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
 ;   sw a4,0(a0)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
 ;   sw zero,0(a0)
-;   sd a1,0(a0)
 ;   sd a1,0(a0)
 ;   sw a4,0(a0)
 ;   sw zero,0(a0)
 ;   sd a1,0(a0)
 ;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
+;   sd zero,0(a0)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
 ;   sw zero,0(a0)
+;   sd zero,0(a0)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
 ;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
 ;   sw a5,0(a0)
 ;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
 ;   sd zero,0(a0)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
 ;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
 ;   sd zero,0(a0)
 ;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   sd zero,0(a0)
-;   sw zero,0(a0)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
 ;   sw zero,0(a0)
@@ -3729,51 +3614,27 @@ block2:
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
 ;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
 ;   sd zero,0(a0)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
 ;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
 ;   sd zero,0(a0)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
 ;   sw zero,0(a0)
+;   sd zero,0(a0)
+;   sw zero,0(a0)
+;   sd zero,0(a0)
+;   sw zero,0(a0)
+;   sd zero,0(a0)
+;   sw zero,0(a0)
+;   sd zero,0(a0)
+;   sw zero,0(a0)
+;   sd zero,0(a0)
+;   sw zero,0(a0)
+;   sd zero,0(a0)
 ;   sw zero,0(a0)
 ;   sd a1,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   sw zero,0(a0)
 ;   sd a1,0(a0)
 ;   sw zero,0(a0)
@@ -3781,19 +3642,12 @@ block2:
 ;   sd a1,0(a0)
 ;   sd a3,0(a0)
 ;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   sw zero,0(a0)
 ;   sd a2,0(a0)
-;   sd a2,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   sd zero,0(a0)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
+;   sw zero,0(a0)
 ;   sd zero,0(a0)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
@@ -3841,17 +3695,17 @@ block2:
 ;   j label17
 ; block17:
 ;   lui a0,509913
-;   addi a1,a0,-193
-;   trap_if user11##(a1 ne zero)
+;   addi a0,a0,-193
+;   trap_if user11##(a0 ne zero)
 ;   j label18
 ; block18:
 ;   j label19
 ; block19:
 ;   j label20
 ; block20:
-;   lui a3,373234
-;   addi a5,a3,1763
-;   trap_if user11##(a5 ne zero)
+;   lui a0,373234
+;   addi a0,a0,1763
+;   trap_if user11##(a0 ne zero)
 ;   j label21
 ; block21:
 ;   j label22
@@ -3891,9 +3745,9 @@ block2:
 ; block34:
 ;   j label35
 ; block35:
-;   lui a0,466898
-;   addi a0,a0,1094
-;   trap_if user11##(a0 ne zero)
+;   lui a2,466898
+;   addi a4,a2,1094
+;   trap_if user11##(a4 ne zero)
 ;   j label36
 ; block36:
 ;   j label37
@@ -3932,68 +3786,68 @@ block2:
 ;   sd a1,0(a0)
 ;   ld a1,[const(242)]
 ;   sd a1,0(a0)
-;   li a2,1
-;   ld a1,[const(241)]
-;   sd a2,0(a1)
-;   ld a1,[const(240)]
-;   sd a1,0(a0)
-;   ld a1,[const(239)]
-;   sd a1,0(a0)
-;   ld a1,[const(238)]
-;   sd a1,0(a0)
-;   ld a1,[const(237)]
-;   sd a1,0(a0)
-;   ld a1,[const(236)]
-;   sd zero,0(a1)
-;   ld a1,[const(235)]
-;   sd a1,0(a0)
-;   ld a1,[const(234)]
-;   sd a1,0(a0)
-;   ld a1,[const(233)]
-;   sd a1,0(a0)
-;   ld a1,[const(232)]
-;   sd a1,0(a0)
-;   ld a1,[const(231)]
-;   sd a1,0(a0)
-;   ld a1,[const(230)]
-;   sd a1,0(a0)
-;   ld a1,[const(229)]
-;   sd zero,0(a1)
-;   ld a1,[const(228)]
-;   sd zero,0(a1)
-;   ld a1,[const(227)]
-;   sd a1,0(a0)
-;   ld a1,[const(226)]
-;   sd a2,0(a1)
-;   ld a1,[const(225)]
-;   sd a1,0(a0)
-;   ld a1,[const(224)]
-;   sd a1,0(a0)
-;   ld a1,[const(223)]
-;   sd a1,0(a0)
-;   ld a1,[const(222)]
-;   sd zero,0(a1)
-;   ld a1,[const(221)]
-;   sd a1,0(a0)
-;   ld a1,[const(220)]
-;   sd a1,0(a0)
-;   ld a1,[const(219)]
-;   sd a1,0(a0)
-;   ld a3,[const(218)]
-;   sd a3,0(a0)
-;   ld a3,[const(217)]
-;   sd a3,0(a0)
-;   ld a4,[const(216)]
-;   sd a4,0(a0)
-;   ld a5,[const(215)]
-;   sd a5,0(a0)
-;   ld a1,[const(214)]
-;   sd a1,0(a0)
-;   ld a1,[const(213)]
-;   sd a1,0(a0)
 ;   li a1,1
+;   ld a2,[const(241)]
+;   sd a1,0(a2)
+;   ld a2,[const(240)]
+;   sd a2,0(a0)
+;   ld a2,[const(239)]
+;   sd a2,0(a0)
+;   ld a2,[const(238)]
+;   sd a2,0(a0)
+;   ld a2,[const(237)]
+;   sd a2,0(a0)
+;   ld a2,[const(236)]
+;   sd zero,0(a2)
+;   ld a2,[const(235)]
+;   sd a2,0(a0)
+;   ld a2,[const(234)]
+;   sd a2,0(a0)
+;   ld a2,[const(233)]
+;   sd a2,0(a0)
+;   ld a2,[const(232)]
+;   sd a2,0(a0)
+;   ld a2,[const(231)]
+;   sd a2,0(a0)
+;   ld a2,[const(230)]
+;   sd a2,0(a0)
+;   ld a2,[const(229)]
+;   sd zero,0(a2)
+;   ld a2,[const(228)]
+;   sd zero,0(a2)
+;   ld a2,[const(227)]
+;   sd a2,0(a0)
+;   ld a2,[const(226)]
+;   sd a1,0(a2)
+;   ld a2,[const(225)]
+;   sd a2,0(a0)
+;   ld a2,[const(224)]
+;   sd a2,0(a0)
+;   ld a2,[const(223)]
+;   sd a2,0(a0)
+;   ld a2,[const(222)]
+;   sd zero,0(a2)
+;   ld a2,[const(221)]
+;   sd a2,0(a0)
+;   ld a2,[const(220)]
+;   sd a2,0(a0)
+;   ld a2,[const(219)]
+;   sd a2,0(a0)
+;   ld a2,[const(218)]
+;   sd a2,0(a0)
+;   ld a2,[const(217)]
+;   sd a2,0(a0)
+;   ld a2,[const(216)]
+;   sd a2,0(a0)
+;   ld a2,[const(215)]
+;   sd a2,0(a0)
+;   ld a2,[const(214)]
+;   sd a2,0(a0)
+;   ld a2,[const(213)]
+;   sd a2,0(a0)
+;   li a2,1
 ;   ld a3,[const(212)]
-;   sw a1,0(a3)
+;   sw a2,0(a3)
 ;   ld a3,[const(211)]
 ;   sd a3,0(a0)
 ;   ld a3,[const(210)]
@@ -4007,69 +3861,50 @@ block2:
 ;   ld a3,[const(206)]
 ;   sd a3,0(a0)
 ;   sd zero,0(a0)
-;   sd zero,0(a0)
 ;   li a3,0
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
 ;   ld a4,[const(205)]
 ;   sd a4,0(a0)
 ;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   ld a4,[const(204)]
 ;   sd a4,0(a0)
-;   sw zero,0(a0)
 ;   sw zero,0(a0)
 ;   ld a4,[const(203)]
 ;   sd a4,0(a0)
 ;   ld a4,[const(202)]
 ;   sd a4,0(a0)
 ;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
 ;   ld a4,[const(201)]
 ;   ld a5,[const(200)]
 ;   sd a4,0(a5)
 ;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   sd zero,0(a0)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
 ;   sw zero,0(a0)
-;   sd zero,0(a0)
 ;   sd zero,0(a0)
 ;   sw zero,0(a0)
 ;   ld a4,[const(199)]
 ;   sd a4,0(a0)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
-;   sd zero,0(a0)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
-;   sw zero,0(a0)
 ;   sw zero,0(a0)
 ;   ld a4,[const(198)]
 ;   sd zero,0(a4)
 ;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   ld a4,[const(197)]
 ;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   sw zero,0(a0)
 ;   ld a4,[const(196)]
 ;   sd a4,0(a0)
 ;   sd zero,0(a0)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   sw zero,0(a0)
 ;   ld a4,[const(195)]
 ;   sd a4,0(a0)
@@ -4084,9 +3919,7 @@ block2:
 ;   ld a4,[const(191)]
 ;   sd a4,0(a0)
 ;   sd zero,0(a0)
-;   sd zero,0(a0)
 ;   sw zero,0(a0)
-;   sd zero,0(a0)
 ;   sd zero,0(a0)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
@@ -4096,7 +3929,6 @@ block2:
 ;   ld a4,[const(190)]
 ;   sd a4,0(a0)
 ;   sd zero,0(a0)
-;   sw zero,0(a0)
 ;   sw zero,0(a0)
 ;   ld a4,[const(189)]
 ;   sd a4,0(a0)
@@ -4108,9 +3940,6 @@ block2:
 ;   ld a4,[const(186)]
 ;   sd a4,0(a0)
 ;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
 ;   sd zero,0(a0)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
@@ -4120,7 +3949,6 @@ block2:
 ;   ld a4,[const(184)]
 ;   sd a4,0(a0)
 ;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   ld a4,[const(183)]
 ;   sd a4,0(a0)
 ;   ld a4,[const(182)]
@@ -4128,39 +3956,24 @@ block2:
 ;   ld a4,[const(181)]
 ;   ld a4,0(a4)
 ;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   sw zero,0(a0)
 ;   ld a4,[const(180)]
 ;   sd a4,0(a0)
 ;   ld a4,[const(179)]
 ;   sd a4,0(a0)
 ;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(178)]
-;   sd a4,0(a0)
+;   ld a5,[const(178)]
+;   sd a5,0(a0)
 ;   ld a4,[const(177)]
 ;   sd a4,0(a0)
-;   sw zero,0(a0)
 ;   sw zero,0(a0)
 ;   ld a4,[const(176)]
 ;   sd a4,0(a0)
 ;   sd zero,0(a0)
 ;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   ld a4,[const(175)]
 ;   sd a4,0(a0)
 ;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
 ;   sw zero,0(a0)
 ;   ld a4,[const(174)]
 ;   sd a4,0(a0)
@@ -4168,37 +3981,21 @@ block2:
 ;   ld a4,[const(173)]
 ;   sd zero,0(a4)
 ;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   sw zero,0(a0)
 ;   ld a4,[const(172)]
 ;   sd a4,0(a0)
 ;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   ld a4,[const(171)]
 ;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   sw zero,0(a0)
 ;   ld a4,[const(170)]
 ;   sd a4,0(a0)
 ;   sd zero,0(a0)
 ;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   ld a4,[const(169)]
 ;   sd a4,0(a0)
-;   sw zero,0(a0)
 ;   sw zero,0(a0)
 ;   ld a4,[const(168)]
 ;   sd a4,0(a0)
@@ -4206,24 +4003,17 @@ block2:
 ;   ld a4,[const(167)]
 ;   sd a4,0(a0)
 ;   sd zero,0(a0)
-;   sd zero,0(a0)
 ;   sw zero,0(a0)
-;   sd zero,0(a0)
 ;   sd zero,0(a0)
 ;   ld a4,[const(166)]
 ;   sd a4,0(a0)
 ;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   ld a4,[const(165)]
 ;   sd a4,0(a0)
-;   sw zero,0(a0)
 ;   sw zero,0(a0)
 ;   ld a4,[const(164)]
 ;   sd a4,0(a0)
 ;   sd zero,0(a0)
-;   sw zero,0(a0)
 ;   sw zero,0(a0)
 ;   ld a4,[const(163)]
 ;   sd a4,0(a0)
@@ -4232,22 +4022,15 @@ block2:
 ;   sd zero,0(a0)
 ;   ld a4,[const(161)]
 ;   ld a4,0(a4)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   sw zero,0(a0)
 ;   ld a4,[const(160)]
 ;   sd a4,0(a0)
 ;   ld a4,[const(159)]
 ;   sd a4,0(a0)
 ;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   ld a4,[const(158)]
 ;   sd a4,0(a0)
 ;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
 ;   ld a4,[const(157)]
@@ -4255,25 +4038,18 @@ block2:
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
 ;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   ld a4,[const(156)]
 ;   sd a4,0(a0)
 ;   sd zero,0(a0)
 ;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
 ;   ld a4,[const(155)]
 ;   sd a4,0(a0)
 ;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   ld a4,[const(154)]
 ;   sd a4,0(a0)
-;   sw zero,0(a0)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
 ;   sw zero,0(a0)
@@ -4281,42 +4057,28 @@ block2:
 ;   sd a4,0(a0)
 ;   sd zero,0(a0)
 ;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   ld a4,[const(152)]
 ;   sd a4,0(a0)
-;   sw zero,0(a0)
 ;   sw zero,0(a0)
 ;   ld a4,[const(151)]
 ;   sd a4,0(a0)
 ;   ld a4,[const(150)]
 ;   sd a4,0(a0)
 ;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   ld a4,[const(149)]
 ;   sd a4,0(a0)
 ;   ld a4,[const(148)]
 ;   sd zero,0(a4)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   sw zero,0(a0)
 ;   ld a4,[const(147)]
 ;   sd a4,0(a0)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
 ;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   sw zero,0(a0)
 ;   ld a4,[const(146)]
 ;   sd a4,0(a0)
-;   sw zero,0(a0)
 ;   sw zero,0(a0)
 ;   ld a4,[const(145)]
 ;   sd a4,0(a0)
@@ -4326,90 +4088,60 @@ block2:
 ;   sd zero,0(a0)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
 ;   ld a4,[const(143)]
 ;   sd a4,0(a0)
 ;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   ld a4,[const(142)]
 ;   sd a4,0(a0)
 ;   sd zero,0(a0)
 ;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   ld a4,[const(141)]
 ;   sd a4,0(a0)
 ;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
 ;   sw zero,0(a0)
 ;   ld a4,[const(140)]
 ;   sd a4,0(a0)
 ;   ld a4,[const(139)]
 ;   sd a4,0(a0)
 ;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   ld a4,[const(138)]
 ;   sd a4,0(a0)
 ;   ld a4,[const(137)]
 ;   sd a4,0(a0)
-;   sw zero,0(a0)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
 ;   ld a4,[const(136)]
 ;   sd a4,0(a0)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
 ;   sw zero,0(a0)
 ;   ld a4,[const(135)]
 ;   sd a4,0(a0)
 ;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   sw zero,0(a0)
 ;   ld a4,[const(134)]
 ;   sd a4,0(a0)
 ;   ld a4,[const(133)]
 ;   sd a4,0(a0)
 ;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   ld a5,[const(132)]
-;   sd a5,0(a0)
+;   ld a4,[const(132)]
+;   sd a4,0(a0)
 ;   sd zero,0(a0)
 ;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   sw zero,0(a0)
 ;   ld a4,[const(131)]
 ;   sd a4,0(a0)
 ;   ld a4,[const(130)]
 ;   sd a4,0(a0)
 ;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(129)]
-;   sd a4,0(a0)
+;   ld a5,[const(129)]
+;   sd a5,0(a0)
 ;   ld a4,[const(128)]
 ;   sd a4,0(a0)
-;   sw zero,0(a0)
 ;   sw zero,0(a0)
 ;   ld a4,[const(127)]
 ;   sd a4,0(a0)
@@ -4417,15 +4149,8 @@ block2:
 ;   sd a4,0(a0)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
 ;   ld a4,[const(125)]
 ;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   sw zero,0(a0)
 ;   ld a4,[const(124)]
 ;   sd a4,0(a0)
@@ -4436,18 +4161,11 @@ block2:
 ;   ld a4,[const(121)]
 ;   sd a4,0(a0)
 ;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
 ;   ld a4,[const(120)]
 ;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   sw zero,0(a0)
 ;   ld a4,[const(119)]
 ;   sd a4,0(a0)
@@ -4459,10 +4177,8 @@ block2:
 ;   ld a4,[const(116)]
 ;   sd a4,0(a0)
 ;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   sd zero,0(a0)
 ;   sw zero,0(a0)
-;   sd zero,0(a0)
 ;   sd zero,0(a0)
 ;   sw zero,0(a0)
 ;   ld a4,[const(115)]
@@ -4473,96 +4189,59 @@ block2:
 ;   ld a4,[const(114)]
 ;   sd a4,0(a0)
 ;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   sd zero,0(a0)
 ;   ld a4,[const(113)]
 ;   sd a4,0(a0)
-;   sw zero,0(a0)
 ;   sw zero,0(a0)
 ;   ld a4,[const(112)]
 ;   sd a4,0(a0)
 ;   ld a4,[const(111)]
 ;   sd a4,0(a0)
 ;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   sw zero,0(a0)
 ;   ld a4,[const(110)]
 ;   sd a4,0(a0)
 ;   ld a4,[const(109)]
 ;   sd a4,0(a0)
 ;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   ld a4,[const(108)]
 ;   sd a4,0(a0)
 ;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   sw zero,0(a0)
 ;   ld a4,[const(107)]
 ;   sd a4,0(a0)
 ;   sw zero,0(a0)
 ;   ld a4,[const(106)]
-;   sd a2,0(a4)
+;   sd a1,0(a4)
 ;   sd zero,0(a0)
 ;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   sw zero,0(a0)
 ;   ld a4,[const(105)]
 ;   sd zero,0(a4)
 ;   sd zero,0(a0)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
 ;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
 ;   sd zero,0(a0)
 ;   ld a4,[const(104)]
 ;   sd a4,0(a0)
 ;   sd zero,0(a0)
-;   sd zero,0(a0)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
 ;   ld a4,[const(103)]
 ;   sd a4,0(a0)
 ;   sd zero,0(a0)
-;   sw zero,0(a0)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
 ;   ld a4,[const(102)]
@@ -4570,21 +4249,14 @@ block2:
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
 ;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   ld a4,[const(101)]
 ;   sd a4,0(a0)
 ;   ld a4,[const(100)]
 ;   sd a4,0(a0)
 ;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   sw zero,0(a0)
 ;   ld a4,[const(99)]
-;   sd a2,0(a4)
+;   sd a1,0(a4)
 ;   ld a4,[const(98)]
 ;   sd a4,0(a0)
 ;   sw zero,0(a0)
@@ -4600,37 +4272,20 @@ block2:
 ;   sd zero,0(a0)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
 ;   ld a4,[const(94)]
 ;   sd a4,0(a0)
 ;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
 ;   sd zero,0(a0)
 ;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   ld a5,[const(93)]
-;   sd a2,0(a5)
+;   ld a4,[const(93)]
+;   sd a1,0(a4)
 ;   ld a4,[const(92)]
 ;   sd a4,0(a0)
 ;   sd zero,0(a0)
-;   sd zero,0(a0)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   sw zero,0(a0)
 ;   ld a4,[const(91)]
 ;   sd a4,0(a0)
@@ -4638,34 +4293,24 @@ block2:
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
 ;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   lui a4,309522
 ;   addi a4,a4,-111
 ;   ld a5,[const(90)]
 ;   sw a4,0(a5)
-;   sw zero,0(a0)
 ;   sw zero,0(a0)
 ;   ld a4,[const(89)]
 ;   sd a4,0(a0)
 ;   ld a4,[const(88)]
 ;   sd a4,0(a0)
 ;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   ld a4,[const(87)]
 ;   sd a4,0(a0)
 ;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
 ;   sd zero,0(a0)
 ;   sw zero,0(a0)
 ;   ld a4,[const(86)]
 ;   sd a4,0(a0)
 ;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
 ;   sw zero,0(a0)
 ;   ld a4,[const(85)]
 ;   sd a4,0(a0)
@@ -4673,49 +4318,28 @@ block2:
 ;   sd a4,0(a0)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
-;   sd zero,0(a0)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
 ;   sw zero,0(a0)
 ;   ld a4,[const(83)]
 ;   sd a4,0(a0)
 ;   sd zero,0(a0)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
+;   sw zero,0(a0)
+;   sd zero,0(a0)
+;   sw zero,0(a0)
 ;   sd zero,0(a0)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
 ;   ld a4,[const(82)]
 ;   sd a4,0(a0)
 ;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   sw zero,0(a0)
 ;   ld a4,[const(81)]
 ;   sd a4,0(a0)
@@ -4725,13 +4349,9 @@ block2:
 ;   ld a4,[const(79)]
 ;   sd a4,0(a0)
 ;   sd zero,0(a0)
-;   sd zero,0(a0)
 ;   ld a4,[const(78)]
 ;   sd a4,0(a0)
 ;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   sw zero,0(a0)
 ;   ld a4,[const(77)]
 ;   sd a4,0(a0)
@@ -4739,14 +4359,10 @@ block2:
 ;   ld a4,[const(76)]
 ;   sd a4,0(a0)
 ;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   sd zero,0(a0)
 ;   ld a4,[const(75)]
 ;   sd a4,0(a0)
 ;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   sw zero,0(a0)
 ;   ld a4,[const(74)]
 ;   sd a4,0(a0)
@@ -4757,27 +4373,19 @@ block2:
 ;   ld a4,[const(72)]
 ;   sd a4,0(a0)
 ;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   ld a4,[const(71)]
 ;   sd a4,0(a0)
 ;   sw zero,0(a0)
 ;   ld a4,[const(70)]
 ;   sd a4,0(a0)
 ;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
 ;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
 ;   sd zero,0(a0)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
+;   sw zero,0(a0)
 ;   sd zero,0(a0)
 ;   sw zero,0(a0)
 ;   ld a4,[const(69)]
@@ -4788,9 +4396,6 @@ block2:
 ;   ld a4,[const(67)]
 ;   lw a4,0(a4)
 ;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   sw zero,0(a0)
 ;   ld a4,[const(66)]
 ;   sd a4,0(a0)
@@ -4799,21 +4404,15 @@ block2:
 ;   ld a4,[const(65)]
 ;   sd a4,0(a0)
 ;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   sd zero,0(a0)
 ;   ld a4,[const(64)]
 ;   sd a4,0(a0)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
 ;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   ld a4,[const(63)]
 ;   sd a4,0(a0)
 ;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
 ;   sw zero,0(a0)
 ;   ld a4,[const(62)]
 ;   sd a4,0(a0)
@@ -4823,43 +4422,30 @@ block2:
 ;   ld a4,[const(60)]
 ;   sd a4,0(a0)
 ;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   ld a4,[const(59)]
 ;   sd a4,0(a0)
 ;   sd zero,0(a0)
 ;   ld a4,[const(58)]
 ;   sw zero,0(a4)
 ;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   sd zero,0(a0)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   sw zero,0(a0)
 ;   ld a4,[const(57)]
 ;   sd a4,0(a0)
 ;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   ld a4,[const(56)]
 ;   sd a4,0(a0)
 ;   ld a4,[const(55)]
-;   sw a1,0(a4)
-;   sw zero,0(a0)
+;   sw a2,0(a4)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
 ;   ld a4,[const(54)]
 ;   sd a4,0(a0)
 ;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   sd zero,0(a0)
 ;   sw zero,0(a0)
-;   sd zero,0(a0)
 ;   sd zero,0(a0)
 ;   ld a4,[const(53)]
 ;   sd a4,0(a0)
@@ -4867,95 +4453,61 @@ block2:
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
 ;   ld a4,[const(52)]
-;   sd a2,0(a4)
-;   sw zero,0(a0)
+;   sd a1,0(a4)
 ;   sw zero,0(a0)
 ;   ld a4,[const(51)]
 ;   sd a4,0(a0)
 ;   ld a4,[const(50)]
 ;   sd a4,0(a0)
 ;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   ld a4,[const(49)]
 ;   sd a4,0(a0)
 ;   sd zero,0(a0)
 ;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
 ;   sd zero,0(a0)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
+;   sw zero,0(a0)
 ;   sd zero,0(a0)
 ;   sb a3,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   sw zero,0(a0)
 ;   ld a4,[const(48)]
 ;   sd a4,0(a0)
 ;   sd zero,0(a0)
 ;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(47)]
-;   sd a4,0(a0)
+;   ld a5,[const(47)]
+;   sd a5,0(a0)
 ;   ld a4,[const(46)]
 ;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   sw zero,0(a0)
 ;   ld a4,[const(45)]
 ;   sd a4,0(a0)
 ;   ld a4,[const(44)]
 ;   sd a4,0(a0)
 ;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   sd zero,0(a0)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   sw zero,0(a0)
 ;   ld a4,[const(43)]
 ;   sd a4,0(a0)
 ;   ld a4,[const(42)]
-;   sd a2,0(a4)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
+;   sd a1,0(a4)
 ;   sw zero,0(a0)
 ;   ld a4,[const(41)]
 ;   sd a4,0(a0)
 ;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   ld a4,[const(40)]
 ;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
 ;   ld a4,[const(39)]
 ;   sd a4,0(a0)
 ;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
 ;   sb a3,0(a0)
 ;   sd zero,0(a0)
-;   sw zero,0(a0)
 ;   sw zero,0(a0)
 ;   ld a4,[const(38)]
 ;   sd a4,0(a0)
@@ -4964,149 +4516,84 @@ block2:
 ;   sd a4,0(a0)
 ;   sd zero,0(a0)
 ;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   ld a4,[const(36)]
 ;   sd a4,0(a0)
 ;   ld a4,[const(35)]
-;   sd a2,0(a4)
+;   sd a1,0(a4)
 ;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
 ;   sd zero,0(a0)
 ;   lw a4,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
 ;   ld a4,[const(34)]
 ;   sd a4,0(a0)
 ;   sd zero,0(a0)
 ;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   ld a4,[const(33)]
 ;   sd a4,0(a0)
 ;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   sw zero,0(a0)
 ;   ld a4,[const(32)]
 ;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
 ;   ld a4,[const(31)]
 ;   sd a4,0(a0)
 ;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
 ;   sd zero,0(a0)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
 ;   sw zero,0(a0)
-;   sd zero,0(a0)
 ;   sd zero,0(a0)
 ;   ld a4,[const(30)]
-;   sd a2,0(a4)
+;   sd a1,0(a4)
 ;   ld a4,[const(29)]
 ;   sd zero,0(a4)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
 ;   sb a3,0(a0)
 ;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
 ;   sw zero,0(a0)
 ;   ld a4,[const(28)]
 ;   sd a4,0(a0)
 ;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
 ;   sw zero,0(a0)
 ;   ld a4,[const(27)]
 ;   sd a4,0(a0)
 ;   sd zero,0(a0)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
 ;   sb a3,0(a0)
 ;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
 ;   sd zero,0(a0)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
+;   sw zero,0(a0)
 ;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
+;   sw zero,0(a0)
 ;   sd zero,0(a0)
 ;   sb a3,0(a0)
-;   sw zero,0(a0)
 ;   sw zero,0(a0)
 ;   ld a4,[const(26)]
 ;   sd a4,0(a0)
 ;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   sd zero,0(a0)
 ;   ld a4,[const(25)]
 ;   sd a4,0(a0)
-;   sd zero,0(a0)
 ;   sd zero,0(a0)
 ;   sw zero,0(a0)
 ;   ld a4,[const(24)]
 ;   sd a4,0(a0)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
-;   sd zero,0(a0)
 ;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
 ;   sd zero,0(a0)
 ;   sb a3,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
 ;   ld a4,[const(23)]
@@ -5118,17 +4605,8 @@ block2:
 ;   ld a4,[const(21)]
 ;   sd a4,0(a0)
 ;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   sw zero,0(a0)
 ;   ld a4,[const(20)]
 ;   sd a4,0(a0)
@@ -5145,7 +4623,6 @@ block2:
 ;   sd zero,0(a4)
 ;   sb a3,0(a0)
 ;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   ld a4,[const(16)]
 ;   sd a4,0(a0)
 ;   sw zero,0(a0)
@@ -5155,20 +4632,16 @@ block2:
 ;   sd a4,0(a0)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
-;   sd zero,0(a0)
 ;   ld a4,[const(13)]
 ;   sd a4,0(a0)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sb a1,0(a0)
+;   sb a2,0(a0)
 ;   sw zero,0(a0)
 ;   ld a4,[const(12)]
 ;   sd a4,0(a0)
 ;   ld a4,[const(11)]
 ;   sd a4,0(a0)
-;   sw zero,0(a0)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
 ;   ld a4,[const(10)]
@@ -5178,73 +4651,56 @@ block2:
 ;   sd a4,0(a0)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
-;   sd zero,0(a0)
 ;   sb a3,0(a0)
 ;   sw zero,0(a0)
-;   sw zero,0(a0)
 ;   ld a3,[const(8)]
-;   sd a2,0(a3)
-;   ld a2,[const(7)]
-;   sd a2,0(a0)
+;   sd a1,0(a3)
+;   ld a1,[const(7)]
+;   sd a1,0(a0)
 ;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   ld a2,[const(6)]
-;   sd a2,0(a0)
-;   ld a2,[const(5)]
+;   ld a1,[const(6)]
+;   sd a1,0(a0)
+;   ld a1,[const(5)]
 ;   lui a3,4
 ;   addi a3,a3,-1824
-;   sd a2,0(a3)
+;   sd a1,0(a3)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
-;   ld a2,[const(4)]
+;   ld a1,[const(4)]
 ;   lui a3,4
 ;   addi a3,a3,-1700
-;   sd a2,0(a3)
+;   sd a1,0(a3)
 ;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sw zero,0(a0)
-;   ld a3,[const(3)]
-;   lui a2,4
-;   addi a4,a2,-1520
-;   sd a3,0(a4)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
 ;   sw zero,0(a0)
+;   ld a1,[const(3)]
+;   lui a3,4
+;   addi a3,a3,-1520
+;   sd a1,0(a3)
 ;   sw zero,0(a0)
-;   ld a2,[const(2)]
+;   sd zero,0(a0)
+;   sw zero,0(a0)
+;   ld a1,[const(2)]
 ;   lui a3,4
 ;   addi a3,a3,-1592
-;   sd a2,0(a3)
-;   ld a2,[const(1)]
+;   sd a1,0(a3)
+;   ld a1,[const(1)]
 ;   lui a3,4
 ;   addi a3,a3,-1600
-;   sd a2,0(a3)
-;   sw zero,0(a0)
+;   sd a1,0(a3)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   ld a2,[const(0)]
+;   ld a1,[const(0)]
 ;   lui a3,4
 ;   addi a3,a3,-1436
-;   sd a2,0(a3)
+;   sd a1,0(a3)
 ;   sw zero,0(a0)
 ;   sd zero,0(a0)
-;   sd zero,0(a0)
-;   sd zero,0(a0)
 ;   sw zero,0(a0)
-;   sext.w a0,a1
+;   sext.w a0,a2
 ;   bne a0,zero,taken(label42),not_taken(label41)
 ; block41:
 ;   lui a0,1
@@ -5278,10 +4734,6 @@ block2:
 ;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
 ;   c.li a2, 4
 ;   c.sd a2, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
@@ -5291,40 +4743,21 @@ block2:
 ;   c.li a1, 1
 ;   c.sd a1, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   c.sd a1, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   c.sd a2, 0(a0) ; trap: heap_oob
 ;   c.sd a1, 0(a0) ; trap: heap_oob
 ;   c.li a4, 1
 ;   c.sw a4, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
@@ -5332,27 +4765,15 @@ block2:
 ;   c.sd a2, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
 ;   c.sd a1, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   c.li a3, 9
 ;   c.sd a3, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   c.sd a3, 0(a0) ; trap: heap_oob
 ;   c.li a3, 0xd
@@ -5362,41 +4783,25 @@ block2:
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
 ;   c.sd a2, 0(a0) ; trap: heap_oob
 ;   c.sd a1, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
 ;   c.sd a1, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   c.sw a4, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   c.sw a4, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
 ;   c.sd a1, 0(a0) ; trap: heap_oob
 ;   c.sd a2, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
 ;   c.li a3, 8
 ;   c.sd a3, 0(a0) ; trap: heap_oob
@@ -5408,22 +4813,13 @@ block2:
 ;   c.sd a1, 0(a0) ; trap: heap_oob
 ;   c.sw a4, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
 ;   c.sw a4, 0(a0) ; trap: heap_oob
 ;   c.sd a1, 0(a0) ; trap: heap_oob
-;   c.sd a1, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   c.sw a4, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
@@ -5432,7 +4828,6 @@ block2:
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   c.sd a1, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
-;   c.sw a4, 0(a0) ; trap: heap_oob
 ;   c.sw a4, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
 ;   c.sw a4, 0(a0) ; trap: heap_oob
@@ -5446,11 +4841,9 @@ block2:
 ;   sd zero, 0(a0) ; trap: heap_oob
 ;   c.sd a3, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
-;   c.sd a1, 0(a0) ; trap: heap_oob
 ;   c.sd a1, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   c.sd a1, 0(a0) ; trap: heap_oob
@@ -5476,104 +4869,52 @@ block2:
 ;   c.sd a1, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
 ;   c.li a5, 8
 ;   c.sw a5, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   c.sd a3, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
 ;   c.sw a4, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
 ;   c.sw a4, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
-;   c.sd a1, 0(a0) ; trap: heap_oob
 ;   c.sd a1, 0(a0) ; trap: heap_oob
 ;   c.sw a4, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   c.sd a1, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
 ;   c.sw a5, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
@@ -5587,51 +4928,27 @@ block2:
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   c.sd a1, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   c.sd a1, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
@@ -5639,1111 +4956,554 @@ block2:
 ;   c.sd a1, 0(a0) ; trap: heap_oob
 ;   c.sd a3, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   c.sd a2, 0(a0) ; trap: heap_oob
-;   c.sd a2, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
 ;   c.sd a1, 0(a0) ; trap: heap_oob
-; block2: ; offset 0x576
+; block2: ; offset 0x338
 ;   lui a0, 0x6a64d
 ;   c.addi a0, 3
 ;   beqz a0, 6
 ;   c.unimp ; trap: user11
-; block3: ; offset 0x582
+; block3: ; offset 0x344
 ;   lui a0, 0x259ad
 ;   addi a0, a0, -0x626
 ;   beqz a0, 6
 ;   c.unimp ; trap: user11
-; block4: ; offset 0x590
+; block4: ; offset 0x352
 ;   c.li a0, 1
 ;   beqz a0, 6
 ;   c.unimp ; trap: user11
-; block5: ; offset 0x598
+; block5: ; offset 0x35a
 ;   lui a0, 0x7c7d9
-;   addi a1, a0, -0xc1
-;   beqz a1, 6
+;   addi a0, a0, -0xc1
+;   beqz a0, 6
 ;   c.unimp ; trap: user11
-; block6: ; offset 0x5a6
-;   lui a3, 0x5b1f2
-;   addi a5, a3, 0x6e3
-;   beqz a5, 6
+; block6: ; offset 0x368
+;   lui a0, 0x5b1f2
+;   addi a0, a0, 0x6e3
+;   beqz a0, 6
 ;   c.unimp ; trap: user11
-; block7: ; offset 0x5b4
+; block7: ; offset 0x376
 ;   lui a0, 0x6f8d1
 ;   addi a0, a0, -0x144
 ;   beqz a0, 6
 ;   c.unimp ; trap: user11
-; block8: ; offset 0x5c2
+; block8: ; offset 0x384
 ;   lui a0, 0x484e2
 ;   addi a0, a0, -0x478
 ;   beqz a0, 6
 ;   c.unimp ; trap: user11
-; block9: ; offset 0x5d0
+; block9: ; offset 0x392
 ;   lui a0, 0x110e5
 ;   addi a0, a0, -0x662
 ;   beqz a0, 6
 ;   c.unimp ; trap: user11
-; block10: ; offset 0x5de
-;   lui a0, 0x71fd2
-;   addi a0, a0, 0x446
-;   beqz a0, 6
+; block10: ; offset 0x3a0
+;   lui a2, 0x71fd2
+;   addi a4, a2, 0x446
+;   beqz a4, 6
 ;   c.unimp ; trap: user11
-; block11: ; offset 0x5ec
+; block11: ; offset 0x3ae
 ;   lui a0, 0x8237d
 ;   addi a0, a0, 0x5b7
 ;   beqz a0, 6
 ;   c.unimp ; trap: user11
-; block12: ; offset 0x5fa
-;   c.j 2
+; block12: ; offset 0x3bc
+;   c.j 4
+;   c.unimp
 ;   auipc t6, 0
 ;   jalr zero, t6, 8
-; block13: ; offset 0x604
+; block13: ; offset 0x3c8
 ;   auipc a1, 1
-;   ld a1, 0x704(a1)
+;   ld a1, 0xd0(a1)
 ;   c.li a0, 0
 ;   c.sd a1, 0(a0) ; trap: heap_oob
 ;   auipc a1, 1
-;   ld a1, 0x700(a1)
+;   ld a1, 0xcc(a1)
 ;   c.sd a1, 0(a0) ; trap: heap_oob
 ;   auipc a1, 1
-;   ld a1, 0x6fe(a1)
+;   ld a1, 0xca(a1)
 ;   c.sd a1, 0(a0) ; trap: heap_oob
 ;   auipc a1, 1
-;   ld a1, 0x6fc(a1)
+;   ld a1, 0xc8(a1)
 ;   c.sd a1, 0(a0) ; trap: heap_oob
 ;   auipc a1, 1
-;   ld a1, 0x6fa(a1)
+;   ld a1, 0xc6(a1)
 ;   c.sd a1, 0(a0) ; trap: heap_oob
 ;   auipc a1, 1
-;   ld a1, 0x6f8(a1)
+;   ld a1, 0xc4(a1)
 ;   c.sd a1, 0(a0) ; trap: heap_oob
 ;   auipc a1, 1
-;   ld a1, 0x6f6(a1)
+;   ld a1, 0xc2(a1)
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   auipc a1, 1
-;   ld a1, 0x6f2(a1)
+;   ld a1, 0xbe(a1)
 ;   c.sd a1, 0(a0) ; trap: heap_oob
 ;   auipc a1, 1
-;   ld a1, 0x6f0(a1)
+;   ld a1, 0xbc(a1)
 ;   c.sd a1, 0(a0) ; trap: heap_oob
 ;   auipc a1, 1
-;   ld a1, 0x6ee(a1)
+;   ld a1, 0xba(a1)
 ;   c.sd a1, 0(a0) ; trap: heap_oob
 ;   auipc a1, 1
-;   ld a1, 0x6ec(a1)
+;   ld a1, 0xb8(a1)
 ;   c.sd a1, 0(a0) ; trap: heap_oob
 ;   auipc a1, 1
-;   ld a1, 0x6ea(a1)
-;   c.sd a1, 0(a0) ; trap: heap_oob
-;   c.li a2, 1
-;   auipc a1, 1
-;   ld a1, 0x6e6(a1)
-;   c.sd a2, 0(a1) ; trap: heap_oob
-;   auipc a1, 1
-;   ld a1, 0x6e4(a1)
-;   c.sd a1, 0(a0) ; trap: heap_oob
-;   auipc a1, 1
-;   ld a1, 0x6e2(a1)
-;   c.sd a1, 0(a0) ; trap: heap_oob
-;   auipc a1, 1
-;   ld a1, 0x6e0(a1)
-;   c.sd a1, 0(a0) ; trap: heap_oob
-;   auipc a1, 1
-;   ld a1, 0x6de(a1)
-;   c.sd a1, 0(a0) ; trap: heap_oob
-;   auipc a1, 1
-;   ld a1, 0x6dc(a1)
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a1, 1
-;   ld a1, 0x6d8(a1)
-;   c.sd a1, 0(a0) ; trap: heap_oob
-;   auipc a1, 1
-;   ld a1, 0x6d6(a1)
-;   c.sd a1, 0(a0) ; trap: heap_oob
-;   auipc a1, 1
-;   ld a1, 0x6d4(a1)
-;   c.sd a1, 0(a0) ; trap: heap_oob
-;   auipc a1, 1
-;   ld a1, 0x6d2(a1)
-;   c.sd a1, 0(a0) ; trap: heap_oob
-;   auipc a1, 1
-;   ld a1, 0x6d0(a1)
-;   c.sd a1, 0(a0) ; trap: heap_oob
-;   auipc a1, 1
-;   ld a1, 0x6ce(a1)
-;   c.sd a1, 0(a0) ; trap: heap_oob
-;   auipc a1, 1
-;   ld a1, 0x6cc(a1)
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a1, 1
-;   ld a1, 0x6c8(a1)
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a1, 1
-;   ld a1, 0x6c4(a1)
-;   c.sd a1, 0(a0) ; trap: heap_oob
-;   auipc a1, 1
-;   ld a1, 0x6c2(a1)
-;   c.sd a2, 0(a1) ; trap: heap_oob
-;   auipc a1, 1
-;   ld a1, 0x6c0(a1)
-;   c.sd a1, 0(a0) ; trap: heap_oob
-;   auipc a1, 1
-;   ld a1, 0x6be(a1)
-;   c.sd a1, 0(a0) ; trap: heap_oob
-;   auipc a1, 1
-;   ld a1, 0x6bc(a1)
-;   c.sd a1, 0(a0) ; trap: heap_oob
-;   auipc a1, 1
-;   ld a1, 0x6ba(a1)
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a1, 1
-;   ld a1, 0x6b6(a1)
-;   c.sd a1, 0(a0) ; trap: heap_oob
-;   auipc a1, 1
-;   ld a1, 0x6b4(a1)
-;   c.sd a1, 0(a0) ; trap: heap_oob
-;   auipc a1, 1
-;   ld a1, 0x6b2(a1)
-;   c.sd a1, 0(a0) ; trap: heap_oob
-;   auipc a3, 1
-;   ld a3, 0x6b0(a3)
-;   c.sd a3, 0(a0) ; trap: heap_oob
-;   auipc a3, 1
-;   ld a3, 0x6ae(a3)
-;   c.sd a3, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x6ac(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, 0x6aa(a5)
-;   c.sd a5, 0(a0) ; trap: heap_oob
-;   auipc a1, 1
-;   ld a1, 0x6a8(a1)
-;   c.sd a1, 0(a0) ; trap: heap_oob
-;   auipc a1, 1
-;   ld a1, 0x6a6(a1)
+;   ld a1, 0xb6(a1)
 ;   c.sd a1, 0(a0) ; trap: heap_oob
 ;   c.li a1, 1
+;   auipc a2, 1
+;   ld a2, 0xb2(a2)
+;   c.sd a1, 0(a2) ; trap: heap_oob
+;   auipc a2, 1
+;   ld a2, 0xb0(a2)
+;   c.sd a2, 0(a0) ; trap: heap_oob
+;   auipc a2, 1
+;   ld a2, 0xae(a2)
+;   c.sd a2, 0(a0) ; trap: heap_oob
+;   auipc a2, 1
+;   ld a2, 0xac(a2)
+;   c.sd a2, 0(a0) ; trap: heap_oob
+;   auipc a2, 1
+;   ld a2, 0xaa(a2)
+;   c.sd a2, 0(a0) ; trap: heap_oob
+;   auipc a2, 1
+;   ld a2, 0xa8(a2)
+;   sd zero, 0(a2) ; trap: heap_oob
+;   auipc a2, 1
+;   ld a2, 0xa4(a2)
+;   c.sd a2, 0(a0) ; trap: heap_oob
+;   auipc a2, 1
+;   ld a2, 0xa2(a2)
+;   c.sd a2, 0(a0) ; trap: heap_oob
+;   auipc a2, 1
+;   ld a2, 0xa0(a2)
+;   c.sd a2, 0(a0) ; trap: heap_oob
+;   auipc a2, 1
+;   ld a2, 0x9e(a2)
+;   c.sd a2, 0(a0) ; trap: heap_oob
+;   auipc a2, 1
+;   ld a2, 0x9c(a2)
+;   c.sd a2, 0(a0) ; trap: heap_oob
+;   auipc a2, 1
+;   ld a2, 0x9a(a2)
+;   c.sd a2, 0(a0) ; trap: heap_oob
+;   auipc a2, 1
+;   ld a2, 0x98(a2)
+;   sd zero, 0(a2) ; trap: heap_oob
+;   auipc a2, 1
+;   ld a2, 0x94(a2)
+;   sd zero, 0(a2) ; trap: heap_oob
+;   auipc a2, 1
+;   ld a2, 0x90(a2)
+;   c.sd a2, 0(a0) ; trap: heap_oob
+;   auipc a2, 1
+;   ld a2, 0x8e(a2)
+;   c.sd a1, 0(a2) ; trap: heap_oob
+;   auipc a2, 1
+;   ld a2, 0x8c(a2)
+;   c.sd a2, 0(a0) ; trap: heap_oob
+;   auipc a2, 1
+;   ld a2, 0x8a(a2)
+;   c.sd a2, 0(a0) ; trap: heap_oob
+;   auipc a2, 1
+;   ld a2, 0x88(a2)
+;   c.sd a2, 0(a0) ; trap: heap_oob
+;   auipc a2, 1
+;   ld a2, 0x86(a2)
+;   sd zero, 0(a2) ; trap: heap_oob
+;   auipc a2, 1
+;   ld a2, 0x82(a2)
+;   c.sd a2, 0(a0) ; trap: heap_oob
+;   auipc a2, 1
+;   ld a2, 0x80(a2)
+;   c.sd a2, 0(a0) ; trap: heap_oob
+;   auipc a2, 1
+;   ld a2, 0x7e(a2)
+;   c.sd a2, 0(a0) ; trap: heap_oob
+;   auipc a2, 1
+;   ld a2, 0x7c(a2)
+;   c.sd a2, 0(a0) ; trap: heap_oob
+;   auipc a2, 1
+;   ld a2, 0x7a(a2)
+;   c.sd a2, 0(a0) ; trap: heap_oob
+;   auipc a2, 1
+;   ld a2, 0x78(a2)
+;   c.sd a2, 0(a0) ; trap: heap_oob
+;   auipc a2, 1
+;   ld a2, 0x76(a2)
+;   c.sd a2, 0(a0) ; trap: heap_oob
+;   auipc a2, 1
+;   ld a2, 0x74(a2)
+;   c.sd a2, 0(a0) ; trap: heap_oob
+;   auipc a2, 1
+;   ld a2, 0x72(a2)
+;   c.sd a2, 0(a0) ; trap: heap_oob
+;   c.li a2, 1
 ;   auipc a3, 1
-;   ld a3, 0x6a2(a3)
-;   c.sw a1, 0(a3) ; trap: heap_oob
+;   ld a3, 0x6e(a3)
+;   c.sw a2, 0(a3) ; trap: heap_oob
 ;   auipc a3, 1
-;   ld a3, 0x6a0(a3)
+;   ld a3, 0x6c(a3)
 ;   c.sd a3, 0(a0) ; trap: heap_oob
 ;   auipc a3, 1
-;   ld a3, 0x69e(a3)
+;   ld a3, 0x6a(a3)
 ;   c.sd a3, 0(a0) ; trap: heap_oob
 ;   auipc a3, 1
-;   ld a3, 0x69c(a3)
+;   ld a3, 0x68(a3)
 ;   sd zero, 0(a3) ; trap: heap_oob
 ;   auipc a3, 1
-;   ld a3, 0x698(a3)
+;   ld a3, 0x64(a3)
 ;   c.sd a3, 0(a0) ; trap: heap_oob
 ;   auipc a3, 1
-;   ld a3, 0x696(a3)
+;   ld a3, 0x62(a3)
 ;   c.sd a3, 0(a0) ; trap: heap_oob
 ;   auipc a3, 1
-;   ld a3, 0x694(a3)
+;   ld a3, 0x60(a3)
 ;   c.sd a3, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
 ;   c.li a3, 0
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
 ;   auipc a4, 1
-;   ld a4, 0x680(a4)
+;   ld a4, 0x50(a4)
 ;   c.sd a4, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
 ;   auipc a4, 1
-;   ld a4, 0x676(a4)
+;   ld a4, 0x4a(a4)
 ;   c.sd a4, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
 ;   auipc a4, 1
-;   ld a4, 0x66c(a4)
+;   ld a4, 0x44(a4)
 ;   c.sd a4, 0(a0) ; trap: heap_oob
 ;   auipc a4, 1
-;   ld a4, 0x66a(a4)
+;   ld a4, 0x42(a4)
 ;   c.sd a4, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
 ;   auipc a4, 1
-;   ld a4, 0x650(a4)
+;   ld a4, 0x34(a4)
 ;   auipc a5, 1
-;   ld a5, 0x650(a5)
+;   ld a5, 0x34(a5)
 ;   c.sd a4, 0(a5) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   auipc a4, 1
-;   ld a4, 0x62a(a4)
+;   ld a4, 0x16(a4)
 ;   c.sd a4, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   auipc a4, 1
-;   ld a4, 0x60c(a4)
+;   ld a4, 0(a4)
 ;   sd zero, 0(a4) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x5fc(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x5ee(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x5c8(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x5c6(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x5c0(a4)
-;   sd zero, 0(a4) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x5bc(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x5b6(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x58c(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x57e(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x57c(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x576(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x574(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x556(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x550(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x546(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x544(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x542(a4)
-;   c.ld a4, 0(a4) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x520(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x51e(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x514(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x512(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x508(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x4f6(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x4d8(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x4d2(a4)
-;   sd zero, 0(a4) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x49e(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x494(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x47a(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x46c(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x462(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x45c(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x446(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x434(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x42a(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x41c(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x41a(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x414(a4)
-;   c.ld a4, 0(a4) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x3fe(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x3fc(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x3f2(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x3dc(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x3ca(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x3a8(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x39a(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x388(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x372(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x368(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x366(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x35c(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x35a(a4)
-;   sd zero, 0(a4) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x34a(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x31c(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x312(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x310(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x2e2(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x2d8(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x2c6(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x2a0(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x29e(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x294(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x292(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x284(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x26a(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x258(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x256(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, 0x24c(a5)
-;   c.sd a5, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x222(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x220(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x216(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x214(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x20a(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x208(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x1ea(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x1dc(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x1da(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x1d8(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x1d6(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x1b0(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x1a2(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x1a0(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x19a(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x198(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x17a(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x16c(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x15a(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x150(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x14e(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x12c(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x12a(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x11c(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0xde(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0xd8(a4)
-;   c.sd a2, 0(a4) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0xb6(a4)
-;   sd zero, 0(a4) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x76(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x48(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x36(a4)
-;   sd zero, 0(a4) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x22(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x20(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -2(a4)
-;   c.sd a2, 0(a4) ; trap: heap_oob
 ;   auipc a4, 1
-;   ld a4, -4(a4)
+;   ld a4, -8(a4)
 ;   c.sd a4, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
 ;   auipc a4, 1
 ;   ld a4, -0xe(a4)
 ;   c.sd a4, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   auipc a4, 1
-;   ld a4, -0x14(a4)
+;   ld a4, -0x20(a4)
 ;   c.sd a4, 0(a0) ; trap: heap_oob
 ;   auipc a4, 1
-;   ld a4, -0x16(a4)
+;   ld a4, -0x22(a4)
 ;   c.sd a4, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
 ;   auipc a4, 1
-;   ld a4, -0x3c(a4)
+;   ld a4, -0x28(a4)
+;   sd zero, 0(a4) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x2c(a4)
 ;   c.sd a4, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x32(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x54(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x5e(a5)
-;   c.sd a2, 0(a5) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x5e(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
 ;   auipc a4, 1
 ;   ld a4, -0x60(a4)
 ;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x66(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x68(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x7a(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x80(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x86(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x88(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x8a(a4)
+;   c.ld a4, 0(a4) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x94(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
 ;   auipc a4, 1
 ;   ld a4, -0x96(a4)
 ;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   lui a4, 0x4b912
-;   addi a4, a4, -0x6f
 ;   auipc a5, 1
-;   ld a5, -0xb4(a5)
-;   c.sw a4, 0(a5) ; trap: heap_oob
+;   ld a5, -0x9c(a5)
+;   c.sd a5, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x9e(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0xa4(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0xae(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0xb8(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
 ;   auipc a4, 1
 ;   ld a4, -0xbe(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0xc0(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0xce(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a4) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0xd2(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0xd8(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0xde(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   auipc a4, 1
 ;   ld a4, -0xe8(a4)
 ;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   auipc a4, 1
-;   ld a4, -0xfe(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x100(a4)
+;   ld a4, -0xee(a4)
 ;   c.sd a4, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
 ;   auipc a4, 1
-;   ld a4, -0x122(a4)
+;   ld a4, -0xf4(a4)
 ;   c.sd a4, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x102(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x108(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x10e(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x118(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x11a(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x120(a4)
+;   c.ld a4, 0(a4) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x126(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x128(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x12e(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x13c(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x14a(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x160(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x166(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x174(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x17e(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x184(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x186(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
 ;   auipc a4, 1
 ;   ld a4, -0x18c(a4)
 ;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x18e(a4)
+;   sd zero, 0(a4) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   auipc a4, 1
-;   ld a4, -0x1ae(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x1b0(a4)
+;   ld a4, -0x196(a4)
 ;   c.sd a4, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x1b6(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x1c0(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   auipc a4, 1
-;   ld a4, -0x1d6(a4)
+;   ld a4, -0x1ac(a4)
 ;   c.sd a4, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   auipc a4, 1
-;   ld a4, -0x1dc(a4)
+;   ld a4, -0x1b2(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x1b4(a4)
 ;   c.sd a4, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
 ;   auipc a4, 1
-;   ld a4, -0x1ea(a4)
+;   ld a4, -0x1ce(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x1d4(a4)
 ;   c.sd a4, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x1de(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x1ec(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x1ee(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x1f4(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x1f6(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
 ;   auipc a4, 1
 ;   ld a4, -0x200(a4)
 ;   c.sd a4, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x202(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
 ;   auipc a4, 1
-;   ld a4, -0x20c(a4)
+;   ld a4, -0x20e(a4)
 ;   c.sd a4, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x218(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
 ;   auipc a4, 1
 ;   ld a4, -0x21a(a4)
 ;   c.sd a4, 0(a0) ; trap: heap_oob
@@ -6752,562 +5512,717 @@ block2:
 ;   ld a4, -0x220(a4)
 ;   c.sd a4, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   auipc a4, 1
-;   ld a4, -0x262(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x268(a4)
+;   ld a4, -0x232(a4)
 ;   c.sd a4, 0(a0) ; trap: heap_oob
 ;   auipc a4, 1
-;   ld a4, -0x26a(a4)
-;   c.lw a4, 0(a4) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
+;   ld a4, -0x234(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x23a(a5)
+;   c.sd a5, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x23c(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   auipc a4, 1
-;   ld a4, -0x280(a4)
+;   ld a4, -0x242(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x244(a4)
 ;   c.sd a4, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
 ;   auipc a4, 1
-;   ld a4, -0x28a(a4)
+;   ld a4, -0x24e(a4)
 ;   c.sd a4, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x254(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x256(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x258(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x25a(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
 ;   auipc a4, 1
-;   ld a4, -0x29c(a4)
+;   ld a4, -0x26c(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x272(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x274(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x27a(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x27c(a4)
 ;   c.sd a4, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x292(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x2a0(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x2aa(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x2b0(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
 ;   auipc a4, 1
 ;   ld a4, -0x2b2(a4)
 ;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   auipc a4, 1
-;   ld a4, -0x2c4(a4)
+;   ld a4, -0x2c0(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x2c2(a4)
 ;   c.sd a4, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   auipc a4, 1
-;   ld a4, -0x2ca(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x2cc(a4)
+;   ld a4, -0x2c8(a4)
 ;   c.sd a4, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   auipc a4, 1
-;   ld a4, -0x2da(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x2e0(a4)
-;   sw zero, 0(a4) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x314(a4)
+;   ld a4, -0x2e6(a4)
 ;   c.sd a4, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x2ec(a4)
+;   c.sd a1, 0(a4) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x2fe(a4)
+;   sd zero, 0(a4) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
 ;   auipc a4, 1
 ;   ld a4, -0x31e(a4)
 ;   c.sd a4, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x320(a4)
-;   c.sw a1, 0(a4) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x32e(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
 ;   auipc a4, 1
-;   ld a4, -0x348(a4)
+;   ld a4, -0x334(a4)
 ;   c.sd a4, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
 ;   auipc a4, 1
-;   ld a4, -0x356(a4)
-;   c.sd a2, 0(a4) ; trap: heap_oob
+;   ld a4, -0x342(a4)
+;   sd zero, 0(a4) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x352(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x354(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x35e(a4)
+;   c.sd a1, 0(a4) ; trap: heap_oob
 ;   auipc a4, 1
 ;   ld a4, -0x360(a4)
 ;   c.sd a4, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
 ;   auipc a4, 1
-;   ld a4, -0x362(a4)
+;   ld a4, -0x36a(a4)
 ;   c.sd a4, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x370(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x372(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x38c(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   auipc a4, 1
-;   ld a4, -0x36c(a4)
+;   ld a4, -0x39a(a4)
+;   c.sd a1, 0(a4) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x39c(a4)
 ;   c.sd a4, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sb a3, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   auipc a4, 1
-;   ld a4, -0x3b2(a4)
+;   ld a4, -0x3ae(a4)
 ;   c.sd a4, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x3c4(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x3c6(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
+;   lui a4, 0x4b912
+;   addi a4, a4, -0x6f
+;   auipc a5, 1
+;   ld a5, -0x3c8(a5)
+;   c.sw a4, 0(a5) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   auipc a4, 1
-;   ld a4, -0x3d4(a4)
+;   ld a4, -0x3ce(a4)
 ;   c.sd a4, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x3d0(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
 ;   auipc a4, 1
 ;   ld a4, -0x3d6(a4)
 ;   c.sd a4, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   auipc a4, 1
-;   ld a4, -0x418(a4)
+;   ld a4, -0x3e4(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x3ee(a4)
 ;   c.sd a4, 0(a0) ; trap: heap_oob
 ;   auipc a4, 1
-;   ld a4, -0x41a(a4)
-;   c.sd a2, 0(a4) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x428(a4)
+;   ld a4, -0x3f0(a4)
 ;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x436(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x406(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x43c(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x44a(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
 ;   auipc a4, 1
 ;   ld a4, -0x44c(a4)
 ;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sb a3, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   auipc a4, 1
-;   ld a4, -0x46e(a4)
+;   ld a4, -0x452(a4)
 ;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
 ;   auipc a4, 1
-;   ld a4, -0x474(a4)
+;   ld a4, -0x458(a4)
 ;   c.sd a4, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x462(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   auipc a4, 1
-;   ld a4, -0x486(a4)
+;   ld a4, -0x468(a4)
 ;   c.sd a4, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x472(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x47c(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x47e(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
 ;   auipc a4, 1
 ;   ld a4, -0x488(a4)
-;   c.sd a2, 0(a4) ; trap: heap_oob
+;   c.sd a4, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x48e(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x494(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   c.lw a4, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x4be(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
 ;   auipc a4, 1
 ;   ld a4, -0x4c4(a4)
 ;   c.sd a4, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x4c6(a4)
+;   c.lw a4, 0(a4) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   auipc a4, 1
-;   ld a4, -0x4d6(a4)
+;   ld a4, -0x4d0(a4)
 ;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x50c(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
 ;   auipc a4, 1
-;   ld a4, -0x51e(a4)
+;   ld a4, -0x4da(a4)
 ;   c.sd a4, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x4e4(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x4f2(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x4fc(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x502(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x504(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x50a(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x510(a4)
+;   sw zero, 0(a4) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x528(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x52e(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x530(a4)
+;   c.sw a2, 0(a4) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x53a(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
 ;   auipc a4, 1
 ;   ld a4, -0x54c(a4)
-;   c.sd a2, 0(a4) ; trap: heap_oob
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
 ;   auipc a4, 1
-;   ld a4, -0x54e(a4)
+;   ld a4, -0x55a(a4)
+;   c.sd a1, 0(a4) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x560(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x562(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x568(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
+;   sb a3, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x58e(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x598(a5)
+;   c.sd a5, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x59a(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x5a0(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x5a2(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x5c0(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x5c2(a4)
+;   c.sd a1, 0(a4) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x5c8(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x5ce(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x5d8(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
+;   sb a3, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x5ea(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x5f0(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x5fa(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x5fc(a4)
+;   c.sd a1, 0(a4) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
+;   c.lw a4, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x610(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x61a(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x628(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x632(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x64c(a4)
+;   c.sd a1, 0(a4) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x64e(a4)
 ;   sd zero, 0(a4) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
+;   sb a3, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x66a(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x678(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
 ;   sb a3, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x58a(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x5a4(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
 ;   sb a3, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x6ba(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x6c4(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x6ce(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
 ;   sb a3, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x622(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
 ;   auipc a4, 1
-;   ld a4, -0x630(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x63e(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sb a3, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x674(a4)
+;   ld a4, -0x6ec(a4)
 ;   c.sd a4, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   auipc a4, 1
-;   ld a4, -0x67a(a4)
+;   ld a4, -0x6f2(a4)
 ;   c.sd a4, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   auipc a4, 1
-;   ld a4, -0x680(a4)
+;   ld a4, -0x6f8(a4)
 ;   c.sd a4, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   auipc a4, 1
-;   ld a4, -0x6b6(a4)
+;   ld a4, -0x70a(a4)
 ;   c.sd a4, 0(a0) ; trap: heap_oob
 ;   auipc a4, 1
-;   ld a4, -0x6b8(a4)
+;   ld a4, -0x70c(a4)
 ;   c.sd a4, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
 ;   auipc a4, 1
-;   ld a4, -0x6c2(a4)
+;   ld a4, -0x716(a4)
 ;   c.sd a4, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   auipc a4, 1
-;   ld a4, -0x6d0(a4)
+;   ld a4, -0x724(a4)
 ;   sd zero, 0(a4) ; trap: heap_oob
 ;   sb a3, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
 ;   auipc a4, 1
-;   ld a4, -0x6e0(a4)
+;   ld a4, -0x730(a4)
 ;   c.sd a4, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   auipc a4, 1
-;   ld a4, -0x6e6(a4)
+;   ld a4, -0x736(a4)
 ;   c.sd a4, 0(a0) ; trap: heap_oob
 ;   auipc a4, 1
-;   ld a4, -0x6e8(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x6f6(a4)
+;   ld a4, -0x738(a4)
 ;   c.sd a4, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sb a1, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
 ;   auipc a4, 1
-;   ld a4, -0x710(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x712(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x720(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x726(a4)
+;   ld a4, -0x742(a4)
 ;   c.sd a4, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
+;   sb a2, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x754(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x756(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   sd zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x760(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, -0x766(a4)
+;   c.sd a4, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
 ;   sb a3, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   auipc a3, 1
-;   ld a3, -0x740(a3)
-;   c.sd a2, 0(a3) ; trap: heap_oob
-;   auipc a2, 1
-;   ld a2, -0x742(a2)
-;   c.sd a2, 0(a0) ; trap: heap_oob
+;   ld a3, -0x778(a3)
+;   c.sd a1, 0(a3) ; trap: heap_oob
+;   auipc a1, 1
+;   ld a1, -0x77a(a1)
+;   c.sd a1, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a2, 1
-;   ld a2, -0x750(a2)
-;   c.sd a2, 0(a0) ; trap: heap_oob
-;   auipc a2, 1
-;   ld a2, -0x752(a2)
+;   auipc a1, 1
+;   ld a1, -0x780(a1)
+;   c.sd a1, 0(a0) ; trap: heap_oob
+;   auipc a1, 1
+;   ld a1, -0x782(a1)
 ;   c.lui a3, 4
 ;   addi a3, a3, -0x720
-;   c.sd a2, 0(a3) ; trap: heap_oob
+;   c.sd a1, 0(a3) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
-;   auipc a2, 1
-;   ld a2, -0x772(a2)
+;   auipc a1, 1
+;   ld a1, -0x79a(a1)
 ;   c.lui a3, 4
 ;   addi a3, a3, -0x6a4
-;   c.sd a2, 0(a3) ; trap: heap_oob
+;   c.sd a1, 0(a3) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a3, 1
-;   ld a3, -0x7a2(a3)
-;   c.lui a2, 4
-;   addi a4, a2, -0x5f0
-;   c.sd a3, 0(a4) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
+;   auipc a1, 1
+;   ld a1, -0x7b2(a1)
+;   c.lui a3, 4
+;   addi a3, a3, -0x5f0
+;   c.sd a1, 0(a3) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a2, 1
-;   ld a2, -0x7ba(a2)
+;   sd zero, 0(a0) ; trap: heap_oob
+;   sw zero, 0(a0) ; trap: heap_oob
+;   auipc a1, 1
+;   ld a1, -0x7c6(a1)
 ;   c.lui a3, 4
 ;   addi a3, a3, -0x638
-;   c.sd a2, 0(a3) ; trap: heap_oob
-;   auipc a2, 1
-;   ld a2, -0x7c2(a2)
+;   c.sd a1, 0(a3) ; trap: heap_oob
+;   auipc a1, 1
+;   ld a1, -0x7ce(a1)
 ;   c.lui a3, 4
 ;   addi a3, a3, -0x640
-;   c.sd a2, 0(a3) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
+;   c.sd a1, 0(a3) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   auipc a2, 1
-;   ld a2, -0x7da(a2)
+;   auipc a1, 1
+;   ld a1, -0x7de(a1)
 ;   c.lui a3, 4
 ;   addi a3, a3, -0x59c
-;   c.sd a2, 0(a3) ; trap: heap_oob
+;   c.sd a1, 0(a3) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
 ;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
 ;   sw zero, 0(a0) ; trap: heap_oob
-;   sext.w a0, a1
+;   sext.w a0, a2
 ;   bnez a0, 6
 ;   c.j 0xa
 ;   auipc t6, 1
-;   jalr zero, t6, -0x7ec
+;   jalr zero, t6, -0x7e8
 ;   auipc t6, 0
-;   jalr zero, t6, 0x7f8
+;   jalr zero, t6, 0x7fc
+;   c.unimp
+;   c.unimp
 ;   c.fldsp fs5, 0x1e0(sp)
 ;   .byte 0xc3, 0xd1
 ;   c.bnez a0, -4
@@ -8254,7 +7169,7 @@ block2:
 ;   c.addi4spn s0, sp, 0x84
 ;   andi a7, s11, -0x6ab
 ;   c.swsp t5, 0xb4(sp)
-; block14: ; offset 0x24f8
+; block14: ; offset 0x1c88
 ;   c.lui a0, 1
 ;   addi a2, a0, -0x438
 ;   c.mv a1, t0
@@ -8262,7 +7177,7 @@ block2:
 ;   auipc ra, 0 ; reloc_external RiscvCallPlt u0:988 0
 ;   jalr ra
 ;   c.unimp ; trap: user1
-; block15: ; offset 0x250c
+; block15: ; offset 0x1c9c
 ;   c.mv a1, t0
 ;   c.li a2, 1
 ;   c.li a3, 2

--- a/tests/disas/idempotent-store.wat
+++ b/tests/disas/idempotent-store.wat
@@ -1,0 +1,35 @@
+;;! target = "x86_64"
+;;! test = "optimize"
+
+(module
+  (memory i32 1)
+
+  (func (export "f") (param i32 i32)
+    local.get 0
+    local.get 1
+    i32.store
+    local.get 0
+    local.get 1
+    i32.store
+  )
+)
+
+;; function u0:0(i64 vmctx, i64, i32, i32) tail {
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv3 = vmctx
+;;     gv4 = load.i64 notrap aligned gv3+64
+;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
+;; @0029                               v5 = load.i64 notrap aligned readonly can_move v0+56
+;; @0029                               v4 = uextend.i64 v2
+;; @0029                               v6 = iadd v5, v4
+;; @0029                               store little heap v3, v6
+;; @0033                               jump block1
+;;
+;;                                 block1:
+;; @0033                               return
+;; }


### PR DESCRIPTION
This is a very particular subset of "dead-store elimination" that we can do without extending the static analysis at all (e.g. we do *not* need to show that the target store is post-dominated by another store to the same location in this case). The key idea is this: if our existing analysis tells us that a memory location L is currently known to contain the value `v0` (such that we could do redundant-load elimination by removing `v8 = load L` and making `v8` an alias of `v0`) then we can remove `store v0, L` because memory location `L` already contains that value. We also do not need to worry about traps because if `L` already has a known-value, that must have been from a load or store to `L` that dominates our idempotent `store` instruction, and if this idempotent `store` would trap, then the original load/store to `L` would have already trapped first.

This does not result in any statistically significant differences in Sightglass.

cc https://github.com/bytecodealliance/wasmtime/issues/4167

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
