### PR TITLE
Add v8 feature to wasmtime-fuzzing

### DIFF
--- a/crates/fuzzing/Cargo.toml
+++ b/crates/fuzzing/Cargo.toml
@@ -81,5 +81,6 @@ tokio = { workspace = true, features = ["rt", "time", "macros", "rt-multi-thread
 wasm-spec-interpreter = { path = "./wasm-spec-interpreter", optional = true, features = ['build-libinterpret'] }
 
 [features]
+default = ['v8']
 fuzz-spec-interpreter = ['dep:wasm-spec-interpreter']
 v8 = ['dep:v8']

--- a/crates/fuzzing/Cargo.toml
+++ b/crates/fuzzing/Cargo.toml
@@ -64,7 +64,7 @@ features = [
 # though, so we could use that if we wanted. For now though just simplify a bit
 # and don't depend on this on Windows.  The same applies on s390x and riscv.
 [target.'cfg(not(any(windows, target_arch = "s390x", target_arch = "riscv64")))'.dependencies]
-v8 = "139.0.0"
+v8 = { version = "139.0.0", optional = true }
 
 [dev-dependencies]
 wat = { workspace = true }
@@ -82,3 +82,4 @@ wasm-spec-interpreter = { path = "./wasm-spec-interpreter", optional = true, fea
 
 [features]
 fuzz-spec-interpreter = ['dep:wasm-spec-interpreter']
+v8 = ['dep:v8']

--- a/crates/fuzzing/src/oracles.rs
+++ b/crates/fuzzing/src/oracles.rs
@@ -38,7 +38,7 @@ use std::time::{Duration, Instant};
 use wasmtime::*;
 use wasmtime_wast::WastContext;
 
-#[cfg(not(any(windows, target_arch = "s390x", target_arch = "riscv64")))]
+#[cfg(feature = "v8")]
 mod diff_v8;
 
 static CNT: AtomicUsize = AtomicUsize::new(0);

--- a/crates/fuzzing/src/oracles/engine.rs
+++ b/crates/fuzzing/src/oracles/engine.rs
@@ -38,9 +38,9 @@ pub fn build(
         #[cfg(not(feature = "fuzz-spec-interpreter"))]
         "spec" => return Ok(None),
 
-        #[cfg(not(any(windows, target_arch = "s390x", target_arch = "riscv64")))]
+        #[cfg(feature = "v8")]
         "v8" => Box::new(crate::oracles::diff_v8::V8Engine::new(config)),
-        #[cfg(any(windows, target_arch = "s390x", target_arch = "riscv64"))]
+        #[cfg(not(feature = "v8"))]
         "v8" => return Ok(None),
 
         _ => panic!("unknown engine {name}"),

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -49,6 +49,7 @@ wasmtime-test-util = { workspace = true, features = ['component-fuzz'] }
 [features]
 default = ['fuzz-spec-interpreter']
 fuzz-spec-interpreter = ['wasmtime-fuzzing/fuzz-spec-interpreter']
+v8 = ['wasmtime-fuzzing/v8']
 chaos = ["cranelift-control/chaos"]
 
 [[bin]]


### PR DESCRIPTION
Allows easily building on platforms where the v8 bindings don't work for whatever reason.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
