### PR TITLE
Fix an off-by one assertion in Wasmtime

### DIFF
--- a/crates/wasmtime/src/runtime/vm/traphandlers.rs
+++ b/crates/wasmtime/src/runtime/vm/traphandlers.rs
@@ -1325,7 +1325,7 @@ pub(crate) mod tls {
         /// we're leaving (e.g. allocated for a fiber).
         pub fn assert_current_state_not_in_range(range: core::ops::Range<usize>) {
             let p = raw::get() as usize;
-            assert!(p < range.start || range.end < p);
+            assert!(!range.contains(&p));
         }
     }
 


### PR DESCRIPTION
When switching off a fiber in Wasmtime there's a guard check to ensure that the `CallThreadState` is no longer present on the stack that we're switching from. This assertion has an off-by-one that's technically unreachable in practice but the check is still incorrect. Use a slightly more idiomatic check to resolve this very minor issue.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
