### PR TITLE
Reimplement `table.{grow,fill}`

### DIFF
--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -3753,7 +3753,7 @@ impl FuncEnvironment<'_> {
         Ok(())
     }
 
-    /// Tests to seew hether `value`, stored as `ty`, can be extracted to a single
+    /// Tests to see whether `value`, stored as `ty`, can be extracted to a single
     /// byte which can be passed to `memset`, or the host's `memory.fill`, to
     /// satisfy this array initialization request.
     fn fill_value_as_memset(

--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -5294,7 +5294,10 @@ impl CheckedEntity {
         match *self {
             CheckedEntity::Memory(_) | CheckedEntity::Data(_) => 1,
             CheckedEntity::Table(table) => env.get_or_create_table(func, table).element_size,
+            #[cfg(feature = "gc")]
             CheckedEntity::Array(ty) => env.array_layout(ty).elem_size,
+            #[cfg(not(feature = "gc"))]
+            CheckedEntity::Array(_) => unreachable!(),
         }
     }
 

--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -2454,34 +2454,53 @@ impl FuncEnvironment<'_> {
     ) -> WasmResult<ir::Value> {
         let mut pos = builder.cursor();
         let table = self.table(table_index);
-        let ty = table.ref_type.heap_type;
         let (table_vmctx, defined_table_index) =
             self.table_vmctx_and_defined_index(&mut pos, table_index);
         let index_type = table.idx_type;
-        let delta = self.cast_index_to_i64(&mut pos, delta, index_type);
+        let delta64 = self.cast_index_to_i64(&mut pos, delta, index_type);
 
-        let mut args: SmallVec<[_; 6]> = smallvec![table_vmctx, defined_table_index, delta];
-        let grow = match ty.top() {
-            WasmHeapTopType::Extern | WasmHeapTopType::Any | WasmHeapTopType::Exn => {
-                args.push(init_value);
-                gc::builtins::table_grow_gc_ref(self, pos.func)?
-            }
-            WasmHeapTopType::Func => {
-                args.push(init_value);
-                self.builtin_functions.table_grow_func_ref(pos.func)
-            }
-            WasmHeapTopType::Cont => {
-                let (revision, contref) =
-                    stack_switching::fatpointer::deconstruct(self, &mut pos, init_value);
-                args.extend_from_slice(&[contref, revision]);
-                stack_switching::builtins::table_grow_cont_obj(self, pos.func)?
-            }
-        };
-
-        let call_inst = pos.ins().call(grow, &args);
+        // Call out to the host to perform the actual growth of the underlying
+        // table. This will initialize table slots as all null. Afterwards the
+        // `init_value` needs to be placed in all slots in compiled code.
+        //
+        // Note that `table_index`'s type may not allow for null entries, and
+        // this creates a small window of time where the table actually has null
+        // entries. Given that this table isn't shared, however, this is fine
+        // because no other wasm instructions (or embedder code) can execute in
+        // this window.
+        let table_grow = self.builtin_functions.table_grow(pos.func);
+        let call_inst = pos
+            .ins()
+            .call(table_grow, &[table_vmctx, defined_table_index, delta64]);
         let result = builder.func.dfg.first_result(call_inst);
+        let result_idx =
+            self.convert_pointer_to_index_type(builder.cursor(), result, index_type, false);
 
-        Ok(self.convert_pointer_to_index_type(builder.cursor(), result, index_type, false))
+        // If `result_idx` indicates success then `init_value` needs to be
+        // placed into the table. This is done with a `table.fill`.
+        // Conditionally call that on growth success, and otherwise fall through
+        // to continue to yield -1 for this growth operation.
+        let current_block = builder.current_block().unwrap();
+        let fill_block = builder.create_block();
+        let done_block = builder.create_block();
+
+        builder.insert_block_after(fill_block, current_block);
+        builder.insert_block_after(done_block, fill_block);
+
+        let failure = builder.ins().iconst(index_type_to_ir_type(index_type), -1);
+        let failed = builder.ins().icmp(IntCC::Equal, result_idx, failure);
+        builder.ins().brif(failed, done_block, &[], fill_block, &[]);
+
+        builder.switch_to_block(fill_block);
+        self.translate_table_fill(builder, table_index, result_idx, init_value, delta)?;
+        builder.ins().jump(done_block, &[]);
+
+        builder.switch_to_block(done_block);
+
+        builder.seal_block(fill_block);
+        builder.seal_block(done_block);
+
+        Ok(result_idx)
     }
 
     pub fn translate_table_get(
@@ -2606,35 +2625,7 @@ impl FuncEnvironment<'_> {
         val: ir::Value,
         len: ir::Value,
     ) -> WasmResult<()> {
-        let mut pos = builder.cursor();
-        let table = self.table(table_index);
-        let ty = table.ref_type.heap_type;
-        let dst = self.cast_index_to_i64(&mut pos, dst, table.idx_type);
-        let len = self.cast_index_to_i64(&mut pos, len, table.idx_type);
-        let (table_vmctx, table_index) = self.table_vmctx_and_defined_index(&mut pos, table_index);
-
-        let mut args: SmallVec<[_; 6]> = smallvec![table_vmctx, table_index, dst];
-        let libcall = match ty.top() {
-            WasmHeapTopType::Any | WasmHeapTopType::Extern | WasmHeapTopType::Exn => {
-                args.push(val);
-                gc::builtins::table_fill_gc_ref(self, &mut pos.func)?
-            }
-            WasmHeapTopType::Func => {
-                args.push(val);
-                self.builtin_functions.table_fill_func_ref(&mut pos.func)
-            }
-            WasmHeapTopType::Cont => {
-                let (revision, contref) =
-                    stack_switching::fatpointer::deconstruct(self, &mut pos, val);
-                args.extend_from_slice(&[contref, revision]);
-                stack_switching::builtins::table_fill_cont_obj(self, &mut pos.func)?
-            }
-        };
-
-        args.push(len);
-        builder.ins().call(libcall, &args);
-
-        Ok(())
+        self.translate_entity_fill(builder, table_index, dst, val, len)
     }
 
     pub fn translate_ref_i31(
@@ -3589,6 +3580,236 @@ impl FuncEnvironment<'_> {
         builder.seal_block(last_chunk_block);
     }
 
+    /// Emits a generic "fill" of `entity` from `dst` for `len` elements,
+    /// setting everything to `val`.
+    ///
+    /// This encompasses the implementation of `memory.fill` and `table.fill`
+    /// for example, as well as various GC array initialization patterns. The
+    /// `dst` and `len` values must be typed appropriately for `entity`. This
+    /// will perform a bounds-check before actually executing the operation and
+    /// then afterwards will perform the operation.
+    fn translate_entity_fill(
+        &mut self,
+        builder: &mut FunctionBuilder<'_>,
+        entity: impl Into<CheckedEntity>,
+        dst: ir::Value,
+        val: ir::Value,
+        len: ir::Value,
+    ) -> WasmResult<()> {
+        let entity = entity.into();
+        let idx_type = entity.index_type(self);
+
+        // Bounds check `dst+len` and convert it to a raw heap address.
+        let raw_dst_addr = self.translate_entity_bounds_check(builder, entity, dst, len);
+
+        // Fit the `len` value to `pointer_type`. Note that at this point it's
+        // guaranteed inbounds so there's no loss in precision.
+        let len_ptr =
+            self.unchecked_cast_wasm_addr_to_native_addr(&mut builder.cursor(), len, idx_type);
+
+        match entity {
+            CheckedEntity::Memory(_) => {
+                self.raw_bulk_memory_operation(
+                    builder,
+                    BulkOp::MemoryFill {
+                        dst: raw_dst_addr,
+                        val,
+                        len: len_ptr,
+                    },
+                );
+            }
+            CheckedEntity::Table(table) => {
+                self.emit_raw_array_or_table_fill(
+                    builder,
+                    entity,
+                    raw_dst_addr,
+                    val,
+                    len_ptr,
+                    &|env, builder, addr, value| {
+                        env.emit_table_set(builder, table, addr, ir::MemFlagsData::trusted(), value)
+                    },
+                )?;
+            }
+            CheckedEntity::Array(_) => todo!(),
+            CheckedEntity::Data(_) => unreachable!(),
+        }
+
+        Ok(())
+    }
+
+    /// Performs a manual element-by-element fill of `entity`, starting at
+    /// `dst_elem_addr`, of `copy_len` elements of the specified `value`.
+    ///
+    /// This is the implementation of `table.fill` and `array.fill` and other
+    /// such array initializations for example. Everything must have already
+    /// been bounds-checked prior to calling this method.
+    ///
+    /// The `dst_elem_addr` and `copy_len` values must have type
+    /// `self.pointer_type()`. The `value` argument must have a type appropriate
+    /// to store in the entity.
+    ///
+    /// The translation of the actual write is performed by `emit_elem_write`,
+    /// which receives ambient state, then the address to write to, then `value`
+    /// again to write.
+    fn emit_raw_array_or_table_fill(
+        &mut self,
+        builder: &mut FunctionBuilder<'_>,
+        entity: CheckedEntity,
+        dst_elem_addr: ir::Value,
+        value: ir::Value,
+        copy_len: ir::Value,
+        emit_elem_write: &dyn Fn(
+            &mut Self,
+            &mut FunctionBuilder<'_>,
+            ir::Value,
+            ir::Value,
+        ) -> WasmResult<()>,
+    ) -> WasmResult<()> {
+        let pointer_ty = self.pointer_type();
+
+        assert_eq!(builder.func.dfg.value_type(dst_elem_addr), pointer_ty);
+        assert_eq!(builder.func.dfg.value_type(copy_len), pointer_ty);
+        let elem_ty = entity.storage_type(self);
+        let elem_size = entity.element_size(self, builder.func);
+        let copy_byte_len = builder.ins().imul_imm(copy_len, i64::from(elem_size));
+
+        // If this is a byte array then specialize its fill to use the same
+        // libcall as `memory.fill`. This gets us to `memset` on the host which
+        // for larger arrays can be a big boost due to the vectorized
+        // implementation.
+        if entity.allows_memset(self)
+            && let Some(value) = self.fill_value_as_memset(builder, elem_ty, value)
+        {
+            self.raw_bulk_memory_operation(
+                builder,
+                BulkOp::MemoryFill {
+                    dst: dst_elem_addr,
+                    val: value,
+                    len: copy_byte_len,
+                },
+            );
+            return Ok(());
+        }
+
+        // Loop to fill the elements, emitting the equivalent of the following
+        // pseudo-CLIF:
+        //
+        // current_block:
+        //     ...
+        //     end_addr = iadd dst_elem_addr, copy_byte_len
+        //     empty = icmp_imm eq copy_len, 0
+        //     brif empty, continue_block, loop_block(dst_elem_addr)
+        //
+        // loop_block(elem_addr):
+        //     .. write `value` to `elem_addr`
+        //     next_elem_addr = iadd elem_addr, elem_size
+        //     done = icmp eq next_elem_addr, end_addr
+        //     brif done, continue_block, loop_block(next_elem_addr)
+        //
+        // continue_block:
+        //     ...
+
+        let current_block = builder.current_block().unwrap();
+        let loop_block = builder.create_block();
+        let continue_block = builder.create_block();
+
+        builder.ensure_inserted_block();
+        builder.insert_block_after(loop_block, current_block);
+        builder.insert_block_after(continue_block, loop_block);
+
+        // Current block: test to see if this is actually an empty copy. If it
+        // is then skip over the entire loop, otherwise enter the loop and
+        // perform the first ieration.
+        let end_addr = builder.ins().iadd(dst_elem_addr, copy_byte_len);
+        let empty = builder.ins().icmp_imm(IntCC::Equal, copy_len, 0);
+        builder.ins().brif(
+            empty,
+            continue_block,
+            &[],
+            loop_block,
+            &[dst_elem_addr.into()],
+        );
+
+        // Loop block: write a single element, increment our destination pointer
+        // by the element size, then see if we turn again or exit.
+        builder.switch_to_block(loop_block);
+        let elem_addr = builder.append_block_param(loop_block, pointer_ty);
+        self.translate_loop_header(builder)?;
+        emit_elem_write(self, builder, elem_addr, value)?;
+        let next_elem_addr = builder.ins().iadd_imm(elem_addr, i64::from(elem_size));
+        let done = builder.ins().icmp(IntCC::Equal, next_elem_addr, end_addr);
+        builder.ins().brif(
+            done,
+            continue_block,
+            &[],
+            loop_block,
+            &[next_elem_addr.into()],
+        );
+
+        // Continue...
+        builder.switch_to_block(continue_block);
+        builder.seal_block(loop_block);
+        builder.seal_block(continue_block);
+        Ok(())
+    }
+
+    /// Tests to seew hether `value`, stored as `ty`, can be extracted to a single
+    /// byte which can be passed to `memset`, or the host's `memory.fill`, to
+    /// satisfy this array initialization request.
+    fn fill_value_as_memset(
+        &self,
+        builder: &mut FunctionBuilder<'_>,
+        ty: WasmStorageType,
+        value: ir::Value,
+    ) -> Option<ir::Value> {
+        // If the storage type is `i8`, then no matter the value we can always use
+        // `memset` regardless of the upper bits.
+        let value_ty = builder.func.dfg.value_type(value);
+        if let WasmStorageType::I8 = ty {
+            assert_eq!(value_ty, ir::types::I32);
+            return Some(value);
+        }
+
+        // Otherwise check to see if `value` is a constant whose value we can
+        // inspect here.
+        let inst = builder.func.dfg.value_def(value).inst()?;
+        let bits = match builder.func.dfg.insts[inst] {
+            ir::InstructionData::UnaryImm {
+                opcode: ir::Opcode::Iconst,
+                imm,
+            } => imm.bits(),
+            ir::InstructionData::UnaryIeee32 {
+                opcode: ir::Opcode::F32const,
+                imm,
+            } => i64::from(imm.bits()),
+            ir::InstructionData::UnaryIeee64 {
+                opcode: ir::Opcode::F64const,
+                imm,
+            } => imm.bits().cast_signed(),
+
+            // For other initialization we don't know what the value is, so we
+            // can't check if a byte-set is valid, so bail out which will fall back
+            // to an element-by-element loop.
+            _ => return None,
+        };
+
+        let width = match ty {
+            // Handled above
+            WasmStorageType::I8 => unreachable!(),
+            // These are initialized with CLIF-level `i32` values, but we only want
+            // to check the lower 2 bytes.
+            WasmStorageType::I16 => 2,
+            // For everything else the natural CLIF value is what's written so
+            // that's the byte width to check.
+            WasmStorageType::Val(_) => value_ty.bytes() as usize,
+        };
+        let bytes = bits.to_le_bytes();
+        if bytes[1..width].iter().any(|b| *b != bytes[0]) {
+            return None;
+        }
+        Some(builder.ins().iconst(ir::types::I32, bits & 0xff))
+    }
+
     pub fn translate_memory_fill(
         &mut self,
         builder: &mut FunctionBuilder<'_>,
@@ -3596,25 +3817,8 @@ impl FuncEnvironment<'_> {
         dst: ir::Value,
         val: ir::Value,
         len: ir::Value,
-    ) {
-        let idx_type = self.memory(memory_index).idx_type;
-
-        // Bounds check `dst+len` and convert it to a raw heap address.
-        let raw_heap_addr = self.translate_entity_bounds_check(builder, memory_index, dst, len);
-
-        // Fit the `len` value to `pointer_type`. Note that at this point it's
-        // guaranteed inbounds so there's no loss in precision.
-        let len_ptr =
-            self.unchecked_cast_wasm_addr_to_native_addr(&mut builder.cursor(), len, idx_type);
-
-        self.raw_bulk_memory_operation(
-            builder,
-            BulkOp::MemoryFill {
-                dst: raw_heap_addr,
-                val,
-                len: len_ptr,
-            },
-        );
+    ) -> WasmResult<()> {
+        self.translate_entity_fill(builder, memory_index, dst, val, len)
     }
 
     pub fn translate_memory_init(
@@ -3736,7 +3940,6 @@ impl FuncEnvironment<'_> {
                 let CheckedEntity::Table(src_table) = src_entity else {
                     unreachable!();
                 };
-                let ty = self.table(dst_table).ref_type;
                 let dst_table = self.get_or_create_table(builder.func, dst_table);
                 let src_table = self.get_or_create_table(builder.func, src_table);
                 assert_eq!(dst_table.element_size, src_table.element_size);
@@ -3747,7 +3950,6 @@ impl FuncEnvironment<'_> {
                     builder,
                     dst_entity,
                     src_entity,
-                    WasmStorageType::Val(WasmValType::Ref(ty)),
                     dst_raw_addr,
                     src_raw_addr,
                     one_elem_size,
@@ -3756,7 +3958,7 @@ impl FuncEnvironment<'_> {
                 )
             }
             // Note that future refactorings will fill this out soon.
