### PR TITLE
docs: fix duplicated words in comments

### DIFF
--- a/crates/debugger/src/lib.rs
+++ b/crates/debugger/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! This crate builds on top of the core Wasmtime crate's
 //! guest-debugger APIs to present an environment where a debugger
-//! runs as a "co-running process" and sees the debuggee as a a
+//! runs as a "co-running process" and sees the debuggee as a
 //! provider of a stream of events, on which actions can be taken
 //! between each event.
 //!

--- a/crates/fuzzing/src/generators/gc_ops/ops.rs
+++ b/crates/fuzzing/src/generators/gc_ops/ops.rs
@@ -14,7 +14,7 @@ use wasm_encoder::{
 };
 
 /// The base offsets and indices for various Wasm entities within
-/// their index spaces in the the encoded Wasm binary.
+/// their index spaces in the encoded Wasm binary.
 #[derive(Clone, Copy)]
 struct WasmEncodingBases {
     struct_type_base: u32,

--- a/crates/wasmtime/src/runtime/vm/gc/enabled/data.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/enabled/data.rs
@@ -204,7 +204,7 @@ impl VMGcObjectData {
         into.copy_from_slice(src);
     }
 
-    /// Copy within this this object's data.
+    /// Copy within this object's data.
     ///
     /// Note that GC data is always stored in little-endian order, and this
     /// method does not do any conversions to/from host endianness for you.

--- a/crates/wasmtime/src/runtime/vm/mmap.rs
+++ b/crates/wasmtime/src/runtime/vm/mmap.rs
@@ -49,7 +49,7 @@ pub struct UnalignedLength {
 /// that is backed purely by memory, and one that is possibly backed by a file.
 ///
 /// Currently, the OS-specific `mmap` implementations in this crate do not make
-/// this this distinction -- alignment is managed at this platform-independent
+/// this distinction -- alignment is managed at this platform-independent
 /// layer. It might make sense to add this distinction to the OS-specific
 /// implementations in the future.
 ///

--- a/crates/wasmtime/src/runtime/vm/sys/unix/pagemap.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/unix/pagemap.rs
@@ -21,7 +21,7 @@ use std::ptr;
 ///
 /// Also note that updating this is not done via mutation but rather it's done
 /// with `dup2` to replace the file descriptor that `File` points to in-place.
-/// The local copy of of `File` is then closed in the atfork handler.
+/// The local copy of `File` is then closed in the atfork handler.
 #[cfg(feature = "pooling-allocator")]
 static PROCESS_PAGEMAP: std::sync::LazyLock<Option<File>> = std::sync::LazyLock::new(|| {
     use rustix::fd::AsRawFd;

--- a/crates/wasmtime/src/runtime/vm/traphandlers.rs
+++ b/crates/wasmtime/src/runtime/vm/traphandlers.rs
@@ -69,7 +69,7 @@ fn lazy_per_thread_init() {
 /// handler created when Wasm was entered. If the state has registered an
 /// exception, this function will perform the unwind action registered: either
 /// resetting PC, FP, and SP to the handler in the middle of the Wasm
-/// activation on the stack, or the entry trampoline back to the the host, if
+/// activation on the stack, or the entry trampoline back to the host, if
 /// the exception is uncaught.
 ///
 /// This is currently only called from the `raise` builtin of

--- a/examples/threads.rs
+++ b/examples/threads.rs
@@ -59,7 +59,7 @@ fn run(engine: &Engine, module: &Module, linker: &Linker<()>) -> Result<()> {
         thread::sleep(time::Duration::from_millis(100));
     }
 
-    // Also note that that a `Store` can also move between threads:
+    // Also note that a `Store` can also move between threads:
     println!("> Moving {:?} to a new thread", thread::current().id());
     let child = thread::spawn(move || run.call(&mut store, ()));
 


### PR DESCRIPTION
Fixes duplicated words in comments/doc text. No runtime behavior change.