### PR TITLE
c-api: Fix reference to wasmtime_config_concurrency_support without ifdef

### DIFF
--- a/crates/c-api/include/wasmtime/config.hh
+++ b/crates/c-api/include/wasmtime/config.hh
@@ -628,6 +628,7 @@ public:
   }
 #endif // WASMTIME_FEATURE_POOLING_ALLOCATOR
 
+#ifdef WASMTIME_FEATURE_COMPONENT_MODEL
   /**
    * \brief Specifies whether support for concurrent execution of WebAssembly is
    * supported within this store.
@@ -638,6 +639,7 @@ public:
   void concurrency_support(bool enable) {
     wasmtime_config_concurrency_support_set(ptr.get(), enable);
   }
+#endif // WASMTIME_FEATURE_COMPONENT_MODEL
 };
 
 } // namespace wasmtime


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->

When updating wasmtime in github.com/proxy-wasm/proxy-wasm-cpp-host (which is now using the C++ API), I noticed that this config setting, introduced in #12703, is behind an `#ifdef` in the c-api, but not in the C++ API. This produces a link-time error when using the c++ API without the concurrency-support feature.