### PR TITLE
Insert fuel/epoch checks in bulk copies/fills

### DIFF
--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -588,11 +588,7 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
     ///
     /// This can be used for expensive opcodes, such as `array.copy`, where the
     /// operation's runtime is a function of the runtime state.
-    #[cfg(feature = "gc")]
     fn manual_fuel_check(&mut self, builder: &mut FunctionBuilder<'_>, fuel_to_consume: ir::Value) {
-        if !self.tunables.consume_fuel {
-            return;
-        }
         self.fuel_increment_var(builder);
 
         let fuel = builder.use_var(self.fuel_var);
@@ -3597,7 +3593,6 @@ impl FuncEnvironment<'_> {
                                 _ => unreachable!(),
                             };
                             env.manual_fuel_check(builder, fuel_consumed);
-                            env.manual_fuel_check(builder, len);
                         }
                         let memory_fill = env.builtin_functions.memory_fill(&mut builder.func);
                         builder.ins().call(memory_fill, &[vmctx, dst, val, len]);

--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -3516,10 +3516,6 @@ impl FuncEnvironment<'_> {
             (IndexType::I64, IndexType::I64) => IndexType::I64,
         };
 
-        let mut pos = builder.cursor();
-        let vmctx = self.vmctx_val(&mut pos);
-        let memory_copy = self.builtin_functions.memory_copy(&mut pos.func);
-
         let src_len = if src_idx_ty == len_idx_ty {
             len
         } else {
@@ -3543,11 +3539,175 @@ impl FuncEnvironment<'_> {
         let len_ptr =
             self.unchecked_cast_wasm_addr_to_native_addr(&mut builder.cursor(), len, len_idx_ty);
 
-        builder
-            .ins()
-            .call(memory_copy, &[vmctx, dst_raw_addr, src_raw_addr, len_ptr]);
+        self.raw_bulk_memory_operation(
+            builder,
+            BulkOp::MemoryCopy {
+                dst: dst_raw_addr,
+                src: src_raw_addr,
+                len: len_ptr,
+            },
+        );
 
         Ok(())
+    }
+
+    /// Perform a raw bulk-memory-like libcall.
+    ///
+    /// The main purpose of this helper is to handle situations when fuel and
+    /// epochs are enabled to break up the copy into a loop of chunks with
+    /// preemption checks between them.
+    fn raw_bulk_memory_operation(&mut self, builder: &mut FunctionBuilder<'_>, mut op: BulkOp) {
+        // Very scientifically chosen. Or, more seriously, this is just an
+        // arbitrary number for now. 100k copies of this size locally takes half
+        // a second, so seems like a reasonably large chunk size to not hit perf
+        // too much by chunking but also enable time slicing.
+        const UNINTERRUPTABLE_CHUNK_SIZE: i64 = 128 << 20;
+
+        let mut pos = builder.cursor();
+        let vmctx = self.vmctx_val(&mut pos);
+        let pointer_type = self.pointer_type();
+
+        // Performs a raw call to the actual libcall, as dictated by the
+        // provided `op`. This unconditionally inserts epoch/fuel checks for all
+        // calls.
+        let raw_call =
+            |env: &mut FuncEnvironment<'_>, builder: &mut FunctionBuilder<'_>, op: &_| {
+                if env.tunables.epoch_interruption {
+                    env.epoch_check(builder);
+                }
+                match *op {
+                    BulkOp::MemoryCopy { dst, src, len } => {
+                        if env.tunables.consume_fuel {
+                            // Note that fuel is always a 64-bit counter.
+                            let fuel_consumed = match env.pointer_type() {
+                                ir::types::I32 => builder.ins().uextend(ir::types::I64, len),
+                                ir::types::I64 => len,
+                                _ => unreachable!(),
+                            };
+                            env.manual_fuel_check(builder, fuel_consumed);
+                        }
+                        let memory_copy = env.builtin_functions.memory_copy(&mut builder.func);
+                        builder.ins().call(memory_copy, &[vmctx, dst, src, len]);
+                    }
+                    BulkOp::MemoryFill { dst, val, len } => {
+                        if env.tunables.consume_fuel {
+                            let fuel_consumed = match env.pointer_type() {
+                                ir::types::I32 => builder.ins().uextend(ir::types::I64, len),
+                                ir::types::I64 => len,
+                                _ => unreachable!(),
+                            };
+                            env.manual_fuel_check(builder, fuel_consumed);
+                            env.manual_fuel_check(builder, len);
+                        }
+                        let memory_fill = env.builtin_functions.memory_fill(&mut builder.func);
+                        builder.ins().call(memory_fill, &[vmctx, dst, val, len]);
+                    }
+                }
+            };
+
+        // If epochs and fuel are disabled, then just call the libcall and
+        // return. No need for the loops below.
+        if !self.tunables.epoch_interruption && !self.tunables.consume_fuel {
+            raw_call(self, builder, &op);
+            return;
+        }
+
+        // If fuel is enabled, first take all the pending fuel and flush it to
+        // our internal variable. This is necessary to avoid picking up all
+        // pending fuel on each turn of the loop below.
+        if self.tunables.consume_fuel {
+            self.fuel_increment_var(builder);
+        }
+
+        let current_block = builder.current_block().unwrap();
+        let chunk_block = builder.create_block();
+        let last_chunk_block = builder.create_block();
+
+        builder.ensure_inserted_block();
+        builder.insert_block_after(chunk_block, current_block);
+        builder.insert_block_after(last_chunk_block, chunk_block);
+
+        let chunk = builder
+            .ins()
+            .iconst(pointer_type, UNINTERRUPTABLE_CHUNK_SIZE);
+
+        // Helper closure to test if the length in `op` is larger than `chunk`,
+        // and if so do a single chunk. Else this goes to the final block with
+        // the final operation.
+        let has_chunk_branch = |builder: &mut FunctionBuilder<'_>, op: &_| {
+            let len = match *op {
+                BulkOp::MemoryCopy { len, .. } | BulkOp::MemoryFill { len, .. } => len,
+            };
+            let has_chunk = builder.ins().icmp(IntCC::UnsignedGreaterThan, len, chunk);
+            match *op {
+                BulkOp::MemoryCopy { dst, src, len } => {
+                    builder.ins().brif(
+                        has_chunk,
+                        chunk_block,
+                        &[dst.into(), src.into(), len.into()],
+                        last_chunk_block,
+                        &[dst.into(), src.into(), len.into()],
+                    );
+                }
+                BulkOp::MemoryFill { dst, len, .. } => {
+                    builder.ins().brif(
+                        has_chunk,
+                        chunk_block,
+                        &[dst.into(), len.into()],
+                        last_chunk_block,
+                        &[dst.into(), len.into()],
+                    );
+                }
+            }
+        };
+        has_chunk_branch(builder, &op);
+
+        let append_block_params = |builder: &mut FunctionBuilder<'_>, block, op: &mut _| match op {
+            BulkOp::MemoryCopy { dst, src, len } => {
+                *dst = builder.append_block_param(block, pointer_type);
+                *src = builder.append_block_param(block, pointer_type);
+                *len = builder.append_block_param(block, pointer_type);
+            }
+            BulkOp::MemoryFill { dst, len, .. } => {
+                *dst = builder.append_block_param(block, pointer_type);
+                *len = builder.append_block_param(block, pointer_type);
+            }
+        };
+
+        // In the block with per-chunk copies, each operation performs `chunk`
+        // length of bytes and then decrements the current length by `chunk`.
+        // Afterwards a condition tests if we do another chunk or break out for
+        // the final chunk.
+        builder.switch_to_block(chunk_block);
+        append_block_params(builder, chunk_block, &mut op);
+        let op_len = match &mut op {
+            BulkOp::MemoryCopy { len, .. } | BulkOp::MemoryFill { len, .. } => len,
+        };
+        let remaining_len = *op_len;
+        *op_len = chunk;
+        raw_call(self, builder, &op);
+        match &mut op {
+            BulkOp::MemoryCopy { dst, src, len } => {
+                *dst = builder.ins().iadd(*dst, chunk);
+                *src = builder.ins().iadd(*src, chunk);
+                *len = builder.ins().isub(remaining_len, chunk);
+            }
+            BulkOp::MemoryFill { len, dst, .. } => {
+                *dst = builder.ins().iadd(*dst, chunk);
+                *len = builder.ins().isub(remaining_len, chunk);
+            }
+        };
+        has_chunk_branch(builder, &op);
+
+        // In the final block we know that the length of the operation is less
+        // than `chunk`. This could still be sizable, though, so a final
+        // fuel/epoch check is inserted.
+        builder.switch_to_block(last_chunk_block);
+        append_block_params(builder, last_chunk_block, &mut op);
+        raw_call(self, builder, &op);
+
+        builder.seal_block(chunk_block);
+        builder.seal_block(last_chunk_block);
     }
 
     pub fn translate_memory_fill(
@@ -3559,9 +3719,6 @@ impl FuncEnvironment<'_> {
         len: ir::Value,
     ) {
         let idx_type = self.memory(memory_index).idx_type;
-        let memory_fill = self.builtin_functions.memory_fill(&mut builder.func);
-        let mut pos = builder.cursor();
-        let vmctx = self.vmctx_val(&mut pos);
 
         // Bounds check `dst+len` and convert it to a raw heap address.
         let raw_heap_addr = self.bounds_check_for_memory_intrinsic(builder, memory_index, dst, len);
@@ -3571,9 +3728,14 @@ impl FuncEnvironment<'_> {
         let len_ptr =
             self.unchecked_cast_wasm_addr_to_native_addr(&mut builder.cursor(), len, idx_type);
 
-        builder
-            .ins()
-            .call(memory_fill, &[vmctx, raw_heap_addr, val, len_ptr]);
+        self.raw_bulk_memory_operation(
+            builder,
+            BulkOp::MemoryFill {
+                dst: raw_heap_addr,
+                val,
+                len: len_ptr,
+            },
+        );
     }
 
     pub fn translate_memory_init(
@@ -4489,4 +4651,29 @@ fn index_type_to_ir_type(index_type: IndexType) -> ir::Type {
         IndexType::I32 => I32,
         IndexType::I64 => I64,
     }
+}
+
+/// Operations to [`FuncEnvironment::raw_bulk_memory_operation`].
+enum BulkOp {
+    /// A `memory.copy` operation, copying memory from `src` to `dst`.
+    ///
+    /// All of `dst`, `src`, and `len` must be pre-validated and inbounds. All
+    /// must have type `env.pointer_type()`.
+    MemoryCopy {
+        dst: ir::Value,
+        src: ir::Value,
+        len: ir::Value,
+    },
+
+    /// A `memory.fill` operation, setting all bytes of `dst` to `val`.
+    ///
+    /// Both of `dst` and `len` must be pre-validated and inbounds. Both must
+    /// have type `env.pointer_type()`.
+    ///
+    /// The `val` field must have type `I32`.
+    MemoryFill {
+        dst: ir::Value,
+        val: ir::Value,
+        len: ir::Value,
+    },
 }

