### PR TITLE
Limit functions executed in `call_async` fuzzer

### DIFF
--- a/crates/fuzzing/src/oracles.rs
+++ b/crates/fuzzing/src/oracles.rs
@@ -1232,6 +1232,10 @@ pub fn call_async(wasm: &[u8], config: &generators::Config, mut poll_amts: &[u32
             let func = e.into_extern().into_func()?;
             Some((name, func))
         })
+        // Each function gets up to 2 seconds, so don't let a lot of exports
+        // which all infinitely loop lock up the fuzzer. Limit the number of
+        // exports run.
+        .take(10)
         .collect::<Vec<_>>();
     for (name, func) in funcs {
         let ty = func.ty(&store);


### PR DESCRIPTION
Otherwise a huge number of slow exports could get invoked which would easily time out.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
