### PR TITLE
Update wasm-tools dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2254,8 +2254,7 @@ dependencies = [
 [[package]]
 name = "json-from-wast"
 version = "0.248.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692e5e6883558fb83746e7ab1da0d94a69b31286f88ecaa9ce6add0f269da0b6"
+source = "git+https://github.com/bytecodealliance/wasm-tools#649c4ea2a33d50705708ed03984f2284031b4667"
 dependencies = [
  "anyhow",
  "serde",
@@ -3744,7 +3743,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand 2.3.0",
- "getrandom 0.4.2",
+ "getrandom 0.3.1",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
@@ -4485,8 +4484,7 @@ checksum = "6ee99da9c5ba11bd675621338ef6fa52296b76b83305e9b6e5c77d4c286d6d49"
 [[package]]
 name = "wasm-compose"
 version = "0.248.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96ba953e2b9b4b4b52a31cf4e3ee1c1374c872b6e012cf2138d1c37cba00bfd6"
+source = "git+https://github.com/bytecodealliance/wasm-tools#649c4ea2a33d50705708ed03984f2284031b4667"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -4522,8 +4520,7 @@ dependencies = [
 [[package]]
 name = "wasm-encoder"
 version = "0.248.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac92cf547bc18d27ecc521015c08c353b4f18b84ab388bb6d1b6b682c620d9b6"
+source = "git+https://github.com/bytecodealliance/wasm-tools#649c4ea2a33d50705708ed03984f2284031b4667"
 dependencies = [
  "leb128fmt",
  "wasmparser 0.248.0",
@@ -4556,8 +4553,7 @@ dependencies = [
 [[package]]
 name = "wasm-metadata"
 version = "0.248.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee4f85f11dcdabc91e805c03eb84ccc7b7ef2282c6610bb83c7a7c853425850c"
+source = "git+https://github.com/bytecodealliance/wasm-tools#649c4ea2a33d50705708ed03984f2284031b4667"
 dependencies = [
  "anyhow",
  "indexmap 2.14.0",
@@ -4568,8 +4564,7 @@ dependencies = [
 [[package]]
 name = "wasm-mutate"
 version = "0.248.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6210f23d92145ecdbc04e27d4b570714148e45c61db913f1f69a38fe80fb61d7"
+source = "git+https://github.com/bytecodealliance/wasm-tools#649c4ea2a33d50705708ed03984f2284031b4667"
 dependencies = [
  "egg",
  "log",
@@ -4582,8 +4577,7 @@ dependencies = [
 [[package]]
 name = "wasm-smith"
 version = "0.248.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "050b559c1cec6dd6b9a558ae984d91d61e5e7b4c3e47081305a13efe6869eea0"
+source = "git+https://github.com/bytecodealliance/wasm-tools#649c4ea2a33d50705708ed03984f2284031b4667"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -4605,8 +4599,7 @@ dependencies = [
 [[package]]
 name = "wasm-wave"
 version = "0.248.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8c928a58132ecc6a4daee3795bb3560702436f6516b5f8c5b3086113031e76"
+source = "git+https://github.com/bytecodealliance/wasm-tools#649c4ea2a33d50705708ed03984f2284031b4667"
 dependencies = [
  "logos",
  "thiserror 2.0.17",
@@ -4690,8 +4683,7 @@ dependencies = [
 [[package]]
 name = "wasmparser"
 version = "0.248.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa4439c5eee9df71ee0c6efb37f63b1fcb1fec38f85f5142c54e7ed05d33091a"
+source = "git+https://github.com/bytecodealliance/wasm-tools#649c4ea2a33d50705708ed03984f2284031b4667"
 dependencies = [
  "bitflags 2.11.1",
  "hashbrown 0.17.0",
@@ -4703,8 +4695,7 @@ dependencies = [
 [[package]]
 name = "wasmprinter"
 version = "0.248.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b264a5410b008d4d199a92bf536eae703cbd614482fc1ec53831cf19e1c183"
+source = "git+https://github.com/bytecodealliance/wasm-tools#649c4ea2a33d50705708ed03984f2284031b4667"
 dependencies = [
  "anyhow",
  "termcolor",
@@ -5471,8 +5462,7 @@ dependencies = [
 [[package]]
 name = "wast"
 version = "248.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acc54622ed5a5cddafcdf152043f9d4aed54d4a653d686b7dfe874809fca99d7"
+source = "git+https://github.com/bytecodealliance/wasm-tools#649c4ea2a33d50705708ed03984f2284031b4667"
 dependencies = [
  "bumpalo",
  "gimli 0.32.3",
@@ -5485,8 +5475,7 @@ dependencies = [
 [[package]]
 name = "wat"
 version = "1.248.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75cd9e510603909748e6ebab89f27cd04472c1d9d85a3c88a7a6fc51a1a7934"
+source = "git+https://github.com/bytecodealliance/wasm-tools#649c4ea2a33d50705708ed03984f2284031b4667"
 dependencies = [
  "wast 248.0.0",
 ]
@@ -6012,8 +6001,7 @@ dependencies = [
 [[package]]
 name = "wit-component"
 version = "0.248.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0012379f0ff47e1d44dd312e76cfa42de2589251f093fb105e9de9db90c89221"
+source = "git+https://github.com/bytecodealliance/wasm-tools#649c4ea2a33d50705708ed03984f2284031b4667"
 dependencies = [
  "anyhow",
  "bitflags 2.11.1",
@@ -6068,8 +6056,7 @@ dependencies = [
 [[package]]
 name = "wit-parser"
 version = "0.248.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "247ad505da2915a082fe13204c5ba8788425aea1de54f43b284818cf82637856"
+source = "git+https://github.com/bytecodealliance/wasm-tools#649c4ea2a33d50705708ed03984f2284031b4667"
 dependencies = [
  "anyhow",
  "hashbrown 0.17.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -769,3 +769,18 @@ fpr = "fpr"
 
 [workspace.metadata.typos.files]
 extend-exclude = [ "docs/js/mermaid*.js", "crates/wasi-nn/**/*.txt", "*.isle" ]
+
+[patch.crates-io]
+wasmparser = { git = 'https://github.com/bytecodealliance/wasm-tools' }
+wat = { git = 'https://github.com/bytecodealliance/wasm-tools' }
+wast = { git = 'https://github.com/bytecodealliance/wasm-tools' }
+wasmprinter = { git = 'https://github.com/bytecodealliance/wasm-tools' }
+wasm-encoder = { git = 'https://github.com/bytecodealliance/wasm-tools' }
+wasm-smith = { git = 'https://github.com/bytecodealliance/wasm-tools' }
+wasm-mutate = { git = 'https://github.com/bytecodealliance/wasm-tools' }
+wit-parser = { git = 'https://github.com/bytecodealliance/wasm-tools' }
+wit-component = { git = 'https://github.com/bytecodealliance/wasm-tools' }
+wasm-wave = { git = 'https://github.com/bytecodealliance/wasm-tools' }
+wasm-compose = { git = 'https://github.com/bytecodealliance/wasm-tools' }
+wasm-metadata = { git = 'https://github.com/bytecodealliance/wasm-tools' }
+json-from-wast = { git = 'https://github.com/bytecodealliance/wasm-tools' }

--- a/crates/environ/src/component/translate.rs
+++ b/crates/environ/src/component/translate.rs
@@ -18,7 +18,7 @@ use wasmparser::component_types::{
     ComponentFuncTypeId, ComponentInstanceTypeId, ComponentValType,
 };
 use wasmparser::types::Types;
-use wasmparser::{Chunk, ComponentImportName, Encoding, Parser, Payload, Validator};
+use wasmparser::{Chunk, ComponentExternName, Encoding, Parser, Payload, Validator};
 
 mod adapt;
 pub use self::adapt::*;
@@ -176,7 +176,7 @@ struct Translation<'data> {
 // is straight from `wasmparser`'s passes.
 enum LocalInitializer<'data> {
     // imports
-    Import(ComponentImportName<'data>, ComponentEntityType),
+    Import(ComponentExternName<'data>, ComponentEntityType),
 
     // An import of an intrinsic for compile-time builtins.
     IntrinsicsImport,
@@ -768,11 +768,12 @@ impl<'a, 'data> Translator<'a, 'data> {
                     let import = import?;
                     let types = self.validator.types(0).unwrap();
                     let ty = types
-                        .component_entity_type_of_import(import.name.0)
-                        .unwrap();
+                        .component_item_for_import(import.name.name)
+                        .unwrap()
+                        .ty;
 
-                    if self.is_unsafe_intrinsics_import(import.name.0) {
-                        self.check_unsafe_intrinsics_import(import.name.0, ty)?;
+                    if self.is_unsafe_intrinsics_import(import.name.name) {
+                        self.check_unsafe_intrinsics_import(import.name.name, ty)?;
                         self.result
                             .initializers
                             .push(LocalInitializer::IntrinsicsImport);
@@ -1309,7 +1310,7 @@ impl<'a, 'data> Translator<'a, 'data> {
                 for export in s {
                     let export = export?;
                     let item = self.kind_to_item(export.kind, export.index)?;
-                    let prev = self.result.exports.insert(export.name.0, item);
+                    let prev = self.result.exports.insert(export.name.name, item);
                     assert!(prev.is_none());
                     self.result
                         .initializers
@@ -1451,7 +1452,7 @@ impl<'a, 'data> Translator<'a, 'data> {
         let mut map = HashMap::with_capacity(exports.len());
         for export in exports {
             let idx = self.kind_to_item(export.kind, export.index)?;
-            map.insert(export.name.0, idx);
+            map.insert(export.name.name, idx);
         }
 
         Ok(LocalInitializer::ComponentSynthetic(map, ty))
@@ -1662,13 +1663,13 @@ impl<'a, 'data> Translator<'a, 'data> {
         );
 
         for (name, ty) in &instance_ty.exports {
-            let ComponentEntityType::Func(func_ty) = ty else {
+            let ComponentEntityType::Func(func_ty) = ty.ty else {
                 bail!(
                     "bad unsafe intrinsics import: imported instance `{import}` must \
                      only export functions"
                 )
             };
-            let func_ty = &types[*func_ty];
+            let func_ty = &types[func_ty];
 
             fn ty_eq(a: &InterfaceType, b: &wasmparser::component_types::ComponentValType) -> bool {
                 use wasmparser::{PrimitiveValType as P, component_types::ComponentValType as C};

--- a/crates/environ/src/component/translate/inline.rs
+++ b/crates/environ/src/component/translate/inline.rs
@@ -114,9 +114,12 @@ pub(super) fn run(
         if let TypeDef::Interface(_) = ty {
             continue;
         }
-        let index = inliner.result.import_types.push((name.0.to_string(), ty));
+        let index = inliner
+            .result
+            .import_types
+            .push((name.name.to_string(), ty));
         let path = ImportPath::root(index);
-        args.insert(name.0, ComponentItemDef::from_import(path, ty)?);
+        args.insert(name.name, ComponentItemDef::from_import(path, ty)?);
     }
 
     // This will run the inliner to completion after being seeded with the
@@ -441,7 +444,7 @@ impl<'a> Inliner<'a> {
             // was provided as an import at the instantiation-site to what was
             // needed during the component's instantiation.
             Import(name, ty) => {
-                let arg = match frame.args.get(name.0) {
+                let arg = match frame.args.get(name.name) {
                     Some(arg) => arg,
 
                     // Not all arguments need to be provided for instantiation,

--- a/crates/environ/src/component/types_builder.rs
+++ b/crates/environ/src/component/types_builder.rs
@@ -325,17 +325,17 @@ impl ComponentTypesBuilder {
         let ty = &types[id];
         let mut result = TypeComponent::default();
         for (name, ty) in ty.imports.iter() {
-            self.register_abstract_component_entity_type(types, *ty);
+            self.register_abstract_component_entity_type(types, ty.ty);
             result.imports.insert(
                 name.clone(),
-                self.convert_component_entity_type(types, *ty)?,
+                self.convert_component_entity_type(types, ty.ty)?,
             );
         }
         for (name, ty) in ty.exports.iter() {
-            self.register_abstract_component_entity_type(types, *ty);
+            self.register_abstract_component_entity_type(types, ty.ty);
             result.exports.insert(
                 name.clone(),
-                self.convert_component_entity_type(types, *ty)?,
+                self.convert_component_entity_type(types, ty.ty)?,
             );
         }
         Ok(self.component_types.components.push(result))
@@ -350,10 +350,10 @@ impl ComponentTypesBuilder {
         let ty = &types[id];
         let mut result = TypeComponentInstance::default();
         for (name, ty) in ty.exports.iter() {
-            self.register_abstract_component_entity_type(types, *ty);
+            self.register_abstract_component_entity_type(types, ty.ty);
             result.exports.insert(
                 name.clone(),
-                self.convert_component_entity_type(types, *ty)?,
+                self.convert_component_entity_type(types, ty.ty)?,
             );
         }
         Ok(self.component_types.component_instances.push(result))

--- a/crates/environ/src/component/types_builder/resources.rs
+++ b/crates/environ/src/component/types_builder/resources.rs
@@ -247,7 +247,7 @@ impl ResourcesBuilder {
                 let ty = &types[id];
                 for (name, ty) in ty.exports.iter() {
                     path.push(name);
-                    self.register_component_entity_type_(types, *ty, path, register);
+                    self.register_component_entity_type_(types, ty.ty, path, register);
                     path.pop();
                 }
             }

--- a/crates/test-util/src/component_fuzz.rs
+++ b/crates/test-util/src/component_fuzz.rs
@@ -1722,6 +1722,21 @@ impl<'a> TestCase<'a> {
 
         let mut options = u.arbitrary::<TestCaseOptions>()?;
 
+        // Handle async ABI options. If async is enabled then the function type
+        // in question must also be `async`.
+        if let LiftAbi::AsyncStackful | LiftAbi::AsyncCallback = options.caller_lift_abi {
+            options.guest_caller_async = true;
+        }
+        if let LiftAbi::AsyncStackful | LiftAbi::AsyncCallback = options.callee_lift_abi {
+            options.guest_callee_async = true;
+        }
+        if let LowerAbi::Async = options.caller_lower_abi {
+            options.guest_callee_async = true;
+        }
+        if let LowerAbi::Async = options.callee_lower_abi {
+            options.host_async = true;
+        }
+
         // Sync tasks cannot call async functions via a sync lower, nor can they
         // block in other ways (e.g. by calling `waitable-set.wait`, returning
         // `CALLBACK_CODE_WAIT`, etc.) prior to returning.  Therefore,

--- a/crates/test-util/src/wast.rs
+++ b/crates/test-util/src/wast.rs
@@ -472,6 +472,9 @@ impl WastTest {
             // changes
             "test/async/same-component-stream-future.wast",
             "test/async/trap-if-block-and-sync.wast",
+            // Not updated upstream yet
+            "test/async/cross-abi-calls.wast",
+            "test/async/trap-on-reenter.wast",
         ];
         if unsupported.iter().any(|part| self.path.ends_with(part)) {
             return true;

--- a/crates/wasmtime/src/compile/code_builder/compile_time_builtins.rs
+++ b/crates/wasmtime/src/compile/code_builder/compile_time_builtins.rs
@@ -89,13 +89,13 @@ impl<'a> CodeBuilder<'a> {
                         // unfortunately the `wasm-compose` API is not powerful
                         // enough for us to do all that.
                         ensure!(
-                            imp.name.0 != intrinsics_import,
+                            imp.name.name != intrinsics_import,
                             "main Wasm cannot import the unsafe intrinsics (`{intrinsics_import}`) \
                              when using compile-time builtins"
                         );
 
                         if let wasmparser::ComponentTypeRef::Instance(_) = imp.ty {
-                            instance_imports.insert(imp.name.0);
+                            instance_imports.insert(imp.name.name);
                         }
                     }
                 }

--- a/crates/wizer/src/component/rewrite.rs
+++ b/crates/wizer/src/component/rewrite.rs
@@ -236,7 +236,7 @@ impl ReencodeComponent for Reencoder<'_> {
     ) -> Result<(), Error> {
         for export in section {
             let export = export?;
-            if !self.wizer.get_keep_init_func() && export.name.0 == self.wizer.get_init_func() {
+            if !self.wizer.get_keep_init_func() && export.name.name == self.wizer.get_init_func() {
                 self.removed_func = Some(self.funcs);
             } else {
                 if export.kind == wasmparser::ComponentExternalKind::Func {

--- a/crates/wizer/tests/all/component.rs
+++ b/crates/wizer/tests/all/component.rs
@@ -637,7 +637,7 @@ async fn export_is_removed() -> Result<()> {
                 wasmparser::Payload::ComponentExportSection(s) => Some(s),
                 _ => None,
             })
-            .flat_map(|section| section.into_iter().map(|e| e.unwrap().name.0))
+            .flat_map(|section| section.into_iter().map(|e| e.unwrap().name.name))
             .collect()
     }
 }

--- a/tests/all/component_model/bindgen.rs
+++ b/tests/all/component_model/bindgen.rs
@@ -108,7 +108,7 @@ mod no_imports_concurrent {
                         (with "" (instance (export "task.return" (func $task-return))))
                     ))
 
-                    (func $f (export "bar")
+                    (func $f (export "bar") async
                         (canon lift (core func $i "bar") async (callback (func $i "callback")))
                     )
 

--- a/tests/all/component_model/func.rs
+++ b/tests/all/component_model/func.rs
@@ -908,7 +908,7 @@ async fn test_many_parameters(dynamic: bool, concurrent: bool) -> Result<()> {
                 (with "libc" (instance $libc))
             ))
 
-            (type $t (func
+            (type $t (func async
                 (param "p1" s8)              ;; offset  0, size 1
                 (param "p2" u64)             ;; offset  8, size 8
                 (param "p3" float32)         ;; offset 16, size 4
@@ -1379,7 +1379,7 @@ async fn test_many_results(dynamic: bool, concurrent: bool) -> Result<()> {
                 (with "libc" (instance $libc))
             ))
 
-            (type $t (func (result $tuple)))
+            (type $t (func async (result $tuple)))
             (func (export "many-results") (type $t)
                 (canon lift
                     (core func $i "foo")

--- a/tests/misc_testsuite/component-model/async/backpressure-deadlock.wast
+++ b/tests/misc_testsuite/component-model/async/backpressure-deadlock.wast
@@ -33,40 +33,40 @@
     ))
 
     (func (export "turn-on-backpressure") (canon lift (core func $i "turn-on-backpressure")))
-    (func (export "f")
+    (func (export "f") async
       (canon lift (core func $i "f") async (callback (func $i "callback"))))
   )
   (instance $A (instantiate $A))
 
   (component $B
     (import "A" (instance $A
-      (export "f" (func))
+      (export "f" (func async))
       (export "turn-on-backpressure" (func))
     ))
-    
+
     (core module $libc (memory (export "mem") 1))
     (core instance $libc (instantiate $libc))
-  
+
     (core func $f (canon lower (func $A "f") async (memory $libc "mem")))
     (core func $turn-on-backpressure (canon lower (func $A "turn-on-backpressure")))
     (core func $waitable-set.new (canon waitable-set.new))
     (core func $waitable.join (canon waitable.join))
     (core func $waitable-set.wait (canon waitable-set.wait (memory $libc "mem")))
-  
+
     (core module $m
       (import "" "f" (func $f (result i32)))
       (import "" "turn-on-backpressure" (func $turn-on-backpressure))
       (import "" "waitable-set.new" (func $waitable-set.new (result i32)))
       (import "" "waitable.join" (func $waitable.join (param i32 i32)))
       (import "" "waitable-set.wait" (func $waitable-set.wait (param i32 i32) (result i32)))
-  
+
       (func (export "f")
         (local $status i32)
         (local $set i32)
         call $turn-on-backpressure
-  
+
         (local.set $status (call $f))
-  
+
         ;; low 4 bits should be "STARTING == 0"
         (i32.ne
           (i32.const 0)
@@ -74,19 +74,19 @@
             (local.get $status)
             (i32.const 0xf)))
         if unreachable end
-  
+
         ;; make a new waitable set and join our subtask into it
         (local.set $set (call $waitable-set.new))
         (call $waitable.join
           (i32.shr_u (local.get $status) (i32.const 4))
           (local.get $set))
-  
+
         ;; block waiting for our task, which should deadlock (?)
         (call $waitable-set.wait (local.get $set) (i32.const 0))
         unreachable
       )
     )
-  
+
     (core instance $i (instantiate $m
       (with "" (instance
         (export "f" (func $f))
@@ -96,13 +96,13 @@
         (export "waitable-set.wait" (func $waitable-set.wait))
       ))
     ))
-  
+
     (func (export "f") async (canon lift (core func $i "f")))
   )
 
   (instance $B (instantiate $B (with "A" (instance $A))))
 
-  (func (export "f") (alias export $B "f"))  
+  (func (export "f") (alias export $B "f"))
 )
 
 (assert_trap (invoke "f") "deadlock detected")

--- a/tests/misc_testsuite/component-model/async/callback-yield-then-exit.wast
+++ b/tests/misc_testsuite/component-model/async/callback-yield-then-exit.wast
@@ -21,13 +21,13 @@
       (with "" (instance (export "task.return" (func $task.return))))
     ))
 
-    (func (export "foo") (param "p1" u32) (result u32)
+    (func (export "foo") async (param "p1" u32) (result u32)
       (canon lift (core func $i "foo") async (callback (func $i "callback")))
     )
   )
 
   (component $B
-    (import "a" (func $foo (param "p1" u32) (result u32)))
+    (import "a" (func $foo async (param "p1" u32) (result u32)))
     (core func $foo (canon lower (func $foo)))
     (core module $m
       (import "" "foo" (func $foo (param i32) (result i32)))
@@ -39,7 +39,7 @@
     (core instance $i (instantiate $m
       (with "" (instance (export "foo" (func $foo))))
     ))
-    (func (export "run") (canon lift (core func $i "run")))
+    (func (export "run") async (canon lift (core func $i "run")))
   )
 
   (instance $A (instantiate $A))

--- a/tests/misc_testsuite/component-model/async/drop-deadlock.wast
+++ b/tests/misc_testsuite/component-model/async/drop-deadlock.wast
@@ -17,7 +17,7 @@
   (func (export "set-backpressure")
     (canon lift (core func $i "set-backpressure")))
 
-  (func (export "target")
+  (func (export "target") async
     (canon lift (core func $i "target") async (callback (func $i "callback"))))
 )
 

--- a/tests/misc_testsuite/component-model/async/fused.wast
+++ b/tests/misc_testsuite/component-model/async/fused.wast
@@ -20,13 +20,13 @@
       (with "" (instance (export "task.return" (func $task-return))))
     ))
 
-    (func (export "foo") (param "p1" u32) (result u32)
+    (func (export "foo") async (param "p1" u32) (result u32)
       (canon lift (core func $i "foo") async (callback (func $i "callback")))
     )
   )
 
   (component $lowerer
-    (import "a" (func $foo (param "p1" u32) (result u32)))
+    (import "a" (func $foo async (param "p1" u32) (result u32)))
     (core module $libc (memory (export "memory") 1))
     (core instance $libc (instantiate $libc))
     (core func $foo (canon lower (func $foo) async (memory $libc "memory")))
@@ -46,7 +46,7 @@
       (with "libc" (instance $libc))
       (with "" (instance (export "foo" (func $foo))))
     ))
-    (func (export "run") (canon lift (core func $i "run")))
+    (func (export "run") async (canon lift (core func $i "run")))
   )
 
   (instance $lifter (instantiate $lifter))
@@ -65,13 +65,13 @@
       )
     )
     (core instance $i (instantiate $m))
-    (func (export "foo") (param "p1" u32) (result u32)
+    (func (export "foo") async (param "p1" u32) (result u32)
       (canon lift (core func $i "foo"))
     )
   )
 
   (component $lowerer
-    (import "a" (func $foo (param "p1" u32) (result u32)))
+    (import "a" (func $foo async (param "p1" u32) (result u32)))
     (core module $libc (memory (export "memory") 1))
     (core instance $libc (instantiate $libc))
     (core func $foo (canon lower (func $foo) async (memory $libc "memory")))
@@ -91,7 +91,7 @@
       (with "libc" (instance $libc))
       (with "" (instance (export "foo" (func $foo))))
     ))
-    (func (export "run") (canon lift (core func $i "run")))
+    (func (export "run") async (canon lift (core func $i "run")))
   )
 
   (instance $lifter (instantiate $lifter))
@@ -117,13 +117,13 @@
       (with "" (instance (export "task.return" (func $task-return))))
     ))
 
-    (func (export "foo") (param "p1" u32) (result u32)
+    (func (export "foo") async (param "p1" u32) (result u32)
       (canon lift (core func $i "foo") async (callback (func $i "callback")))
     )
   )
 
   (component $lowerer
-    (import "a" (func $foo (param "p1" u32) (result u32)))
+    (import "a" (func $foo async (param "p1" u32) (result u32)))
     (core func $foo (canon lower (func $foo)))
     (core module $m
       (import "" "foo" (func $foo (param i32) (result i32)))
@@ -138,7 +138,7 @@
     (core instance $i (instantiate $m
       (with "" (instance (export "foo" (func $foo))))
     ))
-    (func (export "run") (canon lift (core func $i "run")))
+    (func (export "run") async (canon lift (core func $i "run")))
   )
 
   (instance $lifter (instantiate $lifter))

--- a/tests/misc_testsuite/component-model/async/future-read.wast
+++ b/tests/misc_testsuite/component-model/async/future-read.wast
@@ -220,7 +220,7 @@
         (export "return" (func $return))
       ))
     ))
-    (func (export "run") (param "x" $future)
+    (func (export "run") async (param "x" $future)
       (canon lift (core func $i "run") async (callback (func $i "cb"))))
   )
   (instance $child (instantiate $child))
@@ -228,7 +228,7 @@
   (component $other-child
     (type $future (future))
     (import "child" (instance $child
-      (export "run" (func (param "x" $future)))
+      (export "run" (func async (param "x" $future)))
     ))
     (core func $new (canon future.new $future))
     (core func $child-run (canon lower (func $child "run")))

--- a/tests/misc_testsuite/component-model/async/lift.wast
+++ b/tests/misc_testsuite/component-model/async/lift.wast
@@ -9,7 +9,7 @@
   )
   (core instance $i (instantiate $m))
 
-  (func (export "foo") (param "p1" u32) (result u32)
+  (func (export "foo") async (param "p1" u32) (result u32)
     (canon lift (core func $i "foo") async (callback (func $i "callback")))
   )
 )

--- a/tests/misc_testsuite/component-model/async/lower.wast
+++ b/tests/misc_testsuite/component-model/async/lower.wast
@@ -2,10 +2,12 @@
 
 ;; async lower
 (component
-  (import "host-echo-u32" (func $foo (param "p1" u32) (result u32)))
+  (import "host" (instance $host
+    (export "echo-slowly" (func async (param "p1" u32) (result u32)))
+  ))
   (core module $libc (memory (export "memory") 1))
   (core instance $libc (instantiate $libc))
-  (core func $foo (canon lower (func $foo) async (memory $libc "memory")))
+  (core func $foo (canon lower (func $host "echo-slowly") async (memory $libc "memory")))
   (core module $m
     (func (import "" "foo") (param i32 i32) (result i32))
   )

--- a/tests/misc_testsuite/component-model/async/partial-stream-copies.wast
+++ b/tests/misc_testsuite/component-model/async/partial-stream-copies.wast
@@ -129,14 +129,14 @@
       (export "stream.drop-readable" (func $stream.drop-readable))
       (export "stream.drop-writable" (func $stream.drop-writable))
     ))))
-    (func (export "transform") (param "in" (stream u8)) (result (stream u8)) (canon lift
+    (func (export "transform") async (param "in" (stream u8)) (result (stream u8)) (canon lift
       (core func $cm "transform")
       async (memory $memory "mem") (callback (func $cm "transform_cb"))
     ))
   )
 
   (component $D
-    (import "transform" (func $transform (param "in" (stream u8)) (result (stream u8))))
+    (import "transform" (func $transform async (param "in" (stream u8)) (result (stream u8))))
 
     (core module $Memory (memory (export "mem") 1))
     (core instance $memory (instantiate $Memory))

--- a/tests/misc_testsuite/component-model/async/reentrance.wast
+++ b/tests/misc_testsuite/component-model/async/reentrance.wast
@@ -14,12 +14,12 @@
     (core instance $shim (instantiate $shim
         (with "" (instance (export "task.return" (func $task-return))))
     ))
-    (func $shim-export (param "p1" u32) (result u32)
+    (func $shim-export async (param "p1" u32) (result u32)
         (canon lift (core func $shim "export") async (callback (func $shim "callback")))
     )
 
     (component $inner
-        (import "import" (func $import (param "p1" u32) (result u32)))
+        (import "import" (func $import async (param "p1" u32) (result u32)))
         (core module $libc (memory (export "memory") 1))
         (core instance $libc (instantiate $libc))
         (core func $import (canon lower (func $import) async (memory $libc "memory")))
@@ -46,7 +46,7 @@
             ))
             (with "libc" (instance $libc))
         ))
-        (func (export "export") (param "p1" u32) (result u32)
+        (func (export "export") async (param "p1" u32) (result u32)
             (canon lift (core func $i "export") async (callback (func $i "callback")))
         )
     )
@@ -84,7 +84,7 @@
         ))
         (with "libc" (instance $libc))
     ))
-    (func (export "export") (param "p1" u32) (result u32)
+    (func (export "export") async (param "p1" u32) (result u32)
         (canon lift (core func $donut "export") async (callback (func $donut "callback")))
     )
 )

--- a/tests/misc_testsuite/component-model/async/stackful.wast
+++ b/tests/misc_testsuite/component-model/async/stackful.wast
@@ -11,7 +11,7 @@
   )
   (core instance $i (instantiate $m))
 
-  (func (export "foo") (param "p1" u32) (result u32)
+  (func (export "foo") async (param "p1" u32) (result u32)
     (canon lift (core func $i "foo") async)
   )
 )
@@ -28,13 +28,13 @@
       (with "" (instance (export "task.return" (func $task-return))))
     ))
 
-    (func (export "foo") (param "p1" u32) (result u32)
+    (func (export "foo") async (param "p1" u32) (result u32)
       (canon lift (core func $i "foo") async)
     )
   )
 
   (component $lowerer
-    (import "a" (func $foo (param "p1" u32) (result u32)))
+    (import "a" (func $foo async (param "p1" u32) (result u32)))
     (core module $libc (memory (export "memory") 1))
     (core instance $libc (instantiate $libc))
     (core func $foo (canon lower (func $foo) async (memory $libc "memory")))
@@ -54,7 +54,7 @@
       (with "libc" (instance $libc))
       (with "" (instance (export "foo" (func $foo))))
     ))
-    (func (export "run") (canon lift (core func $i "run")))
+    (func (export "run") async (canon lift (core func $i "run")))
   )
 
   (instance $lifter (instantiate $lifter))
@@ -76,13 +76,13 @@
       (with "" (instance (export "task.return" (func $task-return))))
     ))
 
-    (func (export "foo") (param "p1" u32) (result u32)
+    (func (export "foo") async (param "p1" u32) (result u32)
       (canon lift (core func $i "foo") async)
     )
   )
 
   (component $lowerer
-    (import "a" (func $foo (param "p1" u32) (result u32)))
+    (import "a" (func $foo async (param "p1" u32) (result u32)))
     (core func $foo (canon lower (func $foo)))
     (core module $m
       (import "" "foo" (func $foo (param i32) (result i32)))
@@ -97,7 +97,7 @@
     (core instance $i (instantiate $m
       (with "" (instance (export "foo" (func $foo))))
     ))
-    (func (export "run") (canon lift (core func $i "run")))
+    (func (export "run") async (canon lift (core func $i "run")))
   )
 
   (instance $lifter (instantiate $lifter))

--- a/tests/misc_testsuite/component-model/async/streams-massive-send.wast
+++ b/tests/misc_testsuite/component-model/async/streams-massive-send.wast
@@ -156,18 +156,18 @@
       ))
     ))
 
-    (func (export "big-stream") (result $s)
+    (func (export "big-stream") async (result $s)
       (canon lift (core func $m "big-stream") async
         (callback (func $m "cb"))))
-    (func (export "big-future") (result $f)
+    (func (export "big-future") async (result $f)
       (canon lift (core func $m "big-future") async
         (callback (func $m "cb"))))
   )
 
   (component $B
     (import "a" (instance $a
-      (export "big-future" (func (result $f)))
-      (export "big-stream" (func (result $s)))
+      (export "big-future" (func async (result $f)))
+      (export "big-stream" (func async (result $s)))
     ))
 
     (core module $libc

--- a/tests/misc_testsuite/component-model/async/task-builtins.wast
+++ b/tests/misc_testsuite/component-model/async/task-builtins.wast
@@ -295,13 +295,14 @@
         (realloc (func $libc "realloc"))
       )
     )
-    (core func $async-to-sync
-      (canon lower (func $a "run-sync")
-        async
-        (memory $libc "memory")
-        (realloc (func $libc "realloc"))
-      )
-    )
+    ;; NB: this is no longer valid after WebAssembly/component-model#646
+    (; (core func $async-to-sync ;)
+    (;   (canon lower (func $a "run-sync") ;)
+    (;     async ;)
+    (;     (memory $libc "memory") ;)
+    (;     (realloc (func $libc "realloc")) ;)
+    (;   ) ;)
+    (; ) ;)
     (core func $sync-to-async
       (canon lower (func $a "run-async")
         (memory $libc "memory")
@@ -321,7 +322,7 @@
       (import "" "context.get" (func $context.get (result i32)))
       (import "" "sync-to-sync" (func $sync-to-sync (param i32)))
       (import "" "sync-to-async" (func $sync-to-async (param i32)))
-      (import "" "async-to-sync" (func $async-to-sync (param i32) (result i32)))
+      (; (import "" "async-to-sync" (func $async-to-sync (param i32) (result i32))) ;)
       (import "" "async-to-async" (func $async-to-async (param i32) (result i32)))
 
       ;; set this tasks's context before calling $run, in calling $run the
@@ -341,17 +342,17 @@
         (if (i32.ne (call $context.get) (i32.const 500)) (then (unreachable)))
       )
 
-      (func (export "async-to-sync")
-        (call $context.set (i32.const 400))
-        (if
-          (i32.ne
-            (call $async-to-sync (i32.const 20))
-            (i32.const 2) ;; RETURNED
-          )
-          (then (unreachable))
-        )
-        (if (i32.ne (call $context.get) (i32.const 500)) (then (unreachable)))
-      )
+      (; (func (export "async-to-sync") ;)
+      (;   (call $context.set (i32.const 400)) ;)
+      (;   (if ;)
+      (;     (i32.ne ;)
+      (;       (call $async-to-sync (i32.const 20)) ;)
+      (;       (i32.const 2) ;; RETURNED ;)
+      (;     ) ;)
+      (;     (then (unreachable)) ;)
+      (;   ) ;)
+      (;   (if (i32.ne (call $context.get) (i32.const 500)) (then (unreachable))) ;)
+      (; ) ;)
 
       (func (export "async-to-async")
         (call $context.set (i32.const 400))
@@ -370,12 +371,12 @@
       (export "context.get" (func $context.get))
       (export "sync-to-sync" (func $sync-to-sync))
       (export "sync-to-async" (func $sync-to-async))
-      (export "async-to-sync" (func $async-to-sync))
+      (; (export "async-to-sync" (func $async-to-sync)) ;)
       (export "async-to-async" (func $async-to-async))
     ))))
     (func (export "sync-to-sync") async (canon lift (core func $m "sync-to-sync")))
     (func (export "sync-to-async") async (canon lift (core func $m "sync-to-async")))
-    (func (export "async-to-sync") async (canon lift (core func $m "async-to-sync")))
+    (; (func (export "async-to-sync") async (canon lift (core func $m "async-to-sync"))) ;)
     (func (export "async-to-async") async (canon lift (core func $m "async-to-async")))
   )
 
@@ -383,13 +384,13 @@
   (instance $b (instantiate $B (with "a" (instance $a))))
   (export "sync-to-sync" (func $b "sync-to-sync"))
   (export "sync-to-async" (func $b "sync-to-async"))
-  (export "async-to-sync" (func $b "async-to-sync"))
+  (; (export "async-to-sync" (func $b "async-to-sync")) ;)
   (export "async-to-async" (func $b "async-to-async"))
 )
 
 (assert_return (invoke "sync-to-sync"))
 (assert_return (invoke "sync-to-async"))
-(assert_return (invoke "async-to-sync"))
+(; (assert_return (invoke "async-to-sync")) ;)
 (assert_return (invoke "async-to-async"))
 
 ;; Same as above, but when calling the host.

--- a/tests/misc_testsuite/component-model/async/task-return-traps.wast
+++ b/tests/misc_testsuite/component-model/async/task-return-traps.wast
@@ -14,7 +14,7 @@
     (core instance $i (instantiate $m
         (with "" (instance (export "task.return" (func $task-return))))
     ))
-    (func (export "foo") (canon lift (core func $i "foo") async (callback (func $i "callback"))))
+    (func (export "foo") async (canon lift (core func $i "foo") async (callback (func $i "callback"))))
 )
 (assert_trap (invoke "foo") "async-lifted export failed to produce a result")
 
@@ -50,7 +50,7 @@
         ))
         (with "libc" (instance $libc))
     ))
-    (func (export "foo") (canon lift (core func $i "foo") async (callback (func $i "callback"))))
+    (func (export "foo") async (canon lift (core func $i "foo") async (callback (func $i "callback"))))
 )
 
 (assert_trap (invoke "foo") "async-lifted export failed to produce a result")
@@ -85,7 +85,7 @@
         ))
         (with "libc" (instance $libc))
     ))
