### PR TITLE
Move `table.copy` implementation to compiled code 

### DIFF
--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -1,13 +1,13 @@
 mod gc;
 pub(crate) mod stack_switching;
 
-use crate::BuiltinFunctionSignatures;
 use crate::compiler::Compiler;
 use crate::translate::{
     FuncTranslationStacks, GlobalVariable, Heap, HeapData, MemoryKind, StructFieldsVec, TableData,
     TableSize, TargetEnvironment,
 };
 use crate::trap::TranslateTrap;
+use crate::{BuiltinFunctionSignatures, TRAP_ARRAY_OUT_OF_BOUNDS, TRAP_TABLE_OUT_OF_BOUNDS};
 use cranelift_codegen::cursor::FuncCursor;
 use cranelift_codegen::ir::condcodes::{FloatCC, IntCC};
 use cranelift_codegen::ir::immediates::{Imm64, Offset32, V128Imm};
@@ -29,10 +29,9 @@ use wasmtime_environ::{
     BuiltinFunctionIndex, ComponentPC, DataIndex, DefinedFuncIndex, ElemIndex,
     EngineOrModuleTypeIndex, FrameStateSlotBuilder, FrameValType, FuncIndex, FuncKey,
     GlobalConstValue, GlobalIndex, IndexType, Memory, MemoryIndex, MemoryTunables, Module,
-    ModuleInternedTypeIndex, ModuleTranslation, ModuleTypesBuilder, PassiveDataIndex, PtrSize,
-    Table, TableIndex, TagIndex, Tunables, TypeConvert, TypeIndex, VMOffsets,
-    WasmCompositeInnerType, WasmFuncType, WasmHeapTopType, WasmHeapType, WasmRefType, WasmResult,
-    WasmValType,
+    ModuleInternedTypeIndex, ModuleTranslation, ModuleTypesBuilder, PtrSize, Table, TableIndex,
+    TagIndex, Tunables, TypeConvert, TypeIndex, VMOffsets, WasmCompositeInnerType, WasmFuncType,
+    WasmHeapTopType, WasmHeapType, WasmRefType, WasmResult, WasmStorageType, WasmValType,
 };
 use wasmtime_environ::{FUNCREF_INIT_BIT, FUNCREF_MASK};
 
@@ -305,20 +304,6 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
             self.vmctx = Some(vmctx);
             vmctx
         })
-    }
-
-    fn get_table_copy_func(
-        &mut self,
-        func: &mut Function,
-        dst_table_index: TableIndex,
-        src_table_index: TableIndex,
-    ) -> (ir::FuncRef, usize, usize) {
-        let sig = self.builtin_functions.table_copy(func);
-        (
-            sig,
-            dst_table_index.as_u32() as usize,
-            src_table_index.as_u32() as usize,
-        )
     }
 
     #[cfg(feature = "threads")]
@@ -867,7 +852,7 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
         }
     }
 
-    fn get_or_init_func_ref_table_elem(
+    fn table_get_funcref(
         &mut self,
         builder: &mut FunctionBuilder,
         table_index: TableIndex,
@@ -887,6 +872,7 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
         if !self.tunables.table_lazy_init {
             return value;
         }
+        let pointer_type = self.pointer_type();
 
         // Mask off the "initialized bit". See documentation on
         // FUNCREF_INIT_BIT in crates/environ/src/ref_bits.rs for more
@@ -1976,12 +1962,9 @@ impl<'a, 'func, 'module_env> Call<'a, 'func, 'module_env> {
         cold_blocks: bool,
     ) -> WasmResult<Option<(ir::Value, ir::Value)>> {
         // Get the funcref pointer from the table.
-        let funcref_ptr = self.env.get_or_init_func_ref_table_elem(
-            self.builder,
-            table_index,
-            callee,
-            cold_blocks,
-        );
+        let funcref_ptr =
+            self.env
+                .table_get_funcref(self.builder, table_index, callee, cold_blocks);
 
         // If necessary, check the signature.
         let check =
@@ -2524,9 +2507,7 @@ impl FuncEnvironment<'_> {
             }
 
             // Function types.
-            WasmHeapTopType::Func => {
-                Ok(self.get_or_init_func_ref_table_elem(builder, table_index, index, false))
-            }
+            WasmHeapTopType::Func => Ok(self.table_get_funcref(builder, table_index, index, false)),
 
             // Continuation types.
             WasmHeapTopType::Cont => {
@@ -2568,19 +2549,7 @@ impl FuncEnvironment<'_> {
             // Function types.
             WasmHeapTopType::Func => {
                 let (elem_addr, flags) = table_data.prepare_table_addr(self, builder, index);
-                // Set the "initialized bit". See doc-comment on
-                // `FUNCREF_INIT_BIT` in
-                // crates/environ/src/ref_bits.rs for details.
-                let value_with_init_bit = if self.tunables.table_lazy_init {
-                    builder
-                        .ins()
-                        .bor_imm(value, Imm64::from(FUNCREF_INIT_BIT as i64))
-                } else {
-                    value
-                };
-                builder
-                    .ins()
-                    .store(flags, value_with_init_bit, elem_addr, 0);
+                self.table_set_funcref(builder, value, elem_addr, flags);
                 Ok(())
             }
 
@@ -2591,6 +2560,30 @@ impl FuncEnvironment<'_> {
                 Ok(())
             }
         }
+    }
+
+    /// Helper to store the funcref `value` at the raw native address
+    /// `elem_addr` using the `flags` specified.
+    fn table_set_funcref(
+        &mut self,
+        builder: &mut FunctionBuilder,
+        value: ir::Value,
+        elem_addr: ir::Value,
+        flags: ir::MemFlagsData,
+    ) {
+        // Set the "initialized bit". See doc-comment on
+        // `FUNCREF_INIT_BIT` in
+        // crates/environ/src/ref_bits.rs for details.
+        let value_with_init_bit = if self.tunables.table_lazy_init {
+            builder
+                .ins()
+                .bor_imm(value, Imm64::from(FUNCREF_INIT_BIT as i64))
+        } else {
+            value
+        };
+        builder
+            .ins()
+            .store(flags, value_with_init_bit, elem_addr, 0);
     }
 
     pub fn translate_table_fill(
@@ -3414,70 +3407,6 @@ impl FuncEnvironment<'_> {
         ))
     }
 
-    /// Performs a bounds check and raises a trap if `ptr+len` is out-of-bounds
-    /// for `len`.
-    ///
-    /// Returns the raw host-native heap address of `ptr`.
-    fn bounds_check_for_memory_intrinsic(
-        &mut self,
-        builder: &mut FunctionBuilder<'_>,
-        memory_index: MemoryIndex,
-        ptr: ir::Value,
-        len: ir::Value,
-    ) -> ir::Value {
-        let pointer_type = self.pointer_type();
-        let idx_type = self.memory(memory_index).idx_type;
-
-        let idx_clif_type = match idx_type {
-            IndexType::I32 => I32,
-            IndexType::I64 => I64,
-        };
-        debug_assert_eq!(builder.func.dfg.value_type(ptr), idx_clif_type);
-        debug_assert_eq!(builder.func.dfg.value_type(len), idx_clif_type);
-
-        // Load the memory size, as `pointer_type`, which is the size of this
-        // memory currently in
-        // bytes.
-        let size_in_bytes = self.memory_size_in_bytes(&mut builder.cursor(), memory_index);
-
-        // Compute the end address of this operation, casted to the `I64` type.
-        //
-        // Note that addition can't overflow after extending 32-bits to
-        // 64-bits, so no need to check for overflow in the 32-bit index case.
-        let end64 = match idx_type {
-            IndexType::I32 => {
-                let ptr64 = builder.ins().uextend(I64, ptr);
-                let len64 = builder.ins().uextend(I64, len);
-                builder.ins().iadd(ptr64, len64)
-            }
-            IndexType::I64 => {
-                self.uadd_overflow_trap(builder, ptr, len, ir::TrapCode::HEAP_OUT_OF_BOUNDS)
-            }
-        };
-
-        // Cast the host-pointer width to a 64-bit bit width.
-        let size_in_bytes64 = match pointer_type {
-            I32 => builder.ins().uextend(I64, size_in_bytes),
-            I64 => size_in_bytes,
-            _ => unreachable!(),
-        };
-
-        // This is the actual bounds check that verifies that this operation is
-        // in-bounds. Once control flow gets past here we know that nothing can
-        // overflow and everything is in-bounds.
-        let inbounds = builder
-            .ins()
-            .icmp(IntCC::UnsignedLessThanOrEqual, end64, size_in_bytes64);
-        self.trapz(builder, inbounds, ir::TrapCode::HEAP_OUT_OF_BOUNDS);
-
-        // Compute the actual raw heap address to return
-        let mut pos = builder.cursor();
-        let heap = self.get_or_create_heap(pos.func, memory_index);
-        let heap = self.heaps()[heap].clone();
-        let ptr = self.unchecked_cast_wasm_addr_to_native_addr(&mut pos, ptr, idx_type);
-        crate::bounds_checks::compute_addr(&mut pos, &heap, pointer_type, ptr, 0)
-    }
-
     pub fn translate_memory_copy(
         &mut self,
         builder: &mut FunctionBuilder<'_>,
@@ -3487,49 +3416,7 @@ impl FuncEnvironment<'_> {
         src: ir::Value,
         len: ir::Value,
     ) -> WasmResult<()> {
-        let src_idx_ty = self.memory(src_index).idx_type;
-        let dst_idx_ty = self.memory(dst_index).idx_type;
-
-        // The length is 32-bit if either memory is 32-bit, but if they're both
-        // 64-bit then it's 64-bit.
-        let len_idx_ty = match (src_idx_ty, dst_idx_ty) {
-            (IndexType::I32, _) | (_, IndexType::I32) => IndexType::I32,
-            (IndexType::I64, IndexType::I64) => IndexType::I64,
-        };
-
-        let src_len = if src_idx_ty == len_idx_ty {
-            len
-        } else {
-            assert_eq!(src_idx_ty, IndexType::I64);
-            builder.ins().uextend(I64, len)
-        };
-        let dst_len = if dst_idx_ty == len_idx_ty {
-            len
-        } else {
-            assert_eq!(dst_idx_ty, IndexType::I64);
-            builder.ins().uextend(I64, len)
-        };
-
-        // Perform a bounds check for the src/dst memories and compute the raw
-        // heap addresses at the same time.
-        let dst_raw_addr = self.bounds_check_for_memory_intrinsic(builder, dst_index, dst, dst_len);
-        let src_raw_addr = self.bounds_check_for_memory_intrinsic(builder, src_index, src, src_len);
-
-        // Fit the `len` value to `pointer_type`. Note that at this point it's
-        // guaranteed inbounds so there's no loss in precision.
-        let len_ptr =
-            self.unchecked_cast_wasm_addr_to_native_addr(&mut builder.cursor(), len, len_idx_ty);
-
-        self.raw_bulk_memory_operation(
-            builder,
-            BulkOp::MemoryCopy {
-                dst: dst_raw_addr,
-                src: src_raw_addr,
-                len: len_ptr,
-            },
-        );
-
-        Ok(())
+        self.translate_entity_copy(builder, dst_index, src_index, dst, src, len)
     }
 
     /// Perform a raw bulk-memory-like libcall.
@@ -3701,7 +3588,7 @@ impl FuncEnvironment<'_> {
         let idx_type = self.memory(memory_index).idx_type;
 
         // Bounds check `dst+len` and convert it to a raw heap address.
-        let raw_heap_addr = self.bounds_check_for_memory_intrinsic(builder, memory_index, dst, len);
+        let raw_heap_addr = self.translate_entity_bounds_check(builder, memory_index, dst, len);
 
         // Fit the `len` value to `pointer_type`. Note that at this point it's
         // guaranteed inbounds so there's no loss in precision.
@@ -3718,59 +3605,6 @@ impl FuncEnvironment<'_> {
         );
     }
 
-    /// Returns a native pointer to the passive data `segment` provided at
-    /// offset `src`.
-    ///
-    /// This will generate a trap if `src + len` is larger than the current
-    /// length of the passive data segment.
-    fn get_passive_data_pointer(
-        &mut self,
-        builder: &mut FunctionBuilder<'_>,
-        segment: PassiveDataIndex,
-        src: ir::Value,
-        len: ir::Value,
-    ) -> ir::Value {
-        assert_eq!(builder.func.dfg.value_type(src), I32);
-        assert_eq!(builder.func.dfg.value_type(len), I32);
-
-        // Test if `src + len` is inbounds for this passive data segment. To do
-        // that the size of the passive data segment is loaded from the
-        // `VMContext`. This is dynamically filled in at instantiation time and
-        // dynamically reset during `data.drop`.
-        //
-        // Note that `src` and `len` here are unconditionally 32-bit and the
-        // bounds check is done in the 64-bit space to ensure there is no
-        // overflow.
-        let vmctx = self.vmctx_val(&mut builder.cursor());
-        let passive_segment_len = builder.ins().uload32(
-            ir::MemFlagsData::trusted(),
-            vmctx,
-            i32::try_from(self.offsets.vmctx_passive_data_length(segment)).unwrap(),
-        );
-        let src64 = builder.ins().uextend(I64, src);
-        let len64 = builder.ins().uextend(I64, len);
-        let segment_end = builder.ins().iadd(src64, len64);
-        let segment_oob =
-            builder
-                .ins()
-                .icmp(IntCC::UnsignedGreaterThan, segment_end, passive_segment_len);
-        self.trapnz(builder, segment_oob, ir::TrapCode::HEAP_OUT_OF_BOUNDS);
-
-        // Load the base pointer and offset it by `src` bytes.
-        let passive_segment_base = builder.ins().load(
-            self.pointer_type(),
-            ir::MemFlagsData::trusted(),
-            vmctx,
-            i32::try_from(self.offsets.vmctx_passive_data_base(segment)).unwrap(),
-        );
-        let src_ptr = self.unchecked_cast_wasm_addr_to_native_addr(
-            &mut builder.cursor(),
-            src,
-            IndexType::I32,
-        );
-        builder.ins().iadd(passive_segment_base, src_ptr)
-    }
-
     pub fn translate_memory_init(
         &mut self,
         builder: &mut FunctionBuilder<'_>,
@@ -3781,46 +3615,7 @@ impl FuncEnvironment<'_> {
         len: ir::Value,
     ) -> WasmResult<()> {
         let seg_index = DataIndex::from_u32(seg_index);
-
-        // First, perform a bounds check to ensure that `dst + len` is inbounds.
-        // Note that `dst` has a type for `memory_index`'s index type, and `len`
-        // always has type i32. For `bounds_check_for_memory_intrinsic` below
-        // they both need to be typed with the memory's type, so cast the length
-        // here appropriately.
-        let len_with_memory_ty = match self.memory(memory_index).idx_type {
-            IndexType::I32 => len,
-            IndexType::I64 => builder.ins().uextend(I64, len),
-        };
-        let raw_dst =
-            self.bounds_check_for_memory_intrinsic(builder, memory_index, dst, len_with_memory_ty);
-
-        // Next see what passive data segment `seg_index` corresponds to. If
-        // this is actually an active data segment then it unconditionally has
-        // length zero. In this situation perform a conditional trap if `src` or
-        // `len` are nonzero, because if they're nonzero then this is out-of-bounds.
-        let raw_src = match self.translation.passive_data_map[seg_index] {
-            Some(idx) => self.get_passive_data_pointer(builder, idx, src, len),
-            None => {
-                self.trapnz(builder, src, ir::TrapCode::HEAP_OUT_OF_BOUNDS);
-                self.trapnz(builder, len, ir::TrapCode::HEAP_OUT_OF_BOUNDS);
-                return Ok(());
-            }
-        };
-
-        // At this point bounds checks have all passed, so it's time to perform
-        // the actual copy by calling the `memory.copy` libcall.
-        let vmctx = self.vmctx_val(&mut builder.cursor());
-        let memory_copy = self.builtin_functions.memory_copy(&mut builder.func);
-        let len_native = match self.pointer_type() {
-            I32 => len,
-            I64 => builder.ins().uextend(I64, len),
-            _ => unreachable!(),
-        };
-        builder
-            .ins()
-            .call(memory_copy, &[vmctx, raw_dst, raw_src, len_native]);
-
-        Ok(())
+        self.translate_entity_copy(builder, memory_index, seg_index, dst, src, len)
     }
 
     pub fn translate_data_drop(&mut self, mut pos: FuncCursor, seg_index: u32) -> WasmResult<()> {
@@ -3848,14 +3643,237 @@ impl FuncEnvironment<'_> {
         Ok(())
     }
 
