### PR TITLE
Require `async` types when lift/lower uses `async`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2254,8 +2254,7 @@ dependencies = [
 [[package]]
 name = "json-from-wast"
 version = "0.248.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692e5e6883558fb83746e7ab1da0d94a69b31286f88ecaa9ce6add0f269da0b6"
+source = "git+https://github.com/alexcrichton/wasm-tools?branch=gate-async-on-sync-type#9449a9ec810ed5f2650bf88a5a16ca049569d99a"
 dependencies = [
  "anyhow",
  "serde",
@@ -4480,8 +4479,7 @@ checksum = "6ee99da9c5ba11bd675621338ef6fa52296b76b83305e9b6e5c77d4c286d6d49"
 [[package]]
 name = "wasm-compose"
 version = "0.248.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96ba953e2b9b4b4b52a31cf4e3ee1c1374c872b6e012cf2138d1c37cba00bfd6"
+source = "git+https://github.com/alexcrichton/wasm-tools?branch=gate-async-on-sync-type#9449a9ec810ed5f2650bf88a5a16ca049569d99a"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -4517,8 +4515,7 @@ dependencies = [
 [[package]]
 name = "wasm-encoder"
 version = "0.248.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac92cf547bc18d27ecc521015c08c353b4f18b84ab388bb6d1b6b682c620d9b6"
+source = "git+https://github.com/alexcrichton/wasm-tools?branch=gate-async-on-sync-type#9449a9ec810ed5f2650bf88a5a16ca049569d99a"
 dependencies = [
  "leb128fmt",
  "wasmparser 0.248.0",
@@ -4551,8 +4548,7 @@ dependencies = [
 [[package]]
 name = "wasm-metadata"
 version = "0.248.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee4f85f11dcdabc91e805c03eb84ccc7b7ef2282c6610bb83c7a7c853425850c"
+source = "git+https://github.com/alexcrichton/wasm-tools?branch=gate-async-on-sync-type#9449a9ec810ed5f2650bf88a5a16ca049569d99a"
 dependencies = [
  "anyhow",
  "indexmap 2.14.0",
@@ -4563,8 +4559,7 @@ dependencies = [
 [[package]]
 name = "wasm-mutate"
 version = "0.248.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6210f23d92145ecdbc04e27d4b570714148e45c61db913f1f69a38fe80fb61d7"
+source = "git+https://github.com/alexcrichton/wasm-tools?branch=gate-async-on-sync-type#9449a9ec810ed5f2650bf88a5a16ca049569d99a"
 dependencies = [
  "egg",
  "log",
@@ -4577,8 +4572,7 @@ dependencies = [
 [[package]]
 name = "wasm-smith"
 version = "0.248.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "050b559c1cec6dd6b9a558ae984d91d61e5e7b4c3e47081305a13efe6869eea0"
+source = "git+https://github.com/alexcrichton/wasm-tools?branch=gate-async-on-sync-type#9449a9ec810ed5f2650bf88a5a16ca049569d99a"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -4600,8 +4594,7 @@ dependencies = [
 [[package]]
 name = "wasm-wave"
 version = "0.248.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8c928a58132ecc6a4daee3795bb3560702436f6516b5f8c5b3086113031e76"
+source = "git+https://github.com/alexcrichton/wasm-tools?branch=gate-async-on-sync-type#9449a9ec810ed5f2650bf88a5a16ca049569d99a"
 dependencies = [
  "logos",
  "thiserror 2.0.17",
@@ -4685,8 +4678,7 @@ dependencies = [
 [[package]]
 name = "wasmparser"
 version = "0.248.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa4439c5eee9df71ee0c6efb37f63b1fcb1fec38f85f5142c54e7ed05d33091a"
+source = "git+https://github.com/alexcrichton/wasm-tools?branch=gate-async-on-sync-type#9449a9ec810ed5f2650bf88a5a16ca049569d99a"
 dependencies = [
  "bitflags 2.11.1",
  "hashbrown 0.17.0",
@@ -4698,8 +4690,7 @@ dependencies = [
 [[package]]
 name = "wasmprinter"
 version = "0.248.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b264a5410b008d4d199a92bf536eae703cbd614482fc1ec53831cf19e1c183"
+source = "git+https://github.com/alexcrichton/wasm-tools?branch=gate-async-on-sync-type#9449a9ec810ed5f2650bf88a5a16ca049569d99a"
 dependencies = [
  "anyhow",
  "termcolor",
@@ -5466,8 +5457,7 @@ dependencies = [
 [[package]]
 name = "wast"
 version = "248.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acc54622ed5a5cddafcdf152043f9d4aed54d4a653d686b7dfe874809fca99d7"
+source = "git+https://github.com/alexcrichton/wasm-tools?branch=gate-async-on-sync-type#9449a9ec810ed5f2650bf88a5a16ca049569d99a"
 dependencies = [
  "bumpalo",
  "gimli 0.32.3",
@@ -5480,8 +5470,7 @@ dependencies = [
 [[package]]
 name = "wat"
 version = "1.248.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75cd9e510603909748e6ebab89f27cd04472c1d9d85a3c88a7a6fc51a1a7934"
+source = "git+https://github.com/alexcrichton/wasm-tools?branch=gate-async-on-sync-type#9449a9ec810ed5f2650bf88a5a16ca049569d99a"
 dependencies = [
  "wast 248.0.0",
 ]
@@ -6007,8 +5996,7 @@ dependencies = [
 [[package]]
 name = "wit-component"
 version = "0.248.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0012379f0ff47e1d44dd312e76cfa42de2589251f093fb105e9de9db90c89221"
+source = "git+https://github.com/alexcrichton/wasm-tools?branch=gate-async-on-sync-type#9449a9ec810ed5f2650bf88a5a16ca049569d99a"
 dependencies = [
  "anyhow",
  "bitflags 2.11.1",
@@ -6063,8 +6051,7 @@ dependencies = [
 [[package]]
 name = "wit-parser"
 version = "0.248.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "247ad505da2915a082fe13204c5ba8788425aea1de54f43b284818cf82637856"
+source = "git+https://github.com/alexcrichton/wasm-tools?branch=gate-async-on-sync-type#9449a9ec810ed5f2650bf88a5a16ca049569d99a"
 dependencies = [
  "anyhow",
  "hashbrown 0.17.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -769,3 +769,18 @@ fpr = "fpr"
 
 [workspace.metadata.typos.files]
 extend-exclude = [ "docs/js/mermaid*.js", "crates/wasi-nn/**/*.txt", "*.isle" ]
+
+[patch.crates-io]
+wasmparser = { git = 'https://github.com/alexcrichton/wasm-tools', branch = 'gate-async-on-sync-type' }
+wat = { git = 'https://github.com/alexcrichton/wasm-tools', branch = 'gate-async-on-sync-type' }
+wast = { git = 'https://github.com/alexcrichton/wasm-tools', branch = 'gate-async-on-sync-type' }
+wasmprinter = { git = 'https://github.com/alexcrichton/wasm-tools', branch = 'gate-async-on-sync-type' }
+wasm-encoder = { git = 'https://github.com/alexcrichton/wasm-tools', branch = 'gate-async-on-sync-type' }
+wasm-smith = { git = 'https://github.com/alexcrichton/wasm-tools', branch = 'gate-async-on-sync-type' }
+wasm-mutate = { git = 'https://github.com/alexcrichton/wasm-tools', branch = 'gate-async-on-sync-type' }
+wit-parser = { git = 'https://github.com/alexcrichton/wasm-tools', branch = 'gate-async-on-sync-type' }
+wit-component = { git = 'https://github.com/alexcrichton/wasm-tools', branch = 'gate-async-on-sync-type' }
+wasm-wave = { git = 'https://github.com/alexcrichton/wasm-tools', branch = 'gate-async-on-sync-type' }
+wasm-compose = { git = 'https://github.com/alexcrichton/wasm-tools', branch = 'gate-async-on-sync-type' }
+wasm-metadata = { git = 'https://github.com/alexcrichton/wasm-tools', branch = 'gate-async-on-sync-type' }
+json-from-wast = { git = 'https://github.com/alexcrichton/wasm-tools', branch = 'gate-async-on-sync-type' }

--- a/crates/test-util/src/wast.rs
+++ b/crates/test-util/src/wast.rs
@@ -477,6 +477,9 @@ impl WastTest {
             // memory64.
             "test/wasm-tools/memory64.wast",
             "test/wasm-tools/resources.wast",
+            // Not updated upstream yet
+            "test/async/cross-abi-calls.wast",
+            "test/async/trap-on-reenter.wast",
         ];
         if unsupported.iter().any(|part| self.path.ends_with(part)) {
             return true;

--- a/tests/all/component_model/async.rs
+++ b/tests/all/component_model/async.rs
@@ -1352,7 +1352,7 @@ async fn drop_deadlocked_typed_future() -> Result<()> {
               (func (export "set-backpressure")
                 (canon lift (core func $i "set-backpressure")))
 
-              (func (export "target")
+              (func (export "target") async
                 (canon lift (core func $i "target") async (callback (func $i "callback"))))
             )
         "#,

--- a/tests/all/component_model/bindgen.rs
+++ b/tests/all/component_model/bindgen.rs
@@ -108,7 +108,7 @@ mod no_imports_concurrent {
                         (with "" (instance (export "task.return" (func $task-return))))
                     ))
 
-                    (func $f (export "bar")
+                    (func $f (export "bar") async
                         (canon lift (core func $i "bar") async (callback (func $i "callback")))
                     )
 

--- a/tests/all/component_model/func.rs
+++ b/tests/all/component_model/func.rs
@@ -827,12 +827,12 @@ async fn async_reentrance() -> Result<()> {
             (core instance $shim (instantiate $shim
                 (with "" (instance (export "task.return" (func $task-return))))
             ))
-            (func $shim-export (param "p1" u32) (result u32)
+            (func $shim-export async (param "p1" u32) (result u32)
                 (canon lift (core func $shim "export") async (callback (func $shim "callback")))
             )
 
             (component $inner
-                (import "import" (func $import (param "p1" u32) (result u32)))
+                (import "import" (func $import async (param "p1" u32) (result u32)))
                 (core module $libc (memory (export "memory") 1))
                 (core instance $libc (instantiate $libc))
                 (core func $import (canon lower (func $import) async (memory $libc "memory")))
@@ -859,7 +859,7 @@ async fn async_reentrance() -> Result<()> {
                     ))
                     (with "libc" (instance $libc))
                 ))
-                (func (export "export") (param "p1" u32) (result u32)
+                (func (export "export") async (param "p1" u32) (result u32)
                     (canon lift (core func $i "export") async (callback (func $i "callback")))
                 )
             )
@@ -897,7 +897,7 @@ async fn async_reentrance() -> Result<()> {
                 ))
                 (with "libc" (instance $libc))
             ))
-            (func (export "export") (param "p1" u32) (result u32)
+            (func (export "export") async (param "p1" u32) (result u32)
                 (canon lift (core func $donut "export") async (callback (func $donut "callback")))
             )
         )"#;
@@ -946,7 +946,7 @@ async fn missing_task_return_call_stackless() -> Result<()> {
             (core instance $i (instantiate $m
                 (with "" (instance (export "task.return" (func $task-return))))
             ))
-            (func (export "foo") (canon lift (core func $i "foo") async (callback (func $i "callback"))))
+            (func (export "foo") async (canon lift (core func $i "foo") async (callback (func $i "callback"))))
         )"#,
         "wasm trap: async-lifted export failed to produce a result",
     )
@@ -988,7 +988,7 @@ async fn missing_task_return_call_stackless_explicit_thread() -> Result<()> {
                 ))
                 (with "libc" (instance $libc))
             ))
-            (func (export "foo") (canon lift (core func $i "foo") async (callback (func $i "callback"))))
+            (func (export "foo") async (canon lift (core func $i "foo") async (callback (func $i "callback"))))
         )"#,
         "wasm trap: async-lifted export failed to produce a result",
     )
@@ -1028,7 +1028,7 @@ async fn missing_task_return_call_stackful_explicit_thread() -> Result<()> {
                 ))
                 (with "libc" (instance $libc))
             ))
-            (func (export "foo") (canon lift (core func $i "foo") async))
+            (func (export "foo") async (canon lift (core func $i "foo") async))
         )"#,
         "wasm trap: async-lifted export failed to produce a result",
     )
@@ -1047,7 +1047,7 @@ async fn missing_task_return_call_stackful() -> Result<()> {
             (core instance $i (instantiate $m
                 (with "" (instance (export "task.return" (func $task-return))))
             ))
-            (func (export "foo") (canon lift (core func $i "foo") async))
+            (func (export "foo") async (canon lift (core func $i "foo") async))
         )"#,
         "wasm trap: async-lifted export failed to produce a result",
     )
@@ -1066,7 +1066,7 @@ async fn task_return_type_mismatch() -> Result<()> {
             (core instance $i (instantiate $m
                 (with "" (instance (export "task.return" (func $task-return))))
             ))
-            (func (export "foo") (canon lift (core func $i "foo") async))
+            (func (export "foo") async (canon lift (core func $i "foo") async))
         )"#,
         "invalid `task.return` signature and/or options for current task",
     )
@@ -1087,7 +1087,7 @@ async fn task_return_memory_mismatch() -> Result<()> {
             (core instance $i (instantiate $m
                 (with "" (instance (export "task.return" (func $task-return))))
             ))
-            (func (export "foo") (canon lift (core func $i "foo") async))
+            (func (export "foo") async (canon lift (core func $i "foo") async))
         )"#,
         "invalid `task.return` signature and/or options for current task",
     )
@@ -1106,7 +1106,7 @@ async fn task_return_string_encoding_mismatch() -> Result<()> {
             (core instance $i (instantiate $m
                 (with "" (instance (export "task.return" (func $task-return))))
             ))
-            (func (export "foo") (canon lift (core func $i "foo") async))
+            (func (export "foo") async (canon lift (core func $i "foo") async))
         )"#,
         "invalid `task.return` signature and/or options for current task",
     )
@@ -1244,7 +1244,7 @@ async fn test_many_parameters(dynamic: bool, concurrent: bool) -> Result<()> {
                 (with "libc" (instance $libc))
             ))
 
-            (type $t (func
+            (type $t (func async
                 (param "p1" s8)              ;; offset  0, size 1
                 (param "p2" u64)             ;; offset  8, size 8
                 (param "p3" float32)         ;; offset 16, size 4
@@ -1715,7 +1715,7 @@ async fn test_many_results(dynamic: bool, concurrent: bool) -> Result<()> {
                 (with "libc" (instance $libc))
             ))
 
-            (type $t (func (result $tuple)))
+            (type $t (func async (result $tuple)))
             (func (export "many-results") (type $t)
                 (canon lift
                     (core func $i "foo")

--- a/tests/misc_testsuite/component-model/async/backpressure-deadlock.wast
+++ b/tests/misc_testsuite/component-model/async/backpressure-deadlock.wast
@@ -33,40 +33,40 @@
     ))
 
     (func (export "turn-on-backpressure") (canon lift (core func $i "turn-on-backpressure")))
-    (func (export "f")
+    (func (export "f") async
       (canon lift (core func $i "f") async (callback (func $i "callback"))))
   )
   (instance $A (instantiate $A))
 
   (component $B
     (import "A" (instance $A
-      (export "f" (func))
+      (export "f" (func async))
       (export "turn-on-backpressure" (func))
     ))
-    
+
     (core module $libc (memory (export "mem") 1))
     (core instance $libc (instantiate $libc))
-  
+
     (core func $f (canon lower (func $A "f") async (memory $libc "mem")))
     (core func $turn-on-backpressure (canon lower (func $A "turn-on-backpressure")))
     (core func $waitable-set.new (canon waitable-set.new))
     (core func $waitable.join (canon waitable.join))
     (core func $waitable-set.wait (canon waitable-set.wait (memory $libc "mem")))
-  
+
     (core module $m
       (import "" "f" (func $f (result i32)))
       (import "" "turn-on-backpressure" (func $turn-on-backpressure))
       (import "" "waitable-set.new" (func $waitable-set.new (result i32)))
       (import "" "waitable.join" (func $waitable.join (param i32 i32)))
       (import "" "waitable-set.wait" (func $waitable-set.wait (param i32 i32) (result i32)))
-  
+
       (func (export "f")
         (local $status i32)
         (local $set i32)
         call $turn-on-backpressure
-  
+
         (local.set $status (call $f))
-  
+
         ;; low 4 bits should be "STARTING == 0"
         (i32.ne
           (i32.const 0)
@@ -74,19 +74,19 @@
             (local.get $status)
             (i32.const 0xf)))
         if unreachable end
-  
+
         ;; make a new waitable set and join our subtask into it
         (local.set $set (call $waitable-set.new))
         (call $waitable.join
           (i32.shr_u (local.get $status) (i32.const 4))
           (local.get $set))
-  
+
         ;; block waiting for our task, which should deadlock (?)
         (call $waitable-set.wait (local.get $set) (i32.const 0))
         unreachable
       )
     )
-  
+
     (core instance $i (instantiate $m
       (with "" (instance
         (export "f" (func $f))
@@ -96,13 +96,13 @@
         (export "waitable-set.wait" (func $waitable-set.wait))
       ))
     ))
-  
+
     (func (export "f") async (canon lift (core func $i "f")))
   )
 
   (instance $B (instantiate $B (with "A" (instance $A))))
 
-  (func (export "f") (alias export $B "f"))  
+  (func (export "f") (alias export $B "f"))
 )
 
 (assert_trap (invoke "f") "deadlock detected")

--- a/tests/misc_testsuite/component-model/async/callback-yield-then-exit.wast
+++ b/tests/misc_testsuite/component-model/async/callback-yield-then-exit.wast
@@ -21,13 +21,13 @@
       (with "" (instance (export "task.return" (func $task.return))))
     ))
 
-    (func (export "foo") (param "p1" u32) (result u32)
+    (func (export "foo") async (param "p1" u32) (result u32)
       (canon lift (core func $i "foo") async (callback (func $i "callback")))
     )
   )
 
   (component $B
-    (import "a" (func $foo (param "p1" u32) (result u32)))
+    (import "a" (func $foo async (param "p1" u32) (result u32)))
     (core func $foo (canon lower (func $foo)))
     (core module $m
       (import "" "foo" (func $foo (param i32) (result i32)))
@@ -39,7 +39,7 @@
     (core instance $i (instantiate $m
       (with "" (instance (export "foo" (func $foo))))
     ))
-    (func (export "run") (canon lift (core func $i "run")))
+    (func (export "run") async (canon lift (core func $i "run")))
   )
 
   (instance $A (instantiate $A))

--- a/tests/misc_testsuite/component-model/async/fused.wast
+++ b/tests/misc_testsuite/component-model/async/fused.wast
@@ -20,13 +20,13 @@
       (with "" (instance (export "task.return" (func $task-return))))
     ))
 
-    (func (export "foo") (param "p1" u32) (result u32)
+    (func (export "foo") async (param "p1" u32) (result u32)
       (canon lift (core func $i "foo") async (callback (func $i "callback")))
     )
   )
 
   (component $lowerer
-    (import "a" (func $foo (param "p1" u32) (result u32)))
+    (import "a" (func $foo async (param "p1" u32) (result u32)))
     (core module $libc (memory (export "memory") 1))
     (core instance $libc (instantiate $libc))
     (core func $foo (canon lower (func $foo) async (memory $libc "memory")))
@@ -46,7 +46,7 @@
       (with "libc" (instance $libc))
       (with "" (instance (export "foo" (func $foo))))
     ))
-    (func (export "run") (canon lift (core func $i "run")))
+    (func (export "run") async (canon lift (core func $i "run")))
   )
 
   (instance $lifter (instantiate $lifter))
@@ -65,13 +65,13 @@
       )
     )
     (core instance $i (instantiate $m))
