### PR TITLE
isle tuple structs and enum variants

### DIFF
--- a/cranelift/isle/docs/language-reference.md
+++ b/cranelift/isle/docs/language-reference.md
@@ -1491,12 +1491,18 @@ The grammar accepted by the parser is as follows:
 
 <type-body> ::= "(" "primitive" <ident> ")"
               | "(" "enum" <enum-variant>* ")"
-              | "(" "struct" <variant-field>* ")"
+              | "(" "struct" <fields> ")"
 
 <enum-variant> ::= <ident>
-                 | "(" <ident> <variant-field>* ")"
+                 | "(" <ident> <fields> ")"
 
-<variant-field> ::= "(" <ident> <ty> ")"
+<fields> ::= <struct-fields> | <tuple-fields>
+
+<struct-fields> ::= <struct-field>*
+<struct-field> ::= "(" <ident> <ty> ")"
+
+<tuple-fields> ::= <tuple-field>*
+<tuple-field> ::= <ty>
 
 <ty> ::= <ident>
 

--- a/cranelift/isle/isle/isle_examples/run/tuple_variants.isle
+++ b/cranelift/isle/isle/isle_examples/run/tuple_variants.isle
@@ -1,0 +1,29 @@
+(type A (struct u32 u32))
+(type B (enum
+  (Ba (x u32))
+  (Bb u32 u32 u32)))
+(type D (enum
+  (Da A)
+  (Db B)
+  (Dc)))
+
+(type UnitStruct (struct))
+(type UninhabitedEnum (enum))
+
+(decl lower (D) B)
+
+(rule 0
+  (lower (D.Da (A x _)))
+  (B.Ba x))
+
+(rule 0
+  (lower (D.Db (B.Ba x)))
+  (B.Bb x x x))
+
+(rule 0
+  (lower (D.Db (B.Bb _ _ x)))
+  (B.Ba x))
+
+(rule 0
+  (lower (D.Dc))
+  (B.Ba 42))

--- a/cranelift/isle/isle/isle_examples/run/tuple_variants_main.rs
+++ b/cranelift/isle/isle/isle_examples/run/tuple_variants_main.rs
@@ -1,0 +1,31 @@
+extern crate alloc;
+extern crate core;
+
+mod tuple_variants;
+use tuple_variants::*;
+
+struct Context;
+impl tuple_variants::Context for Context {}
+
+fn main() {
+    assert!(matches!(
+        constructor_lower(&mut Context, &D::Da(A(1, 2))),
+        B::Ba { x: 1 }
+    ));
+    assert!(matches!(
+        constructor_lower(&mut Context, &D::Db(B::Ba { x: 6 })),
+        B::Bb(6, 6, 6)
+    ));
+    assert!(matches!(
+        constructor_lower(&mut Context, &D::Db(B::Bb(1, 2, 3))),
+        B::Ba { x: 3 }
+    ));
+    assert!(matches!(
+        constructor_lower(&mut Context, &D::Dc),
+        B::Ba { x: 42 }
+    ));
+
+    let _ = UnitStruct;
+    assert_eq!(size_of::<UnitStruct>(), 0);
+    assert_eq!(size_of::<UninhabitedEnum>(), 0);
+}

--- a/cranelift/isle/isle/src/ast.rs
+++ b/cranelift/isle/isle/src/ast.rs
@@ -46,21 +46,51 @@ pub struct Type {
 pub enum TypeValue {
     Primitive(Ident, Pos),
     Enum(Vec<Variant>, Pos),
-    Struct(Vec<Field>, Pos),
+    Struct(Fields, Pos),
 }
 
 /// One variant of an enum type.
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct Variant {
     pub name: Ident,
-    pub fields: Vec<Field>,
+    pub fields: Fields,
     pub pos: Pos,
 }
 
-/// One field of an enum variant.
+/// The fields of a struct or enum variant, formatted as a struct or tuple.
 #[derive(Clone, PartialEq, Eq, Debug)]
-pub struct Field {
+pub enum Fields {
+    Unit,
+    Struct(StructFields),
+    Tuple(TupleFields),
+}
+
+/// A List of named fields of a struct.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct StructFields {
+    pub fields: Vec<StructField>,
+    pub pos: Pos,
+}
+
+/// One named field of a struct or enum variant.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct StructField {
     pub name: Ident,
+    pub ty: Ident,
+    pub pos: Pos,
+}
+
+/// A List of unnamed fields of a tuple.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct TupleFields {
+    pub fields: Vec<TupleField>,
+    pub pos: Pos,
+}
+
+/// One unnamed field of a tuple.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct TupleField {
+    pub index: usize,
     pub ty: Ident,
     pub pos: Pos,
 }