-    pub fn translate_table_size(
-        &mut self,
-        pos: FuncCursor,
-        table_index: TableIndex,
-    ) -> WasmResult<ir::Value> {
+    pub fn translate_table_size(&mut self, pos: FuncCursor, table_index: TableIndex) -> ir::Value {
         let table_data = self.get_or_create_table(pos.func, table_index);
         let index_type = index_type_to_ir_type(self.table(table_index).idx_type);
-        Ok(table_data.bound.bound(&*self.isa, pos, index_type))
+        table_data.bound.bound(&*self.isa, pos, index_type)
+    }
+
+    /// Copies elements from `src_entity` to `dst_entity`.
+    ///
+    /// This will perform bounds checks for both entities and raise traps if
+    /// anything is out of bounds. Afterwards the actual copy is performed. The
+    /// `dst` and `src` parameters are starting offsets, and `len` is the length
+    /// of the copy. Both `dst` and `src` have types appropriate to index their
+    /// respective entities, and `len` has a type that's the smaller of the two
+    /// index types.
+    fn translate_entity_copy(
+        &mut self,
+        builder: &mut FunctionBuilder<'_>,
+        dst_entity: impl Into<CheckedEntity>,
+        src_entity: impl Into<CheckedEntity>,
+        dst: ir::Value,
+        src: ir::Value,
+        len: ir::Value,
+    ) -> WasmResult<()> {
+        let dst_entity = dst_entity.into();
+        let src_entity = src_entity.into();
+        let dst_idx_ty = dst_entity.index_type(self);
+        let src_idx_ty = src_entity.index_type(self);
+
+        // The length is 32-bit if either is 32-bit, but if they're both 64-bit
+        // then it's 64-bit.
+        let len_idx_ty = match (src_idx_ty, dst_idx_ty) {
+            (IndexType::I32, _) | (_, IndexType::I32) => IndexType::I32,
+            (IndexType::I64, IndexType::I64) => IndexType::I64,
+        };
+        let src_len = if src_idx_ty == len_idx_ty {
+            len
+        } else {
+            assert_eq!(src_idx_ty, IndexType::I64);
+            builder.ins().uextend(I64, len)
+        };
+        let dst_len = if dst_idx_ty == len_idx_ty {
+            len
+        } else {
+            assert_eq!(dst_idx_ty, IndexType::I64);
+            builder.ins().uextend(I64, len)
+        };
+
+        // Perform a bounds check for the src/dst entities and compute the raw
+        // heap addresses at the same time.
+        let dst_raw_addr = self.translate_entity_bounds_check(builder, dst_entity, dst, dst_len);
+        let src_raw_addr = self.translate_entity_bounds_check(builder, src_entity, src, src_len);
+
+        // Fit the `len` value to `pointer_type`. Note that at this point it's
+        // guaranteed inbounds so there's no loss in precision.
+        let len_ptr =
+            self.unchecked_cast_wasm_addr_to_native_addr(&mut builder.cursor(), len, len_idx_ty);
+
+        match dst_entity {
+            // Memories are always a `memcpy`.
+            CheckedEntity::Memory(_) => {
+                assert!(matches!(
+                    src_entity,
+                    CheckedEntity::Memory(_) | CheckedEntity::Data(_)
+                ));
+                self.raw_bulk_memory_operation(
+                    builder,
+                    BulkOp::MemoryCopy {
+                        dst: dst_raw_addr,
+                        src: src_raw_addr,
+                        len: len_ptr,
+                    },
+                );
+                Ok(())
+            }
+
+            // Tables are sometimes a memcpy, sometimes a per-element loop.
+            // Delegate further to figure that out.
+            CheckedEntity::Table(dst_table) => {
+                let CheckedEntity::Table(src_table) = src_entity else {
+                    unreachable!();
+                };
+                let ty = self.table(dst_table).ref_type;
+                let dst_table = self.get_or_create_table(builder.func, dst_table);
+                let src_table = self.get_or_create_table(builder.func, src_table);
+                assert_eq!(dst_table.element_size, src_table.element_size);
+                let one_elem_size = builder
+                    .ins()
+                    .iconst(self.pointer_type(), i64::from(dst_table.element_size));
+                self.emit_raw_array_or_table_copy(
+                    builder,
+                    dst_entity,
+                    src_entity,
+                    WasmStorageType::Val(WasmValType::Ref(ty)),
+                    dst_raw_addr,
+                    src_raw_addr,
+                    one_elem_size,
+                    len_ptr,
+                    src,
+                )
+            }
+            // Note that future refactorings will fill this out soon.
+            CheckedEntity::Array => todo!(),
+
+            // Cannot copy into a data segment in wasm.
+            CheckedEntity::Data(_) => unreachable!(),
+        }
+    }
+
+    /// Performs a bounds check and raises a trap if `idx+len` is out-of-bounds
+    /// for `len`.
+    ///
+    /// Returns the raw host-native address of `idx+len`.
+    fn translate_entity_bounds_check(
+        &mut self,
+        builder: &mut FunctionBuilder<'_>,
+        entity: impl Into<CheckedEntity>,
+        idx: ir::Value,
+        len: ir::Value,
+    ) -> ir::Value {
+        let entity = entity.into();
+        let pointer_type = self.pointer_type();
+        let idx_type = entity.index_type(self);
+        let idx_clif_type = index_type_to_ir_type(idx_type);
+        assert_eq!(builder.func.dfg.value_type(idx), idx_clif_type);
+        assert_eq!(builder.func.dfg.value_type(len), idx_clif_type);
+
+        // Load the entity size, as `pointer_type`.
+        let entity_size = match entity {
+            CheckedEntity::Memory(i) => self.memory_size_in_bytes(&mut builder.cursor(), i),
+            CheckedEntity::Table(i) => {
+                let size = self.translate_table_size(builder.cursor(), i);
+                self.unchecked_cast_wasm_addr_to_native_addr(&mut builder.cursor(), size, idx_type)
+            }
+            CheckedEntity::Data(i) => match self.translation.passive_data_map[i] {
+                Some(passive_index) => {
+                    let vmctx = self.vmctx_val(&mut builder.cursor());
+                    let offset =
+                        i32::try_from(self.offsets.vmctx_passive_data_length(passive_index))
+                            .unwrap();
+                    let flags = ir::MemFlagsData::trusted();
+                    match pointer_type {
+                        I32 => builder.ins().load(I32, flags, vmctx, offset),
+                        I64 => builder.ins().uload32(flags, vmctx, offset),
+                        _ => unreachable!(),
+                    }
+                }
+                None => builder.ins().iconst(pointer_type, 0),
+            },
+            // Note that future refactorings will fill this out soon.
+            CheckedEntity::Array => todo!(),
+        };
+        assert_eq!(builder.func.dfg.value_type(entity_size), pointer_type);
+
+        let trap_code = match entity {
+            CheckedEntity::Memory(_) => ir::TrapCode::HEAP_OUT_OF_BOUNDS,
+            CheckedEntity::Table(_) => TRAP_TABLE_OUT_OF_BOUNDS,
+            CheckedEntity::Data(_) => ir::TrapCode::HEAP_OUT_OF_BOUNDS,
+            CheckedEntity::Array => TRAP_ARRAY_OUT_OF_BOUNDS,
+        };
+
+        // Compute the end index of this operation, casted to the `I64` type.
+        //
+        // Note that addition can't overflow after extending 32-bits to
+        // 64-bits, so no need to check for overflow in the 32-bit index case.
+        let end64 = match idx_type {
+            IndexType::I32 => {
+                let idx64 = builder.ins().uextend(I64, idx);
+                let len64 = builder.ins().uextend(I64, len);
+                builder.ins().iadd(idx64, len64)
+            }
+            IndexType::I64 => self.uadd_overflow_trap(builder, idx, len, trap_code),
+        };
+
+        // Cast the host-pointer width to a 64-bit bit width.
+        let entity_size64 = match pointer_type {
+            I32 => builder.ins().uextend(I64, entity_size),
+            I64 => entity_size,
+            _ => unreachable!(),
+        };
+
+        // This is the actual bounds check that verifies that this operation is
+        // in-bounds. Once control flow gets past here we know that nothing can
+        // overflow and everything is in-bounds.
+        let inbounds = builder
+            .ins()
+            .icmp(IntCC::UnsignedGreaterThan, end64, entity_size64);
+        self.trapnz(builder, inbounds, trap_code);
+
+        // Compute the actual raw heap address to return
+        let (base, elem_size) = match entity {
+            CheckedEntity::Memory(i) => {
+                let heap = self.get_or_create_heap(builder.func, i);
+                let heap = &self.heaps()[heap];
+                (builder.ins().global_value(pointer_type, heap.base), 1)
+            }
+            CheckedEntity::Table(i) => {
+                let table = self.get_or_create_table(builder.func, i);
+                (
+                    builder.ins().global_value(pointer_type, table.base_gv),
+                    table.element_size,
+                )
+            }
+            CheckedEntity::Data(i) => match self.translation.passive_data_map[i] {
+                Some(passive_index) => {
+                    let vmctx = self.vmctx_val(&mut builder.cursor());
+                    let offset =
+                        i32::try_from(self.offsets.vmctx_passive_data_base(passive_index)).unwrap();
+                    let base = builder.ins().load(
+                        self.pointer_type(),
+                        ir::MemFlagsData::trusted(),
+                        vmctx,
+                        offset,
+                    );
+                    (base, 1)
+                }
+
+                // Any address should do for an active data segment, but pick
+                // something non-null for now. Note that the length of an active
+                // data segment is always 0, so we know that the memcpy, if any,
+                // will be 0 elements, so the actual value here doesn't matter.
+                None => (builder.ins().iconst(pointer_type, 1), 1),
+            },
+            // Note that future refactorings will fill this out soon.
+            CheckedEntity::Array => todo!(),
+        };
+        assert_eq!(builder.func.dfg.value_type(base), pointer_type);
+        let idx =
+            self.unchecked_cast_wasm_addr_to_native_addr(&mut builder.cursor(), idx, idx_type);
+        assert_eq!(builder.func.dfg.value_type(idx), pointer_type);
+        let byte_offset = builder.ins().imul_imm(idx, i64::from(elem_size));
+        builder.ins().iadd(base, byte_offset)
     }
 
     pub fn translate_table_copy(
@@ -3867,33 +3885,310 @@ impl FuncEnvironment<'_> {
         src: ir::Value,
         len: ir::Value,
     ) -> WasmResult<()> {
-        let (table_copy, dst_table_index_arg, src_table_index_arg) =
-            self.get_table_copy_func(&mut builder.func, dst_table_index, src_table_index);
+        self.translate_entity_copy(builder, dst_table_index, src_table_index, dst, src, len)
+    }
 
-        let mut pos = builder.cursor();
-        let dst = self.cast_index_to_i64(&mut pos, dst, self.table(dst_table_index).idx_type);
-        let src = self.cast_index_to_i64(&mut pos, src, self.table(src_table_index).idx_type);
-        let len = if index_type_to_ir_type(self.table(dst_table_index).idx_type) == I64
-            && index_type_to_ir_type(self.table(src_table_index).idx_type) == I64
-        {
-            len
-        } else {
-            pos.ins().uextend(I64, len)
-        };
-        let dst_table_index_arg = pos.ins().iconst(I32, dst_table_index_arg as i64);
-        let src_table_index_arg = pos.ins().iconst(I32, src_table_index_arg as i64);
-        let vmctx = self.vmctx_val(&mut pos);
-        pos.ins().call(
-            table_copy,
-            &[
-                vmctx,
-                dst_table_index_arg,
-                src_table_index_arg,
-                dst,
-                src,
-                len,
-            ],
+    /// Emits a copy between two WebAssembly table or array entities.
+    ///
+    /// This will copy from `src_entity` to `dst_entity` and this assumes that
+    /// all bounds checks have already passed. Items will be loaded from
+    /// `src_elem_addr` and stored to `dst_elem_addr`. The `elem_ty` is the type
+    /// being transferred, `one_elem_size` is the byte size of each element,
+    /// `copy_len` is the number of elements being copied, and `src_index` is
+    /// the first index within `src_entity` being loaded.
+    ///
+    /// All values here have type `self.pointer_type()`, except `src_index`
+    /// which is typed appropriately to index `src_entity`.
+    ///
+    /// The main purpose of this function is to deduce if `memcpy` can be used,
+    /// and otherwise this will emit an inline copy loop.
+    fn emit_raw_array_or_table_copy(
+        &mut self,
+        builder: &mut FunctionBuilder<'_>,
+        _dst_entity: CheckedEntity,
+        src_entity: CheckedEntity,
+        elem_ty: WasmStorageType,
+        dst_elem_addr: ir::Value,
+        src_elem_addr: ir::Value,
+        one_elem_size: ir::Value,
+        copy_len: ir::Value,
+        src_index: ir::Value,
+    ) -> WasmResult<()> {
+        let pointer_type = self.pointer_type();
+        assert_eq!(builder.func.dfg.value_type(dst_elem_addr), pointer_type);
+        assert_eq!(builder.func.dfg.value_type(src_elem_addr), pointer_type);
+        assert_eq!(builder.func.dfg.value_type(one_elem_size), pointer_type);
+        assert_eq!(builder.func.dfg.value_type(copy_len), pointer_type);
+        assert_eq!(
+            builder.func.dfg.value_type(src_index),
+            index_type_to_ir_type(src_entity.index_type(self))
         );
+
+        enum CopyKind {
+            Memcpy,
+            VMGcRef,
+            TableFuncref(TableIndex),
+        }
+        let kind = match elem_ty {
+            // Scalar types can always use a memcpy.
+            WasmStorageType::I8
+            | WasmStorageType::I16
+            | WasmStorageType::Val(
+                WasmValType::I32
+                | WasmValType::I64
+                | WasmValType::F32
+                | WasmValType::F64
+                | WasmValType::V128,
+            ) => CopyKind::Memcpy,
+
+            WasmStorageType::Val(WasmValType::Ref(ty)) => match ty.heap_type.top() {
+                // These types are represented the same in all locations (e.g.
+                // tables and the GC heap), so check to see if it's a `VMGcRef`
+                // type. If it is then barriers might be needed, meaning memcpy
+                // can't be used.
+                //
+                // FIXME: should add a method to `GcCompiler` to detect when
+                // the compiler doesn't actually need barriers, in which case
+                // memcpy is fine.
+                WasmHeapTopType::Extern
+                | WasmHeapTopType::Any
+                | WasmHeapTopType::Exn
+                | WasmHeapTopType::Cont => {
+                    if ty.heap_type.is_vmgcref_type_and_not_i31() {
+                        CopyKind::VMGcRef
+                    } else {
+                        CopyKind::Memcpy
+                    }
+                }
+
+                // `funcref` is stored differently in tables and the GC heap, so
+                // futher inspection is necessary of where the copy is
+                // happening.
+                WasmHeapTopType::Func => match src_entity {
+                    // Tables of funcrefs might be lazily initialized which
+                    // would mean that memcpy isn't suitable. If lazy init is
+                    // disabled though then funcrefs are just pointers so a
+                    // memcpy can be used.
+                    CheckedEntity::Table(i) => {
+                        if self.tunables.table_lazy_init {
+                            CopyKind::TableFuncref(i)
+                        } else {
+                            CopyKind::Memcpy
+                        }
+                    }
+                    // The GC heap has integers representing funcrefs, so memcpy
+                    // is fine.
+                    CheckedEntity::Array => CopyKind::Memcpy,
+                    // Not possible
+                    CheckedEntity::Memory(_) | CheckedEntity::Data(_) => unreachable!(),
+                },
+            },
+        };
+
+        match kind {
+            // For memcpy, that's easy, just call the intrinsic with the right
+            // parameters.
+            CopyKind::Memcpy => {
+                let copy_byte_len = builder.ins().imul(one_elem_size, copy_len);
+                self.raw_bulk_memory_operation(
+                    builder,
+                    BulkOp::MemoryCopy {
+                        dst: dst_elem_addr,
+                        src: src_elem_addr,
+                        len: copy_byte_len,
+                    },
+                );
+            }
+
+            // For other copies, this is a per-element loop. Use the helper to
+            // setup the general structure, and then the per-element closures is
+            // used to dispatch `other` further.
+            other => {
+                self.translate_per_element_copy(
+                    builder,
+                    dst_elem_addr,
+                    src_elem_addr,
+                    one_elem_size,
+                    copy_len,
+                    src_index,
+                    &|this, builder, dst, src, src_index| {
+                        match other {
+                            CopyKind::VMGcRef => {
+                                let val =
+                                    gc::read_field_at_addr(this, builder, elem_ty, src, None)?;
+                                gc::write_field_at_addr(this, builder, elem_ty, dst, val)?;
+                            }
+                            CopyKind::TableFuncref(i) => {
+                                // FIXME: this `table_get_funcref` helper is
+                                // duplicating the bounds check already done.
+                                // In theory can be refactored in the future to
+                                // avoid that.
+                                let funcref = this.table_get_funcref(builder, i, src_index, false);
+                                this.table_set_funcref(
+                                    builder,
+                                    funcref,
+                                    dst,
+                                    ir::MemFlagsData::trusted(),
+                                );
+                            }
+                            CopyKind::Memcpy => unreachable!(),
+                        }
+                        Ok(())
+                    },
+                )?;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Performs an inline element-by-element copy from `dst_elem_addr` to
+    /// `src_elem_addr`.
+    ///
+    /// The size of one element  is `one_elem_size` and the number of elements
+    /// being copied is `copy_len`. The actual implementation of copying a
+    /// single element is the `copy_one` closure which receives the `dst`/`src`
+    /// pointers to load/store from, as well as the current index.
+    ///
+    /// All IR values have type `self.pointer_type()`, except `src_index` which
+    /// has an appropriate type to index into the entity copied from.
+    pub fn translate_per_element_copy(
+        &mut self,
+        builder: &mut FunctionBuilder<'_>,
+        dst_elem_addr: ir::Value,
+        src_elem_addr: ir::Value,
+        one_elem_size: ir::Value,
+        copy_len: ir::Value,
+        src_index: ir::Value,
+        copy_one: &dyn Fn(
+            &mut Self,
+            &mut FunctionBuilder<'_>,
+            ir::Value,
+            ir::Value,
+            ir::Value,
+        ) -> WasmResult<()>,
+    ) -> WasmResult<()> {
+        // This is either a forwards copy or a backwards copy depending on the
+        // src/dst pointers. The loop here looks like:
+        //
+        //  current_block:
+        //      ...
+        //      brif len, nonempty_block, done_block
+        //
+        //  nonempty_block:
+        //      forward = icmp ult dst_elem_addr, src_elem_addr
+        //      brif forward,
+        //          forward_block(dst_elem_addr, src_elem_addr, src_index),
+        //          backwards_block(dst_end_addr, src_end_addr, src_index + len)
+        //
+        //  forward_block(dst, src, src_index):
+        //      *dst = *src
+        //      dst += elem_size
+        //      src += elem_size
+        //      src_index += 1
+        //      done = icmp eq src, src_end_addr
+        //      brif done, done_block, forward_block(dst, src, src_index)
+        //
+        //  backwards_block(dst, src, src_index):
+        //      dst -= elem_size
+        //      src -= elem_size
+        //      src_index -= 1
+        //      *dst = *src
+        //      done = icmp eq src, src_elem_addr
+        //      brif done, done_block, backwards_block(dst, src, src_index)
+        //
+        //  done_block:
+        //      ...
+        let current_block = builder.current_block().unwrap();
+        let nonempty_block = builder.create_block();
+        let forward_block = builder.create_block();
+        let backwards_block = builder.create_block();
+        let done_block = builder.create_block();
+
+        builder.ensure_inserted_block();
+        builder.insert_block_after(nonempty_block, current_block);
+        builder.insert_block_after(forward_block, nonempty_block);
+        builder.insert_block_after(backwards_block, forward_block);
+        builder.insert_block_after(done_block, backwards_block);
+
+        // Terminate `current_block` by testing to see if we're copying any
+        // elements at all.
+        builder
+            .ins()
+            .brif(copy_len, nonempty_block, &[], done_block, &[]);
+
+        // In the nonempty_block test to see if this is a forward or backwards
+        // copy.
+        builder.switch_to_block(nonempty_block);
+        let dst_first = builder
+            .ins()
+            .icmp(IntCC::UnsignedLessThan, dst_elem_addr, src_elem_addr);
+        let src_index_ty = builder.func.dfg.value_type(src_index);
+        let copy_byte_len = builder.ins().imul(copy_len, one_elem_size);
+        let dst_end_addr = builder.ins().iadd(dst_elem_addr, copy_byte_len);
+        let src_end_addr = builder.ins().iadd(src_elem_addr, copy_byte_len);
+        let copy_len_as_src_index_ty = match (self.pointer_type(), src_index_ty) {
+            (I32, I32) | (I64, I64) => copy_len,
+            (I32, I64) => builder.ins().uextend(I64, copy_len),
+            (I64, I32) => builder.ins().ireduce(I32, copy_len),
+            _ => unreachable!(),
+        };
+        let end_index = builder.ins().iadd(src_index, copy_len_as_src_index_ty);
+        builder.ins().brif(
+            dst_first,
+            forward_block,
+            &[dst_elem_addr.into(), src_elem_addr.into(), src_index.into()],
+            backwards_block,
+            &[dst_end_addr.into(), src_end_addr.into(), end_index.into()],
+        );
+
+        // Forward copy -- copy one field, then mutate the current pointers, then
+        // check to see if we're done.
+        builder.switch_to_block(forward_block);
+        let dst_cur = builder.append_block_param(forward_block, self.pointer_type());
+        let src_cur = builder.append_block_param(forward_block, self.pointer_type());
+        let src_index = builder.append_block_param(forward_block, src_index_ty);
+        self.translate_loop_header(builder)?;
+        copy_one(self, builder, dst_cur, src_cur, src_index)?;
+        let dst_next = builder.ins().iadd(dst_cur, one_elem_size);
+        let src_next = builder.ins().iadd(src_cur, one_elem_size);
+        let src_index_next = builder.ins().iadd_imm(src_index, 1);
+        let done = builder.ins().icmp(IntCC::Equal, src_next, src_end_addr);
+        builder.ins().brif(
+            done,
+            done_block,
+            &[],
+            forward_block,
+            &[dst_next.into(), src_next.into(), src_index_next.into()],
+        );
+
+        // Backwards copy -- update the pointers, then perform a copy, then check
+        // to see if we're done.
+        builder.switch_to_block(backwards_block);
+        let dst_cur = builder.append_block_param(backwards_block, self.pointer_type());
+        let src_cur = builder.append_block_param(backwards_block, self.pointer_type());
+        let src_index = builder.append_block_param(backwards_block, src_index_ty);
+        self.translate_loop_header(builder)?;
+        let dst_cur = builder.ins().isub(dst_cur, one_elem_size);
+        let src_cur = builder.ins().isub(src_cur, one_elem_size);
+        let one = builder.ins().iconst(src_index_ty, 1);
+        let src_index = builder.ins().isub(src_index, one);
+        copy_one(self, builder, dst_cur, src_cur, src_index)?;
+        let done = builder.ins().icmp(IntCC::Equal, src_cur, src_elem_addr);
+        builder.ins().brif(
+            done,
+            done_block,
+            &[],
+            backwards_block,
+            &[dst_cur.into(), src_cur.into(), src_index.into()],
+        );
+
+        builder.switch_to_block(done_block);
+
+        builder.seal_block(nonempty_block);
+        builder.seal_block(forward_block);
+        builder.seal_block(backwards_block);
+        builder.seal_block(done_block);
 
         Ok(())
     }
@@ -4751,4 +5046,45 @@ enum BulkOp {
         val: ir::Value,
         len: ir::Value,
     },
+}
+
+#[derive(Copy, Clone)]
+enum CheckedEntity {
+    Memory(MemoryIndex),
+    Table(TableIndex),
+    Data(DataIndex),
+    #[cfg_attr(
+        not(feature = "gc"),
+        expect(dead_code, reason = "not worth the #[cfg]")
+    )]
+    Array,
+}
+
+impl From<MemoryIndex> for CheckedEntity {
+    fn from(memory_index: MemoryIndex) -> Self {
+        CheckedEntity::Memory(memory_index)
+    }
+}
+
+impl From<TableIndex> for CheckedEntity {
+    fn from(table_index: TableIndex) -> Self {
+        CheckedEntity::Table(table_index)
+    }
+}
+
+impl From<DataIndex> for CheckedEntity {
+    fn from(data_index: DataIndex) -> Self {
+        CheckedEntity::Data(data_index)
+    }
+}
+
+impl CheckedEntity {
+    fn index_type(&self, env: &FuncEnvironment) -> IndexType {
+        match *self {
+            CheckedEntity::Memory(i) => env.memory(i).idx_type,
+            CheckedEntity::Table(i) => env.table(i).idx_type,
+            CheckedEntity::Data(_) => IndexType::I32,
+            CheckedEntity::Array => IndexType::I32,
+        }
+    }
 }

--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -2529,18 +2529,32 @@ impl FuncEnvironment<'_> {
         value: ir::Value,
         index: ir::Value,
     ) -> WasmResult<()> {
-        let table = self.module.tables[table_index];
         let table_data = self.get_or_create_table(builder.func, table_index);
-        let heap_ty = table.ref_type.heap_type;
-        match heap_ty.top() {
+        let (dst, flags) = table_data.prepare_table_addr(self, builder, index);
+        self.emit_table_set(builder, table_index, dst, flags, value)
+    }
+
+    /// Helper to store `value` into the table address at `addr` using `flags`.
+    ///
+    /// This assumes that `addr` is a native address and is already
+    /// bounds-checked. Additionally `value` must be appropriately typed.
+    fn emit_table_set(
+        &mut self,
+        builder: &mut FunctionBuilder,
+        table_index: TableIndex,
+        addr: ir::Value,
+        flags: ir::MemFlagsData,
+        value: ir::Value,
+    ) -> WasmResult<()> {
+        let table = self.module.tables[table_index];
+        match table.ref_type.heap_type.top() {
             // GC-managed types.
             WasmHeapTopType::Any | WasmHeapTopType::Extern | WasmHeapTopType::Exn => {
-                let (dst, flags) = table_data.prepare_table_addr(self, builder, index);
                 gc::gc_compiler(self)?.translate_write_gc_reference(
                     self,
                     builder,
                     table.ref_type,
-                    dst,
+                    addr,
                     value,
                     flags,
                 )
@@ -2548,15 +2562,13 @@ impl FuncEnvironment<'_> {
 
             // Function types.
             WasmHeapTopType::Func => {
-                let (elem_addr, flags) = table_data.prepare_table_addr(self, builder, index);
-                self.table_set_funcref(builder, value, elem_addr, flags);
+                self.table_set_funcref(builder, value, addr, flags);
                 Ok(())
             }
 
             // Continuation types.
             WasmHeapTopType::Cont => {
-                let (elem_addr, flags) = table_data.prepare_table_addr(self, builder, index);
-                builder.ins().store(flags, value, elem_addr, 0);
+                builder.ins().store(flags, value, addr, 0);
                 Ok(())
             }
         }
@@ -3905,7 +3917,7 @@ impl FuncEnvironment<'_> {
     fn emit_raw_array_or_table_copy(
         &mut self,
         builder: &mut FunctionBuilder<'_>,
-        _dst_entity: CheckedEntity,
+        dst_entity: CheckedEntity,
         src_entity: CheckedEntity,
         elem_ty: WasmStorageType,
         dst_elem_addr: ir::Value,
@@ -3924,12 +3936,7 @@ impl FuncEnvironment<'_> {
             index_type_to_ir_type(src_entity.index_type(self))
         );
 
-        enum CopyKind {
-            Memcpy,
-            VMGcRef,
-            TableFuncref(TableIndex),
-        }
-        let kind = match elem_ty {
+        let type_forbids_memcpy = match elem_ty {
             // Scalar types can always use a memcpy.
             WasmStorageType::I8
             | WasmStorageType::I16
@@ -3939,7 +3946,7 @@ impl FuncEnvironment<'_> {
                 | WasmValType::F32
                 | WasmValType::F64
                 | WasmValType::V128,
-            ) => CopyKind::Memcpy,
+            ) => false,
 
             WasmStorageType::Val(WasmValType::Ref(ty)) => match ty.heap_type.top() {
                 // These types are represented the same in all locations (e.g.
@@ -3953,13 +3960,7 @@ impl FuncEnvironment<'_> {
                 WasmHeapTopType::Extern
                 | WasmHeapTopType::Any
                 | WasmHeapTopType::Exn
-                | WasmHeapTopType::Cont => {
-                    if ty.heap_type.is_vmgcref_type_and_not_i31() {
-                        CopyKind::VMGcRef
-                    } else {
-                        CopyKind::Memcpy
-                    }
-                }
+                | WasmHeapTopType::Cont => ty.heap_type.is_vmgcref_type_and_not_i31(),
 
                 // `funcref` is stored differently in tables and the GC heap, so
                 // futher inspection is necessary of where the copy is
@@ -3969,75 +3970,66 @@ impl FuncEnvironment<'_> {
                     // would mean that memcpy isn't suitable. If lazy init is
                     // disabled though then funcrefs are just pointers so a
                     // memcpy can be used.
-                    CheckedEntity::Table(i) => {
-                        if self.tunables.table_lazy_init {
-                            CopyKind::TableFuncref(i)
-                        } else {
-                            CopyKind::Memcpy
-                        }
-                    }
+                    CheckedEntity::Table(_) => self.tunables.table_lazy_init,
                     // The GC heap has integers representing funcrefs, so memcpy
                     // is fine.
-                    CheckedEntity::Array => CopyKind::Memcpy,
+                    CheckedEntity::Array => false,
                     // Not possible
                     CheckedEntity::Memory(_) | CheckedEntity::Data(_) => unreachable!(),
                 },
             },
         };
 
-        match kind {
-            // For memcpy, that's easy, just call the intrinsic with the right
-            // parameters.
-            CopyKind::Memcpy => {
-                let copy_byte_len = builder.ins().imul(one_elem_size, copy_len);
-                self.raw_bulk_memory_operation(
-                    builder,
-                    BulkOp::MemoryCopy {
-                        dst: dst_elem_addr,
-                        src: src_elem_addr,
-                        len: copy_byte_len,
-                    },
-                );
-            }
-
-            // For other copies, this is a per-element loop. Use the helper to
-            // setup the general structure, and then the per-element closures is
-            // used to dispatch `other` further.
-            other => {
-                self.translate_per_element_copy(
-                    builder,
-                    dst_elem_addr,
-                    src_elem_addr,
-                    one_elem_size,
-                    copy_len,
-                    src_index,
-                    &|this, builder, dst, src, src_index| {
-                        match other {
-                            CopyKind::VMGcRef => {
-                                let val =
-                                    gc::read_field_at_addr(this, builder, elem_ty, src, None)?;
-                                gc::write_field_at_addr(this, builder, elem_ty, dst, val)?;
-                            }
-                            CopyKind::TableFuncref(i) => {
-                                // FIXME: this `table_get_funcref` helper is
-                                // duplicating the bounds check already done.
-                                // In theory can be refactored in the future to
-                                // avoid that.
-                                let funcref = this.table_get_funcref(builder, i, src_index, false);
-                                this.table_set_funcref(
-                                    builder,
-                                    funcref,
-                                    dst,
-                                    ir::MemFlagsData::trusted(),
-                                );
-                            }
-                            CopyKind::Memcpy => unreachable!(),
-                        }
-                        Ok(())
-                    },
-                )?;
-            }
+        // For memcpy, that's easy, just call the intrinsic with the right
+        // parameters.
+        if !type_forbids_memcpy {
+            let copy_byte_len = builder.ins().imul(one_elem_size, copy_len);
+            self.raw_bulk_memory_operation(
+                builder,
+                BulkOp::MemoryCopy {
+                    dst: dst_elem_addr,
+                    src: src_elem_addr,
+                    len: copy_byte_len,
+                },
+            );
+            return Ok(());
         }
+
+        // For other copies, this is a per-element loop. Use the helper to
+        // setup the general structure, and then the per-element closures is
+        // used to dispatch `other` further.
+        self.translate_per_element_copy(
+            builder,
+            dst_elem_addr,
+            src_elem_addr,
+            one_elem_size,
+            copy_len,
+            src_index,
+            &|this, builder, dst, src, src_index| {
+                let val = match src_entity {
+                    // FIXME: ideally this wouldn't redo the bounds check but
+                    // it's easier right now to share the internals of
+                    // `translate_table_get` which are a bit tricky with
+                    // funcrefs.
+                    CheckedEntity::Table(i) => this.translate_table_get(builder, i, src_index)?,
+                    CheckedEntity::Array => {
+                        gc::read_field_at_addr(this, builder, elem_ty, src, None)?
+                    }
+                    CheckedEntity::Memory(_) | CheckedEntity::Data { .. } => unreachable!(),
+                };
+                match dst_entity {
+                    CheckedEntity::Table(i) => {
+                        this.emit_table_set(builder, i, dst, ir::MemFlagsData::trusted(), val)?;
+                    }
+                    CheckedEntity::Array => {
+                        gc::write_field_at_addr(this, builder, elem_ty, dst, val)?
+                    }
+                    CheckedEntity::Memory(_) | CheckedEntity::Data { .. } => unreachable!(),
+                }
+
+                Ok(())
+            },
+        )?;
 
         Ok(())
     }

--- a/crates/cranelift/src/func_environ/gc/disabled.rs
+++ b/crates/cranelift/src/func_environ/gc/disabled.rs
@@ -5,7 +5,9 @@ use crate::func_environ::{Extension, FuncEnvironment};
 use cranelift_codegen::ir;
 use cranelift_frontend::FunctionBuilder;
 use smallvec::SmallVec;
-use wasmtime_environ::{DataIndex, TagIndex, TypeIndex, WasmRefType, WasmResult, wasm_unsupported};
+use wasmtime_environ::{
+    DataIndex, TagIndex, TypeIndex, WasmRefType, WasmResult, WasmStorageType, wasm_unsupported,
+};
 
 fn disabled<T>() -> WasmResult<T> {
     Err(wasm_unsupported!(
@@ -198,6 +200,26 @@ pub fn translate_array_init_data(
     _data_index: DataIndex,
     _data_offset: ir::Value,
     _len: ir::Value,
+) -> WasmResult<()> {
+    disabled()
+}
+
+pub fn read_field_at_addr(
+    _func_env: &mut FuncEnvironment<'_>,
+    _builder: &mut FunctionBuilder<'_>,
+    _ty: WasmStorageType,
+    _addr: ir::Value,
+    _extension: Option<Extension>,
+) -> WasmResult<ir::Value> {
+    disabled()
+}
+
+pub fn write_field_at_addr(
+    _func_env: &mut FuncEnvironment<'_>,
+    _builder: &mut FunctionBuilder<'_>,
+    _field_ty: WasmStorageType,
+    _field_addr: ir::Value,
+    _new_val: ir::Value,
 ) -> WasmResult<()> {
     disabled()
 }

--- a/crates/cranelift/src/func_environ/gc/enabled.rs
+++ b/crates/cranelift/src/func_environ/gc/enabled.rs
@@ -1,7 +1,7 @@
 use super::{ArrayInit, GcCompiler};
 use crate::TRAP_ARRAY_OUT_OF_BOUNDS;
 use crate::bounds_checks::BoundsCheck;
-use crate::func_environ::{BulkOp, Extension, FuncEnvironment};
+use crate::func_environ::{BulkOp, CheckedEntity, Extension, FuncEnvironment};
 use crate::translate::{Heap, HeapData, MemoryKind, StructFieldsVec, TargetEnvironment};
 use crate::trap::TranslateTrap;
 use crate::{Reachability, TRAP_GC_HEAP_CORRUPT, TRAP_INTERNAL_ASSERT};
@@ -15,7 +15,7 @@ use cranelift_entity::packed_option::ReservedValue;
 use cranelift_frontend::FunctionBuilder;
 use smallvec::{SmallVec, smallvec};
 use wasmtime_environ::{
-    Collector, DataIndex, GcArrayLayout, GcLayout, GcStructLayout, I31_DISCRIMINANT,
+    Collector, DataIndex, GcArrayLayout, GcLayout, GcStructLayout, I31_DISCRIMINANT, IndexType,
     ModuleInternedTypeIndex, PtrSize, TagIndex, TypeIndex, VMGcKind, WasmCompositeInnerType,
     WasmHeapTopType, WasmHeapType, WasmRefType, WasmResult, WasmStorageType, WasmValType,
     wasm_unsupported,
@@ -196,7 +196,7 @@ fn emit_gc_kind_assert(
 ///
 /// The given address MUST have already been bounds-checked via
 /// `prepare_gc_ref_access`.
-fn read_field_at_addr(
+pub fn read_field_at_addr(
     func_env: &mut FuncEnvironment<'_>,
     builder: &mut FunctionBuilder<'_>,
     ty: WasmStorageType,
@@ -321,7 +321,7 @@ fn write_func_ref_at_addr(
     Ok(())
 }
 
-fn write_field_at_addr(
+pub fn write_field_at_addr(
     func_env: &mut FuncEnvironment<'_>,
     builder: &mut FunctionBuilder<'_>,
     field_ty: WasmStorageType,
@@ -1003,13 +1003,7 @@ pub fn translate_array_copy(
     let copy_byte_size = builder.ins().imul(copy_len, one_elem_size);
     let copy_byte_size =
         uextend_i32_to_pointer_type(builder, func_env.pointer_type(), copy_byte_size);
-    let src_end_addr = builder.ins().iadd(src_elem_addr, copy_byte_size);
-    let dst_end_addr = builder.ins().iadd(dst_elem_addr, copy_byte_size);
 
-    // If the element of this array isn't a GC reference, or if it's an i31ref,
-    // then there's no need for the barrier-using loops below. Instead use the
-    // `memory.copy` intrinsic to do a raw `memcpy` from one array to another.
-    //
     // Note that like `memory.fill` this is preceded with a defensive check
     // against heap corruption to ensure that, even in the face of heap
     // corruption, the `memory.copy` call on the host should not ever fault.
@@ -1017,13 +1011,15 @@ pub fn translate_array_copy(
         let base = func_env.get_gc_heap_base(builder);
         let bound = func_env.get_gc_heap_bound(builder);
         let heap_end = builder.ins().iadd(base, bound);
+        let src_end = builder.ins().iadd(src_elem_addr, copy_byte_size);
+        let dst_end = builder.ins().iadd(dst_elem_addr, copy_byte_size);
         let corrupt = builder
             .ins()
-            .icmp(IntCC::UnsignedGreaterThan, src_end_addr, heap_end);
+            .icmp(IntCC::UnsignedGreaterThan, src_end, heap_end);
         func_env.trapnz(builder, corrupt, TRAP_GC_HEAP_CORRUPT);
         let corrupt = builder
             .ins()
-            .icmp(IntCC::UnsignedGreaterThan, dst_end_addr, heap_end);
+            .icmp(IntCC::UnsignedGreaterThan, dst_end, heap_end);
         func_env.trapnz(builder, corrupt, TRAP_GC_HEAP_CORRUPT);
 
         func_env.raw_bulk_memory_operation(
@@ -1036,121 +1032,20 @@ pub fn translate_array_copy(
         );
         return Ok(());
     }
-
-    // For GC references, inline the copy loop here with barriers. This is
-    // either a forwards copy or a backwards copy depending on the src/dst
-    // pointers. The loop here looks like:
-    //
-    //  current_block:
-    //      ...
-    //      brif len, nonempty_block, done_block
-    //
-    //  nonempty_block:
-    //      forward = icmp ult dst_elem_addr, src_elem_addr
-    //      brif forward,
-    //          forward_block(dst_elem_addr, src_elem_addr),
-    //          backwards_block(dst_end_addr, src_end_addr)
-    //
-    //  forward_block(dst, src):
-    //      *dst = *src
-    //      dst += elem_size
-    //      src += elem_size
-    //      done = icmp eq src, src_end_addr
-    //      brif done, done_block, forward_block(dst, src)
-    //
-    //  backwards_block(dst, src):
-    //      dst -= elem_size
-    //      src -= elem_size
-    //      *dst = *src
-    //      done = icmp eq src, src_elem_addr
-    //      brif done, done_block, backwards_block(dst, src)
-    //
-    //  done_block:
-    //      ...
-    let current_block = builder.current_block().unwrap();
-    let nonempty_block = builder.create_block();
-    let forward_block = builder.create_block();
-    let backwards_block = builder.create_block();
-    let done_block = builder.create_block();
-
-    builder.ensure_inserted_block();
-    builder.insert_block_after(nonempty_block, current_block);
-    builder.insert_block_after(forward_block, nonempty_block);
-    builder.insert_block_after(backwards_block, forward_block);
-    builder.insert_block_after(done_block, backwards_block);
-
-    let ext = match elem_ty {
-        WasmStorageType::I8 => Some(Extension::Zero),
-        WasmStorageType::I16 => Some(Extension::Zero),
-        _ => None,
-    };
-
-    // Terminate `current_block` by testing to see if we're copying any
-    // elements at all.
-    builder
-        .ins()
-        .brif(copy_len, nonempty_block, &[], done_block, &[]);
-
-    // In the nonempty_block test to see if this is a forward or backwards
-    // copy.
-    builder.switch_to_block(nonempty_block);
     let one_elem_size =
         uextend_i32_to_pointer_type(builder, func_env.pointer_type(), one_elem_size);
-    let dst_first = builder
-        .ins()
-        .icmp(IntCC::UnsignedLessThan, dst_elem_addr, src_elem_addr);
-    builder.ins().brif(
-        dst_first,
-        forward_block,
-        &[dst_elem_addr.into(), src_elem_addr.into()],
-        backwards_block,
-        &[dst_end_addr.into(), src_end_addr.into()],
-    );
-
-    // Forward copy -- copy one field, then mutate the current pointers, then
-    // check to see if we're done.
-    builder.switch_to_block(forward_block);
-    let dst_cur = builder.append_block_param(forward_block, func_env.pointer_type());
-    let src_cur = builder.append_block_param(forward_block, func_env.pointer_type());
-    func_env.translate_loop_header(builder)?;
-    let value = read_field_at_addr(func_env, builder, elem_ty, src_cur, ext)?;
-    write_field_at_addr(func_env, builder, elem_ty, dst_cur, value)?;
-    let dst_next = builder.ins().iadd(dst_cur, one_elem_size);
-    let src_next = builder.ins().iadd(src_cur, one_elem_size);
-    let done = builder.ins().icmp(IntCC::Equal, src_next, src_end_addr);
-    builder.ins().brif(
-        done,
-        done_block,
-        &[],
-        forward_block,
-        &[dst_next.into(), src_next.into()],
-    );
-
-    // Backwards copy -- update the pointers, then perform a copy, then check
-    // to see if we're done.
-    builder.switch_to_block(backwards_block);
-    let dst_cur = builder.append_block_param(backwards_block, func_env.pointer_type());
-    let src_cur = builder.append_block_param(backwards_block, func_env.pointer_type());
-    func_env.translate_loop_header(builder)?;
-    let dst_cur = builder.ins().isub(dst_cur, one_elem_size);
-    let src_cur = builder.ins().isub(src_cur, one_elem_size);
-    let value = read_field_at_addr(func_env, builder, elem_ty, src_cur, ext)?;
-    write_field_at_addr(func_env, builder, elem_ty, dst_cur, value)?;
-    let done = builder.ins().icmp(IntCC::Equal, src_cur, src_elem_addr);
-    builder.ins().brif(
-        done,
-        done_block,
-        &[],
-        backwards_block,
-        &[dst_cur.into(), src_cur.into()],
-    );
-
-    builder.switch_to_block(done_block);
-
-    builder.seal_block(nonempty_block);
-    builder.seal_block(forward_block);
-    builder.seal_block(backwards_block);
-    builder.seal_block(done_block);
+    let copy_len = uextend_i32_to_pointer_type(builder, func_env.pointer_type(), copy_len);
+    func_env.emit_raw_array_or_table_copy(
+        builder,
+        CheckedEntity::Array,
+        CheckedEntity::Array,
+        elem_ty,
+        dst_elem_addr,
+        src_elem_addr,
+        one_elem_size,
+        copy_len,
+        src_index,
+    )?;
 
     Ok(())
 }
@@ -2078,32 +1973,22 @@ pub fn translate_array_new_data(
         ir::TrapCode::HEAP_OUT_OF_BOUNDS,
     );
     let init_byte_length = builder.ins().ireduce(ir::types::I32, init_byte_length);
+    let src_addr =
+        env.translate_entity_bounds_check(builder, data_index, data_offset, init_byte_length);
 
-    let src_addr = match env.translation.passive_data_map[data_index] {
-        Some(idx) => {
-            Some(env.get_passive_data_pointer(builder, idx, data_offset, init_byte_length))
-        }
-        None => {
-            env.trapnz(builder, data_offset, ir::TrapCode::HEAP_OUT_OF_BOUNDS);
-            env.trapnz(builder, len, ir::TrapCode::HEAP_OUT_OF_BOUNDS);
-            None
-        }
-    };
     let array =
         gc_compiler(env)?.alloc_array(env, builder, array_type_index, ArrayInit::Uninit { len })?;
-    if let Some(src_addr) = src_addr {
-        let dst = builder.ins().iconst(ir::types::I32, 0);
-        emit_array_init_data(
-            env,
-            builder,
-            array_type_index,
-            array,
-            len,
-            dst,
-            src_addr,
-            init_byte_length,
-        );
-    }
+    let dst = builder.ins().iconst(ir::types::I32, 0);
+    emit_array_init_data(
+        env,
+        builder,
+        array_type_index,
+        array,
+        len,
+        dst,
+        src_addr,
+        init_byte_length,
+    );
     Ok(array)
 }
 
@@ -2136,18 +2021,8 @@ pub fn translate_array_init_data(
     let len_in_bytes = builder
         .ins()
         .imul_imm(len, i64::from(array_layout.elem_size));
-
-    let src_addr = match env.translation.passive_data_map[data_index] {
-        Some(idx) => env.get_passive_data_pointer(builder, idx, data_offset, len_in_bytes),
-        // If this is an active data segments it's by-definition zero-length so
-        // test the size and then return as we've indeed successfully copied
-        // zero bytes.
-        None => {
-            env.trapnz(builder, data_offset, ir::TrapCode::HEAP_OUT_OF_BOUNDS);
-            env.trapnz(builder, len, ir::TrapCode::HEAP_OUT_OF_BOUNDS);
-            return Ok(());
-        }
-    };
+    let src_addr =
+        env.translate_entity_bounds_check(builder, data_index, data_offset, len_in_bytes);
 
     emit_array_init_data(
         env,
@@ -2197,15 +2072,17 @@ fn emit_array_init_data(
 
     // At this point bounds checks have all passed, so it's time to perform
     // the actual copy by calling the `memory.copy` libcall.
-    let vmctx = env.vmctx_val(&mut builder.cursor());
-    let memory_copy = env.builtin_functions.memory_copy(&mut builder.func);
-    let len_in_bytes_native = match env.pointer_type() {
-        ir::types::I32 => len_in_bytes,
-        ir::types::I64 => builder.ins().uextend(ir::types::I64, len_in_bytes),
-        _ => unreachable!(),
-    };
-    builder.ins().call(
-        memory_copy,
-        &[vmctx, dst_elem_addr, src_addr, len_in_bytes_native],
+    let len_in_bytes = env.unchecked_cast_wasm_addr_to_native_addr(
+        &mut builder.cursor(),
+        len_in_bytes,
+        IndexType::I32,
+    );
+    env.raw_bulk_memory_operation(
+        builder,
+        BulkOp::MemoryCopy {
+            dst: dst_elem_addr,
+            src: src_addr,
+            len: len_in_bytes,
+        },
     );
 }

--- a/crates/cranelift/src/translate/code_translator.rs
+++ b/crates/cranelift/src/translate/code_translator.rs
@@ -1653,7 +1653,7 @@ pub fn translate_operator(
         }
         Operator::TableSize { table: index } => {
             let result =
-                environ.translate_table_size(builder.cursor(), TableIndex::from_u32(*index))?;
+                environ.translate_table_size(builder.cursor(), TableIndex::from_u32(*index));
             environ.stacks.push1(result);
         }
         Operator::TableGrow { table: index } => {

--- a/crates/environ/src/builtin.rs
+++ b/crates/environ/src/builtin.rs
@@ -5,9 +5,6 @@ macro_rules! foreach_builtin_function {
         $mac! {
             // Returns an index for wasm's `memory.grow` builtin function.
             memory_grow(vmctx: vmctx, delta: u64, index: u32) -> pointer;
-            // Returns an index for wasm's `table.copy` when both tables are locally
-            // defined.
-            table_copy(vmctx: vmctx, dst_index: u32, src_index: u32, dst: u64, src: u64, len: u64) -> bool;
             // Returns an index for wasm's `table.init`.
             table_init(vmctx: vmctx, table: u32, elem: u32, dst: u64, src: u64, len: u64) -> bool;
             // Returns an index for wasm's `elem.drop`.

--- a/crates/wasmtime/src/runtime/externals/table.rs
+++ b/crates/wasmtime/src/runtime/externals/table.rs
@@ -406,6 +406,15 @@ impl Table {
     ) -> Result<()> {
         let store = store.as_context_mut().0;
 
+        let src_range = src_index..src_index.checked_add(len).ok_or(Trap::TableOutOfBounds)?;
+        let dst_range = dst_index..dst_index.checked_add(len).ok_or(Trap::TableOutOfBounds)?;
+
+        // Bounds-check up front before any modifications to ensure everything
+        // is in-bounds.
+        if src_range.end > src_table.size_(store) || dst_range.end > dst_table.size_(store) {
+            return Err(Trap::TableOutOfBounds.into());
+        }
+
         let dst_ty = dst_table.ty(&store);
         let src_ty = src_table.ty(&store);
         src_ty
@@ -416,91 +425,25 @@ impl Table {
                  destination table's element type",
             )?;
 
-        // SAFETY: the the two tables have the same type, as type-checked above.
-        unsafe {
-            Self::copy_raw(store, dst_table, dst_index, src_table, src_index, len)?;
+        // Do a forwards or backwards copy depending on the indices involved to
+        // ensure that elements that are part of the copy aren't accidentally
+        // clobbered.
+        if dst_index < src_index {
+            for (src, dst) in src_range.zip(dst_range) {
+                let val = src_table
+                    .get(&mut *store, src)
+                    .ok_or(Trap::TableOutOfBounds)?;
+                dst_table.set(&mut *store, dst, val)?;
+            }
+        } else {
+            for (src, dst) in src_range.rev().zip(dst_range.rev()) {
+                let val = src_table
+                    .get(&mut *store, src)
+                    .ok_or(Trap::TableOutOfBounds)?;
+                dst_table.set(&mut *store, dst, val)?;
+            }
         }
         Ok(())
-    }
-
-    /// Copies the elements of `src_table` to `dst_table`.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the either table doesn't belong to `store`.
-    ///
-    /// # Safety
-    ///
-    /// Requires that the two tables have previously been type-checked to have
-    /// the same type.
-    pub(crate) unsafe fn copy_raw(
-        store: &mut StoreOpaque,
-        dst_table: &Table,
-        dst_index: u64,
-        src_table: &Table,
-        src_index: u64,
-        len: u64,
-    ) -> Result<(), Trap> {
-        // Handle lazy initialization of the source table first before doing
-        // anything else.
-        let src_range = src_index..(src_index.checked_add(len).unwrap_or(u64::MAX));
-        src_table.wasmtime_table(store, src_range);
-
-        // validate `dst_table` belongs to `store`.
-        dst_table.wasmtime_table(store, iter::empty());
-
-        // Figure out which of the three cases we're in:
-        //
-        // 1. Cross-instance table copy.
-        // 2. Intra-instance table copy.
-        // 3. Intra-table copy.
-        //
-        // We handle each of them slightly differently.
-        let src_instance = src_table.instance.instance();
-        let dst_instance = dst_table.instance.instance();
-        match (
-            src_instance == dst_instance,
-            src_table.index == dst_table.index,
-        ) {
-            // 1. Cross-instance table copy: split the mutable store borrow into
-            // two mutable instance borrows, get each instance's defined table,
-            // and do the copy.
-            (false, _) => {
-                // SAFETY: accessing two instances mutably at the same time
-                // requires only accessing defined entities on each instance
-                // which is done below with `get_defined_*` methods.
-                let (gc_store, [src_instance, dst_instance]) = unsafe {
-                    store.optional_gc_store_and_instances_mut([src_instance, dst_instance])
-                };
-                src_instance.get_defined_table(src_table.index).copy_to(
-                    dst_instance.get_defined_table(dst_table.index),
-                    gc_store,
-                    dst_index,
-                    src_index,
-                    len,
-                )
-            }
-
-            // 2. Intra-instance, distinct-tables copy: split the mutable
-            // instance borrow into two distinct mutable table borrows and do
-            // the copy.
-            (true, false) => {
-                let (gc_store, instance) = store.optional_gc_store_and_instance_mut(src_instance);
-                let [(_, src_table), (_, dst_table)] = instance
-                    .tables_mut()
-                    .get_disjoint_mut([src_table.index, dst_table.index])
-                    .unwrap();
-                src_table.copy_to(dst_table, gc_store, dst_index, src_index, len)
-            }
-
-            // 3. Intra-table copy: get the table and copy within it!
-            (true, true) => {
-                let (gc_store, instance) = store.optional_gc_store_and_instance_mut(src_instance);
-                instance
-                    .get_defined_table(src_table.index)
-                    .copy_within(gc_store, dst_index, src_index, len)
-            }
-        }
     }
 
     /// Fill `table[dst..(dst + len)]` with the given value.

--- a/crates/wasmtime/src/runtime/vm/libcalls.rs
+++ b/crates/wasmtime/src/runtime/vm/libcalls.rs
@@ -58,7 +58,7 @@
 use super::stack_switching::VMContObj;
 use crate::bail_bug;
 use crate::prelude::*;
-use crate::runtime::store::{Asyncness, InstanceId, StoreInstanceId, StoreOpaque};
+use crate::runtime::store::{Asyncness, InstanceId, StoreOpaque};
 #[cfg(feature = "gc")]
 use crate::runtime::vm::VMGcRef;
 use crate::runtime::vm::table::TableElementType;
@@ -467,46 +467,6 @@ unsafe fn table_fill_cont_obj(
         }
         _ => panic!("Wrong table filling function"),
     }
-}
-
-// Implementation of `table.copy`.
-fn table_copy(
-    store: &mut dyn VMStore,
-    instance: InstanceId,
-    dst_table_index: u32,
-    src_table_index: u32,
-    dst: u64,
-    src: u64,
-    len: u64,
-) -> Result<(), Trap> {
-    let dst_table_index = TableIndex::from_u32(dst_table_index);
-    let src_table_index = TableIndex::from_u32(src_table_index);
-    let store = store.store_opaque_mut();
-    let mut instance = store.instance_mut(instance);
-
-    // Convert the two table indices relative to `instance` into two
-    // defining instances and the defined table index within that instance.
-    let (dst_def_index, dst_instance) = instance
-        .as_mut()
-        .defined_table_index_and_instance(dst_table_index);
-    let dst_instance_id = dst_instance.id();
-    let (src_def_index, src_instance) = instance
-        .as_mut()
-        .defined_table_index_and_instance(src_table_index);
-    let src_instance_id = src_instance.id();
-
-    let src_table = crate::Table::from_raw(
-        StoreInstanceId::new(store.id(), src_instance_id),
-        src_def_index,
-    );
-    let dst_table = crate::Table::from_raw(
-        StoreInstanceId::new(store.id(), dst_instance_id),
-        dst_def_index,
-    );
-
-    // SAFETY: this is only safe if the two tables have the same type, and that
-    // was validated during wasm-validation time.
-    unsafe { crate::Table::copy_raw(store, &dst_table, dst, &src_table, src, len) }
 }
 
 // Implementation of `table.init`.

--- a/crates/wasmtime/src/runtime/vm/table.rs
+++ b/crates/wasmtime/src/runtime/vm/table.rs
@@ -10,7 +10,7 @@ use crate::runtime::vm::{GcStore, SendSyncPtr, VMGcRef, VmPtr};
 use core::alloc::Layout;
 use core::mem;
 use core::ops::Range;
-use core::ptr::{self, NonNull};
+use core::ptr::NonNull;
 use core::slice;
 use core::{cmp, usize};
 use wasmtime_environ::{
@@ -830,81 +830,6 @@ impl Table {
         Ok(())
     }
 
-    /// Copy `len` elements from `self[src_index..][..len]` into
-    /// `dst_table[dst_index..][..len]`.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the range is out of bounds of either the source or
-    /// destination tables.
-    pub fn copy_to(
-        &self,
-        dst: &mut Table,
-        gc_store: Option<&mut GcStore>,
-        dst_index: u64,
-        src_index: u64,
-        len: u64,
-    ) -> Result<(), Trap> {
-        let (src_range, dst_range) = Table::validate_copy(self, dst, dst_index, src_index, len)?;
-        Self::copy_elements(gc_store, dst, self, dst_range, src_range);
-        Ok(())
-    }
-
-    /// Copy `len` elements from `self[src_index..][..len]` into
-    /// `self[dst_index..][..len]`.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the range is out of bounds of either the source or
-    /// destination tables.
-    pub fn copy_within(
-        &mut self,
-        gc_store: Option<&mut GcStore>,
-        dst_index: u64,
-        src_index: u64,
-        len: u64,
-    ) -> Result<(), Trap> {
-        let (src_range, dst_range) = Table::validate_copy(self, self, dst_index, src_index, len)?;
-        self.copy_elements_within(gc_store, dst_range, src_range);
-        Ok(())
-    }
-
-    /// Copy `len` elements from `src_table[src_index..]` into `dst_table[dst_index..]`.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the range is out of bounds of either the source or
-    /// destination tables.
-    fn validate_copy(
-        src: &Table,
-        dst: &Table,
-        dst_index: u64,
-        src_index: u64,
-        len: u64,
-    ) -> Result<(Range<usize>, Range<usize>), Trap> {
-        // https://webassembly.github.io/bulk-memory-operations/core/exec/instructions.html#exec-table-copy
-
-        let src_index = usize::try_from(src_index).map_err(|_| Trap::TableOutOfBounds)?;
-        let dst_index = usize::try_from(dst_index).map_err(|_| Trap::TableOutOfBounds)?;
-        let len = usize::try_from(len).map_err(|_| Trap::TableOutOfBounds)?;
-
-        if src_index.checked_add(len).map_or(true, |n| n > src.size())
-            || dst_index.checked_add(len).map_or(true, |m| m > dst.size())
-        {
-            return Err(Trap::TableOutOfBounds);
-        }
-
-        debug_assert!(
-            dst.element_type() == src.element_type(),
-            "table element type mismatch"
-        );
-
-        let src_range = src_index..src_index + len;
-        let dst_range = dst_index..dst_index + len;
-
-        Ok((src_range, dst_range))
-    }
-
     /// Return a `VMTableDefinition` for exposing the table to compiled wasm code.
     pub fn vmtable(&mut self) -> VMTableDefinition {
         match self {
@@ -1039,99 +964,6 @@ impl Table {
                 &mut data.as_non_null().as_mut()[..*size]
             },
             _ => unreachable!(),
-        }
-    }
-
-    fn copy_elements(
-        mut gc_store: Option<&mut GcStore>,
-        dst_table: &mut Self,
-        src_table: &Self,
-        dst_range: Range<usize>,
-        src_range: Range<usize>,
-    ) {
-        // This can only be used when copying between different tables
-        debug_assert!(!ptr::eq(dst_table, src_table));
-
-        let ty = dst_table.element_type();
-
-        match ty {
-            TableElementType::Func => {
-                // `funcref` are `Copy`, so just do a mempcy
-                let (dst_funcrefs, dst_lazy_init) = dst_table.funcrefs_mut();
-                let (src_funcrefs, src_lazy_init) = src_table.funcrefs();
-                debug_assert_eq!(dst_lazy_init, src_lazy_init);
-                dst_funcrefs[dst_range].copy_from_slice(&src_funcrefs[src_range]);
-            }
-            TableElementType::GcRef => {
-                assert_eq!(
-                    dst_range.end - dst_range.start,
-                    src_range.end - src_range.start
-                );
-                assert!(dst_range.end <= dst_table.gc_refs().len());
-                assert!(src_range.end <= src_table.gc_refs().len());
-                for (dst, src) in dst_range.zip(src_range) {
-                    GcStore::write_gc_ref_optional_store(
-                        gc_store.as_deref_mut(),
-                        &mut dst_table.gc_refs_mut()[dst],
-                        src_table.gc_refs()[src].as_ref(),
-                    );
-                }
-            }
-            TableElementType::Cont => {
-                // `contref` are `Copy`, so just do a mempcy
-                dst_table.contrefs_mut()[dst_range]
-                    .copy_from_slice(&src_table.contrefs()[src_range]);
-            }
-        }
-    }
-
-    fn copy_elements_within(
-        &mut self,
-        mut gc_store: Option<&mut GcStore>,
-        dst_range: Range<usize>,
-        src_range: Range<usize>,
-    ) {
-        assert_eq!(
-            dst_range.end - dst_range.start,
-            src_range.end - src_range.start
-        );
-
-        // This is a no-op.
-        if src_range.start == dst_range.start {
-            return;
-        }
-
-        let ty = self.element_type();
-        match ty {
-            TableElementType::Func => {
-                // `funcref` are `Copy`, so just do a memmove
-                let (funcrefs, _lazy_init) = self.funcrefs_mut();
-                funcrefs.copy_within(src_range, dst_range.start);
-            }
-            TableElementType::GcRef => {
-                // We need to clone each `externref` while handling overlapping
-                // ranges
-                let elements = self.gc_refs_mut();
-                if dst_range.start < src_range.start {
-                    for (d, s) in dst_range.zip(src_range) {
-                        let (ds, ss) = elements.split_at_mut(s);
-                        let dst = &mut ds[d];
-                        let src = ss[0].as_ref();
-                        GcStore::write_gc_ref_optional_store(gc_store.as_deref_mut(), dst, src);
-                    }
-                } else {
-                    for (s, d) in src_range.rev().zip(dst_range.rev()) {
-                        let (ss, ds) = elements.split_at_mut(d);
-                        let dst = &mut ds[0];
-                        let src = ss[s].as_ref();
-                        GcStore::write_gc_ref_optional_store(gc_store.as_deref_mut(), dst, src);
-                    }
-                }
-            }
-            TableElementType::Cont => {
-                // `contref` are `Copy`, so just do a memmove
-                self.contrefs_mut().copy_within(src_range, dst_range.start);
-            }
         }
     }
 

--- a/tests/disas/array-copy-anyref.wat
+++ b/tests/disas/array-copy-anyref.wat
@@ -21,8 +21,8 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32, v6: i32):
 ;; @002b                               trapz v4, user16
-;; @002b                               v83 = load.i64 notrap aligned readonly can_move v0+8
-;; @002b                               v8 = load.i64 notrap aligned readonly can_move v83+32
+;; @002b                               v93 = load.i64 notrap aligned readonly can_move v0+8
+;; @002b                               v8 = load.i64 notrap aligned readonly can_move v93+32
 ;; @002b                               v7 = uextend.i64 v4
 ;; @002b                               v9 = iadd v8, v7
 ;; @002b                               v10 = iconst.i64 16
@@ -32,15 +32,15 @@
 ;; @002b                               v14 = icmp ugt v13, v12
 ;; @002b                               trapnz v14, user17
 ;; @002b                               v16 = uextend.i64 v12
-;;                                     v85 = iconst.i64 2
-;;                                     v86 = ishl v16, v85  ; v85 = 2
-;;                                     v82 = iconst.i64 32
-;; @002b                               v18 = ushr v86, v82  ; v82 = 32
+;;                                     v95 = iconst.i64 2
+;;                                     v96 = ishl v16, v95  ; v95 = 2
+;;                                     v92 = iconst.i64 32
+;; @002b                               v18 = ushr v96, v92  ; v92 = 32
 ;; @002b                               trapnz v18, user2
-;;                                     v95 = iconst.i32 2
-;;                                     v96 = ishl v12, v95  ; v95 = 2
+;;                                     v105 = iconst.i32 2
+;;                                     v106 = ishl v12, v105  ; v105 = 2
 ;; @002b                               v20 = iconst.i32 20
-;; @002b                               v21 = uadd_overflow_trap v96, v20, user2  ; v20 = 20
+;; @002b                               v21 = uadd_overflow_trap v106, v20, user2  ; v20 = 20
 ;; @002b                               v25 = uadd_overflow_trap v4, v21, user2
 ;; @002b                               trapz v2, user16
 ;; @002b                               v32 = uextend.i64 v2
@@ -51,59 +51,66 @@
 ;; @002b                               v39 = icmp ugt v38, v37
 ;; @002b                               trapnz v39, user17
 ;; @002b                               v41 = uextend.i64 v37
-;;                                     v106 = ishl v41, v85  ; v85 = 2
-;; @002b                               v43 = ushr v106, v82  ; v82 = 32
+;;                                     v116 = ishl v41, v95  ; v95 = 2
+;; @002b                               v43 = ushr v116, v92  ; v92 = 32
 ;; @002b                               trapnz v43, user2
-;;                                     v113 = ishl v37, v95  ; v95 = 2
-;; @002b                               v46 = uadd_overflow_trap v113, v20, user2  ; v20 = 20
+;;                                     v123 = ishl v37, v105  ; v105 = 2
+;; @002b                               v46 = uadd_overflow_trap v123, v20, user2  ; v20 = 20
 ;; @002b                               v50 = uadd_overflow_trap v2, v46, user2
-;; @002b                               brif v6, block2, block5
+;; @002b                               v60 = uextend.i64 v6
+;; @002b                               brif v60, block2, block5
 ;;
 ;;                                 block2:
 ;; @002b                               v51 = uextend.i64 v50
 ;; @002b                               v53 = iadd.i64 v8, v51
-;;                                     v129 = iconst.i32 2
-;;                                     v130 = ishl.i32 v3, v129  ; v129 = 2
-;;                                     v131 = iconst.i32 20
-;;                                     v132 = iadd v130, v131  ; v131 = 20
-;; @002b                               v54 = isub.i32 v46, v132
+;;                                     v141 = iconst.i32 2
+;;                                     v142 = ishl.i32 v3, v141  ; v141 = 2
+;;                                     v143 = iconst.i32 20
+;;                                     v144 = iadd v142, v143  ; v143 = 20
+;; @002b                               v54 = isub.i32 v46, v144
 ;; @002b                               v55 = uextend.i64 v54
 ;; @002b                               v56 = isub v53, v55
 ;; @002b                               v26 = uextend.i64 v25
 ;; @002b                               v28 = iadd.i64 v8, v26
-;;                                     v133 = ishl.i32 v5, v129  ; v129 = 2
-;;                                     v134 = iadd v133, v131  ; v131 = 20
-;; @002b                               v29 = isub.i32 v21, v134
+;;                                     v145 = ishl.i32 v5, v141  ; v141 = 2
+;;                                     v146 = iadd v145, v143  ; v143 = 20
+;; @002b                               v29 = isub.i32 v21, v146
 ;; @002b                               v30 = uextend.i64 v29
 ;; @002b                               v31 = isub v28, v30
-;; @002b                               v62 = icmp ult v56, v31
-;;                                     v135 = ishl.i32 v6, v129  ; v129 = 2
-;; @002b                               v58 = uextend.i64 v135
-;; @002b                               v60 = iadd v56, v58
-;; @002b                               v59 = iadd v31, v58
+;; @002b                               v61 = icmp ult v56, v31
+;;                                     v147 = iconst.i64 2
+;;                                     v148 = ishl.i64 v60, v147  ; v147 = 2
+;; @002b                               v63 = iadd v56, v148
+;; @002b                               v64 = iadd v31, v148
+;; @002b                               v66 = iadd.i32 v5, v6
 ;; @002b                               v15 = iconst.i64 4
-;;                                     v126 = iadd v28, v15  ; v15 = 4
-;; @002b                               brif v62, block3(v56, v31), block4(v60, v59)
+;;                                     v138 = iadd v28, v15  ; v15 = 4
+;; @002b                               v80 = iconst.i32 1
+;; @002b                               brif v61, block3(v56, v31, v5), block4(v63, v64, v66)
 ;;
-;;                                 block3(v63: i64, v64: i64):
-;; @002b                               v65 = load.i32 user2 little v64
-;; @002b                               store user2 little v65, v63
-;;                                     v141 = iconst.i64 4
-;;                                     v142 = iadd v64, v141  ; v141 = 4
-;; @002b                               v68 = icmp eq v142, v59
-;;                                     v143 = iadd v63, v141  ; v141 = 4
-;; @002b                               brif v68, block5, block3(v143, v142)
+;;                                 block3(v67: i64, v68: i64, v69: i32):
+;; @002b                               v70 = load.i32 user2 little v68
+;; @002b                               store user2 little v70, v67
+;;                                     v156 = iconst.i64 4
+;;                                     v157 = iadd v68, v156  ; v156 = 4
+;; @002b                               v74 = icmp eq v157, v64
+;;                                     v158 = iadd v67, v156  ; v156 = 4
+;;                                     v159 = iconst.i32 1
+;;                                     v160 = iadd v69, v159  ; v159 = 1
+;; @002b                               brif v74, block5, block3(v158, v157, v160)
 ;;
-;;                                 block4(v69: i64, v70: i64):
-;;                                     v136 = iconst.i64 4
-;;                                     v137 = isub v70, v136  ; v136 = 4
-;; @002b                               v73 = load.i32 user2 little v137
-;;                                     v138 = isub v69, v136  ; v136 = 4
-;; @002b                               store user2 little v73, v138
-;;                                     v125 = iadd v70, v30
-;;                                     v139 = iadd.i64 v28, v15  ; v15 = 4
-;;                                     v140 = icmp eq v125, v139
-;; @002b                               brif v140, block5, block4(v138, v137)
+;;                                 block4(v75: i64, v76: i64, v77: i32):
+;;                                     v149 = iconst.i64 4
+;;                                     v150 = isub v76, v149  ; v149 = 4
+;; @002b                               v82 = load.i32 user2 little v150
+;;                                     v151 = isub v75, v149  ; v149 = 4
+;; @002b                               store user2 little v82, v151
+;;                                     v137 = iadd v76, v30
+;;                                     v152 = iadd.i64 v28, v15  ; v15 = 4
+;;                                     v153 = icmp eq v137, v152
+;;                                     v154 = iconst.i32 1
+;;                                     v155 = isub v77, v154  ; v154 = 1
+;; @002b                               brif v153, block5, block4(v151, v150, v155)
 ;;
 ;;                                 block5:
 ;; @002f                               jump block1

--- a/tests/disas/array-copy-i64.wat
+++ b/tests/disas/array-copy-i64.wat
@@ -18,7 +18,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64, i64, i64) tail
-;;     fn0 = colocated u805306368:4 sig0
+;;     fn0 = colocated u805306368:3 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32, v6: i32):
@@ -59,7 +59,7 @@
 ;;                                     v109 = ishl v37, v91  ; v91 = 3
 ;; @002b                               v46 = uadd_overflow_trap v109, v20, user2  ; v20 = 32
 ;; @002b                               v50 = uadd_overflow_trap v2, v46, user2
-;; @002b                               v62 = load.i64 notrap aligned v79+40
+;; @002b                               v60 = load.i64 notrap aligned v79+40
 ;; @002b                               v26 = uextend.i64 v25
 ;; @002b                               v28 = iadd v8, v26
 ;;                                     v98 = ishl v5, v91  ; v91 = 3
@@ -69,9 +69,9 @@
 ;; @002b                               v31 = isub v28, v30
 ;;                                     v119 = ishl v6, v91  ; v91 = 3
 ;; @002b                               v58 = uextend.i64 v119
-;; @002b                               v59 = iadd v31, v58
-;; @002b                               v63 = iadd v8, v62
-;; @002b                               v64 = icmp ugt v59, v63
+;; @002b                               v62 = iadd v31, v58
+;; @002b                               v61 = iadd v8, v60
+;; @002b                               v64 = icmp ugt v62, v61
 ;; @002b                               trapnz v64, user2
 ;; @002b                               v51 = uextend.i64 v50
 ;; @002b                               v53 = iadd v8, v51
@@ -80,8 +80,8 @@
 ;; @002b                               v54 = isub v46, v117
 ;; @002b                               v55 = uextend.i64 v54
 ;; @002b                               v56 = isub v53, v55
-;; @002b                               v60 = iadd v56, v58
-;; @002b                               v65 = icmp ugt v60, v63
+;; @002b                               v63 = iadd v56, v58
+;; @002b                               v65 = icmp ugt v63, v61
 ;; @002b                               trapnz v65, user2
 ;; @002b                               call fn0(v0, v56, v31, v58)
 ;; @002f                               jump block1

--- a/tests/disas/array-copy-i8.wat
+++ b/tests/disas/array-copy-i8.wat
@@ -18,7 +18,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64, i64, i64) tail
-;;     fn0 = colocated u805306368:4 sig0
+;;     fn0 = colocated u805306368:3 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32, v6: i32):
@@ -53,7 +53,7 @@
 ;; @002b                               trapnz v43, user2
 ;; @002b                               v46 = uadd_overflow_trap v37, v20, user2  ; v20 = 28
 ;; @002b                               v50 = uadd_overflow_trap v2, v46, user2
-;; @002b                               v62 = load.i64 notrap aligned v79+40
+;; @002b                               v60 = load.i64 notrap aligned v79+40
 ;; @002b                               v26 = uextend.i64 v25
 ;; @002b                               v28 = iadd v8, v26
 ;;                                     v87 = iadd v5, v20  ; v20 = 28
@@ -61,9 +61,9 @@
 ;; @002b                               v30 = uextend.i64 v29
 ;; @002b                               v31 = isub v28, v30
 ;; @002b                               v58 = uextend.i64 v6
-;; @002b                               v59 = iadd v31, v58
-;; @002b                               v63 = iadd v8, v62
-;; @002b                               v64 = icmp ugt v59, v63
+;; @002b                               v62 = iadd v31, v58
+;; @002b                               v61 = iadd v8, v60
+;; @002b                               v64 = icmp ugt v62, v61
 ;; @002b                               trapnz v64, user2
 ;; @002b                               v51 = uextend.i64 v50
 ;; @002b                               v53 = iadd v8, v51
@@ -71,8 +71,8 @@
 ;; @002b                               v54 = isub v46, v92
 ;; @002b                               v55 = uextend.i64 v54
 ;; @002b                               v56 = isub v53, v55
-;; @002b                               v60 = iadd v56, v58
-;; @002b                               v65 = icmp ugt v60, v63
+;; @002b                               v63 = iadd v56, v58
+;; @002b                               v65 = icmp ugt v63, v61
 ;; @002b                               trapnz v65, user2
 ;; @002b                               call fn0(v0, v56, v31, v58)
 ;; @002f                               jump block1

--- a/tests/disas/array-fill-anyref.wat
+++ b/tests/disas/array-fill-anyref.wat
@@ -89,7 +89,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64, i32, i64) tail
-;;     fn0 = colocated u805306368:5 sig0
+;;     fn0 = colocated u805306368:4 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):

--- a/tests/disas/array-fill-externref.wat
+++ b/tests/disas/array-fill-externref.wat
@@ -85,7 +85,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64, i32, i64) tail
-;;     fn0 = colocated u805306368:5 sig0
+;;     fn0 = colocated u805306368:4 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):

--- a/tests/disas/array-fill-f32.wat
+++ b/tests/disas/array-fill-f32.wat
@@ -89,7 +89,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64, i32, i64) tail
-;;     fn0 = colocated u805306368:5 sig0
+;;     fn0 = colocated u805306368:4 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):

--- a/tests/disas/array-fill-f64.wat
+++ b/tests/disas/array-fill-f64.wat
@@ -89,7 +89,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64, i32, i64) tail
-;;     fn0 = colocated u805306368:5 sig0
+;;     fn0 = colocated u805306368:4 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):

--- a/tests/disas/array-fill-funcref.wat
+++ b/tests/disas/array-fill-funcref.wat
@@ -29,7 +29,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64) -> i64 tail
-;;     fn0 = colocated u805306368:26 sig0
+;;     fn0 = colocated u805306368:25 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i64, v5: i32):
@@ -96,7 +96,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64, i32, i64) tail
-;;     fn0 = colocated u805306368:5 sig0
+;;     fn0 = colocated u805306368:4 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
@@ -155,8 +155,8 @@
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32) -> i64 tail
 ;;     sig1 = (i64 vmctx, i64) -> i64 tail
