### PR TITLE
Cranelift: Rewrite conditional branches with constant conditions into unconditional jumps

### DIFF
--- a/cranelift/codegen/src/context.rs
+++ b/cranelift/codegen/src/context.rs
@@ -387,6 +387,16 @@ impl Context {
         log::debug!("egraph stats: {:?}", pass.stats);
         trace!("After egraph optimization:\n{}", self.func.display());
 
-        self.verify_if(fisa)
+        // Branch optimizations can invalidate these.
+        self.cfg.clear();
+        self.domtree.clear();
+
+        if fisa.flags.enable_verifier() {
+            self.compute_cfg();
+            self.compute_domtree();
+            self.verify_if(fisa)?;
+        }
+
+        Ok(())
     }
 }

--- a/cranelift/codegen/src/context.rs
+++ b/cranelift/codegen/src/context.rs
@@ -387,15 +387,11 @@ impl Context {
         log::debug!("egraph stats: {:?}", pass.stats);
         trace!("After egraph optimization:\n{}", self.func.display());
 
-        // Branch optimizations can invalidate these.
-        self.cfg.clear();
-        self.domtree.clear();
+        // Branch optimizations can invalidate these; recompute them.
+        self.compute_cfg();
+        self.compute_domtree();
 
-        if fisa.flags.enable_verifier() {
-            self.compute_cfg();
-            self.compute_domtree();
-            self.verify_if(fisa)?;
-        }
+        self.verify_if(fisa)?;
 
         Ok(())
     }

--- a/cranelift/codegen/src/dominator_tree.rs
+++ b/cranelift/codegen/src/dominator_tree.rs
@@ -31,6 +31,8 @@ struct SpanningTreeNode {
     /// Immediate dominator value for the node.
     /// Initialized to node's ancestor in the spanning tree.
     idom: u32,
+    /// Post-order number assigned during the CFG DFS traversal.
+    post_number: u32,
 }
 
 /// DFS preorder number for unvisited nodes and the virtual root in the spanning tree.
@@ -88,6 +90,7 @@ impl SpanningTree {
             label: pre_number,
             semi: pre_number,
             idom: ancestor,
+            post_number: 0,
         });
 
         pre_number
@@ -127,7 +130,8 @@ struct DominatorTreeNode {
     /// First child node in the domtree.
     child: PackedOption<Block>,
 
-    /// Next sibling node in the domtree. This linked list is ordered according to the CFG RPO.
+    /// Next sibling node in the domtree. This linked list is ordered according to the CFG RPO
+    /// (i.e. decreasing CFG post-order number).
     sibling: PackedOption<Block>,
 
     /// Sequence number for this node in a pre-order traversal of the dominator tree.
@@ -137,6 +141,9 @@ struct DominatorTreeNode {
     /// Maximum `dom_pre_number` for the sub-tree of the dominator tree that is rooted at this node.
     /// This is always >= `dom_pre_number`.
     dom_pre_max: u32,
+
+    /// Post-order number from the CFG DFS traversal. Zero for unreachable blocks.
+    post_number: u32,
 }
 
 /// The dominator tree for a single function,
@@ -156,6 +163,46 @@ pub struct DominatorTree {
     eval_worklist: Vec<u32>,
 
     valid: bool,
+}
+
+impl core::fmt::Debug for DominatorTree {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        if !self.is_valid() {
+            return f.write_str("DominatorTree { <invalid> }");
+        }
+
+        let mut s = f.debug_tuple("DominatorTree");
+
+        if let Some((mut root, _)) = self.nodes.iter().find(|n| n.1.pre_number != NOT_VISITED) {
+            loop {
+                if let Some(b) = self.idom(root)
+                    && b != root
+                {
+                    root = b;
+                } else {
+                    break;
+                }
+            }
+
+            fn fmt_block(domtree: &DominatorTree, block: Block) -> impl core::fmt::Debug {
+                core::fmt::from_fn(move |f| {
+                    let children = domtree
+                        .children(block)
+                        .map(|c| fmt_block(domtree, c))
+                        .collect::<Vec<_>>();
+                    let mut s = f.debug_tuple(&format!("{block}"));
+                    if !children.is_empty() {
+                        s.field(&children);
+                    }
+                    s.finish()
+                })
+            }
+
+            s.field(&fmt_block(self, root));
+        }
+
+        s.finish()
+    }
 }
 
 /// Methods for querying the dominator tree.
@@ -257,10 +304,15 @@ impl DominatorTree {
         na.dom_pre_number <= nb.dom_pre_number && na.dom_pre_max >= nb.dom_pre_max
     }
 
+    /// Returns the CFG post-order number for `block`.
+    pub fn post_number(&self, block: Block) -> u32 {
+        self.nodes[block].post_number
+    }
+
     /// Get an iterator over the direct children of `block` in the dominator tree.
     ///
-    /// These are the blocks whose immediate dominator is `block`, ordered according
-    /// to the CFG reverse post-order.
+    /// These are the blocks whose immediate dominator is `block`, ordered by
+    /// decreasing CFG post-order number.
     pub fn children(&self, block: Block) -> ChildIter<'_> {
         ChildIter {
             domtree: self,
@@ -377,7 +429,11 @@ impl DominatorTree {
                             .map(|successor| TraversalEvent::Enter(pre_number, successor)),
                     );
                 }
-                Some(TraversalEvent::Exit(block)) => self.postorder.push(block),
+                Some(TraversalEvent::Exit(block)) => {
+                    let pre_number = self.nodes[block].pre_number;
+                    self.stree[pre_number].post_number = self.postorder.len() as u32;
+                    self.postorder.push(block);
+                }
                 None => break,
             }
         }
