### PR TITLE
Fix returning `ThrownException` alone

### DIFF
--- a/crates/wasmtime/src/runtime.rs
+++ b/crates/wasmtime/src/runtime.rs
@@ -41,7 +41,6 @@ pub(crate) mod code;
 pub(crate) mod code_memory;
 #[cfg(feature = "debug")]
 pub(crate) mod debug;
-#[cfg(feature = "gc")]
 pub(crate) mod exception;
 pub(crate) mod externals;
 #[cfg(feature = "async")]
@@ -89,7 +88,6 @@ pub(crate) use bug::bail_bug;
 pub use code_memory::CodeMemory;
 #[cfg(feature = "debug")]
 pub use debug::*;
-#[cfg(feature = "gc")]
 pub use exception::*;
 pub use externals::*;
 pub use func::*;

--- a/crates/wasmtime/src/runtime/gc/disabled/rooting.rs
+++ b/crates/wasmtime/src/runtime/gc/disabled/rooting.rs
@@ -183,7 +183,7 @@ impl<T> OwnedRooted<T>
 where
     T: GcRef,
 {
-    pub fn clone(&self, _store: impl AsContextMut) -> Self {
+    pub fn clone(&self) -> Self {
         match self.inner {}
     }
 

--- a/crates/wasmtime/src/runtime/store.rs
+++ b/crates/wasmtime/src/runtime/store.rs
@@ -76,11 +76,6 @@
 //! contents of `StoreOpaque`. This is an invariant that we, as the authors of
 //! `wasmtime`, must uphold for the public interface to be safe.
 
-#[cfg(all(feature = "gc", feature = "debug"))]
-use crate::OwnedRooted;
-use crate::RootSet;
-#[cfg(feature = "gc")]
-use crate::ThrownException;
 use crate::error::OutOfMemory;
 #[cfg(feature = "async")]
 use crate::fiber;
@@ -101,9 +96,10 @@ use crate::trampoline::VMHostGlobalContext;
 #[cfg(feature = "debug")]
 use crate::{BreakpointState, DebugHandler, FrameDataCache};
 use crate::{Engine, Module, Val, ValRaw, module::ModuleRegistry};
-#[cfg(feature = "gc")]
-use crate::{ExnRef, Rooted};
+use crate::{ExnRef, OwnedRooted, RootSet};
 use crate::{Global, Instance, Table};
+#[cfg(feature = "gc")]
+use crate::{Rooted, ThrownException};
 use core::convert::Infallible;
 use core::fmt;
 #[cfg(any(feature = "async", feature = "gc"))]
@@ -1274,9 +1270,8 @@ impl<T> Store<T> {
     /// state, but should not be used as part of the ordinary
     /// exception-handling flow. For the most idiomatic handling, see
     /// [`StoreContextMut::throw`].
-    #[cfg(feature = "gc")]
     pub fn has_pending_exception(&self) -> bool {
-        self.inner.pending_exception.is_some()
+        self.inner.has_pending_exception()
     }
 
     /// Return all breakpoints.
@@ -1478,9 +1473,8 @@ impl<'a, T> StoreContextMut<'a, T> {
     /// Tests whether there is a pending exception.
     ///
     /// See [`Store::has_pending_exception`] for more details.
-    #[cfg(feature = "gc")]
     pub fn has_pending_exception(&self) -> bool {
-        self.0.inner.pending_exception.is_some()
+        self.0.inner.has_pending_exception()
     }
 }
 
@@ -2760,9 +2754,15 @@ at https://bytecodealliance.org/security.
     }
 
     /// Tests whether there is a pending exception.
-    #[cfg(feature = "gc")]
     pub fn has_pending_exception(&self) -> bool {
-        self.pending_exception.is_some()
+        #[cfg(feature = "gc")]
+        {
+            self.pending_exception.is_some()
+        }
+        #[cfg(not(feature = "gc"))]
+        {
+            false
+        }
     }
 
     #[cfg(feature = "gc")]
@@ -2774,19 +2774,25 @@ at https://bytecodealliance.org/security.
 
     /// Get an owned rooted reference to the pending exception,
     /// without taking it off the store.
-    #[cfg(all(feature = "gc", feature = "debug"))]
     pub(crate) fn pending_exception_owned_rooted(
         &mut self,
     ) -> Result<Option<OwnedRooted<ExnRef>>, crate::error::OutOfMemory> {
-        let mut nogc = AutoAssertNoGc::new(self);
-        nogc.pending_exception
-            .take()
-            .map(|vmexnref| {
-                let cloned = nogc.clone_gc_ref(vmexnref.as_gc_ref());
-                nogc.pending_exception = Some(cloned.into_exnref_unchecked());
-                OwnedRooted::new(&mut nogc, vmexnref.into())
-            })
-            .transpose()
+        #[cfg(all(feature = "gc", feature = "debug"))]
+        {
+            let mut nogc = AutoAssertNoGc::new(self);
+            nogc.pending_exception
+                .take()
+                .map(|vmexnref| {
+                    let cloned = nogc.clone_gc_ref(vmexnref.as_gc_ref());
+                    nogc.pending_exception = Some(cloned.into_exnref_unchecked());
+                    OwnedRooted::new(&mut nogc, vmexnref.into())
+                })
+                .transpose()
+        }
+        #[cfg(not(all(feature = "gc", feature = "debug")))]
+        {
+            Ok(None)
+        }
     }
 
     #[cfg(feature = "gc")]

--- a/crates/wasmtime/src/runtime/store.rs
+++ b/crates/wasmtime/src/runtime/store.rs
@@ -76,6 +76,7 @@
 //! contents of `StoreOpaque`. This is an invariant that we, as the authors of
 //! `wasmtime`, must uphold for the public interface to be safe.
 
+use crate::RootSet;
 use crate::error::OutOfMemory;
 #[cfg(feature = "async")]
 use crate::fiber;
@@ -94,12 +95,11 @@ use crate::runtime::vm::{
 };
 use crate::trampoline::VMHostGlobalContext;
 #[cfg(feature = "debug")]
-use crate::{BreakpointState, DebugHandler, FrameDataCache};
+use crate::{BreakpointState, DebugHandler, FrameDataCache, OwnedRooted};
 use crate::{Engine, Module, Val, ValRaw, module::ModuleRegistry};
-use crate::{ExnRef, OwnedRooted, RootSet};
-use crate::{Global, Instance, Table};
 #[cfg(feature = "gc")]
-use crate::{Rooted, ThrownException};
+use crate::{ExnRef, Rooted, ThrownException};
+use crate::{Global, Instance, Table};
 use core::convert::Infallible;
 use core::fmt;
 #[cfg(any(feature = "async", feature = "gc"))]
@@ -2774,10 +2774,11 @@ at https://bytecodealliance.org/security.
 
     /// Get an owned rooted reference to the pending exception,
     /// without taking it off the store.
+    #[cfg(feature = "debug")]
     pub(crate) fn pending_exception_owned_rooted(
         &mut self,
-    ) -> Result<Option<OwnedRooted<ExnRef>>, crate::error::OutOfMemory> {
-        #[cfg(all(feature = "gc", feature = "debug"))]
+    ) -> Result<Option<OwnedRooted<crate::ExnRef>>, crate::error::OutOfMemory> {
+        #[cfg(feature = "gc")]
         {
             let mut nogc = AutoAssertNoGc::new(self);
             nogc.pending_exception
@@ -2789,7 +2790,7 @@ at https://bytecodealliance.org/security.
                 })
                 .transpose()
         }
-        #[cfg(not(all(feature = "gc", feature = "debug")))]
+        #[cfg(not(feature = "gc"))]
         {
             Ok(None)
         }

--- a/crates/wasmtime/src/runtime/trap.rs
+++ b/crates/wasmtime/src/runtime/trap.rs
@@ -1,7 +1,5 @@
 #[cfg(feature = "coredump")]
 use super::coredump::WasmCoreDump;
-#[cfg(feature = "gc")]
-use crate::ThrownException;
 use crate::prelude::*;
 use crate::store::StoreOpaque;
 use crate::{AsContext, Module};
@@ -86,8 +84,6 @@ pub(crate) fn from_runtime_box(
         coredumpstack,
     } = *runtime_trap;
     let (mut error, pc) = match reason {
-        #[cfg(feature = "gc")]
-        crate::runtime::vm::TrapReason::Exception => (ThrownException.into(), None),
         // For user-defined errors they're already an `crate::Error` so no
         // conversion is really necessary here, but a `backtrace` may have
         // been captured so it's attempted to get inserted here.

--- a/crates/wasmtime/src/runtime/vm/libcalls.rs
+++ b/crates/wasmtime/src/runtime/vm/libcalls.rs
@@ -1698,18 +1698,14 @@ fn get_instance_id(_store: &mut dyn VMStore, instance: InstanceId) -> u32 {
 }
 
 #[cfg(feature = "gc")]
-fn throw_ref(
-    store: &mut dyn VMStore,
-    _instance: InstanceId,
-    exnref: u32,
-) -> Result<(), TrapReason> {
+fn throw_ref(store: &mut dyn VMStore, _instance: InstanceId, exnref: u32) -> Result<()> {
     let exnref = VMGcRef::from_raw_u32(exnref).ok_or_else(|| Trap::NullReference)?;
     let exnref = store.unwrap_gc_store_mut().clone_gc_ref(&exnref);
     let exnref = exnref
         .into_exnref(&*store.unwrap_gc_store().gc_heap)
         .expect("gc ref should be an exception object");
     store.set_pending_exception(exnref);
-    Err(TrapReason::Exception)
+    Err(crate::ThrownException.into())
 }
 
 fn breakpoint(store: &mut dyn VMStore, _instance: InstanceId) -> Result<()> {

--- a/crates/wasmtime/src/runtime/vm/traphandlers.rs
+++ b/crates/wasmtime/src/runtime/vm/traphandlers.rs
@@ -28,6 +28,7 @@ use crate::{StoreContextMut, WasmBacktrace};
 use core::cell::Cell;
 use core::num::NonZeroU32;
 use core::ptr::{self, NonNull};
+use wasmtime_core::alloc::PanicOnOom;
 use wasmtime_unwinder::Handler;
 
 #[cfg(feature = "debug")]
@@ -357,7 +358,16 @@ pub struct Trap {
 /// for an exception).
 #[derive(Debug)]
 pub enum TrapReason {
-    /// A user-raised trap through `raise_user_trap`.
+    /// A user-defined error has been raised, such as through a host function
+    /// call.
+    ///
+    /// This is constructed naturally through various `From` conversions leading
+    /// into a `TrapReason`. For example host functions returning `Result<()>`
+    /// will have any errors put here.
+    ///
+    /// Note that this variant can also represent an embedder-thrown exception.
+    /// Embedder-thrown exceptions are encoded as `ThrownException.into()` which
+    /// then looks for various handlers on the stack.
     User(Error),
 
     /// A trap raised from Cranelift-generated code.
@@ -385,26 +395,10 @@ pub enum TrapReason {
 
     /// A trap raised from a wasm libcall
     Wasm(wasmtime_environ::Trap),
-
-    /// An exception.
-    ///
-    /// Note that internally, exceptions are rooted on the Store, while
-    /// when crossing the public API, exceptions are held in a
-    /// `wasmtime::Exception` which contains a boxed root and implements
-    /// `Error`. This choice is intentional, to keep the internal
-    /// implementation lightweight and ensure the types represent only
-    /// allowable states.
-    #[cfg(feature = "gc")]
-    Exception,
 }
 
 impl From<Error> for TrapReason {
     fn from(error: Error) -> Self {
-        #[cfg(feature = "gc")]
-        if error.is::<ThrownException>() {
-            return TrapReason::Exception;
-        }
-
         TrapReason::User(error)
     }
 }
@@ -435,12 +429,6 @@ where
 
     match result {
         Ok(x) => Ok(x),
-        #[cfg(feature = "gc")]
-        Err(UnwindState::UnwindToHost {
-            reason: UnwindReason::Trap(TrapReason::Exception),
-            backtrace: _,
-            coredump_stack: _,
-        }) => Err(ThrownException.into()),
         Err(UnwindState::UnwindToHost {
             reason: UnwindReason::Trap(reason),
             backtrace,
@@ -759,37 +747,39 @@ impl CallThreadState {
             #[cfg(all(feature = "std", panic = "unwind"))]
             UnwindReason::Panic(err) => {
                 // Panics don't need backtraces. There is nowhere to attach the
-                // hypothetical backtrace to and it doesn't really make sense to try
-                // in the first place since this is a Rust problem rather than a
-                // Wasm problem.
+                // hypothetical backtrace to and it doesn't really make sense to
+                // try in the first place since this is a Rust problem rather
+                // than a Wasm problem.
                 UnwindState::UnwindToHost {
                     reason: UnwindReason::Panic(err),
                     backtrace: None,
                     coredump_stack: None,
                 }
             }
-            // An unwind due to an already-set pending exception
-            // triggers the handler-search stack-walk. We store the
-            // resolved handler if one exists. In either case, the
-            // exception remains rooted in the Store until we actually
-            // perform the unwind, and then gets taken and becomes the
-            // payload at that point.
+
+            // An unwind due to an already-set pending exception triggers the
+            // handler-search stack-walk. We store the resolved handler if one
+            // exists. In either case, the exception remains rooted in the Store
+            // until we actually perform the unwind, and then gets taken and
+            // becomes the payload at that point.
+            //
+            // Note that this search only happens if the store actually has a
+            // pending exception. If the embedder returned `ThrownException`
+            // without actually putting anything in the store then the lookup
+            // doesn't happen as there's nothing for wasm to catch.
             #[cfg(feature = "gc")]
-            UnwindReason::Trap(TrapReason::Exception) => {
-                // SAFETY: we are invoking `compute_handler()` while
-                // Wasm is on the stack and we have re-entered via a
-                // trampoline, as required by its stack-walking logic.
-                let handler = unsafe { compute_handler(store) };
-                match handler {
-                    Some(handler) => UnwindState::UnwindToWasm(handler),
-                    None => UnwindState::UnwindToHost {
-                        reason: UnwindReason::Trap(TrapReason::Exception),
-                        backtrace: None,
-                        coredump_stack: None,
-                    },
-                }
+            UnwindReason::Trap(TrapReason::User(err))
+                if err.is::<ThrownException>()
+                    && store.has_pending_exception()
+                    // SAFETY: we are invoking `compute_handler()` while Wasm is
+                    // on the stack and we have re-entered via a trampoline, as
+                    // required by its stack-walking logic.
+                    && let Some(handler) = unsafe { compute_handler(store) } =>
+            {
+                UnwindState::UnwindToWasm(handler)
             }
-            // And if we are just propagating an existing trap that already has
+
+            // If we are just propagating an existing trap that already has
             // a backtrace attached to it, then there is no need to capture a
             // new backtrace either.
             UnwindReason::Trap(TrapReason::User(err))
@@ -801,6 +791,7 @@ impl CallThreadState {
                     coredump_stack: None,
                 }
             }
+
             UnwindReason::Trap(trap) => {
                 log::trace!("Capturing backtrace and coredump for {trap:?}");
                 UnwindState::UnwindToHost {
@@ -848,23 +839,6 @@ impl CallThreadState {
                         .expect("exception should be set when we are throwing");
                     store.block_on_debug_handler(crate::DebugEvent::CaughtExceptionThrown(exn))
                 }
-                #[cfg(feature = "gc")]
-                UnwindState::UnwindToHost {
-                    reason: UnwindReason::Trap(TrapReason::Exception),
-                    ..
-                } => {
-                    use wasmtime_core::alloc::PanicOnOom;
-
-                    let exn = store
-                        .as_store_opaque()
-                        .pending_exception_owned_rooted()
-                        // TODO(#12069): handle allocation failure here
-                        .panic_on_oom()
-                        .expect("exception should be set when we are throwing");
-                    store.block_on_debug_handler(crate::DebugEvent::UncaughtExceptionThrown(
-                        exn.clone(),
-                    ))
-                }
                 UnwindState::UnwindToHost {
                     reason: UnwindReason::Trap(TrapReason::Wasm(trap)),
                     ..
@@ -872,7 +846,27 @@ impl CallThreadState {
                 UnwindState::UnwindToHost {
                     reason: UnwindReason::Trap(TrapReason::User(err)),
                     ..
-                } => store.block_on_debug_handler(crate::DebugEvent::HostcallError(err)),
+                } => {
+                    // This is either a hostcall error or an uncaught wasm
+                    // exception, and it depends on the state of the store and
+                    // the error itself. Note that even if `err` is
+                    // `ThrownException` we still need to check the store to see
+                    // if it has a pending exception because it's possible to do
+                    // one without the other. Only when both match is this
+                    // considered an uncaught wasm exception.
+                    let event = if err.is::<ThrownException>()
+                        && let Some(exn) = store
+                            .as_store_opaque()
+                            .pending_exception_owned_rooted()
+                            // TODO(#12069): handle allocation failure here
+                            .panic_on_oom()
+                    {
+                        crate::DebugEvent::UncaughtExceptionThrown(exn.clone())
+                    } else {
+                        crate::DebugEvent::HostcallError(err)
+                    };
+                    store.block_on_debug_handler(event)
+                }
 
                 UnwindState::UnwindToHost {
                     reason: UnwindReason::Trap(TrapReason::Jit { .. }),

--- a/crates/wasmtime/src/runtime/vm/traphandlers.rs
+++ b/crates/wasmtime/src/runtime/vm/traphandlers.rs
@@ -28,7 +28,7 @@ use crate::{StoreContextMut, WasmBacktrace};
 use core::cell::Cell;
 use core::num::NonZeroU32;
 use core::ptr::{self, NonNull};
-#[cfg(feature = "gc")]
+#[cfg(all(feature = "debug", feature = "gc"))]
 use wasmtime_core::alloc::PanicOnOom;
 use wasmtime_unwinder::Handler;
 

--- a/crates/wasmtime/src/runtime/vm/traphandlers.rs
+++ b/crates/wasmtime/src/runtime/vm/traphandlers.rs
@@ -15,20 +15,16 @@ mod signals;
 #[cfg(all(has_native_signals))]
 pub use self::signals::*;
 
-#[cfg(feature = "gc")]
 use crate::ThrownException;
 use crate::runtime::module::lookup_code;
 use crate::runtime::store::{ExecutorRef, StoreOpaque};
 use crate::runtime::vm::sys::traphandlers;
 use crate::runtime::vm::{InterpreterRef, VMContext, VMStore, VMStoreContext, f32x4, f64x2, i8x16};
-#[cfg(all(feature = "debug", feature = "gc"))]
-use crate::store::AsStoreOpaque;
 use crate::{EntryStoreContext, prelude::*};
 use crate::{StoreContextMut, WasmBacktrace};
 use core::cell::Cell;
 use core::num::NonZeroU32;
 use core::ptr::{self, NonNull};
-#[cfg(all(feature = "debug", feature = "gc"))]
 use wasmtime_core::alloc::PanicOnOom;
 use wasmtime_unwinder::Handler;
 
@@ -758,42 +754,43 @@ impl CallThreadState {
                 }
             }
 
-            // An unwind due to an already-set pending exception triggers the
-            // handler-search stack-walk. We store the resolved handler if one
-            // exists. In either case, the exception remains rooted in the Store
-            // until we actually perform the unwind, and then gets taken and
-            // becomes the payload at that point.
-            //
-            // Note that this search only happens if the store actually has a
-            // pending exception. If the embedder returned `ThrownException`
-            // without actually putting anything in the store then the lookup
-            // doesn't happen as there's nothing for wasm to catch.
-            #[cfg(feature = "gc")]
-            UnwindReason::Trap(TrapReason::User(err))
-                if err.is::<ThrownException>()
+            UnwindReason::Trap(trap) => 'arm: {
+                // An unwind due to an already-set pending exception triggers the
+                // handler-search stack-walk. We store the resolved handler if one
+                // exists. In either case, the exception remains rooted in the Store
+                // until we actually perform the unwind, and then gets taken and
+                // becomes the payload at that point.
+                //
+                // Note that this search only happens if the store actually has a
+                // pending exception. If the embedder returned `ThrownException`
+                // without actually putting anything in the store then the lookup
+                // doesn't happen as there's nothing for wasm to catch.
+                //
+                // SAFETY: we are invoking `compute_handler()` while Wasm is on
+                // the stack and we have re-entered via a trampoline, as
+                // required by its stack-walking logic.
+                #[cfg(feature = "gc")]
+                if let TrapReason::User(err) = &trap
+                    && err.is::<ThrownException>()
                     && store.has_pending_exception()
-                    // SAFETY: we are invoking `compute_handler()` while Wasm is
-                    // on the stack and we have re-entered via a trampoline, as
-                    // required by its stack-walking logic.
-                    && let Some(handler) = unsafe { compute_handler(store) } =>
-            {
-                UnwindState::UnwindToWasm(handler)
-            }
-
-            // If we are just propagating an existing trap that already has
-            // a backtrace attached to it, then there is no need to capture a
-            // new backtrace either.
-            UnwindReason::Trap(TrapReason::User(err))
-                if err.downcast_ref::<WasmBacktrace>().is_some() =>
-            {
-                UnwindState::UnwindToHost {
-                    reason: UnwindReason::Trap(TrapReason::User(err)),
-                    backtrace: None,
-                    coredump_stack: None,
+                    && let Some(handler) = unsafe { compute_handler(store) }
+                {
+                    break 'arm UnwindState::UnwindToWasm(handler);
                 }
-            }
 
-            UnwindReason::Trap(trap) => {
+                // If we are just propagating an existing trap that already has
+                // a backtrace attached to it, then there is no need to capture
+                // a new backtrace either.
+                if let TrapReason::User(err) = &trap
+                    && err.downcast_ref::<WasmBacktrace>().is_some()
+                {
+                    break 'arm UnwindState::UnwindToHost {
+                        reason: UnwindReason::Trap(trap),
+                        backtrace: None,
+                        coredump_stack: None,
+                    };
+                }
+
                 log::trace!("Capturing backtrace and coredump for {trap:?}");
                 UnwindState::UnwindToHost {
                     reason: UnwindReason::Trap(trap),
@@ -829,9 +826,8 @@ impl CallThreadState {
             let result = match &unwind {
                 #[cfg(feature = "gc")]
                 UnwindState::UnwindToWasm(_) => {
-                    assert!(store.as_store_opaque().has_pending_exception());
+                    assert!(store.has_pending_exception());
                     let exn = store
-                        .as_store_opaque()
                         .pending_exception_owned_rooted()
                         // TODO(#12069): handle allocation failure here
                         .panic_on_oom()
@@ -843,30 +839,27 @@ impl CallThreadState {
                     ..
                 } => store.block_on_debug_handler(crate::DebugEvent::Trap(*trap)),
 
-                // For `ThrownException` errors that indicates that we should
-                // look at the store to see if there's a pending exception
-                // there, and if so then that's a different debug event than the
-                // `HostcallError` below.
-                #[cfg(feature = "gc")]
                 UnwindState::UnwindToHost {
                     reason: UnwindReason::Trap(TrapReason::User(err)),
                     ..
-                } if err.is::<ThrownException>()
-                    && let Some(exn) = store
-                        .as_store_opaque()
-                        .pending_exception_owned_rooted()
-                        // TODO(#12069): handle allocation failure here
-                        .panic_on_oom() =>
-                {
-                    store.block_on_debug_handler(crate::DebugEvent::UncaughtExceptionThrown(
-                        exn.clone(),
-                    ))
+                } => {
+                    // For `ThrownException` errors that indicates that we
+                    // should look at the store to see if there's a pending
+                    // exception there, and if so then that's a different debug
+                    // event than the `HostcallError` below.
+                    if err.is::<ThrownException>()
+                        && let Some(exn) = store
+                            .pending_exception_owned_rooted()
+                            // TODO(#12069): handle allocation failure here
+                            .panic_on_oom()
+                    {
+                        store.block_on_debug_handler(crate::DebugEvent::UncaughtExceptionThrown(
+                            exn.clone(),
+                        ))
+                    } else {
+                        store.block_on_debug_handler(crate::DebugEvent::HostcallError(err))
+                    }
                 }
-
-                UnwindState::UnwindToHost {
-                    reason: UnwindReason::Trap(TrapReason::User(err)),
-                    ..
-                } => store.block_on_debug_handler(crate::DebugEvent::HostcallError(err)),
 
                 UnwindState::UnwindToHost {
                     reason: UnwindReason::Trap(TrapReason::Jit { .. }),

--- a/crates/wasmtime/src/runtime/vm/traphandlers.rs
+++ b/crates/wasmtime/src/runtime/vm/traphandlers.rs
@@ -28,6 +28,7 @@ use crate::{StoreContextMut, WasmBacktrace};
 use core::cell::Cell;
 use core::num::NonZeroU32;
 use core::ptr::{self, NonNull};
+#[cfg(feature = "gc")]
 use wasmtime_core::alloc::PanicOnOom;
 use wasmtime_unwinder::Handler;
 
@@ -828,8 +829,6 @@ impl CallThreadState {
             let result = match &unwind {
                 #[cfg(feature = "gc")]
                 UnwindState::UnwindToWasm(_) => {
-                    use wasmtime_core::alloc::PanicOnOom;
-
                     assert!(store.as_store_opaque().has_pending_exception());
                     let exn = store
                         .as_store_opaque()
@@ -843,30 +842,31 @@ impl CallThreadState {
                     reason: UnwindReason::Trap(TrapReason::Wasm(trap)),
                     ..
                 } => store.block_on_debug_handler(crate::DebugEvent::Trap(*trap)),
+
+                // For `ThrownException` errors that indicates that we should
+                // look at the store to see if there's a pending exception
+                // there, and if so then that's a different debug event than the
+                // `HostcallError` below.
+                #[cfg(feature = "gc")]
                 UnwindState::UnwindToHost {
                     reason: UnwindReason::Trap(TrapReason::User(err)),
                     ..
-                } => {
-                    // This is either a hostcall error or an uncaught wasm
-                    // exception, and it depends on the state of the store and
-                    // the error itself. Note that even if `err` is
-                    // `ThrownException` we still need to check the store to see
-                    // if it has a pending exception because it's possible to do
-                    // one without the other. Only when both match is this
-                    // considered an uncaught wasm exception.
-                    let event = if err.is::<ThrownException>()
-                        && let Some(exn) = store
-                            .as_store_opaque()
-                            .pending_exception_owned_rooted()
-                            // TODO(#12069): handle allocation failure here
-                            .panic_on_oom()
-                    {
-                        crate::DebugEvent::UncaughtExceptionThrown(exn.clone())
-                    } else {
-                        crate::DebugEvent::HostcallError(err)
-                    };
-                    store.block_on_debug_handler(event)
+                } if err.is::<ThrownException>()
+                    && let Some(exn) = store
+                        .as_store_opaque()
+                        .pending_exception_owned_rooted()
+                        // TODO(#12069): handle allocation failure here
+                        .panic_on_oom() =>
+                {
+                    store.block_on_debug_handler(crate::DebugEvent::UncaughtExceptionThrown(
+                        exn.clone(),
+                    ))
                 }
+
+                UnwindState::UnwindToHost {
+                    reason: UnwindReason::Trap(TrapReason::User(err)),
+                    ..
+                } => store.block_on_debug_handler(crate::DebugEvent::HostcallError(err)),
 
                 UnwindState::UnwindToHost {
                     reason: UnwindReason::Trap(TrapReason::Jit { .. }),

--- a/crates/wasmtime/src/runtime/vm/traphandlers.rs
+++ b/crates/wasmtime/src/runtime/vm/traphandlers.rs
@@ -15,6 +15,7 @@ mod signals;
 #[cfg(all(has_native_signals))]
 pub use self::signals::*;
 
+#[cfg(feature = "gc")]
 use crate::ThrownException;
 use crate::runtime::module::lookup_code;
 use crate::runtime::store::{ExecutorRef, StoreOpaque};
@@ -25,7 +26,6 @@ use crate::{StoreContextMut, WasmBacktrace};
 use core::cell::Cell;
 use core::num::NonZeroU32;
 use core::ptr::{self, NonNull};
-use wasmtime_core::alloc::PanicOnOom;
 use wasmtime_unwinder::Handler;
 
 #[cfg(feature = "debug")]
@@ -823,6 +823,9 @@ impl CallThreadState {
 
         #[cfg(feature = "debug")]
         {
+            use crate::ThrownException;
+            use wasmtime_core::alloc::PanicOnOom;
+
             let result = match &unwind {
                 #[cfg(feature = "gc")]
                 UnwindState::UnwindToWasm(_) => {

--- a/tests/all/exceptions.rs
+++ b/tests/all/exceptions.rs
@@ -242,3 +242,55 @@ fn gc_with_exnref_global(config: &mut Config) -> Result<()> {
 
     Ok(())
 }
+
+#[wasmtime_test(wasm_features(exceptions))]
+#[cfg_attr(miri, ignore)]
+fn thrown_exception_without_throwing(config: &mut Config) -> Result<()> {
+    let engine = Engine::new(config)?;
+    let mut store = Store::new(&engine, ());
+
+    let module = Module::new(
+        &engine,
+        r#"
+        (module
+            (import "" "" (func))
+
+            (func (export "run") call 0)
+        )
+        "#,
+    )?;
+
+    let func = Func::wrap(&mut store, || -> Result<()> { Err(ThrownException.into()) });
+    let instance = Instance::new(&mut store, &module, &[func.into()])?;
+    let func = instance.get_func(&mut store, "run").unwrap();
+    let err = func.call(&mut store, &[], &mut []).unwrap_err();
+    assert!(err.is::<ThrownException>());
+
+    Ok(())
+}
+
+#[wasmtime_test(wasm_features(exceptions))]
+#[cfg_attr(miri, ignore)]
+fn wasm_exceptions_have_backtraces(config: &mut Config) -> Result<()> {
+    let engine = Engine::new(config)?;
+    let mut store = Store::new(&engine, ());
+
+    let module = Module::new(
+        &engine,
+        r#"
+        (module
+            (tag $t0)
+
+            (func (export "run") throw $t0)
+        )
+        "#,
+    )?;
+
+    let instance = Instance::new(&mut store, &module, &[])?;
+    let func = instance.get_func(&mut store, "run").unwrap();
+    let err = func.call(&mut store, &[], &mut []).unwrap_err();
+    assert!(err.is::<ThrownException>());
+    assert!(err.is::<WasmBacktrace>());
+
+    Ok(())
+}


### PR DESCRIPTION
This commit adjust the exception-handling logic within `traphandlers.rs` to account for when embedders return `ThrownException` without actually putting an exception within the store. This refactoring was done by removing `TrapReason::Exception` entirely and instead reusing the `TrapReason::User(Error)` variant for all exceptions plus some extra guards about doing exception-related things when the store is actually missing an exception.

By preserving the error as-is this additionally keeps the original `Error` around in case it had more context. For example embedders could return `ThrownException.into()` and then attach more context to the error, but all of the context would be lost internally within Wasmtime when the error was discarded in favor of the `TrapReason::Exception` variant. Instead now the original `Error` is preserved to retain all context if it ends up getting uncaught or threaded through.

An additional fix here is that uncaught wasm-originating exceptions now execute the normal logic for "capture a stack trace". Previously the handling of `TrapReason::Exception` didn't account for this logic meaning that uncaught wasm exceptions would not report a backtrace.

Closes #13304

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
