### PR TITLE
riscv64: Move conditional traps out-of-line

### DIFF
--- a/cranelift/codegen/src/isa/riscv64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/emit.rs
@@ -2181,24 +2181,19 @@ impl Inst {
             }
 
             &Inst::TrapIf {
+                cc,
                 rs1,
                 rs2,
-                cc,
                 trap_code,
             } => {
-                let label_end = sink.get_label();
+                let label = sink.defer_trap(trap_code);
                 let cond = IntegerCompare { kind: cc, rs1, rs2 };
-
-                // Jump over the trap if we the condition is false.
                 Inst::CondBr {
-                    taken: CondBrTarget::Label(label_end),
+                    taken: CondBrTarget::Label(label),
                     not_taken: CondBrTarget::Fallthrough,
-                    kind: cond.inverse(),
+                    kind: cond,
                 }
                 .emit(sink, emit_info, state);
-                Inst::Udf { trap_code }.emit(sink, emit_info, state);
-
-                sink.bind_label(label_end, &mut state.ctrl_plane);
             }
             &Inst::Udf { trap_code } => {
                 sink.add_trap(trap_code);

--- a/cranelift/filetests/filetests/isa/riscv64/arithmetic.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/arithmetic.clif
@@ -102,17 +102,17 @@ block0(v0: i64, v1: i64):
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   bnez a1, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_divz
+;   beqz a1, 0x24
 ;   lui a2, 1
 ;   slli a2, a2, 0x33
 ;   xor a2, a0, a2
 ;   not a3, a1
 ;   or a2, a2, a3
-;   bnez a2, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
+;   beqz a2, 0x10
 ;   div a0, a0, a1
 ;   ret
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_divz
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
 
 function %f7(i64) -> i64 {
 block0(v0: i64):
@@ -147,10 +147,10 @@ block0(v0: i64, v1: i64):
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   bnez a1, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_divz
+;   beqz a1, 0xc
 ;   divu a0, a0, a1
 ;   ret
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_divz
 
 function %f9(i64) -> i64 {
 block0(v0: i64):
@@ -185,10 +185,10 @@ block0(v0: i64, v1: i64):
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   bnez a1, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_divz
+;   beqz a1, 0xc
 ;   rem a0, a0, a1
 ;   ret
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_divz
 
 function %f11(i64, i64) -> i64 {
 block0(v0: i64, v1: i64):
@@ -204,10 +204,10 @@ block0(v0: i64, v1: i64):
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   bnez a1, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_divz
+;   beqz a1, 0xc
 ;   remu a0, a0, a1
 ;   ret
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_divz
 
 function %f12(i32, i32) -> i32 {
 block0(v0: i32, v1: i32):
@@ -232,16 +232,16 @@ block0(v0: i32, v1: i32):
 ; block0: ; offset 0x0
 ;   sext.w a0, a0
 ;   sext.w a1, a1
-;   bnez a1, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_divz
+;   beqz a1, 0x20
 ;   lui a2, 0x80000
 ;   xor a2, a0, a2
 ;   not a3, a1
 ;   or a4, a2, a3
-;   bnez a4, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
+;   beqz a4, 0x10
 ;   divw a0, a0, a1
 ;   ret
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_divz
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
 
 function %f13(i32) -> i32 {
 block0(v0: i32):
@@ -280,10 +280,10 @@ block0(v0: i32, v1: i32):
 ; block0: ; offset 0x0
 ;   slli a1, a1, 0x20
 ;   srli a1, a1, 0x20
-;   bnez a1, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_divz
+;   beqz a1, 0xc
 ;   divuw a0, a0, a1
 ;   ret
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_divz
 
 function %f15(i32) -> i32 {
 block0(v0: i32):
@@ -320,10 +320,10 @@ block0(v0: i32, v1: i32):
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sext.w a1, a1
-;   bnez a1, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_divz
+;   beqz a1, 0xc
 ;   remw a0, a0, a1
 ;   ret
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_divz
 
 function %f17(i32, i32) -> i32 {
 block0(v0: i32, v1: i32):
@@ -343,10 +343,10 @@ block0(v0: i32, v1: i32):
 ; block0: ; offset 0x0
 ;   slli a1, a1, 0x20
 ;   srli a1, a1, 0x20
-;   bnez a1, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_divz
+;   beqz a1, 0xc
 ;   remuw a0, a0, a1
 ;   ret
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_divz
 
 function %f18(i64, i64) -> i64 {
 block0(v0: i64, v1: i64):
@@ -758,17 +758,17 @@ block0(v0: i64):
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi a1, zero, -1
-;   bnez a1, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_divz
+;   beqz a1, 0x24
 ;   lui a2, 1
 ;   slli a2, a2, 0x33
 ;   xor a2, a0, a2
 ;   not a3, a1
 ;   or a2, a2, a3
-;   bnez a2, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
+;   beqz a2, 0x10
 ;   div a0, a0, a1
 ;   ret
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_divz
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
 
 function %i8_iadd_const_neg1(i8) -> i8 {
 block0(v0: i8):

--- a/cranelift/filetests/filetests/isa/riscv64/fcvt-small.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/fcvt-small.clif
@@ -102,20 +102,20 @@ block0(v0: f32):
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   feq.s a0, fa0, fa0
-;   bnez a0, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: bad_toint
+;   beqz a0, 0x2c
 ;   lui a0, 0xbf800
 ;   fmv.w.x fa1, a0
 ;   fle.s a0, fa0, fa1
-;   beqz a0, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
+;   bnez a0, 0x20
 ;   lui a2, 0x43800
 ;   fmv.w.x fa4, a2
 ;   fle.s a0, fa4, fa0
-;   beqz a0, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
+;   bnez a0, 0x14
 ;   fcvt.wu.s a0, fa0, rtz ; trap: bad_toint
 ;   ret
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: bad_toint
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
 
 function u0:0(f64) -> i8 {
 block0(v0: f64):
@@ -143,22 +143,22 @@ block0(v0: f64):
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   feq.d a0, fa0, fa0
-;   bnez a0, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: bad_toint
+;   beqz a0, 0x34
 ;   lui a0, 0xbff
 ;   slli a0, a0, 0x28
 ;   fmv.d.x fa1, a0
 ;   fle.d a1, fa0, fa1
-;   beqz a1, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
+;   bnez a1, 0x24
 ;   lui a4, 0x407
 ;   slli a0, a4, 0x28
 ;   fmv.d.x fa1, a0
 ;   fle.d a0, fa1, fa0
-;   beqz a0, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
+;   bnez a0, 0x14
 ;   fcvt.wu.d a0, fa0, rtz ; trap: bad_toint
 ;   ret
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: bad_toint
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
 
 function u0:0(f32) -> i16 {
 block0(v0: f32):
@@ -184,20 +184,20 @@ block0(v0: f32):
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   feq.s a0, fa0, fa0
-;   bnez a0, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: bad_toint
+;   beqz a0, 0x2c
 ;   lui a0, 0xbf800
 ;   fmv.w.x fa1, a0
 ;   fle.s a0, fa0, fa1
-;   beqz a0, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
+;   bnez a0, 0x20
 ;   lui a2, 0x47800
 ;   fmv.w.x fa4, a2
 ;   fle.s a0, fa4, fa0
-;   beqz a0, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
+;   bnez a0, 0x14
 ;   fcvt.wu.s a0, fa0, rtz ; trap: bad_toint
 ;   ret
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: bad_toint
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
 
 function u0:0(f64) -> i16 {
 block0(v0: f64):
@@ -225,20 +225,20 @@ block0(v0: f64):
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   feq.d a0, fa0, fa0
-;   bnez a0, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: bad_toint
+;   beqz a0, 0x34
 ;   lui a0, 0xbff
 ;   slli a0, a0, 0x28
 ;   fmv.d.x fa1, a0
 ;   fle.d a1, fa0, fa1
-;   beqz a1, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
+;   bnez a1, 0x24
 ;   lui a4, 0x40f
 ;   slli a0, a4, 0x28
 ;   fmv.d.x fa1, a0
 ;   fle.d a0, fa1, fa0
-;   beqz a0, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
+;   bnez a0, 0x14
 ;   fcvt.wu.d a0, fa0, rtz ; trap: bad_toint
 ;   ret
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: bad_toint
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
 

--- a/cranelift/filetests/filetests/isa/riscv64/float.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/float.clif
@@ -315,20 +315,20 @@ block0(v0: f32):
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   feq.s a0, fa0, fa0
-;   bnez a0, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: bad_toint
+;   beqz a0, 0x2c
 ;   lui a0, 0xbf800
 ;   fmv.w.x fa1, a0
 ;   fle.s a0, fa0, fa1
-;   beqz a0, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
+;   bnez a0, 0x20
 ;   lui a2, 0x4f800
 ;   fmv.w.x fa4, a2
 ;   fle.s a0, fa4, fa0
-;   beqz a0, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
+;   bnez a0, 0x14
 ;   fcvt.wu.s a0, fa0, rtz ; trap: bad_toint
 ;   ret
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: bad_toint
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
 
 function %f34(f32) -> i32 {
 block0(v0: f32):
@@ -355,21 +355,21 @@ block0(v0: f32):
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   feq.s a0, fa0, fa0
-;   bnez a0, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: bad_toint
+;   beqz a0, 0x30
 ;   lui a0, 0xcf000
 ;   addi a0, a0, 1
 ;   fmv.w.x fa1, a0
 ;   fle.s a1, fa0, fa1
-;   beqz a1, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
+;   bnez a1, 0x20
 ;   lui a4, 0x4f000
 ;   fmv.w.x fa1, a4
 ;   fle.s a0, fa1, fa0
-;   beqz a0, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
+;   bnez a0, 0x14
 ;   fcvt.w.s a0, fa0, rtz ; trap: bad_toint
 ;   ret
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: bad_toint
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
 
 function %f35(f32) -> i64 {
 block0(v0: f32):
@@ -395,20 +395,20 @@ block0(v0: f32):
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   feq.s a0, fa0, fa0
-;   bnez a0, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: bad_toint
+;   beqz a0, 0x2c
 ;   lui a0, 0xbf800
 ;   fmv.w.x fa1, a0
 ;   fle.s a0, fa0, fa1
-;   beqz a0, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
+;   bnez a0, 0x20
 ;   lui a2, 0x5f800
 ;   fmv.w.x fa4, a2
 ;   fle.s a0, fa4, fa0
-;   beqz a0, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
+;   bnez a0, 0x14
 ;   fcvt.lu.s a0, fa0, rtz ; trap: bad_toint
 ;   ret
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: bad_toint
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
 
 function %f36(f32) -> i64 {
 block0(v0: f32):
@@ -435,21 +435,21 @@ block0(v0: f32):
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   feq.s a0, fa0, fa0
-;   bnez a0, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: bad_toint
+;   beqz a0, 0x30
 ;   lui a0, 0xdf000
 ;   addi a0, a0, 1
 ;   fmv.w.x fa1, a0
 ;   fle.s a1, fa0, fa1
-;   beqz a1, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
+;   bnez a1, 0x20
 ;   lui a4, 0x5f000
 ;   fmv.w.x fa1, a4
 ;   fle.s a0, fa1, fa0
-;   beqz a0, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
+;   bnez a0, 0x14
 ;   fcvt.l.s a0, fa0, rtz ; trap: bad_toint
 ;   ret
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: bad_toint
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
 
 function %f37(f64) -> i32 {
 block0(v0: f64):
@@ -477,22 +477,22 @@ block0(v0: f64):
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   feq.d a0, fa0, fa0
-;   bnez a0, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: bad_toint
+;   beqz a0, 0x34
 ;   lui a0, 0xbff
 ;   slli a0, a0, 0x28
 ;   fmv.d.x fa1, a0
 ;   fle.d a1, fa0, fa1
-;   beqz a1, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
+;   bnez a1, 0x24
 ;   lui a4, 0x41f
 ;   slli a0, a4, 0x28
 ;   fmv.d.x fa1, a0
 ;   fle.d a0, fa1, fa0
-;   beqz a0, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
+;   bnez a0, 0x14
 ;   fcvt.wu.d a0, fa0, rtz ; trap: bad_toint
 ;   ret
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: bad_toint
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
 
 function %f38(f64) -> i32 {
 block0(v0: f64):
@@ -519,22 +519,22 @@ block0(v0: f64):
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   feq.d a0, fa0, fa0
-;   bnez a0, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: bad_toint
+;   beqz a0, 0x34
 ;   auipc a0, 0
-;   ld a0, 0x3c(a0)
+;   ld a0, 0x40(a0)
 ;   fmv.d.x fa1, a0
 ;   fle.d a0, fa0, fa1
-;   beqz a0, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
+;   bnez a0, 0x24
 ;   lui a2, 0x20f
 ;   slli a4, a2, 0x29
 ;   fmv.d.x fa1, a4
 ;   fle.d a0, fa1, fa0
-;   beqz a0, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
+;   bnez a0, 0x14
 ;   fcvt.w.d a0, fa0, rtz ; trap: bad_toint
 ;   ret
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: bad_toint
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
 ;   .byte 0x00, 0x00, 0x00, 0x00
 ;   .byte 0x00, 0x00, 0x20, 0x00
 ;   .byte 0x00, 0x00, 0xe0, 0xc1
@@ -565,22 +565,22 @@ block0(v0: f64):
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   feq.d a0, fa0, fa0
-;   bnez a0, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: bad_toint
+;   beqz a0, 0x34
 ;   lui a0, 0xbff
 ;   slli a0, a0, 0x28
 ;   fmv.d.x fa1, a0
 ;   fle.d a1, fa0, fa1
-;   beqz a1, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
+;   bnez a1, 0x24
 ;   lui a4, 0x43f
 ;   slli a0, a4, 0x28
 ;   fmv.d.x fa1, a0
 ;   fle.d a0, fa1, fa0
-;   beqz a0, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
+;   bnez a0, 0x14
 ;   fcvt.lu.d a0, fa0, rtz ; trap: bad_toint
 ;   ret
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: bad_toint
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
 
 function %f40(f64) -> i64 {
 block0(v0: f64):
@@ -607,22 +607,22 @@ block0(v0: f64):
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   feq.d a0, fa0, fa0
-;   bnez a0, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: bad_toint
+;   beqz a0, 0x34
 ;   auipc a0, 0
-;   ld a0, 0x3c(a0)
+;   ld a0, 0x40(a0)
 ;   fmv.d.x fa1, a0
 ;   fle.d a0, fa0, fa1
-;   beqz a0, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
+;   bnez a0, 0x24
 ;   lui a2, 0x21f
 ;   slli a4, a2, 0x29
 ;   fmv.d.x fa1, a4
 ;   fle.d a0, fa1, fa0
-;   beqz a0, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
+;   bnez a0, 0x14
 ;   fcvt.l.d a0, fa0, rtz ; trap: bad_toint
 ;   ret
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: bad_toint
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
 ;   .byte 0x00, 0x00, 0x00, 0x00
 ;   .byte 0x01, 0x00, 0x00, 0x00
 ;   .byte 0x00, 0x00, 0xe0, 0xc3

--- a/cranelift/filetests/filetests/isa/riscv64/issue-12811.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/issue-12811.clif
@@ -4716,9 +4716,8 @@ block2:
 ;   ld t6, 8(a0)
 ;   ld t6, 0x10(t6)
 ;   c.addi t6, 0x10
-;   bgeu sp, t6, 6
-;   c.unimp ; trap: stk_ovf
-; block1: ; offset 0x18
+;   bltu sp, t6, 0x39a
+; block1: ; offset 0x16
 ;   c.li a1, 0
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
@@ -4955,70 +4954,97 @@ block2:
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   c.sd a2, 0(a1) ; trap: heap_oob
-; block2: ; offset 0x33c
+; block2: ; offset 0x33a
 ;   lui a1, 0x6a64d
 ;   c.addi a1, 3
-;   beqz a1, 6
-;   c.unimp ; trap: user11
-; block3: ; offset 0x348
+;   bnez a1, 0x74
+; block3: ; offset 0x344
 ;   lui a1, 0x259ad
 ;   addi a1, a1, -0x626
-;   beqz a1, 6
-;   c.unimp ; trap: user11
-; block4: ; offset 0x356
+;   bnez a1, 0x70
+; block4: ; offset 0x350
 ;   c.li a1, 1
-;   beqz a1, 6
-;   c.unimp ; trap: user11
-; block5: ; offset 0x35e
+;   bnez a1, 0x72
+; block5: ; offset 0x356
 ;   lui a1, 0x7c7d9
 ;   addi a1, a1, -0xc1
-;   beqz a1, 6
-;   c.unimp ; trap: user11
-; block6: ; offset 0x36c
+;   bnez a1, 0x6e
+; block6: ; offset 0x362
 ;   lui a1, 0x5b1f2
 ;   addi a1, a1, 0x6e3
-;   beqz a1, 6
-;   c.unimp ; trap: user11
-; block7: ; offset 0x37a
+;   bnez a1, 0x6a
+; block7: ; offset 0x36e
 ;   lui a1, 0x6f8d1
 ;   addi a1, a1, -0x144
-;   beqz a1, 6
-;   c.unimp ; trap: user11
-; block8: ; offset 0x388
+;   bnez a1, 0x66
+; block8: ; offset 0x37a
 ;   lui a1, 0x484e2
 ;   addi a1, a1, -0x478
-;   beqz a1, 6
-;   c.unimp ; trap: user11
-; block9: ; offset 0x396
+;   bnez a1, 0x62
+; block9: ; offset 0x386
 ;   lui a1, 0x110e5
 ;   addi a1, a1, -0x662
-;   beqz a1, 6
-;   c.unimp ; trap: user11
-; block10: ; offset 0x3a4
+;   bnez a1, 0x5e
+; block10: ; offset 0x392
 ;   lui a1, 0x71fd2
 ;   addi a1, a1, 0x446
-;   beqz a1, 6
-;   c.unimp ; trap: user11
-; block11: ; offset 0x3b2
+;   bnez a1, 0x5a
+; block11: ; offset 0x39e
 ;   lui a3, 0x8237d
 ;   addi a5, a3, 0x5b7
-;   beqz a5, 6
-;   c.unimp ; trap: user11
-; block12: ; offset 0x3c0
-;   c.j 4
-;   c.unimp
+;   bnez a5, 0x56
+; block12: ; offset 0x3aa
+;   c.j 0x5a
 ;   auipc t6, 0
-;   jalr zero, t6, 8
-; block13: ; offset 0x3cc
-;   auipc a2, 1
-;   ld a2, 0xc4(a2)
-;   c.li a1, 0
-;   c.sd a2, 0(a1) ; trap: heap_oob
+;   jalr zero, t6, 0x60
+;   auipc t6, 0
+;   jalr zero, t6, 0x5c
+;   auipc t6, 0
+;   jalr zero, t6, 0x58
+;   auipc t6, 0
+;   jalr zero, t6, 0x54
+;   auipc t6, 0
+;   jalr zero, t6, 0x50
+;   auipc t6, 0
+;   jalr zero, t6, 0x4c
+;   auipc t6, 0
+;   jalr zero, t6, 0x48
+;   auipc t6, 0
+;   jalr zero, t6, 0x44
+;   auipc t6, 0
+;   jalr zero, t6, 0x40
+;   auipc t6, 0
+;   jalr zero, t6, 0x3c
+;   auipc t6, 0
+;   jalr zero, t6, 0x38
+;   auipc t6, 0
+;   jalr zero, t6, 0x34
+;   c.unimp ; trap: stk_ovf
+;   c.unimp
+;   c.unimp ; trap: user11
+;   c.unimp
+;   c.unimp ; trap: user11
+;   c.unimp
+;   c.unimp ; trap: user11
+;   c.unimp
+;   c.unimp ; trap: user11
+;   c.unimp
+;   c.unimp ; trap: user11
+;   c.unimp
+;   c.unimp ; trap: user11
+;   c.unimp
+;   c.unimp ; trap: user11
+;   c.unimp
+;   c.unimp ; trap: user11
+;   c.unimp
+;   c.unimp ; trap: user11
+;   c.unimp
+;   c.unimp ; trap: user11
+;   c.unimp
+; block13: ; offset 0x438
 ;   auipc a2, 1
 ;   ld a2, 0xc0(a2)
-;   c.sd a2, 0(a1) ; trap: heap_oob
-;   auipc a2, 1
-;   ld a2, 0xbe(a2)
+;   c.li a1, 0
 ;   c.sd a2, 0(a1) ; trap: heap_oob
 ;   auipc a2, 1
 ;   ld a2, 0xbc(a2)
@@ -5031,13 +5057,13 @@ block2:
 ;   c.sd a2, 0(a1) ; trap: heap_oob
 ;   auipc a2, 1
 ;   ld a2, 0xb6(a2)
-;   sd zero, 0(a2) ; trap: heap_oob
+;   c.sd a2, 0(a1) ; trap: heap_oob
+;   auipc a2, 1
+;   ld a2, 0xb4(a2)
+;   c.sd a2, 0(a1) ; trap: heap_oob
 ;   auipc a2, 1
 ;   ld a2, 0xb2(a2)
-;   c.sd a2, 0(a1) ; trap: heap_oob
-;   auipc a2, 1
-;   ld a2, 0xb0(a2)
-;   c.sd a2, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a2) ; trap: heap_oob
 ;   auipc a2, 1
 ;   ld a2, 0xae(a2)
 ;   c.sd a2, 0(a1) ; trap: heap_oob
@@ -5047,16 +5073,16 @@ block2:
 ;   auipc a2, 1
 ;   ld a2, 0xaa(a2)
 ;   c.sd a2, 0(a1) ; trap: heap_oob
+;   auipc a2, 1
+;   ld a2, 0xa8(a2)
+;   c.sd a2, 0(a1) ; trap: heap_oob
+;   auipc a2, 1
+;   ld a2, 0xa6(a2)
+;   c.sd a2, 0(a1) ; trap: heap_oob
 ;   c.li a2, 1
 ;   auipc a3, 1
-;   ld a3, 0xa6(a3)
-;   c.sd a2, 0(a3) ; trap: heap_oob
-;   auipc a3, 1
-;   ld a3, 0xa4(a3)
-;   c.sd a3, 0(a1) ; trap: heap_oob
-;   auipc a3, 1
 ;   ld a3, 0xa2(a3)
-;   c.sd a3, 0(a1) ; trap: heap_oob
+;   c.sd a2, 0(a3) ; trap: heap_oob
 ;   auipc a3, 1
 ;   ld a3, 0xa0(a3)
 ;   c.sd a3, 0(a1) ; trap: heap_oob
@@ -5065,13 +5091,13 @@ block2:
 ;   c.sd a3, 0(a1) ; trap: heap_oob
 ;   auipc a3, 1
 ;   ld a3, 0x9c(a3)
-;   sd zero, 0(a3) ; trap: heap_oob
+;   c.sd a3, 0(a1) ; trap: heap_oob
+;   auipc a3, 1
+;   ld a3, 0x9a(a3)
+;   c.sd a3, 0(a1) ; trap: heap_oob
 ;   auipc a3, 1
 ;   ld a3, 0x98(a3)
-;   c.sd a3, 0(a1) ; trap: heap_oob
-;   auipc a3, 1
-;   ld a3, 0x96(a3)
-;   c.sd a3, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a3) ; trap: heap_oob
 ;   auipc a3, 1
 ;   ld a3, 0x94(a3)
 ;   c.sd a3, 0(a1) ; trap: heap_oob
@@ -5086,34 +5112,34 @@ block2:
 ;   c.sd a3, 0(a1) ; trap: heap_oob
 ;   auipc a3, 1
 ;   ld a3, 0x8c(a3)
-;   sd zero, 0(a3) ; trap: heap_oob
+;   c.sd a3, 0(a1) ; trap: heap_oob
+;   auipc a3, 1
+;   ld a3, 0x8a(a3)
+;   c.sd a3, 0(a1) ; trap: heap_oob
 ;   auipc a3, 1
 ;   ld a3, 0x88(a3)
 ;   sd zero, 0(a3) ; trap: heap_oob
 ;   auipc a3, 1
 ;   ld a3, 0x84(a3)
-;   c.sd a3, 0(a1) ; trap: heap_oob
-;   auipc a3, 1
-;   ld a3, 0x82(a3)
-;   c.sd a2, 0(a3) ; trap: heap_oob
+;   sd zero, 0(a3) ; trap: heap_oob
 ;   auipc a3, 1
 ;   ld a3, 0x80(a3)
 ;   c.sd a3, 0(a1) ; trap: heap_oob
 ;   auipc a3, 1
 ;   ld a3, 0x7e(a3)
-;   c.sd a3, 0(a1) ; trap: heap_oob
+;   c.sd a2, 0(a3) ; trap: heap_oob
 ;   auipc a3, 1
 ;   ld a3, 0x7c(a3)
 ;   c.sd a3, 0(a1) ; trap: heap_oob
 ;   auipc a3, 1
 ;   ld a3, 0x7a(a3)
-;   sd zero, 0(a3) ; trap: heap_oob
+;   c.sd a3, 0(a1) ; trap: heap_oob
+;   auipc a3, 1
+;   ld a3, 0x78(a3)
+;   c.sd a3, 0(a1) ; trap: heap_oob
 ;   auipc a3, 1
 ;   ld a3, 0x76(a3)
-;   c.sd a3, 0(a1) ; trap: heap_oob
-;   auipc a3, 1
-;   ld a3, 0x74(a3)
-;   c.sd a3, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a3) ; trap: heap_oob
 ;   auipc a3, 1
 ;   ld a3, 0x72(a3)
 ;   c.sd a3, 0(a1) ; trap: heap_oob
@@ -5135,53 +5161,59 @@ block2:
 ;   auipc a3, 1
 ;   ld a3, 0x66(a3)
 ;   c.sd a3, 0(a1) ; trap: heap_oob
+;   auipc a3, 1
+;   ld a3, 0x64(a3)
+;   c.sd a3, 0(a1) ; trap: heap_oob
+;   auipc a3, 1
+;   ld a3, 0x62(a3)
+;   c.sd a3, 0(a1) ; trap: heap_oob
 ;   c.li a3, 1
 ;   auipc a4, 1
-;   ld a4, 0x62(a4)
+;   ld a4, 0x5e(a4)
 ;   c.sw a3, 0(a4) ; trap: heap_oob
 ;   auipc a4, 1
-;   ld a4, 0x60(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x5e(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   auipc a4, 1
 ;   ld a4, 0x5c(a4)
-;   sd zero, 0(a4) ; trap: heap_oob
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, 0x5a(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
 ;   auipc a4, 1
 ;   ld a4, 0x58(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x56(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a4) ; trap: heap_oob
 ;   auipc a4, 1
 ;   ld a4, 0x54(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, 0x52(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   auipc a4, 1
+;   ld a4, 0x50(a4)
 ;   c.sd a4, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   c.li a4, 0
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, 0x44(a5)
+;   ld a5, 0x40(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, 0x3e(a5)
+;   ld a5, 0x3a(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, 0x38(a5)
+;   ld a5, 0x34(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, 0x36(a5)
+;   ld a5, 0x32(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, 0x28(a5)
+;   ld a5, 0x24(a5)
 ;   auipc a6, 1
-;   ld a6, 0x28(a6)
+;   ld a6, 0x24(a6)
 ;   sd a5, 0(a6) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
@@ -5191,7 +5223,7 @@ block2:
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, 8(a5)
+;   ld a5, 4(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
@@ -5199,36 +5231,36 @@ block2:
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0xe(a5)
+;   ld a5, -0x12(a5)
 ;   sd zero, 0(a5) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x16(a5)
+;   ld a5, -0x1a(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x1c(a5)
+;   ld a5, -0x20(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x2e(a5)
+;   ld a5, -0x32(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x30(a5)
+;   ld a5, -0x34(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x36(a5)
-;   sd zero, 0(a5) ; trap: heap_oob
 ;   auipc a5, 1
 ;   ld a5, -0x3a(a5)
+;   sd zero, 0(a5) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x3e(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x40(a5)
+;   ld a5, -0x44(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
@@ -5239,194 +5271,194 @@ block2:
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x62(a5)
+;   ld a5, -0x66(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x6c(a5)
+;   ld a5, -0x70(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x6e(a5)
+;   ld a5, -0x72(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x74(a5)
+;   ld a5, -0x78(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x76(a5)
+;   ld a5, -0x7a(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x88(a5)
+;   ld a5, -0x8c(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x8e(a5)
+;   ld a5, -0x92(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x94(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x96(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
 ;   ld a5, -0x98(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x9a(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x9c(a5)
 ;   c.ld a5, 0(a5) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0xa2(a5)
+;   ld a5, -0xa6(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0xa4(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0xaa(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0xac(a5)
+;   ld a5, -0xa8(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0xb2(a5)
+;   ld a5, -0xae(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0xb0(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0xb6(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0xbc(a5)
+;   ld a5, -0xc0(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0xc6(a5)
+;   ld a5, -0xca(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0xcc(a5)
+;   ld a5, -0xd0(a5)
 ;   sd zero, 0(a5) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0xe0(a5)
+;   ld a5, -0xe4(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0xe6(a5)
+;   ld a5, -0xea(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0xec(a5)
+;   ld a5, -0xf0(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0xf6(a5)
+;   ld a5, -0xfa(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0xfc(a5)
+;   ld a5, -0x100(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x102(a5)
+;   ld a5, -0x106(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x110(a5)
+;   ld a5, -0x114(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x116(a5)
+;   ld a5, -0x11a(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x11c(a5)
+;   ld a5, -0x120(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x126(a5)
+;   ld a5, -0x12a(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x128(a5)
+;   ld a5, -0x12c(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x12e(a5)
+;   ld a5, -0x132(a5)
 ;   c.ld a5, 0(a5) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x134(a5)
+;   ld a5, -0x138(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x136(a5)
+;   ld a5, -0x13a(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x13c(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x14a(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x158(a5)
+;   ld a5, -0x140(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x16e(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x174(a5)
+;   ld a5, -0x14e(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x182(a5)
+;   ld a5, -0x15c(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x172(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x178(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x186(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x18c(a5)
+;   ld a5, -0x190(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x192(a5)
+;   ld a5, -0x196(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x194(a5)
+;   ld a5, -0x198(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x19a(a5)
+;   ld a5, -0x19e(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x19c(a5)
+;   ld a5, -0x1a0(a5)
 ;   sd zero, 0(a5) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x1a4(a5)
+;   ld a5, -0x1a8(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
@@ -5434,194 +5466,194 @@ block2:
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x1ba(a5)
+;   ld a5, -0x1be(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x1c0(a5)
+;   ld a5, -0x1c4(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x1c2(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x1dc(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x1e2(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x1ec(a5)
+;   ld a5, -0x1c6(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x1fa(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x1fc(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x202(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x204(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x20e(a5)
+;   ld a5, -0x1e0(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x1e6(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x1f0(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x21c(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x226(a5)
+;   ld a5, -0x1fe(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x228(a5)
+;   ld a5, -0x200(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x22e(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x240(a5)
+;   ld a5, -0x206(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x242(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x248(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x24a(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x250(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x252(a5)
+;   ld a5, -0x208(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x25c(a5)
+;   ld a5, -0x212(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x220(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x22a(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x22c(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x262(a5)
+;   ld a5, -0x232(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x244(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x264(a5)
+;   ld a5, -0x246(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x24c(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x24e(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x254(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x256(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x260(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
 ;   ld a5, -0x266(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
 ;   ld a5, -0x268(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x27a(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x280(a5)
+;   ld a5, -0x26a(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x282(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x288(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x28a(a5)
+;   ld a5, -0x26c(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x2a0(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x2ae(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x2b8(a5)
+;   ld a5, -0x27e(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x2be(a5)
+;   ld a5, -0x284(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x2c0(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x2ce(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x2d0(a5)
+;   ld a5, -0x286(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x2d6(a5)
+;   ld a5, -0x28c(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x28e(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x2a4(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x2f4(a5)
+;   ld a5, -0x2b2(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x2bc(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x2fa(a5)
+;   ld a5, -0x2c2(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x2c4(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x2d2(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x2d4(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x2da(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x2f8(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x2fe(a5)
 ;   c.sd a2, 0(a5) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x30c(a5)
+;   ld a5, -0x310(a5)
 ;   sd zero, 0(a5) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
@@ -5631,7 +5663,7 @@ block2:
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x32c(a5)
+;   ld a5, -0x330(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
@@ -5639,67 +5671,67 @@ block2:
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x342(a5)
+;   ld a5, -0x346(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x350(a5)
+;   ld a5, -0x354(a5)
 ;   sd zero, 0(a5) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x360(a5)
+;   ld a5, -0x364(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x362(a5)
+;   ld a5, -0x366(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x36c(a5)
+;   ld a5, -0x370(a5)
 ;   c.sd a2, 0(a5) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x36e(a5)
+;   ld a5, -0x372(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x378(a5)
+;   ld a5, -0x37c(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x37e(a5)
+;   ld a5, -0x382(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x380(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x39a(a5)
+;   ld a5, -0x384(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x3a8(a5)
+;   ld a5, -0x39e(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x3ac(a5)
 ;   c.sd a2, 0(a5) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x3aa(a5)
+;   ld a5, -0x3ae(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x3bc(a5)
+;   ld a5, -0x3c0(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
@@ -5708,108 +5740,40 @@ block2:
 ;   lui a5, 0x4b912
 ;   addi a5, a5, -0x6f
 ;   auipc t0, 1
-;   ld t0, -0x3d6(t0)
+;   ld t0, -0x3da(t0)
 ;   sw a5, 0(t0) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x3de(a5)
+;   ld a5, -0x3e2(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x3e0(a5)
+;   ld a5, -0x3e4(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x3e6(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x3f4(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x3fe(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x400(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x416(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x44c(a5)
+;   ld a5, -0x3ea(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x45a(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x45c(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x462(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x468(a5)
+;   ld a5, -0x3f8(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x472(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x478(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x482(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x48c(a5)
+;   ld a5, -0x402(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x48e(a5)
+;   ld a5, -0x404(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x498(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x49e(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x4a4(a5)
+;   ld a5, -0x41a(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
@@ -5821,56 +5785,124 @@ block2:
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x4ce(a5)
+;   ld a5, -0x450(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x45e(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x460(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x466(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x4d4(a5)
+;   ld a5, -0x46c(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x476(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x47c(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x486(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x490(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x4d6(a5)
+;   ld a5, -0x492(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x49c(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x4a2(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x4a8(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x4d2(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x4d8(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x4da(a5)
 ;   c.lw a5, 0(a5) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x4e0(a5)
+;   ld a5, -0x4e4(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x4ea(a5)
+;   ld a5, -0x4ee(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x4f4(a5)
+;   ld a5, -0x4f8(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x502(a5)
+;   ld a5, -0x506(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x50c(a5)
+;   ld a5, -0x510(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x512(a5)
+;   ld a5, -0x516(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x514(a5)
+;   ld a5, -0x518(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x51a(a5)
+;   ld a5, -0x51e(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x520(a5)
+;   ld a5, -0x524(a5)
 ;   sw zero, 0(a5) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
@@ -5878,43 +5910,43 @@ block2:
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x538(a5)
+;   ld a5, -0x53c(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x53e(a5)
+;   ld a5, -0x542(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x540(a5)
+;   ld a5, -0x544(a5)
 ;   c.sw a3, 0(a5) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x54a(a5)
+;   ld a5, -0x54e(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x55c(a5)
+;   ld a5, -0x560(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x56a(a5)
+;   ld a5, -0x56e(a5)
 ;   c.sd a2, 0(a5) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x570(a5)
+;   ld a5, -0x574(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x572(a5)
+;   ld a5, -0x576(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x578(a5)
+;   ld a5, -0x57c(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
@@ -5926,67 +5958,67 @@ block2:
 ;   sb a4, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x59e(a5)
+;   ld a5, -0x5a2(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x5a8(a5)
+;   ld a5, -0x5ac(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x5aa(a5)
+;   ld a5, -0x5ae(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x5b0(a5)
+;   ld a5, -0x5b4(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x5b2(a5)
+;   ld a5, -0x5b6(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x5d0(a5)
+;   ld a5, -0x5d4(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x5d2(a5)
+;   ld a5, -0x5d6(a5)
 ;   c.sd a2, 0(a5) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x5d8(a5)
+;   ld a5, -0x5dc(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x5de(a5)
+;   ld a5, -0x5e2(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x5e8(a5)
+;   ld a5, -0x5ec(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sb a4, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x5fa(a5)
+;   ld a5, -0x5fe(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x600(a5)
+;   ld a5, -0x604(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x60a(a5)
+;   ld a5, -0x60e(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x60c(a5)
+;   ld a5, -0x610(a5)
 ;   c.sd a2, 0(a5) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
@@ -5994,23 +6026,23 @@ block2:
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x620(a5)
+;   ld a5, -0x624(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x62a(a5)
+;   ld a5, -0x62e(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x638(a5)
+;   ld a5, -0x63c(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x642(a5)
+;   ld a5, -0x646(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
@@ -6019,10 +6051,10 @@ block2:
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x65c(a5)
+;   ld a5, -0x660(a5)
 ;   c.sd a2, 0(a5) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x65e(a5)
+;   ld a5, -0x662(a5)
 ;   sd zero, 0(a5) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
@@ -6031,13 +6063,13 @@ block2:
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x67a(a5)
+;   ld a5, -0x67e(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x688(a5)
+;   ld a5, -0x68c(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
@@ -6056,17 +6088,17 @@ block2:
 ;   sb a4, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x6ca(a5)
+;   ld a5, -0x6ce(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x6d4(a5)
+;   ld a5, -0x6d8(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x6de(a5)
+;   ld a5, -0x6e2(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
@@ -6076,89 +6108,89 @@ block2:
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x6fc(a5)
+;   ld a5, -0x700(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x702(a5)
+;   ld a5, -0x706(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x708(a5)
+;   ld a5, -0x70c(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x71a(a5)
+;   ld a5, -0x71e(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x71c(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x726(a5)
+;   ld a5, -0x720(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x72a(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x734(a5)
+;   ld a5, -0x738(a5)
 ;   sd zero, 0(a5) ; trap: heap_oob
 ;   sb a4, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x740(a5)
+;   ld a5, -0x744(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x746(a5)
+;   ld a5, -0x74a(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x748(a5)
+;   ld a5, -0x74c(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x752(a5)
+;   ld a5, -0x756(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sb a3, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a3, 1
-;   ld a3, -0x764(a3)
+;   ld a3, -0x768(a3)
 ;   c.sd a3, 0(a1) ; trap: heap_oob
 ;   auipc a5, 1
-;   ld a5, -0x766(a5)
+;   ld a5, -0x76a(a5)
 ;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   auipc a3, 1
-;   ld a3, -0x770(a3)
+;   ld a3, -0x774(a3)
 ;   c.sd a3, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a3, 1
-;   ld a3, -0x776(a3)
+;   ld a3, -0x77a(a3)
 ;   c.sd a3, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sb a4, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a3, 1
-;   ld a3, -0x788(a3)
+;   ld a3, -0x78c(a3)
 ;   c.sd a2, 0(a3) ; trap: heap_oob
 ;   auipc a2, 1
-;   ld a2, -0x78a(a2)
+;   ld a2, -0x78e(a2)
 ;   c.sd a2, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a2, 1
-;   ld a2, -0x790(a2)
+;   ld a2, -0x794(a2)
 ;   c.sd a2, 0(a1) ; trap: heap_oob
 ;   auipc a2, 1
-;   ld a2, -0x792(a2)
+;   ld a2, -0x796(a2)
 ;   c.lui a3, 4
 ;   addi a3, a3, -0x720
 ;   c.sd a2, 0(a3) ; trap: heap_oob
@@ -6167,7 +6199,7 @@ block2:
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   auipc a2, 1
-;   ld a2, -0x7aa(a2)
+;   ld a2, -0x7ae(a2)
 ;   c.lui a3, 4
 ;   addi a3, a3, -0x6a4
 ;   c.sd a2, 0(a3) ; trap: heap_oob
@@ -6176,7 +6208,7 @@ block2:
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a2, 1
-;   ld a2, -0x7c2(a2)
+;   ld a2, -0x7c6(a2)
 ;   c.lui a3, 4
 ;   addi a3, a3, -0x5f0
 ;   c.sd a2, 0(a3) ; trap: heap_oob
@@ -6184,19 +6216,19 @@ block2:
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a2, 1
-;   ld a2, -0x7d6(a2)
+;   ld a2, -0x7da(a2)
 ;   c.lui a3, 4
 ;   addi a3, a3, -0x638
 ;   c.sd a2, 0(a3) ; trap: heap_oob
 ;   auipc a2, 1
-;   ld a2, -0x7de(a2)
+;   ld a2, -0x7e2(a2)
 ;   c.lui a3, 4
 ;   addi a3, a3, -0x640
 ;   c.sd a2, 0(a3) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   auipc a2, 1
-;   ld a2, -0x7ee(a2)
+;   ld a2, -0x7f2(a2)
 ;   c.lui a3, 4
 ;   addi a3, a3, -0x59c
 ;   c.sd a2, 0(a3) ; trap: heap_oob
@@ -6205,9 +6237,7 @@ block2:
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   c.j 2
 ;   auipc t6, 0
-;   jalr zero, t6, 0x7fc
-;   c.unimp
-;   c.unimp
+;   jalr zero, t6, 0x7f8
 ;   c.fldsp fs5, 0x1e0(sp)
 ;   .byte 0xc3, 0xd1
 ;   c.bnez a0, -4
@@ -7154,7 +7184,7 @@ block2:
 ;   c.addi4spn s0, sp, 0x84
 ;   andi a7, s11, -0x6ab
 ;   c.swsp t5, 0xb4(sp)
-; block14: ; offset 0x1c80
+; block14: ; offset 0x1ce8
 ;   c.li a2, 1
 ;   c.li a3, 2
 ;   c.mv a1, a0

--- a/cranelift/filetests/filetests/isa/riscv64/stack-limit.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/stack-limit.clif
@@ -70,9 +70,8 @@ block0(v0: i64):
 ;   ld t6, 0(a0)
 ;   ld t6, 4(t6)
 ;   addi t6, t6, 0x10
-;   bgeu sp, t6, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: stk_ovf
-; block1: ; offset 0x24
+;   bltu sp, t6, 0x2c
+; block1: ; offset 0x20
 ;   auipc a0, 0
 ;   ld a0, 0xc(a0)
 ;   j 0xc
@@ -83,6 +82,7 @@ block0(v0: i64):
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
 ;   ret
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: stk_ovf
 
 function %limit_preamble(i64 vmctx) {
     gv0 = vmctx
@@ -120,15 +120,15 @@ block0(v0: i64):
 ;   ld t6, 0(a0)
 ;   ld t6, 4(t6)
 ;   addi t6, t6, 0x20
-;   bgeu sp, t6, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: stk_ovf
+;   bltu sp, t6, 0x1c
 ;   addi sp, sp, -0x20
-; block1: ; offset 0x28
+; block1: ; offset 0x24
 ;   addi sp, sp, 0x20
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
 ;   ret
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: stk_ovf
 
 function %limit_preamble_huge(i64 vmctx) {
     gv0 = vmctx
@@ -175,13 +175,11 @@ block0(v0: i64):
 ;   mv s0, sp
 ;   ld t6, 0(a0)
 ;   ld t6, 4(t6)
-;   bgeu sp, t6, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: stk_ovf
+;   bltu sp, t6, 0x4c
 ;   lui t5, 0x62
 ;   addi t5, t5, -0x580
 ;   add t6, t5, t6
-;   bgeu sp, t6, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: stk_ovf
+;   bltu sp, t6, 0x40
 ;   lui a0, 0x62
 ;   addi a0, a0, -0x580
 ;   auipc ra, 0 ; reloc_external RiscvCallPlt %Probestack 0
@@ -189,7 +187,7 @@ block0(v0: i64):
 ;   lui t6, 0xfff9e
 ;   addi t6, t6, 0x580
 ;   add sp, sp, t6
-; block1: ; offset 0x50
+; block1: ; offset 0x48
 ;   lui t6, 0x62
 ;   addi t6, t6, -0x580
 ;   add sp, sp, t6
@@ -197,6 +195,8 @@ block0(v0: i64):
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
 ;   ret
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: stk_ovf
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: stk_ovf
 
 function %limit_preamble_huge_offset(i64 vmctx) {
     gv0 = vmctx
@@ -234,13 +234,13 @@ block0(v0: i64):
 ;   add t6, t6, a0
 ;   ld t6, 0(t6)
 ;   addi t6, t6, 0x20
-;   bgeu sp, t6, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: stk_ovf
+;   bltu sp, t6, 0x1c
 ;   addi sp, sp, -0x20
-; block1: ; offset 0x30
+; block1: ; offset 0x2c
 ;   addi sp, sp, 0x20
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
 ;   ret
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: stk_ovf
 

--- a/cranelift/filetests/filetests/isa/riscv64/traps.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/traps.clif
@@ -28,9 +28,9 @@ block0(v0: i64):
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   beqz a0, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: user1
+;   bnez a0, 8
 ;   ret
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: user1
 
 function %trapnz_i128(i128) {
 block0(v0: i128):
@@ -47,9 +47,9 @@ block0(v0: i128):
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   or a0, a1, a0
-;   beqz a0, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: user1
+;   bnez a0, 8
 ;   ret
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: user1
 
 function %trapnz_icmp_fold(i64) {
 block0(v0: i64):
@@ -68,9 +68,9 @@ block0(v0: i64):
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi a1, zero, 0x2a
-;   bne a0, a1, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: user1
+;   beq a0, a1, 8
 ;   ret
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: user1
 
 function %trapz(i64) {
 block0(v0: i64):
@@ -85,9 +85,9 @@ block0(v0: i64):
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   bnez a0, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: user1
+;   beqz a0, 8
 ;   ret
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: user1
 
 function %trapz_i128(i128) {
 block0(v0: i128):
@@ -104,9 +104,9 @@ block0(v0: i128):
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   or a0, a1, a0
-;   bnez a0, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: user1
+;   beqz a0, 8
 ;   ret
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: user1
 
 function %trapz_icmp_fold(i64) {
 block0(v0: i64):
@@ -125,9 +125,9 @@ block0(v0: i64):
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi a1, zero, 0x2a
-;   beq a0, a1, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: user1
+;   bne a0, a1, 8
 ;   ret
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: user1
 
 function %h() {
 block0:

--- a/cranelift/filetests/filetests/isa/riscv64/trapz-sign-extend-load32.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/trapz-sign-extend-load32.clif
@@ -27,7 +27,7 @@ block0(v0: i64, v1: i64):
 ;   srli a0, a0, 0x20
 ;   slli a1, a1, 0x20
 ;   srli a1, a1, 0x20
-;   bltu a0, a1, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: user15
+;   bgeu a0, a1, 8
 ;   ret
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: user15
 

--- a/cranelift/filetests/filetests/isa/riscv64/uadd_overflow_trap.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/uadd_overflow_trap.clif
@@ -29,9 +29,9 @@ block0(v0: i32):
 ;   srli a0, a0, 0x20
 ;   add a0, a1, a0
 ;   srli a3, a0, 0x20
-;   beqz a3, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: user1
+;   bnez a3, 8
 ;   ret
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: user1
 
 function %f1(i32) -> i32 {
 block0(v0: i32):
@@ -61,9 +61,9 @@ block0(v0: i32):
 ;   srli a0, a0, 0x20
 ;   add a0, a1, a0
 ;   srli a3, a0, 0x20
-;   beqz a3, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: user1
+;   bnez a3, 8
 ;   ret
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: user1
 
 function %f2(i32, i32) -> i32 {
 block0(v0: i32, v1: i32):
@@ -90,9 +90,9 @@ block0(v0: i32, v1: i32):
 ;   srli a1, a1, 0x20
 ;   add a0, a0, a1
 ;   srli a3, a0, 0x20
-;   beqz a3, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: user1
+;   bnez a3, 8
 ;   ret
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: user1
 
 function %f3(i64) -> i64 {
 block0(v0: i64):
@@ -114,9 +114,9 @@ block0(v0: i64):
 ;   mv a1, a0
 ;   addi a0, zero, 0x7f
 ;   add a0, a1, a0
-;   bgeu a0, a1, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: user1
+;   bltu a0, a1, 8
 ;   ret
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: user1
 
 function %f3(i64) -> i64 {
 block0(v0: i64):
@@ -139,10 +139,10 @@ block0(v0: i64):
 ;   mv a1, a0
 ;   addi a0, zero, 0x7f
 ;   add a1, a0, a1
-;   bgeu a1, a0, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: user1
+;   bltu a1, a0, 0xc
 ;   mv a0, a1
 ;   ret
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: user1
 
 function %f4(i64, i64) -> i64 {
 block0(v0: i64, v1: i64):
@@ -163,7 +163,7 @@ block0(v0: i64, v1: i64):
 ;   mv a2, a0
 ;   add a0, a2, a1
 ;   mv a1, a2
-;   bgeu a0, a1, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: user1
+;   bltu a0, a1, 8
 ;   ret
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: user1
 

--- a/tests/disas/load-store/riscv64/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/riscv64/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -27,8 +27,7 @@
 ;;       slli    a1, a2, 0x20
 ;;       srli    a1, a1, 0x20
 ;;       addi    a2, a4, -4
-;;       bgeu    a2, a1, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a2, a1, 0x20
 ;;       ld      a0, 0x38(a0)
 ;;       add     a0, a0, a1
 ;;       sw      a3, 0(a0)
@@ -36,6 +35,7 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
 ;;       addi    sp, sp, -0x10
@@ -46,8 +46,7 @@
 ;;       slli    a1, a2, 0x20
 ;;       srli    a1, a1, 0x20
 ;;       addi    a2, a3, -4
-;;       bgeu    a2, a1, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a2, a1, 0x20
 ;;       ld      a0, 0x38(a0)
 ;;       add     a0, a0, a1
 ;;       lw      a0, 0(a0)
@@ -55,3 +54,4 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00

--- a/tests/disas/load-store/riscv64/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/riscv64/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -29,8 +29,7 @@
 ;;       lui     a4, 1
 ;;       addi    a4, a4, 4
 ;;       sub     a1, a1, a4
-;;       bgeu    a1, a2, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a1, a2, 0x28
 ;;       ld      a4, 0x38(a0)
 ;;       add     a2, a4, a2
 ;;       lui     t6, 1
@@ -40,6 +39,7 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
 ;;       addi    sp, sp, -0x10
@@ -52,8 +52,7 @@
 ;;       lui     a3, 1
 ;;       addi    a3, a3, 4
 ;;       sub     a1, a1, a3
-;;       bgeu    a1, a2, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a1, a2, 0x28
 ;;       ld      a3, 0x38(a0)
 ;;       add     a2, a3, a2
 ;;       lui     t6, 1
@@ -63,3 +62,4 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00

--- a/tests/disas/load-store/riscv64/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/riscv64/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -29,11 +29,9 @@
 ;;       addi    a5, a4, 1
 ;;       slli    a2, a5, 2
 ;;       add     a5, a1, a2
-;;       bgeu    a5, a1, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a5, a1, 0x34
 ;;       ld      a2, 0x40(a0)
-;;       bgeu    a2, a5, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a2, a5, 0x30
 ;;       ld      a0, 0x38(a0)
 ;;       add     a0, a0, a1
 ;;       lui     a1, 0xffff
@@ -44,6 +42,8 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       .byte   0x00, 0x00, 0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
 ;;       addi    sp, sp, -0x10
@@ -56,11 +56,9 @@
 ;;       addi    a5, a3, 1
 ;;       slli    a2, a5, 2
 ;;       add     a5, a1, a2
-;;       bgeu    a5, a1, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a5, a1, 0x34
 ;;       ld      a2, 0x40(a0)
-;;       bgeu    a2, a5, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a2, a5, 0x30
 ;;       ld      a0, 0x38(a0)
 ;;       add     a0, a0, a1
 ;;       lui     a1, 0xffff
@@ -71,3 +69,5 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       .byte   0x00, 0x00, 0x00, 0x00

--- a/tests/disas/load-store/riscv64/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/riscv64/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -26,8 +26,7 @@
 ;;       ld      a1, 0x40(a0)
 ;;       slli    a2, a2, 0x20
 ;;       srli    a2, a2, 0x20
-;;       bltu    a2, a1, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bgeu    a2, a1, 0x20
 ;;       ld      a0, 0x38(a0)
 ;;       add     a0, a0, a2
 ;;       sb      a3, 0(a0)
@@ -35,6 +34,7 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
 ;;       addi    sp, sp, -0x10
@@ -44,8 +44,7 @@
 ;;       ld      a1, 0x40(a0)
 ;;       slli    a2, a2, 0x20
 ;;       srli    a2, a2, 0x20
-;;       bltu    a2, a1, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bgeu    a2, a1, 0x20
 ;;       ld      a0, 0x38(a0)
 ;;       add     a0, a0, a2
 ;;       lbu     a0, 0(a0)
@@ -53,3 +52,4 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00

--- a/tests/disas/load-store/riscv64/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/riscv64/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -29,8 +29,7 @@
 ;;       lui     a4, 1
 ;;       addi    a4, a4, 1
 ;;       sub     a1, a1, a4
-;;       bgeu    a1, a2, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a1, a2, 0x28
 ;;       ld      a4, 0x38(a0)
 ;;       add     a2, a4, a2
 ;;       lui     t6, 1
@@ -40,6 +39,7 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
 ;;       addi    sp, sp, -0x10
@@ -52,8 +52,7 @@
 ;;       lui     a3, 1
 ;;       addi    a3, a3, 1
 ;;       sub     a1, a1, a3
-;;       bgeu    a1, a2, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a1, a2, 0x28
 ;;       ld      a3, 0x38(a0)
 ;;       add     a2, a3, a2
 ;;       lui     t6, 1
@@ -63,3 +62,4 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00

--- a/tests/disas/load-store/riscv64/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/riscv64/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -28,11 +28,9 @@
 ;;       auipc   a5, 0
 ;;       ld      a5, 0x48(a5)
 ;;       add     a5, a4, a5
-;;       bgeu    a5, a4, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a5, a4, 0x34
 ;;       ld      a1, 0x40(a0)
-;;       bgeu    a1, a5, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a1, a5, 0x30
 ;;       ld      a5, 0x38(a0)
 ;;       add     a5, a5, a4
 ;;       lui     a4, 0xffff
@@ -43,6 +41,8 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       .byte   0x00, 0x00, 0x00, 0x00
 ;;       .byte   0x01, 0x00, 0xff, 0xff
 ;;       .byte   0x00, 0x00, 0x00, 0x00
 ;;
@@ -56,11 +56,9 @@
 ;;       auipc   a3, 0
 ;;       ld      a3, 0x48(a3)
 ;;       add     a3, a4, a3
-;;       bgeu    a3, a4, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a3, a4, 0x34
 ;;       ld      a5, 0x40(a0)
-;;       bgeu    a5, a3, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a5, a3, 0x30
 ;;       ld      a5, 0x38(a0)
 ;;       add     a5, a5, a4
 ;;       lui     a4, 0xffff
@@ -71,5 +69,7 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       .byte   0x00, 0x00, 0x00, 0x00
 ;;       .byte   0x01, 0x00, 0xff, 0xff
 ;;       .byte   0x00, 0x00, 0x00, 0x00

--- a/tests/disas/load-store/riscv64/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/riscv64/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -30,8 +30,7 @@
 ;;       addi    a1, a1, 1
 ;;       slli    a1, a1, 2
 ;;       add     a1, a0, a1
-;;       bgeu    a1, a0, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a1, a0, 0x40
 ;;       ld      a2, 0x40(a4)
 ;;       ld      a4, 0x38(a4)
 ;;       sltu    a1, a2, a1
@@ -47,6 +46,7 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
 ;;       addi    sp, sp, -0x10
@@ -60,8 +60,7 @@
 ;;       addi    a1, a1, 1
 ;;       slli    a1, a1, 2
 ;;       add     a1, a0, a1
-;;       bgeu    a1, a0, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a1, a0, 0x40
 ;;       ld      a2, 0x40(a3)
 ;;       ld      a3, 0x38(a3)
 ;;       sltu    a1, a2, a1
@@ -77,3 +76,4 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00

--- a/tests/disas/load-store/riscv64/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/riscv64/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -29,8 +29,7 @@
 ;;       auipc   a1, 0
 ;;       ld      a1, 0x54(a1)
 ;;       add     a1, a0, a1
-;;       bgeu    a1, a0, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a1, a0, 0x40
 ;;       ld      a2, 0x40(a4)
 ;;       ld      a4, 0x38(a4)
 ;;       sltu    a1, a2, a1
@@ -47,6 +46,7 @@
 ;;       addi    sp, sp, 0x10
 ;;       ret
 ;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       .byte   0x00, 0x00, 0x00, 0x00
 ;;       .byte   0x01, 0x00, 0xff, 0xff
 ;;       .byte   0x00, 0x00, 0x00, 0x00
 ;;
@@ -61,8 +61,7 @@
 ;;       auipc   a1, 0
 ;;       ld      a1, 0x54(a1)
 ;;       add     a1, a0, a1
-;;       bgeu    a1, a0, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a1, a0, 0x40
 ;;       ld      a2, 0x40(a3)
 ;;       ld      a3, 0x38(a3)
 ;;       sltu    a1, a2, a1
@@ -78,6 +77,7 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00
 ;;       .byte   0x00, 0x00, 0x00, 0x00
 ;;       .byte   0x01, 0x00, 0xff, 0xff
 ;;       .byte   0x00, 0x00, 0x00, 0x00

--- a/tests/disas/load-store/riscv64/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/riscv64/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -26,8 +26,7 @@
 ;;       ld      a1, 0x40(a0)
 ;;       slli    a2, a2, 0x20
 ;;       srli    a2, a2, 0x20
-;;       bgeu    a1, a2, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a1, a2, 0x20
 ;;       ld      a0, 0x38(a0)
 ;;       add     a0, a0, a2
 ;;       sw      a3, 0(a0)
@@ -35,6 +34,7 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
 ;;       addi    sp, sp, -0x10
@@ -44,8 +44,7 @@
 ;;       ld      a1, 0x40(a0)
 ;;       slli    a2, a2, 0x20
 ;;       srli    a2, a2, 0x20
-;;       bgeu    a1, a2, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a1, a2, 0x20
 ;;       ld      a0, 0x38(a0)
 ;;       add     a0, a0, a2
 ;;       lw      a0, 0(a0)
@@ -53,3 +52,4 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00

--- a/tests/disas/load-store/riscv64/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/riscv64/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -26,8 +26,7 @@
 ;;       ld      a1, 0x40(a0)
 ;;       slli    a2, a2, 0x20
 ;;       srli    a2, a2, 0x20
-;;       bgeu    a1, a2, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a1, a2, 0x28
 ;;       ld      a0, 0x38(a0)
 ;;       add     a0, a0, a2
 ;;       lui     t6, 1
@@ -37,6 +36,7 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
 ;;       addi    sp, sp, -0x10
@@ -46,8 +46,7 @@
 ;;       ld      a1, 0x40(a0)
 ;;       slli    a2, a2, 0x20
 ;;       srli    a2, a2, 0x20
-;;       bgeu    a1, a2, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a1, a2, 0x28
 ;;       ld      a0, 0x38(a0)
 ;;       add     a0, a0, a2
 ;;       lui     t6, 1
@@ -57,3 +56,4 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00

--- a/tests/disas/load-store/riscv64/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/riscv64/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -26,8 +26,7 @@
 ;;       ld      a1, 0x40(a0)
 ;;       slli    a2, a2, 0x20
 ;;       srli    a2, a2, 0x20
-;;       bgeu    a1, a2, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a1, a2, 0x2c
 ;;       ld      a4, 0x38(a0)
 ;;       add     a2, a4, a2
 ;;       lui     a1, 0xffff
@@ -38,6 +37,7 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
 ;;       addi    sp, sp, -0x10
@@ -47,8 +47,7 @@
 ;;       ld      a1, 0x40(a0)
 ;;       slli    a2, a2, 0x20
 ;;       srli    a2, a2, 0x20
-;;       bgeu    a1, a2, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a1, a2, 0x2c
 ;;       ld      a3, 0x38(a0)
 ;;       add     a2, a3, a2
 ;;       lui     a1, 0xffff
@@ -59,3 +58,4 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00

--- a/tests/disas/load-store/riscv64/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/riscv64/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -26,8 +26,7 @@
 ;;       ld      a1, 0x40(a0)
 ;;       slli    a2, a2, 0x20
 ;;       srli    a2, a2, 0x20
-;;       bltu    a2, a1, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bgeu    a2, a1, 0x20
 ;;       ld      a0, 0x38(a0)
 ;;       add     a0, a0, a2
 ;;       sb      a3, 0(a0)
@@ -35,6 +34,7 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
 ;;       addi    sp, sp, -0x10
@@ -44,8 +44,7 @@
 ;;       ld      a1, 0x40(a0)
 ;;       slli    a2, a2, 0x20
 ;;       srli    a2, a2, 0x20
-;;       bltu    a2, a1, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bgeu    a2, a1, 0x20
 ;;       ld      a0, 0x38(a0)
 ;;       add     a0, a0, a2
 ;;       lbu     a0, 0(a0)
@@ -53,3 +52,4 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00

--- a/tests/disas/load-store/riscv64/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/riscv64/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -26,8 +26,7 @@
 ;;       ld      a1, 0x40(a0)
 ;;       slli    a2, a2, 0x20
 ;;       srli    a2, a2, 0x20
-;;       bgeu    a1, a2, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a1, a2, 0x28
 ;;       ld      a0, 0x38(a0)
 ;;       add     a0, a0, a2
 ;;       lui     t6, 1
@@ -37,6 +36,7 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
 ;;       addi    sp, sp, -0x10
@@ -46,8 +46,7 @@
 ;;       ld      a1, 0x40(a0)
 ;;       slli    a2, a2, 0x20
 ;;       srli    a2, a2, 0x20
-;;       bgeu    a1, a2, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a1, a2, 0x28
 ;;       ld      a0, 0x38(a0)
 ;;       add     a0, a0, a2
 ;;       lui     t6, 1
@@ -57,3 +56,4 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00

--- a/tests/disas/load-store/riscv64/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/riscv64/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -26,8 +26,7 @@
 ;;       ld      a1, 0x40(a0)
 ;;       slli    a2, a2, 0x20
 ;;       srli    a2, a2, 0x20
-;;       bgeu    a1, a2, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a1, a2, 0x2c
 ;;       ld      a4, 0x38(a0)
 ;;       add     a2, a4, a2
 ;;       lui     a1, 0xffff
@@ -38,6 +37,7 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
 ;;       addi    sp, sp, -0x10
@@ -47,8 +47,7 @@
 ;;       ld      a1, 0x40(a0)
 ;;       slli    a2, a2, 0x20
 ;;       srli    a2, a2, 0x20
-;;       bgeu    a1, a2, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a1, a2, 0x2c
 ;;       ld      a3, 0x38(a0)
 ;;       add     a2, a3, a2
 ;;       lui     a1, 0xffff
@@ -59,3 +58,4 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00

--- a/tests/disas/load-store/riscv64/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/riscv64/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -25,8 +25,7 @@
 ;;       mv      s0, sp
 ;;       ld      a1, 0x40(a0)
 ;;       addi    a1, a1, -4
-;;       bgeu    a1, a2, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a1, a2, 0x20
 ;;       ld      a0, 0x38(a0)
 ;;       add     a0, a0, a2
 ;;       sw      a3, 0(a0)
@@ -34,6 +33,7 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
 ;;       addi    sp, sp, -0x10
@@ -42,8 +42,7 @@
 ;;       mv      s0, sp
 ;;       ld      a1, 0x40(a0)
 ;;       addi    a1, a1, -4
-;;       bgeu    a1, a2, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a1, a2, 0x20
 ;;       ld      a0, 0x38(a0)
 ;;       add     a0, a0, a2
 ;;       lw      a0, 0(a0)
@@ -51,3 +50,4 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00

--- a/tests/disas/load-store/riscv64/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/riscv64/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -27,8 +27,7 @@
 ;;       lui     a4, 1
 ;;       addi    a4, a4, 4
 ;;       sub     a1, a1, a4
-;;       bgeu    a1, a2, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a1, a2, 0x28
 ;;       ld      a0, 0x38(a0)
 ;;       add     a0, a0, a2
 ;;       lui     t6, 1
@@ -38,6 +37,7 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
 ;;       addi    sp, sp, -0x10
@@ -48,8 +48,7 @@
 ;;       lui     a3, 1
 ;;       addi    a3, a3, 4
 ;;       sub     a1, a1, a3
-;;       bgeu    a1, a2, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a1, a2, 0x28
 ;;       ld      a0, 0x38(a0)
 ;;       add     a0, a0, a2
 ;;       lui     t6, 1
@@ -59,3 +58,4 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00

--- a/tests/disas/load-store/riscv64/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/riscv64/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -27,11 +27,9 @@
 ;;       addi    a4, a1, 1
 ;;       slli    a5, a4, 2
 ;;       add     a4, a2, a5
-;;       bgeu    a4, a2, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a4, a2, 0x34
 ;;       ld      a5, 0x40(a0)
-;;       bgeu    a5, a4, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a5, a4, 0x30
 ;;       ld      a5, 0x38(a0)
 ;;       add     a5, a5, a2
 ;;       lui     a4, 0xffff
@@ -42,6 +40,8 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       .byte   0x00, 0x00, 0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
 ;;       addi    sp, sp, -0x10
@@ -52,11 +52,9 @@
 ;;       addi    a3, a1, 1
 ;;       slli    a5, a3, 2
 ;;       add     a3, a2, a5
-;;       bgeu    a3, a2, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a3, a2, 0x34
 ;;       ld      a4, 0x40(a0)
-;;       bgeu    a4, a3, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a4, a3, 0x30
 ;;       ld      a5, 0x38(a0)
 ;;       add     a5, a5, a2
 ;;       lui     a4, 0xffff
@@ -67,3 +65,5 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       .byte   0x00, 0x00, 0x00, 0x00

--- a/tests/disas/load-store/riscv64/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/riscv64/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -24,8 +24,7 @@
 ;;       sd      s0, 0(sp)
 ;;       mv      s0, sp
 ;;       ld      a1, 0x40(a0)
-;;       bltu    a2, a1, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bgeu    a2, a1, 0x20
 ;;       ld      a0, 0x38(a0)
 ;;       add     a0, a0, a2
 ;;       sb      a3, 0(a0)
@@ -33,6 +32,7 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
 ;;       addi    sp, sp, -0x10
@@ -40,8 +40,7 @@
 ;;       sd      s0, 0(sp)
 ;;       mv      s0, sp
 ;;       ld      a1, 0x40(a0)
-;;       bltu    a2, a1, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bgeu    a2, a1, 0x20
 ;;       ld      a0, 0x38(a0)
 ;;       add     a0, a0, a2
 ;;       lbu     a0, 0(a0)
@@ -49,3 +48,4 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00

--- a/tests/disas/load-store/riscv64/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/riscv64/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -27,8 +27,7 @@
 ;;       lui     a4, 1
 ;;       addi    a4, a4, 1
 ;;       sub     a1, a1, a4
-;;       bgeu    a1, a2, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a1, a2, 0x28
 ;;       ld      a0, 0x38(a0)
 ;;       add     a0, a0, a2
 ;;       lui     t6, 1
@@ -38,6 +37,7 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
 ;;       addi    sp, sp, -0x10
@@ -48,8 +48,7 @@
 ;;       lui     a3, 1
 ;;       addi    a3, a3, 1
 ;;       sub     a1, a1, a3
-;;       bgeu    a1, a2, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a1, a2, 0x28
 ;;       ld      a0, 0x38(a0)
 ;;       add     a0, a0, a2
 ;;       lui     t6, 1
@@ -59,3 +58,4 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00

--- a/tests/disas/load-store/riscv64/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/riscv64/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -26,11 +26,9 @@
 ;;       auipc   a1, 0
 ;;       ld      a1, 0x48(a1)
 ;;       add     a1, a2, a1
-;;       bgeu    a1, a2, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a1, a2, 0x34
 ;;       ld      a4, 0x40(a0)
-;;       bgeu    a4, a1, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a4, a1, 0x30
 ;;       ld      a4, 0x38(a0)
 ;;       add     a4, a4, a2
 ;;       lui     a2, 0xffff
@@ -41,6 +39,8 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       .byte   0x00, 0x00, 0x00, 0x00
 ;;       .byte   0x01, 0x00, 0xff, 0xff
 ;;       .byte   0x00, 0x00, 0x00, 0x00
 ;;
@@ -52,11 +52,9 @@
 ;;       auipc   a1, 0
 ;;       ld      a1, 0x48(a1)
 ;;       add     a1, a2, a1
-;;       bgeu    a1, a2, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a1, a2, 0x34
 ;;       ld      a3, 0x40(a0)
-;;       bgeu    a3, a1, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a3, a1, 0x30
 ;;       ld      a3, 0x38(a0)
 ;;       add     a3, a3, a2
 ;;       lui     a2, 0xffff
@@ -67,5 +65,7 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       .byte   0x00, 0x00, 0x00, 0x00
 ;;       .byte   0x01, 0x00, 0xff, 0xff
 ;;       .byte   0x00, 0x00, 0x00, 0x00

--- a/tests/disas/load-store/riscv64/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/riscv64/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -27,8 +27,7 @@
 ;;       addi    a1, a5, 1
 ;;       slli    a1, a1, 2
 ;;       add     a1, a2, a1
-;;       bgeu    a1, a2, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a1, a2, 0x40
 ;;       ld      a4, 0x40(a0)
 ;;       ld      a5, 0x38(a0)
 ;;       sltu    a0, a4, a1
@@ -44,6 +43,7 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
 ;;       addi    sp, sp, -0x10
@@ -54,8 +54,7 @@
 ;;       addi    a1, a5, 1
 ;;       slli    a1, a1, 2
 ;;       add     a1, a2, a1
-;;       bgeu    a1, a2, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a1, a2, 0x40
 ;;       ld      a3, 0x40(a0)
 ;;       ld      a4, 0x38(a0)
 ;;       sltu    a0, a3, a1
@@ -71,3 +70,4 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00

--- a/tests/disas/load-store/riscv64/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/riscv64/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -26,8 +26,7 @@
 ;;       auipc   a5, 0
 ;;       ld      a5, 0x50(a5)
 ;;       add     a5, a2, a5
-;;       bgeu    a5, a2, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a5, a2, 0x40
 ;;       ld      a1, 0x40(a0)
 ;;       ld      a4, 0x38(a0)
 ;;       sltu    a0, a1, a5
@@ -43,6 +42,7 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00
 ;;       .byte   0x01, 0x00, 0xff, 0xff
 ;;       .byte   0x00, 0x00, 0x00, 0x00
 ;;
@@ -54,8 +54,7 @@
 ;;       auipc   a5, 0
 ;;       ld      a5, 0x50(a5)
 ;;       add     a5, a2, a5
-;;       bgeu    a5, a2, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a5, a2, 0x40
 ;;       ld      a1, 0x40(a0)
 ;;       ld      a3, 0x38(a0)
 ;;       sltu    a0, a1, a5
@@ -71,5 +70,6 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00
 ;;       .byte   0x01, 0x00, 0xff, 0xff
 ;;       .byte   0x00, 0x00, 0x00, 0x00

--- a/tests/disas/load-store/riscv64/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/riscv64/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -24,8 +24,7 @@
 ;;       sd      s0, 0(sp)
 ;;       mv      s0, sp
 ;;       ld      a1, 0x40(a0)
-;;       bgeu    a1, a2, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a1, a2, 0x20
 ;;       ld      a0, 0x38(a0)
 ;;       add     a0, a0, a2
 ;;       sw      a3, 0(a0)
@@ -33,6 +32,7 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
 ;;       addi    sp, sp, -0x10
@@ -40,8 +40,7 @@
 ;;       sd      s0, 0(sp)
 ;;       mv      s0, sp
 ;;       ld      a1, 0x40(a0)
-;;       bgeu    a1, a2, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a1, a2, 0x20
 ;;       ld      a0, 0x38(a0)
 ;;       add     a0, a0, a2
 ;;       lw      a0, 0(a0)
@@ -49,3 +48,4 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00

--- a/tests/disas/load-store/riscv64/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/riscv64/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -24,8 +24,7 @@
 ;;       sd      s0, 0(sp)
 ;;       mv      s0, sp
 ;;       ld      a1, 0x40(a0)
-;;       bgeu    a1, a2, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a1, a2, 0x28
 ;;       ld      a0, 0x38(a0)
 ;;       add     a0, a0, a2
 ;;       lui     t6, 1
@@ -35,6 +34,7 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
 ;;       addi    sp, sp, -0x10
@@ -42,8 +42,7 @@
 ;;       sd      s0, 0(sp)
 ;;       mv      s0, sp
 ;;       ld      a1, 0x40(a0)
-;;       bgeu    a1, a2, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a1, a2, 0x28
 ;;       ld      a0, 0x38(a0)
 ;;       add     a0, a0, a2
 ;;       lui     t6, 1
@@ -53,3 +52,4 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00

--- a/tests/disas/load-store/riscv64/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/riscv64/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -24,8 +24,7 @@
 ;;       sd      s0, 0(sp)
 ;;       mv      s0, sp
 ;;       ld      a1, 0x40(a0)
-;;       bgeu    a1, a2, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a1, a2, 0x2c
 ;;       ld      a0, 0x38(a0)
 ;;       add     a0, a0, a2
 ;;       lui     a1, 0xffff
@@ -36,6 +35,7 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
 ;;       addi    sp, sp, -0x10
@@ -43,8 +43,7 @@
 ;;       sd      s0, 0(sp)
 ;;       mv      s0, sp
 ;;       ld      a1, 0x40(a0)
-;;       bgeu    a1, a2, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a1, a2, 0x2c
 ;;       ld      a0, 0x38(a0)
 ;;       add     a0, a0, a2
 ;;       lui     a1, 0xffff
@@ -55,3 +54,4 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00

--- a/tests/disas/load-store/riscv64/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/riscv64/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -24,8 +24,7 @@
 ;;       sd      s0, 0(sp)
 ;;       mv      s0, sp
 ;;       ld      a1, 0x40(a0)
-;;       bltu    a2, a1, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bgeu    a2, a1, 0x20
 ;;       ld      a0, 0x38(a0)
 ;;       add     a0, a0, a2
 ;;       sb      a3, 0(a0)
@@ -33,6 +32,7 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
 ;;       addi    sp, sp, -0x10
@@ -40,8 +40,7 @@
 ;;       sd      s0, 0(sp)
 ;;       mv      s0, sp
 ;;       ld      a1, 0x40(a0)
-;;       bltu    a2, a1, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bgeu    a2, a1, 0x20
 ;;       ld      a0, 0x38(a0)
 ;;       add     a0, a0, a2
 ;;       lbu     a0, 0(a0)
@@ -49,3 +48,4 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00

--- a/tests/disas/load-store/riscv64/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/riscv64/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -24,8 +24,7 @@
 ;;       sd      s0, 0(sp)
 ;;       mv      s0, sp
 ;;       ld      a1, 0x40(a0)
-;;       bgeu    a1, a2, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a1, a2, 0x28
 ;;       ld      a0, 0x38(a0)
 ;;       add     a0, a0, a2
 ;;       lui     t6, 1
@@ -35,6 +34,7 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
 ;;       addi    sp, sp, -0x10
@@ -42,8 +42,7 @@
 ;;       sd      s0, 0(sp)
 ;;       mv      s0, sp
 ;;       ld      a1, 0x40(a0)
-;;       bgeu    a1, a2, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a1, a2, 0x28
 ;;       ld      a0, 0x38(a0)
 ;;       add     a0, a0, a2
 ;;       lui     t6, 1
@@ -53,3 +52,4 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00

--- a/tests/disas/load-store/riscv64/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/riscv64/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -24,8 +24,7 @@
 ;;       sd      s0, 0(sp)
 ;;       mv      s0, sp
 ;;       ld      a1, 0x40(a0)
-;;       bgeu    a1, a2, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a1, a2, 0x2c
 ;;       ld      a0, 0x38(a0)
 ;;       add     a0, a0, a2
 ;;       lui     a1, 0xffff
@@ -36,6 +35,7 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
 ;;       addi    sp, sp, -0x10
@@ -43,8 +43,7 @@
 ;;       sd      s0, 0(sp)
 ;;       mv      s0, sp
 ;;       ld      a1, 0x40(a0)
-;;       bgeu    a1, a2, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a1, a2, 0x2c
 ;;       ld      a0, 0x38(a0)
 ;;       add     a0, a0, a2
 ;;       lui     a1, 0xffff
@@ -55,3 +54,4 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00

--- a/tests/disas/load-store/riscv64/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/riscv64/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -28,8 +28,7 @@
 ;;       lui     a2, 0x40000
 ;;       addi    a2, a2, -1
 ;;       slli    a2, a2, 2
-;;       bgeu    a2, a1, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a2, a1, 0x20
 ;;       ld      a2, 0x38(a0)
 ;;       add     a1, a2, a1
 ;;       sw      a3, 0(a1)
@@ -37,6 +36,7 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
 ;;       addi    sp, sp, -0x10
@@ -48,8 +48,7 @@
 ;;       lui     a2, 0x40000
 ;;       addi    a2, a2, -1
 ;;       slli    a2, a2, 2
-;;       bgeu    a2, a1, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a2, a1, 0x20
 ;;       ld      a2, 0x38(a0)
 ;;       add     a1, a2, a1
 ;;       lw      a0, 0(a1)
@@ -57,3 +56,4 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00

--- a/tests/disas/load-store/riscv64/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/riscv64/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -28,8 +28,7 @@
 ;;       lui     a2, 0x40000
 ;;       addi    a2, a2, -0x401
 ;;       slli    a2, a2, 2
-;;       bgeu    a2, a1, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a2, a1, 0x28
 ;;       ld      a2, 0x38(a0)
 ;;       add     a1, a2, a1
 ;;       lui     t6, 1
@@ -39,6 +38,7 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
 ;;       addi    sp, sp, -0x10
@@ -50,8 +50,7 @@
 ;;       lui     a2, 0x40000
 ;;       addi    a2, a2, -0x401
 ;;       slli    a2, a2, 2
-;;       bgeu    a2, a1, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a2, a1, 0x28
 ;;       ld      a2, 0x38(a0)
 ;;       add     a1, a2, a1
 ;;       lui     t6, 1
@@ -61,3 +60,4 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00

--- a/tests/disas/load-store/riscv64/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/riscv64/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -27,8 +27,7 @@
 ;;       srli    a4, a1, 0x20
 ;;       lui     a1, 0x10
 ;;       addi    a5, a1, -4
-;;       bgeu    a5, a4, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a5, a4, 0x2c
 ;;       ld      a5, 0x38(a0)
 ;;       add     a4, a5, a4
 ;;       lui     a2, 0xffff
@@ -39,6 +38,7 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
 ;;       addi    sp, sp, -0x10
@@ -49,8 +49,7 @@
 ;;       srli    a3, a1, 0x20
 ;;       lui     a1, 0x10
 ;;       addi    a4, a1, -4
-;;       bgeu    a4, a3, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a4, a3, 0x2c
 ;;       ld      a4, 0x38(a0)
 ;;       add     a3, a4, a3
 ;;       lui     a2, 0xffff
@@ -61,3 +60,4 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00

--- a/tests/disas/load-store/riscv64/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/riscv64/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -27,8 +27,7 @@
 ;;       srli    a1, a1, 0x20
 ;;       auipc   a2, 0
 ;;       ld      a2, 0x38(a2)
-;;       bgeu    a2, a1, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a2, a1, 0x28
 ;;       ld      a0, 0x38(a0)
 ;;       add     a0, a0, a1
 ;;       lui     t6, 1
@@ -38,6 +37,7 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00
 ;;       .byte   0x00, 0x00, 0x00, 0x00
 ;;       .byte   0xff, 0xef, 0xff, 0xff
 ;;       .byte   0x00, 0x00, 0x00, 0x00
@@ -51,8 +51,7 @@
 ;;       srli    a1, a1, 0x20
 ;;       auipc   a2, 0
 ;;       ld      a2, 0x38(a2)
-;;       bgeu    a2, a1, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a2, a1, 0x28
 ;;       ld      a0, 0x38(a0)
 ;;       add     a0, a0, a1
 ;;       lui     t6, 1
@@ -62,6 +61,7 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00
 ;;       .byte   0x00, 0x00, 0x00, 0x00
 ;;       .byte   0xff, 0xef, 0xff, 0xff
 ;;       .byte   0x00, 0x00, 0x00, 0x00

--- a/tests/disas/load-store/riscv64/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/riscv64/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -27,8 +27,7 @@
 ;;       srli    a4, a1, 0x20
 ;;       lui     a1, 0x10
 ;;       addi    a5, a1, -1
-;;       bgeu    a5, a4, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a5, a4, 0x2c
 ;;       ld      a5, 0x38(a0)
 ;;       add     a4, a5, a4
 ;;       lui     a2, 0xffff
@@ -39,6 +38,7 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
 ;;       addi    sp, sp, -0x10
@@ -49,8 +49,7 @@
 ;;       srli    a3, a1, 0x20
 ;;       lui     a1, 0x10
 ;;       addi    a4, a1, -1
-;;       bgeu    a4, a3, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a4, a3, 0x2c
 ;;       ld      a4, 0x38(a0)
 ;;       add     a3, a4, a3
 ;;       lui     a2, 0xffff
@@ -61,3 +60,4 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00

--- a/tests/disas/load-store/riscv64/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/riscv64/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -26,8 +26,7 @@
 ;;       lui     a1, 0x40000
 ;;       addi    a1, a1, -1
 ;;       slli    a1, a1, 2
-;;       bgeu    a1, a2, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a1, a2, 0x20
 ;;       ld      a0, 0x38(a0)
 ;;       add     a0, a0, a2
 ;;       sw      a3, 0(a0)
@@ -35,6 +34,7 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
 ;;       addi    sp, sp, -0x10
@@ -44,8 +44,7 @@
 ;;       lui     a1, 0x40000
 ;;       addi    a1, a1, -1
 ;;       slli    a1, a1, 2
-;;       bgeu    a1, a2, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a1, a2, 0x20
 ;;       ld      a0, 0x38(a0)
 ;;       add     a0, a0, a2
 ;;       lw      a0, 0(a0)
@@ -53,3 +52,4 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00

--- a/tests/disas/load-store/riscv64/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/riscv64/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -26,8 +26,7 @@
 ;;       lui     a1, 0x40000
 ;;       addi    a1, a1, -0x401
 ;;       slli    a1, a1, 2
-;;       bgeu    a1, a2, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a1, a2, 0x28
 ;;       ld      a0, 0x38(a0)
 ;;       add     a0, a0, a2
 ;;       lui     t6, 1
@@ -37,6 +36,7 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
 ;;       addi    sp, sp, -0x10
@@ -46,8 +46,7 @@
 ;;       lui     a1, 0x40000
 ;;       addi    a1, a1, -0x401
 ;;       slli    a1, a1, 2
-;;       bgeu    a1, a2, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a1, a2, 0x28
 ;;       ld      a0, 0x38(a0)
 ;;       add     a0, a0, a2
 ;;       lui     t6, 1
@@ -57,3 +56,4 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00

--- a/tests/disas/load-store/riscv64/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/riscv64/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -25,8 +25,7 @@
 ;;       mv      s0, sp
 ;;       lui     a1, 0x10
 ;;       addi    a1, a1, -4
-;;       bgeu    a1, a2, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a1, a2, 0x2c
 ;;       ld      a1, 0x38(a0)
 ;;       add     a1, a1, a2
 ;;       lui     a0, 0xffff
@@ -37,6 +36,7 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
 ;;       addi    sp, sp, -0x10
@@ -45,8 +45,7 @@
 ;;       mv      s0, sp
 ;;       lui     a1, 0x10
 ;;       addi    a1, a1, -4
-;;       bgeu    a1, a2, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a1, a2, 0x2c
 ;;       ld      a1, 0x38(a0)
 ;;       add     a1, a1, a2
 ;;       lui     a0, 0xffff
@@ -57,3 +56,4 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00

--- a/tests/disas/load-store/riscv64/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/riscv64/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -25,8 +25,7 @@
 ;;       mv      s0, sp
 ;;       auipc   a1, 0
 ;;       ld      a1, 0x30(a1)
-;;       bgeu    a1, a2, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a1, a2, 0x20
 ;;       ld      a0, 0x38(a0)
 ;;       add     a0, a0, a2
 ;;       sb      a3, 0(a0)
@@ -34,6 +33,7 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00
 ;;       .byte   0x00, 0x00, 0x00, 0x00
 ;;       .byte   0xff, 0xff, 0xff, 0xff
 ;;       .byte   0x00, 0x00, 0x00, 0x00
@@ -45,8 +45,7 @@
 ;;       mv      s0, sp
 ;;       auipc   a1, 0
 ;;       ld      a1, 0x30(a1)
-;;       bgeu    a1, a2, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a1, a2, 0x20
 ;;       ld      a0, 0x38(a0)
 ;;       add     a0, a0, a2
 ;;       lbu     a0, 0(a0)
@@ -54,6 +53,7 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00
 ;;       .byte   0x00, 0x00, 0x00, 0x00
 ;;       .byte   0xff, 0xff, 0xff, 0xff
 ;;       .byte   0x00, 0x00, 0x00, 0x00

--- a/tests/disas/load-store/riscv64/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/riscv64/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -25,8 +25,7 @@
 ;;       mv      s0, sp
 ;;       auipc   a1, 0
 ;;       ld      a1, 0x38(a1)
-;;       bgeu    a1, a2, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a1, a2, 0x28
 ;;       ld      a0, 0x38(a0)
 ;;       add     a0, a0, a2
 ;;       lui     t6, 1
@@ -36,6 +35,7 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00
 ;;       .byte   0x00, 0x00, 0x00, 0x00
 ;;       .byte   0xff, 0xef, 0xff, 0xff
 ;;       .byte   0x00, 0x00, 0x00, 0x00
@@ -47,8 +47,7 @@
 ;;       mv      s0, sp
 ;;       auipc   a1, 0
 ;;       ld      a1, 0x38(a1)
-;;       bgeu    a1, a2, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a1, a2, 0x28
 ;;       ld      a0, 0x38(a0)
 ;;       add     a0, a0, a2
 ;;       lui     t6, 1
@@ -58,6 +57,7 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00
 ;;       .byte   0x00, 0x00, 0x00, 0x00
 ;;       .byte   0xff, 0xef, 0xff, 0xff
 ;;       .byte   0x00, 0x00, 0x00, 0x00

--- a/tests/disas/load-store/riscv64/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/riscv64/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -25,8 +25,7 @@
 ;;       mv      s0, sp
 ;;       lui     a1, 0x10
 ;;       addi    a1, a1, -1
-;;       bgeu    a1, a2, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a1, a2, 0x2c
 ;;       ld      a1, 0x38(a0)
 ;;       add     a1, a1, a2
 ;;       lui     a0, 0xffff
@@ -37,6 +36,7 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
 ;;       addi    sp, sp, -0x10
@@ -45,8 +45,7 @@
 ;;       mv      s0, sp
 ;;       lui     a1, 0x10
 ;;       addi    a1, a1, -1
-;;       bgeu    a1, a2, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a1, a2, 0x2c
 ;;       ld      a1, 0x38(a0)
 ;;       add     a1, a1, a2
 ;;       lui     a0, 0xffff
@@ -57,3 +56,4 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00

--- a/tests/disas/load-store/riscv64/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/riscv64/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -26,8 +26,7 @@
 ;;       lui     a1, 0x40000
 ;;       addi    a1, a1, -1
 ;;       slli    a1, a1, 2
-;;       bgeu    a1, a2, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a1, a2, 0x20
 ;;       ld      a0, 0x38(a0)
 ;;       add     a0, a0, a2
 ;;       sw      a3, 0(a0)
@@ -35,6 +34,7 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
 ;;       addi    sp, sp, -0x10
@@ -44,8 +44,7 @@
 ;;       lui     a1, 0x40000
 ;;       addi    a1, a1, -1
 ;;       slli    a1, a1, 2
-;;       bgeu    a1, a2, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a1, a2, 0x20
 ;;       ld      a0, 0x38(a0)
 ;;       add     a0, a0, a2
 ;;       lw      a0, 0(a0)
@@ -53,3 +52,4 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00

--- a/tests/disas/load-store/riscv64/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/riscv64/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -26,8 +26,7 @@
 ;;       lui     a1, 0x40000
 ;;       addi    a1, a1, -0x401
 ;;       slli    a1, a1, 2
-;;       bgeu    a1, a2, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a1, a2, 0x28
 ;;       ld      a0, 0x38(a0)
 ;;       add     a0, a0, a2
 ;;       lui     t6, 1
@@ -37,6 +36,7 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
 ;;       addi    sp, sp, -0x10
@@ -46,8 +46,7 @@
 ;;       lui     a1, 0x40000
 ;;       addi    a1, a1, -0x401
 ;;       slli    a1, a1, 2
-;;       bgeu    a1, a2, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a1, a2, 0x28
 ;;       ld      a0, 0x38(a0)
 ;;       add     a0, a0, a2
 ;;       lui     t6, 1
@@ -57,3 +56,4 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00

--- a/tests/disas/load-store/riscv64/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/riscv64/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -25,8 +25,7 @@
 ;;       mv      s0, sp
 ;;       lui     a1, 0x10
 ;;       addi    a1, a1, -4
-;;       bgeu    a1, a2, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a1, a2, 0x2c
 ;;       ld      a1, 0x38(a0)
 ;;       add     a1, a1, a2
 ;;       lui     a0, 0xffff
@@ -37,6 +36,7 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
 ;;       addi    sp, sp, -0x10
@@ -45,8 +45,7 @@
 ;;       mv      s0, sp
 ;;       lui     a1, 0x10
 ;;       addi    a1, a1, -4
-;;       bgeu    a1, a2, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a1, a2, 0x2c
 ;;       ld      a1, 0x38(a0)
 ;;       add     a1, a1, a2
 ;;       lui     a0, 0xffff
@@ -57,3 +56,4 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00

--- a/tests/disas/load-store/riscv64/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/riscv64/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -25,8 +25,7 @@
 ;;       mv      s0, sp
 ;;       auipc   a1, 0
 ;;       ld      a1, 0x30(a1)
-;;       bgeu    a1, a2, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a1, a2, 0x20
 ;;       ld      a0, 0x38(a0)
 ;;       add     a0, a0, a2
 ;;       sb      a3, 0(a0)
@@ -34,6 +33,7 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00
 ;;       .byte   0x00, 0x00, 0x00, 0x00
 ;;       .byte   0xff, 0xff, 0xff, 0xff
 ;;       .byte   0x00, 0x00, 0x00, 0x00
@@ -45,8 +45,7 @@
 ;;       mv      s0, sp
 ;;       auipc   a1, 0
 ;;       ld      a1, 0x30(a1)
-;;       bgeu    a1, a2, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a1, a2, 0x20
 ;;       ld      a0, 0x38(a0)
 ;;       add     a0, a0, a2
 ;;       lbu     a0, 0(a0)
@@ -54,6 +53,7 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00
 ;;       .byte   0x00, 0x00, 0x00, 0x00
 ;;       .byte   0xff, 0xff, 0xff, 0xff
 ;;       .byte   0x00, 0x00, 0x00, 0x00

--- a/tests/disas/load-store/riscv64/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/riscv64/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -25,8 +25,7 @@
 ;;       mv      s0, sp
 ;;       auipc   a1, 0
 ;;       ld      a1, 0x38(a1)
-;;       bgeu    a1, a2, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a1, a2, 0x28
 ;;       ld      a0, 0x38(a0)
 ;;       add     a0, a0, a2
 ;;       lui     t6, 1
@@ -36,6 +35,7 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00
 ;;       .byte   0x00, 0x00, 0x00, 0x00
 ;;       .byte   0xff, 0xef, 0xff, 0xff
 ;;       .byte   0x00, 0x00, 0x00, 0x00
@@ -47,8 +47,7 @@
 ;;       mv      s0, sp
 ;;       auipc   a1, 0
 ;;       ld      a1, 0x38(a1)
-;;       bgeu    a1, a2, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a1, a2, 0x28
 ;;       ld      a0, 0x38(a0)
 ;;       add     a0, a0, a2
 ;;       lui     t6, 1
@@ -58,6 +57,7 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00
 ;;       .byte   0x00, 0x00, 0x00, 0x00
 ;;       .byte   0xff, 0xef, 0xff, 0xff
 ;;       .byte   0x00, 0x00, 0x00, 0x00

--- a/tests/disas/load-store/riscv64/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/riscv64/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -25,8 +25,7 @@
 ;;       mv      s0, sp
 ;;       lui     a1, 0x10
 ;;       addi    a1, a1, -1
-;;       bgeu    a1, a2, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a1, a2, 0x2c
 ;;       ld      a1, 0x38(a0)
 ;;       add     a1, a1, a2
 ;;       lui     a0, 0xffff
@@ -37,6 +36,7 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
 ;;       addi    sp, sp, -0x10
@@ -45,8 +45,7 @@
 ;;       mv      s0, sp
 ;;       lui     a1, 0x10
 ;;       addi    a1, a1, -1
-;;       bgeu    a1, a2, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       bltu    a1, a2, 0x2c
 ;;       ld      a1, 0x38(a0)
 ;;       add     a1, a1, a2
 ;;       lui     a0, 0xffff
@@ -57,3 +56,4 @@
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
+;;       .byte   0x00, 0x00, 0x00, 0x00

--- a/tests/disas/riscv64-component-builtins-asm.wat
+++ b/tests/disas/riscv64-component-builtins-asm.wat
@@ -28,9 +28,7 @@
 ;;       sd      a2, 0x38(a1)
 ;;       lw      a1, 0x20(a0)
 ;;       andi    a1, a1, 1
-;;       bnez    a1, 8
-;;       .byte   0x00, 0x00, 0x00, 0x00
-;;       ╰─╼ trap: CannotLeaveComponent
+;;       beqz    a1, 0x6c
 ;;       ld      a1, 8(a0)
 ;;       ld      a5, 0x10(a1)
 ;;       mv      a4, zero
@@ -57,3 +55,5 @@
 ;;       mv      a0, a1
 ;;       jalr    a2
 ;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       .byte   0x00, 0x00, 0x00, 0x00
+;;       ╰─╼ trap: CannotLeaveComponent


### PR DESCRIPTION
This commit leverages the `MachBuffer::defer_trap` function to optimize the codegen of `TrapIf` and defer the trapping instruction to the end of a function to keep the jump-around outside of the main body. This is similar to what other backends do, for example.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
