### PR TITLE
s390x: correct off-by-one error in rotate then select insts

### DIFF
--- a/cranelift/codegen/src/isa/s390x/lower.isle
+++ b/cranelift/codegen/src/isa/s390x/lower.isle
@@ -3571,15 +3571,15 @@
                              WritableReg Reg Reg) Reg)
 ;; 8-bit case: use the low byte of "src" and the high byte of "val".
 (rule (atomic_rmw_body_rxsbg ib $I8 _ op tmp val src)
-      (push_rxsbg ib op tmp val src 32 40 24))
+      (push_rxsbg ib op tmp val src 32 39 24))
 ;; 16-bit big-endian case: use the low two bytes of "src" and the
 ;; high two bytes of "val".
 (rule 1 (atomic_rmw_body_rxsbg ib $I16 (bigendian) op tmp val src)
-      (push_rxsbg ib op tmp val src 32 48 16))
+      (push_rxsbg ib op tmp val src 32 47 16))
 ;; 16-bit little-endian case: use the low two bytes of "src", byte-swapped
 ;; so they end up in the high two bytes, and the low two bytes of "val".
 (rule (atomic_rmw_body_rxsbg ib $I16 (littleendian) op tmp val src)
-      (push_rxsbg ib op tmp val (bswap_reg $I32 src) 48 64 -16))
+      (push_rxsbg ib op tmp val (bswap_reg $I32 src) 48 63 -16))
 
 ;; Invert a subword.
 (decl atomic_rmw_body_invert (VecMInstBuilder Type MemFlags WritableReg Reg) Reg)
@@ -3674,13 +3674,13 @@
       (let ((src_shifted Reg (lshl_imm $I32 src 24))
             (_ Reg (push_break_if ib (cmp_rr op src_shifted val)
                                      (invert_cond cond))))
-        (push_rxsbg ib (RxSBGOp.Insert) tmp val src_shifted 32 40 0)))
+        (push_rxsbg ib (RxSBGOp.Insert) tmp val src_shifted 32 39 0)))
 ;; 16-bit big-endian case: similar, just shift the source by 16 bits.
 (rule 3 (atomic_rmw_body_minmax ib $I16 (bigendian) op cond tmp val src)
       (let ((src_shifted Reg (lshl_imm $I32 src 16))
             (_ Reg (push_break_if ib (cmp_rr op src_shifted val)
                                      (invert_cond cond))))
-        (push_rxsbg ib (RxSBGOp.Insert) tmp val src_shifted 32 48 0)))
+        (push_rxsbg ib (RxSBGOp.Insert) tmp val src_shifted 32 47 0)))
 ;; 16-bit little-endian case: similar, but in addition byte-swap the
 ;; memory value before and after the operation, like for _addsub_.
 (rule (atomic_rmw_body_minmax ib $I16 (littleendian) op cond tmp val src)
@@ -3689,7 +3689,7 @@
             (_ Reg (push_break_if ib (cmp_rr op src_shifted val_swapped)
                                      (invert_cond cond)))
             (res_swapped Reg (push_rxsbg ib (RxSBGOp.Insert)
-                                tmp val_swapped src_shifted 32 48 0)))
+                                tmp val_swapped src_shifted 32 47 0)))
         (push_bswap_reg ib $I32 tmp res_swapped)))
 
 
@@ -3734,16 +3734,16 @@
 ;; break out of the loop, otherwise replace the target byte in "val" with
 ;; the low byte of "src2".
 (rule (atomic_cas_body ib $I8 _ tmp val src1 src2)
-      (let ((_ Reg (push_break_if ib (rxsbg_test (RxSBGOp.Xor) val src1 32 40 24)
+      (let ((_ Reg (push_break_if ib (rxsbg_test (RxSBGOp.Xor) val src1 32 39 24)
                                      (intcc_as_cond (IntCC.NotEqual)))))
-        (push_rxsbg ib (RxSBGOp.Insert) tmp val src2 32 40 24)))
+        (push_rxsbg ib (RxSBGOp.Insert) tmp val src2 32 39 24)))
 
 ;; 16-bit big-endian case: Same as above, except with values in the high
 ;; two bytes of "val" and low two bytes of "src1" and "src2".
 (rule 1 (atomic_cas_body ib $I16 (bigendian) tmp val src1 src2)
-      (let ((_ Reg (push_break_if ib (rxsbg_test (RxSBGOp.Xor) val src1 32 48 16)
+      (let ((_ Reg (push_break_if ib (rxsbg_test (RxSBGOp.Xor) val src1 32 47 16)
                                      (intcc_as_cond (IntCC.NotEqual)))))
-        (push_rxsbg ib (RxSBGOp.Insert) tmp val src2 32 48 16)))
+        (push_rxsbg ib (RxSBGOp.Insert) tmp val src2 32 47 16)))
 
 ;; 16-bit little-endian case: "val" here contains a little-endian value in the
 ;; *low* two bytes.  "src1" and "src2" contain native (i.e. big-endian) values
@@ -3755,9 +3755,9 @@
       (let ((src1_swapped Reg (bswap_reg $I32 src1))
             (src2_swapped Reg (bswap_reg $I32 src2))
             (_ Reg (push_break_if ib
-                     (rxsbg_test (RxSBGOp.Xor) val src1_swapped 48 64 -16)
+                     (rxsbg_test (RxSBGOp.Xor) val src1_swapped 48 63 -16)
                      (intcc_as_cond (IntCC.NotEqual)))))
-        (push_rxsbg ib (RxSBGOp.Insert) tmp val src2_swapped 48 64 -16)))
+        (push_rxsbg ib (RxSBGOp.Insert) tmp val src2_swapped 48 63 -16)))
 
 
 ;;;; Rules for `atomic_load` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/cranelift/filetests/filetests/isa/s390x/atomic_cas-little.clif
+++ b/cranelift/filetests/filetests/isa/s390x/atomic_cas-little.clif
@@ -65,7 +65,7 @@ block0(v0: i64, v1: i16, v2: i16, v3: i64):
 ;   lgr %r3, %r10
 ;   lrvr %r3, %r3
 ;   l %r0, 0(%r5)
-;   0: rll %r1, %r0, 16(%r4) ; rxsbg %r1, %r2, 176, 64, 48 ; jglh 1f ; risbgn %r1, %r3, 48, 64, 48 ; rll %r1, %r1, 16(%r4) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
+;   0: rll %r1, %r0, 16(%r4) ; rxsbg %r1, %r2, 176, 63, 48 ; jglh 1f ; risbgn %r1, %r3, 48, 63, 48 ; rll %r1, %r1, 16(%r4) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 0(%r4)
 ;   lrvr %r2, %r2
 ;   lmg %r10, %r15, 80(%r15)
@@ -83,9 +83,9 @@ block0(v0: i64, v1: i16, v2: i16, v3: i64):
 ;   lrvr %r3, %r3
 ;   l %r0, 0(%r5) ; trap: heap_oob
 ;   rll %r1, %r0, 0x10(%r4)
-;   rxsbg %r1, %r2, 0xb0, 0x40, 0x30
+;   rxsbg %r1, %r2, 0xb0, 0x3f, 0x30
 ;   jglh 0x4c
-;   risbgn %r1, %r3, 0x30, 0x40, 0x30
+;   risbgn %r1, %r3, 0x30, 0x3f, 0x30
 ;   rll %r1, %r1, 0x10(%r4)
 ;   cs %r0, %r1, 0(%r5) ; trap: heap_oob
 ;   jglh 0x24
@@ -108,7 +108,7 @@ block0(v0: i64, v1: i8, v2: i8, v3: i64):
 ;   nill %r5, 65532
 ;   lcr %r2, %r4
 ;   l %r0, 0(%r5)
-;   0: rll %r1, %r0, 0(%r4) ; rxsbg %r1, %r3, 160, 40, 24 ; jglh 1f ; risbgn %r1, %r12, 32, 40, 24 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
+;   0: rll %r1, %r0, 0(%r4) ; rxsbg %r1, %r3, 160, 39, 24 ; jglh 1f ; risbgn %r1, %r12, 32, 39, 24 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r4)
 ;   lmg %r12, %r15, 96(%r15)
 ;   br %r14