-            CheckedEntity::Array => todo!(),
+            CheckedEntity::Array(_) => todo!(),
 
             // Cannot copy into a data segment in wasm.
             CheckedEntity::Data(_) => unreachable!(),
@@ -3804,16 +4006,11 @@ impl FuncEnvironment<'_> {
                 None => builder.ins().iconst(pointer_type, 0),
             },
             // Note that future refactorings will fill this out soon.
-            CheckedEntity::Array => todo!(),
+            CheckedEntity::Array(_) => todo!(),
         };
         assert_eq!(builder.func.dfg.value_type(entity_size), pointer_type);
 
-        let trap_code = match entity {
-            CheckedEntity::Memory(_) => ir::TrapCode::HEAP_OUT_OF_BOUNDS,
-            CheckedEntity::Table(_) => TRAP_TABLE_OUT_OF_BOUNDS,
-            CheckedEntity::Data(_) => ir::TrapCode::HEAP_OUT_OF_BOUNDS,
-            CheckedEntity::Array => TRAP_ARRAY_OUT_OF_BOUNDS,
-        };
+        let trap_code = entity.oob_trap_code();
 
         // Compute the end index of this operation, casted to the `I64` type.
         //
@@ -3878,7 +4075,7 @@ impl FuncEnvironment<'_> {
                 None => (builder.ins().iconst(pointer_type, 1), 1),
             },
             // Note that future refactorings will fill this out soon.
-            CheckedEntity::Array => todo!(),
+            CheckedEntity::Array(_) => todo!(),
         };
         assert_eq!(builder.func.dfg.value_type(base), pointer_type);
         let idx =
@@ -3919,7 +4116,6 @@ impl FuncEnvironment<'_> {
         builder: &mut FunctionBuilder<'_>,
         dst_entity: CheckedEntity,
         src_entity: CheckedEntity,
-        elem_ty: WasmStorageType,
         dst_elem_addr: ir::Value,
         src_elem_addr: ir::Value,
         one_elem_size: ir::Value,
@@ -3936,7 +4132,7 @@ impl FuncEnvironment<'_> {
             index_type_to_ir_type(src_entity.index_type(self))
         );
 
