### PR TITLE
Add configurable RNG seed to `OomTest`

### DIFF
--- a/crates/fuzzing/src/oom.rs
+++ b/crates/fuzzing/src/oom.rs
@@ -207,6 +207,7 @@ pub struct OomTest {
     max_iters: Option<u32>,
     max_duration: Option<time::Duration>,
     allow_alloc_after_oom: bool,
+    seed: u64,
 }
 
 impl OomTest {
@@ -226,6 +227,7 @@ impl OomTest {
             max_iters: None,
             max_duration: None,
             allow_alloc_after_oom: false,
+            seed: 0,
         }
     }
 
@@ -247,6 +249,14 @@ impl OomTest {
     /// The default is `false`.
     pub fn allow_alloc_after_oom(&mut self, allow: bool) -> &mut Self {
         self.allow_alloc_after_oom = allow;
+        self
+    }
+
+    /// Configure the seed for the RNG used in `fuzz` mode.
+    ///
+    /// The default is `0`.
+    pub fn seed(&mut self, seed: u64) -> &mut Self {
+        self.seed = seed;
         self
     }
 
@@ -308,7 +318,7 @@ impl OomTest {
             return Ok(());
         }
 
-        let mut rng = SmallRng::seed_from_u64(0);
+        let mut rng = SmallRng::seed_from_u64(self.seed);
 
         for _ in 0..max_iters {
             let i = rng.random_range(0..total_allocs);


### PR DESCRIPTION
This allows a fuzzer to vary the `OomTest` RNG seed across inputs so that different corpus entries explore different OOM injection patterns.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
