### PR TITLE
Bump Wasmtime to 46.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -296,7 +296,7 @@ dependencies = [
 
 [[package]]
 name = "byte-array-literals"
-version = "45.0.0"
+version = "46.0.0"
 
 [[package]]
 name = "byteorder"
@@ -709,7 +709,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift"
-version = "0.132.0"
+version = "0.133.0"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.132.0"
+version = "0.133.0"
 dependencies = [
  "arbitrary",
  "arbtest",
@@ -740,14 +740,14 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.132.0"
+version = "0.133.0"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.132.0"
+version = "0.133.0"
 dependencies = [
  "cranelift-entity",
  "wasmtime-internal-core",
@@ -755,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.132.0"
+version = "0.133.0"
 dependencies = [
  "arbitrary",
  "serde",
@@ -765,7 +765,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.132.0"
+version = "0.133.0"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.132.0"
+version = "0.133.0"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -812,18 +812,18 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.132.0"
+version = "0.133.0"
 
 [[package]]
 name = "cranelift-control"
-version = "0.132.0"
+version = "0.133.0"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.132.0"
+version = "0.133.0"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.132.0"
+version = "0.133.0"
 dependencies = [
  "cranelift-codegen",
  "env_logger 0.11.5",
@@ -890,7 +890,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-interpreter"
-version = "0.132.0"
+version = "0.133.0"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.132.0"
+version = "0.133.0"
 dependencies = [
  "codespan-reporting",
  "log",
@@ -913,7 +913,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-jit"
-version = "0.132.0"
+version = "0.133.0"
 dependencies = [
  "anyhow",
  "cranelift",
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-module"
-version = "0.132.0"
+version = "0.133.0"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -947,7 +947,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.132.0"
+version = "0.133.0"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-object"
-version = "0.132.0"
+version = "0.133.0"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -971,7 +971,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-reader"
-version = "0.132.0"
+version = "0.133.0"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -981,7 +981,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-serde"
-version = "0.132.0"
+version = "0.133.0"
 dependencies = [
  "clap",
  "cranelift-codegen",
@@ -991,7 +991,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.132.0"
+version = "0.133.0"
 
 [[package]]
 name = "cranelift-tools"
@@ -1253,7 +1253,7 @@ checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "embedding"
-version = "45.0.0"
+version = "46.0.0"
 dependencies = [
  "dlmalloc",
  "raw-cpuid",
@@ -2470,7 +2470,7 @@ dependencies = [
 
 [[package]]
 name = "min-platform-host"
-version = "45.0.0"
+version = "46.0.0"
 dependencies = [
  "libloading",
  "object 0.39.0",
@@ -2943,7 +2943,7 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "45.0.0"
+version = "46.0.0"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -2967,7 +2967,7 @@ dependencies = [
 
 [[package]]
 name = "pulley-macros"
-version = "45.0.0"
+version = "46.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4283,7 +4283,7 @@ version = "0.1.0"
 
 [[package]]
 name = "verify-component-adapter"
-version = "45.0.0"
+version = "46.0.0"
 dependencies = [
  "anyhow",
  "wasmparser 0.248.0",
@@ -4348,7 +4348,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-common"
-version = "45.0.0"
+version = "46.0.0"
 dependencies = [
  "async-trait",
  "bitflags 2.11.1",
@@ -4388,7 +4388,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-preview1-component-adapter"
-version = "45.0.0"
+version = "46.0.0"
 dependencies = [
  "bitflags 2.11.1",
  "byte-array-literals",
@@ -4708,7 +4708,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "45.0.0"
+version = "46.0.0"
 dependencies = [
  "addr2line 0.26.0",
  "async-trait",
@@ -4769,7 +4769,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-bench-api"
-version = "45.0.0"
+version = "46.0.0"
 dependencies = [
  "cap-std",
  "clap",
@@ -4784,14 +4784,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-c-api"
-version = "45.0.0"
+version = "46.0.0"
 dependencies = [
  "wasmtime-c-api-impl",
 ]
 
 [[package]]
 name = "wasmtime-c-api-impl"
-version = "45.0.0"
+version = "46.0.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4811,7 +4811,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli"
-version = "45.0.0"
+version = "46.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4891,7 +4891,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli-flags"
-version = "45.0.0"
+version = "46.0.0"
 dependencies = [
  "clap",
  "file-per-thread-logger",
@@ -4905,7 +4905,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "45.0.0"
+version = "46.0.0"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -5021,7 +5021,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-c-api-macros"
-version = "45.0.0"
+version = "46.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5029,7 +5029,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cache"
-version = "45.0.0"
+version = "46.0.0"
 dependencies = [
  "base64",
  "directories-next",
@@ -5050,7 +5050,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-macro"
-version = "45.0.0"
+version = "46.0.0"
 dependencies = [
  "anyhow",
  "component-macro-test-helpers",
@@ -5070,11 +5070,11 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-util"
-version = "45.0.0"
+version = "46.0.0"
 
 [[package]]
 name = "wasmtime-internal-core"
-version = "45.0.0"
+version = "46.0.0"
 dependencies = [
  "anyhow",
  "hashbrown 0.17.0",
@@ -5084,7 +5084,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "45.0.0"
+version = "46.0.0"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -5109,7 +5109,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-debugger"
-version = "45.0.0"
+version = "46.0.0"
 dependencies = [
  "async-trait",
  "env_logger 0.11.5",
@@ -5122,7 +5122,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-explorer"
-version = "45.0.0"
+version = "46.0.0"
 dependencies = [
  "capstone",
  "serde",
@@ -5136,7 +5136,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-fiber"
-version = "45.0.0"
+version = "46.0.0"
 dependencies = [
  "backtrace",
  "cc",
@@ -5150,7 +5150,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-gdbstub-component"
-version = "45.0.0"
+version = "46.0.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -5166,11 +5166,11 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-gdbstub-component-artifact"
-version = "45.0.0"
+version = "46.0.0"
 
 [[package]]
 name = "wasmtime-internal-jit-debug"
-version = "45.0.0"
+version = "46.0.0"
 dependencies = [
  "cc",
  "object 0.39.0",
@@ -5180,7 +5180,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "45.0.0"
+version = "46.0.0"
 dependencies = [
  "cfg-if",
  "libc",
@@ -5190,7 +5190,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-unwinder"
-version = "45.0.0"
+version = "46.0.0"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -5201,7 +5201,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
-version = "45.0.0"
+version = "46.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5210,7 +5210,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-winch"
-version = "45.0.0"
+version = "46.0.0"
 dependencies = [
  "cranelift-codegen",
  "gimli 0.33.0",
@@ -5225,7 +5225,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-wit-bindgen"
-version = "45.0.0"
+version = "46.0.0"
 dependencies = [
  "anyhow",
  "bitflags 2.11.1",
@@ -5236,7 +5236,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-wmemcheck"
-version = "45.0.0"
+version = "46.0.0"
 
 [[package]]
 name = "wasmtime-test-macros"
@@ -5251,7 +5251,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-test-util"
-version = "45.0.0"
+version = "46.0.0"
 dependencies = [
  "arbitrary",
  "arbtest",
@@ -5274,7 +5274,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "45.0.0"
+version = "46.0.0"
 dependencies = [
  "async-trait",
  "bitflags 2.11.1",
@@ -5308,7 +5308,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-config"
-version = "45.0.0"
+version = "46.0.0"
 dependencies = [
  "test-programs-artifacts",
  "tokio",
@@ -5318,7 +5318,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-http"
-version = "45.0.0"
+version = "46.0.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -5350,7 +5350,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-io"
-version = "45.0.0"
+version = "46.0.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5361,7 +5361,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-keyvalue"
-version = "45.0.0"
+version = "46.0.0"
 dependencies = [
  "test-programs-artifacts",
  "tokio",
@@ -5371,7 +5371,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-nn"
-version = "45.0.0"
+version = "46.0.0"
 dependencies = [
  "cap-std",
  "libtest-mimic",
@@ -5391,7 +5391,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-threads"
-version = "45.0.0"
+version = "46.0.0"
 dependencies = [
  "log",
  "rand 0.10.1",
@@ -5402,7 +5402,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-tls"
-version = "45.0.0"
+version = "46.0.0"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -5423,7 +5423,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wast"
-version = "45.0.0"
+version = "46.0.0"
 dependencies = [
  "json-from-wast",
  "log",
@@ -5437,7 +5437,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wizer"
-version = "45.0.0"
+version = "46.0.0"
 dependencies = [
  "clap",
  "criterion",
@@ -5518,7 +5518,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "45.0.0"
+version = "46.0.0"
 dependencies = [
  "bitflags 2.11.1",
  "proptest",
@@ -5534,7 +5534,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "45.0.0"
+version = "46.0.0"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -5546,7 +5546,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "45.0.0"
+version = "46.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5601,7 +5601,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "45.0.0"
+version = "46.0.0"
 dependencies = [
  "cranelift-assembler-x64",
  "cranelift-codegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -189,7 +189,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "45.0.0"
+version = "46.0.0"
 authors = ["The Wasmtime Project Developers"]
 edition = "2024"
 # Wasmtime's current policy is that this number can be no larger than the
@@ -250,18 +250,18 @@ extra_unused_type_parameters = 'warn'
 # tooling but aren't intended to be widely depended on.
 #
 # All of these crates are supported though in the sense that
-wasmtime = { path = "crates/wasmtime", version = "45.0.0", default-features = false }
-wasmtime-cli-flags = { path = "crates/cli-flags", version = "=45.0.0" }
-wasmtime-environ = { path = "crates/environ", version = "=45.0.0" }
-wasmtime-wasi = { path = "crates/wasi", version = "45.0.0", default-features = false }
-wasmtime-wasi-io = { path = "crates/wasi-io", version = "45.0.0", default-features = false }
-wasmtime-wasi-http = { path = "crates/wasi-http", version = "45.0.0", default-features = false }
-wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "45.0.0" }
-wasmtime-wasi-config = { path = "crates/wasi-config", version = "45.0.0" }
-wasmtime-wasi-keyvalue = { path = "crates/wasi-keyvalue", version = "45.0.0" }
-wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "45.0.0" }
-wasmtime-wasi-tls = { path = "crates/wasi-tls", version = "45.0.0" }
-wasmtime-wast = { path = "crates/wast", version = "=45.0.0" }
+wasmtime = { path = "crates/wasmtime", version = "46.0.0", default-features = false }
+wasmtime-cli-flags = { path = "crates/cli-flags", version = "=46.0.0" }
+wasmtime-environ = { path = "crates/environ", version = "=46.0.0" }
+wasmtime-wasi = { path = "crates/wasi", version = "46.0.0", default-features = false }
+wasmtime-wasi-io = { path = "crates/wasi-io", version = "46.0.0", default-features = false }
+wasmtime-wasi-http = { path = "crates/wasi-http", version = "46.0.0", default-features = false }
+wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "46.0.0" }
+wasmtime-wasi-config = { path = "crates/wasi-config", version = "46.0.0" }
+wasmtime-wasi-keyvalue = { path = "crates/wasi-keyvalue", version = "46.0.0" }
+wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "46.0.0" }
+wasmtime-wasi-tls = { path = "crates/wasi-tls", version = "46.0.0" }
+wasmtime-wast = { path = "crates/wast", version = "=46.0.0" }
 
 # Internal Wasmtime-specific crates.
 #
@@ -270,55 +270,55 @@ wasmtime-wast = { path = "crates/wast", version = "=45.0.0" }
 # that these are internal unsupported crates for external use. These exist as
 # part of the project organization of other public crates in Wasmtime and are
 # otherwise not supported in terms of CVEs for example.
-wasmtime-core = { path = "crates/core", version = "=45.0.0", package = 'wasmtime-internal-core' }
-wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=45.0.0", package = 'wasmtime-internal-wmemcheck' }
-wasmtime-c-api-macros = { path = "crates/c-api-macros", version = "=45.0.0", package = 'wasmtime-internal-c-api-macros' }
-wasmtime-cache = { path = "crates/cache", version = "=45.0.0", package = 'wasmtime-internal-cache' }
-wasmtime-cranelift = { path = "crates/cranelift", version = "=45.0.0", package = 'wasmtime-internal-cranelift' }
-wasmtime-winch = { path = "crates/winch", version = "=45.0.0", package = 'wasmtime-internal-winch'  }
-wasmtime-explorer = { path = "crates/explorer", version = "=45.0.0", package = 'wasmtime-internal-explorer'  }
-wasmtime-fiber = { path = "crates/fiber", version = "=45.0.0", package = 'wasmtime-internal-fiber' }
-wasmtime-jit-debug = { path = "crates/jit-debug", version = "=45.0.0", package = 'wasmtime-internal-jit-debug' }
-wasmtime-component-util = { path = "crates/component-util", version = "=45.0.0", package = 'wasmtime-internal-component-util' }
-wasmtime-component-macro = { path = "crates/component-macro", version = "=45.0.0", package = 'wasmtime-internal-component-macro' }
-wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=45.0.0", package = 'wasmtime-internal-versioned-export-macros' }
-wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=45.0.0", package = 'wasmtime-internal-jit-icache-coherence' }
-wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=45.0.0", package = 'wasmtime-internal-wit-bindgen' }
-wasmtime-unwinder = { path = "crates/unwinder", version = "=45.0.0", package = 'wasmtime-internal-unwinder' }
-wasmtime-debugger = { path = "crates/debugger", version = "=45.0.0", package = "wasmtime-internal-debugger" }
-gdbstub-component-artifact = { path = "crates/gdbstub-component/artifact", version = "=45.0.0", package = "wasmtime-internal-gdbstub-component-artifact" }
-wasmtime-wizer = { path = "crates/wizer", version = "45.0.0" }
+wasmtime-core = { path = "crates/core", version = "=46.0.0", package = 'wasmtime-internal-core' }
+wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=46.0.0", package = 'wasmtime-internal-wmemcheck' }
+wasmtime-c-api-macros = { path = "crates/c-api-macros", version = "=46.0.0", package = 'wasmtime-internal-c-api-macros' }
+wasmtime-cache = { path = "crates/cache", version = "=46.0.0", package = 'wasmtime-internal-cache' }
+wasmtime-cranelift = { path = "crates/cranelift", version = "=46.0.0", package = 'wasmtime-internal-cranelift' }
+wasmtime-winch = { path = "crates/winch", version = "=46.0.0", package = 'wasmtime-internal-winch'  }
+wasmtime-explorer = { path = "crates/explorer", version = "=46.0.0", package = 'wasmtime-internal-explorer'  }
+wasmtime-fiber = { path = "crates/fiber", version = "=46.0.0", package = 'wasmtime-internal-fiber' }
+wasmtime-jit-debug = { path = "crates/jit-debug", version = "=46.0.0", package = 'wasmtime-internal-jit-debug' }
+wasmtime-component-util = { path = "crates/component-util", version = "=46.0.0", package = 'wasmtime-internal-component-util' }
+wasmtime-component-macro = { path = "crates/component-macro", version = "=46.0.0", package = 'wasmtime-internal-component-macro' }
+wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=46.0.0", package = 'wasmtime-internal-versioned-export-macros' }
+wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=46.0.0", package = 'wasmtime-internal-jit-icache-coherence' }
+wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=46.0.0", package = 'wasmtime-internal-wit-bindgen' }
+wasmtime-unwinder = { path = "crates/unwinder", version = "=46.0.0", package = 'wasmtime-internal-unwinder' }
+wasmtime-debugger = { path = "crates/debugger", version = "=46.0.0", package = "wasmtime-internal-debugger" }
+gdbstub-component-artifact = { path = "crates/gdbstub-component/artifact", version = "=46.0.0", package = "wasmtime-internal-gdbstub-component-artifact" }
+wasmtime-wizer = { path = "crates/wizer", version = "46.0.0" }
 
 # Miscellaneous crates without a `wasmtime-*` prefix in their name but still
 # used in the `wasmtime-*` family of crates depending on various features/etc.
-wiggle = { path = "crates/wiggle", version = "=45.0.0", default-features = false }
-wiggle-macro = { path = "crates/wiggle/macro", version = "=45.0.0" }
-wiggle-generate = { path = "crates/wiggle/generate", version = "=45.0.0" }
-wasi-common = { path = "crates/wasi-common", version = "=45.0.0", default-features = false }
-pulley-interpreter = { path = 'pulley', version = "=45.0.0" }
-pulley-macros = { path = 'pulley/macros', version = "=45.0.0" }
+wiggle = { path = "crates/wiggle", version = "=46.0.0", default-features = false }
+wiggle-macro = { path = "crates/wiggle/macro", version = "=46.0.0" }
+wiggle-generate = { path = "crates/wiggle/generate", version = "=46.0.0" }
+wasi-common = { path = "crates/wasi-common", version = "=46.0.0", default-features = false }
+pulley-interpreter = { path = 'pulley', version = "=46.0.0" }
+pulley-macros = { path = 'pulley/macros', version = "=46.0.0" }
 
 # Cranelift crates in this workspace
-cranelift-assembler-x64 = { path = "cranelift/assembler-x64", version = "0.132.0" }
-cranelift-codegen = { path = "cranelift/codegen", version = "0.132.0", default-features = false, features = ["std", "unwind"] }
-cranelift-frontend = { path = "cranelift/frontend", version = "0.132.0" }
-cranelift-entity = { path = "cranelift/entity", version = "0.132.0" }
-cranelift-native = { path = "cranelift/native", version = "0.132.0" }
-cranelift-module = { path = "cranelift/module", version = "0.132.0" }
-cranelift-interpreter = { path = "cranelift/interpreter", version = "0.132.0" }
-cranelift-reader = { path = "cranelift/reader", version = "0.132.0" }
+cranelift-assembler-x64 = { path = "cranelift/assembler-x64", version = "0.133.0" }
+cranelift-codegen = { path = "cranelift/codegen", version = "0.133.0", default-features = false, features = ["std", "unwind"] }
+cranelift-frontend = { path = "cranelift/frontend", version = "0.133.0" }
+cranelift-entity = { path = "cranelift/entity", version = "0.133.0" }
+cranelift-native = { path = "cranelift/native", version = "0.133.0" }
+cranelift-module = { path = "cranelift/module", version = "0.133.0" }
+cranelift-interpreter = { path = "cranelift/interpreter", version = "0.133.0" }
+cranelift-reader = { path = "cranelift/reader", version = "0.133.0" }
 cranelift-filetests = { path = "cranelift/filetests" }
-cranelift-object = { path = "cranelift/object", version = "0.132.0" }
-cranelift-jit = { path = "cranelift/jit", version = "0.132.0" }
+cranelift-object = { path = "cranelift/object", version = "0.133.0" }
+cranelift-jit = { path = "cranelift/jit", version = "0.133.0" }
 cranelift-fuzzgen = { path = "cranelift/fuzzgen" }
-cranelift-bforest = { path = "cranelift/bforest", version = "0.132.0" }
-cranelift-bitset = { path = "cranelift/bitset", version = "0.132.0" }
-cranelift-control = { path = "cranelift/control", version = "0.132.0", default-features = false }
-cranelift-srcgen = { path = "cranelift/srcgen", version = "0.132.0" }
-cranelift = { path = "cranelift/umbrella", version = "0.132.0" }
+cranelift-bforest = { path = "cranelift/bforest", version = "0.133.0" }
+cranelift-bitset = { path = "cranelift/bitset", version = "0.133.0" }
+cranelift-control = { path = "cranelift/control", version = "0.133.0", default-features = false }
+cranelift-srcgen = { path = "cranelift/srcgen", version = "0.133.0" }
+cranelift = { path = "cranelift/umbrella", version = "0.133.0" }
 
 # Winch crates in this workspace.
-winch-codegen = { path = "winch/codegen", version = "=45.0.0" }
+winch-codegen = { path = "winch/codegen", version = "=46.0.0" }
 
 # Internal crates not published to crates.io used in testing, builds, etc
 wasi-preview1-component-adapter = { path = "crates/wasi-preview1-component-adapter" }

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,4 +1,4 @@
-## 45.0.0
+## 46.0.0
 
 Unreleased.
 
@@ -12,6 +12,7 @@ Release notes for previous releases of Wasmtime can be found on the respective
 release branches of the Wasmtime repository.
 
 <!-- ARCHIVE_START -->
+* [45.0.x](https://github.com/bytecodealliance/wasmtime/blob/release-45.0.0/RELEASES.md)
 * [44.0.x](https://github.com/bytecodealliance/wasmtime/blob/release-44.0.0/RELEASES.md)
 * [43.0.x](https://github.com/bytecodealliance/wasmtime/blob/release-43.0.0/RELEASES.md)
 * [42.0.x](https://github.com/bytecodealliance/wasmtime/blob/release-42.0.0/RELEASES.md)

--- a/cranelift/assembler-x64/Cargo.toml
+++ b/cranelift/assembler-x64/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-assembler-x64"
 description = "A Cranelift-specific x64 assembler"
-version = "0.132.0"
+version = "0.133.0"
 license = "Apache-2.0 WITH LLVM-exception"
 edition.workspace = true
 rust-version.workspace = true
@@ -16,7 +16,7 @@ arbtest = { workspace = true }
 capstone = { workspace = true }
 
 [build-dependencies]
-cranelift-assembler-x64-meta = { path = "meta", version = "0.132.0" }
+cranelift-assembler-x64-meta = { path = "meta", version = "0.133.0" }
 
 [lints]
 workspace = true

--- a/cranelift/assembler-x64/meta/Cargo.toml
+++ b/cranelift/assembler-x64/meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-assembler-x64-meta"
 description = "Generate a Cranelift-specific assembler for x64 instructions"
-version = "0.132.0"
+version = "0.133.0"
 license = "Apache-2.0 WITH LLVM-exception"
 edition.workspace = true
 rust-version.workspace = true

--- a/cranelift/bforest/Cargo.toml
+++ b/cranelift/bforest/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bforest"
-version = "0.132.0"
+version = "0.133.0"
 description = "A forest of B+-trees"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-bforest"

--- a/cranelift/bitset/Cargo.toml
+++ b/cranelift/bitset/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bitset"
-version = "0.132.0"
+version = "0.133.0"
 description = "Various bitset stuff for use inside Cranelift"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-bitset"

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen"
-version = "0.132.0"
+version = "0.133.0"
 description = "Low-level code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-codegen"
@@ -25,7 +25,7 @@ anyhow = { workspace = true, optional = true, features = ['std'] }
 bumpalo = { workspace = true }
 capstone = { workspace = true, optional = true }
 cranelift-assembler-x64 = { workspace = true }
-cranelift-codegen-shared = { path = "./shared", version = "0.132.0" }
+cranelift-codegen-shared = { path = "./shared", version = "0.133.0" }
 cranelift-entity = { workspace = true }
 cranelift-bforest = { workspace = true }
 cranelift-bitset = { workspace = true }
@@ -57,8 +57,8 @@ env_logger = { workspace = true }
 proptest = { workspace = true }
 
 [build-dependencies]
-cranelift-codegen-meta = { path = "meta", version = "0.132.0" }
-cranelift-isle = { path = "../isle/isle", version = "=0.132.0" }
+cranelift-codegen-meta = { path = "meta", version = "0.133.0" }
+cranelift-isle = { path = "../isle/isle", version = "=0.133.0" }
 
 [features]
 default = ["std", "unwind", "host-arch", "timing"]

--- a/cranelift/codegen/meta/Cargo.toml
+++ b/cranelift/codegen/meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-codegen-meta"
 authors = ["The Cranelift Project Developers"]
-version = "0.132.0"
+version = "0.133.0"
 description = "Metaprogram for cranelift-codegen code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
@@ -17,8 +17,8 @@ rustdoc-args = ["--document-private-items"]
 
 [dependencies]
 cranelift-srcgen = { workspace = true }
-cranelift-assembler-x64-meta = { path = "../../assembler-x64/meta", version = "0.132.0" }
-cranelift-codegen-shared = { path = "../shared", version = "0.132.0" }
+cranelift-assembler-x64-meta = { path = "../../assembler-x64/meta", version = "0.133.0" }
+cranelift-codegen-shared = { path = "../shared", version = "0.133.0" }
 pulley-interpreter = { workspace = true, optional = true }
 heck = "0.5.0"
 

--- a/cranelift/codegen/shared/Cargo.toml
+++ b/cranelift/codegen/shared/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen-shared"
-version = "0.132.0"
+version = "0.133.0"
 description = "For code shared between cranelift-codegen-meta and cranelift-codegen"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/control/Cargo.toml
+++ b/cranelift/control/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-control"
-version = "0.132.0"
+version = "0.133.0"
 description = "White-box fuzz testing framework"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/entity/Cargo.toml
+++ b/cranelift/entity/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-entity"
-version = "0.132.0"
+version = "0.133.0"
 description = "Data structures using entity references as mapping keys"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-entity"

--- a/cranelift/frontend/Cargo.toml
+++ b/cranelift/frontend/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-frontend"
-version = "0.132.0"
+version = "0.133.0"
 description = "Cranelift IR builder helper"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-frontend"

--- a/cranelift/interpreter/Cargo.toml
+++ b/cranelift/interpreter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-interpreter"
-version = "0.132.0"
+version = "0.133.0"
 authors = ["The Cranelift Project Developers"]
 description = "Interpret Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/isle/isle/Cargo.toml
+++ b/cranelift/isle/isle/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 name = "cranelift-isle"
 readme = "../README.md"
 repository = "https://github.com/bytecodealliance/wasmtime/tree/main/cranelift/isle"
-version = "0.132.0"
+version = "0.133.0"
 
 [lints]
 workspace = true

--- a/cranelift/jit/Cargo.toml
+++ b/cranelift/jit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-jit"
-version = "0.132.0"
+version = "0.133.0"
 authors = ["The Cranelift Project Developers"]
 description = "A JIT library backed by Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/module/Cargo.toml
+++ b/cranelift/module/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-module"
-version = "0.132.0"
+version = "0.133.0"
 authors = ["The Cranelift Project Developers"]
 description = "Support for linking functions and data with Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/native/Cargo.toml
+++ b/cranelift/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-native"
-version = "0.132.0"
+version = "0.133.0"
 authors = ["The Cranelift Project Developers"]
 description = "Support for targeting the host with Cranelift"
 documentation = "https://docs.rs/cranelift-native"

--- a/cranelift/object/Cargo.toml
+++ b/cranelift/object/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-object"
-version = "0.132.0"
+version = "0.133.0"
 authors = ["The Cranelift Project Developers"]
 description = "Emit Cranelift output to native object files with `object`"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/reader/Cargo.toml
+++ b/cranelift/reader/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-reader"
-version = "0.132.0"
+version = "0.133.0"
 description = "Cranelift textual IR reader"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-reader"

--- a/cranelift/serde/Cargo.toml
+++ b/cranelift/serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-serde"
-version = "0.132.0"
+version = "0.133.0"
 authors = ["The Cranelift Project Developers"]
 description = "Serializer/Deserializer for Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/srcgen/Cargo.toml
+++ b/cranelift/srcgen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-srcgen"
-version = "0.132.0"
+version = "0.133.0"
 authors = ["The Wasmtime Project Developers"]
 description = "Helper functions for generating Rust and ISLE files"
 license = "Apache-2.0 WITH LLVM-exception"

--- a/cranelift/umbrella/Cargo.toml
+++ b/cranelift/umbrella/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift"
-version = "0.132.0"
+version = "0.133.0"
 description = "Umbrella for commonly-used cranelift crates"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift"

--- a/crates/c-api/include/wasmtime.h
+++ b/crates/c-api/include/wasmtime.h
@@ -229,11 +229,11 @@
 /**
  * \brief Wasmtime version string.
  */
-#define WASMTIME_VERSION "45.0.0"
+#define WASMTIME_VERSION "46.0.0"
 /**
  * \brief Wasmtime major version number.
  */
-#define WASMTIME_VERSION_MAJOR 45
+#define WASMTIME_VERSION_MAJOR 46
 /**
  * \brief Wasmtime minor version number.
  */

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -5,229 +5,457 @@
 version = "0.132.0"
 audited_as = "0.130.1"
 
+[[unpublished.cranelift]]
+version = "0.133.0"
+audited_as = "0.131.1"
+
 [[unpublished.cranelift-assembler-x64]]
 version = "0.132.0"
 audited_as = "0.130.1"
+
+[[unpublished.cranelift-assembler-x64]]
+version = "0.133.0"
+audited_as = "0.131.1"
 
 [[unpublished.cranelift-assembler-x64-meta]]
 version = "0.132.0"
 audited_as = "0.130.1"
 
+[[unpublished.cranelift-assembler-x64-meta]]
+version = "0.133.0"
+audited_as = "0.131.1"
+
 [[unpublished.cranelift-bforest]]
 version = "0.132.0"
 audited_as = "0.130.1"
+
+[[unpublished.cranelift-bforest]]
+version = "0.133.0"
+audited_as = "0.131.1"
 
 [[unpublished.cranelift-bitset]]
 version = "0.132.0"
 audited_as = "0.130.1"
 
+[[unpublished.cranelift-bitset]]
+version = "0.133.0"
+audited_as = "0.131.1"
+
 [[unpublished.cranelift-codegen]]
 version = "0.132.0"
 audited_as = "0.130.1"
+
+[[unpublished.cranelift-codegen]]
+version = "0.133.0"
+audited_as = "0.131.1"
 
 [[unpublished.cranelift-codegen-meta]]
 version = "0.132.0"
 audited_as = "0.130.1"
 
+[[unpublished.cranelift-codegen-meta]]
+version = "0.133.0"
+audited_as = "0.131.1"
+
 [[unpublished.cranelift-codegen-shared]]
 version = "0.132.0"
 audited_as = "0.130.1"
+
+[[unpublished.cranelift-codegen-shared]]
+version = "0.133.0"
+audited_as = "0.131.1"
 
 [[unpublished.cranelift-control]]
 version = "0.132.0"
 audited_as = "0.130.1"
 
+[[unpublished.cranelift-control]]
+version = "0.133.0"
+audited_as = "0.131.1"
+
 [[unpublished.cranelift-entity]]
 version = "0.132.0"
 audited_as = "0.130.1"
+
+[[unpublished.cranelift-entity]]
+version = "0.133.0"
+audited_as = "0.131.1"
 
 [[unpublished.cranelift-frontend]]
 version = "0.132.0"
 audited_as = "0.130.1"
 
+[[unpublished.cranelift-frontend]]
+version = "0.133.0"
+audited_as = "0.131.1"
+
 [[unpublished.cranelift-interpreter]]
 version = "0.132.0"
 audited_as = "0.130.1"
+
+[[unpublished.cranelift-interpreter]]
+version = "0.133.0"
+audited_as = "0.131.1"
 
 [[unpublished.cranelift-isle]]
 version = "0.132.0"
 audited_as = "0.130.1"
 
+[[unpublished.cranelift-isle]]
+version = "0.133.0"
+audited_as = "0.131.1"
+
 [[unpublished.cranelift-jit]]
 version = "0.132.0"
 audited_as = "0.130.1"
+
+[[unpublished.cranelift-jit]]
+version = "0.133.0"
+audited_as = "0.131.1"
 
 [[unpublished.cranelift-module]]
 version = "0.132.0"
 audited_as = "0.130.1"
 
+[[unpublished.cranelift-module]]
+version = "0.133.0"
+audited_as = "0.131.1"
+
 [[unpublished.cranelift-native]]
 version = "0.132.0"
 audited_as = "0.130.1"
+
+[[unpublished.cranelift-native]]
+version = "0.133.0"
+audited_as = "0.131.1"
 
 [[unpublished.cranelift-object]]
 version = "0.132.0"
 audited_as = "0.130.1"
 
+[[unpublished.cranelift-object]]
+version = "0.133.0"
+audited_as = "0.131.1"
+
 [[unpublished.cranelift-reader]]
 version = "0.132.0"
 audited_as = "0.130.1"
+
+[[unpublished.cranelift-reader]]
+version = "0.133.0"
+audited_as = "0.131.1"
 
 [[unpublished.cranelift-serde]]
 version = "0.132.0"
 audited_as = "0.130.1"
 
+[[unpublished.cranelift-serde]]
+version = "0.133.0"
+audited_as = "0.131.1"
+
 [[unpublished.cranelift-srcgen]]
 version = "0.132.0"
 audited_as = "0.130.1"
+
+[[unpublished.cranelift-srcgen]]
+version = "0.133.0"
+audited_as = "0.131.1"
 
 [[unpublished.pulley-interpreter]]
 version = "45.0.0"
 audited_as = "43.0.1"
 
+[[unpublished.pulley-interpreter]]
+version = "46.0.0"
+audited_as = "44.0.1"
+
 [[unpublished.pulley-macros]]
 version = "45.0.0"
 audited_as = "43.0.1"
+
+[[unpublished.pulley-macros]]
+version = "46.0.0"
+audited_as = "44.0.1"
 
 [[unpublished.wasi-common]]
 version = "45.0.0"
 audited_as = "43.0.1"
 
+[[unpublished.wasi-common]]
+version = "46.0.0"
+audited_as = "44.0.1"
+
 [[unpublished.wasmtime]]
 version = "45.0.0"
 audited_as = "43.0.1"
+
+[[unpublished.wasmtime]]
+version = "46.0.0"
+audited_as = "44.0.1"
 
 [[unpublished.wasmtime-cli]]
 version = "45.0.0"
 audited_as = "43.0.1"
 
+[[unpublished.wasmtime-cli]]
+version = "46.0.0"
+audited_as = "44.0.1"
+
 [[unpublished.wasmtime-cli-flags]]
 version = "45.0.0"
 audited_as = "43.0.1"
+
+[[unpublished.wasmtime-cli-flags]]
+version = "46.0.0"
+audited_as = "44.0.1"
 
 [[unpublished.wasmtime-environ]]
 version = "45.0.0"
 audited_as = "43.0.1"
 
+[[unpublished.wasmtime-environ]]
+version = "46.0.0"
+audited_as = "44.0.1"
+
 [[unpublished.wasmtime-internal-c-api-macros]]
 version = "45.0.0"
 audited_as = "43.0.1"
+
+[[unpublished.wasmtime-internal-c-api-macros]]
+version = "46.0.0"
+audited_as = "44.0.1"
 
 [[unpublished.wasmtime-internal-cache]]
 version = "45.0.0"
 audited_as = "43.0.1"
 
+[[unpublished.wasmtime-internal-cache]]
+version = "46.0.0"
+audited_as = "44.0.1"
+
 [[unpublished.wasmtime-internal-component-macro]]
 version = "45.0.0"
 audited_as = "43.0.1"
+
+[[unpublished.wasmtime-internal-component-macro]]
+version = "46.0.0"
+audited_as = "44.0.1"
 
 [[unpublished.wasmtime-internal-component-util]]
 version = "45.0.0"
 audited_as = "43.0.1"
 
+[[unpublished.wasmtime-internal-component-util]]
+version = "46.0.0"
+audited_as = "44.0.1"
+
 [[unpublished.wasmtime-internal-core]]
 version = "45.0.0"
 audited_as = "43.0.1"
+
+[[unpublished.wasmtime-internal-core]]
+version = "46.0.0"
+audited_as = "44.0.1"
 
 [[unpublished.wasmtime-internal-cranelift]]
 version = "45.0.0"
 audited_as = "43.0.1"
 
+[[unpublished.wasmtime-internal-cranelift]]
+version = "46.0.0"
+audited_as = "44.0.1"
+
 [[unpublished.wasmtime-internal-debugger]]
 version = "45.0.0"
 audited_as = "43.0.1"
+
+[[unpublished.wasmtime-internal-debugger]]
+version = "46.0.0"
+audited_as = "44.0.1"
 
 [[unpublished.wasmtime-internal-explorer]]
 version = "45.0.0"
 audited_as = "43.0.1"
 
+[[unpublished.wasmtime-internal-explorer]]
+version = "46.0.0"
+audited_as = "44.0.1"
+
 [[unpublished.wasmtime-internal-fiber]]
 version = "45.0.0"
 audited_as = "43.0.1"
+
+[[unpublished.wasmtime-internal-fiber]]
+version = "46.0.0"
+audited_as = "44.0.1"
 
 [[unpublished.wasmtime-internal-gdbstub-component-artifact]]
 version = "45.0.0"
 audited_as = "44.0.0"
 
+[[unpublished.wasmtime-internal-gdbstub-component-artifact]]
+version = "46.0.0"
+audited_as = "44.0.1"
+
 [[unpublished.wasmtime-internal-jit-debug]]
 version = "45.0.0"
 audited_as = "43.0.1"
+
+[[unpublished.wasmtime-internal-jit-debug]]
+version = "46.0.0"
+audited_as = "44.0.1"
 
 [[unpublished.wasmtime-internal-jit-icache-coherence]]
 version = "45.0.0"
 audited_as = "43.0.1"
 
+[[unpublished.wasmtime-internal-jit-icache-coherence]]
+version = "46.0.0"
+audited_as = "44.0.1"
+
 [[unpublished.wasmtime-internal-unwinder]]
 version = "45.0.0"
 audited_as = "43.0.1"
+
+[[unpublished.wasmtime-internal-unwinder]]
+version = "46.0.0"
+audited_as = "44.0.1"
 
 [[unpublished.wasmtime-internal-versioned-export-macros]]
 version = "45.0.0"
 audited_as = "43.0.1"
 
+[[unpublished.wasmtime-internal-versioned-export-macros]]
+version = "46.0.0"
+audited_as = "44.0.1"
+
 [[unpublished.wasmtime-internal-winch]]
 version = "45.0.0"
 audited_as = "43.0.1"
+
+[[unpublished.wasmtime-internal-winch]]
+version = "46.0.0"
+audited_as = "44.0.1"
 
 [[unpublished.wasmtime-internal-wit-bindgen]]
 version = "45.0.0"
 audited_as = "43.0.1"
 
+[[unpublished.wasmtime-internal-wit-bindgen]]
+version = "46.0.0"
+audited_as = "44.0.1"
+
 [[unpublished.wasmtime-internal-wmemcheck]]
 version = "45.0.0"
 audited_as = "43.0.1"
+
+[[unpublished.wasmtime-internal-wmemcheck]]
+version = "46.0.0"
+audited_as = "44.0.1"
 
 [[unpublished.wasmtime-wasi]]
 version = "45.0.0"
 audited_as = "43.0.1"
 
+[[unpublished.wasmtime-wasi]]
+version = "46.0.0"
+audited_as = "44.0.1"
+
 [[unpublished.wasmtime-wasi-config]]
 version = "45.0.0"
 audited_as = "43.0.1"
+
+[[unpublished.wasmtime-wasi-config]]
+version = "46.0.0"
+audited_as = "44.0.1"
 
 [[unpublished.wasmtime-wasi-http]]
 version = "45.0.0"
 audited_as = "43.0.1"
 
+[[unpublished.wasmtime-wasi-http]]
+version = "46.0.0"
+audited_as = "44.0.1"
+
 [[unpublished.wasmtime-wasi-io]]
 version = "45.0.0"
 audited_as = "43.0.1"
+
+[[unpublished.wasmtime-wasi-io]]
+version = "46.0.0"
+audited_as = "44.0.1"
 
 [[unpublished.wasmtime-wasi-keyvalue]]
 version = "45.0.0"
 audited_as = "43.0.1"
 
+[[unpublished.wasmtime-wasi-keyvalue]]
+version = "46.0.0"
+audited_as = "44.0.1"
+
 [[unpublished.wasmtime-wasi-nn]]
 version = "45.0.0"
 audited_as = "43.0.1"
+
+[[unpublished.wasmtime-wasi-nn]]
+version = "46.0.0"
+audited_as = "44.0.1"
 
 [[unpublished.wasmtime-wasi-threads]]
 version = "45.0.0"
 audited_as = "43.0.1"
 
+[[unpublished.wasmtime-wasi-threads]]
+version = "46.0.0"
+audited_as = "44.0.1"
+
 [[unpublished.wasmtime-wasi-tls]]
 version = "45.0.0"
 audited_as = "43.0.1"
+
+[[unpublished.wasmtime-wasi-tls]]
+version = "46.0.0"
+audited_as = "44.0.1"
 
 [[unpublished.wasmtime-wast]]
 version = "45.0.0"
 audited_as = "43.0.1"
 
+[[unpublished.wasmtime-wast]]
+version = "46.0.0"
+audited_as = "44.0.1"
+
 [[unpublished.wasmtime-wizer]]
 version = "45.0.0"
 audited_as = "43.0.1"
+
+[[unpublished.wasmtime-wizer]]
+version = "46.0.0"
+audited_as = "44.0.1"
 
 [[unpublished.wiggle]]
 version = "45.0.0"
 audited_as = "43.0.1"
 
+[[unpublished.wiggle]]
+version = "46.0.0"
+audited_as = "44.0.1"
+
 [[unpublished.wiggle-generate]]
 version = "45.0.0"
 audited_as = "43.0.1"
 
+[[unpublished.wiggle-generate]]
+version = "46.0.0"
+audited_as = "44.0.1"
+
 [[unpublished.wiggle-macro]]
 version = "45.0.0"
 audited_as = "43.0.1"
+
+[[unpublished.wiggle-macro]]
+version = "46.0.0"
+audited_as = "44.0.1"
 
 [[unpublished.wiggle-test]]
 version = "0.0.0"
@@ -236,6 +464,10 @@ audited_as = "0.1.0"
 [[unpublished.winch-codegen]]
 version = "45.0.0"
 audited_as = "43.0.1"
+
+[[unpublished.winch-codegen]]
+version = "46.0.0"
+audited_as = "44.0.1"
 
 [[publisher.aho-corasick]]
 version = "1.0.2"
@@ -447,103 +679,103 @@ user-login = "jrmuizel"
 user-name = "Jeff Muizelaar"
 
 [[publisher.cranelift]]
-version = "0.130.1"
-when = "2026-04-09"
+version = "0.131.1"
+when = "2026-04-30"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-assembler-x64]]
-version = "0.130.1"
-when = "2026-04-09"
+version = "0.131.1"
+when = "2026-04-30"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-assembler-x64-meta]]
-version = "0.130.1"
-when = "2026-04-09"
+version = "0.131.1"
+when = "2026-04-30"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-bforest]]
-version = "0.130.1"
-when = "2026-04-09"
+version = "0.131.1"
+when = "2026-04-30"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-bitset]]
-version = "0.130.1"
-when = "2026-04-09"
+version = "0.131.1"
+when = "2026-04-30"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-codegen]]
-version = "0.130.1"
-when = "2026-04-09"
+version = "0.131.1"
+when = "2026-04-30"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-codegen-meta]]
-version = "0.130.1"
-when = "2026-04-09"
+version = "0.131.1"
+when = "2026-04-30"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-codegen-shared]]
-version = "0.130.1"
-when = "2026-04-09"
+version = "0.131.1"
+when = "2026-04-30"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-control]]
-version = "0.130.1"
-when = "2026-04-09"
+version = "0.131.1"
+when = "2026-04-30"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-entity]]
-version = "0.130.1"
-when = "2026-04-09"
+version = "0.131.1"
+when = "2026-04-30"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-frontend]]
-version = "0.130.1"
-when = "2026-04-09"
+version = "0.131.1"
+when = "2026-04-30"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-interpreter]]
-version = "0.130.1"
-when = "2026-04-09"
+version = "0.131.1"
+when = "2026-04-30"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-isle]]
-version = "0.130.1"
-when = "2026-04-09"
+version = "0.131.1"
+when = "2026-04-30"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-jit]]
-version = "0.130.1"
-when = "2026-04-09"
+version = "0.131.1"
+when = "2026-04-30"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-module]]
-version = "0.130.1"
-when = "2026-04-09"
+version = "0.131.1"
+when = "2026-04-30"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-native]]
-version = "0.130.1"
-when = "2026-04-09"
+version = "0.131.1"
+when = "2026-04-30"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-object]]
-version = "0.130.1"
-when = "2026-04-09"
+version = "0.131.1"
+when = "2026-04-30"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-reader]]
-version = "0.130.1"
-when = "2026-04-09"
+version = "0.131.1"
+when = "2026-04-30"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-serde]]
-version = "0.130.1"
-when = "2026-04-09"
+version = "0.131.1"
+when = "2026-04-30"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-srcgen]]
-version = "0.130.1"
-when = "2026-04-09"
+version = "0.131.1"
+when = "2026-04-30"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.derive_arbitrary]]
@@ -870,13 +1102,13 @@ user-login = "dtolnay"
 user-name = "David Tolnay"
 
 [[publisher.pulley-interpreter]]