-        let type_forbids_memcpy = match elem_ty {
+        let type_forbids_memcpy = match dst_entity.storage_type(self) {
             // Scalar types can always use a memcpy.
             WasmStorageType::I8
             | WasmStorageType::I16
@@ -3973,7 +4169,7 @@ impl FuncEnvironment<'_> {
                     CheckedEntity::Table(_) => self.tunables.table_lazy_init,
                     // The GC heap has integers representing funcrefs, so memcpy
                     // is fine.
-                    CheckedEntity::Array => false,
+                    CheckedEntity::Array(_) => false,
                     // Not possible
                     CheckedEntity::Memory(_) | CheckedEntity::Data(_) => unreachable!(),
                 },
@@ -4006,14 +4202,16 @@ impl FuncEnvironment<'_> {
             copy_len,
             src_index,
             &|this, builder, dst, src, src_index| {
+                let read_ty = src_entity.storage_type(this);
+                let write_ty = dst_entity.storage_type(this);
                 let val = match src_entity {
                     // FIXME: ideally this wouldn't redo the bounds check but
                     // it's easier right now to share the internals of
                     // `translate_table_get` which are a bit tricky with
                     // funcrefs.
                     CheckedEntity::Table(i) => this.translate_table_get(builder, i, src_index)?,
-                    CheckedEntity::Array => {
-                        gc::read_field_at_addr(this, builder, elem_ty, src, None)?
+                    CheckedEntity::Array(_) => {
+                        gc::read_field_at_addr(this, builder, read_ty, src, None)?
                     }
                     CheckedEntity::Memory(_) | CheckedEntity::Data { .. } => unreachable!(),
                 };
@@ -4021,8 +4219,8 @@ impl FuncEnvironment<'_> {
                     CheckedEntity::Table(i) => {
                         this.emit_table_set(builder, i, dst, ir::MemFlagsData::trusted(), val)?;
                     }
-                    CheckedEntity::Array => {
-                        gc::write_field_at_addr(this, builder, elem_ty, dst, val)?
+                    CheckedEntity::Array(_) => {
+                        gc::write_field_at_addr(this, builder, write_ty, dst, val)?
                     }
                     CheckedEntity::Memory(_) | CheckedEntity::Data { .. } => unreachable!(),
                 }
@@ -5040,16 +5238,27 @@ enum BulkOp {
     },
 }
 
+/// A list of entities which can participate in various kinds of bulk operations
+/// in wasm.
+///
+/// These entities are used in `{table,array,memory}.{copy,fill}`, for example,
+/// as well as all the other matrix permutations of src/dst/etc. This is here
+/// and used as a helper type to help deduplicate various checks around
+/// modifications of these entities.
 #[derive(Copy, Clone)]
 enum CheckedEntity {
+    /// A WebAssembly linear memory.
     Memory(MemoryIndex),
+    /// A WebAssembly table.
     Table(TableIndex),
+    /// A WebAssembly data segment.
     Data(DataIndex),
+    /// An `arrayref` with the specified type.
     #[cfg_attr(
         not(feature = "gc"),
         expect(dead_code, reason = "not worth the #[cfg]")
     )]
-    Array,
+    Array(ModuleInternedTypeIndex),
 }
 
 impl From<MemoryIndex> for CheckedEntity {
@@ -5071,12 +5280,55 @@ impl From<DataIndex> for CheckedEntity {
 }
 
 impl CheckedEntity {
+    /// Returns the type that's used to index this entity.
     fn index_type(&self, env: &FuncEnvironment) -> IndexType {
         match *self {
             CheckedEntity::Memory(i) => env.memory(i).idx_type,
             CheckedEntity::Table(i) => env.table(i).idx_type,
-            CheckedEntity::Data(_) => IndexType::I32,
-            CheckedEntity::Array => IndexType::I32,
+            CheckedEntity::Data(_) | CheckedEntity::Array(_) => IndexType::I32,
+        }
+    }
+
+    /// Returns the size, in bytes, of an element in this entity.
+    fn element_size(&self, env: &mut FuncEnvironment<'_>, func: &mut ir::Function) -> u32 {
+        match *self {
+            CheckedEntity::Memory(_) | CheckedEntity::Data(_) => 1,
+            CheckedEntity::Table(table) => env.get_or_create_table(func, table).element_size,
+            CheckedEntity::Array(ty) => env.array_layout(ty).elem_size,
+        }
+    }
+
+    /// Returns the WebAssembly type that's stored within this entity.
+    fn storage_type(&self, env: &mut FuncEnvironment<'_>) -> WasmStorageType {
+        match *self {
+            CheckedEntity::Memory(_) | CheckedEntity::Data(_) => WasmStorageType::I8,
+            CheckedEntity::Table(table) => {
+                WasmStorageType::Val(WasmValType::Ref(env.table(table).ref_type))
+            }
+            CheckedEntity::Array(ty) => {
+                let array_ty = env.types.unwrap_array(ty).unwrap();
+                array_ty.0.element_type
+            }
+        }
+    }
+
+    /// Returns the trap code to use when an index into this entity is out-of-bounds.
+    fn oob_trap_code(&self) -> ir::TrapCode {
+        match self {
+            CheckedEntity::Memory(_) | CheckedEntity::Data(_) => ir::TrapCode::HEAP_OUT_OF_BOUNDS,
+            CheckedEntity::Table(_) => TRAP_TABLE_OUT_OF_BOUNDS,
+            CheckedEntity::Array(_) => TRAP_ARRAY_OUT_OF_BOUNDS,
+        }
+    }
+
+    /// Returns whether it's safe to use `memset` on this entity for candidate
+    /// bit patterns.
+    fn allows_memset(&self, env: &FuncEnvironment) -> bool {
+        match self {
+            CheckedEntity::Memory(_) | CheckedEntity::Data(_) | CheckedEntity::Array(_) => true,
+            // Tables that are lazily initialized can't be memset because the
+            // initialized bit needs to be set when storing values.
+            CheckedEntity::Table(_) => !env.tunables.table_lazy_init,
         }
     }
 }

--- a/crates/cranelift/src/func_environ/gc.rs
+++ b/crates/cranelift/src/func_environ/gc.rs
@@ -209,8 +209,6 @@ pub mod builtins {
     }
 
     define_builtin_accessors! {
-        table_grow_gc_ref,
-        table_fill_gc_ref,
         array_new_elem,
         array_init_elem,
     }

--- a/crates/cranelift/src/func_environ/gc/enabled.rs
+++ b/crates/cranelift/src/func_environ/gc/enabled.rs
@@ -947,14 +947,16 @@ pub fn translate_array_copy(
     dst_array_type_index: TypeIndex,
     dst_array: ir::Value,
     dst_index: ir::Value,
-    _src_array_type_index: TypeIndex,
+    src_array_type_index: TypeIndex,
     src_array: ir::Value,
     src_index: ir::Value,
     copy_len: ir::Value,
 ) -> WasmResult<()> {
-    let interned_type_index =
+    let dst_array_type_index =
         func_env.module.types[dst_array_type_index].unwrap_module_type_index();
-    let array_ty = func_env.types[interned_type_index]
+    let src_array_type_index =
+        func_env.module.types[src_array_type_index].unwrap_module_type_index();
+    let array_ty = func_env.types[dst_array_type_index]
         .composite_type
         .inner
         .unwrap_array();
@@ -978,7 +980,7 @@ pub fn translate_array_copy(
             obj_size,
             one_elem_size,
             base_size,
-        } = emit_array_size_info(func_env, builder, interned_type_index, array_len);
+        } = emit_array_size_info(func_env, builder, dst_array_type_index, array_len);
         let offset_in_elems = builder.ins().imul(index, one_elem_size);
         let obj_offset = builder.ins().iadd(base_size, offset_in_elems);
         let elem_addr = func_env.prepare_gc_ref_access(
@@ -1037,9 +1039,8 @@ pub fn translate_array_copy(
     let copy_len = uextend_i32_to_pointer_type(builder, func_env.pointer_type(), copy_len);
     func_env.emit_raw_array_or_table_copy(
         builder,
-        CheckedEntity::Array,
-        CheckedEntity::Array,
-        elem_ty,
+        CheckedEntity::Array(dst_array_type_index),
+        CheckedEntity::Array(src_array_type_index),
         dst_elem_addr,
         src_elem_addr,
         one_elem_size,
@@ -1673,7 +1674,7 @@ impl FuncEnvironment<'_> {
     }
 
     /// Get the `GcArrayLayout` for the array type at the given `type_index`.
-    fn array_layout(&mut self, type_index: ModuleInternedTypeIndex) -> &GcArrayLayout {
+    pub(crate) fn array_layout(&mut self, type_index: ModuleInternedTypeIndex) -> &GcArrayLayout {
         self.gc_layout(type_index).unwrap_array()
     }
 

--- a/crates/cranelift/src/func_environ/stack_switching/mod.rs
+++ b/crates/cranelift/src/func_environ/stack_switching/mod.rs
@@ -31,7 +31,5 @@ pub(crate) mod builtins {
 
     define_builtin_accessors! {
         cont_new,
-        table_grow_cont_obj,
-        table_fill_cont_obj,
     }
 }

--- a/crates/cranelift/src/translate/code_translator.rs
+++ b/crates/cranelift/src/translate/code_translator.rs
@@ -1638,7 +1638,7 @@ pub fn translate_operator(
             let len = environ.stacks.pop1();
             let val = environ.stacks.pop1();
             let dest = environ.stacks.pop1();
-            environ.translate_memory_fill(builder, mem, dest, val, len);
+            environ.translate_memory_fill(builder, mem, dest, val, len)?;
         }
         Operator::MemoryInit { data_index, mem } => {
             let mem = MemoryIndex::from_u32(*mem);

--- a/crates/environ/src/builtin.rs
+++ b/crates/environ/src/builtin.rs
@@ -17,10 +17,9 @@ macro_rules! foreach_builtin_function {
             ref_func(vmctx: vmctx, func: u32) -> pointer;
             // Returns a table entry after lazily initializing it.
             table_get_lazy_init_func_ref(vmctx: vmctx, table: u32, index: u64) -> pointer;
-            // Returns an index for Wasm's `table.grow` instruction for `funcref`s.
-            table_grow_func_ref(vmctx: vmctx, table: u32, delta: u64, init: pointer) -> pointer;
-            // Returns an index for Wasm's `table.fill` instruction for `funcref`s.
-            table_fill_func_ref(vmctx: vmctx, table: u32, dst: u64, val: pointer, len: u64) -> bool;
+            // Grows `table` by `delta` elements, returning the destination
+            // address that new elements should be written at.
+            table_grow(vmctx: vmctx, table: u32, delta: u64) -> pointer;
             // Returns an index for wasm's `memory.atomic.notify` instruction.
             #[cfg(feature = "threads")]
             memory_atomic_notify(vmctx: vmctx, memory: u32, addr: u64, count: u32) -> u64;
@@ -149,14 +148,6 @@ macro_rules! foreach_builtin_function {
                 expected_engine_type: u32
             ) -> u32;
 
-            // Returns an index for Wasm's `table.grow` instruction for GC references.
-            #[cfg(feature = "gc")]
-            table_grow_gc_ref(vmctx: vmctx, table: u32, delta: u64, init: u32) -> pointer;
-
-            // Returns an index for Wasm's `table.fill` instruction for GC references.
-            #[cfg(feature = "gc")]
-            table_fill_gc_ref(vmctx: vmctx, table: u32, dst: u64, val: u32, len: u64) -> bool;
-
             // Wasm floating-point routines for when the CPU instructions aren't available.
             ceil_f32(vmctx: vmctx, x: f32) -> f32;
             ceil_f64(vmctx: vmctx, x: f64) -> f64;
@@ -184,21 +175,6 @@ macro_rules! foreach_builtin_function {
             // Creates a new continuation from a funcref.
             #[cfg(feature = "stack-switching")]
             cont_new(vmctx: vmctx, r: pointer, param_count: u32, result_count: u32) -> pointer;
-
-            // Returns an index for Wasm's `table.grow` instruction
-            // for `contobj`s.  Note that the initial
-            // Option<VMContObj> (i.e., the value to fill the new
-            // slots with) is split into two arguments: The underlying
-            // continuation reference and the revision count.  To
-            // denote the continuation being `None`, `init_contref`
-            // may be 0.
-            #[cfg(feature = "stack-switching")]
-            table_grow_cont_obj(vmctx: vmctx, table: u32, delta: u64, init_contref: pointer, init_revision: size) -> pointer;
-
-            // `value_contref` and `value_revision` together encode
-            // the Option<VMContObj>, as in previous libcall.
-            #[cfg(feature = "stack-switching")]
-            table_fill_cont_obj(vmctx: vmctx, table: u32, dst: u64, value_contref: pointer, value_revision: size, len: u64) -> bool;
 
             // Return the instance ID for a given vmctx.
             #[cfg(feature = "gc")]
@@ -395,9 +371,7 @@ impl BuiltinFunctionIndex {
 
             // Growth-related functions return -2 as a sentinel.
             (@get memory_grow pointer) => (TrapSentinel::NegativeTwo);
-            (@get table_grow_func_ref pointer) => (TrapSentinel::NegativeTwo);
-            (@get table_grow_gc_ref pointer) => (TrapSentinel::NegativeTwo);
-            (@get table_grow_cont_obj pointer) => (TrapSentinel::NegativeTwo);
+            (@get table_grow pointer) => (TrapSentinel::NegativeTwo);
 
             // Atomics-related functions return a negative value to indicate a trap.
             (@get memory_atomic_notify u64) => (TrapSentinel::Negative);

--- a/crates/wasmtime/src/runtime/externals/table.rs
+++ b/crates/wasmtime/src/runtime/externals/table.rs
@@ -1,7 +1,5 @@
 use crate::prelude::*;
-use crate::runtime::vm::{
-    self, GcStore, SendSyncPtr, TableElementType, VMFuncRef, VMGcRef, VMStore,
-};
+use crate::runtime::vm::{self, GcStore, TableElementType, VMFuncRef, VMGcRef, VMStore};
 use crate::store::{AutoAssertNoGc, StoreInstanceId, StoreOpaque, StoreResourceLimiter};
 use crate::trampoline::generate_table_export;
 use crate::{
@@ -305,55 +303,36 @@ impl Table {
 
     async fn _grow<T>(&self, store: StoreContextMut<'_, T>, delta: u64, init: Ref) -> Result<u64> {
         let store = store.0;
-        let ty = self.ty(&store);
         let (mut limiter, store) = store.resource_limiter_and_store_opaque();
         let limiter = limiter.as_mut();
-        let result = match element_type(&ty) {
-            TableElementType::Func => {
-                let element = init
-                    .into_table_func(store, ty.element())?
-                    .map(SendSyncPtr::new);
-                self.instance
-                    .get_mut(store)
-                    .defined_table_grow(self.index, async |table| {
-                        // SAFETY: in the context of `defined_table_grow` this
-                        // is safe to call as it'll update the internal table
-                        // pointer in the instance.
-                        unsafe { table.grow_func(limiter, delta, element).await }
-                    })
-                    .await?
-            }
-            TableElementType::GcRef => {
-                let mut store = AutoAssertNoGc::new(store);
-                let element = init
-                    .into_table_gc_ref(&mut store, ty.element())?
-                    .map(|r| r.unchecked_copy());
-                let (gc_store, instance) = self.instance.get_with_gc_store_mut(&mut store);
-                instance
-                    .defined_table_grow(self.index, async |table| {
-                        // SAFETY: in the context of `defined_table_grow` this
-                        // is safe to call as it'll update the internal table
-                        // pointer in the instance.
-                        unsafe {
-                            table
-                                .grow_gc_ref(limiter, gc_store, delta, element.as_ref())
-                                .await
-                        }
-                    })
-                    .await?
-            }
-            // TODO(#10248) Required to support stack switching in the
-            // embedder API.
-            TableElementType::Cont => bail!("unimplemented table for cont"),
+
+        // First, type-check to make sure that `init` does indeed match this
+        // table's element type.
+        let ty = self.ty_(store);
+        init.ensure_matches_ty(store, ty.element())
+            .context("type mismatch: value does not match table element type")?;
+
+        // SAFETY: the requirement here is that the new table elements, on
+        // success, are filled in with an appropriately typed value. That's done
+        // below in `_fill`.
+        let result = unsafe {
+            self.instance
+                .get_mut(store)
+                .defined_table_grow(self.index, limiter, delta)
+                .await?
         };
-        match result {
-            Some(size) => {
-                // unwrap here should be ok because the runtime should always
-                // guarantee that we can fit the table size in a 64-bit integer.
-                Ok(u64::try_from(size).unwrap())
-            }
+        let start = match result {
+            // unwrap here should be ok because the runtime should always
+            // guarantee that we can fit the table size in a 64-bit integer.
+            Some(size) => u64::try_from(size).unwrap(),
             None => bail!("failed to grow table by `{delta}`"),
-        }
+        };
+        // This should be in-bounds and well-typed, meaning that it should not
+        // fail, hence the unwrap. Note that this is required for the safety of
+        // this operation because this table's type may be non-nullable elements
+        // which means this must happen after growth.
+        self._fill(store, start, init, delta).unwrap();
+        Ok(start)
     }
 
     /// Async variant of [`Table::grow`].
@@ -477,28 +456,16 @@ impl Table {
         val: Ref,
         len: u64,
     ) -> Result<()> {
-        let ty = self.ty_(&store);
-        match element_type(&ty) {
-            TableElementType::Func => {
-                let val = val.into_table_func(store, ty.element())?;
-                let (table, _) = self.wasmtime_table(store, iter::empty());
-                table.fill_func(dst, val, len)?;
-            }
-            TableElementType::GcRef => {
-                // Note that `val` is a `VMGcRef` temporarily read from the
-                // store here, and blocking GC with `AutoAssertNoGc` should
-                // ensure that it's not collected while being worked on here.
-                let mut store = AutoAssertNoGc::new(store);
-                let val = val.into_table_gc_ref(&mut store, ty.element())?;
-                let val = val.map(|g| g.unchecked_copy());
-                let (table, gc_store) = self.wasmtime_table(&mut store, iter::empty());
-                table.fill_gc_ref(gc_store, dst, val.as_ref(), len)?;
-            }
-            // TODO(#10248) Required to support stack switching in the embedder
-            // API.
-            TableElementType::Cont => bail!("unimplemented table for cont"),
+        let ty = self.ty_(store);
+        val.ensure_matches_ty(store, ty.element())
+            .context("type mismatch: value does not match table element type")?;
+        let end = dst.checked_add(len).ok_or(Trap::TableOutOfBounds)?;
+        if end > self.size_(store) {
+            bail!(Trap::TableOutOfBounds);
         }
-
+        for i in dst..dst + len {
+            self.set_(&mut *store, i, val.clone())?;
+        }
         Ok(())
     }
 

--- a/crates/wasmtime/src/runtime/store/data.rs
+++ b/crates/wasmtime/src/runtime/store/data.rs
@@ -1,5 +1,5 @@
 use crate::module::ModuleRegistry;
-use crate::runtime::vm::{self, GcStore, VMStore};
+use crate::runtime::vm::{self, VMStore};
 use crate::store::StoreOpaque;
 use crate::{Engine, StoreContext, StoreContextMut};
 use core::num::NonZeroU64;
@@ -283,16 +283,6 @@ impl StoreInstanceId {
     ) -> (Pin<&'a mut vm::Instance>, &'a ModuleRegistry) {
         self.assert_belongs_to(store.id());
         store.instance_and_module_registry_mut(self.instance)
-    }
-
-    /// Same as [`Self::get_mut`], but also returns the `GcStore`.
-    #[inline]
-    pub(crate) fn get_with_gc_store_mut<'a>(
-        &self,
-        store: &'a mut StoreOpaque,
-    ) -> (Option<&'a mut GcStore>, Pin<&'a mut vm::Instance>) {
-        self.assert_belongs_to(store.id());
-        store.optional_gc_store_and_instance_mut(self.instance)
     }
 }
 

--- a/crates/wasmtime/src/runtime/vm/instance.rs
+++ b/crates/wasmtime/src/runtime/vm/instance.rs
@@ -769,26 +769,28 @@ impl Instance {
         result
     }
 
-    pub(crate) fn table_element_type(
-        self: Pin<&mut Self>,
-        table_index: TableIndex,
-    ) -> TableElementType {
-        self.get_table(table_index).element_type()
-    }
-
     /// Performs a grow operation on the `table_index` specified using `grow`.
     ///
     /// This will handle updating the VMTableDefinition internally as necessary.
-    pub(crate) async fn defined_table_grow(
+    ///
+    /// # Safety
+    ///
+    /// This function requires that the caller, on success, fills in the table
+    /// elements with an appropriately typed value.
+    pub(crate) async unsafe fn defined_table_grow(
         mut self: Pin<&mut Self>,
         table_index: DefinedTableIndex,
-        grow: impl AsyncFnOnce(&mut Table) -> Result<Option<usize>>,
+        limiter: Option<&mut StoreResourceLimiter<'_>>,
+        amt: u64,
     ) -> Result<Option<usize>> {
         let table = self.as_mut().get_defined_table(table_index);
-        let result = grow(table).await;
+        // SAFETY: updating the `VMContext` table pointers and such is done
+        // below, and the responsibility of filling in the new table elements
+        // is forwarded to the caller.
+        let result = unsafe { table.grow(limiter, amt).await? };
         let element = table.vmtable();
         self.set_table(table_index, element);
-        result
+        Ok(result)
     }
 
     fn alloc_layout(offsets: &VMOffsets<HostPtr>) -> Layout {

--- a/crates/wasmtime/src/runtime/vm/libcalls.rs
+++ b/crates/wasmtime/src/runtime/vm/libcalls.rs
@@ -59,7 +59,6 @@ use crate::prelude::*;
 use crate::runtime::store::{Asyncness, InstanceId, StoreOpaque};
 #[cfg(feature = "gc")]
 use crate::runtime::vm::VMGcRef;
-use crate::runtime::vm::vmcontext::VMFuncRef;
 use crate::runtime::vm::{self, HostResultHasUnwindSentinel, VMStore, f32x4, f64x2, i8x16};
 use core::convert::Infallible;
 use core::ptr::NonNull;
@@ -524,6 +523,7 @@ unsafe fn intern_func_ref_for_gc_heap(
     _instance: InstanceId,
     func_ref: *mut u8,
 ) -> Result<u32> {
+    use crate::runtime::vm::vmcontext::VMFuncRef;
     use crate::{store::AutoAssertNoGc, vm::SendSyncPtr};
     use core::ptr::NonNull;
 

--- a/crates/wasmtime/src/runtime/vm/libcalls.rs
+++ b/crates/wasmtime/src/runtime/vm/libcalls.rs
@@ -54,18 +54,13 @@
 //! }
 //! ```
 
-#[cfg(feature = "stack-switching")]
-use super::stack_switching::VMContObj;
 use crate::bail_bug;
 use crate::prelude::*;
 use crate::runtime::store::{Asyncness, InstanceId, StoreOpaque};
 #[cfg(feature = "gc")]
 use crate::runtime::vm::VMGcRef;
-use crate::runtime::vm::table::TableElementType;
 use crate::runtime::vm::vmcontext::VMFuncRef;
-use crate::runtime::vm::{
-    self, HostResultHasUnwindSentinel, SendSyncPtr, VMStore, f32x4, f64x2, i8x16,
-};
+use crate::runtime::vm::{self, HostResultHasUnwindSentinel, VMStore, f32x4, f64x2, i8x16};
 use core::convert::Infallible;
 use core::ptr::NonNull;
 #[cfg(feature = "threads")]
@@ -305,168 +300,24 @@ unsafe impl HostResultHasUnwindSentinel for Option<AllocationSize> {
     }
 }
 
-/// Implementation of `table.grow` for `funcref` tables.
-unsafe fn table_grow_func_ref(
+/// Implementation of `table.grow`.
+unsafe fn table_grow(
     store: &mut dyn VMStore,
     instance: InstanceId,
     defined_table_index: u32,
     delta: u64,
-    init_value: *mut u8,
 ) -> Result<Option<AllocationSize>> {
     let defined_table_index = DefinedTableIndex::from_u32(defined_table_index);
-    let element = NonNull::new(init_value.cast::<VMFuncRef>()).map(SendSyncPtr::new);
     let (mut limiter, store) = store.resource_limiter_and_store_opaque();
     let limiter = limiter.as_mut();
-    block_on!(store, async |store, _| {
-        let mut instance = store.instance_mut(instance);
-        let table_index = instance.env_module().table_index(defined_table_index);
-        debug_assert!(matches!(
-            instance.as_mut().table_element_type(table_index),
-            TableElementType::Func,
-        ));
-        let result = instance
-            .defined_table_grow(defined_table_index, async |table| unsafe {
-                table.grow_func(limiter, delta, element).await
-            })
+    block_on!(store, async |store, _| unsafe {
+        let result = store
+            .instance_mut(instance)
+            .defined_table_grow(defined_table_index, limiter, delta)
             .await?
             .map(AllocationSize);
         Ok(result)
     })?
-}
-
-/// Implementation of `table.grow` for GC-reference tables.
-#[cfg(feature = "gc")]
-fn table_grow_gc_ref(
-    store: &mut dyn VMStore,
-    instance: InstanceId,
-    defined_table_index: u32,
-    delta: u64,
-    init_value: u32,
-) -> Result<Option<AllocationSize>> {
-    let defined_table_index = DefinedTableIndex::from_u32(defined_table_index);
-    let element = VMGcRef::from_raw_u32(init_value);
-    let (mut limiter, store) = store.resource_limiter_and_store_opaque();
-    let limiter = limiter.as_mut();
-    block_on!(store, async |store, _| {
-        let (gc_store, mut instance) = store.optional_gc_store_and_instance_mut(instance);
-        let table_index = instance.env_module().table_index(defined_table_index);
-        debug_assert!(matches!(
-            instance.as_mut().table_element_type(table_index),
-            TableElementType::GcRef,
-        ));
-
-        let result = instance
-            .defined_table_grow(defined_table_index, async |table| unsafe {
-                table
-                    .grow_gc_ref(limiter, gc_store, delta, element.as_ref())
-                    .await
-            })
-            .await?
-            .map(AllocationSize);
-        Ok(result)
-    })?
-}
-
-#[cfg(feature = "stack-switching")]
-unsafe fn table_grow_cont_obj(
-    store: &mut dyn VMStore,
-    instance: InstanceId,
-    defined_table_index: u32,
-    delta: u64,
-    // The following two values together form the initial Option<VMContObj>.
-    // A None value is indicated by the pointer being null.
-    init_value_contref: *mut u8,
-    init_value_revision: usize,
-) -> Result<Option<AllocationSize>> {
-    let defined_table_index = DefinedTableIndex::from_u32(defined_table_index);
-    let element = unsafe { VMContObj::from_raw_parts(init_value_contref, init_value_revision) };
-    let (mut limiter, store) = store.resource_limiter_and_store_opaque();
-    let limiter = limiter.as_mut();
-    block_on!(store, async |store, _| {
-        let mut instance = store.instance_mut(instance);
-        let table_index = instance.env_module().table_index(defined_table_index);
-        debug_assert!(matches!(
-            instance.as_mut().table_element_type(table_index),
-            TableElementType::Cont,
-        ));
-        let result = instance
-            .defined_table_grow(defined_table_index, async |table| unsafe {
-                table.grow_cont(limiter, delta, element).await
-            })
-            .await?
-            .map(AllocationSize);
-        Ok(result)
-    })?
-}
-
-/// Implementation of `table.fill` for `funcref`s.
-unsafe fn table_fill_func_ref(
-    store: &mut dyn VMStore,
-    instance: InstanceId,
-    table_index: u32,
-    dst: u64,
-    val: *mut u8,
-    len: u64,
-) -> Result<()> {
-    let instance = store.instance_mut(instance);
-    let table_index = DefinedTableIndex::from_u32(table_index);
-    let table = instance.get_defined_table(table_index);
-    match table.element_type() {
-        TableElementType::Func => {
-            let val = NonNull::new(val.cast::<VMFuncRef>());
-            table.fill_func(dst, val, len)?;
-            Ok(())
-        }
-        TableElementType::GcRef => unreachable!(),
-        TableElementType::Cont => unreachable!(),
-    }
-}
-
-#[cfg(feature = "gc")]
-fn table_fill_gc_ref(
-    store: &mut dyn VMStore,
-    instance: InstanceId,
-    table_index: u32,
-    dst: u64,
-    val: u32,
-    len: u64,
-) -> Result<()> {
-    let (gc_store, instance) = store.optional_gc_store_and_instance_mut(instance);
-    let table_index = DefinedTableIndex::from_u32(table_index);
-    let table = instance.get_defined_table(table_index);
-    match table.element_type() {
-        TableElementType::Func => unreachable!(),
-        TableElementType::GcRef => {
-            let gc_ref = VMGcRef::from_raw_u32(val);
-            table.fill_gc_ref(gc_store, dst, gc_ref.as_ref(), len)?;
-            Ok(())
-        }
-
-        TableElementType::Cont => unreachable!(),
-    }
-}
-
-#[cfg(feature = "stack-switching")]
-unsafe fn table_fill_cont_obj(
-    store: &mut dyn VMStore,
-    instance: InstanceId,
-    table_index: u32,
-    dst: u64,
-    value_contref: *mut u8,
-    value_revision: usize,
-    len: u64,
-) -> Result<()> {
-    let instance = store.instance_mut(instance);
-    let table_index = DefinedTableIndex::from_u32(table_index);
-    let table = instance.get_defined_table(table_index);
-    match table.element_type() {
-        TableElementType::Cont => {
-            let contobj = unsafe { VMContObj::from_raw_parts(value_contref, value_revision) };
-            table.fill_cont(dst, contobj, len)?;
-            Ok(())
-        }
-        _ => panic!("Wrong table filling function"),
-    }
 }
 
 // Implementation of `table.init`.

--- a/crates/wasmtime/src/runtime/vm/table.rs
+++ b/crates/wasmtime/src/runtime/vm/table.rs
@@ -603,7 +603,7 @@ impl Table {
     /// Returns the previous size of the table if growth is successful.
     ///
     /// Returns `None` if table can't be grown by the specified amount of
-    /// elements, or if the `init_value` is the wrong kind of table element.
+    /// elements.
     ///
     /// # Panics
     ///
@@ -616,52 +616,14 @@ impl Table {
     /// that are used by Wasm, and they need to be fixed up before we call into
     /// Wasm again. Failure to do so will result in use-after-free inside Wasm.
     ///
-    /// Generally, prefer using `InstanceHandle::table_grow`, which encapsulates
-    /// this unsafety.
-    pub async unsafe fn grow_func(
+    /// Additionally after growth this table will have null filled in for all
+    /// new entries, if any. The embedder must fill in these slots with an
+    /// appropriately typed value for this table's usage to still be sound
+    /// because this table may contain non-null elements, for example.
+    pub async unsafe fn grow(
         &mut self,
-        limiter: Option<&mut StoreResourceLimiter<'_>>,
-        delta: u64,
-        init_value: Option<SendSyncPtr<VMFuncRef>>,
-    ) -> Result<Option<usize>, Error> {
-        self._grow(delta, limiter, |me, base, len| {
-            me.fill_func(base, init_value.map(|p| p.as_non_null()), len)
-        })
-        .await
-    }
-
-    /// Same as [`Self::grow_func`], but for GC references.
-    pub async unsafe fn grow_gc_ref(
-        &mut self,
-        limiter: Option<&mut StoreResourceLimiter<'_>>,
-        gc_store: Option<&mut GcStore>,
-        delta: u64,
-        init_value: Option<&VMGcRef>,
-    ) -> Result<Option<usize>, Error> {
-        self._grow(delta, limiter, |me, base, len| {
-            me.fill_gc_ref(gc_store, base, init_value, len)
-        })
-        .await
-    }
-
-    /// Same as [`Self::grow_func`], but for continuations.
-    pub async unsafe fn grow_cont(
-        &mut self,
-        limiter: Option<&mut StoreResourceLimiter<'_>>,
-        delta: u64,
-        init_value: Option<VMContObj>,
-    ) -> Result<Option<usize>, Error> {
-        self._grow(delta, limiter, |me, base, len| {
-            me.fill_cont(base, init_value, len)
-        })
-        .await
-    }
-
-    async fn _grow(
-        &mut self,
-        delta: u64,
         mut limiter: Option<&mut StoreResourceLimiter<'_>>,
-        fill: impl FnOnce(&mut Self, u64, u64) -> Result<(), Trap>,
+        delta: u64,
     ) -> Result<Option<usize>, Error> {
         let old_size = self.size();
 
@@ -742,13 +704,6 @@ impl Table {
                 elements.resize_with(new_size, || None)?;
             }
         }
-
-        fill(
-            self,
-            u64::try_from(old_size).unwrap(),
-            u64::try_from(delta).unwrap(),
-        )
-        .expect("table should not be out of bounds");
 
         Ok(Some(old_size))
     }

--- a/tests/disas/array-fill-funcref.wat
+++ b/tests/disas/array-fill-funcref.wat
@@ -29,7 +29,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64) -> i64 tail
-;;     fn0 = colocated u805306368:25 sig0
+;;     fn0 = colocated u805306368:24 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i64, v5: i32):
@@ -156,7 +156,7 @@
 ;;     sig0 = (i64 vmctx, i32) -> i64 tail
 ;;     sig1 = (i64 vmctx, i64) -> i64 tail
 ;;     fn0 = colocated u805306368:5 sig0
-;;     fn1 = colocated u805306368:25 sig1
+;;     fn1 = colocated u805306368:24 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):

--- a/tests/disas/component-may-leave-without-signals-based-traps.wat
+++ b/tests/disas/component-may-leave-without-signals-based-traps.wat
@@ -44,7 +44,7 @@
 ;;       retq
 ;;  129: movq    %rbx, %rsi
 ;;  12c: movq    0x10(%rsi), %rax
-;;  130: movq    0x168(%rax), %rax
+;;  130: movq    0x150(%rax), %rax
 ;;  137: movq    %rbx, %rdi
 ;;  13a: callq   *%rax
 ;;  13c: ud2

--- a/tests/disas/debug.wat
+++ b/tests/disas/debug.wat
@@ -128,7 +128,7 @@
 ;;       popq    %rbp
 ;;       retq
 ;;  17a: movq    0x10(%rbx), %rax
-;;  17e: movq    0x168(%rax), %rax
+;;  17e: movq    0x150(%rax), %rax
 ;;  185: movq    %rbx, %rdi
 ;;  188: callq   *%rax
 ;;  18a: ud2
@@ -143,7 +143,7 @@
 ;;       movq    8(%r10), %r11
 ;;       movq    %r11, 0x38(%r9)
 ;;       movq    0x10(%rdi), %r11
-;;       movq    0x160(%r11), %r11
+;;       movq    0x148(%r11), %r11
 ;;       movzbq  %sil, %rsi
 ;;       callq   *%r11
 ;;       movq    %rbp, %rsp
@@ -160,7 +160,7 @@
 ;;       movq    8(%r9), %r9
 ;;       movq    %r9, 0x38(%r8)
 ;;       movq    0x10(%rdi), %r9
-;;       movq    0x168(%r9), %r9
+;;       movq    0x150(%r9), %r9
 ;;       callq   *%r9
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
@@ -203,7 +203,7 @@
 ;;       movq    8(%r11), %rax
 ;;       movq    %rax, 0x38(%r10)
 ;;       movq    0x10(%rdi), %rax
-;;       movq    0x198(%rax), %rcx
+;;       movq    0x170(%rax), %rcx
 ;;       movq    %rdi, %rbx
 ;;       callq   *%rcx
 ;;       testb   %al, %al
@@ -239,7 +239,7 @@
 ;;       popq    %rbp
 ;;       retq
 ;;  3af: movq    0x10(%rbx), %rax
-;;  3b3: movq    0x168(%rax), %rax
+;;  3b3: movq    0x150(%rax), %rax
 ;;  3ba: movq    %rbx, %rdi
 ;;  3bd: callq   *%rax
 ;;  3bf: ud2

--- a/tests/disas/epoch-interruption.wat
+++ b/tests/disas/epoch-interruption.wat
@@ -11,7 +11,7 @@
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
 ;;     sig0 = (i64 vmctx) -> i64 tail
-;;     fn0 = colocated u805306368:13 sig0
+;;     fn0 = colocated u805306368:12 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):

--- a/tests/disas/gc/array-copy-with-fuel.wat
+++ b/tests/disas/gc/array-copy-with-fuel.wat
@@ -20,7 +20,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx) -> i8 tail
-;;     fn0 = colocated u805306368:12 sig0
+;;     fn0 = colocated u805306368:11 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32, v6: i32):

--- a/tests/disas/gc/array-new-data.wat
+++ b/tests/disas/gc/array-new-data.wat
@@ -86,7 +86,7 @@
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64, i64, i64) tail
-;;     fn0 = colocated u805306368:24 sig0
+;;     fn0 = colocated u805306368:23 sig0
 ;;     fn1 = colocated u805306368:3 sig1
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/gc/array-new-default-anyref.wat
+++ b/tests/disas/gc/array-new-default-anyref.wat
@@ -20,7 +20,7 @@
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64, i32, i64) tail
-;;     fn0 = colocated u805306368:24 sig0
+;;     fn0 = colocated u805306368:23 sig0
 ;;     fn1 = colocated u805306368:4 sig1
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/gc/array-new-default-exnref.wat
+++ b/tests/disas/gc/array-new-default-exnref.wat
@@ -20,7 +20,7 @@
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64, i32, i64) tail
-;;     fn0 = colocated u805306368:24 sig0
+;;     fn0 = colocated u805306368:23 sig0
 ;;     fn1 = colocated u805306368:4 sig1
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/gc/array-new-default-externref.wat
+++ b/tests/disas/gc/array-new-default-externref.wat
@@ -20,7 +20,7 @@
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64, i32, i64) tail
-;;     fn0 = colocated u805306368:24 sig0
+;;     fn0 = colocated u805306368:23 sig0
 ;;     fn1 = colocated u805306368:4 sig1
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/gc/array-new-default-f32.wat
+++ b/tests/disas/gc/array-new-default-f32.wat
@@ -20,7 +20,7 @@
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64, i32, i64) tail
-;;     fn0 = colocated u805306368:24 sig0
+;;     fn0 = colocated u805306368:23 sig0
 ;;     fn1 = colocated u805306368:4 sig1
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/gc/array-new-default-f64.wat
+++ b/tests/disas/gc/array-new-default-f64.wat
@@ -20,7 +20,7 @@
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64, i32, i64) tail
-;;     fn0 = colocated u805306368:24 sig0
+;;     fn0 = colocated u805306368:23 sig0
 ;;     fn1 = colocated u805306368:4 sig1
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/gc/array-new-default-funcref.wat
+++ b/tests/disas/gc/array-new-default-funcref.wat
@@ -20,7 +20,7 @@
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64, i32, i64) tail
-;;     fn0 = colocated u805306368:24 sig0
+;;     fn0 = colocated u805306368:23 sig0
 ;;     fn1 = colocated u805306368:4 sig1
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/gc/array-new-default-i16.wat
+++ b/tests/disas/gc/array-new-default-i16.wat
@@ -20,7 +20,7 @@
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64, i32, i64) tail
-;;     fn0 = colocated u805306368:24 sig0
+;;     fn0 = colocated u805306368:23 sig0
 ;;     fn1 = colocated u805306368:4 sig1
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/gc/array-new-default-i32.wat
+++ b/tests/disas/gc/array-new-default-i32.wat
@@ -20,7 +20,7 @@
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64, i32, i64) tail
-;;     fn0 = colocated u805306368:24 sig0
+;;     fn0 = colocated u805306368:23 sig0
 ;;     fn1 = colocated u805306368:4 sig1
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/gc/array-new-default-i64.wat
+++ b/tests/disas/gc/array-new-default-i64.wat
@@ -20,7 +20,7 @@
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64, i32, i64) tail
-;;     fn0 = colocated u805306368:24 sig0
+;;     fn0 = colocated u805306368:23 sig0
 ;;     fn1 = colocated u805306368:4 sig1
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/gc/array-new-default-i8.wat
+++ b/tests/disas/gc/array-new-default-i8.wat
@@ -20,7 +20,7 @@
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64, i32, i64) tail
-;;     fn0 = colocated u805306368:24 sig0
+;;     fn0 = colocated u805306368:23 sig0
 ;;     fn1 = colocated u805306368:4 sig1
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/gc/copying/array-new-fixed-of-gc-refs.wat
+++ b/tests/disas/gc/copying/array-new-fixed-of-gc-refs.wat
@@ -19,7 +19,7 @@
 ;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