-    (func (export "foo") (canon lift (core func $i "foo") async))
+    (func (export "foo") async (canon lift (core func $i "foo") async))
 )
 
 (assert_trap (invoke "foo") "async-lifted export failed to produce a result")
@@ -99,7 +99,7 @@
     (core instance $i (instantiate $m
         (with "" (instance (export "task.return" (func $task-return))))
     ))
-    (func (export "foo") (canon lift (core func $i "foo") async))
+    (func (export "foo") async (canon lift (core func $i "foo") async))
 )
 (assert_trap (invoke "foo") "async-lifted export failed to produce a result")
 
@@ -112,7 +112,7 @@
     (core instance $i (instantiate $m
         (with "" (instance (export "task.return" (func $task-return))))
     ))
-    (func (export "foo") (canon lift (core func $i "foo") async))
+    (func (export "foo") async (canon lift (core func $i "foo") async))
 )
 
 (assert_trap (invoke "foo")
@@ -129,7 +129,7 @@
     (core instance $i (instantiate $m
         (with "" (instance (export "task.return" (func $task-return))))
     ))
-    (func (export "foo") (canon lift (core func $i "foo") async))
+    (func (export "foo") async (canon lift (core func $i "foo") async))
 )
 
 (assert_trap (invoke "foo")
@@ -144,7 +144,7 @@
     (core instance $i (instantiate $m
         (with "" (instance (export "task.return" (func $task-return))))
     ))
-    (func (export "foo") (canon lift (core func $i "foo") async))
+    (func (export "foo") async (canon lift (core func $i "foo") async))
 )
 
 (assert_trap (invoke "foo")


### PR DESCRIPTION
Two major changes from this update are:

* Lift/lower with `async` as an option now requires an `async` function type in the component model. This resulted in a number of test changes throughout.

* Tooling now has support for `(implements "...")` in the component model. Support in Wasmtime isn't implemented yet, however, and that'll come in a subsequent PR.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
