### PR TITLE
fuzzing: Disable inlining when stack-switching is enabled

### DIFF
--- a/crates/fuzzing/src/generators/config.rs
+++ b/crates/fuzzing/src/generators/config.rs
@@ -201,6 +201,10 @@ impl Config {
             config.max_memories = 1;
         }
 
+        if self.module_config.stack_switching {
+            self.wasmtime.inlining = Some(Inlining::No);
+        }
+
         if let Some(n) = &mut self.wasmtime.memory_config.memory_reservation {
             *n = (*n).max(limits::MEMORY_SIZE as u64);
         }


### PR DESCRIPTION
Needed for the one wast test we have that uses stack-switching.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