-;;     fn0 = colocated u805306368:24 sig0
+;;     fn0 = colocated u805306368:23 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):

--- a/tests/disas/gc/copying/array-new-fixed.wat
+++ b/tests/disas/gc/copying/array-new-fixed.wat
@@ -16,7 +16,7 @@
 ;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
-;;     fn0 = colocated u805306368:24 sig0
+;;     fn0 = colocated u805306368:23 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64):

--- a/tests/disas/gc/copying/array-new.wat
+++ b/tests/disas/gc/copying/array-new.wat
@@ -16,7 +16,7 @@
 ;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
-;;     fn0 = colocated u805306368:24 sig0
+;;     fn0 = colocated u805306368:23 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):

--- a/tests/disas/gc/copying/br-on-cast-fail.wat
+++ b/tests/disas/gc/copying/br-on-cast-fail.wat
@@ -26,7 +26,7 @@
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64) tail
-;;     fn0 = colocated u805306368:29 sig0
+;;     fn0 = colocated u805306368:28 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/copying/br-on-cast.wat
+++ b/tests/disas/gc/copying/br-on-cast.wat
@@ -26,7 +26,7 @@
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64) tail
-;;     fn0 = colocated u805306368:29 sig0
+;;     fn0 = colocated u805306368:28 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/copying/call-indirect-and-subtyping.wat
+++ b/tests/disas/gc/copying/call-indirect-and-subtyping.wat
@@ -25,7 +25,7 @@
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
 ;;     sig2 = (i64 vmctx, i32, i32) -> i32 tail
 ;;     fn0 = colocated u805306368:6 sig1