-version = "43.0.1"
-when = "2026-04-09"
+version = "44.0.1"
+when = "2026-04-30"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.pulley-macros]]
-version = "43.0.1"
-when = "2026-04-09"
+version = "44.0.1"
+when = "2026-04-30"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.quote]]
@@ -1195,8 +1427,8 @@ user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
 [[publisher.wasi-common]]
-version = "43.0.1"
-when = "2026-04-09"
+version = "44.0.1"
+when = "2026-04-30"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasip1]]
@@ -1317,158 +1549,158 @@ when = "2026-04-28"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
 [[publisher.wasmtime]]
-version = "43.0.1"
-when = "2026-04-09"
+version = "44.0.1"
+when = "2026-04-30"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-cli]]
-version = "43.0.1"
-when = "2026-04-09"
+version = "44.0.1"
+when = "2026-04-30"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-cli-flags]]
-version = "43.0.1"
-when = "2026-04-09"
+version = "44.0.1"
+when = "2026-04-30"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-environ]]
-version = "43.0.1"
-when = "2026-04-09"
+version = "44.0.1"
+when = "2026-04-30"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-c-api-macros]]
-version = "43.0.1"
-when = "2026-04-09"
+version = "44.0.1"
+when = "2026-04-30"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-cache]]
-version = "43.0.1"
-when = "2026-04-09"
+version = "44.0.1"
+when = "2026-04-30"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-component-macro]]
-version = "43.0.1"
-when = "2026-04-09"
+version = "44.0.1"
+when = "2026-04-30"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-component-util]]
-version = "43.0.1"
-when = "2026-04-09"
+version = "44.0.1"
+when = "2026-04-30"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-core]]
-version = "43.0.1"
-when = "2026-04-09"
+version = "44.0.1"
+when = "2026-04-30"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-cranelift]]
-version = "43.0.1"
-when = "2026-04-09"
+version = "44.0.1"
+when = "2026-04-30"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-debugger]]
-version = "43.0.1"
-when = "2026-04-09"
+version = "44.0.1"
+when = "2026-04-30"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-explorer]]
-version = "43.0.1"
-when = "2026-04-09"
+version = "44.0.1"
+when = "2026-04-30"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-fiber]]
-version = "43.0.1"
-when = "2026-04-09"
+version = "44.0.1"
+when = "2026-04-30"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-gdbstub-component-artifact]]
-version = "44.0.0"
-when = "2026-04-20"
+version = "44.0.1"
+when = "2026-04-30"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-jit-debug]]
-version = "43.0.1"
-when = "2026-04-09"
+version = "44.0.1"
+when = "2026-04-30"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-jit-icache-coherence]]
-version = "43.0.1"
-when = "2026-04-09"
+version = "44.0.1"
+when = "2026-04-30"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-unwinder]]
-version = "43.0.1"
-when = "2026-04-09"
+version = "44.0.1"
+when = "2026-04-30"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-versioned-export-macros]]
-version = "43.0.1"
-when = "2026-04-09"
+version = "44.0.1"
+when = "2026-04-30"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-winch]]
-version = "43.0.1"
-when = "2026-04-09"
+version = "44.0.1"
+when = "2026-04-30"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-wit-bindgen]]
-version = "43.0.1"
-when = "2026-04-09"
+version = "44.0.1"
+when = "2026-04-30"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-wmemcheck]]
-version = "43.0.1"
-when = "2026-04-09"
+version = "44.0.1"
+when = "2026-04-30"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wasi]]
-version = "43.0.1"
-when = "2026-04-09"
+version = "44.0.1"
+when = "2026-04-30"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wasi-config]]
-version = "43.0.1"
-when = "2026-04-09"
+version = "44.0.1"
+when = "2026-04-30"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wasi-http]]
-version = "43.0.1"
-when = "2026-04-09"
+version = "44.0.1"
+when = "2026-04-30"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wasi-io]]
-version = "43.0.1"
-when = "2026-04-09"
+version = "44.0.1"
+when = "2026-04-30"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wasi-keyvalue]]
-version = "43.0.1"
-when = "2026-04-09"
+version = "44.0.1"
+when = "2026-04-30"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wasi-nn]]
-version = "43.0.1"
-when = "2026-04-09"
+version = "44.0.1"
+when = "2026-04-30"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wasi-threads]]
-version = "43.0.1"
-when = "2026-04-09"
+version = "44.0.1"
+when = "2026-04-30"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wasi-tls]]
-version = "43.0.1"
-when = "2026-04-09"
+version = "44.0.1"
+when = "2026-04-30"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wast]]
-version = "43.0.1"
-when = "2026-04-09"
+version = "44.0.1"
+when = "2026-04-30"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wizer]]
-version = "43.0.1"
-when = "2026-04-09"
+version = "44.0.1"
+when = "2026-04-30"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wast]]
@@ -1482,18 +1714,18 @@ when = "2026-04-28"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
 [[publisher.wiggle]]
