### PR TITLE
Tweak the `miri-wast.sh` script

### DIFF
--- a/ci/miri-wast.sh
+++ b/ci/miri-wast.sh
@@ -13,9 +13,14 @@
 
 set -ex
 
-rm -rf ./miri-wast
-mkdir ./miri-wast
-cargo run -- wast --target pulley64 --precompile-save ./miri-wast "$@" \
+REPO="$(dirname $0)/.."
+CARGO_TOML="$REPO/Cargo.toml"
+MIRI_WAST="$REPO/target/miri-wast"
+
+rm -rf "$MIRI_WAST"
+mkdir -p "$MIRI_WAST"
+
+cargo run --manifest-path "$CARGO_TOML" -- wast --target pulley64 --precompile-save "$MIRI_WAST" "$@" \
   -O memory-reservation=$((1 << 20)) \
   -O memory-guard-size=0 \
   -O signals-based-traps=n \
@@ -23,7 +28,8 @@ cargo run -- wast --target pulley64 --precompile-save ./miri-wast "$@" \
   -W function-references,gc
 
 MIRIFLAGS="$MIRIFLAGS -Zmiri-disable-isolation -Zmiri-permissive-provenance" \
-  cargo miri run -- wast -Ccache=n --target pulley64 --precompile-load ./miri-wast "$@" \
+cargo miri run --manifest-path "$CARGO_TOML" -- \
+  wast -Ccache=n --target pulley64 --precompile-load "$MIRI_WAST" "$@" \
   -O memory-init-cow=n \
   -W function-references,gc \
   --ignore-error-messages


### PR DESCRIPTION
Just making it a little more robust and putting the `miri-wast` directory that it uses inside of `target`.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