--- a/crates/cranelift/src/func_environ/gc/enabled.rs
+++ b/crates/cranelift/src/func_environ/gc/enabled.rs
@@ -1,6 +1,6 @@
 use super::{ArrayInit, GcCompiler};
 use crate::bounds_checks::BoundsCheck;
-use crate::func_environ::{Extension, FuncEnvironment};
+use crate::func_environ::{BulkOp, Extension, FuncEnvironment};
 use crate::translate::{Heap, HeapData, MemoryKind, StructFieldsVec, TargetEnvironment};
 use crate::trap::TranslateTrap;
 use crate::{Reachability, TRAP_GC_HEAP_CORRUPT, TRAP_INTERNAL_ASSERT};
@@ -804,24 +804,16 @@ fn emit_array_fill_impl(
             .icmp(IntCC::UnsignedGreaterThan, fill_end, heap_end);
         func_env.trapnz(builder, corrupt, TRAP_GC_HEAP_CORRUPT);
 
-        let memory_fill = func_env.builtin_functions.memory_fill(&mut builder.func);
-        let mut pos = builder.cursor();
-        let vmctx = func_env.vmctx_val(&mut pos);
         let len = builder.ins().isub(fill_end, elem_addr);
+        func_env.raw_bulk_memory_operation(
+            builder,
+            BulkOp::MemoryFill {
+                dst: elem_addr,
+                val: value,
+                len,
+            },
+        );
 
-        // Manually consume fuel for this operation because arrays can be large.
-        // This is a noop if fuel is disabled. Note that fuel is always a 64-bit
-        // counter.
-        let fuel_consumed = match func_env.pointer_type() {
-            ir::types::I32 => builder.ins().uextend(ir::types::I64, len),
-            ir::types::I64 => len,
-            _ => unreachable!(),
-        };
-        func_env.manual_fuel_check(builder, fuel_consumed);
-
-        builder
-            .ins()
-            .call(memory_fill, &[vmctx, elem_addr, value, len]);
         return Ok(());
     }
 
