### PR TITLE
Fix pooling allocator instance count leak on OOM during instantiation

### DIFF
--- a/crates/wasmtime/src/runtime/store.rs
+++ b/crates/wasmtime/src/runtime/store.rs
@@ -2289,6 +2289,8 @@ at https://bytecodealliance.org/security.
         runtime_info: &ModuleRuntimeInfo,
         imports: Imports<'_>,
     ) -> Result<InstanceId> {
+        self.instances.reserve(1)?;
+
         let id = self.instances.next_key();
 
         let allocator = match kind {
@@ -2315,20 +2317,24 @@ at https://bytecodealliance.org/security.
                     "Adding instance to store: store={:?}, module={module_id:?}, instance={id:?}",
                     self.id()
                 );
-                self.instances.push(StoreInstance {
-                    handle,
-                    kind: StoreInstanceKind::Real { module_id },
-                })?
+                self.instances
+                    .push(StoreInstance {
+                        handle,
+                        kind: StoreInstanceKind::Real { module_id },
+                    })
+                    .expect("capacity was reserved above")
             }
             AllocateInstanceKind::Dummy { .. } => {
                 log::trace!(
                     "Adding dummy instance to store: store={:?}, instance={id:?}",
                     self.id()
                 );
-                self.instances.push(StoreInstance {
-                    handle,
-                    kind: StoreInstanceKind::Dummy,
-                })?
+                self.instances
+                    .push(StoreInstance {
+                        handle,
+                        kind: StoreInstanceKind::Dummy,
+                    })
+                    .expect("capacity was reserved above")
             }
         };
 

--- a/crates/wasmtime/src/runtime/vm/instance/allocator.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator.rs
@@ -345,17 +345,18 @@ impl dyn InstanceAllocator + '_ {
             .await?;
         self.allocate_tables(&mut request, &mut guard.tables)
             .await?;
-        guard.run_deallocate = false;
         // SAFETY: memories/tables were just allocated from the store within
         // `request` and this function's own contract requires that the
         // imports are valid.
-        return unsafe {
-            Ok(Instance::new(
+        let handle = unsafe {
+            Instance::new(
                 request,
                 mem::take(&mut guard.memories),
                 mem::take(&mut guard.tables),
-            )?)
+            )?
         };
+        guard.run_deallocate = false;
+        return Ok(handle);
 
         struct DeallocateOnDrop<'a> {
             run_deallocate: bool,


### PR DESCRIPTION
Two things:

1. Reserve capacity in the instances map before allocating the instance to prevent OOM during push from leaking the instance.

2. Move `guard.run_deallocate = false` after `Instance::new` succeeds so that a failure in `Instance::new` properly decrements the live instance count.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
