### PR TITLE
Fix: cross component stream copy

### DIFF
--- a/crates/misc/component-async-tests/tests/scenario/streams.rs
+++ b/crates/misc/component-async-tests/tests/scenario/streams.rs
@@ -258,6 +258,13 @@ mod closed_stream {
     });
 }
 
+mod cross_instance_source {
+    wasmtime::component::bindgen!({
+        path: "wit",
+        world: "cross-instance-source",
+    });
+}
+
 #[tokio::test]
 pub async fn async_closed_stream() -> Result<()> {
     let engine = Engine::new(&config())?;
@@ -294,6 +301,69 @@ pub async fn async_closed_stream() -> Result<()> {
             Ok(())
         })
         .await?
+}
+
+#[tokio::test]
+pub async fn async_cross_instance_source() -> Result<()> {
+    let engine = Engine::new(&config())?;
+
+    let source_component = make_component(
+        &engine,
+        &[test_programs_artifacts::ASYNC_CROSS_INSTANCE_SOURCE_COMPONENT],
+    )
+    .await?;
+    let sink_component = make_component(
+        &engine,
+        &[test_programs_artifacts::ASYNC_CLOSED_STREAMS_COMPONENT],
+    )
+    .await?;
+
+    let mut linker = Linker::new(&engine);
+
+    wasmtime_wasi::p2::add_to_linker_async(&mut linker)?;
+
+    let mut store = Store::new(
+        &engine,
+        Ctx {
+            wasi: WasiCtxBuilder::new().inherit_stdio().build(),
+            table: ResourceTable::default(),
+            continue_: false,
+        },
+    );
+
+    let source_instance = linker
+        .instantiate_async(&mut store, &source_component)
+        .await?;
+    let sink_instance = linker
+        .instantiate_async(&mut store, &sink_component)
+        .await?;
+
+    let source = cross_instance_source::CrossInstanceSource::new(&mut store, &source_instance)?;
+    let sink = closed_streams::bindings::ClosedStreams::new(&mut store, &sink_instance)?;
+
+    let stream_expected = vec![2_u8, 4, 6, 8, 9];
+    let future_expected = 10_u8;
+    let (_, ignored_future_rx) = oneshot::channel();
+    let ignored_future = FutureReader::new(&mut store, OneshotProducer::new(ignored_future_rx))?;
+
+    store
+        .run_concurrent(async move |accessor| {
+            let (stream, future) = source
+                .local_local_cross_instance()
+                .call_make(accessor)
+                .await?;
+
+            let closed = sink.local_local_closed();
+            let read_stream = closed.call_read_stream(accessor, stream, stream_expected);
+            let read_future =
+                closed.call_read_future(accessor, future, future_expected, ignored_future);
+
+            future::try_join(read_stream, read_future).await?;
+            wasmtime::error::Ok(())
+        })
+        .await??;
+
+    Ok(())
 }
 
 struct VecProducer<T> {

--- a/crates/misc/component-async-tests/tests/test_all.rs
+++ b/crates/misc/component-async-tests/tests/test_all.rs
@@ -30,7 +30,9 @@ use scenario::round_trip_many::{
     async_round_trip_many_stackful, async_round_trip_many_stackless,
     async_round_trip_many_synchronous, async_round_trip_many_wait,
 };
-use scenario::streams::{async_closed_stream, async_closed_streams, async_short_reads};
+use scenario::streams::{
+    async_closed_stream, async_closed_streams, async_cross_instance_source, async_short_reads,
+};
 use scenario::transmit::{
     async_cancel_callee, async_cancel_caller, async_cancel_transmit, async_intertask_communication,
     async_poll_stackless, async_poll_synchronous, async_readiness, async_synchronous_transmit,

--- a/crates/misc/component-async-tests/wit/test.wit
+++ b/crates/misc/component-async-tests/wit/test.wit
@@ -175,6 +175,10 @@ interface synchronous-transmit {
   start: async func(s: stream<u8>, s-expected: list<u8>, f: future<u8>, f-expected: u8) -> tuple<stream<u8>, list<u8>, future<u8>, u8>;
 }
 
+interface cross-instance {
+  make: async func() -> tuple<stream<u8>, future<u8>>;
+}
+
 interface yield-post-return {
   run: async func(times: u64);
 }
@@ -344,6 +348,10 @@ world readiness-guest {
 
 world synchronous-transmit-guest {
   export synchronous-transmit;
+}
+
+world cross-instance-source {
+  export cross-instance;
 }
 
 world yield-post-return-callee {

--- a/crates/test-programs/src/bin/async_cross_instance_source.rs
+++ b/crates/test-programs/src/bin/async_cross_instance_source.rs
@@ -1,0 +1,33 @@
+mod bindings {
+    wit_bindgen::generate!({
+        path: "../misc/component-async-tests/wit",
+        world: "cross-instance-source",
+    });
+
+    use super::Component;
+    export!(Component);
+}
+
+use {
+    bindings::{exports::local::local::cross_instance::Guest, wit_future, wit_stream},
+    wit_bindgen::{FutureReader, StreamReader},
+};
+
+struct Component;
+
+impl Guest for Component {
+    async fn make() -> (StreamReader<u8>, FutureReader<u8>) {
+        let (mut stream_tx, stream_rx) = wit_stream::new();
+        let (future_tx, future_rx) = wit_future::new(|| 0);
+
+        wit_bindgen::spawn(async move {
+            assert!(stream_tx.write_all(vec![2, 4, 6, 8, 9]).await.is_empty());
+            future_tx.write(10).await.unwrap();
+        });
+
+        (stream_rx, future_rx)
+    }
+}
+
+// Unused function; required since this file is built as a `bin`:
+fn main() {}

--- a/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams.rs
@@ -3269,7 +3269,6 @@ impl Instance {
     /// Copy `count` items from `read_address` to `write_address` for the
     /// specified stream or future.
     fn copy<T: 'static>(
-        self,
         store: StoreContextMut<T>,
         flat_abi: Option<FlatAbi>,
         write_instance: Instance,
@@ -3614,7 +3613,7 @@ impl Instance {
 
                 let count = count.min(read_count);
 
-                self.copy(
+                Instance::copy(
                     store.as_context_mut(),
                     flat_abi,
                     self,
@@ -3852,7 +3851,7 @@ impl Instance {
 
                 let count = count.min(write_count);
 
-                self.copy(
+                Instance::copy(
                     store.as_context_mut(),
                     flat_abi,
                     write_instance,

--- a/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams.rs
@@ -3902,7 +3902,7 @@ impl Instance {
                 if write_buffer_remaining {
                     let transmit = concurrent_state.get_mut(transmit_id)?;
                     transmit.write = WriteState::GuestReady {
-                        instance: self,
+                        instance: write_instance,
                         caller: write_caller,
                         ty: write_ty,
                         flat_abi: write_flat_abi,

--- a/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams.rs
@@ -3272,10 +3272,12 @@ impl Instance {
         self,
         store: StoreContextMut<T>,
         flat_abi: Option<FlatAbi>,
+        write_instance: Instance,
         write_caller_instance: RuntimeComponentInstanceIndex,
         write_ty: TransmitIndex,
         write_options: OptionsIndex,
         write_address: usize,
+        read_instance: Instance,
         read_caller_instance: RuntimeComponentInstanceIndex,
         read_caller_thread: QualifiedThreadId,
         read_ty: TransmitIndex,
@@ -3284,15 +3286,17 @@ impl Instance {
         count: ItemCount,
         rep: u32,
     ) -> Result<()> {
-        let (component, mut store) = self.component_and_store_mut(store.0);
-        let types = component.types();
+        let (write_component, store) = write_instance.component_and_store_mut(store.0);
+        let (read_component, mut store) = read_instance.component_and_store_mut(store);
+        let write_types = write_component.types();
+        let read_types = read_component.types();
         let count = count.as_usize();
 
         // Validate `write_ty` w.r.t. `write_address` to ensure it's properly
         // aligned and in-bounds.
-        let write_payload_ty = write_ty.payload(types);
+        let write_payload_ty = write_ty.payload(write_types);
         let write_abi = match write_payload_ty {
-            Some(ty) => types.canonical_abi(ty),
+            Some(ty) => write_types.canonical_abi(ty),
             None => &CanonicalAbiInfo::ZERO,
         };
         let write_length_in_bytes = match flat_abi {
@@ -3303,15 +3307,16 @@ impl Instance {
             if write_address % usize::try_from(write_abi.align32)? != 0 {
                 bail!("write pointer not aligned");
             }
-            self.options_memory(store, write_options)
+            write_instance
+                .options_memory(store, write_options)
                 .get(write_address..)
                 .and_then(|b| b.get(..write_length_in_bytes))
                 .ok_or_else(|| crate::format_err!("write pointer out of bounds"))?;
         }
 
-        let read_payload_ty = read_ty.payload(types);
+        let read_payload_ty = read_ty.payload(read_types);
         let read_abi = match read_payload_ty {
-            Some(ty) => types.canonical_abi(ty),
+            Some(ty) => read_types.canonical_abi(ty),
             None => &CanonicalAbiInfo::ZERO,
         };
         let read_length_in_bytes = match flat_abi {
@@ -3322,7 +3327,8 @@ impl Instance {
             if read_address % usize::try_from(read_abi.align32)? != 0 {
                 bail!("read pointer not aligned");
             }
-            self.options_memory(store, read_options)
+            read_instance
+                .options_memory(store, read_options)
                 .get(read_address..)
                 .and_then(|b| b.get(..read_length_in_bytes))
                 .ok_or_else(|| crate::format_err!("read pointer out of bounds"))?;
@@ -3344,7 +3350,7 @@ impl Instance {
 
                 let val = write_payload_ty
                     .map(|ty| {
-                        let lift = &mut LiftContext::new(store, write_options, self);
+                        let lift = &mut LiftContext::new(store, write_options, write_instance);
                         let bytes = &lift.memory()[write_address..][..write_length_in_bytes];
                         Val::load(lift, *ty, bytes)
                     })
@@ -3355,7 +3361,8 @@ impl Instance {
                     // set the guest's thread context in case realloc requires it, and restore the original
                     // thread context after the copy is complete.
                     let old_thread = store.set_thread(read_caller_thread)?;
-                    let lower = &mut LowerContext::new(store.as_context_mut(), read_options, self);
+                    let lower =
+                        &mut LowerContext::new(store.as_context_mut(), read_options, read_instance);
                     let ptr = func::validate_inbounds_dynamic(
                         read_abi,
                         lower.as_slice_mut(),
@@ -3387,19 +3394,23 @@ impl Instance {
 
                     assert_eq!(read_length_in_bytes, write_length_in_bytes);
 
-                    if self.options_memory(store_opaque, read_options).as_ptr()
-                        == self.options_memory(store_opaque, write_options).as_ptr()
+                    if read_instance
+                        .options_memory(store_opaque, read_options)
+                        .as_ptr()
+                        == write_instance
+                            .options_memory(store_opaque, write_options)
+                            .as_ptr()
                     {
-                        let memory = self.options_memory_mut(store_opaque, read_options);
+                        let memory = read_instance.options_memory_mut(store_opaque, read_options);
                         memory.copy_within(
                             write_address..write_address + write_length_in_bytes,
                             read_address,
                         );
                     } else {
-                        let src = self.options_memory(store_opaque, write_options)[write_address..]
-                            [..write_length_in_bytes]
+                        let src = write_instance.options_memory(store_opaque, write_options)
+                            [write_address..][..write_length_in_bytes]
                             .as_ptr();
-                        let dst = self.options_memory_mut(store_opaque, read_options)
+                        let dst = read_instance.options_memory_mut(store_opaque, read_options)
                             [read_address..][..read_length_in_bytes]
                             .as_mut_ptr();
 
@@ -3418,7 +3429,7 @@ impl Instance {
                     }
                 } else {
                     let store_opaque = store.store_opaque_mut();
-                    let lift = &mut LiftContext::new(store_opaque, write_options, self);
+                    let lift = &mut LiftContext::new(store_opaque, write_options, write_instance);
                     let bytes = &lift.memory()[write_address..][..write_length_in_bytes];
                     lift.consume_fuel_array(count, size_of::<Val>())?;
 
@@ -3436,7 +3447,8 @@ impl Instance {
                     // set the guest's thread context in case realloc requires it, and restore the original
                     // thread context after the copy is complete.
                     let old_thread = store.set_thread(read_caller_thread)?;
-                    let lower = &mut LowerContext::new(store.as_context_mut(), read_options, self);
+                    let lower =
+                        &mut LowerContext::new(store.as_context_mut(), read_options, read_instance);
                     let mut ptr = read_address;
                     for value in values {
                         value.store(lower, *read_payload_ty, ptr)?;
@@ -3605,10 +3617,12 @@ impl Instance {
                 self.copy(
                     store.as_context_mut(),
                     flat_abi,
+                    self,
                     caller,
                     ty,
                     options,
                     address,
+                    read_instance,
                     read_caller_instance,
                     read_caller_thread,
                     read_ty,
@@ -3618,9 +3632,9 @@ impl Instance {
                     rep,
                 )?;
 
-                let instance = self.id().get_mut(store.0);
+                let instance = read_instance.id().get(store.0);
                 let types = instance.component().types();
-                let item_size = match ty.payload(types) {
+                let item_size = match read_ty.payload(types) {
                     Some(ty) => usize::try_from(types.canonical_abi(ty).size32)?,
                     None => 0,
                 };
@@ -3809,7 +3823,7 @@ impl Instance {
 
         let mut result = match mem::replace(&mut transmit.write, new_state) {
             WriteState::GuestReady {
-                instance: _,
+                instance: write_instance,
                 ty: write_ty,
                 flat_abi: write_flat_abi,
                 options: write_options,
@@ -3841,10 +3855,12 @@ impl Instance {
                 self.copy(
                     store.as_context_mut(),
                     flat_abi,
+                    write_instance,
                     write_caller,
                     write_ty,
                     write_options,
                     write_address,
+                    self,
                     caller_instance,
                     caller_thread,
                     ty,
@@ -3854,9 +3870,9 @@ impl Instance {
                     rep,
                 )?;
 
-                let instance = self.id().get_mut(store.0);
+                let instance = write_instance.id().get(store.0);
                 let types = instance.component().types();
-                let item_size = match ty.payload(types) {
+                let item_size = match write_ty.payload(types) {
                     Some(ty) => usize::try_from(types.canonical_abi(ty).size32)?,
                     None => 0,
                 };


### PR DESCRIPTION
## Summary

Fix cross-component async `stream` / `future` copy logic so writer-side payload metadata and memory are resolved from the writer component instance, while reader-side payload metadata and memory are resolved from the reader component instance.

Previously, `Instance::copy` resolved both `write_ty` and `read_ty` against `self.component().types()`. That works when both endpoints are inside one composed component graph, but breaks when the stream crosses dynamically linked component instances with distinct `ComponentTypes` tables.

## Problem

When a guest-created `stream<T>` is returned by one component and passed into another dynamically linked component, the stream handle can be valid while the payload copy uses the wrong component type table or memory/options.

The same issue can also surface as internal panics such as:

```text
BUG: expected write payload type to be present
```

## Fix

`Instance::copy` now receives both endpoint instances:

- `write_instance` for writer payload ABI, writer memory, and `LiftContext`
- `read_instance` for reader payload ABI, reader memory, and `LowerContext`

The guest write/read rendezvous call sites now pass the correct endpoint instances through to `copy`.

This also fixes partial stream writes by preserving the original `write_instance` when re-storing a pending `WriteState::GuestReady`; otherwise subsequent reads of the remaining write buffer could accidentally use the reader instance.

## Validation

Only Validated locally with wasmCloud’s [`examples/patch-stream`](https://github.com/wasmCloud/wasmCloud/pull/5171) a setup (which I will promptly create for wasmtime), where:

- a producer component returns `stream<u8>`
- a consumer component forwards that stream to a third component
- the sink component drains and logs each NDJSON patch line

Before this fix, the sink saw corrupted binary-looking data. After this fix, it receives all expected patch lines and the stream closes cleanly:

Also ran:

```sh
cargo check -p wasmtime --features component-model,component-model-async
```