-    (func (export "foo") (param "p1" u32) (result u32)
+    (func (export "foo") async (param "p1" u32) (result u32)
       (canon lift (core func $i "foo"))
     )
   )
 
   (component $lowerer
-    (import "a" (func $foo (param "p1" u32) (result u32)))
+    (import "a" (func $foo async (param "p1" u32) (result u32)))
     (core module $libc (memory (export "memory") 1))
     (core instance $libc (instantiate $libc))
     (core func $foo (canon lower (func $foo) async (memory $libc "memory")))
@@ -91,7 +91,7 @@
       (with "libc" (instance $libc))
       (with "" (instance (export "foo" (func $foo))))
     ))
-    (func (export "run") (canon lift (core func $i "run")))
+    (func (export "run") async (canon lift (core func $i "run")))
   )
 
   (instance $lifter (instantiate $lifter))
@@ -117,13 +117,13 @@
       (with "" (instance (export "task.return" (func $task-return))))
     ))
 
-    (func (export "foo") (param "p1" u32) (result u32)
+    (func (export "foo") async (param "p1" u32) (result u32)
       (canon lift (core func $i "foo") async (callback (func $i "callback")))
     )
   )
 
   (component $lowerer
-    (import "a" (func $foo (param "p1" u32) (result u32)))
+    (import "a" (func $foo async (param "p1" u32) (result u32)))
     (core func $foo (canon lower (func $foo)))
     (core module $m
       (import "" "foo" (func $foo (param i32) (result i32)))
@@ -138,7 +138,7 @@
     (core instance $i (instantiate $m
       (with "" (instance (export "foo" (func $foo))))
     ))
-    (func (export "run") (canon lift (core func $i "run")))
+    (func (export "run") async (canon lift (core func $i "run")))
   )
 
   (instance $lifter (instantiate $lifter))

--- a/tests/misc_testsuite/component-model/async/future-read.wast
+++ b/tests/misc_testsuite/component-model/async/future-read.wast
@@ -220,7 +220,7 @@
         (export "return" (func $return))
       ))
     ))
