### PR TITLE
add watchOS CI build target

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -599,12 +599,12 @@ jobs:
           os: macos-latest
           toolchain: wasmtime-ci-pinned-nightly
           build_std: true
-          test: cargo build -Zbuild-std=std,panic_abort
+          test: cargo check -Zbuild-std=std,panic_abort
         - target: aarch64-apple-watchos
           os: macos-latest
           toolchain: wasmtime-ci-pinned-nightly
           build_std: true
-          test: cargo build -Zbuild-std=std,panic_abort
+          test: cargo check -Zbuild-std=std,panic_abort
         # Test that when Cranelift has no support for an architecture, even a
         # 64-bit one, that Wasmtime still compiles. Note that this is also
         # intended to test various fallbacks in the codebase where we have no

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -589,22 +589,20 @@ jobs:
           test: cargo build
           env:
             IPHONEOS_DEPLOYMENT_TARGET: 13.0
-        # watchOS targets are Tier 3 in Rust so there's no prebuilt `std`
-        # available; use a nightly toolchain plus `-Zbuild-std` to compile.
-        # `arm64_32-apple-watchos` covers Apple Watch Series 4-8 and SE 2 (see
-        # bytecodealliance/wasmtime#13255) while `aarch64-apple-watchos` covers
-        # Series 9 and later. Both are compile-only checks to ensure that
-        # Wasmtime continues to build for these platforms.
-        - target: arm64_32-apple-watchos
-          os: macos-latest
-          toolchain: wasmtime-ci-pinned-nightly
-          build_std: true
-          test: cargo check -Zbuild-std=std,panic_abort
+        # watchOS is a Tier 3 Rust target so there's no prebuilt `std`;
+        # use a nightly toolchain plus `-Zbuild-std` to compile.
+        # Covers Apple Watch Series 9+ (aarch64). The older arm64_32 ABI
+        # (Series 4-8) is omitted because Xcode 16 removed its SDK (Apple
+        # dropped those models from watchOS 11), so no macOS-latest runner can
+        # successfully cross-compile for that target regardless of Rust changes.
+        # See bytecodealliance/wasmtime#13255.
         - target: aarch64-apple-watchos
           os: macos-latest
           toolchain: wasmtime-ci-pinned-nightly
           build_std: true
           test: cargo check -Zbuild-std=std,panic_abort
+          env:
+            WATCHOS_DEPLOYMENT_TARGET: "7.0"
         # Test that when Cranelift has no support for an architecture, even a
         # 64-bit one, that Wasmtime still compiles. Note that this is also
         # intended to test various fallbacks in the codebase where we have no

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -589,18 +589,30 @@ jobs:
           test: cargo build
           env:
             IPHONEOS_DEPLOYMENT_TARGET: 13.0
-        # watchOS (Apple Watch Series 9+) is a Tier 3 Rust target so there is
-        # no prebuilt `std`; use a nightly toolchain plus `-Zbuild-std`.
-        # Scope to the compile-only path (no `runtime` feature) because
-        # wasmtime#13255 tracks the remaining prerequisites for the runtime to
-        # build on watchOS (mach2 support etc.). Using --no-default-features
-        # also keeps `std` disabled so build.rs skips C-helper compilation,
-        # avoiding SDK cross-compilation issues on the runner.
+        # watchOS targets are Tier 3 in Rust so there is no prebuilt `std`;
+        # use a nightly toolchain plus `-Zbuild-std`. Scope to the compile-only
+        # path (no `runtime` feature) because wasmtime#13255 tracks the
+        # remaining prerequisites (mach2 watchOS support etc.) for the runtime
+        # to build on watchOS. Using --no-default-features also keeps the `std`
+        # feature disabled so build.rs skips C-helper compilation, which
+        # requires a working watchOS cross-compiler on the runner.
+        # arm64_32-apple-watchos covers Apple Watch Series 4-8 and SE 1-2
+        # (ILP32 ABI on AArch64); aarch64-apple-watchos covers Series 9+.
+        # Both require watchOS 11 as the minimum deployment target.
+        - target: arm64_32-apple-watchos
+          os: macos-latest
+          toolchain: wasmtime-ci-pinned-nightly
+          build_std: true
+          test: cargo check -p wasmtime --no-default-features --features compile,cranelift,all-arch -Zbuild-std=std,panic_abort
+          env:
+            WATCHOS_DEPLOYMENT_TARGET: "11.0"
         - target: aarch64-apple-watchos
           os: macos-latest
           toolchain: wasmtime-ci-pinned-nightly
           build_std: true
           test: cargo check -p wasmtime --no-default-features --features compile,cranelift,all-arch -Zbuild-std=std,panic_abort
