### PR TITLE
riscv64: Omit sign-extension of some `band` instructions

### DIFF
--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -2344,11 +2344,22 @@
 ;; extension is from 32 to 64, 16/8-bit operations are explicitly excluded here.
 ;; There are no native instructions for the 16/8 bit operations so they must
 ;; fall through to actual sign extension above.
-(rule 1 (val_already_extended (ExtendOp.Signed) (has_type $I32 (ishl _ _ _))) true)
-(rule 1 (val_already_extended (ExtendOp.Signed) (has_type $I32 (ushr _ _ _))) true)
-(rule 1 (val_already_extended (ExtendOp.Signed) (has_type $I32 (sshr _ _ _))) true)
-(rule 1 (val_already_extended (ExtendOp.Signed) (has_type $I32 (iadd _ _ _))) true)
-(rule 1 (val_already_extended (ExtendOp.Signed) (has_type $I32 (isub _ _ _))) true)
+(rule 1 (val_already_extended (ExtendOp.Signed) (ishl $I32 _ _)) true)
+(rule 1 (val_already_extended (ExtendOp.Signed) (ushr $I32 _ _)) true)
+(rule 1 (val_already_extended (ExtendOp.Signed) (sshr $I32 _ _)) true)
+(rule 1 (val_already_extended (ExtendOp.Signed) (iadd $I32 _ _)) true)
+(rule 1 (val_already_extended (ExtendOp.Signed) (isub $I32 _ _)) true)
+
+;; For `band`-with-`imm12` immediate, that'll get lowered as `rv_andi`. In this
+;; situation the immediate is sign-extended to the full register width and a
+;; bit-and operation is done. If the immediate is positive then that means we're
+;; guaranteed that the sign bit of the result of the `band` is zero, and that
+;; all upper bits in the register are also zero. That means that this satisifes
+;; both a zero and sign-extension.
+(rule 1 (val_already_extended _ (band _ _ (i64_from_iconst n)))
+  (if-let true (i64_gt_eq n 0))
+  (if-let (imm12_from_i64 _) n)
+  true)
 
 (type ExtendOp
   (enum

--- a/cranelift/filetests/filetests/isa/riscv64/extend.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/extend.clif
@@ -275,3 +275,59 @@ block0(v0: f64, v1: f64):
 ;   flt.d a0, fa0, fa1
 ;   ret
 
+function %extend_band(i32, i32) -> i64 {
+block0(v0: i32, v1: i32):
+  v3 = band v0, v1
+  v4 = sextend.i64 v3
+  return v4
+}
+
+; VCode:
+; block0:
+;   and a0,a0,a1
+;   sext.w a0,a0
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   and a0, a0, a1
+;   sext.w a0, a0
+;   ret
+
+function %extend_band_1(i32) -> i64 {
+block0(v0: i32):
+  v3 = band_imm v0, 1
+  v4 = sextend.i64 v3
+  return v4
+}
+
+; VCode:
+; block0:
+;   andi a0,a0,1
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   andi a0, a0, 1
+;   ret
+
+
+function %extend_band_minus_2(i32) -> i64 {
+block0(v0: i32):
+  v3 = band_imm v0, -2
+  v4 = sextend.i64 v3
+  return v4
+}
+
+; VCode:
+; block0:
+;   andi a0,a0,-2
+;   sext.w a0,a0
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   andi a0, a0, -2
+;   sext.w a0, a0
+;   ret
+

--- a/tests/disas/riscv64-component-builtins-asm.wat
+++ b/tests/disas/riscv64-component-builtins-asm.wat
@@ -17,10 +17,10 @@
 ;;       sd      s0, 0(sp)
 ;;       mv      s0, sp
 ;;       addi    sp, sp, -0x10
-;;       sd      s5, 8(sp)
-;;       sd      s9, 0(sp)
-;;       mv      s5, a1
-;;       mv      s9, a2
+;;       sd      s4, 8(sp)
+;;       sd      s8, 0(sp)
+;;       mv      s4, a1
+;;       mv      s8, a2
 ;;       mv      a3, s0
 ;;       ld      a1, 8(a1)
 ;;       sd      a3, 0x30(a1)
@@ -28,7 +28,6 @@
 ;;       sd      a2, 0x38(a1)
 ;;       lw      a1, 0x20(a0)
 ;;       andi    a1, a1, 1
-;;       sext.w  a1, a1
 ;;       bnez    a1, 8
 ;;       .byte   0x00, 0x00, 0x00, 0x00
 ;;       ╰─╼ trap: Normal(CannotLeaveComponent)
@@ -39,20 +38,20 @@
 ;;       srai    a1, a1, 0x20
 ;;       slli    a2, a4, 0x20
 ;;       srai    a2, a2, 0x20
-;;       mv      a3, s9
+;;       mv      a3, s8
 ;;       slli    a3, a3, 0x20
 ;;       srai    a3, a3, 0x20
 ;;       jalr    a5
 ;;       addi    a1, zero, -1
 ;;       beq     a0, a1, 0x20
-;;       ld      s5, 8(sp)
-;;       ld      s9, 0(sp)
+;;       ld      s4, 8(sp)
+;;       ld      s8, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ld      ra, 8(sp)
 ;;       ld      s0, 0(sp)
 ;;       addi    sp, sp, 0x10
 ;;       ret
-;;       mv      a1, s5
+;;       mv      a1, s4
 ;;       ld      a0, 0x10(a1)
 ;;       ld      a2, 0x1a0(a0)
 ;;       mv      a0, a1


### PR DESCRIPTION
This is a minor optimization for the riscv64 backend where a sign/zero extension operation can be skipped for a `band` instruction with an immediate that fits in an `Imm12`. In this situation, with a positive immediate, the instruction generated will already zero extend the immediate which guarantees the sign bit and all upper bits are 0. In this situation no further extension is needed.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
