### PR TITLE
[ci] More CI critical-path length optimizations

### DIFF
--- a/.github/actions/install-rust/action.yml
+++ b/.github/actions/install-rust/action.yml
@@ -10,6 +10,10 @@ inputs:
     description: 'Versions later-than-latest-Rust the MSRV supports'
     required: false
     default: '2'
+  wasm-targets:
+    description: 'Install wasm32 compilation targets (wasip2, wasip1, unknown-unknown)'
+    required: false
+    default: 'true'
 
 runs:
   using: composite
@@ -78,5 +82,6 @@ runs:
       run: echo WIT_REQUIRE_SEMICOLONS=1 >> "$GITHUB_ENV"
 
     - name: Install the WASI target
+      if: inputs.wasm-targets == 'true'
       shell: bash
       run: rustup target add wasm32-wasip2 wasm32-wasip1 wasm32-unknown-unknown

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -493,12 +493,7 @@ jobs:
     - run: rustup component add clippy
     - run: cargo clippy --workspace --all-targets --features p3,component-model-async
 
-  # Verify that the workspace compiles cleanly under the MSRV toolchain. This
-  # job replaces a previous `Test MSRV` matrix entry which ran the full test
-  # suite under MSRV; running tests adds no coverage beyond running them on
-  # current stable on the same target, while `cargo check` catches the
-  # behavior we actually care about: "did we use a Rust feature too new for
-  # our MSRV?".
+  # Verify that the workspace compiles cleanly under the MSRV toolchain.
   #
   # The excludes mirror `ci/run-tests.py` so that crates which require
   # nightly toolchains or external dependencies (OCaml, SMT solvers) are

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -514,6 +514,12 @@ jobs:
       with:
         toolchain: msrv
     - run: |
+        # wasi-preview1-component-adapter has mutually-exclusive features
+        # (command/reactor/proxy) that compile-error under --all-features.
+        # It's a wasm32-only artifact built separately by
+        # ci/build-wasi-preview1-component-adapter.sh against
+        # wasm32-unknown-unknown, not user-facing on the host toolchain,
+        # so MSRV doesn't apply.
         cargo check --workspace --all-targets --all-features --locked \
           --exclude test-programs \
           --exclude wasmtime-wasi-nn \
@@ -521,7 +527,8 @@ jobs:
           --exclude wasmtime-fuzzing \
           --exclude wasm-spec-interpreter \
           --exclude veri_engine \
-          --exclude calculator
+          --exclude calculator \
+          --exclude wasi-preview1-component-adapter
 
   # Similar to `micro_checks` but where we need to install some more state
   # (e.g. Android NDK) and we haven't factored support for those things out into

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1288,7 +1288,8 @@ jobs:
         include:
           - crate: "wasmtime --features component-model-async-bytes"
           - crate: "wasmtime-cli --test all"
-          - crate: "wasmtime-cli --lib --bins --test disable_host_trap_handlers --test rlimited-memory"
+          - crate: "wasmtime-cli"
+            miri_remaining: true
           - crate: "wasmtime-environ --all-features"
           - crate: "pulley-interpreter --all-features"
           - crate: "wasmtime-internal-core"
@@ -1315,7 +1316,31 @@ jobs:
         version: 0.9.133
     - run: |
         cargo miri nextest run -j4 --no-fail-fast -p ${{ matrix.crate }}
