### PR TITLE
Ensure trace info is available for `exnref`

### DIFF
--- a/crates/wasmtime/src/runtime/externals/global.rs
+++ b/crates/wasmtime/src/runtime/externals/global.rs
@@ -310,7 +310,7 @@ impl Global {
                 return;
             }
 
-            if let Some(gc_ref) = unsafe { self.definition(store).as_ref().as_gc_ref() } {
+            if let Some(gc_ref) = unsafe { self.definition(store).as_mut().as_gc_ref_mut() } {
                 unsafe {
                     gc_roots_list.add_vmgcref_root(gc_ref.into(), "Wasm global");
                 }

--- a/crates/wasmtime/src/runtime/gc/enabled/arrayref.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/arrayref.rs
@@ -76,14 +76,6 @@ impl ArrayRefPre {
 
     pub(crate) fn _new(store: &mut StoreOpaque, ty: ArrayType) -> Self {
         store.insert_gc_host_alloc_type(ty.registered_type().clone());
-
-        // If a GC heap is already allocated, eagerly register trace info
-        // now. Otherwise, trace info will be registered when the GC heap
-        // is allocated in `StoreOpaque::allocate_gc_store`.
-        if let Some(gc_store) = store.optional_gc_store_mut() {
-            gc_store.ensure_trace_info(ty.registered_type().index());
-        }
-
         let store_id = store.id();
         ArrayRefPre { store_id, ty }
     }

--- a/crates/wasmtime/src/runtime/gc/enabled/exnref.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/exnref.rs
@@ -80,7 +80,6 @@ impl ExnRefPre {
     pub(crate) fn _new(store: &mut StoreOpaque, ty: ExnType) -> Self {
         store.insert_gc_host_alloc_type(ty.registered_type().clone());
         let store_id = store.id();
-
         ExnRefPre { store_id, ty }
     }
 

--- a/crates/wasmtime/src/runtime/gc/enabled/structref.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/structref.rs
@@ -76,14 +76,6 @@ impl StructRefPre {
 
     pub(crate) fn _new(store: &mut StoreOpaque, ty: StructType) -> Self {
         store.insert_gc_host_alloc_type(ty.registered_type().clone());
-
-        // If a GC heap is already allocated, eagerly register trace info
-        // now. Otherwise, trace info will be registered when the GC heap
-        // is allocated in `StoreOpaque::allocate_gc_store`.
-        if let Some(gc_store) = store.optional_gc_store_mut() {
-            gc_store.ensure_trace_info(ty.registered_type().index());
-        }
-
         let store_id = store.id();
         StructRefPre { store_id, ty }
     }

--- a/crates/wasmtime/src/runtime/store.rs
+++ b/crates/wasmtime/src/runtime/store.rs
@@ -2363,6 +2363,12 @@ impl StoreOpaque {
     /// store are holding it alive).
     #[cfg(feature = "gc")]
     pub(crate) fn insert_gc_host_alloc_type(&mut self, ty: crate::type_registry::RegisteredType) {
+        // If a GC heap is already allocated, eagerly register trace info
+        // now. Otherwise, trace info will be registered when the GC heap
+        // is allocated in `StoreOpaque::allocate_gc_store`.
+        if let Some(gc_store) = self.optional_gc_store_mut() {
+            gc_store.ensure_trace_info(ty.index());
+        }
         self.gc_host_alloc_types.insert(ty);
     }
 

--- a/crates/wasmtime/src/runtime/vm/vmcontext.rs
+++ b/crates/wasmtime/src/runtime/vm/vmcontext.rs
@@ -795,6 +795,14 @@ impl VMGlobalDefinition {
         ret
     }
 
+    /// Return a reference to the global value as a borrowed GC reference.
+    pub unsafe fn as_gc_ref_mut(&mut self) -> Option<&mut VMGcRef> {
+        let raw_ptr = self.storage.as_mut().as_mut_ptr().cast::<Option<VMGcRef>>();
+        let ret = unsafe { (*raw_ptr).as_mut() };
+        assert!(cfg!(feature = "gc") || ret.is_none());
+        ret
+    }
+
     /// Initialize a global to the given GC reference.
     pub unsafe fn init_gc_ref(&mut self, store: &mut StoreOpaque, gc_ref: Option<&VMGcRef>) {
         let dest = unsafe {

--- a/tests/all/arrays.rs
+++ b/tests/all/arrays.rs
@@ -1000,3 +1000,45 @@ fn issue_13034_array_layout_overflow() -> Result<()> {
     }
     Ok(())
 }
+
+#[test]
+fn host_arrayref_has_trace_info_for_gc() -> Result<()> {
+    for collector in [Collector::Copying, Collector::DeferredReferenceCounting] {
+        println!("Using GC collector: {collector:?}");
+
+        let mut config = Config::new();
+        config.wasm_exceptions(true).wasm_gc(true);
+        config.collector(collector);
+
+        let engine = Engine::new(&config)?;
+
+        // Create a store and allocate the GC store by instantiating a module
+        let mut store = Store::new(&engine, ());
+        let module = Module::new(
+            &engine,
+            r#"(module
+              (global (export "g") (mut arrayref) (ref.null array))
+              (table 1 anyref)
+            )"#,
+        )?;
+        let instance = Instance::new(&mut store, &module, &[])?;
+        let g = instance.get_global(&mut store, "g").unwrap();
+
+        // Allocate a host arrayref object in a nested scope and put it into the
+        // module that was just allocated.
+        let array_ty = ArrayType::new(&engine, FieldType::new(Mutability::Const, StorageType::I8));
+        let arraypre = ArrayRefPre::new(&mut store, array_ty.clone());
+        {
+            let mut scope = RootScope::new(&mut store);
+            let array = ArrayRef::new(&mut scope, &arraypre, &Val::I32(29), 1)?;
+            g.set(&mut scope, Val::AnyRef(Some(array.into())))?;
+        }
+
+        // The arrayref should stay alive and be traced properly...
+        store.gc(None)?;
+
+        assert!(matches!(g.get(&mut store), Val::AnyRef(Some(_))));
+    }
+
+    Ok(())
+}

--- a/tests/all/exnrefs.rs
+++ b/tests/all/exnrefs.rs
@@ -83,3 +83,46 @@ fn exn_objects() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn host_exnref_has_trace_info_for_gc() -> Result<()> {
+    for collector in [Collector::Copying, Collector::DeferredReferenceCounting] {
+        println!("Using GC collector: {collector:?}");
+
+        let mut config = Config::new();
+        config.wasm_exceptions(true).wasm_gc(true);
+        config.collector(collector);
+
+        let engine = Engine::new(&config)?;
+
+        // Create a store and allocate the GC store by instantiating a module
+        let mut store = Store::new(&engine, ());
+        let module = Module::new(
+            &engine,
+            r#"(module
+              (global (export "g") (mut exnref) (ref.null exn))
+              (table 1 anyref)
+            )"#,
+        )?;
+        let instance = Instance::new(&mut store, &module, &[])?;
+        let g = instance.get_global(&mut store, "g").unwrap();
+
+        // Allocate a host exnref object in a nested scope and put it into the
+        // module that was just allocated.
+        let exn_ty = ExnType::new(&engine, [ValType::I32])?;
+        let exnpre = ExnRefPre::new(&mut store, exn_ty.clone());
+        let tag = Tag::new(&mut store, &exn_ty.tag_type())?;
+        {
+            let mut scope = RootScope::new(&mut store);
+            let exn = ExnRef::new(&mut scope, &exnpre, &tag, &[Val::I32(43)])?;
+            g.set(&mut scope, Val::ExnRef(Some(exn)))?;
+        }
+
+        // The exnref should stay alive and be traced properly...
+        store.gc(None)?;
+
+        assert!(matches!(g.get(&mut store), Val::ExnRef(Some(_))));
+    }
+
+    Ok(())
+}

--- a/tests/all/structs.rs
+++ b/tests/all/structs.rs
@@ -910,3 +910,48 @@ fn issue_9714(config: &mut Config) -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn host_structref_has_trace_info_for_gc() -> Result<()> {
+    for collector in [Collector::Copying, Collector::DeferredReferenceCounting] {
+        println!("Using GC collector: {collector:?}");
+
+        let mut config = Config::new();
+        config.wasm_exceptions(true).wasm_gc(true);
+        config.collector(collector);
+
+        let engine = Engine::new(&config)?;
+
+        // Create a store and allocate the GC store by instantiating a module
+        let mut store = Store::new(&engine, ());
+        let module = Module::new(
+            &engine,
+            r#"(module
+              (global (export "g") (mut structref) (ref.null struct))
+              (table 1 anyref)
+            )"#,
+        )?;
+        let instance = Instance::new(&mut store, &module, &[])?;
+        let g = instance.get_global(&mut store, "g").unwrap();
+
+        // Allocate a host structref object in a nested scope and put it into the
+        // module that was just allocated.
+        let struct_ty = StructType::new(
+            &engine,
+            [FieldType::new(Mutability::Const, StorageType::I8)],
+        )?;
+        let structpre = StructRefPre::new(&mut store, struct_ty.clone());
+        {
+            let mut scope = RootScope::new(&mut store);
+            let s = StructRef::new(&mut scope, &structpre, &[Val::I32(29)])?;
+            g.set(&mut scope, Val::AnyRef(Some(s.into())))?;
+        }
+
+        // The structref should stay alive and be traced properly...
+        store.gc(None)?;
+
+        assert!(matches!(g.get(&mut store), Val::AnyRef(Some(_))));
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
This commit fixes a minor mistake from #13317 where `exnref` was omitted from the eager ensuring of trace info when creating a host-defined object. The fix here is to avoid duplication across the various GC types we have and to instead hook into the preexisting
`insert_gc_host_alloc_type` method that these all call. Tests are added for `exnref` which reproduces the issue in addition to the struct/array cases too to ensure they don't regress.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
