### PR TITLE
Use TryBTreeMap for Module passive element and data maps

### DIFF
--- a/crates/environ/src/collections/btree_map.rs
+++ b/crates/environ/src/collections/btree_map.rs
@@ -15,6 +15,16 @@ where
     map: cranelift_bforest::Map<K, Id>,
 }
 
+impl<K, V> core::fmt::Debug for TryBTreeMap<K, V>
+where
+    K: Copy + Ord + core::fmt::Debug,
+    V: core::fmt::Debug,
+{
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_map().entries(self.iter()).finish()
+    }
+}
+
 impl<K, V> Default for TryBTreeMap<K, V>
 where
     K: Copy,
@@ -648,6 +658,65 @@ where
                 Err(oom)
             }
         }
+    }
+}
+
+impl<K, V> serde::ser::Serialize for TryBTreeMap<K, V>
+where
+    K: Copy + Ord + serde::ser::Serialize,
+    V: serde::ser::Serialize,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeMap;
+        let mut map = serializer.serialize_map(Some(self.len()))?;
+        for (k, v) in self.iter() {
+            map.serialize_entry(&k, v)?;
+        }
+        map.end()
+    }
+}
+
+impl<'de, K, V> serde::de::Deserialize<'de> for TryBTreeMap<K, V>
+where
+    K: Copy + Ord + serde::de::Deserialize<'de>,
+    V: serde::de::Deserialize<'de>,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        use core::marker::PhantomData;
+
+        struct Visitor<K: Copy, V>(PhantomData<fn() -> TryBTreeMap<K, V>>);
+
+        impl<'de, K, V> serde::de::Visitor<'de> for Visitor<K, V>
+        where
+            K: Copy + Ord + serde::de::Deserialize<'de>,
+            V: serde::de::Deserialize<'de>,
+        {
+            type Value = TryBTreeMap<K, V>;
+
+            fn expecting(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                f.write_str("a map")
+            }
+
+            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::MapAccess<'de>,
+            {
+                use serde::de::Error as _;
+                let mut result = TryBTreeMap::new();
+                while let Some((k, v)) = map.next_entry()? {
+                    result.insert(k, v).map_err(|oom| A::Error::custom(oom))?;
+                }
+                Ok(result)
+            }
+        }
+
+        deserializer.deserialize_map(Visitor(PhantomData))
     }
 }
 

--- a/crates/environ/src/compile/module_environ.rs
+++ b/crates/environ/src/compile/module_environ.rs
@@ -574,7 +574,7 @@ impl<'a, 'data> ModuleEnvironment<'a, 'data> {
                             self.result
                                 .module
                                 .passive_elements_map
-                                .insert(elem_index, passive_index);
+                                .insert(elem_index, passive_index)?;
                         }
 
                         ElementKind::Declared => {}
@@ -689,7 +689,7 @@ impl<'a, 'data> ModuleEnvironment<'a, 'data> {
                             self.result
                                 .module
                                 .passive_data_map
-                                .insert(data_index, range);
+                                .insert(data_index, range)?;
                         }
                     }
                 }

--- a/crates/environ/src/module.rs
+++ b/crates/environ/src/module.rs
@@ -2,7 +2,6 @@
 
 use crate::prelude::*;
 use crate::*;
-use alloc::collections::BTreeMap;
 use core::ops::Range;
 use cranelift_entity::{EntityRef, packed_option::ReservedValue};
 use serde_derive::{Deserialize, Serialize};
@@ -325,10 +324,10 @@ pub struct Module {
 
     /// The map from passive element index (element segment index space) to
     /// index in `passive_elements`.
-    pub passive_elements_map: BTreeMap<ElemIndex, PassiveElemIndex>,
+    pub passive_elements_map: TryBTreeMap<ElemIndex, PassiveElemIndex>,
 
     /// The map from passive data index (data segment index space) to index in `passive_data`.
-    pub passive_data_map: BTreeMap<DataIndex, Range<u32>>,
+    pub passive_data_map: TryBTreeMap<DataIndex, Range<u32>>,
 
     /// Types declared in the wasm module.
     pub types: TryPrimaryMap<TypeIndex, EngineOrModuleTypeIndex>,

--- a/crates/wasmtime/src/runtime/vm/instance.rs
+++ b/crates/wasmtime/src/runtime/vm/instance.rs
@@ -907,7 +907,7 @@ impl Instance {
         let Some(passive) = self
             .env_module()
             .passive_elements_map
-            .get(&elem_index)
+            .get(elem_index)
             .copied()
         else {
             return &[];
@@ -1001,7 +1001,7 @@ impl Instance {
         let Some(passive_index) = self
             .env_module()
             .passive_elements_map
-            .get(&elem_index)
+            .get(elem_index)
             .copied()
         else {
             // Note: dropping a non-passive segment is a no-op (not a trap).
@@ -1045,7 +1045,7 @@ impl Instance {
 
     /// Get the internal storage range of a particular Wasm data segment.
     pub(crate) fn wasm_data_range(&self, index: DataIndex) -> Range<u32> {
-        match self.env_module().passive_data_map.get(&index) {
+        match self.env_module().passive_data_map.get(index) {
             Some(range) if !self.dropped_data.contains(index) => range.clone(),
             _ => 0..0,
         }


### PR DESCRIPTION
Add Serialize, Deserialize, and Debug impls to TryBTreeMap, then switch Module's passive_elements_map and passive_data_map from std BTreeMap to TryBTreeMap so their insertions during module translation can propagate OOM instead of aborting.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