@@ -123,9 +123,9 @@ block0(v0: i64, v1: i8, v2: i8, v3: i64):
 ;   lcr %r2, %r4
 ;   l %r0, 0(%r5) ; trap: heap_oob
 ;   rll %r1, %r0, 0(%r4)
-;   rxsbg %r1, %r3, 0xa0, 0x28, 0x18
+;   rxsbg %r1, %r3, 0xa0, 0x27, 0x18
 ;   jglh 0x42
-;   risbgn %r1, %r12, 0x20, 0x28, 0x18
+;   risbgn %r1, %r12, 0x20, 0x27, 0x18
 ;   rll %r1, %r1, 0(%r2)
 ;   cs %r0, %r1, 0(%r5) ; trap: heap_oob
 ;   jglh 0x1a

--- a/cranelift/filetests/filetests/isa/s390x/atomic_cas.clif
+++ b/cranelift/filetests/filetests/isa/s390x/atomic_cas.clif
@@ -49,7 +49,7 @@ block0(v0: i64, v1: i16, v2: i16, v3: i64):
 ;   sllk %r4, %r5, 3
 ;   nill %r5, 65532
 ;   l %r0, 0(%r5)
-;   0: rll %r1, %r0, 0(%r4) ; rxsbg %r1, %r3, 160, 48, 16 ; jglh 1f ; risbgn %r1, %r2, 32, 48, 16 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
+;   0: rll %r1, %r0, 0(%r4) ; rxsbg %r1, %r3, 160, 47, 16 ; jglh 1f ; risbgn %r1, %r2, 32, 47, 16 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 16(%r4)
 ;   br %r14
 ;
@@ -60,9 +60,9 @@ block0(v0: i64, v1: i16, v2: i16, v3: i64):
 ;   nill %r5, 0xfffc
 ;   l %r0, 0(%r5) ; trap: heap_oob
 ;   rll %r1, %r0, 0(%r4)
-;   rxsbg %r1, %r3, 0xa0, 0x30, 0x10
+;   rxsbg %r1, %r3, 0xa0, 0x2f, 0x10
 ;   jglh 0x3a
-;   risbgn %r1, %r2, 0x20, 0x30, 0x10
+;   risbgn %r1, %r2, 0x20, 0x2f, 0x10
 ;   rll %r1, %r1, 0(%r4)
 ;   cs %r0, %r1, 0(%r5) ; trap: heap_oob
 ;   jglh 0x12
@@ -83,7 +83,7 @@ block0(v0: i64, v1: i8, v2: i8, v3: i64):
 ;   nill %r5, 65532
 ;   lcr %r2, %r4
 ;   l %r0, 0(%r5)
-;   0: rll %r1, %r0, 0(%r4) ; rxsbg %r1, %r3, 160, 40, 24 ; jglh 1f ; risbgn %r1, %r12, 32, 40, 24 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
+;   0: rll %r1, %r0, 0(%r4) ; rxsbg %r1, %r3, 160, 39, 24 ; jglh 1f ; risbgn %r1, %r12, 32, 39, 24 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r4)
 ;   lmg %r12, %r15, 96(%r15)
 ;   br %r14
@@ -98,9 +98,9 @@ block0(v0: i64, v1: i8, v2: i8, v3: i64):
 ;   lcr %r2, %r4
 ;   l %r0, 0(%r5) ; trap: heap_oob
 ;   rll %r1, %r0, 0(%r4)
-;   rxsbg %r1, %r3, 0xa0, 0x28, 0x18
+;   rxsbg %r1, %r3, 0xa0, 0x27, 0x18
 ;   jglh 0x42
-;   risbgn %r1, %r12, 0x20, 0x28, 0x18
+;   risbgn %r1, %r12, 0x20, 0x27, 0x18
 ;   rll %r1, %r1, 0(%r2)
 ;   cs %r0, %r1, 0(%r5) ; trap: heap_oob
 ;   jglh 0x1a

--- a/cranelift/filetests/filetests/isa/s390x/atomic_rmw-arch13.clif
+++ b/cranelift/filetests/filetests/isa/s390x/atomic_rmw-arch13.clif
@@ -60,7 +60,7 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   sllk %r4, %r3, 3
 ;   nill %r3, 65532
 ;   l %r0, 0(%r3)
-;   0: rll %r1, %r0, 0(%r4) ; rnsbg %r1, %r2, 32, 48, 16 ; xilf %r1, 4294901760 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   0: rll %r1, %r0, 0(%r4) ; rnsbg %r1, %r2, 32, 47, 16 ; xilf %r1, 4294901760 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 16(%r4)
 ;   br %r14
 ;
@@ -71,7 +71,7 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   nill %r3, 0xfffc
 ;   l %r0, 0(%r3) ; trap: heap_oob
 ;   rll %r1, %r0, 0(%r4)
-;   rnsbg %r1, %r2, 0x20, 0x30, 0x10
+;   rnsbg %r1, %r2, 0x20, 0x2f, 0x10
 ;   xilf %r1, 0xffff0000
 ;   rll %r1, %r1, 0(%r4)
 ;   cs %r0, %r1, 0(%r3) ; trap: heap_oob
