### PR TITLE
Some more config massaging for `.wast` tests and GC and fuzzing

### DIFF
--- a/crates/fuzzing/src/generators/config.rs
+++ b/crates/fuzzing/src/generators/config.rs
@@ -204,6 +204,9 @@ impl Config {
         if let Some(n) = &mut self.wasmtime.memory_config.memory_reservation {
             *n = (*n).max(limits::MEMORY_SIZE as u64);
         }
+        if let Some(n) = &mut self.wasmtime.memory_config.gc_heap_reservation {
+            *n = (*n).max(limits::GC_HEAP_SIZE as u64);
+        }
 
         // FIXME: it might be more ideal to avoid the need for this entirely
         // and to just let the test fail. If a test fails due to a pooling
@@ -238,7 +241,10 @@ impl Config {
                 .max_memories_per_component
                 .max(limits::MEMORIES_PER_MODULE);
             pooling.total_core_instances = pooling.total_core_instances.max(limits::CORE_INSTANCES);
-            pooling.max_memory_size = pooling.max_memory_size.max(limits::MEMORY_SIZE);
+            pooling.max_memory_size = pooling
+                .max_memory_size
+                .max(limits::MEMORY_SIZE)
+                .max(limits::GC_HEAP_SIZE);
             pooling.table_elements = pooling.table_elements.max(limits::TABLE_ELEMENTS);
             pooling.core_instance_size = pooling.core_instance_size.max(limits::CORE_INSTANCE_SIZE);
             pooling.component_instance_size = pooling
@@ -835,9 +841,20 @@ impl WasmtimeConfig {
         // When using the pooling allocator, GC heap tunables must match memory
         // tunables.
         if let InstanceAllocationStrategy::Pooling(_) = &self.strategy {
-            mcfg.gc_heap_reservation = mcfg.memory_reservation;
-            mcfg.gc_heap_guard_size = mcfg.memory_guard_size;
-            mcfg.gc_heap_reservation_for_growth = mcfg.memory_reservation_for_growth;
+            let reservation = mcfg.gc_heap_reservation.max(mcfg.memory_reservation);
+            mcfg.gc_heap_reservation = reservation;
+            mcfg.memory_reservation = reservation;
+
+            let guard_size = mcfg.gc_heap_guard_size.max(mcfg.memory_guard_size);
+            mcfg.gc_heap_guard_size = guard_size;
+            mcfg.memory_guard_size = guard_size;
+
+            let res_for_growth = mcfg
+                .gc_heap_reservation_for_growth
+                .max(mcfg.memory_reservation_for_growth);
+            mcfg.gc_heap_reservation_for_growth = res_for_growth;
+            mcfg.memory_reservation_for_growth = res_for_growth;
+
             // memory_may_move is not in MemoryConfig, but gc_heap_may_move
             // must not conflict. Set it to None so the default matches.
             mcfg.gc_heap_may_move = None;

--- a/crates/test-util/src/wast.rs
+++ b/crates/test-util/src/wast.rs
@@ -18,6 +18,7 @@ use wasmtime_environ::prelude::*;
 pub mod limits {
     pub const MEMORY_SIZE: usize = 805 << 16;
     pub const MEMORIES: u32 = 450;
+    pub const GC_HEAP_SIZE: usize = 1 << 16;
     pub const TABLES: u32 = 200;
     pub const MEMORIES_PER_MODULE: u32 = 9;
     pub const TABLES_PER_MODULE: u32 = 5;


### PR DESCRIPTION
Should hopefully resolve issues I'm seeing in CI like

```
failures:

---- oracles::tests::wast_smoke_test stdout ----

thread 'oracles::tests::wast_smoke_test' (7102) panicked at crates/fuzzing/src/oracles.rs:777:10:
called `Result::unwrap()` on an `Err` value: failed directive on /home/runner/work/wasmtime/wasmtime/tests/misc_testsuite/gc/binary-tree.wast:64

Caused by:
    0: error while executing at wasm backtrace:
    0:     0x82 - <unknown>!build
    1:     0x67 - <unknown>!build
    2:     0x67 - <unknown>!build
    3:     0x67 - <unknown>!build
    4:     0x67 - <unknown>!build
    5:     0xb3 - <unknown>!<wasm function 3>
note: using the `WASMTIME_BACKTRACE_DETAILS=1` environment variable may show more debugging information
    1: GC heap out of memory: no capacity for allocation of 40 bytes

note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

failures:
    oracles::tests::wast_smoke_test
```

https://github.com/bytecodealliance/wasmtime/actions/runs/25401865884/job/74503282576#step:4:489

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