-      if: ${{ matrix.crate }}
+      if: matrix.crate && !matrix.miri_remaining
+    - name: Miri (remaining wasmtime-cli tests)
+      if: matrix.miri_remaining
+      run: |
+        # Dynamically compute --test targets for wasmtime-cli that are:
+        #  - standard harness (custom-harness tests can't run under nextest)
+        #  - not "all" (has its own dedicated Miri bucket)
+        # This uses cargo metadata for the full target list and Cargo.toml for
+        # the harness flag, so new [[test]] entries are picked up automatically.
+        tests=$(python3 -c "
+        import tomllib, json, subprocess
+        # Get all test targets from cargo metadata
+        meta = json.loads(subprocess.check_output(['cargo', 'metadata', '--format-version=1', '--no-deps']))
+        pkg = next(p for p in meta['packages'] if p['name'] == 'wasmtime-cli')
+        all_tests = {t['name'] for t in pkg['targets'] if 'test' in t['kind']}
+        # Find custom-harness tests from Cargo.toml
+        with open('Cargo.toml', 'rb') as f:
+            manifest = tomllib.load(f)
+        custom_harness = {t['name'] for t in manifest.get('test', []) if not t.get('harness', True)}
+        # Exclude custom-harness tests and 'all' (has its own bucket)
+        excluded = custom_harness | {'all'}
+        for t in sorted(all_tests - excluded):
+            print(f'--test {t}')
+        ")
+        cargo miri nextest run -j4 --no-fail-fast -p wasmtime-cli --lib --bins $tests
     - run: ${{ matrix.script }}
       if: ${{ matrix.script }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1287,7 +1287,9 @@ jobs:
       matrix:
         include:
           - crate: "wasmtime --features component-model-async-bytes"
-          - crate: "wasmtime-cli"
+          - crate: "wasmtime-cli --test all"
+          - crate: "wasmtime-cli --test wast"
+          - crate: "wasmtime-cli --lib --bins --test disable_host_trap_handlers --test disas --test rlimited-memory --test wasi"
           - crate: "wasmtime-environ --all-features"
           - crate: "pulley-interpreter --all-features"
           - crate: "wasmtime-internal-core"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -962,22 +962,14 @@ jobs:
     # Since MPK (PKU) is not present on some GitHub runners, we check if it is
     # available before force-enabling it. This occasional testing is better than
     # none at all; ideally we would test in a system-mode QEMU VM.
-    #
-    # We probe via /proc/cpuinfo rather than `cargo run --example
-    # mpk-available` because the latter previously cost ~3.5 minutes by
-    # building wasmtime with a feature set that did not match the subsequent
-    # `cargo test --all-features` step, forcing a rebuild. The conditions
-    # checked here mirror what `wasmtime::vm::mpk::is_supported` does on
-    # Linux x86_64: Intel CPU with the PKU CPUID bit set.
     - name: Force-run with MPK enabled, if available
       if: ${{ contains(matrix.name, 'MPK') }}
       run: |
-        if grep -q '^vendor_id.*GenuineIntel' /proc/cpuinfo \
-           && grep -qE '^flags.*\bpku\b' /proc/cpuinfo; then
+        if cargo run -q -p wasmtime-internal-core --example mpk-available; then
           echo "::notice::This CI run will force-enable MPK; this ensures tests conditioned with the \`WASMTIME_TEST_FORCE_MPK\` environment variable will run with MPK-protected memory pool stripes."
           echo WASMTIME_TEST_FORCE_MPK=1 >> $GITHUB_ENV
         else
-          echo "::warning::This CI run will not test MPK; it has been detected as not available on this machine (no Intel CPU with PKU flag in /proc/cpuinfo)."
+          echo "::warning::This CI run will not test MPK; it has been detected as not available on this machine."
         fi
 
     # Install VTune, see `cli_tests::profile_with_vtune`.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1327,14 +1327,13 @@ jobs:
   build:
     needs: determine
     if: needs.determine.outputs.run-full
-    name: Release ${{ matrix.component }} for ${{ matrix.platform.build }}
-    runs-on: ${{ matrix.platform.os }}
+    name: Release ${{ matrix.component }} for ${{ matrix.build }}
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: ${{ github.event_name != 'pull_request' }}
       matrix:
-        component: [cli, capi]
-        platform: ${{ fromJson(needs.determine.outputs.build-matrix) }}
-    env: ${{ matrix.platform.env || fromJSON('{}') }}
+        include: ${{ fromJson(needs.determine.outputs.build-matrix) }}
+    env: ${{ matrix.env || fromJSON('{}') }}
     steps:
     - uses: actions/checkout@v6
       with:
@@ -1343,43 +1342,40 @@ jobs:
         submodules: false
 
     - uses: ./.github/actions/docker-build-cached
-      if: ${{ matrix.platform.env.DOCKER_IMAGE }}
+      if: ${{ matrix.env.DOCKER_IMAGE }}
       with:
         context: ci/docker
-        file: ${{ matrix.platform.env.DOCKER_IMAGE }}
-        cache_key_prefix: docker-${{ matrix.platform.target }}
+        file: ${{ matrix.env.DOCKER_IMAGE }}
+        cache_key_prefix: docker-${{ matrix.target }}
 
     - uses: ./.github/actions/install-ninja
-      if: matrix.component == 'capi' && !matrix.platform.env.DOCKER_IMAGE
+      if: matrix.component == 'capi' && !matrix.env.DOCKER_IMAGE
 
     - uses: ./.github/actions/install-rust
       with:
-        toolchain: ${{ matrix.platform.rust }}
+        toolchain: ${{ matrix.rust }}
         wasm-targets: 'false'
     - run: |
-        rustup target add ${{ matrix.platform.target }}
+        rustup target add ${{ matrix.target }}
     - run: rustup component add rust-src
-      if: contains(matrix.platform.build, '-min')
+      if: contains(matrix.build, '-min')
 
     # On one builder produce the source tarball since there's no need to produce
     # it everywhere
     - run: ./ci/build-src-tarball.sh
-      if: matrix.component == 'cli' && matrix.platform.build == 'x86_64-linux'
+      if: matrix.component == 'cli' && matrix.build == 'x86_64-linux'
 
     - uses: ./.github/actions/android-ndk
-      if: contains(matrix.platform.target, 'android')
+      if: contains(matrix.target, 'android')
       with:
-        target: ${{ matrix.platform.target }}
+        target: ${{ matrix.target }}
 
-    - run: ./ci/build-release-artifacts.sh "${{ matrix.platform.build }}" "${{ matrix.platform.target }}" "${{ matrix.component }}"
-
-    # Assemble release artifacts appropriate for this platform, then upload them
-    # unconditionally to this workflow's files so we have a copy of them.
-    - run: ./ci/build-tarballs.sh "${{ matrix.platform.build }}" "${{ matrix.platform.target }}" "${{ matrix.component }}"
+    - run: ./ci/build-release-artifacts.sh "${{ matrix.build }}" "${{ matrix.target }}" "${{ matrix.component }}"
+    - run: ./ci/build-tarballs.sh "${{ matrix.build }}" "${{ matrix.target }}" "${{ matrix.component }}"
 
     - uses: actions/upload-artifact@v6
       with:
-        name: bins-${{ matrix.component }}-${{ matrix.platform.build }}
+        name: bins-${{ matrix.component }}-${{ matrix.build }}
         path: dist
 
   # This is a "join node" which depends on all prior workflows. The merge queue,

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1335,7 +1335,9 @@ jobs:
     steps:
     - uses: actions/checkout@v6
       with:
-        submodules: true
+        # Release builds don't run tests and don't need the test submodules
+        # (spec-testsuite, wasi-testsuite, component-model, etc.).
+        submodules: false
 
     # Build the docker image here, before it's built below, to have
     # finer-grained control over caching. The way this is set up is that the
@@ -1357,9 +1359,11 @@ jobs:
     - uses: ./.github/actions/install-rust
       with:
         toolchain: ${{ matrix.rust }}
+        wasm-targets: 'false'
     - run: |
-        rustup component add rust-src
         rustup target add ${{ matrix.target }}
+    - run: rustup component add rust-src
+      if: contains(matrix.build, '-min')
 
     # On one builder produce the source tarball since there's no need to produce
     # it everywhere

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -493,6 +493,36 @@ jobs:
     - run: rustup component add clippy
     - run: cargo clippy --workspace --all-targets --features p3,component-model-async
 
+  # Verify that the workspace compiles cleanly under the MSRV toolchain. This
+  # job replaces a previous `Test MSRV` matrix entry which ran the full test
+  # suite under MSRV; running tests adds no coverage beyond running them on
+  # current stable on the same target, while `cargo check` catches the
+  # behavior we actually care about: "did we use a Rust feature too new for
+  # our MSRV?".
+  #
+  # The excludes mirror `ci/run-tests.py` so that crates which require
+  # nightly toolchains or external dependencies (OCaml, SMT solvers) are
+  # skipped.
+  msrv_check:
+    name: MSRV check
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        submodules: true
+    - uses: ./.github/actions/install-rust
+      with:
+        toolchain: msrv
+    - run: |
+        cargo check --workspace --all-targets --all-features --locked \
+          --exclude test-programs \
+          --exclude wasmtime-wasi-nn \
+          --exclude wasmtime-wasi-tls \
+          --exclude wasmtime-fuzzing \
+          --exclude wasm-spec-interpreter \
+          --exclude veri_engine \
+          --exclude calculator
+
   # Similar to `micro_checks` but where we need to install some more state
   # (e.g. Android NDK) and we haven't factored support for those things out into
   # a parallel jobs yet.
@@ -930,14 +960,22 @@ jobs:
     # Since MPK (PKU) is not present on some GitHub runners, we check if it is
     # available before force-enabling it. This occasional testing is better than
     # none at all; ideally we would test in a system-mode QEMU VM.
+    #
+    # We probe via /proc/cpuinfo rather than `cargo run --example
+    # mpk-available` because the latter previously cost ~3.5 minutes by
+    # building wasmtime with a feature set that did not match the subsequent
+    # `cargo test --all-features` step, forcing a rebuild. The conditions
+    # checked here mirror what `wasmtime::vm::mpk::is_supported` does on
+    # Linux x86_64: Intel CPU with the PKU CPUID bit set.
     - name: Force-run with MPK enabled, if available
       if: ${{ contains(matrix.name, 'MPK') }}
       run: |
-        if cargo run --example mpk-available; then
+        if grep -q '^vendor_id.*GenuineIntel' /proc/cpuinfo \
+           && grep -qE '^flags.*\bpku\b' /proc/cpuinfo; then
           echo "::notice::This CI run will force-enable MPK; this ensures tests conditioned with the \`WASMTIME_TEST_FORCE_MPK\` environment variable will run with MPK-protected memory pool stripes."
           echo WASMTIME_TEST_FORCE_MPK=1 >> $GITHUB_ENV
         else
-          echo "::warning::This CI run will not test MPK; it has been detected as not available on this machine (\`cargo run --example mpk-available\`)."
+          echo "::warning::This CI run will not test MPK; it has been detected as not available on this machine (no Intel CPU with PKU flag in /proc/cpuinfo)."
         fi
 
     # Install VTune, see `cli_tests::profile_with_vtune`.
@@ -1387,6 +1425,7 @@ jobs:
       - special_tests
       - test_wasi_tls
       - clippy
+      - msrv_check
       - monolith_checks
       - platform_checks
       - bench

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1320,7 +1320,7 @@ jobs:
     - run: ${{ matrix.script }}
       if: ${{ matrix.script }}
 
-  # Perform release builds of `wasmtime` and `libwasmtime.so`. Builds a variety
+  # Perform release builds of `wasmtime` (the CLI binary). Builds a variety
   # of platforms and architectures and then uploads the release artifacts to
   # this workflow run's list of artifacts.
   #
@@ -1328,12 +1328,14 @@ jobs:
   build:
     needs: determine
     if: needs.determine.outputs.run-full
-    name: Release build for ${{ matrix.build }}
-    runs-on: ${{ matrix.os }}
+    name: Release ${{ matrix.component }} for ${{ matrix.platform.build }}
+    runs-on: ${{ matrix.platform.os }}
     strategy:
       fail-fast: ${{ github.event_name != 'pull_request' }}
-      matrix: ${{ fromJson(needs.determine.outputs.build-matrix) }}
-    env: ${{ matrix.env || fromJSON('{}') }}
+      matrix:
+        component: [cli, capi]
+        platform: ${{ fromJson(needs.determine.outputs.build-matrix) }}
+    env: ${{ matrix.platform.env || fromJSON('{}') }}
     steps:
     - uses: actions/checkout@v6
       with:
@@ -1341,51 +1343,44 @@ jobs:
         # (spec-testsuite, wasi-testsuite, component-model, etc.).
         submodules: false
 
-    # Build the docker image here, before it's built below, to have
-    # finer-grained control over caching. The way this is set up is that the
-    # build in this step is picked up by the later step automatically, and if
-    # this one's buggy the next one will just take a bit longer.
-    #
-    # The goal here is to hit the network less because apt-get servers tend
-    # to be relatively flaky...
     - uses: ./.github/actions/docker-build-cached
-      if: ${{ matrix.env.DOCKER_IMAGE }}
+      if: ${{ matrix.platform.env.DOCKER_IMAGE }}
       with:
         context: ci/docker
-        file: ${{ matrix.env.DOCKER_IMAGE }}
-        cache_key_prefix: docker-${{ matrix.target }}
+        file: ${{ matrix.platform.env.DOCKER_IMAGE }}
+        cache_key_prefix: docker-${{ matrix.platform.target }}
 
     - uses: ./.github/actions/install-ninja
-      if: '${{ !matrix.env.DOCKER_IMAGE }}'
+      if: matrix.component == 'capi' && !matrix.platform.env.DOCKER_IMAGE
 
     - uses: ./.github/actions/install-rust
       with:
-        toolchain: ${{ matrix.rust }}
+        toolchain: ${{ matrix.platform.rust }}
         wasm-targets: 'false'
     - run: |
-        rustup target add ${{ matrix.target }}
+        rustup target add ${{ matrix.platform.target }}
     - run: rustup component add rust-src
-      if: contains(matrix.build, '-min')
+      if: contains(matrix.platform.build, '-min')
 
     # On one builder produce the source tarball since there's no need to produce
     # it everywhere
     - run: ./ci/build-src-tarball.sh
-      if: matrix.build == 'x86_64-linux'
+      if: matrix.component == 'cli' && matrix.platform.build == 'x86_64-linux'
 
     - uses: ./.github/actions/android-ndk
-      if: contains(matrix.target, 'android')
+      if: contains(matrix.platform.target, 'android')
       with:
-        target: ${{ matrix.target }}
+        target: ${{ matrix.platform.target }}
 
-    - run: ./ci/build-release-artifacts.sh "${{ matrix.build }}" "${{ matrix.target }}"
+    - run: ./ci/build-release-artifacts.sh "${{ matrix.platform.build }}" "${{ matrix.platform.target }}" "${{ matrix.component }}"
 
     # Assemble release artifacts appropriate for this platform, then upload them
     # unconditionally to this workflow's files so we have a copy of them.
-    - run: ./ci/build-tarballs.sh "${{ matrix.build }}" "${{ matrix.target }}"
+    - run: ./ci/build-tarballs.sh "${{ matrix.platform.build }}" "${{ matrix.platform.target }}" "${{ matrix.component }}"
 
     - uses: actions/upload-artifact@v6
       with:
-        name: bins-${{ matrix.build }}
+        name: bins-${{ matrix.component }}-${{ matrix.platform.build }}
         path: dist
 
   # This is a "join node" which depends on all prior workflows. The merge queue,

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1288,8 +1288,7 @@ jobs:
         include:
           - crate: "wasmtime --features component-model-async-bytes"
           - crate: "wasmtime-cli --test all"
-          - crate: "wasmtime-cli --test wast"
-          - crate: "wasmtime-cli --lib --bins --test disable_host_trap_handlers --test disas --test rlimited-memory --test wasi"
+          - crate: "wasmtime-cli --lib --bins --test disable_host_trap_handlers --test rlimited-memory"
           - crate: "wasmtime-environ --all-features"
           - crate: "pulley-interpreter --all-features"
           - crate: "wasmtime-internal-core"

--- a/ci/build-build-matrix.js
+++ b/ci/build-build-matrix.js
@@ -137,4 +137,13 @@ for (let build of array) {
   builds.push(build);
 }
 
-console.log(JSON.stringify(builds));
+// Expand each platform entry into two jobs: one for the CLI binary and one for
+// the C API. This lets them build in parallel on separate runners.
+const expanded = [];
+for (const entry of builds) {
+  for (const component of ["cli", "capi"]) {
+    expanded.push(Object.assign({}, entry, { component }));
+  }
+}
+
+console.log(JSON.stringify(expanded));

--- a/ci/build-release-artifacts.sh
+++ b/ci/build-release-artifacts.sh
@@ -8,11 +8,17 @@
 # This script takes a Rust target as its first input and optionally a parameter
 # afterwards which can be "-min" to indicate that a minimal build should be
 # produced with as many features as possible stripped out.
+#
+# An optional third parameter selects which component to build:
+#   "cli"  — only the wasmtime CLI binary
+#   "capi" — only the C API (via cmake)
+#   ""     — both (default, for backwards compatibility)
 
 set -ex
 
 build=$1
 target=$2
+component=${3:-}
 wrapper=""
 
 # If `$DOCKER_IMAGE` is set then run the build inside of that docker container
@@ -68,37 +74,41 @@ if [[ "$target" = "x86_64-pc-windows-msvc" ]]; then
   export CXX=clang++
 fi
 
-cargo build --release $flags --target $target -p wasmtime-cli $bin_flags --features run
+if [[ "$component" != "capi" ]]; then
+  cargo build --release $flags --target $target -p wasmtime-cli $bin_flags --features run
+fi
 
-# For the C API force unwind tables to be emitted to make the generated objects
-# more flexible. Embedders can always build without this but this enables
-# libunwind to produce better backtraces by default when Wasmtime is linked into
-# a different project that wants to unwind.
-export RUSTFLAGS="$RUSTFLAGS -C force-unwind-tables"
+if [[ "$component" != "cli" ]]; then
+  # For the C API force unwind tables to be emitted to make the generated objects
+  # more flexible. Embedders can always build without this but this enables
+  # libunwind to produce better backtraces by default when Wasmtime is linked into
+  # a different project that wants to unwind.
+  export RUSTFLAGS="$RUSTFLAGS -C force-unwind-tables"
 
-# Shrink the size of `*.a` artifacts without spending too much extra time in CI.
-# See #11476 for some more context. Here Windows builds achieve this with 1 CGU
-# which results in modest size gains, and other platforms use LTO to achieve
-# much more significant size gains. The reason the platforms are different is
-# that CI is extremely slow on Windows, almost 2x slower, so this is an attempt
-# to keep CI cycle time under control.
-case $build in
-  *-mingw* | *-windows*)
-    export CARGO_PROFILE_RELEASE_CODEGEN_UNITS=1
-    ;;
-  *)
-    export CARGO_PROFILE_RELEASE_LTO=true
-    ;;
-esac
+  # Shrink the size of `*.a` artifacts without spending too much extra time in CI.
+  # See #11476 for some more context. Here Windows builds achieve this with 1 CGU
+  # which results in modest size gains, and other platforms use LTO to achieve
+  # much more significant size gains. The reason the platforms are different is
+  # that CI is extremely slow on Windows, almost 2x slower, so this is an attempt
+  # to keep CI cycle time under control.
+  case $build in
+    *-mingw* | *-windows*)
+      export CARGO_PROFILE_RELEASE_CODEGEN_UNITS=1
+      ;;
+    *)
+      export CARGO_PROFILE_RELEASE_LTO=true
+      ;;
+  esac
 
