### PR TITLE
Add a fuzzing mode to `OomTest`

### DIFF
--- a/crates/fuzzing/Cargo.toml
+++ b/crates/fuzzing/Cargo.toml
@@ -21,6 +21,7 @@ arbitrary = { workspace = true, features = ["derive"] }
 env_logger = { workspace = true }
 log = { workspace = true }
 mutatis = { workspace = true }
+rand = { workspace = true }
 rayon = "1.2.1"
 smallvec = { workspace = true }
 target-lexicon = { workspace = true }

--- a/crates/fuzzing/src/oom.rs
+++ b/crates/fuzzing/src/oom.rs
@@ -4,6 +4,7 @@
 //! https://firefox-source-docs.mozilla.org/js/hacking_tips.html#how-to-debug-oomtest-failures
 
 use backtrace::Backtrace;
+use rand::{RngExt, SeedableRng, rngs::SmallRng};
 use std::{
     alloc::GlobalAlloc,
     cell::Cell,
@@ -279,45 +280,88 @@ impl OomTest {
             }
 
             log::trace!("=== Injecting OOM after {i} allocations ===");
+            Self::run_one_oom_injection(&test_func, i, self.allow_alloc_after_oom).await?;
+        }
 
-            let future = std::pin::pin!(test_func());
-            let (result, oom_state) = OomTestFuture::new(
-                future,
-                OomState::OomOnAlloc {
-                    counter: i,
-                    allow_alloc_after: self.allow_alloc_after_oom,
-                },
-            )
-            .await;
+        Ok(())
+    }
 
