### PR TITLE
aarch64: Simplify and improve handling of conditionals

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/inst.isle
+++ b/cranelift/codegen/src/isa/aarch64/inst.isle
@@ -2297,6 +2297,12 @@
          (MInst.AluRRR alu_op (operand_size ty) dst src1 src2)
          dst)))
 
+;; Should only be used for AdcS and SbcS
+(decl sbcs_side_effect (Type Reg Reg) ProducesFlags)
+(rule (sbcs_side_effect ty src1 src2)
+  (ProducesFlags.ProducesFlagsSideEffect
+    (MInst.AluRRR (ALUOp.SbcS) (operand_size ty) (writable_zero_reg) src1 src2)))
+
 ;; Helper for emitting `MInst.BitRR` instructions.
 (decl bit_rr (BitOp Type Reg) Reg)
 (rule (bit_rr op ty src)
@@ -2326,15 +2332,6 @@
       (let ((dst WritableReg (temp_writable_reg $I64)))
         (ProducesFlags.ProducesFlagsReturnsResultWithConsumer
          (MInst.AluRRR (ALUOp.SubS) (operand_size ty) dst src1 src2)
-         dst)))
-
-;; Helper for materializing a boolean value into a register from
-;; flags.
-(decl materialize_bool_result (Cond) ConsumesFlags)
-(rule (materialize_bool_result cond)
-      (let ((dst WritableReg (temp_writable_reg $I64)))
-        (ConsumesFlags.ConsumesFlagsReturnsReg
-         (MInst.CSet dst cond)
          dst)))
 
 (decl cmn_imm (OperandSize Reg Imm12) ProducesFlags)
@@ -3542,41 +3539,20 @@
 
 ;; Helper for generating a `trapif` instruction.
 
-(decl trap_if (ProducesFlags TrapCode Cond) InstOutput)
-(rule (trap_if flags trap_code cond)
-      (side_effect
-       (with_flags_side_effect flags
-        (ConsumesFlags.ConsumesFlagsSideEffect
-         (MInst.TrapIf (cond_br_cond cond) trap_code)))))
+(decl trap_if_cond (Cond TrapCode) ConsumesFlags)
+(rule (trap_if_cond cond trap_code)
+  (ConsumesFlags.ConsumesFlagsSideEffect
+    (MInst.TrapIf (cond_br_cond cond) trap_code)))
 
-;; Helpers for lowering `trapz` and `trapnz`.
-(type ZeroCond
-      (enum
-       Zero
-       NonZero))
+(decl trap_if_zero (Reg OperandSize TrapCode) SideEffectNoResult)
+(rule (trap_if_zero reg size trap_code)
+  (SideEffectNoResult.Inst
+    (MInst.TrapIf (cond_br_zero reg size) trap_code)))
 
-(decl zero_cond_to_cond_br (ZeroCond Reg OperandSize) CondBrKind)
-(rule (zero_cond_to_cond_br (ZeroCond.Zero) reg size)
-      (cond_br_zero reg size))
-
-(rule (zero_cond_to_cond_br (ZeroCond.NonZero) reg size)
-      (cond_br_not_zero reg size))
-
-(decl trap_if_val (ZeroCond Value TrapCode) InstOutput)
-(rule (trap_if_val zero_cond val @ (value_type (fits_in_64 _)) trap_code)
-      (let ((reg Reg (put_in_reg_zext64 val)))
-      (side_effect
-       (SideEffectNoResult.Inst
-        (MInst.TrapIf (zero_cond_to_cond_br zero_cond reg (operand_size $I64)) trap_code)))))
-
-(rule -1 (trap_if_val zero_cond val @ (value_type $I128) trap_code)
-  (let ((c ValueRegs (put_in_regs val))
-        (c_lo Reg (value_regs_get c 0))
-        (c_hi Reg (value_regs_get c 1))
-        (c_test Reg (orr $I64 c_lo c_hi)))
-      (side_effect
-       (SideEffectNoResult.Inst
-        (MInst.TrapIf (zero_cond_to_cond_br zero_cond c_test (operand_size $I64)) trap_code)))))
+(decl trap_if_not_zero (Reg OperandSize TrapCode) SideEffectNoResult)
+(rule (trap_if_not_zero reg size trap_code)
+  (SideEffectNoResult.Inst
+    (MInst.TrapIf (cond_br_not_zero reg size) trap_code)))
 
 ;; Immediate value helpers ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -4644,6 +4620,158 @@
             (_ Unit (emit (MInst.MachOTlsGetAddr name dst))))
         dst))
 
+;; Representation of the result of a conditional instruction.
+;;
+;; Each variant here has what produces some condition flags in addition to
+;; what condition code is being tested as a result of whatever produced the
+;; flags.
+;;
+;; This type is intended to be a "narrow waist" for anything producing a
+;; conditional which `icmp` might flow into for example.
+;;
+;; TODO: words
+(type CondResult (enum
+  (Zero (reg Reg) (size OperandSize))
+  (NotZero (reg Reg) (size OperandSize))
+  (Cond (flags ProducesFlags) (cond Cond))
+))
+
+(decl cond_result_invert (CondResult) CondResult)
+(rule (cond_result_invert (CondResult.Zero reg size)) (CondResult.NotZero reg size))
+(rule (cond_result_invert (CondResult.NotZero reg size)) (CondResult.Zero reg size))
+(rule (cond_result_invert (CondResult.Cond flags cc)) (CondResult.Cond flags (invert_cond cc)))
+
+(decl is_nonzero_cmp (Value) CondResult)
+
+(rule 1 (is_nonzero_cmp (maybe_uextend (fcmp _ cc a b))) (emit_fcmp cc a b))
+(rule 1 (is_nonzero_cmp (maybe_uextend (icmp _ cc a b))) (emit_icmp cc a b))
+(rule 0 (is_nonzero_cmp val) (is_nonzero val))
+
+;; Converts a `Value` to a `CondResult` with the condition being tested if
+;; `Value` is nonzero.
+;;
+;; Note that this is used as the base entry case for instruction lowering such
+;; as `select` and `brif`. The `Value` here is expected to, via CLIF validation,
+;; have an integer type (and it can be I128)
+(decl is_nonzero (Value) CondResult)
+(rule 0 (is_nonzero val @ (value_type (fits_in_32 ty)))
+  (CondResult.NotZero (put_in_reg_zext32 val) (OperandSize.Size32)))
+(rule 1 (is_nonzero val @ (value_type $I64))
+  (CondResult.NotZero val (OperandSize.Size64)))
+(rule 2 (is_nonzero val @ (value_type $I128))
+      (let ((c ValueRegs (put_in_regs val))
+            (lo Reg (value_regs_get c 0))
+            (hi Reg (value_regs_get c 1)))
+          (CondResult.NotZero (orr $I64 lo hi) (OperandSize.Size64))))
+(rule 3 (is_nonzero val @ (value_type $I8))
+  (CondResult.Cond (tst_imm $I32 val (u64_into_imm_logic $I32 255)) (Cond.Ne)))
+
+(decl emit_icmp (IntCC Value Value) CondResult)
+
+;; 8/16-bit base signed/unsigned cases
+(rule 0 (emit_icmp cc rn rm @ (value_type (fits_in_16 ty)))
+  (if (signed_cond_code cc))
+  (CondResult.Cond
+    (cmp_extend
+      (OperandSize.Size32)
+      (put_in_reg_sext32 rn)
+      rm
+      (lower_extend_op ty (ArgumentExtension.Sext)))
+    (cond_code cc)))
+(rule 1 (emit_icmp cc rn rm @ (value_type (fits_in_16 ty)))
+  (if (unsigned_cond_code cc))
+  (CondResult.Cond
+    (cmp_extend
+      (OperandSize.Size32)
+      (put_in_reg_zext32 rn)
+      rm
+      (lower_extend_op ty (ArgumentExtension.Uext)))
+    (cond_code cc)))
+
+;; 32/64-bit base case
+(rule 2 (emit_icmp cc rn rm @ (value_type (ty_32_or_64 ty)))
+  (CondResult.Cond
+    (cmp (operand_size ty) rn rm)
+    (cond_code cc)))
+
+;; 8/16-bit case with an unsigned immediate
+(rule 3 (emit_icmp cc rn @ (value_type (fits_in_16 ty)) (imm12_from_value rm))
+  (if (unsigned_cond_code cc))
+  (CondResult.Cond
+    (cmp_imm (OperandSize.Size32) (put_in_reg_zext32 rn) rm)
+    (cond_code cc)))
+
+;; 128-bit base case
+(rule 4 (emit_icmp cc a @ (value_type $I128) b)
+      (let ((a_lo Reg (value_regs_get a 0))
+            (a_hi Reg (value_regs_get a 1))
+            (b_lo Reg (value_regs_get b 0))
+            (b_hi Reg (value_regs_get b 1)))
+        (emit_icmp_i128 cc a_lo a_hi b_lo b_hi)))
+
+;; We get better encodings when testing against an immediate that's even instead
+;; of odd, so rewrite comparisons to use even immediates:
+;;
+;;         A >= B + 1
+;;     ==> A - 1 >= B
+;;     ==> A > B
+(rule 5 (emit_icmp (IntCC.UnsignedGreaterThanOrEqual) a @ (value_type (ty_32_or_64 ty)) (u64_from_iconst b))
+      (if-let true (u64_is_odd b))
+      (if-let (imm12_from_u64 imm) (u64_wrapping_sub b 1))
+  (CondResult.Cond (cmp_imm (operand_size ty) a imm) (Cond.Hi)))
+
+(rule 5 (emit_icmp (IntCC.SignedGreaterThanOrEqual) a @ (value_type (ty_32_or_64 ty)) (u64_from_iconst b))
+      (if-let true (u64_is_odd b))
+      (if-let (imm12_from_u64 imm) (u64_wrapping_sub b 1))
+  (CondResult.Cond (cmp_imm (operand_size ty) a imm) (Cond.Gt)))
+
+(rule 6 (emit_icmp cond rn @ (value_type (ty_32_or_64 ty)) (u64_from_iconst (imm12_from_u64 c)))
+  (CondResult.Cond (cmp_imm (operand_size ty) rn c) (cond_code cond)))
+
+;; For direct equality comparisons to zero transform the other operand into a
+;; nonzero comparison and then invert the whole conditional to test for zero.
+(rule 7 (emit_icmp (IntCC.Equal) a (u64_from_iconst 0)) (cond_result_invert (is_nonzero a)))
+(rule 8 (emit_icmp (IntCC.Equal) (u64_from_iconst 0) a) (cond_result_invert (is_nonzero a)))
+(rule 7 (emit_icmp (IntCC.NotEqual) a (u64_from_iconst 0)) (is_nonzero a))
+(rule 8 (emit_icmp (IntCC.NotEqual) (u64_from_iconst 0) a) (is_nonzero a))
+
+; Recursion: at most one to eliminate "greater than"
+(decl rec emit_icmp_i128 (IntCC Reg Reg Reg Reg) CondResult)
+
+;; Switch "greater than" cases to "less than"
+(rule 1 (emit_icmp_i128 (IntCC.SignedGreaterThan) a_lo a_hi b_lo b_hi)
+        (emit_icmp_i128 (IntCC.SignedLessThan)    b_lo b_hi a_lo a_hi))
+(rule 1 (emit_icmp_i128 (IntCC.UnsignedGreaterThan) a_lo a_hi b_lo b_hi)
+        (emit_icmp_i128 (IntCC.UnsignedLessThan)    b_lo b_hi a_lo a_hi))
+(rule 1 (emit_icmp_i128 (IntCC.SignedLessThanOrEqual)    a_lo a_hi b_lo b_hi)
+        (emit_icmp_i128 (IntCC.SignedGreaterThanOrEqual) b_lo b_hi a_lo a_hi))
+(rule 1 (emit_icmp_i128 (IntCC.UnsignedLessThanOrEqual)    a_lo a_hi b_lo b_hi)
+        (emit_icmp_i128 (IntCC.UnsignedGreaterThanOrEqual) b_lo b_hi a_lo a_hi))
+
+;; == and !=
+(rule 1 (emit_icmp_i128 (IntCC.Equal) a_lo a_hi b_lo b_hi)
+  (CondResult.Cond (emit_icmp_i128_eq_ne a_lo a_hi b_lo b_hi) (Cond.Eq)))
+(rule 1 (emit_icmp_i128 (IntCC.NotEqual) a_lo a_hi b_lo b_hi)
+  (CondResult.Cond (emit_icmp_i128_eq_ne a_lo a_hi b_lo b_hi) (Cond.Ne)))
+
+(decl emit_icmp_i128_eq_ne (Reg Reg Reg Reg) ProducesFlags)
+(rule (emit_icmp_i128_eq_ne a_lo a_hi b_lo b_hi)
+  (ccmp (OperandSize.Size64) a_hi b_hi (nzcv false false false false) (Cond.Eq)
+    (cmp (OperandSize.Size64) a_lo b_lo)))
+
+;; Handling all "less than" cases. Use a trick lifted from the x64 backend to
+;; compress this to just two instructions.
+(rule 0 (emit_icmp_i128 cc a_lo a_hi b_lo b_hi)
+  (CondResult.Cond
+    (produces_flags_concat
+      (cmp (OperandSize.Size64) a_lo b_lo)
+      (sbcs_side_effect $I64 a_hi b_hi))
+    (cond_code cc)))
+
+(decl emit_fcmp (FloatCC Value Value) CondResult)
+(rule (emit_fcmp cc a b @ (value_type ty))
+  (CondResult.Cond (fpu_cmp (scalar_size ty) a b) (fp_cond_code cc)))
+
 ;; A tuple of `ProducesFlags` and `IntCC`.
 (type FlagsAndCC (enum (FlagsAndCC (flags ProducesFlags)
                                    (cc IntCC))))
@@ -4696,7 +4824,7 @@
 ;; Materialize a `FlagsAndCC` into a boolean `ValueRegs`.
 (decl flags_and_cc_to_bool (FlagsAndCC) ValueRegs)
 (rule (flags_and_cc_to_bool (FlagsAndCC.FlagsAndCC flags cc))
-      (with_flags flags (materialize_bool_result (cond_code cc))))
+      (with_flags flags (cset (cond_code cc))))
 
 ;; Get the `ProducesFlags` out of a `FlagsAndCC`.
 (decl flags_and_cc_flags (FlagsAndCC) ProducesFlags)
@@ -4705,141 +4833,6 @@
 ;; Get the `IntCC` out of a `FlagsAndCC`.
 (decl flags_and_cc_cc (FlagsAndCC) IntCC)
 (rule (flags_and_cc_cc (FlagsAndCC.FlagsAndCC _flags cc)) cc)
