### PR TITLE
OomTest: count allocations first, before injecting OOMs

### DIFF
--- a/crates/fuzzing/src/oom.rs
+++ b/crates/fuzzing/src/oom.rs
@@ -32,6 +32,9 @@ enum OomState {
     #[default]
     OutsideOomTest,
 
+    /// We are inside an OOM test's dry run, counting total allocations.
+    Counting { count: u32 },
+
     /// We are inside an OOM test and should inject an OOM when the counter
     /// reaches zero.
     OomOnAlloc {
@@ -112,6 +115,11 @@ unsafe impl GlobalAlloc for OomTestAllocator {
 
             match old_state {
                 OomState::OutsideOomTest => unreachable!("handled above"),
+
+                OomState::Counting { count } => {
+                    new_state = OomState::Counting { count: count + 1 };
+                    ptr = unsafe { std::alloc::System.alloc(layout) };
+                }
 
                 OomState::OomOnAlloc {
                     counter: 0,
@@ -259,9 +267,11 @@ impl OomTest {
 
     /// The same as `test` but `async`.
     pub async fn test_async(&self, test_func: impl AsyncFn() -> Result<()>) -> Result<()> {
+        let total_allocs = Self::count_allocations(&test_func).await?;
+
         let start = time::Instant::now();
 
-        for i in 0.. {
+        for i in 0..total_allocs {
             if self.max_iters.is_some_and(|n| i >= n)
                 || self.max_duration.is_some_and(|d| start.elapsed() >= d)
             {
@@ -281,11 +291,12 @@ impl OomTest {
             .await;
 
             match (result, oom_state) {
-                (_, OomState::OutsideOomTest) => unreachable!(),
+                (_, OomState::OutsideOomTest | OomState::Counting { .. }) => unreachable!(),
 
-                // The test function completed successfully before we ran out of
-                // allocation fuel, so we're done.
-                (Ok(()), OomState::OomOnAlloc { .. }) => break,
+                // The test function completed successfully before we reached
+                // this allocation point (allocation count may differ slightly
+                // between the counting run and OOM injection runs).
+                (Ok(()), OomState::OomOnAlloc { .. }) => {}
 
                 // We injected an OOM and the test function handled it
                 // correctly; continue to the next iteration.
@@ -311,6 +322,38 @@ impl OomTest {
         }
 
         Ok(())
+    }
+
+    /// Run the test function without injecting OOMs, counting allocations.
+    ///
+    /// Repeats until the count stabilizes across two consecutive runs,
+    /// since the first run may change internal state (e.g. grow hash map
+    /// capacities) that subsequent runs reuse.
+    async fn count_allocations(test_func: &impl AsyncFn() -> Result<()>) -> Result<u32> {
+        const MAX_DRY_RUN_ITERS: usize = 10;
+
+        let mut total_allocs = u32::MAX;
+        for i in 0..MAX_DRY_RUN_ITERS {
+            log::trace!("=== Counting allocations (dry run {i}) ===");
+            let future = std::pin::pin!(test_func());
+            let (result, oom_state) =
+                OomTestFuture::new(future, OomState::Counting { count: 0 }).await;
+            result?;
+            let count = match oom_state {
+                OomState::Counting { count } => count,
+                _ => unreachable!(),
+            };
+            log::trace!("=== Counted {count} allocations ===");
+            if count == total_allocs {
+                return Ok(total_allocs);
+            }
+            total_allocs = count;
+        }
+
+        bail!(
+            "allocation count did not stabilize after {MAX_DRY_RUN_ITERS} \
+             dry-run iterations (last count: {total_allocs})"
+        )
     }
 }
 

--- a/crates/wasmtime/src/runtime/type_registry.rs
+++ b/crates/wasmtime/src/runtime/type_registry.rs
@@ -143,6 +143,18 @@ impl Engine {
             .write()
             .register_module_types(gc_runtime, module_types)?;
 
+        // Wrap rec_groups in an Undo guard so that if any of the
+        // following fallible operations fail before we construct the
+        // TypeCollection, we properly decref the registered types.
+        let rec_groups = Undo::new(rec_groups, |rec_groups| {
+            let mut inner = registry.0.write();
+            for entry in &rec_groups {
+                if entry.decref("register_and_canonicalize_types cleanup") {
+                    inner.unregister_entry(entry.clone());
+                }
+            }
+        });
+
         // Then build our map from each function type's engine index to the
         // module-index of its trampoline. Trampoline functions are queried by
         // module-index in a compiled module, and doing this engine-to-module
@@ -169,6 +181,7 @@ impl Engine {
             module.canonicalize_for_runtime_usage(&mut |idx| types[idx]);
         }
 
+        let rec_groups = Undo::commit(rec_groups);
         Ok(TypeCollection {
             engine,
             rec_groups,


### PR DESCRIPTION
This is a precursor to adding a fuzzing mode which will count allocations and then choose a random `i` in `0..n` and inject an OOM on the `i`th allocation.

Also fix a bug where we would not unregister transitively referenced types if allocation failed in the middle of registering new types that was uncovered by this change.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