@@ -92,7 +92,7 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   nill %r3, 65532
 ;   lcr %r2, %r4
 ;   l %r0, 0(%r3)
-;   0: rll %r1, %r0, 0(%r4) ; rnsbg %r1, %r5, 32, 40, 24 ; xilf %r1, 4278190080 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   0: rll %r1, %r0, 0(%r4) ; rnsbg %r1, %r5, 32, 39, 24 ; xilf %r1, 4278190080 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r4)
 ;   br %r14
 ;
@@ -104,7 +104,7 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   lcr %r2, %r4
 ;   l %r0, 0(%r3) ; trap: heap_oob
 ;   rll %r1, %r0, 0(%r4)
-;   rnsbg %r1, %r5, 0x20, 0x28, 0x18
+;   rnsbg %r1, %r5, 0x20, 0x27, 0x18
 ;   xilf %r1, 0xff000000
 ;   rll %r1, %r1, 0(%r2)
 ;   cs %r0, %r1, 0(%r3) ; trap: heap_oob
@@ -176,7 +176,7 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   nill %r3, 65532
 ;   lrvr %r2, %r2
 ;   l %r0, 0(%r3)
-;   0: rll %r1, %r0, 16(%r4) ; rnsbg %r1, %r2, 48, 64, 48 ; xilf %r1, 65535 ; rll %r1, %r1, 16(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   0: rll %r1, %r0, 16(%r4) ; rnsbg %r1, %r2, 48, 63, 48 ; xilf %r1, 65535 ; rll %r1, %r1, 16(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 0(%r4)
 ;   lrvr %r2, %r2
 ;   br %r14
@@ -189,7 +189,7 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   lrvr %r2, %r2
 ;   l %r0, 0(%r3) ; trap: heap_oob
 ;   rll %r1, %r0, 0x10(%r4)
-;   rnsbg %r1, %r2, 0x30, 0x40, 0x30
+;   rnsbg %r1, %r2, 0x30, 0x3f, 0x30
 ;   xilf %r1, 0xffff
 ;   rll %r1, %r1, 0x10(%r4)
 ;   cs %r0, %r1, 0(%r3) ; trap: heap_oob
@@ -211,7 +211,7 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   nill %r3, 65532
 ;   lcr %r2, %r4
 ;   l %r0, 0(%r3)
-;   0: rll %r1, %r0, 0(%r4) ; rnsbg %r1, %r5, 32, 40, 24 ; xilf %r1, 4278190080 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   0: rll %r1, %r0, 0(%r4) ; rnsbg %r1, %r5, 32, 39, 24 ; xilf %r1, 4278190080 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r4)
 ;   br %r14
 ;
@@ -223,7 +223,7 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   lcr %r2, %r4
 ;   l %r0, 0(%r3) ; trap: heap_oob
 ;   rll %r1, %r0, 0(%r4)
-;   rnsbg %r1, %r5, 0x20, 0x28, 0x18
+;   rnsbg %r1, %r5, 0x20, 0x27, 0x18
 ;   xilf %r1, 0xff000000
 ;   rll %r1, %r1, 0(%r2)
 ;   cs %r0, %r1, 0(%r3) ; trap: heap_oob

--- a/cranelift/filetests/filetests/isa/s390x/atomic_rmw-little.clif
+++ b/cranelift/filetests/filetests/isa/s390x/atomic_rmw-little.clif
@@ -64,7 +64,7 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   nill %r3, 65532
 ;   lrvr %r2, %r2
 ;   l %r0, 0(%r3)
-;   0: rll %r1, %r0, 16(%r4) ; risbgn %r1, %r2, 48, 64, 48 ; rll %r1, %r1, 16(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   0: rll %r1, %r0, 16(%r4) ; risbgn %r1, %r2, 48, 63, 48 ; rll %r1, %r1, 16(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 0(%r4)
 ;   lrvr %r2, %r2
 ;   br %r14
@@ -77,7 +77,7 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   lrvr %r2, %r2
 ;   l %r0, 0(%r3) ; trap: heap_oob
 ;   rll %r1, %r0, 0x10(%r4)
-;   risbgn %r1, %r2, 0x30, 0x40, 0x30
+;   risbgn %r1, %r2, 0x30, 0x3f, 0x30
 ;   rll %r1, %r1, 0x10(%r4)
 ;   cs %r0, %r1, 0(%r3) ; trap: heap_oob
 ;   jglh 0x16
@@ -98,7 +98,7 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   nill %r3, 65532
 ;   lcr %r2, %r4
 ;   l %r0, 0(%r3)
-;   0: rll %r1, %r0, 0(%r4) ; risbgn %r1, %r5, 32, 40, 24 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   0: rll %r1, %r0, 0(%r4) ; risbgn %r1, %r5, 32, 39, 24 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r4)
 ;   br %r14
 ;
@@ -110,7 +110,7 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   lcr %r2, %r4
 ;   l %r0, 0(%r3) ; trap: heap_oob
 ;   rll %r1, %r0, 0(%r4)
-;   risbgn %r1, %r5, 0x20, 0x28, 0x18
+;   risbgn %r1, %r5, 0x20, 0x27, 0x18
 ;   rll %r1, %r1, 0(%r2)
 ;   cs %r0, %r1, 0(%r3) ; trap: heap_oob
 ;   jglh 0x14
@@ -402,7 +402,7 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   nill %r3, 65532
 ;   lrvr %r2, %r2
 ;   l %r0, 0(%r3)
-;   0: rll %r1, %r0, 16(%r4) ; rnsbg %r1, %r2, 48, 64, 48 ; rll %r1, %r1, 16(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   0: rll %r1, %r0, 16(%r4) ; rnsbg %r1, %r2, 48, 63, 48 ; rll %r1, %r1, 16(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 0(%r4)
 ;   lrvr %r2, %r2
 ;   br %r14
@@ -415,7 +415,7 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   lrvr %r2, %r2
 ;   l %r0, 0(%r3) ; trap: heap_oob
 ;   rll %r1, %r0, 0x10(%r4)
-;   rnsbg %r1, %r2, 0x30, 0x40, 0x30
+;   rnsbg %r1, %r2, 0x30, 0x3f, 0x30
 ;   rll %r1, %r1, 0x10(%r4)
 ;   cs %r0, %r1, 0(%r3) ; trap: heap_oob
 ;   jglh 0x16
@@ -436,7 +436,7 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   nill %r3, 65532
 ;   lcr %r2, %r4
 ;   l %r0, 0(%r3)
-;   0: rll %r1, %r0, 0(%r4) ; rnsbg %r1, %r5, 32, 40, 24 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   0: rll %r1, %r0, 0(%r4) ; rnsbg %r1, %r5, 32, 39, 24 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r4)
 ;   br %r14
 ;
@@ -448,7 +448,7 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   lcr %r2, %r4
 ;   l %r0, 0(%r3) ; trap: heap_oob
 ;   rll %r1, %r0, 0(%r4)
-;   rnsbg %r1, %r5, 0x20, 0x28, 0x18
+;   rnsbg %r1, %r5, 0x20, 0x27, 0x18
 ;   rll %r1, %r1, 0(%r2)
 ;   cs %r0, %r1, 0(%r3) ; trap: heap_oob
 ;   jglh 0x14
@@ -508,7 +508,7 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   nill %r3, 65532
 ;   lrvr %r2, %r2
 ;   l %r0, 0(%r3)
-;   0: rll %r1, %r0, 16(%r4) ; rosbg %r1, %r2, 48, 64, 48 ; rll %r1, %r1, 16(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   0: rll %r1, %r0, 16(%r4) ; rosbg %r1, %r2, 48, 63, 48 ; rll %r1, %r1, 16(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 0(%r4)
 ;   lrvr %r2, %r2
 ;   br %r14
@@ -521,7 +521,7 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   lrvr %r2, %r2
 ;   l %r0, 0(%r3) ; trap: heap_oob
 ;   rll %r1, %r0, 0x10(%r4)
-;   rosbg %r1, %r2, 0x30, 0x40, 0x30
+;   rosbg %r1, %r2, 0x30, 0x3f, 0x30
 ;   rll %r1, %r1, 0x10(%r4)
 ;   cs %r0, %r1, 0(%r3) ; trap: heap_oob
 ;   jglh 0x16
@@ -542,7 +542,7 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   nill %r3, 65532
 ;   lcr %r2, %r4
 ;   l %r0, 0(%r3)
-;   0: rll %r1, %r0, 0(%r4) ; rosbg %r1, %r5, 32, 40, 24 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   0: rll %r1, %r0, 0(%r4) ; rosbg %r1, %r5, 32, 39, 24 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r4)
 ;   br %r14
 ;
@@ -554,7 +554,7 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   lcr %r2, %r4
 ;   l %r0, 0(%r3) ; trap: heap_oob
 ;   rll %r1, %r0, 0(%r4)
-;   rosbg %r1, %r5, 0x20, 0x28, 0x18
+;   rosbg %r1, %r5, 0x20, 0x27, 0x18
 ;   rll %r1, %r1, 0(%r2)
 ;   cs %r0, %r1, 0(%r3) ; trap: heap_oob
 ;   jglh 0x14
@@ -614,7 +614,7 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   nill %r3, 65532
 ;   lrvr %r2, %r2
 ;   l %r0, 0(%r3)
-;   0: rll %r1, %r0, 16(%r4) ; rxsbg %r1, %r2, 48, 64, 48 ; rll %r1, %r1, 16(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   0: rll %r1, %r0, 16(%r4) ; rxsbg %r1, %r2, 48, 63, 48 ; rll %r1, %r1, 16(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 0(%r4)
 ;   lrvr %r2, %r2
 ;   br %r14
@@ -627,7 +627,7 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   lrvr %r2, %r2
 ;   l %r0, 0(%r3) ; trap: heap_oob
 ;   rll %r1, %r0, 0x10(%r4)
-;   rxsbg %r1, %r2, 0x30, 0x40, 0x30
+;   rxsbg %r1, %r2, 0x30, 0x3f, 0x30
 ;   rll %r1, %r1, 0x10(%r4)
 ;   cs %r0, %r1, 0(%r3) ; trap: heap_oob
 ;   jglh 0x16
@@ -648,7 +648,7 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   nill %r3, 65532
 ;   lcr %r2, %r4
 ;   l %r0, 0(%r3)
-;   0: rll %r1, %r0, 0(%r4) ; rxsbg %r1, %r5, 32, 40, 24 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   0: rll %r1, %r0, 0(%r4) ; rxsbg %r1, %r5, 32, 39, 24 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r4)
 ;   br %r14
 ;
@@ -660,7 +660,7 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   lcr %r2, %r4
 ;   l %r0, 0(%r3) ; trap: heap_oob
 ;   rll %r1, %r0, 0(%r4)
-;   rxsbg %r1, %r5, 0x20, 0x28, 0x18
+;   rxsbg %r1, %r5, 0x20, 0x27, 0x18
 ;   rll %r1, %r1, 0(%r2)
 ;   cs %r0, %r1, 0(%r3) ; trap: heap_oob
 ;   jglh 0x14
@@ -731,7 +731,7 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   nill %r3, 65532
 ;   lrvr %r2, %r2
 ;   l %r0, 0(%r3)
-;   0: rll %r1, %r0, 16(%r4) ; rnsbg %r1, %r2, 48, 64, 48 ; xilf %r1, 65535 ; rll %r1, %r1, 16(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   0: rll %r1, %r0, 16(%r4) ; rnsbg %r1, %r2, 48, 63, 48 ; xilf %r1, 65535 ; rll %r1, %r1, 16(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 0(%r4)
 ;   lrvr %r2, %r2
 ;   br %r14
@@ -744,7 +744,7 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   lrvr %r2, %r2
 ;   l %r0, 0(%r3) ; trap: heap_oob
 ;   rll %r1, %r0, 0x10(%r4)
-;   rnsbg %r1, %r2, 0x30, 0x40, 0x30
+;   rnsbg %r1, %r2, 0x30, 0x3f, 0x30
 ;   xilf %r1, 0xffff
 ;   rll %r1, %r1, 0x10(%r4)
 ;   cs %r0, %r1, 0(%r3) ; trap: heap_oob
@@ -766,7 +766,7 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   nill %r3, 65532
 ;   lcr %r2, %r4
 ;   l %r0, 0(%r3)
-;   0: rll %r1, %r0, 0(%r4) ; rnsbg %r1, %r5, 32, 40, 24 ; xilf %r1, 4278190080 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   0: rll %r1, %r0, 0(%r4) ; rnsbg %r1, %r5, 32, 39, 24 ; xilf %r1, 4278190080 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r4)
 ;   br %r14
 ;
@@ -778,7 +778,7 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   lcr %r2, %r4
 ;   l %r0, 0(%r3) ; trap: heap_oob
 ;   rll %r1, %r0, 0(%r4)
-;   rnsbg %r1, %r5, 0x20, 0x28, 0x18
+;   rnsbg %r1, %r5, 0x20, 0x27, 0x18
 ;   xilf %r1, 0xff000000
 ;   rll %r1, %r1, 0(%r2)
 ;   cs %r0, %r1, 0(%r3) ; trap: heap_oob
@@ -849,7 +849,7 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   nill %r3, 65532
 ;   sllk %r2, %r2, 16
 ;   l %r0, 0(%r3)
-;   0: rll %r1, %r0, 16(%r4) ; lrvr %r1, %r1 ; cr %r2, %r1 ; jgnl 1f ; risbgn %r1, %r2, 32, 48, 0 ; lrvr %r1, %r1 ; rll %r1, %r1, 16(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   0: rll %r1, %r0, 16(%r4) ; lrvr %r1, %r1 ; cr %r2, %r1 ; jgnl 1f ; risbgn %r1, %r2, 32, 47, 0 ; lrvr %r1, %r1 ; rll %r1, %r1, 16(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 0(%r4)
 ;   lrvr %r2, %r2
 ;   br %r14
@@ -865,7 +865,7 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   lrvr %r1, %r1
 ;   cr %r2, %r1
 ;   jgnl 0x44
-;   risbgn %r1, %r2, 0x20, 0x30, 0
+;   risbgn %r1, %r2, 0x20, 0x2f, 0
 ;   lrvr %r1, %r1
 ;   rll %r1, %r1, 0x10(%r4)
 ;   cs %r0, %r1, 0(%r3) ; trap: heap_oob
@@ -887,7 +887,7 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   sllk %r2, %r4, 24
 ;   lcr %r4, %r5
 ;   l %r0, 0(%r3)
-;   0: rll %r1, %r0, 0(%r5) ; cr %r2, %r1 ; jgnl 1f ; risbgn %r1, %r2, 32, 40, 0 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   0: rll %r1, %r0, 0(%r5) ; cr %r2, %r1 ; jgnl 1f ; risbgn %r1, %r2, 32, 39, 0 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r5)
 ;   br %r14
 ;
@@ -901,7 +901,7 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   rll %r1, %r0, 0(%r5)
 ;   cr %r2, %r1
 ;   jgnl 0x3a
-;   risbgn %r1, %r2, 0x20, 0x28, 0
+;   risbgn %r1, %r2, 0x20, 0x27, 0
 ;   rll %r1, %r1, 0(%r4)
 ;   cs %r0, %r1, 0(%r3) ; trap: heap_oob
 ;   jglh 0x16
@@ -971,7 +971,7 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   nill %r3, 65532
 ;   sllk %r2, %r2, 16
 ;   l %r0, 0(%r3)
-;   0: rll %r1, %r0, 16(%r4) ; lrvr %r1, %r1 ; cr %r2, %r1 ; jgnh 1f ; risbgn %r1, %r2, 32, 48, 0 ; lrvr %r1, %r1 ; rll %r1, %r1, 16(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   0: rll %r1, %r0, 16(%r4) ; lrvr %r1, %r1 ; cr %r2, %r1 ; jgnh 1f ; risbgn %r1, %r2, 32, 47, 0 ; lrvr %r1, %r1 ; rll %r1, %r1, 16(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 0(%r4)
 ;   lrvr %r2, %r2
 ;   br %r14
@@ -987,7 +987,7 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   lrvr %r1, %r1
 ;   cr %r2, %r1
 ;   jgnh 0x44
-;   risbgn %r1, %r2, 0x20, 0x30, 0
+;   risbgn %r1, %r2, 0x20, 0x2f, 0
 ;   lrvr %r1, %r1
 ;   rll %r1, %r1, 0x10(%r4)
 ;   cs %r0, %r1, 0(%r3) ; trap: heap_oob
@@ -1009,7 +1009,7 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   sllk %r2, %r4, 24
 ;   lcr %r4, %r5
 ;   l %r0, 0(%r3)
-;   0: rll %r1, %r0, 0(%r5) ; cr %r2, %r1 ; jgnh 1f ; risbgn %r1, %r2, 32, 40, 0 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   0: rll %r1, %r0, 0(%r5) ; cr %r2, %r1 ; jgnh 1f ; risbgn %r1, %r2, 32, 39, 0 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r5)
 ;   br %r14
 ;
@@ -1023,7 +1023,7 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   rll %r1, %r0, 0(%r5)
 ;   cr %r2, %r1
 ;   jgnh 0x3a
-;   risbgn %r1, %r2, 0x20, 0x28, 0
+;   risbgn %r1, %r2, 0x20, 0x27, 0
 ;   rll %r1, %r1, 0(%r4)
 ;   cs %r0, %r1, 0(%r3) ; trap: heap_oob
 ;   jglh 0x16
@@ -1093,7 +1093,7 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   nill %r3, 65532
 ;   sllk %r2, %r2, 16
 ;   l %r0, 0(%r3)
-;   0: rll %r1, %r0, 16(%r4) ; lrvr %r1, %r1 ; clr %r2, %r1 ; jgnl 1f ; risbgn %r1, %r2, 32, 48, 0 ; lrvr %r1, %r1 ; rll %r1, %r1, 16(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   0: rll %r1, %r0, 16(%r4) ; lrvr %r1, %r1 ; clr %r2, %r1 ; jgnl 1f ; risbgn %r1, %r2, 32, 47, 0 ; lrvr %r1, %r1 ; rll %r1, %r1, 16(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 0(%r4)
 ;   lrvr %r2, %r2
 ;   br %r14
@@ -1109,7 +1109,7 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   lrvr %r1, %r1
 ;   clr %r2, %r1
 ;   jgnl 0x44
-;   risbgn %r1, %r2, 0x20, 0x30, 0
+;   risbgn %r1, %r2, 0x20, 0x2f, 0
 ;   lrvr %r1, %r1
 ;   rll %r1, %r1, 0x10(%r4)
 ;   cs %r0, %r1, 0(%r3) ; trap: heap_oob
@@ -1131,7 +1131,7 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   sllk %r2, %r4, 24
 ;   lcr %r4, %r5
 ;   l %r0, 0(%r3)
-;   0: rll %r1, %r0, 0(%r5) ; clr %r2, %r1 ; jgnl 1f ; risbgn %r1, %r2, 32, 40, 0 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   0: rll %r1, %r0, 0(%r5) ; clr %r2, %r1 ; jgnl 1f ; risbgn %r1, %r2, 32, 39, 0 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r5)
 ;   br %r14
 ;
@@ -1145,7 +1145,7 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   rll %r1, %r0, 0(%r5)
 ;   clr %r2, %r1
 ;   jgnl 0x3a
-;   risbgn %r1, %r2, 0x20, 0x28, 0
+;   risbgn %r1, %r2, 0x20, 0x27, 0
 ;   rll %r1, %r1, 0(%r4)
 ;   cs %r0, %r1, 0(%r3) ; trap: heap_oob
 ;   jglh 0x16
@@ -1215,7 +1215,7 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   nill %r3, 65532
 ;   sllk %r2, %r2, 16
 ;   l %r0, 0(%r3)
-;   0: rll %r1, %r0, 16(%r4) ; lrvr %r1, %r1 ; clr %r2, %r1 ; jgnh 1f ; risbgn %r1, %r2, 32, 48, 0 ; lrvr %r1, %r1 ; rll %r1, %r1, 16(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   0: rll %r1, %r0, 16(%r4) ; lrvr %r1, %r1 ; clr %r2, %r1 ; jgnh 1f ; risbgn %r1, %r2, 32, 47, 0 ; lrvr %r1, %r1 ; rll %r1, %r1, 16(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 0(%r4)
 ;   lrvr %r2, %r2
 ;   br %r14
@@ -1231,7 +1231,7 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   lrvr %r1, %r1
 ;   clr %r2, %r1
 ;   jgnh 0x44
-;   risbgn %r1, %r2, 0x20, 0x30, 0
+;   risbgn %r1, %r2, 0x20, 0x2f, 0
 ;   lrvr %r1, %r1
 ;   rll %r1, %r1, 0x10(%r4)
 ;   cs %r0, %r1, 0(%r3) ; trap: heap_oob
@@ -1253,7 +1253,7 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   sllk %r2, %r4, 24
 ;   lcr %r4, %r5
 ;   l %r0, 0(%r3)
-;   0: rll %r1, %r0, 0(%r5) ; clr %r2, %r1 ; jgnh 1f ; risbgn %r1, %r2, 32, 40, 0 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   0: rll %r1, %r0, 0(%r5) ; clr %r2, %r1 ; jgnh 1f ; risbgn %r1, %r2, 32, 39, 0 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r5)
 ;   br %r14
 ;
@@ -1267,7 +1267,7 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   rll %r1, %r0, 0(%r5)
 ;   clr %r2, %r1
 ;   jgnh 0x3a
-;   risbgn %r1, %r2, 0x20, 0x28, 0
+;   risbgn %r1, %r2, 0x20, 0x27, 0
 ;   rll %r1, %r1, 0(%r4)
 ;   cs %r0, %r1, 0(%r3) ; trap: heap_oob
 ;   jglh 0x16

--- a/cranelift/filetests/filetests/isa/s390x/atomic_rmw.clif
+++ b/cranelift/filetests/filetests/isa/s390x/atomic_rmw.clif
@@ -59,7 +59,7 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   sllk %r4, %r3, 3
 ;   nill %r3, 65532
 ;   l %r0, 0(%r3)
-;   0: rll %r1, %r0, 0(%r4) ; risbgn %r1, %r2, 32, 48, 16 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   0: rll %r1, %r0, 0(%r4) ; risbgn %r1, %r2, 32, 47, 16 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 16(%r4)
 ;   br %r14
 ;
@@ -70,7 +70,7 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   nill %r3, 0xfffc
 ;   l %r0, 0(%r3) ; trap: heap_oob
 ;   rll %r1, %r0, 0(%r4)
-;   risbgn %r1, %r2, 0x20, 0x30, 0x10
+;   risbgn %r1, %r2, 0x20, 0x2f, 0x10
 ;   rll %r1, %r1, 0(%r4)
 ;   cs %r0, %r1, 0(%r3) ; trap: heap_oob
 ;   jglh 0x12
@@ -90,7 +90,7 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   nill %r3, 65532
 ;   lcr %r2, %r4
 ;   l %r0, 0(%r3)
-;   0: rll %r1, %r0, 0(%r4) ; risbgn %r1, %r5, 32, 40, 24 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   0: rll %r1, %r0, 0(%r4) ; risbgn %r1, %r5, 32, 39, 24 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r4)
 ;   br %r14
 ;
@@ -102,7 +102,7 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   lcr %r2, %r4
 ;   l %r0, 0(%r3) ; trap: heap_oob
 ;   rll %r1, %r0, 0(%r4)
-;   risbgn %r1, %r5, 0x20, 0x28, 0x18
+;   risbgn %r1, %r5, 0x20, 0x27, 0x18
 ;   rll %r1, %r1, 0(%r2)
 ;   cs %r0, %r1, 0(%r3) ; trap: heap_oob
 ;   jglh 0x14
@@ -349,7 +349,7 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   sllk %r4, %r3, 3
 ;   nill %r3, 65532
 ;   l %r0, 0(%r3)
-;   0: rll %r1, %r0, 0(%r4) ; rnsbg %r1, %r2, 32, 48, 16 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   0: rll %r1, %r0, 0(%r4) ; rnsbg %r1, %r2, 32, 47, 16 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 16(%r4)
 ;   br %r14
 ;
@@ -360,7 +360,7 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   nill %r3, 0xfffc
 ;   l %r0, 0(%r3) ; trap: heap_oob
 ;   rll %r1, %r0, 0(%r4)
-;   rnsbg %r1, %r2, 0x20, 0x30, 0x10
+;   rnsbg %r1, %r2, 0x20, 0x2f, 0x10
 ;   rll %r1, %r1, 0(%r4)
 ;   cs %r0, %r1, 0(%r3) ; trap: heap_oob
 ;   jglh 0x12
@@ -380,7 +380,7 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   nill %r3, 65532
 ;   lcr %r2, %r4
 ;   l %r0, 0(%r3)
-;   0: rll %r1, %r0, 0(%r4) ; rnsbg %r1, %r5, 32, 40, 24 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   0: rll %r1, %r0, 0(%r4) ; rnsbg %r1, %r5, 32, 39, 24 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r4)
 ;   br %r14
 ;
@@ -392,7 +392,7 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   lcr %r2, %r4
 ;   l %r0, 0(%r3) ; trap: heap_oob
 ;   rll %r1, %r0, 0(%r4)
-;   rnsbg %r1, %r5, 0x20, 0x28, 0x18
+;   rnsbg %r1, %r5, 0x20, 0x27, 0x18
 ;   rll %r1, %r1, 0(%r2)
 ;   cs %r0, %r1, 0(%r3) ; trap: heap_oob
 ;   jglh 0x14
@@ -443,7 +443,7 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   sllk %r4, %r3, 3
 ;   nill %r3, 65532
 ;   l %r0, 0(%r3)
-;   0: rll %r1, %r0, 0(%r4) ; rosbg %r1, %r2, 32, 48, 16 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   0: rll %r1, %r0, 0(%r4) ; rosbg %r1, %r2, 32, 47, 16 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 16(%r4)
 ;   br %r14
 ;
@@ -454,7 +454,7 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   nill %r3, 0xfffc
 ;   l %r0, 0(%r3) ; trap: heap_oob
 ;   rll %r1, %r0, 0(%r4)
-;   rosbg %r1, %r2, 0x20, 0x30, 0x10
+;   rosbg %r1, %r2, 0x20, 0x2f, 0x10
 ;   rll %r1, %r1, 0(%r4)
 ;   cs %r0, %r1, 0(%r3) ; trap: heap_oob
 ;   jglh 0x12
@@ -474,7 +474,7 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   nill %r3, 65532
 ;   lcr %r2, %r4
 ;   l %r0, 0(%r3)
-;   0: rll %r1, %r0, 0(%r4) ; rosbg %r1, %r5, 32, 40, 24 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   0: rll %r1, %r0, 0(%r4) ; rosbg %r1, %r5, 32, 39, 24 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r4)
 ;   br %r14
 ;
@@ -486,7 +486,7 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   lcr %r2, %r4
 ;   l %r0, 0(%r3) ; trap: heap_oob
 ;   rll %r1, %r0, 0(%r4)
-;   rosbg %r1, %r5, 0x20, 0x28, 0x18
+;   rosbg %r1, %r5, 0x20, 0x27, 0x18
 ;   rll %r1, %r1, 0(%r2)
 ;   cs %r0, %r1, 0(%r3) ; trap: heap_oob
 ;   jglh 0x14
@@ -537,7 +537,7 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   sllk %r4, %r3, 3
 ;   nill %r3, 65532
 ;   l %r0, 0(%r3)
-;   0: rll %r1, %r0, 0(%r4) ; rxsbg %r1, %r2, 32, 48, 16 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   0: rll %r1, %r0, 0(%r4) ; rxsbg %r1, %r2, 32, 47, 16 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 16(%r4)
 ;   br %r14
 ;
@@ -548,7 +548,7 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   nill %r3, 0xfffc
 ;   l %r0, 0(%r3) ; trap: heap_oob
 ;   rll %r1, %r0, 0(%r4)
-;   rxsbg %r1, %r2, 0x20, 0x30, 0x10
+;   rxsbg %r1, %r2, 0x20, 0x2f, 0x10
 ;   rll %r1, %r1, 0(%r4)
 ;   cs %r0, %r1, 0(%r3) ; trap: heap_oob
 ;   jglh 0x12
@@ -568,7 +568,7 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   nill %r3, 65532
 ;   lcr %r2, %r4
 ;   l %r0, 0(%r3)
-;   0: rll %r1, %r0, 0(%r4) ; rxsbg %r1, %r5, 32, 40, 24 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   0: rll %r1, %r0, 0(%r4) ; rxsbg %r1, %r5, 32, 39, 24 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r4)
 ;   br %r14
 ;
@@ -580,7 +580,7 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   lcr %r2, %r4
 ;   l %r0, 0(%r3) ; trap: heap_oob
 ;   rll %r1, %r0, 0(%r4)
-;   rxsbg %r1, %r5, 0x20, 0x28, 0x18
+;   rxsbg %r1, %r5, 0x20, 0x27, 0x18
 ;   rll %r1, %r1, 0(%r2)
 ;   cs %r0, %r1, 0(%r3) ; trap: heap_oob
 ;   jglh 0x14
@@ -646,7 +646,7 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   sllk %r4, %r3, 3
 ;   nill %r3, 65532
 ;   l %r0, 0(%r3)
-;   0: rll %r1, %r0, 0(%r4) ; rnsbg %r1, %r2, 32, 48, 16 ; xilf %r1, 4294901760 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   0: rll %r1, %r0, 0(%r4) ; rnsbg %r1, %r2, 32, 47, 16 ; xilf %r1, 4294901760 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 16(%r4)
 ;   br %r14
 ;
@@ -657,7 +657,7 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   nill %r3, 0xfffc
 ;   l %r0, 0(%r3) ; trap: heap_oob
 ;   rll %r1, %r0, 0(%r4)
-;   rnsbg %r1, %r2, 0x20, 0x30, 0x10
+;   rnsbg %r1, %r2, 0x20, 0x2f, 0x10
 ;   xilf %r1, 0xffff0000
 ;   rll %r1, %r1, 0(%r4)
 ;   cs %r0, %r1, 0(%r3) ; trap: heap_oob
@@ -678,7 +678,7 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   nill %r3, 65532
 ;   lcr %r2, %r4
 ;   l %r0, 0(%r3)
-;   0: rll %r1, %r0, 0(%r4) ; rnsbg %r1, %r5, 32, 40, 24 ; xilf %r1, 4278190080 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   0: rll %r1, %r0, 0(%r4) ; rnsbg %r1, %r5, 32, 39, 24 ; xilf %r1, 4278190080 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r4)
 ;   br %r14
 ;
@@ -690,7 +690,7 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   lcr %r2, %r4
 ;   l %r0, 0(%r3) ; trap: heap_oob
 ;   rll %r1, %r0, 0(%r4)
-;   rnsbg %r1, %r5, 0x20, 0x28, 0x18
+;   rnsbg %r1, %r5, 0x20, 0x27, 0x18
 ;   xilf %r1, 0xff000000
 ;   rll %r1, %r1, 0(%r2)
 ;   cs %r0, %r1, 0(%r3) ; trap: heap_oob
@@ -757,7 +757,7 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   nill %r3, 65532
 ;   sllk %r2, %r2, 16
 ;   l %r0, 0(%r3)
-;   0: rll %r1, %r0, 0(%r4) ; cr %r2, %r1 ; jgnl 1f ; risbgn %r1, %r2, 32, 48, 0 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   0: rll %r1, %r0, 0(%r4) ; cr %r2, %r1 ; jgnl 1f ; risbgn %r1, %r2, 32, 47, 0 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 16(%r4)
 ;   br %r14
 ;
@@ -771,7 +771,7 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   rll %r1, %r0, 0(%r4)
 ;   cr %r2, %r1
 ;   jgnl 0x3c
-;   risbgn %r1, %r2, 0x20, 0x30, 0
+;   risbgn %r1, %r2, 0x20, 0x2f, 0
 ;   rll %r1, %r1, 0(%r4)
 ;   cs %r0, %r1, 0(%r3) ; trap: heap_oob
 ;   jglh 0x18
@@ -791,7 +791,7 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   sllk %r2, %r4, 24
 ;   lcr %r4, %r5
 ;   l %r0, 0(%r3)
-;   0: rll %r1, %r0, 0(%r5) ; cr %r2, %r1 ; jgnl 1f ; risbgn %r1, %r2, 32, 40, 0 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   0: rll %r1, %r0, 0(%r5) ; cr %r2, %r1 ; jgnl 1f ; risbgn %r1, %r2, 32, 39, 0 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r5)
 ;   br %r14
 ;
@@ -805,7 +805,7 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   rll %r1, %r0, 0(%r5)
 ;   cr %r2, %r1
 ;   jgnl 0x3a
-;   risbgn %r1, %r2, 0x20, 0x28, 0
+;   risbgn %r1, %r2, 0x20, 0x27, 0
 ;   rll %r1, %r1, 0(%r4)
 ;   cs %r0, %r1, 0(%r3) ; trap: heap_oob
 ;   jglh 0x16
@@ -871,7 +871,7 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   nill %r3, 65532
 ;   sllk %r2, %r2, 16
 ;   l %r0, 0(%r3)
-;   0: rll %r1, %r0, 0(%r4) ; cr %r2, %r1 ; jgnh 1f ; risbgn %r1, %r2, 32, 48, 0 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   0: rll %r1, %r0, 0(%r4) ; cr %r2, %r1 ; jgnh 1f ; risbgn %r1, %r2, 32, 47, 0 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 16(%r4)
 ;   br %r14
 ;
@@ -885,7 +885,7 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   rll %r1, %r0, 0(%r4)
 ;   cr %r2, %r1
 ;   jgnh 0x3c
-;   risbgn %r1, %r2, 0x20, 0x30, 0
+;   risbgn %r1, %r2, 0x20, 0x2f, 0
 ;   rll %r1, %r1, 0(%r4)
 ;   cs %r0, %r1, 0(%r3) ; trap: heap_oob
 ;   jglh 0x18
@@ -905,7 +905,7 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   sllk %r2, %r4, 24
 ;   lcr %r4, %r5
 ;   l %r0, 0(%r3)
-;   0: rll %r1, %r0, 0(%r5) ; cr %r2, %r1 ; jgnh 1f ; risbgn %r1, %r2, 32, 40, 0 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   0: rll %r1, %r0, 0(%r5) ; cr %r2, %r1 ; jgnh 1f ; risbgn %r1, %r2, 32, 39, 0 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r5)
 ;   br %r14
 ;
@@ -919,7 +919,7 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   rll %r1, %r0, 0(%r5)
 ;   cr %r2, %r1
 ;   jgnh 0x3a
-;   risbgn %r1, %r2, 0x20, 0x28, 0
+;   risbgn %r1, %r2, 0x20, 0x27, 0
 ;   rll %r1, %r1, 0(%r4)
 ;   cs %r0, %r1, 0(%r3) ; trap: heap_oob
 ;   jglh 0x16
@@ -985,7 +985,7 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   nill %r3, 65532
 ;   sllk %r2, %r2, 16
 ;   l %r0, 0(%r3)
-;   0: rll %r1, %r0, 0(%r4) ; clr %r2, %r1 ; jgnl 1f ; risbgn %r1, %r2, 32, 48, 0 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   0: rll %r1, %r0, 0(%r4) ; clr %r2, %r1 ; jgnl 1f ; risbgn %r1, %r2, 32, 47, 0 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 16(%r4)
 ;   br %r14
 ;
@@ -999,7 +999,7 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   rll %r1, %r0, 0(%r4)
 ;   clr %r2, %r1
 ;   jgnl 0x3c
-;   risbgn %r1, %r2, 0x20, 0x30, 0
+;   risbgn %r1, %r2, 0x20, 0x2f, 0
 ;   rll %r1, %r1, 0(%r4)
 ;   cs %r0, %r1, 0(%r3) ; trap: heap_oob
 ;   jglh 0x18
@@ -1019,7 +1019,7 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   sllk %r2, %r4, 24
 ;   lcr %r4, %r5
 ;   l %r0, 0(%r3)
-;   0: rll %r1, %r0, 0(%r5) ; clr %r2, %r1 ; jgnl 1f ; risbgn %r1, %r2, 32, 40, 0 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   0: rll %r1, %r0, 0(%r5) ; clr %r2, %r1 ; jgnl 1f ; risbgn %r1, %r2, 32, 39, 0 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r5)
 ;   br %r14
 ;
@@ -1033,7 +1033,7 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   rll %r1, %r0, 0(%r5)
 ;   clr %r2, %r1
 ;   jgnl 0x3a
-;   risbgn %r1, %r2, 0x20, 0x28, 0
+;   risbgn %r1, %r2, 0x20, 0x27, 0
 ;   rll %r1, %r1, 0(%r4)
 ;   cs %r0, %r1, 0(%r3) ; trap: heap_oob
 ;   jglh 0x16
@@ -1099,7 +1099,7 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   nill %r3, 65532
 ;   sllk %r2, %r2, 16
 ;   l %r0, 0(%r3)
-;   0: rll %r1, %r0, 0(%r4) ; clr %r2, %r1 ; jgnh 1f ; risbgn %r1, %r2, 32, 48, 0 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   0: rll %r1, %r0, 0(%r4) ; clr %r2, %r1 ; jgnh 1f ; risbgn %r1, %r2, 32, 47, 0 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 16(%r4)
 ;   br %r14
 ;
@@ -1113,7 +1113,7 @@ block0(v0: i64, v1: i64, v2: i16):
 ;   rll %r1, %r0, 0(%r4)
 ;   clr %r2, %r1
 ;   jgnh 0x3c
-;   risbgn %r1, %r2, 0x20, 0x30, 0
+;   risbgn %r1, %r2, 0x20, 0x2f, 0
 ;   rll %r1, %r1, 0(%r4)
 ;   cs %r0, %r1, 0(%r3) ; trap: heap_oob
 ;   jglh 0x18
@@ -1133,7 +1133,7 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   sllk %r2, %r4, 24
 ;   lcr %r4, %r5
 ;   l %r0, 0(%r3)
-;   0: rll %r1, %r0, 0(%r5) ; clr %r2, %r1 ; jgnh 1f ; risbgn %r1, %r2, 32, 40, 0 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
+;   0: rll %r1, %r0, 0(%r5) ; clr %r2, %r1 ; jgnh 1f ; risbgn %r1, %r2, 32, 39, 0 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r5)
 ;   br %r14
 ;
@@ -1147,7 +1147,7 @@ block0(v0: i64, v1: i64, v2: i8):
 ;   rll %r1, %r0, 0(%r5)
 ;   clr %r2, %r1
 ;   jgnh 0x3a
-;   risbgn %r1, %r2, 0x20, 0x28, 0
+;   risbgn %r1, %r2, 0x20, 0x27, 0
 ;   rll %r1, %r1, 0(%r4)
 ;   cs %r0, %r1, 0(%r3) ; trap: heap_oob
 ;   jglh 0x16


### PR DESCRIPTION
The bug this corrects is that the range specified by the rotate then <bool-op> select bits instructions is specified with an inclusive range start _and_ end. The prior implementation incorrectly specified the end of the range as if it were exclusive.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