-;;     fn0 = colocated u805306368:6 sig0
-;;     fn1 = colocated u805306368:26 sig1
+;;     fn0 = colocated u805306368:5 sig0
+;;     fn1 = colocated u805306368:25 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):

--- a/tests/disas/array-fill-i16.wat
+++ b/tests/disas/array-fill-i16.wat
@@ -91,7 +91,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64, i32, i64) tail
-;;     fn0 = colocated u805306368:5 sig0
+;;     fn0 = colocated u805306368:4 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
@@ -146,7 +146,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64, i32, i64) tail
-;;     fn0 = colocated u805306368:5 sig0
+;;     fn0 = colocated u805306368:4 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):

--- a/tests/disas/array-fill-i31ref.wat
+++ b/tests/disas/array-fill-i31ref.wat
@@ -89,7 +89,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64, i32, i64) tail
-;;     fn0 = colocated u805306368:5 sig0
+;;     fn0 = colocated u805306368:4 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):

--- a/tests/disas/array-fill-i32.wat
+++ b/tests/disas/array-fill-i32.wat
@@ -93,7 +93,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64, i32, i64) tail
-;;     fn0 = colocated u805306368:5 sig0
+;;     fn0 = colocated u805306368:4 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
@@ -150,7 +150,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64, i32, i64) tail
-;;     fn0 = colocated u805306368:5 sig0
+;;     fn0 = colocated u805306368:4 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):

--- a/tests/disas/array-fill-i64.wat
+++ b/tests/disas/array-fill-i64.wat
@@ -93,7 +93,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64, i32, i64) tail
-;;     fn0 = colocated u805306368:5 sig0
+;;     fn0 = colocated u805306368:4 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
@@ -150,7 +150,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64, i32, i64) tail
-;;     fn0 = colocated u805306368:5 sig0
+;;     fn0 = colocated u805306368:4 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):

--- a/tests/disas/call-indirect.wat
+++ b/tests/disas/call-indirect.wat
@@ -16,7 +16,7 @@
 ;;     gv5 = load.i64 notrap aligned gv3+56
 ;;     sig0 = (i64 vmctx, i64, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
-;;     fn0 = colocated u805306368:7 sig1
+;;     fn0 = colocated u805306368:6 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):

--- a/tests/disas/component-may-leave-without-signals-based-traps.wat
+++ b/tests/disas/component-may-leave-without-signals-based-traps.wat
@@ -44,7 +44,7 @@
 ;;       retq
 ;;  129: movq    %rbx, %rsi
 ;;  12c: movq    0x10(%rsi), %rax
-;;  130: movq    0x170(%rax), %rax
+;;  130: movq    0x168(%rax), %rax
 ;;  137: movq    %rbx, %rdi
 ;;  13a: callq   *%rax
 ;;  13c: ud2

--- a/tests/disas/debug.wat
+++ b/tests/disas/debug.wat
@@ -128,7 +128,7 @@
 ;;       popq    %rbp
 ;;       retq
 ;;  17a: movq    0x10(%rbx), %rax
-;;  17e: movq    0x170(%rax), %rax
+;;  17e: movq    0x168(%rax), %rax
 ;;  185: movq    %rbx, %rdi
 ;;  188: callq   *%rax
 ;;  18a: ud2
@@ -143,7 +143,7 @@
 ;;       movq    8(%r10), %r11
 ;;       movq    %r11, 0x38(%r9)
 ;;       movq    0x10(%rdi), %r11
