### PR TITLE
Fix timing information in cranelift

### DIFF
--- a/cranelift/codegen/src/timing.rs
+++ b/cranelift/codegen/src/timing.rs
@@ -291,7 +291,7 @@ mod enabled {
     impl Drop for DefaultTimingToken {
         fn drop(&mut self) {
             let now = monotonic_instant();
-            let duration = self.start.duration_since(now);
+            let duration = now.duration_since(self.start);
             log::debug!("timing: Ending {}: {}ms", self.pass, duration.as_millis());
             let old_cur = CURRENT_PASS.with(|p| p.replace(self.prev));
             assert_eq!(self.pass, old_cur, "Timing tokens dropped out of order");


### PR DESCRIPTION
A typo in #12709 accidentally led to all passes clocking in at 0ns. Swap the order of arguments to get true timing information.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