-mkdir -p target/c-api-build
-cd target/c-api-build
-cmake \
-  -G Ninja \
-  ../../crates/c-api \
-  $cmake_flags \
-  -DCMAKE_BUILD_TYPE=Release \
-  -DWASMTIME_TARGET=$target \
-  -DCMAKE_INSTALL_PREFIX=../c-api-install \
-  -DCMAKE_INSTALL_LIBDIR=../c-api-install/lib
-cmake --build . --target install
+  mkdir -p target/c-api-build
+  cd target/c-api-build
+  cmake \
+    -G Ninja \
+    ../../crates/c-api \
+    $cmake_flags \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DWASMTIME_TARGET=$target \
+    -DCMAKE_INSTALL_PREFIX=../c-api-install \
+    -DCMAKE_INSTALL_LIBDIR=../c-api-install/lib
+  cmake --build . --target install
+fi

--- a/ci/build-tarballs.sh
+++ b/ci/build-tarballs.sh
@@ -6,6 +6,10 @@
 #
 # * The first argument is the name of the "build", used to name the release.
 # * The second argument is the Rust target that the build was performed for.
+# * An optional third argument selects which component to package:
+#   "cli"  — only the CLI binary tarball (+ MSI on Windows)
+#   "capi" — only the C API tarball
+#   ""     — both (default, for backwards compatibility)
 #
 # This expects the build to already be done and will assemble release artifacts
 # in `dist/`