-;;       movq    0x168(%r11), %r11
+;;       movq    0x160(%r11), %r11
 ;;       movzbq  %sil, %rsi
 ;;       callq   *%r11
 ;;       movq    %rbp, %rsp
@@ -160,7 +160,7 @@
 ;;       movq    8(%r9), %r9
 ;;       movq    %r9, 0x38(%r8)
 ;;       movq    0x10(%rdi), %r9
-;;       movq    0x170(%r9), %r9
+;;       movq    0x168(%r9), %r9
 ;;       callq   *%r9
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
@@ -203,7 +203,7 @@
 ;;       movq    8(%r11), %rax
 ;;       movq    %rax, 0x38(%r10)
 ;;       movq    0x10(%rdi), %rax
-;;       movq    0x1a0(%rax), %rcx
+;;       movq    0x198(%rax), %rcx
 ;;       movq    %rdi, %rbx
 ;;       callq   *%rcx
 ;;       testb   %al, %al
@@ -239,7 +239,7 @@
 ;;       popq    %rbp
 ;;       retq
 ;;  3af: movq    0x10(%rbx), %rax
-;;  3b3: movq    0x170(%rax), %rax
+;;  3b3: movq    0x168(%rax), %rax
 ;;  3ba: movq    %rbx, %rdi
 ;;  3bd: callq   *%rax
 ;;  3bf: ud2

--- a/tests/disas/duplicate-function-types.wat
+++ b/tests/disas/duplicate-function-types.wat
@@ -26,7 +26,7 @@
 ;;     gv6 = load.i64 notrap aligned gv4+8
 ;;     sig0 = (i64 vmctx, i64) -> i32 tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
-;;     fn0 = colocated u805306368:7 sig1
+;;     fn0 = colocated u805306368:6 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/epoch-interruption.wat
+++ b/tests/disas/epoch-interruption.wat
@@ -11,7 +11,7 @@
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
 ;;     sig0 = (i64 vmctx) -> i64 tail
-;;     fn0 = colocated u805306368:14 sig0
+;;     fn0 = colocated u805306368:13 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):

--- a/tests/disas/gc/array-copy-with-fuel.wat
+++ b/tests/disas/gc/array-copy-with-fuel.wat
@@ -20,34 +20,34 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx) -> i8 tail
-;;     fn0 = colocated u805306368:13 sig0
+;;     fn0 = colocated u805306368:12 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32, v6: i32):
-;;                                     v145 = stack_addr.i64 ss0
-;;                                     store notrap v2, v145
-;;                                     v144 = stack_addr.i64 ss1
-;;                                     store notrap v4, v144
+;;                                     v155 = stack_addr.i64 ss0
+;;                                     store notrap v2, v155
+;;                                     v154 = stack_addr.i64 ss1
+;;                                     store notrap v4, v154
 ;; @0020                               v7 = load.i64 notrap aligned readonly can_move v0+8
 ;; @0020                               v8 = load.i64 notrap aligned v7
-;;                                     v142 = iconst.i64 1
-;; @0020                               v9 = iadd v8, v142  ; v142 = 1
+;;                                     v152 = iconst.i64 1
+;; @0020                               v9 = iadd v8, v152  ; v152 = 1
 ;; @0020                               v10 = iconst.i64 0
 ;; @0020                               v11 = icmp sge v9, v10  ; v10 = 0
 ;; @0020                               brif v11, block2, block3(v9)
 ;;
 ;;                                 block2:
-;;                                     v190 = iadd.i64 v8, v142  ; v142 = 1
-;; @0020                               store notrap aligned v190, v7
+;;                                     v202 = iadd.i64 v8, v152  ; v152 = 1
+;; @0020                               store notrap aligned v202, v7
 ;; @0020                               v14 = call fn0(v0), stack_map=[i32 @ ss0+0, i32 @ ss1+0]
 ;; @0020                               v16 = load.i64 notrap aligned v7
 ;; @0020                               jump block3(v16)
 ;;
-;;                                 block3(v107: i64):
-;;                                     v117 = load.i32 notrap v144
-;; @002b                               trapz v117, user16
+;;                                 block3(v116: i64):
+;;                                     v126 = load.i32 notrap v154
+;; @002b                               trapz v126, user16
 ;; @002b                               v23 = load.i64 notrap aligned readonly can_move v7+32
-;; @002b                               v22 = uextend.i64 v117
+;; @002b                               v22 = uextend.i64 v126
 ;; @002b                               v24 = iadd v23, v22
 ;; @002b                               v25 = iconst.i64 16
 ;; @002b                               v26 = iadd v24, v25  ; v25 = 16
@@ -56,19 +56,19 @@
 ;; @002b                               v29 = icmp ugt v28, v27
 ;; @002b                               trapnz v29, user17
 ;; @002b                               v31 = uextend.i64 v27
-;;                                     v146 = iconst.i64 2
-;;                                     v147 = ishl v31, v146  ; v146 = 2
-;;                                     v135 = iconst.i64 32
-;; @002b                               v33 = ushr v147, v135  ; v135 = 32
+;;                                     v156 = iconst.i64 2
+;;                                     v157 = ishl v31, v156  ; v156 = 2
+;;                                     v145 = iconst.i64 32
+;; @002b                               v33 = ushr v157, v145  ; v145 = 32
 ;; @002b                               trapnz v33, user2
-;;                                     v156 = iconst.i32 2
-;;                                     v157 = ishl v27, v156  ; v156 = 2
+;;                                     v166 = iconst.i32 2
+;;                                     v167 = ishl v27, v166  ; v166 = 2
 ;; @002b                               v35 = iconst.i32 20
-;; @002b                               v36 = uadd_overflow_trap v157, v35, user2  ; v35 = 20
-;; @002b                               v40 = uadd_overflow_trap v117, v36, user2
-;;                                     v114 = load.i32 notrap v145
-;; @002b                               trapz v114, user16
-;; @002b                               v47 = uextend.i64 v114
+;; @002b                               v36 = uadd_overflow_trap v167, v35, user2  ; v35 = 20
+;; @002b                               v40 = uadd_overflow_trap v126, v36, user2
+;;                                     v123 = load.i32 notrap v155
+;; @002b                               trapz v123, user16
+;; @002b                               v47 = uextend.i64 v123
 ;; @002b                               v49 = iadd v23, v47
 ;; @002b                               v51 = iadd v49, v25  ; v25 = 16
 ;; @002b                               v52 = load.i32 user2 readonly v51
@@ -76,89 +76,96 @@
 ;; @002b                               v54 = icmp ugt v53, v52
 ;; @002b                               trapnz v54, user17
 ;; @002b                               v56 = uextend.i64 v52
-;;                                     v167 = ishl v56, v146  ; v146 = 2
-;; @002b                               v58 = ushr v167, v135  ; v135 = 32
+;;                                     v177 = ishl v56, v156  ; v156 = 2
+;; @002b                               v58 = ushr v177, v145  ; v145 = 32
 ;; @002b                               trapnz v58, user2
-;;                                     v174 = ishl v52, v156  ; v156 = 2
-;; @002b                               v61 = uadd_overflow_trap v174, v35, user2  ; v35 = 20
-;; @002b                               v65 = uadd_overflow_trap v114, v61, user2
-;; @002b                               brif.i32 v6, block4, block7(v107)
+;;                                     v184 = ishl v52, v166  ; v166 = 2
+;; @002b                               v61 = uadd_overflow_trap v184, v35, user2  ; v35 = 20
+;; @002b                               v65 = uadd_overflow_trap v123, v61, user2
+;; @002b                               v75 = uextend.i64 v6
+;; @002b                               brif v75, block4, block7(v116)
 ;;
 ;;                                 block4:
 ;; @002b                               v66 = uextend.i64 v65
 ;; @002b                               v68 = iadd.i64 v23, v66
-;;                                     v191 = iconst.i32 2
-;;                                     v192 = ishl.i32 v3, v191  ; v191 = 2
-;;                                     v193 = iconst.i32 20
-;;                                     v194 = iadd v192, v193  ; v193 = 20
-;; @002b                               v69 = isub.i32 v61, v194
+;;                                     v203 = iconst.i32 2
+;;                                     v204 = ishl.i32 v3, v203  ; v203 = 2
+;;                                     v205 = iconst.i32 20
+;;                                     v206 = iadd v204, v205  ; v205 = 20
+;; @002b                               v69 = isub.i32 v61, v206
 ;; @002b                               v70 = uextend.i64 v69
 ;; @002b                               v71 = isub v68, v70
 ;; @002b                               v41 = uextend.i64 v40
 ;; @002b                               v43 = iadd.i64 v23, v41
-;;                                     v195 = ishl.i32 v5, v191  ; v191 = 2
-;;                                     v196 = iadd v195, v193  ; v193 = 20
-;; @002b                               v44 = isub.i32 v36, v196
+;;                                     v207 = ishl.i32 v5, v203  ; v203 = 2
+;;                                     v208 = iadd v207, v205  ; v205 = 20
+;; @002b                               v44 = isub.i32 v36, v208
 ;; @002b                               v45 = uextend.i64 v44
 ;; @002b                               v46 = isub v43, v45
-;; @002b                               v77 = icmp ult v71, v46
-;;                                     v197 = ishl.i32 v6, v191  ; v191 = 2
-;; @002b                               v73 = uextend.i64 v197
-;; @002b                               v75 = iadd v71, v73
-;; @002b                               v74 = iadd v46, v73
+;; @002b                               v76 = icmp ult v71, v46
+;;                                     v209 = iconst.i64 2
+;;                                     v210 = ishl.i64 v75, v209  ; v209 = 2
+;; @002b                               v78 = iadd v71, v210
+;; @002b                               v79 = iadd v46, v210
+;; @002b                               v81 = iadd.i32 v5, v6
 ;; @002b                               v30 = iconst.i64 4
-;;                                     v187 = iadd v43, v30  ; v30 = 4
-;;                                     v123 = iconst.i64 6
-;; @002b                               brif v77, block5(v71, v46, v107), block6(v75, v74, v107)
+;;                                     v199 = iadd v43, v30  ; v30 = 4
+;; @002b                               v112 = iconst.i32 1
+;;                                     v133 = iconst.i64 6
+;; @002b                               brif v76, block5(v71, v46, v5, v116), block6(v78, v79, v81, v116)
 ;;
-;;                                 block5(v78: i64, v79: i64, v80: i64):
-;;                                     v205 = iconst.i64 6
-;;                                     v206 = iadd v80, v205  ; v205 = 6
-;;                                     v207 = iconst.i64 0
-;;                                     v208 = icmp sge v206, v207  ; v207 = 0
-;; @002b                               brif v208, block8, block9(v206)
+;;                                 block5(v82: i64, v83: i64, v84: i32, v85: i64):
+;;                                     v220 = iconst.i64 6
+;;                                     v221 = iadd v85, v220  ; v220 = 6
+;;                                     v222 = iconst.i64 0
+;;                                     v223 = icmp sge v221, v222  ; v222 = 0
+;; @002b                               brif v223, block8, block9(v221)
 ;;
-;;                                 block6(v93: i64, v94: i64, v96: i64):
-;;                                     v198 = iconst.i64 0
-;;                                     v199 = icmp sge v96, v198  ; v198 = 0
-;; @002b                               brif v199, block10, block11(v96)
+;;                                 block6(v99: i64, v100: i64, v101: i32, v103: i64):
+;;                                     v211 = iconst.i64 0
+;;                                     v212 = icmp sge v103, v211  ; v211 = 0
+;; @002b                               brif v212, block10, block11(v103)
 ;;
-;;                                 block7(v111: i64):
+;;                                 block7(v120: i64):
 ;; @002f                               jump block1
 ;;
 ;;                                 block8:
-;; @002b                               store.i64 notrap aligned v206, v7
-;; @002b                               v86 = call fn0(v0)
-;; @002b                               v88 = load.i64 notrap aligned v7
-;; @002b                               jump block9(v88)
+;; @002b                               store.i64 notrap aligned v221, v7
+;; @002b                               v91 = call fn0(v0)
+;; @002b                               v93 = load.i64 notrap aligned v7
+;; @002b                               jump block9(v93)
 ;;
-;;                                 block9(v108: i64):
-;; @002b                               v89 = load.i32 user2 little v79
-;; @002b                               store user2 little v89, v78
-;;                                     v209 = iconst.i64 4
-;;                                     v210 = iadd.i64 v79, v209  ; v209 = 4
-;; @002b                               v92 = icmp eq v210, v74
-;;                                     v211 = iadd.i64 v78, v209  ; v209 = 4
-;; @002b                               brif v92, block7(v108), block5(v211, v210, v108)
+;;                                 block9(v117: i64):
+;; @002b                               v94 = load.i32 user2 little v83
+;; @002b                               store user2 little v94, v82
+;;                                     v224 = iconst.i64 4
+;;                                     v225 = iadd.i64 v83, v224  ; v224 = 4
+;; @002b                               v98 = icmp eq v225, v79
+;;                                     v226 = iadd.i64 v82, v224  ; v224 = 4
+;;                                     v227 = iconst.i32 1
+;;                                     v228 = iadd.i32 v84, v227  ; v227 = 1
+;; @002b                               brif v98, block7(v117), block5(v226, v225, v228, v117)
 ;;
 ;;                                 block10:
-;; @002b                               store.i64 notrap aligned v96, v7
-;; @002b                               v100 = call fn0(v0)
-;; @002b                               v102 = load.i64 notrap aligned v7
-;; @002b                               jump block11(v102)
+;; @002b                               store.i64 notrap aligned v103, v7
+;; @002b                               v107 = call fn0(v0)
+;; @002b                               v109 = load.i64 notrap aligned v7
+;; @002b                               jump block11(v109)
 ;;
-;;                                 block11(v109: i64):
-;;                                     v200 = iconst.i64 4
-;;                                     v201 = isub.i64 v94, v200  ; v200 = 4
-;; @002b                               v105 = load.i32 user2 little v201
-;;                                     v202 = isub.i64 v93, v200  ; v200 = 4
-;; @002b                               store user2 little v105, v202
-;;                                     v186 = iadd.i64 v94, v45
-;;                                     v203 = iadd.i64 v43, v30  ; v30 = 4
-;;                                     v204 = icmp eq v186, v203
-;; @002b                               brif v204, block7(v109), block6(v202, v201, v109)
+;;                                 block11(v118: i64):
+;;                                     v213 = iconst.i64 4
+;;                                     v214 = isub.i64 v100, v213  ; v213 = 4
+;; @002b                               v114 = load.i32 user2 little v214
+;;                                     v215 = isub.i64 v99, v213  ; v213 = 4
+;; @002b                               store user2 little v114, v215
+;;                                     v198 = iadd.i64 v100, v45
+;;                                     v216 = iadd.i64 v43, v30  ; v30 = 4
+;;                                     v217 = icmp eq v198, v216
+;;                                     v218 = iconst.i32 1
+;;                                     v219 = isub.i32 v101, v218  ; v218 = 1
+;; @002b                               brif v217, block7(v118), block6(v215, v214, v219, v118)
 ;;
 ;;                                 block1:
-;; @002f                               store.i64 notrap aligned v111, v7
+;; @002f                               store.i64 notrap aligned v120, v7
 ;; @002f                               return
 ;; }

--- a/tests/disas/gc/array-fill-i8.wat
+++ b/tests/disas/gc/array-fill-i8.wat
@@ -18,7 +18,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64, i32, i64) tail
-;;     fn0 = colocated u805306368:5 sig0
+;;     fn0 = colocated u805306368:4 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):

--- a/tests/disas/gc/array-init-data.wat
+++ b/tests/disas/gc/array-init-data.wat
@@ -22,13 +22,13 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64, i64, i64) tail
-;;     fn0 = colocated u805306368:4 sig0
+;;     fn0 = colocated u805306368:3 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
 ;; @002a                               trapz v2, user16
-;; @002a                               v50 = load.i64 notrap aligned readonly can_move v0+8
-;; @002a                               v7 = load.i64 notrap aligned readonly can_move v50+32
+;; @002a                               v53 = load.i64 notrap aligned readonly can_move v0+8
+;; @002a                               v7 = load.i64 notrap aligned readonly can_move v53+32
 ;; @002a                               v6 = uextend.i64 v2
 ;; @002a                               v8 = iadd v7, v6
 ;; @002a                               v9 = iconst.i64 24
@@ -45,21 +45,21 @@
 ;; @002a                               v22 = iadd v20, v14
 ;; @002a                               v23 = icmp ugt v22, v19
 ;; @002a                               trapnz v23, heap_oob
-;; @002a                               v24 = load.i64 notrap aligned v0+48
-;;                                     v48 = iconst.i64 32
-;; @002a                               v30 = ushr v12, v48  ; v48 = 32
-;; @002a                               trapnz v30, user2
-;; @002a                               v32 = iconst.i32 28
-;; @002a                               v33 = uadd_overflow_trap v11, v32, user2  ; v32 = 28
-;; @002a                               v37 = uadd_overflow_trap v2, v33, user2
-;; @002a                               v38 = uextend.i64 v37
-;; @002a                               v40 = iadd v7, v38
-;;                                     v58 = iadd v3, v32  ; v32 = 28
-;; @002a                               v41 = isub v33, v58
-;; @002a                               v42 = uextend.i64 v41
-;; @002a                               v43 = isub v40, v42
-;; @002a                               v26 = iadd v24, v20
-;; @002a                               call fn0(v0, v43, v26, v14)
+;; @002a                               v25 = load.i64 notrap aligned v0+48
+;;                                     v50 = iconst.i64 32
+;; @002a                               v32 = ushr v12, v50  ; v50 = 32
+;; @002a                               trapnz v32, user2
+;; @002a                               v34 = iconst.i32 28
+;; @002a                               v35 = uadd_overflow_trap v11, v34, user2  ; v34 = 28
+;; @002a                               v39 = uadd_overflow_trap v2, v35, user2
+;; @002a                               v40 = uextend.i64 v39
+;; @002a                               v42 = iadd v7, v40
+;;                                     v62 = iadd v3, v34  ; v34 = 28
+;; @002a                               v43 = isub v35, v62
+;; @002a                               v44 = uextend.i64 v43
+;; @002a                               v45 = isub v42, v44
+;; @002a                               v28 = iadd v25, v20
+;; @002a                               call fn0(v0, v45, v28, v14)
 ;; @002e                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/array-new-data.wat
+++ b/tests/disas/gc/array-new-data.wat
@@ -86,53 +86,53 @@
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64, i64, i64) tail
-;;     fn0 = colocated u805306368:25 sig0
-;;     fn1 = colocated u805306368:4 sig1
+;;     fn0 = colocated u805306368:24 sig0
+;;     fn1 = colocated u805306368:3 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
 ;; @0025                               v5 = uextend.i64 v3
-;;                                     v73 = iconst.i64 32
-;; @0025                               v7 = ushr v5, v73  ; v73 = 32
+;;                                     v76 = iconst.i64 32
+;; @0025                               v7 = ushr v5, v76  ; v76 = 32
 ;; @0025                               trapnz v7, heap_oob
 ;; @0025                               v10 = uload32 notrap aligned v0+56
 ;; @0025                               v11 = uextend.i64 v2
 ;; @0025                               v13 = iadd v11, v5
 ;; @0025                               v14 = icmp ugt v13, v10
 ;; @0025                               trapnz v14, heap_oob
-;; @0025                               v15 = load.i64 notrap aligned v0+48
+;; @0025                               v16 = load.i64 notrap aligned v0+48
 ;; @0025                               trapnz v7, user18
-;; @0025                               v18 = iconst.i32 28
-;; @0025                               v23 = uadd_overflow_trap v18, v3, user18  ; v18 = 28
-;; @0025                               v25 = iconst.i32 -1476395008
-;; @0025                               v27 = load.i64 notrap aligned readonly can_move v0+40
-;; @0025                               v28 = load.i32 notrap aligned readonly can_move v27
-;; @0025                               v29 = iconst.i32 8
-;; @0025                               v30 = call fn0(v0, v25, v28, v23, v29)  ; v25 = -1476395008, v29 = 8
-;;                                     v70 = stack_addr.i64 ss0
-;;                                     store notrap v30, v70
-;; @0025                               v68 = load.i64 notrap aligned readonly can_move v0+8
-;; @0025                               v31 = load.i64 notrap aligned readonly can_move v68+32
-;; @0025                               v32 = uextend.i64 v30
-;; @0025                               v33 = iadd v31, v32
-;;                                     v66 = iconst.i64 24
-;; @0025                               v34 = iadd v33, v66  ; v66 = 24
-;; @0025                               store user2 v3, v34
-;; @0025                               v42 = ushr v5, v73  ; v73 = 32
-;; @0025                               trapnz v42, user2
-;; @0025                               v45 = uadd_overflow_trap v3, v18, user2  ; v18 = 28
-;;                                     v59 = load.i32 notrap v70
-;; @0025                               v49 = uadd_overflow_trap v59, v45, user2
-;; @0025                               v50 = uextend.i64 v49
-;; @0025                               v52 = iadd v31, v50
-;; @0025                               v53 = isub v45, v18  ; v18 = 28
-;; @0025                               v54 = uextend.i64 v53
-;; @0025                               v55 = isub v52, v54
-;; @0025                               v17 = iadd v15, v11
-;; @0025                               call fn1(v0, v55, v17, v5), stack_map=[i32 @ ss0+0]
-;;                                     v58 = load.i32 notrap v70
+;; @0025                               v20 = iconst.i32 28
+;; @0025                               v25 = uadd_overflow_trap v20, v3, user18  ; v20 = 28
+;; @0025                               v27 = iconst.i32 -1476395008
+;; @0025                               v29 = load.i64 notrap aligned readonly can_move v0+40
+;; @0025                               v30 = load.i32 notrap aligned readonly can_move v29
+;; @0025                               v31 = iconst.i32 8
+;; @0025                               v32 = call fn0(v0, v27, v30, v25, v31)  ; v27 = -1476395008, v31 = 8
+;;                                     v72 = stack_addr.i64 ss0
+;;                                     store notrap v32, v72
+;; @0025                               v70 = load.i64 notrap aligned readonly can_move v0+8
+;; @0025                               v33 = load.i64 notrap aligned readonly can_move v70+32
+;; @0025                               v34 = uextend.i64 v32
+;; @0025                               v35 = iadd v33, v34
+;;                                     v68 = iconst.i64 24
+;; @0025                               v36 = iadd v35, v68  ; v68 = 24
+;; @0025                               store user2 v3, v36
+;; @0025                               v44 = ushr v5, v76  ; v76 = 32
+;; @0025                               trapnz v44, user2
+;; @0025                               v47 = uadd_overflow_trap v3, v20, user2  ; v20 = 28
+;;                                     v61 = load.i32 notrap v72
+;; @0025                               v51 = uadd_overflow_trap v61, v47, user2
+;; @0025                               v52 = uextend.i64 v51
+;; @0025                               v54 = iadd v33, v52
+;; @0025                               v55 = isub v47, v20  ; v20 = 28
+;; @0025                               v56 = uextend.i64 v55
+;; @0025                               v57 = isub v54, v56
+;; @0025                               v19 = iadd v16, v11
+;; @0025                               call fn1(v0, v57, v19, v5), stack_map=[i32 @ ss0+0]
+;;                                     v60 = load.i32 notrap v72
 ;; @0029                               jump block1
 ;;
 ;;                                 block1:
-;; @0029                               return v58
+;; @0029                               return v60
 ;; }

--- a/tests/disas/gc/array-new-default-anyref.wat
+++ b/tests/disas/gc/array-new-default-anyref.wat
@@ -20,8 +20,8 @@
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64, i32, i64) tail
-;;     fn0 = colocated u805306368:25 sig0
-;;     fn1 = colocated u805306368:5 sig1
+;;     fn0 = colocated u805306368:24 sig0
+;;     fn1 = colocated u805306368:4 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/array-new-default-exnref.wat
+++ b/tests/disas/gc/array-new-default-exnref.wat
@@ -20,8 +20,8 @@
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64, i32, i64) tail
-;;     fn0 = colocated u805306368:25 sig0
-;;     fn1 = colocated u805306368:5 sig1
+;;     fn0 = colocated u805306368:24 sig0
+;;     fn1 = colocated u805306368:4 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/array-new-default-externref.wat
+++ b/tests/disas/gc/array-new-default-externref.wat
@@ -20,8 +20,8 @@
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64, i32, i64) tail
-;;     fn0 = colocated u805306368:25 sig0
-;;     fn1 = colocated u805306368:5 sig1
+;;     fn0 = colocated u805306368:24 sig0
+;;     fn1 = colocated u805306368:4 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/array-new-default-f32.wat
+++ b/tests/disas/gc/array-new-default-f32.wat
@@ -20,8 +20,8 @@
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64, i32, i64) tail
-;;     fn0 = colocated u805306368:25 sig0
-;;     fn1 = colocated u805306368:5 sig1
+;;     fn0 = colocated u805306368:24 sig0
+;;     fn1 = colocated u805306368:4 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/array-new-default-f64.wat
+++ b/tests/disas/gc/array-new-default-f64.wat
@@ -20,8 +20,8 @@
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64, i32, i64) tail
-;;     fn0 = colocated u805306368:25 sig0
-;;     fn1 = colocated u805306368:5 sig1
+;;     fn0 = colocated u805306368:24 sig0
+;;     fn1 = colocated u805306368:4 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/array-new-default-funcref.wat
+++ b/tests/disas/gc/array-new-default-funcref.wat
@@ -20,8 +20,8 @@
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64, i32, i64) tail
-;;     fn0 = colocated u805306368:25 sig0
-;;     fn1 = colocated u805306368:5 sig1
+;;     fn0 = colocated u805306368:24 sig0
+;;     fn1 = colocated u805306368:4 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/array-new-default-i16.wat
+++ b/tests/disas/gc/array-new-default-i16.wat
@@ -20,8 +20,8 @@
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64, i32, i64) tail
-;;     fn0 = colocated u805306368:25 sig0
-;;     fn1 = colocated u805306368:5 sig1
+;;     fn0 = colocated u805306368:24 sig0
+;;     fn1 = colocated u805306368:4 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/array-new-default-i32.wat
+++ b/tests/disas/gc/array-new-default-i32.wat
@@ -20,8 +20,8 @@
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64, i32, i64) tail
-;;     fn0 = colocated u805306368:25 sig0
-;;     fn1 = colocated u805306368:5 sig1
+;;     fn0 = colocated u805306368:24 sig0
+;;     fn1 = colocated u805306368:4 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/array-new-default-i64.wat
+++ b/tests/disas/gc/array-new-default-i64.wat
@@ -20,8 +20,8 @@
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64, i32, i64) tail
-;;     fn0 = colocated u805306368:25 sig0
-;;     fn1 = colocated u805306368:5 sig1
+;;     fn0 = colocated u805306368:24 sig0
+;;     fn1 = colocated u805306368:4 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/array-new-default-i8.wat
+++ b/tests/disas/gc/array-new-default-i8.wat
@@ -20,8 +20,8 @@
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64, i32, i64) tail
-;;     fn0 = colocated u805306368:25 sig0
-;;     fn1 = colocated u805306368:5 sig1
+;;     fn0 = colocated u805306368:24 sig0
+;;     fn1 = colocated u805306368:4 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/copying/array-new-fixed-of-gc-refs.wat
+++ b/tests/disas/gc/copying/array-new-fixed-of-gc-refs.wat
@@ -19,7 +19,7 @@
 ;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
-;;     fn0 = colocated u805306368:25 sig0
+;;     fn0 = colocated u805306368:24 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):

--- a/tests/disas/gc/copying/array-new-fixed.wat
+++ b/tests/disas/gc/copying/array-new-fixed.wat
@@ -16,7 +16,7 @@
 ;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
-;;     fn0 = colocated u805306368:25 sig0
+;;     fn0 = colocated u805306368:24 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64):

--- a/tests/disas/gc/copying/array-new.wat
+++ b/tests/disas/gc/copying/array-new.wat
@@ -16,7 +16,7 @@
 ;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
-;;     fn0 = colocated u805306368:25 sig0
+;;     fn0 = colocated u805306368:24 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):

--- a/tests/disas/gc/copying/br-on-cast-fail.wat
+++ b/tests/disas/gc/copying/br-on-cast-fail.wat
@@ -26,7 +26,7 @@
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64) tail
-;;     fn0 = colocated u805306368:30 sig0
+;;     fn0 = colocated u805306368:29 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/copying/br-on-cast.wat
+++ b/tests/disas/gc/copying/br-on-cast.wat
@@ -26,7 +26,7 @@
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64) tail
-;;     fn0 = colocated u805306368:30 sig0
+;;     fn0 = colocated u805306368:29 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/copying/call-indirect-and-subtyping.wat
+++ b/tests/disas/gc/copying/call-indirect-and-subtyping.wat
@@ -24,8 +24,8 @@
 ;;     sig0 = (i64 vmctx, i64) tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
 ;;     sig2 = (i64 vmctx, i32, i32) -> i32 tail
-;;     fn0 = colocated u805306368:7 sig1
-;;     fn1 = colocated u805306368:30 sig2
+;;     fn0 = colocated u805306368:6 sig1
+;;     fn1 = colocated u805306368:29 sig2
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/copying/funcref-in-gc-heap-get.wat
+++ b/tests/disas/gc/copying/funcref-in-gc-heap-get.wat
@@ -17,7 +17,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32) -> i64 tail
-;;     fn0 = colocated u805306368:27 sig0
+;;     fn0 = colocated u805306368:26 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/copying/funcref-in-gc-heap-new.wat
+++ b/tests/disas/gc/copying/funcref-in-gc-heap-new.wat
@@ -18,8 +18,8 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64) -> i64 tail
-;;     fn0 = colocated u805306368:25 sig0
-;;     fn1 = colocated u805306368:26 sig1
+;;     fn0 = colocated u805306368:24 sig0
+;;     fn1 = colocated u805306368:25 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):

--- a/tests/disas/gc/copying/funcref-in-gc-heap-set.wat
+++ b/tests/disas/gc/copying/funcref-in-gc-heap-set.wat
@@ -17,7 +17,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64) -> i64 tail
-;;     fn0 = colocated u805306368:26 sig0
+;;     fn0 = colocated u805306368:25 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i64):

--- a/tests/disas/gc/copying/ref-cast.wat
+++ b/tests/disas/gc/copying/ref-cast.wat
@@ -17,7 +17,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32) -> i32 tail
-;;     fn0 = colocated u805306368:30 sig0
+;;     fn0 = colocated u805306368:29 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/copying/ref-test-concrete-func-type.wat
+++ b/tests/disas/gc/copying/ref-test-concrete-func-type.wat
@@ -13,7 +13,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i32, i32) -> i32 tail
-;;     fn0 = colocated u805306368:30 sig0
+;;     fn0 = colocated u805306368:29 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):

--- a/tests/disas/gc/copying/ref-test-concrete-type.wat
+++ b/tests/disas/gc/copying/ref-test-concrete-type.wat
@@ -16,7 +16,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32) -> i32 tail
-;;     fn0 = colocated u805306368:30 sig0
+;;     fn0 = colocated u805306368:29 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/copying/struct-new-default.wat
+++ b/tests/disas/gc/copying/struct-new-default.wat
@@ -18,7 +18,7 @@
 ;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
-;;     fn0 = colocated u805306368:25 sig0
+;;     fn0 = colocated u805306368:24 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):

--- a/tests/disas/gc/copying/struct-new.wat
+++ b/tests/disas/gc/copying/struct-new.wat
@@ -19,7 +19,7 @@
 ;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
-;;     fn0 = colocated u805306368:25 sig0
+;;     fn0 = colocated u805306368:24 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: f32, v3: i32, v4: i32):

--- a/tests/disas/gc/drc/array-new-fixed-of-gc-refs.wat
+++ b/tests/disas/gc/drc/array-new-fixed-of-gc-refs.wat
@@ -21,7 +21,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
-;;     fn0 = colocated u805306368:25 sig0
+;;     fn0 = colocated u805306368:24 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):

--- a/tests/disas/gc/drc/array-new-fixed.wat
+++ b/tests/disas/gc/drc/array-new-fixed.wat
@@ -17,7 +17,7 @@
 ;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
-;;     fn0 = colocated u805306368:25 sig0
+;;     fn0 = colocated u805306368:24 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64):

