### PR TITLE
Cranelift: add "fuel" to egraph rewrites.

### DIFF
--- a/cranelift/codegen/src/egraph/mod.rs
+++ b/cranelift/codegen/src/egraph/mod.rs
@@ -281,10 +281,11 @@ const MATCHES_LIMIT: usize = 5;
 /// The maximum number of enodes in any given eclass.
 const ECLASS_ENODE_LIMIT: usize = 5;
 
-/// The amount of "fuel" available for each top-level rewrite invocation.
+/// The amount of "fuel" available for each top-level rewrite
+/// invocation's eclass extractors.
 ///
 /// Each yield from a multi-extractor iterator consumes one unit.
-pub(crate) const REWRITE_FUEL: u32 = 500;
+pub(crate) const EXTRACTOR_FUEL: u32 = 500;
 
 /// Context passed through node insertion and optimization.
 pub(crate) struct OptimizeCtx<'opt, 'analysis>
@@ -306,7 +307,7 @@ where
     ctrl_plane: &'opt mut ControlPlane,
     // Held locally during optimization of one node (recursively):
     pub(crate) rewrite_depth: usize,
-    pub(crate) fuel: u32,
+    pub(crate) extractor_fuel: u32,
     pub(crate) subsume_values: FxHashSet<Value>,
     optimized_values: SmallVec<[Value; MATCHES_LIMIT]>,
     optimized_insts: SmallVec<[SkeletonInstSimplification; MATCHES_LIMIT]>,
@@ -1062,7 +1063,7 @@ impl<'a> EgraphPass<'a> {
                     available_block: &mut available_block,
                     eclass_size: &mut eclass_size,
                     rewrite_depth: 0,
-                    fuel: REWRITE_FUEL,
+                    extractor_fuel: EXTRACTOR_FUEL,
                     subsume_values: FxHashSet::default(),
                     remat_values: &mut self.remat_values,
                     stats: &mut self.stats,

--- a/cranelift/codegen/src/egraph/mod.rs
+++ b/cranelift/codegen/src/egraph/mod.rs
@@ -281,6 +281,11 @@ const MATCHES_LIMIT: usize = 5;
 /// The maximum number of enodes in any given eclass.
 const ECLASS_ENODE_LIMIT: usize = 5;
 
+/// The amount of "fuel" available for each top-level rewrite invocation.
+///
+/// Each yield from a multi-extractor iterator consumes one unit.
+pub(crate) const REWRITE_FUEL: u32 = 500;
+
 /// Context passed through node insertion and optimization.
 pub(crate) struct OptimizeCtx<'opt, 'analysis>
 where
@@ -301,6 +306,7 @@ where
     ctrl_plane: &'opt mut ControlPlane,
     // Held locally during optimization of one node (recursively):
     pub(crate) rewrite_depth: usize,
+    pub(crate) fuel: u32,
     pub(crate) subsume_values: FxHashSet<Value>,
     optimized_values: SmallVec<[Value; MATCHES_LIMIT]>,
     optimized_insts: SmallVec<[SkeletonInstSimplification; MATCHES_LIMIT]>,
@@ -1056,6 +1062,7 @@ impl<'a> EgraphPass<'a> {
                     available_block: &mut available_block,
                     eclass_size: &mut eclass_size,
                     rewrite_depth: 0,
+                    fuel: REWRITE_FUEL,
                     subsume_values: FxHashSet::default(),
                     remat_values: &mut self.remat_values,
                     stats: &mut self.stats,
@@ -1274,6 +1281,7 @@ pub(crate) struct Stats {
     pub(crate) rewrite_rule_invoked: u64,
     pub(crate) rewrite_rule_results: u64,
     pub(crate) rewrite_depth_limit: u64,
+    pub(crate) rewrite_fuel_exhausted: u64,
     pub(crate) elaborate_visit_node: u64,
     pub(crate) elaborate_memoize_hit: u64,
     pub(crate) elaborate_memoize_miss: u64,

--- a/cranelift/codegen/src/opts.rs
+++ b/cranelift/codegen/src/opts.rs
@@ -103,6 +103,17 @@ where
                     continue;
                 }
                 ValueDef::Result(inst, _) if ctx.ctx.func.dfg.inst_results(inst).len() == 1 => {
+                    // Charge one unit of fuel per yielded match. When
+                    // fuel is exhausted, terminate iteration early:
+                    // returning no matches is always semantically valid
+                    // (we just skip would-be rewrites) and bounds work
+                    // per top-level ISLE invocation.
+                    if ctx.ctx.fuel == 0 {
+                        ctx.ctx.stats.rewrite_fuel_exhausted += 1;
+                        trace!(" -> rewrite fuel exhausted");
+                        return None;
+                    }
+                    ctx.ctx.fuel -= 1;
                     let ty = ctx.ctx.func.dfg.value_type(value);
                     trace!(" -> value of type {}", ty);
                     return Some((ty, ctx.ctx.func.dfg.insts[inst]));

--- a/cranelift/codegen/src/opts.rs
+++ b/cranelift/codegen/src/opts.rs
@@ -108,12 +108,12 @@ where
                     // returning no matches is always semantically valid
                     // (we just skip would-be rewrites) and bounds work
                     // per top-level ISLE invocation.
-                    if ctx.ctx.fuel == 0 {
+                    if ctx.ctx.extractor_fuel == 0 {
                         ctx.ctx.stats.rewrite_fuel_exhausted += 1;
                         trace!(" -> rewrite fuel exhausted");
                         return None;
                     }
-                    ctx.ctx.fuel -= 1;
+                    ctx.ctx.extractor_fuel -= 1;
                     let ty = ctx.ctx.func.dfg.value_type(value);
                     trace!(" -> value of type {}", ty);
                     return Some((ty, ctx.ctx.func.dfg.insts[inst]));


### PR DESCRIPTION
This addresses the kind of blowup seen in #13068 (and analyzed in #13204). Specifically, even though we limit the rewrite depth, and size of eclasses, one can still get into situations where the Cartesian product of match possibilities on the left-hand side blows up.

The ISLE rules in the mid-end are compiled to Rust that loops over iterators over each eclass, so if we limit what those iterators can return, we can limit the only dynamic factor in the runtime of the ruleset. This PR implements "fuel" that imposes a hard cutoff of 500 LHS matches per top-level rewrite invocation, with iterators returning `None` afterward. The mid-end failing to find a match is always OK -- it just means that we don't rewrite/optimize -- so cutting off early is always a correct/valid choice.

The cutoff limit of 500 might seem a little high at first glance, but note that this is *every* LHS match; including e.g. in sub-matchers; 50 turned out to miss a few rewrites in our tests, so I turned the knob up to 500. This is still sufficient to limit the blowup case shown in #13068 from 2.31s to 0.01s, with RSS decreasing from 855 MiB to 17 MiB, which is a significant win.

Fixes #13204.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
