### PR TITLE
Propagate OOM from `dummy_linker`'s `define` calls

### DIFF
--- a/crates/fuzzing/src/oracles/dummy.rs
+++ b/crates/fuzzing/src/oracles/dummy.rs
@@ -15,9 +15,7 @@ pub fn dummy_linker<T>(store: &mut Store<T>, module: &Module) -> Result<Linker<T
                 import.ty(),
             )
         })?;
-        linker
-            .define(&store, import.module(), import.name(), extern_)
-            .unwrap();
+        linker.define(&store, import.module(), import.name(), extern_)?;
     }
     Ok(linker)
 }


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
