### PR TITLE
Fix slow WASI stdin reads by passing size hint to worker thread

### DIFF
--- a/crates/wasi/src/cli/worker_thread_stdin.rs
+++ b/crates/wasi/src/cli/worker_thread_stdin.rs
@@ -108,8 +108,9 @@ fn create() -> GlobalStdin {
 
             // Extract the size hint from the request and cap it to `MAX_READ_SIZE_ALLOC`
             // to avoid guest-controlled unbounded allocation.
+            // The `.max(1)` ensures a zero-length read is never misinterpreted as EOF.
             let size_hint = match *lock {
-                StdinState::ReadRequested(size) => size.min(MAX_READ_SIZE_ALLOC).max(1024),
+                StdinState::ReadRequested(size) => size.min(MAX_READ_SIZE_ALLOC).max(1),
                 _ => unreachable!(),
             };
             drop(lock);
@@ -147,6 +148,9 @@ struct WasiStdin;
 #[async_trait::async_trait]
 impl InputStream for WasiStdin {
     fn read(&mut self, size: usize) -> Result<Bytes, StreamError> {
+        if size == 0 {
+            return Ok(Bytes::new());
+        }
         let g = GlobalStdin::get();
         let mut locked = g.state.lock().unwrap();
         match mem::replace(&mut *locked, StdinState::ReadRequested(size)) {

--- a/crates/wasi/src/cli/worker_thread_stdin.rs
+++ b/crates/wasi/src/cli/worker_thread_stdin.rs
@@ -38,6 +38,8 @@ use wasmtime_wasi_io::{
     streams::{InputStream, StreamError},
 };
 
+use crate::MAX_READ_SIZE_ALLOC;
+
 // Implementation for tokio::io::Stdin
 impl IsTerminal for tokio::io::Stdin {
     fn is_terminal(&self) -> bool {
@@ -79,7 +81,7 @@ struct GlobalStdin {
 enum StdinState {
     #[default]
     ReadNotRequested,
-    ReadRequested,
+    ReadRequested(usize),
     Data(BytesMut),
     Error(std::io::Error),
     Closed,
@@ -101,11 +103,18 @@ fn create() -> GlobalStdin {
             let mut lock = state.state.lock().unwrap();
             lock = state
                 .read_requested
-                .wait_while(lock, |state| !matches!(state, StdinState::ReadRequested))
+                .wait_while(lock, |state| !matches!(state, StdinState::ReadRequested(_)))
                 .unwrap();
+
+            // Extract the size hint from the request and cap it to `MAX_READ_SIZE_ALLOC`
+            // to avoid guest-controlled unbounded allocation.
+            let size_hint = match *lock {
+                StdinState::ReadRequested(size) => size.min(MAX_READ_SIZE_ALLOC).max(1024),
+                _ => unreachable!(),
+            };
             drop(lock);
 
-            let mut bytes = BytesMut::zeroed(1024);
+            let mut bytes = BytesMut::zeroed(size_hint);
             let (new_state, done) = match std::io::stdin().read(&mut bytes) {
                 Ok(0) => (StdinState::Closed, true),
                 Ok(nbytes) => {
@@ -119,7 +128,7 @@ fn create() -> GlobalStdin {
             // tampered with.
             debug_assert!(matches!(
                 *state.state.lock().unwrap(),
-                StdinState::ReadRequested
+                StdinState::ReadRequested(_)
             ));
             let mut lock = state.state.lock().unwrap();
             *lock = new_state;
@@ -140,12 +149,17 @@ impl InputStream for WasiStdin {
     fn read(&mut self, size: usize) -> Result<Bytes, StreamError> {
         let g = GlobalStdin::get();
         let mut locked = g.state.lock().unwrap();
-        match mem::replace(&mut *locked, StdinState::ReadRequested) {
+        match mem::replace(&mut *locked, StdinState::ReadRequested(size)) {
             StdinState::ReadNotRequested => {
                 g.read_requested.notify_one();
                 Ok(Bytes::new())
             }
-            StdinState::ReadRequested => Ok(Bytes::new()),
+            StdinState::ReadRequested(prev_size) => {
+                // Preserve the larger of the two requested sizes
+                // so the worker thread allocates an adequate buffer.
+                *locked = StdinState::ReadRequested(prev_size.max(size));
+                Ok(Bytes::new())
+            }
             StdinState::Data(mut data) => {
                 let size = data.len().min(size);
                 let bytes = data.split_to(size);
@@ -178,13 +192,15 @@ impl Pollable for WasiStdin {
         let notified = {
             let mut locked = g.state.lock().unwrap();
             match *locked {
-                // If a read isn't requested yet
+                // If a read isn't requested yet, use `MAX_READ_SIZE_ALLOC`
+                // as the buffer size since `ready()` doesn't know what size
+                // will be requested by the subsequent `read()` call.
                 StdinState::ReadNotRequested => {
                     g.read_requested.notify_one();
-                    *locked = StdinState::ReadRequested;
+                    *locked = StdinState::ReadRequested(MAX_READ_SIZE_ALLOC);
                     g.read_completed.notified()
                 }
-                StdinState::ReadRequested => g.read_completed.notified(),
+                StdinState::ReadRequested(_) => g.read_completed.notified(),
                 StdinState::Data(_) | StdinState::Closed | StdinState::Error(_) => return,
             }
         };
@@ -231,7 +247,7 @@ impl AsyncRead for WasiStdinAsyncRead {
 
             // Once we're in the "ready" state then take a look at the global
             // state of stdin.
-            match mem::replace(&mut *locked, StdinState::ReadRequested) {
+            match mem::replace(&mut *locked, StdinState::ReadRequested(buf.remaining())) {
                 // If data is available then drain what we can into `buf`.
                 StdinState::Data(mut data) => {
                     let size = data.len().min(buf.remaining());
@@ -264,7 +280,10 @@ impl AsyncRead for WasiStdinAsyncRead {
                 StdinState::ReadNotRequested => {
                     g.read_requested.notify_one();
                 }
-                StdinState::ReadRequested => {}
+                StdinState::ReadRequested(prev_size) => {
+                    // Preserve the larger of the previous and current size hint
+                    *locked = StdinState::ReadRequested(prev_size.max(buf.remaining()));
+                }
             }
 
             self.set(WasiStdinAsyncRead::Waiting(g.read_completed.notified()));


### PR DESCRIPTION
While working on a program that reads a large amount of data through stdin, I was surprised by slow stdin throughput under wasmtime. Piping 1 GiB into a simple WASI program that reads in 64 KiB chunks took about 38 seconds (~28 MiB/s). I expected something in the gigabytes-per-second order of magnitude.

To demonstrate the issue, below is a minimal WASI program that reads stdin in configurable chunks.

Piping 1 GiB of zeroes and attempting to read in 65536 bytes chunks:

```sh
# Before the changes in this PR: takes ~38s -> ~28 MiB/s
time dd if=/dev/zero bs=65536 count=16384 2>/dev/null | /path/to/wasmtime stdio_bench.wasm 65536

# With the changes in this PR: takes ~1.2s -> ~900 MiB/s
time dd if=/dev/zero bs=65536 count=16384 2>/dev/null | /path/to/wasmtime stdio_bench.wasm 65536
```

Benchmark application code:

```rust
// build with: cargo build --release --target wasm32-wasip1
use std::env;
use std::io::{self, Read};
use std::process;

fn main() {
    let chunk_size: usize = env::args()
        .nth(1)
        .and_then(|s| s.parse().ok())
        .unwrap_or_else(|| {
            eprintln!("Usage: stdin_bench <chunk-size-bytes>");
            process::exit(1);
        });

    let stdin = io::stdin();
    let mut handle = stdin.lock();
    let mut buf = vec![0u8; chunk_size];
    let mut total: u64 = 0;

    loop {
        match handle.read(&mut buf) {
            Ok(0) => break,
            Ok(n) => total += n as u64,
            Err(e) => {
                eprintln!("read error: {e}");
                process::exit(1);
            }
        }
    }

    eprintln!("{total} bytes read");
}
```

## Root cause

Regardless of how many bytes were requested (e.g. 65536) the worker thread would read at most 1024 bytes (hard-coded number) per round-trip, which results in slow performance.
See [worker_thread_stdin.rs:108](https://github.com/bytecodealliance/wasmtime/blob/b6eef22336989e0d8a0f827b721ba410bbe6c2da/crates/wasi/src/cli/worker_thread_stdin.rs#L108).

## Fix

`StdinState::ReadRequested` now has a `usize` size hint from the caller. The worker thread uses this hint to size its read buffer, clamped to `[1, MAX_READ_SIZE_ALLOC]` to avoid guest-controlled unbounded allocation while still enabling efficient bulk reads.

Callers now store a size hint when transitioning to `ReadRequested`; `Pollable::ready` uses `MAX_READ_SIZE_ALLOC` because it does not know the size of the following read.

When reading 1 GiB in 64 KiB chunks, I now get:

| Before | After | Speedup |
|--------|-------|---------|
| ~28 MiB/s | ~900 MiB/s | **32x** |
