### PR TITLE
cranelift(x64): lower bare `ctz`/`clz` boolean tests via `test`+CC

### DIFF
--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -3826,6 +3826,27 @@
 (rule 2 (is_nonzero (band _ a @ (value_type (ty_int (fits_in_64 ty))) b))
       (is_nonzero_band ty a b))
 
+;; `ctz(X)` and `clz(X)` flow into a boolean context (`brif`, `select`, `trap`,
+;; ...) more directly than the icmp-mediated form rewritten in the egraph at
+;; `opts/icmp.isle`. The wasm front-end emits `brif (ireduce.i32 (ctz.i64 X))`
+;; for `if (ctz X)`-style tests without ever materialising an `icmp`, so those
+;; egraph rules don't fire on this shape; specializing here closes the gap.
+;;
+;; `ctz(X) != 0`  iff  LSB(X) == 0  iff  `(X & 1) == 0` — emit `test X, 1; CC.Z`.
+;; `clz(X) != 0`  iff  MSB(X) == 0  iff  X >=signed 0 — emit `test X, X; CC.NS`.
+;;
+;; Both the bare and the `ireduce`-wrapped form are recognised: the latter is
+;; the wasm-frontend's `i32.wrap_i64` over a 64-bit `ctz`/`clz`, which is a
+;; no-op on values in [0, bitwidth].
+(rule 3 (is_nonzero (ctz (ty_32_or_64 ty) val))
+      (CondResult.CC (x64_test ty val (RegMemImm.Imm 1)) (CC.Z)))
+(rule 3 (is_nonzero (ireduce _ (ctz (ty_32_or_64 ty) val)))
+      (CondResult.CC (x64_test ty val (RegMemImm.Imm 1)) (CC.Z)))
+(rule 3 (is_nonzero (clz (ty_32_or_64 ty) val))
+      (let ((gpr Gpr val)) (CondResult.CC (x64_test ty gpr gpr) (CC.NS))))
+(rule 3 (is_nonzero (ireduce _ (clz (ty_32_or_64 ty) val)))
+      (let ((gpr Gpr val)) (CondResult.CC (x64_test ty gpr gpr) (CC.NS))))
+
 
 ;; Like `is_nonzero` but with additional specializations for compare
 ;; operators. We break this out from `is_nonzero` because we want to

--- a/tests/disas/ctz-clz-bool-condition.wat
+++ b/tests/disas/ctz-clz-bool-condition.wat
@@ -108,14 +108,11 @@
 ;; wasm[0]::function[2]::if_ctz_bare_i32:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movl    $0x20, %esi
-;;       bsfl    %edx, %r9d
-;;       cmovel  %esi, %r9d
-;;       testl   %r9d, %r9d
-;;       jne     0xa4
-;;   9a: movl    $0xc8, %eax
-;;       jmp     0xa9
-;;   a4: movl    $0x64, %eax
+;;       testl   $1, %edx
+;;       je      0x9a
+;;   90: movl    $0xc8, %eax
+;;       jmp     0x9f
+;;   9a: movl    $0x64, %eax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
@@ -167,14 +164,11 @@
 ;; wasm[0]::function[7]::if_ctz_bare_i64:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movl    $0x40, %esi
-;;       bsfq    %rdx, %r9
-;;       cmoveq  %rsi, %r9
-;;       testl   %r9d, %r9d
-;;       jne     0x1a4
-;;  19a: movl    $0xc8, %eax
-;;       jmp     0x1a9
-;;  1a4: movl    $0x64, %eax
+;;       testq   $1, %rdx
+;;       je      0x19b
+;;  191: movl    $0xc8, %eax
+;;       jmp     0x1a0
+;;  19b: movl    $0x64, %eax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
@@ -216,16 +210,11 @@
 ;; wasm[0]::function[11]::if_clz_bare_i32:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movq    $18446744073709551615, %rsi
-;;       bsrl    %edx, %r9d
-;;       cmovel  %esi, %r9d
-;;       movl    $0x1f, %eax
-;;       subl    %r9d, %eax
-;;       testl   %eax, %eax
-;;       jne     0x24d
-;;  243: movl    $0xc8, %eax
-;;       jmp     0x252
-;;  24d: movl    $0x64, %eax
+;;       testl   %edx, %edx
+;;       jns     0x236
+;;  22c: movl    $0xc8, %eax
+;;       jmp     0x23b
+;;  236: movl    $0x64, %eax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
@@ -244,10 +233,10 @@
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       testq   %rdx, %rdx
-;;       jl      0x297
-;;  28d: movl    $0xc8, %eax
-;;       jmp     0x29c
-;;  297: movl    $0x64, %eax
+;;       jl      0x277
+;;  26d: movl    $0xc8, %eax
+;;       jmp     0x27c
+;;  277: movl    $0x64, %eax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
@@ -256,10 +245,10 @@
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       testq   %rdx, %rdx
-;;       jge     0x2d7
-;;  2cd: movl    $0xc8, %eax
-;;       jmp     0x2dc
-;;  2d7: movl    $0x64, %eax
+;;       jge     0x2b7
+;;  2ad: movl    $0xc8, %eax
+;;       jmp     0x2bc
+;;  2b7: movl    $0x64, %eax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
@@ -271,10 +260,10 @@
 ;;       bsfl    %edx, %r9d
 ;;       cmovel  %esi, %r9d
 ;;       cmpl    $4, %r9d
