### PR TITLE
c-api: Expose type reflection of GC values

### DIFF
--- a/crates/c-api/include/wasmtime/_anyref_class.hh
+++ b/crates/c-api/include/wasmtime/_anyref_class.hh
@@ -5,9 +5,11 @@
 
 #ifdef WASMTIME_FEATURE_GC
 
+#include <assert.h>
 #include <wasmtime/_store_class.hh>
 #include <wasmtime/anyref.h>
 #include <wasmtime/helpers.hh>
+#include <wasmtime/types/val.hh>
 
 namespace wasmtime {
 
@@ -51,22 +53,30 @@ class AnyRef {
   }
 
   /// \brief Returns `true` if this anyref is an eqref.
-  inline bool is_eqref(Store::Context cx) const;
+  bool is_eqref(Store::Context cx) const;
 
   /// \brief Returns `true` if this anyref is a structref.
-  inline bool is_struct(Store::Context cx) const;
+  bool is_struct(Store::Context cx) const;
 
   /// \brief Returns `true` if this anyref is an arrayref.
-  inline bool is_array(Store::Context cx) const;
+  bool is_array(Store::Context cx) const;
 
   /// \brief Downcast to eqref. Returns null eqref if not an eqref.
-  inline std::optional<EqRef> as_eqref(Store::Context cx) const;
+  std::optional<EqRef> as_eqref(Store::Context cx) const;
 
   /// \brief Downcast to structref. Returns null structref if not a structref.
-  inline std::optional<StructRef> as_struct(Store::Context cx) const;
+  std::optional<StructRef> as_struct(Store::Context cx) const;
 
   /// \brief Downcast to arrayref. Returns null arrayref if not an arrayref.
-  inline std::optional<ArrayRef> as_array(Store::Context cx) const;
+  std::optional<ArrayRef> as_array(Store::Context cx) const;
+
+  /// \brief Returns the type of this `AnyRef`.
+  HeapType ty(Store::Context cx) const {
+    wasmtime_heaptype_t out;
+    bool ok = wasmtime_anyref_type(cx.capi(), &raw, &out);
+    assert(ok);
+    return HeapType(out);
+  }
 };
 
 } // namespace wasmtime

--- a/crates/c-api/include/wasmtime/_arrayref_class.hh
+++ b/crates/c-api/include/wasmtime/_arrayref_class.hh
@@ -69,6 +69,12 @@ public:
 
   /// Upcast to eqref.
   EqRef to_eqref() const;
+
+  /// \brief Returns the type of this `ArrayRef`.
+  ArrayType ty(Store::Context cx) const {
+    auto *ret = wasmtime_arrayref_type(cx.capi(), &raw);
+    return ArrayType(ret);
+  }
 };
 
 } // namespace wasmtime

--- a/crates/c-api/include/wasmtime/_eqref_class.hh
+++ b/crates/c-api/include/wasmtime/_eqref_class.hh
@@ -9,6 +9,7 @@
 #include <wasmtime/_store_class.hh>
 #include <wasmtime/eqref.h>
 #include <wasmtime/helpers.hh>
+#include <wasmtime/types/val.hh>
 
 namespace wasmtime {
 
@@ -81,6 +82,14 @@ public:
   //
   // as_array() defined after ArrayRef below.
   std::optional<ArrayRef> as_array(Store::Context cx) const;
+
+  /// \brief Returns the type of this `EqRef`.
+  HeapType ty(Store::Context cx) const {
+    wasmtime_heaptype_t out;
+    bool ok = wasmtime_eqref_type(cx.capi(), &raw, &out);
+    assert(ok);
+    return HeapType(out);
+  }
 };
 
 } // namespace wasmtime

--- a/crates/c-api/include/wasmtime/_exnref_class.hh
+++ b/crates/c-api/include/wasmtime/_exnref_class.hh
@@ -11,6 +11,7 @@
 #include <wasmtime/exnref.h>
 #include <wasmtime/helpers.hh>
 #include <wasmtime/tag.hh>