-;;     fn1 = colocated u805306368:29 sig2
+;;     fn1 = colocated u805306368:28 sig2
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/copying/funcref-in-gc-heap-get.wat
+++ b/tests/disas/gc/copying/funcref-in-gc-heap-get.wat
@@ -17,7 +17,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32) -> i64 tail
-;;     fn0 = colocated u805306368:26 sig0
+;;     fn0 = colocated u805306368:25 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/copying/funcref-in-gc-heap-new.wat
+++ b/tests/disas/gc/copying/funcref-in-gc-heap-new.wat
@@ -18,8 +18,8 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64) -> i64 tail
-;;     fn0 = colocated u805306368:24 sig0
-;;     fn1 = colocated u805306368:25 sig1
+;;     fn0 = colocated u805306368:23 sig0
+;;     fn1 = colocated u805306368:24 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):

--- a/tests/disas/gc/copying/funcref-in-gc-heap-set.wat
+++ b/tests/disas/gc/copying/funcref-in-gc-heap-set.wat
@@ -17,7 +17,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64) -> i64 tail
-;;     fn0 = colocated u805306368:25 sig0
+;;     fn0 = colocated u805306368:24 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i64):

--- a/tests/disas/gc/copying/ref-cast.wat
+++ b/tests/disas/gc/copying/ref-cast.wat
@@ -17,7 +17,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32) -> i32 tail
-;;     fn0 = colocated u805306368:29 sig0
+;;     fn0 = colocated u805306368:28 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/copying/ref-test-concrete-func-type.wat
+++ b/tests/disas/gc/copying/ref-test-concrete-func-type.wat
@@ -13,7 +13,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i32, i32) -> i32 tail
-;;     fn0 = colocated u805306368:29 sig0
+;;     fn0 = colocated u805306368:28 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):

--- a/tests/disas/gc/copying/ref-test-concrete-type.wat
+++ b/tests/disas/gc/copying/ref-test-concrete-type.wat
@@ -16,7 +16,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32) -> i32 tail
-;;     fn0 = colocated u805306368:29 sig0
+;;     fn0 = colocated u805306368:28 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/copying/struct-new-default.wat
+++ b/tests/disas/gc/copying/struct-new-default.wat
@@ -18,7 +18,7 @@
 ;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
