### PR TITLE
Cranelift: MachBuffer: resolve deadline issues with very large islands.

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/mod.rs
@@ -1166,6 +1166,19 @@ impl MachInst for Inst {
         44
     }
 
+    fn worst_case_island_growth() -> CodeOffset {
+        // A single `Inst` may add to the buffer's pending-island state:
+        //
+        // - Up to three 8-byte constants (the saturating int-to-float sequence
+        //   noted above); count alignment padding into each.
+        // - Up to one deferred trap (TrapIf and similar), 4 bytes.
+        // - Up to one fixup per emitted instruction word, each contributing at
+        //   most `worst_case_veneer_size()` (= 20) bytes of veneer.
+        //
+        // We pick a conservative bound that comfortably covers these.
+        128
+    }
+
     fn ref_type_regclass(_: &settings::Flags) -> RegClass {
         RegClass::Int
     }

--- a/cranelift/codegen/src/isa/pulley_shared/inst/mod.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/inst/mod.rs
@@ -591,6 +591,14 @@ where
         22
     }
 
+    fn worst_case_island_growth() -> CodeOffset {
+        // A single instruction may add an embedded constant, a deferred
+        // trap, and a few fixup records. Pulley's label-uses all have
+        // ~2 GiB range and don't support veneers, so this just covers
+        // constants and trap bytes; we pick a conservative bound.
+        32
+    }
+
     fn ref_type_regclass(_settings: &settings::Flags) -> RegClass {
         RegClass::Int
     }

--- a/cranelift/codegen/src/isa/riscv64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/mod.rs
@@ -859,6 +859,14 @@ impl MachInst for Inst {
         84
     }
 
+    fn worst_case_island_growth() -> CodeOffset {
+        // Conservative upper bound on per-instruction additions to the
+        // buffer's pending-island state: several embedded constants, a
+        // deferred trap, and a handful of fixups whose worst-case veneers
+        // are 8 bytes apiece. Sized comfortably to cover real cases.
+        128
+    }
+
     fn ref_type_regclass(_settings: &settings::Flags) -> RegClass {
         RegClass::Int
     }

--- a/cranelift/codegen/src/isa/s390x/inst/mod.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/mod.rs
@@ -1265,6 +1265,10 @@ impl MachInst for Inst {
         44
     }
 
+    fn worst_case_island_growth() -> CodeOffset {
+        0
+    }
+
     fn ref_type_regclass(_: &settings::Flags) -> RegClass {
         RegClass::Int
     }

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -1463,6 +1463,10 @@ impl MachInst for Inst {
         15
     }
 
+    fn worst_case_island_growth() -> CodeOffset {
+        0
+    }
+
     fn ref_type_regclass(_: &settings::Flags) -> RegClass {
         RegClass::Int
     }

--- a/cranelift/codegen/src/machinst/buffer.rs
+++ b/cranelift/codegen/src/machinst/buffer.rs
@@ -38,10 +38,9 @@
 //!
 //! - To solve this problem, we emit "islands" full of "veneers". An island is
 //!   simply a chunk of code inserted in the middle of the code actually produced
-//!   by the emitter (e.g., vcode iterating over instruction structs). The emitter
-//!   has some awareness of this: it either asks for an island between blocks, so
-//!   it is not accidentally executed, or else it emits a branch around the island
-//!   when all other options fail (see `Inst::EmitIsland` meta-instruction).
+//!   by the emitter (e.g., VCode iterating over instruction structs). Islands
+//!   are emitted at "safe" points (no fall-through into the island contents):
+//!   between basic blocks during emission, or via a jump around the island.
 //!
 //! - A "veneer" is an instruction (or sequence of instructions) in an "island"
 //!   that implements a longer-range reference to a label. The idea is that, for
@@ -139,6 +138,35 @@
 //!
 //! Given these invariants, we argue why each optimization preserves execution
 //! semantics below (grep for "Preserves execution semantics").
+//!
+//! # Deadline-correctness for islands
+//!
+//! Every label-use (and indirectly every pending constant/trap, since
+//! each is referred to by a fixup) imposes a *deadline*: the maximum
+//! offset at which the use's target may be bound while still
+//! remaining in range. Each item that may be emitted into an island
+//! (a veneer, a pending constant, or a pending trap) also contributes
+//! a bounded number of bytes to a worst-case island size. The
+//! buffer's central invariant is:
+//!
+//! > `worst_case_end_of_island(0) <= soonest_deadline`
+//!
+//! Equivalently, "if we emitted an island right now, its end offset
+//! would land before the closest expiring deadline." Given this
+//! invariant, an island is always *feasible*: items can be laid out
+//! in any order and each one lands at an offset no later than the
+//! soonest deadline, which is no later than each individual item's
+//! deadline.
+//!
+//! To maintain the invariant, the buffer's user is expected to treat
+//! *one `MachInst` emission* as the atomic commit unit. After each
+//! instruction, the worst-case end-of-island and the soonest deadline
+//! can shift by no more than `worst_case_size() +
+//! worst_case_island_growth()` and one "smallest label-use range"
+//! worth of new deadline, respectively. The user (in VCode emission)
+//! consults [`MachBuffer::island_needed`] after each instruction and
+//! if one is needed, emits a jump-around branch followed by
+//! [`MachBuffer::emit_island`].
 //!
 //! # Avoiding Quadratic Behavior
 //!