@@ -14,6 +18,7 @@ set -ex
 
 build=$1
 target=$2
+component=${3:-}
 
 rm -rf tmp
 mkdir tmp
@@ -34,56 +39,20 @@ fi
 bin_pkgname=wasmtime-$tag-$build_pkgname
 api_pkgname=wasmtime-$tag-$build_pkgname-c-api
 
-api_install=target/c-api-install
-mkdir tmp/$api_pkgname
-mkdir tmp/$bin_pkgname
-cp LICENSE README.md tmp/$api_pkgname
-cp LICENSE README.md tmp/$bin_pkgname
+fmt=tar
+case $build in
+  *-mingw* | *-windows*)
+    fmt=zip
+    ;;
+esac
 
 # For *-min builds rename artifacts with a `-min` suffix to avoid eventual
 # clashes with the normal builds when the tarballs are unioned together.
 if [[ $build == *-min ]]; then
   min="-min"
-  mkdir tmp/$api_pkgname/min
-  cp -r $api_install/include tmp/$api_pkgname/min
-  cp -r $api_install/lib tmp/$api_pkgname/min
 else
-  cp -r $api_install/include tmp/$api_pkgname
-  cp -r $api_install/lib tmp/$api_pkgname
+  min=""
 fi
-
-
-fmt=tar
-
-case $build in
-  x86_64-windows*)
-    cp target/$target/release/wasmtime.exe tmp/$bin_pkgname/wasmtime$min.exe
-    fmt=zip
-
-    if [ "$min" = "" ]; then
-      # Generate a `*.msi` installer for Windows as well
-      export WT_VERSION=`cat Cargo.toml | sed -n 's/^version = "\([^"]*\)".*/\1/p'`
-      "$WIX/bin/candle" -arch x64 -out target/wasmtime.wixobj ci/wasmtime.wxs
-      "$WIX/bin/light" -out dist/$bin_pkgname.msi target/wasmtime.wixobj -ext WixUtilExtension
-      rm dist/$bin_pkgname.wixpdb
-    fi
-    ;;
-
-  # Skip the MSI for non-x86_64 builds of Windows
-  x86_64-mingw* | *-windows*)
-    cp target/$target/release/wasmtime.exe tmp/$bin_pkgname/wasmtime$min.exe
-    fmt=zip
-    ;;
-
-  *-macos*)
-    cp target/$target/release/wasmtime tmp/$bin_pkgname/wasmtime$min
-    ;;
-
-  *)
-    cp target/$target/release/wasmtime tmp/$bin_pkgname/wasmtime$min
-    ;;
-esac
-
 
 mktarball() {
   dir=$1
@@ -96,5 +65,55 @@ mktarball() {
   fi
 }
 
-mktarball $api_pkgname
-mktarball $bin_pkgname
+# --- CLI binary tarball ---
+if [[ "$component" != "capi" ]]; then
+  mkdir tmp/$bin_pkgname
+  cp LICENSE README.md tmp/$bin_pkgname
+
+  case $build in
+    x86_64-windows*)
+      cp target/$target/release/wasmtime.exe tmp/$bin_pkgname/wasmtime$min.exe
+
+      if [ "$min" = "" ]; then
+        # Generate a `*.msi` installer for Windows as well
+        export WT_VERSION=`cat Cargo.toml | sed -n 's/^version = "\([^"]*\)".*/\1/p'`
+        "$WIX/bin/candle" -arch x64 -out target/wasmtime.wixobj ci/wasmtime.wxs
+        "$WIX/bin/light" -out dist/$bin_pkgname.msi target/wasmtime.wixobj -ext WixUtilExtension
+        rm dist/$bin_pkgname.wixpdb
+      fi
+      ;;
+
+    # Skip the MSI for non-x86_64 builds of Windows
+    x86_64-mingw* | *-windows*)
+      cp target/$target/release/wasmtime.exe tmp/$bin_pkgname/wasmtime$min.exe
+      ;;
+
+    *-macos*)
+      cp target/$target/release/wasmtime tmp/$bin_pkgname/wasmtime$min
+      ;;
+
+    *)
+      cp target/$target/release/wasmtime tmp/$bin_pkgname/wasmtime$min
+      ;;
+  esac
+
+  mktarball $bin_pkgname
+fi
+
+# --- C API tarball ---
+if [[ "$component" != "cli" ]]; then
+  api_install=target/c-api-install
+  mkdir tmp/$api_pkgname
+  cp LICENSE README.md tmp/$api_pkgname
+
+  if [[ $build == *-min ]]; then
+    mkdir tmp/$api_pkgname/min
+    cp -r $api_install/include tmp/$api_pkgname/min
+    cp -r $api_install/lib tmp/$api_pkgname/min
+  else
+    cp -r $api_install/include tmp/$api_pkgname
+    cp -r $api_install/lib tmp/$api_pkgname
+  fi
+
+  mktarball $api_pkgname
+fi