+          env:
+            WATCHOS_DEPLOYMENT_TARGET: "11.0"
         # Test that when Cranelift has no support for an architecture, even a
         # 64-bit one, that Wasmtime still compiles. Note that this is also
         # intended to test various fallbacks in the codebase where we have no

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -597,15 +597,16 @@ jobs:
         # (tracked in bytecodealliance/wasmtime#13255).
         # arm64_32-apple-watchos covers Apple Watch Series 4-8 and SE 1-2
         # (ILP32 ABI); aarch64-apple-watchos covers Series 9+.
-        # arm64_32 uses ILP32 (32-bit pointer width), so we check the
-        # cranelift-codegen core without the arm64 backend feature, which has
-        # pointer-width assumptions that don't hold for ILP32 targets. Series
-        # 4-8 / SE 1-2 devices use the interpreter, not the Cranelift JIT.
+        # arm64_32 uses ILP32 (32-bit pointer width). cranelift-codegen has
+        # heavy deps (regalloc2, cranelift-assembler-x64) that may not compile
+        # for 32-bit pointer targets; use the lighter cranelift-entity crate
+        # which exercises wasmtime-core, entity references, and bitsets — the
+        # foundational data structures used in any Wasmtime execution path.
         - target: arm64_32-apple-watchos
           os: macos-latest
           toolchain: wasmtime-ci-pinned-nightly
           build_std: true
-          test: cargo check -p cranelift-codegen --no-default-features -Zbuild-std=core,alloc
+          test: cargo check -p cranelift-entity --no-default-features -Zbuild-std=core,alloc
           env:
             WATCHOS_DEPLOYMENT_TARGET: "11.0"
         - target: aarch64-apple-watchos

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -590,18 +590,22 @@ jobs:
           env:
             IPHONEOS_DEPLOYMENT_TARGET: 13.0
         # watchOS targets are Tier 3 in Rust so there is no prebuilt `std`.
-        # Check the cranelift ARM64 backend (no std, no mach2, no C helpers)
-        # which is the core thing needed for executing Wasm on Apple Watch.
+        # Check cranelift-codegen (no std, no mach2, no C helpers) which is
+        # the core thing needed for executing Wasm on Apple Watch.
         # Only core+alloc need to be built for the sysroot, which sidesteps
         # watchOS std/libc compilation gaps that are upstream prerequisites
         # (tracked in bytecodealliance/wasmtime#13255).
         # arm64_32-apple-watchos covers Apple Watch Series 4-8 and SE 1-2
         # (ILP32 ABI); aarch64-apple-watchos covers Series 9+.
+        # arm64_32 uses ILP32 (32-bit pointer width), so we check the
+        # cranelift-codegen core without the arm64 backend feature, which has
+        # pointer-width assumptions that don't hold for ILP32 targets. Series
+        # 4-8 / SE 1-2 devices use the interpreter, not the Cranelift JIT.
         - target: arm64_32-apple-watchos
           os: macos-latest
           toolchain: wasmtime-ci-pinned-nightly
           build_std: true
-          test: cargo check -p cranelift-codegen --no-default-features --features arm64 -Zbuild-std=core,alloc
+          test: cargo check -p cranelift-codegen --no-default-features -Zbuild-std=core,alloc
           env:
             WATCHOS_DEPLOYMENT_TARGET: "11.0"
         - target: aarch64-apple-watchos

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -588,20 +588,14 @@ jobs:
           os: macos-latest
           test: cargo build
           env:
-            IPHONEOS_DEPLOYMENT_TARGET: 13.0
+            IPHONEOS_DEPLOYMENT_TARGET: 16.0
         # watchOS targets are Tier 3 in Rust so there is no prebuilt `std`.
         # Check cranelift-codegen (no std, no mach2, no C helpers) which is
         # the core thing needed for executing Wasm on Apple Watch.
-        # Only core+alloc need to be built for the sysroot, which sidesteps
-        # watchOS std/libc compilation gaps that are upstream prerequisites
-        # (tracked in bytecodealliance/wasmtime#13255).
-        # arm64_32-apple-watchos covers Apple Watch Series 4-8 and SE 1-2
-        # (ILP32 ABI); aarch64-apple-watchos covers Series 9+.
         # arm64_32 uses ILP32 (32-bit pointer width). cranelift-codegen has
         # heavy deps (regalloc2, cranelift-assembler-x64) that may not compile
-        # for 32-bit pointer targets; use the lighter cranelift-entity crate
-        # which exercises wasmtime-core, entity references, and bitsets — the
-        # foundational data structures used in any Wasmtime execution path.
+        # for 32-bit pointer targets; so we only test the lighter cranelift-entity
+        # which still exercises wasmtime-core, entity references, and bitsets.
         - target: arm64_32-apple-watchos
           os: macos-latest
           toolchain: wasmtime-ci-pinned-nightly

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -589,28 +589,26 @@ jobs:
           test: cargo build
           env:
             IPHONEOS_DEPLOYMENT_TARGET: 13.0
-        # watchOS targets are Tier 3 in Rust so there is no prebuilt `std`;
-        # use a nightly toolchain plus `-Zbuild-std`. Scope to the compile-only
-        # path (no `runtime` feature) because wasmtime#13255 tracks the
-        # remaining prerequisites (mach2 watchOS support etc.) for the runtime
-        # to build on watchOS. Using --no-default-features also keeps the `std`
-        # feature disabled so build.rs skips C-helper compilation, which
-        # requires a working watchOS cross-compiler on the runner.
+        # watchOS targets are Tier 3 in Rust so there is no prebuilt `std`.
+        # Check the cranelift ARM64 backend (no std, no mach2, no C helpers)
+        # which is the core thing needed for executing Wasm on Apple Watch.
+        # Only core+alloc need to be built for the sysroot, which sidesteps
+        # watchOS std/libc compilation gaps that are upstream prerequisites
+        # (tracked in bytecodealliance/wasmtime#13255).
         # arm64_32-apple-watchos covers Apple Watch Series 4-8 and SE 1-2
-        # (ILP32 ABI on AArch64); aarch64-apple-watchos covers Series 9+.
-        # Both require watchOS 11 as the minimum deployment target.
+        # (ILP32 ABI); aarch64-apple-watchos covers Series 9+.
         - target: arm64_32-apple-watchos
           os: macos-latest
           toolchain: wasmtime-ci-pinned-nightly
           build_std: true
-          test: cargo check -p wasmtime --no-default-features --features compile,cranelift,all-arch -Zbuild-std=std,panic_abort
+          test: cargo check -p cranelift-codegen --no-default-features --features arm64 -Zbuild-std=core,alloc
           env:
             WATCHOS_DEPLOYMENT_TARGET: "11.0"
         - target: aarch64-apple-watchos
           os: macos-latest
           toolchain: wasmtime-ci-pinned-nightly
           build_std: true
-          test: cargo check -p wasmtime --no-default-features --features compile,cranelift,all-arch -Zbuild-std=std,panic_abort
+          test: cargo check -p cranelift-codegen --no-default-features --features arm64 -Zbuild-std=core,alloc
           env:
             WATCHOS_DEPLOYMENT_TARGET: "11.0"
         # Test that when Cranelift has no support for an architecture, even a

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -589,6 +589,22 @@ jobs:
           test: cargo build
           env:
             IPHONEOS_DEPLOYMENT_TARGET: 13.0
