### PR TITLE
c-api: add wasmtime_call_future_poll_with_notify and async_allow_sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4804,6 +4804,7 @@ dependencies = [
  "cap-std",
  "env_logger 0.11.5",
  "futures",
+ "libc",
  "log",
  "tokio",
  "tracing",
@@ -4813,6 +4814,7 @@ dependencies = [
  "wasmtime-wasi-http",
  "wasmtime-wasi-io",
  "wat",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/c-api/Cargo.toml
+++ b/crates/c-api/Cargo.toml
@@ -41,6 +41,12 @@ bytes = { workspace = true, optional = true }
 # Optional dependencies for the `async` feature
 futures = { workspace = true, optional = true }
 
+[target.'cfg(unix)'.dependencies]
+libc = { workspace = true }
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { workspace = true, features = ["Win32_Networking_WinSock"] }
+
 [features]
 # WASMTIME_FEATURE_LIST
 async = ['wasmtime/async', 'futures']

--- a/crates/c-api/include/wasmtime/async.h
+++ b/crates/c-api/include/wasmtime/async.h
@@ -68,6 +68,21 @@ extern "C" {
 WASMTIME_CONFIG_PROP(void, async_stack_size, size_t)
 
 /**
+ * \brief Configures whether synchronous calls are permitted on stores that
+ * have async host functions linked.
+ *
+ * When enabled, synchronous function calls will not be rejected even if
+ * the store has async host functions (e.g. WASI async bindings). This is
+ * intended for embedders that manage sync vs async dispatch themselves.
+ *
+ * If a synchronously-called function attempts to suspend, the runtime will
+ * panic.
+ *
+ * By default this option is false.
+ */
+WASMTIME_CONFIG_PROP(void, async_allow_sync, bool)
+
+/**
  * \brief Configures a Store to yield execution of async WebAssembly code
  * periodically.
  *
@@ -182,6 +197,22 @@ typedef struct wasmtime_call_future wasmtime_call_future_t;
  *
  */
 WASM_API_EXTERN bool wasmtime_call_future_poll(wasmtime_call_future_t *future);
+
+/**
+ * \brief Poll a call future with a notification socket.
+ *
+ * Like wasmtime_call_future_poll, but instead of a no-op waker, uses a waker
+ * that writes a byte to \p socket when the future is ready to make progress.
+ * This allows a foreign event loop to sleep on the socket instead of
+ * busy-polling.
+ *
+ * \p socket is the raw handle of the write end of a socket pair. On Unix this
+ * is a file descriptor; on Windows it is a SOCKET handle. The host should
+ * monitor the read end for readability.
+ */
+WASM_API_EXTERN bool
+wasmtime_call_future_poll_with_notify(wasmtime_call_future_t *future,
+                                      int64_t socket);
 
 /**
  * \brief Frees the underlying memory for a future.

--- a/crates/c-api/src/async.rs
+++ b/crates/c-api/src/async.rs
@@ -22,6 +22,11 @@ pub extern "C" fn wasmtime_config_async_stack_size_set(c: &mut wasm_config_t, si
 }
 
 #[unsafe(no_mangle)]
+pub extern "C" fn wasmtime_config_async_allow_sync_set(c: &mut wasm_config_t, enable: bool) {
+    c.config.async_allow_sync(enable);
+}
+
+#[unsafe(no_mangle)]
 pub extern "C" fn wasmtime_context_epoch_deadline_async_yield_and_update(
     mut store: WasmtimeStoreContextMut<'_>,
     delta: u64,
@@ -202,6 +207,40 @@ pub extern "C" fn wasmtime_call_future_poll(future: &mut wasmtime_call_future_t)
         .underlying
         .as_mut()
         .poll(&mut Context::from_waker(Waker::noop()))
+    {
+        Poll::Ready(()) => true,
+        Poll::Pending => false,
+    }
+}
+
+/// A [`Waker`] that writes a single byte to a socket when woken.
+struct SocketWaker(i64);
+
+impl std::task::Wake for SocketWaker {
+    fn wake(self: std::sync::Arc<Self>) {
+        #[cfg(unix)]
+        unsafe {
+            libc::write(self.0 as libc::c_int, [1u8].as_ptr() as *const _, 1);
+        }
+        #[cfg(windows)]
+        unsafe {
+            windows_sys::Win32::Networking::WinSock::send(self.0 as usize, [1u8].as_ptr(), 1, 0);
+        }
+    }
+}
+
+/// Like [`wasmtime_call_future_poll`] but registers a [`SocketWaker`] so the
+/// host is notified via `socket` when the future can make progress.
+#[unsafe(no_mangle)]
+pub extern "C" fn wasmtime_call_future_poll_with_notify(
+    future: &mut wasmtime_call_future_t,
+    socket: i64,
+) -> bool {
+    let waker = Waker::from(std::sync::Arc::new(SocketWaker(socket)));
+    match future
+        .underlying
+        .as_mut()
+        .poll(&mut Context::from_waker(&waker))
     {
         Poll::Ready(()) => true,
         Poll::Pending => false,

--- a/crates/c-api/tests/async.cc
+++ b/crates/c-api/tests/async.cc
@@ -1,3 +1,4 @@
+#include <cstring>
 #include <gtest/gtest.h>
 #include <wasmtime.h>
 #include <wasmtime.hh>
@@ -63,6 +64,116 @@ TEST(async, instantiate_async) {
 
   EXPECT_EQ(trap, nullptr);
   EXPECT_EQ(error, nullptr);
+}
+
+TEST(async, call_func_poll_with_notify) {
+  Engine engine;
+  Store store(engine);
+
+  wasmtime_func_async_callback_t callback =
+      [](void *, wasmtime_caller_t *, const wasmtime_val_t *args, size_t,
+         wasmtime_val_t *results, size_t, wasm_trap_t **,
+         wasmtime_async_continuation_t *cont) {
+        results[0].kind = WASMTIME_I32;
+        results[0].of.i32 = args[0].of.i32 + args[1].of.i32;
+        auto *count = new int(0);
+        cont->env = count;
+        cont->callback = [](void *env) -> bool {
+          return ++(*static_cast<int *>(env)) > 1;
+        };
+        cont->finalizer = [](void *env) { delete static_cast<int *>(env); };
+      };
+
+  wasm_functype_t *ty = wasm_functype_new_2_1(
+      wasm_valtype_new_i32(), wasm_valtype_new_i32(), wasm_valtype_new_i32());
+  Linker linker(engine);
+  wasmtime_linker_define_async_func(linker.capi(), "host", 4, "add", 3, ty,
+                                    callback, nullptr, nullptr);
+  wasm_functype_delete(ty);
+
+  Module m =
+      Module::compile(
+          engine,
+          "(module"
+          "  (import \"host\" \"add\" (func $add (param i32 i32) (result i32)))"
+          "  (func (export \"f\") (param i32 i32) (result i32)"
+          "    local.get 0 local.get 1 call $add))")
+          .unwrap();
+
+  wasmtime_instance_t instance;
+  auto *inst_future =
+      wasmtime_linker_instantiate_async(linker.capi(), store.context().capi(),
+                                        m.capi(), &instance, nullptr, nullptr);
+  while (!wasmtime_call_future_poll(inst_future)) {
+  }
+  wasmtime_call_future_delete(inst_future);
+
+  wasmtime_extern_t ext;
+  wasmtime_instance_export_get(store.context().capi(), &instance, "f", 1, &ext);
+
+  wasmtime_val_t params[2] = {{.kind = WASMTIME_I32, .of = {.i32 = 7}},
+                              {.kind = WASMTIME_I32, .of = {.i32 = 8}}};
+  wasmtime_val_t results[1] = {};
+  wasm_trap_t *trap = nullptr;
+  wasmtime_error_t *error = nullptr;
+  auto *future = wasmtime_func_call_async(store.context().capi(), &ext.of.func,
+                                          params, 2, results, 1, &trap, &error);
+
+  EXPECT_FALSE(wasmtime_call_future_poll_with_notify(future, -1));
+  EXPECT_TRUE(wasmtime_call_future_poll_with_notify(future, -1));
+
+  wasmtime_call_future_delete(future);
+
+  EXPECT_EQ(error, nullptr);
+  EXPECT_EQ(results[0].of.i32, 15);
+}
+
+TEST(async, async_allow_sync) {
+  Config config;
+  wasmtime_config_async_allow_sync_set(config.capi(), true);
+  Engine engine(std::move(config));
+  Store store(engine);
+
+  wasmtime_func_async_callback_t callback =
+      [](void *, wasmtime_caller_t *, const wasmtime_val_t *, size_t,
+         wasmtime_val_t *results, size_t, wasm_trap_t **,
+         wasmtime_async_continuation_t *cont) {
+        results[0].kind = WASMTIME_I32;
+        results[0].of.i32 = 99;
+        cont->callback = [](void *) -> bool { return true; };
+        cont->env = nullptr;
+        cont->finalizer = nullptr;
+      };
+
+  wasm_functype_t *ty = wasm_functype_new_0_1(wasm_valtype_new_i32());
+  Linker linker(engine);
+  wasmtime_linker_define_async_func(linker.capi(), "host", 4, "f", 1, ty,
+                                    callback, nullptr, nullptr);
+  wasm_functype_delete(ty);
+
+  Module m = Module::compile(
+                 engine, "(module"
+                         "  (import \"host\" \"f\" (func (result i32)))"
+                         "  (func (export \"g\") (result i32) i32.const 42))")
+                 .unwrap();
+
+  wasmtime_instance_t instance;
+  auto *inst_future =
+      wasmtime_linker_instantiate_async(linker.capi(), store.context().capi(),
+                                        m.capi(), &instance, nullptr, nullptr);
+  while (!wasmtime_call_future_poll(inst_future)) {
+  }
+  wasmtime_call_future_delete(inst_future);
+
+  wasmtime_extern_t ext;
+  wasmtime_instance_export_get(store.context().capi(), &instance, "g", 1, &ext);
+
+  wasmtime_val_t results[1] = {};
+  wasm_trap_t *trap = nullptr;
+  auto *error = wasmtime_func_call(store.context().capi(), &ext.of.func,
+                                   nullptr, 0, results, 1, &trap);
+  EXPECT_EQ(error, nullptr);
+  EXPECT_EQ(results[0].of.i32, 42);
 }
 
 #endif // WASMTIME_FEATURE_ASYNC

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -187,6 +187,8 @@ pub struct Config {
     #[cfg(feature = "async")]
     pub(crate) async_stack_zeroing: bool,
     #[cfg(feature = "async")]
+    pub(crate) async_allow_sync: bool,
+    #[cfg(feature = "async")]
     pub(crate) stack_creator: Option<Arc<dyn RuntimeFiberStackCreator>>,
     pub(crate) module_version: ModuleVersionStrategy,
     pub(crate) parallel_compilation: bool,
@@ -293,6 +295,8 @@ impl Config {
             async_stack_size: 2 << 20,
             #[cfg(feature = "async")]
             async_stack_zeroing: false,
+            #[cfg(feature = "async")]
+            async_allow_sync: false,
             #[cfg(feature = "async")]
             stack_creator: None,
             module_version: ModuleVersionStrategy::default(),
@@ -856,6 +860,20 @@ impl Config {
     #[cfg(feature = "async")]
     pub fn async_stack_zeroing(&mut self, enable: bool) -> &mut Self {
         self.async_stack_zeroing = enable;
+        self
+    }
+
+    /// Permits synchronous calls on stores that have async host functions.
+    ///
+    /// By default, linking async host functions causes wasmtime to reject
+    /// sync calls. This option lifts that restriction for embedders that
+    /// manage sync/async dispatch themselves. If a sync-called function
+    /// actually suspends, the runtime will panic.
+    ///
+    /// Defaults to `false`.
+    #[cfg(feature = "async")]
+    pub fn async_allow_sync(&mut self, enable: bool) -> &mut Self {
+        self.async_allow_sync = enable;
         self
     }
 

--- a/crates/wasmtime/src/runtime/store.rs
+++ b/crates/wasmtime/src/runtime/store.rs
@@ -2818,7 +2818,7 @@ at https://bytecodealliance.org/security.
     #[inline]
     pub(crate) fn validate_sync_call(&self) -> Result<()> {
         #[cfg(feature = "async")]
-        if self.async_state.async_required {
+        if self.async_state.async_required && !self.engine().config().async_allow_sync {
             bail!("store configuration requires that `*_async` functions are used instead");
         }
         Ok(())

--- a/tests/all/missing_async.rs
+++ b/tests/all/missing_async.rs
@@ -271,6 +271,17 @@ async fn async_disallows_structref_new() -> Result<()> {
 }
 
 #[test]
+fn async_allow_sync_permits_sync_calls() {
+    let mut config = Config::new();
+    config.async_allow_sync(true);
+    let engine = Engine::new(&config).unwrap();
+    let mut store = Store::new(&engine, ());
+    Func::wrap_async(&mut store, |_, ()| Box::new(async {}));
+    let module = Module::new(&engine, "(module)").unwrap();
+    assert!(Instance::new(&mut store, &module, &[]).is_ok());
+}
+
+#[test]
 fn epoch_yield_disallowed_without_async() -> Result<()> {
     let mut config = Config::new();
     config.epoch_interruption(true);


### PR DESCRIPTION
Closes #12991.

This PR adds two features to the C API for embedders integrating wasmtime with foreign async event loops (e.g. Python's asyncio):

**`wasmtime_call_future_poll_with_notify`** — like `wasmtime_call_future_poll`, but accepts a socket fd. A `SocketWaker` writes a byte to the socket when the future can make progress, allowing the host to sleep on the socket instead of busy-polling.

**`Config::async_allow_sync`** — permits synchronous calls on stores that have async host functions linked. Intended for embedders that manage sync/async dispatch themselves and know certain exports will never suspend.

These are the wasmtime-side changes needed for [wasmtime-py async support](https://github.com/pgrayy/wasmtime-py/commit/37c1eff). A corresponding wasmtime-py PR is in development.

### Motivation

We are building Python bindings (wasmtime-py) that call WASM component functions using `asyncio`. The component uses `wasi:http` backed by wasmtime's internal Tokio runtime. Today, `wasmtime_call_future_poll` uses `Waker::noop()`, so the only way to know when to re-poll is busy-polling with `asyncio.sleep(0)`. This wastes CPU and adds latency.

With `poll_with_notify`, Python creates a socket pair, passes the write fd to wasmtime, and awaits readability on the read end via `loop.sock_recv()`. When Tokio completes background I/O and wakes the future, the `SocketWaker` writes a byte, waking Python's event loop.

For convenience, the same embedder also wants to call non-suspending exports synchronously (avoiding the overhead of setting up a socket pair and poll loop for functions that will complete immediately). Since linking WASI async bindings sets `async_required` on the store, sync calls are rejected by default. `Config::async_allow_sync` lets the embedder opt into managing sync/async dispatch themselves.

### Design decisions

- **Separate function (not modifying `wasmtime_call_future_poll`):** C doesn't support optional parameters. Adding a parameter would break all existing callers. A new function is non-breaking.

### Testing

- Rust integration test in `tests/all/missing_async.rs`
- C API tests in `crates/c-api/tests/async.cc` (cross-platform socket helpers, exercises pending→waker fires→ready cycle)
- End-to-end validation via wasmtime-py demo (WASI HTTP call with Tokio background threads)