--- a/cranelift/isle/isle/src/codegen.rs
+++ b/cranelift/isle/isle/src/codegen.rs
@@ -2,12 +2,13 @@
 
 use crate::files::Files;
 use crate::sema::{
-    BuiltinType, ExternalSig, Field, IntType, ReturnKind, Term, TermEnv, TermId, Type, TypeEnv,
+    BuiltinType, ExternalSig, Fields, IntType, ReturnKind, Term, TermEnv, TermId, Type, TypeEnv,
     TypeId,
 };
 use crate::serialize::{Block, ControlFlow, EvalStep, MatchArm};
 use crate::stablemapset::StableSet;
 use crate::trie_again::{Binding, BindingId, Constraint, RuleSet};
+use std::borrow::Cow;
 use std::fmt::Write;
 use std::slice::Iter;
 use std::sync::Arc;
@@ -412,7 +413,7 @@ impl<L: Length, C> Length for ContextIterWrapper<L, C> {{
 
                     // Generate the `derive`s.
                     let debug_derive = if is_nodebug { "" } else { ", Debug" };
-                    if variants.iter().all(|v| v.fields.is_empty()) {
+                    if variants.iter().all(|v| v.fields == Fields::Unit) {
                         writeln!(code, "#[derive(Copy, Clone, PartialEq, Eq{debug_derive})]")
                             .unwrap();
                     } else {
@@ -422,18 +423,10 @@ impl<L: Length, C> Length for ContextIterWrapper<L, C> {{
                     writeln!(code, "pub enum {name} {{").unwrap();
                     for variant in variants {
                         let name = &self.typeenv.syms[variant.name.index()];
-                        if variant.fields.is_empty() {
-                            writeln!(code, "    {name},").unwrap();
-                        } else {
-                            writeln!(code, "    {name} {{").unwrap();
-                            for field in &variant.fields {
-                                let name = &self.typeenv.syms[field.name.index()];
-                                let ty_name =
-                                    self.typeenv.types[field.ty.index()].name(self.typeenv);
-                                writeln!(code, "        {name}: {ty_name},").unwrap();
-                            }
-                            writeln!(code, "    }},").unwrap();
-                        }
+                        write!(code, "    {name}").unwrap();
+                        self.generate_fields(&mut *code, &variant.fields, "    ", false)
+                            .unwrap();
+                        writeln!(code, ",").unwrap();
                     }
                     writeln!(code, "}}").unwrap();
                 }
@@ -456,22 +449,56 @@ impl<L: Length, C> Length for ContextIterWrapper<L, C> {{
 
                     // Generate the `derive`s.
                     let debug_derive = if is_nodebug { "" } else { ", Debug" };
-                    if fields.is_empty() {
-                        writeln!(code, "#[derive(Copy, Clone, PartialEq, Eq{debug_derive})]")
-                            .unwrap();
-                        writeln!(code, "pub struct {name};").unwrap();
-                    } else {
-                        writeln!(code, "#[derive(Clone{debug_derive})]").unwrap();
-                        writeln!(code, "pub struct {name} {{").unwrap();
-                        for field in fields {
-                            let name = &self.typeenv.syms[field.name.index()];
-                            let ty_name = self.typeenv.types[field.ty.index()].name(self.typeenv);
-                            writeln!(code, "    pub {name}: {ty_name},").unwrap();
+                    match fields {
+                        Fields::Unit => {
+                            writeln!(code, "#[derive(Copy, Clone, PartialEq, Eq{debug_derive})]")
+                                .unwrap();
+                            writeln!(code, "pub struct {name};").unwrap();
                         }
-                        writeln!(code, "}}").unwrap();
+                        Fields::Tuple(_) | Fields::Struct(_) => {
+                            writeln!(code, "#[derive(Clone{debug_derive})]").unwrap();
+                            write!(code, "pub struct {name}").unwrap();
+                            self.generate_fields(&mut *code, &fields, "", true).unwrap();
+                            if matches!(fields, Fields::Tuple(_)) {
+                                write!(code, ";").unwrap();
+                            }
+                        }
                     }
                 }
                 _ => {}
+            }
+        }
+    }
+
+    fn generate_fields(
+        &self,
+        code: &mut String,
+        fields: &Fields,
+        pad: &str,
+        allow_pub: bool,
+    ) -> std::fmt::Result {
+        let _pub = if allow_pub { "pub " } else { "" };
+        match fields {
+            Fields::Unit => Ok(()),
+            Fields::Struct(fields) => {
+                writeln!(code, " {{")?;
+                for field in &fields.fields {
+                    let name = &self.typeenv.syms[field.name.index()];
+                    let ty_name = self.typeenv.types[field.ty.index()].name(self.typeenv);
+                    writeln!(code, "{pad}    {_pub}{name}: {ty_name},")?;
+                }
+                write!(code, "{pad}}}")
+            }
+            Fields::Tuple(fields) => {
+                write!(code, "(")?;
+                for (i, field) in fields.fields.iter().enumerate() {
+                    let ty_name = self.typeenv.types[field.ty.index()].name(self.typeenv);
+                    write!(code, "{_pub}{ty_name}")?;
+                    if i < fields.fields.len() - 1 {
+                        write!(code, ", ")?;
+                    }
+                }
+                write!(code, ")")
             }
         }
     }
@@ -926,17 +953,19 @@ impl<L: Length, C> Length for ContextIterWrapper<L, C> {{
 
         let extract_fields = |ctx: &mut BodyContext<W>,
                               field_bindings: &[BindingId],
-                              type_fields: &[Field]|
+                              fields: &Fields|
          -> std::fmt::Result {
             if !field_bindings.is_empty() {
                 ctx.begin_block()?;
-                for (field, value) in type_fields.iter().zip(field_bindings.iter()) {
-                    write!(
-                        ctx.out,
-                        "{}{}: ",
-                        &ctx.indent,
-                        &self.typeenv.syms[field.name.index()],
-                    )?;
+                for (i, value) in field_bindings.iter().enumerate() {
+                    let field_name = match fields {
+                        Fields::Unit => panic!(),
+                        Fields::Struct(fields) => {
+                            Cow::Borrowed(&self.typeenv.syms[fields.fields[i].name.index()])
+                        }
+                        Fields::Tuple(_) => Cow::Owned(format!("{i}")),
+                    };
+                    write!(ctx.out, "{}{field_name}: ", &ctx.indent)?;
                     self.emit_expr(ctx, *value)?;
                     if ctx.is_ref.contains(value) {
                         write!(ctx.out, ".clone()")?;
@@ -1095,20 +1124,24 @@ impl<L: Length, C> Length for ContextIterWrapper<L, C> {{
         &self,
         ctx: &mut BodyContext<W>,
         bindings: &[Option<BindingId>],
-        fields: &[Field],
+        fields: &Fields,
     ) -> std::fmt::Result {
         if !bindings.is_empty() {
             ctx.begin_block()?;
             let mut skipped_some = false;
-            for (&binding, field) in bindings.iter().zip(fields.iter()) {
+            for (i, &binding) in bindings.iter().enumerate() {
                 if let Some(binding) = binding {
-                    write!(
-                        ctx.out,
-                        "{}{}: ",
-                        &ctx.indent,
-                        &self.typeenv.syms[field.name.index()]
-                    )?;
-                    let (is_ref, _) = self.ty(field.ty);
+                    let (field_name, field_ty) = match fields {
+                        Fields::Unit => panic!(),
+                        Fields::Struct(fields) => {
+                            let field = &fields.fields[i];
+                            let name = &self.typeenv.syms[field.name.index()];
+                            (Cow::Borrowed(name), field.ty)
+                        }
+                        Fields::Tuple(fields) => (Cow::Owned(format!("{i}")), fields.fields[i].ty),
+                    };
+                    write!(ctx.out, "{}{field_name}: ", &ctx.indent)?;
+                    let (is_ref, _) = self.ty(field_ty);
                     if is_ref {
                         ctx.set_ref(binding, true);
                         write!(ctx.out, "ref ")?;

--- a/cranelift/isle/isle/src/parser.rs
+++ b/cranelift/isle/isle/src/parser.rs
@@ -295,10 +295,7 @@ impl<'a> Parser<'a> {
             self.expect_rparen()?;
             Ok(TypeValue::Enum(variants, pos))
         } else if self.eat_sym_str("struct")? {
-            let mut fields = vec![];
-            while !self.is_rparen() {
-                fields.push(self.parse_type_field()?);
-            }
+            let fields = self.parse_fields()?;
             self.expect_rparen()?;
             Ok(TypeValue::Struct(fields, pos))
         } else {
@@ -312,29 +309,60 @@ impl<'a> Parser<'a> {
             let name = self.parse_ident()?;
             Ok(Variant {
                 name,
-                fields: vec![],
+                fields: Fields::Unit,
                 pos,
             })
         } else {
             let pos = self.pos();
             self.expect_lparen()?;
             let name = self.parse_ident()?;
-            let mut fields = vec![];
-            while !self.is_rparen() {
-                fields.push(self.parse_type_field()?);
-            }
+            let fields = self.parse_fields()?;
             self.expect_rparen()?;
             Ok(Variant { name, fields, pos })
         }
     }
 
-    fn parse_type_field(&mut self) -> Result<Field> {
+    fn parse_fields(&mut self) -> Result<Fields> {
+        if self.is_rparen() {
+            Ok(Fields::Unit)
+        } else if self.is_lparen() {
+            Ok(Fields::Struct(self.parse_struct_fields()?))
+        } else {
+            Ok(Fields::Tuple(self.parse_tuple_fields()?))
+        }
+    }
+
+    fn parse_struct_fields(&mut self) -> Result<StructFields> {
+        let pos = self.pos();
+        let mut fields = vec![];
+        while !self.is_rparen() {
+            fields.push(self.parse_struct_field()?);
+        }
+        Ok(StructFields { fields, pos })
+    }
+
+    fn parse_struct_field(&mut self) -> Result<StructField> {
         let pos = self.pos();
         self.expect_lparen()?;
         let name = self.parse_ident()?;
         let ty = self.parse_ident()?;
         self.expect_rparen()?;
-        Ok(Field { name, ty, pos })
+        Ok(StructField { name, ty, pos })
+    }
+
+    fn parse_tuple_fields(&mut self) -> Result<TupleFields> {
+        let pos = self.pos();
+        let mut fields = vec![];
+        while !self.is_rparen() {
+            fields.push(self.parse_tuple_field(fields.len())?);
+        }
+        Ok(TupleFields { fields, pos })
+    }
+
+    fn parse_tuple_field(&mut self, index: usize) -> Result<TupleField> {
+        let pos = self.pos();
+        let ty = self.parse_ident()?;
+        Ok(TupleField { index, ty, pos })
     }
 
     fn parse_decl(&mut self) -> Result<Decl> {

--- a/cranelift/isle/isle/src/printer.rs
+++ b/cranelift/isle/isle/src/printer.rs
@@ -402,7 +402,7 @@ impl ToSExpr for TypeValue {
             }
             TypeValue::Struct(fields, _) => {
                 let mut parts = vec![SExpr::atom("struct")];
-                parts.extend(fields.iter().map(ToSExpr::to_sexpr));
+                parts.extend(fields.to_sexpr_iter());
                 SExpr::List(parts)
             }
         }
@@ -417,15 +417,43 @@ impl ToSExpr for Variant {
             pos: _,
         } = self;
         let mut parts = vec![name.to_sexpr()];
-        parts.extend(fields.iter().map(ToSExpr::to_sexpr));
+        parts.extend(fields.to_sexpr_iter());
         SExpr::List(parts)
     }
 }
 
-impl ToSExpr for Field {
+impl Fields {
+    fn to_sexpr_iter(&self) -> Vec<SExpr> {
+        match self {
+            Fields::Unit => Vec::new(),
+            Fields::Struct(f) => f.to_sexpr_iter(),
+            Fields::Tuple(f) => f.to_sexpr_iter(),
+        }
+    }
+}
+
+impl StructFields {
+    fn to_sexpr_iter(&self) -> Vec<SExpr> {
+        self.fields.iter().map(ToSExpr::to_sexpr).collect()
+    }
+}
+
+impl ToSExpr for StructField {
     fn to_sexpr(&self) -> SExpr {
-        let Field { name, ty, pos: _ } = self;
+        let StructField { name, ty, pos: _ } = self;
         SExpr::List(vec![name.to_sexpr(), ty.to_sexpr()])
+    }
+}
+
+impl TupleFields {
+    fn to_sexpr_iter(&self) -> Vec<SExpr> {
+        self.fields.iter().map(ToSExpr::to_sexpr).collect()
+    }
+}
+
+impl ToSExpr for TupleField {
+    fn to_sexpr(&self) -> SExpr {
+        self.ty.to_sexpr()
     }
 }
 

--- a/cranelift/isle/isle/src/sema.rs
+++ b/cranelift/isle/isle/src/sema.rs
@@ -287,8 +287,8 @@ pub enum Type {
         ///
         /// Incompatible with `is_extern`.
         is_nodebug: bool,
-        /// The different variants for this enum.
-        fields: Vec<Field>,
+        /// The different variants for this struct.
+        fields: Fields,
         /// The ISLE source position where this `enum` is defined.
         pos: Pos,
     },
@@ -343,14 +343,59 @@ pub struct Variant {
     pub id: VariantId,
 
     /// The data fields of this enum variant.
-    pub fields: Vec<Field>,
+    pub fields: Fields,
 }
 
-/// A field of a `Variant`.
+/// The fields of a struct or enum variant, formatted as a struct or tuple.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub enum Fields {
+    /// a struct or enum variant without fields
+    Unit,
+    /// Named fields
+    Struct(StructFields),
+    /// Unnamed fields like a tuple
+    Tuple(TupleFields),
+}
+
+impl Fields {
+    /// Vec of all field types
+    pub fn types(&self) -> Vec<TypeId> {
+        match self {
+            Fields::Unit => Vec::new(),
+            Fields::Struct(fields) => fields.fields.iter().map(|f| f.ty).collect(),
+            Fields::Tuple(fields) => fields.fields.iter().map(|f| f.ty).collect(),
+        }
+    }
+}
+
+/// A List of named fields of a struct.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct StructFields {
+    /// the fields
+    pub fields: Vec<StructField>,
+}
+
+/// One named field of a struct or enum variant.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct Field {
+pub struct StructField {
     /// The name of this field.
     pub name: Sym,
+    /// This field's id.
+    pub id: FieldId,
+    /// The type of this field.
+    pub ty: TypeId,
+}
+
+/// A List of unnamed fields of a tuple.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct TupleFields {
+    /// the fields
+    pub fields: Vec<TupleField>,
+}
+
+/// One unnamed field of a tuple.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TupleField {
     /// This field's id.
     pub id: FieldId,
     /// The type of this field.
@@ -1344,13 +1389,29 @@ impl TypeEnv {
 
     fn fields_from_ast(
         &mut self,
-        fields: &[ast::Field],
+        fields: &ast::Fields,
         variant_name: Option<&ast::Ident>,
-    ) -> Option<Vec<Field>> {
-        let mut out = Vec::with_capacity(fields.len());
-        for field in fields {
+    ) -> Option<Fields> {
+        match fields {
+            ast::Fields::Unit => Some(Fields::Unit),
+            ast::Fields::Struct(fields) => Some(Fields::Struct(
+                self.struct_fields_from_ast(fields, variant_name)?,
+            )),
+            ast::Fields::Tuple(fields) => Some(Fields::Tuple(
+                self.tuple_fields_from_ast(fields, variant_name)?,
+            )),
+        }
+    }
+
+    fn struct_fields_from_ast(
+        &mut self,
+        fields: &ast::StructFields,
+        variant_name: Option<&ast::Ident>,
+    ) -> Option<StructFields> {
+        let mut out = Vec::with_capacity(fields.fields.len());
+        for field in &fields.fields {
             let field_name = self.intern_mut(&field.name);
-            if out.iter().any(|f: &Field| f.name == field_name) {
+            if out.iter().any(|f: &StructField| f.name == field_name) {
                 let msg = if let Some(variant_name) = variant_name {
                     format!(
                         "Duplicate field name '{}' in variant '{}' of type",
@@ -1377,13 +1438,46 @@ impl TypeEnv {
                     return None;
                 }
             };
-            out.push(Field {
+            out.push(StructField {
                 name: field_name,
                 id: FieldId(out.len()),
                 ty: field_tid,
             });
         }
-        Some(out)
+        Some(StructFields { fields: out })
+    }
+
+    fn tuple_fields_from_ast(
+        &mut self,
+        fields: &ast::TupleFields,
+        variant_name: Option<&ast::Ident>,
+    ) -> Option<TupleFields> {
+        let mut out = Vec::with_capacity(fields.fields.len());
+        for field in &fields.fields {
+            let field_tid = match self.get_type_by_name(&field.ty) {
+                Some(tid) => tid,
+                None => {
+                    let msg = if let Some(variant_name) = variant_name {
+                        format!(
+                            "Unknown type '{}' for tuple field '{}' in variant '{}'",
+                            field.ty.0, field.index, variant_name.0
+                        )
+                    } else {
+                        format!(
+                            "Unknown type '{}' for tuple field '{}'",
+                            field.ty.0, field.index
+                        )
+                    };
+                    self.report_error(field.ty.1, msg);
+                    return None;
+                }
+            };
+            out.push(TupleField {
+                id: FieldId(out.len()),
+                ty: field_tid,
+            });
+        }
+        Some(TupleFields { fields: out })
     }
 
     fn error(&self, pos: Pos, msg: impl Into<String>) -> Error {
@@ -1600,7 +1694,7 @@ impl TermEnv {
                             continue 'types;
                         }
                         let tid = TermId(self.terms.len());
-                        let arg_tys = variant.fields.iter().map(|fld| fld.ty).collect::<Vec<_>>();
+                        let arg_tys = variant.fields.types();
                         let ret_ty = id;
                         self.terms.push(Term {
                             id: tid,
@@ -1628,7 +1722,7 @@ impl TermEnv {
                         continue 'types;
                     }
                     let tid = TermId(self.terms.len());
-                    let arg_tys = fields.iter().map(|fld| fld.ty).collect::<Vec<_>>();
+                    let arg_tys = fields.types();
                     let ret_ty = id;
                     self.terms.push(Term {
                         id: tid,
@@ -2841,28 +2935,32 @@ mod test {
                         name: sym_b,
                         fullname: sym_a_b,
                         id: VariantId(0),
-                        fields: vec![
-                            Field {
-                                name: sym_f1,
-                                id: FieldId(0),
-                                ty: TypeId::U32,
-                            },
-                            Field {
-                                name: sym_f2,
-                                id: FieldId(1),
-                                ty: TypeId::U32,
-                            },
-                        ],
+                        fields: Fields::Struct(StructFields {
+                            fields: vec![
+                                StructField {
+                                    name: sym_f1,
+                                    id: FieldId(0),
+                                    ty: TypeId::U32,
+                                },
+                                StructField {
+                                    name: sym_f2,
+                                    id: FieldId(1),
+                                    ty: TypeId::U32,
+                                },
+                            ],
+                        }),
                     },
                     Variant {
                         name: sym_c,
                         fullname: sym_a_c,
                         id: VariantId(1),
-                        fields: vec![Field {
-                            name: sym_f1,
-                            id: FieldId(0),
-                            ty: TypeId::U32,
-                        }],
+                        fields: Fields::Struct(StructFields {
+                            fields: vec![StructField {
+                                name: sym_f1,
+                                id: FieldId(0),
+                                ty: TypeId::U32,
+                            }],
+                        }),
                     },
                 ],
                 pos: Pos {


### PR DESCRIPTION
# Requires https://github.com/bytecodealliance/wasmtime/pull/13319
This is a stacked PR and the above PR must be merged first. Unfortunately, I can't change the base to be that PR due to github limitations, so please **only review the top commit**. I'll keep this one a draft until the above is merged.

Adds support for tuple-like field declarations in isle:
```lisp
(type A (struct u32 u32))
(type B (enum
  (Ba (x u32))
  (Bb u32 u32 u32)))
(type D (enum
  (Da A)
  (Db B)
  (Dc)))
```

Which codegen's types like these:
```rust
/// Internal type A: defined at isle_examples/run/tuple_variants.isle line 0.
#[derive(Clone, Debug)]
pub struct A(pub u32, pub u32);
/// Internal type B: defined at isle_examples/run/tuple_variants.isle line 1.
#[derive(Clone, Debug)]
pub enum B {
    Ba {
        x: u32,
    },
    Bb(u32, u32, u32),
}

/// Internal type D: defined at isle_examples/run/tuple_variants.isle line 4.
#[derive(Clone, Debug)]
pub enum D {
    Da(A),
    Db(B),
    Dc,
}
```

As mentioned in https://github.com/bytecodealliance/wasmtime/pull/13319, I have an external enum with tuple-like fields that I would like to model in isle without modifying the existing data structure, if possible:
```rust
pub enum MInst {
    IAdd(IAdd),
    IConst(IConst),
}
```

I derived the ast and sema type names from [Rust's grammar](https://doc.rust-lang.org/reference/items/structs.html).