--- a/tests/disas/gc/drc/array-new.wat
+++ b/tests/disas/gc/drc/array-new.wat
@@ -17,7 +17,7 @@
 ;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
-;;     fn0 = colocated u805306368:25 sig0
+;;     fn0 = colocated u805306368:24 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):

--- a/tests/disas/gc/drc/br-on-cast-fail.wat
+++ b/tests/disas/gc/drc/br-on-cast-fail.wat
@@ -27,7 +27,7 @@
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64) tail
-;;     fn0 = colocated u805306368:30 sig0
+;;     fn0 = colocated u805306368:29 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/drc/br-on-cast.wat
+++ b/tests/disas/gc/drc/br-on-cast.wat
@@ -27,7 +27,7 @@
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64) tail
-;;     fn0 = colocated u805306368:30 sig0
+;;     fn0 = colocated u805306368:29 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/drc/call-indirect-and-subtyping.wat
+++ b/tests/disas/gc/drc/call-indirect-and-subtyping.wat
@@ -25,8 +25,8 @@
 ;;     sig0 = (i64 vmctx, i64) tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
 ;;     sig2 = (i64 vmctx, i32, i32) -> i32 tail
-;;     fn0 = colocated u805306368:7 sig1
-;;     fn1 = colocated u805306368:30 sig2
+;;     fn0 = colocated u805306368:6 sig1
+;;     fn1 = colocated u805306368:29 sig2
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/drc/externref-globals.wat
+++ b/tests/disas/gc/drc/externref-globals.wat
@@ -78,7 +78,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32) tail
-;;     fn0 = colocated u805306368:23 sig0
+;;     fn0 = colocated u805306368:22 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/drc/funcref-in-gc-heap-get.wat
+++ b/tests/disas/gc/drc/funcref-in-gc-heap-get.wat
@@ -18,7 +18,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32) -> i64 tail
-;;     fn0 = colocated u805306368:27 sig0
+;;     fn0 = colocated u805306368:26 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/drc/funcref-in-gc-heap-new.wat
+++ b/tests/disas/gc/drc/funcref-in-gc-heap-new.wat
@@ -19,8 +19,8 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64) -> i64 tail
-;;     fn0 = colocated u805306368:25 sig0
-;;     fn1 = colocated u805306368:26 sig1
+;;     fn0 = colocated u805306368:24 sig0
+;;     fn1 = colocated u805306368:25 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):

--- a/tests/disas/gc/drc/funcref-in-gc-heap-set.wat
+++ b/tests/disas/gc/drc/funcref-in-gc-heap-set.wat
@@ -18,7 +18,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64) -> i64 tail
-;;     fn0 = colocated u805306368:26 sig0
+;;     fn0 = colocated u805306368:25 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i64):

--- a/tests/disas/gc/drc/ref-cast.wat
+++ b/tests/disas/gc/drc/ref-cast.wat
@@ -18,7 +18,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32) -> i32 tail
-;;     fn0 = colocated u805306368:30 sig0
+;;     fn0 = colocated u805306368:29 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/drc/ref-test-concrete-func-type.wat
+++ b/tests/disas/gc/drc/ref-test-concrete-func-type.wat
@@ -14,7 +14,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i32, i32) -> i32 tail
-;;     fn0 = colocated u805306368:30 sig0
+;;     fn0 = colocated u805306368:29 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):

--- a/tests/disas/gc/drc/ref-test-concrete-type.wat
+++ b/tests/disas/gc/drc/ref-test-concrete-type.wat
@@ -17,7 +17,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32) -> i32 tail
-;;     fn0 = colocated u805306368:30 sig0
+;;     fn0 = colocated u805306368:29 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/drc/struct-new-default.wat
+++ b/tests/disas/gc/drc/struct-new-default.wat
@@ -20,7 +20,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
-;;     fn0 = colocated u805306368:25 sig0
+;;     fn0 = colocated u805306368:24 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):

--- a/tests/disas/gc/drc/struct-new.wat
+++ b/tests/disas/gc/drc/struct-new.wat
@@ -21,7 +21,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
-;;     fn0 = colocated u805306368:25 sig0
+;;     fn0 = colocated u805306368:24 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: f32, v3: i32, v4: i32):

--- a/tests/disas/gc/drc/struct-set.wat
+++ b/tests/disas/gc/drc/struct-set.wat
@@ -78,7 +78,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32) tail
-;;     fn0 = colocated u805306368:23 sig0
+;;     fn0 = colocated u805306368:22 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):

--- a/tests/disas/gc/null/array-new-fixed-of-gc-refs.wat
+++ b/tests/disas/gc/null/array-new-fixed-of-gc-refs.wat
@@ -21,7 +21,7 @@
 ;;     gv5 = load.i64 notrap aligned gv4+40
 ;;     gv6 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     sig0 = (i64 vmctx, i64) -> i8 tail
-;;     fn0 = colocated u805306368:24 sig0
+;;     fn0 = colocated u805306368:23 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):

--- a/tests/disas/gc/null/array-new-fixed.wat
+++ b/tests/disas/gc/null/array-new-fixed.wat
@@ -18,7 +18,7 @@
 ;;     gv5 = load.i64 notrap aligned gv4+40
 ;;     gv6 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     sig0 = (i64 vmctx, i64) -> i8 tail
-;;     fn0 = colocated u805306368:24 sig0
+;;     fn0 = colocated u805306368:23 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64):

--- a/tests/disas/gc/null/array-new.wat
+++ b/tests/disas/gc/null/array-new.wat
@@ -18,7 +18,7 @@
 ;;     gv5 = load.i64 notrap aligned gv4+40
 ;;     gv6 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     sig0 = (i64 vmctx, i64) -> i8 tail
-;;     fn0 = colocated u805306368:24 sig0
+;;     fn0 = colocated u805306368:23 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):

--- a/tests/disas/gc/null/br-on-cast-fail.wat
+++ b/tests/disas/gc/null/br-on-cast-fail.wat
@@ -27,7 +27,7 @@
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64) tail
-;;     fn0 = colocated u805306368:30 sig0
+;;     fn0 = colocated u805306368:29 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/null/br-on-cast.wat
+++ b/tests/disas/gc/null/br-on-cast.wat
@@ -27,7 +27,7 @@
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64) tail
-;;     fn0 = colocated u805306368:30 sig0
+;;     fn0 = colocated u805306368:29 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/null/call-indirect-and-subtyping.wat
+++ b/tests/disas/gc/null/call-indirect-and-subtyping.wat
@@ -25,8 +25,8 @@
 ;;     sig0 = (i64 vmctx, i64) tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
 ;;     sig2 = (i64 vmctx, i32, i32) -> i32 tail
-;;     fn0 = colocated u805306368:7 sig1
-;;     fn1 = colocated u805306368:30 sig2
+;;     fn0 = colocated u805306368:6 sig1
+;;     fn1 = colocated u805306368:29 sig2
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/null/funcref-in-gc-heap-get.wat
+++ b/tests/disas/gc/null/funcref-in-gc-heap-get.wat
@@ -18,7 +18,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32) -> i64 tail
-;;     fn0 = colocated u805306368:27 sig0
+;;     fn0 = colocated u805306368:26 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/null/funcref-in-gc-heap-new.wat
+++ b/tests/disas/gc/null/funcref-in-gc-heap-new.wat
@@ -19,8 +19,8 @@
 ;;     gv6 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     sig0 = (i64 vmctx, i64) -> i8 tail
 ;;     sig1 = (i64 vmctx, i64) -> i64 tail
-;;     fn0 = colocated u805306368:24 sig0
-;;     fn1 = colocated u805306368:26 sig1
+;;     fn0 = colocated u805306368:23 sig0
+;;     fn1 = colocated u805306368:25 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):

--- a/tests/disas/gc/null/funcref-in-gc-heap-set.wat
+++ b/tests/disas/gc/null/funcref-in-gc-heap-set.wat
@@ -18,7 +18,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64) -> i64 tail
-;;     fn0 = colocated u805306368:26 sig0
+;;     fn0 = colocated u805306368:25 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i64):

--- a/tests/disas/gc/null/ref-cast.wat
+++ b/tests/disas/gc/null/ref-cast.wat
@@ -18,7 +18,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32) -> i32 tail
-;;     fn0 = colocated u805306368:30 sig0
+;;     fn0 = colocated u805306368:29 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/null/ref-test-concrete-func-type.wat
+++ b/tests/disas/gc/null/ref-test-concrete-func-type.wat
@@ -14,7 +14,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i32, i32) -> i32 tail
-;;     fn0 = colocated u805306368:30 sig0
+;;     fn0 = colocated u805306368:29 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):

--- a/tests/disas/gc/null/ref-test-concrete-type.wat
+++ b/tests/disas/gc/null/ref-test-concrete-type.wat
@@ -17,7 +17,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32) -> i32 tail
-;;     fn0 = colocated u805306368:30 sig0
+;;     fn0 = colocated u805306368:29 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/null/struct-new-default.wat
+++ b/tests/disas/gc/null/struct-new-default.wat
@@ -20,7 +20,7 @@
 ;;     gv5 = load.i64 notrap aligned gv4+40
 ;;     gv6 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     sig0 = (i64 vmctx, i64) -> i8 tail
-;;     fn0 = colocated u805306368:24 sig0
+;;     fn0 = colocated u805306368:23 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):

--- a/tests/disas/gc/null/struct-new.wat
+++ b/tests/disas/gc/null/struct-new.wat
@@ -21,7 +21,7 @@
 ;;     gv5 = load.i64 notrap aligned gv4+40
 ;;     gv6 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     sig0 = (i64 vmctx, i64) -> i8 tail
-;;     fn0 = colocated u805306368:24 sig0
+;;     fn0 = colocated u805306368:23 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: f32, v3: i32, v4: i32):

--- a/tests/disas/gc/struct-new-default.wat
+++ b/tests/disas/gc/struct-new-default.wat
@@ -21,7 +21,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
-;;     fn0 = colocated u805306368:25 sig0
+;;     fn0 = colocated u805306368:24 sig0
 ;;     const0 = 0x00000000000000000000000000000000
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/gc/struct-new.wat
+++ b/tests/disas/gc/struct-new.wat
@@ -21,7 +21,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
-;;     fn0 = colocated u805306368:25 sig0
+;;     fn0 = colocated u805306368:24 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: f32, v3: i32, v4: i32):

--- a/tests/disas/icall-loop.wat
+++ b/tests/disas/icall-loop.wat
@@ -30,7 +30,7 @@
 ;;     gv4 = load.i64 notrap aligned readonly can_move gv3+48
 ;;     sig0 = (i64 vmctx, i64) -> i32 tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
-;;     fn0 = colocated u805306368:7 sig1
+;;     fn0 = colocated u805306368:6 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -78,7 +78,7 @@
 ;;     gv4 = load.i64 notrap aligned readonly can_move gv3+48
 ;;     sig0 = (i64 vmctx, i64) -> i32 tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
-;;     fn0 = colocated u805306368:7 sig1
+;;     fn0 = colocated u805306368:6 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):

--- a/tests/disas/icall-simd.wat
+++ b/tests/disas/icall-simd.wat
@@ -16,7 +16,7 @@
 ;;     gv4 = load.i64 notrap aligned readonly can_move gv3+48
 ;;     sig0 = (i64 vmctx, i64, i8x16) -> i8x16 tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
-;;     fn0 = colocated u805306368:7 sig1
+;;     fn0 = colocated u805306368:6 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i8x16):

--- a/tests/disas/icall.wat
+++ b/tests/disas/icall.wat
@@ -16,7 +16,7 @@
 ;;     gv4 = load.i64 notrap aligned readonly can_move gv3+48
 ;;     sig0 = (i64 vmctx, i64, f32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
-;;     fn0 = colocated u805306368:7 sig1
+;;     fn0 = colocated u805306368:6 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: f32):

--- a/tests/disas/indirect-call-no-caching.wat
+++ b/tests/disas/indirect-call-no-caching.wat
@@ -70,7 +70,7 @@
 ;;     gv4 = load.i64 notrap aligned readonly can_move gv3+48
 ;;     sig0 = (i64 vmctx, i64) -> i32 tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
-;;     fn0 = colocated u805306368:7 sig1
+;;     fn0 = colocated u805306368:6 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/memory-copy-epochs.wat
+++ b/tests/disas/memory-copy-epochs.wat
@@ -18,8 +18,8 @@
 ;;     gv6 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     sig0 = (i64 vmctx) -> i64 tail
 ;;     sig1 = (i64 vmctx, i64, i64, i64) tail
-;;     fn0 = colocated u805306368:14 sig0
-;;     fn1 = colocated u805306368:4 sig1
+;;     fn0 = colocated u805306368:13 sig0
+;;     fn1 = colocated u805306368:3 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
@@ -34,63 +34,63 @@
 ;; @001e                               v12 = call fn0(v0)
 ;; @001e                               jump block2(v12)
 ;;
-;;                                 block2(v68: i64):
+;;                                 block2(v70: i64):
 ;; @0025                               v17 = load.i64 notrap aligned v0+64
 ;; @0025                               v18 = uextend.i64 v2
 ;; @0025                               v19 = uextend.i64 v4
 ;; @0025                               v20 = iadd v18, v19
-;; @0025                               v21 = icmp ule v20, v17
-;; @0025                               trapz v21, heap_oob
-;; @0025                               v27 = uextend.i64 v3
-;; @0025                               v29 = iadd v27, v19
-;; @0025                               v30 = icmp ule v29, v17
-;; @0025                               trapz v30, heap_oob
-;; @0025                               v36 = iconst.i64 0x0800_0000
-;; @0025                               v37 = icmp ugt v19, v36  ; v36 = 0x0800_0000
-;; @0025                               v23 = load.i64 notrap aligned readonly can_move v0+56
-;; @0025                               v24 = iadd v23, v18
-;; @0025                               v33 = iadd v23, v27
-;; @0025                               brif v37, block4(v24, v33, v19, v68), block5(v24, v33, v19, v68)
+;; @0025                               v21 = icmp ugt v20, v17
+;; @0025                               trapnz v21, heap_oob
+;; @0025                               v28 = uextend.i64 v3
+;; @0025                               v30 = iadd v28, v19
+;; @0025                               v31 = icmp ugt v30, v17
+;; @0025                               trapnz v31, heap_oob
+;; @0025                               v38 = iconst.i64 0x0800_0000
+;; @0025                               v39 = icmp ugt v19, v38  ; v38 = 0x0800_0000
+;; @0025                               v22 = load.i64 notrap aligned readonly can_move v0+56
+;; @0025                               v25 = iadd v22, v18
+;; @0025                               v35 = iadd v22, v28
+;; @0025                               brif v39, block4(v25, v35, v19, v70), block5(v25, v35, v19, v70)
 ;;
-;;                                 block4(v38: i64, v39: i64, v40: i64, v43: i64):
-;; @0025                               v42 = load.i64 notrap aligned v6
-;; @0025                               v44 = icmp uge v42, v43
-;; @0025                               brif v44, block7, block6(v43)
+;;                                 block4(v40: i64, v41: i64, v42: i64, v45: i64):
+;; @0025                               v44 = load.i64 notrap aligned v6
+;; @0025                               v46 = icmp uge v44, v45
+;; @0025                               brif v46, block7, block6(v45)
 ;;
-;;                                 block5(v54: i64, v55: i64, v56: i64, v59: i64):
-;; @0025                               v58 = load.i64 notrap aligned v6
-;; @0025                               v60 = icmp uge v58, v59
-;; @0025                               brif v60, block10, block9
+;;                                 block5(v56: i64, v57: i64, v58: i64, v61: i64):
+;; @0025                               v60 = load.i64 notrap aligned v6
+;; @0025                               v62 = icmp uge v60, v61
+;; @0025                               brif v62, block10, block9
 ;;
 ;;                                 block7 cold:
-;; @0025                               v46 = load.i64 notrap aligned v8+8
-;; @0025                               v47 = icmp.i64 uge v42, v46
-;; @0025                               brif v47, block8, block6(v46)
+;; @0025                               v48 = load.i64 notrap aligned v8+8
+;; @0025                               v49 = icmp.i64 uge v44, v48
+;; @0025                               brif v49, block8, block6(v48)
 ;;
 ;;                                 block8 cold:
-;; @0025                               v49 = call fn0(v0)
-;; @0025                               jump block6(v49)
+;; @0025                               v51 = call fn0(v0)
+;; @0025                               jump block6(v51)
 ;;
-;;                                 block6(v69: i64):
-;;                                     v75 = iconst.i64 0x0800_0000
-;; @0025                               call fn1(v0, v38, v39, v75)  ; v75 = 0x0800_0000
-;;                                     v76 = isub.i64 v40, v75  ; v75 = 0x0800_0000
-;;                                     v77 = icmp ugt v76, v75  ; v75 = 0x0800_0000
-;;                                     v78 = iadd.i64 v38, v75  ; v75 = 0x0800_0000
-;;                                     v79 = iadd.i64 v39, v75  ; v75 = 0x0800_0000
-;; @0025                               brif v77, block4(v78, v79, v76, v69), block5(v78, v79, v76, v69)
+;;                                 block6(v71: i64):
+;;                                     v82 = iconst.i64 0x0800_0000
+;; @0025                               call fn1(v0, v40, v41, v82)  ; v82 = 0x0800_0000
+;;                                     v83 = isub.i64 v42, v82  ; v82 = 0x0800_0000
+;;                                     v84 = icmp ugt v83, v82  ; v82 = 0x0800_0000
+;;                                     v85 = iadd.i64 v40, v82  ; v82 = 0x0800_0000
+;;                                     v86 = iadd.i64 v41, v82  ; v82 = 0x0800_0000
+;; @0025                               brif v84, block4(v85, v86, v83, v71), block5(v85, v86, v83, v71)
 ;;
 ;;                                 block10 cold:
-;; @0025                               v62 = load.i64 notrap aligned v8+8
-;; @0025                               v63 = icmp.i64 uge v58, v62
-;; @0025                               brif v63, block11, block9
+;; @0025                               v64 = load.i64 notrap aligned v8+8
+;; @0025                               v65 = icmp.i64 uge v60, v64
+;; @0025                               brif v65, block11, block9
 ;;
 ;;                                 block11 cold:
-;; @0025                               v65 = call fn0(v0)
+;; @0025                               v67 = call fn0(v0)
 ;; @0025                               jump block9
 ;;
 ;;                                 block9:
-;; @0025                               call fn1(v0, v54, v55, v56)
+;; @0025                               call fn1(v0, v56, v57, v58)
 ;; @0029                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/memory-copy-fuel.wat
+++ b/tests/disas/memory-copy-fuel.wat
@@ -18,85 +18,85 @@
 ;;     gv6 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     sig0 = (i64 vmctx) -> i8 tail
 ;;     sig1 = (i64 vmctx, i64, i64, i64) tail
-;;     fn0 = colocated u805306368:13 sig0
-;;     fn1 = colocated u805306368:4 sig1
+;;     fn0 = colocated u805306368:12 sig0
+;;     fn1 = colocated u805306368:3 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @001e                               v5 = load.i64 notrap aligned readonly can_move v0+8
 ;; @001e                               v6 = load.i64 notrap aligned v5
-;;                                     v83 = iconst.i64 1
-;; @001e                               v7 = iadd v6, v83  ; v83 = 1
+;;                                     v87 = iconst.i64 1
+;; @001e                               v7 = iadd v6, v87  ; v87 = 1
 ;; @001e                               v8 = iconst.i64 0
 ;; @001e                               v9 = icmp sge v7, v8  ; v8 = 0
 ;; @001e                               brif v9, block2, block3(v7)
 ;;
 ;;                                 block2:
-;;                                     v85 = iadd.i64 v6, v83  ; v83 = 1
-;; @001e                               store notrap aligned v85, v5
+;;                                     v91 = iadd.i64 v6, v87  ; v87 = 1
+;; @001e                               store notrap aligned v91, v5
 ;; @001e                               v12 = call fn0(v0)
 ;; @001e                               v14 = load.i64 notrap aligned v5
 ;; @001e                               jump block3(v14)
 ;;
-;;                                 block3(v38: i64):
+;;                                 block3(v40: i64):
 ;; @0025                               v19 = load.i64 notrap aligned v0+64
 ;; @0025                               v20 = uextend.i64 v2
 ;; @0025                               v21 = uextend.i64 v4
 ;; @0025                               v22 = iadd v20, v21
-;; @0025                               v23 = icmp ule v22, v19
-;; @0025                               trapz v23, heap_oob
-;; @0025                               v29 = uextend.i64 v3
-;; @0025                               v31 = iadd v29, v21
-;; @0025                               v32 = icmp ule v31, v19
-;; @0025                               trapz v32, heap_oob
-;; @0025                               v40 = iconst.i64 0x0800_0000
-;; @0025                               v41 = icmp ugt v21, v40  ; v40 = 0x0800_0000
-;; @0025                               v25 = load.i64 notrap aligned readonly can_move v0+56
-;; @0025                               v26 = iadd v25, v20
-;; @0025                               v35 = iadd v25, v29
-;;                                     v78 = iconst.i64 4
-;; @0025                               v39 = iadd v38, v78  ; v78 = 4
-;; @0025                               brif v41, block4(v26, v35, v21, v39), block5(v26, v35, v21, v39)
+;; @0025                               v23 = icmp ugt v22, v19
+;; @0025                               trapnz v23, heap_oob
+;; @0025                               v30 = uextend.i64 v3
+;; @0025                               v32 = iadd v30, v21
+;; @0025                               v33 = icmp ugt v32, v19
+;; @0025                               trapnz v33, heap_oob
+;; @0025                               v42 = iconst.i64 0x0800_0000
+;; @0025                               v43 = icmp ugt v21, v42  ; v42 = 0x0800_0000
+;; @0025                               v24 = load.i64 notrap aligned readonly can_move v0+56
+;; @0025                               v27 = iadd v24, v20
+;; @0025                               v37 = iadd v24, v30
+;;                                     v80 = iconst.i64 4
+;; @0025                               v41 = iadd v40, v80  ; v80 = 4
+;; @0025                               brif v43, block4(v27, v37, v21, v41), block5(v27, v37, v21, v41)
 ;;
-;;                                 block4(v42: i64, v43: i64, v44: i64, v45: i64):
-;;                                     v86 = iconst.i64 0x0800_0000
-;;                                     v87 = iadd v45, v86  ; v86 = 0x0800_0000
-;;                                     v88 = iconst.i64 0
-;;                                     v89 = icmp sge v87, v88  ; v88 = 0
-;; @0025                               brif v89, block6, block7(v87)
+;;                                 block4(v44: i64, v45: i64, v46: i64, v47: i64):
+;;                                     v92 = iconst.i64 0x0800_0000
+;;                                     v93 = iadd v47, v92  ; v92 = 0x0800_0000
+;;                                     v94 = iconst.i64 0
+;;                                     v95 = icmp sge v93, v94  ; v94 = 0
+;; @0025                               brif v95, block6, block7(v93)
 ;;
-;;                                 block5(v58: i64, v59: i64, v60: i64, v61: i64):
-;; @0025                               v62 = iadd v61, v60
-;;                                     v95 = iconst.i64 0
-;;                                     v96 = icmp sge v62, v95  ; v95 = 0
-;; @0025                               brif v96, block8, block9(v62)
+;;                                 block5(v60: i64, v61: i64, v62: i64, v63: i64):
+;; @0025                               v64 = iadd v63, v62
+;;                                     v101 = iconst.i64 0
+;;                                     v102 = icmp sge v64, v101  ; v101 = 0
+;; @0025                               brif v102, block8, block9(v64)
 ;;
 ;;                                 block6:
-;; @0025                               store.i64 notrap aligned v87, v5
-;; @0025                               v51 = call fn0(v0)
-;; @0025                               v53 = load.i64 notrap aligned v5
-;; @0025                               jump block7(v53)
+;; @0025                               store.i64 notrap aligned v93, v5
+;; @0025                               v53 = call fn0(v0)
+;; @0025                               v55 = load.i64 notrap aligned v5
+;; @0025                               jump block7(v55)
 ;;
-;;                                 block7(v70: i64):
-;;                                     v90 = iconst.i64 0x0800_0000
-;; @0025                               call fn1(v0, v42, v43, v90)  ; v90 = 0x0800_0000
-;;                                     v91 = isub.i64 v44, v90  ; v90 = 0x0800_0000
-;;                                     v92 = icmp ugt v91, v90  ; v90 = 0x0800_0000
-;;                                     v93 = iadd.i64 v42, v90  ; v90 = 0x0800_0000
-;;                                     v94 = iadd.i64 v43, v90  ; v90 = 0x0800_0000
-;; @0025                               brif v92, block4(v93, v94, v91, v70), block5(v93, v94, v91, v70)
+;;                                 block7(v72: i64):
+;;                                     v96 = iconst.i64 0x0800_0000
+;; @0025                               call fn1(v0, v44, v45, v96)  ; v96 = 0x0800_0000
+;;                                     v97 = isub.i64 v46, v96  ; v96 = 0x0800_0000
+;;                                     v98 = icmp ugt v97, v96  ; v96 = 0x0800_0000
+;;                                     v99 = iadd.i64 v44, v96  ; v96 = 0x0800_0000
+;;                                     v100 = iadd.i64 v45, v96  ; v96 = 0x0800_0000
+;; @0025                               brif v98, block4(v99, v100, v97, v72), block5(v99, v100, v97, v72)
 ;;
 ;;                                 block8:
-;; @0025                               store.i64 notrap aligned v62, v5
-;; @0025                               v67 = call fn0(v0)
-;; @0025                               v69 = load.i64 notrap aligned v5
-;; @0025                               jump block9(v69)
+;; @0025                               store.i64 notrap aligned v64, v5
+;; @0025                               v69 = call fn0(v0)
+;; @0025                               v71 = load.i64 notrap aligned v5
+;; @0025                               jump block9(v71)
 ;;
-;;                                 block9(v72: i64):
-;; @0025                               call fn1(v0, v58, v59, v60)
+;;                                 block9(v74: i64):
+;; @0025                               call fn1(v0, v60, v61, v62)
 ;; @0029                               jump block1
 ;;
 ;;                                 block1:
-;; @0029                               store.i64 notrap aligned v72, v5
+;; @0029                               store.i64 notrap aligned v74, v5
 ;; @0029                               return
 ;; }

--- a/tests/disas/memory_copy_host32.wat
+++ b/tests/disas/memory_copy_host32.wat
@@ -54,7 +54,7 @@
 ;;     gv1 = load.i32 notrap aligned gv0+44
 ;;     gv2 = load.i32 notrap aligned can_move gv0+40
 ;;     sig0 = (i32 vmctx, i32, i32, i32) tail
-;;     fn0 = colocated u805306368:4 sig0
+;;     fn0 = colocated u805306368:3 sig0
 ;;
 ;;                                 block0(v0: i32, v1: i32, v2: i32, v3: i32, v4: i32):
 ;; @0042                               v6 = load.i32 notrap aligned v0+44
@@ -62,16 +62,16 @@
 ;; @0042                               v8 = uextend.i64 v4
 ;; @0042                               v9 = iadd v7, v8
 ;; @0042                               v10 = uextend.i64 v6
-;; @0042                               v11 = icmp ule v9, v10
-;; @0042                               trapz v11, heap_oob
+;; @0042                               v11 = icmp ugt v9, v10
+;; @0042                               trapnz v11, heap_oob
 ;; @0042                               v12 = load.i32 notrap aligned can_move v0+40
-;; @0042                               v16 = uextend.i64 v3
-;; @0042                               v18 = iadd v16, v8
-;; @0042                               v20 = icmp ule v18, v10
-;; @0042                               trapz v20, heap_oob
-;; @0042                               v13 = iadd v12, v2
-;; @0042                               v22 = iadd v12, v3
-;; @0042                               call fn0(v0, v13, v22, v4)
+;; @0042                               v17 = uextend.i64 v3
+;; @0042                               v19 = iadd v17, v8
+;; @0042                               v21 = icmp ugt v19, v10
+;; @0042                               trapnz v21, heap_oob
+;; @0042                               v14 = iadd v12, v2
+;; @0042                               v24 = iadd v12, v3
+;; @0042                               call fn0(v0, v14, v24, v4)
 ;; @0046                               jump block1
 ;;
 ;;                                 block1:
@@ -85,7 +85,7 @@
 ;;     gv3 = load.i32 notrap aligned gv0+52
 ;;     gv4 = load.i32 notrap aligned can_move gv0+48
 ;;     sig0 = (i32 vmctx, i32, i32, i32) tail
-;;     fn0 = colocated u805306368:4 sig0
+;;     fn0 = colocated u805306368:3 sig0
 ;;
 ;;                                 block0(v0: i32, v1: i32, v2: i32, v3: i32, v4: i32):
 ;; @004f                               v6 = load.i32 notrap aligned v0+52
@@ -93,19 +93,19 @@
 ;; @004f                               v8 = uextend.i64 v4
 ;; @004f                               v9 = iadd v7, v8
 ;; @004f                               v10 = uextend.i64 v6
-;; @004f                               v11 = icmp ule v9, v10
-;; @004f                               trapz v11, heap_oob
+;; @004f                               v11 = icmp ugt v9, v10
+;; @004f                               trapnz v11, heap_oob
 ;; @004f                               v12 = load.i32 notrap aligned can_move v0+48
-;; @004f                               v15 = load.i32 notrap aligned v0+44
-;; @004f                               v16 = uextend.i64 v3
-;; @004f                               v18 = iadd v16, v8
-;; @004f                               v19 = uextend.i64 v15
-;; @004f                               v20 = icmp ule v18, v19
-;; @004f                               trapz v20, heap_oob
-;; @004f                               v21 = load.i32 notrap aligned can_move v0+40
-;; @004f                               v13 = iadd v12, v2
-;; @004f                               v22 = iadd v21, v3
-;; @004f                               call fn0(v0, v13, v22, v4)
+;; @004f                               v16 = load.i32 notrap aligned v0+44
+;; @004f                               v17 = uextend.i64 v3
+;; @004f                               v19 = iadd v17, v8
+;; @004f                               v20 = uextend.i64 v16
+;; @004f                               v21 = icmp ugt v19, v20
+;; @004f                               trapnz v21, heap_oob
+;; @004f                               v22 = load.i32 notrap aligned can_move v0+40
+;; @004f                               v14 = iadd v12, v2
+;; @004f                               v24 = iadd v22, v3
+;; @004f                               call fn0(v0, v14, v24, v4)
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:
@@ -119,27 +119,27 @@
 ;;     gv3 = load.i32 notrap aligned gv0+60
 ;;     gv4 = load.i32 notrap aligned can_move gv0+56
 ;;     sig0 = (i32 vmctx, i32, i32, i32) tail
-;;     fn0 = colocated u805306368:4 sig0
+;;     fn0 = colocated u805306368:3 sig0
 ;;
 ;;                                 block0(v0: i32, v1: i32, v2: i64, v3: i32, v4: i32):
 ;; @005c                               v7 = load.i32 notrap aligned v0+60
 ;; @005c                               v5 = uextend.i64 v4
 ;; @005c                               v8 = uadd_overflow_trap v2, v5, heap_oob
 ;; @005c                               v9 = uextend.i64 v7
-;; @005c                               v10 = icmp ule v8, v9
-;; @005c                               trapz v10, heap_oob
-;; @005c                               v12 = load.i32 notrap aligned can_move v0+56
-;; @005c                               v15 = load.i32 notrap aligned v0+44
-;; @005c                               v16 = uextend.i64 v3
-;; @005c                               v18 = iadd v16, v5
-;; @005c                               v19 = uextend.i64 v15
-;; @005c                               v20 = icmp ule v18, v19
-;; @005c                               trapz v20, heap_oob
-;; @005c                               v21 = load.i32 notrap aligned can_move v0+40
-;; @005c                               v11 = ireduce.i32 v2
-;; @005c                               v13 = iadd v12, v11
-;; @005c                               v22 = iadd v21, v3
-;; @005c                               call fn0(v0, v13, v22, v4)
+;; @005c                               v10 = icmp ugt v8, v9
+;; @005c                               trapnz v10, heap_oob
+;; @005c                               v11 = load.i32 notrap aligned can_move v0+56
+;; @005c                               v16 = load.i32 notrap aligned v0+44
+;; @005c                               v17 = uextend.i64 v3
+;; @005c                               v19 = iadd v17, v5
+;; @005c                               v20 = uextend.i64 v16
+;; @005c                               v21 = icmp ugt v19, v20
+;; @005c                               trapnz v21, heap_oob
+;; @005c                               v22 = load.i32 notrap aligned can_move v0+40
+;; @005c                               v12 = ireduce.i32 v2
+;; @005c                               v14 = iadd v11, v12
+;; @005c                               v24 = iadd v22, v3
+;; @005c                               call fn0(v0, v14, v24, v4)
 ;; @0060                               jump block1
 ;;
 ;;                                 block1:
@@ -151,24 +151,24 @@
 ;;     gv1 = load.i32 notrap aligned gv0+60
 ;;     gv2 = load.i32 notrap aligned can_move gv0+56
 ;;     sig0 = (i32 vmctx, i32, i32, i32) tail
-;;     fn0 = colocated u805306368:4 sig0
+;;     fn0 = colocated u805306368:3 sig0
 ;;
 ;;                                 block0(v0: i32, v1: i32, v2: i64, v3: i64, v4: i64):
 ;; @0069                               v6 = load.i32 notrap aligned v0+60
 ;; @0069                               v7 = uadd_overflow_trap v2, v4, heap_oob
 ;; @0069                               v8 = uextend.i64 v6
-;; @0069                               v9 = icmp ule v7, v8
-;; @0069                               trapz v9, heap_oob
-;; @0069                               v11 = load.i32 notrap aligned can_move v0+56
-;; @0069                               v15 = uadd_overflow_trap v3, v4, heap_oob
-;; @0069                               v17 = icmp ule v15, v8
-;; @0069                               trapz v17, heap_oob
-;; @0069                               v10 = ireduce.i32 v2
-;; @0069                               v12 = iadd v11, v10
-;; @0069                               v18 = ireduce.i32 v3
-;; @0069                               v20 = iadd v11, v18
-;; @0069                               v21 = ireduce.i32 v4
-;; @0069                               call fn0(v0, v12, v20, v21)
+;; @0069                               v9 = icmp ugt v7, v8
+;; @0069                               trapnz v9, heap_oob
+;; @0069                               v10 = load.i32 notrap aligned can_move v0+56
+;; @0069                               v16 = uadd_overflow_trap v3, v4, heap_oob
+;; @0069                               v18 = icmp ugt v16, v8
+;; @0069                               trapnz v18, heap_oob
+;; @0069                               v11 = ireduce.i32 v2
+;; @0069                               v13 = iadd v10, v11
+;; @0069                               v20 = ireduce.i32 v3
+;; @0069                               v22 = iadd v10, v20
+;; @0069                               v23 = ireduce.i32 v4
+;; @0069                               call fn0(v0, v13, v22, v23)
 ;; @006d                               jump block1
 ;;
 ;;                                 block1:
@@ -182,27 +182,27 @@
 ;;     gv3 = load.i32 notrap aligned gv0+68
 ;;     gv4 = load.i32 notrap aligned can_move gv0+64
 ;;     sig0 = (i32 vmctx, i32, i32, i32) tail
-;;     fn0 = colocated u805306368:4 sig0
+;;     fn0 = colocated u805306368:3 sig0
 ;;
 ;;                                 block0(v0: i32, v1: i32, v2: i64, v3: i64, v4: i64):
 ;; @0076                               v6 = load.i32 notrap aligned v0+68
 ;; @0076                               v7 = uadd_overflow_trap v2, v4, heap_oob
 ;; @0076                               v8 = uextend.i64 v6
-;; @0076                               v9 = icmp ule v7, v8
-;; @0076                               trapz v9, heap_oob
-;; @0076                               v11 = load.i32 notrap aligned can_move v0+64
-;; @0076                               v14 = load.i32 notrap aligned v0+60
-;; @0076                               v15 = uadd_overflow_trap v3, v4, heap_oob
-;; @0076                               v16 = uextend.i64 v14
-;; @0076                               v17 = icmp ule v15, v16
-;; @0076                               trapz v17, heap_oob
+;; @0076                               v9 = icmp ugt v7, v8
+;; @0076                               trapnz v9, heap_oob
+;; @0076                               v10 = load.i32 notrap aligned can_move v0+64
+;; @0076                               v15 = load.i32 notrap aligned v0+60
+;; @0076                               v16 = uadd_overflow_trap v3, v4, heap_oob
+;; @0076                               v17 = uextend.i64 v15
+;; @0076                               v18 = icmp ugt v16, v17
+;; @0076                               trapnz v18, heap_oob
 ;; @0076                               v19 = load.i32 notrap aligned can_move v0+56
-;; @0076                               v10 = ireduce.i32 v2
-;; @0076                               v12 = iadd v11, v10
-;; @0076                               v18 = ireduce.i32 v3
-;; @0076                               v20 = iadd v19, v18
-;; @0076                               v21 = ireduce.i32 v4
-;; @0076                               call fn0(v0, v12, v20, v21)
+;; @0076                               v11 = ireduce.i32 v2
+;; @0076                               v13 = iadd v10, v11
+;; @0076                               v20 = ireduce.i32 v3
+;; @0076                               v22 = iadd v19, v20
+;; @0076                               v23 = ireduce.i32 v4
+;; @0076                               call fn0(v0, v13, v22, v23)
 ;; @007a                               jump block1
 ;;
 ;;                                 block1:
@@ -216,7 +216,7 @@
 ;;     gv3 = load.i32 notrap aligned gv0+44
 ;;     gv4 = load.i32 notrap aligned can_move gv0+40
 ;;     sig0 = (i32 vmctx, i32, i32, i32) tail
-;;     fn0 = colocated u805306368:4 sig0
+;;     fn0 = colocated u805306368:3 sig0
 ;;
 ;;                                 block0(v0: i32, v1: i32, v2: i32, v3: i64, v4: i32):
 ;; @0083                               v7 = load.i32 notrap aligned v0+44
@@ -224,19 +224,19 @@
 ;; @0083                               v5 = uextend.i64 v4
 ;; @0083                               v10 = iadd v8, v5
 ;; @0083                               v11 = uextend.i64 v7
-;; @0083                               v12 = icmp ule v10, v11
-;; @0083                               trapz v12, heap_oob
+;; @0083                               v12 = icmp ugt v10, v11
+;; @0083                               trapnz v12, heap_oob
 ;; @0083                               v13 = load.i32 notrap aligned can_move v0+40
-;; @0083                               v16 = load.i32 notrap aligned v0+60
-;; @0083                               v17 = uadd_overflow_trap v3, v5, heap_oob
-;; @0083                               v18 = uextend.i64 v16
-;; @0083                               v19 = icmp ule v17, v18
-;; @0083                               trapz v19, heap_oob
+;; @0083                               v17 = load.i32 notrap aligned v0+60
+;; @0083                               v18 = uadd_overflow_trap v3, v5, heap_oob
+;; @0083                               v19 = uextend.i64 v17
+;; @0083                               v20 = icmp ugt v18, v19
+;; @0083                               trapnz v20, heap_oob
 ;; @0083                               v21 = load.i32 notrap aligned can_move v0+56
-;; @0083                               v14 = iadd v13, v2
-;; @0083                               v20 = ireduce.i32 v3
-;; @0083                               v22 = iadd v21, v20
-;; @0083                               call fn0(v0, v14, v22, v4)
+;; @0083                               v15 = iadd v13, v2
+;; @0083                               v22 = ireduce.i32 v3
+;; @0083                               v24 = iadd v21, v22
+;; @0083                               call fn0(v0, v15, v24, v4)
 ;; @0087                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/memory_copy_host64.wat
+++ b/tests/disas/memory_copy_host64.wat
@@ -57,7 +57,7 @@
 ;;     gv4 = load.i64 notrap aligned gv3+88
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv3+80
 ;;     sig0 = (i64 vmctx, i64, i64, i64) tail
-;;     fn0 = colocated u805306368:4 sig0
+;;     fn0 = colocated u805306368:3 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
@@ -65,16 +65,16 @@
 ;; @0042                               v7 = uextend.i64 v2
 ;; @0042                               v8 = uextend.i64 v4
 ;; @0042                               v9 = iadd v7, v8
-;; @0042                               v10 = icmp ule v9, v6
-;; @0042                               trapz v10, heap_oob
-;; @0042                               v16 = uextend.i64 v3
-;; @0042                               v18 = iadd v16, v8
-;; @0042                               v19 = icmp ule v18, v6
-;; @0042                               trapz v19, heap_oob
-;; @0042                               v12 = load.i64 notrap aligned readonly can_move v0+80
-;; @0042                               v13 = iadd v12, v7
-;; @0042                               v22 = iadd v12, v16
-;; @0042                               call fn0(v0, v13, v22, v8)
+;; @0042                               v10 = icmp ugt v9, v6
+;; @0042                               trapnz v10, heap_oob
+;; @0042                               v17 = uextend.i64 v3
+;; @0042                               v19 = iadd v17, v8
+;; @0042                               v20 = icmp ugt v19, v6
+;; @0042                               trapnz v20, heap_oob
+;; @0042                               v11 = load.i64 notrap aligned readonly can_move v0+80
+;; @0042                               v14 = iadd v11, v7
+;; @0042                               v24 = iadd v11, v17
+;; @0042                               call fn0(v0, v14, v24, v8)
 ;; @0046                               jump block1
 ;;
 ;;                                 block1:
@@ -91,7 +91,7 @@
 ;;     gv6 = load.i64 notrap aligned gv3+104
 ;;     gv7 = load.i64 notrap aligned readonly can_move gv3+96
 ;;     sig0 = (i64 vmctx, i64, i64, i64) tail
-;;     fn0 = colocated u805306368:4 sig0
+;;     fn0 = colocated u805306368:3 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
@@ -99,18 +99,18 @@
 ;; @004f                               v7 = uextend.i64 v2
 ;; @004f                               v8 = uextend.i64 v4
 ;; @004f                               v9 = iadd v7, v8
-;; @004f                               v10 = icmp ule v9, v6
-;; @004f                               trapz v10, heap_oob
-;; @004f                               v15 = load.i64 notrap aligned v0+88
-;; @004f                               v16 = uextend.i64 v3
-;; @004f                               v18 = iadd v16, v8
-;; @004f                               v19 = icmp ule v18, v15
-;; @004f                               trapz v19, heap_oob
-;; @004f                               v12 = load.i64 notrap aligned readonly can_move v0+96
-;; @004f                               v13 = iadd v12, v7
+;; @004f                               v10 = icmp ugt v9, v6
+;; @004f                               trapnz v10, heap_oob
+;; @004f                               v16 = load.i64 notrap aligned v0+88
+;; @004f                               v17 = uextend.i64 v3
+;; @004f                               v19 = iadd v17, v8
+;; @004f                               v20 = icmp ugt v19, v16
+;; @004f                               trapnz v20, heap_oob
+;; @004f                               v11 = load.i64 notrap aligned readonly can_move v0+96
+;; @004f                               v14 = iadd v11, v7
 ;; @004f                               v21 = load.i64 notrap aligned readonly can_move v0+80
-;; @004f                               v22 = iadd v21, v16
-;; @004f                               call fn0(v0, v13, v22, v8)
+;; @004f                               v24 = iadd v21, v17
+;; @004f                               call fn0(v0, v14, v24, v8)
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:
@@ -127,25 +127,25 @@
 ;;     gv6 = load.i64 notrap aligned gv3+120
 ;;     gv7 = load.i64 notrap aligned can_move gv3+112
 ;;     sig0 = (i64 vmctx, i64, i64, i64) tail
-;;     fn0 = colocated u805306368:4 sig0
+;;     fn0 = colocated u805306368:3 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32, v4: i32):
 ;; @005c                               v7 = load.i64 notrap aligned v0+120
 ;; @005c                               v5 = uextend.i64 v4
 ;; @005c                               v8 = uadd_overflow_trap v2, v5, heap_oob
-;; @005c                               v9 = icmp ule v8, v7
-;; @005c                               trapz v9, heap_oob
+;; @005c                               v9 = icmp ugt v8, v7
+;; @005c                               trapnz v9, heap_oob
 ;; @005c                               v10 = load.i64 notrap aligned can_move v0+112
-;; @005c                               v13 = load.i64 notrap aligned v0+88
-;; @005c                               v14 = uextend.i64 v3
-;; @005c                               v16 = iadd v14, v5
-;; @005c                               v17 = icmp ule v16, v13
-;; @005c                               trapz v17, heap_oob
-;; @005c                               v11 = iadd v10, v2
+;; @005c                               v14 = load.i64 notrap aligned v0+88
+;; @005c                               v15 = uextend.i64 v3
+;; @005c                               v17 = iadd v15, v5
+;; @005c                               v18 = icmp ugt v17, v14
+;; @005c                               trapnz v18, heap_oob
+;; @005c                               v12 = iadd v10, v2
 ;; @005c                               v19 = load.i64 notrap aligned readonly can_move v0+80
-;; @005c                               v20 = iadd v19, v14
-;; @005c                               call fn0(v0, v11, v20, v5)
+;; @005c                               v22 = iadd v19, v15
+;; @005c                               call fn0(v0, v12, v22, v5)
 ;; @0060                               jump block1
 ;;
 ;;                                 block1:
@@ -160,21 +160,21 @@
 ;;     gv4 = load.i64 notrap aligned gv3+120
 ;;     gv5 = load.i64 notrap aligned can_move gv3+112
 ;;     sig0 = (i64 vmctx, i64, i64, i64) tail
-;;     fn0 = colocated u805306368:4 sig0
+;;     fn0 = colocated u805306368:3 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64):
 ;; @0069                               v6 = load.i64 notrap aligned v0+120
 ;; @0069                               v7 = uadd_overflow_trap v2, v4, heap_oob
-;; @0069                               v8 = icmp ule v7, v6
-;; @0069                               trapz v8, heap_oob
+;; @0069                               v8 = icmp ugt v7, v6
+;; @0069                               trapnz v8, heap_oob
 ;; @0069                               v9 = load.i64 notrap aligned can_move v0+112
-;; @0069                               v13 = uadd_overflow_trap v3, v4, heap_oob
-;; @0069                               v14 = icmp ule v13, v6
-;; @0069                               trapz v14, heap_oob
-;; @0069                               v10 = iadd v9, v2
-;; @0069                               v16 = iadd v9, v3
-;; @0069                               call fn0(v0, v10, v16, v4)
+;; @0069                               v14 = uadd_overflow_trap v3, v4, heap_oob
+;; @0069                               v15 = icmp ugt v14, v6
+;; @0069                               trapnz v15, heap_oob
+;; @0069                               v11 = iadd v9, v2
+;; @0069                               v18 = iadd v9, v3
+;; @0069                               call fn0(v0, v11, v18, v4)
 ;; @006d                               jump block1
 ;;
 ;;                                 block1:
@@ -191,23 +191,23 @@
 ;;     gv6 = load.i64 notrap aligned gv3+136
 ;;     gv7 = load.i64 notrap aligned can_move gv3+128
 ;;     sig0 = (i64 vmctx, i64, i64, i64) tail
-;;     fn0 = colocated u805306368:4 sig0
+;;     fn0 = colocated u805306368:3 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64):
 ;; @0076                               v6 = load.i64 notrap aligned v0+136
 ;; @0076                               v7 = uadd_overflow_trap v2, v4, heap_oob
-;; @0076                               v8 = icmp ule v7, v6
-;; @0076                               trapz v8, heap_oob
+;; @0076                               v8 = icmp ugt v7, v6
+;; @0076                               trapnz v8, heap_oob
 ;; @0076                               v9 = load.i64 notrap aligned can_move v0+128
-;; @0076                               v12 = load.i64 notrap aligned v0+120
-;; @0076                               v13 = uadd_overflow_trap v3, v4, heap_oob
-;; @0076                               v14 = icmp ule v13, v12
-;; @0076                               trapz v14, heap_oob
-;; @0076                               v15 = load.i64 notrap aligned can_move v0+112
-;; @0076                               v10 = iadd v9, v2
-;; @0076                               v16 = iadd v15, v3
-;; @0076                               call fn0(v0, v10, v16, v4)
+;; @0076                               v13 = load.i64 notrap aligned v0+120
+;; @0076                               v14 = uadd_overflow_trap v3, v4, heap_oob
+;; @0076                               v15 = icmp ugt v14, v13
+;; @0076                               trapnz v15, heap_oob
+;; @0076                               v16 = load.i64 notrap aligned can_move v0+112
+;; @0076                               v11 = iadd v9, v2
+;; @0076                               v18 = iadd v16, v3
+;; @0076                               call fn0(v0, v11, v18, v4)
 ;; @007a                               jump block1
 ;;
 ;;                                 block1:
@@ -224,7 +224,7 @@
 ;;     gv6 = load.i64 notrap aligned gv3+88
 ;;     gv7 = load.i64 notrap aligned readonly can_move gv3+80
 ;;     sig0 = (i64 vmctx, i64, i64, i64) tail
-;;     fn0 = colocated u805306368:4 sig0
+;;     fn0 = colocated u805306368:3 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i64, v4: i32):
@@ -232,17 +232,17 @@
 ;; @0083                               v8 = uextend.i64 v2
 ;; @0083                               v5 = uextend.i64 v4
 ;; @0083                               v10 = iadd v8, v5
-;; @0083                               v11 = icmp ule v10, v7
-;; @0083                               trapz v11, heap_oob
-;; @0083                               v16 = load.i64 notrap aligned v0+120
-;; @0083                               v17 = uadd_overflow_trap v3, v5, heap_oob
-;; @0083                               v18 = icmp ule v17, v16
-;; @0083                               trapz v18, heap_oob
-;; @0083                               v19 = load.i64 notrap aligned can_move v0+112
-;; @0083                               v13 = load.i64 notrap aligned readonly can_move v0+80
-;; @0083                               v14 = iadd v13, v8
-;; @0083                               v20 = iadd v19, v3
-;; @0083                               call fn0(v0, v14, v20, v5)
+;; @0083                               v11 = icmp ugt v10, v7
+;; @0083                               trapnz v11, heap_oob
+;; @0083                               v17 = load.i64 notrap aligned v0+120
+;; @0083                               v18 = uadd_overflow_trap v3, v5, heap_oob
+;; @0083                               v19 = icmp ugt v18, v17
+;; @0083                               trapnz v19, heap_oob
+;; @0083                               v20 = load.i64 notrap aligned can_move v0+112
+;; @0083                               v12 = load.i64 notrap aligned readonly can_move v0+80
+;; @0083                               v15 = iadd v12, v8
+;; @0083                               v22 = iadd v20, v3
+;; @0083                               call fn0(v0, v15, v22, v5)
 ;; @0087                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/memory_fill_host32.wat
+++ b/tests/disas/memory_fill_host32.wat
@@ -51,7 +51,7 @@
 ;;     gv1 = load.i32 notrap aligned gv0+48
 ;;     gv2 = load.i32 notrap aligned can_move gv0+44
 ;;     sig0 = (i32 vmctx, i32, i32, i32) tail
-;;     fn0 = colocated u805306368:5 sig0
+;;     fn0 = colocated u805306368:4 sig0
 ;;
 ;;                                 block0(v0: i32, v1: i32, v2: i32, v3: i32):
 ;; @003c                               v6 = load.i32 notrap aligned v0+48
@@ -59,12 +59,12 @@
 ;; @003c                               v8 = uextend.i64 v3
 ;; @003c                               v9 = iadd v7, v8
 ;; @003c                               v10 = uextend.i64 v6
-;; @003c                               v11 = icmp ule v9, v10
-;; @003c                               trapz v11, heap_oob
+;; @003c                               v11 = icmp ugt v9, v10
+;; @003c                               trapnz v11, heap_oob
 ;; @003c                               v12 = load.i32 notrap aligned can_move v0+44
-;; @003c                               v13 = iadd v12, v2
+;; @003c                               v14 = iadd v12, v2
 ;; @0038                               v4 = iconst.i32 0
-;; @003c                               call fn0(v0, v13, v4, v3)  ; v4 = 0
+;; @003c                               call fn0(v0, v14, v4, v3)  ; v4 = 0
 ;; @003f                               jump block1
 ;;
 ;;                                 block1:
@@ -76,20 +76,20 @@
 ;;     gv1 = load.i32 notrap aligned gv0+56
 ;;     gv2 = load.i32 notrap aligned can_move gv0+52
 ;;     sig0 = (i32 vmctx, i32, i32, i32) tail
-;;     fn0 = colocated u805306368:5 sig0
+;;     fn0 = colocated u805306368:4 sig0
 ;;
 ;;                                 block0(v0: i32, v1: i32, v2: i64, v3: i64):
 ;; @0048                               v6 = load.i32 notrap aligned v0+56
 ;; @0048                               v7 = uadd_overflow_trap v2, v3, heap_oob
 ;; @0048                               v8 = uextend.i64 v6
-;; @0048                               v9 = icmp ule v7, v8
-;; @0048                               trapz v9, heap_oob
-;; @0048                               v11 = load.i32 notrap aligned can_move v0+52
-;; @0048                               v10 = ireduce.i32 v2
-;; @0048                               v12 = iadd v11, v10
+;; @0048                               v9 = icmp ugt v7, v8
+;; @0048                               trapnz v9, heap_oob
+;; @0048                               v10 = load.i32 notrap aligned can_move v0+52
+;; @0048                               v11 = ireduce.i32 v2
+;; @0048                               v13 = iadd v10, v11
 ;; @0044                               v4 = iconst.i32 0
-;; @0048                               v13 = ireduce.i32 v3
-;; @0048                               call fn0(v0, v12, v4, v13)  ; v4 = 0
+;; @0048                               v14 = ireduce.i32 v3
+;; @0048                               call fn0(v0, v13, v4, v14)  ; v4 = 0
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:
@@ -101,7 +101,7 @@
 ;;     gv1 = load.i32 notrap aligned gv0+64
 ;;     gv2 = load.i32 notrap aligned can_move gv0+60
 ;;     sig0 = (i32 vmctx, i32, i32, i32) tail
-;;     fn0 = colocated u805306368:5 sig0
+;;     fn0 = colocated u805306368:4 sig0
 ;;
 ;;                                 block0(v0: i32, v1: i32, v2: i32, v3: i32):
 ;; @0054                               v6 = load.i32 notrap aligned v0+64
@@ -109,12 +109,12 @@
 ;; @0054                               v8 = uextend.i64 v3
 ;; @0054                               v9 = iadd v7, v8
 ;; @0054                               v10 = uextend.i64 v6
-;; @0054                               v11 = icmp ule v9, v10
-;; @0054                               trapz v11, heap_oob
+;; @0054                               v11 = icmp ugt v9, v10
+;; @0054                               trapnz v11, heap_oob
 ;; @0054                               v12 = load.i32 notrap aligned can_move v0+60
-;; @0054                               v13 = iadd v12, v2
+;; @0054                               v14 = iadd v12, v2
 ;; @0050                               v4 = iconst.i32 0
-;; @0054                               call fn0(v0, v13, v4, v3)  ; v4 = 0
+;; @0054                               call fn0(v0, v14, v4, v3)  ; v4 = 0
 ;; @0057                               jump block1
 ;;
 ;;                                 block1:
@@ -126,20 +126,20 @@
 ;;     gv1 = load.i32 notrap aligned gv0+72
 ;;     gv2 = load.i32 notrap aligned can_move gv0+68
 ;;     sig0 = (i32 vmctx, i32, i32, i32) tail
-;;     fn0 = colocated u805306368:5 sig0
+;;     fn0 = colocated u805306368:4 sig0
 ;;
 ;;                                 block0(v0: i32, v1: i32, v2: i64, v3: i64):
 ;; @0060                               v6 = load.i32 notrap aligned v0+72
 ;; @0060                               v7 = uadd_overflow_trap v2, v3, heap_oob
 ;; @0060                               v8 = uextend.i64 v6
-;; @0060                               v9 = icmp ule v7, v8
-;; @0060                               trapz v9, heap_oob
-;; @0060                               v11 = load.i32 notrap aligned can_move v0+68
-;; @0060                               v10 = ireduce.i32 v2
-;; @0060                               v12 = iadd v11, v10
+;; @0060                               v9 = icmp ugt v7, v8
+;; @0060                               trapnz v9, heap_oob
+;; @0060                               v10 = load.i32 notrap aligned can_move v0+68
+;; @0060                               v11 = ireduce.i32 v2
+;; @0060                               v13 = iadd v10, v11
 ;; @005c                               v4 = iconst.i32 0
-;; @0060                               v13 = ireduce.i32 v3
-;; @0060                               call fn0(v0, v12, v4, v13)  ; v4 = 0
+;; @0060                               v14 = ireduce.i32 v3
+;; @0060                               call fn0(v0, v13, v4, v14)  ; v4 = 0
 ;; @0063                               jump block1
 ;;
 ;;                                 block1:
@@ -151,7 +151,7 @@
 ;;     gv1 = load.i32 notrap aligned gv0+80
 ;;     gv2 = load.i32 notrap aligned readonly can_move gv0+76
 ;;     sig0 = (i32 vmctx, i32, i32, i32) tail
-;;     fn0 = colocated u805306368:5 sig0
+;;     fn0 = colocated u805306368:4 sig0
 ;;
 ;;                                 block0(v0: i32, v1: i32, v2: i32, v3: i32):
 ;; @006c                               v6 = load.i32 notrap aligned v0+80
@@ -159,12 +159,12 @@
 ;; @006c                               v8 = uextend.i64 v3
 ;; @006c                               v9 = iadd v7, v8
 ;; @006c                               v10 = uextend.i64 v6
-;; @006c                               v11 = icmp ule v9, v10
-;; @006c                               trapz v11, heap_oob
+;; @006c                               v11 = icmp ugt v9, v10
+;; @006c                               trapnz v11, heap_oob
 ;; @006c                               v12 = load.i32 notrap aligned readonly can_move v0+76
-;; @006c                               v13 = iadd v12, v2
+;; @006c                               v14 = iadd v12, v2
 ;; @0068                               v4 = iconst.i32 0
-;; @006c                               call fn0(v0, v13, v4, v3)  ; v4 = 0
+;; @006c                               call fn0(v0, v14, v4, v3)  ; v4 = 0
 ;; @006f                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/memory_fill_host64.wat
+++ b/tests/disas/memory_fill_host64.wat
@@ -51,7 +51,7 @@
 ;;     gv4 = load.i64 notrap aligned gv3+96
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv3+88
 ;;     sig0 = (i64 vmctx, i64, i32, i64) tail
-;;     fn0 = colocated u805306368:5 sig0
+;;     fn0 = colocated u805306368:4 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -59,12 +59,12 @@
 ;; @003c                               v7 = uextend.i64 v2
 ;; @003c                               v8 = uextend.i64 v3
 ;; @003c                               v9 = iadd v7, v8
-;; @003c                               v10 = icmp ule v9, v6
-;; @003c                               trapz v10, heap_oob
-;; @003c                               v12 = load.i64 notrap aligned readonly can_move v0+88
-;; @003c                               v13 = iadd v12, v7
+;; @003c                               v10 = icmp ugt v9, v6
+;; @003c                               trapnz v10, heap_oob
+;; @003c                               v11 = load.i64 notrap aligned readonly can_move v0+88
+;; @003c                               v14 = iadd v11, v7
 ;; @0038                               v4 = iconst.i32 0
-;; @003c                               call fn0(v0, v13, v4, v8)  ; v4 = 0
+;; @003c                               call fn0(v0, v14, v4, v8)  ; v4 = 0
 ;; @003f                               jump block1
 ;;
 ;;                                 block1:
@@ -79,18 +79,18 @@
 ;;     gv4 = load.i64 notrap aligned gv3+112
 ;;     gv5 = load.i64 notrap aligned can_move gv3+104
 ;;     sig0 = (i64 vmctx, i64, i32, i64) tail
-;;     fn0 = colocated u805306368:5 sig0
+;;     fn0 = colocated u805306368:4 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i64):
 ;; @0048                               v6 = load.i64 notrap aligned v0+112
 ;; @0048                               v7 = uadd_overflow_trap v2, v3, heap_oob
-;; @0048                               v8 = icmp ule v7, v6
-;; @0048                               trapz v8, heap_oob
+;; @0048                               v8 = icmp ugt v7, v6
+;; @0048                               trapnz v8, heap_oob
 ;; @0048                               v9 = load.i64 notrap aligned can_move v0+104
-;; @0048                               v10 = iadd v9, v2
+;; @0048                               v11 = iadd v9, v2
 ;; @0044                               v4 = iconst.i32 0
-;; @0048                               call fn0(v0, v10, v4, v3)  ; v4 = 0
+;; @0048                               call fn0(v0, v11, v4, v3)  ; v4 = 0
 ;; @004b                               jump block1
 ;;
 ;;                                 block1:
@@ -105,7 +105,7 @@
 ;;     gv4 = load.i64 notrap aligned gv3+128
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv3+120
 ;;     sig0 = (i64 vmctx, i64, i32, i64) tail
-;;     fn0 = colocated u805306368:5 sig0
+;;     fn0 = colocated u805306368:4 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -113,12 +113,12 @@
 ;; @0054                               v7 = uextend.i64 v2
 ;; @0054                               v8 = uextend.i64 v3
 ;; @0054                               v9 = iadd v7, v8
-;; @0054                               v10 = icmp ule v9, v6
-;; @0054                               trapz v10, heap_oob
-;; @0054                               v12 = load.i64 notrap aligned readonly can_move v0+120
-;; @0054                               v13 = iadd v12, v7
+;; @0054                               v10 = icmp ugt v9, v6
+;; @0054                               trapnz v10, heap_oob
+;; @0054                               v11 = load.i64 notrap aligned readonly can_move v0+120
+;; @0054                               v14 = iadd v11, v7
 ;; @0050                               v4 = iconst.i32 0
-;; @0054                               call fn0(v0, v13, v4, v8)  ; v4 = 0
+;; @0054                               call fn0(v0, v14, v4, v8)  ; v4 = 0
 ;; @0057                               jump block1
 ;;
 ;;                                 block1:
@@ -133,18 +133,18 @@
 ;;     gv4 = load.i64 notrap aligned gv3+144
 ;;     gv5 = load.i64 notrap aligned can_move gv3+136
 ;;     sig0 = (i64 vmctx, i64, i32, i64) tail
-;;     fn0 = colocated u805306368:5 sig0
+;;     fn0 = colocated u805306368:4 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i64):
 ;; @0060                               v6 = load.i64 notrap aligned v0+144
 ;; @0060                               v7 = uadd_overflow_trap v2, v3, heap_oob
-;; @0060                               v8 = icmp ule v7, v6
-;; @0060                               trapz v8, heap_oob
+;; @0060                               v8 = icmp ugt v7, v6
+;; @0060                               trapnz v8, heap_oob
 ;; @0060                               v9 = load.i64 notrap aligned can_move v0+136
-;; @0060                               v10 = iadd v9, v2
+;; @0060                               v11 = iadd v9, v2
 ;; @005c                               v4 = iconst.i32 0
-;; @0060                               call fn0(v0, v10, v4, v3)  ; v4 = 0
+;; @0060                               call fn0(v0, v11, v4, v3)  ; v4 = 0
 ;; @0063                               jump block1
 ;;
 ;;                                 block1:
@@ -159,7 +159,7 @@
 ;;     gv4 = load.i64 notrap aligned gv3+160
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv3+152
 ;;     sig0 = (i64 vmctx, i64, i32, i64) tail
-;;     fn0 = colocated u805306368:5 sig0
+;;     fn0 = colocated u805306368:4 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -167,12 +167,12 @@
 ;; @006c                               v7 = uextend.i64 v2
 ;; @006c                               v8 = uextend.i64 v3
 ;; @006c                               v9 = iadd v7, v8
-;; @006c                               v10 = icmp ule v9, v6
-;; @006c                               trapz v10, heap_oob
-;; @006c                               v12 = load.i64 notrap aligned readonly can_move v0+152
-;; @006c                               v13 = iadd v12, v7
+;; @006c                               v10 = icmp ugt v9, v6
+;; @006c                               trapnz v10, heap_oob
+;; @006c                               v11 = load.i64 notrap aligned readonly can_move v0+152
+;; @006c                               v14 = iadd v11, v7
 ;; @0068                               v4 = iconst.i32 0