@@ -1030,17 +1022,13 @@ pub fn translate_array_copy(
             .icmp(IntCC::UnsignedGreaterThan, dst_end_addr, heap_end);
         func_env.trapnz(builder, corrupt, TRAP_GC_HEAP_CORRUPT);
 
-        let memory_copy = func_env.builtin_functions.memory_copy(&mut builder.func);
-        let mut pos = builder.cursor();
-        let vmctx = func_env.vmctx_val(&mut pos);
-
-        // Manually consume fuel for this operation because arrays can be large.
-        // This is a noop if fuel is disabled.
-        func_env.manual_fuel_check(builder, copy_byte_size);
-
-        builder.ins().call(
-            memory_copy,
-            &[vmctx, dst_elem_addr, src_elem_addr, copy_byte_size],
+        func_env.raw_bulk_memory_operation(
+            builder,
+            BulkOp::MemoryCopy {
+                dst: dst_elem_addr,
+                src: src_elem_addr,
+                len: copy_byte_size,
+            },
         );
         return Ok(());
     }

--- a/tests/disas/gc/array-new-default-anyref.wat
+++ b/tests/disas/gc/array-new-default-anyref.wat
@@ -58,8 +58,8 @@
 ;;                                     v62 = iconst.i64 28
 ;;                                     v67 = iadd v20, v62  ; v62 = 28
 ;; @001f                               v4 = iconst.i32 0
-;; @001f                               v35 = isub v28, v67
-;; @001f                               call fn1(v0, v67, v4, v35), stack_map=[i32 @ ss0+0]  ; v4 = 0
+;; @001f                               v34 = isub v28, v67
+;; @001f                               call fn1(v0, v67, v4, v34), stack_map=[i32 @ ss0+0]  ; v4 = 0
 ;;                                     v36 = load.i32 notrap v47
 ;; @0022                               jump block1
 ;;

--- a/tests/disas/gc/array-new-default-exnref.wat
+++ b/tests/disas/gc/array-new-default-exnref.wat
@@ -58,8 +58,8 @@
 ;;                                     v62 = iconst.i64 28
 ;;                                     v67 = iadd v20, v62  ; v62 = 28
 ;; @001f                               v4 = iconst.i32 0
-;; @001f                               v35 = isub v28, v67
-;; @001f                               call fn1(v0, v67, v4, v35), stack_map=[i32 @ ss0+0]  ; v4 = 0
+;; @001f                               v34 = isub v28, v67
+;; @001f                               call fn1(v0, v67, v4, v34), stack_map=[i32 @ ss0+0]  ; v4 = 0
 ;;                                     v36 = load.i32 notrap v47
 ;; @0022                               jump block1
 ;;

--- a/tests/disas/gc/array-new-default-externref.wat
+++ b/tests/disas/gc/array-new-default-externref.wat
@@ -58,8 +58,8 @@
 ;;                                     v62 = iconst.i64 28
 ;;                                     v67 = iadd v20, v62  ; v62 = 28
 ;; @001f                               v4 = iconst.i32 0
-;; @001f                               v35 = isub v28, v67
-;; @001f                               call fn1(v0, v67, v4, v35), stack_map=[i32 @ ss0+0]  ; v4 = 0
+;; @001f                               v34 = isub v28, v67
+;; @001f                               call fn1(v0, v67, v4, v34), stack_map=[i32 @ ss0+0]  ; v4 = 0
 ;;                                     v36 = load.i32 notrap v47
 ;; @0022                               jump block1
 ;;

--- a/tests/disas/gc/array-new-default-f32.wat
+++ b/tests/disas/gc/array-new-default-f32.wat
@@ -58,8 +58,8 @@
 ;;                                     v62 = iconst.i64 28
 ;;                                     v67 = iadd v20, v62  ; v62 = 28
 ;; @001f                               v29 = iconst.i32 0
-;; @001f                               v35 = isub v28, v67
-;; @001f                               call fn1(v0, v67, v29, v35), stack_map=[i32 @ ss0+0]  ; v29 = 0
+;; @001f                               v34 = isub v28, v67
+;; @001f                               call fn1(v0, v67, v29, v34), stack_map=[i32 @ ss0+0]  ; v29 = 0
 ;;                                     v36 = load.i32 notrap v47
 ;; @0022                               jump block1
 ;;

--- a/tests/disas/gc/array-new-default-f64.wat
+++ b/tests/disas/gc/array-new-default-f64.wat
@@ -57,8 +57,8 @@
 ;; @001f                               trapnz v33, user2
 ;;                                     v66 = iadd v20, v48  ; v48 = 32
 ;; @001f                               v29 = iconst.i32 0
-;; @001f                               v35 = isub v28, v66
-;; @001f                               call fn1(v0, v66, v29, v35), stack_map=[i32 @ ss0+0]  ; v29 = 0
+;; @001f                               v34 = isub v28, v66
+;; @001f                               call fn1(v0, v66, v29, v34), stack_map=[i32 @ ss0+0]  ; v29 = 0
 ;;                                     v36 = load.i32 notrap v47
 ;; @0022                               jump block1
 ;;

--- a/tests/disas/gc/array-new-default-funcref.wat
+++ b/tests/disas/gc/array-new-default-funcref.wat
@@ -58,8 +58,8 @@
 ;;                                     v62 = iconst.i64 28
 ;;                                     v67 = iadd v20, v62  ; v62 = 28
 ;; @001f                               v29 = iconst.i32 0
-;; @001f                               v35 = isub v28, v67
-;; @001f                               call fn1(v0, v67, v29, v35), stack_map=[i32 @ ss0+0]  ; v29 = 0
+;; @001f                               v34 = isub v28, v67
+;; @001f                               call fn1(v0, v67, v29, v34), stack_map=[i32 @ ss0+0]  ; v29 = 0
 ;;                                     v36 = load.i32 notrap v47
 ;; @0022                               jump block1
 ;;

--- a/tests/disas/gc/array-new-default-i16.wat
+++ b/tests/disas/gc/array-new-default-i16.wat
@@ -57,8 +57,8 @@
 ;;                                     v67 = iconst.i64 28
 ;;                                     v72 = iadd v20, v67  ; v67 = 28
 ;; @001f                               v4 = iconst.i32 0
-;; @001f                               v35 = isub v28, v72
-;; @001f                               call fn1(v0, v72, v4, v35), stack_map=[i32 @ ss0+0]  ; v4 = 0
+;; @001f                               v34 = isub v28, v72
+;; @001f                               call fn1(v0, v72, v4, v34), stack_map=[i32 @ ss0+0]  ; v4 = 0
 ;;                                     v36 = load.i32 notrap v47
 ;; @0022                               jump block1
 ;;

--- a/tests/disas/gc/array-new-default-i32.wat
+++ b/tests/disas/gc/array-new-default-i32.wat
@@ -58,8 +58,8 @@
 ;;                                     v62 = iconst.i64 28
 ;;                                     v67 = iadd v20, v62  ; v62 = 28
 ;; @001f                               v4 = iconst.i32 0
-;; @001f                               v35 = isub v28, v67
-;; @001f                               call fn1(v0, v67, v4, v35), stack_map=[i32 @ ss0+0]  ; v4 = 0
+;; @001f                               v34 = isub v28, v67
+;; @001f                               call fn1(v0, v67, v4, v34), stack_map=[i32 @ ss0+0]  ; v4 = 0
 ;;                                     v36 = load.i32 notrap v47
 ;; @0022                               jump block1
 ;;

--- a/tests/disas/gc/array-new-default-i64.wat
+++ b/tests/disas/gc/array-new-default-i64.wat
@@ -57,8 +57,8 @@
 ;; @001f                               trapnz v33, user2
 ;;                                     v66 = iadd v20, v48  ; v48 = 32
 ;; @001f                               v29 = iconst.i32 0
-;; @001f                               v35 = isub v28, v66
-;; @001f                               call fn1(v0, v66, v29, v35), stack_map=[i32 @ ss0+0]  ; v29 = 0
+;; @001f                               v34 = isub v28, v66
+;; @001f                               call fn1(v0, v66, v29, v34), stack_map=[i32 @ ss0+0]  ; v29 = 0
 ;;                                     v36 = load.i32 notrap v47
 ;; @0022                               jump block1
 ;;

--- a/tests/disas/gc/array-new-default-i8.wat
+++ b/tests/disas/gc/array-new-default-i8.wat
@@ -54,8 +54,8 @@
 ;;                                     v52 = iconst.i64 28
 ;;                                     v57 = iadd v20, v52  ; v52 = 28
 ;; @001f                               v4 = iconst.i32 0
-;; @001f                               v34 = isub v28, v57
-;; @001f                               call fn1(v0, v57, v4, v34), stack_map=[i32 @ ss0+0]  ; v4 = 0
+;; @001f                               v33 = isub v28, v57
+;; @001f                               call fn1(v0, v57, v4, v33), stack_map=[i32 @ ss0+0]  ; v4 = 0
 ;;                                     v35 = load.i32 notrap v46
 ;; @0022                               jump block1
 ;;

--- a/tests/disas/memory-copy-epochs.wat
+++ b/tests/disas/memory-copy-epochs.wat
@@ -1,0 +1,98 @@
+;;! target = 'x86_64'
+;;! test = 'optimize'
+;;! flags = '-Wepoch-interruption'
+
+(module
+  (memory 1)
+  (func $copy (param i32 i32 i32)
+    (memory.copy (local.get 0) (local.get 1) (local.get 2))
+  )
+)
+;; function u0:0(i64 vmctx, i64, i32, i32, i32) tail {
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv3 = vmctx
+;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv5 = load.i64 notrap aligned gv3+64
+;;     gv6 = load.i64 notrap aligned readonly can_move gv3+56
+;;     sig0 = (i64 vmctx) -> i64 tail
+;;     sig1 = (i64 vmctx, i64, i64, i64) tail
+;;     fn0 = colocated u805306368:16 sig0
+;;     fn1 = colocated u805306368:4 sig1
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
+;; @001e                               v6 = load.i64 notrap aligned v0+24
+;; @001e                               v7 = load.i64 notrap aligned v6
+;; @001e                               v8 = load.i64 notrap aligned readonly can_move v0+8
+;; @001e                               v9 = load.i64 notrap aligned v8+8
+;; @001e                               v10 = icmp uge v7, v9
+;; @001e                               brif v10, block3, block2(v9)
+;;
+;;                                 block3 cold:
+;; @001e                               v12 = call fn0(v0)
+;; @001e                               jump block2(v12)
+;;
+;;                                 block2(v68: i64):
+;; @0025                               v17 = load.i64 notrap aligned v0+64
+;; @0025                               v18 = uextend.i64 v2
+;; @0025                               v19 = uextend.i64 v4
+;; @0025                               v20 = iadd v18, v19
+;; @0025                               v21 = icmp ule v20, v17
+;; @0025                               trapz v21, heap_oob
+;; @0025                               v27 = uextend.i64 v3
+;; @0025                               v29 = iadd v27, v19
+;; @0025                               v30 = icmp ule v29, v17
+;; @0025                               trapz v30, heap_oob
+;; @0025                               v36 = iconst.i64 0x0800_0000
+;; @0025                               v37 = icmp ugt v19, v36  ; v36 = 0x0800_0000
+;; @0025                               v23 = load.i64 notrap aligned readonly can_move v0+56
+;; @0025                               v24 = iadd v23, v18
+;; @0025                               v33 = iadd v23, v27
+;; @0025                               brif v37, block4(v24, v33, v19, v68), block5(v24, v33, v19, v68)
+;;
+;;                                 block4(v38: i64, v39: i64, v40: i64, v43: i64):
+;; @0025                               v42 = load.i64 notrap aligned v6
+;; @0025                               v44 = icmp uge v42, v43
+;; @0025                               brif v44, block7, block6(v43)
+;;
+;;                                 block5(v54: i64, v55: i64, v56: i64, v59: i64):
+;; @0025                               v58 = load.i64 notrap aligned v6
+;; @0025                               v60 = icmp uge v58, v59
+;; @0025                               brif v60, block10, block9
+;;
+;;                                 block7 cold:
+;; @0025                               v46 = load.i64 notrap aligned v8+8
+;; @0025                               v47 = icmp.i64 uge v42, v46
+;; @0025                               brif v47, block8, block6(v46)
+;;
+;;                                 block8 cold:
+;; @0025                               v49 = call fn0(v0)
+;; @0025                               jump block6(v49)
+;;
+;;                                 block6(v69: i64):
+;;                                     v75 = iconst.i64 0x0800_0000
+;; @0025                               call fn1(v0, v38, v39, v75)  ; v75 = 0x0800_0000
+;;                                     v76 = isub.i64 v40, v75  ; v75 = 0x0800_0000
+;;                                     v77 = icmp ugt v76, v75  ; v75 = 0x0800_0000
+;;                                     v78 = iadd.i64 v38, v75  ; v75 = 0x0800_0000
+;;                                     v79 = iadd.i64 v39, v75  ; v75 = 0x0800_0000
+;; @0025                               brif v77, block4(v78, v79, v76, v69), block5(v78, v79, v76, v69)
+;;
+;;                                 block10 cold:
+;; @0025                               v62 = load.i64 notrap aligned v8+8
+;; @0025                               v63 = icmp.i64 uge v58, v62
+;; @0025                               brif v63, block11, block9
+;;
+;;                                 block11 cold:
+;; @0025                               v65 = call fn0(v0)
+;; @0025                               jump block9
+;;
+;;                                 block9:
+;; @0025                               call fn1(v0, v54, v55, v56)
+;; @0029                               jump block1
+;;
+;;                                 block1:
+;; @0029                               return
+;; }

--- a/tests/disas/memory-copy-fuel.wat
+++ b/tests/disas/memory-copy-fuel.wat
@@ -1,0 +1,102 @@
+;;! target = 'x86_64'
+;;! test = 'optimize'
+;;! flags = '-Wfuel=100'
+
+(module
+  (memory 1)
+  (func $copy (param i32 i32 i32)
+    (memory.copy (local.get 0) (local.get 1) (local.get 2))
+  )
+)
+;; function u0:0(i64 vmctx, i64, i32, i32, i32) tail {
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv2 = load.i64 notrap aligned gv1+24
+;;     gv3 = vmctx
+;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
+;;     gv5 = load.i64 notrap aligned gv3+64
+;;     gv6 = load.i64 notrap aligned readonly can_move gv3+56
+;;     sig0 = (i64 vmctx) -> i8 tail
+;;     sig1 = (i64 vmctx, i64, i64, i64) tail
+;;     fn0 = colocated u805306368:15 sig0
+;;     fn1 = colocated u805306368:4 sig1
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
+;; @001e                               v5 = load.i64 notrap aligned readonly can_move v0+8
+;; @001e                               v6 = load.i64 notrap aligned v5
+;;                                     v83 = iconst.i64 1
+;; @001e                               v7 = iadd v6, v83  ; v83 = 1
+;; @001e                               v8 = iconst.i64 0
+;; @001e                               v9 = icmp sge v7, v8  ; v8 = 0
+;; @001e                               brif v9, block2, block3(v7)
+;;
+;;                                 block2:
+;;                                     v85 = iadd.i64 v6, v83  ; v83 = 1
+;; @001e                               store notrap aligned v85, v5
+;; @001e                               v12 = call fn0(v0)
+;; @001e                               v14 = load.i64 notrap aligned v5
+;; @001e                               jump block3(v14)
+;;
+;;                                 block3(v38: i64):
+;; @0025                               v19 = load.i64 notrap aligned v0+64
+;; @0025                               v20 = uextend.i64 v2
+;; @0025                               v21 = uextend.i64 v4
+;; @0025                               v22 = iadd v20, v21
+;; @0025                               v23 = icmp ule v22, v19
+;; @0025                               trapz v23, heap_oob
+;; @0025                               v29 = uextend.i64 v3
+;; @0025                               v31 = iadd v29, v21
+;; @0025                               v32 = icmp ule v31, v19
+;; @0025                               trapz v32, heap_oob
+;; @0025                               v40 = iconst.i64 0x0800_0000
+;; @0025                               v41 = icmp ugt v21, v40  ; v40 = 0x0800_0000
+;; @0025                               v25 = load.i64 notrap aligned readonly can_move v0+56
+;; @0025                               v26 = iadd v25, v20
+;; @0025                               v35 = iadd v25, v29
+;;                                     v78 = iconst.i64 4
+;; @0025                               v39 = iadd v38, v78  ; v78 = 4
+;; @0025                               brif v41, block4(v26, v35, v21, v39), block5(v26, v35, v21, v39)
+;;
+;;                                 block4(v42: i64, v43: i64, v44: i64, v45: i64):
+;;                                     v86 = iconst.i64 0x0800_0000
+;;                                     v87 = iadd v45, v86  ; v86 = 0x0800_0000
+;;                                     v88 = iconst.i64 0
+;;                                     v89 = icmp sge v87, v88  ; v88 = 0
+;; @0025                               brif v89, block6, block7(v87)
+;;
+;;                                 block5(v58: i64, v59: i64, v60: i64, v61: i64):
+;; @0025                               v62 = iadd v61, v60
+;;                                     v95 = iconst.i64 0
+;;                                     v96 = icmp sge v62, v95  ; v95 = 0
+;; @0025                               brif v96, block8, block9(v62)
+;;
+;;                                 block6:
+;; @0025                               store.i64 notrap aligned v87, v5
+;; @0025                               v51 = call fn0(v0)
+;; @0025                               v53 = load.i64 notrap aligned v5
+;; @0025                               jump block7(v53)
+;;
+;;                                 block7(v70: i64):
+;;                                     v90 = iconst.i64 0x0800_0000
+;; @0025                               call fn1(v0, v42, v43, v90)  ; v90 = 0x0800_0000
+;;                                     v91 = isub.i64 v44, v90  ; v90 = 0x0800_0000
+;;                                     v92 = icmp ugt v91, v90  ; v90 = 0x0800_0000
+;;                                     v93 = iadd.i64 v42, v90  ; v90 = 0x0800_0000
+;;                                     v94 = iadd.i64 v43, v90  ; v90 = 0x0800_0000
+;; @0025                               brif v92, block4(v93, v94, v91, v70), block5(v93, v94, v91, v70)
+;;
+;;                                 block8:
+;; @0025                               store.i64 notrap aligned v62, v5
+;; @0025                               v67 = call fn0(v0)
+;; @0025                               v69 = load.i64 notrap aligned v5
+;; @0025                               jump block9(v69)
+;;
+;;                                 block9(v72: i64):
+;; @0025                               call fn1(v0, v58, v59, v60)
+;; @0029                               jump block1
+;;
+;;                                 block1:
+;; @0029                               store.i64 notrap aligned v72, v5
+;; @0029                               return
+;; }

--- a/tests/disas/memory_copy_host32.wat
+++ b/tests/disas/memory_copy_host32.wat
@@ -57,21 +57,21 @@
 ;;     fn0 = colocated u805306368:4 sig0
 ;;
 ;;                                 block0(v0: i32, v1: i32, v2: i32, v3: i32, v4: i32):
-;; @0042                               v7 = load.i32 notrap aligned v0+44
-;; @0042                               v8 = uextend.i64 v2
-;; @0042                               v9 = uextend.i64 v4
-;; @0042                               v10 = iadd v8, v9
-;; @0042                               v11 = uextend.i64 v7
-;; @0042                               v12 = icmp ule v10, v11
-;; @0042                               trapz v12, heap_oob
-;; @0042                               v13 = load.i32 notrap aligned can_move v0+40
-;; @0042                               v17 = uextend.i64 v3
-;; @0042                               v19 = iadd v17, v9
-;; @0042                               v21 = icmp ule v19, v11
-;; @0042                               trapz v21, heap_oob
-;; @0042                               v14 = iadd v13, v2
-;; @0042                               v23 = iadd v13, v3
-;; @0042                               call fn0(v0, v14, v23, v4)
+;; @0042                               v6 = load.i32 notrap aligned v0+44
+;; @0042                               v7 = uextend.i64 v2
+;; @0042                               v8 = uextend.i64 v4
+;; @0042                               v9 = iadd v7, v8
+;; @0042                               v10 = uextend.i64 v6
+;; @0042                               v11 = icmp ule v9, v10
+;; @0042                               trapz v11, heap_oob
+;; @0042                               v12 = load.i32 notrap aligned can_move v0+40
+;; @0042                               v16 = uextend.i64 v3
+;; @0042                               v18 = iadd v16, v8
+;; @0042                               v20 = icmp ule v18, v10
+;; @0042                               trapz v20, heap_oob
+;; @0042                               v13 = iadd v12, v2
+;; @0042                               v22 = iadd v12, v3
+;; @0042                               call fn0(v0, v13, v22, v4)
 ;; @0046                               jump block1
 ;;
 ;;                                 block1:
@@ -88,24 +88,24 @@
 ;;     fn0 = colocated u805306368:4 sig0
 ;;
 ;;                                 block0(v0: i32, v1: i32, v2: i32, v3: i32, v4: i32):
-;; @004f                               v7 = load.i32 notrap aligned v0+52
-;; @004f                               v8 = uextend.i64 v2
-;; @004f                               v9 = uextend.i64 v4
-;; @004f                               v10 = iadd v8, v9
-;; @004f                               v11 = uextend.i64 v7
-;; @004f                               v12 = icmp ule v10, v11
-;; @004f                               trapz v12, heap_oob
-;; @004f                               v13 = load.i32 notrap aligned can_move v0+48
-;; @004f                               v16 = load.i32 notrap aligned v0+44
-;; @004f                               v17 = uextend.i64 v3
-;; @004f                               v19 = iadd v17, v9
-;; @004f                               v20 = uextend.i64 v16
-;; @004f                               v21 = icmp ule v19, v20
-;; @004f                               trapz v21, heap_oob
-;; @004f                               v22 = load.i32 notrap aligned can_move v0+40
-;; @004f                               v14 = iadd v13, v2
-;; @004f                               v23 = iadd v22, v3
-;; @004f                               call fn0(v0, v14, v23, v4)
+;; @004f                               v6 = load.i32 notrap aligned v0+52
+;; @004f                               v7 = uextend.i64 v2
+;; @004f                               v8 = uextend.i64 v4
+;; @004f                               v9 = iadd v7, v8
+;; @004f                               v10 = uextend.i64 v6
+;; @004f                               v11 = icmp ule v9, v10
+;; @004f                               trapz v11, heap_oob
+;; @004f                               v12 = load.i32 notrap aligned can_move v0+48
+;; @004f                               v15 = load.i32 notrap aligned v0+44
+;; @004f                               v16 = uextend.i64 v3
+;; @004f                               v18 = iadd v16, v8
+;; @004f                               v19 = uextend.i64 v15
+;; @004f                               v20 = icmp ule v18, v19
+;; @004f                               trapz v20, heap_oob
+;; @004f                               v21 = load.i32 notrap aligned can_move v0+40
+;; @004f                               v13 = iadd v12, v2
+;; @004f                               v22 = iadd v21, v3
+;; @004f                               call fn0(v0, v13, v22, v4)
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:
@@ -122,24 +122,24 @@
 ;;     fn0 = colocated u805306368:4 sig0
 ;;
 ;;                                 block0(v0: i32, v1: i32, v2: i64, v3: i32, v4: i32):
-;; @005c                               v8 = load.i32 notrap aligned v0+60
-;; @005c                               v6 = uextend.i64 v4
-;; @005c                               v9 = uadd_overflow_trap v2, v6, heap_oob
-;; @005c                               v10 = uextend.i64 v8
-;; @005c                               v11 = icmp ule v9, v10
-;; @005c                               trapz v11, heap_oob
-;; @005c                               v13 = load.i32 notrap aligned can_move v0+56
-;; @005c                               v16 = load.i32 notrap aligned v0+44
-;; @005c                               v17 = uextend.i64 v3
-;; @005c                               v19 = iadd v17, v6
-;; @005c                               v20 = uextend.i64 v16
-;; @005c                               v21 = icmp ule v19, v20
-;; @005c                               trapz v21, heap_oob
-;; @005c                               v22 = load.i32 notrap aligned can_move v0+40
-;; @005c                               v12 = ireduce.i32 v2
-;; @005c                               v14 = iadd v13, v12
-;; @005c                               v23 = iadd v22, v3
-;; @005c                               call fn0(v0, v14, v23, v4)
+;; @005c                               v7 = load.i32 notrap aligned v0+60
+;; @005c                               v5 = uextend.i64 v4
+;; @005c                               v8 = uadd_overflow_trap v2, v5, heap_oob
+;; @005c                               v9 = uextend.i64 v7
+;; @005c                               v10 = icmp ule v8, v9
+;; @005c                               trapz v10, heap_oob
+;; @005c                               v12 = load.i32 notrap aligned can_move v0+56
+;; @005c                               v15 = load.i32 notrap aligned v0+44
+;; @005c                               v16 = uextend.i64 v3
+;; @005c                               v18 = iadd v16, v5
+;; @005c                               v19 = uextend.i64 v15
+;; @005c                               v20 = icmp ule v18, v19
+;; @005c                               trapz v20, heap_oob
+;; @005c                               v21 = load.i32 notrap aligned can_move v0+40
+;; @005c                               v11 = ireduce.i32 v2
+;; @005c                               v13 = iadd v12, v11
+;; @005c                               v22 = iadd v21, v3
+;; @005c                               call fn0(v0, v13, v22, v4)
 ;; @0060                               jump block1
 ;;
 ;;                                 block1:
@@ -154,21 +154,21 @@
 ;;     fn0 = colocated u805306368:4 sig0
 ;;
 ;;                                 block0(v0: i32, v1: i32, v2: i64, v3: i64, v4: i64):
-;; @0069                               v7 = load.i32 notrap aligned v0+60
-;; @0069                               v8 = uadd_overflow_trap v2, v4, heap_oob
-;; @0069                               v9 = uextend.i64 v7
-;; @0069                               v10 = icmp ule v8, v9
-;; @0069                               trapz v10, heap_oob
-;; @0069                               v12 = load.i32 notrap aligned can_move v0+56
-;; @0069                               v16 = uadd_overflow_trap v3, v4, heap_oob
-;; @0069                               v18 = icmp ule v16, v9
-;; @0069                               trapz v18, heap_oob
-;; @0069                               v11 = ireduce.i32 v2
-;; @0069                               v13 = iadd v12, v11
-;; @0069                               v19 = ireduce.i32 v3
-;; @0069                               v21 = iadd v12, v19
-;; @0069                               v22 = ireduce.i32 v4
-;; @0069                               call fn0(v0, v13, v21, v22)
+;; @0069                               v6 = load.i32 notrap aligned v0+60
+;; @0069                               v7 = uadd_overflow_trap v2, v4, heap_oob
+;; @0069                               v8 = uextend.i64 v6
+;; @0069                               v9 = icmp ule v7, v8
+;; @0069                               trapz v9, heap_oob
+;; @0069                               v11 = load.i32 notrap aligned can_move v0+56
+;; @0069                               v15 = uadd_overflow_trap v3, v4, heap_oob
+;; @0069                               v17 = icmp ule v15, v8
+;; @0069                               trapz v17, heap_oob
+;; @0069                               v10 = ireduce.i32 v2
+;; @0069                               v12 = iadd v11, v10
+;; @0069                               v18 = ireduce.i32 v3
+;; @0069                               v20 = iadd v11, v18
+;; @0069                               v21 = ireduce.i32 v4
+;; @0069                               call fn0(v0, v12, v20, v21)
 ;; @006d                               jump block1
 ;;
 ;;                                 block1:
@@ -185,24 +185,24 @@
 ;;     fn0 = colocated u805306368:4 sig0
 ;;
 ;;                                 block0(v0: i32, v1: i32, v2: i64, v3: i64, v4: i64):
-;; @0076                               v7 = load.i32 notrap aligned v0+68
-;; @0076                               v8 = uadd_overflow_trap v2, v4, heap_oob
-;; @0076                               v9 = uextend.i64 v7
-;; @0076                               v10 = icmp ule v8, v9
-;; @0076                               trapz v10, heap_oob
-;; @0076                               v12 = load.i32 notrap aligned can_move v0+64
-;; @0076                               v15 = load.i32 notrap aligned v0+60
-;; @0076                               v16 = uadd_overflow_trap v3, v4, heap_oob
-;; @0076                               v17 = uextend.i64 v15
-;; @0076                               v18 = icmp ule v16, v17
-;; @0076                               trapz v18, heap_oob
-;; @0076                               v20 = load.i32 notrap aligned can_move v0+56
-;; @0076                               v11 = ireduce.i32 v2
-;; @0076                               v13 = iadd v12, v11
-;; @0076                               v19 = ireduce.i32 v3
-;; @0076                               v21 = iadd v20, v19
-;; @0076                               v22 = ireduce.i32 v4
-;; @0076                               call fn0(v0, v13, v21, v22)
+;; @0076                               v6 = load.i32 notrap aligned v0+68
+;; @0076                               v7 = uadd_overflow_trap v2, v4, heap_oob
+;; @0076                               v8 = uextend.i64 v6
+;; @0076                               v9 = icmp ule v7, v8
+;; @0076                               trapz v9, heap_oob
+;; @0076                               v11 = load.i32 notrap aligned can_move v0+64
+;; @0076                               v14 = load.i32 notrap aligned v0+60
+;; @0076                               v15 = uadd_overflow_trap v3, v4, heap_oob
+;; @0076                               v16 = uextend.i64 v14
+;; @0076                               v17 = icmp ule v15, v16
+;; @0076                               trapz v17, heap_oob
+;; @0076                               v19 = load.i32 notrap aligned can_move v0+56
+;; @0076                               v10 = ireduce.i32 v2
+;; @0076                               v12 = iadd v11, v10
+;; @0076                               v18 = ireduce.i32 v3
+;; @0076                               v20 = iadd v19, v18
+;; @0076                               v21 = ireduce.i32 v4
+;; @0076                               call fn0(v0, v12, v20, v21)
 ;; @007a                               jump block1
 ;;
 ;;                                 block1:
@@ -219,24 +219,24 @@
 ;;     fn0 = colocated u805306368:4 sig0
 ;;
 ;;                                 block0(v0: i32, v1: i32, v2: i32, v3: i64, v4: i32):
-;; @0083                               v8 = load.i32 notrap aligned v0+44
-;; @0083                               v9 = uextend.i64 v2
-;; @0083                               v6 = uextend.i64 v4
-;; @0083                               v11 = iadd v9, v6
-;; @0083                               v12 = uextend.i64 v8
-;; @0083                               v13 = icmp ule v11, v12
-;; @0083                               trapz v13, heap_oob
-;; @0083                               v14 = load.i32 notrap aligned can_move v0+40
-;; @0083                               v17 = load.i32 notrap aligned v0+60
-;; @0083                               v18 = uadd_overflow_trap v3, v6, heap_oob
-;; @0083                               v19 = uextend.i64 v17
-;; @0083                               v20 = icmp ule v18, v19
-;; @0083                               trapz v20, heap_oob
-;; @0083                               v22 = load.i32 notrap aligned can_move v0+56
-;; @0083                               v15 = iadd v14, v2
-;; @0083                               v21 = ireduce.i32 v3
-;; @0083                               v23 = iadd v22, v21
-;; @0083                               call fn0(v0, v15, v23, v4)
+;; @0083                               v7 = load.i32 notrap aligned v0+44
+;; @0083                               v8 = uextend.i64 v2
+;; @0083                               v5 = uextend.i64 v4
+;; @0083                               v10 = iadd v8, v5
+;; @0083                               v11 = uextend.i64 v7
+;; @0083                               v12 = icmp ule v10, v11
+;; @0083                               trapz v12, heap_oob
+;; @0083                               v13 = load.i32 notrap aligned can_move v0+40
+;; @0083                               v16 = load.i32 notrap aligned v0+60
+;; @0083                               v17 = uadd_overflow_trap v3, v5, heap_oob
+;; @0083                               v18 = uextend.i64 v16
+;; @0083                               v19 = icmp ule v17, v18
+;; @0083                               trapz v19, heap_oob
+;; @0083                               v21 = load.i32 notrap aligned can_move v0+56
+;; @0083                               v14 = iadd v13, v2
+;; @0083                               v20 = ireduce.i32 v3
+;; @0083                               v22 = iadd v21, v20
+;; @0083                               call fn0(v0, v14, v22, v4)
 ;; @0087                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/memory_copy_host64.wat
+++ b/tests/disas/memory_copy_host64.wat
@@ -61,20 +61,20 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
-;; @0042                               v7 = load.i64 notrap aligned v0+88
-;; @0042                               v8 = uextend.i64 v2
-;; @0042                               v9 = uextend.i64 v4
-;; @0042                               v10 = iadd v8, v9
-;; @0042                               v11 = icmp ule v10, v7
-;; @0042                               trapz v11, heap_oob
-;; @0042                               v17 = uextend.i64 v3
-;; @0042                               v19 = iadd v17, v9
-;; @0042                               v20 = icmp ule v19, v7
-;; @0042                               trapz v20, heap_oob
-;; @0042                               v13 = load.i64 notrap aligned readonly can_move v0+80
-;; @0042                               v14 = iadd v13, v8
-;; @0042                               v23 = iadd v13, v17
-;; @0042                               call fn0(v0, v14, v23, v9)
+;; @0042                               v6 = load.i64 notrap aligned v0+88
+;; @0042                               v7 = uextend.i64 v2
+;; @0042                               v8 = uextend.i64 v4
+;; @0042                               v9 = iadd v7, v8
+;; @0042                               v10 = icmp ule v9, v6
+;; @0042                               trapz v10, heap_oob
+;; @0042                               v16 = uextend.i64 v3
+;; @0042                               v18 = iadd v16, v8
+;; @0042                               v19 = icmp ule v18, v6
+;; @0042                               trapz v19, heap_oob
+;; @0042                               v12 = load.i64 notrap aligned readonly can_move v0+80
+;; @0042                               v13 = iadd v12, v7
+;; @0042                               v22 = iadd v12, v16
+;; @0042                               call fn0(v0, v13, v22, v8)
 ;; @0046                               jump block1
 ;;
 ;;                                 block1:
@@ -95,22 +95,22 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
-;; @004f                               v7 = load.i64 notrap aligned v0+104
-;; @004f                               v8 = uextend.i64 v2
-;; @004f                               v9 = uextend.i64 v4
-;; @004f                               v10 = iadd v8, v9
-;; @004f                               v11 = icmp ule v10, v7
-;; @004f                               trapz v11, heap_oob
-;; @004f                               v16 = load.i64 notrap aligned v0+88
-;; @004f                               v17 = uextend.i64 v3
-;; @004f                               v19 = iadd v17, v9
-;; @004f                               v20 = icmp ule v19, v16
-;; @004f                               trapz v20, heap_oob
-;; @004f                               v13 = load.i64 notrap aligned readonly can_move v0+96
-;; @004f                               v14 = iadd v13, v8
-;; @004f                               v22 = load.i64 notrap aligned readonly can_move v0+80
-;; @004f                               v23 = iadd v22, v17
-;; @004f                               call fn0(v0, v14, v23, v9)
+;; @004f                               v6 = load.i64 notrap aligned v0+104
+;; @004f                               v7 = uextend.i64 v2
+;; @004f                               v8 = uextend.i64 v4
+;; @004f                               v9 = iadd v7, v8
+;; @004f                               v10 = icmp ule v9, v6
+;; @004f                               trapz v10, heap_oob
+;; @004f                               v15 = load.i64 notrap aligned v0+88
+;; @004f                               v16 = uextend.i64 v3
+;; @004f                               v18 = iadd v16, v8
+;; @004f                               v19 = icmp ule v18, v15
+;; @004f                               trapz v19, heap_oob
+;; @004f                               v12 = load.i64 notrap aligned readonly can_move v0+96
+;; @004f                               v13 = iadd v12, v7
+;; @004f                               v21 = load.i64 notrap aligned readonly can_move v0+80
+;; @004f                               v22 = iadd v21, v16
+;; @004f                               call fn0(v0, v13, v22, v8)
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:
@@ -131,21 +131,21 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32, v4: i32):
-;; @005c                               v8 = load.i64 notrap aligned v0+120
-;; @005c                               v6 = uextend.i64 v4
-;; @005c                               v9 = uadd_overflow_trap v2, v6, heap_oob
-;; @005c                               v10 = icmp ule v9, v8
-;; @005c                               trapz v10, heap_oob
-;; @005c                               v11 = load.i64 notrap aligned can_move v0+112
-;; @005c                               v14 = load.i64 notrap aligned v0+88
-;; @005c                               v15 = uextend.i64 v3
-;; @005c                               v17 = iadd v15, v6
-;; @005c                               v18 = icmp ule v17, v14
-;; @005c                               trapz v18, heap_oob
-;; @005c                               v12 = iadd v11, v2
-;; @005c                               v20 = load.i64 notrap aligned readonly can_move v0+80
-;; @005c                               v21 = iadd v20, v15
-;; @005c                               call fn0(v0, v12, v21, v6)
+;; @005c                               v7 = load.i64 notrap aligned v0+120
+;; @005c                               v5 = uextend.i64 v4
+;; @005c                               v8 = uadd_overflow_trap v2, v5, heap_oob
+;; @005c                               v9 = icmp ule v8, v7
+;; @005c                               trapz v9, heap_oob
+;; @005c                               v10 = load.i64 notrap aligned can_move v0+112
+;; @005c                               v13 = load.i64 notrap aligned v0+88
+;; @005c                               v14 = uextend.i64 v3
+;; @005c                               v16 = iadd v14, v5
+;; @005c                               v17 = icmp ule v16, v13
+;; @005c                               trapz v17, heap_oob
+;; @005c                               v11 = iadd v10, v2
+;; @005c                               v19 = load.i64 notrap aligned readonly can_move v0+80
+;; @005c                               v20 = iadd v19, v14
+;; @005c                               call fn0(v0, v11, v20, v5)
 ;; @0060                               jump block1
 ;;
 ;;                                 block1:
@@ -164,17 +164,17 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64):
-;; @0069                               v7 = load.i64 notrap aligned v0+120
-;; @0069                               v8 = uadd_overflow_trap v2, v4, heap_oob
-;; @0069                               v9 = icmp ule v8, v7
-;; @0069                               trapz v9, heap_oob
-;; @0069                               v10 = load.i64 notrap aligned can_move v0+112
-;; @0069                               v14 = uadd_overflow_trap v3, v4, heap_oob
-;; @0069                               v15 = icmp ule v14, v7
-;; @0069                               trapz v15, heap_oob
-;; @0069                               v11 = iadd v10, v2
-;; @0069                               v17 = iadd v10, v3
-;; @0069                               call fn0(v0, v11, v17, v4)
+;; @0069                               v6 = load.i64 notrap aligned v0+120
+;; @0069                               v7 = uadd_overflow_trap v2, v4, heap_oob
+;; @0069                               v8 = icmp ule v7, v6
+;; @0069                               trapz v8, heap_oob
+;; @0069                               v9 = load.i64 notrap aligned can_move v0+112
+;; @0069                               v13 = uadd_overflow_trap v3, v4, heap_oob
+;; @0069                               v14 = icmp ule v13, v6
+;; @0069                               trapz v14, heap_oob
+;; @0069                               v10 = iadd v9, v2
+;; @0069                               v16 = iadd v9, v3
+;; @0069                               call fn0(v0, v10, v16, v4)
 ;; @006d                               jump block1
 ;;
 ;;                                 block1:
@@ -195,19 +195,19 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64):
-;; @0076                               v7 = load.i64 notrap aligned v0+136
-;; @0076                               v8 = uadd_overflow_trap v2, v4, heap_oob
-;; @0076                               v9 = icmp ule v8, v7
-;; @0076                               trapz v9, heap_oob
-;; @0076                               v10 = load.i64 notrap aligned can_move v0+128
-;; @0076                               v13 = load.i64 notrap aligned v0+120
-;; @0076                               v14 = uadd_overflow_trap v3, v4, heap_oob
-;; @0076                               v15 = icmp ule v14, v13
-;; @0076                               trapz v15, heap_oob
-;; @0076                               v16 = load.i64 notrap aligned can_move v0+112
-;; @0076                               v11 = iadd v10, v2
-;; @0076                               v17 = iadd v16, v3
-;; @0076                               call fn0(v0, v11, v17, v4)
+;; @0076                               v6 = load.i64 notrap aligned v0+136
+;; @0076                               v7 = uadd_overflow_trap v2, v4, heap_oob
+;; @0076                               v8 = icmp ule v7, v6
+;; @0076                               trapz v8, heap_oob
+;; @0076                               v9 = load.i64 notrap aligned can_move v0+128
+;; @0076                               v12 = load.i64 notrap aligned v0+120
+;; @0076                               v13 = uadd_overflow_trap v3, v4, heap_oob
+;; @0076                               v14 = icmp ule v13, v12
+;; @0076                               trapz v14, heap_oob
+;; @0076                               v15 = load.i64 notrap aligned can_move v0+112
+;; @0076                               v10 = iadd v9, v2
+;; @0076                               v16 = iadd v15, v3
+;; @0076                               call fn0(v0, v10, v16, v4)
 ;; @007a                               jump block1
 ;;
 ;;                                 block1:
@@ -228,21 +228,21 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i64, v4: i32):
-;; @0083                               v8 = load.i64 notrap aligned v0+88
-;; @0083                               v9 = uextend.i64 v2
-;; @0083                               v6 = uextend.i64 v4
-;; @0083                               v11 = iadd v9, v6
-;; @0083                               v12 = icmp ule v11, v8
-;; @0083                               trapz v12, heap_oob
-;; @0083                               v17 = load.i64 notrap aligned v0+120
-;; @0083                               v18 = uadd_overflow_trap v3, v6, heap_oob
-;; @0083                               v19 = icmp ule v18, v17
-;; @0083                               trapz v19, heap_oob
-;; @0083                               v20 = load.i64 notrap aligned can_move v0+112
-;; @0083                               v14 = load.i64 notrap aligned readonly can_move v0+80
-;; @0083                               v15 = iadd v14, v9
-;; @0083                               v21 = iadd v20, v3
-;; @0083                               call fn0(v0, v15, v21, v6)
+;; @0083                               v7 = load.i64 notrap aligned v0+88
+;; @0083                               v8 = uextend.i64 v2
+;; @0083                               v5 = uextend.i64 v4
+;; @0083                               v10 = iadd v8, v5
+;; @0083                               v11 = icmp ule v10, v7
+;; @0083                               trapz v11, heap_oob
+;; @0083                               v16 = load.i64 notrap aligned v0+120
+;; @0083                               v17 = uadd_overflow_trap v3, v5, heap_oob
+;; @0083                               v18 = icmp ule v17, v16
+;; @0083                               trapz v18, heap_oob
+;; @0083                               v19 = load.i64 notrap aligned can_move v0+112
+;; @0083                               v13 = load.i64 notrap aligned readonly can_move v0+80
+;; @0083                               v14 = iadd v13, v8
+;; @0083                               v20 = iadd v19, v3
+;; @0083                               call fn0(v0, v14, v20, v5)
 ;; @0087                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/memory_fill_host32.wat