+#include <wasmtime/types/exnref.hh>
 
 namespace wasmtime {
 
@@ -55,6 +56,12 @@ class ExnRef {
 
   /// Reads a field value by index.
   Result<Val> field(Store::Context cx, size_t index) const;
+
+  /// \brief Returns the type of this `ExnRef`.
+  ExnType ty(Store::Context cx) const {
+    auto *ret = wasmtime_exnref_type(cx.capi(), &raw);
+    return ExnType(ret);
+  }
 };
 
 } // namespace wasmtime

--- a/crates/c-api/include/wasmtime/_structref_class.hh
+++ b/crates/c-api/include/wasmtime/_structref_class.hh
@@ -56,6 +56,12 @@ class StructRef {
 
   /// Upcast to eqref.
   EqRef to_eqref() const;
+
+  /// \brief Returns the type of this `StructRef`.
+  StructType ty(Store::Context cx) const {
+    auto *ret = wasmtime_structref_type(cx.capi(), &raw);
+    return StructType(ret);
+  }
 };
 
 } // namespace wasmtime

--- a/crates/c-api/include/wasmtime/_val_class.hh
+++ b/crates/c-api/include/wasmtime/_val_class.hh
@@ -9,6 +9,7 @@
 #include <wasmtime/_func_class.hh>
 #include <wasmtime/_store_class.hh>
 #include <wasmtime/_structref_class.hh>
+#include <wasmtime/_exnref_class.hh>
 #include <wasmtime/types/val.hh>
 #include <wasmtime/val.h>
 
@@ -106,6 +107,10 @@ public:
   /// Creates a new `anyref` WebAssembly value which is not `ref.null
   /// any`.
   Val(AnyRef ptr);
+  /// Creates a new `exnref` value.
+  Val(std::optional<ExnRef> ptr);
+  /// Creates a new `exnref` WebAssembly value which is not `ref.null exn`.
+  Val(ExnRef ptr);
 #endif
 
   /// Copy constructor to clone `other`.
@@ -221,6 +226,13 @@ public:
   /// Note that `anyref` is a nullable reference, hence the `optional` return
   /// value.
   std::optional<AnyRef> anyref() const;
+
+  /// Returns the underlying `exnref`, requires `kind() == KindExnRef` or
+  /// aborts the process.
+  ///
+  /// Note that `exnref` is a nullable reference, hence the `optional` return
+  /// value.
+  std::optional<ExnRef> exnref() const;
 #endif
 
   /// Returns the underlying `funcref`, requires `kind() == KindFuncRef` or

--- a/crates/c-api/include/wasmtime/_val_class.hh
+++ b/crates/c-api/include/wasmtime/_val_class.hh
@@ -5,11 +5,11 @@
 #include <wasmtime/_anyref_class.hh>
 #include <wasmtime/_arrayref_class.hh>
 #include <wasmtime/_eqref_class.hh>
+#include <wasmtime/_exnref_class.hh>
 #include <wasmtime/_externref_class.hh>
 #include <wasmtime/_func_class.hh>
 #include <wasmtime/_store_class.hh>
 #include <wasmtime/_structref_class.hh>
-#include <wasmtime/_exnref_class.hh>
 #include <wasmtime/types/val.hh>
 #include <wasmtime/val.h>
 

--- a/crates/c-api/include/wasmtime/anyref.h
+++ b/crates/c-api/include/wasmtime/anyref.h
@@ -9,6 +9,7 @@
 
 #ifdef WASMTIME_FEATURE_GC
 
+#include <wasmtime/types/val.h>
 #include <wasmtime/val.h>
 
 #ifdef __cplusplus