-    (func (export "run") (param "x" $future)
+    (func (export "run") async (param "x" $future)
       (canon lift (core func $i "run") async (callback (func $i "cb"))))
   )
   (instance $child (instantiate $child))
@@ -228,7 +228,7 @@
   (component $other-child
     (type $future (future))
     (import "child" (instance $child
-      (export "run" (func (param "x" $future)))
+      (export "run" (func async (param "x" $future)))
     ))
     (core func $new (canon future.new $future))
     (core func $child-run (canon lower (func $child "run")))

--- a/tests/misc_testsuite/component-model/async/lift.wast
+++ b/tests/misc_testsuite/component-model/async/lift.wast
@@ -9,7 +9,7 @@
   )
   (core instance $i (instantiate $m))
 
-  (func (export "foo") (param "p1" u32) (result u32)
+  (func (export "foo") async (param "p1" u32) (result u32)
     (canon lift (core func $i "foo") async (callback (func $i "callback")))
   )
 )

--- a/tests/misc_testsuite/component-model/async/lower.wast
+++ b/tests/misc_testsuite/component-model/async/lower.wast
@@ -2,10 +2,12 @@
 
 ;; async lower
 (component
-  (import "host-echo-u32" (func $foo (param "p1" u32) (result u32)))
+  (import "host" (instance $host
+    (export "echo-slowly" (func async (param "p1" u32) (result u32)))
+  ))
   (core module $libc (memory (export "memory") 1))
   (core instance $libc (instantiate $libc))
-  (core func $foo (canon lower (func $foo) async (memory $libc "memory")))
+  (core func $foo (canon lower (func $host "echo-slowly") async (memory $libc "memory")))
   (core module $m
     (func (import "" "foo") (param i32 i32) (result i32))
   )

--- a/tests/misc_testsuite/component-model/async/partial-stream-copies.wast
+++ b/tests/misc_testsuite/component-model/async/partial-stream-copies.wast
@@ -129,14 +129,14 @@
       (export "stream.drop-readable" (func $stream.drop-readable))
       (export "stream.drop-writable" (func $stream.drop-writable))
     ))))