+++ b/tests/disas/memory_fill_host32.wat
@@ -54,17 +54,17 @@
 ;;     fn0 = colocated u805306368:5 sig0
 ;;
 ;;                                 block0(v0: i32, v1: i32, v2: i32, v3: i32):
-;; @003c                               v7 = load.i32 notrap aligned v0+48
-;; @003c                               v8 = uextend.i64 v2
-;; @003c                               v9 = uextend.i64 v3
-;; @003c                               v10 = iadd v8, v9
-;; @003c                               v11 = uextend.i64 v7
-;; @003c                               v12 = icmp ule v10, v11
-;; @003c                               trapz v12, heap_oob
-;; @003c                               v13 = load.i32 notrap aligned can_move v0+44
-;; @003c                               v14 = iadd v13, v2
+;; @003c                               v6 = load.i32 notrap aligned v0+48
+;; @003c                               v7 = uextend.i64 v2
+;; @003c                               v8 = uextend.i64 v3
+;; @003c                               v9 = iadd v7, v8
+;; @003c                               v10 = uextend.i64 v6
+;; @003c                               v11 = icmp ule v9, v10
+;; @003c                               trapz v11, heap_oob
+;; @003c                               v12 = load.i32 notrap aligned can_move v0+44
+;; @003c                               v13 = iadd v12, v2
 ;; @0038                               v4 = iconst.i32 0
-;; @003c                               call fn0(v0, v14, v4, v3)  ; v4 = 0
+;; @003c                               call fn0(v0, v13, v4, v3)  ; v4 = 0
 ;; @003f                               jump block1
 ;;
 ;;                                 block1:
@@ -79,17 +79,17 @@
 ;;     fn0 = colocated u805306368:5 sig0
 ;;
 ;;                                 block0(v0: i32, v1: i32, v2: i64, v3: i64):
-;; @0048                               v7 = load.i32 notrap aligned v0+56
-;; @0048                               v8 = uadd_overflow_trap v2, v3, heap_oob
-;; @0048                               v9 = uextend.i64 v7
-;; @0048                               v10 = icmp ule v8, v9
-;; @0048                               trapz v10, heap_oob
-;; @0048                               v12 = load.i32 notrap aligned can_move v0+52
-;; @0048                               v11 = ireduce.i32 v2
-;; @0048                               v13 = iadd v12, v11
+;; @0048                               v6 = load.i32 notrap aligned v0+56
+;; @0048                               v7 = uadd_overflow_trap v2, v3, heap_oob
+;; @0048                               v8 = uextend.i64 v6
+;; @0048                               v9 = icmp ule v7, v8
+;; @0048                               trapz v9, heap_oob
+;; @0048                               v11 = load.i32 notrap aligned can_move v0+52
+;; @0048                               v10 = ireduce.i32 v2
+;; @0048                               v12 = iadd v11, v10
 ;; @0044                               v4 = iconst.i32 0
-;; @0048                               v14 = ireduce.i32 v3
-;; @0048                               call fn0(v0, v13, v4, v14)  ; v4 = 0
+;; @0048                               v13 = ireduce.i32 v3
+;; @0048                               call fn0(v0, v12, v4, v13)  ; v4 = 0
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:
@@ -104,17 +104,17 @@
 ;;     fn0 = colocated u805306368:5 sig0
 ;;
 ;;                                 block0(v0: i32, v1: i32, v2: i32, v3: i32):
-;; @0054                               v7 = load.i32 notrap aligned v0+64
-;; @0054                               v8 = uextend.i64 v2
-;; @0054                               v9 = uextend.i64 v3
-;; @0054                               v10 = iadd v8, v9
-;; @0054                               v11 = uextend.i64 v7
-;; @0054                               v12 = icmp ule v10, v11
-;; @0054                               trapz v12, heap_oob
-;; @0054                               v13 = load.i32 notrap aligned can_move v0+60
-;; @0054                               v14 = iadd v13, v2
+;; @0054                               v6 = load.i32 notrap aligned v0+64
+;; @0054                               v7 = uextend.i64 v2
+;; @0054                               v8 = uextend.i64 v3
+;; @0054                               v9 = iadd v7, v8
+;; @0054                               v10 = uextend.i64 v6
+;; @0054                               v11 = icmp ule v9, v10
+;; @0054                               trapz v11, heap_oob
+;; @0054                               v12 = load.i32 notrap aligned can_move v0+60
+;; @0054                               v13 = iadd v12, v2
 ;; @0050                               v4 = iconst.i32 0
-;; @0054                               call fn0(v0, v14, v4, v3)  ; v4 = 0
+;; @0054                               call fn0(v0, v13, v4, v3)  ; v4 = 0
 ;; @0057                               jump block1
 ;;
 ;;                                 block1:
@@ -129,17 +129,17 @@
 ;;     fn0 = colocated u805306368:5 sig0
 ;;
 ;;                                 block0(v0: i32, v1: i32, v2: i64, v3: i64):
