### PR TITLE
Warn about CLI usage of wasi-common or wasi-threads

### DIFF
--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -1121,6 +1121,18 @@ impl RunCommand {
                         // are enabled, then use the historical preview1
                         // implementation.
                         (Some(false), _) | (None, Some(true)) => {
+                            let flag = if self.run.common.wasi.preview2 == Some(false) {
+                                "-Spreview2=n"
+                            } else {
+                                "-Sthreads"
+                            };
+                            eprintln!(
+                                "\
+WARNING: the `{flag}` flag will be a hard error in Wasmtime 47.0.0 on 2026-07-20. \
+For more information see https://github.com/bytecodealliance/rfcs/pull/47 and \
+please reach out on Zulip with questions.
+                            "
+                            );
                             wasi_common::tokio::add_to_linker(linker, |host| {
                                 host.legacy_p1_ctx.as_mut().unwrap()
                             })?;


### PR DESCRIPTION
This commit adds a warning to the CLI for
https://github.com/bytecodealliance/rfcs/pull/47 being merged to prepare any would-be users about the upcoming change. This is expected to be around for 2 versions of Wasmtime, 45.0.0 and 46.0.0, and in 47.0.0 the warning will become a hard error with the removal of `wasi-common` and `wasi-threads`.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