-    (func (export "transform") (param "in" (stream u8)) (result (stream u8)) (canon lift
+    (func (export "transform") async (param "in" (stream u8)) (result (stream u8)) (canon lift
       (core func $cm "transform")
       async (memory $memory "mem") (callback (func $cm "transform_cb"))
     ))
   )
 
   (component $D
-    (import "transform" (func $transform (param "in" (stream u8)) (result (stream u8))))
+    (import "transform" (func $transform async (param "in" (stream u8)) (result (stream u8))))
 
     (core module $Memory (memory (export "mem") 1))
     (core instance $memory (instantiate $Memory))

--- a/tests/misc_testsuite/component-model/async/stackful.wast
+++ b/tests/misc_testsuite/component-model/async/stackful.wast
@@ -11,7 +11,7 @@
   )
   (core instance $i (instantiate $m))
 
-  (func (export "foo") (param "p1" u32) (result u32)
+  (func (export "foo") async (param "p1" u32) (result u32)
     (canon lift (core func $i "foo") async)
   )
 )
@@ -28,13 +28,13 @@
       (with "" (instance (export "task.return" (func $task-return))))
     ))
 
-    (func (export "foo") (param "p1" u32) (result u32)
+    (func (export "foo") async (param "p1" u32) (result u32)
       (canon lift (core func $i "foo") async)
     )
   )
 
   (component $lowerer
-    (import "a" (func $foo (param "p1" u32) (result u32)))
+    (import "a" (func $foo async (param "p1" u32) (result u32)))
     (core module $libc (memory (export "memory") 1))
     (core instance $libc (instantiate $libc))
     (core func $foo (canon lower (func $foo) async (memory $libc "memory")))
@@ -54,7 +54,7 @@
       (with "libc" (instance $libc))
       (with "" (instance (export "foo" (func $foo))))
     ))
