### PR TITLE
winch(x64): Ensure correct operand size on memory alignment check

### DIFF
--- a/tests/disas/winch/x64/atomic/load/i32_atomic_load16_u.wat
+++ b/tests/disas/winch/x64/atomic/load/i32_atomic_load16_u.wat
@@ -20,8 +20,8 @@
 ;;       movq    %rsi, 0x10(%rsp)
 ;;       movl    %edx, 0xc(%rsp)
 ;;       movl    0xc(%rsp), %eax
-;;       andw    $1, %ax
-;;       cmpw    $0, %ax
+;;       andl    $1, %eax
+;;       cmpl    $0, %eax
 ;;       jne     0x65
 ;;   46: movl    0xc(%rsp), %eax
 ;;       movq    0x30(%r14), %r11

--- a/tests/disas/winch/x64/atomic/load/i64_atomic_load.wat
+++ b/tests/disas/winch/x64/atomic/load/i64_atomic_load.wat
@@ -14,16 +14,16 @@
 ;;       movq    0x18(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x5e
+;;       ja      0x5c
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
 ;;       movl    $0, %eax
-;;       andq    $7, %rax
-;;       cmpq    $0, %rax
-;;       jne     0x60
-;;   44: movl    $0, %eax
+;;       andl    $7, %eax
+;;       cmpl    $0, %eax
+;;       jne     0x5e
+;;   42: movl    $0, %eax
 ;;       movq    0x38(%r14), %rcx
 ;;       movl    %eax, %eax
 ;;       addq    %rax, %rcx
@@ -31,5 +31,5 @@
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
+;;   5c: ud2
 ;;   5e: ud2
-;;   60: ud2

--- a/tests/disas/winch/x64/atomic/load/i64_atomic_load16_u.wat
+++ b/tests/disas/winch/x64/atomic/load/i64_atomic_load16_u.wat
@@ -20,8 +20,8 @@
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
 ;;       movl    $0, %eax
-;;       andw    $1, %ax
-;;       cmpw    $0, %ax
+;;       andl    $1, %eax
+;;       cmpl    $0, %eax
 ;;       jne     0x5f
 ;;   42: movl    $0, %eax
 ;;       movq    0x38(%r14), %rcx

--- a/tests/disas/winch/x64/atomic/load/large_offset.wat
+++ b/tests/disas/winch/x64/atomic/load/large_offset.wat
@@ -1,0 +1,53 @@
+;;! target = "x86_64"
+;;! test = "winch"
+
+(module
+  (memory 2)
+  (func (export "f") (param i32) (result i32)
+    local.get 0
+    i32.atomic.load16_u offset=0x80000000
+  )
+)
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    0x18(%r11), %r11
+;;       addq    $0x20, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x9c
+;;   1c: movq    %rdi, %r14
+;;       subq    $0x20, %rsp
+;;       movq    %rdi, 0x18(%rsp)
+;;       movq    %rsi, 0x10(%rsp)
+;;       movl    %edx, 0xc(%rsp)
+;;       movl    0xc(%rsp), %eax
+;;       movl    $0x80000000, %r11d
+;;       addl    %r11d, %eax
+;;       andl    $1, %eax
+;;       cmpl    $0, %eax
+;;       jne     0x9e
+;;   4f: movl    0xc(%rsp), %eax
+;;       movq    0x40(%r14), %rcx
+;;       movl    %eax, %edx
+;;       movl    $0x80000002, %r11d
+;;       addq    %r11, %rdx
+;;       jb      0xa0
+;;   68: cmpq    %rcx, %rdx
+;;       ja      0xa2
+;;   71: movq    0x38(%r14), %rbx
+;;       movl    %eax, %eax
+;;       addq    %rax, %rbx
+;;       movl    $0x80000000, %r11d
+;;       addq    %r11, %rbx
+;;       movl    $0, %esi
+;;       cmpq    %rcx, %rdx
+;;       cmovaq  %rsi, %rbx
+;;       movzwq  (%rbx), %rax
+;;       addq    $0x20, %rsp
+;;       popq    %rbp
+;;       retq
+;;   9c: ud2
+;;   9e: ud2
+;;   a0: ud2
+;;   a2: ud2

--- a/tests/disas/winch/x64/atomic/rmw/add/i32_atomic_rmw16_addu.wat
+++ b/tests/disas/winch/x64/atomic/rmw/add/i32_atomic_rmw16_addu.wat
@@ -19,8 +19,8 @@
 ;;       movq    %rsi, (%rsp)
 ;;       movl    $0x2a, %eax
 ;;       movl    $0, %ecx
-;;       andw    $1, %cx
-;;       cmpw    $0, %cx
+;;       andl    $1, %ecx
+;;       cmpl    $0, %ecx
 ;;       jne     0x6c
 ;;   48: movl    $0, %ecx
 ;;       movq    0x30(%r14), %r11

--- a/tests/disas/winch/x64/atomic/rmw/add/i64_atomic_rmw16_addu.wat
+++ b/tests/disas/winch/x64/atomic/rmw/add/i64_atomic_rmw16_addu.wat
@@ -19,8 +19,8 @@
 ;;       movq    %rsi, (%rsp)
 ;;       movl    $0x2a, %eax
 ;;       movl    $0, %ecx
-;;       andw    $1, %cx
-;;       cmpw    $0, %cx
+;;       andl    $1, %ecx
+;;       cmpl    $0, %ecx
 ;;       jne     0x6d
 ;;   48: movl    $0, %ecx
 ;;       movq    0x30(%r14), %r11

--- a/tests/disas/winch/x64/atomic/rmw/add/i64_atomic_rmw_add.wat
+++ b/tests/disas/winch/x64/atomic/rmw/add/i64_atomic_rmw_add.wat
@@ -12,17 +12,17 @@
 ;;       movq    0x18(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x69
+;;       ja      0x67
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
 ;;       movl    $0x2a, %eax
 ;;       movl    $0, %ecx
-;;       andq    $7, %rcx
-;;       cmpq    $0, %rcx
-;;       jne     0x6b
-;;   4a: movl    $0, %ecx
+;;       andl    $7, %ecx
+;;       cmpl    $0, %ecx
+;;       jne     0x69
+;;   48: movl    $0, %ecx
 ;;       movq    0x30(%r14), %r11
 ;;       movq    (%r11), %rdx
 ;;       movl    %ecx, %ecx
@@ -31,5 +31,5 @@
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
+;;   67: ud2
 ;;   69: ud2
-;;   6b: ud2

--- a/tests/disas/winch/x64/atomic/rmw/and/i32_atomic_rmw16_andu.wat
+++ b/tests/disas/winch/x64/atomic/rmw/and/i32_atomic_rmw16_andu.wat
@@ -19,8 +19,8 @@
 ;;       movq    %rsi, (%rsp)
 ;;       movl    $0x2a, %eax
 ;;       movl    $0, %ecx
-;;       andw    $1, %cx
-;;       cmpw    $0, %cx
+;;       andl    $1, %ecx
+;;       cmpl    $0, %ecx
 ;;       jne     0x91
 ;;   48: movl    $0, %ecx
 ;;       movq    0x30(%r14), %r11

--- a/tests/disas/winch/x64/atomic/rmw/and/i64_atomic_rmw16_andu.wat
+++ b/tests/disas/winch/x64/atomic/rmw/and/i64_atomic_rmw16_andu.wat
@@ -19,8 +19,8 @@
 ;;       movq    %rsi, (%rsp)
 ;;       movl    $0x2a, %eax
 ;;       movl    $0, %ecx
-;;       andw    $1, %cx
-;;       cmpw    $0, %cx
+;;       andl    $1, %ecx
+;;       cmpl    $0, %ecx
 ;;       jne     0x80
 ;;   48: movl    $0, %ecx
 ;;       movq    0x30(%r14), %r11

--- a/tests/disas/winch/x64/atomic/rmw/and/i64_atomic_rmw_and.wat
+++ b/tests/disas/winch/x64/atomic/rmw/and/i64_atomic_rmw_and.wat
@@ -12,17 +12,17 @@
 ;;       movq    0x18(%r11), %r11
 ;;       addq    $0x18, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x7a
+;;       ja      0x78
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
 ;;       movl    $0x2a, %eax
 ;;       movl    $0, %ecx
-;;       andq    $7, %rcx
-;;       cmpq    $0, %rcx
-;;       jne     0x7c
-;;   4a: movl    $0, %ecx
+;;       andl    $7, %ecx
+;;       cmpl    $0, %ecx
+;;       jne     0x7a
+;;   48: movl    $0, %ecx
 ;;       movq    0x30(%r14), %r11
 ;;       movq    (%r11), %rdx
 ;;       movl    %ecx, %ecx
@@ -33,9 +33,9 @@
 ;;       movq    %rax, %r11
 ;;       andq    %rcx, %r11
 ;;       lock cmpxchgq %r11, (%rdx)
-;;       jne     0x60
-;;   71: addq    $0x10, %rsp
+;;       jne     0x5e
+;;   6f: addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
+;;   78: ud2
 ;;   7a: ud2
-;;   7c: ud2

--- a/tests/disas/winch/x64/atomic/rmw/cmpxchg/i32_atomic_rmw16_cmpxchgu.wat
+++ b/tests/disas/winch/x64/atomic/rmw/cmpxchg/i32_atomic_rmw16_cmpxchgu.wat
@@ -20,8 +20,8 @@
 ;;       movl    $0x539, %eax
 ;;       movl    $0x2a, %ecx
 ;;       movl    $0, %edx
-;;       andw    $1, %dx
-;;       cmpw    $0, %dx
+;;       andl    $1, %edx
+;;       cmpl    $0, %edx
 ;;       jne     0x99
 ;;   4d: movl    $0, %edx
 ;;       movq    0x30(%r14), %r11

--- a/tests/disas/winch/x64/atomic/rmw/cmpxchg/i64_atomic_rmw16_cmpxchgu.wat
+++ b/tests/disas/winch/x64/atomic/rmw/cmpxchg/i64_atomic_rmw16_cmpxchgu.wat
@@ -20,8 +20,8 @@
 ;;       movl    $0x539, %eax
 ;;       movl    $0x2a, %ecx
 ;;       movl    $0, %edx
-;;       andw    $1, %dx
-;;       cmpw    $0, %dx
+;;       andl    $1, %edx
+;;       cmpl    $0, %edx
 ;;       jne     0x76
 ;;   4d: movl    $0, %edx
 ;;       movq    0x30(%r14), %r11

--- a/tests/disas/winch/x64/atomic/rmw/cmpxchg/i64_atomic_rmw_cmpxchg.wat
+++ b/tests/disas/winch/x64/atomic/rmw/cmpxchg/i64_atomic_rmw_cmpxchg.wat
@@ -12,7 +12,7 @@
 ;;       movq    0x18(%r11), %r11
 ;;       addq    $0x20, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x72
+;;       ja      0x70
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -20,10 +20,10 @@
 ;;       movl    $0x539, %eax
 ;;       movl    $0x2a, %ecx
 ;;       movl    $0, %edx
-;;       andq    $7, %rdx
-;;       cmpq    $0, %rdx
-;;       jne     0x74
-;;   4f: movl    $0, %edx
+;;       andl    $7, %edx
+;;       cmpl    $0, %edx
+;;       jne     0x72
+;;   4d: movl    $0, %edx
 ;;       movq    0x30(%r14), %r11
 ;;       movq    (%r11), %rbx
 ;;       movl    %edx, %edx
@@ -36,5 +36,5 @@
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
+;;   70: ud2
 ;;   72: ud2
-;;   74: ud2

--- a/tests/disas/winch/x64/atomic/rmw/or/i32_atomic_rmw16_oru.wat
+++ b/tests/disas/winch/x64/atomic/rmw/or/i32_atomic_rmw16_oru.wat
@@ -19,8 +19,8 @@
 ;;       movq    %rsi, (%rsp)
 ;;       movl    $0x2a, %eax
 ;;       movl    $0, %ecx
-;;       andw    $1, %cx
-;;       cmpw    $0, %cx
+;;       andl    $1, %ecx
+;;       cmpl    $0, %ecx
 ;;       jne     0x91
 ;;   48: movl    $0, %ecx
 ;;       movq    0x30(%r14), %r11

--- a/tests/disas/winch/x64/atomic/rmw/or/i64_atomic_rmw16_oru.wat
+++ b/tests/disas/winch/x64/atomic/rmw/or/i64_atomic_rmw16_oru.wat
@@ -19,8 +19,8 @@
 ;;       movq    %rsi, (%rsp)
 ;;       movl    $0x2a, %eax
 ;;       movl    $0, %ecx
-;;       andw    $1, %cx
-;;       cmpw    $0, %cx
+;;       andl    $1, %ecx
+;;       cmpl    $0, %ecx
 ;;       jne     0x80
 ;;   48: movl    $0, %ecx
 ;;       movq    0x30(%r14), %r11

--- a/tests/disas/winch/x64/atomic/rmw/or/i64_atomic_rmw_or.wat
+++ b/tests/disas/winch/x64/atomic/rmw/or/i64_atomic_rmw_or.wat
@@ -12,17 +12,17 @@
 ;;       movq    0x18(%r11), %r11
 ;;       addq    $0x18, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x7a
+;;       ja      0x78
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
 ;;       movl    $0x2a, %eax
 ;;       movl    $0, %ecx
-;;       andq    $7, %rcx
-;;       cmpq    $0, %rcx
-;;       jne     0x7c
-;;   4a: movl    $0, %ecx
+;;       andl    $7, %ecx
+;;       cmpl    $0, %ecx
+;;       jne     0x7a
+;;   48: movl    $0, %ecx
 ;;       movq    0x30(%r14), %r11
 ;;       movq    (%r11), %rdx
 ;;       movl    %ecx, %ecx
@@ -33,9 +33,9 @@
 ;;       movq    %rax, %r11
 ;;       orq     %rcx, %r11
 ;;       lock cmpxchgq %r11, (%rdx)
-;;       jne     0x60
-;;   71: addq    $0x10, %rsp
+;;       jne     0x5e
+;;   6f: addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
+;;   78: ud2
 ;;   7a: ud2
-;;   7c: ud2

--- a/tests/disas/winch/x64/atomic/rmw/sub/i32_atomic_rmw16_subu.wat
+++ b/tests/disas/winch/x64/atomic/rmw/sub/i32_atomic_rmw16_subu.wat
@@ -19,8 +19,8 @@
 ;;       movq    %rsi, (%rsp)
 ;;       movl    $0x2a, %eax
 ;;       movl    $0, %ecx
-;;       andw    $1, %cx
-;;       cmpw    $0, %cx
+;;       andl    $1, %ecx
+;;       cmpl    $0, %ecx
 ;;       jne     0x6f
 ;;   48: movl    $0, %ecx
 ;;       movq    0x30(%r14), %r11

--- a/tests/disas/winch/x64/atomic/rmw/sub/i64_atomic_rmw16_subu.wat
+++ b/tests/disas/winch/x64/atomic/rmw/sub/i64_atomic_rmw16_subu.wat
@@ -19,8 +19,8 @@
 ;;       movq    %rsi, (%rsp)
 ;;       movl    $0x2a, %eax
 ;;       movl    $0, %ecx
-;;       andw    $1, %cx
-;;       cmpw    $0, %cx
+;;       andl    $1, %ecx
+;;       cmpl    $0, %ecx
 ;;       jne     0x70
 ;;   48: movl    $0, %ecx
 ;;       movq    0x30(%r14), %r11

--- a/tests/disas/winch/x64/atomic/rmw/sub/i64_atomic_rmw_sub.wat
+++ b/tests/disas/winch/x64/atomic/rmw/sub/i64_atomic_rmw_sub.wat
@@ -12,17 +12,17 @@
 ;;       movq    0x18(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x6c
+;;       ja      0x6a
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
 ;;       movl    $0x2a, %eax
 ;;       movl    $0, %ecx
-;;       andq    $7, %rcx
-;;       cmpq    $0, %rcx
-;;       jne     0x6e
-;;   4a: movl    $0, %ecx
+;;       andl    $7, %ecx
+;;       cmpl    $0, %ecx
+;;       jne     0x6c
+;;   48: movl    $0, %ecx
 ;;       movq    0x30(%r14), %r11
 ;;       movq    (%r11), %rdx
 ;;       movl    %ecx, %ecx
@@ -32,5 +32,5 @@
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
+;;   6a: ud2
 ;;   6c: ud2
-;;   6e: ud2

--- a/tests/disas/winch/x64/atomic/rmw/xchg/i32_atomic_rmw16_xchgu.wat
+++ b/tests/disas/winch/x64/atomic/rmw/xchg/i32_atomic_rmw16_xchgu.wat
@@ -19,8 +19,8 @@
 ;;       movq    %rsi, (%rsp)
 ;;       movl    $0x2a, %eax
 ;;       movl    $0, %ecx
-;;       andw    $1, %cx
-;;       cmpw    $0, %cx
+;;       andl    $1, %ecx
+;;       cmpl    $0, %ecx
 ;;       jne     0x6a
 ;;   48: movl    $0, %ecx
 ;;       movq    0x30(%r14), %r11

--- a/tests/disas/winch/x64/atomic/rmw/xchg/i64_atomic_rmw16_xchgu.wat
+++ b/tests/disas/winch/x64/atomic/rmw/xchg/i64_atomic_rmw16_xchgu.wat
@@ -19,8 +19,8 @@
 ;;       movq    %rsi, (%rsp)
 ;;       movl    $0x2a, %eax
 ;;       movl    $0, %ecx
-;;       andw    $1, %cx
-;;       cmpw    $0, %cx
+;;       andl    $1, %ecx
+;;       cmpl    $0, %ecx
 ;;       jne     0x6b
 ;;   48: movl    $0, %ecx
 ;;       movq    0x30(%r14), %r11

--- a/tests/disas/winch/x64/atomic/rmw/xchg/i64_atomic_rmw_xchg.wat
+++ b/tests/disas/winch/x64/atomic/rmw/xchg/i64_atomic_rmw_xchg.wat
@@ -12,17 +12,17 @@
 ;;       movq    0x18(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x67
+;;       ja      0x65
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
 ;;       movl    $0x2a, %eax
 ;;       movl    $0, %ecx
-;;       andq    $7, %rcx
-;;       cmpq    $0, %rcx
-;;       jne     0x69
-;;   4a: movl    $0, %ecx
+;;       andl    $7, %ecx
+;;       cmpl    $0, %ecx
+;;       jne     0x67
+;;   48: movl    $0, %ecx
 ;;       movq    0x30(%r14), %r11
 ;;       movq    (%r11), %rdx
 ;;       movl    %ecx, %ecx
@@ -31,5 +31,5 @@
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
+;;   65: ud2
 ;;   67: ud2
-;;   69: ud2

--- a/tests/disas/winch/x64/atomic/rmw/xor/i32_atomic_rmw16_xoru.wat
+++ b/tests/disas/winch/x64/atomic/rmw/xor/i32_atomic_rmw16_xoru.wat
@@ -19,8 +19,8 @@
 ;;       movq    %rsi, (%rsp)
 ;;       movl    $0x2a, %eax
 ;;       movl    $0, %ecx
-;;       andw    $1, %cx
-;;       cmpw    $0, %cx
+;;       andl    $1, %ecx
+;;       cmpl    $0, %ecx
 ;;       jne     0x91
 ;;   48: movl    $0, %ecx
 ;;       movq    0x30(%r14), %r11

--- a/tests/disas/winch/x64/atomic/rmw/xor/i64_atomic_rmw16_xoru.wat
+++ b/tests/disas/winch/x64/atomic/rmw/xor/i64_atomic_rmw16_xoru.wat
@@ -19,8 +19,8 @@
 ;;       movq    %rsi, (%rsp)
 ;;       movl    $0x2a, %eax
 ;;       movl    $0, %ecx
-;;       andw    $1, %cx
-;;       cmpw    $0, %cx
+;;       andl    $1, %ecx
+;;       cmpl    $0, %ecx
 ;;       jne     0x80
 ;;   48: movl    $0, %ecx
 ;;       movq    0x30(%r14), %r11

--- a/tests/disas/winch/x64/atomic/rmw/xor/i64_atomic_rmw_xor.wat
+++ b/tests/disas/winch/x64/atomic/rmw/xor/i64_atomic_rmw_xor.wat
@@ -12,17 +12,17 @@
 ;;       movq    0x18(%r11), %r11
 ;;       addq    $0x18, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x7a
+;;       ja      0x78
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
 ;;       movl    $0x2a, %eax
 ;;       movl    $0, %ecx
-;;       andq    $7, %rcx
-;;       cmpq    $0, %rcx
-;;       jne     0x7c
-;;   4a: movl    $0, %ecx
+;;       andl    $7, %ecx
+;;       cmpl    $0, %ecx
+;;       jne     0x7a
+;;   48: movl    $0, %ecx
 ;;       movq    0x30(%r14), %r11
 ;;       movq    (%r11), %rdx
 ;;       movl    %ecx, %ecx
@@ -33,9 +33,9 @@
 ;;       movq    %rax, %r11
 ;;       xorq    %rcx, %r11
 ;;       lock cmpxchgq %r11, (%rdx)
-;;       jne     0x60
-;;   71: addq    $0x10, %rsp
+;;       jne     0x5e
+;;   6f: addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
+;;   78: ud2
 ;;   7a: ud2
-;;   7c: ud2

--- a/tests/disas/winch/x64/atomic/store/i32_atomic_store16.wat
+++ b/tests/disas/winch/x64/atomic/store/i32_atomic_store16.wat
@@ -18,8 +18,8 @@
 ;;       movq    %rsi, (%rsp)
 ;;       movl    $0x2a, %eax
 ;;       movl    $0, %ecx
-;;       andw    $1, %cx
-;;       cmpw    $0, %cx
+;;       andl    $1, %ecx
+;;       cmpl    $0, %ecx
 ;;       jne     0x6a
 ;;   48: movl    $0, %ecx
 ;;       movq    0x30(%r14), %r11

--- a/tests/disas/winch/x64/atomic/store/i64_atomic_store.wat
+++ b/tests/disas/winch/x64/atomic/store/i64_atomic_store.wat
@@ -11,17 +11,17 @@
 ;;       movq    0x18(%r11), %r11
 ;;       addq    $0x10, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x6a
+;;       ja      0x68
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
 ;;       movl    $0x2a, %eax
 ;;       movl    $0, %ecx
-;;       andq    $7, %rcx
-;;       cmpq    $0, %rcx
-;;       jne     0x6c
-;;   4a: movl    $0, %ecx
+;;       andl    $7, %ecx
+;;       cmpl    $0, %ecx
+;;       jne     0x6a
+;;   48: movl    $0, %ecx
 ;;       movq    0x30(%r14), %r11
 ;;       movq    (%r11), %rdx
 ;;       movl    %ecx, %ecx
@@ -31,5 +31,5 @@
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
+;;   68: ud2
 ;;   6a: ud2
-;;   6c: ud2

--- a/tests/disas/winch/x64/atomic/store/i64_atomic_store16.wat
+++ b/tests/disas/winch/x64/atomic/store/i64_atomic_store16.wat
@@ -18,8 +18,8 @@
 ;;       movq    %rsi, (%rsp)
 ;;       movl    $0x2a, %eax
 ;;       movl    $0, %ecx
-;;       andw    $1, %cx
-;;       cmpw    $0, %cx
+;;       andl    $1, %ecx
+;;       cmpl    $0, %ecx
 ;;       jne     0x6a
 ;;   48: movl    $0, %ecx
 ;;       movq    0x30(%r14), %r11

--- a/winch/codegen/src/codegen/mod.rs
+++ b/winch/codegen/src/codegen/mod.rs
@@ -669,6 +669,7 @@ where
     /// detecting an out of bounds access at compile time.
     pub fn emit_compute_heap_address(
         &mut self,
+        heap: &HeapData,
         memarg: &MemArg,
         access_size: OperandSize,
     ) -> Result<Option<Reg>> {
@@ -678,8 +679,6 @@ where
             (access_size.bytes() as u64) + (offset.as_u32() as u64)
         };
 
-        let memory_index = MemoryIndex::from_u32(memarg.memory);
-        let heap = self.env.resolve_heap(memory_index);
         let index = Index::from_typed_reg(self.context.pop_to_reg(self.masm, None)?);
 
         let offset = bounds::ensure_index_and_offset(
@@ -866,10 +865,16 @@ where
         Ok(addr)
     }
 
-    /// Emit checks to ensure that the address at `memarg` is correctly aligned for `size`.
-    fn emit_check_align(&mut self, memarg: &MemArg, size: OperandSize) -> Result<()> {
-        if size.bytes() > 1 {
-            // Peek addr from top of the stack by popping and pushing.
+    /// Emit checks to ensure that the address at `memarg` is
+    /// correctly aligned for the access size.
+    fn emit_check_align(
+        &mut self,
+        heap: &HeapData,
+        memarg: &MemArg,
+        access_size: OperandSize,
+    ) -> Result<()> {
+        if access_size.bytes() > 1 {
+            let heap_ty_size: OperandSize = heap.index_type().try_into()?;
             let addr = *self
                 .context
                 .stack
@@ -883,18 +888,18 @@ where
                     writable!(tmp),
                     tmp,
                     RegImm::Imm(Imm::I64(memarg.offset)),
-                    size,
+                    heap_ty_size,
                 )?;
             }
 
             self.masm.and(
                 writable!(tmp),
                 tmp,
-                RegImm::Imm(Imm::I32(size.bytes() - 1)),
-                size,
+                RegImm::Imm(Imm::I32(access_size.bytes() - 1)),
+                heap_ty_size,
             )?;
 
-            self.masm.cmp(tmp, RegImm::Imm(Imm::i64(0)), size)?;
+            self.masm.cmp(tmp, RegImm::Imm(Imm::i64(0)), heap_ty_size)?;
             self.masm.trapif(IntCmpKind::Ne, TRAP_HEAP_MISALIGNED)?;
             self.context.free_reg(tmp);
         }
@@ -904,11 +909,12 @@ where
 
     pub fn emit_compute_heap_address_align_checked(
         &mut self,
+        heap: &HeapData,
         memarg: &MemArg,
         access_size: OperandSize,
     ) -> Result<Option<Reg>> {
-        self.emit_check_align(memarg, access_size)?;
-        self.emit_compute_heap_address(memarg, access_size)
+        self.emit_check_align(heap, memarg, access_size)?;
+        self.emit_compute_heap_address(heap, memarg, access_size)
     }
 
     /// Emit a WebAssembly load.
@@ -928,6 +934,9 @@ where
             Ok(())
         };
 
+        let memory_index = MemoryIndex::from_u32(arg.memory);
+        let heap = self.env.resolve_heap(memory_index);
+
         // Ensure that the destination register is not allocated if
         // `emit_compute_heap_address` does not return an address.
         match kind {
@@ -936,7 +945,8 @@ where
                 // `emit_compute_heap_address` expects an integer register
                 // containing the address to load to be at the top of the stack.
                 let dst = self.context.pop_to_reg(self.masm, None)?;
-                let addr = self.emit_compute_heap_address(&arg, kind.derive_operand_size())?;
+                let addr =
+                    self.emit_compute_heap_address(&heap, &arg, kind.derive_operand_size())?;
                 if let Some(addr) = addr {
                     emit_load(self, dst.reg, addr, kind)?;
                 } else {
@@ -946,10 +956,11 @@ where
             _ => {
                 let maybe_addr = match kind {
                     LoadKind::Atomic(_, _) => self.emit_compute_heap_address_align_checked(
+                        &heap,
                         &arg,
                         kind.derive_operand_size(),
                     )?,
-                    _ => self.emit_compute_heap_address(&arg, kind.derive_operand_size())?,
+                    _ => self.emit_compute_heap_address(&heap, &arg, kind.derive_operand_size())?,
                 };
 
                 if let Some(addr) = maybe_addr {
@@ -970,12 +981,16 @@ where
 
     /// Emit a WebAssembly store.
     pub fn emit_wasm_store(&mut self, arg: &MemArg, kind: StoreKind) -> Result<()> {
+        let memory_index = MemoryIndex::from_u32(arg.memory);
+        let heap = self.env.resolve_heap(memory_index);
         let src = self.context.pop_to_reg(self.masm, None)?;
 
         let maybe_addr = match kind {
-            StoreKind::Atomic(size) => self.emit_compute_heap_address_align_checked(&arg, size)?,
+            StoreKind::Atomic(size) => {
+                self.emit_compute_heap_address_align_checked(&heap, &arg, size)?
+            }
             StoreKind::Operand(size) | StoreKind::VectorLane(LaneSelector { size, .. }) => {
-                self.emit_compute_heap_address(&arg, size)?
+                self.emit_compute_heap_address(&heap, &arg, size)?
             }
         };
 
@@ -1396,11 +1411,13 @@ where
         size: OperandSize,
         extend: Option<Extend<Zero>>,
     ) -> Result<()> {
+        let memory_index = MemoryIndex::from_u32(arg.memory);
+        let heap = self.env.resolve_heap(memory_index);
         // We need to pop-push the operand to compute the address before passing control over to
         // masm, because some architectures may have specific requirements for the registers used
         // in some atomic operations.
         let operand = self.context.pop_to_reg(self.masm, None)?;
-        if let Some(addr) = self.emit_compute_heap_address_align_checked(arg, size)? {
+        if let Some(addr) = self.emit_compute_heap_address_align_checked(&heap, arg, size)? {
             let src = self.masm.address_at_reg(addr, 0)?;
             self.context.stack.push(operand.into());
             self.masm
@@ -1437,7 +1454,9 @@ where
         let replacement = self.context.pop_to_reg(self.masm, None)?;
         let expected = self.context.pop_to_reg(self.masm, None)?;
 
-        if let Some(addr) = self.emit_compute_heap_address_align_checked(arg, size)? {
+        let memory_index = MemoryIndex::from_u32(arg.memory);
+        let heap = self.env.resolve_heap(memory_index);
+        if let Some(addr) = self.emit_compute_heap_address_align_checked(&heap, arg, size)? {
             self.context.stack.push(expected.into());
             self.context.stack.push(replacement.into());
 


### PR DESCRIPTION
Prior to this commit, the alignment check implementation part of the threads proposal was erroneously relying on the byte access size to calcuate the effective address, this would result in a panic at Cranelift's emission layer when mixing immediates and access sizes smaller than 4-bytes.

The fix relies on the heap size for the arithmetic operations related to calculating the effective address and alignment calculation, mirroring what the heap address calculation will use prior to a memory access.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
