### PR TITLE
Trigger GC in the DRC collector when the OASR list is twice the size it was after the last GC

### DIFF
--- a/crates/cranelift/src/func_environ/gc/enabled/drc.rs
+++ b/crates/cranelift/src/func_environ/gc/enabled/drc.rs
@@ -15,12 +15,32 @@ use wasmtime_environ::{
     WasmResult, WasmStorageType, WasmValType, drc::DrcTypeLayouts,
 };
 
+// The minimum over-approximated stack roots list size for which we will trigger
+// a GC.
+const MIN_OVER_APPROX_STACK_ROOTS_GC_THRESHOLD: i64 = 1024;
+
 #[derive(Default)]
 pub struct DrcCompiler {
     layouts: DrcTypeLayouts,
 }
 
 impl DrcCompiler {
+    /// Load the pointer to the `VMDrcHeapData` from vmctx.
+    fn load_vmdrc_heap_data_ptr(
+        func_env: &mut FuncEnvironment<'_>,
+        builder: &mut FunctionBuilder,
+    ) -> ir::Value {
+        let ptr_ty = func_env.pointer_type();
+        let vmctx = func_env.vmctx(&mut builder.func);
+        let vmctx = builder.ins().global_value(ptr_ty, vmctx);
+        builder.ins().load(
+            ptr_ty,
+            ir::MemFlagsData::trusted().with_readonly().with_can_move(),
+            vmctx,
+            i32::from(func_env.offsets.ptr.vmctx_gc_heap_data()),
+        )
+    }
+
     /// Generate code to load the given GC reference's ref count.
     ///
     /// Assumes that the given `gc_ref` is a non-null, non-i31 GC reference.
@@ -115,6 +135,11 @@ impl DrcCompiler {
 
         // Commit this object as the new head of the list.
         builder.ins().store(GC_MEMFLAGS, gc_ref, head, 0);
+
+        // Increment the list's length.
+        let current_len = self.load_current_over_approximated_stack_roots_len(func_env, builder);
+        let new_current_len = builder.ins().iadd_imm(current_len, 1);
+        self.store_current_over_approximated_stack_roots_len(func_env, builder, new_current_len);
     }
 
     /// Load a pointer to the first element of the DRC heap's
@@ -124,15 +149,121 @@ impl DrcCompiler {
         func_env: &mut FuncEnvironment<'_>,
         builder: &mut FunctionBuilder,
     ) -> ir::Value {
-        let ptr_ty = func_env.pointer_type();
-        let vmctx = func_env.vmctx(&mut builder.func);
-        let vmctx = builder.ins().global_value(ptr_ty, vmctx);
+        let ptr = Self::load_vmdrc_heap_data_ptr(func_env, builder);
+        let offset = i64::from(
+            func_env
+                .offsets
+                .ptr
+                .vmdrc_heap_data_over_approximated_stack_roots(),
+        );
+        if offset == 0 {
+            ptr
+        } else {
+            builder.ins().iadd_imm(ptr, offset)
+        }
+    }
+
+    /// Load the current size of the over-approximated-stack-roots list.
+    fn load_current_over_approximated_stack_roots_len(
+        &mut self,
+        func_env: &mut FuncEnvironment<'_>,
+        builder: &mut FunctionBuilder,
+    ) -> ir::Value {
+        let ptr = Self::load_vmdrc_heap_data_ptr(func_env, builder);
         builder.ins().load(
-            ptr_ty,
-            ir::MemFlagsData::trusted().with_readonly(),
-            vmctx,
-            i32::from(func_env.offsets.ptr.vmctx_gc_heap_data()),
+            ir::types::I32,
+            ir::MemFlagsData::trusted(),
+            ptr,
+            i32::from(
+                func_env
+                    .offsets
+                    .ptr
+                    .vmdrc_heap_data_current_over_approximated_stack_roots_len(),
+            ),
         )
+    }
+
+    /// Load the over-approximated-stack-roots list size after the last GC.
+    fn load_over_approximated_stack_roots_len_after_last_gc(
+        &mut self,
+        func_env: &mut FuncEnvironment<'_>,
+        builder: &mut FunctionBuilder,
+    ) -> ir::Value {
+        let ptr = Self::load_vmdrc_heap_data_ptr(func_env, builder);
+        builder.ins().load(
+            ir::types::I32,
+            ir::MemFlagsData::trusted(),
+            ptr,
+            i32::from(
+                func_env
+                    .offsets
+                    .ptr
+                    .vmdrc_heap_data_over_approximated_stack_roots_len_after_last_gc(),
+            ),
+        )
+    }
+
+    /// Store the current size of the over-approximated-stack-roots list.
+    fn store_current_over_approximated_stack_roots_len(
+        &mut self,
+        func_env: &mut FuncEnvironment<'_>,
+        builder: &mut FunctionBuilder,
+        len: ir::Value,
+    ) {
+        let ptr = Self::load_vmdrc_heap_data_ptr(func_env, builder);
+        builder.ins().store(
+            ir::MemFlagsData::trusted(),
+            len,
+            ptr,
+            i32::from(
+                func_env
+                    .offsets
+                    .ptr
+                    .vmdrc_heap_data_current_over_approximated_stack_roots_len(),
+            ),
+        );
+    }
+
+    /// Trigger a GC when the over-approximated-stack-roots list has doubled
+    /// since the last collection, subject to a minimum threshold.
+    fn emit_maybe_force_gc(
+        &mut self,
+        func_env: &mut FuncEnvironment<'_>,
+        builder: &mut FunctionBuilder,
+    ) {
+        let current_block = builder.current_block().unwrap();
+        let gc_block = builder.create_block();
+        let continue_block = builder.create_block();
+
+        builder.ensure_inserted_block();
+        builder.insert_block_after(gc_block, current_block);
+        builder.insert_block_after(continue_block, gc_block);
+
+        let current_len = self.load_current_over_approximated_stack_roots_len(func_env, builder);
+        let last_len = self.load_over_approximated_stack_roots_len_after_last_gc(func_env, builder);
+        let doubled_last_len = builder.ins().iadd(last_len, last_len);
+        let min_threshold = builder
+            .ins()
+            .iconst(ir::types::I32, MIN_OVER_APPROX_STACK_ROOTS_GC_THRESHOLD);
+        let threshold = builder.ins().umax(doubled_last_len, min_threshold);
+        let should_gc =
+            builder
+                .ins()
+                .icmp(IntCC::UnsignedGreaterThanOrEqual, current_len, threshold);
+        builder
+            .ins()
+            .brif(should_gc, gc_block, &[], continue_block, &[]);
+
+        builder.switch_to_block(gc_block);
+        builder.seal_block(gc_block);
+        builder.set_cold_block(gc_block);
+        let force_gc = func_env.builtin_functions.force_gc(builder.func);
+        let vmctx = func_env.vmctx_val(&mut builder.cursor());
+        builder.ins().call(force_gc, &[vmctx]);
+        builder.ins().jump(continue_block, &[]);
+
+        builder.switch_to_block(continue_block);
+        builder.seal_block(continue_block);
     }
 
     /// Set the `VMDrcHeader::next_over_approximated_stack_root` field.
@@ -676,6 +807,7 @@ impl GcCompiler for DrcCompiler {
             "DRC read barrier: push the object onto the over-approximated-stack-roots list"
         );
         self.push_onto_over_approximated_stack_roots(func_env, builder, gc_ref, reserved);
+        self.emit_maybe_force_gc(func_env, builder);
         builder.ins().jump(continue_block, &[]);
 
         // Join point after we're done with the GC barrier.

--- a/crates/cranelift/src/func_environ/gc/enabled/drc.rs
+++ b/crates/cranelift/src/func_environ/gc/enabled/drc.rs
@@ -137,6 +137,12 @@ impl DrcCompiler {
         builder.ins().store(GC_MEMFLAGS, gc_ref, head, 0);
 
         // Increment the list's length.
+        //
+        // Can't overflow because the list's max length is the number of objects
+        // in the GC heap and the GC heap's max byte size is `u32::MAX` but the
+        // smallest GC object has a `VMGcHeader` which is multiple bytes large,
+        // meaning that there are always fewer objects in the GC heap than
+        // `u32::MAX`.
         let current_len = self.load_current_over_approximated_stack_roots_len(func_env, builder);
         let new_current_len = builder.ins().iadd_imm(current_len, 1);
         self.store_current_over_approximated_stack_roots_len(func_env, builder, new_current_len);

--- a/crates/environ/src/builtin.rs
+++ b/crates/environ/src/builtin.rs
@@ -184,6 +184,10 @@ macro_rules! foreach_builtin_function {
             #[cfg(feature = "gc")]
             throw_ref(vmctx: vmctx, exnref: u32) -> bool;
 
+            // Force a GC cycle for the DRC collector.
+            #[cfg(feature = "gc-drc")]
+            force_gc(vmctx: vmctx) -> bool;
+
             // Process a debug breakpoint.
             breakpoint(vmctx: vmctx) -> bool;
         }

--- a/crates/environ/src/vmoffsets.rs
+++ b/crates/environ/src/vmoffsets.rs
@@ -487,6 +487,40 @@ pub trait PtrSize {
         self.vmctx_epoch_ptr() + self.size()
     }
 
+    /// Return the offset of the `over_approximated_stack_roots` field within
+    /// `VMDrcHeapData`.
+    #[inline]
+    fn vmdrc_heap_data_over_approximated_stack_roots(&self) -> u8 {
+        0
+    }
+
+    /// Return the offset of the `current_over_approximated_stack_roots_len`
+    /// field within `VMDrcHeapData`.
+    #[inline]
+    fn vmdrc_heap_data_current_over_approximated_stack_roots_len(&self) -> u8 {
+        4
+    }
+
+    /// Return the offset of the
+    /// `over_approximated_stack_roots_len_after_last_gc` field within
+    /// `VMDrcHeapData`.
+    #[inline]
+    fn vmdrc_heap_data_over_approximated_stack_roots_len_after_last_gc(&self) -> u8 {
+        8
+    }
+
+    /// Return the size of `VMDrcHeapData`.
+    #[inline]
+    fn size_of_vmdrc_heap_data(&self) -> u8 {
+        12
+    }
+
+    /// Return the alignment of `VMDrcHeapData`.
+    #[inline]
+    fn align_of_vmdrc_heap_data(&self) -> u8 {
+        4
+    }
+
     /// Return the offset of the `bump_ptr` field within `VMCopyingHeapData`.
     #[inline]
     fn vmcopying_heap_data_bump_ptr(&self) -> u8 {

--- a/crates/wasmtime/src/runtime/vm.rs
+++ b/crates/wasmtime/src/runtime/vm.rs
@@ -151,9 +151,9 @@ mod cow_disabled;
 #[cfg(has_virtual_memory)]
 mod mmap;
 
-#[cfg(feature = "gc")]
+#[cfg(any(feature = "gc-null", feature = "gc-drc"))]
 mod send_sync_unsafe_cell;
-#[cfg(feature = "gc")]
+#[cfg(any(feature = "gc-null", feature = "gc-drc"))]
 pub use send_sync_unsafe_cell::SendSyncUnsafeCell;
 
 cfg_if::cfg_if! {

--- a/crates/wasmtime/src/runtime/vm.rs
+++ b/crates/wasmtime/src/runtime/vm.rs
@@ -151,9 +151,9 @@ mod cow_disabled;
 #[cfg(has_virtual_memory)]
 mod mmap;
 
-#[cfg(any(feature = "gc-null", feature = "gc-drc"))]
+#[allow(unused, reason = "hard to cfg on/off, weird feature interactions")]
 mod send_sync_unsafe_cell;
-#[cfg(any(feature = "gc-null", feature = "gc-drc"))]
+#[allow(unused, reason = "hard to cfg on/off, weird feature interactions")]
 pub use send_sync_unsafe_cell::SendSyncUnsafeCell;
 
 cfg_if::cfg_if! {

--- a/crates/wasmtime/src/runtime/vm.rs
+++ b/crates/wasmtime/src/runtime/vm.rs
@@ -151,9 +151,9 @@ mod cow_disabled;
 #[cfg(has_virtual_memory)]
 mod mmap;
 
-#[cfg(feature = "gc-null")]
+#[cfg(feature = "gc")]
 mod send_sync_unsafe_cell;
-#[cfg(feature = "gc-null")]
+#[cfg(feature = "gc")]
 pub use send_sync_unsafe_cell::SendSyncUnsafeCell;
 
 cfg_if::cfg_if! {

--- a/crates/wasmtime/src/runtime/vm/gc/enabled/drc.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/enabled/drc.rs
@@ -50,7 +50,8 @@ use super::{VMArrayRef, VMGcObjectData};
 use crate::hash_set::HashSet;
 use crate::runtime::vm::{
     ExternRefHostDataId, ExternRefHostDataTable, GarbageCollection, GcHeap, GcHeapObject,
-    GcProgress, GcRootsIter, GcRuntime, TypedGcRef, VMExternRef, VMGcHeader, VMGcRef,
+    GcProgress, GcRootsIter, GcRuntime, SendSyncUnsafeCell, TypedGcRef, VMExternRef, VMGcHeader,
+    VMGcRef,
 };
 use crate::vm::VMMemoryDefinition;
 use crate::{Engine, prelude::*};
@@ -95,6 +96,74 @@ unsafe impl GcRuntime for DrcCollector {
     }
 }
 
+/// JIT-accessible DRC heap data.
+#[derive(Default)]
+#[repr(C)]
+struct VMDrcHeapDataInner {
+    /// The head of the over-approximated-stack-roots list.
+    over_approximated_stack_roots: Option<VMGcRef>,
+
+    /// The current size of the over-approximated-stack-roots list.
+    current_over_approximated_stack_roots_len: u32,
+
+    /// The size of the over-approximated-stack-roots list immediately after the
+    /// last GC.
+    over_approximated_stack_roots_len_after_last_gc: u32,
+}
+
+#[derive(Default)]
+#[repr(transparent)]
+struct VMDrcHeapData {
+    inner: SendSyncUnsafeCell<VMDrcHeapDataInner>,
+}
+
+impl VMDrcHeapData {
+    fn over_approximated_stack_roots(&self) -> Option<VMGcRef> {
+        // Safety: `inner` is valid to read from.
+        unsafe {
+            (*self.inner.get())
+                .over_approximated_stack_roots
+                .as_ref()
+                .map(|r: &VMGcRef| r.unchecked_copy())
+        }
+    }
+
+    fn set_over_approximated_stack_roots(&mut self, gc_ref: Option<VMGcRef>) {
+        self.inner.get_mut().over_approximated_stack_roots = gc_ref;
+    }
+
+    fn current_over_approximated_stack_roots_len(&self) -> u32 {
+        // Safety: `inner` is valid to read from.
+        unsafe { (*self.inner.get()).current_over_approximated_stack_roots_len }
+    }
+
+    fn increment_current_over_approximated_stack_roots_len(&mut self) {
+        self.inner
+            .get_mut()
+            .current_over_approximated_stack_roots_len += 1;
+    }
+
+    fn decrement_current_over_approximated_stack_roots_len(&mut self) {
+        let len = &mut self
+            .inner
+            .get_mut()
+            .current_over_approximated_stack_roots_len;
+        debug_assert!(*len > 0);
+        *len -= 1;
+    }
+
+    fn over_approximated_stack_roots_len_after_last_gc(&self) -> u32 {
+        // Safety: `inner` is valid to read from.
+        unsafe { (*self.inner.get()).over_approximated_stack_roots_len_after_last_gc }
+    }
+
+    fn set_over_approximated_stack_roots_len_after_last_gc(&mut self, len: u32) {
+        self.inner
+            .get_mut()
+            .over_approximated_stack_roots_len_after_last_gc = len;
+    }
+}
+
 /// A deferred reference-counting (DRC) heap.
 struct DrcHeap {
     /// For every type that we have allocated in this heap, how do we trace it?
@@ -107,7 +176,7 @@ struct DrcHeap {
     ///
     /// Note that this is exposed directly to compiled Wasm code through the
     /// vmctx, so must not move.
-    over_approximated_stack_roots: Box<Option<VMGcRef>>,
+    vmctx_data: Box<VMDrcHeapData>,
 
     /// The storage for the GC heap itself.
     memory: Option<crate::vm::Memory>,
@@ -154,7 +223,7 @@ impl DrcHeap {
         Ok(Self {
             trace_infos: TraceInfos::new(engine, GC_REF_ARRAY_ELEMS_OFFSET),
             no_gc_count: 0,
-            over_approximated_stack_roots: Box::new(None),
+            vmctx_data: Box::default(),
             memory: None,
             vmmemory: None,
             free_list: None,
@@ -357,9 +426,7 @@ impl DrcHeap {
 
     /// Iterate over the over-approximated-stack-roots list.
     fn iter_over_approximated_stack_roots(&self) -> impl Iterator<Item = VMGcRef> + '_ {
-        let mut link = (*self.over_approximated_stack_roots)
-            .as_ref()
-            .map(|r| r.unchecked_copy());
+        let mut link = self.vmctx_data.over_approximated_stack_roots();
 
         core::iter::from_fn(move || {
             let r = link.as_ref()?.unchecked_copy();
@@ -405,6 +472,12 @@ impl DrcHeap {
                 "over-approx list: cycle or duplicate detected at heap index {idx}",
             );
         }
+
+        assert_eq!(
+            self.vmctx_data.current_over_approximated_stack_roots_len() as usize,
+            visited.len(),
+            "over-approx list: tracked size does not match actual size",
+        );
     }
 
     /// Assert that every free block in the free list is filled with the poison
@@ -542,9 +615,7 @@ impl DrcHeap {
 
         // The `VMGcRef` of the next object in the over-approximated-stack-roots
         // list, if any.
-        let mut next = (*self.over_approximated_stack_roots)
-            .as_ref()
-            .map(|r| r.unchecked_copy());
+        let mut next = self.vmctx_data.over_approximated_stack_roots();
 
         while let Some(gc_ref) = next {
             log::trace!("sweeping gc ref: {gc_ref:#p}");
@@ -576,13 +647,20 @@ impl DrcHeap {
             let prev_next = header.next_over_approximated_stack_root();
             header.set_in_over_approximated_stack_roots_bit(false);
             match &prev {
-                None => *self.over_approximated_stack_roots = prev_next,
+                None => self.vmctx_data.set_over_approximated_stack_roots(prev_next),
                 Some(prev) => self
                     .index_mut(drc_ref(prev))
                     .set_next_over_approximated_stack_root(prev_next),
             }
+            self.vmctx_data
+                .decrement_current_over_approximated_stack_roots_len();
             self.dec_ref_and_maybe_dealloc(host_data_table, &gc_ref);
         }
+
+        self.vmctx_data
+            .set_over_approximated_stack_roots_len_after_last_gc(
+                self.vmctx_data.current_over_approximated_stack_roots_len(),
+            );
 
         log::trace!("Done sweeping");
 
@@ -763,7 +841,16 @@ unsafe impl GcHeap for DrcHeap {
     fn attach(&mut self, memory: crate::vm::Memory) {
         assert!(!self.is_attached());
         assert!(!memory.is_shared_memory());
-        debug_assert!(self.over_approximated_stack_roots.is_none());
+        debug_assert!(self.vmctx_data.over_approximated_stack_roots().is_none());
+        debug_assert_eq!(
+            self.vmctx_data.current_over_approximated_stack_roots_len(),
+            0
+        );
+        debug_assert_eq!(
+            self.vmctx_data
+                .over_approximated_stack_roots_len_after_last_gc(),
+            0
+        );
         let len = memory.vmmemory().current_length();
         self.free_list = Some(FreeList::new(len));
         self.vmmemory = Some(memory.vmmemory());
@@ -781,7 +868,7 @@ unsafe impl GcHeap for DrcHeap {
 
         let DrcHeap {
             no_gc_count,
-            over_approximated_stack_roots,
+            vmctx_data,
             free_list,
             dec_ref_stack,
             large_array_dec_ref_stack,
@@ -793,7 +880,7 @@ unsafe impl GcHeap for DrcHeap {
         } = self;
 
         *no_gc_count = 0;
-        **over_approximated_stack_roots = None;
+        **vmctx_data = VMDrcHeapData::default();
         *free_list = None;
         *vmmemory = None;
         *allocated_bytes = 0;
@@ -857,9 +944,7 @@ unsafe impl GcHeap for DrcHeap {
 
     fn expose_gc_ref_to_wasm(&mut self, gc_ref: VMGcRef) {
         // Read the current list head before borrowing through index_mut.
-        let next = (*self.over_approximated_stack_roots)
-            .as_ref()
-            .map(|r| r.unchecked_copy());
+        let next = self.vmctx_data.over_approximated_stack_roots();
 
         let header = self.index_mut(drc_ref(&gc_ref));
         if header.is_in_over_approximated_stack_roots() {
@@ -879,7 +964,10 @@ unsafe impl GcHeap for DrcHeap {
         // list using a single index_mut call.
         header.set_in_over_approximated_stack_roots_bit(true);
         header.set_next_over_approximated_stack_root(next);
-        *self.over_approximated_stack_roots = Some(gc_ref);
+        self.vmctx_data
+            .set_over_approximated_stack_roots(Some(gc_ref));
+        self.vmctx_data
+            .increment_current_over_approximated_stack_roots_len();
     }
 
     fn alloc_externref(
@@ -1060,7 +1148,7 @@ unsafe impl GcHeap for DrcHeap {
     }
 
     unsafe fn vmctx_gc_heap_data(&self) -> NonNull<u8> {
-        let ptr: NonNull<Option<VMGcRef>> = NonNull::from(&*self.over_approximated_stack_roots);
+        let ptr: NonNull<VMDrcHeapData> = NonNull::from(&*self.vmctx_data);
         ptr.cast()
     }
 
@@ -1121,7 +1209,9 @@ impl<'a> GarbageCollection<'a> for DrcCollection<'a> {
     fn collect_increment(&mut self) -> GcProgress {
         match self.phase {
             DrcCollectionPhase::Trace => {
-                log::trace!("Begin DRC trace");
+                #[cfg(feature = "std")]
+                let start = std::time::Instant::now();
+                log::debug!("Begin DRC trace");
 
                 self.heap.assert_over_approximated_stack_roots_integrity();
                 self.heap.assert_free_blocks_are_poisoned();
@@ -1131,12 +1221,17 @@ impl<'a> GarbageCollection<'a> for DrcCollection<'a> {
                 self.heap.assert_over_approximated_stack_roots_integrity();
                 self.heap.assert_free_blocks_are_poisoned();
 
-                log::trace!("End DRC trace");
+                log::debug!("End DRC trace");
+                #[cfg(feature = "std")]
+                log::debug!("  -> {:.3} seconds", start.elapsed().as_secs_f64());
+
                 self.phase = DrcCollectionPhase::Sweep;
                 GcProgress::Continue
             }
             DrcCollectionPhase::Sweep => {
-                log::trace!("Begin DRC sweep");
+                #[cfg(feature = "std")]
+                let start = std::time::Instant::now();
+                log::debug!("Begin DRC sweep");
 
                 self.heap.assert_over_approximated_stack_roots_integrity();
                 self.heap.assert_free_blocks_are_poisoned();
@@ -1146,7 +1241,10 @@ impl<'a> GarbageCollection<'a> for DrcCollection<'a> {
                 self.heap.assert_over_approximated_stack_roots_integrity();
                 self.heap.assert_free_blocks_are_poisoned();
 
-                log::trace!("End DRC sweep");
+                log::debug!("End DRC sweep");
+                #[cfg(feature = "std")]
+                log::debug!("  -> {:.3} seconds", start.elapsed().as_secs_f64());
+
                 self.phase = DrcCollectionPhase::Done;
                 GcProgress::Complete
             }
@@ -1191,7 +1289,7 @@ impl<T> DerefMut for DebugOnly<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use wasmtime_environ::HostPtr;
+    use wasmtime_environ::{HostPtr, PtrSize};
 
     #[test]
     fn vm_drc_header_size_align() {
@@ -1246,6 +1344,60 @@ mod tests {
         assert_eq!(
             offsets.vm_drc_header_ref_count(),
             u32::try_from(actual_offset).unwrap(),
+        );
+    }
+
+    #[test]
+    fn vm_drc_heap_data_over_approximated_stack_roots_offset() {
+        assert_eq!(
+            HostPtr.vmdrc_heap_data_over_approximated_stack_roots() as usize,
+            core::mem::offset_of!(VMDrcHeapDataInner, over_approximated_stack_roots),
+        );
+    }
+
+    #[test]
+    fn vm_drc_heap_data_current_over_approximated_stack_roots_len_offset() {
+        assert_eq!(
+            HostPtr.vmdrc_heap_data_current_over_approximated_stack_roots_len() as usize,
+            core::mem::offset_of!(
+                VMDrcHeapDataInner,
+                current_over_approximated_stack_roots_len
+            ),
+        );
+    }
+
+    #[test]
+    fn vm_drc_heap_data_over_approximated_stack_roots_len_after_last_gc_offset() {
+        assert_eq!(
+            HostPtr.vmdrc_heap_data_over_approximated_stack_roots_len_after_last_gc() as usize,
+            core::mem::offset_of!(
+                VMDrcHeapDataInner,
+                over_approximated_stack_roots_len_after_last_gc
+            ),
+        );
+    }
+
+    #[test]
+    fn vm_drc_heap_data_size() {
+        assert_eq!(
+            HostPtr.size_of_vmdrc_heap_data() as usize,
+            core::mem::size_of::<VMDrcHeapData>(),
+        );
+        assert_eq!(
+            HostPtr.size_of_vmdrc_heap_data() as usize,
+            core::mem::size_of::<VMDrcHeapDataInner>(),
+        );
+    }
+
+    #[test]
+    fn vm_drc_heap_data_align() {
+        assert_eq!(
+            HostPtr.align_of_vmdrc_heap_data() as usize,
+            core::mem::align_of::<VMDrcHeapData>(),
+        );
+        assert_eq!(
+            HostPtr.align_of_vmdrc_heap_data() as usize,
+            core::mem::align_of::<VMDrcHeapDataInner>(),
         );
     }
 }

--- a/crates/wasmtime/src/runtime/vm/libcalls.rs
+++ b/crates/wasmtime/src/runtime/vm/libcalls.rs
@@ -416,6 +416,17 @@ fn drop_gc_ref(store: &mut dyn VMStore, _instance: InstanceId, gc_ref: u32) {
         .drop_gc_ref(gc_ref);
 }
 
+/// Force a DRC GC cycle.
+#[cfg(feature = "gc-drc")]
+fn force_gc(store: &mut dyn VMStore, _instance: InstanceId) -> Result<()> {
+    let store = store.store_opaque_mut();
+    block_on!(store, async |store, asyncness| {
+        store.gc(None, None, None, asyncness).await;
+        Ok::<(), Error>(())
+    })??;
+    Ok(())
+}
+
 /// Grow the GC heap.
 #[cfg(feature = "gc-null")]
 fn grow_gc_heap(store: &mut dyn VMStore, _instance: InstanceId, bytes_needed: u64) -> Result<()> {

--- a/crates/wasmtime/src/runtime/vm/send_sync_unsafe_cell.rs
+++ b/crates/wasmtime/src/runtime/vm/send_sync_unsafe_cell.rs
@@ -2,6 +2,7 @@ use core::cell::UnsafeCell;
 
 /// A wrapper around `UnsafeCell` that implements `Send` and `Sync` for types
 /// that are themselves `Send` and `Sync`.
+#[derive(Default)]
 pub struct SendSyncUnsafeCell<T>(UnsafeCell<T>);
 
 // Safety: `T` is `Send` and users guarantee that any pointers derived from the

--- a/tests/disas/debug.wat
+++ b/tests/disas/debug.wat
@@ -22,7 +22,7 @@
 ;;       jb      0x62
 ;;   29: movq    %rdi, (%rsp)
 ;;       nopl    (%rax, %rax)
-;;       ├─╼ debug frame state (after previous inst): func key DefinedWasmFunction(StaticModuleIndex(0), DefinedFuncIndex(0)), wasm PC 0x24, slot at FP-0x30, locals I32 @ slot+0x8, I32 @ slot+0xc, stack
+;;       ├─╼ debug frame state (after previous inst): func key DefinedWasmFunction(StaticModuleIndex(0), DefinedFuncIndex(0)), wasm PC 0x24, slot at FP-0x30, locals I32 @ slot+0x8, I32 @ slot+0xc, stack 
 ;;       ╰─╼ breakpoint patch: wasm PC 0x24, patch bytes [232, 184, 1, 0, 0]
 ;;       movl    %edx, 0x10(%rsp)
 ;;       nopl    (%rax, %rax)
@@ -48,7 +48,7 @@
 ;;   67: callq   0x18c
 ;;   6c: movq    %r12, %rdi
 ;;   6f: callq   0x1bd
-;;       ╰─╼ debug frame state (after previous inst): func key DefinedWasmFunction(StaticModuleIndex(0), DefinedFuncIndex(0)), wasm PC 0x23, slot at FP-0x30, locals I32 @ slot+0x8, I32 @ slot+0xc, stack
+;;       ╰─╼ debug frame state (after previous inst): func key DefinedWasmFunction(StaticModuleIndex(0), DefinedFuncIndex(0)), wasm PC 0x23, slot at FP-0x30, locals I32 @ slot+0x8, I32 @ slot+0xc, stack 
 ;;   74: ud2
 ;;
 ;; wasm[0]::array_to_wasm_trampoline[0]:
@@ -203,7 +203,7 @@
 ;;       movq    8(%r11), %rax
 ;;       movq    %rax, 0x38(%r10)
 ;;       movq    0x10(%rdi), %rax
-;;       movq    0x170(%rax), %rcx
+;;       movq    0x178(%rax), %rcx
 ;;       movq    %rdi, %rbx
 ;;       callq   *%rcx
 ;;       testb   %al, %al

--- a/tests/disas/debug.wat
+++ b/tests/disas/debug.wat
@@ -22,7 +22,7 @@
 ;;       jb      0x62
 ;;   29: movq    %rdi, (%rsp)
 ;;       nopl    (%rax, %rax)
-;;       ├─╼ debug frame state (after previous inst): func key DefinedWasmFunction(StaticModuleIndex(0), DefinedFuncIndex(0)), wasm PC 0x24, slot at FP-0x30, locals I32 @ slot+0x8, I32 @ slot+0xc, stack 
+;;       ├─╼ debug frame state (after previous inst): func key DefinedWasmFunction(StaticModuleIndex(0), DefinedFuncIndex(0)), wasm PC 0x24, slot at FP-0x30, locals I32 @ slot+0x8, I32 @ slot+0xc, stack
 ;;       ╰─╼ breakpoint patch: wasm PC 0x24, patch bytes [232, 184, 1, 0, 0]
 ;;       movl    %edx, 0x10(%rsp)
 ;;       nopl    (%rax, %rax)
@@ -48,7 +48,7 @@
 ;;   67: callq   0x18c
 ;;   6c: movq    %r12, %rdi
 ;;   6f: callq   0x1bd
-;;       ╰─╼ debug frame state (after previous inst): func key DefinedWasmFunction(StaticModuleIndex(0), DefinedFuncIndex(0)), wasm PC 0x23, slot at FP-0x30, locals I32 @ slot+0x8, I32 @ slot+0xc, stack 
+;;       ╰─╼ debug frame state (after previous inst): func key DefinedWasmFunction(StaticModuleIndex(0), DefinedFuncIndex(0)), wasm PC 0x23, slot at FP-0x30, locals I32 @ slot+0x8, I32 @ slot+0xc, stack
 ;;   74: ud2
 ;;
 ;; wasm[0]::array_to_wasm_trampoline[0]:

--- a/tests/disas/gc/drc/externref-globals.wat
+++ b/tests/disas/gc/drc/externref-globals.wat
@@ -22,7 +22,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx) -> i8 tail
-;;     fn0 = colocated u805306368:52 sig0
+;;     fn0 = colocated u805306368:46 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):

--- a/tests/disas/gc/drc/externref-globals.wat
+++ b/tests/disas/gc/drc/externref-globals.wat
@@ -13,6 +13,7 @@
 )
 
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
+;;     ss0 = explicit_slot 4, align = 4
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -20,23 +21,27 @@
 ;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
+;;     sig0 = (i64 vmctx) -> i8 tail
+;;     fn0 = colocated u805306368:52 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;;                                     v54 = iconst.i64 48
-;; @0034                               v4 = iadd v0, v54  ; v54 = 48
+;;                                     v92 = iconst.i64 48
+;; @0034                               v4 = iadd v0, v92  ; v92 = 48
 ;; @0034                               v5 = load.i32 notrap aligned v4
-;;                                     v53 = iconst.i32 1
-;; @0034                               v6 = band v5, v53  ; v53 = 1
-;;                                     v52 = iconst.i32 0
-;; @0034                               v7 = icmp eq v5, v52  ; v52 = 0
+;;                                     v91 = stack_addr.i64 ss0
+;;                                     store notrap v5, v91
+;;                                     v89 = iconst.i32 1
+;; @0034                               v6 = band v5, v89  ; v89 = 1
+;;                                     v87 = iconst.i32 0
+;; @0034                               v7 = icmp eq v5, v87  ; v87 = 0
 ;; @0034                               v8 = uextend.i32 v7
 ;; @0034                               v9 = bor v6, v8
 ;; @0034                               brif v9, block4, block2
 ;;
 ;;                                 block2:
-;; @0034                               v50 = load.i64 notrap aligned readonly can_move v0+8
-;; @0034                               v11 = load.i64 notrap aligned readonly can_move v50+32
+;; @0034                               v84 = load.i64 notrap aligned readonly can_move v0+8
+;; @0034                               v11 = load.i64 notrap aligned readonly can_move v84+32
 ;; @0034                               v10 = uextend.i64 v5
 ;; @0034                               v12 = iadd v11, v10
 ;; @0034                               v13 = load.i32 user2 v12
@@ -45,28 +50,52 @@
 ;; @0034                               brif v15, block4, block3
 ;;
 ;;                                 block3:
-;; @0034                               v17 = load.i64 notrap aligned readonly v0+32
+;; @0034                               v17 = load.i64 notrap aligned readonly can_move v0+32
 ;; @0034                               v18 = load.i32 user2 v17
 ;; @0034                               v22 = iconst.i64 16
 ;; @0034                               v23 = iadd.i64 v12, v22  ; v22 = 16
 ;; @0034                               store user2 v18, v23
-;;                                     v55 = iconst.i32 2
-;;                                     v56 = bor.i32 v13, v55  ; v55 = 2
-;; @0034                               store user2 v56, v12
+;;                                     v63 = load.i32 notrap v91
+;;                                     v93 = iconst.i32 2
+;;                                     v94 = bor.i32 v13, v93  ; v93 = 2
+;; @0034                               v26 = uextend.i64 v63
+;; @0034                               v28 = iadd.i64 v11, v26
+;; @0034                               store user2 v94, v28
+;;                                     v62 = load.i32 notrap v91
+;; @0034                               v29 = uextend.i64 v62
+;; @0034                               v31 = iadd.i64 v11, v29
 ;; @0034                               v32 = iconst.i64 8
-;; @0034                               v33 = iadd.i64 v12, v32  ; v32 = 8
+;; @0034                               v33 = iadd v31, v32  ; v32 = 8
 ;; @0034                               v34 = load.i64 user2 v33
-;;                                     v43 = iconst.i64 1
-;; @0034                               v35 = iadd v34, v43  ; v43 = 1
+;;                                     v74 = iconst.i64 1
+;; @0034                               v35 = iadd v34, v74  ; v74 = 1
 ;; @0034                               store user2 v35, v33
-;; @0034                               store.i32 user2 v5, v17
+;;                                     v60 = load.i32 notrap v91
+;; @0034                               store user2 v60, v17
+;; @0034                               v43 = load.i32 notrap aligned v17+4
+;;                                     v95 = iconst.i32 1
+;;                                     v96 = iadd v43, v95  ; v95 = 1
+;; @0034                               store notrap aligned v96, v17+4
+;; @0034                               v52 = load.i32 notrap aligned v17+8
+;; @0034                               v53 = iadd v52, v52
+;; @0034                               v54 = iconst.i32 1024
+;; @0034                               v55 = umax v53, v54  ; v54 = 1024
+;; @0034                               v56 = icmp uge v96, v55
+;; @0034                               brif v56, block5, block6
+;;
+;;                                 block5 cold:
+;; @0034                               v58 = call fn0(v0), stack_map=[i32 @ ss0+0]
+;; @0034                               jump block6
+;;
+;;                                 block6:
 ;; @0034                               jump block4
 ;;
 ;;                                 block4:
+;;                                     v59 = load.i32 notrap v91
 ;; @0036                               jump block1
 ;;
 ;;                                 block1:
-;; @0036                               return v5
+;; @0036                               return v59
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) tail {

--- a/tests/disas/gc/drc/struct-get.wat
+++ b/tests/disas/gc/drc/struct-get.wat
@@ -110,7 +110,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx) -> i8 tail
-;;     fn0 = colocated u805306368:52 sig0
+;;     fn0 = colocated u805306368:46 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/drc/struct-get.wat
+++ b/tests/disas/gc/drc/struct-get.wat
@@ -101,6 +101,7 @@
 ;; }
 ;;
 ;; function u0:3(i64 vmctx, i64, i32) -> i32 tail {
+;;     ss0 = explicit_slot 4, align = 4
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -108,21 +109,25 @@
 ;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
+;;     sig0 = (i64 vmctx) -> i8 tail
+;;     fn0 = colocated u805306368:52 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
 ;; @004e                               trapz v2, user16
-;; @004e                               v58 = load.i64 notrap aligned readonly can_move v0+8
-;; @004e                               v5 = load.i64 notrap aligned readonly can_move v58+32
+;; @004e                               v96 = load.i64 notrap aligned readonly can_move v0+8
+;; @004e                               v5 = load.i64 notrap aligned readonly can_move v96+32
 ;; @004e                               v4 = uextend.i64 v2
 ;; @004e                               v6 = iadd v5, v4
 ;; @004e                               v7 = iconst.i64 32
 ;; @004e                               v8 = iadd v6, v7  ; v7 = 32
 ;; @004e                               v9 = load.i32 user2 little v8
-;;                                     v57 = iconst.i32 1
-;; @004e                               v10 = band v9, v57  ; v57 = 1
-;;                                     v56 = iconst.i32 0
-;; @004e                               v11 = icmp eq v9, v56  ; v56 = 0
+;;                                     v95 = stack_addr.i64 ss0
+;;                                     store notrap v9, v95
+;;                                     v93 = iconst.i32 1
+;; @004e                               v10 = band v9, v93  ; v93 = 1
+;;                                     v91 = iconst.i32 0
+;; @004e                               v11 = icmp eq v9, v91  ; v91 = 0
 ;; @004e                               v12 = uextend.i32 v11
 ;; @004e                               v13 = bor v10, v12
 ;; @004e                               brif v13, block4, block2
@@ -136,26 +141,50 @@
 ;; @004e                               brif v19, block4, block3
 ;;
 ;;                                 block3:
-;; @004e                               v21 = load.i64 notrap aligned readonly v0+32
+;; @004e                               v21 = load.i64 notrap aligned readonly can_move v0+32
 ;; @004e                               v22 = load.i32 user2 v21
 ;; @004e                               v26 = iconst.i64 16
 ;; @004e                               v27 = iadd.i64 v16, v26  ; v26 = 16
 ;; @004e                               store user2 v22, v27
-;;                                     v60 = iconst.i32 2
-;;                                     v61 = bor.i32 v17, v60  ; v60 = 2
-;; @004e                               store user2 v61, v16
+;;                                     v67 = load.i32 notrap v95
+;;                                     v98 = iconst.i32 2
+;;                                     v99 = bor.i32 v17, v98  ; v98 = 2
+;; @004e                               v30 = uextend.i64 v67
+;; @004e                               v32 = iadd.i64 v5, v30
+;; @004e                               store user2 v99, v32
+;;                                     v66 = load.i32 notrap v95
+;; @004e                               v33 = uextend.i64 v66
+;; @004e                               v35 = iadd.i64 v5, v33
 ;; @004e                               v36 = iconst.i64 8
-;; @004e                               v37 = iadd.i64 v16, v36  ; v36 = 8
+;; @004e                               v37 = iadd v35, v36  ; v36 = 8
 ;; @004e                               v38 = load.i64 user2 v37
-;;                                     v47 = iconst.i64 1
-;; @004e                               v39 = iadd v38, v47  ; v47 = 1
+;;                                     v78 = iconst.i64 1
+;; @004e                               v39 = iadd v38, v78  ; v78 = 1
 ;; @004e                               store user2 v39, v37
-;; @004e                               store.i32 user2 v9, v21
+;;                                     v64 = load.i32 notrap v95
+;; @004e                               store user2 v64, v21
+;; @004e                               v47 = load.i32 notrap aligned v21+4
+;;                                     v100 = iconst.i32 1
+;;                                     v101 = iadd v47, v100  ; v100 = 1
+;; @004e                               store notrap aligned v101, v21+4
+;; @004e                               v56 = load.i32 notrap aligned v21+8
+;; @004e                               v57 = iadd v56, v56
+;; @004e                               v58 = iconst.i32 1024
+;; @004e                               v59 = umax v57, v58  ; v58 = 1024
+;; @004e                               v60 = icmp uge v101, v59
+;; @004e                               brif v60, block5, block6
+;;
+;;                                 block5 cold:
+;; @004e                               v62 = call fn0(v0), stack_map=[i32 @ ss0+0]
+;; @004e                               jump block6
+;;
+;;                                 block6:
 ;; @004e                               jump block4
 ;;
 ;;                                 block4:
+;;                                     v63 = load.i32 notrap v95
 ;; @0052                               jump block1
 ;;
 ;;                                 block1:
-;; @0052                               return v9
+;; @0052                               return v63
 ;; }

--- a/tests/disas/ref-func-0.wat
+++ b/tests/disas/ref-func-0.wat
@@ -14,6 +14,8 @@
   (global (export "funcref-local") funcref (ref.func $local)))
 
 ;; function u0:0(i64 vmctx, i64) -> i32, i32, i64, i64 tail {
+;;     ss0 = explicit_slot 4, align = 4
+;;     ss1 = explicit_slot 4, align = 4
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -21,24 +23,34 @@
 ;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
+;;     sig0 = (i64 vmctx) -> i8 tail
+;;     fn0 = colocated u805306368:52 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;;                                     v113 = iconst.i64 80
-;; @008f                               v7 = iadd v0, v113  ; v113 = 80
+;;                                     v189 = iconst.i64 80
+;; @008f                               v7 = iadd v0, v189  ; v189 = 80
 ;; @008f                               v8 = load.i32 notrap aligned readonly can_move v7
-;;                                     v112 = iconst.i32 1
-;; @008f                               v9 = band v8, v112  ; v112 = 1
-;;                                     v111 = iconst.i32 0
-;; @008f                               v10 = icmp eq v8, v111  ; v111 = 0
+;;                                     v188 = stack_addr.i64 ss0
+;;                                     store notrap v8, v188
+;;                                     v187 = stack_addr.i64 ss0
+;;                                     v139 = load.i32 notrap v187
+;;                                     v186 = iconst.i32 1
+;; @008f                               v9 = band v139, v186  ; v186 = 1
+;;                                     v185 = stack_addr.i64 ss0
+;;                                     v138 = load.i32 notrap v185
+;;                                     v184 = iconst.i32 0
+;; @008f                               v10 = icmp eq v138, v184  ; v184 = 0
 ;; @008f                               v11 = uextend.i32 v10
 ;; @008f                               v12 = bor v9, v11
 ;; @008f                               brif v12, block4, block2
 ;;
 ;;                                 block2:
-;; @008f                               v13 = uextend.i64 v8
-;; @008f                               v109 = load.i64 notrap aligned readonly can_move v0+8
-;; @008f                               v14 = load.i64 notrap aligned readonly can_move v109+32
+;;                                     v183 = stack_addr.i64 ss0
+;;                                     v137 = load.i32 notrap v183
+;; @008f                               v13 = uextend.i64 v137
+;; @008f                               v181 = load.i64 notrap aligned readonly can_move v0+8
+;; @008f                               v14 = load.i64 notrap aligned readonly can_move v181+32
 ;; @008f                               v15 = iadd v14, v13
 ;; @008f                               v16 = load.i32 user2 v15
 ;; @008f                               v17 = iconst.i32 2
@@ -46,104 +58,178 @@
 ;; @008f                               brif v18, block4, block3
 ;;
 ;;                                 block3:
-;; @008f                               v20 = load.i64 notrap aligned readonly v0+32
+;; @008f                               v20 = load.i64 notrap aligned readonly can_move v0+32
 ;; @008f                               v21 = load.i32 user2 v20
-;; @008f                               v22 = uextend.i64 v8
-;; @008f                               v107 = load.i64 notrap aligned readonly can_move v0+8
-;; @008f                               v23 = load.i64 notrap aligned readonly can_move v107+32
+;;                                     v180 = stack_addr.i64 ss0
+;;                                     v136 = load.i32 notrap v180
+;; @008f                               v22 = uextend.i64 v136
+;; @008f                               v178 = load.i64 notrap aligned readonly can_move v0+8
+;; @008f                               v23 = load.i64 notrap aligned readonly can_move v178+32
 ;; @008f                               v24 = iadd v23, v22
 ;; @008f                               v25 = iconst.i64 16
 ;; @008f                               v26 = iadd v24, v25  ; v25 = 16
 ;; @008f                               store user2 v21, v26
 ;; @008f                               v27 = iconst.i32 2
 ;; @008f                               v28 = bor.i32 v16, v27  ; v27 = 2
-;; @008f                               v29 = uextend.i64 v8
-;; @008f                               v105 = load.i64 notrap aligned readonly can_move v0+8
-;; @008f                               v30 = load.i64 notrap aligned readonly can_move v105+32
+;;                                     v177 = stack_addr.i64 ss0
+;;                                     v135 = load.i32 notrap v177
+;; @008f                               v29 = uextend.i64 v135
+;; @008f                               v175 = load.i64 notrap aligned readonly can_move v0+8
+;; @008f                               v30 = load.i64 notrap aligned readonly can_move v175+32
 ;; @008f                               v31 = iadd v30, v29
 ;; @008f                               store user2 v28, v31
-;; @008f                               v32 = uextend.i64 v8
-;; @008f                               v103 = load.i64 notrap aligned readonly can_move v0+8
-;; @008f                               v33 = load.i64 notrap aligned readonly can_move v103+32
+;;                                     v174 = stack_addr.i64 ss0
+;;                                     v134 = load.i32 notrap v174
+;; @008f                               v32 = uextend.i64 v134
+;; @008f                               v172 = load.i64 notrap aligned readonly can_move v0+8
+;; @008f                               v33 = load.i64 notrap aligned readonly can_move v172+32
 ;; @008f                               v34 = iadd v33, v32
 ;; @008f                               v35 = iconst.i64 8
 ;; @008f                               v36 = iadd v34, v35  ; v35 = 8
 ;; @008f                               v37 = load.i64 user2 v36
-;;                                     v102 = iconst.i64 1
-;; @008f                               v38 = iadd v37, v102  ; v102 = 1
-;; @008f                               v39 = uextend.i64 v8
-;; @008f                               v100 = load.i64 notrap aligned readonly can_move v0+8
-;; @008f                               v40 = load.i64 notrap aligned readonly can_move v100+32
+;;                                     v171 = iconst.i64 1
+;; @008f                               v38 = iadd v37, v171  ; v171 = 1
+;;                                     v170 = stack_addr.i64 ss0
+;;                                     v133 = load.i32 notrap v170
+;; @008f                               v39 = uextend.i64 v133
+;; @008f                               v168 = load.i64 notrap aligned readonly can_move v0+8
+;; @008f                               v40 = load.i64 notrap aligned readonly can_move v168+32
 ;; @008f                               v41 = iadd v40, v39
 ;; @008f                               v42 = iconst.i64 8
 ;; @008f                               v43 = iadd v41, v42  ; v42 = 8
 ;; @008f                               store user2 v38, v43
-;; @008f                               store.i32 user2 v8, v20
+;;                                     v167 = stack_addr.i64 ss0
+;;                                     v132 = load.i32 notrap v167
+;; @008f                               store user2 v132, v20
+;; @008f                               v45 = load.i64 notrap aligned readonly can_move v0+32
+;; @008f                               v46 = load.i32 notrap aligned v45+4
+;;                                     v166 = iconst.i32 1
+;; @008f                               v47 = iadd v46, v166  ; v166 = 1
+;; @008f                               v49 = load.i64 notrap aligned readonly can_move v0+32
+;; @008f                               store notrap aligned v47, v49+4
+;; @008f                               v51 = load.i64 notrap aligned readonly can_move v0+32
+;; @008f                               v52 = load.i32 notrap aligned v51+4
+;; @008f                               v54 = load.i64 notrap aligned readonly can_move v0+32
+;; @008f                               v55 = load.i32 notrap aligned v54+8
+;; @008f                               v56 = iadd v55, v55
+;; @008f                               v57 = iconst.i32 1024
+;; @008f                               v58 = umax v56, v57  ; v57 = 1024
+;; @008f                               v59 = icmp uge v52, v58
+;; @008f                               brif v59, block5, block6
+;;
+;;                                 block5 cold:
+;; @008f                               v61 = call fn0(v0), stack_map=[i32 @ ss0+0]
+;; @008f                               jump block6
+;;
+;;                                 block6:
 ;; @008f                               jump block4
 ;;
 ;;                                 block4:
-;;                                     v99 = iconst.i64 96
-;; @0091                               v45 = iadd.i64 v0, v99  ; v99 = 96
-;; @0091                               v46 = load.i32 notrap aligned readonly can_move v45
-;;                                     v98 = iconst.i32 1
-;; @0091                               v47 = band v46, v98  ; v98 = 1
-;;                                     v97 = iconst.i32 0
-;; @0091                               v48 = icmp eq v46, v97  ; v97 = 0
-;; @0091                               v49 = uextend.i32 v48
-;; @0091                               v50 = bor v47, v49
-;; @0091                               brif v50, block7, block5
-;;
-;;                                 block5:
-;; @0091                               v51 = uextend.i64 v46
-;; @0091                               v95 = load.i64 notrap aligned readonly can_move v0+8
-;; @0091                               v52 = load.i64 notrap aligned readonly can_move v95+32
-;; @0091                               v53 = iadd v52, v51
-;; @0091                               v54 = load.i32 user2 v53
-;; @0091                               v55 = iconst.i32 2
-;; @0091                               v56 = band v54, v55  ; v55 = 2
-;; @0091                               brif v56, block7, block6
-;;
-;;                                 block6:
-;; @0091                               v58 = load.i64 notrap aligned readonly v0+32
-;; @0091                               v59 = load.i32 user2 v58
-;; @0091                               v60 = uextend.i64 v46
-;; @0091                               v93 = load.i64 notrap aligned readonly can_move v0+8
-;; @0091                               v61 = load.i64 notrap aligned readonly can_move v93+32
-;; @0091                               v62 = iadd v61, v60
-;; @0091                               v63 = iconst.i64 16
-;; @0091                               v64 = iadd v62, v63  ; v63 = 16
-;; @0091                               store user2 v59, v64
-;; @0091                               v65 = iconst.i32 2
-;; @0091                               v66 = bor.i32 v54, v65  ; v65 = 2
-;; @0091                               v67 = uextend.i64 v46
-;; @0091                               v91 = load.i64 notrap aligned readonly can_move v0+8
-;; @0091                               v68 = load.i64 notrap aligned readonly can_move v91+32
-;; @0091                               v69 = iadd v68, v67
-;; @0091                               store user2 v66, v69
-;; @0091                               v70 = uextend.i64 v46
-;; @0091                               v89 = load.i64 notrap aligned readonly can_move v0+8
-;; @0091                               v71 = load.i64 notrap aligned readonly can_move v89+32
-;; @0091                               v72 = iadd v71, v70
-;; @0091                               v73 = iconst.i64 8
-;; @0091                               v74 = iadd v72, v73  ; v73 = 8
-;; @0091                               v75 = load.i64 user2 v74
-;;                                     v88 = iconst.i64 1
-;; @0091                               v76 = iadd v75, v88  ; v88 = 1
-;; @0091                               v77 = uextend.i64 v46
-;; @0091                               v86 = load.i64 notrap aligned readonly can_move v0+8
-;; @0091                               v78 = load.i64 notrap aligned readonly can_move v86+32
-;; @0091                               v79 = iadd v78, v77
-;; @0091                               v80 = iconst.i64 8
-;; @0091                               v81 = iadd v79, v80  ; v80 = 8
-;; @0091                               store user2 v76, v81
-;; @0091                               store.i32 user2 v46, v58
-;; @0091                               jump block7
+;;                                     v165 = iconst.i64 96
+;; @0091                               v63 = iadd.i64 v0, v165  ; v165 = 96
+;; @0091                               v64 = load.i32 notrap aligned readonly can_move v63
+;;                                     v164 = stack_addr.i64 ss1
+;;                                     store notrap v64, v164
+;;                                     v163 = stack_addr.i64 ss1
+;;                                     v131 = load.i32 notrap v163
+;;                                     v162 = iconst.i32 1
+;; @0091                               v65 = band v131, v162  ; v162 = 1
+;;                                     v161 = stack_addr.i64 ss1
+;;                                     v130 = load.i32 notrap v161
+;;                                     v160 = iconst.i32 0
+;; @0091                               v66 = icmp eq v130, v160  ; v160 = 0
+;; @0091                               v67 = uextend.i32 v66
+;; @0091                               v68 = bor v65, v67
+;; @0091                               brif v68, block9, block7
 ;;
 ;;                                 block7:
-;; @0093                               v83 = load.i64 notrap aligned table v0+112
-;; @0095                               v85 = load.i64 notrap aligned table v0+128
+;;                                     v159 = stack_addr.i64 ss1
+;;                                     v129 = load.i32 notrap v159
+;; @0091                               v69 = uextend.i64 v129
+;; @0091                               v157 = load.i64 notrap aligned readonly can_move v0+8
+;; @0091                               v70 = load.i64 notrap aligned readonly can_move v157+32
+;; @0091                               v71 = iadd v70, v69
+;; @0091                               v72 = load.i32 user2 v71
+;; @0091                               v73 = iconst.i32 2
+;; @0091                               v74 = band v72, v73  ; v73 = 2
+;; @0091                               brif v74, block9, block8
+;;
+;;                                 block8:
+;; @0091                               v76 = load.i64 notrap aligned readonly can_move v0+32
+;; @0091                               v77 = load.i32 user2 v76
+;;                                     v156 = stack_addr.i64 ss1
+;;                                     v128 = load.i32 notrap v156
+;; @0091                               v78 = uextend.i64 v128
+;; @0091                               v154 = load.i64 notrap aligned readonly can_move v0+8
+;; @0091                               v79 = load.i64 notrap aligned readonly can_move v154+32
+;; @0091                               v80 = iadd v79, v78
+;; @0091                               v81 = iconst.i64 16
+;; @0091                               v82 = iadd v80, v81  ; v81 = 16
+;; @0091                               store user2 v77, v82
+;; @0091                               v83 = iconst.i32 2
+;; @0091                               v84 = bor.i32 v72, v83  ; v83 = 2
+;;                                     v153 = stack_addr.i64 ss1
+;;                                     v127 = load.i32 notrap v153
+;; @0091                               v85 = uextend.i64 v127
+;; @0091                               v151 = load.i64 notrap aligned readonly can_move v0+8
+;; @0091                               v86 = load.i64 notrap aligned readonly can_move v151+32
+;; @0091                               v87 = iadd v86, v85
+;; @0091                               store user2 v84, v87
+;;                                     v150 = stack_addr.i64 ss1
+;;                                     v126 = load.i32 notrap v150
+;; @0091                               v88 = uextend.i64 v126
+;; @0091                               v148 = load.i64 notrap aligned readonly can_move v0+8
+;; @0091                               v89 = load.i64 notrap aligned readonly can_move v148+32
+;; @0091                               v90 = iadd v89, v88
+;; @0091                               v91 = iconst.i64 8
+;; @0091                               v92 = iadd v90, v91  ; v91 = 8
+;; @0091                               v93 = load.i64 user2 v92
+;;                                     v147 = iconst.i64 1
+;; @0091                               v94 = iadd v93, v147  ; v147 = 1
+;;                                     v146 = stack_addr.i64 ss1
+;;                                     v125 = load.i32 notrap v146
+;; @0091                               v95 = uextend.i64 v125
+;; @0091                               v144 = load.i64 notrap aligned readonly can_move v0+8
+;; @0091                               v96 = load.i64 notrap aligned readonly can_move v144+32
+;; @0091                               v97 = iadd v96, v95
+;; @0091                               v98 = iconst.i64 8
+;; @0091                               v99 = iadd v97, v98  ; v98 = 8
+;; @0091                               store user2 v94, v99
+;;                                     v143 = stack_addr.i64 ss1
+;;                                     v124 = load.i32 notrap v143
+;; @0091                               store user2 v124, v76
+;; @0091                               v101 = load.i64 notrap aligned readonly can_move v0+32
+;; @0091                               v102 = load.i32 notrap aligned v101+4
+;;                                     v142 = iconst.i32 1
+;; @0091                               v103 = iadd v102, v142  ; v142 = 1
+;; @0091                               v105 = load.i64 notrap aligned readonly can_move v0+32
+;; @0091                               store notrap aligned v103, v105+4
+;; @0091                               v107 = load.i64 notrap aligned readonly can_move v0+32
+;; @0091                               v108 = load.i32 notrap aligned v107+4
+;; @0091                               v110 = load.i64 notrap aligned readonly can_move v0+32
+;; @0091                               v111 = load.i32 notrap aligned v110+8
+;; @0091                               v112 = iadd v111, v111
+;; @0091                               v113 = iconst.i32 1024
+;; @0091                               v114 = umax v112, v113  ; v113 = 1024
+;; @0091                               v115 = icmp uge v108, v114
+;; @0091                               brif v115, block10, block11
+;;
+;;                                 block10 cold:
+;; @0091                               v117 = call fn0(v0), stack_map=[i32 @ ss0+0, i32 @ ss1+0]
+;; @0091                               jump block11
+;;
+;;                                 block11:
+;; @0091                               jump block9
+;;
+;;                                 block9:
+;; @0093                               v119 = load.i64 notrap aligned table v0+112
+;; @0095                               v121 = load.i64 notrap aligned table v0+128
+;;                                     v141 = stack_addr.i64 ss0
+;;                                     v122 = load.i32 notrap v141
+;;                                     v140 = stack_addr.i64 ss1
+;;                                     v123 = load.i32 notrap v140
 ;; @0097                               jump block1
 ;;
 ;;                                 block1:
-;; @0097                               return v8, v46, v83, v85
+;; @0097                               return v122, v123, v119, v121
 ;; }

--- a/tests/disas/ref-func-0.wat
+++ b/tests/disas/ref-func-0.wat
@@ -24,7 +24,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx) -> i8 tail
-;;     fn0 = colocated u805306368:52 sig0
+;;     fn0 = colocated u805306368:46 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):

--- a/tests/disas/table-get-fixed-size.wat
+++ b/tests/disas/table-get-fixed-size.wat
@@ -16,6 +16,7 @@
     table.get 0))
 
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
+;;     ss0 = explicit_slot 4, align = 4
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -24,6 +25,8 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv3+8
 ;;     gv6 = load.i64 notrap aligned readonly can_move gv5+32
 ;;     gv7 = load.i64 notrap aligned gv5+40
+;;     sig0 = (i64 vmctx) -> i8 tail
+;;     fn0 = colocated u805306368:52 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
@@ -32,24 +35,32 @@
 ;; @0054                               v5 = icmp uge v3, v4  ; v3 = 0, v4 = 7
 ;; @0054                               v6 = uextend.i64 v3  ; v3 = 0
 ;; @0054                               v7 = load.i64 notrap aligned readonly can_move v0+48
-;;                                     v61 = iconst.i64 2
-;; @0054                               v8 = ishl v6, v61  ; v61 = 2
+;;                                     v99 = iconst.i64 2
+;; @0054                               v8 = ishl v6, v99  ; v99 = 2
 ;; @0054                               v9 = iadd v7, v8
 ;; @0054                               v10 = iconst.i64 0
 ;; @0054                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
 ;; @0054                               v12 = load.i32 user6 aligned table v11
-;;                                     v60 = iconst.i32 1
-;; @0054                               v13 = band v12, v60  ; v60 = 1
-;;                                     v59 = iconst.i32 0
-;; @0054                               v14 = icmp eq v12, v59  ; v59 = 0
+;;                                     v98 = stack_addr.i64 ss0
+;;                                     store notrap v12, v98
+;;                                     v97 = stack_addr.i64 ss0
+;;                                     v74 = load.i32 notrap v97
+;;                                     v96 = iconst.i32 1
+;; @0054                               v13 = band v74, v96  ; v96 = 1
+;;                                     v95 = stack_addr.i64 ss0
+;;                                     v73 = load.i32 notrap v95
+;;                                     v94 = iconst.i32 0
+;; @0054                               v14 = icmp eq v73, v94  ; v94 = 0
 ;; @0054                               v15 = uextend.i32 v14
 ;; @0054                               v16 = bor v13, v15
 ;; @0054                               brif v16, block4, block2
 ;;
 ;;                                 block2:
-;; @0054                               v17 = uextend.i64 v12
-;; @0054                               v57 = load.i64 notrap aligned readonly can_move v0+8
-;; @0054                               v18 = load.i64 notrap aligned readonly can_move v57+32
+;;                                     v93 = stack_addr.i64 ss0
+;;                                     v72 = load.i32 notrap v93
+;; @0054                               v17 = uextend.i64 v72
+;; @0054                               v91 = load.i64 notrap aligned readonly can_move v0+8
+;; @0054                               v18 = load.i64 notrap aligned readonly can_move v91+32
 ;; @0054                               v19 = iadd v18, v17
 ;; @0054                               v20 = load.i32 user2 v19
 ;; @0054                               v21 = iconst.i32 2
@@ -57,49 +68,83 @@
 ;; @0054                               brif v22, block4, block3
 ;;
 ;;                                 block3:
-;; @0054                               v24 = load.i64 notrap aligned readonly v0+32
+;; @0054                               v24 = load.i64 notrap aligned readonly can_move v0+32
 ;; @0054                               v25 = load.i32 user2 v24
-;; @0054                               v26 = uextend.i64 v12
-;; @0054                               v55 = load.i64 notrap aligned readonly can_move v0+8
-;; @0054                               v27 = load.i64 notrap aligned readonly can_move v55+32
+;;                                     v90 = stack_addr.i64 ss0
+;;                                     v71 = load.i32 notrap v90
+;; @0054                               v26 = uextend.i64 v71
+;; @0054                               v88 = load.i64 notrap aligned readonly can_move v0+8
+;; @0054                               v27 = load.i64 notrap aligned readonly can_move v88+32
 ;; @0054                               v28 = iadd v27, v26
 ;; @0054                               v29 = iconst.i64 16
 ;; @0054                               v30 = iadd v28, v29  ; v29 = 16
 ;; @0054                               store user2 v25, v30
 ;; @0054                               v31 = iconst.i32 2
 ;; @0054                               v32 = bor.i32 v20, v31  ; v31 = 2
-;; @0054                               v33 = uextend.i64 v12
-;; @0054                               v53 = load.i64 notrap aligned readonly can_move v0+8
-;; @0054                               v34 = load.i64 notrap aligned readonly can_move v53+32
+;;                                     v87 = stack_addr.i64 ss0
+;;                                     v70 = load.i32 notrap v87
+;; @0054                               v33 = uextend.i64 v70
+;; @0054                               v85 = load.i64 notrap aligned readonly can_move v0+8
+;; @0054                               v34 = load.i64 notrap aligned readonly can_move v85+32
 ;; @0054                               v35 = iadd v34, v33
 ;; @0054                               store user2 v32, v35
-;; @0054                               v36 = uextend.i64 v12
-;; @0054                               v51 = load.i64 notrap aligned readonly can_move v0+8
-;; @0054                               v37 = load.i64 notrap aligned readonly can_move v51+32
+;;                                     v84 = stack_addr.i64 ss0
+;;                                     v69 = load.i32 notrap v84
+;; @0054                               v36 = uextend.i64 v69
+;; @0054                               v82 = load.i64 notrap aligned readonly can_move v0+8
+;; @0054                               v37 = load.i64 notrap aligned readonly can_move v82+32
 ;; @0054                               v38 = iadd v37, v36
 ;; @0054                               v39 = iconst.i64 8
 ;; @0054                               v40 = iadd v38, v39  ; v39 = 8
 ;; @0054                               v41 = load.i64 user2 v40
-;;                                     v50 = iconst.i64 1
-;; @0054                               v42 = iadd v41, v50  ; v50 = 1
-;; @0054                               v43 = uextend.i64 v12
-;; @0054                               v48 = load.i64 notrap aligned readonly can_move v0+8
-;; @0054                               v44 = load.i64 notrap aligned readonly can_move v48+32
+;;                                     v81 = iconst.i64 1
+;; @0054                               v42 = iadd v41, v81  ; v81 = 1
+;;                                     v80 = stack_addr.i64 ss0
+;;                                     v68 = load.i32 notrap v80
+;; @0054                               v43 = uextend.i64 v68
+;; @0054                               v78 = load.i64 notrap aligned readonly can_move v0+8
+;; @0054                               v44 = load.i64 notrap aligned readonly can_move v78+32
 ;; @0054                               v45 = iadd v44, v43
 ;; @0054                               v46 = iconst.i64 8
 ;; @0054                               v47 = iadd v45, v46  ; v46 = 8
 ;; @0054                               store user2 v42, v47
-;; @0054                               store.i32 user2 v12, v24
+;;                                     v77 = stack_addr.i64 ss0
+;;                                     v67 = load.i32 notrap v77
+;; @0054                               store user2 v67, v24
+;; @0054                               v49 = load.i64 notrap aligned readonly can_move v0+32
+;; @0054                               v50 = load.i32 notrap aligned v49+4
+;;                                     v76 = iconst.i32 1
+;; @0054                               v51 = iadd v50, v76  ; v76 = 1
+;; @0054                               v53 = load.i64 notrap aligned readonly can_move v0+32
+;; @0054                               store notrap aligned v51, v53+4
+;; @0054                               v55 = load.i64 notrap aligned readonly can_move v0+32
+;; @0054                               v56 = load.i32 notrap aligned v55+4
+;; @0054                               v58 = load.i64 notrap aligned readonly can_move v0+32
+;; @0054                               v59 = load.i32 notrap aligned v58+8
+;; @0054                               v60 = iadd v59, v59
+;; @0054                               v61 = iconst.i32 1024
+;; @0054                               v62 = umax v60, v61  ; v61 = 1024
+;; @0054                               v63 = icmp uge v56, v62
+;; @0054                               brif v63, block5, block6
+;;
+;;                                 block5 cold:
+;; @0054                               v65 = call fn0(v0), stack_map=[i32 @ ss0+0]
+;; @0054                               jump block6
+;;
+;;                                 block6:
 ;; @0054                               jump block4
 ;;
 ;;                                 block4:
+;;                                     v75 = stack_addr.i64 ss0
+;;                                     v66 = load.i32 notrap v75
 ;; @0056                               jump block1
 ;;
 ;;                                 block1:
-;; @0056                               return v12
+;; @0056                               return v66
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
+;;     ss0 = explicit_slot 4, align = 4
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -108,6 +153,8 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv3+8
 ;;     gv6 = load.i64 notrap aligned readonly can_move gv5+32
 ;;     gv7 = load.i64 notrap aligned gv5+40
+;;     sig0 = (i64 vmctx) -> i8 tail
+;;     fn0 = colocated u805306368:52 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -115,24 +162,32 @@
 ;; @005b                               v5 = icmp uge v2, v4  ; v4 = 7
 ;; @005b                               v6 = uextend.i64 v2
 ;; @005b                               v7 = load.i64 notrap aligned readonly can_move v0+48
-;;                                     v61 = iconst.i64 2
-;; @005b                               v8 = ishl v6, v61  ; v61 = 2
+;;                                     v99 = iconst.i64 2
+;; @005b                               v8 = ishl v6, v99  ; v99 = 2
 ;; @005b                               v9 = iadd v7, v8
 ;; @005b                               v10 = iconst.i64 0
 ;; @005b                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
 ;; @005b                               v12 = load.i32 user6 aligned table v11
-;;                                     v60 = iconst.i32 1
-;; @005b                               v13 = band v12, v60  ; v60 = 1
-;;                                     v59 = iconst.i32 0
-;; @005b                               v14 = icmp eq v12, v59  ; v59 = 0
+;;                                     v98 = stack_addr.i64 ss0
+;;                                     store notrap v12, v98
+;;                                     v97 = stack_addr.i64 ss0
+;;                                     v74 = load.i32 notrap v97
+;;                                     v96 = iconst.i32 1
+;; @005b                               v13 = band v74, v96  ; v96 = 1
+;;                                     v95 = stack_addr.i64 ss0
+;;                                     v73 = load.i32 notrap v95
+;;                                     v94 = iconst.i32 0
+;; @005b                               v14 = icmp eq v73, v94  ; v94 = 0
 ;; @005b                               v15 = uextend.i32 v14
 ;; @005b                               v16 = bor v13, v15
 ;; @005b                               brif v16, block4, block2
 ;;
 ;;                                 block2:
-;; @005b                               v17 = uextend.i64 v12
-;; @005b                               v57 = load.i64 notrap aligned readonly can_move v0+8
-;; @005b                               v18 = load.i64 notrap aligned readonly can_move v57+32
+;;                                     v93 = stack_addr.i64 ss0
+;;                                     v72 = load.i32 notrap v93
+;; @005b                               v17 = uextend.i64 v72
+;; @005b                               v91 = load.i64 notrap aligned readonly can_move v0+8
+;; @005b                               v18 = load.i64 notrap aligned readonly can_move v91+32
 ;; @005b                               v19 = iadd v18, v17
 ;; @005b                               v20 = load.i32 user2 v19
 ;; @005b                               v21 = iconst.i32 2
@@ -140,44 +195,77 @@
 ;; @005b                               brif v22, block4, block3
 ;;
 ;;                                 block3:
-;; @005b                               v24 = load.i64 notrap aligned readonly v0+32
+;; @005b                               v24 = load.i64 notrap aligned readonly can_move v0+32
 ;; @005b                               v25 = load.i32 user2 v24
-;; @005b                               v26 = uextend.i64 v12
-;; @005b                               v55 = load.i64 notrap aligned readonly can_move v0+8
-;; @005b                               v27 = load.i64 notrap aligned readonly can_move v55+32
+;;                                     v90 = stack_addr.i64 ss0
+;;                                     v71 = load.i32 notrap v90
+;; @005b                               v26 = uextend.i64 v71
+;; @005b                               v88 = load.i64 notrap aligned readonly can_move v0+8
+;; @005b                               v27 = load.i64 notrap aligned readonly can_move v88+32
 ;; @005b                               v28 = iadd v27, v26
 ;; @005b                               v29 = iconst.i64 16
 ;; @005b                               v30 = iadd v28, v29  ; v29 = 16
 ;; @005b                               store user2 v25, v30
 ;; @005b                               v31 = iconst.i32 2
 ;; @005b                               v32 = bor.i32 v20, v31  ; v31 = 2
-;; @005b                               v33 = uextend.i64 v12
-;; @005b                               v53 = load.i64 notrap aligned readonly can_move v0+8
-;; @005b                               v34 = load.i64 notrap aligned readonly can_move v53+32
+;;                                     v87 = stack_addr.i64 ss0
+;;                                     v70 = load.i32 notrap v87
+;; @005b                               v33 = uextend.i64 v70
+;; @005b                               v85 = load.i64 notrap aligned readonly can_move v0+8
+;; @005b                               v34 = load.i64 notrap aligned readonly can_move v85+32
 ;; @005b                               v35 = iadd v34, v33
 ;; @005b                               store user2 v32, v35
-;; @005b                               v36 = uextend.i64 v12
-;; @005b                               v51 = load.i64 notrap aligned readonly can_move v0+8
-;; @005b                               v37 = load.i64 notrap aligned readonly can_move v51+32
+;;                                     v84 = stack_addr.i64 ss0
+;;                                     v69 = load.i32 notrap v84
+;; @005b                               v36 = uextend.i64 v69
+;; @005b                               v82 = load.i64 notrap aligned readonly can_move v0+8
+;; @005b                               v37 = load.i64 notrap aligned readonly can_move v82+32
 ;; @005b                               v38 = iadd v37, v36
 ;; @005b                               v39 = iconst.i64 8
 ;; @005b                               v40 = iadd v38, v39  ; v39 = 8
 ;; @005b                               v41 = load.i64 user2 v40
-;;                                     v50 = iconst.i64 1
-;; @005b                               v42 = iadd v41, v50  ; v50 = 1
-;; @005b                               v43 = uextend.i64 v12
-;; @005b                               v48 = load.i64 notrap aligned readonly can_move v0+8
-;; @005b                               v44 = load.i64 notrap aligned readonly can_move v48+32
+;;                                     v81 = iconst.i64 1
+;; @005b                               v42 = iadd v41, v81  ; v81 = 1
+;;                                     v80 = stack_addr.i64 ss0
+;;                                     v68 = load.i32 notrap v80
+;; @005b                               v43 = uextend.i64 v68
+;; @005b                               v78 = load.i64 notrap aligned readonly can_move v0+8
+;; @005b                               v44 = load.i64 notrap aligned readonly can_move v78+32
 ;; @005b                               v45 = iadd v44, v43
 ;; @005b                               v46 = iconst.i64 8
 ;; @005b                               v47 = iadd v45, v46  ; v46 = 8
 ;; @005b                               store user2 v42, v47
-;; @005b                               store.i32 user2 v12, v24
+;;                                     v77 = stack_addr.i64 ss0
+;;                                     v67 = load.i32 notrap v77
+;; @005b                               store user2 v67, v24
+;; @005b                               v49 = load.i64 notrap aligned readonly can_move v0+32
+;; @005b                               v50 = load.i32 notrap aligned v49+4
+;;                                     v76 = iconst.i32 1
+;; @005b                               v51 = iadd v50, v76  ; v76 = 1
+;; @005b                               v53 = load.i64 notrap aligned readonly can_move v0+32
+;; @005b                               store notrap aligned v51, v53+4
+;; @005b                               v55 = load.i64 notrap aligned readonly can_move v0+32
+;; @005b                               v56 = load.i32 notrap aligned v55+4
+;; @005b                               v58 = load.i64 notrap aligned readonly can_move v0+32
+;; @005b                               v59 = load.i32 notrap aligned v58+8
+;; @005b                               v60 = iadd v59, v59
+;; @005b                               v61 = iconst.i32 1024
+;; @005b                               v62 = umax v60, v61  ; v61 = 1024
+;; @005b                               v63 = icmp uge v56, v62
+;; @005b                               brif v63, block5, block6
+;;
+;;                                 block5 cold:
+;; @005b                               v65 = call fn0(v0), stack_map=[i32 @ ss0+0]
+;; @005b                               jump block6
+;;
+;;                                 block6:
 ;; @005b                               jump block4
 ;;
 ;;                                 block4:
+;;                                     v75 = stack_addr.i64 ss0
+;;                                     v66 = load.i32 notrap v75
 ;; @005d                               jump block1
 ;;
 ;;                                 block1:
-;; @005d                               return v12
+;; @005d                               return v66
 ;; }

--- a/tests/disas/table-get-fixed-size.wat
+++ b/tests/disas/table-get-fixed-size.wat
@@ -26,7 +26,7 @@
 ;;     gv6 = load.i64 notrap aligned readonly can_move gv5+32
 ;;     gv7 = load.i64 notrap aligned gv5+40
 ;;     sig0 = (i64 vmctx) -> i8 tail
-;;     fn0 = colocated u805306368:52 sig0
+;;     fn0 = colocated u805306368:46 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
@@ -154,7 +154,7 @@
 ;;     gv6 = load.i64 notrap aligned readonly can_move gv5+32
 ;;     gv7 = load.i64 notrap aligned gv5+40
 ;;     sig0 = (i64 vmctx) -> i8 tail
-;;     fn0 = colocated u805306368:52 sig0
+;;     fn0 = colocated u805306368:46 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/table-get.wat
+++ b/tests/disas/table-get.wat
@@ -15,6 +15,7 @@
     table.get 0))
 
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
+;;     ss0 = explicit_slot 4, align = 4
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -24,6 +25,8 @@
 ;;     gv6 = load.i64 notrap aligned readonly can_move gv3+8
 ;;     gv7 = load.i64 notrap aligned readonly can_move gv6+32
 ;;     gv8 = load.i64 notrap aligned gv6+40
+;;     sig0 = (i64 vmctx) -> i8 tail
+;;     fn0 = colocated u805306368:52 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
@@ -33,24 +36,32 @@
 ;; @0053                               v6 = icmp uge v3, v5  ; v3 = 0
 ;; @0053                               v7 = uextend.i64 v3  ; v3 = 0
 ;; @0053                               v8 = load.i64 notrap aligned v0+48
-;;                                     v62 = iconst.i64 2
-;; @0053                               v9 = ishl v7, v62  ; v62 = 2
+;;                                     v100 = iconst.i64 2
+;; @0053                               v9 = ishl v7, v100  ; v100 = 2
 ;; @0053                               v10 = iadd v8, v9
 ;; @0053                               v11 = iconst.i64 0
 ;; @0053                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
 ;; @0053                               v13 = load.i32 user6 aligned table v12
-;;                                     v61 = iconst.i32 1
-;; @0053                               v14 = band v13, v61  ; v61 = 1
-;;                                     v60 = iconst.i32 0
-;; @0053                               v15 = icmp eq v13, v60  ; v60 = 0
+;;                                     v99 = stack_addr.i64 ss0
+;;                                     store notrap v13, v99
+;;                                     v98 = stack_addr.i64 ss0
+;;                                     v75 = load.i32 notrap v98
+;;                                     v97 = iconst.i32 1
+;; @0053                               v14 = band v75, v97  ; v97 = 1
+;;                                     v96 = stack_addr.i64 ss0
+;;                                     v74 = load.i32 notrap v96
+;;                                     v95 = iconst.i32 0
+;; @0053                               v15 = icmp eq v74, v95  ; v95 = 0
 ;; @0053                               v16 = uextend.i32 v15
 ;; @0053                               v17 = bor v14, v16
 ;; @0053                               brif v17, block4, block2
 ;;
 ;;                                 block2:
-;; @0053                               v18 = uextend.i64 v13
-;; @0053                               v58 = load.i64 notrap aligned readonly can_move v0+8
-;; @0053                               v19 = load.i64 notrap aligned readonly can_move v58+32
+;;                                     v94 = stack_addr.i64 ss0
+;;                                     v73 = load.i32 notrap v94
+;; @0053                               v18 = uextend.i64 v73
+;; @0053                               v92 = load.i64 notrap aligned readonly can_move v0+8
+;; @0053                               v19 = load.i64 notrap aligned readonly can_move v92+32
 ;; @0053                               v20 = iadd v19, v18
 ;; @0053                               v21 = load.i32 user2 v20
 ;; @0053                               v22 = iconst.i32 2
@@ -58,49 +69,83 @@
 ;; @0053                               brif v23, block4, block3
 ;;
 ;;                                 block3:
-;; @0053                               v25 = load.i64 notrap aligned readonly v0+32
+;; @0053                               v25 = load.i64 notrap aligned readonly can_move v0+32
 ;; @0053                               v26 = load.i32 user2 v25
-;; @0053                               v27 = uextend.i64 v13
-;; @0053                               v56 = load.i64 notrap aligned readonly can_move v0+8
-;; @0053                               v28 = load.i64 notrap aligned readonly can_move v56+32
+;;                                     v91 = stack_addr.i64 ss0
+;;                                     v72 = load.i32 notrap v91
+;; @0053                               v27 = uextend.i64 v72
+;; @0053                               v89 = load.i64 notrap aligned readonly can_move v0+8
+;; @0053                               v28 = load.i64 notrap aligned readonly can_move v89+32
 ;; @0053                               v29 = iadd v28, v27
 ;; @0053                               v30 = iconst.i64 16
 ;; @0053                               v31 = iadd v29, v30  ; v30 = 16
 ;; @0053                               store user2 v26, v31
 ;; @0053                               v32 = iconst.i32 2
 ;; @0053                               v33 = bor.i32 v21, v32  ; v32 = 2
-;; @0053                               v34 = uextend.i64 v13
-;; @0053                               v54 = load.i64 notrap aligned readonly can_move v0+8
-;; @0053                               v35 = load.i64 notrap aligned readonly can_move v54+32
+;;                                     v88 = stack_addr.i64 ss0
+;;                                     v71 = load.i32 notrap v88
+;; @0053                               v34 = uextend.i64 v71
+;; @0053                               v86 = load.i64 notrap aligned readonly can_move v0+8
+;; @0053                               v35 = load.i64 notrap aligned readonly can_move v86+32
 ;; @0053                               v36 = iadd v35, v34
 ;; @0053                               store user2 v33, v36
-;; @0053                               v37 = uextend.i64 v13
-;; @0053                               v52 = load.i64 notrap aligned readonly can_move v0+8
-;; @0053                               v38 = load.i64 notrap aligned readonly can_move v52+32
+;;                                     v85 = stack_addr.i64 ss0
+;;                                     v70 = load.i32 notrap v85
+;; @0053                               v37 = uextend.i64 v70
+;; @0053                               v83 = load.i64 notrap aligned readonly can_move v0+8
+;; @0053                               v38 = load.i64 notrap aligned readonly can_move v83+32
 ;; @0053                               v39 = iadd v38, v37
 ;; @0053                               v40 = iconst.i64 8
 ;; @0053                               v41 = iadd v39, v40  ; v40 = 8
 ;; @0053                               v42 = load.i64 user2 v41
-;;                                     v51 = iconst.i64 1
-;; @0053                               v43 = iadd v42, v51  ; v51 = 1
-;; @0053                               v44 = uextend.i64 v13
-;; @0053                               v49 = load.i64 notrap aligned readonly can_move v0+8
-;; @0053                               v45 = load.i64 notrap aligned readonly can_move v49+32
+;;                                     v82 = iconst.i64 1
+;; @0053                               v43 = iadd v42, v82  ; v82 = 1
+;;                                     v81 = stack_addr.i64 ss0
+;;                                     v69 = load.i32 notrap v81
+;; @0053                               v44 = uextend.i64 v69
+;; @0053                               v79 = load.i64 notrap aligned readonly can_move v0+8
+;; @0053                               v45 = load.i64 notrap aligned readonly can_move v79+32
 ;; @0053                               v46 = iadd v45, v44
 ;; @0053                               v47 = iconst.i64 8
 ;; @0053                               v48 = iadd v46, v47  ; v47 = 8
 ;; @0053                               store user2 v43, v48
-;; @0053                               store.i32 user2 v13, v25
+;;                                     v78 = stack_addr.i64 ss0
+;;                                     v68 = load.i32 notrap v78
+;; @0053                               store user2 v68, v25
+;; @0053                               v50 = load.i64 notrap aligned readonly can_move v0+32
+;; @0053                               v51 = load.i32 notrap aligned v50+4
+;;                                     v77 = iconst.i32 1
+;; @0053                               v52 = iadd v51, v77  ; v77 = 1
+;; @0053                               v54 = load.i64 notrap aligned readonly can_move v0+32
+;; @0053                               store notrap aligned v52, v54+4
+;; @0053                               v56 = load.i64 notrap aligned readonly can_move v0+32
+;; @0053                               v57 = load.i32 notrap aligned v56+4
+;; @0053                               v59 = load.i64 notrap aligned readonly can_move v0+32
+;; @0053                               v60 = load.i32 notrap aligned v59+8
+;; @0053                               v61 = iadd v60, v60
+;; @0053                               v62 = iconst.i32 1024
+;; @0053                               v63 = umax v61, v62  ; v62 = 1024
+;; @0053                               v64 = icmp uge v57, v63
+;; @0053                               brif v64, block5, block6
+;;
+;;                                 block5 cold:
+;; @0053                               v66 = call fn0(v0), stack_map=[i32 @ ss0+0]
+;; @0053                               jump block6
+;;
+;;                                 block6:
 ;; @0053                               jump block4
 ;;
 ;;                                 block4:
+;;                                     v76 = stack_addr.i64 ss0
+;;                                     v67 = load.i32 notrap v76
 ;; @0055                               jump block1
 ;;
 ;;                                 block1:
-;; @0055                               return v13
+;; @0055                               return v67
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
+;;     ss0 = explicit_slot 4, align = 4
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
 ;;     gv2 = load.i64 notrap aligned gv1+24
@@ -110,6 +155,8 @@
 ;;     gv6 = load.i64 notrap aligned readonly can_move gv3+8
 ;;     gv7 = load.i64 notrap aligned readonly can_move gv6+32
 ;;     gv8 = load.i64 notrap aligned gv6+40
+;;     sig0 = (i64 vmctx) -> i8 tail
+;;     fn0 = colocated u805306368:52 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -118,24 +165,32 @@
 ;; @005a                               v6 = icmp uge v2, v5
 ;; @005a                               v7 = uextend.i64 v2
 ;; @005a                               v8 = load.i64 notrap aligned v0+48
-;;                                     v62 = iconst.i64 2
-;; @005a                               v9 = ishl v7, v62  ; v62 = 2
+;;                                     v100 = iconst.i64 2
+;; @005a                               v9 = ishl v7, v100  ; v100 = 2
 ;; @005a                               v10 = iadd v8, v9
 ;; @005a                               v11 = iconst.i64 0
 ;; @005a                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
 ;; @005a                               v13 = load.i32 user6 aligned table v12
-;;                                     v61 = iconst.i32 1
-;; @005a                               v14 = band v13, v61  ; v61 = 1
-;;                                     v60 = iconst.i32 0
-;; @005a                               v15 = icmp eq v13, v60  ; v60 = 0
+;;                                     v99 = stack_addr.i64 ss0
+;;                                     store notrap v13, v99
+;;                                     v98 = stack_addr.i64 ss0
+;;                                     v75 = load.i32 notrap v98
+;;                                     v97 = iconst.i32 1
+;; @005a                               v14 = band v75, v97  ; v97 = 1
+;;                                     v96 = stack_addr.i64 ss0
+;;                                     v74 = load.i32 notrap v96
+;;                                     v95 = iconst.i32 0
+;; @005a                               v15 = icmp eq v74, v95  ; v95 = 0
 ;; @005a                               v16 = uextend.i32 v15
 ;; @005a                               v17 = bor v14, v16
 ;; @005a                               brif v17, block4, block2
 ;;
 ;;                                 block2:
-;; @005a                               v18 = uextend.i64 v13
-;; @005a                               v58 = load.i64 notrap aligned readonly can_move v0+8
-;; @005a                               v19 = load.i64 notrap aligned readonly can_move v58+32
+;;                                     v94 = stack_addr.i64 ss0
+;;                                     v73 = load.i32 notrap v94
+;; @005a                               v18 = uextend.i64 v73
+;; @005a                               v92 = load.i64 notrap aligned readonly can_move v0+8
+;; @005a                               v19 = load.i64 notrap aligned readonly can_move v92+32
 ;; @005a                               v20 = iadd v19, v18
 ;; @005a                               v21 = load.i32 user2 v20
 ;; @005a                               v22 = iconst.i32 2
@@ -143,44 +198,77 @@
 ;; @005a                               brif v23, block4, block3
 ;;
 ;;                                 block3:
-;; @005a                               v25 = load.i64 notrap aligned readonly v0+32
+;; @005a                               v25 = load.i64 notrap aligned readonly can_move v0+32
 ;; @005a                               v26 = load.i32 user2 v25
-;; @005a                               v27 = uextend.i64 v13
-;; @005a                               v56 = load.i64 notrap aligned readonly can_move v0+8
-;; @005a                               v28 = load.i64 notrap aligned readonly can_move v56+32
+;;                                     v91 = stack_addr.i64 ss0
+;;                                     v72 = load.i32 notrap v91
+;; @005a                               v27 = uextend.i64 v72
+;; @005a                               v89 = load.i64 notrap aligned readonly can_move v0+8
+;; @005a                               v28 = load.i64 notrap aligned readonly can_move v89+32
 ;; @005a                               v29 = iadd v28, v27
 ;; @005a                               v30 = iconst.i64 16
 ;; @005a                               v31 = iadd v29, v30  ; v30 = 16
 ;; @005a                               store user2 v26, v31
 ;; @005a                               v32 = iconst.i32 2
 ;; @005a                               v33 = bor.i32 v21, v32  ; v32 = 2
-;; @005a                               v34 = uextend.i64 v13
-;; @005a                               v54 = load.i64 notrap aligned readonly can_move v0+8
-;; @005a                               v35 = load.i64 notrap aligned readonly can_move v54+32
+;;                                     v88 = stack_addr.i64 ss0
+;;                                     v71 = load.i32 notrap v88
+;; @005a                               v34 = uextend.i64 v71
+;; @005a                               v86 = load.i64 notrap aligned readonly can_move v0+8
+;; @005a                               v35 = load.i64 notrap aligned readonly can_move v86+32
 ;; @005a                               v36 = iadd v35, v34
 ;; @005a                               store user2 v33, v36
-;; @005a                               v37 = uextend.i64 v13
-;; @005a                               v52 = load.i64 notrap aligned readonly can_move v0+8
-;; @005a                               v38 = load.i64 notrap aligned readonly can_move v52+32
+;;                                     v85 = stack_addr.i64 ss0
+;;                                     v70 = load.i32 notrap v85
+;; @005a                               v37 = uextend.i64 v70
+;; @005a                               v83 = load.i64 notrap aligned readonly can_move v0+8
+;; @005a                               v38 = load.i64 notrap aligned readonly can_move v83+32
 ;; @005a                               v39 = iadd v38, v37
 ;; @005a                               v40 = iconst.i64 8
 ;; @005a                               v41 = iadd v39, v40  ; v40 = 8
 ;; @005a                               v42 = load.i64 user2 v41
-;;                                     v51 = iconst.i64 1
-;; @005a                               v43 = iadd v42, v51  ; v51 = 1
-;; @005a                               v44 = uextend.i64 v13
-;; @005a                               v49 = load.i64 notrap aligned readonly can_move v0+8
-;; @005a                               v45 = load.i64 notrap aligned readonly can_move v49+32
+;;                                     v82 = iconst.i64 1
+;; @005a                               v43 = iadd v42, v82  ; v82 = 1
+;;                                     v81 = stack_addr.i64 ss0
+;;                                     v69 = load.i32 notrap v81
+;; @005a                               v44 = uextend.i64 v69
+;; @005a                               v79 = load.i64 notrap aligned readonly can_move v0+8
+;; @005a                               v45 = load.i64 notrap aligned readonly can_move v79+32
 ;; @005a                               v46 = iadd v45, v44
 ;; @005a                               v47 = iconst.i64 8
 ;; @005a                               v48 = iadd v46, v47  ; v47 = 8
 ;; @005a                               store user2 v43, v48
-;; @005a                               store.i32 user2 v13, v25
+;;                                     v78 = stack_addr.i64 ss0
+;;                                     v68 = load.i32 notrap v78
+;; @005a                               store user2 v68, v25
+;; @005a                               v50 = load.i64 notrap aligned readonly can_move v0+32
+;; @005a                               v51 = load.i32 notrap aligned v50+4
+;;                                     v77 = iconst.i32 1
+;; @005a                               v52 = iadd v51, v77  ; v77 = 1
+;; @005a                               v54 = load.i64 notrap aligned readonly can_move v0+32
+;; @005a                               store notrap aligned v52, v54+4
+;; @005a                               v56 = load.i64 notrap aligned readonly can_move v0+32
+;; @005a                               v57 = load.i32 notrap aligned v56+4
+;; @005a                               v59 = load.i64 notrap aligned readonly can_move v0+32
+;; @005a                               v60 = load.i32 notrap aligned v59+8
+;; @005a                               v61 = iadd v60, v60
+;; @005a                               v62 = iconst.i32 1024
+;; @005a                               v63 = umax v61, v62  ; v62 = 1024
+;; @005a                               v64 = icmp uge v57, v63
+;; @005a                               brif v64, block5, block6
+;;
+;;                                 block5 cold:
+;; @005a                               v66 = call fn0(v0), stack_map=[i32 @ ss0+0]
+;; @005a                               jump block6
+;;
+;;                                 block6:
 ;; @005a                               jump block4
 ;;
 ;;                                 block4:
+;;                                     v76 = stack_addr.i64 ss0
+;;                                     v67 = load.i32 notrap v76
 ;; @005c                               jump block1
 ;;
 ;;                                 block1:
-;; @005c                               return v13
+;; @005c                               return v67
 ;; }

--- a/tests/disas/table-get.wat
+++ b/tests/disas/table-get.wat
@@ -26,7 +26,7 @@
 ;;     gv7 = load.i64 notrap aligned readonly can_move gv6+32
 ;;     gv8 = load.i64 notrap aligned gv6+40
 ;;     sig0 = (i64 vmctx) -> i8 tail
-;;     fn0 = colocated u805306368:52 sig0
+;;     fn0 = colocated u805306368:46 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
@@ -156,7 +156,7 @@
 ;;     gv7 = load.i64 notrap aligned readonly can_move gv6+32
 ;;     gv8 = load.i64 notrap aligned gv6+40
 ;;     sig0 = (i64 vmctx) -> i8 tail
-;;     fn0 = colocated u805306368:52 sig0
+;;     fn0 = colocated u805306368:46 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):


### PR DESCRIPTION
This should trigger collection in more situations than just filling up the heap from allocation.

Fixes https://github.com/bytecodealliance/wasmtime/issues/13403 in theory, but I haven't been able to measure sweep times reported in that issue without this fix on my laptop. FWIW, that issue does refer to Android, and so is probably using radically different hardware.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