-    (func (export "run") (canon lift (core func $i "run")))
+    (func (export "run") async (canon lift (core func $i "run")))
   )
 
   (instance $lifter (instantiate $lifter))
@@ -76,13 +76,13 @@
       (with "" (instance (export "task.return" (func $task-return))))
     ))
 
-    (func (export "foo") (param "p1" u32) (result u32)
+    (func (export "foo") async (param "p1" u32) (result u32)
       (canon lift (core func $i "foo") async)
     )
   )
 
   (component $lowerer
-    (import "a" (func $foo (param "p1" u32) (result u32)))
+    (import "a" (func $foo async (param "p1" u32) (result u32)))
     (core func $foo (canon lower (func $foo)))
     (core module $m
       (import "" "foo" (func $foo (param i32) (result i32)))
@@ -97,7 +97,7 @@
     (core instance $i (instantiate $m
       (with "" (instance (export "foo" (func $foo))))
     ))
-    (func (export "run") (canon lift (core func $i "run")))
+    (func (export "run") async (canon lift (core func $i "run")))
   )
 
   (instance $lifter (instantiate $lifter))

--- a/tests/misc_testsuite/component-model/async/streams-massive-send.wast
+++ b/tests/misc_testsuite/component-model/async/streams-massive-send.wast
@@ -156,18 +156,18 @@
       ))
     ))
 