@@ -469,10 +525,16 @@ impl DominatorTree {
     ///
     /// This populates child/sibling links and preorder numbers for fast dominance checks.
     fn compute_domtree_preorder(&mut self) {
+        // Step 0: Assign CFG post-order numbers to each block.
+        for (i, &block) in self.postorder.iter().enumerate() {
+            self.nodes[block].post_number = i as u32;
+        }
+
         // Step 1: Populate the child and sibling links.
         //
         // By following the CFG post-order and pushing to the front of the lists, we make sure that
-        // sibling lists are ordered according to the CFG reverse post-order.
+        // sibling lists are ordered according to the CFG reverse post-order (i.e. decreasing CFG
+        // post-order number).
         for &block in &self.postorder {
             if let Some(idom) = self.idom(block) {
                 let sib = mem::replace(&mut self.nodes[idom].child, block.into());

--- a/cranelift/codegen/src/egraph/mod.rs
+++ b/cranelift/codegen/src/egraph/mod.rs
@@ -27,6 +27,209 @@ use smallvec::SmallVec;
 mod cost;
 mod elaborate;
 
+/// An iterator that yields blocks in a depth-first pre-order traversal of the
+/// dominator tree, where each node's children are visited in order of
+/// decreasing CFG post-order number.
+///
+/// This ordering satisfies two properties simultaneously:
+///
+/// 1. **Dominator-tree DFS pre-order**: The `ScopedHashMap` used for GVN
+///    requires that we visit dominator-tree ancestors before their descendants,
+///    and that we can "pop" scopes as we backtrack up the dominator tree. This
+///    is a DFS pre-order traversal of the dominator tree: we process every
+///    dominator before the blocks it dominates, and the scope stack always
+///    mirrors the dominator-tree path from the root to the current block.
+///
+/// 2. **Non-back-edge predecessors before successors**: Branch optimization
+///    (e.g. replacing a `brif` with a constant condition with a `jump`) can
+///    make blocks unreachable. We track reachable blocks in an `EntitySet`,
+///    inserting each successor block as we visit each block's terminator. For
+///    this to work correctly, we must visit all of a block's non-back-edge CFG
+///    predecessors before visiting the block itself, otherwise we might
+///    incorrectly conclude that a block is unreachable because we just haven't
+///    seen some predecessor that would otherwise mark it reachable yet.
+///
+/// Both properties hold when dominator-tree children are visited in order of
+/// decreasing CFG post-order number. The full proof follows.
+///
+/// # Proof
+///
+/// Let `post(v)` be the post-order numbering of a node `v` assigned by the DFS
+/// traversal of the original graph (the same traversal that produces the
+/// spanning tree used for dominator computation).
+///
+/// The *lowest common ancestor* (LCA) of two nodes `x` and `y` in a rooted
+/// tree is the deepest node that is an ancestor of both `x` and `y`.
+///
+/// Given a DFS traversal of the graph from the root, each edge `u -> v` falls
+/// into exactly one of the following categories:
+///
+/// - *Back edge*: `v` is an ancestor of `u` in the DFS spanning tree (the edge
+///   leads back up the current DFS call stack).
+///
+/// - *Tree edge*: `u -> v` is an edge of the DFS spanning tree itself (i.e.
+///   `v` was first discovered via `u`).
+///
+/// - *Forward edge*: `v` is a descendant of `u` in the DFS spanning tree, but
+///   `u -> v` is not a spanning tree edge (it skips over one or more tree
+///   edges).
+///
+/// - *Cross edge*: `v` is neither an ancestor nor a descendant of `u` in the
+///   DFS spanning tree; `v` was fully finished before `u` was even discovered.
+///
+/// ## Lemma 1
+///
+/// Given a spanning tree edge `a -> b`, then `post(a) > post(b)`.
+///
+/// ### Proof
+///
+/// `post(a) > post(b)`: by the definition of post-order numbering, where
+/// successors are numbered before predecessors.
+///
+/// ## Lemma 2
+///
+/// Given that `a` strictly dominates `b`, then `post(a) > post(b)`.
+///
+/// ### Proof
+///
+/// - All spanning tree paths from `root` to `b` pass through `a`: by the
+///   definition of strict dominance.
+/// - `post(a) > post(b)`: by Lemma 1 applied to each successive tree edge on
+///   the path from `a` to `b`, and transitivity.
+///
+/// ## Lemma 3
+///
+/// For any non-back edge `u -> v` (i.e. a tree, forward, or cross edge),
+/// `post(u) > post(v)`.
+///
+/// ### Proof
+///
+/// - *Tree edge* `u -> v`: `v` is discovered from `u` and finishes before `u`
+///   returns, so `post(v) < post(u)`.
+/// - *Forward edge* `u -> v`: `v` is a descendant of `u` in the DFS tree and
+///   is already finished before `u` revisits it, so `post(v) < post(u)`.
+/// - *Cross edge* `u -> v`: `v` was in a subtree explored entirely before `u`
+///   was discovered, so `post(v) < post(u)`.
+///
+/// ## Lemma 4
+///
+/// If `u -> v` is a non-back edge and `u` does not strictly dominate `v`, then
+/// `v` is a direct child of `LCA(u, v)` in the dominator tree.
+///
+/// ### Proof
+///
+/// Let `p = LCA(u, v)`, `c_u` the child of `p` that is an ancestor-or-equal
+/// of `u` in the dominator tree, and `c_v` the child of `p` that is an
+/// ancestor-or-equal of `v`.
+///
+/// - `p != u`: `u` does not dominate `v`, so `u` is not an ancestor of `v` in
+///   the dominator tree.
+/// - `p != v`: if `v` dominated `u` then every graph path from `root` to `u`
+///   would pass through `v`, making `u -> v` a back edge; but `u -> v` is
+///   non-back.
+/// - `c_u != c_v`: since `p != u` and `p != v`, the paths from `p` to `u` and
+///   `v` diverge at distinct children of `p`.
+///
+/// Suppose for contradiction that `c_v != v`, so `c_v` strictly dominates `v`.
+///
+/// - `c_v` does not dominate `c_u`: `c_u` and `c_v` are different children of
+///   `p`, so neither is an ancestor of the other in the dominator tree.
+/// - `c_v` does not dominate `u`: the dominator tree path from `root` to `u`
+///   passes through `p -> c_u -> ... -> u` and not through `c_v`.
+/// - `c_v != u`: if `c_v = u` then `u` is a strict ancestor of `v` in the
+///   dominator tree, meaning `u` strictly dominates `v`; but `u` does not
+///   strictly dominate `v` by the precondition of the lemma.
+/// - There is a graph path `root -> ... -> u` avoiding `c_v`: by the
+///   definition of dominance, since `c_v` does not dominate `u`.
+/// - There is a graph path `root -> ... -> u -> v` avoiding `c_v`: append the
+///   edge `u -> v`; the path avoids `c_v` because `c_v` is not in
+///   `root -> ... -> u` (previous step), `c_v != u` (above), and `c_v != v`
+///   (contradiction assumption).
+/// - Contradiction: `c_v` strictly dominates `v`, so every path from `root` to
+///   `v` must pass through `c_v`.
+///
+/// Therefore `c_v = v`.
+///
+/// ## Theorem 1
+///
+/// A depth-first pre-order traversal of a graph's dominator tree, where each
+/// child `c` of `idom(c)` is visited in order from greatest to least
+/// `post(c)`, visits all of a node's non-back-edge predecessors before visiting
+/// the node itself.
+///
+/// ### Proof
+///
+/// Let `u -> v` be any non-back edge. We show `u` is visited before `v`.
+///
+/// - Case 1: `u` strictly dominates `v`.
+///
+///   `u` is a proper ancestor of `v` in the dominator tree: by the definition
+///   of strict dominance. `u` is visited before `v`: DFS pre-order visits every
+///   ancestor before any of its descendants.
+///
+/// - Case 2: `u` does not strictly dominate `v` (and `u != v`)
+///
+///   Let `p = LCA(u, v)`, `c_u` the child of `p` that is an ancestor-or-equal
+///   of `u`, and `c_v = v` (by Lemma 4).
+///
+///   `post(c_u) > post(c_v)`:
+///   - if `c_u = u`: `post(c_u) = post(u) > post(v) = post(c_v)` by Lemma 3.
+///   - if `c_u != u`: `post(c_u) > post(u) > post(v) = post(c_v)` by Lemma 2
+///     then Lemma 3.
+///
+///   `c_u` is visited before `c_v` in the traversal: children of `p` are visited
+///   in decreasing `post` order and `post(c_u) > post(c_v)`.
+///
+///   `u` is visited before `v`: DFS pre-order visits all of `c_u`'s subtree
+///   before `c_v`, with `u` in `c_u`'s subtree and `v = c_v`.
+///
+/// Both cases establish that `u` is visited before `v` for every non-back edge
+/// `u -> v`, which is exactly what the theorem claims.
+struct EgraphBlockIter<'a> {
+    domtree: &'a DominatorTree,
+    stack: Vec<Block>,
+    children: SmallVec<[Block; 8]>,
+}
+
+impl<'a> EgraphBlockIter<'a> {
+    fn new(domtree: &'a DominatorTree) -> Self {
+        let mut iter = Self {
+            domtree,
+            stack: Vec::new(),
+            children: SmallVec::new(),
+        };
+        if let Some(&root) = domtree.cfg_postorder().last() {
+            iter.stack.push(root);
+        }
+        iter
+    }
+}
+
+impl Iterator for EgraphBlockIter<'_> {
+    type Item = Block;
+
+    fn next(&mut self) -> Option<Block> {
+        let block = self.stack.pop()?;
+
+        // Collect children into `self.children`, reusing the allocation.
+        self.children.clear();
+        self.children.extend(self.domtree.children(block));
+
+        // Assert that `children()` yields in decreasing post-order number.
+        debug_assert!(
+            self.children
+                .windows(2)
+                .all(|w| { self.domtree.post_number(w[0]) > self.domtree.post_number(w[1]) })
+        );
+
+        // Push in reverse so that the highest-post-number child ends up on top
+        // of the stack and is visited first.
+        self.stack.extend(self.children.iter().rev().copied());
+
+        Some(block)
+    }
+}
+
 /// Pass over a Function that does the whole aegraph thing.
 ///
 /// - Removes non-skeleton nodes from the Layout.
@@ -768,41 +971,10 @@ impl<'a> EgraphPass<'a> {
         // this is likely to realloc again later.
         available_block.resize(cursor.func.dfg.num_values());
 
-        // We always iterate over blocks in *reverse-post order*.
-        //
-        // Why? Consider a function with the following CFG:
-        //
-        //        block0
-        //       /      \
-        // block1        block2
-        //       \      /      \
-        //        block3        block4
-        //
-        // And therefore this dominator tree:
-        //
-        // - block0
-        //   - block1
-        //   - block2
-        //     - block4
-        //   - block3
-        //
-        // Furthermore, assume that the edge `block2 -> block3` can be optimized
-        // away.
-        //
-        // We used to iterate over blocks in *dominator-tree order*. One valid
-        // dominator-tree ordering for this example is `[block0, block2, block4,
-        // block3, block1]`. But if we visit in this order, and if we optimize
-        // away the `block2 -> block3` edge, then we will never mark `block2` as
-        // reachable before visiting the block, which will lead us to removing
-        // the block, which is invalid because we still have an edge from
-        // `block1` to `block3`.
-        //
-        // Therefore, we instead visit blocks in *reverse-post order*, which
-        // guarantees that we will always visit predecessors before successors
-        // (and therefore visit `block1` before `block3` and properly mark
-        // `block3` as reachable before it is visited).
+        // See `EgraphBlockIter` for why we use this particular block
+        // ordering.
         let domtree = self.domtree;
-        for &block in domtree.cfg_rpo() {
+        for block in EgraphBlockIter::new(domtree) {
             // Maintain GVN scoping: pop scopes until the top of the
             // stack is the immediate dominator of this block.
             while gvn_map_blocks
@@ -815,6 +987,18 @@ impl<'a> EgraphPass<'a> {
 
             gvn_map.increment_depth();
             gvn_map_blocks.push(block);
+
+            debug_assert_eq!(gvn_map_blocks, {
+                let mut b = Some(block);
+                let mut v = core::iter::from_fn(move || {
+                    let block = b;
+                    b = b.map(|b| domtree.idom(b))?;
+                    block
+                })
+                .collect::<Vec<_>>();
+                v.reverse();
+                v
+            });
 
             if !self.reachable_blocks.contains(block) {
                 cursor.func.layout.remove_block_and_insts(block);

--- a/cranelift/codegen/src/egraph/mod.rs
+++ b/cranelift/codegen/src/egraph/mod.rs
@@ -1026,7 +1026,12 @@ impl<'a> EgraphPass<'a> {
                 cursor.func.dfg.map_inst_values(inst, |arg| {
                     let new_value = value_to_opt_value[arg];
                     trace!("rewriting arg {} of inst {} to {}", arg, inst, new_value);
-                    debug_assert_ne!(new_value, Value::reserved_value());
+                    debug_assert_ne!(
+                        new_value,
+                        Value::reserved_value(),
+                        "rewriting arg {arg} of {inst} to {new_value}, but \
+                         {new_value} == Value::reserved_value()"
+                    );
                     new_value
                 });
 
@@ -1137,10 +1142,7 @@ impl<'a> EgraphPass<'a> {
             forward_val(cursor, old_val, new_val);
         }
 
-        // Back up so that the next iteration of the outer egraph loop will
-        // process the new instruction.
         cursor.goto_inst(new_inst);
-        cursor.prev_inst();
     }
 
     /// Scoped elaboration: compute a final ordering of op computation

--- a/cranelift/codegen/src/egraph/mod.rs
+++ b/cranelift/codegen/src/egraph/mod.rs
@@ -20,8 +20,8 @@ use alloc::vec::Vec;
 use core::cmp::Ordering;
 use core::hash::Hasher;
 use cranelift_control::ControlPlane;
-use cranelift_entity::SecondaryMap;
 use cranelift_entity::packed_option::ReservedValue;
+use cranelift_entity::{EntitySet, SecondaryMap};
 use smallvec::SmallVec;
 
 mod cost;
@@ -60,6 +60,11 @@ pub struct EgraphPass<'a> {
     /// Chaos-mode control-plane so we can test that we still get
     /// correct results when our heuristics make bad decisions.
     ctrl_plane: &'a mut ControlPlane,
+    /// The set of blocks that are reachable from the entry block given
+    /// the (potentially simplified/optimized) terminators. Used to
+    /// remove blocks that become unreachable after branch
+    /// simplification.
+    reachable_blocks: EntitySet<Block>,
     /// Which Values do we want to rematerialize in each block where
     /// they're used?
     remat_values: FxHashSet<Value>,
@@ -517,57 +522,16 @@ where
     /// Find the best simplification of the given skeleton instruction, if any,
     /// by consulting our `simplify_skeleton` ISLE rules.
     fn simplify_skeleton_inst(&mut self, inst: Inst) -> Option<SkeletonInstSimplification> {
-        // We cannot currently simplify terminators, or simplify into
-        // terminators. Anything that could change the control-flow graph is off
-        // limits.
+        // NB: we support simplifying branch terminators (e.g. `brif` with a
+        // constant condition into `jump`). This can make blocks unreachable,
+        // but the caller handles that via the `reachable_blocks` set: blocks
+        // not in the set are removed from the layout (along with all their
+        // instructions and value uses).
         //
-        // Consider the following CLIF snippet:
-        //
-        //     block0(v0: i64):
-        //         v1 = iconst.i32 0
-        //         trapz v1, user42
-        //         v2 = load.i32 v0
-        //         brif v1, block1, block2
-        //     block1:
-        //         return v2
-        //     block2:
-        //         v3 = iconst.i32 1
-        //         v4 = iadd v2, v3
-        //         return v4
-        //
-        // We would ideally like to perform simplifications like replacing the
-        // `trapz` with an unconditional `trap` and the conditional `brif`
-        // branch with an unconditional `jump`. Note, however, that blocks
-        // `block1` and `block2` are dominated by `block0` and therefore can and
-        // do use values defined in `block0`. This presents challenges:
-        //
-        // * If we replace the `brif` with a `jump`, then we've mutated the
-        //   control-flow graph and removed that domination property. The uses
-        //   of `v2` and `v3` in those blocks become invalid.
-        //
-        // * Even worse, if we turn the `trapz` into a `trap`, we are
-        //   introducing a terminator into the middle of the block, which leaves
-        //   us with two choices to fix up the IR so that there aren't any
-        //   instructions following the terminator in the block:
-        //
-        //   1. We can split the unreachable instructions off into a new
-        //      block. However, there is no control-flow edge from the current
-        //      block to this new block and so, again, the new block isn't
-        //      dominated by the current block, and therefore the can't use
-        //      values defined in this block or any dominating it. The `load`
-        //      instruction uses `v0` but is not dominated by `v0`'s
-        //      definition.
-        //
-        //   2. Alternatively, we can simply delete the trailing instructions,
-        //      since they are unreachable. But then not only are the old
-        //      instructions' uses no longer dominated by their definitions, but
-        //      the definitions do not exist at all anymore!
-        //
-        // Whatever approach we would take, we would invalidate value uses, and
-        // would need to track and fix them up.
-        if self.func.dfg.insts[inst].opcode().is_branch() {
-            return None;
-        }
+        // We do NOT yet support simplifying non-terminators into terminators
+        // (e.g. `trapz` into `trap`) because that would introduce a
+        // terminator in the middle of a block, requiring removal of trailing
+        // instructions and their value definitions.
 
         let mut guard = TakeAndReplace::new(self, |x| &mut x.optimized_insts);
         let (ctx, optimized_insts) = guard.get();
@@ -647,12 +611,6 @@ where
             };
 
             if cfg!(debug_assertions) {
-                let opcode = ctx.func.dfg.insts[inst].opcode();
-                debug_assert!(
-                    !(opcode.is_terminator() || opcode.is_branch()),
-                    "simplifying control-flow instructions and terminators is not yet supported",
-                );
-
                 let old_vals = ctx.func.dfg.inst_results(inst);
                 let new_vals = if let Some(val) = new_val.as_ref() {
                     core::slice::from_ref(val)
@@ -701,12 +659,15 @@ impl<'a> EgraphPass<'a> {
         alias_analysis: &'a mut AliasAnalysis<'a>,
         ctrl_plane: &'a mut ControlPlane,
     ) -> Self {
+        let mut reachable_blocks = EntitySet::with_capacity(func.dfg.num_blocks());
+        reachable_blocks.insert(func.layout.entry_block().unwrap());
         Self {
             func,
             domtree,
             loop_analysis,
             alias_analysis,
             ctrl_plane,
+            reachable_blocks,
             stats: Stats::default(),
             remat_values: FxHashSet::default(),
         }
@@ -807,103 +768,137 @@ impl<'a> EgraphPass<'a> {
         // this is likely to realloc again later.
         available_block.resize(cursor.func.dfg.num_values());
 
-        // In domtree preorder, visit blocks. (TODO: factor out an
-        // iterator from this and elaborator.)
-        let root = cursor.layout().entry_block().unwrap();
-        enum StackEntry {
-            Visit(Block),
-            Pop,
-        }
-        let mut block_stack = vec![StackEntry::Visit(root)];
-        while let Some(entry) = block_stack.pop() {
-            match entry {
-                StackEntry::Visit(block) => {
-                    // We popped this block; push children
-                    // immediately, then process this block.
-                    block_stack.push(StackEntry::Pop);
-                    block_stack.extend(
-                        self.ctrl_plane
-                            .shuffled(self.domtree.children(block))
-                            .map(StackEntry::Visit),
-                    );
-                    gvn_map.increment_depth();
-                    gvn_map_blocks.push(block);
+        // We always iterate over blocks in *reverse-post order*.
+        //
+        // Why? Consider a function with the following CFG:
+        //
+        //        block0
+        //       /      \
+        // block1        block2
+        //       \      /      \
+        //        block3        block4
+        //
+        // And therefore this dominator tree:
+        //
+        // - block0
+        //   - block1
+        //   - block2
+        //     - block4
+        //   - block3
+        //
+        // Furthermore, assume that the edge `block2 -> block3` can be optimized
+        // away.
+        //
+        // We used to iterate over blocks in *dominator-tree order*. One valid
+        // dominator-tree ordering for this example is `[block0, block2, block4,
+        // block3, block1]`. But if we visit in this order, and if we optimize
+        // away the `block2 -> block3` edge, then we will never mark `block2` as
+        // reachable before visiting the block, which will lead us to removing
+        // the block, which is invalid because we still have an edge from
+        // `block1` to `block3`.
+        //
+        // Therefore, we instead visit blocks in *reverse-post order*, which
+        // guarantees that we will always visit predecessors before successors
+        // (and therefore visit `block1` before `block3` and properly mark
+        // `block3` as reachable before it is visited).
+        let domtree = self.domtree;
+        for &block in domtree.cfg_rpo() {
+            // Maintain GVN scoping: pop scopes until the top of the
+            // stack is the immediate dominator of this block.
+            while gvn_map_blocks
+                .last()
+                .is_some_and(|&dom| domtree.idom(block) != Some(dom))
+            {
+                gvn_map_blocks.pop();
+                gvn_map.decrement_depth();
+            }
 
-                    trace!("Processing block {}", block);
-                    cursor.set_position(CursorPosition::Before(block));
+            gvn_map.increment_depth();
+            gvn_map_blocks.push(block);
 
-                    let mut alias_analysis_state = self.alias_analysis.block_starting_state(block);
+            if !self.reachable_blocks.contains(block) {
+                cursor.func.layout.remove_block_and_insts(block);
+                continue;
+            }
 
-                    for &param in cursor.func.dfg.block_params(block) {
-                        trace!("creating initial singleton eclass for blockparam {}", param);
-                        value_to_opt_value[param] = param;
-                        available_block[param] = block;
-                    }
-                    while let Some(inst) = cursor.next_inst() {
-                        trace!(
-                            "Processing inst {inst}: {}",
-                            cursor.func.dfg.display_inst(inst),
+            trace!("Processing block {}", block);
+            cursor.set_position(CursorPosition::Before(block));
+
+            let mut alias_analysis_state = self.alias_analysis.block_starting_state(block);
+
+            for &param in cursor.func.dfg.block_params(block) {
+                trace!("creating initial singleton eclass for blockparam {}", param);
+                value_to_opt_value[param] = param;
+                available_block[param] = block;
+            }
+            while let Some(inst) = cursor.next_inst() {
+                trace!(
+                    "Processing inst {inst}: {}",
+                    cursor.func.dfg.display_inst(inst),
+                );
+
+                // Rewrite args of *all* instructions using the
+                // value-to-opt-value map.
+                cursor.func.dfg.map_inst_values(inst, |arg| {
+                    let new_value = value_to_opt_value[arg];
+                    trace!("rewriting arg {} of inst {} to {}", arg, inst, new_value);
+                    debug_assert_ne!(new_value, Value::reserved_value());
+                    new_value
+                });
+
+                // Build a context for optimization, with borrows of
+                // state. We can't invoke a method on `self` because
+                // we've borrowed `self.func` mutably (as
+                // `cursor.func`) so we pull apart the pieces instead
+                // here.
+                let mut ctx = OptimizeCtx {
+                    func: cursor.func,
+                    value_to_opt_value: &mut value_to_opt_value,
+                    gvn_map: &mut gvn_map,
+                    gvn_map_blocks: &mut gvn_map_blocks,
+                    available_block: &mut available_block,
+                    eclass_size: &mut eclass_size,
+                    rewrite_depth: 0,
+                    subsume_values: FxHashSet::default(),
+                    remat_values: &mut self.remat_values,
+                    stats: &mut self.stats,
+                    domtree: &self.domtree,
+                    alias_analysis: self.alias_analysis,
+                    alias_analysis_state: &mut alias_analysis_state,
+                    ctrl_plane: self.ctrl_plane,
+                    optimized_values: Default::default(),
+                    optimized_insts: Default::default(),
+                };
+
+                if is_pure_for_egraph(ctx.func, inst) {
+                    // Insert into GVN map and optimize any new nodes
+                    // inserted (recursively performing this work for
+                    // any nodes the optimization rules produce).
+                    let inst = NewOrExistingInst::Existing(inst);
+                    ctx.insert_pure_enode(inst);
+                    // We've now rewritten all uses, or will when we
+                    // see them, and the instruction exists as a pure
+                    // enode in the eclass, so we can remove it.
+                    cursor.remove_inst_and_step_back();
+                } else {
+                    if let Some(cmd) = ctx.optimize_skeleton_inst(inst, block) {
+                        Self::execute_skeleton_inst_simplification(
+                            cmd,
+                            &mut cursor,
+                            &mut value_to_opt_value,
+                            inst,
                         );
-
-                        // Rewrite args of *all* instructions using the
-                        // value-to-opt-value map.
-                        cursor.func.dfg.map_inst_values(inst, |arg| {
-                            let new_value = value_to_opt_value[arg];
-                            trace!("rewriting arg {} of inst {} to {}", arg, inst, new_value);
-                            debug_assert_ne!(new_value, Value::reserved_value());
-                            new_value
-                        });
-
-                        // Build a context for optimization, with borrows of
-                        // state. We can't invoke a method on `self` because
-                        // we've borrowed `self.func` mutably (as
-                        // `cursor.func`) so we pull apart the pieces instead
-                        // here.
-                        let mut ctx = OptimizeCtx {
-                            func: cursor.func,
-                            value_to_opt_value: &mut value_to_opt_value,
-                            gvn_map: &mut gvn_map,
-                            gvn_map_blocks: &mut gvn_map_blocks,
-                            available_block: &mut available_block,
-                            eclass_size: &mut eclass_size,
-                            rewrite_depth: 0,
-                            subsume_values: FxHashSet::default(),
-                            remat_values: &mut self.remat_values,
-                            stats: &mut self.stats,
-                            domtree: &self.domtree,
-                            alias_analysis: self.alias_analysis,
-                            alias_analysis_state: &mut alias_analysis_state,
-                            ctrl_plane: self.ctrl_plane,
-                            optimized_values: Default::default(),
-                            optimized_insts: Default::default(),
-                        };
-
-                        if is_pure_for_egraph(ctx.func, inst) {
-                            // Insert into GVN map and optimize any new nodes
-                            // inserted (recursively performing this work for
-                            // any nodes the optimization rules produce).
-                            let inst = NewOrExistingInst::Existing(inst);
-                            ctx.insert_pure_enode(inst);
-                            // We've now rewritten all uses, or will when we
-                            // see them, and the instruction exists as a pure
-                            // enode in the eclass, so we can remove it.
-                            cursor.remove_inst_and_step_back();
-                        } else {
-                            if let Some(cmd) = ctx.optimize_skeleton_inst(inst, block) {
-                                Self::execute_skeleton_inst_simplification(
-                                    cmd,
-                                    &mut cursor,
-                                    &mut value_to_opt_value,
-                                    inst,
-                                );
-                            }
-                        }
                     }
                 }
-                StackEntry::Pop => {
-                    gvn_map.decrement_depth();
-                    gvn_map_blocks.pop();
-                }
+            }
+
+            let terminator_inst = cursor.func.layout.last_inst(block).unwrap();
+            for dest in cursor.func.dfg.insts[terminator_inst].branch_destination(
+                &cursor.func.dfg.jump_tables,
+                &cursor.func.dfg.exception_tables,
+            ) {
+                self.reachable_blocks
+                    .insert(dest.block(&cursor.func.dfg.value_lists));
             }
         }
     }
@@ -939,7 +934,6 @@ impl<'a> EgraphPass<'a> {
 
         // Replace the old instruction with the new one.
         cursor.replace_inst(new_inst);
-        debug_assert!(!cursor.func.dfg.insts[new_inst].opcode().is_terminator());
 
         // Redirect the old instruction's result values to our new instruction's
         // result values.

--- a/cranelift/codegen/src/ir/layout.rs
+++ b/cranelift/codegen/src/ir/layout.rs
@@ -288,6 +288,15 @@ impl Layout {
         }
     }
 
+    /// Remove all instructions from `block` and then remove it from
+    /// the layout.
+    pub fn remove_block_and_insts(&mut self, block: Block) {
+        while let Some(inst) = self.first_inst(block) {
+            self.remove_inst(inst);
+        }
+        self.remove_block(block);
+    }
+
     /// Remove `block` from the layout.
     pub fn remove_block(&mut self, block: Block) {
         debug_assert!(self.is_block_inserted(block), "block not in the layout");

--- a/cranelift/codegen/src/opts.rs
+++ b/cranelift/codegen/src/opts.rs
@@ -10,7 +10,7 @@ use crate::ir::instructions::InstructionFormat;
 pub use crate::ir::types::*;
 pub use crate::ir::{
     AtomicRmwOp, BlockCall, Constant, DynamicStackSlot, FuncRef, GlobalValue, Immediate,
-    InstructionData, MemFlags, Opcode, StackSlot, TrapCode, Type, Value,
+    InstructionData, JumpTable, MemFlags, Opcode, StackSlot, TrapCode, Type, Value,
 };
 use crate::isle_common_prelude_methods;
 use crate::machinst::isle::*;
@@ -238,6 +238,18 @@ impl<'a, 'b, 'c> generated_code::Context for IsleContext<'a, 'b, 'c> {
     #[inline]
     fn value_type(&mut self, val: Value) -> Type {
         self.ctx.func.dfg.value_type(val)
+    }
+
+    fn resolve_jump_table_entry(&mut self, table: JumpTable, index: u64) -> BlockCall {
+        let jt_data = &self.ctx.func.dfg.jump_tables[table];
+        let entries = jt_data.as_slice();
+        if let Ok(index) = usize::try_from(index)
+            && index < entries.len()
+        {
+            entries[index]
+        } else {
+            jt_data.default_block()
+        }
     }
 
     fn iconst_sextend_etor(

--- a/cranelift/codegen/src/opts/skeleton.isle
+++ b/cranelift/codegen/src/opts/skeleton.isle
@@ -18,6 +18,20 @@
 (rule (simplify_skeleton (uadd_overflow_trap a @ (uextend ty _) b @ (uextend ty _) _))
       (iadd ty a b))
 
+;; Conditional branches with known-true condition.
+(rule (simplify_skeleton (brif (iconst_u _ (u64_when_non_zero)) then_dest _))
+      (jump then_dest))
+
+;; Conditional branches with known-false condition.
+(rule (simplify_skeleton (brif (iconst_u _ 0) _ else_dest))
+      (jump else_dest))
+
+;; Branch table with known index: resolve the destination from the
+;; jump table data and replace with an unconditional jump.
+(rule (simplify_skeleton (br_table (iconst_u _ idx) jt))
+      (if-let dest (resolve_jump_table_entry jt idx))
+      (jump dest))
+
 ;; TODO: We can't simplify into unconditional traps yet. See the comment in
 ;; `simplify_skeleton_inst` for more details.
 ;;

--- a/cranelift/codegen/src/prelude_opt.isle
+++ b/cranelift/codegen/src/prelude_opt.isle
@@ -36,6 +36,12 @@
 (decl value_array_3_ctor (Value Value Value) ValueArray3)
 (extern constructor value_array_3_ctor value_array_3_ctor)
 
+;; Resolve a constant index into a jump table, returning the target
+;; BlockCall. If the index is in bounds, returns the indexed entry;
+;; otherwise returns the default block.
+(decl pure resolve_jump_table_entry (JumpTable u64) BlockCall)
+(extern constructor resolve_jump_table_entry resolve_jump_table_entry)
+
 (rule (eq ty x y) (icmp ty (IntCC.Equal) x y))
 (rule (ne ty x y) (icmp ty (IntCC.NotEqual) x y))
 (rule (ult ty x y) (icmp ty (IntCC.UnsignedLessThan) x y))

--- a/cranelift/filetests/filetests/egraph/issue-7891.clif
+++ b/cranelift/filetests/filetests/egraph/issue-7891.clif
@@ -94,10 +94,10 @@ block2:
 
 ; check: block1:
 ; check:     v1 = load.i64 heap v0
-; check:     v7 = iconst.i64 0
-; check:     v8 = icmp.i64 eq v0, v7  ; v7 = 0
-; check:     return v8
-; check: block2:
 ; check:     v6 = iconst.i64 0
-; check:     v3 = icmp.i64 eq v0, v6  ; v6 = 0
-; check:     return v3
+; check:     v7 = icmp.i64 eq v0, v6  ; v6 = 0
+; check:     return v7
+; check: block2:
+; check:     v4 = iconst.i64 0
+; check:     v5 = icmp.i64 eq v0, v4  ; v4 = 0
+; check:     return v5

--- a/cranelift/filetests/filetests/egraph/issue-7891.clif
+++ b/cranelift/filetests/filetests/egraph/issue-7891.clif
@@ -66,8 +66,8 @@ block3:
 
 ; check: block2(v2: i32):
 ; check:     v8 = iconst.i32 0
-; check:     v4 = icmp.i32 eq v0, v8  ; v8 = 0
-; check:     return v4
+; check:     v5 = icmp.i32 eq v0, v8  ; v8 = 0
+; check:     return v5
 ; check: block3:
 ; check:     v6 = iconst.i32 0
 ; check:     v7 = icmp.i32 eq v0, v6  ; v6 = 0

--- a/cranelift/filetests/filetests/egraph/skeleton.clif
+++ b/cranelift/filetests/filetests/egraph/skeleton.clif
@@ -341,6 +341,82 @@ block2:
 ;     return v1
 ; }
 
+;; When folding a brif-true into a jump, verify we use the then-branch's
+;; block call arguments, not the else-branch's.
+function %brif_true_args(i32, i32) -> i32 {
+block0(v0: i32, v1: i32):
+    v2 = iconst.i32 1
+    brif v2, block1(v0), block1(v1)
+block1(v3: i32):
+    return v3
+}
+
+; function %brif_true_args(i32, i32) -> i32 fast {
+; block0(v0: i32, v1: i32):
+;     jump block1(v0)
+;
+; block1(v3: i32):
+;     return v3
+; }
+
+;; When folding a brif-false into a jump, verify we use the else-branch's
+;; block call arguments, not the then-branch's.
+function %brif_false_args(i32, i32) -> i32 {
+block0(v0: i32, v1: i32):
+    v2 = iconst.i32 0
+    brif v2, block1(v0), block1(v1)
+block1(v3: i32):
+    return v3
+}
+
+; function %brif_false_args(i32, i32) -> i32 fast {
+; block0(v0: i32, v1: i32):
+;     jump block1(v1)
+;
+; block1(v3: i32):
+;     return v3
+; }
+
+;; When folding a brif-true with multiple block args, verify we preserve
+;; all of the then-branch's arguments.
+function %brif_true_multiple_args(i32, i32, i32, i32) -> i32 {
+block0(v0: i32, v1: i32, v2: i32, v3: i32):
+    v4 = iconst.i32 1
+    brif v4, block1(v0, v1), block1(v2, v3)
+block1(v5: i32, v6: i32):
+    v7 = iadd v5, v6
+    return v7
+}
+
+; function %brif_true_multiple_args(i32, i32, i32, i32) -> i32 fast {
+; block0(v0: i32, v1: i32, v2: i32, v3: i32):
+;     jump block1(v0, v1)
+;
+; block1(v5: i32, v6: i32):
+;     v7 = iadd v5, v6
+;     return v7
+; }
+
+;; When folding a brif-false with multiple block args, verify we preserve
+;; all of the else-branch's arguments.
+function %brif_false_multiple_args(i32, i32, i32, i32) -> i32 {
+block0(v0: i32, v1: i32, v2: i32, v3: i32):
+    v4 = iconst.i32 0
+    brif v4, block1(v0, v1), block1(v2, v3)
+block1(v5: i32, v6: i32):
+    v7 = iadd v5, v6
+    return v7
+}
+
+; function %brif_false_multiple_args(i32, i32, i32, i32) -> i32 fast {
+; block0(v0: i32, v1: i32, v2: i32, v3: i32):
+;     jump block1(v2, v3)
+;
+; block1(v5: i32, v6: i32):
+;     v7 = iadd v5, v6
+;     return v7
+; }
+
 ;; This function has the following CFG:
 ;;
 ;;        block0

--- a/cranelift/filetests/filetests/egraph/skeleton.clif
+++ b/cranelift/filetests/filetests/egraph/skeleton.clif
@@ -304,3 +304,151 @@ block0:
 ;     v2 = uadd_overflow_trap v0, v1, user42  ; v0 = -1, v1 = 1
 ;     return v2
 ; }
+
+function %brif_true(i32, i32) -> i32 {
+block0(v0: i32, v1: i32):
+    v2 = iconst.i32 1
+    brif v2, block1, block2
+block1:
+    return v0
+block2:
+    return v1
+}
+
+; function %brif_true(i32, i32) -> i32 fast {
+; block0(v0: i32, v1: i32):
+;     jump block1
+;
+; block1:
+;     return v0
+; }
+
+function %brif_false(i32, i32) -> i32 {
+block0(v0: i32, v1: i32):
+    v2 = iconst.i32 0
+    brif v2, block1, block2
+block1:
+    return v0
+block2:
+    return v1
+}
+
+; function %brif_false(i32, i32) -> i32 fast {
+; block0(v0: i32, v1: i32):
+;     jump block2
+;
+; block2:
+;     return v1
+; }
+
+;; This function has the following CFG:
+;;
+;;        block0
+;;       /      \
+;; block1        block2
+;;       \      /      \
+;;        block3        block4
+;;
+;; And this dominator tree:
+;;
+;; - block0
+;;   - block1
+;;   - block2
+;;     - block4
+;;   - block3
+;;
+;; Furthermore, note that the edge `block2 -> block3` can be optimized away.
+;;
+;; A valid *dominator-tree order* for visiting blocks is `[block0, block2,
+;; block4, block3, block1]`. If the egraph pass visits in this order, and if we
+;; optimize away the `block2 -> block3` edge, then it will never mark `block2`
+;; as reachable before visiting the block, which will lead it to removing the
+;; block, which is invalid because we still have an edge `block1->block3`.
+;;
+;; Therefore, we instead visit blocks in *reverse-post order*, which guarantees
+;; that we will always visit predecessors before successors (and therefore visit
+;; `block1` before `block3` and properly mark `block3` as reachable before it is
+;; visited).
+function %diamond_one_side_unreachable(i32) -> i32 {
+block0(v0: i32):
+    brif v0, block1, block2
+block1:
+    jump block3
+block2:
+    v1 = iconst.i32 0
+    brif v1, block3, block4
+block3:
+    return v0
+block4:
+    v2 = iconst.i32 42
+    return v2
+}
+
+; function %diamond_one_side_unreachable(i32) -> i32 fast {
+; block0(v0: i32):
+;     brif v0, block1, block2
+;
+; block1:
+;     jump block3
+;
+; block2:
+;     jump block4
+;
+; block3:
+;     return v0
+;
+; block4:
+;     v2 = iconst.i32 42
+;     return v2  ; v2 = 42
+; }
+
+function %br_table_in_bounds() -> i32 {
+block0:
+    v0 = iconst.i32 1
+    br_table v0, block4, [block1, block2, block3]
+block1:
+    v1 = iconst.i32 10
+    return v1
+block2:
+    v2 = iconst.i32 20
+    return v2
+block3:
+    v3 = iconst.i32 30
+    return v3
+block4:
+    v4 = iconst.i32 -1
+    return v4
+}
+
+; function %br_table_in_bounds() -> i32 fast {
+; block0:
+;     jump block2
+;
+; block2:
+;     v2 = iconst.i32 20
+;     return v2  ; v2 = 20
+; }
+
+function %br_table_out_of_bounds() -> i32 {
+block0:
+    v0 = iconst.i32 99
+    br_table v0, block3, [block1, block2]
+block1:
+    v1 = iconst.i32 10
+    return v1
+block2:
+    v2 = iconst.i32 20
+    return v2
+block3:
+    v3 = iconst.i32 -1
+    return v3
+}
+
+; function %br_table_out_of_bounds() -> i32 fast {
+; block0:
+;     jump block3
+;
+; block3:
+;     v3 = iconst.i32 -1
+;     return v3  ; v3 = -1
+; }

--- a/cranelift/filetests/filetests/isa/riscv64/issue-12811.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/issue-12811.clif
@@ -3415,261 +3415,260 @@ block2:
 ;   addi t6,t6,16
 ;   trap_if stk_ovf##(sp ult t6)
 ; block0:
-;   mv t0,a0
-;   li a0,0
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   li a2,4
-;   sd a2,0(a0)
-;   sd zero,0(a0)
-;   sd a2,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   li a1,1
-;   sd a1,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd a1,0(a0)
-;   sw zero,0(a0)
-;   sd a2,0(a0)
-;   sd a1,0(a0)
-;   li a4,1
-;   sw a4,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sw a4,0(a0)
-;   sd a2,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd a1,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   li a3,9
-;   sd a3,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd a3,0(a0)
-;   li a3,13
-;   sw a3,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sd a2,0(a0)
-;   sd a1,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sd a1,0(a0)
-;   sw zero,0(a0)
-;   sw a4,0(a0)
-;   sw zero,0(a0)
-;   sw a4,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sd a1,0(a0)
-;   sd a2,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   li a3,8
-;   sd a3,0(a0)
-;   sw a4,0(a0)
-;   sw zero,0(a0)
-;   sd a2,0(a0)
-;   sd a3,0(a0)
-;   sw a4,0(a0)
-;   sd a1,0(a0)
-;   sw a4,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw a4,0(a0)
-;   sd a1,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sw a4,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd a2,0(a0)
-;   sw zero,0(a0)
-;   sd a1,0(a0)
-;   sw zero,0(a0)
-;   sw a4,0(a0)
-;   sd zero,0(a0)
-;   sw a4,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sd a1,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sd a1,0(a0)
-;   sd zero,0(a0)
-;   sd a3,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd a1,0(a0)
-;   sw zero,0(a0)
-;   sd a1,0(a0)
-;   li a5,3
-;   sw a5,0(a0)
-;   sd a1,0(a0)
-;   sb a4,0(a0)
-;   sw zero,0(a0)
-;   sd a2,0(a0)
-;   sd zero,0(a0)
-;   sw a4,0(a0)
-;   sw zero,0(a0)
-;   sw a4,0(a0)
-;   sw zero,0(a0)
-;   sd a3,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sw a4,0(a0)
-;   sw zero,0(a0)
-;   sd a1,0(a0)
-;   sd a2,0(a0)
-;   sw a4,0(a0)
-;   sd a1,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   li a5,8
-;   sw a5,0(a0)
-;   sw zero,0(a0)
-;   sd a3,0(a0)
-;   sw zero,0(a0)
-;   sw a4,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw a4,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd a1,0(a0)
-;   sw a4,0(a0)
-;   sw zero,0(a0)
-;   sd a1,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw a5,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd a1,0(a0)
-;   sw zero,0(a0)
-;   sd a1,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sd a1,0(a0)
-;   sd a3,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd a2,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sd a1,0(a0)
+;   li a1,0
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   li a3,4
+;   sd a3,0(a1)
+;   sd zero,0(a1)
+;   sd a3,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   li a2,1
+;   sd a2,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd a2,0(a1)
+;   sw zero,0(a1)
+;   sd a3,0(a1)
+;   sd a2,0(a1)
+;   li a5,1
+;   sw a5,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sw a5,0(a1)
+;   sd a3,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd a2,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   li a4,9
+;   sd a4,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd a4,0(a1)
+;   li a4,13
+;   sw a4,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sd a3,0(a1)
+;   sd a2,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sd a2,0(a1)
+;   sw zero,0(a1)
+;   sw a5,0(a1)
+;   sw zero,0(a1)
+;   sw a5,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sd a2,0(a1)
+;   sd a3,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   li a4,8
+;   sd a4,0(a1)
+;   sw a5,0(a1)
+;   sw zero,0(a1)
+;   sd a3,0(a1)
+;   sd a4,0(a1)
+;   sw a5,0(a1)
+;   sd a2,0(a1)
+;   sw a5,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw a5,0(a1)
+;   sd a2,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sw a5,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd a3,0(a1)
+;   sw zero,0(a1)
+;   sd a2,0(a1)
+;   sw zero,0(a1)
+;   sw a5,0(a1)
+;   sd zero,0(a1)
+;   sw a5,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sd a2,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sd a2,0(a1)
+;   sd zero,0(a1)
+;   sd a4,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd a2,0(a1)
+;   sw zero,0(a1)
+;   sd a2,0(a1)
+;   li t0,3
+;   sw t0,0(a1)
+;   sd a2,0(a1)
+;   sb a5,0(a1)
+;   sw zero,0(a1)
+;   sd a3,0(a1)
+;   sd zero,0(a1)
+;   sw a5,0(a1)
+;   sw zero,0(a1)
+;   sw a5,0(a1)
+;   sw zero,0(a1)
+;   sd a4,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sw a5,0(a1)
+;   sw zero,0(a1)
+;   sd a2,0(a1)
+;   sd a3,0(a1)
+;   sw a5,0(a1)
+;   sd a2,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   li t0,8
+;   sw t0,0(a1)
+;   sw zero,0(a1)
+;   sd a4,0(a1)
+;   sw zero,0(a1)
+;   sw a5,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw a5,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd a2,0(a1)
+;   sw a5,0(a1)
+;   sw zero,0(a1)
+;   sd a2,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw t0,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd a2,0(a1)
+;   sw zero,0(a1)
+;   sd a2,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sd a2,0(a1)
+;   sd a4,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd a3,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sd a2,0(a1)
 ;   j label1
 ; block1:
-;   lui a0,435789
-;   addi a0,a0,3
-;   trap_if user11##(a0 ne zero)
+;   lui a1,435789
+;   addi a1,a1,3
+;   trap_if user11##(a1 ne zero)
 ;   j label2
 ; block2:
-;   lui a0,154029
-;   addi a0,a0,-1574
-;   trap_if user11##(a0 ne zero)
+;   lui a1,154029
+;   addi a1,a1,-1574
+;   trap_if user11##(a1 ne zero)
 ;   j label3
 ; block3:
 ;   j label4
 ; block4:
 ;   j label5
 ; block5:
-;   li a0,1
-;   trap_if user11##(a0 ne zero)
+;   li a1,1
+;   trap_if user11##(a1 ne zero)
 ;   j label6
 ; block6:
 ;   j label7
@@ -3694,18 +3693,18 @@ block2:
 ; block16:
 ;   j label17
 ; block17:
-;   lui a0,509913
-;   addi a0,a0,-193
-;   trap_if user11##(a0 ne zero)
+;   lui a1,509913
+;   addi a1,a1,-193
+;   trap_if user11##(a1 ne zero)
 ;   j label18
 ; block18:
 ;   j label19
 ; block19:
 ;   j label20
 ; block20:
-;   lui a0,373234
-;   addi a0,a0,1763
-;   trap_if user11##(a0 ne zero)
+;   lui a1,373234
+;   addi a1,a1,1763
+;   trap_if user11##(a1 ne zero)
 ;   j label21
 ; block21:
 ;   j label22
@@ -3718,16 +3717,16 @@ block2:
 ; block25:
 ;   j label26
 ; block26:
-;   lui a0,456913
-;   addi a0,a0,-324
-;   trap_if user11##(a0 ne zero)
+;   lui a1,456913
+;   addi a1,a1,-324
+;   trap_if user11##(a1 ne zero)
 ;   j label27
 ; block27:
 ;   j label28
 ; block28:
-;   lui a0,296162
-;   addi a0,a0,-1144
-;   trap_if user11##(a0 ne zero)
+;   lui a1,296162
+;   addi a1,a1,-1144
+;   trap_if user11##(a1 ne zero)
 ;   j label29
 ; block29:
 ;   j label30
@@ -3736,984 +3735,975 @@ block2:
 ; block31:
 ;   j label32
 ; block32:
-;   lui a0,69861
-;   addi a0,a0,-1634
-;   trap_if user11##(a0 ne zero)
+;   lui a1,69861
+;   addi a1,a1,-1634
+;   trap_if user11##(a1 ne zero)
 ;   j label33
 ; block33:
 ;   j label34
 ; block34:
 ;   j label35
 ; block35:
-;   lui a2,466898
-;   addi a4,a2,1094
-;   trap_if user11##(a4 ne zero)
+;   lui a1,466898
+;   addi a1,a1,1094
+;   trap_if user11##(a1 ne zero)
 ;   j label36
 ; block36:
 ;   j label37
 ; block37:
 ;   j label38
 ; block38:
-;   lui a0,-515203
-;   addi a0,a0,1463
-;   trap_if user11##(a0 ne zero)
+;   lui a3,-515203
+;   addi a5,a3,1463
+;   trap_if user11##(a5 ne zero)
 ;   j label39
 ; block39:
 ;   j label40
 ; block40:
-;   ld a1,[const(253)]
-;   li a0,0
-;   sd a1,0(a0)
-;   ld a1,[const(252)]
-;   sd a1,0(a0)
-;   ld a1,[const(251)]
-;   sd a1,0(a0)
-;   ld a1,[const(250)]
-;   sd a1,0(a0)
-;   ld a1,[const(249)]
-;   sd a1,0(a0)
-;   ld a1,[const(248)]
-;   sd a1,0(a0)
-;   ld a1,[const(247)]
-;   sd zero,0(a1)
-;   ld a1,[const(246)]
-;   sd a1,0(a0)
-;   ld a1,[const(245)]
-;   sd a1,0(a0)
-;   ld a1,[const(244)]
-;   sd a1,0(a0)
-;   ld a1,[const(243)]
-;   sd a1,0(a0)
-;   ld a1,[const(242)]
-;   sd a1,0(a0)
-;   li a1,1
-;   ld a2,[const(241)]
-;   sd a1,0(a2)
-;   ld a2,[const(240)]
-;   sd a2,0(a0)
-;   ld a2,[const(239)]
-;   sd a2,0(a0)
-;   ld a2,[const(238)]
-;   sd a2,0(a0)
-;   ld a2,[const(237)]
-;   sd a2,0(a0)
-;   ld a2,[const(236)]
+;   ld a2,[const(253)]
+;   li a1,0
+;   sd a2,0(a1)
+;   ld a2,[const(252)]
+;   sd a2,0(a1)
+;   ld a2,[const(251)]
+;   sd a2,0(a1)
+;   ld a2,[const(250)]
+;   sd a2,0(a1)
+;   ld a2,[const(249)]
+;   sd a2,0(a1)
+;   ld a2,[const(248)]
+;   sd a2,0(a1)
+;   ld a2,[const(247)]
 ;   sd zero,0(a2)
-;   ld a2,[const(235)]
-;   sd a2,0(a0)
-;   ld a2,[const(234)]
-;   sd a2,0(a0)
-;   ld a2,[const(233)]
-;   sd a2,0(a0)
-;   ld a2,[const(232)]
-;   sd a2,0(a0)
-;   ld a2,[const(231)]
-;   sd a2,0(a0)
-;   ld a2,[const(230)]
-;   sd a2,0(a0)
-;   ld a2,[const(229)]
-;   sd zero,0(a2)
-;   ld a2,[const(228)]
-;   sd zero,0(a2)
-;   ld a2,[const(227)]
-;   sd a2,0(a0)
-;   ld a2,[const(226)]
-;   sd a1,0(a2)
-;   ld a2,[const(225)]
-;   sd a2,0(a0)
-;   ld a2,[const(224)]
-;   sd a2,0(a0)
-;   ld a2,[const(223)]
-;   sd a2,0(a0)
-;   ld a2,[const(222)]
-;   sd zero,0(a2)
-;   ld a2,[const(221)]
-;   sd a2,0(a0)
-;   ld a2,[const(220)]
-;   sd a2,0(a0)
-;   ld a2,[const(219)]
-;   sd a2,0(a0)
-;   ld a2,[const(218)]
-;   sd a2,0(a0)
-;   ld a2,[const(217)]
-;   sd a2,0(a0)
-;   ld a2,[const(216)]
-;   sd a2,0(a0)
-;   ld a2,[const(215)]
-;   sd a2,0(a0)
-;   ld a2,[const(214)]
-;   sd a2,0(a0)
-;   ld a2,[const(213)]
-;   sd a2,0(a0)
+;   ld a2,[const(246)]
+;   sd a2,0(a1)
+;   ld a2,[const(245)]
+;   sd a2,0(a1)
+;   ld a2,[const(244)]
+;   sd a2,0(a1)
+;   ld a2,[const(243)]
+;   sd a2,0(a1)
+;   ld a2,[const(242)]
+;   sd a2,0(a1)
 ;   li a2,1
-;   ld a3,[const(212)]
-;   sw a2,0(a3)
-;   ld a3,[const(211)]
-;   sd a3,0(a0)
-;   ld a3,[const(210)]
-;   sd a3,0(a0)
-;   ld a3,[const(209)]
+;   ld a3,[const(241)]
+;   sd a2,0(a3)
+;   ld a3,[const(240)]
+;   sd a3,0(a1)
+;   ld a3,[const(239)]
+;   sd a3,0(a1)
+;   ld a3,[const(238)]
+;   sd a3,0(a1)
+;   ld a3,[const(237)]
+;   sd a3,0(a1)
+;   ld a3,[const(236)]
 ;   sd zero,0(a3)
-;   ld a3,[const(208)]
-;   sd a3,0(a0)
-;   ld a3,[const(207)]
-;   sd a3,0(a0)
-;   ld a3,[const(206)]
-;   sd a3,0(a0)
-;   sd zero,0(a0)
-;   li a3,0
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   ld a4,[const(205)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(204)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(203)]
-;   sd a4,0(a0)
-;   ld a4,[const(202)]
-;   sd a4,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   ld a4,[const(201)]
-;   ld a5,[const(200)]
-;   sd a4,0(a5)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(199)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(198)]
+;   ld a3,[const(235)]
+;   sd a3,0(a1)
+;   ld a3,[const(234)]
+;   sd a3,0(a1)
+;   ld a3,[const(233)]
+;   sd a3,0(a1)
+;   ld a3,[const(232)]
+;   sd a3,0(a1)
+;   ld a3,[const(231)]
+;   sd a3,0(a1)
+;   ld a3,[const(230)]
+;   sd a3,0(a1)
+;   ld a3,[const(229)]
+;   sd zero,0(a3)
+;   ld a3,[const(228)]
+;   sd zero,0(a3)
+;   ld a3,[const(227)]
+;   sd a3,0(a1)
+;   ld a3,[const(226)]
+;   sd a2,0(a3)
+;   ld a3,[const(225)]
+;   sd a3,0(a1)
+;   ld a3,[const(224)]
+;   sd a3,0(a1)
+;   ld a3,[const(223)]
+;   sd a3,0(a1)
+;   ld a3,[const(222)]
+;   sd zero,0(a3)
+;   ld a3,[const(221)]
+;   sd a3,0(a1)
+;   ld a3,[const(220)]
+;   sd a3,0(a1)
+;   ld a3,[const(219)]
+;   sd a3,0(a1)
+;   ld a3,[const(218)]
+;   sd a3,0(a1)
+;   ld a3,[const(217)]
+;   sd a3,0(a1)
+;   ld a3,[const(216)]
+;   sd a3,0(a1)
+;   ld a3,[const(215)]
+;   sd a3,0(a1)
+;   ld a3,[const(214)]
+;   sd a3,0(a1)
+;   ld a3,[const(213)]
+;   sd a3,0(a1)
+;   li a3,1
+;   ld a4,[const(212)]
+;   sw a3,0(a4)
+;   ld a4,[const(211)]
+;   sd a4,0(a1)
+;   ld a4,[const(210)]
+;   sd a4,0(a1)
+;   ld a4,[const(209)]
 ;   sd zero,0(a4)
-;   sw zero,0(a0)
-;   ld a4,[const(197)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(196)]
-;   sd a4,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(195)]
-;   sd a4,0(a0)
-;   ld a4,[const(194)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(193)]
-;   sd zero,0(a4)
-;   ld a4,[const(192)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(191)]
-;   sd a4,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(190)]
-;   sd a4,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(189)]
-;   sd a4,0(a0)
-;   ld a4,[const(188)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(187)]
-;   sd a4,0(a0)
-;   ld a4,[const(186)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   ld a4,[const(185)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(184)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(183)]
-;   sd a4,0(a0)
-;   ld a4,[const(182)]
-;   sd a4,0(a0)
-;   ld a4,[const(181)]
-;   ld a4,0(a4)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(180)]
-;   sd a4,0(a0)
-;   ld a4,[const(179)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
+;   ld a4,[const(208)]
+;   sd a4,0(a1)
+;   ld a4,[const(207)]
+;   sd a4,0(a1)
+;   ld a4,[const(206)]
+;   sd a4,0(a1)
+;   sd zero,0(a1)
+;   li a4,0
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   ld a5,[const(205)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(204)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(203)]
+;   sd a5,0(a1)
+;   ld a5,[const(202)]
+;   sd a5,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   ld a5,[const(201)]
+;   ld a6,[const(200)]
+;   sd a5,0(a6)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(199)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(198)]
+;   sd zero,0(a5)
+;   sw zero,0(a1)
+;   ld a5,[const(197)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(196)]
+;   sd a5,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(195)]
+;   sd a5,0(a1)
+;   ld a5,[const(194)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(193)]
+;   sd zero,0(a5)
+;   ld a5,[const(192)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(191)]
+;   sd a5,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(190)]
+;   sd a5,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(189)]
+;   sd a5,0(a1)
+;   ld a5,[const(188)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(187)]
+;   sd a5,0(a1)
+;   ld a5,[const(186)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   ld a5,[const(185)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(184)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(183)]
+;   sd a5,0(a1)
+;   ld a5,[const(182)]
+;   sd a5,0(a1)
+;   ld a5,[const(181)]
+;   ld a5,0(a5)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(180)]
+;   sd a5,0(a1)
+;   ld a5,[const(179)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
 ;   ld a5,[const(178)]
-;   sd a5,0(a0)
-;   ld a4,[const(177)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(176)]
-;   sd a4,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(175)]
-;   sd a4,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(174)]
-;   sd a4,0(a0)
-;   sd zero,0(a0)
-;   ld a4,[const(173)]
-;   sd zero,0(a4)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(172)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(171)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(170)]
-;   sd a4,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(169)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(168)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(167)]
-;   sd a4,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   ld a4,[const(166)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(165)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(164)]
-;   sd a4,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(163)]
-;   sd a4,0(a0)
-;   ld a4,[const(162)]
-;   sd a4,0(a0)
-;   sd zero,0(a0)
-;   ld a4,[const(161)]
-;   ld a4,0(a4)
-;   sw zero,0(a0)
-;   ld a4,[const(160)]
-;   sd a4,0(a0)
-;   ld a4,[const(159)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(158)]
-;   sd a4,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   ld a4,[const(157)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(156)]
-;   sd a4,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   ld a4,[const(155)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(154)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(153)]
-;   sd a4,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(152)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(151)]
-;   sd a4,0(a0)
-;   ld a4,[const(150)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(149)]
-;   sd a4,0(a0)
-;   ld a4,[const(148)]
-;   sd zero,0(a4)
-;   sw zero,0(a0)
-;   ld a4,[const(147)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(146)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(145)]
-;   sd a4,0(a0)
-;   ld a4,[const(144)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   ld a4,[const(143)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(142)]
-;   sd a4,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(141)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(140)]
-;   sd a4,0(a0)
-;   ld a4,[const(139)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(138)]
-;   sd a4,0(a0)
-;   ld a4,[const(137)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   ld a4,[const(136)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(135)]
-;   sd a4,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(134)]
-;   sd a4,0(a0)
-;   ld a4,[const(133)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(132)]
-;   sd a4,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(131)]
-;   sd a4,0(a0)
-;   ld a4,[const(130)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
+;   sd a5,0(a1)
+;   ld a5,[const(177)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(176)]
+;   sd a5,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(175)]
+;   sd a5,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(174)]
+;   sd a5,0(a1)
+;   sd zero,0(a1)
+;   ld a5,[const(173)]
+;   sd zero,0(a5)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(172)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(171)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(170)]
+;   sd a5,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(169)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(168)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(167)]
+;   sd a5,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   ld a5,[const(166)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(165)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(164)]
+;   sd a5,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(163)]
+;   sd a5,0(a1)
+;   ld a5,[const(162)]
+;   sd a5,0(a1)
+;   sd zero,0(a1)
+;   ld a5,[const(161)]
+;   ld a5,0(a5)
+;   sw zero,0(a1)
+;   ld a5,[const(160)]
+;   sd a5,0(a1)
+;   ld a5,[const(159)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(158)]
+;   sd a5,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   ld a5,[const(157)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(156)]
+;   sd a5,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   ld a5,[const(155)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(154)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(153)]
+;   sd a5,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(152)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(151)]
+;   sd a5,0(a1)
+;   ld a5,[const(150)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(149)]
+;   sd a5,0(a1)
+;   ld a5,[const(148)]
+;   sd zero,0(a5)
+;   sw zero,0(a1)
+;   ld a5,[const(147)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(146)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(145)]
+;   sd a5,0(a1)
+;   ld a5,[const(144)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   ld a5,[const(143)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(142)]
+;   sd a5,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(141)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(140)]
+;   sd a5,0(a1)
+;   ld a5,[const(139)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(138)]
+;   sd a5,0(a1)
+;   ld a5,[const(137)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   ld a5,[const(136)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(135)]
+;   sd a5,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(134)]
+;   sd a5,0(a1)
+;   ld a5,[const(133)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(132)]
+;   sd a5,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(131)]
+;   sd a5,0(a1)
+;   ld a5,[const(130)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
 ;   ld a5,[const(129)]
-;   sd a5,0(a0)
-;   ld a4,[const(128)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(127)]
-;   sd a4,0(a0)
-;   ld a4,[const(126)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   ld a4,[const(125)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(124)]
-;   sd a4,0(a0)
-;   ld a4,[const(123)]
-;   sd a4,0(a0)
-;   ld a4,[const(122)]
-;   sd a4,0(a0)
-;   ld a4,[const(121)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   ld a4,[const(120)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(119)]
-;   sd a4,0(a0)
-;   ld a4,[const(118)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(117)]
-;   sd a4,0(a0)
-;   ld a4,[const(116)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(115)]
-;   sd a4,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   ld a4,[const(114)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   ld a4,[const(113)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(112)]
-;   sd a4,0(a0)
-;   ld a4,[const(111)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(110)]
-;   sd a4,0(a0)
-;   ld a4,[const(109)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(108)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(107)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(106)]
-;   sd a1,0(a4)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(105)]
-;   sd zero,0(a4)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   ld a4,[const(104)]
-;   sd a4,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   ld a4,[const(103)]
-;   sd a4,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   ld a4,[const(102)]
-;   sd zero,0(a4)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(101)]
-;   sd a4,0(a0)
-;   ld a4,[const(100)]
-;   sd a4,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(99)]
-;   sd a1,0(a4)
-;   ld a4,[const(98)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   ld a4,[const(97)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(96)]
-;   sd a4,0(a0)
-;   ld a4,[const(95)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   ld a4,[const(94)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(93)]
-;   sd a1,0(a4)
-;   ld a4,[const(92)]
-;   sd a4,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(91)]
-;   sd a4,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   lui a4,309522
-;   addi a4,a4,-111
-;   ld a5,[const(90)]
-;   sw a4,0(a5)
-;   sw zero,0(a0)
-;   ld a4,[const(89)]
-;   sd a4,0(a0)
-;   ld a4,[const(88)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(87)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(86)]
-;   sd a4,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(85)]
-;   sd a4,0(a0)
-;   ld a4,[const(84)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(83)]
-;   sd a4,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   ld a4,[const(82)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(81)]
-;   sd a4,0(a0)
-;   ld a4,[const(80)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(79)]
-;   sd a4,0(a0)
-;   sd zero,0(a0)
-;   ld a4,[const(78)]
-;   sd a4,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(77)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(76)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   ld a4,[const(75)]
-;   sd a4,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(74)]
-;   sd a4,0(a0)
-;   ld a4,[const(73)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   ld a4,[const(72)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(71)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(70)]
-;   sd a4,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(69)]
-;   sd a4,0(a0)
-;   sd zero,0(a0)
-;   ld a4,[const(68)]
-;   sd a4,0(a0)
-;   ld a4,[const(67)]
-;   lw a4,0(a4)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(66)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   ld a4,[const(65)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   ld a4,[const(64)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(63)]
-;   sd a4,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(62)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(61)]
-;   sd a4,0(a0)
-;   ld a4,[const(60)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(59)]
-;   sd a4,0(a0)
-;   sd zero,0(a0)
-;   ld a4,[const(58)]
-;   sw zero,0(a4)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(57)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(56)]
-;   sd a4,0(a0)
-;   ld a4,[const(55)]
-;   sw a2,0(a4)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   ld a4,[const(54)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   ld a4,[const(53)]
-;   sd a4,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   ld a4,[const(52)]
-;   sd a1,0(a4)
-;   sw zero,0(a0)
-;   ld a4,[const(51)]
-;   sd a4,0(a0)
-;   ld a4,[const(50)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(49)]
-;   sd a4,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sb a3,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(48)]
-;   sd a4,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
+;   sd a5,0(a1)
+;   ld a5,[const(128)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(127)]
+;   sd a5,0(a1)
+;   ld a5,[const(126)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   ld a5,[const(125)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(124)]
+;   sd a5,0(a1)
+;   ld a5,[const(123)]
+;   sd a5,0(a1)
+;   ld a5,[const(122)]
+;   sd a5,0(a1)
+;   ld a5,[const(121)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   ld a5,[const(120)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(119)]
+;   sd a5,0(a1)
+;   ld a5,[const(118)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(117)]
+;   sd a5,0(a1)
+;   ld a5,[const(116)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(115)]
+;   sd a5,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   ld a5,[const(114)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   ld a5,[const(113)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(112)]
+;   sd a5,0(a1)
+;   ld a5,[const(111)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(110)]
+;   sd a5,0(a1)
+;   ld a5,[const(109)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(108)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(107)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(106)]
+;   sd a2,0(a5)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(105)]
+;   sd zero,0(a5)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   ld a5,[const(104)]
+;   sd a5,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   ld a5,[const(103)]
+;   sd a5,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   ld a5,[const(102)]
+;   sd zero,0(a5)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(101)]
+;   sd a5,0(a1)
+;   ld a5,[const(100)]
+;   sd a5,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(99)]
+;   sd a2,0(a5)
+;   ld a5,[const(98)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   ld a5,[const(97)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(96)]
+;   sd a5,0(a1)
+;   ld a5,[const(95)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   ld a5,[const(94)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(93)]
+;   sd a2,0(a5)
+;   ld a5,[const(92)]
+;   sd a5,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(91)]
+;   sd a5,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   lui a5,309522
+;   addi a5,a5,-111
+;   ld t0,[const(90)]
+;   sw a5,0(t0)
+;   sw zero,0(a1)
+;   ld a5,[const(89)]
+;   sd a5,0(a1)
+;   ld a5,[const(88)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(87)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(86)]
+;   sd a5,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(85)]
+;   sd a5,0(a1)
+;   ld a5,[const(84)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(83)]
+;   sd a5,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   ld a5,[const(82)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(81)]
+;   sd a5,0(a1)
+;   ld a5,[const(80)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(79)]
+;   sd a5,0(a1)
+;   sd zero,0(a1)
+;   ld a5,[const(78)]
+;   sd a5,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(77)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(76)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   ld a5,[const(75)]
+;   sd a5,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(74)]
+;   sd a5,0(a1)
+;   ld a5,[const(73)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   ld a5,[const(72)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(71)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(70)]
+;   sd a5,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(69)]
+;   sd a5,0(a1)
+;   sd zero,0(a1)
+;   ld a5,[const(68)]
+;   sd a5,0(a1)
+;   ld a5,[const(67)]
+;   lw a5,0(a5)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(66)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   ld a5,[const(65)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   ld a5,[const(64)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(63)]
+;   sd a5,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(62)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(61)]
+;   sd a5,0(a1)
+;   ld a5,[const(60)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(59)]
+;   sd a5,0(a1)
+;   sd zero,0(a1)
+;   ld a5,[const(58)]
+;   sw zero,0(a5)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(57)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(56)]
+;   sd a5,0(a1)
+;   ld a5,[const(55)]
+;   sw a3,0(a5)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   ld a5,[const(54)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   ld a5,[const(53)]
+;   sd a5,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   ld a5,[const(52)]
+;   sd a2,0(a5)
+;   sw zero,0(a1)
+;   ld a5,[const(51)]
+;   sd a5,0(a1)
+;   ld a5,[const(50)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(49)]
+;   sd a5,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sb a4,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(48)]
+;   sd a5,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
 ;   ld a5,[const(47)]
