### PR TITLE
aarch64: Fix bitop rule firing for floats

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/lower.isle
+++ b/cranelift/codegen/src/isa/aarch64/lower.isle
@@ -1365,7 +1365,7 @@
       (orr_not_shift ty (zero_reg) x amt))
 
 ;; Special-cases for fusing a bnot with bxor
-(rule 2 (lower (has_type (fits_in_64 ty) (bnot _ (bxor _ x y))))
+(rule 2 (lower (has_type (fits_in_64 (ty_int ty)) (bnot _ (bxor _ x y))))
       (alu_rs_imm_logic (ALUOp.EorNot) ty x y))
 (rule 3 (lower (has_type $I128 (bnot _ (bxor _ x y)))) (i128_alu_bitop (ALUOp.EorNot) $I64 x y))
 

--- a/cranelift/filetests/filetests/runtests/fp-bitops.clif
+++ b/cranelift/filetests/filetests/runtests/fp-bitops.clif
@@ -6,6 +6,7 @@ target riscv64
 target riscv64 has_c has_zcb
 target s390x has_mie3
 target x86_64
+target aarch64
 
 set opt_level=speed
 target s390x
@@ -13,6 +14,7 @@ target riscv64
 target riscv64 has_c has_zcb
 target s390x has_mie3
 target x86_64
+target aarch64
 
 function %test_bnot_f32(f32) -> f32 fast {
 block0(v0: f32):
@@ -77,3 +79,12 @@ block0(v0: f64, v1: f64):
 }
 
 ; run: %test_bxor_f64(0x1.ff, 0x1.0ff) == 0x0.f0fp-1022
+
+function %test_bnot_bxor_f32(f32, f32) -> f32 {
+block0(v0: f32, v1: f32):
+    v2 = bxor v0, v1
+    v3 = bnot v2
+    return v3
+}
+
+; run: %test_bnot_bxor_f32(0x1.ff, 0x1.0ff) == -sNaN:0x787ff


### PR DESCRIPTION
Lowering for `EorNot` is only applicable to integer types, so a clause is added here to specifically exclude floats.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