-    (func (export "big-stream") (result $s)
+    (func (export "big-stream") async (result $s)
       (canon lift (core func $m "big-stream") async
         (callback (func $m "cb"))))
-    (func (export "big-future") (result $f)
+    (func (export "big-future") async (result $f)
       (canon lift (core func $m "big-future") async
         (callback (func $m "cb"))))
   )
 
   (component $B
     (import "a" (instance $a
-      (export "big-future" (func (result $f)))
-      (export "big-stream" (func (result $s)))
+      (export "big-future" (func async (result $f)))
+      (export "big-stream" (func async (result $s)))
     ))
 
     (core module $libc

--- a/tests/misc_testsuite/component-model/async/task-builtins.wast
+++ b/tests/misc_testsuite/component-model/async/task-builtins.wast
@@ -295,13 +295,14 @@
         (realloc (func $libc "realloc"))
       )
     )
-    (core func $async-to-sync
-      (canon lower (func $a "run-sync")
-        async
-        (memory $libc "memory")
-        (realloc (func $libc "realloc"))
-      )
-    )
+    ;; NB: this is no longer valid after WebAssembly/component-model#646
+    (; (core func $async-to-sync ;)
+    (;   (canon lower (func $a "run-sync") ;)
+    (;     async ;)
+    (;     (memory $libc "memory") ;)
+    (;     (realloc (func $libc "realloc")) ;)
+    (;   ) ;)
+    (; ) ;)
     (core func $sync-to-async
       (canon lower (func $a "run-async")
         (memory $libc "memory")
@@ -321,7 +322,7 @@
       (import "" "context.get" (func $context.get (result i32)))
       (import "" "sync-to-sync" (func $sync-to-sync (param i32)))
       (import "" "sync-to-async" (func $sync-to-async (param i32)))
-      (import "" "async-to-sync" (func $async-to-sync (param i32) (result i32)))
+      (; (import "" "async-to-sync" (func $async-to-sync (param i32) (result i32))) ;)
       (import "" "async-to-async" (func $async-to-async (param i32) (result i32)))
 
       ;; set this tasks's context before calling $run, in calling $run the
@@ -341,17 +342,17 @@
         (if (i32.ne (call $context.get) (i32.const 500)) (then (unreachable)))
       )
 
-      (func (export "async-to-sync")
-        (call $context.set (i32.const 400))
-        (if
-          (i32.ne
-            (call $async-to-sync (i32.const 20))
-            (i32.const 2) ;; RETURNED
-          )
-          (then (unreachable))
-        )
-        (if (i32.ne (call $context.get) (i32.const 500)) (then (unreachable)))
-      )
+      (; (func (export "async-to-sync") ;)
+      (;   (call $context.set (i32.const 400)) ;)
+      (;   (if ;)
+      (;     (i32.ne ;)
+      (;       (call $async-to-sync (i32.const 20)) ;)
+      (;       (i32.const 2) ;; RETURNED ;)
+      (;     ) ;)
+      (;     (then (unreachable)) ;)
+      (;   ) ;)
+      (;   (if (i32.ne (call $context.get) (i32.const 500)) (then (unreachable))) ;)
+      (; ) ;)
 
       (func (export "async-to-async")
         (call $context.set (i32.const 400))
@@ -370,12 +371,12 @@
       (export "context.get" (func $context.get))
       (export "sync-to-sync" (func $sync-to-sync))
       (export "sync-to-async" (func $sync-to-async))
-      (export "async-to-sync" (func $async-to-sync))
+      (; (export "async-to-sync" (func $async-to-sync)) ;)
       (export "async-to-async" (func $async-to-async))
     ))))
     (func (export "sync-to-sync") async (canon lift (core func $m "sync-to-sync")))
     (func (export "sync-to-async") async (canon lift (core func $m "sync-to-async")))