--- a/ci/build-test-matrix.js
+++ b/ci/build-test-matrix.js
@@ -13,7 +13,35 @@ const GENERIC_BUCKETS = 3;
 
 // Crates which are their own buckets. These are the very slowest to
 // compile-and-test crates.
-const SINGLE_CRATE_BUCKETS = ["wasmtime", "wasmtime-cli", "wasmtime-wasi"];
+//
+// An entry may be a string (the crate name, producing one bucket) or an
+// object `{ crate, sub: [{ name, args }, ...] }` to split a single crate's
+// tests across multiple buckets. Sub-bucketing is reserved for crates whose
+// integration tests dominate the wall clock and split cleanly along
+// `--test` boundaries; the build of the crate's dependencies and test
+// binaries is duplicated across the sub-buckets, but the test-execution
+// portion (the longer half on slow targets like QEMU) parallelizes.
+const SINGLE_CRATE_BUCKETS = [
+  "wasmtime",
+  {
+    "crate": "wasmtime-cli",
+    "sub": [
+      // The two largest integration suites; each gets its own bucket.
+      { "name": "all", "args": "--test all" },
+      { "name": "wast", "args": "--test wast" },
+      // Everything else in the crate: library, binaries, and the smaller
+      // integration tests. Cargo doesn't have an "exclude test" flag, so the
+      // remaining `--test` targets are enumerated explicitly.
+      { "name": "other", "args": "--lib --bins --test disable_host_trap_handlers --test disas --test rlimited-memory --test wasi" },
+    ],
+  },
+  "wasmtime-wasi",
+];
+
+// Helper: get just the crate name from a SINGLE_CRATE_BUCKETS entry.
+function singleBucketCrateName(entry) {
+  return typeof entry === "string" ? entry : entry.crate;
+}
 
 const ubuntu = 'ubuntu-24.04';
 const windows = 'windows-2025';
