### PR TITLE
Restore `#![no_std]` support for cranelift

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -606,6 +606,7 @@ jobs:
             cargo check -p cranelift-control --no-default-features &&
             cargo check -p cranelift-assembler-x64 --lib &&
             cargo check -p cranelift-codegen --no-default-features --features x86,arm64 &&
+            cargo check -p cranelift-frontend --no-default-features &&
             cargo check -p pulley-interpreter --features encode,decode,disas,interp &&
             cargo check -p wasmtime-wasi-io --no-default-features
         # Use `cross` for illumos to have a C compiler/linker available.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -300,7 +300,7 @@ pulley-macros = { path = 'pulley/macros', version = "=46.0.0" }
 
 # Cranelift crates in this workspace
 cranelift-assembler-x64 = { path = "cranelift/assembler-x64", version = "0.133.0" }
-cranelift-codegen = { path = "cranelift/codegen", version = "0.133.0", default-features = false, features = ["std", "unwind"] }
+cranelift-codegen = { path = "cranelift/codegen", version = "0.133.0", default-features = false, features = ["unwind"] }
 cranelift-frontend = { path = "cranelift/frontend", version = "0.133.0" }
 cranelift-entity = { path = "cranelift/entity", version = "0.133.0" }
 cranelift-native = { path = "cranelift/native", version = "0.133.0" }

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -121,6 +121,7 @@ enable-serde = [
     "cranelift-entity/enable-serde",
     "cranelift-bitset/enable-serde",
     "regalloc2/enable-serde",
+    "hashbrown/serde",
     "smallvec/serde",
 ]
 

--- a/cranelift/frontend/Cargo.toml
+++ b/cranelift/frontend/Cargo.toml
@@ -18,7 +18,7 @@ workspace = true
 cranelift-codegen = { workspace = true }
 target-lexicon = { workspace = true }
 log = { workspace = true }
-hashbrown = { workspace = true, optional = true }
+hashbrown = { workspace = true }
 smallvec = { workspace = true }
 
 [dev-dependencies]
@@ -29,4 +29,4 @@ cranelift-codegen = { workspace = true, features = ['x86'] }
 [features]
 default = ["std"]
 std = ["cranelift-codegen/std"]
-core = ["hashbrown", "cranelift-codegen/core"]
+core = ["cranelift-codegen/core"]

--- a/cranelift/frontend/src/frontend.rs
+++ b/cranelift/frontend/src/frontend.rs
@@ -1,7 +1,7 @@
 //! A frontend for building Cranelift IR from other languages.
 use crate::ssa::{SSABuilder, SideEffects};
 use crate::variable::Variable;
-use alloc::vec::Vec;
+use alloc::{vec, vec::Vec};
 use core::fmt::{self, Debug};
 use cranelift_codegen::cursor::{Cursor, CursorPosition, FuncCursor};
 use cranelift_codegen::entity::{EntityRef, EntitySet, PrimaryMap, SecondaryMap};
@@ -242,7 +242,7 @@ impl fmt::Display for UseVariableError {
     }
 }
 
-impl std::error::Error for UseVariableError {}
+impl core::error::Error for UseVariableError {}
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 /// An error encountered when defining the initial value of a variable.
@@ -1107,8 +1107,8 @@ impl<'a> FunctionBuilder<'a> {
         left: Value,
         right: Value,
         size: u64,
-        left_align: std::num::NonZeroU8,
-        right_align: std::num::NonZeroU8,
+        left_align: core::num::NonZeroU8,
+        right_align: core::num::NonZeroU8,
         flags: MemFlagsData,
     ) -> Value {
         use IntCC::*;

--- a/cranelift/frontend/src/ssa.rs
+++ b/cranelift/frontend/src/ssa.rs
@@ -8,7 +8,7 @@
 //! <https://link.springer.com/content/pdf/10.1007/978-3-642-37051-9_6.pdf>
 
 use crate::Variable;
-use alloc::vec::Vec;
+use alloc::{vec, vec::Vec};
 use core::mem;
 use cranelift_codegen::cursor::{Cursor, FuncCursor};
 use cranelift_codegen::entity::{EntityList, EntitySet, ListPool, SecondaryMap};

--- a/cranelift/frontend/src/switch.rs
+++ b/cranelift/frontend/src/switch.rs
@@ -1,6 +1,6 @@
 use super::HashMap;
 use crate::frontend::FunctionBuilder;
-use alloc::vec::Vec;
+use alloc::{vec, vec::Vec};
 use cranelift_codegen::ir::condcodes::IntCC;
 use cranelift_codegen::ir::*;
 


### PR DESCRIPTION
Hello,

Support for `#![no_std]` for cranelift is currently broken, and this PR attempts to fix this.

I integrated https://github.com/bytecodealliance/wasmtime/pull/12947 for the changes in the frontend crate, alongside with the changes to the CI that were requested in the PR review.

I've also removed the requirement on the `std` feature of `cranelift-codegen`, as otherwise `cranelift-frontend` automatically pulls in this `std` feature.
I did this last change a bit blindly. A quick git blame has led me to https://github.com/bytecodealliance/wasmtime/pull/7369. Unfortunately I don't know enough to know to know whether removing this `std` breaks anything, nor if it makes sense to leave `unwind`.
