### PR TITLE
Add a bunch of `#[test]`s for `StructRef`

### DIFF
--- a/tests/all/structs.rs
+++ b/tests/all/structs.rs
@@ -752,6 +752,130 @@ fn struct_ref_struct_in_same_rec_group_in_global() -> Result<()> {
     Ok(())
 }
 
+#[test]
+fn structref_to_anyref_rooted() -> Result<()> {
+    let mut store = gc_store()?;
+    let struct_ty = StructType::new(
+        store.engine(),
+        [FieldType::new(Mutability::Const, ValType::I32.into())],
+    )?;
+    let pre = StructRefPre::new(&mut store, struct_ty);
+    let s = StructRef::new(&mut store, &pre, &[Val::I32(10)])?;
+
+    // Rooted<StructRef>::to_anyref upcast
+    let any: Rooted<AnyRef> = s.to_anyref();
+    assert!(any.is_struct(&store)?);
+
+    Ok(())
+}
+
+#[test]
+fn structref_to_eqref_rooted() -> Result<()> {
+    let mut store = gc_store()?;
+    let struct_ty = StructType::new(
+        store.engine(),
+        [FieldType::new(Mutability::Const, ValType::I32.into())],
+    )?;
+    let pre = StructRefPre::new(&mut store, struct_ty);
+    let s = StructRef::new(&mut store, &pre, &[Val::I32(10)])?;
+
+    // Rooted<StructRef>::to_eqref upcast
+    let eq: Rooted<EqRef> = s.to_eqref();
+    assert!(eq.is_struct(&store)?);
+
+    Ok(())
+}
+
+#[test]
+fn structref_owned_to_anyref() -> Result<()> {
+    let mut store = gc_store()?;
+    let struct_ty = StructType::new(
+        store.engine(),
+        [FieldType::new(Mutability::Const, ValType::I32.into())],
+    )?;
+    let pre = StructRefPre::new(&mut store, struct_ty);
+    let s = StructRef::new(&mut store, &pre, &[Val::I32(5)])?;
+    let owned = s.to_owned_rooted(&mut store)?;
+
+    // OwnedRooted<StructRef>::to_anyref upcast
+    let any_owned: OwnedRooted<AnyRef> = owned.to_anyref();
+    let any = any_owned.to_rooted(&mut store);
+    assert!(any.is_struct(&store)?);
+
+    Ok(())
+}
+
+#[test]
+fn structref_owned_to_eqref() -> Result<()> {
+    let mut store = gc_store()?;
+    let struct_ty = StructType::new(
+        store.engine(),
+        [FieldType::new(Mutability::Const, ValType::I32.into())],
+    )?;
+    let pre = StructRefPre::new(&mut store, struct_ty);
+    let s = StructRef::new(&mut store, &pre, &[Val::I32(5)])?;
+    let owned = s.to_owned_rooted(&mut store)?;
+
+    // OwnedRooted<StructRef>::to_eqref upcast
+    let eq_owned: OwnedRooted<EqRef> = owned.to_eqref();
+    let eq = eq_owned.to_rooted(&mut store);
+    assert!(eq.is_struct(&store)?);
+
+    Ok(())
+}
+
+#[test]
+fn structref_ty() -> Result<()> {
+    let mut store = gc_store()?;
+    let struct_ty = StructType::new(
+        store.engine(),
+        [FieldType::new(Mutability::Const, ValType::I32.into())],
+    )?;
+    let pre = StructRefPre::new(&mut store, struct_ty.clone());
+    let s = StructRef::new(&mut store, &pre, &[Val::I32(99)])?;
+
+    let ty = s.ty(&store)?;
+    assert!(ty.matches(&struct_ty));
+
+    Ok(())
+}
+
+#[test]
+fn structref_matches_ty() -> Result<()> {
+    let mut store = gc_store()?;
+    let struct_ty = StructType::new(
+        store.engine(),
+        [FieldType::new(Mutability::Const, ValType::I32.into())],
+    )?;
+    let pre = StructRefPre::new(&mut store, struct_ty.clone());
+    let s = StructRef::new(&mut store, &pre, &[Val::I32(0)])?;
+
+    assert!(s.matches_ty(&store, &struct_ty)?);
+
+    Ok(())
+}
+
+#[test]
+fn structref_fields() -> Result<()> {
+    let mut store = gc_store()?;
+    let struct_ty = StructType::new(
+        store.engine(),
+        [
+            FieldType::new(Mutability::Const, ValType::I32.into()),
+            FieldType::new(Mutability::Const, ValType::I64.into()),
+        ],
+    )?;
+    let pre = StructRefPre::new(&mut store, struct_ty);
+    let s = StructRef::new(&mut store, &pre, &[Val::I32(11), Val::I64(22)])?;
+
+    let fields: Vec<Val> = s.fields(&mut store)?.collect();
+    assert_eq!(fields.len(), 2);
+    assert_eq!(fields[0].unwrap_i32(), 11);
+    assert_eq!(fields[1].unwrap_i64(), 22);
+
+    Ok(())
+}
+
 #[wasmtime_test(wasm_features(function_references, gc))]
 #[cfg_attr(miri, ignore)]
 fn issue_9714(config: &mut Config) -> Result<()> {


### PR DESCRIPTION
Continuing to fill out test coverage for GC stuff.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
