### PR TITLE
Account for null collector's 1-byte bump offset in `<NullHeap as GcHeap>::allocated_bytes`

### DIFF
--- a/crates/wasmtime/src/runtime/vm/gc/enabled/null.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/enabled/null.rs
@@ -332,9 +332,11 @@ unsafe impl GcHeap for NullHeap {
 
     fn allocated_bytes(&self) -> usize {
         // The null collector never frees, so everything from the start of
-        // the heap up to the bump pointer is allocated.
+        // the heap up to the bump pointer is allocated. Subtract 1 because
+        // the bump pointer starts at index 1 (index 0 is unused since
+        // `VMGcRef` uses `NonZeroU32`), not because any byte was allocated.
         let next = unsafe { *self.next.get() };
-        usize::try_from(next.get()).unwrap()
+        usize::try_from(next.get()).unwrap() - 1
     }
 
     fn gc<'a>(

--- a/tests/misc_testsuite/gc/issue-13247.wast
+++ b/tests/misc_testsuite/gc/issue-13247.wast
@@ -1,0 +1,32 @@
+;;! gc = true
+
+;; Regression test for https://github.com/bytecodealliance/wasmtime/issues/13247
+;;
+;; The null collector's bump pointer starts at index 1 (index 0 is reserved
+;; because `VMGcRef` uses `NonZeroU32`). The `allocated_bytes()` method was
+;; returning the raw bump pointer value, reporting 1 byte allocated on a fresh
+;; heap with no actual allocations. The GC heap starts with 0-byte capacity, so
+;; triggering a GC before any allocations stored `last_post_gc_allocated_bytes =
+;; 1`, and a subsequent allocation OOM hit `debug_assert!(1 <= 0)` inside
+;; `should_collect_first`.
+;;
+;; The `struct.new` in `test` ensures the compiled module sets
+;; `needs_gc_heap = true`, so the GC store is created during instantiation with
+;; a 0-byte heap. The start function triggers a GC before any heap allocations.
+;; After instantiation, `(ref.extern 1)` allocates an externref through the
+;; runtime path (`retry_after_gc_async`), which is where the assertion fired.
+
+(module
+  (import "wasmtime" "gc" (func $gc))
+  (type $s (struct))
+  (start $init)
+  (func $init
+    call $gc
+  )
+  (func (export "test") (param externref)
+    struct.new $s
+    drop
+  )
+)
+
+(invoke "test" (ref.extern 1))


### PR DESCRIPTION


Fixes https://github.com/bytecodealliance/wasmtime/issues/13247

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