@@ -1306,9 +1334,10 @@ impl<I: VCodeInst> MachBuffer<I> {
         // the worst-case size for each platform. This is an over-generalization
         // to avoid iterating over the `fixup_records` list or maintaining
         // information about it as we go along.
-        let island_worst_case_size = ((self.fixup_records.len() + self.pending_fixup_records.len())
-            as u32)
-            * (I::LabelUse::worst_case_veneer_size())
+        let max_veneer_count =
+            u32::try_from(self.fixup_records.len() + self.pending_fixup_records.len()).unwrap();
+        let island_worst_case_size = max_veneer_count
+            .saturating_mul(I::LabelUse::worst_case_veneer_size())
             + self.pending_constants_size
             + (self.pending_traps.len() * I::TRAP_OPCODE.len()) as u32;
         self.cur_offset()
@@ -1321,6 +1350,11 @@ impl<I: VCodeInst> MachBuffer<I> {
     /// Should only be called if `island_needed()` returns true, i.e., if we
     /// actually reach a deadline. It's not necessarily a problem to do so
     /// otherwise but it may result in unnecessary work during emission.
+    ///
+    /// The current code-emission position must be a "safe" location for an
+    /// island: i.e., no fallthrough into the island contents from the
+    /// previous instruction is possible. Callers emitting inside a basic
+    /// block should emit a jump-around branch.
     pub fn emit_island(&mut self, distance: CodeOffset, ctrl_plane: &mut ControlPlane) {
         self.emit_island_maybe_forced(ForceVeneers::No, distance, ctrl_plane);
     }
@@ -2521,7 +2555,7 @@ mod test {
     use crate::isa::aarch64;
     use crate::isa::aarch64::inst::{BranchTarget, CondBrKind, EmitInfo, Inst};
     use crate::isa::aarch64::inst::{OperandSize, xreg};
-    use crate::machinst::{MachInstEmit, MachInstEmitState};
+    use crate::machinst::{MachInst, MachInstEmit, MachInstEmitState};
     use crate::settings;
 
     fn label(n: u32) -> MachLabel {
@@ -2970,5 +3004,146 @@ mod test {
                 .collect::<Vec<_>>(),
             vec![(2, Reloc::Abs4), (3, Reloc::Abs8)]
         );
+    }
+
+    /// Drive the buffer in the same idiom that VCode emission uses:
+    /// emit instruction bytes via the given closure, then run the
+    /// per-instruction island check.
+    fn emit_with_island_check(
+        buf: &mut MachBuffer<Inst>,
+        state: &mut <Inst as MachInstEmit>::State,
+        f: impl FnOnce(&mut MachBuffer<Inst>, &mut <Inst as MachInstEmit>::State),
+    ) {
+        f(buf, state);
+        let lookahead = Inst::worst_case_size() + Inst::worst_case_island_growth();
+        if buf.island_needed(lookahead) {
+            let jump_around = buf.get_label();
+            Inst::gen_jump(jump_around).emit(buf, &emit_info(), state);
+            buf.emit_island(0, state.ctrl_plane_mut());
+            buf.bind_label(jump_around, state.ctrl_plane_mut());
+        }
+    }
+
+    /// Many constant loads in a single basic block: each emits an
+    /// `Ldr19` reference (+/- 1 MiB range, no veneer support) and
+    /// adds a 16-byte constant to the pool. Without the
+    /// per-instruction island check, the pool would grow past the
+    /// reach of earlier `ldr`s and the buffer would panic during the
+    /// final fixup pass (see issue #12968).
+    #[test]
+    fn test_many_constants_in_one_block() {
+        use crate::ir::constant::ConstantData;
+
+        let mut buf = MachBuffer::<Inst>::new();
+        let mut state = <Inst as MachInstEmit>::State::default();
+        let mut constants = VCodeConstants::default();
+
+        let n = 200_000;
+        let mut handles = Vec::with_capacity(n);
+        for i in 0..n {
+            let bytes: Vec<u8> = (0..16).map(|b| ((i + b) & 0xff) as u8).collect();
+            let data = VCodeConstantData::Generated(ConstantData::from(&bytes[..]));
+            handles.push(constants.insert(data));
+        }
+        buf.register_constants(&constants);
+
+        buf.reserve_labels_for_blocks(1);
+        buf.bind_label(label(0), state.ctrl_plane_mut());
+
+        for &handle in &handles {
+            emit_with_island_check(&mut buf, &mut state, |buf, _state| {
+                let off = buf.cur_offset();
+                let const_label = buf.get_label_for_constant(handle);
+                buf.use_label_at_offset(off, const_label, aarch64::inst::LabelUse::Ldr19);
+                // Placeholder ldr literal instruction.
+                buf.put4(0);
+            });
+        }
+
+        let _ = buf.finish(&constants, state.ctrl_plane_mut());
+    }
+
+    /// Mix conditional branches with short ranges (`Branch19`, +/- 1
+    /// MiB) and many constant loads. The branches' veneers must
+    /// remain in range as the constant pool grows.
+    #[test]
+    fn test_short_branch_amid_constants() {
+        use crate::ir::constant::ConstantData;
+
+        let mut buf = MachBuffer::<Inst>::new();
+        let mut state = <Inst as MachInstEmit>::State::default();
+        let mut constants = VCodeConstants::default();
+
+        let n = 100_000;
+        let mut handles = Vec::with_capacity(n);
+        for i in 0..n {
+            let bytes: Vec<u8> = (0..16).map(|b| ((i ^ b) & 0xff) as u8).collect();
+            handles.push(
+                constants.insert(VCodeConstantData::Generated(ConstantData::from(&bytes[..]))),
+            );
+        }
+        buf.register_constants(&constants);
+
+        buf.reserve_labels_for_blocks(2);
+        buf.bind_label(label(0), state.ctrl_plane_mut());
+
+        emit_with_island_check(&mut buf, &mut state, |buf, state| {
+            let inst = Inst::CondBr {
+                kind: CondBrKind::NotZero(xreg(0), OperandSize::Size64),
+                taken: target(1),
+                not_taken: target(0),
+            };
+            inst.emit(buf, &emit_info(), state);
+        });
+
+        for &handle in &handles {
+            emit_with_island_check(&mut buf, &mut state, |buf, _state| {
+                let off = buf.cur_offset();
+                let const_label = buf.get_label_for_constant(handle);
+                buf.use_label_at_offset(off, const_label, aarch64::inst::LabelUse::Ldr19);
+                buf.put4(0);
+            });
+        }
+
+        buf.bind_label(label(1), state.ctrl_plane_mut());
+        let _ = buf.finish(&constants, state.ctrl_plane_mut());
+    }
+
+    /// Driving an island in the middle of a block via the
+    /// jump-around-plus-`emit_island` idiom must emit a branch followed
+    /// by the island contents, such that fall-through reaches the
+    /// post-island code.
+    #[test]
+    fn test_mid_block_island_via_gen_jump() {
+        let mut buf = MachBuffer::<Inst>::new();
+        let mut state = <Inst as MachInstEmit>::State::default();
+        let constants = VCodeConstants::default();
+
+        buf.reserve_labels_for_blocks(1);
+        buf.bind_label(label(0), state.ctrl_plane_mut());
+
+        // Place a trap which will need to be emitted in the next island.
+        let trap_label = buf.defer_trap(TrapCode::HEAP_OUT_OF_BOUNDS);
+        let off = buf.cur_offset();
+        buf.use_label_at_offset(off, trap_label, aarch64::inst::LabelUse::Branch19);
+        buf.put4(0); // placeholder for cbnz-like reference
+
+        let before = buf.cur_offset();
+        let jump_around = buf.get_label();
+        Inst::gen_jump(jump_around).emit(&mut buf, &emit_info(), &mut state);
+        buf.emit_island(0, state.ctrl_plane_mut());
+        buf.bind_label(jump_around, state.ctrl_plane_mut());
+        let after = buf.cur_offset();
+
+        // The jump-around branch (4 bytes on AArch64) plus at least the
+        // deferred trap (4 bytes) gives a minimum island growth of 8 bytes.
+        assert!(
+            after - before >= 8,
+            "island grew too little: {}",
+            after - before
+        );
+
+        let buf = buf.finish(&constants, state.ctrl_plane_mut());
+        let _ = buf.total_size();
     }
 }

--- a/cranelift/codegen/src/machinst/mod.rs
+++ b/cranelift/codegen/src/machinst/mod.rs
@@ -189,6 +189,19 @@ pub trait MachInst: Clone + Debug {
     /// What is the worst-case instruction size emitted by this instruction type?
     fn worst_case_size() -> CodeOffset;
 
+    /// Worst-case growth, in bytes, that emitting a single `MachInst`
+    /// instruction may add to the `MachBuffer`'s pending-island state
+    /// (constants, deferred traps, and worst-case veneers for new
+    /// fixups).
+    ///
+    /// `MachBuffer` treats one instruction emission as the atomic
+    /// "commit unit" and uses `worst_case_size() +
+    /// worst_case_island_growth()` as the per-instruction lookahead
+    /// bound when deciding whether to flush an island. Backends whose
+    /// label-use kinds always have wide enough range that islands are
+    /// never required may leave this at zero.
+    fn worst_case_island_growth() -> CodeOffset;
+
     /// What is the register class used for reference types (GC-observable pointers)? Can
     /// be dependent on compilation flags.
     fn ref_type_regclass(_flags: &Flags) -> RegClass;

--- a/cranelift/codegen/src/machinst/vcode.rs
+++ b/cranelift/codegen/src/machinst/vcode.rs
@@ -1100,18 +1100,23 @@ impl<I: VCodeInst> VCode<I> {
             // test case generating a GB+ memory footprint in Cranelift for
             // example.
             if !bb_padding.is_empty() {
+                // The padding bytes go directly into the buffer without
+                // passing through `do_emit`, so check the deadline invariant
+                // *before* writing them: if the padding would push the
+                // worst-case end of an island past any pending deadline,
+                // drain pending fixups via an island now. We're between
+                // blocks, so no jump-around is needed.
+                let padding_len = bb_padding.len() as u32 + I::LabelUse::ALIGN - 1;
+                let lookahead = I::worst_case_size() + I::worst_case_island_growth();
+                if buffer.island_needed(padding_len + lookahead) {
+                    buffer.emit_island(padding_len + lookahead, ctrl_plane);
+                }
+
                 buffer.put_data(&bb_padding);
                 buffer.align_to(I::LabelUse::ALIGN);
                 total_bb_padding += bb_padding.len();
                 if total_bb_padding > (150 << 20) {
                     bb_padding = Vec::new();
-                }
-                // The padding consumes raw buffer bytes without going through
-                // `do_emit`, so re-check the deadline invariant here. We're
-                // between blocks, so no jump-around is needed.
-                let lookahead = I::worst_case_size() + I::worst_case_island_growth();
-                if buffer.island_needed(lookahead) {
-                    buffer.emit_island(lookahead, ctrl_plane);
                 }
             }
         }

--- a/cranelift/codegen/src/machinst/vcode.rs
+++ b/cranelift/codegen/src/machinst/vcode.rs
@@ -820,7 +820,7 @@ impl<I: VCodeInst> VCode<I> {
         };
         let mut total_bb_padding = 0;
 
-        for (block_order_idx, &block) in final_order.iter().enumerate() {
+        for &block in final_order.iter() {
             trace!("emitting block {:?}", block);
 
             // Call the new block hook for state
@@ -844,6 +844,17 @@ impl<I: VCodeInst> VCode<I> {
                     writeln!(disasm, "  {}", inst.pretty_print_inst(&mut s)).unwrap();
                 }
                 inst.emit(buffer, &self.emit_info, state);
+                // The buffer maintains its deadline invariant per-`MachInst`:
+                // after each instruction, ensure that the worst-case end of
+                // any island the buffer might emit lies before the soonest
+                // deadline, even after the next instruction.
+                let lookahead = I::worst_case_size() + I::worst_case_island_growth();
+                if buffer.island_needed(lookahead) {
+                    let jump_around = buffer.get_label();
+                    I::gen_jump(jump_around).emit(buffer, &self.emit_info, state);
+                    buffer.emit_island(0, state.ctrl_plane_mut());
+                    buffer.bind_label(jump_around, state.ctrl_plane_mut());
+                }
             };
 
             // Is this the first block? Emit the prologue directly if so.
@@ -1080,27 +1091,6 @@ impl<I: VCodeInst> VCode<I> {
                 cur_srcloc = None;
             }
 
-            // Do we need an island? Get the worst-case size of the next BB, add
-            // it to the optional padding behind the block, and pass this to the
-            // `MachBuffer` to determine if an island is necessary.
-            let worst_case_next_bb = if block_order_idx < final_order.len() - 1 {
-                let next_block = final_order[block_order_idx + 1];
-                let next_block_range = self.block_ranges.get(next_block.index());
-                let next_block_size = next_block_range.len() as u32;
-                let next_block_ra_insertions = ra_edits_per_block[next_block.index()];
-                I::worst_case_size() * (next_block_size + next_block_ra_insertions)
-            } else {
-                0
-            };
-            let padding = if bb_padding.is_empty() {
-                0
-            } else {
-                bb_padding.len() as u32 + I::LabelUse::ALIGN - 1
-            };
-            if buffer.island_needed(padding + worst_case_next_bb) {
-                buffer.emit_island(padding + worst_case_next_bb, ctrl_plane);
-            }
-
             // Insert padding, if configured, to stress the `MachBuffer`'s
             // relocation and island calculations.
             //
@@ -1115,6 +1105,13 @@ impl<I: VCodeInst> VCode<I> {
                 total_bb_padding += bb_padding.len();
                 if total_bb_padding > (150 << 20) {
                     bb_padding = Vec::new();
+                }
+                // The padding consumes raw buffer bytes without going through
+                // `do_emit`, so re-check the deadline invariant here. We're
+                // between blocks, so no jump-around is needed.
+                let lookahead = I::worst_case_size() + I::worst_case_island_growth();
+                if buffer.island_needed(lookahead) {
+                    buffer.emit_island(lookahead, ctrl_plane);
                 }
             }
         }

--- a/cranelift/filetests/filetests/isa/riscv64/issue-12811.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/issue-12811.clif
@@ -5029,1207 +5029,152 @@ block2:
 ;   beqz a1, 6
 ;   c.unimp ; trap: user11
 ; block12: ; offset 0x3dc
-;   c.j 4
-;   c.unimp
-;   auipc t6, 0
-;   jalr zero, t6, 8
-; block13: ; offset 0x3e8
-;   auipc a2, 1
-;   ld a2, 0xc0(a2)
+;   auipc a2, 0
+;   ld a2, 0x1ec(a2)
 ;   c.li a1, 0
 ;   c.sd a2, 0(a1) ; trap: heap_oob
-;   auipc a2, 1
-;   ld a2, 0xbc(a2)
+;   auipc a2, 0
+;   ld a2, 0x1e8(a2)
 ;   c.sd a2, 0(a1) ; trap: heap_oob
-;   auipc a2, 1
-;   ld a2, 0xba(a2)
+;   auipc a2, 0
+;   ld a2, 0x1e6(a2)
 ;   c.sd a2, 0(a1) ; trap: heap_oob
-;   auipc a2, 1
-;   ld a2, 0xb8(a2)
+;   auipc a2, 0
+;   ld a2, 0x1e4(a2)
 ;   c.sd a2, 0(a1) ; trap: heap_oob
-;   auipc a2, 1
-;   ld a2, 0xb6(a2)
+;   auipc a2, 0
+;   ld a2, 0x1e2(a2)
 ;   c.sd a2, 0(a1) ; trap: heap_oob
-;   auipc a2, 1
-;   ld a2, 0xb4(a2)
+;   auipc a2, 0
+;   ld a2, 0x1e0(a2)
 ;   c.sd a2, 0(a1) ; trap: heap_oob
-;   auipc a2, 1
-;   ld a2, 0xb2(a2)
+;   auipc a2, 0
+;   ld a2, 0x1de(a2)
 ;   sd zero, 0(a2) ; trap: heap_oob
-;   auipc a2, 1
-;   ld a2, 0xae(a2)
+;   auipc a2, 0
+;   ld a2, 0x1da(a2)
 ;   c.sd a2, 0(a1) ; trap: heap_oob
-;   auipc a2, 1
-;   ld a2, 0xac(a2)
+;   auipc a2, 0
+;   ld a2, 0x1d8(a2)
 ;   c.sd a2, 0(a1) ; trap: heap_oob
-;   auipc a2, 1
-;   ld a2, 0xaa(a2)
+;   auipc a2, 0
+;   ld a2, 0x1d6(a2)
 ;   c.sd a2, 0(a1) ; trap: heap_oob
-;   auipc a2, 1
-;   ld a2, 0xa8(a2)
+;   auipc a2, 0
+;   ld a2, 0x1d4(a2)
 ;   c.sd a2, 0(a1) ; trap: heap_oob
-;   auipc a2, 1
-;   ld a2, 0xa6(a2)
+;   auipc a2, 0
+;   ld a2, 0x1d2(a2)
 ;   c.sd a2, 0(a1) ; trap: heap_oob
 ;   c.li a2, 1
-;   auipc a3, 1
-;   ld a3, 0xa2(a3)
+;   auipc a3, 0
+;   ld a3, 0x1ce(a3)
 ;   c.sd a2, 0(a3) ; trap: heap_oob
-;   auipc a3, 1
-;   ld a3, 0xa0(a3)
+;   auipc a3, 0
+;   ld a3, 0x1cc(a3)
 ;   c.sd a3, 0(a1) ; trap: heap_oob
-;   auipc a3, 1
-;   ld a3, 0x9e(a3)
+;   auipc a3, 0
+;   ld a3, 0x1ca(a3)
 ;   c.sd a3, 0(a1) ; trap: heap_oob
-;   auipc a3, 1
-;   ld a3, 0x9c(a3)
+;   auipc a3, 0
+;   ld a3, 0x1c8(a3)
 ;   c.sd a3, 0(a1) ; trap: heap_oob
-;   auipc a3, 1
-;   ld a3, 0x9a(a3)
+;   auipc a3, 0
+;   ld a3, 0x1c6(a3)
 ;   c.sd a3, 0(a1) ; trap: heap_oob
-;   auipc a3, 1
-;   ld a3, 0x98(a3)
+;   auipc a3, 0
+;   ld a3, 0x1c4(a3)
 ;   sd zero, 0(a3) ; trap: heap_oob
-;   auipc a3, 1
-;   ld a3, 0x94(a3)
+;   auipc a3, 0
+;   ld a3, 0x1c0(a3)
 ;   c.sd a3, 0(a1) ; trap: heap_oob
-;   auipc a3, 1
-;   ld a3, 0x92(a3)
+;   auipc a3, 0
+;   ld a3, 0x1be(a3)
 ;   c.sd a3, 0(a1) ; trap: heap_oob
-;   auipc a3, 1
-;   ld a3, 0x90(a3)
+;   auipc a3, 0
+;   ld a3, 0x1bc(a3)
 ;   c.sd a3, 0(a1) ; trap: heap_oob
-;   auipc a3, 1
-;   ld a3, 0x8e(a3)
+;   auipc a3, 0
+;   ld a3, 0x1ba(a3)
 ;   c.sd a3, 0(a1) ; trap: heap_oob
-;   auipc a3, 1
-;   ld a3, 0x8c(a3)
+;   auipc a3, 0
+;   ld a3, 0x1b8(a3)
 ;   c.sd a3, 0(a1) ; trap: heap_oob
-;   auipc a3, 1
-;   ld a3, 0x8a(a3)
+;   auipc a3, 0
+;   ld a3, 0x1b6(a3)
 ;   c.sd a3, 0(a1) ; trap: heap_oob
-;   auipc a3, 1
-;   ld a3, 0x88(a3)
+;   auipc a3, 0
+;   ld a3, 0x1b4(a3)
 ;   sd zero, 0(a3) ; trap: heap_oob
-;   auipc a3, 1
-;   ld a3, 0x84(a3)
+;   auipc a3, 0
+;   ld a3, 0x1b0(a3)
 ;   sd zero, 0(a3) ; trap: heap_oob
-;   auipc a3, 1
-;   ld a3, 0x80(a3)
+;   auipc a3, 0
+;   ld a3, 0x1ac(a3)
 ;   c.sd a3, 0(a1) ; trap: heap_oob
-;   auipc a3, 1
-;   ld a3, 0x7e(a3)
+;   auipc a3, 0
+;   ld a3, 0x1aa(a3)
 ;   c.sd a2, 0(a3) ; trap: heap_oob
-;   auipc a3, 1
-;   ld a3, 0x7c(a3)
+;   auipc a3, 0
+;   ld a3, 0x1a8(a3)
 ;   c.sd a3, 0(a1) ; trap: heap_oob
-;   auipc a3, 1
-;   ld a3, 0x7a(a3)
+;   auipc a3, 0
+;   ld a3, 0x1a6(a3)
 ;   c.sd a3, 0(a1) ; trap: heap_oob
-;   auipc a3, 1
-;   ld a3, 0x78(a3)
+;   auipc a3, 0
+;   ld a3, 0x1a4(a3)
 ;   c.sd a3, 0(a1) ; trap: heap_oob
-;   auipc a3, 1
-;   ld a3, 0x76(a3)
+;   auipc a3, 0
+;   ld a3, 0x1a2(a3)
 ;   sd zero, 0(a3) ; trap: heap_oob
-;   auipc a3, 1
-;   ld a3, 0x72(a3)
+;   auipc a3, 0
+;   ld a3, 0x19e(a3)
 ;   c.sd a3, 0(a1) ; trap: heap_oob
-;   auipc a3, 1
-;   ld a3, 0x70(a3)
+;   auipc a3, 0
+;   ld a3, 0x19c(a3)
 ;   c.sd a3, 0(a1) ; trap: heap_oob
-;   auipc a3, 1
-;   ld a3, 0x6e(a3)
+;   auipc a3, 0
+;   ld a3, 0x19a(a3)
 ;   c.sd a3, 0(a1) ; trap: heap_oob
-;   auipc a3, 1
-;   ld a3, 0x6c(a3)
+;   auipc a3, 0
+;   ld a3, 0x198(a3)
 ;   c.sd a3, 0(a1) ; trap: heap_oob
-;   auipc a3, 1
-;   ld a3, 0x6a(a3)
+;   auipc a3, 0
+;   ld a3, 0x196(a3)
 ;   c.sd a3, 0(a1) ; trap: heap_oob
-;   auipc a3, 1
-;   ld a3, 0x68(a3)
+;   auipc a3, 0
+;   ld a3, 0x194(a3)
 ;   c.sd a3, 0(a1) ; trap: heap_oob
-;   auipc a3, 1
-;   ld a3, 0x66(a3)
+;   auipc a3, 0
+;   ld a3, 0x192(a3)
 ;   c.sd a3, 0(a1) ; trap: heap_oob
-;   auipc a3, 1
-;   ld a3, 0x64(a3)
+;   auipc a3, 0
+;   ld a3, 0x190(a3)
 ;   c.sd a3, 0(a1) ; trap: heap_oob
-;   auipc a3, 1
-;   ld a3, 0x62(a3)
+;   auipc a3, 0
+;   ld a3, 0x18e(a3)
 ;   c.sd a3, 0(a1) ; trap: heap_oob
 ;   c.li a3, 1
-;   auipc a4, 1
-;   ld a4, 0x5e(a4)
+;   auipc a4, 0
+;   ld a4, 0x18a(a4)
 ;   c.sw a3, 0(a4) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x5c(a4)
+;   auipc a4, 0
+;   ld a4, 0x188(a4)
 ;   c.sd a4, 0(a1) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x5a(a4)
+;   auipc a4, 0
+;   ld a4, 0x186(a4)
 ;   c.sd a4, 0(a1) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x58(a4)
+;   auipc a4, 0
+;   ld a4, 0x184(a4)
 ;   sd zero, 0(a4) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x54(a4)
+;   auipc a4, 0
+;   ld a4, 0x180(a4)
 ;   c.sd a4, 0(a1) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x52(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, 0x50(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   c.li a4, 0
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, 0x40(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, 0x3a(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, 0x34(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, 0x32(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, 0x24(a5)
-;   auipc s8, 1
-;   ld s8, 0x24(s8)
-;   sd a5, 0(s8) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, 4(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x12(a5)
-;   sd zero, 0(a5) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x1a(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x20(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x32(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x34(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x3a(a5)
-;   sd zero, 0(a5) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x3e(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x44(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x66(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x70(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x72(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x78(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x7a(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x8c(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x92(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x98(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x9a(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x9c(a5)
-;   c.ld a5, 0(a5) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0xa6(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0xa8(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0xae(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0xb0(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0xb6(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0xc0(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0xca(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0xd0(a5)
-;   sd zero, 0(a5) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0xe4(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0xea(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0xf0(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0xfa(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x100(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x106(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x114(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x11a(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x120(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x12a(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x12c(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x132(a5)
-;   c.ld a5, 0(a5) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x138(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x13a(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x140(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x14e(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x15c(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x172(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x178(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x186(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x190(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x196(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x198(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x19e(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x1a0(a5)
-;   sd zero, 0(a5) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x1a8(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x1be(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x1c4(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x1c6(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x1e0(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x1e6(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x1f0(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x1fe(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x200(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x206(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x208(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x212(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x220(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x22a(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x22c(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x232(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x244(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x246(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x24c(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x24e(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x254(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x256(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x260(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x266(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x268(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x26a(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x26c(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x27e(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x284(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x286(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x28c(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x28e(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x2a4(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x2b2(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x2bc(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x2c2(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x2c4(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x2d2(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x2d4(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x2da(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x2f8(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x2fe(a5)
-;   c.sd a2, 0(a5) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x310(a5)
-;   sd zero, 0(a5) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x330(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x346(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x354(a5)
-;   sd zero, 0(a5) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x364(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x366(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x370(a5)
-;   c.sd a2, 0(a5) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x372(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x37c(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x382(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x384(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x39e(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x3ac(a5)
-;   c.sd a2, 0(a5) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x3ae(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x3c0(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   lui a5, 0x4b912
-;   addi a5, a5, -0x6f
-;   auipc a6, 1
-;   ld a6, -0x3da(a6)
-;   sw a5, 0(a6) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x3e2(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x3e4(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x3ea(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x3f8(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x402(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x404(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x41a(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x450(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x45e(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x460(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x466(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x46c(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x476(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x47c(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x486(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x490(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x492(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x49c(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x4a2(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x4a8(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x4d2(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x4d8(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x4da(a5)
-;   c.lw a5, 0(a5) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x4e4(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x4ee(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x4f8(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x506(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x510(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x516(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x518(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x51e(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x524(a5)
-;   sw zero, 0(a5) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x53c(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x542(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x544(a5)
-;   c.sw a3, 0(a5) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x54e(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x560(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x56e(a5)
-;   c.sd a2, 0(a5) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x574(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x576(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x57c(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sb a4, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x5a2(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x5ac(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x5ae(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x5b4(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x5b6(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x5d4(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x5d6(a5)
-;   c.sd a2, 0(a5) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x5dc(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x5e2(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x5ec(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sb a4, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x5fe(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x604(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x60e(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x610(a5)
-;   c.sd a2, 0(a5) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   c.lw a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x624(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x62e(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x63c(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x646(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x660(a5)
-;   c.sd a2, 0(a5) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x662(a5)
-;   sd zero, 0(a5) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sb a4, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x67e(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x68c(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sb a4, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sb a4, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x6ce(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x6d8(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x6e2(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sb a4, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x700(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x706(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x70c(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x71e(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x720(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x72a(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x738(a5)
-;   sd zero, 0(a5) ; trap: heap_oob
-;   sb a4, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x744(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x74a(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x74c(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a5, 1
-;   ld a5, -0x756(a5)
-;   c.sd a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sb a3, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a3, 1
-;   ld a3, -0x768(a3)
-;   c.sd a3, 0(a1) ; trap: heap_oob
-;   auipc a3, 1
-;   ld a3, -0x76a(a3)
-;   c.sd a3, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a3, 1
-;   ld a3, -0x774(a3)
-;   c.sd a3, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a3, 1
-;   ld a3, -0x77a(a3)
-;   c.sd a3, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sb a4, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a3, 1
-;   ld a3, -0x78c(a3)
-;   c.sd a2, 0(a3) ; trap: heap_oob
-;   auipc a2, 1
-;   ld a2, -0x78e(a2)
-;   c.sd a2, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a2, 1
-;   ld a2, -0x794(a2)
-;   c.sd a2, 0(a1) ; trap: heap_oob
-;   auipc a2, 1
-;   ld a2, -0x796(a2)
-;   c.lui a3, 4
-;   addi a3, a3, -0x720
-;   c.sd a2, 0(a3) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a2, 1
-;   ld a2, -0x7ae(a2)
-;   c.lui a3, 4
-;   addi a3, a3, -0x6a4
-;   c.sd a2, 0(a3) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a2, 1
-;   ld a2, -0x7c6(a2)
-;   c.lui a3, 4
-;   addi a3, a3, -0x5f0
-;   c.sd a2, 0(a3) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a2, 1
-;   ld a2, -0x7da(a2)
-;   c.lui a3, 4
-;   addi a3, a3, -0x638
-;   c.sd a2, 0(a3) ; trap: heap_oob
-;   auipc a2, 1
-;   ld a2, -0x7e2(a2)
-;   c.lui a3, 4
-;   addi a3, a3, -0x640
-;   c.sd a2, 0(a3) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a2, 1
-;   ld a2, -0x7f2(a2)
-;   c.lui a3, 4
-;   addi a3, a3, -0x59c
-;   c.sd a2, 0(a3) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   c.j 2
-;   auipc t6, 0
-;   jalr zero, t6, 0x7f8
+;   auipc a4, 0
+;   ld a4, 0x17e(a4)
+;   c.j 0x17e
+;   c.unimp
+;   c.unimp
 ;   c.fldsp fs5, 0x1e0(sp)
 ;   .byte 0xc3, 0xd1
 ;   c.bnez a0, -4
@@ -6410,6 +5355,46 @@ block2:
 ;   c.fsdsp fa5, 0x30(sp)
 ;   c.li t0, 8
 ;   c.sw a3, 0x24(a1)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   auipc a4, 0
+;   ld a4, 0x8e(a4)
+;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   c.li a4, 0
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x7e(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x78(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x72(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x70(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x62(a5)
+;   auipc s8, 0
+;   ld s8, 0x62(s8)
+;   sd a5, 0(s8) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x42(a5)
+;   c.j 0x42
 ;   fmadd.d fs0, fs7, fs11, fs6, rne
 ;   c.lwsp a7, 0x64(sp)
 ;   c.bnez a1, 0xb2
@@ -6439,6 +5424,63 @@ block2:
 ;   c.addiw t5, -0x10
 ;   c.addi4spn a1, sp, 0x88
 ;   c.fsdsp fa1, 0x90(sp)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0xba(a5)
+;   sd zero, 0(a5) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0xb2(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0xac(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x9a(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x98(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x92(a5)
+;   sd zero, 0(a5) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x8e(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x88(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x66(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x5c(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x5a(a5)
+;   c.j 0x5a
 ;   andi s2, s2, -0x1cd
 ;   c.unimp
 ;   c.unimp
@@ -6478,6 +5520,28 @@ block2:
 ;   c.sdsp a6, 0x1c8(sp)
 ;   .byte 0x8c, 0x9d
 ;   fmsub.d fs3, fa4, ft5, fs4, rne
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x42(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x40(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x2e(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x28(a5)
+;   c.j 0x28
+;   c.unimp
+;   c.unimp
+;   c.unimp
 ;   c.srai s0, 0x1d
 ;   c.slli s9, 8
 ;   .byte 0x04, 0x94
@@ -6493,6 +5557,19 @@ block2:
 ;   c.fsd fa1, 0x10(a5)
 ;   addi t2, a4, 0x44b
 ;   c.swsp t6, 0x5c(sp)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x22(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x20(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x1e(a5)
+;   c.ld a5, 0(a5) ; trap: heap_oob
+;   c.j 0x1c
+;   c.unimp
 ;   .byte 0x33, 0xf7
 ;   c.lw a2, 0x28(a4)
 ;   ori gp, s2, 0x376
@@ -6504,6 +5581,16 @@ block2:
 ;   .byte 0x23, 0xc2
 ;   c.unimp
 ;   c.unimp
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x18(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x16(a5)
+;   c.j 0x16
+;   c.unimp
+;   c.unimp
 ;   c.mv a4, t3
 ;   .byte 0x0f, 0x41
 ;   c.addi4spn a0, sp, 0x210
@@ -6512,41 +5599,1023 @@ block2:
 ;   c.fsdsp fs0, 0x38(sp)
 ;   c.fsdsp ft7, 0x88(sp)
 ;   c.beqz s1, 0x5a
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   c.j 2
+;   auipc a5, 0
+;   ld a5, 0x10(a5)
+;   c.j 0x10
+;   c.unimp
+;   c.unimp
+;   c.unimp
 ;   c.beqz s0, -0x100
 ;   .byte 0xdf, 0xec
 ;   c.lwsp t0, 0x70(sp)
 ;   c.lui t6, 0xfffe6
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   c.j 2
+;   auipc a5, 0
+;   ld a5, 0xc(a5)
+;   c.j 0xc
+;   c.unimp
 ;   c.fld fa1, 0x58(a0)
 ;   c.lw a1, 0x24(a5)
 ;   c.fldsp fa2, 0x60(sp)
 ;   c.beqz a2, -0x36
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   c.j 2
+;   sw zero, 0(a1) ; trap: heap_oob
+;   c.j 2
+;   auipc a5, 0
+;   ld a5, 0xe(a5)
+;   c.j 0xe
+;   c.unimp
+;   c.unimp
 ;   c.fsd fs0, 0xf8(s1)
 ;   c.sd s1, 0x40(s0)
 ;   c.sub a5, a4
 ;   c.swsp a5, 0x78(sp)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   c.j 2
+;   sd zero, 0(a1) ; trap: heap_oob
+;   c.j 2
+;   sw zero, 0(a1) ; trap: heap_oob
+;   c.j 2
+;   auipc a5, 0
+;   ld a5, 0x10(a5)
+;   c.j 0x10
+;   c.unimp
+;   c.unimp
+;   c.unimp
 ;   c.fsd fa4, 0x70(a1)
 ;   c.ld a2, 0x60(s0)
 ;   .byte 0xf0, 0x96
 ;   c.fsdsp fa0, 0x180(sp)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   c.j 2
+;   sd zero, 0(a1) ; trap: heap_oob
+;   c.j 2
+;   sw zero, 0(a1) ; trap: heap_oob
+;   c.j 2
+;   auipc a5, 0
+;   ld a5, 0x10(a5)
+;   c.j 0x10
+;   c.unimp
+;   c.unimp
+;   c.unimp
 ;   c.fld fa4, 0x70(a0)
 ;   c.swsp t0, 0x60(sp)
 ;   c.j 0x44c
 ;   c.addi4spn s1, sp, 0x3ac
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   c.j 2
+;   sd zero, 0(a1) ; trap: heap_oob
+;   c.j 2
+;   auipc a5, 0
+;   ld a5, 0xe(a5)
+;   c.j 0xe
+;   c.unimp
+;   c.unimp
 ;   c.j -0x648
 ;   .byte 0x73, 0xca
 ;   c.unimp
 ;   c.unimp
+;   sd zero, 0(a5) ; trap: heap_oob
+;   c.j 2
+;   sd zero, 0(a1) ; trap: heap_oob
+;   c.j 2
+;   sw zero, 0(a1) ; trap: heap_oob
+;   c.j 2
+;   sd zero, 0(a1) ; trap: heap_oob
+;   c.j 2
+;   sw zero, 0(a1) ; trap: heap_oob
+;   c.j 2
+;   auipc a5, 0
+;   ld a5, 0xa(a5)
+;   c.j 0xa
 ;   auipc t6, 0x4769
 ;   fnmadd.d fa5, ft1, fa6, fs9, rup
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   c.j 2
+;   sw zero, 0(a1) ; trap: heap_oob
+;   c.j 2
+;   auipc a5, 0
+;   ld a5, 0xe(a5)
+;   c.j 0xe
+;   c.unimp
+;   c.unimp
 ;   fmsub.s ft4, fs5, fa0, fa6, rdn
 ;   c.ld a1, 0x78(a4)
 ;   c.beqz a1, 0x5c
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   c.j 2
+;   sw zero, 0(a1) ; trap: heap_oob
+;   c.j 2
+;   auipc a5, 0
+;   ld a5, 0xe(a5)
+;   c.j 0xe
+;   c.unimp
+;   c.unimp
 ;   csrrw s0, 3434, s3
 ;   fnmsub.s ft4, ft9, ft5, ft8
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   c.j 2
+;   sd zero, 0(a1) ; trap: heap_oob
+;   c.j 2
+;   sw zero, 0(a1) ; trap: heap_oob
+;   c.j 2
+;   auipc a5, 0
+;   ld a5, 0x18(a5)
+;   c.j 4
+;   c.unimp
+;   auipc t6, 0
+;   jalr zero, t6, 0x14
+;   c.unimp
+;   c.unimp
 ;   c.beqz a1, 0xb6
 ;   .byte 0xbf, 0x7f
 ;   c.fsdsp ft7, 0x180(sp)
 ;   c.bnez a1, 0x3c
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x39e(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x3a4(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x3b2(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x3b8(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x3be(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x3c8(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x3ca(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x3d0(a5)
+;   c.ld a5, 0(a5) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x3d6(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x3d8(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x3de(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x3ec(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x3fa(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x410(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x416(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x424(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x42e(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x434(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x436(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x43c(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x43e(a5)
+;   sd zero, 0(a5) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x446(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x45c(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x462(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x464(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x47e(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x484(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x48e(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x49c(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x49e(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x4a4(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x4a6(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x4b0(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x4be(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x4c8(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x4ca(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x4d0(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x4e2(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x4e4(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x4ea(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x4ec(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x4f2(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x4f4(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x4fe(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x504(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x506(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x508(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x50a(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x51c(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x522(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x524(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x52a(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x52c(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x542(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x550(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x55a(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x560(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x562(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x570(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x572(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x578(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x596(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x59c(a5)
+;   c.sd a2, 0(a5) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x5ae(a5)
+;   sd zero, 0(a5) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x5ce(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x5e4(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x5f2(a5)
+;   sd zero, 0(a5) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x602(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x604(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x60e(a5)
+;   c.sd a2, 0(a5) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x610(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x61a(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x620(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x622(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x63c(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x64a(a5)
+;   c.sd a2, 0(a5) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x64c(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x65e(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   lui a5, 0x4b912
+;   addi a5, a5, -0x6f
+;   auipc a6, 1
+;   ld a6, -0x678(a6)
+;   sw a5, 0(a6) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x680(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x682(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x688(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x696(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x6a0(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x6a2(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x6b8(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x6ee(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x6fc(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x6fe(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x704(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x70a(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x714(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x71a(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x724(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x72e(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x730(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x73a(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x740(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x746(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x770(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x776(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x778(a5)
+;   c.lw a5, 0(a5) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x782(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x78c(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x796(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x7a4(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x7ae(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x7b4(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x7b6(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x7bc(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x7c2(a5)
+;   sw zero, 0(a5) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x7da(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x7e0(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x7e2(a5)
+;   c.sw a3, 0(a5) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x7ec(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 1
+;   ld a5, -0x7fe(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x7f4(a5)
+;   c.sd a2, 0(a5) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x7ee(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x7ec(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x7e6(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sb a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x7c0(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x7b6(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x7b4(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x7ae(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x7ac(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x78e(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x78c(a5)
+;   c.sd a2, 0(a5) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x786(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x780(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x776(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sb a4, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x764(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x75e(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x754(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x752(a5)
+;   c.sd a2, 0(a5) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   c.lw a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x73e(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x734(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x726(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x71c(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x702(a5)
+;   c.sd a2, 0(a5) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x700(a5)
+;   sd zero, 0(a5) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sb a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x6e4(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x6d6(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sb a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sb a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x694(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x68a(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x680(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sb a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x662(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x65c(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x656(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x644(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x642(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x638(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x62a(a5)
+;   sd zero, 0(a5) ; trap: heap_oob
+;   sb a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x61e(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x618(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x616(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x60c(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sb a3, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a3, 0
+;   ld a3, 0x5fa(a3)
+;   c.sd a3, 0(a1) ; trap: heap_oob
+;   auipc a3, 0
+;   ld a3, 0x5f8(a3)
+;   c.sd a3, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a3, 0
+;   ld a3, 0x5ee(a3)
+;   c.sd a3, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a3, 0
+;   ld a3, 0x5e8(a3)
+;   c.sd a3, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sb a4, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a3, 0
+;   ld a3, 0x5d6(a3)
+;   c.sd a2, 0(a3) ; trap: heap_oob
+;   auipc a2, 0
+;   ld a2, 0x5d4(a2)
+;   c.sd a2, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a2, 0
+;   ld a2, 0x5ce(a2)
+;   c.sd a2, 0(a1) ; trap: heap_oob
+;   auipc a2, 0
+;   ld a2, 0x5cc(a2)
+;   c.lui a3, 4
+;   addi a3, a3, -0x720
+;   c.sd a2, 0(a3) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a2, 0
+;   ld a2, 0x5b4(a2)
+;   c.lui a3, 4
+;   addi a3, a3, -0x6a4
+;   c.sd a2, 0(a3) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a2, 0
+;   ld a2, 0x59c(a2)
+;   c.lui a3, 4
+;   addi a3, a3, -0x5f0
+;   c.sd a2, 0(a3) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a2, 0
+;   ld a2, 0x588(a2)
+;   c.lui a3, 4
+;   addi a3, a3, -0x638
+;   c.sd a2, 0(a3) ; trap: heap_oob
+;   auipc a2, 0
+;   ld a2, 0x580(a2)
+;   c.lui a3, 4
+;   addi a3, a3, -0x640
+;   c.sd a2, 0(a3) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a2, 0
+;   ld a2, 0x570(a2)
+;   c.lui a3, 4
+;   addi a3, a3, -0x59c
+;   c.sd a2, 0(a3) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   c.j 4
+;   c.j 0xa
+;   auipc t6, 0
+;   jalr zero, t6, 0x558
+;   auipc t6, 0
+;   jalr zero, t6, 0x550
 ;   c.slli s10, 0x39
 ;   c.fldsp ft8, 0x80(sp)
 ;   c.slli t1, 0x3d
@@ -7176,7 +7245,7 @@ block2:
 ;   c.addi4spn s0, sp, 0x84
 ;   andi a7, s11, -0x6ab
 ;   c.swsp t5, 0xb4(sp)
-; block14: ; offset 0x1c98
+; block13: ; offset 0x1d28
 ;   c.li a2, 1
 ;   c.li a3, 2
 ;   c.mv a1, a0


### PR DESCRIPTION
Fixes #12968.

It turns out that the actual fix is pretty simple if we permit islands to occur in the middle of basic blocks, which is I think also actually necessary in some corner cases: making that check, and reasoning about the maximal *new contribution* of island size from each instruction, lets us avoid having to cleverly sort island contents and dispense with deadlines in a just-in-time order. I am happy that this is both simpler to reason about and verify at a glance, and also more robust.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