-;   sd a5,0(a0)
-;   ld a4,[const(46)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(45)]
-;   sd a4,0(a0)
-;   ld a4,[const(44)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(43)]
-;   sd a4,0(a0)
-;   ld a4,[const(42)]
-;   sd a1,0(a4)
-;   sw zero,0(a0)
-;   ld a4,[const(41)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(40)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   ld a4,[const(39)]
-;   sd a4,0(a0)
-;   sd zero,0(a0)
-;   sb a3,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(38)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(37)]
-;   sd a4,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(36)]
-;   sd a4,0(a0)
-;   ld a4,[const(35)]
-;   sd a1,0(a4)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   lw a4,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   ld a4,[const(34)]
-;   sd a4,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(33)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(32)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   ld a4,[const(31)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   ld a4,[const(30)]
-;   sd a1,0(a4)
-;   ld a4,[const(29)]
-;   sd zero,0(a4)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sb a3,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(28)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(27)]
-;   sd a4,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sb a3,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sb a3,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(26)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   ld a4,[const(25)]
-;   sd a4,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(24)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sb a3,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   ld a4,[const(23)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(22)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(21)]
-;   sd a4,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(20)]
-;   sd a4,0(a0)
-;   ld a4,[const(19)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   ld a4,[const(18)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(17)]
-;   sd zero,0(a4)
-;   sb a3,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(16)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(15)]
-;   sd a4,0(a0)
-;   ld a4,[const(14)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   ld a4,[const(13)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sb a2,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(12)]
-;   sd a4,0(a0)
-;   ld a4,[const(11)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   ld a4,[const(10)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   ld a4,[const(9)]
-;   sd a4,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sb a3,0(a0)
-;   sw zero,0(a0)
+;   sd a5,0(a1)
+;   ld a5,[const(46)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(45)]
+;   sd a5,0(a1)
+;   ld a5,[const(44)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(43)]
+;   sd a5,0(a1)
+;   ld a5,[const(42)]
+;   sd a2,0(a5)
+;   sw zero,0(a1)
+;   ld a5,[const(41)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(40)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   ld a5,[const(39)]
+;   sd a5,0(a1)
+;   sd zero,0(a1)
+;   sb a4,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(38)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(37)]
+;   sd a5,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(36)]
+;   sd a5,0(a1)
+;   ld a5,[const(35)]
+;   sd a2,0(a5)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   lw a5,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   ld a5,[const(34)]
+;   sd a5,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(33)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(32)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   ld a5,[const(31)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   ld a5,[const(30)]
+;   sd a2,0(a5)
+;   ld a5,[const(29)]
+;   sd zero,0(a5)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sb a4,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(28)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(27)]
+;   sd a5,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sb a4,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sb a4,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(26)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   ld a5,[const(25)]
+;   sd a5,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(24)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sb a4,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   ld a5,[const(23)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(22)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(21)]
+;   sd a5,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(20)]
+;   sd a5,0(a1)
+;   ld a5,[const(19)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   ld a5,[const(18)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(17)]
+;   sd zero,0(a5)
+;   sb a4,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(16)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(15)]
+;   sd a5,0(a1)
+;   ld a5,[const(14)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   ld a5,[const(13)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sb a3,0(a1)
+;   sw zero,0(a1)
+;   ld a3,[const(12)]
+;   sd a3,0(a1)
+;   ld a5,[const(11)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   ld a3,[const(10)]
+;   sd a3,0(a1)
+;   sw zero,0(a1)
+;   ld a3,[const(9)]
+;   sd a3,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sb a4,0(a1)
+;   sw zero,0(a1)
 ;   ld a3,[const(8)]
-;   sd a1,0(a3)
-;   ld a1,[const(7)]
-;   sd a1,0(a0)
-;   sw zero,0(a0)
-;   ld a1,[const(6)]
-;   sd a1,0(a0)
-;   ld a1,[const(5)]
+;   sd a2,0(a3)
+;   ld a2,[const(7)]
+;   sd a2,0(a1)
+;   sw zero,0(a1)
+;   ld a2,[const(6)]
+;   sd a2,0(a1)
+;   ld a2,[const(5)]
 ;   lui a3,4
 ;   addi a3,a3,-1824
-;   sd a1,0(a3)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   ld a1,[const(4)]
+;   sd a2,0(a3)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   ld a2,[const(4)]
 ;   lui a3,4
 ;   addi a3,a3,-1700
-;   sd a1,0(a3)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   ld a1,[const(3)]
+;   sd a2,0(a3)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   ld a2,[const(3)]
 ;   lui a3,4
 ;   addi a3,a3,-1520
-;   sd a1,0(a3)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   ld a1,[const(2)]
+;   sd a2,0(a3)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   ld a2,[const(2)]
 ;   lui a3,4
 ;   addi a3,a3,-1592
-;   sd a1,0(a3)
-;   ld a1,[const(1)]
+;   sd a2,0(a3)
+;   ld a2,[const(1)]
 ;   lui a3,4
 ;   addi a3,a3,-1600
-;   sd a1,0(a3)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   ld a1,[const(0)]
+;   sd a2,0(a3)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   ld a2,[const(0)]
 ;   lui a3,4
 ;   addi a3,a3,-1436
-;   sd a1,0(a3)
-;   sw zero,0(a0)
-;   sd zero,0(a0)
-;   sw zero,0(a0)
-;   sext.w a0,a2
-;   bne a0,zero,taken(label42),not_taken(label41)
+;   sd a2,0(a3)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   j label41
 ; block41:
-;   lui a0,1
-;   addi a2,a0,-1080
-;   mv a1,t0
-;   mv a0,a1
-;   call userextname0
-;   udf##trap_code=user1
-; block42:
-;   mv a1,t0
 ;   li a2,1
 ;   li a3,2
-;   mv a0,a1
+;   mv a1,a0
 ;   call userextname1
 ;   udf##trap_code=user11
 ;
@@ -4729,1496 +4719,1491 @@ block2:
 ;   bgeu sp, t6, 6
 ;   c.unimp ; trap: stk_ovf
 ; block1: ; offset 0x18
-;   c.mv t0, a0
-;   c.li a0, 0
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   c.li a2, 4
-;   c.sd a2, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   c.sd a2, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
+;   c.li a1, 0
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   c.li a3, 4
+;   c.sd a3, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   c.sd a3, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   c.li a2, 1
+;   c.sd a2, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   c.sd a2, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   c.sd a3, 0(a1) ; trap: heap_oob
+;   c.sd a2, 0(a1) ; trap: heap_oob
+;   c.li a5, 1
+;   c.sw a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   c.sw a5, 0(a1) ; trap: heap_oob
+;   c.sd a3, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   c.sd a2, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   c.li a4, 9
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   c.li a4, 0xd
+;   c.sw a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   c.sd a3, 0(a1) ; trap: heap_oob
+;   c.sd a2, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   c.sd a2, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   c.sw a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   c.sw a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   c.sd a2, 0(a1) ; trap: heap_oob
+;   c.sd a3, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   c.li a4, 8
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   c.sw a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   c.sd a3, 0(a1) ; trap: heap_oob
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   c.sw a5, 0(a1) ; trap: heap_oob
+;   c.sd a2, 0(a1) ; trap: heap_oob
+;   c.sw a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   c.sw a5, 0(a1) ; trap: heap_oob
+;   c.sd a2, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   c.sw a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   c.sd a3, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   c.sd a2, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   c.sw a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   c.sw a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   c.sd a2, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   c.sd a2, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   c.sd a2, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   c.sd a2, 0(a1) ; trap: heap_oob
+;   c.li t0, 3
+;   sw t0, 0(a1) ; trap: heap_oob
+;   c.sd a2, 0(a1) ; trap: heap_oob
+;   sb a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   c.sd a3, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   c.sw a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   c.sw a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   c.sw a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   c.sd a2, 0(a1) ; trap: heap_oob
+;   c.sd a3, 0(a1) ; trap: heap_oob
+;   c.sw a5, 0(a1) ; trap: heap_oob
+;   c.sd a2, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   c.li t0, 8
+;   sw t0, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   c.sw a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   c.sw a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   c.sd a2, 0(a1) ; trap: heap_oob
+;   c.sw a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   c.sd a2, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw t0, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   c.sd a2, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   c.sd a2, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   c.sd a2, 0(a1) ; trap: heap_oob
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   c.sd a3, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   c.sd a2, 0(a1) ; trap: heap_oob
+; block2: ; offset 0x33c
+;   lui a1, 0x6a64d
+;   c.addi a1, 3
+;   beqz a1, 6
+;   c.unimp ; trap: user11
+; block3: ; offset 0x348
+;   lui a1, 0x259ad
+;   addi a1, a1, -0x626
+;   beqz a1, 6
+;   c.unimp ; trap: user11
+; block4: ; offset 0x356
 ;   c.li a1, 1
-;   c.sd a1, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   c.sd a1, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   c.sd a2, 0(a0) ; trap: heap_oob
-;   c.sd a1, 0(a0) ; trap: heap_oob
-;   c.li a4, 1
-;   c.sw a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   c.sw a4, 0(a0) ; trap: heap_oob
-;   c.sd a2, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   c.sd a1, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   c.li a3, 9
-;   c.sd a3, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   c.sd a3, 0(a0) ; trap: heap_oob
-;   c.li a3, 0xd
-;   c.sw a3, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   c.sd a2, 0(a0) ; trap: heap_oob
-;   c.sd a1, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   c.sd a1, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   c.sw a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   c.sw a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   c.sd a1, 0(a0) ; trap: heap_oob
-;   c.sd a2, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   c.li a3, 8
-;   c.sd a3, 0(a0) ; trap: heap_oob
-;   c.sw a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   c.sd a2, 0(a0) ; trap: heap_oob
-;   c.sd a3, 0(a0) ; trap: heap_oob
-;   c.sw a4, 0(a0) ; trap: heap_oob
-;   c.sd a1, 0(a0) ; trap: heap_oob
-;   c.sw a4, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   c.sw a4, 0(a0) ; trap: heap_oob
-;   c.sd a1, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   c.sw a4, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   c.sd a2, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   c.sd a1, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   c.sw a4, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   c.sw a4, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   c.sd a1, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   c.sd a1, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   c.sd a3, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   c.sd a1, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   c.sd a1, 0(a0) ; trap: heap_oob
-;   c.li a5, 3
-;   c.sw a5, 0(a0) ; trap: heap_oob
-;   c.sd a1, 0(a0) ; trap: heap_oob
-;   sb a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   c.sd a2, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   c.sw a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   c.sw a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   c.sd a3, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   c.sw a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   c.sd a1, 0(a0) ; trap: heap_oob
-;   c.sd a2, 0(a0) ; trap: heap_oob
-;   c.sw a4, 0(a0) ; trap: heap_oob
-;   c.sd a1, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   c.li a5, 8
-;   c.sw a5, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   c.sd a3, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   c.sw a4, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   c.sw a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   c.sd a1, 0(a0) ; trap: heap_oob
-;   c.sw a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   c.sd a1, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   c.sw a5, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   c.sd a1, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   c.sd a1, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   c.sd a1, 0(a0) ; trap: heap_oob
-;   c.sd a3, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   c.sd a2, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   c.sd a1, 0(a0) ; trap: heap_oob
-; block2: ; offset 0x338
-;   lui a0, 0x6a64d
-;   c.addi a0, 3
-;   beqz a0, 6
+;   beqz a1, 6
 ;   c.unimp ; trap: user11
-; block3: ; offset 0x344
-;   lui a0, 0x259ad
-;   addi a0, a0, -0x626
-;   beqz a0, 6
+; block5: ; offset 0x35e
+;   lui a1, 0x7c7d9
+;   addi a1, a1, -0xc1
+;   beqz a1, 6
 ;   c.unimp ; trap: user11
-; block4: ; offset 0x352
-;   c.li a0, 1
-;   beqz a0, 6
+; block6: ; offset 0x36c
+;   lui a1, 0x5b1f2
+;   addi a1, a1, 0x6e3
+;   beqz a1, 6
 ;   c.unimp ; trap: user11
-; block5: ; offset 0x35a
-;   lui a0, 0x7c7d9
-;   addi a0, a0, -0xc1
-;   beqz a0, 6
+; block7: ; offset 0x37a
+;   lui a1, 0x6f8d1
+;   addi a1, a1, -0x144
+;   beqz a1, 6
 ;   c.unimp ; trap: user11
-; block6: ; offset 0x368
-;   lui a0, 0x5b1f2
-;   addi a0, a0, 0x6e3
-;   beqz a0, 6
+; block8: ; offset 0x388
+;   lui a1, 0x484e2
+;   addi a1, a1, -0x478
+;   beqz a1, 6
 ;   c.unimp ; trap: user11
-; block7: ; offset 0x376
-;   lui a0, 0x6f8d1
-;   addi a0, a0, -0x144
-;   beqz a0, 6
+; block9: ; offset 0x396
+;   lui a1, 0x110e5
+;   addi a1, a1, -0x662
+;   beqz a1, 6
 ;   c.unimp ; trap: user11
-; block8: ; offset 0x384
-;   lui a0, 0x484e2
-;   addi a0, a0, -0x478
-;   beqz a0, 6
+; block10: ; offset 0x3a4
+;   lui a1, 0x71fd2
+;   addi a1, a1, 0x446
+;   beqz a1, 6
 ;   c.unimp ; trap: user11
-; block9: ; offset 0x392
-;   lui a0, 0x110e5
-;   addi a0, a0, -0x662
-;   beqz a0, 6
+; block11: ; offset 0x3b2
+;   lui a3, 0x8237d
+;   addi a5, a3, 0x5b7
+;   beqz a5, 6
 ;   c.unimp ; trap: user11
-; block10: ; offset 0x3a0
-;   lui a2, 0x71fd2
-;   addi a4, a2, 0x446
-;   beqz a4, 6
-;   c.unimp ; trap: user11
-; block11: ; offset 0x3ae
-;   lui a0, 0x8237d
-;   addi a0, a0, 0x5b7
-;   beqz a0, 6
-;   c.unimp ; trap: user11
-; block12: ; offset 0x3bc
+; block12: ; offset 0x3c0
 ;   c.j 4
 ;   c.unimp
 ;   auipc t6, 0
 ;   jalr zero, t6, 8
-; block13: ; offset 0x3c8
-;   auipc a1, 1
-;   ld a1, 0xd0(a1)
-;   c.li a0, 0
-;   c.sd a1, 0(a0) ; trap: heap_oob
-;   auipc a1, 1
-;   ld a1, 0xcc(a1)
-;   c.sd a1, 0(a0) ; trap: heap_oob
-;   auipc a1, 1
-;   ld a1, 0xca(a1)
-;   c.sd a1, 0(a0) ; trap: heap_oob
-;   auipc a1, 1
-;   ld a1, 0xc8(a1)
-;   c.sd a1, 0(a0) ; trap: heap_oob
-;   auipc a1, 1
-;   ld a1, 0xc6(a1)
-;   c.sd a1, 0(a0) ; trap: heap_oob
-;   auipc a1, 1
-;   ld a1, 0xc4(a1)
-;   c.sd a1, 0(a0) ; trap: heap_oob
-;   auipc a1, 1
-;   ld a1, 0xc2(a1)
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a1, 1
-;   ld a1, 0xbe(a1)
-;   c.sd a1, 0(a0) ; trap: heap_oob
-;   auipc a1, 1
-;   ld a1, 0xbc(a1)
-;   c.sd a1, 0(a0) ; trap: heap_oob
-;   auipc a1, 1
-;   ld a1, 0xba(a1)
-;   c.sd a1, 0(a0) ; trap: heap_oob
-;   auipc a1, 1
-;   ld a1, 0xb8(a1)
-;   c.sd a1, 0(a0) ; trap: heap_oob
-;   auipc a1, 1
-;   ld a1, 0xb6(a1)
-;   c.sd a1, 0(a0) ; trap: heap_oob
-;   c.li a1, 1
+; block13: ; offset 0x3cc
+;   auipc a2, 1
+;   ld a2, 0xc4(a2)
+;   c.li a1, 0
+;   c.sd a2, 0(a1) ; trap: heap_oob
+;   auipc a2, 1
+;   ld a2, 0xc0(a2)
+;   c.sd a2, 0(a1) ; trap: heap_oob
+;   auipc a2, 1
+;   ld a2, 0xbe(a2)
+;   c.sd a2, 0(a1) ; trap: heap_oob
+;   auipc a2, 1
+;   ld a2, 0xbc(a2)
+;   c.sd a2, 0(a1) ; trap: heap_oob
+;   auipc a2, 1
+;   ld a2, 0xba(a2)
+;   c.sd a2, 0(a1) ; trap: heap_oob
+;   auipc a2, 1
+;   ld a2, 0xb8(a2)
+;   c.sd a2, 0(a1) ; trap: heap_oob
+;   auipc a2, 1
+;   ld a2, 0xb6(a2)
+;   sd zero, 0(a2) ; trap: heap_oob
 ;   auipc a2, 1
 ;   ld a2, 0xb2(a2)
-;   c.sd a1, 0(a2) ; trap: heap_oob
+;   c.sd a2, 0(a1) ; trap: heap_oob
 ;   auipc a2, 1
 ;   ld a2, 0xb0(a2)
-;   c.sd a2, 0(a0) ; trap: heap_oob
+;   c.sd a2, 0(a1) ; trap: heap_oob
 ;   auipc a2, 1
 ;   ld a2, 0xae(a2)
-;   c.sd a2, 0(a0) ; trap: heap_oob
+;   c.sd a2, 0(a1) ; trap: heap_oob
 ;   auipc a2, 1
 ;   ld a2, 0xac(a2)
-;   c.sd a2, 0(a0) ; trap: heap_oob
+;   c.sd a2, 0(a1) ; trap: heap_oob
 ;   auipc a2, 1
 ;   ld a2, 0xaa(a2)
-;   c.sd a2, 0(a0) ; trap: heap_oob
-;   auipc a2, 1
-;   ld a2, 0xa8(a2)
-;   sd zero, 0(a2) ; trap: heap_oob
-;   auipc a2, 1
-;   ld a2, 0xa4(a2)
-;   c.sd a2, 0(a0) ; trap: heap_oob
-;   auipc a2, 1
-;   ld a2, 0xa2(a2)
-;   c.sd a2, 0(a0) ; trap: heap_oob
-;   auipc a2, 1
-;   ld a2, 0xa0(a2)
-;   c.sd a2, 0(a0) ; trap: heap_oob
-;   auipc a2, 1
-;   ld a2, 0x9e(a2)
-;   c.sd a2, 0(a0) ; trap: heap_oob
-;   auipc a2, 1
-;   ld a2, 0x9c(a2)
-;   c.sd a2, 0(a0) ; trap: heap_oob
-;   auipc a2, 1
-;   ld a2, 0x9a(a2)
-;   c.sd a2, 0(a0) ; trap: heap_oob
-;   auipc a2, 1
-;   ld a2, 0x98(a2)
-;   sd zero, 0(a2) ; trap: heap_oob
-;   auipc a2, 1
-;   ld a2, 0x94(a2)
-;   sd zero, 0(a2) ; trap: heap_oob
-;   auipc a2, 1
-;   ld a2, 0x90(a2)
-;   c.sd a2, 0(a0) ; trap: heap_oob
-;   auipc a2, 1
-;   ld a2, 0x8e(a2)
-;   c.sd a1, 0(a2) ; trap: heap_oob
-;   auipc a2, 1
-;   ld a2, 0x8c(a2)
-;   c.sd a2, 0(a0) ; trap: heap_oob
-;   auipc a2, 1
-;   ld a2, 0x8a(a2)
-;   c.sd a2, 0(a0) ; trap: heap_oob
-;   auipc a2, 1
-;   ld a2, 0x88(a2)
-;   c.sd a2, 0(a0) ; trap: heap_oob
-;   auipc a2, 1
-;   ld a2, 0x86(a2)
-;   sd zero, 0(a2) ; trap: heap_oob
-;   auipc a2, 1
-;   ld a2, 0x82(a2)
-;   c.sd a2, 0(a0) ; trap: heap_oob
-;   auipc a2, 1
-;   ld a2, 0x80(a2)
-;   c.sd a2, 0(a0) ; trap: heap_oob
-;   auipc a2, 1
-;   ld a2, 0x7e(a2)
-;   c.sd a2, 0(a0) ; trap: heap_oob
-;   auipc a2, 1
-;   ld a2, 0x7c(a2)
-;   c.sd a2, 0(a0) ; trap: heap_oob
-;   auipc a2, 1
-;   ld a2, 0x7a(a2)
-;   c.sd a2, 0(a0) ; trap: heap_oob
-;   auipc a2, 1
-;   ld a2, 0x78(a2)
-;   c.sd a2, 0(a0) ; trap: heap_oob
-;   auipc a2, 1
-;   ld a2, 0x76(a2)
-;   c.sd a2, 0(a0) ; trap: heap_oob
-;   auipc a2, 1
-;   ld a2, 0x74(a2)
-;   c.sd a2, 0(a0) ; trap: heap_oob
-;   auipc a2, 1
-;   ld a2, 0x72(a2)
-;   c.sd a2, 0(a0) ; trap: heap_oob
+;   c.sd a2, 0(a1) ; trap: heap_oob
 ;   c.li a2, 1
 ;   auipc a3, 1
-;   ld a3, 0x6e(a3)
-;   c.sw a2, 0(a3) ; trap: heap_oob
+;   ld a3, 0xa6(a3)
+;   c.sd a2, 0(a3) ; trap: heap_oob
 ;   auipc a3, 1
-;   ld a3, 0x6c(a3)
-;   c.sd a3, 0(a0) ; trap: heap_oob
+;   ld a3, 0xa4(a3)
+;   c.sd a3, 0(a1) ; trap: heap_oob
 ;   auipc a3, 1
-;   ld a3, 0x6a(a3)
-;   c.sd a3, 0(a0) ; trap: heap_oob
+;   ld a3, 0xa2(a3)
+;   c.sd a3, 0(a1) ; trap: heap_oob
 ;   auipc a3, 1
-;   ld a3, 0x68(a3)
+;   ld a3, 0xa0(a3)
+;   c.sd a3, 0(a1) ; trap: heap_oob
+;   auipc a3, 1
+;   ld a3, 0x9e(a3)
+;   c.sd a3, 0(a1) ; trap: heap_oob
+;   auipc a3, 1
+;   ld a3, 0x9c(a3)
 ;   sd zero, 0(a3) ; trap: heap_oob
 ;   auipc a3, 1
-;   ld a3, 0x64(a3)
-;   c.sd a3, 0(a0) ; trap: heap_oob
+;   ld a3, 0x98(a3)
+;   c.sd a3, 0(a1) ; trap: heap_oob
 ;   auipc a3, 1
-;   ld a3, 0x62(a3)
-;   c.sd a3, 0(a0) ; trap: heap_oob
+;   ld a3, 0x96(a3)
+;   c.sd a3, 0(a1) ; trap: heap_oob
 ;   auipc a3, 1
-;   ld a3, 0x60(a3)
-;   c.sd a3, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   c.li a3, 0
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x50(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x4a(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x44(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x42(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x34(a4)
-;   auipc a5, 1
-;   ld a5, 0x34(a5)
-;   c.sd a4, 0(a5) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x16(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0(a4)
-;   sd zero, 0(a4) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -8(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0xe(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x20(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x22(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x28(a4)
-;   sd zero, 0(a4) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x2c(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x32(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x54(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x5e(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x60(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x66(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x68(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x7a(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x80(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x86(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x88(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x8a(a4)
-;   c.ld a4, 0(a4) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x94(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x96(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x9c(a5)
-;   c.sd a5, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x9e(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0xa4(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0xae(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0xb8(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0xbe(a4)
-;   sd zero, 0(a4) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0xd2(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0xd8(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0xde(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0xe8(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0xee(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0xf4(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x102(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x108(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x10e(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x118(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x11a(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x120(a4)
-;   c.ld a4, 0(a4) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x126(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x128(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x12e(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x13c(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x14a(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x160(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x166(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x174(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x17e(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x184(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x186(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x18c(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x18e(a4)
-;   sd zero, 0(a4) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x196(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x1ac(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x1b2(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x1b4(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x1ce(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x1d4(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x1de(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x1ec(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x1ee(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x1f4(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x1f6(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x200(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x20e(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x218(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x21a(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x220(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x232(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x234(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x23a(a5)
-;   c.sd a5, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x23c(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x242(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x244(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x24e(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x254(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x256(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x258(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x25a(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x26c(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x272(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x274(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x27a(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x27c(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x292(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x2a0(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x2aa(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x2b0(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x2b2(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x2c0(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x2c2(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x2c8(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x2e6(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x2ec(a4)
-;   c.sd a1, 0(a4) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x2fe(a4)
-;   sd zero, 0(a4) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x31e(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x334(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x342(a4)
-;   sd zero, 0(a4) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x352(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x354(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x35e(a4)
-;   c.sd a1, 0(a4) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x360(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x36a(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x370(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x372(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x38c(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x39a(a4)
-;   c.sd a1, 0(a4) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x39c(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x3ae(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   lui a4, 0x4b912
-;   addi a4, a4, -0x6f
-;   auipc a5, 1
-;   ld a5, -0x3c8(a5)
-;   c.sw a4, 0(a5) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x3ce(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x3d0(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x3d6(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x3e4(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x3ee(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x3f0(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x406(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x43c(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x44a(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x44c(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x452(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x458(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x462(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x468(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x472(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x47c(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x47e(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x488(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x48e(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x494(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x4be(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x4c4(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x4c6(a4)
-;   c.lw a4, 0(a4) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x4d0(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x4da(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x4e4(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x4f2(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x4fc(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x502(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x504(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x50a(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x510(a4)
-;   sw zero, 0(a4) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x528(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x52e(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x530(a4)
-;   c.sw a2, 0(a4) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x53a(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x54c(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x55a(a4)
-;   c.sd a1, 0(a4) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x560(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x562(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x568(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sb a3, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x58e(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x598(a5)
-;   c.sd a5, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x59a(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x5a0(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x5a2(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x5c0(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x5c2(a4)
-;   c.sd a1, 0(a4) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x5c8(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x5ce(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x5d8(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sb a3, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x5ea(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x5f0(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x5fa(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x5fc(a4)
-;   c.sd a1, 0(a4) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   c.lw a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x610(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x61a(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x628(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x632(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x64c(a4)
-;   c.sd a1, 0(a4) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x64e(a4)
-;   sd zero, 0(a4) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sb a3, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x66a(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x678(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sb a3, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sb a3, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x6ba(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x6c4(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x6ce(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sb a3, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x6ec(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x6f2(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x6f8(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x70a(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x70c(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x716(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x724(a4)
-;   sd zero, 0(a4) ; trap: heap_oob
-;   sb a3, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x730(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x736(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x738(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x742(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sb a2, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x754(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x756(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x760(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x766(a4)
-;   c.sd a4, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sb a3, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
+;   ld a3, 0x94(a3)
+;   c.sd a3, 0(a1) ; trap: heap_oob
 ;   auipc a3, 1
-;   ld a3, -0x778(a3)
-;   c.sd a1, 0(a3) ; trap: heap_oob
-;   auipc a1, 1
-;   ld a1, -0x77a(a1)
-;   c.sd a1, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a1, 1
-;   ld a1, -0x780(a1)
-;   c.sd a1, 0(a0) ; trap: heap_oob
-;   auipc a1, 1
-;   ld a1, -0x782(a1)
+;   ld a3, 0x92(a3)
+;   c.sd a3, 0(a1) ; trap: heap_oob
+;   auipc a3, 1
+;   ld a3, 0x90(a3)
+;   c.sd a3, 0(a1) ; trap: heap_oob
+;   auipc a3, 1
+;   ld a3, 0x8e(a3)
+;   c.sd a3, 0(a1) ; trap: heap_oob
+;   auipc a3, 1
+;   ld a3, 0x8c(a3)
+;   sd zero, 0(a3) ; trap: heap_oob
+;   auipc a3, 1
+;   ld a3, 0x88(a3)
+;   sd zero, 0(a3) ; trap: heap_oob
+;   auipc a3, 1
+;   ld a3, 0x84(a3)
+;   c.sd a3, 0(a1) ; trap: heap_oob
+;   auipc a3, 1
+;   ld a3, 0x82(a3)
+;   c.sd a2, 0(a3) ; trap: heap_oob
+;   auipc a3, 1
+;   ld a3, 0x80(a3)
+;   c.sd a3, 0(a1) ; trap: heap_oob
+;   auipc a3, 1
+;   ld a3, 0x7e(a3)
+;   c.sd a3, 0(a1) ; trap: heap_oob
+;   auipc a3, 1
+;   ld a3, 0x7c(a3)
+;   c.sd a3, 0(a1) ; trap: heap_oob
+;   auipc a3, 1
+;   ld a3, 0x7a(a3)
+;   sd zero, 0(a3) ; trap: heap_oob
+;   auipc a3, 1
+;   ld a3, 0x76(a3)
+;   c.sd a3, 0(a1) ; trap: heap_oob
+;   auipc a3, 1
+;   ld a3, 0x74(a3)
+;   c.sd a3, 0(a1) ; trap: heap_oob
+;   auipc a3, 1
+;   ld a3, 0x72(a3)
+;   c.sd a3, 0(a1) ; trap: heap_oob
+;   auipc a3, 1
+;   ld a3, 0x70(a3)
+;   c.sd a3, 0(a1) ; trap: heap_oob
+;   auipc a3, 1
+;   ld a3, 0x6e(a3)
+;   c.sd a3, 0(a1) ; trap: heap_oob
+;   auipc a3, 1
+;   ld a3, 0x6c(a3)
+;   c.sd a3, 0(a1) ; trap: heap_oob
+;   auipc a3, 1
+;   ld a3, 0x6a(a3)
+;   c.sd a3, 0(a1) ; trap: heap_oob
+;   auipc a3, 1
+;   ld a3, 0x68(a3)
+;   c.sd a3, 0(a1) ; trap: heap_oob
+;   auipc a3, 1
+;   ld a3, 0x66(a3)
+;   c.sd a3, 0(a1) ; trap: heap_oob
+;   c.li a3, 1
+;   auipc a4, 1
+;   ld a4, 0x62(a4)
+;   c.sw a3, 0(a4) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, 0x60(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, 0x5e(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, 0x5c(a4)
+;   sd zero, 0(a4) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, 0x58(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, 0x56(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, 0x54(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   c.li a4, 0
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, 0x44(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, 0x3e(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, 0x38(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, 0x36(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, 0x28(a5)
+;   auipc a6, 1
+;   ld a6, 0x28(a6)
+;   sd a5, 0(a6) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, 8(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0xe(a5)
+;   sd zero, 0(a5) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x16(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x1c(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x2e(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x30(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x36(a5)
+;   sd zero, 0(a5) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x3a(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x40(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x62(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x6c(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x6e(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x74(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x76(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x88(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x8e(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x94(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x96(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x98(a5)
+;   c.ld a5, 0(a5) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0xa2(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0xa4(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0xaa(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0xac(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0xb2(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0xbc(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0xc6(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0xcc(a5)
+;   sd zero, 0(a5) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0xe0(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0xe6(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0xec(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0xf6(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0xfc(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x102(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x110(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x116(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x11c(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x126(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x128(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x12e(a5)
+;   c.ld a5, 0(a5) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x134(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x136(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x13c(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x14a(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x158(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x16e(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x174(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x182(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x18c(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x192(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x194(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x19a(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x19c(a5)
+;   sd zero, 0(a5) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x1a4(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x1ba(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x1c0(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x1c2(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x1dc(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x1e2(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x1ec(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x1fa(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x1fc(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x202(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x204(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x20e(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x21c(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x226(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x228(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x22e(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x240(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x242(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x248(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x24a(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x250(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x252(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x25c(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x262(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x264(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x266(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x268(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x27a(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x280(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x282(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x288(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x28a(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x2a0(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x2ae(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x2b8(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x2be(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x2c0(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x2ce(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x2d0(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x2d6(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x2f4(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x2fa(a5)
+;   c.sd a2, 0(a5) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x30c(a5)
+;   sd zero, 0(a5) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x32c(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x342(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x350(a5)
+;   sd zero, 0(a5) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x360(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x362(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x36c(a5)
+;   c.sd a2, 0(a5) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x36e(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x378(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x37e(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x380(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x39a(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x3a8(a5)
+;   c.sd a2, 0(a5) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x3aa(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x3bc(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   lui a5, 0x4b912
+;   addi a5, a5, -0x6f
+;   auipc t0, 1
+;   ld t0, -0x3d6(t0)
+;   sw a5, 0(t0) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x3de(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x3e0(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x3e6(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x3f4(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x3fe(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x400(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x416(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x44c(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x45a(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x45c(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x462(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x468(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x472(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x478(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x482(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x48c(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x48e(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x498(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x49e(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x4a4(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x4ce(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x4d4(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x4d6(a5)
+;   c.lw a5, 0(a5) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x4e0(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x4ea(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x4f4(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x502(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x50c(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x512(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x514(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x51a(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x520(a5)
+;   sw zero, 0(a5) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x538(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x53e(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x540(a5)
+;   c.sw a3, 0(a5) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x54a(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x55c(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x56a(a5)
+;   c.sd a2, 0(a5) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x570(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x572(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x578(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sb a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x59e(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x5a8(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x5aa(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x5b0(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x5b2(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x5d0(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x5d2(a5)
+;   c.sd a2, 0(a5) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x5d8(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x5de(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x5e8(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sb a4, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x5fa(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x600(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x60a(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x60c(a5)
+;   c.sd a2, 0(a5) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   c.lw a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x620(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x62a(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x638(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x642(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x65c(a5)
+;   c.sd a2, 0(a5) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x65e(a5)
+;   sd zero, 0(a5) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sb a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x67a(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x688(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sb a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sb a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x6ca(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x6d4(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x6de(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sb a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x6fc(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x702(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x708(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x71a(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x71c(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x726(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x734(a5)
+;   sd zero, 0(a5) ; trap: heap_oob
+;   sb a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x740(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x746(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x748(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x752(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sb a3, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a3, 1
+;   ld a3, -0x764(a3)
+;   c.sd a3, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x766(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a3, 1
+;   ld a3, -0x770(a3)
+;   c.sd a3, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a3, 1
+;   ld a3, -0x776(a3)
+;   c.sd a3, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sb a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a3, 1
+;   ld a3, -0x788(a3)
+;   c.sd a2, 0(a3) ; trap: heap_oob
+;   auipc a2, 1
+;   ld a2, -0x78a(a2)
+;   c.sd a2, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a2, 1
+;   ld a2, -0x790(a2)
+;   c.sd a2, 0(a1) ; trap: heap_oob
+;   auipc a2, 1
+;   ld a2, -0x792(a2)
 ;   c.lui a3, 4
 ;   addi a3, a3, -0x720
-;   c.sd a1, 0(a3) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   auipc a1, 1
-;   ld a1, -0x79a(a1)
+;   c.sd a2, 0(a3) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a2, 1
+;   ld a2, -0x7aa(a2)
 ;   c.lui a3, 4
 ;   addi a3, a3, -0x6a4
-;   c.sd a1, 0(a3) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a1, 1
-;   ld a1, -0x7b2(a1)
+;   c.sd a2, 0(a3) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a2, 1
+;   ld a2, -0x7c2(a2)
 ;   c.lui a3, 4
 ;   addi a3, a3, -0x5f0
-;   c.sd a1, 0(a3) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   auipc a1, 1
-;   ld a1, -0x7c6(a1)
+;   c.sd a2, 0(a3) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a2, 1
+;   ld a2, -0x7d6(a2)
 ;   c.lui a3, 4
 ;   addi a3, a3, -0x638
-;   c.sd a1, 0(a3) ; trap: heap_oob
-;   auipc a1, 1
-;   ld a1, -0x7ce(a1)
+;   c.sd a2, 0(a3) ; trap: heap_oob
+;   auipc a2, 1
+;   ld a2, -0x7de(a2)
 ;   c.lui a3, 4
 ;   addi a3, a3, -0x640
-;   c.sd a1, 0(a3) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   auipc a1, 1
-;   ld a1, -0x7de(a1)
+;   c.sd a2, 0(a3) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a2, 1
+;   ld a2, -0x7ee(a2)
 ;   c.lui a3, 4
 ;   addi a3, a3, -0x59c
-;   c.sd a1, 0(a3) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sd zero, 0(a0) ; trap: heap_oob
-;   sw zero, 0(a0) ; trap: heap_oob
-;   sext.w a0, a2
-;   bnez a0, 6
-;   c.j 0xa
-;   auipc t6, 1
-;   jalr zero, t6, -0x7e8
+;   c.sd a2, 0(a3) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   c.j 2
 ;   auipc t6, 0
 ;   jalr zero, t6, 0x7fc
 ;   c.unimp
@@ -7169,19 +7154,10 @@ block2:
 ;   c.addi4spn s0, sp, 0x84
 ;   andi a7, s11, -0x6ab
 ;   c.swsp t5, 0xb4(sp)
-; block14: ; offset 0x1c88
-;   c.lui a0, 1
-;   addi a2, a0, -0x438
-;   c.mv a1, t0
-;   c.mv a0, a1
-;   auipc ra, 0 ; reloc_external RiscvCallPlt u0:988 0
-;   jalr ra
-;   c.unimp ; trap: user1
-; block15: ; offset 0x1c9c
-;   c.mv a1, t0
+; block14: ; offset 0x1c80
 ;   c.li a2, 1
 ;   c.li a3, 2
-;   c.mv a0, a1
+;   c.mv a1, a0
 ;   auipc ra, 0 ; reloc_external RiscvCallPlt u0:1 0
 ;   jalr ra
 ;   c.unimp ; trap: user11

--- a/tests/disas/gc/drc/array-new-fixed-of-gc-refs.wat
+++ b/tests/disas/gc/drc/array-new-fixed-of-gc-refs.wat
@@ -57,11 +57,11 @@
 ;;                                 block2:
 ;; @0025                               v32 = uextend.i64 v93
 ;; @0025                               v34 = iadd.i64 v20, v32
-;;                                     v165 = iconst.i64 8
-;; @0025                               v36 = iadd v34, v165  ; v165 = 8
+;; @0025                               v35 = iconst.i64 8
+;; @0025                               v36 = iadd v34, v35  ; v35 = 8
 ;; @0025                               v37 = load.i64 notrap aligned v36
-;;                                     v98 = iconst.i64 1
-;; @0025                               v38 = iadd v37, v98  ; v98 = 1
+;;                                     v122 = iconst.i64 1
+;; @0025                               v38 = iadd v37, v122  ; v122 = 1
 ;; @0025                               store notrap aligned v38, v36
 ;; @0025                               jump block3
 ;;
@@ -71,22 +71,22 @@
 ;;                                     v156 = iadd.i64 v22, v151  ; v151 = 28
 ;; @0025                               store notrap aligned little v89, v156
 ;;                                     v88 = load.i32 notrap v136
-;;                                     v243 = iconst.i32 1
-;;                                     v244 = band v88, v243  ; v243 = 1
-;;                                     v245 = iconst.i32 0
-;;                                     v246 = icmp eq v88, v245  ; v245 = 0
-;; @0025                               v47 = uextend.i32 v246
-;; @0025                               v48 = bor v244, v47
+;;                                     v242 = iconst.i32 1
+;;                                     v243 = band v88, v242  ; v242 = 1
+;;                                     v244 = iconst.i32 0
+;;                                     v245 = icmp eq v88, v244  ; v244 = 0
+;; @0025                               v47 = uextend.i32 v245
+;; @0025                               v48 = bor v243, v47
 ;; @0025                               brif v48, block5, block4
 ;;
 ;;                                 block4:
 ;; @0025                               v49 = uextend.i64 v88
 ;; @0025                               v51 = iadd.i64 v20, v49
-;;                                     v247 = iconst.i64 8
-;; @0025                               v53 = iadd v51, v247  ; v247 = 8
+;;                                     v246 = iconst.i64 8
+;; @0025                               v53 = iadd v51, v246  ; v246 = 8
 ;; @0025                               v54 = load.i64 notrap aligned v53
-;;                                     v248 = iconst.i64 1
-;; @0025                               v55 = iadd v54, v248  ; v248 = 1
+;;                                     v247 = iconst.i64 1
+;; @0025                               v55 = iadd v54, v247  ; v247 = 1
 ;; @0025                               store notrap aligned v55, v53
 ;; @0025                               jump block5
 ;;
@@ -96,30 +96,30 @@
 ;;                                     v163 = iadd.i64 v22, v133  ; v133 = 32
 ;; @0025                               store notrap aligned little v84, v163
 ;;                                     v83 = load.i32 notrap v135
-;;                                     v249 = iconst.i32 1
-;;                                     v250 = band v83, v249  ; v249 = 1
-;;                                     v251 = iconst.i32 0
-;;                                     v252 = icmp eq v83, v251  ; v251 = 0
-;; @0025                               v64 = uextend.i32 v252
-;; @0025                               v65 = bor v250, v64
+;;                                     v248 = iconst.i32 1
+;;                                     v249 = band v83, v248  ; v248 = 1
+;;                                     v250 = iconst.i32 0
+;;                                     v251 = icmp eq v83, v250  ; v250 = 0
+;; @0025                               v64 = uextend.i32 v251
+;; @0025                               v65 = bor v249, v64
 ;; @0025                               brif v65, block7, block6
 ;;
 ;;                                 block6:
 ;; @0025                               v66 = uextend.i64 v83
 ;; @0025                               v68 = iadd.i64 v20, v66
-;;                                     v253 = iconst.i64 8
-;; @0025                               v70 = iadd v68, v253  ; v253 = 8
+;;                                     v252 = iconst.i64 8
+;; @0025                               v70 = iadd v68, v252  ; v252 = 8
 ;; @0025                               v71 = load.i64 notrap aligned v70
-;;                                     v254 = iconst.i64 1
-;; @0025                               v72 = iadd v71, v254  ; v254 = 1
+;;                                     v253 = iconst.i64 1
+;; @0025                               v72 = iadd v71, v253  ; v253 = 1
 ;; @0025                               store notrap aligned v72, v70
 ;; @0025                               jump block7
 ;;
 ;;                                 block7:
 ;;                                     v79 = load.i32 notrap v135
-;;                                     v179 = iconst.i64 36
-;;                                     v184 = iadd.i64 v22, v179  ; v179 = 36
-;; @0025                               store notrap aligned little v79, v184
+;;                                     v178 = iconst.i64 36
+;;                                     v183 = iadd.i64 v22, v178  ; v178 = 36
+;; @0025                               store notrap aligned little v79, v183
 ;; @0029                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/drc/externref-globals.wat
+++ b/tests/disas/gc/drc/externref-globals.wat
@@ -94,40 +94,40 @@
 ;; @003b                               brif v9, block3, block2
 ;;
 ;;                                 block2:
-;; @003b                               v44 = load.i64 notrap aligned readonly can_move v0+8
-;; @003b                               v27 = load.i64 notrap aligned readonly can_move v44+32
+;; @003b                               v51 = load.i64 notrap aligned readonly can_move v0+8
+;; @003b                               v11 = load.i64 notrap aligned readonly can_move v51+32
 ;; @003b                               v10 = uextend.i64 v2
-;; @003b                               v12 = iadd v27, v10
-;; @003b                               v29 = iconst.i64 8
-;; @003b                               v14 = iadd v12, v29  ; v29 = 8
+;; @003b                               v12 = iadd v11, v10
+;; @003b                               v13 = iconst.i64 8
+;; @003b                               v14 = iadd v12, v13  ; v13 = 8
 ;; @003b                               v15 = load.i64 notrap aligned v14
-;;                                     v63 = iconst.i64 1
-;; @003b                               v16 = iadd v15, v63  ; v63 = 1
+;;                                     v50 = iconst.i64 1
+;; @003b                               v16 = iadd v15, v50  ; v50 = 1
 ;; @003b                               store notrap aligned v16, v14
 ;; @003b                               jump block3
 ;;
 ;;                                 block3:
-;;                                     v69 = iadd.i64 v0, v55  ; v55 = 48
-;; @003b                               store.i32 notrap aligned v2, v69
-;;                                     v70 = iconst.i32 1
-;;                                     v71 = band.i32 v5, v70  ; v70 = 1
-;;                                     v72 = iconst.i32 0
-;;                                     v73 = icmp.i32 eq v5, v72  ; v72 = 0
-;; @003b                               v24 = uextend.i32 v73
-;; @003b                               v25 = bor v71, v24
+;;                                     v68 = iadd.i64 v0, v55  ; v55 = 48
+;; @003b                               store.i32 notrap aligned v2, v68
+;;                                     v69 = iconst.i32 1
+;;                                     v70 = band.i32 v5, v69  ; v69 = 1
+;;                                     v71 = iconst.i32 0
+;;                                     v72 = icmp.i32 eq v5, v71  ; v71 = 0
+;; @003b                               v24 = uextend.i32 v72
+;; @003b                               v25 = bor v70, v24
 ;; @003b                               brif v25, block7, block4
 ;;
 ;;                                 block4:
-;;                                     v74 = load.i64 notrap aligned readonly can_move v0+8
-;;                                     v75 = load.i64 notrap aligned readonly can_move v74+32
+;;                                     v73 = load.i64 notrap aligned readonly can_move v0+8
+;;                                     v74 = load.i64 notrap aligned readonly can_move v73+32
 ;; @003b                               v26 = uextend.i64 v5
-;; @003b                               v28 = iadd v75, v26
-;;                                     v76 = iconst.i64 8
-;; @003b                               v30 = iadd v28, v76  ; v76 = 8
+;; @003b                               v28 = iadd v74, v26
+;;                                     v75 = iconst.i64 8
+;; @003b                               v30 = iadd v28, v75  ; v75 = 8
 ;; @003b                               v31 = load.i64 notrap aligned v30
-;;                                     v77 = iconst.i64 1
-;;                                     v67 = icmp eq v31, v77  ; v77 = 1
-;; @003b                               brif v67, block5, block6
+;;                                     v76 = iconst.i64 1
+;;                                     v66 = icmp eq v31, v76  ; v76 = 1
+;; @003b                               brif v66, block5, block6
 ;;
 ;;                                 block5 cold:
 ;; @003b                               call fn0(v0, v5)
@@ -136,8 +136,8 @@
 ;;                                 block6:
 ;;                                     v43 = iconst.i64 -1
 ;; @003b                               v32 = iadd.i64 v31, v43  ; v43 = -1
-;;                                     v78 = iadd.i64 v28, v76  ; v76 = 8
-;; @003b                               store notrap aligned v32, v78
+;;                                     v77 = iadd.i64 v28, v75  ; v75 = 8
+;; @003b                               store notrap aligned v32, v77
 ;; @003b                               jump block7
 ;;
 ;;                                 block7:

--- a/tests/disas/gc/drc/struct-new-default.wat
+++ b/tests/disas/gc/drc/struct-new-default.wat
@@ -42,23 +42,13 @@
 ;;                                     v44 = iconst.i64 28
 ;; @0021                               v18 = iadd v16, v44  ; v44 = 28
 ;; @0021                               istore8 notrap aligned little v4, v18  ; v4 = 0
-;;                                     v42 = iconst.i32 1
-;; @0021                               brif v42, block3, block2  ; v42 = 1
-;;
-;;                                 block2:
-;; @0021                               v27 = iconst.i64 8
-;; @0021                               v28 = iadd.i64 v14, v27  ; v27 = 8
-;; @0021                               v29 = load.i64 notrap aligned v28
-;;                                     v38 = iconst.i64 1
-;; @0021                               v30 = iadd v29, v38  ; v38 = 1
-;; @0021                               store notrap aligned v30, v28
-;; @0021                               jump block3
+;;                                     jump block3
 ;;
 ;;                                 block3:
-;;                                     v65 = iconst.i32 0
+;;                                     v64 = iconst.i32 0
 ;;                                     v43 = iconst.i64 32
 ;; @0021                               v19 = iadd.i64 v16, v43  ; v43 = 32
-;; @0021                               store notrap aligned little v65, v19  ; v65 = 0
+;; @0021                               store notrap aligned little v64, v19  ; v64 = 0
 ;; @0024                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/drc/struct-set.wat
+++ b/tests/disas/gc/drc/struct-set.wat
@@ -101,34 +101,34 @@
 ;;                                 block2:
 ;; @004a                               v14 = uextend.i64 v3
 ;; @004a                               v16 = iadd.i64 v5, v14
-;; @004a                               v33 = iconst.i64 8
-;; @004a                               v18 = iadd v16, v33  ; v33 = 8
+;; @004a                               v17 = iconst.i64 8
+;; @004a                               v18 = iadd v16, v17  ; v17 = 8
 ;; @004a                               v19 = load.i64 notrap aligned v18
-;;                                     v68 = iconst.i64 1
-;; @004a                               v20 = iadd v19, v68  ; v68 = 1
+;;                                     v54 = iconst.i64 1
+;; @004a                               v20 = iadd v19, v54  ; v54 = 1
 ;; @004a                               store notrap aligned v20, v18
 ;; @004a                               jump block3
 ;;
 ;;                                 block3:
-;;                                     v74 = iadd.i64 v6, v7  ; v7 = 32
-;; @004a                               store.i32 notrap aligned little v3, v74
-;;                                     v75 = iconst.i32 1
-;;                                     v76 = band.i32 v9, v75  ; v75 = 1
-;;                                     v77 = iconst.i32 0
-;;                                     v78 = icmp.i32 eq v9, v77  ; v77 = 0
-;; @004a                               v28 = uextend.i32 v78
-;; @004a                               v29 = bor v76, v28
+;;                                     v73 = iadd.i64 v6, v7  ; v7 = 32
+;; @004a                               store.i32 notrap aligned little v3, v73
+;;                                     v74 = iconst.i32 1
+;;                                     v75 = band.i32 v9, v74  ; v74 = 1
+;;                                     v76 = iconst.i32 0
+;;                                     v77 = icmp.i32 eq v9, v76  ; v76 = 0
+;; @004a                               v28 = uextend.i32 v77
+;; @004a                               v29 = bor v75, v28
 ;; @004a                               brif v29, block7, block4
 ;;
 ;;                                 block4:
 ;; @004a                               v30 = uextend.i64 v9
 ;; @004a                               v32 = iadd.i64 v5, v30
-;;                                     v79 = iconst.i64 8
-;; @004a                               v34 = iadd v32, v79  ; v79 = 8
+;;                                     v78 = iconst.i64 8
+;; @004a                               v34 = iadd v32, v78  ; v78 = 8
 ;; @004a                               v35 = load.i64 notrap aligned v34
-;;                                     v80 = iconst.i64 1
-;;                                     v72 = icmp eq v35, v80  ; v80 = 1
-;; @004a                               brif v72, block5, block6
+;;                                     v79 = iconst.i64 1
+;;                                     v71 = icmp eq v35, v79  ; v79 = 1
+;; @004a                               brif v71, block5, block6
 ;;
 ;;                                 block5 cold:
 ;; @004a                               call fn0(v0, v9)
@@ -137,8 +137,8 @@
 ;;                                 block6:
 ;;                                     v47 = iconst.i64 -1
 ;; @004a                               v36 = iadd.i64 v35, v47  ; v47 = -1
-;;                                     v81 = iadd.i64 v32, v79  ; v79 = 8
-;; @004a                               store notrap aligned v36, v81
+;;                                     v80 = iadd.i64 v32, v78  ; v78 = 8
+;; @004a                               store notrap aligned v36, v80
 ;; @004a                               jump block7
 ;;
 ;;                                 block7:

--- a/tests/disas/gc/struct-new-default.wat
+++ b/tests/disas/gc/struct-new-default.wat
@@ -44,23 +44,13 @@
 ;;                                     v47 = iconst.i64 28
 ;; @0023                               v19 = iadd v17, v47  ; v47 = 28
 ;; @0023                               istore8 notrap aligned little v4, v19  ; v4 = 0
-;;                                     v45 = iconst.i32 1
-;; @0023                               brif v45, block3, block2  ; v45 = 1
-;;
-;;                                 block2:
-;; @0023                               v28 = iconst.i64 8
-;; @0023                               v29 = iadd.i64 v15, v28  ; v28 = 8
-;; @0023                               v30 = load.i64 notrap aligned v29
-;;                                     v41 = iconst.i64 1
-;; @0023                               v31 = iadd v30, v41  ; v41 = 1
-;; @0023                               store notrap aligned v31, v29
-;; @0023                               jump block3
+;;                                     jump block3
 ;;
 ;;                                 block3:
-;;                                     v68 = iconst.i32 0
+;;                                     v67 = iconst.i32 0
 ;;                                     v46 = iconst.i64 32
 ;; @0023                               v20 = iadd.i64 v17, v46  ; v46 = 32
-;; @0023                               store notrap aligned little v68, v20  ; v68 = 0
+;; @0023                               store notrap aligned little v67, v20  ; v67 = 0
 ;; @0023                               v6 = vconst.i8x16 const0
 ;;                                     v38 = iconst.i64 48
 ;; @0023                               v37 = iadd.i64 v17, v38  ; v38 = 48

--- a/tests/disas/issue-12808.wat
+++ b/tests/disas/issue-12808.wat
@@ -14,36 +14,33 @@
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       subq    $0x30, %rsp
-;;       movq    %rbx, 0x20(%rsp)
+;;       movq    %r14, 0x20(%rsp)
 ;;       movq    8(%rdi), %rax
 ;;       movq    0x18(%rax), %rax
 ;;       movq    %rsp, %rcx
 ;;       cmpq    %rax, %rcx
-;;       jb      0xb4
+;;       jb      0x93
 ;;   21: movq    %rdi, (%rsp)
 ;;       nopl    (%rax, %rax)
 ;;       ├─╼ debug frame state (after previous inst): func key DefinedWasmFunction(StaticModuleIndex(0), DefinedFuncIndex(0)), wasm PC 0x1f, slot at FP-0x30, locals , stack 
-;;       ╰─╼ breakpoint patch: wasm PC 0x1f, patch bytes [232, 4, 2, 0, 0]
+;;       ╰─╼ breakpoint patch: wasm PC 0x1f, patch bytes [232, 227, 1, 0, 0]
 ;;       movl    $0, 8(%rsp)
 ;;       nopl    (%rax, %rax)
 ;;       ├─╼ debug frame state (after previous inst): func key DefinedWasmFunction(StaticModuleIndex(0), DefinedFuncIndex(0)), wasm PC 0x21, slot at FP-0x30, locals , stack I32 @ slot+0x8
-;;       ╰─╼ breakpoint patch: wasm PC 0x21, patch bytes [232, 247, 1, 0, 0]
+;;       ╰─╼ breakpoint patch: wasm PC 0x21, patch bytes [232, 214, 1, 0, 0]
 ;;       movl    $0, 0xc(%rsp)
 ;;       nopl    (%rax, %rax)
 ;;       ├─╼ debug frame state (after previous inst): func key DefinedWasmFunction(StaticModuleIndex(0), DefinedFuncIndex(0)), wasm PC 0x23, slot at FP-0x30, locals , stack I32 @ slot+0x8, I32 @ slot+0xc
-;;       ╰─╼ breakpoint patch: wasm PC 0x23, patch bytes [232, 234, 1, 0, 0]
+;;       ╰─╼ breakpoint patch: wasm PC 0x23, patch bytes [232, 201, 1, 0, 0]
 ;;       movl    $0, 0x10(%rsp)
 ;;       nopl    (%rax, %rax)
 ;;       ├─╼ debug frame state (after previous inst): func key DefinedWasmFunction(StaticModuleIndex(0), DefinedFuncIndex(0)), wasm PC 0x25, slot at FP-0x30, locals , stack I32 @ slot+0x8, I32 @ slot+0xc, I32 @ slot+0x10
-;;       ╰─╼ breakpoint patch: wasm PC 0x25, patch bytes [232, 221, 1, 0, 0]
+;;       ╰─╼ breakpoint patch: wasm PC 0x25, patch bytes [232, 188, 1, 0, 0]
 ;;       movl    $0, 0x14(%rsp)
 ;;       nopl    (%rax, %rax)
 ;;       ├─╼ debug frame state (after previous inst): func key DefinedWasmFunction(StaticModuleIndex(0), DefinedFuncIndex(0)), wasm PC 0x27, slot at FP-0x30, locals , stack I32 @ slot+0x8, I32 @ slot+0xc, I32 @ slot+0x10, I32 @ slot+0x14
-;;       ╰─╼ breakpoint patch: wasm PC 0x27, patch bytes [232, 208, 1, 0, 0]
-;;       xorl    %eax, %eax
-;;       testb   %al, %al
-;;       jne     0x9d
-;;   68: movq    0x30(%rdi), %rax
+;;       ╰─╼ breakpoint patch: wasm PC 0x27, patch bytes [232, 175, 1, 0, 0]
+;;       movq    0x30(%rdi), %rax
 ;;       movq    (%rax), %rcx
 ;;       xorl    %eax, %eax
 ;;       lock cmpxchgl %eax, (%rcx)
@@ -51,26 +48,19 @@
 ;;       movq    %rax, %rcx
 ;;       nopl    (%rax, %rax)
 ;;       ├─╼ debug frame state (after previous inst): func key DefinedWasmFunction(StaticModuleIndex(0), DefinedFuncIndex(0)), wasm PC 0x2b, slot at FP-0x30, locals , stack I32 @ slot+0x8, I32 @ slot+0xc
-;;       ╰─╼ breakpoint patch: wasm PC 0x2b, patch bytes [232, 173, 1, 0, 0]
+;;       ╰─╼ breakpoint patch: wasm PC 0x2b, patch bytes [232, 150, 1, 0, 0]
 ;;       xorl    %eax, %eax
 ;;       movl    $0, 8(%rsp)
 ;;       movl    %ecx, 0xc(%rsp)
-;;       movq    0x20(%rsp), %rbx
+;;       movq    0x20(%rsp), %r14
 ;;       addq    $0x30, %rsp
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   9d: movq    %rdi, %rbx
-;;   a0: movl    $2, %esi
-;;   a5: callq   0x1d0
-;;   aa: movq    %rbx, %rdi
-;;   ad: callq   0x201
-;;       ╰─╼ debug frame state (after previous inst): func key DefinedWasmFunction(StaticModuleIndex(0), DefinedFuncIndex(0)), wasm PC 0x27, slot at FP-0x30, locals , stack I32 @ slot+0x8, I32 @ slot+0xc
-;;   b2: ud2
-;;   b4: movq    %rdi, %rbx
-;;   b7: xorl    %esi, %esi
-;;   b9: callq   0x1d0
-;;   be: movq    %rbx, %rdi
-;;   c1: callq   0x201
+;;   93: movq    %rdi, %r14
+;;   96: xorl    %esi, %esi
+;;   98: callq   0x1af
+;;   9d: movq    %r14, %rdi
+;;   a0: callq   0x1e0
 ;;       ╰─╼ debug frame state (after previous inst): func key DefinedWasmFunction(StaticModuleIndex(0), DefinedFuncIndex(0)), wasm PC 0x1e, slot at FP-0x30, locals , stack 
-;;   c6: ud2
+;;   a5: ud2


### PR DESCRIPTION
This requires two tweaks to the egraph pass's machinery:

1. We maintain a set of reachable blocks. This is initialized to the entry block. After optimizing a block's intructions, we look at the terminator and mark any other block it branches to as reachable. When visiting blocks to optimize their instructions, we skip unreachable blocks and remove them and their instructions from the function's layout.

2. We always visit blocks in reverse-post order, rather than dominator-tree order (which is related but slightly weaker). This ensures that we always visit predecessors before successors, and therefore that if a block is not marked reachable, then it really is unreachable and is safe to remove. See code comments for the details of when dominator-tree order breaks down.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
