### PR TITLE
Clear trace info on `GcHeap::detach`

### DIFF
--- a/crates/wasmtime/src/runtime/vm/gc/enabled/copying.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/enabled/copying.rs
@@ -625,10 +625,7 @@ unsafe impl GcHeap for CopyingHeap {
             worklist_ptr,
             active_extern_ref_set_head,
             idle_extern_ref_set_head,
-            // NB: we will only ever be reused with the same engine, so no need
-            // to clear out our tracing info just to fill it back in with the
-            // same exact stuff.
-            trace_infos: _,
+            trace_infos,
         } = self;
 
         *no_gc_count = 0;
@@ -639,6 +636,7 @@ unsafe impl GcHeap for CopyingHeap {
         *worklist_ptr = 0;
         *active_extern_ref_set_head = None;
         *idle_extern_ref_set_head = None;
+        trace_infos.clear();
 
         memory.take().unwrap()
     }

--- a/crates/wasmtime/src/runtime/vm/gc/enabled/drc.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/enabled/drc.rs
@@ -789,11 +789,7 @@ unsafe impl GcHeap for DrcHeap {
             memory,
             vmmemory,
             allocated_bytes,
-
-            // NB: we will only ever be reused with the same engine, so no need
-            // to clear out our tracing info just to fill it back in with the
-            // same exact stuff.
-            trace_infos: _,
+            trace_infos,
         } = self;
 
         *no_gc_count = 0;
@@ -801,6 +797,7 @@ unsafe impl GcHeap for DrcHeap {
         *free_list = None;
         *vmmemory = None;
         *allocated_bytes = 0;
+        trace_infos.clear();
         debug_assert!(dec_ref_stack.as_ref().is_some_and(|s| s.is_empty()));
         debug_assert!(
             large_array_dec_ref_stack

--- a/crates/wasmtime/src/runtime/vm/gc/enabled/trace_info.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/enabled/trace_info.rs
@@ -106,6 +106,11 @@ impl TraceInfos {
         self.engine.upgrade().unwrap()
     }
 
+    /// Remove all trace info from this collection.
+    pub fn clear(&mut self) {
+        self.map.clear();
+    }
+
     /// Index into the trace infos, panicking if the type is not present.
     pub fn trace_info(&self, ty: &VMSharedTypeIndex) -> &TraceInfo {
         &self.map[ty]

--- a/tests/misc_testsuite/gc/issue-13417.wast
+++ b/tests/misc_testsuite/gc/issue-13417.wast
@@ -1,0 +1,34 @@
+;;! gc = true
+
+(module)
+
+(thread $old
+  (module
+    ;; Register stale trace metadata for a large struct whose final field is a
+    ;; GC reference. The field offset is valid for this type, but not for the
+    ;; smaller type instantiated after this thread's Store is dropped.
+    (type $old (struct
+      (field i64) (field i64) (field i64) (field i64)
+      (field i64) (field i64) (field i64) (field i64)
+      (field i64) (field i64) (field i64) (field i64)
+      (field i64) (field i64) (field i64) (field i64)
+      (field anyref)))
+    (global (ref null $old)
+      (struct.new $old
+        (i64.const 0) (i64.const 0) (i64.const 0) (i64.const 0)
+        (i64.const 0) (i64.const 0) (i64.const 0) (i64.const 0)
+        (i64.const 0) (i64.const 0) (i64.const 0) (i64.const 0)
+        (i64.const 0) (i64.const 0) (i64.const 0) (i64.const 0)
+        (ref.null any)))))
+(wait $old)
+
+(module
+  (type $new (struct (field (mut i32))))
+  (global $g (mut (ref null $new))
+    (struct.new $new (i32.const 1)))
+  (func (export "trigger")
+    ;; Overwriting the global makes DRC decrement and deallocate the old value,
+    ;; consuming the stale trace metadata without forcing an explicit GC.
+    (global.set $g (ref.null $new))))
+
+(invoke "trigger")


### PR DESCRIPTION
The `VMSharedTypeIndex` keys can become stale before re-attachment.

Fixes https://github.com/bytecodealliance/wasmtime/issues/13417

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