-version = "43.0.1"
-when = "2026-04-09"
+version = "44.0.1"
+when = "2026-04-30"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wiggle-generate]]
-version = "43.0.1"
-when = "2026-04-09"
+version = "44.0.1"
+when = "2026-04-30"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wiggle-macro]]
-version = "43.0.1"
-when = "2026-04-09"
+version = "44.0.1"
+when = "2026-04-30"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wiggle-test]]
@@ -1511,8 +1743,8 @@ user-login = "BurntSushi"
 user-name = "Andrew Gallant"
 
 [[publisher.winch-codegen]]
-version = "43.0.1"
-when = "2026-04-09"
+version = "44.0.1"
+when = "2026-04-30"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.windows]]


### PR DESCRIPTION
This is an [automated pull request][process] from CI which indicates that the next [`release-45.0.0` branch][branch] has been created and the `main` branch is getting its version number bumped from 45.0.0 to 46.0.0.

Maintainers should take a moment to review the [release notes][RELEASES.md] for 45.0.0 and any updates should be made directly to the [release branch][branch].

Another automated PR will be made in roughly 2 weeks time when for the actual release itself.

If any issues arise on the `main` branch before the release is made then the issue should first be fixed on `main` and then backport to the `release-45.0.0` branch.

[RELEASES.md]: https://github.com/bytecodealliance/wasmtime/blob/release-45.0.0/RELEASES.md
[branch]: https://github.com/bytecodealliance/wasmtime/tree/release-45.0.0
[process]: https://docs.wasmtime.dev/contributing-release-process.html