@@ -57,22 +85,29 @@ const FAST_MATRIX = [
 // * `sde` - if `true`, indicates this test should use Intel SDE for instruction
 //   emulation. SDE will be set up and configured as the test runner.
 //
+// * `crates` - if a string, this config is not sharded across the workspace
+//   and instead runs against only the named crate. If an array of strings,
+//   the config produces one job per named crate (each job's name suffixed
+//   with the crate name) and skips the generic buckets entirely. Used to
+//   restrict env-var-toggled test variants to only the crates that observe
+//   that env var (e.g. MPK).
+//
 // * `rust` - the Rust version to install, and if unset this'll be set to
 //   `default`
 const FULL_MATRIX = [
   ...FAST_MATRIX,
   {
-    "name": "Test MSRV",
-    "os": ubuntu,
-    "filter": "linux-x64",
-    "isa": "x64",
-    "rust": "msrv",
-  },
-  {
+    // MPK is only observed at test time by code that reads
+    // WASMTIME_TEST_FORCE_MPK (the `wasmtime` runtime crate and the
+    // root-level integration tests under `wasmtime-cli`). Restricting MPK
+    // testing to those two crates eliminates four redundant shards
+    // (3 generic + wasmtime-wasi) that produce identical results to
+    // `Test Linux x86_64`.
     "name": "Test MPK",
     "os": ubuntu,
     "filter": "linux-x64",
-    "isa": "x64"
+    "isa": "x64",
+    "crates": ["wasmtime", "wasmtime-cli"],
   },
   {
     "name": "Test ASAN",
@@ -219,40 +254,72 @@ async function shard(configs) {
 
   // Divide the workspace crates into N disjoint subsets. Crates that are
   // particularly expensive to compile and test form their own singleton subset.
+  // A bucket is either a Set of crate names (used as-is for `cargo test
+  // --workspace --exclude ...`) or an object `{ crate, sub }` describing a
+  // single-crate bucket that should be further split by `--test` filter.
+  const singleBucketCrateNames = new Set(SINGLE_CRATE_BUCKETS.map(singleBucketCrateName));
   const buckets = Array.from({ length: GENERIC_BUCKETS }, _ => new Set());
   let i = 0;
   for (const crate of members) {
-    if (SINGLE_CRATE_BUCKETS.indexOf(crate) != -1) continue;
+    if (singleBucketCrateNames.has(crate)) continue;
     buckets[i].add(crate);
     i = (i + 1) % GENERIC_BUCKETS;
   }
-  for (crate of SINGLE_CRATE_BUCKETS) {
-    buckets.push(new Set([crate]));
+  for (const entry of SINGLE_CRATE_BUCKETS) {
+    if (typeof entry === "string") {
+      buckets.push(new Set([entry]));
+    } else {
+      // A crate with sub-buckets: push one bucket per `sub` entry, retaining
+      // the crate name and extra-args for naming and bucket-arg expansion.
+      for (const sub of entry.sub) {
+        buckets.push({ crate: entry.crate, name: sub.name, args: sub.args });
+      }
+    }
   }
 
   // For each config, expand it into N configs, one for each disjoint set we
   // created above.
   const sharded = [];
   for (const config of configs) {
-    // If crates is specified, don't shard, just use the specified crates
+    // If `crates` is specified, don't shard against the generic buckets.
+    // A string value produces a single job for that crate; an array value
+    // produces one job per crate with the crate name appended to `name`.
     if (config.crates) {
-      sharded.push(Object.assign(
-        {},
-        config,
-        {
-          bucket: members
-            .map(c => c === config.crates ? `--package ${c}` : `--exclude ${c}`)
-            .join(" ")
-        }
-      ));
+      const cratesList = Array.isArray(config.crates) ? config.crates : [config.crates];
+      const useSuffix = Array.isArray(config.crates);
+      for (const crate of cratesList) {
+        sharded.push(Object.assign(
+          {},
+          config,
+          {
+            name: useSuffix ? `${config.name} (${crate})` : config.name,
+            bucket: members
+              .map(c => c === crate ? `--package ${c}` : `--exclude ${c}`)
+              .join(" "),
+          }
+        ));
+      }
       continue;
     }
 
     let nbucket = 1;
     for (const bucket of buckets) {
-      let bucket_name = `${nbucket}/${buckets.length}`;
-      if (bucket.size === 1)
-        bucket_name = Array.from(bucket)[0];
+      let bucket_name;
+      let bucket_args;
+      if (bucket instanceof Set) {
+        bucket_name = bucket.size === 1
+          ? Array.from(bucket)[0]
+          : `${nbucket}/${buckets.length}`;
+        bucket_args = members
+          .map(c => bucket.has(c) ? `--package ${c}` : `--exclude ${c}`)
+          .join(" ");
+      } else {
+        // Sub-bucket of a single crate.
+        bucket_name = `${bucket.crate}-${bucket.name}`;
+        bucket_args = members
+          .map(c => c === bucket.crate ? `--package ${c}` : `--exclude ${c}`)
+          .join(" ") + " " + bucket.args;
+      }
 
       sharded.push(Object.assign(
         {},
@@ -262,9 +329,7 @@ async function shard(configs) {
           // We run tests via `cargo test --workspace`, so exclude crates that
           // aren't in this bucket, rather than naming only the crates that are
           // in this bucket.
-          bucket: members
-            .map(c => bucket.has(c) ? `--package ${c}` : `--exclude ${c}`)
-            .join(" "),
+          bucket: bucket_args,
         }
       ));
       nbucket += 1;

--- a/ci/build-test-matrix.js
+++ b/ci/build-test-matrix.js
@@ -29,10 +29,10 @@ const SINGLE_CRATE_BUCKETS = [
       // The two largest integration suites; each gets its own bucket.
       { "name": "all", "args": "--test all" },
       { "name": "wast", "args": "--test wast" },
-      // Everything else in the crate: library, binaries, and the smaller
-      // integration tests. Cargo doesn't have an "exclude test" flag, so the
-      // remaining `--test` targets are enumerated explicitly.
-      { "name": "other", "args": "--lib --bins --test disable_host_trap_handlers --test disas --test rlimited-memory --test wasi" },
+      // Everything else in the crate: library, binaries, and the remaining
+      // integration tests. The test list is computed dynamically from cargo
+      // metadata so that new [[test]] targets are picked up automatically.
+      { "name": "other", "args": "--lib --bins", "remaining": true },
     ],
   },
   "wasmtime-wasi",
@@ -195,8 +195,9 @@ const FULL_MATRIX = [
   },
 ];
 
-/// Get the workspace's full list of member crates.
-async function getWorkspaceMembers() {
+/// Get workspace metadata: the list of member crate names and, for each
+/// member, the names of its `[[test]]` targets.
+async function getWorkspaceMetadata() {
   // Spawn a `cargo metadata` subprocess, accumulate its JSON output from
   // `stdout`, and wait for it to exit.
   const child = spawn("cargo", ["metadata"], { encoding: "utf8" });
@@ -207,15 +208,28 @@ async function getWorkspaceMembers() {
     child.on("error", reject);
   });
 
-  // Get the names of the crates in the workspace from the JSON metadata by
-  // building a package-id to name map and then translating the package-ids
-  // listed as workspace members.
+  // Get the names and test targets of the crates in the workspace from the 
+  // JSON metadata by building a package-id to package map and then translating
+  // the package-ids listed as workspace members.
   const metadata = JSON.parse(data);
-  const id_to_name = {};
+  const id_to_pkg = {};
   for (const pkg of metadata.packages) {
-    id_to_name[pkg.id] = pkg.name;
+    id_to_pkg[pkg.id] = pkg;
   }
-  return metadata.workspace_members.map(m => id_to_name[m]);
+
+  const members = [];
+  const testTargets = {};
+  for (const id of metadata.workspace_members) {
+    const pkg = id_to_pkg[id];
+    members.push(pkg.name);
+    const tests = pkg.targets
+      .filter(t => t.kind.includes("test"))
+      .map(t => t.name);
+    if (tests.length > 0) {
+      testTargets[pkg.name] = tests;
+    }
+  }
+  return { members, testTargets };
 }
 
 /// For each given target configuration, shard the workspace's crates into
@@ -250,7 +264,7 @@ async function getWorkspaceMembers() {
 /// `bucket` key, which contains the CLI flags we must pass to `cargo` to run
 /// tests for just this config's subset of crates.
 async function shard(configs) {
-  const members = await getWorkspaceMembers();
+  const { members, testTargets } = await getWorkspaceMetadata();
 
   // Divide the workspace crates into N disjoint subsets. Crates that are
   // particularly expensive to compile and test form their own singleton subset.
@@ -271,8 +285,26 @@ async function shard(configs) {
     } else {
       // A crate with sub-buckets: push one bucket per `sub` entry, retaining
       // the crate name and extra-args for naming and bucket-arg expansion.
+      // Collect test names claimed by non-remaining sub-buckets so that
+      // `remaining: true` entries can include everything else.
+      const claimed = new Set();
       for (const sub of entry.sub) {
-        buckets.push({ crate: entry.crate, name: sub.name, args: sub.args });
+        if (!sub.remaining) {
+          const m = sub.args.match(/--test\s+(\S+)/g);
+          if (m) {
+            m.forEach(s => claimed.add(s.replace(/^--test\s+/, "")));
+          }
+        }
+      }
+      const allTests = testTargets[entry.crate] || [];
+      const remainingTests = allTests.filter(t => !claimed.has(t));
+
+      for (const sub of entry.sub) {
+        let args = sub.args;
+        if (sub.remaining && remainingTests.length > 0) {
+          args += " " + remainingTests.map(t => `--test ${t}`).join(" ");
+        }
+        buckets.push({ crate: entry.crate, name: sub.name, args });
       }
     }
   }

--- a/crates/core/examples/mpk-available.rs
+++ b/crates/core/examples/mpk-available.rs
@@ -1,0 +1,17 @@
+//! Exit 0 if Wasmtime's MPK runtime support is available on this host,
+//! 1 otherwise. This shares the detection logic with `wasmtime`'s runtime
+//! `is_supported()` check via [`wasmtime_internal_core::mpk::is_supported`],
+//! so CI's "should we set `WASMTIME_TEST_FORCE_MPK=1`?" decision can never
+//! drift from what the runtime itself reports.
+
+use std::process::exit;
+
+fn main() {
+    if wasmtime_internal_core::mpk::is_supported() {
+        eprintln!("MPK is available");
+        exit(0);
+    } else {
+        eprintln!("MPK is not available");
+        exit(1);
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -21,6 +21,7 @@ extern crate std;
 pub mod alloc;
 pub mod error;
 pub mod math;
+pub mod mpk;
 pub mod non_max;
 pub mod slab;
 pub mod undo;

--- a/crates/core/src/mpk.rs
+++ b/crates/core/src/mpk.rs
@@ -1,0 +1,44 @@
+//! Detection of Memory Protection Keys (MPK) support on the host system.
+//!
+//! This is the single source of truth for whether Wasmtime's MPK
+//! implementation can be used on the current target. The runtime in the
+//! `wasmtime` crate consults [`is_supported`], and `examples/mpk-available.rs`
+//! exposes it as a CLI exit code so CI can decide whether to set
+//! `WASMTIME_TEST_FORCE_MPK=1`.
+
+/// Returns `true` if Wasmtime's MPK support can be used on this host.
+pub fn is_supported() -> bool {
+    cfg!(target_os = "linux") && cpuid_pku_bit_set()
+}
+
+/// Check the `ECX.PKU` flag (bit 3, zero-based) of the `07h` `CPUID` leaf; see
+/// the Intel Software Development Manual, vol 3a, section 2.7. This flag is
+/// only set on Intel CPUs, so this function also checks the `CPUID` vendor
+/// string.
+#[cfg(target_arch = "x86_64")]
+fn cpuid_pku_bit_set() -> bool {
+    is_intel_cpu() && {
+        #[allow(
+            unused_unsafe,
+            reason = "rust is transitioning to `__cpuid` being a safe function"
+        )]
+        let result = unsafe { core::arch::x86_64::__cpuid(0x07) };
+        (result.ecx & 0b1000) != 0
+    }
+}
+
+#[cfg(not(target_arch = "x86_64"))]
+fn cpuid_pku_bit_set() -> bool {
+    false
+}
+
+/// Check the `CPUID` vendor string for `GenuineIntel`; see the Intel Software
+/// Development Manual, vol 2a, `CPUID` description.
+#[cfg(target_arch = "x86_64")]
+fn is_intel_cpu() -> bool {
+    #[allow(unused_unsafe, reason = "see above about __cpuid")]
+    let result = unsafe { core::arch::x86_64::__cpuid(0) };
+    result.ebx == u32::from_le_bytes(*b"Genu")
+        && result.edx == u32::from_le_bytes(*b"ineI")
+        && result.ecx == u32::from_le_bytes(*b"ntel")
+}

--- a/crates/wasmtime/src/runtime/vm/mpk/enabled.rs
+++ b/crates/wasmtime/src/runtime/vm/mpk/enabled.rs
@@ -6,7 +6,7 @@ use std::sync::OnceLock;
 
 /// Check if the MPK feature is supported.
 pub fn is_supported() -> bool {
-    cfg!(target_os = "linux") && cfg!(target_arch = "x86_64") && pkru::has_cpuid_bit_set()
+    wasmtime_core::mpk::is_supported()
 }
 
 /// Allocate up to `max` protection keys.

--- a/crates/wasmtime/src/runtime/vm/mpk/pkru.rs
+++ b/crates/wasmtime/src/runtime/vm/mpk/pkru.rs
@@ -55,32 +55,6 @@ pub fn write(pkru: u32) {
     }
 }
 
-/// Check the `ECX.PKU` flag (bit 3, zero-based) of the `07h` `CPUID` leaf; see
-/// the Intel Software Development Manual, vol 3a, section 2.7. This flag is
-/// only set on Intel CPUs, so this function also checks the `CPUID` vendor
-/// string.
-pub fn has_cpuid_bit_set() -> bool {
-    #[allow(
-        unused_unsafe,
-        reason = "rust is transitioning to `__cpuid` being a safe function"
-    )]
-    let result = unsafe { core::arch::x86_64::__cpuid(0x07) };
-    is_intel_cpu() && (result.ecx & 0b1000) != 0
-}
-
-/// Check the `CPUID` vendor string for `GenuineIntel`; see the Intel Software
-/// Development Manual, vol 2a, `CPUID` description.
-pub fn is_intel_cpu() -> bool {
-    // To read the CPU vendor string, we pass 0 in EAX and read 12 ASCII bytes
-    // from EBX, EDX, and ECX (in that order).
-    #[allow(unused_unsafe, reason = "see above about __cpuid")]
-    let result = unsafe { core::arch::x86_64::__cpuid(0) };
-    // Then we check if the vendor string matches "GenuineIntel".
-    result.ebx == u32::from_le_bytes(*b"Genu")
-        && result.edx == u32::from_le_bytes(*b"ineI")
-        && result.ecx == u32::from_le_bytes(*b"ntel")
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
These ones are a bit more speculative than the ones in #13340, and are meant to shorten the wall-clock duration of full CI runs, not just PR runs.

More speculative because at least the last commit, parallelizing release builds of the wasmtime CLI and libwasmtime, comes at the cost of a fairly high degree of duplicate work per job, so we'll have to assess whether the reduction in wall-clock time is worth it.

Stacked on top of #13340.