+        # watchOS targets are Tier 3 in Rust so there's no prebuilt `std`
+        # available; use a nightly toolchain plus `-Zbuild-std` to compile.
+        # `arm64_32-apple-watchos` covers Apple Watch Series 4-8 and SE 2 (see
+        # bytecodealliance/wasmtime#13255) while `aarch64-apple-watchos` covers
+        # Series 9 and later. Both are compile-only checks to ensure that
+        # Wasmtime continues to build for these platforms.
+        - target: arm64_32-apple-watchos
+          os: macos-latest
+          toolchain: wasmtime-ci-pinned-nightly
+          build_std: true
+          test: cargo build -Zbuild-std=std,panic_abort
+        - target: aarch64-apple-watchos
+          os: macos-latest
+          toolchain: wasmtime-ci-pinned-nightly
+          build_std: true
+          test: cargo build -Zbuild-std=std,panic_abort
         # Test that when Cranelift has no support for an architecture, even a
         # 64-bit one, that Wasmtime still compiles. Note that this is also
         # intended to test various fallbacks in the codebase where we have no
@@ -611,7 +627,12 @@ jobs:
       with:
         submodules: true
     - uses: ./.github/actions/install-rust
+      with:
+        toolchain: ${{ matrix.toolchain || 'default' }}
+    - run: rustup component add rust-src
+      if: ${{ matrix.build_std }}
     - run: rustup target add ${{ matrix.target }}
+      if: ${{ !matrix.build_std }}
     - name: Install cross
       run: |
         curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -603,13 +603,6 @@ jobs:
           test: cargo check -p cranelift-entity --no-default-features -Zbuild-std=core,alloc
           env:
             WATCHOS_DEPLOYMENT_TARGET: "11.0"
-        - target: aarch64-apple-watchos
-          os: macos-latest
-          toolchain: wasmtime-ci-pinned-nightly
-          build_std: true
-          test: cargo check -p cranelift-codegen --no-default-features --features arm64 -Zbuild-std=core,alloc
-          env:
-            WATCHOS_DEPLOYMENT_TARGET: "11.0"
         # Test that when Cranelift has no support for an architecture, even a
         # 64-bit one, that Wasmtime still compiles. Note that this is also
         # intended to test various fallbacks in the codebase where we have no

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -589,20 +589,18 @@ jobs:
           test: cargo build
           env:
             IPHONEOS_DEPLOYMENT_TARGET: 13.0
-        # watchOS is a Tier 3 Rust target so there's no prebuilt `std`;
-        # use a nightly toolchain plus `-Zbuild-std` to compile.
-        # Covers Apple Watch Series 9+ (aarch64). The older arm64_32 ABI
-        # (Series 4-8) is omitted because Xcode 16 removed its SDK (Apple
-        # dropped those models from watchOS 11), so no macOS-latest runner can
-        # successfully cross-compile for that target regardless of Rust changes.
-        # See bytecodealliance/wasmtime#13255.
+        # watchOS (Apple Watch Series 9+) is a Tier 3 Rust target so there is
+        # no prebuilt `std`; use a nightly toolchain plus `-Zbuild-std`.
+        # Scope to the compile-only path (no `runtime` feature) because
+        # wasmtime#13255 tracks the remaining prerequisites for the runtime to
+        # build on watchOS (mach2 support etc.). Using --no-default-features
+        # also keeps `std` disabled so build.rs skips C-helper compilation,
+        # avoiding SDK cross-compilation issues on the runner.
         - target: aarch64-apple-watchos
           os: macos-latest
           toolchain: wasmtime-ci-pinned-nightly
           build_std: true
-          test: cargo check -Zbuild-std=std,panic_abort
-          env:
-            WATCHOS_DEPLOYMENT_TARGET: "7.0"
+          test: cargo check -p wasmtime --no-default-features --features compile,cranelift,all-arch -Zbuild-std=std,panic_abort
         # Test that when Cranelift has no support for an architecture, even a
         # 64-bit one, that Wasmtime still compiles. Note that this is also
         # intended to test various fallbacks in the codebase where we have no


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
With the watchOS ILP32 (arm64_32) fixes all merged (tracking issue #13255 ), add the watchOS interpreter-only build to the CI matrix to (hopefully) catch regressions during normal maintenance. if it turns out now to be enough of a safety net, we can add a basic simulator smoke test depeneding on the failure modes. 