### PR TITLE
Use fallible allocation for Wasm backtraces

### DIFF
--- a/crates/wasmtime/src/runtime/trap.rs
+++ b/crates/wasmtime/src/runtime/trap.rs
@@ -5,6 +5,7 @@ use crate::store::StoreOpaque;
 use crate::{AsContext, Module, bug};
 use core::fmt;
 use core::num::NonZeroUsize;
+use wasmtime_core::alloc::TryVec;
 use wasmtime_environ::{
     CompiledTrap, FilePos, demangle_function_name, demangle_function_name_or_index,
 };
@@ -313,7 +314,16 @@ impl WasmBacktrace {
                 _runtime_trace: crate::runtime::vm::Backtrace::empty(),
             };
         };
-        let mut wasm_trace = Vec::<FrameInfo>::with_capacity(max_frames.get());
+        let mut wasm_trace = match TryVec::with_capacity(max_frames.get()) {
+            Ok(v) => v,
+            Err(_) => {
+                return Self {
+                    wasm_trace: Vec::new(),
+                    hint_wasm_backtrace_details_env: false,
+                    _runtime_trace: crate::runtime::vm::Backtrace::empty(),
+                };
+            }
+        };
         let mut hint_wasm_backtrace_details_env = false;
         let wasm_backtrace_details_env_used =
             store.engine().config().wasm_backtrace_details_env_used;
@@ -366,7 +376,10 @@ impl WasmBacktrace {
             // and we ignore frames from modules that were not registered in
             // this store's module registry.
             if let Some((info, module)) = store.modules().lookup_frame_info(pc_to_lookup) {
-                wasm_trace.push(info);
+                if wasm_trace.push(info).is_err() {
+                    // Better to return a partial backtrace than none.
+                    break;
+                }
 
                 // If this frame has unparsed debug information and the
                 // store's configuration indicates that we were
@@ -386,7 +399,7 @@ impl WasmBacktrace {
         }
 
         Self {
-            wasm_trace,
+            wasm_trace: wasm_trace.into(),
             _runtime_trace: runtime_trace,
             hint_wasm_backtrace_details_env,
         }

--- a/crates/wasmtime/src/runtime/vm/traphandlers/backtrace.rs
+++ b/crates/wasmtime/src/runtime/vm/traphandlers/backtrace.rs
@@ -31,7 +31,6 @@ use crate::runtime::vm::{
 #[cfg(all(feature = "gc", feature = "stack-switching"))]
 use crate::vm::stack_switching::{VMContRef, VMStackState};
 use core::ops::ControlFlow;
-use wasmtime_core::alloc::TryVec;
 use wasmtime_unwinder::Frame;
 #[cfg(feature = "debug")]
 use wasmtime_unwinder::FrameCursor;

--- a/crates/wasmtime/src/runtime/vm/traphandlers/backtrace.rs
+++ b/crates/wasmtime/src/runtime/vm/traphandlers/backtrace.rs
@@ -31,13 +31,14 @@ use crate::runtime::vm::{
 #[cfg(all(feature = "gc", feature = "stack-switching"))]
 use crate::vm::stack_switching::{VMContRef, VMStackState};
 use core::ops::ControlFlow;
+use wasmtime_core::alloc::TryVec;
 use wasmtime_unwinder::Frame;
 #[cfg(feature = "debug")]
 use wasmtime_unwinder::FrameCursor;
 
 /// A WebAssembly stack trace.
 #[derive(Debug)]
-pub struct Backtrace(Vec<Frame>);
+pub struct Backtrace(TryVec<Frame>);
 
 /// One activation: information sufficient to trace an activation on a
 /// frame as long as that frame remains alive.
@@ -66,7 +67,7 @@ impl Activation {
 impl Backtrace {
     /// Returns an empty backtrace
     pub fn empty() -> Backtrace {
-        Backtrace(Vec::new())
+        Backtrace(TryVec::new())
     }
 
     /// Capture the current Wasm stack in a backtrace.
@@ -77,7 +78,7 @@ impl Backtrace {
             Some(state) => unsafe {
                 Self::new_with_trap_state(vm_store_context, unwind, state, None)
             },
-            None => Backtrace(vec![]),
+            None => Backtrace(TryVec::new()),
         })
     }
 
@@ -92,16 +93,16 @@ impl Backtrace {
         state: &CallThreadState,
         trap_pc_and_fp: Option<(usize, usize)>,
     ) -> Backtrace {
-        let mut frames = vec![];
+        let mut frames = TryVec::new();
         let f = |activation: Activation| unsafe {
             wasmtime_unwinder::visit_frames(
                 unwind,
                 activation.exit_pc,
                 activation.exit_fp,
                 activation.entry_trampoline_fp,
-                |frame| {
-                    frames.push(frame);
-                    ControlFlow::Continue(())
+                |frame| match frames.push(frame) {
+                    Ok(()) => ControlFlow::Continue(()),
+                    Err(_) => ControlFlow::Break(()),
                 },
             )
         };


### PR DESCRIPTION
Switch the internal `vm::Backtrace` to use `TryVec` instead of `Vec`, breaking out of frame collection on OOM instead of aborting. In the public `WasmBacktrace`, use `TryVec::with_capacity` and gracefully return an empty backtrace if the initial allocation fails, or break out of the loop if a push fails.

Truncated backtraces are better than aborting the process.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