-;;     fn0 = colocated u805306368:24 sig0
+;;     fn0 = colocated u805306368:23 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):

--- a/tests/disas/gc/copying/struct-new.wat
+++ b/tests/disas/gc/copying/struct-new.wat
@@ -19,7 +19,7 @@
 ;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
-;;     fn0 = colocated u805306368:24 sig0
+;;     fn0 = colocated u805306368:23 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: f32, v3: i32, v4: i32):

--- a/tests/disas/gc/drc/array-new-fixed-of-gc-refs.wat
+++ b/tests/disas/gc/drc/array-new-fixed-of-gc-refs.wat
@@ -21,7 +21,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
-;;     fn0 = colocated u805306368:24 sig0
+;;     fn0 = colocated u805306368:23 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):

--- a/tests/disas/gc/drc/array-new-fixed.wat
+++ b/tests/disas/gc/drc/array-new-fixed.wat
@@ -17,7 +17,7 @@
 ;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
-;;     fn0 = colocated u805306368:24 sig0
+;;     fn0 = colocated u805306368:23 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64):

--- a/tests/disas/gc/drc/array-new.wat
+++ b/tests/disas/gc/drc/array-new.wat
@@ -17,7 +17,7 @@
 ;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
-;;     fn0 = colocated u805306368:24 sig0
+;;     fn0 = colocated u805306368:23 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):

--- a/tests/disas/gc/drc/br-on-cast-fail.wat
+++ b/tests/disas/gc/drc/br-on-cast-fail.wat
@@ -27,7 +27,7 @@
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64) tail
-;;     fn0 = colocated u805306368:29 sig0
+;;     fn0 = colocated u805306368:28 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/drc/br-on-cast.wat
+++ b/tests/disas/gc/drc/br-on-cast.wat
@@ -27,7 +27,7 @@
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64) tail
-;;     fn0 = colocated u805306368:29 sig0
+;;     fn0 = colocated u805306368:28 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/drc/call-indirect-and-subtyping.wat
+++ b/tests/disas/gc/drc/call-indirect-and-subtyping.wat
@@ -26,7 +26,7 @@
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
 ;;     sig2 = (i64 vmctx, i32, i32) -> i32 tail
 ;;     fn0 = colocated u805306368:6 sig1
-;;     fn1 = colocated u805306368:29 sig2
+;;     fn1 = colocated u805306368:28 sig2
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/drc/externref-globals.wat
+++ b/tests/disas/gc/drc/externref-globals.wat
@@ -78,7 +78,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32) tail
-;;     fn0 = colocated u805306368:22 sig0
+;;     fn0 = colocated u805306368:21 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/drc/funcref-in-gc-heap-get.wat
+++ b/tests/disas/gc/drc/funcref-in-gc-heap-get.wat
@@ -18,7 +18,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32) -> i64 tail
-;;     fn0 = colocated u805306368:26 sig0
+;;     fn0 = colocated u805306368:25 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/drc/funcref-in-gc-heap-new.wat
+++ b/tests/disas/gc/drc/funcref-in-gc-heap-new.wat
@@ -19,8 +19,8 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64) -> i64 tail
-;;     fn0 = colocated u805306368:24 sig0
-;;     fn1 = colocated u805306368:25 sig1
+;;     fn0 = colocated u805306368:23 sig0
+;;     fn1 = colocated u805306368:24 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):

--- a/tests/disas/gc/drc/funcref-in-gc-heap-set.wat
+++ b/tests/disas/gc/drc/funcref-in-gc-heap-set.wat
@@ -18,7 +18,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64) -> i64 tail
-;;     fn0 = colocated u805306368:25 sig0
+;;     fn0 = colocated u805306368:24 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i64):

--- a/tests/disas/gc/drc/ref-cast.wat
+++ b/tests/disas/gc/drc/ref-cast.wat
@@ -18,7 +18,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32) -> i32 tail
-;;     fn0 = colocated u805306368:29 sig0
+;;     fn0 = colocated u805306368:28 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/drc/ref-test-concrete-func-type.wat
+++ b/tests/disas/gc/drc/ref-test-concrete-func-type.wat
@@ -14,7 +14,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i32, i32) -> i32 tail
-;;     fn0 = colocated u805306368:29 sig0
+;;     fn0 = colocated u805306368:28 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):

--- a/tests/disas/gc/drc/ref-test-concrete-type.wat
+++ b/tests/disas/gc/drc/ref-test-concrete-type.wat
@@ -17,7 +17,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32) -> i32 tail
-;;     fn0 = colocated u805306368:29 sig0
+;;     fn0 = colocated u805306368:28 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/drc/struct-new-default.wat
+++ b/tests/disas/gc/drc/struct-new-default.wat
@@ -20,7 +20,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
-;;     fn0 = colocated u805306368:24 sig0
+;;     fn0 = colocated u805306368:23 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):

--- a/tests/disas/gc/drc/struct-new.wat
+++ b/tests/disas/gc/drc/struct-new.wat
@@ -21,7 +21,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
-;;     fn0 = colocated u805306368:24 sig0
+;;     fn0 = colocated u805306368:23 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: f32, v3: i32, v4: i32):

--- a/tests/disas/gc/drc/struct-set.wat
+++ b/tests/disas/gc/drc/struct-set.wat
@@ -78,7 +78,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32) tail
-;;     fn0 = colocated u805306368:22 sig0
+;;     fn0 = colocated u805306368:21 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):

--- a/tests/disas/gc/null/array-new-fixed-of-gc-refs.wat
+++ b/tests/disas/gc/null/array-new-fixed-of-gc-refs.wat
@@ -21,7 +21,7 @@
 ;;     gv5 = load.i64 notrap aligned gv4+40
 ;;     gv6 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     sig0 = (i64 vmctx, i64) -> i8 tail
-;;     fn0 = colocated u805306368:23 sig0
+;;     fn0 = colocated u805306368:22 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):

--- a/tests/disas/gc/null/array-new-fixed.wat
+++ b/tests/disas/gc/null/array-new-fixed.wat
@@ -18,7 +18,7 @@
 ;;     gv5 = load.i64 notrap aligned gv4+40
 ;;     gv6 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     sig0 = (i64 vmctx, i64) -> i8 tail
-;;     fn0 = colocated u805306368:23 sig0
+;;     fn0 = colocated u805306368:22 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64):

--- a/tests/disas/gc/null/array-new.wat
+++ b/tests/disas/gc/null/array-new.wat
@@ -18,7 +18,7 @@
 ;;     gv5 = load.i64 notrap aligned gv4+40
 ;;     gv6 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     sig0 = (i64 vmctx, i64) -> i8 tail
-;;     fn0 = colocated u805306368:23 sig0
+;;     fn0 = colocated u805306368:22 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):

--- a/tests/disas/gc/null/br-on-cast-fail.wat
+++ b/tests/disas/gc/null/br-on-cast-fail.wat
@@ -27,7 +27,7 @@
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64) tail
-;;     fn0 = colocated u805306368:29 sig0
+;;     fn0 = colocated u805306368:28 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/null/br-on-cast.wat
+++ b/tests/disas/gc/null/br-on-cast.wat
@@ -27,7 +27,7 @@
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64) tail
-;;     fn0 = colocated u805306368:29 sig0
+;;     fn0 = colocated u805306368:28 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/null/call-indirect-and-subtyping.wat
+++ b/tests/disas/gc/null/call-indirect-and-subtyping.wat
@@ -26,7 +26,7 @@
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
 ;;     sig2 = (i64 vmctx, i32, i32) -> i32 tail
 ;;     fn0 = colocated u805306368:6 sig1
-;;     fn1 = colocated u805306368:29 sig2
+;;     fn1 = colocated u805306368:28 sig2
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/null/funcref-in-gc-heap-get.wat
+++ b/tests/disas/gc/null/funcref-in-gc-heap-get.wat
@@ -18,7 +18,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32) -> i64 tail
-;;     fn0 = colocated u805306368:26 sig0
+;;     fn0 = colocated u805306368:25 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/null/funcref-in-gc-heap-new.wat
+++ b/tests/disas/gc/null/funcref-in-gc-heap-new.wat
@@ -19,8 +19,8 @@
 ;;     gv6 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     sig0 = (i64 vmctx, i64) -> i8 tail
 ;;     sig1 = (i64 vmctx, i64) -> i64 tail
-;;     fn0 = colocated u805306368:23 sig0
-;;     fn1 = colocated u805306368:25 sig1
+;;     fn0 = colocated u805306368:22 sig0
+;;     fn1 = colocated u805306368:24 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):

--- a/tests/disas/gc/null/funcref-in-gc-heap-set.wat
+++ b/tests/disas/gc/null/funcref-in-gc-heap-set.wat
@@ -18,7 +18,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64) -> i64 tail
-;;     fn0 = colocated u805306368:25 sig0
+;;     fn0 = colocated u805306368:24 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i64):

--- a/tests/disas/gc/null/ref-cast.wat
+++ b/tests/disas/gc/null/ref-cast.wat
@@ -18,7 +18,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32) -> i32 tail
-;;     fn0 = colocated u805306368:29 sig0
+;;     fn0 = colocated u805306368:28 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/null/ref-test-concrete-func-type.wat
+++ b/tests/disas/gc/null/ref-test-concrete-func-type.wat
@@ -14,7 +14,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i32, i32) -> i32 tail
-;;     fn0 = colocated u805306368:29 sig0
+;;     fn0 = colocated u805306368:28 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):

--- a/tests/disas/gc/null/ref-test-concrete-type.wat
+++ b/tests/disas/gc/null/ref-test-concrete-type.wat
@@ -17,7 +17,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32) -> i32 tail
-;;     fn0 = colocated u805306368:29 sig0
+;;     fn0 = colocated u805306368:28 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/null/struct-new-default.wat
+++ b/tests/disas/gc/null/struct-new-default.wat
@@ -20,7 +20,7 @@
 ;;     gv5 = load.i64 notrap aligned gv4+40
 ;;     gv6 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     sig0 = (i64 vmctx, i64) -> i8 tail
-;;     fn0 = colocated u805306368:23 sig0
+;;     fn0 = colocated u805306368:22 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):

--- a/tests/disas/gc/null/struct-new.wat
+++ b/tests/disas/gc/null/struct-new.wat
@@ -21,7 +21,7 @@
 ;;     gv5 = load.i64 notrap aligned gv4+40
 ;;     gv6 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     sig0 = (i64 vmctx, i64) -> i8 tail
-;;     fn0 = colocated u805306368:23 sig0
+;;     fn0 = colocated u805306368:22 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: f32, v3: i32, v4: i32):

--- a/tests/disas/gc/struct-new-default.wat
+++ b/tests/disas/gc/struct-new-default.wat
@@ -21,7 +21,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
-;;     fn0 = colocated u805306368:24 sig0
+;;     fn0 = colocated u805306368:23 sig0
 ;;     const0 = 0x00000000000000000000000000000000
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/gc/struct-new.wat
+++ b/tests/disas/gc/struct-new.wat
@@ -21,7 +21,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
-;;     fn0 = colocated u805306368:24 sig0
+;;     fn0 = colocated u805306368:23 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: f32, v3: i32, v4: i32):

--- a/tests/disas/memory-copy-epochs.wat
+++ b/tests/disas/memory-copy-epochs.wat
@@ -18,7 +18,7 @@
 ;;     gv6 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     sig0 = (i64 vmctx) -> i64 tail
 ;;     sig1 = (i64 vmctx, i64, i64, i64) tail
-;;     fn0 = colocated u805306368:13 sig0
+;;     fn0 = colocated u805306368:12 sig0
 ;;     fn1 = colocated u805306368:3 sig1
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/memory-copy-fuel.wat
+++ b/tests/disas/memory-copy-fuel.wat
@@ -18,7 +18,7 @@
 ;;     gv6 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     sig0 = (i64 vmctx) -> i8 tail
 ;;     sig1 = (i64 vmctx, i64, i64, i64) tail
-;;     fn0 = colocated u805306368:12 sig0
+;;     fn0 = colocated u805306368:11 sig0
 ;;     fn1 = colocated u805306368:3 sig1
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/metadata-for-internal-asserts.wat
+++ b/tests/disas/metadata-for-internal-asserts.wat
@@ -39,7 +39,7 @@
 ;;       popq    %rbp
 ;;       retq
 ;;   5e: movq    0x10(%rbx), %rax
-;;   62: movq    0x168(%rax), %rax
+;;   62: movq    0x150(%rax), %rax
 ;;   69: movq    %rbx, %rdi
 ;;   6c: callq   *%rax
 ;;   6e: ud2