-;;       je      0x325
-;;  31b: movl    $0xc8, %eax
-;;       jmp     0x32a
-;;  325: movl    $0x64, %eax
+;;       je      0x305
+;;  2fb: movl    $0xc8, %eax
+;;       jmp     0x30a
+;;  305: movl    $0x64, %eax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq


### PR DESCRIPTION
## Summary

Follow-up to #13332. That PR added egraph rules collapsing `(eq (ctz X) 0)` / `(ne (ctz X) 0)` / `(eq (clz X) 0)` / `(ne (clz X) 0)` to direct LSB / sign-bit tests — but only when the comparison is mediated by an explicit `icmp`. The wasm front-end translates `wasm if (ctz X)` to `brif (ireduce.i32 (ctz.i64 X))` directly (no `icmp`), so the egraph rules don't fire on the wasm-natural shape.

This PR closes the gap by specialising `is_nonzero` in the x64 backend — the helper that all `brif`/`select`/`trapif` lowerings funnel through.

## Rules

In `cranelift/codegen/src/isa/x64/inst.isle`:

```isle
(rule 3 (is_nonzero (ctz (ty_32_or_64 ty) val))
      (CondResult.CC (x64_test ty val (RegMemImm.Imm 1)) (CC.Z)))
(rule 3 (is_nonzero (ireduce _ (ctz (ty_32_or_64 ty) val)))
      (CondResult.CC (x64_test ty val (RegMemImm.Imm 1)) (CC.Z)))
(rule 3 (is_nonzero (clz (ty_32_or_64 ty) val))
      (let ((gpr Gpr val)) (CondResult.CC (x64_test ty gpr gpr) (CC.NS))))
(rule 3 (is_nonzero (ireduce _ (clz (ty_32_or_64 ty) val)))
      (let ((gpr Gpr val)) (CondResult.CC (x64_test ty gpr gpr) (CC.NS))))
```

The `ireduce` variant catches the wasm front-end's `i32.wrap_i64` over a 64-bit `ctz`/`clz` — a no-op on values in [0, bitwidth].

## Test deltas (`tests/disas/ctz-clz-bool-condition.wat`)

| consumer | before | after |
|---|---|---|
| `if_ctz_bare_i32` | 5 insns (`bsfl + cmovel + test + jne`) | **2** (`testl $1, %edx; je`) |
| `if_ctz_bare_i64` | 5 insns (`bsfq + cmovq + test + jne`) | **2** (`testq $1, %rdx; je`) |
| `if_clz_bare_i32` | 7 insns (`bsr + cmov + sub + test + jne`) | **2** (`testl + jns`) |

The icmp-mediated cases (collapsed by #13332's egraph rules) are unchanged. The numeric-comparison negative test (`(ctz X) == 4`) stays untouched.

## Motivation

Motoko's `moc` codegen emits `i64.ctz X; i32.wrap_i64; if` for compactness/sign tests in the EOP backend (see caffeinelabs/motoko#6103). Before this PR, that lowers to 5 native instructions per dispatch; after, 2.

A concrete idiomatic example: in Motoko, the `let-else` pattern over `Result`

```motoko
let #ok payload = queryProp(...) else return defaultValue;
```

desugars to a 2-arm refutable variant match (`#ok` vs `#err`). The variant-tag hashes are `hash("ok") = 0x611C` (LSB 0) and `hash("err") = 0x4D0765` (LSB 1) — they differ exactly at the LSB. The planned variant-switch `BitTest` dispatch (caffeinelabs/motoko's `gabor/variant-switch`) recognizes this and emits a single LSB-test for the dispatch; combined with this PR, the entire let-else lowers to **`load hash; testq $1, ...; jcc`** on x64 — three instructions for a pattern match. Every `Result`-returning API + every `let-else`-style early return collapses to this shape.

Aggregated across hot paths (variant-switch dispatch, GC compact/heap discriminator, sign tests, …) this is meaningful.

## Follow-ups (not in this PR)

- aarch64, riscv64, s390x analogues — separate PRs once x64 reviewer feedback lands.
- `select`-consumer variant — `select` already routes through `is_nonzero_cmp` → `is_nonzero`, so this PR's rules cover it too without extra work.