-;; @006c                               call fn0(v0, v13, v4, v8)  ; v4 = 0
+;; @006c                               call fn0(v0, v14, v4, v8)  ; v4 = 0
 ;; @006f                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/metadata-for-internal-asserts.wat
+++ b/tests/disas/metadata-for-internal-asserts.wat
@@ -39,7 +39,7 @@
 ;;       popq    %rbp
 ;;       retq
 ;;   5e: movq    0x10(%rbx), %rax
-;;   62: movq    0x170(%rax), %rax
+;;   62: movq    0x168(%rax), %rax
 ;;   69: movq    %rbx, %rdi
 ;;   6c: callq   *%rax
 ;;   6e: ud2

--- a/tests/disas/passive-data.wat
+++ b/tests/disas/passive-data.wat
@@ -21,7 +21,7 @@
 ;;     gv4 = load.i64 notrap aligned gv3+64
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     sig0 = (i64 vmctx, i64, i64, i64) tail
-;;     fn0 = colocated u805306368:4 sig0
+;;     fn0 = colocated u805306368:3 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
@@ -29,22 +29,26 @@
 ;; @003d                               v7 = uextend.i64 v2
 ;; @003d                               v8 = uextend.i64 v4
 ;; @003d                               v9 = iadd v7, v8
-;; @003d                               v10 = icmp ule v9, v6
-;; @003d                               trapz v10, heap_oob
-;; @003d                               v11 = uextend.i64 v2
-;; @003d                               v12 = load.i64 notrap aligned readonly can_move v0+56
-;; @003d                               v13 = iadd v12, v11
-;; @003d                               v15 = uload32 notrap aligned v0+152
-;; @003d                               v16 = uextend.i64 v3
-;; @003d                               v17 = uextend.i64 v4
-;; @003d                               v18 = iadd v16, v17
-;; @003d                               v19 = icmp ugt v18, v15
-;; @003d                               trapnz v19, heap_oob
-;; @003d                               v20 = load.i64 notrap aligned v0+144
-;; @003d                               v21 = uextend.i64 v3
-;; @003d                               v22 = iadd v20, v21
-;; @003d                               v24 = uextend.i64 v4
-;; @003d                               call fn0(v0, v13, v22, v24)
+;; @003d                               v10 = icmp ugt v9, v6
+;; @003d                               trapnz v10, heap_oob
+;; @003d                               v11 = load.i64 notrap aligned readonly can_move v0+56
+;; @003d                               v12 = uextend.i64 v2
+;;                                     v29 = iconst.i64 1
+;; @003d                               v13 = imul v12, v29  ; v29 = 1
+;; @003d                               v14 = iadd v11, v13
+;; @003d                               v16 = uload32 notrap aligned v0+152
+;; @003d                               v17 = uextend.i64 v3
+;; @003d                               v18 = uextend.i64 v4
+;; @003d                               v19 = iadd v17, v18
+;; @003d                               v20 = icmp ugt v19, v16
+;; @003d                               trapnz v20, heap_oob
+;; @003d                               v22 = load.i64 notrap aligned v0+144
+;; @003d                               v23 = uextend.i64 v3
+;;                                     v28 = iconst.i64 1
+;; @003d                               v24 = imul v23, v28  ; v28 = 1
+;; @003d                               v25 = iadd v22, v24
+;; @003d                               v26 = uextend.i64 v4
+;; @003d                               call fn0(v0, v14, v25, v26)
 ;; @0041                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/readonly-funcrefs.wat
+++ b/tests/disas/readonly-funcrefs.wat
@@ -39,7 +39,7 @@
 ;;     gv4 = load.i64 notrap aligned readonly can_move gv3+48
 ;;     sig0 = (i64 vmctx, i64) tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
-;;     fn0 = colocated u805306368:7 sig1
+;;     fn0 = colocated u805306368:6 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/riscv64-component-builtins-asm.wat
+++ b/tests/disas/riscv64-component-builtins-asm.wat
@@ -54,7 +54,7 @@
 ;;       ret
 ;;       mv      a1, s5
 ;;       ld      a0, 0x10(a1)
-;;       ld      a2, 0x170(a0)
+;;       ld      a2, 0x168(a0)
 ;;       mv      a0, a1
 ;;       jalr    a2
 ;;       .byte   0x00, 0x00, 0x00, 0x00

--- a/tests/disas/riscv64-component-builtins.wat
+++ b/tests/disas/riscv64-component-builtins.wat
@@ -34,7 +34,7 @@
 ;;
 ;; block1 cold:
 ;;     v15 = load.i64 notrap aligned readonly v1+16
-;;     v16 = load.i64 notrap aligned readonly v15+368
+;;     v16 = load.i64 notrap aligned readonly v15+360
 ;;     call_indirect sig1, v16(v1)
 ;;     trap user1
 ;;

--- a/tests/disas/stack-switching/resume-suspend-data-passing.wat
+++ b/tests/disas/stack-switching/resume-suspend-data-passing.wat
@@ -152,8 +152,8 @@
 ;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i32) -> i64 tail
 ;;     sig1 = (i64 vmctx, i64, i32, i32) -> i64 tail
-;;     fn0 = colocated u805306368:6 sig0
-;;     fn1 = colocated u805306368:47 sig1
+;;     fn0 = colocated u805306368:5 sig0
+;;     fn1 = colocated u805306368:46 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):

--- a/tests/disas/stack-switching/resume-suspend.wat
+++ b/tests/disas/stack-switching/resume-suspend.wat
@@ -113,8 +113,8 @@
 ;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i32) -> i64 tail
 ;;     sig1 = (i64 vmctx, i64, i32, i32) -> i64 tail
-;;     fn0 = colocated u805306368:6 sig0
-;;     fn1 = colocated u805306368:47 sig1
+;;     fn0 = colocated u805306368:5 sig0
+;;     fn1 = colocated u805306368:46 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):

--- a/tests/disas/stack-switching/symmetric-switch.wat
+++ b/tests/disas/stack-switching/symmetric-switch.wat
@@ -33,8 +33,8 @@
 ;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i32) -> i64 tail
 ;;     sig1 = (i64 vmctx, i64, i32, i32) -> i64 tail
-;;     fn0 = colocated u805306368:6 sig0
-;;     fn1 = colocated u805306368:47 sig1
+;;     fn0 = colocated u805306368:5 sig0
+;;     fn1 = colocated u805306368:46 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
@@ -248,8 +248,8 @@
 ;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i32) -> i64 tail
 ;;     sig1 = (i64 vmctx, i64, i32, i32) -> i64 tail
-;;     fn0 = colocated u805306368:6 sig0
-;;     fn1 = colocated u805306368:47 sig1
+;;     fn0 = colocated u805306368:5 sig0
+;;     fn1 = colocated u805306368:46 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):

--- a/tests/disas/table-copy.wat
+++ b/tests/disas/table-copy.wat
@@ -67,18 +67,121 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     sig0 = (i64 vmctx, i32, i32, i64, i64, i64) -> i8 tail
-;;     fn0 = colocated u805306368:1 sig0
+;;     gv4 = load.i64 notrap aligned readonly can_move gv3+48
+;;     gv5 = load.i64 notrap aligned gv4
+;;     gv6 = load.i64 notrap aligned gv4+8
+;;     gv7 = load.i64 notrap aligned readonly can_move gv3+72
+;;     sig0 = (i64 vmctx, i32, i64) -> i64 tail
+;;     fn0 = colocated u805306368:6 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
-;; @0090                               v7 = uextend.i64 v3
-;; @0090                               v8 = uextend.i64 v4
-;; @0090                               v9 = uextend.i64 v5
-;; @0090                               v10 = iconst.i32 0
-;; @0090                               v11 = iconst.i32 1
-;; @0090                               v13 = call fn0(v0, v10, v11, v7, v8, v9)  ; v10 = 0, v11 = 1
+;; @0090                               v97 = load.i64 notrap aligned readonly can_move v0+48
+;; @0090                               v7 = load.i64 notrap aligned v97+8
+;; @0090                               v8 = ireduce.i32 v7
+;; @0090                               v9 = uextend.i64 v8
+;; @0090                               v10 = uextend.i64 v3
+;; @0090                               v11 = uextend.i64 v5
+;; @0090                               v12 = iadd v10, v11
+;; @0090                               v13 = icmp ugt v12, v9
+;; @0090                               trapnz v13, user6
+;; @0090                               v95 = load.i64 notrap aligned readonly can_move v0+48
+;; @0090                               v14 = load.i64 notrap aligned v95
+;; @0090                               v15 = uextend.i64 v3
+;;                                     v94 = iconst.i64 8
+;; @0090                               v16 = imul v15, v94  ; v94 = 8
+;; @0090                               v17 = iadd v14, v16
+;; @0090                               v18 = iconst.i32 6
+;; @0090                               v19 = uextend.i64 v18  ; v18 = 6
+;; @0090                               v20 = uextend.i64 v4
+;; @0090                               v21 = uextend.i64 v5
+;; @0090                               v22 = iadd v20, v21
+;; @0090                               v23 = icmp ugt v22, v19
+;; @0090                               trapnz v23, user6
+;; @0090                               v24 = load.i64 notrap aligned readonly can_move v0+72
+;; @0090                               v25 = uextend.i64 v4
+;;                                     v92 = iconst.i64 8
+;; @0090                               v26 = imul v25, v92  ; v92 = 8
+;; @0090                               v27 = iadd v24, v26
+;; @0090                               v28 = uextend.i64 v5
+;; @0090                               v29 = iconst.i64 8
+;; @0090                               brif v28, block2, block5
+;;
+;;                                 block2:
+;; @0090                               v30 = icmp.i64 ult v17, v27
+;; @0090                               v31 = imul.i64 v28, v29  ; v29 = 8
+;; @0090                               v32 = iadd.i64 v17, v31
+;; @0090                               v33 = iadd.i64 v27, v31
+;; @0090                               v34 = ireduce.i32 v28
+;; @0090                               v35 = iadd.i32 v4, v34
+;; @0090                               brif v30, block3(v17, v27, v4), block4(v32, v33, v35)
+;;
+;;                                 block3(v36: i64, v37: i64, v38: i32):
+;; @0090                               v39 = iconst.i32 6
+;; @0090                               v40 = icmp uge v38, v39  ; v39 = 6
+;; @0090                               v41 = uextend.i64 v38
+;; @0090                               v42 = load.i64 notrap aligned readonly can_move v0+72
+;;                                     v90 = iconst.i64 3
+;; @0090                               v43 = ishl v41, v90  ; v90 = 3
+;; @0090                               v44 = iadd v42, v43
+;; @0090                               v45 = iconst.i64 0
+;; @0090                               v46 = select_spectre_guard v40, v45, v44  ; v45 = 0
+;; @0090                               v47 = load.i64 user6 aligned table v46
+;;                                     v89 = iconst.i64 -2
+;; @0090                               v48 = band v47, v89  ; v89 = -2
+;; @0090                               brif v47, block7(v48), block6
+;;
+;;                                 block4(v59: i64, v60: i64, v61: i32):
+;; @0090                               v62 = isub v59, v29  ; v29 = 8
+;; @0090                               v63 = isub v60, v29  ; v29 = 8
+;; @0090                               v64 = iconst.i32 1
+;; @0090                               v65 = isub v61, v64  ; v64 = 1
+;; @0090                               v66 = iconst.i32 6
+;; @0090                               v67 = icmp uge v65, v66  ; v66 = 6
+;; @0090                               v68 = uextend.i64 v65
+;; @0090                               v69 = load.i64 notrap aligned readonly can_move v0+72
+;;                                     v87 = iconst.i64 3
+;; @0090                               v70 = ishl v68, v87  ; v87 = 3
+;; @0090                               v71 = iadd v69, v70
+;; @0090                               v72 = iconst.i64 0
+;; @0090                               v73 = select_spectre_guard v67, v72, v71  ; v72 = 0
+;; @0090                               v74 = load.i64 user6 aligned table v73
+;;                                     v86 = iconst.i64 -2
+;; @0090                               v75 = band v74, v86  ; v86 = -2
+;; @0090                               brif v74, block9(v75), block8
+;;
+;;                                 block5:
 ;; @0094                               jump block1
+;;
+;;                                 block6 cold:
+;; @0090                               v50 = iconst.i32 1
+;; @0090                               v52 = uextend.i64 v38
+;; @0090                               v53 = call fn0(v0, v50, v52)  ; v50 = 1
+;; @0090                               jump block7(v53)
+;;
+;;                                 block7(v49: i64):
+;;                                     v85 = iconst.i64 1
+;; @0090                               v54 = bor v49, v85  ; v85 = 1
+;; @0090                               store notrap aligned v54, v36
+;; @0090                               v55 = iadd.i64 v36, v29  ; v29 = 8
+;; @0090                               v56 = iadd.i64 v37, v29  ; v29 = 8
+;;                                     v84 = iconst.i32 1
+;; @0090                               v57 = iadd.i32 v38, v84  ; v84 = 1
+;; @0090                               v58 = icmp eq v56, v33
+;; @0090                               brif v58, block5, block3(v55, v56, v57)
+;;
+;;                                 block8 cold:
+;; @0090                               v77 = iconst.i32 1
+;; @0090                               v79 = uextend.i64 v65
+;; @0090                               v80 = call fn0(v0, v77, v79)  ; v77 = 1
+;; @0090                               jump block9(v80)
+;;
+;;                                 block9(v76: i64):
+;;                                     v83 = iconst.i64 1
+;; @0090                               v81 = bor v76, v83  ; v83 = 1
+;; @0090                               store notrap aligned v81, v62
+;; @0090                               v82 = icmp.i64 eq v63, v27
+;; @0090                               brif v82, block5, block4(v62, v63, v65)
 ;;
 ;;                                 block1:
 ;; @0094                               return v2
@@ -89,18 +192,127 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
-;;     sig0 = (i64 vmctx, i32, i32, i64, i64, i64) -> i8 tail
-;;     fn0 = colocated u805306368:1 sig0
+;;     gv4 = load.i64 notrap aligned readonly can_move gv3+72
+;;     gv5 = load.i64 notrap aligned readonly can_move gv3+48
+;;     gv6 = load.i64 notrap aligned gv5
+;;     gv7 = load.i64 notrap aligned gv5+8
+;;     sig0 = (i64 vmctx, i32, i64) -> i64 tail
+;;     fn0 = colocated u805306368:6 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
-;; @009f                               v7 = uextend.i64 v3
-;; @009f                               v8 = uextend.i64 v4
-;; @009f                               v9 = uextend.i64 v5
-;; @009f                               v10 = iconst.i32 1
-;; @009f                               v11 = iconst.i32 0
-;; @009f                               v13 = call fn0(v0, v10, v11, v7, v8, v9)  ; v10 = 1, v11 = 0
+;; @009f                               v7 = iconst.i32 6
+;; @009f                               v8 = uextend.i64 v7  ; v7 = 6
+;; @009f                               v9 = uextend.i64 v3
+;; @009f                               v10 = uextend.i64 v5
+;; @009f                               v11 = iadd v9, v10
+;; @009f                               v12 = icmp ugt v11, v8
+;; @009f                               trapnz v12, user6
+;; @009f                               v13 = load.i64 notrap aligned readonly can_move v0+72
+;; @009f                               v14 = uextend.i64 v3
+;;                                     v105 = iconst.i64 8
+;; @009f                               v15 = imul v14, v105  ; v105 = 8
+;; @009f                               v16 = iadd v13, v15
+;; @009f                               v103 = load.i64 notrap aligned readonly can_move v0+48
+;; @009f                               v17 = load.i64 notrap aligned v103+8
+;; @009f                               v18 = ireduce.i32 v17
+;; @009f                               v19 = uextend.i64 v18
+;; @009f                               v20 = uextend.i64 v4
+;; @009f                               v21 = uextend.i64 v5
+;; @009f                               v22 = iadd v20, v21
+;; @009f                               v23 = icmp ugt v22, v19
+;; @009f                               trapnz v23, user6
+;; @009f                               v101 = load.i64 notrap aligned readonly can_move v0+48
+;; @009f                               v24 = load.i64 notrap aligned v101
+;; @009f                               v25 = uextend.i64 v4
+;;                                     v100 = iconst.i64 8
+;; @009f                               v26 = imul v25, v100  ; v100 = 8
+;; @009f                               v27 = iadd v24, v26
+;; @009f                               v28 = uextend.i64 v5
+;; @009f                               v29 = iconst.i64 8
+;; @009f                               brif v28, block2, block5
+;;
+;;                                 block2:
+;; @009f                               v30 = icmp.i64 ult v16, v27
+;; @009f                               v31 = imul.i64 v28, v29  ; v29 = 8
+;; @009f                               v32 = iadd.i64 v16, v31
+;; @009f                               v33 = iadd.i64 v27, v31
+;; @009f                               v34 = ireduce.i32 v28
+;; @009f                               v35 = iadd.i32 v4, v34
+;; @009f                               brif v30, block3(v16, v27, v4), block4(v32, v33, v35)
+;;
+;;                                 block3(v36: i64, v37: i64, v38: i32):
+;; @009f                               v98 = load.i64 notrap aligned readonly can_move v0+48
+;; @009f                               v39 = load.i64 notrap aligned v98+8
+;; @009f                               v40 = ireduce.i32 v39
+;; @009f                               v41 = icmp uge v38, v40
+;; @009f                               v42 = uextend.i64 v38
+;; @009f                               v96 = load.i64 notrap aligned readonly can_move v0+48
+;; @009f                               v43 = load.i64 notrap aligned v96
+;;                                     v95 = iconst.i64 3
+;; @009f                               v44 = ishl v42, v95  ; v95 = 3
+;; @009f                               v45 = iadd v43, v44
+;; @009f                               v46 = iconst.i64 0
+;; @009f                               v47 = select_spectre_guard v41, v46, v45  ; v46 = 0
+;; @009f                               v48 = load.i64 user6 aligned table v47
+;;                                     v94 = iconst.i64 -2
+;; @009f                               v49 = band v48, v94  ; v94 = -2
+;; @009f                               brif v48, block7(v49), block6
+;;
+;;                                 block4(v60: i64, v61: i64, v62: i32):
+;; @009f                               v63 = isub v60, v29  ; v29 = 8
+;; @009f                               v64 = isub v61, v29  ; v29 = 8
+;; @009f                               v65 = iconst.i32 1
+;; @009f                               v66 = isub v62, v65  ; v65 = 1
+;; @009f                               v92 = load.i64 notrap aligned readonly can_move v0+48
+;; @009f                               v67 = load.i64 notrap aligned v92+8
+;; @009f                               v68 = ireduce.i32 v67
+;; @009f                               v69 = icmp uge v66, v68
+;; @009f                               v70 = uextend.i64 v66
+;; @009f                               v90 = load.i64 notrap aligned readonly can_move v0+48
+;; @009f                               v71 = load.i64 notrap aligned v90
+;;                                     v89 = iconst.i64 3
+;; @009f                               v72 = ishl v70, v89  ; v89 = 3
+;; @009f                               v73 = iadd v71, v72
+;; @009f                               v74 = iconst.i64 0
+;; @009f                               v75 = select_spectre_guard v69, v74, v73  ; v74 = 0
+;; @009f                               v76 = load.i64 user6 aligned table v75
+;;                                     v88 = iconst.i64 -2
+;; @009f                               v77 = band v76, v88  ; v88 = -2
+;; @009f                               brif v76, block9(v77), block8
+;;
+;;                                 block5:
 ;; @00a3                               jump block1
+;;
+;;                                 block6 cold:
+;; @009f                               v51 = iconst.i32 0
+;; @009f                               v53 = uextend.i64 v38
+;; @009f                               v54 = call fn0(v0, v51, v53)  ; v51 = 0
+;; @009f                               jump block7(v54)
+;;
+;;                                 block7(v50: i64):
+;;                                     v87 = iconst.i64 1
+;; @009f                               v55 = bor v50, v87  ; v87 = 1
+;; @009f                               store notrap aligned v55, v36
+;; @009f                               v56 = iadd.i64 v36, v29  ; v29 = 8
+;; @009f                               v57 = iadd.i64 v37, v29  ; v29 = 8
+;;                                     v86 = iconst.i32 1
+;; @009f                               v58 = iadd.i32 v38, v86  ; v86 = 1
+;; @009f                               v59 = icmp eq v57, v33
+;; @009f                               brif v59, block5, block3(v56, v57, v58)
+;;
+;;                                 block8 cold:
+;; @009f                               v79 = iconst.i32 0
+;; @009f                               v81 = uextend.i64 v66
+;; @009f                               v82 = call fn0(v0, v79, v81)  ; v79 = 0
+;; @009f                               jump block9(v82)
+;;
+;;                                 block9(v78: i64):
+;;                                     v85 = iconst.i64 1
+;; @009f                               v83 = bor v78, v85  ; v85 = 1
+;; @009f                               store notrap aligned v83, v63
+;; @009f                               v84 = icmp.i64 eq v64, v27
+;; @009f                               brif v84, block5, block4(v63, v64, v66)
 ;;
 ;;                                 block1:
 ;; @00a3                               return v2

--- a/tests/disas/table-set-fixed-size.wat
+++ b/tests/disas/table-set-fixed-size.wat
@@ -26,7 +26,7 @@
 ;;     gv6 = load.i64 notrap aligned readonly can_move gv5+32
 ;;     gv7 = load.i64 notrap aligned gv5+40
 ;;     sig0 = (i64 vmctx, i32) tail
-;;     fn0 = colocated u805306368:23 sig0
+;;     fn0 = colocated u805306368:22 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -123,7 +123,7 @@
 ;;     gv6 = load.i64 notrap aligned readonly can_move gv5+32
 ;;     gv7 = load.i64 notrap aligned gv5+40
 ;;     sig0 = (i64 vmctx, i32) tail
-;;     fn0 = colocated u805306368:23 sig0
+;;     fn0 = colocated u805306368:22 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):

--- a/tests/disas/table-set.wat
+++ b/tests/disas/table-set.wat
@@ -27,7 +27,7 @@
 ;;     gv7 = load.i64 notrap aligned readonly can_move gv6+32
 ;;     gv8 = load.i64 notrap aligned gv6+40
 ;;     sig0 = (i64 vmctx, i32) tail
-;;     fn0 = colocated u805306368:23 sig0
+;;     fn0 = colocated u805306368:22 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -126,7 +126,7 @@
 ;;     gv7 = load.i64 notrap aligned readonly can_move gv6+32
 ;;     gv8 = load.i64 notrap aligned gv6+40
 ;;     sig0 = (i64 vmctx, i32) tail
-;;     fn0 = colocated u805306368:23 sig0
+;;     fn0 = colocated u805306368:22 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):