--- a/tests/disas/riscv64-component-builtins-asm.wat
+++ b/tests/disas/riscv64-component-builtins-asm.wat
@@ -54,7 +54,7 @@
 ;;       ret
 ;;       mv      a1, s5
 ;;       ld      a0, 0x10(a1)
-;;       ld      a2, 0x168(a0)
+;;       ld      a2, 0x150(a0)
 ;;       mv      a0, a1
 ;;       jalr    a2
 ;;       .byte   0x00, 0x00, 0x00, 0x00

--- a/tests/disas/riscv64-component-builtins.wat
+++ b/tests/disas/riscv64-component-builtins.wat
@@ -34,7 +34,7 @@
 ;;
 ;; block1 cold:
 ;;     v15 = load.i64 notrap aligned readonly v1+16
-;;     v16 = load.i64 notrap aligned readonly v15+360
+;;     v16 = load.i64 notrap aligned readonly v15+336
 ;;     call_indirect sig1, v16(v1)
 ;;     trap user1
 ;;

--- a/tests/disas/stack-switching/resume-suspend-data-passing.wat
+++ b/tests/disas/stack-switching/resume-suspend-data-passing.wat
@@ -153,7 +153,7 @@
 ;;     sig0 = (i64 vmctx, i32) -> i64 tail
 ;;     sig1 = (i64 vmctx, i64, i32, i32) -> i64 tail
 ;;     fn0 = colocated u805306368:5 sig0
-;;     fn1 = colocated u805306368:46 sig1
+;;     fn1 = colocated u805306368:43 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):

--- a/tests/disas/stack-switching/resume-suspend.wat
+++ b/tests/disas/stack-switching/resume-suspend.wat
@@ -114,7 +114,7 @@
 ;;     sig0 = (i64 vmctx, i32) -> i64 tail
 ;;     sig1 = (i64 vmctx, i64, i32, i32) -> i64 tail
 ;;     fn0 = colocated u805306368:5 sig0
-;;     fn1 = colocated u805306368:46 sig1
+;;     fn1 = colocated u805306368:43 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):

--- a/tests/disas/stack-switching/symmetric-switch.wat
+++ b/tests/disas/stack-switching/symmetric-switch.wat
@@ -34,7 +34,7 @@
 ;;     sig0 = (i64 vmctx, i32) -> i64 tail
 ;;     sig1 = (i64 vmctx, i64, i32, i32) -> i64 tail
 ;;     fn0 = colocated u805306368:5 sig0
-;;     fn1 = colocated u805306368:46 sig1
+;;     fn1 = colocated u805306368:43 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
@@ -249,7 +249,7 @@
 ;;     sig0 = (i64 vmctx, i32) -> i64 tail
 ;;     sig1 = (i64 vmctx, i64, i32, i32) -> i64 tail
 ;;     fn0 = colocated u805306368:5 sig0
-;;     fn1 = colocated u805306368:46 sig1
+;;     fn1 = colocated u805306368:43 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):

--- a/tests/disas/table-set-fixed-size.wat
+++ b/tests/disas/table-set-fixed-size.wat
@@ -26,7 +26,7 @@
 ;;     gv6 = load.i64 notrap aligned readonly can_move gv5+32
 ;;     gv7 = load.i64 notrap aligned gv5+40
 ;;     sig0 = (i64 vmctx, i32) tail
-;;     fn0 = colocated u805306368:22 sig0
+;;     fn0 = colocated u805306368:21 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -123,7 +123,7 @@
 ;;     gv6 = load.i64 notrap aligned readonly can_move gv5+32
 ;;     gv7 = load.i64 notrap aligned gv5+40
 ;;     sig0 = (i64 vmctx, i32) tail
-;;     fn0 = colocated u805306368:22 sig0
+;;     fn0 = colocated u805306368:21 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):

--- a/tests/disas/table-set.wat
+++ b/tests/disas/table-set.wat
@@ -27,7 +27,7 @@
 ;;     gv7 = load.i64 notrap aligned readonly can_move gv6+32
 ;;     gv8 = load.i64 notrap aligned gv6+40
 ;;     sig0 = (i64 vmctx, i32) tail
-;;     fn0 = colocated u805306368:22 sig0
+;;     fn0 = colocated u805306368:21 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -126,7 +126,7 @@
 ;;     gv7 = load.i64 notrap aligned readonly can_move gv6+32
 ;;     gv8 = load.i64 notrap aligned gv6+40
 ;;     sig0 = (i64 vmctx, i32) tail
-;;     fn0 = colocated u805306368:22 sig0
+;;     fn0 = colocated u805306368:21 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):

--- a/tests/disas/winch/x64/table/fill.wat
+++ b/tests/disas/winch/x64/table/fill.wat
@@ -78,7 +78,7 @@
 ;;       movq    0x18(%r11), %r11
 ;;       addq    $0x40, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x1fa
+;;       ja      0x22a
 ;;   dc: movq    %rdi, %r14
 ;;       subq    $0x30, %rsp
 ;;       movq    %rdi, 0x28(%rsp)
@@ -96,7 +96,7 @@
 ;;       movq    %r14, %rdx
 ;;       movq    0x38(%rdx), %rbx
 ;;       cmpq    %rbx, %rcx
-;;       jae     0x1fc
+;;       jae     0x22c
 ;;  138: movq    %rcx, %r11
 ;;       imulq   $8, %r11, %r11
 ;;       movq    0x30(%rdx), %rdx
@@ -113,31 +113,48 @@
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
 ;;       movl    0xc(%rsp), %edx
-;;       callq   0x4e7
+;;       callq   0x51d
 ;;       addq    $0xc, %rsp
 ;;       addq    $4, %rsp
 ;;       movq    0x28(%rsp), %r14
 ;;       jmp     0x19f
 ;;  199: andq    $0xfffffffffffffffe, %rax
 ;;       movq    %rax, 0xc(%rsp)
-;;       movl    0x1c(%rsp), %r11d
-;;       subq    $4, %rsp
-;;       movl    %r11d, (%rsp)
-;;       movq    0x10(%rsp), %r11
-;;       pushq   %r11
-;;       movl    0x20(%rsp), %r11d
-;;       subq    $4, %rsp
-;;       movl    %r11d, (%rsp)
+;;       movl    0x14(%rsp), %eax
+;;       movq    0xc(%rsp), %rcx
+;;       movl    0x1c(%rsp), %edx
+;;       movq    %r14, %r11
+;;       movq    0x48(%r11), %rbx
+;;       movl    %edx, %esi
+;;       addl    %eax, %esi
+;;       jb      0x22e
+;;  1c2: cmpl    %ebx, %esi
+;;       ja      0x230
+;;  1ca: cmpq    $0, %rax
+;;       je      0x221
+;;  1d4: movq    %rdx, %rbx
+;;       movq    %rcx, %rsi
 ;;       movq    %r14, %rdi
-;;       movl    $1, %esi
-;;       movl    0xc(%rsp), %edx
-;;       movq    4(%rsp), %rcx
-;;       movl    (%rsp), %r8d
-;;       callq   0x512
-;;       addq    $0x10, %rsp
-;;       movq    0x28(%rsp), %r14
-;;       addq    $0x30, %rsp
+;;       movq    0x48(%rdi), %r8
+;;       cmpq    %r8, %rbx
+;;       jae     0x232
+;;  1ea: movq    %rbx, %r11
+;;       imulq   $8, %r11, %r11
+;;       movq    0x40(%rdi), %rdi
+;;       movq    %rdi, %r9
+;;       addq    %r11, %rdi
+;;       cmpq    %r8, %rbx
+;;       cmovaeq %r9, %rdi
+;;       orq     $1, %rsi
+;;       movq    %rsi, (%rdi)
+;;       addq    $1, %rdx
+;;       subq    $1, %rax
+;;       jmp     0x1ca
+;;  221: addq    $0x30, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;  1fa: ud2
-;;  1fc: ud2
+;;  22a: ud2
+;;  22c: ud2
+;;  22e: ud2
+;;  230: ud2
+;;  232: ud2

--- a/tests/disas/winch/x64/table/grow.wat
+++ b/tests/disas/winch/x64/table/grow.wat
@@ -17,25 +17,65 @@
 ;;       movq    0x18(%r11), %r11
 ;;       addq    $0x30, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x78
+;;       ja      0x108
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
 ;;       movq    %rsi, 0x10(%rsp)
 ;;       movq    %rdx, 8(%rsp)
+;;       movl    $0xa, %eax
+;;       movl    %eax, %ecx
 ;;       movq    8(%rsp), %r11
 ;;       pushq   %r11
-;;       subq    $8, %rsp
+;;       subq    $4, %rsp
+;;       movl    %ecx, (%rsp)
+;;       subq    $4, %rsp
+;;       movl    %eax, (%rsp)
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
-;;       movl    $0xa, %edx
-;;       movq    8(%rsp), %rcx
-;;       callq   0x179
-;;       addq    $8, %rsp
-;;       addq    $8, %rsp
-;;       movq    0x18(%rsp), %r14
-;;       movl    %eax, %eax
+;;       movl    (%rsp), %edx
+;;       callq   0x20f
+;;       addq    $4, %rsp
+;;       movq    0x24(%rsp), %r14
+;;       movl    (%rsp), %ecx
+;;       addq    $4, %rsp
+;;       popq    %rdx
+;;       movq    %rax, %rbx
+;;       cmpq    $-1, %rax
+;;       je      0xfb
+;;   8b: movq    %r14, %r11
+;;       movq    0x38(%r11), %rsi
+;;       movl    %eax, %edi
+;;       addl    %ecx, %edi
+;;       jb      0x10a
+;;   9c: cmpl    %esi, %edi
+;;       ja      0x10c
+;;   a4: cmpq    $0, %rcx
+;;       je      0xfb
+;;   ae: movq    %rax, %rsi
+;;       movq    %rdx, %rdi
+;;       movq    %r14, %r8
+;;       movq    0x38(%r8), %r9
+;;       cmpq    %r9, %rsi
+;;       jae     0x10e
+;;   c4: movq    %rsi, %r11
+;;       imulq   $8, %r11, %r11
+;;       movq    0x30(%r8), %r8
+;;       movq    %r8, %r10
+;;       addq    %r11, %r8
+;;       cmpq    %r9, %rsi
+;;       cmovaeq %r10, %r8
+;;       orq     $1, %rdi
+;;       movq    %rdi, (%r8)
+;;       addq    $1, %rax
+;;       subq    $1, %rcx
+;;       jmp     0xa4
+;;   fb: movl    %ebx, %ebx
+;;       movl    %ebx, %eax
 ;;       addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   78: ud2
+;;  108: ud2
+;;  10a: ud2
+;;  10c: ud2
+;;  10e: ud2

--- a/tests/disas/x64-simd-round-without-sse41.wat
+++ b/tests/disas/x64-simd-round-without-sse41.wat
@@ -17,7 +17,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, f32) -> f32 tail
-;;     fn0 = colocated u805306368:32 sig0
+;;     fn0 = colocated u805306368:29 sig0
 ;;     const0 = 0x00000000000000000000000000000000
 ;;     stack_limit = gv2
 ;;
@@ -49,7 +49,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, f32) -> f32 tail
-;;     fn0 = colocated u805306368:34 sig0
+;;     fn0 = colocated u805306368:31 sig0
 ;;     const0 = 0x00000000000000000000000000000000
 ;;     stack_limit = gv2
 ;;
@@ -81,7 +81,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, f32) -> f32 tail
-;;     fn0 = colocated u805306368:36 sig0
+;;     fn0 = colocated u805306368:33 sig0
 ;;     const0 = 0x00000000000000000000000000000000
 ;;     stack_limit = gv2
 ;;
@@ -113,7 +113,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, f32) -> f32 tail
-;;     fn0 = colocated u805306368:38 sig0
+;;     fn0 = colocated u805306368:35 sig0
 ;;     const0 = 0x00000000000000000000000000000000
 ;;     stack_limit = gv2
 ;;
@@ -145,7 +145,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, f64) -> f64 tail
-;;     fn0 = colocated u805306368:33 sig0
+;;     fn0 = colocated u805306368:30 sig0
 ;;     const0 = 0x00000000000000000000000000000000
 ;;     stack_limit = gv2
 ;;
@@ -171,7 +171,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, f64) -> f64 tail
-;;     fn0 = colocated u805306368:35 sig0
+;;     fn0 = colocated u805306368:32 sig0
 ;;     const0 = 0x00000000000000000000000000000000
 ;;     stack_limit = gv2
 ;;
@@ -197,7 +197,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, f64) -> f64 tail
-;;     fn0 = colocated u805306368:37 sig0
+;;     fn0 = colocated u805306368:34 sig0
 ;;     const0 = 0x00000000000000000000000000000000
 ;;     stack_limit = gv2
 ;;