-    (func (export "async-to-sync") async (canon lift (core func $m "async-to-sync")))
+    (; (func (export "async-to-sync") async (canon lift (core func $m "async-to-sync"))) ;)
     (func (export "async-to-async") async (canon lift (core func $m "async-to-async")))
   )
 
@@ -383,13 +384,13 @@
   (instance $b (instantiate $B (with "a" (instance $a))))
   (export "sync-to-sync" (func $b "sync-to-sync"))
   (export "sync-to-async" (func $b "sync-to-async"))
-  (export "async-to-sync" (func $b "async-to-sync"))
+  (; (export "async-to-sync" (func $b "async-to-sync")) ;)
   (export "async-to-async" (func $b "async-to-async"))
 )
 
 (assert_return (invoke "sync-to-sync"))
 (assert_return (invoke "sync-to-async"))
-(assert_return (invoke "async-to-sync"))
+(; (assert_return (invoke "async-to-sync")) ;)
 (assert_return (invoke "async-to-async"))
 
 ;; Same as above, but when calling the host.


### PR DESCRIPTION
This is a companion PR to bytecodealliance/wasm-tools#2512 which is itself also an accompanying PR for WebAssembly/component-model#646. Like with wasm-tools a number of updates were needed in this repository, but it's effectively all handwritten tests that should have already been updated in theory but didn't need to be.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