-            match (result, oom_state) {
-                (_, OomState::OutsideOomTest | OomState::Counting { .. }) => unreachable!(),
+    /// Similar to `test` but instead of exhaustively injecting OOMs on every
+    /// allocation, randomly chooses which allocation to OOM each iteration.
+    ///
+    /// Requires `max_iters` to be set.
+    pub fn fuzz(&self, test_func: impl Fn() -> Result<()>) -> Result<()> {
+        let future = self.fuzz_async(|| async { test_func() });
+        crate::block_on(future)
+    }
 
-                // The test function completed successfully before we reached
-                // this allocation point (allocation count may differ slightly
-                // between the counting run and OOM injection runs).
-                (Ok(()), OomState::OomOnAlloc { .. }) => {}
+    /// The same as `fuzz` but `async`.
+    pub async fn fuzz_async(&self, test_func: impl AsyncFn() -> Result<()>) -> Result<()> {
+        let max_iters = match self.max_iters {
+            Some(n) => n,
+            None => bail!("OomTest::fuzz requires max_iters to be set"),
+        };
 
-                // We injected an OOM and the test function handled it
-                // correctly; continue to the next iteration.
-                (Err(e), OomState::DidOom { .. }) if e.is::<OutOfMemory>() => {}
+        let total_allocs = Self::count_allocations(&test_func).await?;
 
-                // Missed OOMs.
-                (Ok(()), OomState::DidOom { .. }) => {
-                    bail!("OOM test function missed an OOM: returned Ok(())");
-                }
-                (Err(e), OomState::DidOom { .. }) => {
-                    return Err(
-                        e.context("OOM test function missed an OOM: returned non-OOM error")
-                    );
-                }
+        if total_allocs == 0 {
+            return Ok(());
+        }
 
-                // Unexpected error.
-                (Err(e), OomState::OomOnAlloc { .. }) => {
-                    return Err(
-                        e.context("OOM test function returned an error when there was no OOM")
-                    );
-                }
+        let mut rng = SmallRng::seed_from_u64(0);
+
+        for _ in 0..max_iters {
+            let i = rng.random_range(0..total_allocs);
+            log::trace!("=== Injecting OOM after {i} allocations (fuzz) ===");
+            Self::run_one_oom_injection(&test_func, i, self.allow_alloc_after_oom).await?;
+        }
+
+        Ok(())
+    }
+
+    /// Run the test function once, injecting OOM on the `i`th allocation, and
+    /// check that the result correctly reflects whether an OOM was hit.
+    async fn run_one_oom_injection(
+        test_func: &impl AsyncFn() -> Result<()>,
+        i: u32,
+        allow_alloc_after_oom: bool,
+    ) -> Result<()> {
+        let future = std::pin::pin!(test_func());
+        let (result, oom_state) = OomTestFuture::new(
+            future,
+            OomState::OomOnAlloc {
+                counter: i,
+                allow_alloc_after: allow_alloc_after_oom,
+            },
+        )
+        .await;
+
+        match (result, oom_state) {
+            (_, OomState::OutsideOomTest | OomState::Counting { .. }) => unreachable!(),
+
+            // The test function completed successfully before we reached
+            // this allocation point (allocation count may differ slightly
+            // between the counting run and OOM injection runs).
+            (Ok(()), OomState::OomOnAlloc { .. }) => {}
+
+            // We injected an OOM and the test function handled it correctly.
+            (Err(e), OomState::DidOom { .. }) if e.is::<OutOfMemory>() => {}
+
+            // Missed OOMs.
+            (Ok(()), OomState::DidOom { .. }) => {
+                bail!("OOM test function missed an OOM: returned Ok(())");
+            }
+            (Err(e), OomState::DidOom { .. }) => {
+                return Err(
+                    e.context("OOM test function missed an OOM: returned non-OOM error")
+                );
+            }
+
+            // Unexpected error.
+            (Err(e), OomState::OomOnAlloc { .. }) => {
+                return Err(
+                    e.context("OOM test function returned an error when there was no OOM")
+                );
             }
         }
 

--- a/crates/fuzzing/src/oom.rs
+++ b/crates/fuzzing/src/oom.rs
@@ -352,16 +352,12 @@ impl OomTest {
                 bail!("OOM test function missed an OOM: returned Ok(())");
             }
             (Err(e), OomState::DidOom { .. }) => {
-                return Err(
-                    e.context("OOM test function missed an OOM: returned non-OOM error")
-                );
+                return Err(e.context("OOM test function missed an OOM: returned non-OOM error"));
             }
 
             // Unexpected error.
             (Err(e), OomState::OomOnAlloc { .. }) => {
-                return Err(
-                    e.context("OOM test function returned an error when there was no OOM")
-                );
+                return Err(e.context("OOM test function returned an error when there was no OOM"));
             }
         }
 

--- a/crates/fuzzing/tests/oom/fuzz.rs
+++ b/crates/fuzzing/tests/oom/fuzz.rs
@@ -1,0 +1,54 @@
+#![cfg(arc_try_new)]
+
+use wasmtime::{Config, Engine, Func, Instance, Module, Result, Store};
+use wasmtime_fuzzing::oom::OomTest;
+
+fn make_module_bytes() -> Vec<u8> {
+    let mut config = Config::new();
+    config.concurrency_support(false);
+    let engine = Engine::new(&config).unwrap();
+    Module::new(
+        &engine,
+        "(module (import \"\" \"f\" (func)) (func (export \"g\") (call 0)))",
+    )
+    .unwrap()
+    .serialize()
+    .unwrap()
+}
+
+#[test]
+fn test_fuzz() -> Result<()> {
+    let module_bytes = make_module_bytes();
+    let mut config = Config::new();
+    config.enable_compiler(false);
+    config.concurrency_support(false);
+    let engine = Engine::new(&config)?;
+    let module = unsafe { Module::deserialize(&engine, &module_bytes)? };
+
+    OomTest::new().max_iters(100).fuzz(|| {
+        let mut store = Store::try_new(&engine, ())?;
+        let func = Func::try_wrap(&mut store, || {})?;
+        let _instance = Instance::new(&mut store, &module, &[func.into()])?;
+        Ok(())
+    })
+}
+
+#[tokio::test]
+async fn test_fuzz_async() -> Result<()> {
+    let module_bytes = make_module_bytes();
+    let mut config = Config::new();
+    config.enable_compiler(false);
+    config.concurrency_support(false);
+    let engine = Engine::new(&config)?;
+    let module = unsafe { Module::deserialize(&engine, &module_bytes)? };
+
+    OomTest::new()
+        .max_iters(100)
+        .fuzz_async(|| async {
+            let mut store = Store::try_new(&engine, ())?;
+            let func = Func::try_wrap(&mut store, || {})?;
+            let _instance = Instance::new_async(&mut store, &module, &[func.into()]).await?;
+            Ok(())
+        })
+        .await
+}

--- a/crates/fuzzing/tests/oom/main.rs
+++ b/crates/fuzzing/tests/oom/main.rs
@@ -1,5 +1,6 @@
 mod arc;
 mod bforest_map;
+mod fuzz;
 mod bforest_set;
 mod bit_set;
 mod boxed;

--- a/crates/fuzzing/tests/oom/main.rs
+++ b/crates/fuzzing/tests/oom/main.rs
@@ -1,6 +1,5 @@
 mod arc;
 mod bforest_map;
-mod fuzz;
 mod bforest_set;
 mod bit_set;
 mod boxed;
@@ -17,6 +16,7 @@ mod entity_set;
 mod error;
 mod func;
 mod func_type;
+mod fuzz;
 mod global;
 mod hash_map;
 mod hash_set;


### PR DESCRIPTION
Chooses random allocations to inject OOM on, rather than exhaustively injecting OOM on every allocation in `0..N`.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
