### PR TITLE
Use fallible `Arc` allocation in `MmapMemory::grow_to`

### DIFF
--- a/crates/fuzzing/src/oom.rs
+++ b/crates/fuzzing/src/oom.rs
@@ -14,7 +14,7 @@ use std::{
     task::{Context, Poll},
     time,
 };
-use wasmtime_core::error::{OutOfMemory, Result, bail};
+use wasmtime_core::error::{OutOfMemory, Result, bail, ensure};
 
 /// An allocator for use with `OomTest`.
 #[non_exhaustive]
@@ -126,7 +126,7 @@ unsafe impl GlobalAlloc for OomTestAllocator {
                     counter: 0,
                     allow_alloc_after,
                 } => {
-                    log::trace!(
+                    log::debug!(
                         "injecting OOM for allocation: {layout:?}\nAllocation backtrace:\n{bt}"
                     );
                     new_state = OomState::DidOom {
@@ -150,7 +150,7 @@ unsafe impl GlobalAlloc for OomTestAllocator {
                     log::trace!("Attempt to allocate {layout:?} after OOM:\n{bt}");
                     if allow_alloc {
                         new_state = OomState::DidOom { allow_alloc: true };
-                        ptr = ptr::null_mut();
+                        ptr = unsafe { std::alloc::System.alloc(layout) };
                     } else {
                         panic!(
                             "OOM test attempted to allocate after OOM: {layout:?}\n\
@@ -207,6 +207,7 @@ pub struct OomTest {
     max_iters: Option<u32>,
     max_duration: Option<time::Duration>,
     allow_alloc_after_oom: bool,
+    allow_missed_oom_errors: bool,
     seed: u64,
 }
 
@@ -227,6 +228,7 @@ impl OomTest {
             max_iters: None,
             max_duration: None,
             allow_alloc_after_oom: false,
+            allow_missed_oom_errors: false,
             seed: 0,
         }
     }
@@ -249,6 +251,16 @@ impl OomTest {
     /// The default is `false`.
     pub fn allow_alloc_after_oom(&mut self, allow: bool) -> &mut Self {
         self.allow_alloc_after_oom = allow;
+        self
+    }
+
+    /// Configure whether to allow a test to pass if it does not return
+    /// `Err(OutOfMemory)` when a synthetic OOM was injected (perhaps because it
+    /// is exercising logic that is robust to OOM).
+    ///
+    /// The default is `false`.
+    pub fn allow_missed_oom_errors(&mut self, allow: bool) -> &mut Self {
+        self.allow_missed_oom_errors = allow;
         self
     }
 
@@ -290,7 +302,13 @@ impl OomTest {
             }
 
             log::trace!("=== Injecting OOM after {i} allocations ===");
-            Self::run_one_oom_injection(&test_func, i, self.allow_alloc_after_oom).await?;
+            Self::run_one_oom_injection(
+                &test_func,
+                i,
+                self.allow_alloc_after_oom,
+                self.allow_missed_oom_errors,
+            )
+            .await?;
         }
 
         Ok(())
@@ -323,7 +341,13 @@ impl OomTest {
         for _ in 0..max_iters {
             let i = rng.random_range(0..total_allocs);
             log::trace!("=== Injecting OOM after {i} allocations (fuzz) ===");
-            Self::run_one_oom_injection(&test_func, i, self.allow_alloc_after_oom).await?;
+            Self::run_one_oom_injection(
+                &test_func,
+                i,
+                self.allow_alloc_after_oom,
+                self.allow_missed_oom_errors,
+            )
+            .await?;
         }
 
         Ok(())
@@ -335,6 +359,7 @@ impl OomTest {
         test_func: &impl AsyncFn() -> Result<()>,
         i: u32,
         allow_alloc_after_oom: bool,
+        allow_missed_oom_errors: bool,
     ) -> Result<()> {
         let future = std::pin::pin!(test_func());
         let (result, oom_state) = OomTestFuture::new(
@@ -359,7 +384,10 @@ impl OomTest {
 
             // Missed OOMs.
             (Ok(()), OomState::DidOom { .. }) => {
-                bail!("OOM test function missed an OOM: returned Ok(())");
+                ensure!(
+                    allow_missed_oom_errors,
+                    "OOM test function missed an OOM: returned Ok(())"
+                );
             }
             (Err(e), OomState::DidOom { .. }) => {
                 return Err(e.context("OOM test function missed an OOM: returned non-OOM error"));

--- a/crates/fuzzing/src/oom.rs
+++ b/crates/fuzzing/src/oom.rs
@@ -41,10 +41,14 @@ enum OomState {
     OomOnAlloc {
         counter: u32,
         allow_alloc_after: bool,
+        alloc_succeeds_after: bool,
     },
 
     /// We are inside an OOM test and we already injected an OOM.
-    DidOom { allow_alloc: bool },
+    DidOom {
+        allow_alloc: bool,
+        alloc_succeeds_after: bool,
+    },
 }
 
 thread_local! {
@@ -125,12 +129,14 @@ unsafe impl GlobalAlloc for OomTestAllocator {
                 OomState::OomOnAlloc {
                     counter: 0,
                     allow_alloc_after,
+                    alloc_succeeds_after,
                 } => {
                     log::debug!(
                         "injecting OOM for allocation: {layout:?}\nAllocation backtrace:\n{bt}"
                     );
                     new_state = OomState::DidOom {
                         allow_alloc: allow_alloc_after,
+                        alloc_succeeds_after,
                     };
                     ptr = ptr::null_mut();
                 }
@@ -138,19 +144,31 @@ unsafe impl GlobalAlloc for OomTestAllocator {
                 OomState::OomOnAlloc {
                     counter: c,
                     allow_alloc_after,
+                    alloc_succeeds_after,
                 } => {
                     new_state = OomState::OomOnAlloc {
                         counter: c - 1,
                         allow_alloc_after,
+                        alloc_succeeds_after,
                     };
                     ptr = unsafe { std::alloc::System.alloc(layout) };
                 }
 
-                OomState::DidOom { allow_alloc } => {
+                OomState::DidOom {
+                    allow_alloc,
+                    alloc_succeeds_after,
+                } => {
                     log::trace!("Attempt to allocate {layout:?} after OOM:\n{bt}");
                     if allow_alloc {
-                        new_state = OomState::DidOom { allow_alloc: true };
-                        ptr = unsafe { std::alloc::System.alloc(layout) };
+                        new_state = OomState::DidOom {
+                            allow_alloc: true,
+                            alloc_succeeds_after,
+                        };
+                        ptr = if alloc_succeeds_after {
+                            unsafe { std::alloc::System.alloc(layout) }
+                        } else {
+                            ptr::null_mut()
+                        };
                     } else {
                         panic!(
                             "OOM test attempted to allocate after OOM: {layout:?}\n\
@@ -207,6 +225,7 @@ pub struct OomTest {
     max_iters: Option<u32>,
     max_duration: Option<time::Duration>,
     allow_alloc_after_oom: bool,
+    alloc_succeeds_after_oom: bool,
     allow_missed_oom_errors: bool,
     seed: u64,
 }
@@ -228,6 +247,7 @@ impl OomTest {
             max_iters: None,
             max_duration: None,
             allow_alloc_after_oom: false,
+            alloc_succeeds_after_oom: false,
             allow_missed_oom_errors: false,
             seed: 0,
         }
@@ -251,6 +271,15 @@ impl OomTest {
     /// The default is `false`.
     pub fn allow_alloc_after_oom(&mut self, allow: bool) -> &mut Self {
         self.allow_alloc_after_oom = allow;
+        self
+    }
+
+    /// Configure whether allocations after an OOM (assuming
+    /// `allow_alloc_after_oom(true)`) will succeed or will always return null.
+    ///
+    /// The default is `false`.
+    pub fn alloc_succeeds_after_oom(&mut self, succeeds: bool) -> &mut Self {
+        self.alloc_succeeds_after_oom = succeeds;
         self
     }
 
@@ -302,13 +331,7 @@ impl OomTest {
             }
 
             log::trace!("=== Injecting OOM after {i} allocations ===");
-            Self::run_one_oom_injection(
-                &test_func,
-                i,
-                self.allow_alloc_after_oom,
-                self.allow_missed_oom_errors,
-            )
-            .await?;
+            self.run_one_oom_injection(&test_func, i).await?;
         }
 
         Ok(())
@@ -341,13 +364,7 @@ impl OomTest {
         for _ in 0..max_iters {
             let i = rng.random_range(0..total_allocs);
             log::trace!("=== Injecting OOM after {i} allocations (fuzz) ===");
-            Self::run_one_oom_injection(
-                &test_func,
-                i,
-                self.allow_alloc_after_oom,
-                self.allow_missed_oom_errors,
-            )
-            .await?;
+            self.run_one_oom_injection(&test_func, i).await?;
         }
 
         Ok(())
@@ -356,17 +373,17 @@ impl OomTest {
     /// Run the test function once, injecting OOM on the `i`th allocation, and
     /// check that the result correctly reflects whether an OOM was hit.
     async fn run_one_oom_injection(
+        &self,
         test_func: &impl AsyncFn() -> Result<()>,
         i: u32,
-        allow_alloc_after_oom: bool,
-        allow_missed_oom_errors: bool,
     ) -> Result<()> {
         let future = std::pin::pin!(test_func());
         let (result, oom_state) = OomTestFuture::new(
             future,
             OomState::OomOnAlloc {
                 counter: i,
-                allow_alloc_after: allow_alloc_after_oom,
+                allow_alloc_after: self.allow_alloc_after_oom,
+                alloc_succeeds_after: self.alloc_succeeds_after_oom,
             },
         )
         .await;
@@ -385,17 +402,25 @@ impl OomTest {
             // Missed OOMs.
             (Ok(()), OomState::DidOom { .. }) => {
                 ensure!(
-                    allow_missed_oom_errors,
+                    self.allow_missed_oom_errors,
                     "OOM test function missed an OOM: returned Ok(())"
                 );
             }
             (Err(e), OomState::DidOom { .. }) => {
-                return Err(e.context("OOM test function missed an OOM: returned non-OOM error"));
+                if !self.allow_missed_oom_errors {
+                    return Err(
+                        e.context("OOM test function missed an OOM: returned non-OOM error")
+                    );
+                }
             }
 
             // Unexpected error.
             (Err(e), OomState::OomOnAlloc { .. }) => {
-                return Err(e.context("OOM test function returned an error when there was no OOM"));
+                if !self.allow_missed_oom_errors {
+                    return Err(
+                        e.context("OOM test function returned an error when there was no OOM")
+                    );
+                }
             }
         }
 

--- a/crates/fuzzing/tests/oom/memory.rs
+++ b/crates/fuzzing/tests/oom/memory.rs
@@ -198,6 +198,7 @@ fn wasm_memory_grow_relocate() -> Result<()> {
 
     OomTest::new()
         .allow_alloc_after_oom(true)
+        .alloc_succeeds_after_oom(true)
         .allow_missed_oom_errors(true)
         .test(|| {
             let mut store = Store::try_new(&engine, ())?;

--- a/crates/fuzzing/tests/oom/memory.rs
+++ b/crates/fuzzing/tests/oom/memory.rs
@@ -196,12 +196,15 @@ fn wasm_memory_grow_relocate() -> Result<()> {
     let linker = Linker::<()>::new(&engine);
     let instance_pre = linker.instantiate_pre(&module)?;
 
-    OomTest::new().allow_alloc_after_oom(true).test(|| {
-        let mut store = Store::try_new(&engine, ())?;
-        let instance = instance_pre.instantiate(&mut store)?;
-        let grow = instance.get_func(&mut store, "grow").unwrap();
-        let mut results = [Val::I32(0)];
-        let _ = grow.call(&mut store, &[Val::I32(1)], &mut results);
-        Ok(())
-    })
+    OomTest::new()
+        .allow_alloc_after_oom(true)
+        .allow_missed_oom_errors(true)
+        .test(|| {
+            let mut store = Store::try_new(&engine, ())?;
+            let instance = instance_pre.instantiate(&mut store)?;
+            let grow = instance.get_func(&mut store, "grow").unwrap();
+            let mut results = [Val::I32(0)];
+            grow.call(&mut store, &[Val::I32(1)], &mut results)?;
+            Ok(())
+        })
 }

--- a/crates/fuzzing/tests/oom/memory.rs
+++ b/crates/fuzzing/tests/oom/memory.rs
@@ -1,6 +1,6 @@
 #![cfg(arc_try_new)]
 
-use wasmtime::{Config, Engine, Memory, MemoryType, Result, Store};
+use wasmtime::{Config, Engine, Linker, Memory, MemoryType, Module, Result, Store, Val};
 use wasmtime_fuzzing::oom::OomTest;
 
 #[test]
@@ -163,6 +163,45 @@ fn memory_data_mut() -> Result<()> {
         let data = memory.data_mut(&mut store);
         data[0] = 42;
         assert_eq!(data[0], 42);
+        Ok(())
+    })
+}
+
+#[test]
+fn wasm_memory_grow_relocate() -> Result<()> {
+    let module_bytes = {
+        let mut config = Config::new();
+        config.concurrency_support(false);
+        config.memory_reservation(65536);
+        config.memory_reservation_for_growth(0);
+        let engine = Engine::new(&config)?;
+        Module::new(
+            &engine,
+            r#"(module
+                (memory (export "memory") 1)
+                (func (export "grow") (param i32) (result i32)
+                    (memory.grow (local.get 0))
+                )
+            )"#,
+        )?
+        .serialize()?
+    };
+    let mut config = Config::new();
+    config.enable_compiler(false);
+    config.concurrency_support(false);
+    config.memory_reservation(65536);
+    config.memory_reservation_for_growth(0);
+    let engine = Engine::new(&config)?;
+    let module = unsafe { Module::deserialize(&engine, &module_bytes)? };
+    let linker = Linker::<()>::new(&engine);
+    let instance_pre = linker.instantiate_pre(&module)?;
+
+    OomTest::new().allow_alloc_after_oom(true).test(|| {
+        let mut store = Store::try_new(&engine, ())?;
+        let instance = instance_pre.instantiate(&mut store)?;
+        let grow = instance.get_func(&mut store, "grow").unwrap();
+        let mut results = [Val::I32(0)];
+        let _ = grow.call(&mut store, &[Val::I32(1)], &mut results);
         Ok(())
     })
 }

--- a/crates/wasmtime/src/runtime/vm/memory/mmap.rs
+++ b/crates/wasmtime/src/runtime/vm/memory/mmap.rs
@@ -187,7 +187,7 @@ impl RuntimeLinearMemory for MmapMemory {
                 dst.copy_from_slice(src);
             }
 
-            self.mmap = Arc::new(new_mmap);
+            self.mmap = try_new::<Arc<_>>(new_mmap)?;
         } else {
             // If the new size of this heap fits within the existing allocation
             // then all we need to do is to make the new pages accessible. This


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