-;; @0060                               v7 = load.i32 notrap aligned v0+72
-;; @0060                               v8 = uadd_overflow_trap v2, v3, heap_oob
-;; @0060                               v9 = uextend.i64 v7
-;; @0060                               v10 = icmp ule v8, v9
-;; @0060                               trapz v10, heap_oob
-;; @0060                               v12 = load.i32 notrap aligned can_move v0+68
-;; @0060                               v11 = ireduce.i32 v2
-;; @0060                               v13 = iadd v12, v11
+;; @0060                               v6 = load.i32 notrap aligned v0+72
+;; @0060                               v7 = uadd_overflow_trap v2, v3, heap_oob
+;; @0060                               v8 = uextend.i64 v6
+;; @0060                               v9 = icmp ule v7, v8
+;; @0060                               trapz v9, heap_oob
+;; @0060                               v11 = load.i32 notrap aligned can_move v0+68
+;; @0060                               v10 = ireduce.i32 v2
+;; @0060                               v12 = iadd v11, v10
 ;; @005c                               v4 = iconst.i32 0
-;; @0060                               v14 = ireduce.i32 v3
-;; @0060                               call fn0(v0, v13, v4, v14)  ; v4 = 0
+;; @0060                               v13 = ireduce.i32 v3
+;; @0060                               call fn0(v0, v12, v4, v13)  ; v4 = 0
 ;; @0063                               jump block1
 ;;
 ;;                                 block1:
@@ -154,17 +154,17 @@
 ;;     fn0 = colocated u805306368:5 sig0
 ;;
 ;;                                 block0(v0: i32, v1: i32, v2: i32, v3: i32):
-;; @006c                               v7 = load.i32 notrap aligned v0+80
-;; @006c                               v8 = uextend.i64 v2
-;; @006c                               v9 = uextend.i64 v3
-;; @006c                               v10 = iadd v8, v9
-;; @006c                               v11 = uextend.i64 v7
-;; @006c                               v12 = icmp ule v10, v11
-;; @006c                               trapz v12, heap_oob
-;; @006c                               v13 = load.i32 notrap aligned readonly can_move v0+76
-;; @006c                               v14 = iadd v13, v2
+;; @006c                               v6 = load.i32 notrap aligned v0+80
+;; @006c                               v7 = uextend.i64 v2
+;; @006c                               v8 = uextend.i64 v3
+;; @006c                               v9 = iadd v7, v8
+;; @006c                               v10 = uextend.i64 v6
+;; @006c                               v11 = icmp ule v9, v10
+;; @006c                               trapz v11, heap_oob
+;; @006c                               v12 = load.i32 notrap aligned readonly can_move v0+76
+;; @006c                               v13 = iadd v12, v2
 ;; @0068                               v4 = iconst.i32 0
-;; @006c                               call fn0(v0, v14, v4, v3)  ; v4 = 0
+;; @006c                               call fn0(v0, v13, v4, v3)  ; v4 = 0
 ;; @006f                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/memory_fill_host64.wat
+++ b/tests/disas/memory_fill_host64.wat
@@ -55,16 +55,16 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @003c                               v7 = load.i64 notrap aligned v0+96
-;; @003c                               v8 = uextend.i64 v2
-;; @003c                               v9 = uextend.i64 v3
-;; @003c                               v10 = iadd v8, v9
-;; @003c                               v11 = icmp ule v10, v7
-;; @003c                               trapz v11, heap_oob
-;; @003c                               v13 = load.i64 notrap aligned readonly can_move v0+88
-;; @003c                               v14 = iadd v13, v8
+;; @003c                               v6 = load.i64 notrap aligned v0+96
+;; @003c                               v7 = uextend.i64 v2
+;; @003c                               v8 = uextend.i64 v3
+;; @003c                               v9 = iadd v7, v8
+;; @003c                               v10 = icmp ule v9, v6
+;; @003c                               trapz v10, heap_oob
+;; @003c                               v12 = load.i64 notrap aligned readonly can_move v0+88
+;; @003c                               v13 = iadd v12, v7
 ;; @0038                               v4 = iconst.i32 0
-;; @003c                               call fn0(v0, v14, v4, v9)  ; v4 = 0
+;; @003c                               call fn0(v0, v13, v4, v8)  ; v4 = 0
 ;; @003f                               jump block1
 ;;
 ;;                                 block1:
@@ -83,14 +83,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i64):
-;; @0048                               v7 = load.i64 notrap aligned v0+112
-;; @0048                               v8 = uadd_overflow_trap v2, v3, heap_oob
-;; @0048                               v9 = icmp ule v8, v7
-;; @0048                               trapz v9, heap_oob
-;; @0048                               v10 = load.i64 notrap aligned can_move v0+104
-;; @0048                               v11 = iadd v10, v2
+;; @0048                               v6 = load.i64 notrap aligned v0+112
+;; @0048                               v7 = uadd_overflow_trap v2, v3, heap_oob
+;; @0048                               v8 = icmp ule v7, v6
+;; @0048                               trapz v8, heap_oob
+;; @0048                               v9 = load.i64 notrap aligned can_move v0+104
+;; @0048                               v10 = iadd v9, v2
 ;; @0044                               v4 = iconst.i32 0
-;; @0048                               call fn0(v0, v11, v4, v3)  ; v4 = 0
+;; @0048                               call fn0(v0, v10, v4, v3)  ; v4 = 0
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:
@@ -109,16 +109,16 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @0054                               v7 = load.i64 notrap aligned v0+128
-;; @0054                               v8 = uextend.i64 v2
-;; @0054                               v9 = uextend.i64 v3
-;; @0054                               v10 = iadd v8, v9
-;; @0054                               v11 = icmp ule v10, v7
-;; @0054                               trapz v11, heap_oob
-;; @0054                               v13 = load.i64 notrap aligned readonly can_move v0+120
-;; @0054                               v14 = iadd v13, v8
+;; @0054                               v6 = load.i64 notrap aligned v0+128
+;; @0054                               v7 = uextend.i64 v2
+;; @0054                               v8 = uextend.i64 v3
+;; @0054                               v9 = iadd v7, v8
+;; @0054                               v10 = icmp ule v9, v6
+;; @0054                               trapz v10, heap_oob
+;; @0054                               v12 = load.i64 notrap aligned readonly can_move v0+120
+;; @0054                               v13 = iadd v12, v7
 ;; @0050                               v4 = iconst.i32 0
-;; @0054                               call fn0(v0, v14, v4, v9)  ; v4 = 0
+;; @0054                               call fn0(v0, v13, v4, v8)  ; v4 = 0
 ;; @0057                               jump block1
 ;;
 ;;                                 block1:
@@ -137,14 +137,14 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i64):
-;; @0060                               v7 = load.i64 notrap aligned v0+144
-;; @0060                               v8 = uadd_overflow_trap v2, v3, heap_oob
-;; @0060                               v9 = icmp ule v8, v7
-;; @0060                               trapz v9, heap_oob
-;; @0060                               v10 = load.i64 notrap aligned can_move v0+136
-;; @0060                               v11 = iadd v10, v2
+;; @0060                               v6 = load.i64 notrap aligned v0+144
+;; @0060                               v7 = uadd_overflow_trap v2, v3, heap_oob
+;; @0060                               v8 = icmp ule v7, v6
+;; @0060                               trapz v8, heap_oob
+;; @0060                               v9 = load.i64 notrap aligned can_move v0+136
+;; @0060                               v10 = iadd v9, v2
 ;; @005c                               v4 = iconst.i32 0
-;; @0060                               call fn0(v0, v11, v4, v3)  ; v4 = 0
+;; @0060                               call fn0(v0, v10, v4, v3)  ; v4 = 0
 ;; @0063                               jump block1
 ;;
 ;;                                 block1:
@@ -163,16 +163,16 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @006c                               v7 = load.i64 notrap aligned v0+160
-;; @006c                               v8 = uextend.i64 v2
-;; @006c                               v9 = uextend.i64 v3
-;; @006c                               v10 = iadd v8, v9
-;; @006c                               v11 = icmp ule v10, v7
-;; @006c                               trapz v11, heap_oob
-;; @006c                               v13 = load.i64 notrap aligned readonly can_move v0+152
-;; @006c                               v14 = iadd v13, v8
+;; @006c                               v6 = load.i64 notrap aligned v0+160
+;; @006c                               v7 = uextend.i64 v2
+;; @006c                               v8 = uextend.i64 v3
+;; @006c                               v9 = iadd v7, v8
+;; @006c                               v10 = icmp ule v9, v6
+;; @006c                               trapz v10, heap_oob
+;; @006c                               v12 = load.i64 notrap aligned readonly can_move v0+152
+;; @006c                               v13 = iadd v12, v7
 ;; @0068                               v4 = iconst.i32 0
-;; @006c                               call fn0(v0, v14, v4, v9)  ; v4 = 0
+;; @006c                               call fn0(v0, v13, v4, v8)  ; v4 = 0
 ;; @006f                               jump block1
 ;;
 ;;                                 block1:


### PR DESCRIPTION
This commit builds on previous refactors to enable splitting up large bulk copies/fills into chunks with explicit preemption checks between them. This additionally consumes fuel proportional to the size of the operation as opposed to previously where a constant amount of fuel was consumed regardless.

This notably does not handle instructions like `memory.init` nor `table.copy`. That'll come in a future commit.

cc #13387

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