@@ -179,6 +180,17 @@ WASM_API_EXTERN bool wasmtime_anyref_is_array(wasmtime_context_t *context,
 WASM_API_EXTERN bool wasmtime_anyref_as_array(wasmtime_context_t *context,
                                               const wasmtime_anyref_t *anyref,
                                               wasmtime_arrayref_t *out);
+
+/**
+ * \brief Returns the type of the specified `anyref`.
+ *
+ * \return If `anyref` is NULL or represents `ref.null any`, then `false` is
+ * returned. Otherwise the type of this value is written to `out` which the
+ * caller must deallocate, and `true` is returned.
+ */
+WASM_API_EXTERN bool wasmtime_anyref_type(wasmtime_context_t *context,
+                                          const wasmtime_anyref_t *anyref,
+                                          wasmtime_heaptype_t *out);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/crates/c-api/include/wasmtime/arrayref.h
+++ b/crates/c-api/include/wasmtime/arrayref.h
@@ -142,6 +142,17 @@ wasmtime_arrayref_set(wasmtime_context_t *context,
                       const wasmtime_arrayref_t *arrayref, uint32_t index,
                       const wasmtime_val_t *val);
 
+/**
+ * \brief Returns the type of the specified `arrayref`.
+ *
+ * \return If `arrayref` is NULL or represents `ref.null array`, then NULL is
+ * returned. Otherwise the type of this value is returned. Callers must delete
+ * the returned value.
+ */
+WASM_API_EXTERN wasmtime_array_type_t *
+wasmtime_arrayref_type(wasmtime_context_t *context,
+                       const wasmtime_arrayref_t *arrayref);
+
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/crates/c-api/include/wasmtime/eqref.h
+++ b/crates/c-api/include/wasmtime/eqref.h
@@ -11,6 +11,7 @@
 
 #ifdef WASMTIME_FEATURE_GC
 
+#include <wasmtime/types/val.h>
 #include <wasmtime/val.h>
 
 #ifdef __cplusplus
@@ -136,6 +137,17 @@ WASM_API_EXTERN bool wasmtime_eqref_is_struct(wasmtime_context_t *context,
 WASM_API_EXTERN bool wasmtime_eqref_as_struct(wasmtime_context_t *context,
                                               const wasmtime_eqref_t *eqref,
                                               wasmtime_structref_t *out);
+
+/**
+ * \brief Returns the type of the specified `eqref`.
+ *
+ * \return If `eqref` is NULL or represents `ref.null eq`, then `false` is
+ * returned. Otherwise the type of this value is written to `out` which the
+ * caller must deallocate, and `true` is returned.
+ */
+WASM_API_EXTERN bool wasmtime_eqref_type(wasmtime_context_t *context,
+                                         const wasmtime_eqref_t *eqref,
+                                         wasmtime_heaptype_t *out);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/crates/c-api/include/wasmtime/exnref.h
+++ b/crates/c-api/include/wasmtime/exnref.h
@@ -11,6 +11,7 @@
 
 #ifdef WASMTIME_FEATURE_GC
 
+#include <wasmtime/types/exnref.h>
 #include <wasmtime/val.h>
 
 #ifdef __cplusplus
@@ -164,6 +165,17 @@ wasmtime_context_take_exception(wasmtime_context_t *store,
  * \return true if a pending exception is set, false otherwise.
  */
 WASM_API_EXTERN bool wasmtime_context_has_exception(wasmtime_context_t *store);
+
+/**
+ * \brief Returns the type of the specified `exnref`.
+ *
+ * \return If `exnref` is NULL or represents `ref.null exn`, then NULL is
+ * returned. Otherwise the type of this value is returned. Callers must delete
+ * the returned value.
+ */
+WASM_API_EXTERN wasmtime_exn_type_t *
+wasmtime_exnref_type(wasmtime_context_t *context,
+                     const wasmtime_exnref_t *exnref);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/crates/c-api/include/wasmtime/structref.h
+++ b/crates/c-api/include/wasmtime/structref.h
@@ -129,6 +129,17 @@ wasmtime_structref_set_field(wasmtime_context_t *context,
                              const wasmtime_structref_t *structref,
                              size_t index, const wasmtime_val_t *val);
 
+/**
+ * \brief Returns the type of the specified `structref`.
+ *
+ * \return If `structref` is NULL or represents `ref.null struct`, then NULL is
+ * returned. Otherwise the type of this value is returned. Callers must delete
+ * the returned value.
+ */
+WASM_API_EXTERN wasmtime_struct_type_t *
+wasmtime_structref_type(wasmtime_context_t *context,
+                        const wasmtime_structref_t *structref);
+
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/crates/c-api/include/wasmtime/types/val.hh
+++ b/crates/c-api/include/wasmtime/types/val.hh
@@ -25,6 +25,11 @@ class HeapType {
   HeapType(wasmtime_heaptype_kind_t ty) { this->ty.kind = ty; }
 
 public:
+  /// Constructor from the raw C API representation.
+  HeapType(wasmtime_heaptype_t &ty) : ty(ty) {
+    ty.kind = WASMTIME_HEAPTYPE_KIND_NONE;
+  }
+
   /// Copy constructor.
   HeapType(const HeapType &other) { wasmtime_heaptype_clone(&other.ty, &ty); }
   /// Copy assignment operator.

--- a/crates/c-api/include/wasmtime/val.hh
+++ b/crates/c-api/include/wasmtime/val.hh
@@ -9,6 +9,7 @@
 #include <wasmtime/_externref_class.hh>
 #include <wasmtime/_func_class.hh>
 #include <wasmtime/_val_class.hh>
+#include <wasmtime/_exnref_class.hh>
 
 namespace wasmtime {
 
@@ -81,6 +82,30 @@ inline std::optional<ExternRef> Val::externref() const {
   wasmtime_externref_t other;
   wasmtime_externref_clone(&val.of.externref, &other);
   return ExternRef(other);
+}
+
+inline Val::Val(std::optional<ExnRef> ptr) : val{} {
+  val.kind = WASMTIME_EXNREF;
+  if (ptr) {
+    val.of.exnref = *ptr->capi();
+    wasmtime_exnref_set_null(ptr->capi());
+  } else {
+    wasmtime_exnref_set_null(&val.of.exnref);
+  }
+}
+
+inline Val::Val(ExnRef ptr) : Val(std::optional(ptr)) {}
+
+inline std::optional<ExnRef> Val::exnref() const {
+  if (val.kind != WASMTIME_EXNREF) {
+    std::abort();
+  }
+  if (wasmtime_exnref_is_null(&val.of.exnref)) {
+    return std::nullopt;
+  }
+  wasmtime_exnref_t other;
+  wasmtime_exnref_clone(&val.of.exnref, &other);
+  return ExnRef(other);
 }
 
 #endif // WASMTIME_FEATURE_GC

--- a/crates/c-api/include/wasmtime/val.hh
+++ b/crates/c-api/include/wasmtime/val.hh
@@ -6,10 +6,10 @@
 #define WASMTIME_VAL_HH
 
 #include <wasmtime/_anyref_class.hh>
+#include <wasmtime/_exnref_class.hh>
 #include <wasmtime/_externref_class.hh>
 #include <wasmtime/_func_class.hh>
 #include <wasmtime/_val_class.hh>
-#include <wasmtime/_exnref_class.hh>
 
 namespace wasmtime {
 

--- a/crates/c-api/src/anyref.rs
+++ b/crates/c-api/src/anyref.rs
@@ -1,4 +1,7 @@
-use crate::{WasmtimeStoreContextMut, wasmtime_arrayref_t, wasmtime_eqref_t, wasmtime_structref_t};
+use crate::{
+    WasmtimeStoreContextMut, wasmtime_arrayref_t, wasmtime_eqref_t, wasmtime_heaptype_t,
+    wasmtime_structref_t,
+};
 use std::mem::MaybeUninit;
 use wasmtime::{AnyRef, ArrayRef, EqRef, I31, OwnedRooted, RootScope, StructRef};
 
@@ -288,4 +291,20 @@ pub unsafe extern "C" fn wasmtime_anyref_as_array(
     }
     crate::initialize(out, None::<OwnedRooted<ArrayRef>>.into());
     false
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn wasmtime_anyref_type(
+    mut cx: WasmtimeStoreContextMut<'_>,
+    anyref: Option<&wasmtime_anyref_t>,
+    out: &mut MaybeUninit<wasmtime_heaptype_t>,
+) -> bool {
+    match anyref.and_then(|a| a.as_wasmtime()) {
+        Some(anyref) => {
+            let ty = anyref.ty(&mut cx).expect("should be rooted");
+            out.write(ty.into());
+            true
+        }
+        None => false,
+    }
 }

--- a/crates/c-api/src/arrayref.rs
+++ b/crates/c-api/src/arrayref.rs
@@ -126,3 +126,13 @@ pub unsafe extern "C" fn wasmtime_arrayref_set(
         Err(e) => Some(Box::new(e.into())),
     }
 }
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn wasmtime_arrayref_type(
+    mut cx: WasmtimeStoreContextMut<'_>,
+    arrayref: Option<&wasmtime_arrayref_t>,
+) -> Option<Box<crate::wasmtime_array_type_t>> {
+    let arrayref = arrayref.and_then(|a| a.as_wasmtime())?;
+    let ty = arrayref.ty(&mut cx).expect("should be rooted");
+    Some(Box::new(ty.into()))
+}

--- a/crates/c-api/src/eqref.rs
+++ b/crates/c-api/src/eqref.rs
@@ -1,5 +1,6 @@
 use crate::{
-    WasmtimeStoreContextMut, wasmtime_anyref_t, wasmtime_arrayref_t, wasmtime_structref_t,
+    WasmtimeStoreContextMut, wasmtime_anyref_t, wasmtime_arrayref_t, wasmtime_heaptype_t,
+    wasmtime_structref_t,
 };
 use std::mem::MaybeUninit;
 use wasmtime::{ArrayRef, EqRef, I31, OwnedRooted, RootScope, StructRef};
@@ -133,4 +134,20 @@ pub unsafe extern "C" fn wasmtime_eqref_as_array(
     }
     crate::initialize(out, None::<OwnedRooted<ArrayRef>>.into());
     false
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn wasmtime_eqref_type(
+    mut cx: WasmtimeStoreContextMut<'_>,
+    eqref: Option<&wasmtime_eqref_t>,
+    out: &mut MaybeUninit<wasmtime_heaptype_t>,
+) -> bool {
+    match eqref.and_then(|a| a.as_wasmtime()) {
+        Some(eqref) => {
+            let ty = eqref.ty(&mut cx).expect("should be rooted");
+            out.write(ty.into());
+            true
+        }
+        None => false,
+    }
 }

--- a/crates/c-api/src/exnref.rs
+++ b/crates/c-api/src/exnref.rs
@@ -1,5 +1,6 @@
 use crate::{
-    WasmtimeStoreContextMut, handle_result, wasm_trap_t, wasmtime_error_t, wasmtime_val_t,
+    WasmtimeStoreContextMut, handle_result, wasm_trap_t, wasmtime_error_t, wasmtime_exn_type_t,
+    wasmtime_val_t,
 };
 use std::mem::MaybeUninit;
 use wasmtime::{AsContextMut, ExnRef, ExnRefPre, ExnType, RootScope, Tag};
@@ -111,4 +112,14 @@ pub extern "C" fn wasmtime_context_take_exception(
 #[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_context_has_exception(store: WasmtimeStoreContextMut<'_>) -> bool {
     store.has_pending_exception()
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn wasmtime_exnref_type(
+    mut cx: WasmtimeStoreContextMut<'_>,
+    exnref: Option<&wasmtime_exnref_t>,
+) -> Option<Box<wasmtime_exn_type_t>> {
+    let exnref = exnref.and_then(|a| a.as_wasmtime())?;
+    let ty = exnref.ty(&mut cx).expect("should be rooted");
+    Some(Box::new(ty.into()))
 }

--- a/crates/c-api/src/structref.rs
+++ b/crates/c-api/src/structref.rs
@@ -111,3 +111,13 @@ pub unsafe extern "C" fn wasmtime_structref_set_field(
         Err(e) => Some(Box::new(e.into())),
     }
 }
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn wasmtime_structref_type(
+    mut cx: WasmtimeStoreContextMut<'_>,
+    structref: Option<&wasmtime_structref_t>,
+) -> Option<Box<crate::wasmtime_struct_type_t>> {
+    let structref = structref.and_then(|a| a.as_wasmtime())?;
+    let ty = structref.ty(&mut cx).expect("should be rooted");
+    Some(Box::new(ty.into()))
+}

--- a/crates/c-api/src/types/arrayref.rs
+++ b/crates/c-api/src/types/arrayref.rs
@@ -8,6 +8,12 @@ pub struct wasmtime_array_type_t {
 }
 wasmtime_c_api_macros::declare_ty!(wasmtime_array_type_t);
 
+impl From<ArrayType> for wasmtime_array_type_t {
+    fn from(ty: ArrayType) -> Self {
+        Self { ty }
+    }
+}
+
 #[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_array_type_new(
     engine: &crate::wasm_engine_t,

--- a/crates/c-api/src/types/exn.rs
+++ b/crates/c-api/src/types/exn.rs
@@ -8,6 +8,12 @@ pub struct wasmtime_exn_type_t {
 }
 wasmtime_c_api_macros::declare_ty!(wasmtime_exn_type_t);
 
+impl From<ExnType> for wasmtime_exn_type_t {
+    fn from(ty: ExnType) -> Self {
+        Self { ty }
+    }
+}
+
 #[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_exn_type_new(
     engine: &crate::wasm_engine_t,

--- a/crates/c-api/src/types/structref.rs
+++ b/crates/c-api/src/types/structref.rs
@@ -95,6 +95,12 @@ pub struct wasmtime_struct_type_t {
 }
 wasmtime_c_api_macros::declare_ty!(wasmtime_struct_type_t);
 
+impl From<StructType> for wasmtime_struct_type_t {
+    fn from(ty: StructType) -> Self {
+        Self { ty }
+    }
+}
+
 #[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_struct_type_new(
     engine: &crate::wasm_engine_t,

--- a/crates/c-api/src/types/val.rs
+++ b/crates/c-api/src/types/val.rs
@@ -160,15 +160,13 @@ pub enum wasmtime_heaptype_t {
     NoExn,
 }
 
-impl From<&HeapType> for wasmtime_heaptype_t {
-    fn from(r: &HeapType) -> Self {
+impl From<HeapType> for wasmtime_heaptype_t {
+    fn from(r: HeapType) -> Self {
         match r {
             HeapType::Extern => Self::Extern,
             HeapType::NoExtern => Self::NoExtern,
             HeapType::Func => Self::Func,
-            HeapType::ConcreteFunc(f) => {
-                Self::ConcreteFunc(Box::new(wasm_functype_t::new(f.clone())))
-            }
+            HeapType::ConcreteFunc(f) => Self::ConcreteFunc(Box::new(wasm_functype_t::new(f))),
             HeapType::NoFunc => Self::NoFunc,
             HeapType::Any => Self::Any,
             HeapType::None => Self::None,
@@ -176,16 +174,14 @@ impl From<&HeapType> for wasmtime_heaptype_t {
             HeapType::I31 => Self::I31,
             HeapType::Array => Self::Array,
             HeapType::ConcreteArray(a) => {
-                Self::ConcreteArray(Box::new(wasmtime_array_type_t { ty: a.clone() }))
+                Self::ConcreteArray(Box::new(wasmtime_array_type_t { ty: a }))
             }
             HeapType::Struct => Self::Struct,
             HeapType::ConcreteStruct(s) => {
-                Self::ConcreteStruct(Box::new(wasmtime_struct_type_t { ty: s.clone() }))
+                Self::ConcreteStruct(Box::new(wasmtime_struct_type_t { ty: s }))
             }
             HeapType::Exn => Self::Exn,
-            HeapType::ConcreteExn(e) => {
-                Self::ConcreteExn(Box::new(wasmtime_exn_type_t { ty: e.clone() }))
-            }
+            HeapType::ConcreteExn(e) => Self::ConcreteExn(Box::new(wasmtime_exn_type_t { ty: e })),
             HeapType::NoExn => Self::NoExn,
             HeapType::Cont | HeapType::ConcreteCont(_) | HeapType::NoCont => {
                 crate::abort("missing support for contref")
@@ -224,7 +220,7 @@ impl From<&RefType> for wasmtime_reftype_t {
     fn from(r: &RefType) -> Self {
         Self {
             nullable: r.is_nullable(),
-            hty: r.heap_type().into(),
+            hty: r.heap_type().clone().into(),
         }
     }
 }

--- a/crates/c-api/tests/exception.cc
+++ b/crates/c-api/tests/exception.cc
@@ -40,6 +40,12 @@ TEST(Exception, ConstructAndExamine) {
   auto f1 = exn.field(cx, 1).unwrap();
   EXPECT_EQ(f1.kind(), ValKind::I64);
   EXPECT_EQ(f1.i64(), 100);
+
+  auto fty = exn.ty(cx).tag_type()->functype();
+  EXPECT_EQ(fty->params().size(), 2);
+  EXPECT_EQ(*fty->params().begin(), ValType::i32());
+  EXPECT_EQ(*(fty->params().begin() + 1), ValType::i64());
+  EXPECT_EQ(fty->results().size(), 0);
 }
 
 TEST(Exception, TagFromModule) {
@@ -148,6 +154,13 @@ TEST(Exception, ExnRefRoundTripThroughVal) {
   // The returned value should be an exnref.
   auto &exnref_val = result.ok()[0];
   EXPECT_EQ(exnref_val.kind(), ValKind::ExnRef);
+
+  auto exnref = exnref_val.exnref();
+  ASSERT_TRUE(exnref);
+  auto fty = exnref->ty(cx).tag_type()->functype();
+  EXPECT_EQ(fty->params().size(), 1);
+  EXPECT_EQ(*fty->params().begin(), ValType::i32());
+  EXPECT_EQ(fty->results().size(), 0);
 
   // Pass the exnref back into a wasm function that extracts the i32 payload.
   Module module2 =

--- a/crates/c-api/tests/gc.cc
+++ b/crates/c-api/tests/gc.cc
@@ -27,11 +27,15 @@ TEST(EqRef, CopyAndMove) {
   // Move assignment
   EqRef eq5 = std::move(eq4);
 
+  EXPECT_TRUE(eq.ty(cx).is_i31());
+
   // Upcast to anyref and check value
   AnyRef upcast = eq.to_anyref();
   auto val = upcast.u31(cx);
   ASSERT_TRUE(val.has_value());
   EXPECT_EQ(*val, 42u);
+
+  EXPECT_TRUE(upcast.ty(cx).is_i31());
 }
 
 TEST(EqRef, NullEqRef) {
@@ -108,6 +112,7 @@ TEST(StructRef, CreateAndReadFields) {
       StructRef::create(cx, pre, {Val(int32_t(10)), Val(int32_t(20))});
   ASSERT_TRUE(result);
   StructRef s = result.ok();
+  EXPECT_EQ(s.ty(cx).num_fields(), 2);
 
   // Read fields back.
   auto v0 = s.field(cx, 0);
@@ -142,11 +147,17 @@ TEST(StructRef, UpcastAndDowncast) {
   auto result = StructRef::create(cx, pre, {Val(int32_t(99))});
   ASSERT_TRUE(result);
   StructRef s = result.ok();
+  EXPECT_EQ(s.ty(cx).num_fields(), 1);
 
   // Upcast to eqref.
   EqRef eq = s.to_eqref();
   EXPECT_TRUE(eq.is_struct(cx));
   EXPECT_FALSE(eq.is_i31(cx));
+
+  auto eqty = eq.ty(cx);
+  auto *sty = eqty.as_concrete_struct();
+  ASSERT_TRUE(sty);
+  EXPECT_EQ(sty->num_fields(), 1);
 
   // Downcast back to structref.
   auto s2_opt = eq.as_struct(cx);
@@ -159,6 +170,11 @@ TEST(StructRef, UpcastAndDowncast) {
   // Upcast to anyref.
   AnyRef any = s.to_anyref();
   EXPECT_FALSE(any.is_i31(cx));
+
+  auto anyty = any.ty(cx);
+  sty = anyty.as_concrete_struct();
+  ASSERT_TRUE(sty);
+  EXPECT_EQ(sty->num_fields(), 1);
 }
 
 TEST(ArrayRef, CreateAndReadElements) {
@@ -176,6 +192,7 @@ TEST(ArrayRef, CreateAndReadElements) {
   auto result = ArrayRef::create(cx, pre, Val(int32_t(7)), 5);
   ASSERT_TRUE(result);
   ArrayRef arr = result.ok();
+  EXPECT_TRUE(arr.ty(cx).element_type().is_mutable());
 
   // Check length.
   auto len_result = arr.len(cx);
@@ -211,12 +228,18 @@ TEST(ArrayRef, UpcastAndDowncast) {
   auto result = ArrayRef::create(cx, pre, Val(int32_t(99)), 3);
   ASSERT_TRUE(result);
   ArrayRef arr = result.ok();
+  EXPECT_FALSE(arr.ty(cx).element_type().is_mutable());
 
   // Upcast to eqref.
   EqRef eq = arr.to_eqref();
   EXPECT_TRUE(eq.is_array(cx));
   EXPECT_FALSE(eq.is_struct(cx));
   EXPECT_FALSE(eq.is_i31(cx));
+
+  auto eqty = eq.ty(cx);
+  auto *aty = eqty.as_concrete_array();
+  ASSERT_TRUE(aty);
+  EXPECT_FALSE(aty->element_type().is_mutable());
 
   // Downcast back to arrayref.
   auto arr2_opt = eq.as_array(cx);
@@ -233,6 +256,11 @@ TEST(ArrayRef, UpcastAndDowncast) {
   // Upcast to anyref.
   AnyRef any = arr.to_anyref();
   EXPECT_FALSE(any.is_i31(cx));
+
+  auto anyty = any.ty(cx);
+  aty = anyty.as_concrete_array();
+  ASSERT_TRUE(aty);
+  EXPECT_FALSE(aty->element_type().is_mutable());
 }
 
 TEST(AnyRef, DowncastI31) {
@@ -247,6 +275,7 @@ TEST(AnyRef, DowncastI31) {
   EXPECT_TRUE(any.is_eqref(cx));
   EXPECT_FALSE(any.is_struct(cx));
   EXPECT_FALSE(any.is_array(cx));
+  EXPECT_TRUE(any.ty(cx).is_i31());
 
   // Downcast to eqref.
   auto opt_eq = any.as_eqref(cx);
@@ -256,6 +285,7 @@ TEST(AnyRef, DowncastI31) {
   auto val = eq.i31_get_u(cx);
   ASSERT_TRUE(val.has_value());
   EXPECT_EQ(*val, 42u);
+  EXPECT_TRUE(eq.ty(cx).is_i31());
 }
 
 TEST(AnyRef, DowncastStruct) {


### PR DESCRIPTION
All of the types in the Rust API have a `ty` method which returns the type of the value, and this is now reflected into the C and C++ APIs as well.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