-
-;; Helpers for lowering `icmp` sequences.
-;; `lower_icmp` contains shared functionality for lowering `icmp`
-;; sequences, which `lower_icmp_into_{reg,flags}` extend from.
-(spec (lower_icmp c x y in_ty)
-      (provide
-            (= result
-               (concat
-                  (extract 67 64
-                    (if (or (= c (IntCC.SignedGreaterThanOrEqual))
-                            (= c (IntCC.SignedGreaterThan))
-                            (= c (IntCC.SignedLessThanOrEqual))
-                            (= c (IntCC.SignedLessThan)))
-                        (if (<= in_ty 32)
-                            (subs 32 (sign_ext 64 x) (sign_ext 64 y))
-                            (subs 64 (sign_ext 64 x) (sign_ext 64 y)))
-                        (if (<= in_ty 32)
-                            (subs 32 (zero_ext 64 x) (zero_ext 64 y))
-                            (subs 64 (zero_ext 64 x) (zero_ext 64 y)))))
-                  c)))
-      (require
-            (or
-                (= c (IntCC.Equal))
-                (= c (IntCC.NotEqual))
-                (= c (IntCC.UnsignedGreaterThanOrEqual))
-                (= c (IntCC.UnsignedGreaterThan))
-                (= c (IntCC.UnsignedLessThanOrEqual))
-                (= c (IntCC.UnsignedLessThan))
-                (= c (IntCC.SignedGreaterThanOrEqual))
-                (= c (IntCC.SignedGreaterThan))
-                (= c (IntCC.SignedLessThanOrEqual))
-                (= c (IntCC.SignedLessThan)))
-            (or (= in_ty 8)
-                (= in_ty 16)
-                (= in_ty 32)
-                (= in_ty 64))
-            (= in_ty (widthof x))
-            (= in_ty (widthof y))))
-(instantiate lower_icmp
-    ((args (bv 8) (bv 8) (bv 8) Int) (ret (bv 12)) (canon (bv 8)))
-    ((args (bv 8) (bv 16) (bv 16) Int) (ret (bv 12)) (canon (bv 16)))
-    ((args (bv 8) (bv 32) (bv 32) Int) (ret (bv 12)) (canon (bv 32)))
-    ((args (bv 8) (bv 64) (bv 64) Int) (ret (bv 12)) (canon (bv 64)))
-)
-(decl lower_icmp (IntCC Value Value Type) FlagsAndCC)
-
-(spec (lower_icmp_into_reg c x y in_ty out_ty)
-      (provide
-            (= result
-               (switch c
-                 ((IntCC.Equal) (if (= x y) #x01 #x00))
-                 ((IntCC.NotEqual) (if (not (= x y)) #x01 #x00))
-                 ((IntCC.SignedGreaterThan) (if (bvsgt x y) #x01 #x00))
-                 ((IntCC.SignedGreaterThanOrEqual) (if (bvsge x y) #x01 #x00))
-                 ((IntCC.SignedLessThan) (if (bvslt x y) #x01 #x00))
-                 ((IntCC.SignedLessThanOrEqual) (if (bvsle x y) #x01 #x00))
-                 ((IntCC.UnsignedGreaterThan) (if (bvugt x y) #x01 #x00))
-                 ((IntCC.UnsignedGreaterThanOrEqual) (if (bvuge x y) #x01 #x00))
-                 ((IntCC.UnsignedLessThan) (if (bvult x y) #x01 #x00))
-                 ((IntCC.UnsignedLessThanOrEqual) (if (bvule x y) #x01 #x00)))))
-      (require
-            (or
-                (= c (IntCC.Equal))
-                (= c (IntCC.NotEqual))
-                (= c (IntCC.UnsignedGreaterThanOrEqual))
-                (= c (IntCC.UnsignedGreaterThan))
-                (= c (IntCC.UnsignedLessThanOrEqual))
-                (= c (IntCC.UnsignedLessThan))
-                (= c (IntCC.SignedGreaterThanOrEqual))
-                (= c (IntCC.SignedGreaterThan))
-                (= c (IntCC.SignedLessThanOrEqual))
-                (= c (IntCC.SignedLessThan)))
-            (or (= in_ty 8)
-                (= in_ty 16)
-                (= in_ty 32)
-                (= in_ty 64))
-            (= in_ty (widthof x))
-            (= in_ty (widthof y))
-            (= out_ty 8)))
-(instantiate lower_icmp_into_reg
-    ((args (bv 8) (bv 8) (bv 8) Int Int) (ret (bv 8)) (canon (bv 8)))
-    ((args (bv 8) (bv 16) (bv 16) Int Int) (ret (bv 8)) (canon (bv 16)))
-    ((args (bv 8) (bv 32) (bv 32) Int Int) (ret (bv 8)) (canon (bv 32)))
-    ((args (bv 8) (bv 64) (bv 64) Int Int) (ret (bv 8)) (canon (bv 64)))
-)
-(decl lower_icmp_into_reg (IntCC Value Value Type Type) ValueRegs)
-(decl lower_icmp_into_flags (IntCC Value Value Type) FlagsAndCC)
-
-(spec (lower_icmp_const c x y in_ty)
-      (provide
-            (= result
-               (concat (extract 67 64
-                              (if (or (= c (IntCC.SignedGreaterThanOrEqual))
-                                      (= c (IntCC.SignedGreaterThan))
-                                      (= c (IntCC.SignedLessThanOrEqual))
-                                      (= c (IntCC.SignedLessThan)))
-                                    (if (<= in_ty 32)
-                                          (subs 32 (sign_ext 64 x) y)
-                                          (subs 64 (sign_ext 64 x) y))
-                                    (if (<= in_ty 32)
-                                          (subs 32 (zero_ext 64 x) y)
-                                          (subs 64 (zero_ext 64 x) y))))
-                       c)))
-       (require
-            (or
-                (= c (IntCC.Equal))
-                (= c (IntCC.NotEqual))
-                (= c (IntCC.UnsignedGreaterThanOrEqual))
-                (= c (IntCC.UnsignedGreaterThan))
-                (= c (IntCC.UnsignedLessThanOrEqual))
-                (= c (IntCC.UnsignedLessThan))
-                (= c (IntCC.SignedGreaterThanOrEqual))
-                (= c (IntCC.SignedGreaterThan))
-                (= c (IntCC.SignedLessThanOrEqual))
-                (= c (IntCC.SignedLessThan)))
-            (or (= in_ty 32) (= in_ty 64))
-            (= in_ty (widthof x))))
-(instantiate lower_icmp_const
-    ((args (bv 8) (bv 8) (bv 64) Int) (ret (bv 12)) (canon (bv 8)))
-    ((args (bv 8) (bv 16) (bv 64) Int) (ret (bv 12)) (canon (bv 16)))
-    ((args (bv 8) (bv 32) (bv 64) Int) (ret (bv 12)) (canon (bv 32)))
-    ((args (bv 8) (bv 64) (bv 64) Int) (ret (bv 12)) (canon (bv 64)))
-)
-(decl lower_icmp_const (IntCC Value u64 Type) FlagsAndCC)
-;; For most cases, `lower_icmp_into_flags` is the same as `lower_icmp`,
-;; except for some I128 cases (see below).
-(rule -1 (lower_icmp_into_flags cond x y ty) (lower_icmp cond x y ty))
-
-;; Vectors.
-;; `icmp` into flags for vectors is invalid.
-(rule 1 (lower_icmp_into_reg cond x y in_ty @ (multi_lane _ _) _out_ty)
-      (let ((cond Cond (cond_code cond))
-            (rn Reg (put_in_reg x))
-            (rm Reg (put_in_reg y)))
-       (vec_cmp rn rm in_ty cond)))
 
 ;; Determines the appropriate extend op given the value type and the given ArgumentExtension.
 (spec (lower_extend_op ty b)
@@ -4857,115 +4850,9 @@
 (rule (lower_extend_op $I8 (ArgumentExtension.Uext)) (ExtendOp.UXTB))
 (rule (lower_extend_op $I16 (ArgumentExtension.Uext)) (ExtendOp.UXTH))
 
-;; Integers <= 64-bits.
-(rule lower_icmp_into_reg_8_16_32_64 -2 (lower_icmp_into_reg cond rn rm in_ty out_ty)
-      (if (ty_int_ref_scalar_64 in_ty))
-      (let ((cc Cond (cond_code cond)))
-        (flags_and_cc_to_bool (lower_icmp cond rn rm in_ty))))
-
-(rule lower_icmp_8_16_signed 1 (lower_icmp cond rn rm (fits_in_16 ty))
-      (if (signed_cond_code cond))
-      (let ((rn Reg (put_in_reg_sext32 rn)))
-      (flags_and_cc (cmp_extend (operand_size ty) rn rm (lower_extend_op ty (ArgumentExtension.Sext))) cond)))
-(rule lower_icmp_8_16_unsigned_imm -1 (lower_icmp cond rn (imm12_from_value rm) (fits_in_16 ty))
-      (let ((rn Reg (put_in_reg_zext32 rn)))
-      (flags_and_cc (cmp_imm (operand_size ty) rn rm) cond)))
-(rule lower_icmp_8_16_unsigned -2 (lower_icmp cond rn rm (fits_in_16 ty))
-      (let ((rn Reg (put_in_reg_zext32 rn)))
-      (flags_and_cc (cmp_extend (operand_size ty) rn rm (lower_extend_op ty (ArgumentExtension.Uext))) cond)))
-(rule lower_icmp_32_64_const -3 (lower_icmp cond rn (u64_from_iconst c) ty)
-      (if (ty_int_ref_scalar_64 ty))
-      (lower_icmp_const cond rn c ty))
-(rule lower_icmp_32_64 -4 (lower_icmp cond rn rm ty)
-      (if (ty_int_ref_scalar_64 ty))
-      (flags_and_cc (cmp (operand_size ty) rn rm) cond))
-
-;; We get better encodings when testing against an immediate that's even instead
-;; of odd, so rewrite comparisons to use even immediates:
-;;
-;;         A >= B + 1
-;;     ==> A - 1 >= B
-;;     ==> A > B
-(rule lower_icmp_const_32_64_ugte (lower_icmp_const (IntCC.UnsignedGreaterThanOrEqual) a b ty)
-      (if (ty_int_ref_scalar_64 ty))
-      (if-let true (u64_is_odd b))
-      (if-let (imm12_from_u64 imm) (u64_wrapping_sub b 1))
-  (flags_and_cc (cmp_imm (operand_size ty) a imm) (IntCC.UnsignedGreaterThan)))
-
-(rule lower_icmp_const_32_64_sgte (lower_icmp_const (IntCC.SignedGreaterThanOrEqual) a b ty)
-      (if (ty_int_ref_scalar_64 ty))
-      (if-let true (u64_is_odd b))
-      (if-let (imm12_from_u64 imm) (u64_wrapping_sub b 1))
-  (flags_and_cc (cmp_imm (operand_size ty) a imm) (IntCC.SignedGreaterThan)))
-
-(rule lower_icmp_const_32_64_imm -1 (lower_icmp_const cond rn (imm12_from_u64 c) ty)
-      (if (ty_int_ref_scalar_64 ty))
-  (flags_and_cc (cmp_imm (operand_size ty) rn c) cond))
-(rule lower_icmp_const_32_64 -2 (lower_icmp_const cond rn c ty)
-      (if (ty_int_ref_scalar_64 ty))
-  (flags_and_cc (cmp (operand_size ty) rn (imm ty (ImmExtend.Zero) c)) cond))
-
-
-;; 128-bit integers.
-(rule (lower_icmp_into_reg cond @ (IntCC.Equal) rn rm $I128 $I8)
-      (let ((cc Cond (cond_code cond)))
-       (flags_and_cc_to_bool
-        (lower_icmp cond rn rm $I128))))
-(rule (lower_icmp_into_reg cond @ (IntCC.NotEqual) rn rm $I128 $I8)
-      (let ((cc Cond (cond_code cond)))
-       (flags_and_cc_to_bool
-        (lower_icmp cond rn rm $I128))))
-
-;; cmp lhs_lo, rhs_lo
-;; ccmp lhs_hi, rhs_hi, #0, eq
-(decl lower_icmp_i128_eq_ne (Value Value) ProducesFlags)
-(rule (lower_icmp_i128_eq_ne lhs rhs)
-      (let ((lhs ValueRegs (put_in_regs lhs))
-            (rhs ValueRegs (put_in_regs rhs))
-            (lhs_lo Reg (value_regs_get lhs 0))
-            (lhs_hi Reg (value_regs_get lhs 1))
-            (rhs_lo Reg (value_regs_get rhs 0))
-            (rhs_hi Reg (value_regs_get rhs 1))
-            (cmp_inst ProducesFlags (cmp (OperandSize.Size64) lhs_lo rhs_lo)))
-       (ccmp (OperandSize.Size64) lhs_hi rhs_hi
-        (nzcv false false false false) (Cond.Eq) cmp_inst)))
-
-(rule (lower_icmp (IntCC.Equal) lhs rhs $I128)
-      (flags_and_cc (lower_icmp_i128_eq_ne lhs rhs) (IntCC.Equal)))
-(rule (lower_icmp (IntCC.NotEqual) lhs rhs $I128)
-      (flags_and_cc (lower_icmp_i128_eq_ne lhs rhs) (IntCC.NotEqual)))
-
-;; cmp      lhs_lo, rhs_lo
-;; cset     tmp1, unsigned_cond
-;; cmp      lhs_hi, rhs_hi
-;; cset     tmp2, cond
-;; csel     dst, tmp1, tmp2, eq
-(rule -1 (lower_icmp_into_reg cond lhs rhs $I128 $I8)
-      (let ((unsigned_cond Cond (cond_code (intcc_unsigned cond)))
-            (cond Cond (cond_code cond))
-            (lhs ValueRegs (put_in_regs lhs))
-            (rhs ValueRegs (put_in_regs rhs))
-            (lhs_lo Reg (value_regs_get lhs 0))
-            (lhs_hi Reg (value_regs_get lhs 1))
-            (rhs_lo Reg (value_regs_get rhs 0))
-            (rhs_hi Reg (value_regs_get rhs 1))
-            (tmp1 Reg (with_flags_reg (cmp (OperandSize.Size64) lhs_lo rhs_lo)
-                                      (materialize_bool_result unsigned_cond))))
-        (with_flags (cmp (OperandSize.Size64) lhs_hi rhs_hi)
-                    (lower_icmp_i128_consumer cond tmp1))))
-
-(decl lower_icmp_i128_consumer (Cond Reg) ConsumesFlags)
-(rule (lower_icmp_i128_consumer cond tmp1)
-      (let ((tmp2 WritableReg (temp_writable_reg $I64))
-            (dst WritableReg (temp_writable_reg $I64)))
-       (ConsumesFlags.ConsumesFlagsTwiceReturnsValueRegs
-        (MInst.CSet tmp2 cond)
-        (MInst.CSel dst (Cond.Eq) tmp1 tmp2)
-        (value_reg dst))))
 
 ; Recursion: bounded since recursive calls reduce type width (128-bit to 64-bit).
 (decl rec lower_bmask (Type Type ValueRegs) ValueRegs)
-
 
 ;; For conversions that exactly fit a register, we can use csetm.
 ;;
@@ -5012,59 +4899,26 @@
       (let ((masked Reg (and_imm $I32 (value_regs_get val 0) mask_bits)))
         (lower_bmask out_ty $I32 masked)))
 
-;; Exceptional `lower_icmp_into_flags` rules.
-;; We need to guarantee that the flags for `cond` are correct, so we
-;; compare `dst` with 1.
-(rule (lower_icmp_into_flags cond @ (IntCC.SignedGreaterThanOrEqual) lhs rhs $I128)
-      (let ((dst ValueRegs (lower_icmp_into_reg cond lhs rhs $I128 $I8))
-            (dst Reg (value_regs_get dst 0))
-            (tmp Reg (imm $I64 (ImmExtend.Sign) 1))) ;; mov tmp, #1
-        (flags_and_cc (cmp (OperandSize.Size64) dst tmp) cond)))
-(rule (lower_icmp_into_flags cond @ (IntCC.UnsignedGreaterThanOrEqual) lhs rhs $I128)
-      (let ((dst ValueRegs (lower_icmp_into_reg cond lhs rhs $I128 $I8))
-            (dst Reg (value_regs_get dst 0))
-            (tmp Reg (imm $I64 (ImmExtend.Zero) 1)))
-        (flags_and_cc (cmp (OperandSize.Size64) dst tmp) cond)))
-(rule (lower_icmp_into_flags cond @ (IntCC.SignedLessThanOrEqual) lhs rhs $I128)
-      (let ((dst ValueRegs (lower_icmp_into_reg cond lhs rhs $I128 $I8))
-            (dst Reg (value_regs_get dst 0))
-            (tmp Reg (imm $I64 (ImmExtend.Sign) 1)))
-       (flags_and_cc (cmp (OperandSize.Size64) tmp dst) cond)))
-(rule (lower_icmp_into_flags cond @ (IntCC.UnsignedLessThanOrEqual) lhs rhs $I128)
-      (let ((dst ValueRegs (lower_icmp_into_reg cond lhs rhs $I128 $I8))
-            (dst Reg (value_regs_get dst 0))
-            (tmp Reg (imm $I64 (ImmExtend.Zero) 1)))
-        (flags_and_cc (cmp (OperandSize.Size64) tmp dst) cond)))
-;; For strict comparisons, we compare with 0.
-(rule (lower_icmp_into_flags cond @ (IntCC.SignedGreaterThan) lhs rhs $I128)
-      (let ((dst ValueRegs (lower_icmp_into_reg cond lhs rhs $I128 $I8))
-            (dst Reg (value_regs_get dst 0)))
-        (flags_and_cc (cmp (OperandSize.Size64) dst (zero_reg)) cond)))
-(rule (lower_icmp_into_flags cond @ (IntCC.UnsignedGreaterThan) lhs rhs $I128)
-      (let ((dst ValueRegs (lower_icmp_into_reg cond lhs rhs $I128 $I8))
-            (dst Reg (value_regs_get dst 0)))
-        (flags_and_cc (cmp (OperandSize.Size64) dst (zero_reg)) cond)))
-(rule (lower_icmp_into_flags cond @ (IntCC.SignedLessThan) lhs rhs $I128)
-      (let ((dst ValueRegs (lower_icmp_into_reg cond lhs rhs $I128 $I8))
-            (dst Reg (value_regs_get dst 0)))
-       (flags_and_cc (cmp (OperandSize.Size64) (zero_reg) dst) cond)))
-(rule (lower_icmp_into_flags cond @ (IntCC.UnsignedLessThan) lhs rhs $I128)
-      (let ((dst ValueRegs (lower_icmp_into_reg cond lhs rhs $I128 $I8))
-            (dst Reg (value_regs_get dst 0)))
-       (flags_and_cc (cmp (OperandSize.Size64) (zero_reg) dst) cond)))
-
 ;; Helpers for generating select instruction sequences.
-(decl lower_select (ProducesFlags Cond Type Value Value) ValueRegs)
-(rule 2 (lower_select flags cond (ty_scalar_float (fits_in_64 ty)) rn rm)
-      (with_flags flags (fpu_csel ty cond rn rm)))
-(rule 4 (lower_select flags cond $F128 rn rm)
-      (with_flags flags (vec_csel cond rn rm)))
-(rule 3 (lower_select flags cond (ty_vec128 ty) rn rm)
-      (with_flags flags (vec_csel cond rn rm)))
-(rule (lower_select flags cond ty rn rm)
-      (if (ty_vec64 ty))
-      (with_flags flags (fpu_csel $F64 cond rn rm)))
-(rule 4 (lower_select flags cond $I128 rn rm)
+(decl lower_select (Type CondResult Value Value) ValueRegs)
+(rule (lower_select ty (CondResult.Zero reg size) a b)
+      (lower_select_cond ty (cmp size reg (zero_reg)) (Cond.Eq) a b))
+(rule (lower_select ty (CondResult.NotZero reg size) a b)
+      (lower_select_cond ty (cmp size reg (zero_reg)) (Cond.Ne) a b))
+(rule (lower_select ty (CondResult.Cond flags cond) a b)
+      (lower_select_cond ty flags cond a b))
+
+(decl lower_select_cond (Type ProducesFlags Cond Value Value) ValueRegs)
+(rule 2 (lower_select_cond (ty_scalar_float (fits_in_64 ty)) flags cond rn rm)
+  (with_flags flags (fpu_csel ty cond rn rm)))
+(rule 4 (lower_select_cond $F128 flags cond rn rm)
+  (with_flags flags (vec_csel cond rn rm)))
+(rule 3 (lower_select_cond (ty_vec128 ty) flags cond rn rm)
+  (with_flags flags (vec_csel cond rn rm)))
+(rule (lower_select_cond ty flags cond rn rm)
+  (if (ty_vec64 ty))
+  (with_flags flags (fpu_csel $F64 cond rn rm)))
+(rule 4 (lower_select_cond $I128 flags cond rn rm)
       (let ((dst_lo WritableReg (temp_writable_reg $I64))
             (dst_hi WritableReg (temp_writable_reg $I64))
             (rn ValueRegs (put_in_regs rn))
@@ -5078,9 +4932,9 @@
          (MInst.CSel dst_lo cond rn_lo rm_lo)
          (MInst.CSel dst_hi cond rn_hi rm_hi)
          (value_regs dst_lo dst_hi)))))
-(rule 1 (lower_select flags cond ty rn rm)
-      (if (ty_int_ref_scalar_64 ty))
-      (with_flags flags (csel cond rn rm)))
+(rule 1 (lower_select_cond ty flags cond rn rm)
+  (if (ty_int_ref_scalar_64 ty))
+  (with_flags flags (csel cond rn rm)))
 
 ;; Helper for emitting `MInst.Jump` instructions.
 (decl aarch64_jump (BranchTarget) SideEffectNoResult)
@@ -5112,11 +4966,19 @@
        (ConsumesFlags.ConsumesFlagsSideEffect
         (MInst.JTSequence default targets ridx rtmp1 rtmp2))))
 
-;; Helper for emitting `MInst.CondBr` instructions.
-(decl cond_br (BranchTarget BranchTarget CondBrKind) ConsumesFlags)
-(rule (cond_br taken not_taken kind)
+;; Helpers for emitting `MInst.CondBr` instructions.
+(decl a64_br_cond (Cond BranchTarget BranchTarget) ConsumesFlags)
+(rule (a64_br_cond cond taken not_taken)
       (ConsumesFlags.ConsumesFlagsSideEffect
-       (MInst.CondBr taken not_taken kind)))
+       (MInst.CondBr taken not_taken (cond_br_cond cond))))
+(decl a64_br_zero (Reg OperandSize BranchTarget BranchTarget) SideEffectNoResult)
+(rule (a64_br_zero reg size taken not_taken)
+      (SideEffectNoResult.Inst
+       (MInst.CondBr taken not_taken (cond_br_zero reg size))))
+(decl a64_br_not_zero (Reg OperandSize BranchTarget BranchTarget) SideEffectNoResult)
+(rule (a64_br_not_zero reg size taken not_taken)
+      (SideEffectNoResult.Inst
+       (MInst.CondBr taken not_taken (cond_br_not_zero reg size))))
 
 ;; Helper for emitting `MInst.TestBitAndBranch` instructions.
 (decl test_branch (TestBitAndBranchKind BranchTarget BranchTarget Reg u8) SideEffectNoResult)

--- a/cranelift/codegen/src/isa/aarch64/inst.isle
+++ b/cranelift/codegen/src/isa/aarch64/inst.isle
@@ -2297,7 +2297,7 @@
          (MInst.AluRRR alu_op (operand_size ty) dst src1 src2)
          dst)))
 
-;; Should only be used for AdcS and SbcS
+;; Helper to create a `sbcs` instruction with no destination register.
 (decl sbcs_side_effect (Type Reg Reg) ProducesFlags)
 (rule (sbcs_side_effect ty src1 src2)
   (ProducesFlags.ProducesFlagsSideEffect
@@ -4627,9 +4627,12 @@
 ;; flags.
 ;;
 ;; This type is intended to be a "narrow waist" for anything producing a
-;; conditional which `icmp` might flow into for example.
+;; conditional which `icmp` might flow into for example. For example this is used
+;; by `trapnz`, `trapz`, `icmp`, `select`, `fcmp`, `brif`, and
+;; `select_spectre_guard` to handle lowering conditionals into a boolean.
 ;;
-;; TODO: words
+;; This is primarily created by the `is_nonzero_cmp` helper which does all
+;; dispatching needed internally to create this shape.
 (type CondResult (enum
   (Zero (reg Reg) (size OperandSize))
   (NotZero (reg Reg) (size OperandSize))

--- a/cranelift/codegen/src/isa/aarch64/inst/unwind/systemv.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/unwind/systemv.rs
@@ -148,7 +148,7 @@ mod tests {
 
         assert_eq!(
             format!("{fde:?}"),
-            "FrameDescriptionEntry { address: Constant(4321), length: 16, lsda: None, instructions: [] }"
+            "FrameDescriptionEntry { address: Constant(4321), length: 12, lsda: None, instructions: [] }"
         );
     }
 

--- a/cranelift/codegen/src/isa/aarch64/lower.isle
+++ b/cranelift/codegen/src/isa/aarch64/lower.isle
@@ -306,7 +306,7 @@
       (let ((x1 Reg (cmeq0 x (VectorSize.Size64x2)))
             (x2 Reg (addp x1 x1 (VectorSize.Size64x2))))
        (with_flags (fpu_cmp (ScalarSize.Size64) x2 x2)
-                   (materialize_bool_result (Cond.Eq)))))
+                   (cset (Cond.Eq)))))
 
 (rule (lower (vall_true _ x @ (value_type (multi_lane 32 2))))
       (let ((x1 Reg (mov_from_vec x 0 (ScalarSize.Size64))))
@@ -330,13 +330,13 @@
       (let ((x1 Reg (vec_lanes (VecLanesOp.Uminv) x (vector_size ty)))
             (x2 Reg (mov_from_vec x1 0 (ScalarSize.Size64))))
        (with_flags (cmp_imm (OperandSize.Size64) x2 (u8_into_imm12 0))
-                   (materialize_bool_result (Cond.Ne)))))
+                   (cset (Cond.Ne)))))
 
 ;;;; Rules for `vany_true` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (vany_true _ x @ (value_type in_ty)))
       (with_flags (vanytrue x in_ty)
-                  (materialize_bool_result (Cond.Ne))))
+                  (cset (Cond.Ne))))
 
 ;;;; Rules for `iadd_pairwise` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -2160,12 +2160,10 @@
             (vec_size VectorSize (vector_size ty)))
           (value_reg (float_cmp_zero_swap cond rn vec_size))))
 
-(rule 0 (lower (has_type out_ty
-              (fcmp _ cond x @ (value_type (ty_scalar_float in_ty)) y)))
-      (with_flags (fpu_cmp (scalar_size in_ty) x y)
-                  (materialize_bool_result (fp_cond_code cond))))
+(rule 0 (lower (fcmp _ cond x @ (value_type (ty_scalar_float in_ty)) y))
+  (lower_cond_result_bool (emit_fcmp cond x y)))
 
-(rule -1 (lower (has_type out_ty (fcmp _ cond x @ (value_type in_ty) y)))
+(rule -1 (lower (fcmp _ cond x @ (value_type in_ty) y))
       (if (ty_vector_float in_ty))
       (vec_cmp x y in_ty (fp_cond_code cond)))
 
@@ -2195,8 +2193,23 @@
             (vec_size VectorSize (vector_size ty)))
           (value_reg (int_cmp_zero_swap cond rn vec_size))))
 
-(rule icmp_8_16_32_64 -1 (lower (icmp _ cond x @ (value_type in_ty) y))
-      (lower_icmp_into_reg cond x y in_ty $I8))
+(rule -1 (lower (icmp (multi_lane _ _) cond x y @ (value_type in_ty)))
+  (let ((cond Cond (cond_code cond))
+        (rn Reg (put_in_reg x))
+        (rm Reg (put_in_reg y)))
+   (vec_cmp rn rm in_ty cond)))
+
+(rule -2 (lower (icmp _ cond x @ (value_type (ty_int ty)) y))
+  (lower_cond_result_bool (emit_icmp cond x y)))
+
+;; Helper to put a `CondResult` into a general register.
+(decl lower_cond_result_bool (CondResult) Reg)
+(rule (lower_cond_result_bool (CondResult.Zero reg size))
+  (value_regs_get (with_flags (cmp_imm size reg (u8_into_imm12 0)) (cset (Cond.Eq))) 0))
+(rule (lower_cond_result_bool (CondResult.NotZero reg size))
+  (value_regs_get (with_flags (cmp_imm size reg (u8_into_imm12 0)) (cset (Cond.Ne))) 0))
+(rule (lower_cond_result_bool (CondResult.Cond flags cc))
+  (value_regs_get (with_flags flags (cset cc)) 0))
 
 ;;;; Rules for `trap` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -2206,63 +2219,26 @@
 ;;;;;  Rules for `trapz`;;;;;;;;;
 
 (rule (lower (trapz val trap_code))
-  (trap_if_val (ZeroCond.Zero) val trap_code))
+  (side_effect (trap_if_cond_result (cond_result_invert (is_nonzero_cmp val)) trap_code)))
+
+;; Helper to emit a `TrapIf` instruction for the `CondResult` provided
+(decl trap_if_cond_result (CondResult TrapCode) SideEffectNoResult)
+(rule (trap_if_cond_result (CondResult.Zero reg size) tc)
+  (trap_if_zero reg size tc))
+(rule (trap_if_cond_result (CondResult.NotZero reg size) tc)
+  (trap_if_not_zero reg size tc))
+(rule (trap_if_cond_result (CondResult.Cond flags cc) tc)
+  (with_flags_side_effect flags (trap_if_cond cc tc)))
 
 ;;;;;  Rules for `trapnz`;;;;;;;;;
 
 (rule (lower (trapnz val trap_code))
-  (trap_if_val (ZeroCond.NonZero) val trap_code))
+  (side_effect (trap_if_cond_result (is_nonzero_cmp val) trap_code)))
 
 ;;;; Rules for `select` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(rule (lower (has_type ty
-                       (select _ (maybe_uextend (icmp _ cc
-                                                    x @ (value_type in_ty)
-                                                    y))
-                               rn
-                               rm)))
-      (let ((comparison FlagsAndCC (lower_icmp_into_flags cc x y in_ty)))
-       (lower_select (flags_and_cc_flags comparison)
-                     (cond_code (flags_and_cc_cc comparison))
-                     ty
-                     rn
-                     rm)))
-
-(rule (lower (has_type ty
-                       (select _ (maybe_uextend (fcmp _ cc x @ (value_type in_ty) y))
-                               rn
-                               rm)))
-      (let ((cond Cond (fp_cond_code cc)))
-       (lower_select
-        (fpu_cmp (scalar_size in_ty) x y)
-        cond ty rn rm)))
-
-(rule -1 (lower (has_type ty (select _ rcond @ (value_type $I8) rn rm)))
-      (let ((rcond Reg rcond))
-       (lower_select
-         (tst_imm $I32 rcond (u64_into_imm_logic $I32 255))
-         (Cond.Ne) ty rn rm)))
-
-(rule -2 (lower (has_type ty (select _ rcond @ (value_type (fits_in_32 _)) rn rm)))
-      (let ((rcond Reg (put_in_reg_zext32 rcond)))
-       (lower_select
-        (cmp (OperandSize.Size32) rcond (zero_reg))
-        (Cond.Ne) ty rn rm)))
-
-(rule -3 (lower (has_type ty (select _ rcond @ (value_type (fits_in_64 _)) rn rm)))
-      (let ((rcond Reg (put_in_reg_zext64 rcond)))
-       (lower_select
-        (cmp (OperandSize.Size64) rcond (zero_reg))
-        (Cond.Ne) ty rn rm)))
-
-(rule -4 (lower (has_type ty (select _ rcond @ (value_type $I128) rn rm)))
-      (let ((c ValueRegs (put_in_regs rcond))
-            (c_lo Reg (value_regs_get c 0))
-            (c_hi Reg (value_regs_get c 1))
-            (rt Reg (orr $I64 c_lo c_hi)))
-        (lower_select
-         (cmp (OperandSize.Size64) rt (zero_reg))
-         (Cond.Ne) ty rn rm)))
+(rule (lower (select ty cond rn rm))
+  (lower_select ty (is_nonzero_cmp cond) rn rm))
 
 ;;;; Rules for `select_spectre_guard` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -2274,33 +2250,8 @@
   (if-let false (use_csdb))
   dst)
 
-(rule (lower (has_type ty
-                       (select_spectre_guard _ (maybe_uextend (icmp _ cc x @ (value_type in_ty) y))
-                                             if_true
-                                             if_false)))
-      (let ((comparison FlagsAndCC (lower_icmp_into_flags cc x y in_ty))
-            (dst ValueRegs (lower_select
-                            (flags_and_cc_flags comparison)
-                            (cond_code (flags_and_cc_cc comparison))
-                            ty
-                            if_true
-                            if_false)))
-       (maybe_csdb_after_select dst)))
-
-(rule -1 (lower (has_type ty (select_spectre_guard _ rcond @ (value_type (fits_in_64 _)) rn rm)))
-      (let ((rcond Reg (put_in_reg_zext64 rcond)))
-       (lower_select
-        (cmp (OperandSize.Size64) rcond (zero_reg))
-        (Cond.Ne) ty rn rm)))
-
-(rule -2 (lower (has_type ty (select_spectre_guard _ rcond @ (value_type $I128) rn rm)))
-      (let ((c ValueRegs (put_in_regs rcond))
-            (c_lo Reg (value_regs_get c 0))
-            (c_hi Reg (value_regs_get c 1))
-            (rt Reg (orr $I64 c_lo c_hi)))
-        (lower_select
-         (cmp (OperandSize.Size64) rt (zero_reg))
-         (Cond.Ne) ty rn rm)))
+(rule (lower (select_spectre_guard ty cond if_true if_false))
+  (maybe_csdb_after_select (lower_select ty (is_nonzero_cmp cond) if_true if_false)))
 
 ;;;; Rules for `vconst` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -3206,41 +3157,18 @@
 
 ;;; Rules for `brif` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;; `brif` following `icmp`
-(rule (lower_branch (brif (maybe_uextend (icmp _ cc x @ (value_type ty) y)) _ _) (two_targets taken not_taken))
-      (let ((comparison FlagsAndCC (lower_icmp_into_flags cc x y ty))
-            (cond Cond (cond_code (flags_and_cc_cc comparison))))
-        (emit_side_effect
-         (with_flags_side_effect (flags_and_cc_flags comparison)
-                                 (cond_br taken
-                                          not_taken
-                                          (cond_br_cond cond))))))
+;; `brif` base case
+(rule (lower_branch (brif val _ _) (two_targets taken not_taken))
+  (emit_side_effect (br_cond_result (is_nonzero_cmp val) taken not_taken)))
 
-;; `brif` following `fcmp`
-(rule (lower_branch (brif (maybe_uextend (fcmp _ cc x @ (value_type (ty_scalar_float ty)) y)) _ _) (two_targets taken not_taken))
-      (let ((cond Cond (fp_cond_code cc)))
-       (emit_side_effect
-        (with_flags_side_effect (fpu_cmp (scalar_size ty) x y)
-                                (cond_br taken not_taken
-                                 (cond_br_cond cond))))))
-
-;; standard `brif`
-(rule -1 (lower_branch (brif c @ (value_type $I128) _ _) (two_targets taken not_taken))
-      (let ((flags ProducesFlags (flags_to_producesflags c))
-            (c ValueRegs (put_in_regs c))
-            (c_lo Reg (value_regs_get c 0))
-            (c_hi Reg (value_regs_get c 1))
-            (rt Reg (orr $I64 c_lo c_hi)))
-       (emit_side_effect
-        (with_flags_side_effect flags
-         (cond_br taken not_taken (cond_br_not_zero rt (operand_size $I64)))))))
-(rule -2 (lower_branch (brif c @ (value_type ty) _ _) (two_targets taken not_taken))
-      (if (ty_int_ref_scalar_64 ty))
-      (let ((flags ProducesFlags (flags_to_producesflags c))
-            (rt Reg (put_in_reg_zext64 c)))
-       (emit_side_effect
-        (with_flags_side_effect flags
-         (cond_br taken not_taken (cond_br_not_zero rt (operand_size $I64)))))))
+;; Helper to emit a branching instruction based on  a `CondResult`
+(decl br_cond_result (CondResult MachLabel MachLabel) SideEffectNoResult)
+(rule (br_cond_result (CondResult.Zero reg size) taken not_taken)
+  (a64_br_zero reg size taken not_taken))
+(rule (br_cond_result (CondResult.NotZero reg size) taken not_taken)
+  (a64_br_not_zero reg size taken not_taken))
+(rule (br_cond_result (CondResult.Cond flags cc) taken not_taken)
+  (with_flags_side_effect flags (a64_br_cond cc taken not_taken)))
 
 ;; Special lowerings for `tbnz` - "Test bit and Branch if Nonzero"
 (rule 1 (lower_branch (brif (band _ x @ (value_type ty) (u64_from_iconst n)) _ _)

--- a/cranelift/codegen/src/isle_prelude.rs
+++ b/cranelift/codegen/src/isle_prelude.rs
@@ -853,6 +853,22 @@ macro_rules! isle_common_prelude_methods {
         }
 
         #[inline]
+        fn unsigned_cond_code(&mut self, cc: &IntCC) -> Option<IntCC> {
+            match cc {
+                IntCC::Equal
+                | IntCC::UnsignedGreaterThanOrEqual
+                | IntCC::UnsignedGreaterThan
+                | IntCC::UnsignedLessThanOrEqual
+                | IntCC::UnsignedLessThan
+                | IntCC::NotEqual => Some(*cc),
+                IntCC::SignedGreaterThanOrEqual
+                | IntCC::SignedGreaterThan
+                | IntCC::SignedLessThanOrEqual
+                | IntCC::SignedLessThan => None,
+            }
+        }
+
+        #[inline]
         fn intcc_swap_args(&mut self, cc: &IntCC) -> IntCC {
             cc.swap_args()
         }

--- a/cranelift/codegen/src/prelude.isle
+++ b/cranelift/codegen/src/prelude.isle
@@ -635,6 +635,8 @@
     (require (and (bvuge c #x02) (bvule c #x05))))
 (decl pure partial signed_cond_code (IntCC) IntCC)
 (extern constructor signed_cond_code signed_cond_code)
+(decl pure partial unsigned_cond_code (IntCC) IntCC)
+(extern constructor unsigned_cond_code unsigned_cond_code)
 
 ;;;; Helpers for Working with TrapCode ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/cranelift/filetests/filetests/isa/aarch64/cold-blocks.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/cold-blocks.clif
@@ -16,8 +16,7 @@ block2:
 
 ; VCode:
 ; block0:
-;   mov w4, w0
-;   cbnz x4, label1 ; b label2
+;   cbnz w0, label1 ; b label2
 ; block1:
 ;   b label3
 ; block2:
@@ -28,11 +27,10 @@ block2:
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   mov w4, w0
-;   cbnz x4, #0xc
-; block1: ; offset 0x8
+;   cbnz w0, #8
+; block1: ; offset 0x4
 ;   mov w0, #0x61
-; block2: ; offset 0xc
+; block2: ; offset 0x8
 ;   ret
 
 function %cold_annotation(i32) -> i32 {
@@ -49,8 +47,7 @@ block2 cold:
 
 ; VCode:
 ; block0:
-;   mov w4, w0
-;   cbnz x4, label1 ; b label2
+;   cbnz w0, label1 ; b label2
 ; block1:
 ;   b label3
 ; block3:
@@ -61,11 +58,10 @@ block2 cold:
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   mov w4, w0
-;   cbz x4, #0xc
-; block1: ; offset 0x8
+;   cbz w0, #8
+; block1: ; offset 0x4
 ;   ret
-; block2: ; offset 0xc
+; block2: ; offset 0x8
 ;   mov w0, #0x61
-;   b #8
+;   b #4
 

--- a/cranelift/filetests/filetests/isa/aarch64/condbr.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/condbr.clif
@@ -69,19 +69,15 @@ block0(v0: i128, v1: i128):
 ; VCode:
 ; block0:
 ;   subs xzr, x0, x2
-;   cset x6, lo
-;   subs xzr, x1, x3
-;   cset x9, lt
-;   csel x0, x6, x9, eq
+;   sbcs xzr, x1, x3
+;   cset x0, lt
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmp x0, x2
-;   cset x6, lo
-;   cmp x1, x3
-;   cset x9, lt
-;   csel x0, x6, x9, eq
+;   sbcs xzr, x1, x3
+;   cset x0, lt
 ;   ret
 
 function %icmp_ult_i128(i128, i128) -> i8 {
@@ -93,19 +89,15 @@ block0(v0: i128, v1: i128):
 ; VCode:
 ; block0:
 ;   subs xzr, x0, x2
-;   cset x6, lo
-;   subs xzr, x1, x3
-;   cset x9, lo
-;   csel x0, x6, x9, eq
+;   sbcs xzr, x1, x3
+;   cset x0, lo
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmp x0, x2
-;   cset x6, lo
-;   cmp x1, x3
-;   cset x9, lo
-;   csel x0, x6, x9, eq
+;   sbcs xzr, x1, x3
+;   cset x0, lo
 ;   ret
 
 function %icmp_sle_i128(i128, i128) -> i8 {
@@ -116,20 +108,16 @@ block0(v0: i128, v1: i128):
 
 ; VCode:
 ; block0:
-;   subs xzr, x0, x2
-;   cset x6, ls
-;   subs xzr, x1, x3
-;   cset x9, le
-;   csel x0, x6, x9, eq
+;   subs xzr, x2, x0
+;   sbcs xzr, x3, x1
+;   cset x0, ge
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   cmp x0, x2
-;   cset x6, ls
-;   cmp x1, x3
-;   cset x9, le
-;   csel x0, x6, x9, eq
+;   cmp x2, x0
+;   sbcs xzr, x3, x1
+;   cset x0, ge
 ;   ret
 
 function %icmp_ule_i128(i128, i128) -> i8 {
@@ -140,20 +128,16 @@ block0(v0: i128, v1: i128):
 
 ; VCode:
 ; block0:
-;   subs xzr, x0, x2
-;   cset x6, ls
-;   subs xzr, x1, x3
-;   cset x9, ls
-;   csel x0, x6, x9, eq
+;   subs xzr, x2, x0
+;   sbcs xzr, x3, x1
+;   cset x0, hs
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   cmp x0, x2
-;   cset x6, ls
-;   cmp x1, x3
-;   cset x9, ls
-;   csel x0, x6, x9, eq
+;   cmp x2, x0
+;   sbcs xzr, x3, x1
+;   cset x0, hs
 ;   ret
 
 function %icmp_sgt_i128(i128, i128) -> i8 {
@@ -164,20 +148,16 @@ block0(v0: i128, v1: i128):
 
 ; VCode:
 ; block0:
-;   subs xzr, x0, x2
-;   cset x6, hi
-;   subs xzr, x1, x3
-;   cset x9, gt
-;   csel x0, x6, x9, eq
+;   subs xzr, x2, x0
+;   sbcs xzr, x3, x1
+;   cset x0, lt
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   cmp x0, x2
-;   cset x6, hi
-;   cmp x1, x3
-;   cset x9, gt
-;   csel x0, x6, x9, eq
+;   cmp x2, x0
+;   sbcs xzr, x3, x1
+;   cset x0, lt
 ;   ret
 
 function %icmp_ugt_i128(i128, i128) -> i8 {
@@ -188,20 +168,16 @@ block0(v0: i128, v1: i128):
 
 ; VCode:
 ; block0:
-;   subs xzr, x0, x2
-;   cset x6, hi
-;   subs xzr, x1, x3
-;   cset x9, hi
-;   csel x0, x6, x9, eq
+;   subs xzr, x2, x0
+;   sbcs xzr, x3, x1
+;   cset x0, lo
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   cmp x0, x2
-;   cset x6, hi
-;   cmp x1, x3
-;   cset x9, hi
-;   csel x0, x6, x9, eq
+;   cmp x2, x0
+;   sbcs xzr, x3, x1
+;   cset x0, lo
 ;   ret
 
 function %icmp_sge_i128(i128, i128) -> i8 {
@@ -213,19 +189,15 @@ block0(v0: i128, v1: i128):
 ; VCode:
 ; block0:
 ;   subs xzr, x0, x2
-;   cset x6, hs
-;   subs xzr, x1, x3
-;   cset x9, ge
-;   csel x0, x6, x9, eq
+;   sbcs xzr, x1, x3
+;   cset x0, ge
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmp x0, x2
-;   cset x6, hs
-;   cmp x1, x3
-;   cset x9, ge
-;   csel x0, x6, x9, eq
+;   sbcs xzr, x1, x3
+;   cset x0, ge
 ;   ret
 
 function %icmp_uge_i128(i128, i128) -> i8 {
@@ -237,19 +209,15 @@ block0(v0: i128, v1: i128):
 ; VCode:
 ; block0:
 ;   subs xzr, x0, x2
-;   cset x6, hs
-;   subs xzr, x1, x3
-;   cset x9, hs
-;   csel x0, x6, x9, eq
+;   sbcs xzr, x1, x3
+;   cset x0, hs
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmp x0, x2
-;   cset x6, hs
-;   cmp x1, x3
-;   cset x9, hs
-;   csel x0, x6, x9, eq
+;   sbcs xzr, x1, x3
+;   cset x0, hs
 ;   ret
 
 function %f(i64, i64) -> i64 {
@@ -442,11 +410,7 @@ block1:
 ; VCode:
 ; block0:
 ;   subs xzr, x0, x2
-;   cset x6, lo
-;   subs xzr, x1, x3
-;   cset x9, lt
-;   csel x11, x6, x9, eq
-;   subs xzr, xzr, x11
+;   sbcs xzr, x1, x3
 ;   b.lt label1 ; b label2
 ; block1:
 ;   b label3
@@ -458,12 +422,8 @@ block1:
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmp x0, x2
-;   cset x6, lo
-;   cmp x1, x3
-;   cset x9, lt
-;   csel x11, x6, x9, eq
-;   cmp xzr, x11
-; block1: ; offset 0x18
+;   sbcs xzr, x1, x3
+; block1: ; offset 0x8
 ;   ret
 
 function %i128_bricmp_ult(i128, i128) {
@@ -479,11 +439,7 @@ block1:
 ; VCode:
 ; block0:
 ;   subs xzr, x0, x2
-;   cset x6, lo
-;   subs xzr, x1, x3
-;   cset x9, lo
-;   csel x11, x6, x9, eq
-;   subs xzr, xzr, x11
+;   sbcs xzr, x1, x3
 ;   b.lo label1 ; b label2
 ; block1:
 ;   b label3
@@ -495,12 +451,8 @@ block1:
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmp x0, x2
-;   cset x6, lo
-;   cmp x1, x3
-;   cset x9, lo
-;   csel x11, x6, x9, eq
-;   cmp xzr, x11
-; block1: ; offset 0x18
+;   sbcs xzr, x1, x3
+; block1: ; offset 0x8
 ;   ret
 
 function %i128_bricmp_sle(i128, i128) {
@@ -515,14 +467,9 @@ block1:
 
 ; VCode:
 ; block0:
-;   subs xzr, x0, x2
-;   cset x6, ls
-;   subs xzr, x1, x3
-;   cset x9, le
-;   csel x11, x6, x9, eq
-;   movz w13, #1
-;   subs xzr, x13, x11
-;   b.le label1 ; b label2
+;   subs xzr, x2, x0
+;   sbcs xzr, x3, x1
+;   b.ge label1 ; b label2
 ; block1:
 ;   b label3
 ; block2:
@@ -532,14 +479,9 @@ block1:
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   cmp x0, x2
-;   cset x6, ls
-;   cmp x1, x3
-;   cset x9, le
-;   csel x11, x6, x9, eq
-;   mov w13, #1
-;   cmp x13, x11
-; block1: ; offset 0x1c
+;   cmp x2, x0
+;   sbcs xzr, x3, x1
+; block1: ; offset 0x8
 ;   ret
 
 function %i128_bricmp_ule(i128, i128) {
@@ -554,14 +496,9 @@ block1:
 
 ; VCode:
 ; block0:
-;   subs xzr, x0, x2
-;   cset x6, ls
-;   subs xzr, x1, x3
-;   cset x9, ls
-;   csel x11, x6, x9, eq
-;   movz x13, #1
-;   subs xzr, x13, x11
-;   b.ls label1 ; b label2
+;   subs xzr, x2, x0
+;   sbcs xzr, x3, x1
+;   b.hs label1 ; b label2
 ; block1:
 ;   b label3
 ; block2:
@@ -571,14 +508,9 @@ block1:
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   cmp x0, x2
-;   cset x6, ls
-;   cmp x1, x3
-;   cset x9, ls
-;   csel x11, x6, x9, eq
-;   mov x13, #1
-;   cmp x13, x11
-; block1: ; offset 0x1c
+;   cmp x2, x0
+;   sbcs xzr, x3, x1
+; block1: ; offset 0x8
 ;   ret
 
 function %i128_bricmp_sgt(i128, i128) {
@@ -593,13 +525,9 @@ block1:
 
 ; VCode:
 ; block0:
-;   subs xzr, x0, x2
-;   cset x6, hi
-;   subs xzr, x1, x3
-;   cset x9, gt
-;   csel x11, x6, x9, eq
-;   subs xzr, x11, xzr
-;   b.gt label1 ; b label2
+;   subs xzr, x2, x0
+;   sbcs xzr, x3, x1
+;   b.lt label1 ; b label2
 ; block1:
 ;   b label3
 ; block2:
@@ -609,13 +537,9 @@ block1:
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   cmp x0, x2
-;   cset x6, hi
-;   cmp x1, x3
-;   cset x9, gt
-;   csel x11, x6, x9, eq
-;   cmp x11, xzr
-; block1: ; offset 0x18
+;   cmp x2, x0
+;   sbcs xzr, x3, x1
+; block1: ; offset 0x8
 ;   ret
 
 function %i128_bricmp_ugt(i128, i128) {
@@ -630,13 +554,9 @@ block1:
 
 ; VCode:
 ; block0:
-;   subs xzr, x0, x2
-;   cset x6, hi
-;   subs xzr, x1, x3
-;   cset x9, hi
-;   csel x11, x6, x9, eq
-;   subs xzr, x11, xzr
-;   b.hi label1 ; b label2
+;   subs xzr, x2, x0
+;   sbcs xzr, x3, x1
+;   b.lo label1 ; b label2
 ; block1:
 ;   b label3
 ; block2:
@@ -646,13 +566,9 @@ block1:
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   cmp x0, x2
-;   cset x6, hi
-;   cmp x1, x3
-;   cset x9, hi
-;   csel x11, x6, x9, eq
-;   cmp x11, xzr
-; block1: ; offset 0x18
+;   cmp x2, x0
+;   sbcs xzr, x3, x1
+; block1: ; offset 0x8
 ;   ret
 
 function %i128_bricmp_sge(i128, i128) {
@@ -668,12 +584,7 @@ block1:
 ; VCode:
 ; block0:
 ;   subs xzr, x0, x2
-;   cset x6, hs
-;   subs xzr, x1, x3
-;   cset x9, ge
-;   csel x11, x6, x9, eq
-;   movz w13, #1
-;   subs xzr, x11, x13
+;   sbcs xzr, x1, x3
 ;   b.ge label1 ; b label2
 ; block1:
 ;   b label3
@@ -685,13 +596,8 @@ block1:
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmp x0, x2
-;   cset x6, hs
-;   cmp x1, x3
-;   cset x9, ge
-;   csel x11, x6, x9, eq
-;   mov w13, #1
-;   cmp x11, x13
-; block1: ; offset 0x1c
+;   sbcs xzr, x1, x3
+; block1: ; offset 0x8
 ;   ret
 
 function %i128_bricmp_uge(i128, i128) {
@@ -707,12 +613,7 @@ block1:
 ; VCode:
 ; block0:
 ;   subs xzr, x0, x2
-;   cset x6, hs
-;   subs xzr, x1, x3
-;   cset x9, hs
-;   csel x11, x6, x9, eq
-;   movz x13, #1
-;   subs xzr, x11, x13
+;   sbcs xzr, x1, x3
 ;   b.hs label1 ; b label2
 ; block1:
 ;   b label3
@@ -724,13 +625,8 @@ block1:
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   cmp x0, x2
-;   cset x6, hs
-;   cmp x1, x3
-;   cset x9, hs
-;   csel x11, x6, x9, eq
-;   mov x13, #1
-;   cmp x11, x13
-; block1: ; offset 0x1c
+;   sbcs xzr, x1, x3
+; block1: ; offset 0x8
 ;   ret
 
 function %tbnz_i8(i8) {
@@ -858,10 +754,9 @@ block2:
 
 ; VCode:
 ; block0:
-;   movz w4, #0
-;   and w4, w0, w4
-;   uxtb w4, w4
-;   subs wzr, w4, #0
+;   movz w3, #0
+;   and w3, w0, w3
+;   ands wzr, w3, #255
 ;   b.eq label2 ; b label1
 ; block1:
 ;   ret
@@ -870,14 +765,13 @@ block2:
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   mov w4, #0
-;   and w4, w0, w4
-;   uxtb w4, w4
-;   cmp w4, #0
-;   b.eq #0x18
-; block1: ; offset 0x14
+;   mov w3, #0
+;   and w3, w0, w3
+;   tst w3, #0xff
+;   b.eq #0x14
+; block1: ; offset 0x10
 ;   ret
-; block2: ; offset 0x18
+; block2: ; offset 0x14
 ;   ret
 
 function %not_tbz2(i8) {
@@ -894,9 +788,8 @@ block2:
 
 ; VCode:
 ; block0:
-;   and w3, w0, #3
-;   uxtb w3, w3
-;   subs wzr, w3, #0
+;   and w2, w0, #3
+;   ands wzr, w2, #255
 ;   b.eq label2 ; b label1
 ; block1:
 ;   ret
@@ -905,11 +798,11 @@ block2:
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   and w3, w0, #3
-;   uxtb w3, w3
-;   cmp w3, #0
-;   b.eq #0x14
-; block1: ; offset 0x10
+;   and w2, w0, #3
+;   tst w2, #0xff
+;   b.eq #0x10
+; block1: ; offset 0xc
 ;   ret
-; block2: ; offset 0x14
+; block2: ; offset 0x10
 ;   ret
+

--- a/cranelift/filetests/filetests/isa/aarch64/icmp-const.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/icmp-const.clif
@@ -52,17 +52,17 @@ block0(v0: i32):
 
 ; VCode:
 ; block0:
-;   movz w3, #4369
-;   movk w3, w3, #17, LSL #16
-;   subs wzr, w0, w3
+;   movz w4, #4369
+;   movk w4, w4, #17, LSL #16
+;   subs wzr, w0, w4
 ;   cset x0, hs
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   mov w3, #0x1111
-;   movk w3, #0x11, lsl #16
-;   cmp w0, w3
+;   mov w4, #0x1111
+;   movk w4, #0x11, lsl #16
+;   cmp w0, w4
 ;   cset x0, hs
 ;   ret
 
@@ -75,17 +75,17 @@ block0(v0: i32):
 
 ; VCode:
 ; block0:
-;   movz w3, #4368
-;   movk w3, w3, #17, LSL #16
-;   subs wzr, w0, w3
+;   movz w4, #4368
+;   movk w4, w4, #17, LSL #16
+;   subs wzr, w0, w4
 ;   cset x0, hs
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   mov w3, #0x1110
-;   movk w3, #0x11, lsl #16
-;   cmp w0, w3
+;   mov w4, #0x1110
+;   movk w4, #0x11, lsl #16
+;   cmp w0, w4
 ;   cset x0, hs
 ;   ret
 
@@ -136,17 +136,17 @@ block0(v0: i32):
 
 ; VCode:
 ; block0:
-;   movz w3, #4369
-;   movk w3, w3, #17, LSL #16
-;   subs wzr, w0, w3
+;   movz w4, #4369
+;   movk w4, w4, #17, LSL #16
+;   subs wzr, w0, w4
 ;   cset x0, ge
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   mov w3, #0x1111
-;   movk w3, #0x11, lsl #16
-;   cmp w0, w3
+;   mov w4, #0x1111
+;   movk w4, #0x11, lsl #16
+;   cmp w0, w4
 ;   cset x0, ge
 ;   ret
 
@@ -159,17 +159,17 @@ block0(v0: i32):
 
 ; VCode:
 ; block0:
-;   movz w3, #4368
-;   movk w3, w3, #17, LSL #16
-;   subs wzr, w0, w3
+;   movz w4, #4368
+;   movk w4, w4, #17, LSL #16
+;   subs wzr, w0, w4
 ;   cset x0, ge
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   mov w3, #0x1110
-;   movk w3, #0x11, lsl #16
-;   cmp w0, w3
+;   mov w4, #0x1110
+;   movk w4, #0x11, lsl #16
+;   cmp w0, w4
 ;   cset x0, ge
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/aarch64/return-call-indirect.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/return-call-indirect.clif
@@ -118,15 +118,13 @@ block0(v0: i8):
 
 ; VCode:
 ; block0:
-;   uxtb w2, w2
-;   subs wzr, w2, #0
+;   ands wzr, w2, #255
 ;   cset x2, eq
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   uxtb w2, w2
-;   cmp w2, #0
+;   tst w2, #0xff
 ;   cset x2, eq
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/aarch64/return-call.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/return-call.clif
@@ -109,15 +109,13 @@ block0(v0: i8):
 
 ; VCode:
 ; block0:
-;   uxtb w2, w2
-;   subs wzr, w2, #0
+;   ands wzr, w2, #255
 ;   cset x2, eq
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   uxtb w2, w2
-;   cmp w2, #0
+;   tst w2, #0xff
 ;   cset x2, eq
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/aarch64/traps.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/traps.clif
@@ -104,3 +104,168 @@ block0(v0: i128):
 ;   cbnz x3, #0xc
 ;   ret
 ;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: user1
+
+function %trapz_icmp(i64, i64) {
+block0(v0: i64, v1: i64):
+  v2 = icmp eq v0, v1
+  trapz v2, user1
+  return
+}
+
+; VCode:
+; block0:
+;   subs xzr, x0, x1
+;   b.ne #trap=user1
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   cmp x0, x1
+;   b.ne #0xc
+;   ret
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: user1
+
+function %trapnz_icmp(i64, i64) {
+block0(v0: i64, v1: i64):
+  v2 = icmp eq v0, v1
+  trapnz v2, user1
+  return
+}
+
+; VCode:
+; block0:
+;   subs xzr, x0, x1
+;   b.eq #trap=user1
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   cmp x0, x1
+;   b.eq #0xc
+;   ret
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: user1
+
+function %trapz_fcmp(f64, f64) {
+block0(v0: f64, v1: f64):
+  v2 = fcmp eq v0, v1
+  trapz v2, user1
+  return
+}
+
+; VCode:
+; block0:
+;   fcmp d0, d1
+;   b.ne #trap=user1
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   fcmp d0, d1
+;   b.ne #0xc
+;   ret
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: user1
+
+function %trapnz_fcmp(f64, f64) {
+block0(v0: f64, v1: f64):
+  v2 = fcmp eq v0, v1
+  trapnz v2, user1
+  return
+}
+
+; VCode:
+; block0:
+;   fcmp d0, d1
+;   b.eq #trap=user1
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   fcmp d0, d1
+;   b.eq #0xc
+;   ret
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: user1
+
+function %trapz_uextend_icmp(i64, i64) {
+block0(v0: i64, v1: i64):
+  v2 = icmp eq v0, v1
+  v3 = uextend.i32 v2
+  trapz v3, user1
+  return
+}
+
+; VCode:
+; block0:
+;   subs xzr, x0, x1
+;   b.ne #trap=user1
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   cmp x0, x1
+;   b.ne #0xc
+;   ret
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: user1
+
+function %trapnz_uextend_icmp(i64, i64) {
+block0(v0: i64, v1: i64):
+  v2 = icmp eq v0, v1
+  v3 = uextend.i32 v2
+  trapnz v3, user1
+  return
+}
+
+; VCode:
+; block0:
+;   subs xzr, x0, x1
+;   b.eq #trap=user1
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   cmp x0, x1
+;   b.eq #0xc
+;   ret
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: user1
+
+function %trapz_uextend_fcmp(f64, f64) {
+block0(v0: f64, v1: f64):
+  v2 = fcmp eq v0, v1
+  v3 = uextend.i32 v2
+  trapz v3, user1
+  return
+}
+
+; VCode:
+; block0:
+;   fcmp d0, d1
+;   b.ne #trap=user1
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   fcmp d0, d1
+;   b.ne #0xc
+;   ret
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: user1
+
+function %trapnz_uextend_fcmp(f64, f64) {
+block0(v0: f64, v1: f64):
+  v2 = fcmp eq v0, v1
+  v3 = uextend.i32 v2
+  trapnz v3, user1
+  return
+}
+
+; VCode:
+; block0:
+;   fcmp d0, d1
+;   b.eq #trap=user1
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   fcmp d0, d1
+;   b.eq #0xc
+;   ret
+;   .byte 0x1f, 0xc1, 0x00, 0x00 ; trap: user1
+

--- a/tests/disas/debug-exceptions.wat
+++ b/tests/disas/debug-exceptions.wat
@@ -30,35 +30,35 @@
 ;;       ldr     x0, [x0, #0x18]
 ;;       mov     x1, sp
 ;;       cmp     x1, x0
-;;       b.lo    #0x19c
+;;       b.lo    #0x194
 ;;   44: stur    x2, [sp]
 ;;       mov     x0, x2
 ;;       stur    x2, [sp, #0x10]
 ;;       nop
 ;;       ├─╼ debug frame state (after previous inst): func key DefinedWasmFunction(StaticModuleIndex(0), DefinedFuncIndex(0)), wasm PC 0x35, slot at FP-0xc0, locals , stack 
-;;       ╰─╼ breakpoint patch: wasm PC 0x35, patch bytes [40, 1, 0, 148]
+;;       ╰─╼ breakpoint patch: wasm PC 0x35, patch bytes [37, 1, 0, 148]
 ;;       ldur    x0, [sp, #0x10]
 ;;       nop
 ;;       ├─╼ debug frame state (after previous inst): func key DefinedWasmFunction(StaticModuleIndex(0), DefinedFuncIndex(0)), wasm PC 0x37, slot at FP-0xc0, locals , stack 
-;;       ╰─╼ breakpoint patch: wasm PC 0x37, patch bytes [38, 1, 0, 148]
+;;       ╰─╼ breakpoint patch: wasm PC 0x37, patch bytes [35, 1, 0, 148]
 ;;       ldur    x0, [sp, #0x10]
 ;;       nop
 ;;       ├─╼ debug frame state (after previous inst): func key DefinedWasmFunction(StaticModuleIndex(0), DefinedFuncIndex(0)), wasm PC 0x3d, slot at FP-0xc0, locals , stack 
-;;       ╰─╼ breakpoint patch: wasm PC 0x3d, patch bytes [36, 1, 0, 148]
+;;       ╰─╼ breakpoint patch: wasm PC 0x3d, patch bytes [33, 1, 0, 148]
 ;;       mov     w19, #0x2a
 ;;       stur    w19, [sp, #8]
 ;;       nop
 ;;       ├─╼ debug frame state (after previous inst): func key DefinedWasmFunction(StaticModuleIndex(0), DefinedFuncIndex(0)), wasm PC 0x3f, slot at FP-0xc0, locals , stack I32 @ slot+0x8
-;;       ╰─╼ breakpoint patch: wasm PC 0x3f, patch bytes [33, 1, 0, 148]
+;;       ╰─╼ breakpoint patch: wasm PC 0x3f, patch bytes [30, 1, 0, 148]
 ;;       nop
 ;;       ├─╼ debug frame state (after previous inst): func key DefinedWasmFunction(StaticModuleIndex(0), DefinedFuncIndex(0)), wasm PC 0x40, slot at FP-0xc0, locals , stack 
-;;       ╰─╼ breakpoint patch: wasm PC 0x40, patch bytes [32, 1, 0, 148]
+;;       ╰─╼ breakpoint patch: wasm PC 0x40, patch bytes [29, 1, 0, 148]
 ;;       stur    w19, [sp, #8]
 ;;       nop
 ;;       ├─╼ debug frame state (after previous inst): func key DefinedWasmFunction(StaticModuleIndex(0), DefinedFuncIndex(0)), wasm PC 0x42, slot at FP-0xc0, locals , stack I32 @ slot+0x8
-;;       ╰─╼ breakpoint patch: wasm PC 0x42, patch bytes [30, 1, 0, 148]
+;;       ╰─╼ breakpoint patch: wasm PC 0x42, patch bytes [27, 1, 0, 148]
 ;;       ldur    x2, [sp, #0x10]
-;;       bl      #0x450
+;;       bl      #0x444
 ;;   84: mov     x20, x2
 ;;       mov     w3, #0x4000000
 ;;       ldur    x0, [sp, #0x10]
@@ -67,7 +67,7 @@
 ;;       mov     w5, #0x28
 ;;       mov     w6, #8
 ;;       ldur    x2, [sp, #0x10]
-;;       bl      #0x370
+;;       bl      #0x368
 ;;   a8: ldur    x0, [sp, #0x10]
 ;;       ldr     x5, [x0, #8]
 ;;       ldr     x6, [x5, #0x20]
@@ -83,14 +83,14 @@
 ;;       str     w3, [x4, w2, uxtw]
 ;;       mov     x3, x2
 ;;       ldur    x2, [sp, #0x10]
-;;       bl      #0x488
+;;       bl      #0x47c
 ;;       ├─╼ exception frame offset: SP = FP - 0xc0
 ;;       ╰─╼ exception handler: tag=0, context at [SP+0x10], handler=0x100
 ;;   e8: mov     w3, #9
 ;;       ldur    x2, [sp, #0x10]
-;;       bl      #0x3e4
+;;       bl      #0x3d8
 ;;   f4: ldur    x2, [sp, #0x10]
-;;       bl      #0x41c
+;;       bl      #0x410
 ;;       ╰─╼ debug frame state (after previous inst): func key DefinedWasmFunction(StaticModuleIndex(0), DefinedFuncIndex(0)), wasm PC 0x42, slot at FP-0xc0, locals , stack I32 @ slot+0x8
 ;;   fc: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;       mov     x2, x0
@@ -98,35 +98,33 @@
 ;;       mov     x4, #0x28
 ;;       adds    x3, x3, x4
 ;;       cset    x4, hs
-;;       uxtb    w4, w4
-;;       cbnz    x4, #0x1b4
+;;       tst     w4, #0xff
+;;       b.ne    #0x1ac
 ;;  11c: ldur    x5, [sp, #0x20]
 ;;       ldr     x1, [x5, #0x28]
 ;;       cmp     x3, x1
-;;       cset    x1, hi
-;;       uxtb    w1, w1
-;;       cbnz    x1, #0x1b8
-;;  134: ldur    x6, [sp, #0x18]
+;;       b.hi    #0x1b0
+;;  12c: ldur    x6, [sp, #0x18]
 ;;       add     x0, x6, #0x20
 ;;       ldr     w0, [x0, w2, uxtw]
 ;;       stur    w0, [sp, #8]
 ;;       ldur    x0, [sp, #0x10]
 ;;       nop
 ;;       ├─╼ debug frame state (after previous inst): func key DefinedWasmFunction(StaticModuleIndex(0), DefinedFuncIndex(0)), wasm PC 0x48, slot at FP-0xc0, locals , stack I32 @ slot+0x8
-;;       ╰─╼ breakpoint patch: wasm PC 0x48, patch bytes [234, 0, 0, 148]
+;;       ╰─╼ breakpoint patch: wasm PC 0x48, patch bytes [233, 0, 0, 148]
 ;;       ldur    x1, [sp, #0x10]
 ;;       ldr     x0, [x1, #0x38]
 ;;       ldr     x2, [x1, #0x48]
 ;;       ldur    x3, [sp, #0x10]
 ;;       blr     x0
 ;;       ╰─╼ debug frame state (after previous inst): func key DefinedWasmFunction(StaticModuleIndex(0), DefinedFuncIndex(0)), wasm PC 0x4a, slot at FP-0xc0, locals , stack I32 @ slot+0x8
-;;  160: ldur    x0, [sp, #0x10]
+;;  158: ldur    x0, [sp, #0x10]
 ;;       nop
 ;;       ├─╼ debug frame state (after previous inst): func key DefinedWasmFunction(StaticModuleIndex(0), DefinedFuncIndex(0)), wasm PC 0x4a, slot at FP-0xc0, locals , stack I32 @ slot+0x8
-;;       ╰─╼ breakpoint patch: wasm PC 0x4a, patch bytes [227, 0, 0, 148]
+;;       ╰─╼ breakpoint patch: wasm PC 0x4a, patch bytes [226, 0, 0, 148]
 ;;       nop
 ;;       ├─╼ debug frame state (after previous inst): func key DefinedWasmFunction(StaticModuleIndex(0), DefinedFuncIndex(0)), wasm PC 0x4b, slot at FP-0xc0, locals , stack 
-;;       ╰─╼ breakpoint patch: wasm PC 0x4b, patch bytes [226, 0, 0, 148]
+;;       ╰─╼ breakpoint patch: wasm PC 0x4b, patch bytes [225, 0, 0, 148]
 ;;       add     sp, sp, #0x30
 ;;       ldp     d8, d9, [sp], #0x10
 ;;       ldp     d10, d11, [sp], #0x10
@@ -139,12 +137,12 @@
 ;;       ldp     x27, x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;  19c: stur    x2, [sp, #0x10]
-;;  1a0: mov     w3, #0
-;;  1a4: bl      #0x3e4
-;;  1a8: ldur    x2, [sp, #0x10]
-;;  1ac: bl      #0x41c
+;;  194: stur    x2, [sp, #0x10]
+;;  198: mov     w3, #0
+;;  19c: bl      #0x3d8
+;;  1a0: ldur    x2, [sp, #0x10]
+;;  1a4: bl      #0x410
 ;;       ╰─╼ debug frame state (after previous inst): func key DefinedWasmFunction(StaticModuleIndex(0), DefinedFuncIndex(0)), wasm PC 0x34, slot at FP-0xc0, locals , stack 
+;;  1a8: .byte   0x1f, 0xc1, 0x00, 0x00
+;;  1ac: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;  1b0: .byte   0x1f, 0xc1, 0x00, 0x00
-;;  1b4: .byte   0x1f, 0xc1, 0x00, 0x00
-;;  1b8: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -21,31 +21,27 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x9, [x2, #0x40]
-;;       mov     w10, w4
-;;       sub     x9, x9, #4
-;;       cmp     x10, x9
-;;       cset    x10, hi
-;;       uxtb    w10, w10
-;;       cbnz    x10, #0x34
-;;   24: ldr     x11, [x2, #0x38]
-;;       str     w5, [x11, w4, uxtw]
+;;       ldr     x7, [x2, #0x40]
+;;       mov     w8, w4
+;;       sub     x7, x7, #4
+;;       cmp     x8, x7
+;;       b.hi    #0x2c
+;;   1c: ldr     x9, [x2, #0x38]
+;;       str     w5, [x9, w4, uxtw]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   34: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   2c: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x9, [x2, #0x40]
-;;       mov     w10, w4
-;;       sub     x9, x9, #4
-;;       cmp     x10, x9
-;;       cset    x10, hi
-;;       uxtb    w10, w10
-;;       cbnz    x10, #0x74
-;;   64: ldr     x11, [x2, #0x38]
-;;       ldr     w2, [x11, w4, uxtw]
+;;       ldr     x7, [x2, #0x40]
+;;       mov     w8, w4
+;;       sub     x7, x7, #4
+;;       cmp     x8, x7
+;;       b.hi    #0x6c
+;;   5c: ldr     x9, [x2, #0x38]
+;;       ldr     w2, [x9, w4, uxtw]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   74: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   6c: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -21,35 +21,31 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x11, [x2, #0x40]
-;;       mov     w12, w4
-;;       mov     x13, #0x1004
-;;       sub     x11, x11, x13
-;;       cmp     x12, x11
-;;       cset    x12, hi
-;;       uxtb    w12, w12
-;;       cbnz    x12, #0x3c
-;;   28: ldr     x13, [x2, #0x38]
-;;       add     x13, x13, #1, lsl #12
-;;       str     w5, [x13, w4, uxtw]
+;;       ldr     x9, [x2, #0x40]
+;;       mov     w10, w4
+;;       mov     x11, #0x1004
+;;       sub     x9, x9, x11
+;;       cmp     x10, x9
+;;       b.hi    #0x34
+;;   20: ldr     x11, [x2, #0x38]
+;;       add     x11, x11, #1, lsl #12
+;;       str     w5, [x11, w4, uxtw]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   3c: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   34: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x11, [x2, #0x40]
-;;       mov     w12, w4
-;;       mov     x13, #0x1004
-;;       sub     x11, x11, x13
-;;       cmp     x12, x11
-;;       cset    x12, hi
-;;       uxtb    w12, w12
-;;       cbnz    x12, #0x7c
-;;   68: ldr     x13, [x2, #0x38]
-;;       add     x12, x13, #1, lsl #12
-;;       ldr     w2, [x12, w4, uxtw]
+;;       ldr     x9, [x2, #0x40]
+;;       mov     w10, w4
+;;       mov     x11, #0x1004
+;;       sub     x9, x9, x11
+;;       cmp     x10, x9
+;;       b.hi    #0x74
+;;   60: ldr     x11, [x2, #0x38]
+;;       add     x10, x11, #1, lsl #12
+;;       ldr     w2, [x10, w4, uxtw]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   7c: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   74: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -21,41 +21,37 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     w12, w4
-;;       mov     w13, #-0xfffc
-;;       adds    x12, x12, x13
-;;       b.hs    #0x44
-;;   18: ldr     x13, [x2, #0x40]
-;;       cmp     x12, x13
-;;       cset    x14, hi
-;;       uxtb    w14, w14
-;;       cbnz    x14, #0x48
-;;   2c: ldr     x15, [x2, #0x38]
-;;       add     x15, x15, w4, uxtw
-;;       mov     x0, #0xffff0000
-;;       str     w5, [x15, x0]
+;;       mov     w10, w4
+;;       mov     w11, #-0xfffc
+;;       adds    x10, x10, x11
+;;       b.hs    #0x3c
+;;   18: ldr     x11, [x2, #0x40]
+;;       cmp     x10, x11
+;;       b.hi    #0x40
+;;   24: ldr     x13, [x2, #0x38]
+;;       add     x13, x13, w4, uxtw
+;;       mov     x14, #0xffff0000
+;;       str     w5, [x13, x14]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   44: .byte   0x1f, 0xc1, 0x00, 0x00
-;;   48: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   3c: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   40: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     w12, w4
-;;       mov     w13, #-0xfffc
-;;       adds    x12, x12, x13
-;;       b.hs    #0xa4
-;;   78: ldr     x13, [x2, #0x40]
-;;       cmp     x12, x13
-;;       cset    x14, hi
-;;       uxtb    w14, w14
-;;       cbnz    x14, #0xa8
-;;   8c: ldr     x15, [x2, #0x38]
-;;       add     x15, x15, w4, uxtw
-;;       mov     x0, #0xffff0000
-;;       ldr     w2, [x15, x0]
+;;       mov     w10, w4
+;;       mov     w11, #-0xfffc
+;;       adds    x10, x10, x11
+;;       b.hs    #0x9c
+;;   78: ldr     x11, [x2, #0x40]
+;;       cmp     x10, x11
+;;       b.hi    #0xa0
+;;   84: ldr     x13, [x2, #0x38]
+;;       add     x13, x13, w4, uxtw
+;;       mov     x14, #0xffff0000
+;;       ldr     w2, [x13, x14]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   a4: .byte   0x1f, 0xc1, 0x00, 0x00
-;;   a8: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   9c: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   a0: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -21,29 +21,25 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x8, [x2, #0x40]
-;;       mov     w9, w4
-;;       cmp     x9, x8
-;;       cset    x9, hs
-;;       uxtb    w9, w9
-;;       cbnz    x9, #0x30
-;;   20: ldr     x10, [x2, #0x38]
-;;       strb    w5, [x10, w4, uxtw]
+;;       ldr     x6, [x2, #0x40]
+;;       mov     w7, w4
+;;       cmp     x7, x6
+;;       b.hs    #0x28
+;;   18: ldr     x8, [x2, #0x38]
+;;       strb    w5, [x8, w4, uxtw]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   30: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   28: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x8, [x2, #0x40]
-;;       mov     w9, w4
-;;       cmp     x9, x8
-;;       cset    x9, hs
-;;       uxtb    w9, w9
-;;       cbnz    x9, #0x70
-;;   60: ldr     x10, [x2, #0x38]
-;;       ldrb    w2, [x10, w4, uxtw]
+;;       ldr     x6, [x2, #0x40]
+;;       mov     w7, w4
+;;       cmp     x7, x6
+;;       b.hs    #0x68
+;;   58: ldr     x8, [x2, #0x38]
+;;       ldrb    w2, [x8, w4, uxtw]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   70: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   68: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -21,35 +21,31 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x11, [x2, #0x40]
-;;       mov     w12, w4
-;;       mov     x13, #0x1001
-;;       sub     x11, x11, x13
-;;       cmp     x12, x11
-;;       cset    x12, hi
-;;       uxtb    w12, w12
-;;       cbnz    x12, #0x3c
-;;   28: ldr     x13, [x2, #0x38]
-;;       add     x13, x13, #1, lsl #12
-;;       strb    w5, [x13, w4, uxtw]
+;;       ldr     x9, [x2, #0x40]
+;;       mov     w10, w4
+;;       mov     x11, #0x1001
+;;       sub     x9, x9, x11
+;;       cmp     x10, x9
+;;       b.hi    #0x34
+;;   20: ldr     x11, [x2, #0x38]
+;;       add     x11, x11, #1, lsl #12
+;;       strb    w5, [x11, w4, uxtw]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   3c: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   34: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x11, [x2, #0x40]
-;;       mov     w12, w4
-;;       mov     x13, #0x1001
-;;       sub     x11, x11, x13
-;;       cmp     x12, x11
-;;       cset    x12, hi
-;;       uxtb    w12, w12
-;;       cbnz    x12, #0x7c
-;;   68: ldr     x13, [x2, #0x38]
-;;       add     x12, x13, #1, lsl #12
-;;       ldrb    w2, [x12, w4, uxtw]
+;;       ldr     x9, [x2, #0x40]
+;;       mov     w10, w4
+;;       mov     x11, #0x1001
+;;       sub     x9, x9, x11
+;;       cmp     x10, x9
+;;       b.hi    #0x74
+;;   60: ldr     x11, [x2, #0x38]
+;;       add     x10, x11, #1, lsl #12
+;;       ldrb    w2, [x10, w4, uxtw]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   7c: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   74: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -21,41 +21,37 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     w12, w4
-;;       mov     w13, #-0xffff
-;;       adds    x12, x12, x13
-;;       b.hs    #0x44
-;;   18: ldr     x13, [x2, #0x40]
-;;       cmp     x12, x13
-;;       cset    x14, hi
-;;       uxtb    w14, w14
-;;       cbnz    x14, #0x48
-;;   2c: ldr     x15, [x2, #0x38]
-;;       add     x15, x15, w4, uxtw
-;;       mov     x0, #0xffff0000
-;;       strb    w5, [x15, x0]
+;;       mov     w10, w4
+;;       mov     w11, #-0xffff
+;;       adds    x10, x10, x11
+;;       b.hs    #0x3c
+;;   18: ldr     x11, [x2, #0x40]
+;;       cmp     x10, x11
+;;       b.hi    #0x40
+;;   24: ldr     x13, [x2, #0x38]
+;;       add     x13, x13, w4, uxtw
+;;       mov     x14, #0xffff0000
+;;       strb    w5, [x13, x14]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   44: .byte   0x1f, 0xc1, 0x00, 0x00
-;;   48: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   3c: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   40: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     w12, w4
-;;       mov     w13, #-0xffff
-;;       adds    x12, x12, x13
-;;       b.hs    #0xa4
-;;   78: ldr     x13, [x2, #0x40]
-;;       cmp     x12, x13
-;;       cset    x14, hi
-;;       uxtb    w14, w14
-;;       cbnz    x14, #0xa8
-;;   8c: ldr     x15, [x2, #0x38]
-;;       add     x15, x15, w4, uxtw
-;;       mov     x0, #0xffff0000
-;;       ldrb    w2, [x15, x0]
+;;       mov     w10, w4
+;;       mov     w11, #-0xffff
+;;       adds    x10, x10, x11
+;;       b.hs    #0x9c
+;;   78: ldr     x11, [x2, #0x40]
+;;       cmp     x10, x11
+;;       b.hi    #0xa0
+;;   84: ldr     x13, [x2, #0x38]
+;;       add     x13, x13, w4, uxtw
+;;       mov     x14, #0xffff0000
+;;       ldrb    w2, [x13, x14]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   a4: .byte   0x1f, 0xc1, 0x00, 0x00
-;;   a8: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   9c: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   a0: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -21,29 +21,25 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x8, [x2, #0x40]
-;;       mov     w9, w4
-;;       cmp     x9, x8
-;;       cset    x9, hi
-;;       uxtb    w9, w9
-;;       cbnz    x9, #0x30
-;;   20: ldr     x10, [x2, #0x38]
-;;       str     w5, [x10, w4, uxtw]
+;;       ldr     x6, [x2, #0x40]
+;;       mov     w7, w4
+;;       cmp     x7, x6
+;;       b.hi    #0x28
+;;   18: ldr     x8, [x2, #0x38]
+;;       str     w5, [x8, w4, uxtw]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   30: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   28: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x8, [x2, #0x40]
-;;       mov     w9, w4
-;;       cmp     x9, x8
-;;       cset    x9, hi
-;;       uxtb    w9, w9
-;;       cbnz    x9, #0x70
-;;   60: ldr     x10, [x2, #0x38]
-;;       ldr     w2, [x10, w4, uxtw]
+;;       ldr     x6, [x2, #0x40]
+;;       mov     w7, w4
+;;       cmp     x7, x6
+;;       b.hi    #0x68
+;;   58: ldr     x8, [x2, #0x38]
+;;       ldr     w2, [x8, w4, uxtw]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   70: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   68: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -21,31 +21,27 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x9, [x2, #0x40]
-;;       mov     w10, w4
-;;       cmp     x10, x9
-;;       cset    x10, hi
-;;       uxtb    w10, w10
-;;       cbnz    x10, #0x34
-;;   20: ldr     x11, [x2, #0x38]
-;;       add     x11, x11, #1, lsl #12
-;;       str     w5, [x11, w4, uxtw]
+;;       ldr     x7, [x2, #0x40]
+;;       mov     w8, w4
+;;       cmp     x8, x7
+;;       b.hi    #0x2c
+;;   18: ldr     x9, [x2, #0x38]
+;;       add     x9, x9, #1, lsl #12
+;;       str     w5, [x9, w4, uxtw]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   34: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   2c: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x9, [x2, #0x40]
-;;       mov     w10, w4
-;;       cmp     x10, x9
-;;       cset    x10, hi
-;;       uxtb    w10, w10
-;;       cbnz    x10, #0x74
-;;   60: ldr     x11, [x2, #0x38]
-;;       add     x10, x11, #1, lsl #12
-;;       ldr     w2, [x10, w4, uxtw]
+;;       ldr     x7, [x2, #0x40]
+;;       mov     w8, w4
+;;       cmp     x8, x7
+;;       b.hi    #0x6c
+;;   58: ldr     x9, [x2, #0x38]
+;;       add     x8, x9, #1, lsl #12
+;;       ldr     w2, [x8, w4, uxtw]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   74: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   6c: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -21,33 +21,29 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x10, [x2, #0x40]
-;;       mov     w11, w4
-;;       cmp     x11, x10
-;;       cset    x11, hi
-;;       uxtb    w11, w11
-;;       cbnz    x11, #0x38
-;;   20: ldr     x12, [x2, #0x38]
-;;       add     x12, x12, w4, uxtw
-;;       mov     x13, #0xffff0000
-;;       str     w5, [x12, x13]
+;;       ldr     x8, [x2, #0x40]
+;;       mov     w9, w4
+;;       cmp     x9, x8
+;;       b.hi    #0x30
+;;   18: ldr     x10, [x2, #0x38]
+;;       add     x10, x10, w4, uxtw
+;;       mov     x11, #0xffff0000
+;;       str     w5, [x10, x11]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   38: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   30: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x10, [x2, #0x40]
-;;       mov     w11, w4
-;;       cmp     x11, x10
-;;       cset    x11, hi
-;;       uxtb    w11, w11
-;;       cbnz    x11, #0x78
-;;   60: ldr     x12, [x2, #0x38]
-;;       add     x12, x12, w4, uxtw
-;;       mov     x13, #0xffff0000
-;;       ldr     w2, [x12, x13]
+;;       ldr     x8, [x2, #0x40]
+;;       mov     w9, w4
+;;       cmp     x9, x8
+;;       b.hi    #0x70
+;;   58: ldr     x10, [x2, #0x38]
+;;       add     x10, x10, w4, uxtw
+;;       mov     x11, #0xffff0000
+;;       ldr     w2, [x10, x11]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   78: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   70: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -21,29 +21,25 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x8, [x2, #0x40]
-;;       mov     w9, w4
-;;       cmp     x9, x8
-;;       cset    x9, hs
-;;       uxtb    w9, w9
-;;       cbnz    x9, #0x30
-;;   20: ldr     x10, [x2, #0x38]
-;;       strb    w5, [x10, w4, uxtw]
+;;       ldr     x6, [x2, #0x40]
+;;       mov     w7, w4
+;;       cmp     x7, x6
+;;       b.hs    #0x28
+;;   18: ldr     x8, [x2, #0x38]
+;;       strb    w5, [x8, w4, uxtw]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   30: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   28: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x8, [x2, #0x40]
-;;       mov     w9, w4
-;;       cmp     x9, x8
-;;       cset    x9, hs
-;;       uxtb    w9, w9
-;;       cbnz    x9, #0x70
-;;   60: ldr     x10, [x2, #0x38]
-;;       ldrb    w2, [x10, w4, uxtw]
+;;       ldr     x6, [x2, #0x40]
+;;       mov     w7, w4
+;;       cmp     x7, x6
+;;       b.hs    #0x68
+;;   58: ldr     x8, [x2, #0x38]
+;;       ldrb    w2, [x8, w4, uxtw]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   70: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   68: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -21,31 +21,27 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x9, [x2, #0x40]
-;;       mov     w10, w4
-;;       cmp     x10, x9
-;;       cset    x10, hi
-;;       uxtb    w10, w10
-;;       cbnz    x10, #0x34
-;;   20: ldr     x11, [x2, #0x38]
-;;       add     x11, x11, #1, lsl #12
-;;       strb    w5, [x11, w4, uxtw]
+;;       ldr     x7, [x2, #0x40]
+;;       mov     w8, w4
+;;       cmp     x8, x7
+;;       b.hi    #0x2c
+;;   18: ldr     x9, [x2, #0x38]
+;;       add     x9, x9, #1, lsl #12
+;;       strb    w5, [x9, w4, uxtw]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   34: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   2c: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x9, [x2, #0x40]
-;;       mov     w10, w4
-;;       cmp     x10, x9
-;;       cset    x10, hi
-;;       uxtb    w10, w10
-;;       cbnz    x10, #0x74
-;;   60: ldr     x11, [x2, #0x38]
-;;       add     x10, x11, #1, lsl #12
-;;       ldrb    w2, [x10, w4, uxtw]
+;;       ldr     x7, [x2, #0x40]
+;;       mov     w8, w4
+;;       cmp     x8, x7
+;;       b.hi    #0x6c
+;;   58: ldr     x9, [x2, #0x38]
+;;       add     x8, x9, #1, lsl #12
+;;       ldrb    w2, [x8, w4, uxtw]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   74: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   6c: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -21,33 +21,29 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x10, [x2, #0x40]
-;;       mov     w11, w4
-;;       cmp     x11, x10
-;;       cset    x11, hi
-;;       uxtb    w11, w11
-;;       cbnz    x11, #0x38
-;;   20: ldr     x12, [x2, #0x38]
-;;       add     x12, x12, w4, uxtw
-;;       mov     x13, #0xffff0000
-;;       strb    w5, [x12, x13]
+;;       ldr     x8, [x2, #0x40]
+;;       mov     w9, w4
+;;       cmp     x9, x8
+;;       b.hi    #0x30
+;;   18: ldr     x10, [x2, #0x38]
+;;       add     x10, x10, w4, uxtw
+;;       mov     x11, #0xffff0000
+;;       strb    w5, [x10, x11]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   38: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   30: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x10, [x2, #0x40]
-;;       mov     w11, w4
-;;       cmp     x11, x10
-;;       cset    x11, hi
-;;       uxtb    w11, w11
-;;       cbnz    x11, #0x78
-;;   60: ldr     x12, [x2, #0x38]
-;;       add     x12, x12, w4, uxtw
-;;       mov     x13, #0xffff0000
-;;       ldrb    w2, [x12, x13]
+;;       ldr     x8, [x2, #0x40]
+;;       mov     w9, w4
+;;       cmp     x9, x8
+;;       b.hi    #0x70
+;;   58: ldr     x10, [x2, #0x38]
+;;       add     x10, x10, w4, uxtw
+;;       mov     x11, #0xffff0000
+;;       ldrb    w2, [x10, x11]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   78: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   70: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -21,29 +21,25 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x8, [x2, #0x40]
-;;       sub     x8, x8, #4
-;;       cmp     x4, x8
-;;       cset    x9, hi
-;;       uxtb    w9, w9
-;;       cbnz    x9, #0x30
-;;   20: ldr     x10, [x2, #0x38]
-;;       str     w5, [x10, x4]
+;;       ldr     x6, [x2, #0x40]
+;;       sub     x6, x6, #4
+;;       cmp     x4, x6
+;;       b.hi    #0x28
+;;   18: ldr     x8, [x2, #0x38]
+;;       str     w5, [x8, x4]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   30: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   28: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x8, [x2, #0x40]
-;;       sub     x8, x8, #4
-;;       cmp     x4, x8
-;;       cset    x9, hi
-;;       uxtb    w9, w9
-;;       cbnz    x9, #0x70
-;;   60: ldr     x10, [x2, #0x38]
-;;       ldr     w2, [x10, x4]
+;;       ldr     x6, [x2, #0x40]
+;;       sub     x6, x6, #4
+;;       cmp     x4, x6
+;;       b.hi    #0x68
+;;   58: ldr     x8, [x2, #0x38]
+;;       ldr     w2, [x8, x4]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   70: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   68: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -21,33 +21,29 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x10, [x2, #0x40]
-;;       mov     x11, #0x1004
-;;       sub     x10, x10, x11
-;;       cmp     x4, x10
-;;       cset    x11, hi
-;;       uxtb    w11, w11
-;;       cbnz    x11, #0x38
-;;   24: ldr     x12, [x2, #0x38]
-;;       add     x12, x12, #1, lsl #12
-;;       str     w5, [x12, x4]
+;;       ldr     x8, [x2, #0x40]
+;;       mov     x9, #0x1004
+;;       sub     x8, x8, x9
+;;       cmp     x4, x8
+;;       b.hi    #0x30
+;;   1c: ldr     x10, [x2, #0x38]
+;;       add     x10, x10, #1, lsl #12
+;;       str     w5, [x10, x4]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   38: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   30: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x10, [x2, #0x40]
-;;       mov     x11, #0x1004
-;;       sub     x10, x10, x11
-;;       cmp     x4, x10
-;;       cset    x11, hi
-;;       uxtb    w11, w11
-;;       cbnz    x11, #0x78
-;;   64: ldr     x12, [x2, #0x38]
-;;       add     x11, x12, #1, lsl #12
-;;       ldr     w2, [x11, x4]
+;;       ldr     x8, [x2, #0x40]
+;;       mov     x9, #0x1004
+;;       sub     x8, x8, x9
+;;       cmp     x4, x8
+;;       b.hi    #0x70
+;;   5c: ldr     x10, [x2, #0x38]
+;;       add     x9, x10, #1, lsl #12
+;;       ldr     w2, [x9, x4]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   78: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   70: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -21,39 +21,35 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     w11, #-0xfffc
-;;       adds    x11, x4, x11
-;;       b.hs    #0x40
-;;   14: ldr     x12, [x2, #0x40]
-;;       cmp     x11, x12
-;;       cset    x13, hi
-;;       uxtb    w13, w13
-;;       cbnz    x13, #0x44
-;;   28: ldr     x14, [x2, #0x38]
-;;       add     x14, x14, x4
-;;       mov     x15, #0xffff0000
-;;       str     w5, [x14, x15]
+;;       mov     w9, #-0xfffc
+;;       adds    x9, x4, x9
+;;       b.hs    #0x38
+;;   14: ldr     x10, [x2, #0x40]
+;;       cmp     x9, x10
+;;       b.hi    #0x3c
+;;   20: ldr     x12, [x2, #0x38]
+;;       add     x12, x12, x4
+;;       mov     x13, #0xffff0000
+;;       str     w5, [x12, x13]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   40: .byte   0x1f, 0xc1, 0x00, 0x00
-;;   44: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   38: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   3c: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     w11, #-0xfffc
-;;       adds    x11, x4, x11
-;;       b.hs    #0xa0
-;;   74: ldr     x12, [x2, #0x40]
-;;       cmp     x11, x12
-;;       cset    x13, hi
-;;       uxtb    w13, w13
-;;       cbnz    x13, #0xa4
-;;   88: ldr     x14, [x2, #0x38]
-;;       add     x14, x14, x4
-;;       mov     x15, #0xffff0000
-;;       ldr     w2, [x14, x15]
+;;       mov     w9, #-0xfffc
+;;       adds    x9, x4, x9
+;;       b.hs    #0x78
+;;   54: ldr     x10, [x2, #0x40]
+;;       cmp     x9, x10
+;;       b.hi    #0x7c
+;;   60: ldr     x12, [x2, #0x38]
+;;       add     x12, x12, x4
+;;       mov     x13, #0xffff0000
+;;       ldr     w2, [x12, x13]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   a0: .byte   0x1f, 0xc1, 0x00, 0x00
-;;   a4: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   78: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   7c: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -21,27 +21,23 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x7, [x2, #0x40]
-;;       cmp     x4, x7
-;;       cset    x8, hs
-;;       uxtb    w8, w8
-;;       cbnz    x8, #0x2c
-;;   1c: ldr     x9, [x2, #0x38]
-;;       strb    w5, [x9, x4]
+;;       ldr     x6, [x2, #0x40]
+;;       cmp     x4, x6
+;;       b.hs    #0x24
+;;   14: ldr     x7, [x2, #0x38]
+;;       strb    w5, [x7, x4]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   2c: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   24: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x7, [x2, #0x40]
-;;       cmp     x4, x7
-;;       cset    x8, hs
-;;       uxtb    w8, w8
-;;       cbnz    x8, #0x6c
-;;   5c: ldr     x9, [x2, #0x38]
-;;       ldrb    w2, [x9, x4]
+;;       ldr     x5, [x2, #0x40]
+;;       cmp     x4, x5
+;;       b.hs    #0x64
+;;   54: ldr     x7, [x2, #0x38]
+;;       ldrb    w2, [x7, x4]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   6c: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   64: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -21,33 +21,29 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x10, [x2, #0x40]
-;;       mov     x11, #0x1001
-;;       sub     x10, x10, x11
-;;       cmp     x4, x10
-;;       cset    x11, hi
-;;       uxtb    w11, w11
-;;       cbnz    x11, #0x38
-;;   24: ldr     x12, [x2, #0x38]
-;;       add     x12, x12, #1, lsl #12
-;;       strb    w5, [x12, x4]
+;;       ldr     x8, [x2, #0x40]
+;;       mov     x9, #0x1001
+;;       sub     x8, x8, x9
+;;       cmp     x4, x8
+;;       b.hi    #0x30
+;;   1c: ldr     x10, [x2, #0x38]
+;;       add     x10, x10, #1, lsl #12
+;;       strb    w5, [x10, x4]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   38: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   30: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x10, [x2, #0x40]
-;;       mov     x11, #0x1001
-;;       sub     x10, x10, x11
-;;       cmp     x4, x10
-;;       cset    x11, hi
-;;       uxtb    w11, w11
-;;       cbnz    x11, #0x78
-;;   64: ldr     x12, [x2, #0x38]
-;;       add     x11, x12, #1, lsl #12
-;;       ldrb    w2, [x11, x4]
+;;       ldr     x8, [x2, #0x40]
+;;       mov     x9, #0x1001
+;;       sub     x8, x8, x9
+;;       cmp     x4, x8
+;;       b.hi    #0x70
+;;   5c: ldr     x10, [x2, #0x38]
+;;       add     x9, x10, #1, lsl #12
+;;       ldrb    w2, [x9, x4]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   78: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   70: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -21,39 +21,35 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     w11, #-0xffff
-;;       adds    x11, x4, x11
-;;       b.hs    #0x40
-;;   14: ldr     x12, [x2, #0x40]
-;;       cmp     x11, x12
-;;       cset    x13, hi
-;;       uxtb    w13, w13
-;;       cbnz    x13, #0x44
-;;   28: ldr     x14, [x2, #0x38]
-;;       add     x14, x14, x4
-;;       mov     x15, #0xffff0000
-;;       strb    w5, [x14, x15]
+;;       mov     w9, #-0xffff
+;;       adds    x9, x4, x9
+;;       b.hs    #0x38
+;;   14: ldr     x10, [x2, #0x40]
+;;       cmp     x9, x10
+;;       b.hi    #0x3c
+;;   20: ldr     x12, [x2, #0x38]
+;;       add     x12, x12, x4
+;;       mov     x13, #0xffff0000
+;;       strb    w5, [x12, x13]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   40: .byte   0x1f, 0xc1, 0x00, 0x00
-;;   44: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   38: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   3c: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     w11, #-0xffff
-;;       adds    x11, x4, x11
-;;       b.hs    #0xa0
-;;   74: ldr     x12, [x2, #0x40]
-;;       cmp     x11, x12
-;;       cset    x13, hi
-;;       uxtb    w13, w13
-;;       cbnz    x13, #0xa4
-;;   88: ldr     x14, [x2, #0x38]
-;;       add     x14, x14, x4
-;;       mov     x15, #0xffff0000
-;;       ldrb    w2, [x14, x15]
+;;       mov     w9, #-0xffff
+;;       adds    x9, x4, x9
+;;       b.hs    #0x78
+;;   54: ldr     x10, [x2, #0x40]
+;;       cmp     x9, x10
+;;       b.hi    #0x7c
+;;   60: ldr     x12, [x2, #0x38]
+;;       add     x12, x12, x4
+;;       mov     x13, #0xffff0000
+;;       ldrb    w2, [x12, x13]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   a0: .byte   0x1f, 0xc1, 0x00, 0x00
-;;   a4: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   78: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   7c: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -21,27 +21,23 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x7, [x2, #0x40]
-;;       cmp     x4, x7
-;;       cset    x8, hi
-;;       uxtb    w8, w8
-;;       cbnz    x8, #0x2c
-;;   1c: ldr     x9, [x2, #0x38]
-;;       str     w5, [x9, x4]
+;;       ldr     x6, [x2, #0x40]
+;;       cmp     x4, x6
+;;       b.hi    #0x24
+;;   14: ldr     x7, [x2, #0x38]
+;;       str     w5, [x7, x4]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   2c: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   24: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x7, [x2, #0x40]
-;;       cmp     x4, x7
-;;       cset    x8, hi
-;;       uxtb    w8, w8
-;;       cbnz    x8, #0x6c
-;;   5c: ldr     x9, [x2, #0x38]
-;;       ldr     w2, [x9, x4]
+;;       ldr     x5, [x2, #0x40]
+;;       cmp     x4, x5
+;;       b.hi    #0x64
+;;   54: ldr     x7, [x2, #0x38]
+;;       ldr     w2, [x7, x4]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   6c: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   64: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -21,29 +21,25 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x8, [x2, #0x40]
-;;       cmp     x4, x8
-;;       cset    x9, hi
-;;       uxtb    w9, w9
-;;       cbnz    x9, #0x30
-;;   1c: ldr     x10, [x2, #0x38]
-;;       add     x10, x10, #1, lsl #12
-;;       str     w5, [x10, x4]
+;;       ldr     x6, [x2, #0x40]
+;;       cmp     x4, x6
+;;       b.hi    #0x28
+;;   14: ldr     x8, [x2, #0x38]
+;;       add     x8, x8, #1, lsl #12
+;;       str     w5, [x8, x4]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   30: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   28: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x8, [x2, #0x40]
-;;       cmp     x4, x8
-;;       cset    x9, hi
-;;       uxtb    w9, w9
-;;       cbnz    x9, #0x70
-;;   5c: ldr     x10, [x2, #0x38]
-;;       add     x9, x10, #1, lsl #12
-;;       ldr     w2, [x9, x4]
+;;       ldr     x6, [x2, #0x40]
+;;       cmp     x4, x6
+;;       b.hi    #0x68
+;;   54: ldr     x8, [x2, #0x38]
+;;       add     x7, x8, #1, lsl #12
+;;       ldr     w2, [x7, x4]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   70: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   68: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -21,31 +21,27 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x9, [x2, #0x40]
-;;       cmp     x4, x9
-;;       cset    x10, hi
-;;       uxtb    w10, w10
-;;       cbnz    x10, #0x34
-;;   1c: ldr     x11, [x2, #0x38]
-;;       add     x11, x11, x4
-;;       mov     x12, #0xffff0000
-;;       str     w5, [x11, x12]
+;;       ldr     x7, [x2, #0x40]
+;;       cmp     x4, x7
+;;       b.hi    #0x2c
+;;   14: ldr     x9, [x2, #0x38]
+;;       add     x9, x9, x4
+;;       mov     x10, #0xffff0000
+;;       str     w5, [x9, x10]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   34: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   2c: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x9, [x2, #0x40]
-;;       cmp     x4, x9
-;;       cset    x10, hi
-;;       uxtb    w10, w10
-;;       cbnz    x10, #0x74
-;;   5c: ldr     x11, [x2, #0x38]
-;;       add     x11, x11, x4
-;;       mov     x12, #0xffff0000
-;;       ldr     w2, [x11, x12]
+;;       ldr     x7, [x2, #0x40]
+;;       cmp     x4, x7
+;;       b.hi    #0x6c
+;;   54: ldr     x9, [x2, #0x38]
+;;       add     x9, x9, x4
+;;       mov     x10, #0xffff0000
+;;       ldr     w2, [x9, x10]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   74: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   6c: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -21,27 +21,23 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x7, [x2, #0x40]
-;;       cmp     x4, x7
-;;       cset    x8, hs
-;;       uxtb    w8, w8
-;;       cbnz    x8, #0x2c
-;;   1c: ldr     x9, [x2, #0x38]
-;;       strb    w5, [x9, x4]
+;;       ldr     x6, [x2, #0x40]
+;;       cmp     x4, x6
+;;       b.hs    #0x24
+;;   14: ldr     x7, [x2, #0x38]
+;;       strb    w5, [x7, x4]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   2c: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   24: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x7, [x2, #0x40]
-;;       cmp     x4, x7
-;;       cset    x8, hs
-;;       uxtb    w8, w8
-;;       cbnz    x8, #0x6c
-;;   5c: ldr     x9, [x2, #0x38]
-;;       ldrb    w2, [x9, x4]
+;;       ldr     x5, [x2, #0x40]
+;;       cmp     x4, x5
+;;       b.hs    #0x64
+;;   54: ldr     x7, [x2, #0x38]
+;;       ldrb    w2, [x7, x4]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   6c: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   64: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -21,29 +21,25 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x8, [x2, #0x40]
-;;       cmp     x4, x8
-;;       cset    x9, hi
-;;       uxtb    w9, w9
-;;       cbnz    x9, #0x30
-;;   1c: ldr     x10, [x2, #0x38]
-;;       add     x10, x10, #1, lsl #12
-;;       strb    w5, [x10, x4]
+;;       ldr     x6, [x2, #0x40]
+;;       cmp     x4, x6
+;;       b.hi    #0x28
+;;   14: ldr     x8, [x2, #0x38]
+;;       add     x8, x8, #1, lsl #12
+;;       strb    w5, [x8, x4]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   30: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   28: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x8, [x2, #0x40]
-;;       cmp     x4, x8
-;;       cset    x9, hi
-;;       uxtb    w9, w9
-;;       cbnz    x9, #0x70
-;;   5c: ldr     x10, [x2, #0x38]
-;;       add     x9, x10, #1, lsl #12
-;;       ldrb    w2, [x9, x4]
+;;       ldr     x6, [x2, #0x40]
+;;       cmp     x4, x6
+;;       b.hi    #0x68
+;;   54: ldr     x8, [x2, #0x38]
+;;       add     x7, x8, #1, lsl #12
+;;       ldrb    w2, [x7, x4]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   70: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   68: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -21,31 +21,27 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x9, [x2, #0x40]
-;;       cmp     x4, x9
-;;       cset    x10, hi
-;;       uxtb    w10, w10
-;;       cbnz    x10, #0x34
-;;   1c: ldr     x11, [x2, #0x38]
-;;       add     x11, x11, x4
-;;       mov     x12, #0xffff0000
-;;       strb    w5, [x11, x12]
+;;       ldr     x7, [x2, #0x40]
+;;       cmp     x4, x7
+;;       b.hi    #0x2c
+;;   14: ldr     x9, [x2, #0x38]
+;;       add     x9, x9, x4
+;;       mov     x10, #0xffff0000
+;;       strb    w5, [x9, x10]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   34: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   2c: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       ldr     x9, [x2, #0x40]
-;;       cmp     x4, x9
-;;       cset    x10, hi
-;;       uxtb    w10, w10
-;;       cbnz    x10, #0x74
-;;   5c: ldr     x11, [x2, #0x38]
-;;       add     x11, x11, x4
-;;       mov     x12, #0xffff0000
-;;       ldrb    w2, [x11, x12]
+;;       ldr     x7, [x2, #0x40]
+;;       cmp     x4, x7
+;;       b.hi    #0x6c
+;;   54: ldr     x9, [x2, #0x38]
+;;       add     x9, x9, x4
+;;       mov     x10, #0xffff0000
+;;       ldrb    w2, [x9, x10]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   74: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   6c: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -21,29 +21,25 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     w8, w4
+;;       mov     w6, w4
 ;;       orr     x7, xzr, #0xfffffffc
-;;       cmp     x8, x7
-;;       cset    x10, hi
-;;       uxtb    w9, w10
-;;       cbnz    x9, #0x30
-;;   20: ldr     x10, [x2, #0x38]
-;;       str     w5, [x10, w4, uxtw]
+;;       cmp     x6, x7
+;;       b.hi    #0x28
+;;   18: ldr     x8, [x2, #0x38]
+;;       str     w5, [x8, w4, uxtw]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   30: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   28: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     w8, w4
+;;       mov     w6, w4
 ;;       orr     x7, xzr, #0xfffffffc
-;;       cmp     x8, x7
-;;       cset    x10, hi
-;;       uxtb    w9, w10
-;;       cbnz    x9, #0x70
-;;   60: ldr     x10, [x2, #0x38]
-;;       ldr     w2, [x10, w4, uxtw]
+;;       cmp     x6, x7
+;;       b.hi    #0x68
+;;   58: ldr     x8, [x2, #0x38]
+;;       ldr     w2, [x8, w4, uxtw]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   70: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   68: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -21,31 +21,27 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     w9, w4
+;;       mov     w7, w4
 ;;       mov     w8, #-0x1004
-;;       cmp     x9, x8
-;;       cset    x11, hi
-;;       uxtb    w10, w11
-;;       cbnz    x10, #0x34
-;;   20: ldr     x11, [x2, #0x38]
-;;       add     x11, x11, #1, lsl #12
-;;       str     w5, [x11, w4, uxtw]
+;;       cmp     x7, x8
+;;       b.hi    #0x2c
+;;   18: ldr     x9, [x2, #0x38]
+;;       add     x9, x9, #1, lsl #12
+;;       str     w5, [x9, w4, uxtw]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   34: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   2c: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     w9, w4
+;;       mov     w7, w4
 ;;       mov     w8, #-0x1004
-;;       cmp     x9, x8
-;;       cset    x11, hi
-;;       uxtb    w10, w11
-;;       cbnz    x10, #0x74
-;;   60: ldr     x11, [x2, #0x38]
-;;       add     x10, x11, #1, lsl #12
-;;       ldr     w2, [x10, w4, uxtw]
+;;       cmp     x7, x8
+;;       b.hi    #0x6c
+;;   58: ldr     x9, [x2, #0x38]
+;;       add     x8, x9, #1, lsl #12
+;;       ldr     w2, [x8, w4, uxtw]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   74: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   6c: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -21,33 +21,29 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     w10, w4
+;;       mov     w8, w4
 ;;       mov     x9, #0xfffc
-;;       cmp     x10, x9
-;;       cset    x12, hi
-;;       uxtb    w11, w12
-;;       cbnz    x11, #0x38
-;;   20: ldr     x12, [x2, #0x38]
-;;       add     x12, x12, w4, uxtw
-;;       mov     x13, #0xffff0000
-;;       str     w5, [x12, x13]
+;;       cmp     x8, x9
+;;       b.hi    #0x30
+;;   18: ldr     x10, [x2, #0x38]
+;;       add     x10, x10, w4, uxtw
+;;       mov     x11, #0xffff0000
+;;       str     w5, [x10, x11]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   38: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   30: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     w10, w4
+;;       mov     w8, w4
 ;;       mov     x9, #0xfffc
-;;       cmp     x10, x9
-;;       cset    x12, hi
-;;       uxtb    w11, w12
-;;       cbnz    x11, #0x78
-;;   60: ldr     x12, [x2, #0x38]
-;;       add     x12, x12, w4, uxtw
-;;       mov     x13, #0xffff0000
-;;       ldr     w2, [x12, x13]
+;;       cmp     x8, x9
+;;       b.hi    #0x70
+;;   58: ldr     x10, [x2, #0x38]
+;;       add     x10, x10, w4, uxtw
+;;       mov     x11, #0xffff0000
+;;       ldr     w2, [x10, x11]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   78: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   70: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -21,31 +21,27 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     w9, w4
+;;       mov     w7, w4
 ;;       mov     w8, #-0x1001
-;;       cmp     x9, x8
-;;       cset    x11, hi
-;;       uxtb    w10, w11
-;;       cbnz    x10, #0x34
-;;   20: ldr     x11, [x2, #0x38]
-;;       add     x11, x11, #1, lsl #12
-;;       strb    w5, [x11, w4, uxtw]
+;;       cmp     x7, x8
+;;       b.hi    #0x2c
+;;   18: ldr     x9, [x2, #0x38]
+;;       add     x9, x9, #1, lsl #12
+;;       strb    w5, [x9, w4, uxtw]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   34: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   2c: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     w9, w4
+;;       mov     w7, w4
 ;;       mov     w8, #-0x1001
-;;       cmp     x9, x8
-;;       cset    x11, hi
-;;       uxtb    w10, w11
-;;       cbnz    x10, #0x74
-;;   60: ldr     x11, [x2, #0x38]
-;;       add     x10, x11, #1, lsl #12
-;;       ldrb    w2, [x10, w4, uxtw]
+;;       cmp     x7, x8
+;;       b.hi    #0x6c
+;;   58: ldr     x9, [x2, #0x38]
+;;       add     x8, x9, #1, lsl #12
+;;       ldrb    w2, [x8, w4, uxtw]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   74: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   6c: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -21,33 +21,29 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     w10, w4
+;;       mov     w8, w4
 ;;       mov     x9, #0xffff
-;;       cmp     x10, x9
-;;       cset    x12, hi
-;;       uxtb    w11, w12
-;;       cbnz    x11, #0x38
-;;   20: ldr     x12, [x2, #0x38]
-;;       add     x12, x12, w4, uxtw
-;;       mov     x13, #0xffff0000
-;;       strb    w5, [x12, x13]
+;;       cmp     x8, x9
+;;       b.hi    #0x30
+;;   18: ldr     x10, [x2, #0x38]
+;;       add     x10, x10, w4, uxtw
+;;       mov     x11, #0xffff0000
+;;       strb    w5, [x10, x11]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   38: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   30: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     w10, w4
+;;       mov     w8, w4
 ;;       mov     x9, #0xffff
-;;       cmp     x10, x9
-;;       cset    x12, hi
-;;       uxtb    w11, w12
-;;       cbnz    x11, #0x78
-;;   60: ldr     x12, [x2, #0x38]
-;;       add     x12, x12, w4, uxtw
-;;       mov     x13, #0xffff0000
-;;       ldrb    w2, [x12, x13]
+;;       cmp     x8, x9
+;;       b.hi    #0x70
+;;   58: ldr     x10, [x2, #0x38]
+;;       add     x10, x10, w4, uxtw
+;;       mov     x11, #0xffff0000
+;;       ldrb    w2, [x10, x11]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   78: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   70: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -22,13 +22,13 @@
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
 ;;       mov     w9, w4
-;;       mov     x10, #0
-;;       ldr     x11, [x2, #0x38]
-;;       add     x11, x11, w4, uxtw
-;;       orr     x8, xzr, #0xfffffffc
-;;       cmp     x9, x8
-;;       csel    x11, x10, x11, hi
-;;       str     w5, [x11]
+;;       orr     x10, xzr, #0xfffffffc
+;;       mov     x11, #0
+;;       ldr     x12, [x2, #0x38]
+;;       add     x12, x12, w4, uxtw
+;;       cmp     x9, x10
+;;       csel    x10, x11, x12, hi
+;;       str     w5, [x10]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;
@@ -36,12 +36,12 @@
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
 ;;       mov     w9, w4
-;;       mov     x10, #0
-;;       ldr     x11, [x2, #0x38]
-;;       add     x11, x11, w4, uxtw
-;;       orr     x8, xzr, #0xfffffffc
-;;       cmp     x9, x8
-;;       csel    x11, x10, x11, hi
-;;       ldr     w2, [x11]
+;;       orr     x10, xzr, #0xfffffffc
+;;       mov     x11, #0
+;;       ldr     x12, [x2, #0x38]
+;;       add     x12, x12, w4, uxtw
+;;       cmp     x9, x10
+;;       csel    x10, x11, x12, hi
+;;       ldr     w2, [x10]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -22,14 +22,14 @@
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
 ;;       mov     w10, w4
-;;       mov     x11, #0
-;;       ldr     x12, [x2, #0x38]
-;;       add     x12, x12, w4, uxtw
-;;       add     x12, x12, #1, lsl #12
-;;       mov     w9, #-0x1004
-;;       cmp     x10, x9
-;;       csel    x12, x11, x12, hi
-;;       str     w5, [x12]
+;;       mov     w11, #-0x1004
+;;       mov     x12, #0
+;;       ldr     x13, [x2, #0x38]
+;;       add     x13, x13, w4, uxtw
+;;       add     x13, x13, #1, lsl #12
+;;       cmp     x10, x11
+;;       csel    x11, x12, x13, hi
+;;       str     w5, [x11]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;
@@ -37,13 +37,13 @@
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
 ;;       mov     w10, w4
-;;       mov     x11, #0
-;;       ldr     x12, [x2, #0x38]
-;;       add     x12, x12, w4, uxtw
-;;       add     x12, x12, #1, lsl #12
-;;       mov     w9, #-0x1004
-;;       cmp     x10, x9
-;;       csel    x12, x11, x12, hi
-;;       ldr     w2, [x12]
+;;       mov     w11, #-0x1004
+;;       mov     x12, #0
+;;       ldr     x13, [x2, #0x38]
+;;       add     x13, x13, w4, uxtw
+;;       add     x13, x13, #1, lsl #12
+;;       cmp     x10, x11
+;;       csel    x11, x12, x13, hi
+;;       ldr     w2, [x11]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -22,15 +22,15 @@
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
 ;;       mov     w11, w4
-;;       mov     x12, #0
-;;       ldr     x13, [x2, #0x38]
-;;       add     x13, x13, w4, uxtw
-;;       mov     x14, #0xffff0000
-;;       add     x13, x13, x14
-;;       mov     x10, #0xfffc
-;;       cmp     x11, x10
-;;       csel    x13, x12, x13, hi
-;;       str     w5, [x13]
+;;       mov     x12, #0xfffc
+;;       mov     x13, #0
+;;       ldr     x14, [x2, #0x38]
+;;       add     x14, x14, w4, uxtw
+;;       mov     x15, #0xffff0000
+;;       add     x14, x14, x15
+;;       cmp     x11, x12
+;;       csel    x12, x13, x14, hi
+;;       str     w5, [x12]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;
@@ -38,14 +38,14 @@
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
 ;;       mov     w11, w4
-;;       mov     x12, #0
-;;       ldr     x13, [x2, #0x38]
-;;       add     x13, x13, w4, uxtw
-;;       mov     x14, #0xffff0000
-;;       add     x13, x13, x14
-;;       mov     x10, #0xfffc
-;;       cmp     x11, x10
-;;       csel    x13, x12, x13, hi
-;;       ldr     w2, [x13]
+;;       mov     x12, #0xfffc
+;;       mov     x13, #0
+;;       ldr     x14, [x2, #0x38]
+;;       add     x14, x14, w4, uxtw
+;;       mov     x15, #0xffff0000
+;;       add     x14, x14, x15
+;;       cmp     x11, x12
+;;       csel    x12, x13, x14, hi
+;;       ldr     w2, [x12]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -22,14 +22,14 @@
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
 ;;       mov     w10, w4
-;;       mov     x11, #0
-;;       ldr     x12, [x2, #0x38]
-;;       add     x12, x12, w4, uxtw
-;;       add     x12, x12, #1, lsl #12
-;;       mov     w9, #-0x1001
-;;       cmp     x10, x9
-;;       csel    x12, x11, x12, hi
-;;       strb    w5, [x12]
+;;       mov     w11, #-0x1001
+;;       mov     x12, #0
+;;       ldr     x13, [x2, #0x38]
+;;       add     x13, x13, w4, uxtw
+;;       add     x13, x13, #1, lsl #12
+;;       cmp     x10, x11
+;;       csel    x11, x12, x13, hi
+;;       strb    w5, [x11]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;
@@ -37,13 +37,13 @@
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
 ;;       mov     w10, w4
-;;       mov     x11, #0
-;;       ldr     x12, [x2, #0x38]
-;;       add     x12, x12, w4, uxtw
-;;       add     x12, x12, #1, lsl #12
-;;       mov     w9, #-0x1001
-;;       cmp     x10, x9
-;;       csel    x12, x11, x12, hi
-;;       ldrb    w2, [x12]
+;;       mov     w11, #-0x1001
+;;       mov     x12, #0
+;;       ldr     x13, [x2, #0x38]
+;;       add     x13, x13, w4, uxtw
+;;       add     x13, x13, #1, lsl #12
+;;       cmp     x10, x11
+;;       csel    x11, x12, x13, hi
+;;       ldrb    w2, [x11]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -22,15 +22,15 @@
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
 ;;       mov     w11, w4
-;;       mov     x12, #0
-;;       ldr     x13, [x2, #0x38]
-;;       add     x13, x13, w4, uxtw
-;;       mov     x14, #0xffff0000
-;;       add     x13, x13, x14
-;;       mov     x10, #0xffff
-;;       cmp     x11, x10
-;;       csel    x13, x12, x13, hi
-;;       strb    w5, [x13]
+;;       mov     x12, #0xffff
+;;       mov     x13, #0
+;;       ldr     x14, [x2, #0x38]
+;;       add     x14, x14, w4, uxtw
+;;       mov     x15, #0xffff0000
+;;       add     x14, x14, x15
+;;       cmp     x11, x12
+;;       csel    x12, x13, x14, hi
+;;       strb    w5, [x12]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;
@@ -38,14 +38,14 @@
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
 ;;       mov     w11, w4
-;;       mov     x12, #0
-;;       ldr     x13, [x2, #0x38]
-;;       add     x13, x13, w4, uxtw
-;;       mov     x14, #0xffff0000
-;;       add     x13, x13, x14
-;;       mov     x10, #0xffff
-;;       cmp     x11, x10
-;;       csel    x13, x12, x13, hi
-;;       ldrb    w2, [x13]
+;;       mov     x12, #0xffff
+;;       mov     x13, #0
+;;       ldr     x14, [x2, #0x38]
+;;       add     x14, x14, w4, uxtw
+;;       mov     x15, #0xffff0000
+;;       add     x14, x14, x15
+;;       cmp     x11, x12
+;;       csel    x12, x13, x14, hi
+;;       ldrb    w2, [x12]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -23,25 +23,21 @@
 ;;       mov     x29, sp
 ;;       orr     x6, xzr, #0xfffffffc
 ;;       cmp     x4, x6
-;;       cset    x9, hi
-;;       uxtb    w8, w9
-;;       cbnz    x8, #0x2c
-;;   1c: ldr     x9, [x2, #0x38]
-;;       str     w5, [x9, x4]
+;;       b.hi    #0x24
+;;   14: ldr     x7, [x2, #0x38]
+;;       str     w5, [x7, x4]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   2c: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   24: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       orr     x6, xzr, #0xfffffffc
-;;       cmp     x4, x6
-;;       cset    x9, hi
-;;       uxtb    w8, w9
-;;       cbnz    x8, #0x6c
-;;   5c: ldr     x9, [x2, #0x38]
-;;       ldr     w2, [x9, x4]
+;;       orr     x5, xzr, #0xfffffffc
+;;       cmp     x4, x5
+;;       b.hi    #0x64
+;;   54: ldr     x7, [x2, #0x38]
+;;       ldr     w2, [x7, x4]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   6c: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   64: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -21,29 +21,25 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     w7, #-0x1004
-;;       cmp     x4, x7
-;;       cset    x10, hi
-;;       uxtb    w9, w10
-;;       cbnz    x9, #0x30
-;;   1c: ldr     x10, [x2, #0x38]
-;;       add     x10, x10, #1, lsl #12
-;;       str     w5, [x10, x4]
+;;       mov     w6, #-0x1004
+;;       cmp     x4, x6
+;;       b.hi    #0x28
+;;   14: ldr     x8, [x2, #0x38]
+;;       add     x8, x8, #1, lsl #12
+;;       str     w5, [x8, x4]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   30: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   28: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     w7, #-0x1004
-;;       cmp     x4, x7
-;;       cset    x10, hi
-;;       uxtb    w9, w10
-;;       cbnz    x9, #0x70
-;;   5c: ldr     x10, [x2, #0x38]
-;;       add     x9, x10, #1, lsl #12
-;;       ldr     w2, [x9, x4]
+;;       mov     w6, #-0x1004
+;;       cmp     x4, x6
+;;       b.hi    #0x68
+;;   54: ldr     x8, [x2, #0x38]
+;;       add     x7, x8, #1, lsl #12
+;;       ldr     w2, [x7, x4]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   70: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   68: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -21,31 +21,27 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     x8, #0xfffc
-;;       cmp     x4, x8
-;;       cset    x11, hi
-;;       uxtb    w10, w11
-;;       cbnz    x10, #0x34
-;;   1c: ldr     x11, [x2, #0x38]
-;;       add     x11, x11, x4
-;;       mov     x12, #0xffff0000
-;;       str     w5, [x11, x12]
+;;       mov     x7, #0xfffc
+;;       cmp     x4, x7
+;;       b.hi    #0x2c
+;;   14: ldr     x9, [x2, #0x38]
+;;       add     x9, x9, x4
+;;       mov     x10, #0xffff0000
+;;       str     w5, [x9, x10]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   34: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   2c: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     x8, #0xfffc
-;;       cmp     x4, x8
-;;       cset    x11, hi
-;;       uxtb    w10, w11
-;;       cbnz    x10, #0x74
-;;   5c: ldr     x11, [x2, #0x38]
-;;       add     x11, x11, x4
-;;       mov     x12, #0xffff0000
-;;       ldr     w2, [x11, x12]
+;;       mov     x7, #0xfffc
+;;       cmp     x4, x7
+;;       b.hi    #0x6c
+;;   54: ldr     x9, [x2, #0x38]
+;;       add     x9, x9, x4
+;;       mov     x10, #0xffff0000
+;;       ldr     w2, [x9, x10]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   74: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   6c: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -23,25 +23,21 @@
 ;;       mov     x29, sp
 ;;       orr     x6, xzr, #0xffffffff
 ;;       cmp     x4, x6
-;;       cset    x9, hi
-;;       uxtb    w8, w9
-;;       cbnz    x8, #0x2c
-;;   1c: ldr     x9, [x2, #0x38]
-;;       strb    w5, [x9, x4]
+;;       b.hi    #0x24
+;;   14: ldr     x7, [x2, #0x38]
+;;       strb    w5, [x7, x4]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   2c: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   24: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       orr     x6, xzr, #0xffffffff
-;;       cmp     x4, x6
-;;       cset    x9, hi
-;;       uxtb    w8, w9
-;;       cbnz    x8, #0x6c
-;;   5c: ldr     x9, [x2, #0x38]
-;;       ldrb    w2, [x9, x4]
+;;       orr     x5, xzr, #0xffffffff
+;;       cmp     x4, x5
+;;       b.hi    #0x64
+;;   54: ldr     x7, [x2, #0x38]
+;;       ldrb    w2, [x7, x4]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   6c: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   64: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -21,29 +21,25 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     w7, #-0x1001
-;;       cmp     x4, x7
-;;       cset    x10, hi
-;;       uxtb    w9, w10
-;;       cbnz    x9, #0x30
-;;   1c: ldr     x10, [x2, #0x38]
-;;       add     x10, x10, #1, lsl #12
-;;       strb    w5, [x10, x4]
+;;       mov     w6, #-0x1001
+;;       cmp     x4, x6
+;;       b.hi    #0x28
+;;   14: ldr     x8, [x2, #0x38]
+;;       add     x8, x8, #1, lsl #12
+;;       strb    w5, [x8, x4]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   30: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   28: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     w7, #-0x1001
-;;       cmp     x4, x7
-;;       cset    x10, hi
-;;       uxtb    w9, w10
-;;       cbnz    x9, #0x70
-;;   5c: ldr     x10, [x2, #0x38]
-;;       add     x9, x10, #1, lsl #12
-;;       ldrb    w2, [x9, x4]
+;;       mov     w6, #-0x1001
+;;       cmp     x4, x6
+;;       b.hi    #0x68
+;;   54: ldr     x8, [x2, #0x38]
+;;       add     x7, x8, #1, lsl #12
+;;       ldrb    w2, [x7, x4]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   70: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   68: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -21,31 +21,27 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     x8, #0xffff
-;;       cmp     x4, x8
-;;       cset    x11, hi
-;;       uxtb    w10, w11
-;;       cbnz    x10, #0x34
-;;   1c: ldr     x11, [x2, #0x38]
-;;       add     x11, x11, x4
-;;       mov     x12, #0xffff0000
-;;       strb    w5, [x11, x12]
+;;       mov     x7, #0xffff
+;;       cmp     x4, x7
+;;       b.hi    #0x2c
+;;   14: ldr     x9, [x2, #0x38]
+;;       add     x9, x9, x4
+;;       mov     x10, #0xffff0000
+;;       strb    w5, [x9, x10]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   34: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   2c: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     x8, #0xffff
-;;       cmp     x4, x8
-;;       cset    x11, hi
-;;       uxtb    w10, w11
-;;       cbnz    x10, #0x74
-;;   5c: ldr     x11, [x2, #0x38]
-;;       add     x11, x11, x4
-;;       mov     x12, #0xffff0000
-;;       ldrb    w2, [x11, x12]
+;;       mov     x7, #0xffff
+;;       cmp     x4, x7
+;;       b.hi    #0x6c
+;;   54: ldr     x9, [x2, #0x38]
+;;       add     x9, x9, x4
+;;       mov     x10, #0xffff0000
+;;       ldrb    w2, [x9, x10]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   74: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   6c: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -21,25 +21,25 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     x8, #0
-;;       ldr     x9, [x2, #0x38]
-;;       add     x9, x9, x4
-;;       orr     x7, xzr, #0xfffffffc
-;;       cmp     x4, x7
-;;       csel    x10, x8, x9, hi
-;;       str     w5, [x10]
+;;       orr     x8, xzr, #0xfffffffc
+;;       mov     x9, #0
+;;       ldr     x10, [x2, #0x38]
+;;       add     x10, x10, x4
+;;       cmp     x4, x8
+;;       csel    x9, x9, x10, hi
+;;       str     w5, [x9]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     x8, #0
-;;       ldr     x9, [x2, #0x38]
-;;       add     x9, x9, x4
-;;       orr     x7, xzr, #0xfffffffc
-;;       cmp     x4, x7
-;;       csel    x10, x8, x9, hi
-;;       ldr     w2, [x10]
+;;       orr     x8, xzr, #0xfffffffc
+;;       mov     x9, #0
+;;       ldr     x10, [x2, #0x38]
+;;       add     x10, x10, x4
+;;       cmp     x4, x8
+;;       csel    x9, x9, x10, hi
+;;       ldr     w2, [x9]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -21,27 +21,27 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     x9, #0
-;;       ldr     x10, [x2, #0x38]
-;;       add     x10, x10, x4
-;;       add     x10, x10, #1, lsl #12
-;;       mov     w8, #-0x1004
-;;       cmp     x4, x8
-;;       csel    x11, x9, x10, hi
-;;       str     w5, [x11]
+;;       mov     w9, #-0x1004
+;;       mov     x10, #0
+;;       ldr     x11, [x2, #0x38]
+;;       add     x11, x11, x4
+;;       add     x11, x11, #1, lsl #12
+;;       cmp     x4, x9
+;;       csel    x10, x10, x11, hi
+;;       str     w5, [x10]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     x9, #0
-;;       ldr     x10, [x2, #0x38]
-;;       add     x10, x10, x4
-;;       add     x10, x10, #1, lsl #12
-;;       mov     w8, #-0x1004
-;;       cmp     x4, x8
-;;       csel    x11, x9, x10, hi
-;;       ldr     w2, [x11]
+;;       mov     w9, #-0x1004
+;;       mov     x10, #0
+;;       ldr     x11, [x2, #0x38]
+;;       add     x11, x11, x4
+;;       add     x11, x11, #1, lsl #12
+;;       cmp     x4, x9
+;;       csel    x10, x10, x11, hi
+;;       ldr     w2, [x10]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -21,29 +21,29 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     x10, #0
-;;       ldr     x11, [x2, #0x38]
-;;       add     x11, x11, x4
-;;       mov     x12, #0xffff0000
-;;       add     x11, x11, x12
-;;       mov     x9, #0xfffc
-;;       cmp     x4, x9
-;;       csel    x12, x10, x11, hi
-;;       str     w5, [x12]
+;;       mov     x10, #0xfffc
+;;       mov     x11, #0
+;;       ldr     x12, [x2, #0x38]
+;;       add     x12, x12, x4
+;;       mov     x13, #0xffff0000
+;;       add     x12, x12, x13
+;;       cmp     x4, x10
+;;       csel    x11, x11, x12, hi
+;;       str     w5, [x11]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     x10, #0
-;;       ldr     x11, [x2, #0x38]
-;;       add     x11, x11, x4
-;;       mov     x12, #0xffff0000
-;;       add     x11, x11, x12
-;;       mov     x9, #0xfffc
-;;       cmp     x4, x9
-;;       csel    x12, x10, x11, hi
-;;       ldr     w2, [x12]
+;;       mov     x10, #0xfffc
+;;       mov     x11, #0
+;;       ldr     x12, [x2, #0x38]
+;;       add     x12, x12, x4
+;;       mov     x13, #0xffff0000
+;;       add     x12, x12, x13
+;;       cmp     x4, x10
+;;       csel    x11, x11, x12, hi
+;;       ldr     w2, [x11]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0_offset.wat
@@ -21,25 +21,25 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     x8, #0
-;;       ldr     x9, [x2, #0x38]
-;;       add     x9, x9, x4
-;;       orr     x7, xzr, #0xffffffff
-;;       cmp     x4, x7
-;;       csel    x10, x8, x9, hi
-;;       strb    w5, [x10]
+;;       orr     x8, xzr, #0xffffffff
+;;       mov     x9, #0
+;;       ldr     x10, [x2, #0x38]
+;;       add     x10, x10, x4
+;;       cmp     x4, x8
+;;       csel    x9, x9, x10, hi
+;;       strb    w5, [x9]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     x8, #0
-;;       ldr     x9, [x2, #0x38]
-;;       add     x9, x9, x4
-;;       orr     x7, xzr, #0xffffffff
-;;       cmp     x4, x7
-;;       csel    x10, x8, x9, hi
-;;       ldrb    w2, [x10]
+;;       orr     x8, xzr, #0xffffffff
+;;       mov     x9, #0
+;;       ldr     x10, [x2, #0x38]
+;;       add     x10, x10, x4
+;;       cmp     x4, x8
+;;       csel    x9, x9, x10, hi
+;;       ldrb    w2, [x9]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -21,27 +21,27 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     x9, #0
-;;       ldr     x10, [x2, #0x38]
-;;       add     x10, x10, x4
-;;       add     x10, x10, #1, lsl #12
-;;       mov     w8, #-0x1001
-;;       cmp     x4, x8
-;;       csel    x11, x9, x10, hi
-;;       strb    w5, [x11]
+;;       mov     w9, #-0x1001
+;;       mov     x10, #0
+;;       ldr     x11, [x2, #0x38]
+;;       add     x11, x11, x4
+;;       add     x11, x11, #1, lsl #12
+;;       cmp     x4, x9
+;;       csel    x10, x10, x11, hi
+;;       strb    w5, [x10]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     x9, #0
-;;       ldr     x10, [x2, #0x38]
-;;       add     x10, x10, x4
-;;       add     x10, x10, #1, lsl #12
-;;       mov     w8, #-0x1001
-;;       cmp     x4, x8
-;;       csel    x11, x9, x10, hi
-;;       ldrb    w2, [x11]
+;;       mov     w9, #-0x1001
+;;       mov     x10, #0
+;;       ldr     x11, [x2, #0x38]
+;;       add     x11, x11, x4
+;;       add     x11, x11, #1, lsl #12
+;;       cmp     x4, x9
+;;       csel    x10, x10, x11, hi
+;;       ldrb    w2, [x10]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -21,29 +21,29 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     x10, #0
-;;       ldr     x11, [x2, #0x38]
-;;       add     x11, x11, x4
-;;       mov     x12, #0xffff0000
-;;       add     x11, x11, x12
-;;       mov     x9, #0xffff
-;;       cmp     x4, x9
-;;       csel    x12, x10, x11, hi
-;;       strb    w5, [x12]
+;;       mov     x10, #0xffff
+;;       mov     x11, #0
+;;       ldr     x12, [x2, #0x38]
+;;       add     x12, x12, x4
+;;       mov     x13, #0xffff0000
+;;       add     x12, x12, x13
+;;       cmp     x4, x10
+;;       csel    x11, x11, x12, hi
+;;       strb    w5, [x11]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     x10, #0
-;;       ldr     x11, [x2, #0x38]
-;;       add     x11, x11, x4
-;;       mov     x12, #0xffff0000
-;;       add     x11, x11, x12
-;;       mov     x9, #0xffff
-;;       cmp     x4, x9
-;;       csel    x12, x10, x11, hi
-;;       ldrb    w2, [x12]
+;;       mov     x10, #0xffff
+;;       mov     x11, #0
+;;       ldr     x12, [x2, #0x38]
+;;       add     x12, x12, x4
+;;       mov     x13, #0xffff0000
+;;       add     x12, x12, x13
+;;       cmp     x4, x10
+;;       csel    x11, x11, x12, hi
+;;       ldrb    w2, [x11]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -23,25 +23,21 @@
 ;;       mov     x29, sp
 ;;       orr     x6, xzr, #0xfffffffc
 ;;       cmp     x4, x6
-;;       cset    x9, hi
-;;       uxtb    w8, w9
-;;       cbnz    x8, #0x2c
-;;   1c: ldr     x9, [x2, #0x38]
-;;       str     w5, [x9, x4]
+;;       b.hi    #0x24
+;;   14: ldr     x7, [x2, #0x38]
+;;       str     w5, [x7, x4]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   2c: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   24: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       orr     x6, xzr, #0xfffffffc
-;;       cmp     x4, x6
-;;       cset    x9, hi
-;;       uxtb    w8, w9
-;;       cbnz    x8, #0x6c
-;;   5c: ldr     x9, [x2, #0x38]
-;;       ldr     w2, [x9, x4]
+;;       orr     x5, xzr, #0xfffffffc
+;;       cmp     x4, x5
+;;       b.hi    #0x64
+;;   54: ldr     x7, [x2, #0x38]
+;;       ldr     w2, [x7, x4]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   6c: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   64: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -21,29 +21,25 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     w7, #-0x1004
-;;       cmp     x4, x7
-;;       cset    x10, hi
-;;       uxtb    w9, w10
-;;       cbnz    x9, #0x30
-;;   1c: ldr     x10, [x2, #0x38]
-;;       add     x10, x10, #1, lsl #12
-;;       str     w5, [x10, x4]
+;;       mov     w6, #-0x1004
+;;       cmp     x4, x6
+;;       b.hi    #0x28
+;;   14: ldr     x8, [x2, #0x38]
+;;       add     x8, x8, #1, lsl #12
+;;       str     w5, [x8, x4]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   30: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   28: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     w7, #-0x1004
-;;       cmp     x4, x7
-;;       cset    x10, hi
-;;       uxtb    w9, w10
-;;       cbnz    x9, #0x70
-;;   5c: ldr     x10, [x2, #0x38]
-;;       add     x9, x10, #1, lsl #12
-;;       ldr     w2, [x9, x4]
+;;       mov     w6, #-0x1004
+;;       cmp     x4, x6
+;;       b.hi    #0x68
+;;   54: ldr     x8, [x2, #0x38]
+;;       add     x7, x8, #1, lsl #12
+;;       ldr     w2, [x7, x4]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   70: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   68: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -21,31 +21,27 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     x8, #0xfffc
-;;       cmp     x4, x8
-;;       cset    x11, hi
-;;       uxtb    w10, w11
-;;       cbnz    x10, #0x34
-;;   1c: ldr     x11, [x2, #0x38]
-;;       add     x11, x11, x4
-;;       mov     x12, #0xffff0000
-;;       str     w5, [x11, x12]
+;;       mov     x7, #0xfffc
+;;       cmp     x4, x7
+;;       b.hi    #0x2c
+;;   14: ldr     x9, [x2, #0x38]
+;;       add     x9, x9, x4
+;;       mov     x10, #0xffff0000
+;;       str     w5, [x9, x10]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   34: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   2c: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     x8, #0xfffc
-;;       cmp     x4, x8
-;;       cset    x11, hi
-;;       uxtb    w10, w11
-;;       cbnz    x10, #0x74
-;;   5c: ldr     x11, [x2, #0x38]
-;;       add     x11, x11, x4
-;;       mov     x12, #0xffff0000
-;;       ldr     w2, [x11, x12]
+;;       mov     x7, #0xfffc
+;;       cmp     x4, x7
+;;       b.hi    #0x6c
+;;   54: ldr     x9, [x2, #0x38]
+;;       add     x9, x9, x4
+;;       mov     x10, #0xffff0000
+;;       ldr     w2, [x9, x10]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   74: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   6c: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -23,25 +23,21 @@
 ;;       mov     x29, sp
 ;;       orr     x6, xzr, #0xffffffff
 ;;       cmp     x4, x6
-;;       cset    x9, hi
-;;       uxtb    w8, w9
-;;       cbnz    x8, #0x2c
-;;   1c: ldr     x9, [x2, #0x38]
-;;       strb    w5, [x9, x4]
+;;       b.hi    #0x24
+;;   14: ldr     x7, [x2, #0x38]
+;;       strb    w5, [x7, x4]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   2c: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   24: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       orr     x6, xzr, #0xffffffff
-;;       cmp     x4, x6
-;;       cset    x9, hi
-;;       uxtb    w8, w9
-;;       cbnz    x8, #0x6c
-;;   5c: ldr     x9, [x2, #0x38]
-;;       ldrb    w2, [x9, x4]
+;;       orr     x5, xzr, #0xffffffff
+;;       cmp     x4, x5
+;;       b.hi    #0x64
+;;   54: ldr     x7, [x2, #0x38]
+;;       ldrb    w2, [x7, x4]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   6c: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   64: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -21,29 +21,25 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     w7, #-0x1001
-;;       cmp     x4, x7
-;;       cset    x10, hi
-;;       uxtb    w9, w10
-;;       cbnz    x9, #0x30
-;;   1c: ldr     x10, [x2, #0x38]
-;;       add     x10, x10, #1, lsl #12
-;;       strb    w5, [x10, x4]
+;;       mov     w6, #-0x1001
+;;       cmp     x4, x6
+;;       b.hi    #0x28
+;;   14: ldr     x8, [x2, #0x38]
+;;       add     x8, x8, #1, lsl #12
+;;       strb    w5, [x8, x4]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   30: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   28: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     w7, #-0x1001
-;;       cmp     x4, x7
-;;       cset    x10, hi
-;;       uxtb    w9, w10
-;;       cbnz    x9, #0x70
-;;   5c: ldr     x10, [x2, #0x38]
-;;       add     x9, x10, #1, lsl #12
-;;       ldrb    w2, [x9, x4]
+;;       mov     w6, #-0x1001
+;;       cmp     x4, x6
+;;       b.hi    #0x68
+;;   54: ldr     x8, [x2, #0x38]
+;;       add     x7, x8, #1, lsl #12
+;;       ldrb    w2, [x7, x4]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   70: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   68: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -21,31 +21,27 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     x8, #0xffff
-;;       cmp     x4, x8
-;;       cset    x11, hi
-;;       uxtb    w10, w11
-;;       cbnz    x10, #0x34
-;;   1c: ldr     x11, [x2, #0x38]
-;;       add     x11, x11, x4
-;;       mov     x12, #0xffff0000
-;;       strb    w5, [x11, x12]
+;;       mov     x7, #0xffff
+;;       cmp     x4, x7
+;;       b.hi    #0x2c
+;;   14: ldr     x9, [x2, #0x38]
+;;       add     x9, x9, x4
+;;       mov     x10, #0xffff0000
+;;       strb    w5, [x9, x10]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   34: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   2c: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     x8, #0xffff
-;;       cmp     x4, x8
-;;       cset    x11, hi
-;;       uxtb    w10, w11
-;;       cbnz    x10, #0x74
-;;   5c: ldr     x11, [x2, #0x38]
-;;       add     x11, x11, x4
-;;       mov     x12, #0xffff0000
-;;       ldrb    w2, [x11, x12]
+;;       mov     x7, #0xffff
+;;       cmp     x4, x7
+;;       b.hi    #0x6c
+;;   54: ldr     x9, [x2, #0x38]
+;;       add     x9, x9, x4
+;;       mov     x10, #0xffff0000
+;;       ldrb    w2, [x9, x10]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;   74: .byte   0x1f, 0xc1, 0x00, 0x00
+;;   6c: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
@@ -21,25 +21,25 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     x8, #0
-;;       ldr     x9, [x2, #0x38]
-;;       add     x9, x9, x4
-;;       orr     x7, xzr, #0xfffffffc
-;;       cmp     x4, x7
-;;       csel    x10, x8, x9, hi
-;;       str     w5, [x10]
+;;       orr     x8, xzr, #0xfffffffc
+;;       mov     x9, #0
+;;       ldr     x10, [x2, #0x38]
+;;       add     x10, x10, x4
+;;       cmp     x4, x8
+;;       csel    x9, x9, x10, hi
+;;       str     w5, [x9]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     x8, #0
-;;       ldr     x9, [x2, #0x38]
-;;       add     x9, x9, x4
-;;       orr     x7, xzr, #0xfffffffc
-;;       cmp     x4, x7
-;;       csel    x10, x8, x9, hi
-;;       ldr     w2, [x10]
+;;       orr     x8, xzr, #0xfffffffc
+;;       mov     x9, #0
+;;       ldr     x10, [x2, #0x38]
+;;       add     x10, x10, x4
+;;       cmp     x4, x8
+;;       csel    x9, x9, x10, hi
+;;       ldr     w2, [x9]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -21,27 +21,27 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     x9, #0
-;;       ldr     x10, [x2, #0x38]
-;;       add     x10, x10, x4
-;;       add     x10, x10, #1, lsl #12
-;;       mov     w8, #-0x1004
-;;       cmp     x4, x8
-;;       csel    x11, x9, x10, hi
-;;       str     w5, [x11]
+;;       mov     w9, #-0x1004
+;;       mov     x10, #0
+;;       ldr     x11, [x2, #0x38]
+;;       add     x11, x11, x4
+;;       add     x11, x11, #1, lsl #12
+;;       cmp     x4, x9
+;;       csel    x10, x10, x11, hi
+;;       str     w5, [x10]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     x9, #0
-;;       ldr     x10, [x2, #0x38]
-;;       add     x10, x10, x4
-;;       add     x10, x10, #1, lsl #12
-;;       mov     w8, #-0x1004
-;;       cmp     x4, x8
-;;       csel    x11, x9, x10, hi
-;;       ldr     w2, [x11]
+;;       mov     w9, #-0x1004
+;;       mov     x10, #0
+;;       ldr     x11, [x2, #0x38]
+;;       add     x11, x11, x4
+;;       add     x11, x11, #1, lsl #12
+;;       cmp     x4, x9
+;;       csel    x10, x10, x11, hi
+;;       ldr     w2, [x10]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -21,29 +21,29 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     x10, #0
-;;       ldr     x11, [x2, #0x38]
-;;       add     x11, x11, x4
-;;       mov     x12, #0xffff0000
-;;       add     x11, x11, x12
-;;       mov     x9, #0xfffc
-;;       cmp     x4, x9
-;;       csel    x12, x10, x11, hi
-;;       str     w5, [x12]
+;;       mov     x10, #0xfffc
+;;       mov     x11, #0
+;;       ldr     x12, [x2, #0x38]
+;;       add     x12, x12, x4
+;;       mov     x13, #0xffff0000
+;;       add     x12, x12, x13
+;;       cmp     x4, x10
+;;       csel    x11, x11, x12, hi
+;;       str     w5, [x11]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     x10, #0
-;;       ldr     x11, [x2, #0x38]
-;;       add     x11, x11, x4
-;;       mov     x12, #0xffff0000
-;;       add     x11, x11, x12
-;;       mov     x9, #0xfffc
-;;       cmp     x4, x9
-;;       csel    x12, x10, x11, hi
-;;       ldr     w2, [x12]
+;;       mov     x10, #0xfffc
+;;       mov     x11, #0
+;;       ldr     x12, [x2, #0x38]
+;;       add     x12, x12, x4
+;;       mov     x13, #0xffff0000
+;;       add     x12, x12, x13
+;;       cmp     x4, x10
+;;       csel    x11, x11, x12, hi
+;;       ldr     w2, [x11]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
@@ -21,25 +21,25 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     x8, #0
-;;       ldr     x9, [x2, #0x38]
-;;       add     x9, x9, x4
-;;       orr     x7, xzr, #0xffffffff
-;;       cmp     x4, x7
-;;       csel    x10, x8, x9, hi
-;;       strb    w5, [x10]
+;;       orr     x8, xzr, #0xffffffff
+;;       mov     x9, #0
+;;       ldr     x10, [x2, #0x38]
+;;       add     x10, x10, x4
+;;       cmp     x4, x8
+;;       csel    x9, x9, x10, hi
+;;       strb    w5, [x9]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     x8, #0
-;;       ldr     x9, [x2, #0x38]
-;;       add     x9, x9, x4
-;;       orr     x7, xzr, #0xffffffff
-;;       cmp     x4, x7
-;;       csel    x10, x8, x9, hi
-;;       ldrb    w2, [x10]
+;;       orr     x8, xzr, #0xffffffff
+;;       mov     x9, #0
+;;       ldr     x10, [x2, #0x38]
+;;       add     x10, x10, x4
+;;       cmp     x4, x8
+;;       csel    x9, x9, x10, hi
+;;       ldrb    w2, [x9]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -21,27 +21,27 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     x9, #0
-;;       ldr     x10, [x2, #0x38]
-;;       add     x10, x10, x4
-;;       add     x10, x10, #1, lsl #12
-;;       mov     w8, #-0x1001
-;;       cmp     x4, x8
-;;       csel    x11, x9, x10, hi
-;;       strb    w5, [x11]
+;;       mov     w9, #-0x1001
+;;       mov     x10, #0
+;;       ldr     x11, [x2, #0x38]
+;;       add     x11, x11, x4
+;;       add     x11, x11, #1, lsl #12
+;;       cmp     x4, x9
+;;       csel    x10, x10, x11, hi
+;;       strb    w5, [x10]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     x9, #0
-;;       ldr     x10, [x2, #0x38]
-;;       add     x10, x10, x4
-;;       add     x10, x10, #1, lsl #12
-;;       mov     w8, #-0x1001
-;;       cmp     x4, x8
-;;       csel    x11, x9, x10, hi
-;;       ldrb    w2, [x11]
+;;       mov     w9, #-0x1001
+;;       mov     x10, #0
+;;       ldr     x11, [x2, #0x38]
+;;       add     x11, x11, x4
+;;       add     x11, x11, #1, lsl #12
+;;       cmp     x4, x9
+;;       csel    x10, x10, x11, hi
+;;       ldrb    w2, [x10]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret

--- a/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/aarch64/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -21,29 +21,29 @@
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     x10, #0
-;;       ldr     x11, [x2, #0x38]
-;;       add     x11, x11, x4
-;;       mov     x12, #0xffff0000
-;;       add     x11, x11, x12
-;;       mov     x9, #0xffff
-;;       cmp     x4, x9
-;;       csel    x12, x10, x11, hi
-;;       strb    w5, [x12]
+;;       mov     x10, #0xffff
+;;       mov     x11, #0
+;;       ldr     x12, [x2, #0x38]
+;;       add     x12, x12, x4
+;;       mov     x13, #0xffff0000
+;;       add     x12, x12, x13
+;;       cmp     x4, x10
+;;       csel    x11, x11, x12, hi
+;;       strb    w5, [x11]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;
 ;; wasm[0]::function[1]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
-;;       mov     x10, #0
-;;       ldr     x11, [x2, #0x38]
-;;       add     x11, x11, x4
-;;       mov     x12, #0xffff0000
-;;       add     x11, x11, x12
-;;       mov     x9, #0xffff
-;;       cmp     x4, x9
-;;       csel    x12, x10, x11, hi
-;;       ldrb    w2, [x12]
+;;       mov     x10, #0xffff
+;;       mov     x11, #0
+;;       ldr     x12, [x2, #0x38]
+;;       add     x12, x12, x4
+;;       mov     x13, #0xffff0000
+;;       add     x12, x12, x13
+;;       cmp     x4, x10
+;;       csel    x11, x11, x12, hi
+;;       ldrb    w2, [x11]
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret


### PR DESCRIPTION
This commit refactors the aarch64 backend to match the x64 backend with how it handles conditionals. Specifically there's now a "narrow waist" of a `CondResult` type which is used for `trapnz`, `trapz`, `select`, `icmp`, `brif`, and `select_spectre_guard`. This means that any lowering optimizations to handle conditionals are equally applied to all of these locations. Notably the smattering of optimizations and implementations across these instructions have all been deduplicated an unified. Codegen of `trap{n,}z` is much better than before, and minor optimizations such as testing if an 8-bit value is 0 are now improved across the board. Finally, jumping after comparing a less-than-64-bit value now will use a 32-bit comparison instruction instead of a 64-bit comparison instruction, sometimes eliding the need to extend a 32-bit value to a 64-bit value.

During this refactoring the method of comparing 128-bit integers was copied over from the x64 backend as well. This additionally significantly improves codegen over the previous iteration.

The end result is that it should be significantly easier to apply optimizations and bug fixes in the future. For example some float comparison orderings are not yet currently supported in the aarch64 backend, but are supported in the x64 backend, and this paves the way to make it much easier to add support for this feature as only one comparison-generation location need be updated and a small set of do-something-with-a-comparison locations will be specialized to the condition necessary.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
