### PR TITLE
examples-debugging-guest.md is missing for mdbook build.

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -24,6 +24,7 @@
   - [Memory Protection Keys](./examples-mpk.md)
   - [Async Host Functions](./examples-async.md)
   - [Debugging WebAssembly](./examples-debugging.md)
+    - [Guest Debugging with `lldb`](./examples-debugging-guest.md)
     - [Debugging with `gdb` and `lldb`](./examples-debugging-native-debugger.md)
     - [Debugging with Core Dumps](./examples-debugging-core-dumps.md)
   - [Profiling WebAssembly](./examples-profiling.md)


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->

https://github.com/bytecodealliance/wasmtime/blob/main/docs/examples-debugging-guest.md is missing for mdbook, that causes https://docs.wasmtime.dev/examples-debugging-guest.html