### PR TITLE
c-api: Defensively zero-extend kind in wasm_valtype_new

### DIFF
--- a/crates/c-api/src/types/val.rs
+++ b/crates/c-api/src/types/val.rs
@@ -19,6 +19,13 @@ pub const WASM_FUNCREF: wasm_valkind_t = 129;
 
 #[unsafe(no_mangle)]
 pub extern "C" fn wasm_valtype_new(kind: wasm_valkind_t) -> Box<wasm_valtype_t> {
+    // The SysV AMD64 ABI does not require callers to zero/sign-extend
+    // sub-`int` arguments, and some C compilers (e.g. GCC) pass `WASM_FUNCREF`
+    // (= 129) sign-extended as `0xffffff81` in `%edi`. Without this volatile
+    // round-trip, rustc may compile the match below as a 32-bit comparison
+    // against the unextended register and fall through to the panic arm.
+    // See https://github.com/rust-lang/rust/issues/97463.
+    let kind = unsafe { std::ptr::read_volatile(&kind) };
     Box::new(match kind {
         WASM_I32 => ValType::I32,
         WASM_I64 => ValType::I64,


### PR DESCRIPTION
## Summary

The SysV AMD64 ABI does not require callers to zero- or sign-extend sub-`int` arguments. GCC, for example, emits `mov $0xffffff81, %edi` when passing `WASM_FUNCREF` (= 129) to `wasm_valtype_new`, leaving the upper bytes of `%rdi` holding the sign-extended representation.

Recent rustc/LLVM versions (observed with 1.95.0) compile the `match` over `kind: u8` as a comparison against the full 32-bit `%edi` rather than `%dil`. Because `0xffffff81 != 0x81`, the `WASM_FUNCREF` arm does not match and the function aborts with `unexpected value type kind`, even though the C caller supplied a perfectly valid kind.

This patch forces a memory round-trip via `std::ptr::read_volatile` so LLVM emits a `movzbl` load before the comparisons. Cost: one extra load per call. Benefit: robustness against any conformant C caller.

## Reproduction

Observed in the wild: tree-sitter's `ts_wasm_store_new` calls `wasm_valtype_new(WASM_FUNCREF)` while embedded in the [Zed editor](https://github.com/zed-industries/zed). With rustc 1.95.0 + gcc 14 on Linux x86_64, every file open aborts the editor.

Disassembly of the unpatched function shows:

\`\`\`asm
mov  %dil, 0x7(%rsp)        ; stores low byte (correct)
cmp  \$0x4,  %edi            ; ❌ compares full 32-bit %edi
cmp  \$0x80, %edi            ; ❌ also full register
cmp  \$0x81, %edi            ; ❌ 0xffffff81 != 0x81 → falls through to abort
\`\`\`

After the patch:

\`\`\`asm
mov    %dil, 0x6(%rsp)
movzbl 0x6(%rsp), %eax       ; ✅ zero-extending load
cmp    \$0x80, %eax           ; ✅ now sees 0x81
cmp    \$0x81, %eax           ; ✅ matches WASM_FUNCREF
\`\`\`

## Notes

- Related: [rust-lang/rust#97463](https://github.com/rust-lang/rust/issues/97463)
- Other `extern "C"` entry points in the C API that take small integer args and `match` on them may have the same latent bug; this PR only fixes the demonstrated case. Happy to extend the fix to other call sites if maintainers prefer.