@@ -223,7 +223,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, f64) -> f64 tail
-;;     fn0 = colocated u805306368:39 sig0
+;;     fn0 = colocated u805306368:36 sig0
 ;;     const0 = 0x00000000000000000000000000000000
 ;;     stack_limit = gv2
 ;;

--- a/winch/codegen/src/codegen/mod.rs
+++ b/winch/codegen/src/codegen/mod.rs
@@ -24,7 +24,7 @@ use wasmparser::{
 };
 use wasmtime_cranelift::{TRAP_BAD_SIGNATURE, TRAP_HEAP_MISALIGNED, TRAP_TABLE_OUT_OF_BOUNDS};
 use wasmtime_environ::{
-    DataIndex, FUNCREF_INIT_BIT, FUNCREF_MASK, GlobalIndex, MemoryIndex, MemoryKind,
+    DataIndex, FUNCREF_INIT_BIT, FUNCREF_MASK, GlobalIndex, IndexType, MemoryIndex, MemoryKind,
     MemoryTunables, PtrSize, TableIndex, Tunables, TypeIndex, WasmHeapType, WasmValType,
 };
 
@@ -689,6 +689,173 @@ where
         self.context.free_reg(value);
         self.context.free_reg(index);
         self.context.free_reg(base);
+        Ok(())
+    }
+
+    /// Emit the `table.grow` operation.
+    pub fn emit_table_grow(&mut self, table_index: TableIndex) -> Result<()> {
+        let ptr_type = self.env.ptr_type();
+        let idx_type = self.env.table(table_index).idx_type;
+
+        // Duplicate the `delta` argument on the stack since we'll need it at
+        // the end if growth succeeds.
+        let delta = self.context.pop_to_reg(self.masm, None)?;
+        let tmp = self.context.any_gpr(self.masm)?;
+        self.masm
+            .mov(writable!(tmp), delta.reg.into(), delta.ty.try_into()?)?;
+        self.context.stack.push(TypedReg::new(delta.ty, tmp).into());
+        self.context.stack.push(delta.into());
+
+        // Invoke the `table.grow` builtin on the host which will return whether
+        // the growth succeeded, and if so where it's located.
+        let at = self.context.stack.ensure_index_at(1)?;
+        let builtin = self.env.builtins.table_grow::<M::ABI>()?;
+        let builtin = self.prepare_builtin_defined_table_arg(table_index, at, builtin)?;
+        FnCall::emit::<M>(&mut self.env, self.masm, &mut self.context, builtin)?;
+
+        // Pop everything that's on the stack now. The builtin took `delta` and
+        // pushed a result, and then peel off our duplicate of `delta` plus the
+        // initialization element of `table.grow` itself.
+        let result = self.context.pop_to_reg(self.masm, None)?;
+        let len = self.context.pop_to_reg(self.masm, None)?;
+        let init = self.context.pop_to_reg(self.masm, None)?;
+
+        // Save a copy of `result` on the stack since we'll need it after
+        // `table.fill` is done.
+        let tmp_result = self.context.any_gpr(self.masm)?;
+        self.masm.mov(
+            writable!(tmp_result),
+            result.reg.into(),
+            result.ty.try_into()?,
+        )?;
+        self.context
+            .stack
+            .push(TypedReg::new(result.ty, tmp_result).into());
+
+        // Test if the result of growth is -1. If it is, then we're done.
+        // Otherwise fall through to `table.fill`.
+        let done = self.masm.get_label()?;
+        self.masm.branch(
+            IntCmpKind::Eq,
+            result.reg,
+            RegImm::i64(-1),
+            done,
+            OperandSize::S64,
+        )?;
+
+        // Prepare the arguments for `table.fill` in the order the wasm
+        // instruction expects.
+        self.context.stack.push(result.into());
+        self.context.stack.push(init.into());
+        self.context.stack.push(len.into());
+        self.emit_table_fill(table_index)?;
+
+        self.masm.bind(done)?;
+
+        // Similar to the memory.grow builtin, `table.grow` returns a
+        // pointer, however, we need to ensure that the returned index
+        // is representative of the address space for tables.
+        match (ptr_type, idx_type) {
+            (WasmValType::I64, IndexType::I64) => Ok(()),
+            (WasmValType::I64, IndexType::I32) => {
+                let top: Reg = self.context.pop_to_reg(self.masm, None)?.into();
+                self.masm.wrap(writable!(top), top)?;
+                self.context.stack.push(TypedReg::i32(top).into());
+                Ok(())
+            }
+
+            _ => Err(format_err!(CodeGenError::unsupported_32_bit_platform())),
+        }
+    }
+
+    /// Emit the `table.fill` operation.
+    pub fn emit_table_fill(&mut self, table_index: TableIndex) -> Result<()> {
+        // Put all of this opcode's arguments into registers.
+        let len = self.context.pop_to_reg(self.masm, None)?;
+        let init = self.context.pop_to_reg(self.masm, None)?;
+        let offset = self.context.pop_to_reg(self.masm, None)?;
+
+        // Perform a bounds check to see if `offset+len` is inbounds.
+        let table_data = self.env.resolve_table_data(table_index);
+        self.emit_compute_table_size(&table_data)?;
+        let table_size = self.context.pop_to_reg(self.masm, None)?;
+        let tmp = self.context.any_gpr(self.masm)?;
+        let idx_size = table_data.index_type().try_into()?;
+        self.masm.mov(writable!(tmp), offset.reg.into(), idx_size)?;
+        self.masm.checked_uadd(
+            writable!(tmp),
+            tmp,
+            len.reg.into(),
+            idx_size,
+            TRAP_TABLE_OUT_OF_BOUNDS,
+        )?;
+        self.masm.cmp(tmp, table_size.reg.into(), idx_size)?;
+        self.masm
+            .trapif(IntCmpKind::GtU, TRAP_TABLE_OUT_OF_BOUNDS)?;
+        self.context.free_reg(tmp);
+        self.context.free_reg(table_size);
+
+        let header = self.masm.get_label()?;
+        let exit = self.masm.get_label()?;
+
+        self.masm.bind(header)?;
+
+        // Exit the loop once there are no more elements to copy.
+        self.masm.branch(
+            IntCmpKind::Eq,
+            len.reg,
+            RegImm::i64(0),
+            exit,
+            OperandSize::S64,
+        )?;
+
+        // Duplicate `offset`, where we're writing, and `init` what we're
+        // writing, into temporary registers. These are used by `emit_table_set`
+        // below.
+        let tmp_index = self.context.any_gpr(self.masm)?;
+        let tmp_init = self.context.any_gpr(self.masm)?;
+        self.masm
+            .mov(writable!(tmp_index), offset.reg.into(), OperandSize::S64)?;
+        self.masm
+            .mov(writable!(tmp_init), init.reg.into(), OperandSize::S64)?;
+
+        // Spill all this loop's variables onto the stack.
+        self.context.stack.push(TypedReg::i64(len.reg).into());
+        self.context.stack.push(TypedReg::i64(init.reg).into());
+        self.context.stack.push(TypedReg::i64(offset.reg).into());
+
+        // Emit `table.set`, consuming our temporary registers.
+        self.context.stack.push(TypedReg::i64(tmp_index).into());
+        self.context.stack.push(TypedReg::i64(tmp_init).into());
+        self.emit_table_set(table_index)?;
+
+        // Reload this loop's variables into the same registers as the start of
+        // the loop.
+        self.context.pop_to_reg(self.masm, Some(offset.reg))?;
+        self.context.pop_to_reg(self.masm, Some(init.reg))?;
+        self.context.pop_to_reg(self.masm, Some(len.reg))?;
+
+        // Advance the destination we're writing to, and decrement the number of
+        // elements left to write.
+        self.masm.add(
+            writable!(offset.reg),
+            offset.reg,
+            RegImm::i64(1),
+            OperandSize::S64,
+        )?;
+        self.masm.sub(
+            writable!(len.reg),
+            len.reg,
+            RegImm::i64(1),
+            OperandSize::S64,
+        )?;
+        self.masm.jmp(header)?;
+
+        self.masm.bind(exit)?;
+
+        self.context.free_reg(offset);
+        self.context.free_reg(init);
+        self.context.free_reg(len);
         Ok(())
     }
 

--- a/winch/codegen/src/visitor.rs
+++ b/winch/codegen/src/visitor.rs
@@ -19,7 +19,7 @@ use crate::masm::{
 };
 use crate::reg::{Reg, writable};
 use crate::stack::{TypedReg, Val};
-use crate::{Result, bail, ensure, format_err};
+use crate::{Result, bail, format_err};
 use regalloc2::RegClass;
 use smallvec::{SmallVec, smallvec};
 use wasmparser::{
@@ -28,7 +28,7 @@ use wasmparser::{
 };
 use wasmtime_cranelift::TRAP_INDIRECT_CALL_TO_NULL;
 use wasmtime_environ::{
-    DataIndex, FuncIndex, GlobalIndex, IndexType, MemoryIndex, TableIndex, TypeIndex, WasmHeapType,
+    DataIndex, FuncIndex, GlobalIndex, MemoryIndex, TableIndex, TypeIndex, WasmHeapType,
     WasmValType,
 };
 
@@ -1743,46 +1743,7 @@ where
 
     fn visit_table_grow(&mut self, table: u32) -> Self::Output {
         let table_index = TableIndex::from_u32(table);
-        let ptr_type = self.env.ptr_type();
-        let (heap_type, idx_type) = {
-            let table_ty = self.env.table(table_index);
-            (table_ty.ref_type.heap_type, table_ty.idx_type)
-        };
-        let builtin = match heap_type {
-            WasmHeapType::Func => self.env.builtins.table_grow_func_ref::<M::ABI>()?,
-            _ => bail!(CodeGenError::unsupported_wasm_type()),
-        };
-
-        let len = self.context.stack.len();
-        // table.grow` requires at least 2 elements on the value stack.
-        let at = self.context.stack.ensure_index_at(2)?;
-
-        // The table_grow builtin expects the parameters in a different
-        // order.
-        // The value stack at this point should contain:
-        // [ init_value | delta ] (stack top)
-        // but the builtin function expects the init value as the last
-        // argument.
-        self.context.stack.inner_mut().swap(len - 1, len - 2);
-
-        let builtin = self.prepare_builtin_defined_table_arg(table_index, at, builtin)?;
-
-        FnCall::emit::<M>(&mut self.env, self.masm, &mut self.context, builtin)?;
-
-        // Similar to the memory.grow builtin, `table.grow` returns a
-        // pointer, however, we need to ensure that the returned index
-        // is representative of the address space for tables.
-        match (ptr_type, idx_type) {
-            (WasmValType::I64, IndexType::I64) => Ok(()),
-            (WasmValType::I64, IndexType::I32) => {
-                let top: Reg = self.context.pop_to_reg(self.masm, None)?.into();
-                self.masm.wrap(writable!(top), top)?;
-                self.context.stack.push(TypedReg::i32(top).into());
-                Ok(())
-            }
-
-            _ => Err(format_err!(CodeGenError::unsupported_32_bit_platform())),
-        }
+        self.emit_table_grow(table_index)
     }
 
     fn visit_table_size(&mut self, table: u32) -> Self::Output {
@@ -1793,21 +1754,7 @@ where
 
     fn visit_table_fill(&mut self, table: u32) -> Self::Output {
         let table_index = TableIndex::from_u32(table);
-        let table_ty = self.env.table(table_index);
-
-        ensure!(
-            table_ty.ref_type.heap_type == WasmHeapType::Func,
-            CodeGenError::unsupported_wasm_type()
-        );
-
-        let builtin = self.env.builtins.table_fill_func_ref::<M::ABI>()?;
-
-        let at = self.context.stack.ensure_index_at(3)?;
-
-        let callee = self.prepare_builtin_defined_table_arg(table_index, at, builtin)?;
-        FnCall::emit::<M>(&mut self.env, self.masm, &mut self.context, callee)?;
-
-        self.context.pop_and_free(self.masm)
+        self.emit_table_fill(table_index)
     }
 
     fn visit_table_set(&mut self, table: u32) -> Self::Output {


### PR DESCRIPTION
This commit refactors the implementation of the `table.{grow,fill}` WebAssembly instructions to perform more work in compiled code rather than within the runtime itself. This shrinks the amount of libcalls needed, for example, simplifies some internals by having them build on each other, and additionally helps address #13387 by routing more bulk operations through a "narrow waist".

This refactors the internals of `memory.fill` and `array.fill`, previously refactored before, to share more implementation details. The end result is that the implementation of `table.fill` is a one-liner to a generic "fill this thing with this value" helper. Additionally the `table.grow` instruction is reimplemented in terms of this, meaning that the host is responsible for growth, but compiled code is responsible for initializing the table.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
