### PR TITLE
Fix a MIRI violation when tracing passive element segment GC roots

### DIFF
--- a/crates/wasmtime/src/runtime/vm/instance.rs
+++ b/crates/wasmtime/src/runtime/vm/instance.rs
@@ -226,7 +226,7 @@ impl Instance {
     ) {
         for segment in self.passive_elements_mut().iter_mut() {
             if segment.needs_gc_rooting {
-                for e in segment.elements() {
+                for e in segment.elements_mut() {
                     if e.get_vmgcref().is_none() {
                         continue;
                     }
@@ -1987,5 +1987,11 @@ impl PassiveElementSegment {
     /// The elements of this segment.
     pub(crate) fn elements(&self) -> &[ValRaw] {
         &self.elements
+    }
+
+    /// The elements of this segment.
+    #[cfg(feature = "gc")]
+    pub(crate) fn elements_mut(&mut self) -> &mut [ValRaw] {
+        &mut self.elements
     }
 }


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
