### PR TITLE
wasi-keyvalue: add optional redb persistent backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3122,6 +3122,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redb"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e925444704b5f17d32bf42f5b6e2df050bceebc3dcd6e71cc73dafe8092e839"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5367,6 +5376,8 @@ dependencies = [
 name = "wasmtime-wasi-keyvalue"
 version = "46.0.0"
 dependencies = [
+ "anyhow",
+ "redb",
  "test-programs-artifacts",
  "tokio",
  "wasmtime",

--- a/crates/wasi-keyvalue/Cargo.toml
+++ b/crates/wasi-keyvalue/Cargo.toml
@@ -11,8 +11,13 @@ description = "Wasmtime implementation of the wasi-keyvalue API"
 [lints]
 workspace = true
 
+[features]
+redb = ["dep:redb", "dep:anyhow"]
+
 [dependencies]
 wasmtime = { workspace = true, features = ["runtime", "component-model", "std"] }
+redb = { version = "4.1", optional = true }
+anyhow = { workspace = true, optional = true }
 
 [dev-dependencies]
 test-programs-artifacts = { workspace = true }

--- a/crates/wasi-keyvalue/src/lib.rs
+++ b/crates/wasi-keyvalue/src/lib.rs
@@ -5,7 +5,15 @@
 //! [wasi-keyvalue] and provide components with access to key-value storages.
 //!
 //! Currently supported storage backends:
-//! * In-Memory (empty identifier)
+//! * In-Memory (empty identifier `""`)
+//! * redb — persistent embedded store (feature `redb`, identifier `"redb"` or `"redb:<bucket>"`)
+//!
+//! ## redb backend
+//!
+//! Enable with `features = ["redb"]`. Configure via [`WasiKeyValueCtxBuilder::redb_file`].
+//! An identifier of `"redb"` opens the `"default"` bucket; `"redb:mybucket"` opens `"mybucket"`.
+//! All buckets share one database file. The null-byte separator used internally (`\0`) is safe
+//! because WIT identifiers cannot contain it.
 //!
 //! # Examples
 //!
@@ -83,6 +91,16 @@ use std::collections::HashMap;
 use wasmtime::Result;
 use wasmtime::component::{HasData, Resource, ResourceTable, ResourceTableError};
 
+#[cfg(feature = "redb")]
+use redb::{Database, ReadableDatabase, ReadableTable, TableDefinition};
+#[cfg(feature = "redb")]
+use std::sync::Arc;
+
+/// Single redb table used by all buckets when the `redb` feature is enabled.
+/// Keys are encoded as `{bucket_name}\0{user_key}`.
+#[cfg(feature = "redb")]
+const KV: TableDefinition<&str, &[u8]> = TableDefinition::new("wasi_kv");
+
 #[doc(hidden)]
 pub enum Error {
     NoSuchStore,
@@ -96,15 +114,38 @@ impl From<ResourceTableError> for Error {
     }
 }
 
+#[cfg(feature = "redb")]
+macro_rules! impl_from_redb_error {
+    ($($t:ty),*) => {
+        $(impl From<$t> for Error {
+            fn from(e: $t) -> Self { Self::Other(e.to_string()) }
+        })*
+    }
+}
+
+#[cfg(feature = "redb")]
+impl_from_redb_error!(
+    redb::Error,
+    redb::DatabaseError,
+    redb::TableError,
+    redb::StorageError,
+    redb::TransactionError,
+    redb::CommitError
+);
+
 #[doc(hidden)]
-pub struct Bucket {
-    in_memory_data: HashMap<String, Vec<u8>>,
+pub enum Bucket {
+    InMemory(HashMap<String, Vec<u8>>),
+    #[cfg(feature = "redb")]
+    Redb(String),
 }
 
 /// Builder-style structure used to create a [`WasiKeyValueCtx`].
 #[derive(Default)]
 pub struct WasiKeyValueCtxBuilder {
     in_memory_data: HashMap<String, Vec<u8>>,
+    #[cfg(feature = "redb")]
+    redb: Option<Arc<Database>>,
 }
 
 impl WasiKeyValueCtxBuilder {
@@ -127,10 +168,26 @@ impl WasiKeyValueCtxBuilder {
         self
     }
 
+    /// Open (or create) a redb database file at `path` for use with the `"redb"` identifier.
+    ///
+    /// Only available with the `redb` feature enabled.
+    #[cfg(feature = "redb")]
+    pub fn redb_file(mut self, path: impl AsRef<std::path::Path>) -> anyhow::Result<Self> {
+        let db = Database::create(path.as_ref())?;
+        // Ensure the KV table exists.
+        let txn = db.begin_write()?;
+        txn.open_table(KV)?;
+        txn.commit()?;
+        self.redb = Some(Arc::new(db));
+        Ok(self)
+    }
+
     /// Uses the configured context so far to construct the final [`WasiKeyValueCtx`].
     pub fn build(self) -> WasiKeyValueCtx {
         WasiKeyValueCtx {
             in_memory_data: self.in_memory_data,
+            #[cfg(feature = "redb")]
+            redb: self.redb,
         }
     }
 }
@@ -138,6 +195,8 @@ impl WasiKeyValueCtxBuilder {
 /// Capture the state necessary for use in the `wasi-keyvalue` API implementation.
 pub struct WasiKeyValueCtx {
     in_memory_data: HashMap<String, Vec<u8>>,
+    #[cfg(feature = "redb")]
+    redb: Option<Arc<Database>>,
 }
 
 impl WasiKeyValueCtx {
@@ -163,9 +222,23 @@ impl<'a> WasiKeyValue<'a> {
 impl keyvalue::store::Host for WasiKeyValue<'_> {
     fn open(&mut self, identifier: String) -> Result<Resource<Bucket>, Error> {
         match identifier.as_str() {
-            "" => Ok(self.table.push(Bucket {
-                in_memory_data: self.ctx.in_memory_data.clone(),
-            })?),
+            "" => Ok(self.table.push(Bucket::InMemory(
+                self.ctx.in_memory_data.clone(),
+            ))?),
+            #[cfg(feature = "redb")]
+            s if s == "redb" || s.starts_with("redb:") => {
+                match &self.ctx.redb {
+                    Some(_) => {
+                        let bucket_name = if s == "redb" {
+                            "default".to_string()
+                        } else {
+                            s["redb:".len()..].to_string()
+                        };
+                        Ok(self.table.push(Bucket::Redb(bucket_name))?)
+                    }
+                    None => Err(Error::NoSuchStore),
+                }
+            }
             _ => Err(Error::NoSuchStore),
         }
     }
@@ -181,25 +254,64 @@ impl keyvalue::store::Host for WasiKeyValue<'_> {
 
 impl keyvalue::store::HostBucket for WasiKeyValue<'_> {
     fn get(&mut self, bucket: Resource<Bucket>, key: String) -> Result<Option<Vec<u8>>, Error> {
-        let bucket = self.table.get_mut(&bucket)?;
-        Ok(bucket.in_memory_data.get(&key).cloned())
+        match self.table.get_mut(&bucket)? {
+            Bucket::InMemory(map) => Ok(map.get(&key).cloned()),
+            #[cfg(feature = "redb")]
+            Bucket::Redb(name) => {
+                let encoded = redb_encode(name, &key);
+                let db = self.ctx.redb.as_ref().unwrap();
+                let txn = db.begin_read()?;
+                let table = txn.open_table(KV)?;
+                match table.get(encoded.as_str()).map_err(Error::from)? {
+                    Some(g) => Ok(Some(g.value().to_vec())),
+                    None => Ok(None),
+                }
+            }
+        }
     }
 
     fn set(&mut self, bucket: Resource<Bucket>, key: String, value: Vec<u8>) -> Result<(), Error> {
-        let bucket = self.table.get_mut(&bucket)?;
-        bucket.in_memory_data.insert(key, value);
-        Ok(())
+        match self.table.get_mut(&bucket)? {
+            Bucket::InMemory(map) => { map.insert(key, value); Ok(()) }
+            #[cfg(feature = "redb")]
+            Bucket::Redb(name) => {
+                let encoded = redb_encode(name, &key);
+                let db = self.ctx.redb.as_ref().unwrap();
+                let txn = db.begin_write()?;
+                { txn.open_table(KV)?.insert(encoded.as_str(), value.as_slice())?; }
+                txn.commit()?;
+                Ok(())
+            }
+        }
     }
 
     fn delete(&mut self, bucket: Resource<Bucket>, key: String) -> Result<(), Error> {
-        let bucket = self.table.get_mut(&bucket)?;
-        bucket.in_memory_data.remove(&key);
-        Ok(())
+        match self.table.get_mut(&bucket)? {
+            Bucket::InMemory(map) => { map.remove(&key); Ok(()) }
+            #[cfg(feature = "redb")]
+            Bucket::Redb(name) => {
+                let encoded = redb_encode(name, &key);
+                let db = self.ctx.redb.as_ref().unwrap();
+                let txn = db.begin_write()?;
+                { txn.open_table(KV)?.remove(encoded.as_str())?; }
+                txn.commit()?;
+                Ok(())
+            }
+        }
     }
 
     fn exists(&mut self, bucket: Resource<Bucket>, key: String) -> Result<bool, Error> {
-        let bucket = self.table.get_mut(&bucket)?;
-        Ok(bucket.in_memory_data.contains_key(&key))
+        match self.table.get_mut(&bucket)? {
+            Bucket::InMemory(map) => Ok(map.contains_key(&key)),
+            #[cfg(feature = "redb")]
+            Bucket::Redb(name) => {
+                let encoded = redb_encode(name, &key);
+                let db = self.ctx.redb.as_ref().unwrap();
+                let txn = db.begin_read()?;
+                let table = txn.open_table(KV)?;
+                Ok(table.get(encoded.as_str()).map_err(Error::from)?.is_some())
+            }
+        }
     }
 
     fn list_keys(
@@ -207,14 +319,32 @@ impl keyvalue::store::HostBucket for WasiKeyValue<'_> {
         bucket: Resource<Bucket>,
         cursor: Option<u64>,
     ) -> Result<keyvalue::store::KeyResponse, Error> {
-        let bucket = self.table.get_mut(&bucket)?;
-        let keys: Vec<String> = bucket.in_memory_data.keys().cloned().collect();
-        let cursor = cursor.unwrap_or(0) as usize;
-        let keys_slice = &keys[cursor..];
-        Ok(keyvalue::store::KeyResponse {
-            keys: keys_slice.to_vec(),
-            cursor: None,
-        })
+        match self.table.get_mut(&bucket)? {
+            Bucket::InMemory(map) => {
+                let keys: Vec<String> = map.keys().cloned().collect();
+                let cursor = cursor.unwrap_or(0) as usize;
+                Ok(keyvalue::store::KeyResponse {
+                    keys: keys[cursor..].to_vec(),
+                    cursor: None,
+                })
+            }
+            #[cfg(feature = "redb")]
+            Bucket::Redb(name) => {
+                let prefix = format!("{}\0", name);
+                let end = format!("{}\x01", name);
+                let prefix_len = prefix.len();
+                let db = self.ctx.redb.as_ref().unwrap();
+                let txn = db.begin_read()?;
+                let table = txn.open_table(KV)?;
+                let skip = cursor.unwrap_or(0) as usize;
+                let mut keys = Vec::new();
+                for entry in table.range(prefix.as_str()..end.as_str()).map_err(Error::from)?.skip(skip) {
+                    let (k, _) = entry.map_err(Error::from)?;
+                    keys.push(k.value()[prefix_len..].to_string());
+                }
+                Ok(keyvalue::store::KeyResponse { keys, cursor: None })
+            }
+        }
     }
 
     fn drop(&mut self, bucket: Resource<Bucket>) -> Result<()> {
@@ -230,18 +360,37 @@ impl keyvalue::atomics::Host for WasiKeyValue<'_> {
         key: String,
         delta: u64,
     ) -> Result<u64, Error> {
-        let bucket = self.table.get_mut(&bucket)?;
-        let value = bucket
-            .in_memory_data
-            .entry(key.clone())
-            .or_insert("0".to_string().into_bytes());
-        let current_value = String::from_utf8(value.clone())
-            .map_err(|e| Error::Other(e.to_string()))?
-            .parse::<u64>()
-            .map_err(|e| Error::Other(e.to_string()))?;
-        let new_value = current_value + delta;
-        *value = new_value.to_string().into_bytes();
-        Ok(new_value)
+        match self.table.get_mut(&bucket)? {
+            Bucket::InMemory(map) => {
+                let value = map.entry(key.clone()).or_insert("0".to_string().into_bytes());
+                let current_value = String::from_utf8(value.clone())
+                    .map_err(|e| Error::Other(e.to_string()))?
+                    .parse::<u64>()
+                    .map_err(|e| Error::Other(e.to_string()))?;
+                let new_value = current_value + delta;
+                *value = new_value.to_string().into_bytes();
+                Ok(new_value)
+            }
+            #[cfg(feature = "redb")]
+            Bucket::Redb(name) => {
+                let encoded = redb_encode(name, &key);
+                let db = self.ctx.redb.as_ref().unwrap();
+                let txn = db.begin_write()?;
+                let new_value = {
+                    let mut table = txn.open_table(KV)?;
+                    let current: u64 = match table.get(encoded.as_str()).map_err(Error::from)? {
+                        Some(g) => std::str::from_utf8(g.value()).ok()
+                            .and_then(|s| s.parse().ok()).unwrap_or(0),
+                        None => 0,
+                    };
+                    let next = current.saturating_add(delta);
+                    table.insert(encoded.as_str(), next.to_string().as_bytes())?;
+                    next
+                };
+                txn.commit()?;
+                Ok(new_value)
+            }
+        }
     }
 }
 
@@ -251,16 +400,27 @@ impl keyvalue::batch::Host for WasiKeyValue<'_> {
         bucket: Resource<Bucket>,
         keys: Vec<String>,
     ) -> Result<Vec<Option<(String, Vec<u8>)>>, Error> {
-        let bucket = self.table.get_mut(&bucket)?;
-        Ok(keys
-            .into_iter()
-            .map(|key| {
-                bucket
-                    .in_memory_data
-                    .get(&key)
-                    .map(|value| (key.clone(), value.clone()))
-            })
-            .collect())
+        match self.table.get_mut(&bucket)? {
+            Bucket::InMemory(map) => Ok(keys.into_iter()
+                .map(|key| map.get(&key).map(|v| (key.clone(), v.clone())))
+                .collect()),
+            #[cfg(feature = "redb")]
+            Bucket::Redb(name) => {
+                let db = self.ctx.redb.as_ref().unwrap();
+                let txn = db.begin_read()?;
+                let table = txn.open_table(KV)?;
+                let mut results = Vec::with_capacity(keys.len());
+                for key in keys {
+                    let encoded = redb_encode(name, &key);
+                    let entry = match table.get(encoded.as_str()).map_err(Error::from)? {
+                        Some(g) => Some((key.clone(), g.value().to_vec())),
+                        None => None,
+                    };
+                    results.push(entry);
+                }
+                Ok(results)
+            }
+        }
     }
 
     fn set_many(
@@ -268,20 +428,55 @@ impl keyvalue::batch::Host for WasiKeyValue<'_> {
         bucket: Resource<Bucket>,
         key_values: Vec<(String, Vec<u8>)>,
     ) -> Result<(), Error> {
-        let bucket = self.table.get_mut(&bucket)?;
-        for (key, value) in key_values {
-            bucket.in_memory_data.insert(key, value);
+        match self.table.get_mut(&bucket)? {
+            Bucket::InMemory(map) => {
+                for (key, value) in key_values { map.insert(key, value); }
+                Ok(())
+            }
+            #[cfg(feature = "redb")]
+            Bucket::Redb(name) => {
+                let db = self.ctx.redb.as_ref().unwrap();
+                let txn = db.begin_write()?;
+                {
+                    let mut table = txn.open_table(KV)?;
+                    for (key, value) in &key_values {
+                        let encoded = redb_encode(name, key);
+                        table.insert(encoded.as_str(), value.as_slice())?;
+                    }
+                }
+                txn.commit()?;
+                Ok(())
+            }
         }
-        Ok(())
     }
 
     fn delete_many(&mut self, bucket: Resource<Bucket>, keys: Vec<String>) -> Result<(), Error> {
-        let bucket = self.table.get_mut(&bucket)?;
-        for key in keys {
-            bucket.in_memory_data.remove(&key);
+        match self.table.get_mut(&bucket)? {
+            Bucket::InMemory(map) => {
+                for key in keys { map.remove(&key); }
+                Ok(())
+            }
+            #[cfg(feature = "redb")]
+            Bucket::Redb(name) => {
+                let db = self.ctx.redb.as_ref().unwrap();
+                let txn = db.begin_write()?;
+                {
+                    let mut table = txn.open_table(KV)?;
+                    for key in &keys {
+                        let encoded = redb_encode(name, key);
+                        table.remove(encoded.as_str())?;
+                    }
+                }
+                txn.commit()?;
+                Ok(())
+            }
         }
-        Ok(())
     }
+}
+
+#[cfg(feature = "redb")]
+fn redb_encode(bucket: &str, key: &str) -> String {
+    format!("{}\0{}", bucket, key)
 }
 
 /// Add all the `wasi-keyvalue` world's interfaces to a [`wasmtime::component::Linker`].

--- a/crates/wasi-keyvalue/src/lib.rs
+++ b/crates/wasi-keyvalue/src/lib.rs
@@ -222,23 +222,21 @@ impl<'a> WasiKeyValue<'a> {
 impl keyvalue::store::Host for WasiKeyValue<'_> {
     fn open(&mut self, identifier: String) -> Result<Resource<Bucket>, Error> {
         match identifier.as_str() {
-            "" => Ok(self.table.push(Bucket::InMemory(
-                self.ctx.in_memory_data.clone(),
-            ))?),
+            "" => Ok(self
+                .table
+                .push(Bucket::InMemory(self.ctx.in_memory_data.clone()))?),
             #[cfg(feature = "redb")]
-            s if s == "redb" || s.starts_with("redb:") => {
-                match &self.ctx.redb {
-                    Some(_) => {
-                        let bucket_name = if s == "redb" {
-                            "default".to_string()
-                        } else {
-                            s["redb:".len()..].to_string()
-                        };
-                        Ok(self.table.push(Bucket::Redb(bucket_name))?)
-                    }
-                    None => Err(Error::NoSuchStore),
+            s if s == "redb" || s.starts_with("redb:") => match &self.ctx.redb {
+                Some(_) => {
+                    let bucket_name = if s == "redb" {
+                        "default".to_string()
+                    } else {
+                        s["redb:".len()..].to_string()
+                    };
+                    Ok(self.table.push(Bucket::Redb(bucket_name))?)
                 }
-            }
+                None => Err(Error::NoSuchStore),
+            },
             _ => Err(Error::NoSuchStore),
         }
     }
@@ -272,13 +270,19 @@ impl keyvalue::store::HostBucket for WasiKeyValue<'_> {
 
     fn set(&mut self, bucket: Resource<Bucket>, key: String, value: Vec<u8>) -> Result<(), Error> {
         match self.table.get_mut(&bucket)? {
-            Bucket::InMemory(map) => { map.insert(key, value); Ok(()) }
+            Bucket::InMemory(map) => {
+                map.insert(key, value);
+                Ok(())
+            }
             #[cfg(feature = "redb")]
             Bucket::Redb(name) => {
                 let encoded = redb_encode(name, &key);
                 let db = self.ctx.redb.as_ref().unwrap();
                 let txn = db.begin_write()?;
-                { txn.open_table(KV)?.insert(encoded.as_str(), value.as_slice())?; }
+                {
+                    txn.open_table(KV)?
+                        .insert(encoded.as_str(), value.as_slice())?;
+                }
                 txn.commit()?;
                 Ok(())
             }
@@ -287,13 +291,18 @@ impl keyvalue::store::HostBucket for WasiKeyValue<'_> {
 
     fn delete(&mut self, bucket: Resource<Bucket>, key: String) -> Result<(), Error> {
         match self.table.get_mut(&bucket)? {
-            Bucket::InMemory(map) => { map.remove(&key); Ok(()) }
+            Bucket::InMemory(map) => {
+                map.remove(&key);
+                Ok(())
+            }
             #[cfg(feature = "redb")]
             Bucket::Redb(name) => {
                 let encoded = redb_encode(name, &key);
                 let db = self.ctx.redb.as_ref().unwrap();
                 let txn = db.begin_write()?;
-                { txn.open_table(KV)?.remove(encoded.as_str())?; }
+                {
+                    txn.open_table(KV)?.remove(encoded.as_str())?;
+                }
                 txn.commit()?;
                 Ok(())
             }
@@ -338,7 +347,11 @@ impl keyvalue::store::HostBucket for WasiKeyValue<'_> {
                 let table = txn.open_table(KV)?;
                 let skip = cursor.unwrap_or(0) as usize;
                 let mut keys = Vec::new();
-                for entry in table.range(prefix.as_str()..end.as_str()).map_err(Error::from)?.skip(skip) {
+                for entry in table
+                    .range(prefix.as_str()..end.as_str())
+                    .map_err(Error::from)?
+                    .skip(skip)
+                {
                     let (k, _) = entry.map_err(Error::from)?;
                     keys.push(k.value()[prefix_len..].to_string());
                 }
@@ -362,7 +375,9 @@ impl keyvalue::atomics::Host for WasiKeyValue<'_> {
     ) -> Result<u64, Error> {
         match self.table.get_mut(&bucket)? {
             Bucket::InMemory(map) => {
-                let value = map.entry(key.clone()).or_insert("0".to_string().into_bytes());
+                let value = map
+                    .entry(key.clone())
+                    .or_insert("0".to_string().into_bytes());
                 let current_value = String::from_utf8(value.clone())
                     .map_err(|e| Error::Other(e.to_string()))?
                     .parse::<u64>()
@@ -379,8 +394,10 @@ impl keyvalue::atomics::Host for WasiKeyValue<'_> {
                 let new_value = {
                     let mut table = txn.open_table(KV)?;
                     let current: u64 = match table.get(encoded.as_str()).map_err(Error::from)? {
-                        Some(g) => std::str::from_utf8(g.value()).ok()
-                            .and_then(|s| s.parse().ok()).unwrap_or(0),
+                        Some(g) => std::str::from_utf8(g.value())
+                            .ok()
+                            .and_then(|s| s.parse().ok())
+                            .unwrap_or(0),
                         None => 0,
                     };
                     let next = current.saturating_add(delta);
@@ -401,7 +418,8 @@ impl keyvalue::batch::Host for WasiKeyValue<'_> {
         keys: Vec<String>,
     ) -> Result<Vec<Option<(String, Vec<u8>)>>, Error> {
         match self.table.get_mut(&bucket)? {
-            Bucket::InMemory(map) => Ok(keys.into_iter()
+            Bucket::InMemory(map) => Ok(keys
+                .into_iter()
                 .map(|key| map.get(&key).map(|v| (key.clone(), v.clone())))
                 .collect()),
             #[cfg(feature = "redb")]
@@ -430,7 +448,9 @@ impl keyvalue::batch::Host for WasiKeyValue<'_> {
     ) -> Result<(), Error> {
         match self.table.get_mut(&bucket)? {
             Bucket::InMemory(map) => {
-                for (key, value) in key_values { map.insert(key, value); }
+                for (key, value) in key_values {
+                    map.insert(key, value);
+                }
                 Ok(())
             }
             #[cfg(feature = "redb")]
@@ -453,7 +473,9 @@ impl keyvalue::batch::Host for WasiKeyValue<'_> {
     fn delete_many(&mut self, bucket: Resource<Bucket>, keys: Vec<String>) -> Result<(), Error> {
         match self.table.get_mut(&bucket)? {
             Bucket::InMemory(map) => {
-                for key in keys { map.remove(&key); }
+                for key in keys {
+                    map.remove(&key);
+                }
                 Ok(())
             }
             #[cfg(feature = "redb")]

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -439,10 +439,6 @@ criteria = "safe-to-deploy"
 version = "0.4.3"
 criteria = "safe-to-deploy"
 
-[[exemptions.redb]]
-version = "4.1.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.region]]
 version = "2.2.0"
 criteria = "safe-to-deploy"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -439,6 +439,10 @@ criteria = "safe-to-deploy"
 version = "0.4.3"
 criteria = "safe-to-deploy"
 
+[[exemptions.redb]]
+version = "4.1.0"
+criteria = "safe-to-deploy"
+
 [[exemptions.region]]
 version = "2.2.0"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
## Summary

Adds a persistent [redb](https://www.redb.org)-backed storage backend to \`wasmtime-wasi-keyvalue\`, behind an optional \`redb\` Cargo feature. The existing in-memory backend is completely unchanged.

Related discussion: posted in the \`#wasi\` channel on the Bytecode Alliance Zulip (bytecodealliance.zulipchat.com) — topic: *wasi-keyvalue redb backend (approach question)*.

Standalone reference implementation: https://github.com/cargopete/wasmtime-wasi-keyvalue-redb

## Design

- New \`redb\` feature gate — zero cost when not enabled
- \`Bucket\` becomes an enum: \`InMemory(HashMap<...>)\` | \`Redb(String)\`  
- \`WasiKeyValueCtxBuilder::redb_file(path)\` configures the database
- Identifiers: \`"redb"\` → default bucket, \`"redb:<name>"\` → named bucket
- All buckets share one database file; keys encoded as \`{bucket}\0{key}\`
- Full \`store\` + \`atomics\` + \`batch\` interface coverage

## Usage

\`\`\`rust
let ctx = WasiKeyValueCtxBuilder::new()
    .redb_file("/var/lib/my-component/kv.redb")?
    .build();
\`\`\`

Then \`open("redb")\` or \`open("redb:mybucket")\` from the component.

## Notes

Opening this as a draft since I've posted in \`#wasi\` on Zulip asking whether the preferred approach is an in-crate feature (this PR) or a separate published crate. Happy to go either direction — wanted to show concrete code either way.

I'm also aware redb doesn't satisfy the Phase 2 portability criteria directly (those require Redis/DynamoDB etc.). A Redis backend is next on my list — just wanted to validate the host trait shape first with a dependency-free embedded store.