### PR TITLE
Update Wasm GC stability docs

### DIFF
--- a/docs/stability-wasm-proposals.md
+++ b/docs/stability-wasm-proposals.md
@@ -49,7 +49,7 @@ The emoji legend is:
 | [`custom-page-sizes`]    | ❌      | ✅    | ✅       | ✅     | ✅  | ✅     |
 | [`exception-handling`]   | ✅      | ✅    | ✅       | ✅     | ✅  | ✅     |
 | [`function-references`]  | ✅      | ✅    | ✅       | 🚧     | ✅  | ❌     |
-| [`gc`] [^5]              | ✅      | ✅    | 🚧[^6]   | 🚧[^7] | ✅  | ✅     |
+| [`gc`] [^5]              | ✅      | ✅    | 🚧[^6]   | ✅     | ✅  | ✅     |
 | [`threads`]              | ✅      | ✅    | 🚧[^8]   | ❌[^4] | ✅  | ✅     |
 | [`wide-arithmetic`]      | ❌      | ✅    | ✅       | ✅     | ✅  | ✅     |
 
@@ -60,12 +60,8 @@ The emoji legend is:
     GC proposal.
 [^6]: The implementation of Wasm GC is feature complete from a specification
     perspective, however a number of quality-of-implementation tasks
-    [remain](https://github.com/bytecodealliance/wasmtime/issues/5032), notably
-    a tracing collector that can reclaim garbage cycles.
-[^7]: The GC proposal is lightly fuzzed via `wasm-smith` and our usual
-    whole-module fuzz targets like `differential`, but we would like to
-    additionally [extend the `table_ops` fuzz target to exercise more of the GC
-    proposal](https://github.com/bytecodealliance/wasmtime/issues/10327).
+    [remain](https://github.com/bytecodealliance/wasmtime/issues/13216) that
+    we'd like to resolve before promoting Wasm GC to tier 1.
 [^8]: There are [known
     issues](https://github.com/bytecodealliance/wasmtime/issues/4245) with
     shared memories and the implementation/API in Wasmtime, for example they


### PR DESCRIPTION
I think we can consider it fuzzed between the new GC accessors fuzzer, wasm-smith's Wasm GC support, and the ongoing GC ops fuzzer work. Additionally, when we accidentally introduced GC-related bugs recently (e.g. when splitting GC heap tunables out from the existing memory tunables) the fuzzers quickly and successfully found these bugs.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