--- a/tests/disas/typed-funcrefs.wat
+++ b/tests/disas/typed-funcrefs.wat
@@ -134,7 +134,7 @@
 ;;     gv4 = load.i64 notrap aligned readonly can_move gv3+48
 ;;     sig0 = (i64 vmctx, i32, i64) -> i64 tail
 ;;     sig1 = (i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail
-;;     fn0 = colocated u805306368:7 sig0
+;;     fn0 = colocated u805306368:6 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
@@ -188,7 +188,7 @@
 ;;     gv4 = load.i64 notrap aligned readonly can_move gv3+48
 ;;     sig0 = (i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
-;;     fn0 = colocated u805306368:7 sig1
+;;     fn0 = colocated u805306368:6 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):

--- a/tests/disas/winch/x64/table/init_copy_drop.wat
+++ b/tests/disas/winch/x64/table/init_copy_drop.wat
@@ -129,9 +129,9 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
 ;;       movq    0x18(%r11), %r11
-;;       addq    $0x10, %r11
+;;       addq    $0x40, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x2b4
+;;       ja      0x8b3
 ;;  15c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -142,11 +142,11 @@
 ;;       movl    $7, %ecx
 ;;       movl    $0, %r8d
 ;;       movl    $4, %r9d
-;;       callq   0x93a
+;;       callq   0xf2f
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $1, %esi
-;;       callq   0x985
+;;       callq   0xf7a
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
@@ -154,56 +154,471 @@
 ;;       movl    $0xf, %ecx
 ;;       movl    $1, %r8d
 ;;       movl    $3, %r9d
-;;       callq   0x93a
+;;       callq   0xf2f
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $3, %esi
-;;       callq   0x985
+;;       callq   0xf7a
 ;;       movq    8(%rsp), %r14
+;;       movl    $5, %eax
+;;       movl    $0xf, %ecx
+;;       movl    $0x14, %edx
+;;       movl    %eax, %eax
+;;       movl    %ecx, %ecx
+;;       movl    %edx, %edx
+;;       movq    %r14, %r11
+;;       movq    0xd8(%r11), %rbx
+;;       movq    %rcx, %rsi
+;;       addq    %rax, %rsi
+;;       jb      0x8b5
+;;  20e: cmpq    %rbx, %rsi
+;;       ja      0x8b7
+;;  217: movq    %r14, %r11
+;;       movq    0xd8(%r11), %rbx
+;;       movq    %rdx, %rsi
+;;       addq    %rax, %rsi
+;;       jb      0x8b9
+;;  22d: cmpq    %rbx, %rsi
+;;       ja      0x8bb
+;;  236: cmpq    %rcx, %rdx
+;;       jbe     0x25f
+;;  23f: movq    $18446744073709551615, %rbx
+;;       addq    %rax, %rcx
+;;       subq    $1, %rcx
+;;       addq    %rax, %rdx
+;;       subq    $1, %rdx
+;;       jmp     0x264
+;;  25f: movl    $1, %ebx
+;;       cmpq    $0, %rax
+;;       je      0x33e
+;;  26e: movq    %rcx, %rsi
+;;       pushq   %rbx
+;;       pushq   %rax
+;;       pushq   %rdx
+;;       pushq   %rcx
+;;       pushq   %rsi
+;;       popq    %rcx
+;;       movq    %r14, %rdx
+;;       movq    0xd8(%rdx), %rbx
+;;       cmpq    %rbx, %rcx
+;;       jae     0x8bd
+;;  28a: movq    %rcx, %r11
+;;       imulq   $8, %r11, %r11
+;;       movq    0xd0(%rdx), %rdx
+;;       movq    %rdx, %rsi
+;;       addq    %r11, %rdx
+;;       cmpq    %rbx, %rcx
+;;       cmovaeq %rsi, %rdx
+;;       movq    (%rdx), %rax
+;;       testq   %rax, %rax
+;;       jne     0x2e6
+;;  2b4: pushq   %rcx
+;;       subq    $8, %rsp
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
-;;       movl    $0, %edx
+;;       movq    8(%rsp), %rdx
+;;       callq   0xfc2
+;;       addq    $8, %rsp
+;;       addq    $8, %rsp
+;;       movq    0x28(%rsp), %r14
+;;       jmp     0x2ec
+;;  2e6: andq    $0xfffffffffffffffe, %rax
+;;       popq    %rcx
+;;       popq    %rdx
+;;       movq    %rdx, %rbx
+;;       movq    %r14, %rsi
+;;       movq    0xd8(%rsi), %rdi
+;;       cmpq    %rdi, %rbx
+;;       jae     0x8bf
+;;  304: movq    %rbx, %r11
+;;       imulq   $8, %r11, %r11
+;;       movq    0xd0(%rsi), %rsi
+;;       movq    %rsi, %r8
+;;       addq    %r11, %rsi
+;;       cmpq    %rdi, %rbx
+;;       cmovaeq %r8, %rsi
+;;       orq     $1, %rax
+;;       movq    %rax, (%rsi)
+;;       popq    %rax
+;;       popq    %rbx
+;;       addq    %rbx, %rdx
+;;       addq    %rbx, %rcx
+;;       subq    $1, %rax
+;;       jmp     0x264
+;;  33e: movl    $1, %eax
+;;       movl    $0x1d, %ecx
+;;       movl    $0x15, %edx
+;;       movl    %eax, %eax
+;;       movl    %ecx, %ecx
+;;       movl    %edx, %edx
+;;       movq    %r14, %r11
+;;       movq    0xd8(%r11), %rbx
+;;       movq    %rcx, %rsi
+;;       addq    %rax, %rsi
+;;       jb      0x8c1
+;;  369: cmpq    %rbx, %rsi
+;;       ja      0x8c3
+;;  372: movq    %r14, %r11
+;;       movq    0xd8(%r11), %rbx
+;;       movq    %rdx, %rsi
+;;       addq    %rax, %rsi
+;;       jb      0x8c5
+;;  388: cmpq    %rbx, %rsi
+;;       ja      0x8c7
+;;  391: cmpq    %rcx, %rdx
+;;       jbe     0x3ba
+;;  39a: movq    $18446744073709551615, %rbx
+;;       addq    %rax, %rcx
+;;       subq    $1, %rcx
+;;       addq    %rax, %rdx
+;;       subq    $1, %rdx
+;;       jmp     0x3bf
+;;  3ba: movl    $1, %ebx
+;;       cmpq    $0, %rax
+;;       je      0x499
+;;  3c9: movq    %rcx, %rsi
+;;       pushq   %rbx
+;;       pushq   %rax
+;;       pushq   %rdx
+;;       pushq   %rcx
+;;       pushq   %rsi
+;;       popq    %rcx
+;;       movq    %r14, %rdx
+;;       movq    0xd8(%rdx), %rbx
+;;       cmpq    %rbx, %rcx
+;;       jae     0x8c9
+;;  3e5: movq    %rcx, %r11
+;;       imulq   $8, %r11, %r11
+;;       movq    0xd0(%rdx), %rdx
+;;       movq    %rdx, %rsi
+;;       addq    %r11, %rdx
+;;       cmpq    %rbx, %rcx
+;;       cmovaeq %rsi, %rdx
+;;       movq    (%rdx), %rax
+;;       testq   %rax, %rax
+;;       jne     0x441
+;;  40f: pushq   %rcx
+;;       subq    $8, %rsp
+;;       movq    %r14, %rdi
+;;       movl    $0, %esi
+;;       movq    8(%rsp), %rdx
+;;       callq   0xfc2
+;;       addq    $8, %rsp
+;;       addq    $8, %rsp
+;;       movq    0x28(%rsp), %r14
+;;       jmp     0x447
+;;  441: andq    $0xfffffffffffffffe, %rax
+;;       popq    %rcx
+;;       popq    %rdx
+;;       movq    %rdx, %rbx
+;;       movq    %r14, %rsi
+;;       movq    0xd8(%rsi), %rdi
+;;       cmpq    %rdi, %rbx
+;;       jae     0x8cb
+;;  45f: movq    %rbx, %r11
+;;       imulq   $8, %r11, %r11
+;;       movq    0xd0(%rsi), %rsi
+;;       movq    %rsi, %r8
+;;       addq    %r11, %rsi
+;;       cmpq    %rdi, %rbx
+;;       cmovaeq %r8, %rsi
+;;       orq     $1, %rax
+;;       movq    %rax, (%rsi)
+;;       popq    %rax
+;;       popq    %rbx
+;;       addq    %rbx, %rdx
+;;       addq    %rbx, %rcx
+;;       subq    $1, %rax
+;;       jmp     0x3bf
+;;  499: movl    $1, %eax
+;;       movl    $0xa, %ecx
+;;       movl    $0x18, %edx
+;;       movl    %eax, %eax
+;;       movl    %ecx, %ecx
+;;       movl    %edx, %edx
+;;       movq    %r14, %r11
+;;       movq    0xd8(%r11), %rbx
+;;       movq    %rcx, %rsi
+;;       addq    %rax, %rsi
+;;       jb      0x8cd
+;;  4c4: cmpq    %rbx, %rsi
+;;       ja      0x8cf
+;;  4cd: movq    %r14, %r11
+;;       movq    0xd8(%r11), %rbx
+;;       movq    %rdx, %rsi
+;;       addq    %rax, %rsi
+;;       jb      0x8d1
+;;  4e3: cmpq    %rbx, %rsi
+;;       ja      0x8d3
+;;  4ec: cmpq    %rcx, %rdx
+;;       jbe     0x515
+;;  4f5: movq    $18446744073709551615, %rbx
+;;       addq    %rax, %rcx
+;;       subq    $1, %rcx
+;;       addq    %rax, %rdx
+;;       subq    $1, %rdx
+;;       jmp     0x51a
+;;  515: movl    $1, %ebx
+;;       cmpq    $0, %rax
+;;       je      0x5f4
+;;  524: movq    %rcx, %rsi
+;;       pushq   %rbx
+;;       pushq   %rax
+;;       pushq   %rdx
+;;       pushq   %rcx
+;;       pushq   %rsi
+;;       popq    %rcx
+;;       movq    %r14, %rdx
+;;       movq    0xd8(%rdx), %rbx
+;;       cmpq    %rbx, %rcx
+;;       jae     0x8d5
+;;  540: movq    %rcx, %r11
+;;       imulq   $8, %r11, %r11
+;;       movq    0xd0(%rdx), %rdx
+;;       movq    %rdx, %rsi
+;;       addq    %r11, %rdx
+;;       cmpq    %rbx, %rcx
+;;       cmovaeq %rsi, %rdx
+;;       movq    (%rdx), %rax
+;;       testq   %rax, %rax
+;;       jne     0x59c
+;;  56a: pushq   %rcx
+;;       subq    $8, %rsp
+;;       movq    %r14, %rdi
+;;       movl    $0, %esi
+;;       movq    8(%rsp), %rdx
+;;       callq   0xfc2
+;;       addq    $8, %rsp
+;;       addq    $8, %rsp
+;;       movq    0x28(%rsp), %r14
+;;       jmp     0x5a2
+;;  59c: andq    $0xfffffffffffffffe, %rax
+;;       popq    %rcx
+;;       popq    %rdx
+;;       movq    %rdx, %rbx
+;;       movq    %r14, %rsi
+;;       movq    0xd8(%rsi), %rdi
+;;       cmpq    %rdi, %rbx
+;;       jae     0x8d7
+;;  5ba: movq    %rbx, %r11
+;;       imulq   $8, %r11, %r11
+;;       movq    0xd0(%rsi), %rsi
+;;       movq    %rsi, %r8
+;;       addq    %r11, %rsi
+;;       cmpq    %rdi, %rbx
+;;       cmovaeq %r8, %rsi
+;;       orq     $1, %rax
+;;       movq    %rax, (%rsi)
+;;       popq    %rax
+;;       popq    %rbx
+;;       addq    %rbx, %rdx
+;;       addq    %rbx, %rcx
+;;       subq    $1, %rax
+;;       jmp     0x51a
+;;  5f4: movl    $4, %eax
+;;       movl    $0xb, %ecx
+;;       movl    $0xd, %edx
+;;       movl    %eax, %eax
+;;       movl    %ecx, %ecx
+;;       movl    %edx, %edx
+;;       movq    %r14, %r11
+;;       movq    0xd8(%r11), %rbx
+;;       movq    %rcx, %rsi
+;;       addq    %rax, %rsi
+;;       jb      0x8d9
+;;  61f: cmpq    %rbx, %rsi
+;;       ja      0x8db
+;;  628: movq    %r14, %r11
+;;       movq    0xd8(%r11), %rbx
+;;       movq    %rdx, %rsi
+;;       addq    %rax, %rsi
+;;       jb      0x8dd
+;;  63e: cmpq    %rbx, %rsi
+;;       ja      0x8df
+;;  647: cmpq    %rcx, %rdx
+;;       jbe     0x670
+;;  650: movq    $18446744073709551615, %rbx
+;;       addq    %rax, %rcx
+;;       subq    $1, %rcx
+;;       addq    %rax, %rdx
+;;       subq    $1, %rdx
+;;       jmp     0x675
+;;  670: movl    $1, %ebx
+;;       cmpq    $0, %rax
+;;       je      0x74f
+;;  67f: movq    %rcx, %rsi
+;;       pushq   %rbx
+;;       pushq   %rax
+;;       pushq   %rdx
+;;       pushq   %rcx
+;;       pushq   %rsi
+;;       popq    %rcx
+;;       movq    %r14, %rdx
+;;       movq    0xd8(%rdx), %rbx
+;;       cmpq    %rbx, %rcx
+;;       jae     0x8e1
+;;  69b: movq    %rcx, %r11
+;;       imulq   $8, %r11, %r11
+;;       movq    0xd0(%rdx), %rdx
+;;       movq    %rdx, %rsi
+;;       addq    %r11, %rdx
+;;       cmpq    %rbx, %rcx
+;;       cmovaeq %rsi, %rdx
+;;       movq    (%rdx), %rax
+;;       testq   %rax, %rax
+;;       jne     0x6f7
+;;  6c5: pushq   %rcx
+;;       subq    $8, %rsp
+;;       movq    %r14, %rdi
+;;       movl    $0, %esi
+;;       movq    8(%rsp), %rdx
+;;       callq   0xfc2
+;;       addq    $8, %rsp
+;;       addq    $8, %rsp
+;;       movq    0x28(%rsp), %r14
+;;       jmp     0x6fd
+;;  6f7: andq    $0xfffffffffffffffe, %rax
+;;       popq    %rcx
+;;       popq    %rdx
+;;       movq    %rdx, %rbx
+;;       movq    %r14, %rsi
+;;       movq    0xd8(%rsi), %rdi
+;;       cmpq    %rdi, %rbx
+;;       jae     0x8e3
+;;  715: movq    %rbx, %r11
+;;       imulq   $8, %r11, %r11
+;;       movq    0xd0(%rsi), %rsi
+;;       movq    %rsi, %r8
+;;       addq    %r11, %rsi
+;;       cmpq    %rdi, %rbx
+;;       cmovaeq %r8, %rsi
+;;       orq     $1, %rax
+;;       movq    %rax, (%rsi)
+;;       popq    %rax
+;;       popq    %rbx
+;;       addq    %rbx, %rdx
+;;       addq    %rbx, %rcx
+;;       subq    $1, %rax
+;;       jmp     0x675
+;;  74f: movl    $5, %eax
 ;;       movl    $0x14, %ecx
-;;       movl    $0xf, %r8d
-;;       movl    $5, %r9d
-;;       callq   0x8ef
-;;       movq    8(%rsp), %r14
+;;       movl    $0x13, %edx
+;;       movl    %eax, %eax
+;;       movl    %ecx, %ecx
+;;       movl    %edx, %edx
+;;       movq    %r14, %r11
+;;       movq    0xd8(%r11), %rbx
+;;       movq    %rcx, %rsi
+;;       addq    %rax, %rsi
+;;       jb      0x8e5
+;;  77a: cmpq    %rbx, %rsi
+;;       ja      0x8e7
+;;  783: movq    %r14, %r11
+;;       movq    0xd8(%r11), %rbx
+;;       movq    %rdx, %rsi
+;;       addq    %rax, %rsi
+;;       jb      0x8e9
+;;  799: cmpq    %rbx, %rsi
+;;       ja      0x8eb
+;;  7a2: cmpq    %rcx, %rdx
+;;       jbe     0x7cb
+;;  7ab: movq    $18446744073709551615, %rbx
+;;       addq    %rax, %rcx
+;;       subq    $1, %rcx
+;;       addq    %rax, %rdx
+;;       subq    $1, %rdx
+;;       jmp     0x7d0
+;;  7cb: movl    $1, %ebx
+;;       cmpq    $0, %rax
+;;       je      0x8aa
+;;  7da: movq    %rcx, %rsi
+;;       pushq   %rbx
+;;       pushq   %rax
+;;       pushq   %rdx
+;;       pushq   %rcx
+;;       pushq   %rsi
+;;       popq    %rcx
+;;       movq    %r14, %rdx
+;;       movq    0xd8(%rdx), %rbx
+;;       cmpq    %rbx, %rcx
+;;       jae     0x8ed
+;;  7f6: movq    %rcx, %r11
+;;       imulq   $8, %r11, %r11
+;;       movq    0xd0(%rdx), %rdx
+;;       movq    %rdx, %rsi
+;;       addq    %r11, %rdx
+;;       cmpq    %rbx, %rcx
+;;       cmovaeq %rsi, %rdx
+;;       movq    (%rdx), %rax
+;;       testq   %rax, %rax
+;;       jne     0x852
+;;  820: pushq   %rcx
+;;       subq    $8, %rsp
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
-;;       movl    $0, %edx
-;;       movl    $0x15, %ecx
-;;       movl    $0x1d, %r8d
-;;       movl    $1, %r9d
-;;       callq   0x8ef
-;;       movq    8(%rsp), %r14
-;;       movq    %r14, %rdi
-;;       movl    $0, %esi
-;;       movl    $0, %edx
-;;       movl    $0x18, %ecx
-;;       movl    $0xa, %r8d
-;;       movl    $1, %r9d
-;;       callq   0x8ef
-;;       movq    8(%rsp), %r14
-;;       movq    %r14, %rdi
-;;       movl    $0, %esi
-;;       movl    $0, %edx
-;;       movl    $0xd, %ecx
-;;       movl    $0xb, %r8d
-;;       movl    $4, %r9d
-;;       callq   0x8ef
-;;       movq    8(%rsp), %r14
-;;       movq    %r14, %rdi
-;;       movl    $0, %esi
-;;       movl    $0, %edx
-;;       movl    $0x13, %ecx
-;;       movl    $0x14, %r8d
-;;       movl    $5, %r9d
-;;       callq   0x8ef
-;;       movq    8(%rsp), %r14
-;;       addq    $0x10, %rsp
+;;       movq    8(%rsp), %rdx
+;;       callq   0xfc2
+;;       addq    $8, %rsp
+;;       addq    $8, %rsp
+;;       movq    0x28(%rsp), %r14
+;;       jmp     0x858
+;;  852: andq    $0xfffffffffffffffe, %rax
+;;       popq    %rcx
+;;       popq    %rdx
+;;       movq    %rdx, %rbx
+;;       movq    %r14, %rsi
+;;       movq    0xd8(%rsi), %rdi
+;;       cmpq    %rdi, %rbx
+;;       jae     0x8ef
+;;  870: movq    %rbx, %r11
+;;       imulq   $8, %r11, %r11
+;;       movq    0xd0(%rsi), %rsi
+;;       movq    %rsi, %r8
+;;       addq    %r11, %rsi
+;;       cmpq    %rdi, %rbx
+;;       cmovaeq %r8, %rsi
+;;       orq     $1, %rax
+;;       movq    %rax, (%rsi)
+;;       popq    %rax
+;;       popq    %rbx
+;;       addq    %rbx, %rdx
+;;       addq    %rbx, %rcx
+;;       subq    $1, %rax
+;;       jmp     0x7d0
+;;  8aa: addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;  2b4: ud2
+;;  8b3: ud2
+;;  8b5: ud2
+;;  8b7: ud2
+;;  8b9: ud2
+;;  8bb: ud2
+;;  8bd: ud2
+;;  8bf: ud2
+;;  8c1: ud2
+;;  8c3: ud2
+;;  8c5: ud2
+;;  8c7: ud2
+;;  8c9: ud2
+;;  8cb: ud2
+;;  8cd: ud2
+;;  8cf: ud2
+;;  8d1: ud2
+;;  8d3: ud2
+;;  8d5: ud2
+;;  8d7: ud2
+;;  8d9: ud2
+;;  8db: ud2
+;;  8dd: ud2
+;;  8df: ud2
+;;  8e1: ud2
+;;  8e3: ud2
+;;  8e5: ud2
+;;  8e7: ud2
+;;  8e9: ud2
+;;  8eb: ud2
+;;  8ed: ud2
+;;  8ef: ud2
 ;;
 ;; wasm[0]::function[11]:
 ;;       pushq   %rbp
@@ -212,8 +627,8 @@
 ;;       movq    0x18(%r11), %r11
 ;;       addq    $0x30, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x3c6
-;;  2dc: movq    %rdi, %r14
+;;       ja      0xa06
+;;  91c: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
 ;;       movq    %rsi, 0x10(%rsp)
@@ -226,8 +641,8 @@
 ;;       movq    %r14, %rdx
 ;;       movq    0xd8(%rdx), %rbx
 ;;       cmpq    %rbx, %rcx
-;;       jae     0x3c8
-;;  321: movq    %rcx, %r11
+;;       jae     0xa08
+;;  961: movq    %rcx, %r11
 ;;       imulq   $8, %r11, %r11
 ;;       movq    0xd0(%rdx), %rdx
 ;;       movq    %rdx, %rsi
@@ -236,27 +651,27 @@
 ;;       cmovaeq %rsi, %rdx
 ;;       movq    (%rdx), %rax
 ;;       testq   %rax, %rax
-;;       jne     0x385
-;;  34b: subq    $4, %rsp
+;;       jne     0x9c5
+;;  98b: subq    $4, %rsp
 ;;       movl    %ecx, (%rsp)
 ;;       subq    $0xc, %rsp
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
 ;;       movl    0xc(%rsp), %edx
-;;       callq   0x9cd
+;;       callq   0xfc2
 ;;       addq    $0xc, %rsp
 ;;       addq    $4, %rsp
 ;;       movq    0x18(%rsp), %r14
-;;       jmp     0x38b
-;;  385: andq    $0xfffffffffffffffe, %rax
+;;       jmp     0x9cb
+;;  9c5: andq    $0xfffffffffffffffe, %rax
 ;;       testq   %rax, %rax
-;;       je      0x3ca
-;;  394: movq    0x28(%r14), %r11
+;;       je      0xa0a
+;;  9d4: movq    0x28(%r14), %r11
 ;;       movl    (%r11), %ecx
 ;;       movl    0x10(%rax), %edx
 ;;       cmpl    %edx, %ecx
-;;       jne     0x3cc
-;;  3a6: pushq   %rax
+;;       jne     0xa0c
+;;  9e6: pushq   %rax
 ;;       popq    %rcx
 ;;       movq    0x18(%rcx), %rbx
 ;;       movq    8(%rcx), %rdx
@@ -267,7 +682,7 @@
 ;;       addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;  3c6: ud2
-;;  3c8: ud2
-;;  3ca: ud2
-;;  3cc: ud2
+;;  a06: ud2
+;;  a08: ud2
+;;  a0a: ud2
+;;  a0c: ud2

--- a/tests/disas/x64-simd-round-without-sse41.wat
+++ b/tests/disas/x64-simd-round-without-sse41.wat
@@ -17,7 +17,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, f32) -> f32 tail
-;;     fn0 = colocated u805306368:33 sig0
+;;     fn0 = colocated u805306368:32 sig0
 ;;     const0 = 0x00000000000000000000000000000000
 ;;     stack_limit = gv2
 ;;
@@ -49,7 +49,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, f32) -> f32 tail
-;;     fn0 = colocated u805306368:35 sig0
+;;     fn0 = colocated u805306368:34 sig0
 ;;     const0 = 0x00000000000000000000000000000000
 ;;     stack_limit = gv2
 ;;
@@ -81,7 +81,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, f32) -> f32 tail
-;;     fn0 = colocated u805306368:37 sig0
+;;     fn0 = colocated u805306368:36 sig0
 ;;     const0 = 0x00000000000000000000000000000000
 ;;     stack_limit = gv2
 ;;
@@ -113,7 +113,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, f32) -> f32 tail
-;;     fn0 = colocated u805306368:39 sig0
+;;     fn0 = colocated u805306368:38 sig0
 ;;     const0 = 0x00000000000000000000000000000000
 ;;     stack_limit = gv2
 ;;
@@ -145,7 +145,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, f64) -> f64 tail
-;;     fn0 = colocated u805306368:34 sig0
+;;     fn0 = colocated u805306368:33 sig0
 ;;     const0 = 0x00000000000000000000000000000000
 ;;     stack_limit = gv2
 ;;
@@ -171,7 +171,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, f64) -> f64 tail
-;;     fn0 = colocated u805306368:36 sig0
+;;     fn0 = colocated u805306368:35 sig0
 ;;     const0 = 0x00000000000000000000000000000000
 ;;     stack_limit = gv2
 ;;
@@ -197,7 +197,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, f64) -> f64 tail
-;;     fn0 = colocated u805306368:38 sig0
+;;     fn0 = colocated u805306368:37 sig0
 ;;     const0 = 0x00000000000000000000000000000000
 ;;     stack_limit = gv2
 ;;
@@ -223,7 +223,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, f64) -> f64 tail
-;;     fn0 = colocated u805306368:40 sig0
+;;     fn0 = colocated u805306368:39 sig0
 ;;     const0 = 0x00000000000000000000000000000000
 ;;     stack_limit = gv2
 ;;

--- a/winch/codegen/src/codegen/mod.rs
+++ b/winch/codegen/src/codegen/mod.rs
@@ -24,8 +24,8 @@ use wasmparser::{
 };
 use wasmtime_cranelift::{TRAP_BAD_SIGNATURE, TRAP_HEAP_MISALIGNED, TRAP_TABLE_OUT_OF_BOUNDS};
 use wasmtime_environ::{
-    DataIndex, FUNCREF_MASK, GlobalIndex, MemoryIndex, MemoryKind, MemoryTunables, PtrSize,
-    TableIndex, Tunables, TypeIndex, WasmHeapType, WasmValType,
+    DataIndex, FUNCREF_INIT_BIT, FUNCREF_MASK, GlobalIndex, MemoryIndex, MemoryKind,
+    MemoryTunables, PtrSize, TableIndex, Tunables, TypeIndex, WasmHeapType, WasmValType,
 };
 
 mod context;
@@ -567,13 +567,22 @@ where
         }
     }
 
-    pub fn emit_lazy_init_funcref(&mut self, table_index: TableIndex) -> Result<()> {
-        assert!(self.tunables.table_lazy_init, "unsupported eager init");
+    pub fn emit_table_get(&mut self, table_index: TableIndex) -> Result<()> {
+        let table = self.env.table(table_index);
+        let heap_type = table.ref_type.heap_type;
+        ensure!(
+            heap_type == WasmHeapType::Func,
+            CodeGenError::unsupported_wasm_type()
+        );
+        ensure!(
+            self.tunables.table_lazy_init,
+            CodeGenError::unsupported_table_eager_init()
+        );
         let table_data = self.env.resolve_table_data(table_index);
         let ptr_type = self.env.ptr_type();
         let builtin = self.env.builtins.table_get_lazy_init_func_ref::<M::ABI>()?;
 
-        // Request the builtin's  result register and use it to hold the table
+        // Request the builtin's result register and use it to hold the table
         // element value. We preemptively spill and request this register to
         // avoid conflict at the control flow merge below. Requesting the result
         // register is safe since we know ahead-of-time the builtin's signature.
@@ -645,6 +654,239 @@ where
             .and(writable!(dst), dst, imm, top.ty.try_into()?)?;
 
         self.masm.bind(cont)
+    }
+
+    /// Emit the `table.set` operation for a function-reference table.
+    ///
+    /// Expects the value stack to contain `[index, value]` (with `value` on
+    /// top) and consumes both.
+    pub fn emit_table_set(&mut self, table_index: TableIndex) -> Result<()> {
+        let table = self.env.table(table_index);
+        ensure!(
+            table.ref_type.heap_type == WasmHeapType::Func,
+            CodeGenError::unsupported_wasm_type()
+        );
+        ensure!(
+            self.tunables.table_lazy_init,
+            CodeGenError::unsupported_table_eager_init()
+        );
+        let ptr_type = self.env.ptr_type();
+        let table_data = self.env.resolve_table_data(table_index);
+        let value = self.context.pop_to_reg(self.masm, None)?;
+        let index = self.context.pop_to_reg(self.masm, None)?;
+        let base = self.context.any_gpr(self.masm)?;
+        let elem_addr = self.emit_compute_table_elem_addr(index.into(), base, &table_data)?;
+        // Set the initialized bit.
+        self.masm.or(
+            writable!(value.into()),
+            value.into(),
+            RegImm::i64(FUNCREF_INIT_BIT as i64),
+            ptr_type.try_into()?,
+        )?;
+
+        self.masm.store_ptr(value.into(), elem_addr)?;
+
+        self.context.free_reg(value);
+        self.context.free_reg(index);
+        self.context.free_reg(base);
+        Ok(())
+    }
+
+    /// Emits a bounds check for the range `[idx, idx + len)` against the
+    /// current size of `table_data`, trapping with `TRAP_TABLE_OUT_OF_BOUNDS`
+    /// if the range is out-of-bounds.
+    ///
+    /// Both `idx` and `len` are expected to be 64-bit values.
+    fn emit_table_range_bounds_check(
+        &mut self,
+        table_data: &TableData,
+        idx: Reg,
+        len: Reg,
+    ) -> Result<()> {
+        self.emit_compute_table_size(table_data)?;
+        let size = self.context.pop_to_reg(self.masm, None)?;
+
+        // Compute `end = idx + len`, trapping on overflow, and then trap if
+        // `end > size`.
+        let end = self.context.any_gpr(self.masm)?;
+        self.masm
+            .mov(writable!(end), idx.into(), OperandSize::S64)?;
+        self.masm.checked_uadd(
+            writable!(end),
+            end,
+            len.into(),
+            OperandSize::S64,
+            TRAP_TABLE_OUT_OF_BOUNDS,
+        )?;
+        self.masm.cmp(end, size.reg.into(), OperandSize::S64)?;
+        self.masm
+            .trapif(IntCmpKind::GtU, TRAP_TABLE_OUT_OF_BOUNDS)?;
+
+        self.context.free_reg(size);
+        self.context.free_reg(end);
+        Ok(())
+    }
+
+    /// Emit the `table.copy` operation.
+    pub fn emit_table_copy(&mut self, dst_table: TableIndex, src_table: TableIndex) -> Result<()> {
+        let dst_data = self.env.resolve_table_data(dst_table);
+        let src_data = self.env.resolve_table_data(src_table);
+
+        // The value stack contains `[dst, src, len]` (top is `len`).
+        let len = self.context.pop_to_reg(self.masm, None)?;
+        let src = self.context.pop_to_reg(self.masm, None)?;
+        let dst = self.context.pop_to_reg(self.masm, None)?;
+
+        // Zero-extend each operand to a full 64-bit value so that the
+        // arithmetic and bounds checks below can uniformly operate on 64-bit
+        // quantities regardless of the table's index type.
+        for op in [&len, &src, &dst] {
+            if op.ty == WasmValType::I32 {
+                self.masm.extend(
+                    writable!(op.reg),
+                    op.reg,
+                    Extend::<Zero>::I64Extend32.into(),
+                )?;
+            }
+        }
+
+        // Bounds check both ranges up-front; `table.copy` traps without
+        // copying anything if either range is out-of-bounds.
+        self.emit_table_range_bounds_check(&src_data, src.reg, len.reg)?;
+        self.emit_table_range_bounds_check(&dst_data, dst.reg, len.reg)?;
+
+        // Decide the copy direction. If `dst <= src` then do a forwards copy
+        // and otherwise it's backwards.
+        let step = self.context.any_gpr(self.masm)?;
+        let forward = self.masm.get_label()?;
+        let setup_done = self.masm.get_label()?;
+        self.masm.branch(
+            IntCmpKind::LeU,
+            dst.reg,
+            src.reg.into(),
+            forward,
+            OperandSize::S64,
+        )?;
+        // Backwards: start at the last element and walk down.
+        {
+            self.masm
+                .mov(writable!(step), RegImm::i64(-1), OperandSize::S64)?;
+            self.masm.add(
+                writable!(src.reg),
+                src.reg,
+                len.reg.into(),
+                OperandSize::S64,
+            )?;
+            self.masm.sub(
+                writable!(src.reg),
+                src.reg,
+                RegImm::i64(1),
+                OperandSize::S64,
+            )?;
+            self.masm.add(
+                writable!(dst.reg),
+                dst.reg,
+                len.reg.into(),
+                OperandSize::S64,
+            )?;
+            self.masm.sub(
+                writable!(dst.reg),
+                dst.reg,
+                RegImm::i64(1),
+                OperandSize::S64,
+            )?;
+        }
+        self.masm.jmp(setup_done)?;
+        // Forwards: start at the first element and walk up.
+        self.masm.bind(forward)?;
+        {
+            self.masm
+                .mov(writable!(step), RegImm::i64(1), OperandSize::S64)?;
+        }
+
+        self.masm.bind(setup_done)?;
+
+        let header = self.masm.get_label()?;
+        let exit = self.masm.get_label()?;
+
+        self.masm.bind(header)?;
+
+        // Exit the loop once there are no more elements to copy.
+        self.masm.branch(
+            IntCmpKind::Eq,
+            len.reg,
+            RegImm::i64(0),
+            exit,
+            OperandSize::S64,
+        )?;
+
+        // Spill all loop variables to the stack for the body of the loop.
+        // These will get reloaded back into the same registers at the end of
+        // the loop.
+        self.context.stack.push(TypedReg::i64(step).into());
+        self.context.stack.push(TypedReg::i64(len.reg).into());
+        self.context.stack.push(TypedReg::i64(dst.reg).into());
+        self.context.stack.push(TypedReg::i64(src.reg).into());
+
+        // Do a `table.get` followed by a `table.set`. Note that this'll redo
+        // bounds checks which technically aren't necessary, but it's less code
+        // duplication/complexity in Winch.
+        //
+        // Note that `dst` and `src` are on the stack and are needed for these
+        // operations. They're also needed at the end of the loop, so some
+        // stack-shuffling is necessary to "dup" the right values and get
+        // everything in the expected shapes for `emit_table_{get,set}`.
+        {
+            let tmp_src = self.context.pop_to_reg(self.masm, None)?;
+            let s = self.context.any_gpr(self.masm)?;
+            self.masm
+                .mov(writable!(s), tmp_src.reg.into(), OperandSize::S64)?;
+            self.context.stack.push(tmp_src.into());
+            self.context.stack.push(TypedReg::i64(s).into());
+            self.emit_table_get(src_table)?;
+            let funcref = self.context.pop_to_reg(self.masm, None)?;
+
+            let tmp_src = self.context.pop_to_reg(self.masm, None)?;
+            let tmp_dst = self.context.pop_to_reg(self.masm, None)?;
+
+            let d = self.context.any_gpr(self.masm)?;
+            self.masm
+                .mov(writable!(d), tmp_dst.reg.into(), OperandSize::S64)?;
+            self.context.stack.push(tmp_dst.into());
+            self.context.stack.push(tmp_src.into());
+            self.context.stack.push(TypedReg::i64(d).into());
+            self.context.stack.push(funcref.into());
+            self.emit_table_set(dst_table)?;
+        }
+
+        // Reload loop variables specifically back into the same registers to
+        // ensure that modifications below are picked up on the next iteration.
+        self.context.pop_to_reg(self.masm, Some(src.reg))?;
+        self.context.pop_to_reg(self.masm, Some(dst.reg))?;
+        self.context.pop_to_reg(self.masm, Some(len.reg))?;
+        self.context.pop_to_reg(self.masm, Some(step))?;
+
+        // Advance the running indices and decrement the remaining count.
+        self.masm
+            .add(writable!(dst.reg), dst.reg, step.into(), OperandSize::S64)?;
+        self.masm
+            .add(writable!(src.reg), src.reg, step.into(), OperandSize::S64)?;
+        self.masm.sub(
+            writable!(len.reg),
+            len.reg,
+            RegImm::i64(1),
+            OperandSize::S64,
+        )?;
+
+        self.masm.jmp(header)?;
+
+        self.masm.bind(exit)?;
+
+        self.context.free_reg(src);
+        self.context.free_reg(dst);
+        self.context.free_reg(len);
+        self.context.free_reg(step);
+        Ok(())
     }
 
     /// Emits a series of instructions to bounds check and calculate the address

--- a/winch/codegen/src/visitor.rs
+++ b/winch/codegen/src/visitor.rs
@@ -28,8 +28,8 @@ use wasmparser::{
 };
 use wasmtime_cranelift::TRAP_INDIRECT_CALL_TO_NULL;
 use wasmtime_environ::{
-    DataIndex, FUNCREF_INIT_BIT, FuncIndex, GlobalIndex, IndexType, MemoryIndex, TableIndex,
-    TypeIndex, WasmHeapType, WasmValType,
+    DataIndex, FuncIndex, GlobalIndex, IndexType, MemoryIndex, TableIndex, TypeIndex, WasmHeapType,
+    WasmValType,
 };
 
 /// A macro to define unsupported WebAssembly operators.
@@ -1684,7 +1684,7 @@ where
     }
 
     fn visit_call_indirect(&mut self, type_index: u32, table_index: u32) -> Self::Output {
-        // Spill now because `emit_lazy_init_funcref` and the `FnCall::emit`
+        // Spill now because `emit_table_get` and the `FnCall::emit`
         // invocations will both trigger spills since they both call functions.
         // However, the machine instructions for the spill emitted by
         // `emit_lazy_funcref` will be jumped over if the funcref was previously
@@ -1695,10 +1695,10 @@ where
         let type_index = TypeIndex::from_u32(type_index);
         let table_index = TableIndex::from_u32(table_index);
 
-        self.emit_lazy_init_funcref(table_index)?;
+        self.emit_table_get(table_index)?;
 
         // Perform the indirect call.
-        // This code assumes that [`Self::emit_lazy_init_funcref`] will
+        // This code assumes that [`Self::emit_table_get`] will
         // push the funcref to the value stack.
         let funcref_ptr = self
             .context
@@ -1733,30 +1733,12 @@ where
     }
 
     fn visit_table_copy(&mut self, dst: u32, src: u32) -> Self::Output {
-        let at = self.context.stack.ensure_index_at(3)?;
-        self.context
-            .stack
-            .insert_many(at, &[dst.try_into()?, src.try_into()?]);
-
-        let builtin = self.env.builtins.table_copy::<M::ABI>()?;
-        FnCall::emit::<M>(
-            &mut self.env,
-            self.masm,
-            &mut self.context,
-            Callee::Builtin(builtin),
-        )?;
-        self.context.pop_and_free(self.masm)
+        self.emit_table_copy(TableIndex::from_u32(dst), TableIndex::from_u32(src))
     }
 
     fn visit_table_get(&mut self, table: u32) -> Self::Output {
         let table_index = TableIndex::from_u32(table);
-        let table = self.env.table(table_index);
-        let heap_type = table.ref_type.heap_type;
-
-        match heap_type {
-            WasmHeapType::Func => self.emit_lazy_init_funcref(table_index),
-            _ => Err(format_err!(CodeGenError::unsupported_wasm_type())),
-        }
+        self.emit_table_get(table_index)
     }
 
     fn visit_table_grow(&mut self, table: u32) -> Self::Output {
@@ -1829,38 +1811,8 @@ where
     }
 
     fn visit_table_set(&mut self, table: u32) -> Self::Output {
-        let ptr_type = self.env.ptr_type();
         let table_index = TableIndex::from_u32(table);
-        let table_data = self.env.resolve_table_data(table_index);
-        let table = self.env.table(table_index);
-        match table.ref_type.heap_type {
-            WasmHeapType::Func => {
-                ensure!(
-                    self.tunables.table_lazy_init,
-                    CodeGenError::unsupported_table_eager_init()
-                );
-                let value = self.context.pop_to_reg(self.masm, None)?;
-                let index = self.context.pop_to_reg(self.masm, None)?;
-                let base = self.context.any_gpr(self.masm)?;
-                let elem_addr =
-                    self.emit_compute_table_elem_addr(index.into(), base, &table_data)?;
-                // Set the initialized bit.
-                self.masm.or(
-                    writable!(value.into()),
-                    value.into(),
-                    RegImm::i64(FUNCREF_INIT_BIT as i64),
-                    ptr_type.try_into()?,
-                )?;
-
-                self.masm.store_ptr(value.into(), elem_addr)?;
-
-                self.context.free_reg(value);
-                self.context.free_reg(index);
-                self.context.free_reg(base);
-                Ok(())
-            }
-            _ => Err(format_err!(CodeGenError::unsupported_wasm_type())),
-        }
+        self.emit_table_set(table_index)
     }
 
     fn visit_elem_drop(&mut self, index: u32) -> Self::Output {


### PR DESCRIPTION
This commit is the dual of https://github.com/bytecodealliance/wasmtime/pull/13382 but for tables. The goal here is to
move the copying operation into WebAssembly to enable fuel/epoch
checking during larger copies (https://github.com/bytecodealliance/wasmtime/issues/13387). This additionally enables
removing quite a lot of library code to implement this in the host.
Finally, most of the code to do this was already implemented for
compilation, so much of this PR focuses on refactoring all of that to
reuse all of the existing logic in a way that table support "falls out
by default".

> **Note**: the first commit here comes from #13394 for now.