### PR TITLE
Release Wasmtime 36.0.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -289,7 +289,7 @@ dependencies = [
 
 [[package]]
 name = "byte-array-literals"
-version = "36.0.9"
+version = "36.0.10"
 
 [[package]]
 name = "byteorder"
@@ -693,7 +693,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift"
-version = "0.123.9"
+version = "0.123.10"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",
@@ -706,7 +706,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.123.9"
+version = "0.123.10"
 dependencies = [
  "arbitrary",
  "arbtest",
@@ -724,21 +724,21 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.123.9"
+version = "0.123.10"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.123.9"
+version = "0.123.10"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.123.9"
+version = "0.123.10"
 dependencies = [
  "arbitrary",
  "serde",
@@ -747,7 +747,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.123.9"
+version = "0.123.10"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -782,7 +782,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.123.9"
+version = "0.123.10"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -793,18 +793,18 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.123.9"
+version = "0.123.10"
 
 [[package]]
 name = "cranelift-control"
-version = "0.123.9"
+version = "0.123.10"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.123.9"
+version = "0.123.10"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.123.9"
+version = "0.123.10"
 dependencies = [
  "cranelift-codegen",
  "env_logger 0.11.5",
@@ -869,7 +869,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-interpreter"
-version = "0.123.9"
+version = "0.123.10"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.123.9"
+version = "0.123.10"
 dependencies = [
  "codespan-reporting",
  "log",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-jit"
-version = "0.123.9"
+version = "0.123.10"
 dependencies = [
  "anyhow",
  "cranelift",
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-module"
-version = "0.123.9"
+version = "0.123.10"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -926,7 +926,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.123.9"
+version = "0.123.10"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-object"
-version = "0.123.9"
+version = "0.123.10"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -950,7 +950,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-reader"
-version = "0.123.9"
+version = "0.123.10"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -960,7 +960,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-serde"
-version = "0.123.9"
+version = "0.123.10"
 dependencies = [
  "clap",
  "cranelift-codegen",
@@ -970,7 +970,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.123.9"
+version = "0.123.10"
 
 [[package]]
 name = "cranelift-tools"
@@ -1221,7 +1221,7 @@ checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
 
 [[package]]
 name = "embedding"
-version = "36.0.9"
+version = "36.0.10"
 dependencies = [
  "anyhow",
  "dlmalloc",
@@ -2372,7 +2372,7 @@ dependencies = [
 
 [[package]]
 name = "min-platform-host"
-version = "36.0.9"
+version = "36.0.10"
 dependencies = [
  "anyhow",
  "libloading",
@@ -2815,7 +2815,7 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "36.0.9"
+version = "36.0.10"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -2839,7 +2839,7 @@ dependencies = [
 
 [[package]]
 name = "pulley-macros"
-version = "36.0.9"
+version = "36.0.10"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4065,7 +4065,7 @@ version = "0.1.0"
 
 [[package]]
 name = "verify-component-adapter"
-version = "36.0.9"
+version = "36.0.10"
 dependencies = [
  "anyhow",
  "wasmparser 0.236.0",
@@ -4133,7 +4133,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-common"
-version = "36.0.9"
+version = "36.0.10"
 dependencies = [
  "anyhow",
  "bitflags 2.6.0",
@@ -4172,7 +4172,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-preview1-component-adapter"
-version = "36.0.9"
+version = "36.0.10"
 dependencies = [
  "bitflags 2.6.0",
  "byte-array-literals",
@@ -4443,7 +4443,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "36.0.9"
+version = "36.0.10"
 dependencies = [
  "addr2line 0.25.0",
  "anyhow",
@@ -4508,7 +4508,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-bench-api"
-version = "36.0.9"
+version = "36.0.10"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -4524,14 +4524,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-c-api"
-version = "36.0.9"
+version = "36.0.10"
 dependencies = [
  "wasmtime-c-api-impl",
 ]
 
 [[package]]
 name = "wasmtime-c-api-impl"
-version = "36.0.9"
+version = "36.0.10"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -4548,7 +4548,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli"
-version = "36.0.9"
+version = "36.0.10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4621,7 +4621,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli-flags"
-version = "36.0.9"
+version = "36.0.10"
 dependencies = [
  "anyhow",
  "clap",
@@ -4636,7 +4636,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "36.0.9"
+version = "36.0.10"
 dependencies = [
  "anyhow",
  "clap",
@@ -4742,14 +4742,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-asm-macros"
-version = "36.0.9"
+version = "36.0.10"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "wasmtime-internal-c-api-macros"
-version = "36.0.9"
+version = "36.0.10"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4757,7 +4757,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cache"
-version = "36.0.9"
+version = "36.0.10"
 dependencies = [
  "anyhow",
  "base64",
@@ -4778,7 +4778,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-macro"
-version = "36.0.9"
+version = "36.0.10"
 dependencies = [
  "anyhow",
  "component-macro-test-helpers",
@@ -4798,11 +4798,11 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-util"
-version = "36.0.9"
+version = "36.0.10"
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "36.0.9"
+version = "36.0.10"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4827,7 +4827,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-explorer"
-version = "36.0.9"
+version = "36.0.10"
 dependencies = [
  "anyhow",
  "capstone",
@@ -4842,7 +4842,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-fiber"
-version = "36.0.9"
+version = "36.0.10"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -4857,7 +4857,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-debug"
-version = "36.0.9"
+version = "36.0.10"
 dependencies = [
  "cc",
  "object 0.37.1",
@@ -4867,7 +4867,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "36.0.9"
+version = "36.0.10"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4877,18 +4877,18 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-math"
-version = "36.0.9"
+version = "36.0.10"
 dependencies = [
  "libm",
 ]
 
 [[package]]
 name = "wasmtime-internal-slab"
-version = "36.0.9"
+version = "36.0.10"
 
 [[package]]
 name = "wasmtime-internal-unwinder"
-version = "36.0.9"
+version = "36.0.10"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4899,7 +4899,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
-version = "36.0.9"
+version = "36.0.10"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4908,7 +4908,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-winch"
-version = "36.0.9"
+version = "36.0.10"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -4923,7 +4923,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-wit-bindgen"
-version = "36.0.9"
+version = "36.0.10"
 dependencies = [
  "anyhow",
  "bitflags 2.6.0",
@@ -4934,7 +4934,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-wmemcheck"
-version = "36.0.9"
+version = "36.0.10"
 
 [[package]]
 name = "wasmtime-test-macros"
@@ -4949,7 +4949,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-test-util"
-version = "36.0.9"
+version = "36.0.10"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -4967,7 +4967,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "36.0.9"
+version = "36.0.10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5002,7 +5002,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-config"
-version = "36.0.9"
+version = "36.0.10"
 dependencies = [
  "anyhow",
  "test-programs-artifacts",
@@ -5013,7 +5013,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-http"
-version = "36.0.9"
+version = "36.0.10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5040,7 +5040,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-io"
-version = "36.0.9"
+version = "36.0.10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5051,7 +5051,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-keyvalue"
-version = "36.0.9"
+version = "36.0.10"
 dependencies = [
  "anyhow",
  "test-programs-artifacts",
@@ -5062,7 +5062,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-nn"
-version = "36.0.9"
+version = "36.0.10"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -5083,7 +5083,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-threads"
-version = "36.0.9"
+version = "36.0.10"
 dependencies = [
  "anyhow",
  "log",
@@ -5095,7 +5095,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-tls"
-version = "36.0.9"
+version = "36.0.10"
 dependencies = [
  "anyhow",
  "bytes",
@@ -5111,7 +5111,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-tls-nativetls"
-version = "36.0.9"
+version = "36.0.10"
 dependencies = [
  "anyhow",
  "futures",
@@ -5126,7 +5126,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wast"
-version = "36.0.9"
+version = "36.0.10"
 dependencies = [
  "anyhow",
  "json-from-wast",
@@ -5204,7 +5204,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "36.0.9"
+version = "36.0.10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5221,7 +5221,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "36.0.9"
+version = "36.0.10"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -5233,7 +5233,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "36.0.9"
+version = "36.0.10"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5288,7 +5288,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "36.0.9"
+version = "36.0.10"
 dependencies = [
  "anyhow",
  "cranelift-assembler-x64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -174,7 +174,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "36.0.9"
+version = "36.0.10"
 authors = ["The Wasmtime Project Developers"]
 edition = "2024"
 # Wasmtime's current policy is that this number can be no larger than the
@@ -226,19 +226,19 @@ redundant_field_names = 'warn'
 # tooling but aren't intended to be widely depended on.
 #
 # All of these crates are supported though in the sense that
-wasmtime = { path = "crates/wasmtime", version = "36.0.9", default-features = false }
-wasmtime-cli-flags = { path = "crates/cli-flags", version = "=36.0.9" }
-wasmtime-environ = { path = "crates/environ", version = "=36.0.9" }
-wasmtime-wasi = { path = "crates/wasi", version = "36.0.9", default-features = false }
-wasmtime-wasi-io = { path = "crates/wasi-io", version = "36.0.9", default-features = false }
-wasmtime-wasi-http = { path = "crates/wasi-http", version = "36.0.9", default-features = false }
-wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "36.0.9" }
-wasmtime-wasi-config = { path = "crates/wasi-config", version = "36.0.9" }
-wasmtime-wasi-keyvalue = { path = "crates/wasi-keyvalue", version = "36.0.9" }
-wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "36.0.9" }
-wasmtime-wasi-tls = { path = "crates/wasi-tls", version = "36.0.9" }
-wasmtime-wasi-tls-nativetls = { path = "crates/wasi-tls-nativetls", version = "36.0.9" }
-wasmtime-wast = { path = "crates/wast", version = "=36.0.9" }
+wasmtime = { path = "crates/wasmtime", version = "36.0.10", default-features = false }
+wasmtime-cli-flags = { path = "crates/cli-flags", version = "=36.0.10" }
+wasmtime-environ = { path = "crates/environ", version = "=36.0.10" }
+wasmtime-wasi = { path = "crates/wasi", version = "36.0.10", default-features = false }
+wasmtime-wasi-io = { path = "crates/wasi-io", version = "36.0.10", default-features = false }
+wasmtime-wasi-http = { path = "crates/wasi-http", version = "36.0.10", default-features = false }
+wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "36.0.10" }
+wasmtime-wasi-config = { path = "crates/wasi-config", version = "36.0.10" }
+wasmtime-wasi-keyvalue = { path = "crates/wasi-keyvalue", version = "36.0.10" }
+wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "36.0.10" }
+wasmtime-wasi-tls = { path = "crates/wasi-tls", version = "36.0.10" }
+wasmtime-wasi-tls-nativetls = { path = "crates/wasi-tls-nativetls", version = "36.0.10" }
+wasmtime-wast = { path = "crates/wast", version = "=36.0.10" }
 
 # Internal Wasmtime-specific crates.
 #
@@ -247,54 +247,54 @@ wasmtime-wast = { path = "crates/wast", version = "=36.0.9" }
 # that these are internal unsupported crates for external use. These exist as
 # part of the project organization of other public crates in Wasmtime and are
 # otherwise not supported in terms of CVEs for example.
-wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=36.0.9", package = 'wasmtime-internal-wmemcheck' }
-wasmtime-c-api-macros = { path = "crates/c-api-macros", version = "=36.0.9", package = 'wasmtime-internal-c-api-macros' }
-wasmtime-cache = { path = "crates/cache", version = "=36.0.9", package = 'wasmtime-internal-cache' }
-wasmtime-cranelift = { path = "crates/cranelift", version = "=36.0.9", package = 'wasmtime-internal-cranelift' }
-wasmtime-winch = { path = "crates/winch", version = "=36.0.9", package = 'wasmtime-internal-winch'  }
-wasmtime-explorer = { path = "crates/explorer", version = "=36.0.9", package = 'wasmtime-internal-explorer'  }
-wasmtime-fiber = { path = "crates/fiber", version = "=36.0.9", package = 'wasmtime-internal-fiber' }
-wasmtime-jit-debug = { path = "crates/jit-debug", version = "=36.0.9", package = 'wasmtime-internal-jit-debug' }
-wasmtime-component-util = { path = "crates/component-util", version = "=36.0.9", package = 'wasmtime-internal-component-util' }
-wasmtime-component-macro = { path = "crates/component-macro", version = "=36.0.9", package = 'wasmtime-internal-component-macro' }
-wasmtime-asm-macros = { path = "crates/asm-macros", version = "=36.0.9", package = 'wasmtime-internal-asm-macros' }
-wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=36.0.9", package = 'wasmtime-internal-versioned-export-macros' }
-wasmtime-slab = { path = "crates/slab", version = "=36.0.9", package = 'wasmtime-internal-slab' }
-wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=36.0.9", package = 'wasmtime-internal-jit-icache-coherence' }
-wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=36.0.9", package = 'wasmtime-internal-wit-bindgen' }
-wasmtime-math = { path = "crates/math", version = "=36.0.9", package = 'wasmtime-internal-math'  }
-wasmtime-unwinder = { path = "crates/unwinder", version = "=36.0.9", package = 'wasmtime-internal-unwinder' }
+wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=36.0.10", package = 'wasmtime-internal-wmemcheck' }
+wasmtime-c-api-macros = { path = "crates/c-api-macros", version = "=36.0.10", package = 'wasmtime-internal-c-api-macros' }
+wasmtime-cache = { path = "crates/cache", version = "=36.0.10", package = 'wasmtime-internal-cache' }
+wasmtime-cranelift = { path = "crates/cranelift", version = "=36.0.10", package = 'wasmtime-internal-cranelift' }
+wasmtime-winch = { path = "crates/winch", version = "=36.0.10", package = 'wasmtime-internal-winch'  }
+wasmtime-explorer = { path = "crates/explorer", version = "=36.0.10", package = 'wasmtime-internal-explorer'  }
+wasmtime-fiber = { path = "crates/fiber", version = "=36.0.10", package = 'wasmtime-internal-fiber' }
+wasmtime-jit-debug = { path = "crates/jit-debug", version = "=36.0.10", package = 'wasmtime-internal-jit-debug' }
+wasmtime-component-util = { path = "crates/component-util", version = "=36.0.10", package = 'wasmtime-internal-component-util' }
+wasmtime-component-macro = { path = "crates/component-macro", version = "=36.0.10", package = 'wasmtime-internal-component-macro' }
+wasmtime-asm-macros = { path = "crates/asm-macros", version = "=36.0.10", package = 'wasmtime-internal-asm-macros' }
+wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=36.0.10", package = 'wasmtime-internal-versioned-export-macros' }
+wasmtime-slab = { path = "crates/slab", version = "=36.0.10", package = 'wasmtime-internal-slab' }
+wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=36.0.10", package = 'wasmtime-internal-jit-icache-coherence' }
+wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=36.0.10", package = 'wasmtime-internal-wit-bindgen' }
+wasmtime-math = { path = "crates/math", version = "=36.0.10", package = 'wasmtime-internal-math'  }
+wasmtime-unwinder = { path = "crates/unwinder", version = "=36.0.10", package = 'wasmtime-internal-unwinder' }
 
 # Miscellaneous crates without a `wasmtime-*` prefix in their name but still
 # used in the `wasmtime-*` family of crates depending on various features/etc.
-wiggle = { path = "crates/wiggle", version = "=36.0.9", default-features = false }
-wiggle-macro = { path = "crates/wiggle/macro", version = "=36.0.9" }
-wiggle-generate = { path = "crates/wiggle/generate", version = "=36.0.9" }
-wasi-common = { path = "crates/wasi-common", version = "=36.0.9", default-features = false }
-pulley-interpreter = { path = 'pulley', version = "=36.0.9" }
-pulley-macros = { path = 'pulley/macros', version = "=36.0.9" }
+wiggle = { path = "crates/wiggle", version = "=36.0.10", default-features = false }
+wiggle-macro = { path = "crates/wiggle/macro", version = "=36.0.10" }
+wiggle-generate = { path = "crates/wiggle/generate", version = "=36.0.10" }
+wasi-common = { path = "crates/wasi-common", version = "=36.0.10", default-features = false }
+pulley-interpreter = { path = 'pulley', version = "=36.0.10" }
+pulley-macros = { path = 'pulley/macros', version = "=36.0.10" }
 
 # Cranelift crates in this workspace
-cranelift-assembler-x64 = { path = "cranelift/assembler-x64", version = "0.123.9" }
-cranelift-codegen = { path = "cranelift/codegen", version = "0.123.9", default-features = false, features = ["std", "unwind"] }
-cranelift-frontend = { path = "cranelift/frontend", version = "0.123.9" }
-cranelift-entity = { path = "cranelift/entity", version = "0.123.9" }
-cranelift-native = { path = "cranelift/native", version = "0.123.9" }
-cranelift-module = { path = "cranelift/module", version = "0.123.9" }
-cranelift-interpreter = { path = "cranelift/interpreter", version = "0.123.9" }
-cranelift-reader = { path = "cranelift/reader", version = "0.123.9" }
+cranelift-assembler-x64 = { path = "cranelift/assembler-x64", version = "0.123.10" }
+cranelift-codegen = { path = "cranelift/codegen", version = "0.123.10", default-features = false, features = ["std", "unwind"] }
+cranelift-frontend = { path = "cranelift/frontend", version = "0.123.10" }
+cranelift-entity = { path = "cranelift/entity", version = "0.123.10" }
+cranelift-native = { path = "cranelift/native", version = "0.123.10" }
+cranelift-module = { path = "cranelift/module", version = "0.123.10" }
+cranelift-interpreter = { path = "cranelift/interpreter", version = "0.123.10" }
+cranelift-reader = { path = "cranelift/reader", version = "0.123.10" }
 cranelift-filetests = { path = "cranelift/filetests" }
-cranelift-object = { path = "cranelift/object", version = "0.123.9" }
-cranelift-jit = { path = "cranelift/jit", version = "0.123.9" }
+cranelift-object = { path = "cranelift/object", version = "0.123.10" }
+cranelift-jit = { path = "cranelift/jit", version = "0.123.10" }
 cranelift-fuzzgen = { path = "cranelift/fuzzgen" }
-cranelift-bforest = { path = "cranelift/bforest", version = "0.123.9" }
-cranelift-bitset = { path = "cranelift/bitset", version = "0.123.9" }
-cranelift-control = { path = "cranelift/control", version = "0.123.9" }
-cranelift-srcgen = { path = "cranelift/srcgen", version = "0.123.9" }
-cranelift = { path = "cranelift/umbrella", version = "0.123.9" }
+cranelift-bforest = { path = "cranelift/bforest", version = "0.123.10" }
+cranelift-bitset = { path = "cranelift/bitset", version = "0.123.10" }
+cranelift-control = { path = "cranelift/control", version = "0.123.10" }
+cranelift-srcgen = { path = "cranelift/srcgen", version = "0.123.10" }
+cranelift = { path = "cranelift/umbrella", version = "0.123.10" }
 
 # Winch crates in this workspace.
-winch-codegen = { path = "winch/codegen", version = "=36.0.9" }
+winch-codegen = { path = "winch/codegen", version = "=36.0.10" }
 
 # Internal crates not published to crates.io used in testing, builds, etc
 wasi-preview1-component-adapter = { path = "crates/wasi-preview1-component-adapter" }

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,6 +1,6 @@
 ## 36.0.10
 
-Unreleased.
+Released 2026-05-21.
 
 ### Fixed
 

--- a/cranelift/assembler-x64/Cargo.toml
+++ b/cranelift/assembler-x64/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-assembler-x64"
 description = "A Cranelift-specific x64 assembler"
-version = "0.123.9"
+version = "0.123.10"
 license = "Apache-2.0 WITH LLVM-exception"
 edition.workspace = true
 rust-version.workspace = true
@@ -16,7 +16,7 @@ arbtest = "0.3.1"
 capstone = { workspace = true }
 
 [build-dependencies]
-cranelift-assembler-x64-meta = { path = "meta", version = "0.123.9" }
+cranelift-assembler-x64-meta = { path = "meta", version = "0.123.10" }
 
 [lints]
 workspace = true

--- a/cranelift/assembler-x64/meta/Cargo.toml
+++ b/cranelift/assembler-x64/meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-assembler-x64-meta"
 description = "Generate a Cranelift-specific assembler for x64 instructions"
-version = "0.123.9"
+version = "0.123.10"
 license = "Apache-2.0 WITH LLVM-exception"
 edition.workspace = true
 rust-version.workspace = true

--- a/cranelift/bforest/Cargo.toml
+++ b/cranelift/bforest/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bforest"
-version = "0.123.9"
+version = "0.123.10"
 description = "A forest of B+-trees"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-bforest"

--- a/cranelift/bitset/Cargo.toml
+++ b/cranelift/bitset/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bitset"
-version = "0.123.9"
+version = "0.123.10"
 description = "Various bitset stuff for use inside Cranelift"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-bitset"

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen"
-version = "0.123.9"
+version = "0.123.10"
 description = "Low-level code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-codegen"
@@ -25,7 +25,7 @@ anyhow = { workspace = true, optional = true, features = ['std'] }
 bumpalo = "3"
 capstone = { workspace = true, optional = true }
 cranelift-assembler-x64 = { workspace = true }
-cranelift-codegen-shared = { path = "./shared", version = "0.123.9" }
+cranelift-codegen-shared = { path = "./shared", version = "0.123.10" }
 cranelift-entity = { workspace = true }
 cranelift-bforest = { workspace = true }
 cranelift-bitset = { workspace = true }
@@ -56,8 +56,8 @@ env_logger = { workspace = true }
 proptest = { workspace = true }
 
 [build-dependencies]
-cranelift-codegen-meta = { path = "meta", version = "0.123.9" }
-cranelift-isle = { path = "../isle/isle", version = "=0.123.9" }
+cranelift-codegen-meta = { path = "meta", version = "0.123.10" }
+cranelift-isle = { path = "../isle/isle", version = "=0.123.10" }
 
 [features]
 default = ["std", "unwind", "host-arch", "timing"]

--- a/cranelift/codegen/meta/Cargo.toml
+++ b/cranelift/codegen/meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-codegen-meta"
 authors = ["The Cranelift Project Developers"]
-version = "0.123.9"
+version = "0.123.10"
 description = "Metaprogram for cranelift-codegen code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
@@ -17,8 +17,8 @@ rustdoc-args = ["--document-private-items"]
 
 [dependencies]
 cranelift-srcgen = { workspace = true }
-cranelift-assembler-x64-meta = { path = "../../assembler-x64/meta", version = "0.123.9" }
-cranelift-codegen-shared = { path = "../shared", version = "0.123.9" }
+cranelift-assembler-x64-meta = { path = "../../assembler-x64/meta", version = "0.123.10" }
+cranelift-codegen-shared = { path = "../shared", version = "0.123.10" }
 pulley-interpreter = { workspace = true, optional = true }
 heck = "0.5.0"
 

--- a/cranelift/codegen/shared/Cargo.toml
+++ b/cranelift/codegen/shared/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen-shared"
-version = "0.123.9"
+version = "0.123.10"
 description = "For code shared between cranelift-codegen-meta and cranelift-codegen"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/control/Cargo.toml
+++ b/cranelift/control/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-control"
-version = "0.123.9"
+version = "0.123.10"
 description = "White-box fuzz testing framework"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/entity/Cargo.toml
+++ b/cranelift/entity/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-entity"
-version = "0.123.9"
+version = "0.123.10"
 description = "Data structures using entity references as mapping keys"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-entity"

--- a/cranelift/frontend/Cargo.toml
+++ b/cranelift/frontend/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-frontend"
-version = "0.123.9"
+version = "0.123.10"
 description = "Cranelift IR builder helper"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-frontend"

--- a/cranelift/interpreter/Cargo.toml
+++ b/cranelift/interpreter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-interpreter"
-version = "0.123.9"
+version = "0.123.10"
 authors = ["The Cranelift Project Developers"]
 description = "Interpret Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/isle/isle/Cargo.toml
+++ b/cranelift/isle/isle/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 name = "cranelift-isle"
 readme = "../README.md"
 repository = "https://github.com/bytecodealliance/wasmtime/tree/main/cranelift/isle"
-version = "0.123.9"
+version = "0.123.10"
 
 [lints]
 workspace = true

--- a/cranelift/jit/Cargo.toml
+++ b/cranelift/jit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-jit"
-version = "0.123.9"
+version = "0.123.10"
 authors = ["The Cranelift Project Developers"]
 description = "A JIT library backed by Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/module/Cargo.toml
+++ b/cranelift/module/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-module"
-version = "0.123.9"
+version = "0.123.10"
 authors = ["The Cranelift Project Developers"]
 description = "Support for linking functions and data with Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/native/Cargo.toml
+++ b/cranelift/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-native"
-version = "0.123.9"
+version = "0.123.10"
 authors = ["The Cranelift Project Developers"]
 description = "Support for targeting the host with Cranelift"
 documentation = "https://docs.rs/cranelift-native"

--- a/cranelift/object/Cargo.toml
+++ b/cranelift/object/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-object"
-version = "0.123.9"
+version = "0.123.10"
 authors = ["The Cranelift Project Developers"]
 description = "Emit Cranelift output to native object files with `object`"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/reader/Cargo.toml
+++ b/cranelift/reader/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-reader"
-version = "0.123.9"
+version = "0.123.10"
 description = "Cranelift textual IR reader"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-reader"

--- a/cranelift/serde/Cargo.toml
+++ b/cranelift/serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-serde"
-version = "0.123.9"
+version = "0.123.10"
 authors = ["The Cranelift Project Developers"]
 description = "Serializer/Deserializer for Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/srcgen/Cargo.toml
+++ b/cranelift/srcgen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-srcgen"
-version = "0.123.9"
+version = "0.123.10"
 authors = ["The Wasmtime Project Developers"]
 description = "Helper functions for generating Rust and ISLE files"
 license = "Apache-2.0 WITH LLVM-exception"

--- a/cranelift/umbrella/Cargo.toml
+++ b/cranelift/umbrella/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift"
-version = "0.123.9"
+version = "0.123.10"
 description = "Umbrella for commonly-used cranelift crates"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift"

--- a/crates/c-api/include/wasmtime.h
+++ b/crates/c-api/include/wasmtime.h
@@ -213,7 +213,7 @@
 /**
  * \brief Wasmtime version string.
  */
-#define WASMTIME_VERSION "36.0.9"
+#define WASMTIME_VERSION "36.0.10"
 /**
  * \brief Wasmtime major version number.
  */
@@ -225,6 +225,6 @@
 /**
  * \brief Wasmtime patch version number.
  */
-#define WASMTIME_VERSION_PATCH 9
+#define WASMTIME_VERSION_PATCH 10
 
 #endif // WASMTIME_API_H

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -49,6 +49,10 @@ audited_as = "0.123.7"
 version = "0.123.9"
 audited_as = "0.123.8"
 
+[[unpublished.cranelift]]
+version = "0.123.10"
+audited_as = "0.123.9"
+
 [[unpublished.cranelift-assembler-x64]]
 version = "0.121.0"
 audited_as = "0.120.0"
@@ -96,6 +100,10 @@ audited_as = "0.123.7"
 [[unpublished.cranelift-assembler-x64]]
 version = "0.123.9"
 audited_as = "0.123.8"
+
+[[unpublished.cranelift-assembler-x64]]
+version = "0.123.10"
+audited_as = "0.123.9"
 
 [[unpublished.cranelift-assembler-x64-meta]]
 version = "0.121.0"
@@ -145,6 +153,10 @@ audited_as = "0.123.7"
 version = "0.123.9"
 audited_as = "0.123.8"
 
+[[unpublished.cranelift-assembler-x64-meta]]
+version = "0.123.10"
+audited_as = "0.123.9"
+
 [[unpublished.cranelift-bforest]]
 version = "0.121.0"
 audited_as = "0.120.0"
@@ -192,6 +204,10 @@ audited_as = "0.123.7"
 [[unpublished.cranelift-bforest]]
 version = "0.123.9"
 audited_as = "0.123.8"
+
+[[unpublished.cranelift-bforest]]
+version = "0.123.10"
+audited_as = "0.123.9"
 
 [[unpublished.cranelift-bitset]]
 version = "0.121.0"
@@ -241,6 +257,10 @@ audited_as = "0.123.7"
 version = "0.123.9"
 audited_as = "0.123.8"
 
+[[unpublished.cranelift-bitset]]
+version = "0.123.10"
+audited_as = "0.123.9"
+
 [[unpublished.cranelift-codegen]]
 version = "0.121.0"
 audited_as = "0.120.0"
@@ -288,6 +308,10 @@ audited_as = "0.123.7"
 [[unpublished.cranelift-codegen]]
 version = "0.123.9"
 audited_as = "0.123.8"
+
+[[unpublished.cranelift-codegen]]
+version = "0.123.10"
+audited_as = "0.123.9"
 
 [[unpublished.cranelift-codegen-meta]]
 version = "0.121.0"
@@ -337,6 +361,10 @@ audited_as = "0.123.7"
 version = "0.123.9"
 audited_as = "0.123.8"
 
+[[unpublished.cranelift-codegen-meta]]
+version = "0.123.10"
+audited_as = "0.123.9"
+
 [[unpublished.cranelift-codegen-shared]]
 version = "0.121.0"
 audited_as = "0.120.0"
@@ -384,6 +412,10 @@ audited_as = "0.123.7"
 [[unpublished.cranelift-codegen-shared]]
 version = "0.123.9"
 audited_as = "0.123.8"
+
+[[unpublished.cranelift-codegen-shared]]
+version = "0.123.10"
+audited_as = "0.123.9"
 
 [[unpublished.cranelift-control]]
 version = "0.121.0"
@@ -433,6 +465,10 @@ audited_as = "0.123.7"
 version = "0.123.9"
 audited_as = "0.123.8"
 
+[[unpublished.cranelift-control]]
+version = "0.123.10"
+audited_as = "0.123.9"
+
 [[unpublished.cranelift-entity]]
 version = "0.121.0"
 audited_as = "0.120.0"
@@ -481,6 +517,10 @@ audited_as = "0.123.7"
 version = "0.123.9"
 audited_as = "0.123.8"
 
+[[unpublished.cranelift-entity]]
+version = "0.123.10"
+audited_as = "0.123.9"
+
 [[unpublished.cranelift-frontend]]
 version = "0.121.0"
 audited_as = "0.120.0"
@@ -529,6 +569,10 @@ audited_as = "0.123.7"
 version = "0.123.9"
 audited_as = "0.123.8"
 
+[[unpublished.cranelift-frontend]]
+version = "0.123.10"
+audited_as = "0.123.9"
+
 [[unpublished.cranelift-interpreter]]
 version = "0.121.0"
 audited_as = "0.120.0"
@@ -577,6 +621,10 @@ audited_as = "0.123.7"
 version = "0.123.9"
 audited_as = "0.123.8"
 
+[[unpublished.cranelift-interpreter]]
+version = "0.123.10"
+audited_as = "0.123.9"
+
 [[unpublished.cranelift-isle]]
 version = "0.121.0"
 audited_as = "0.120.0"
@@ -625,6 +673,10 @@ audited_as = "0.123.7"
 version = "0.123.9"
 audited_as = "0.123.8"
 
+[[unpublished.cranelift-isle]]
+version = "0.123.10"
+audited_as = "0.123.9"
+
 [[unpublished.cranelift-jit]]
 version = "0.121.0"
 audited_as = "0.120.0"
@@ -673,6 +725,10 @@ audited_as = "0.123.7"
 version = "0.123.9"
 audited_as = "0.123.8"
 
+[[unpublished.cranelift-jit]]
+version = "0.123.10"
+audited_as = "0.123.9"
+
 [[unpublished.cranelift-module]]
 version = "0.121.0"
 audited_as = "0.120.0"
@@ -721,6 +777,10 @@ audited_as = "0.123.7"
 version = "0.123.9"
 audited_as = "0.123.8"
 
+[[unpublished.cranelift-module]]
+version = "0.123.10"
+audited_as = "0.123.9"
+
 [[unpublished.cranelift-native]]
 version = "0.121.0"
 audited_as = "0.120.0"
@@ -769,6 +829,10 @@ audited_as = "0.123.7"
 version = "0.123.9"
 audited_as = "0.123.8"
 
+[[unpublished.cranelift-native]]
+version = "0.123.10"
+audited_as = "0.123.9"
+
 [[unpublished.cranelift-object]]
 version = "0.121.0"
 audited_as = "0.120.0"
@@ -817,6 +881,10 @@ audited_as = "0.123.7"
 version = "0.123.9"
 audited_as = "0.123.8"
 
+[[unpublished.cranelift-object]]
+version = "0.123.10"
+audited_as = "0.123.9"
+
 [[unpublished.cranelift-reader]]
 version = "0.121.0"
 audited_as = "0.120.0"
@@ -865,6 +933,10 @@ audited_as = "0.123.7"
 version = "0.123.9"
 audited_as = "0.123.8"
 
+[[unpublished.cranelift-reader]]
+version = "0.123.10"
+audited_as = "0.123.9"
+
 [[unpublished.cranelift-serde]]
 version = "0.121.0"
 audited_as = "0.120.0"
@@ -913,6 +985,10 @@ audited_as = "0.123.7"
 version = "0.123.9"
 audited_as = "0.123.8"
 
+[[unpublished.cranelift-serde]]
+version = "0.123.10"
+audited_as = "0.123.9"
+
 [[unpublished.cranelift-srcgen]]
 version = "0.121.0"
 audited_as = "0.120.0"
@@ -960,6 +1036,10 @@ audited_as = "0.123.7"
 [[unpublished.cranelift-srcgen]]
 version = "0.123.9"
 audited_as = "0.123.8"
+
+[[unpublished.cranelift-srcgen]]
+version = "0.123.10"
+audited_as = "0.123.9"
 
 [[unpublished.pulley-interpreter]]
 version = "34.0.0"
@@ -1008,6 +1088,10 @@ audited_as = "36.0.7"
 [[unpublished.pulley-interpreter]]
 version = "36.0.9"
 audited_as = "36.0.8"
+
+[[unpublished.pulley-interpreter]]
+version = "36.0.10"
+audited_as = "36.0.9"
 
 [[unpublished.pulley-macros]]
 version = "35.0.0"
@@ -1053,6 +1137,10 @@ audited_as = "36.0.7"
 version = "36.0.9"
 audited_as = "36.0.8"
 
+[[unpublished.pulley-macros]]
+version = "36.0.10"
+audited_as = "36.0.9"
+
 [[unpublished.wasi-common]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -1101,6 +1189,10 @@ audited_as = "36.0.7"
 version = "36.0.9"
 audited_as = "36.0.8"
 
+[[unpublished.wasi-common]]
+version = "36.0.10"
+audited_as = "36.0.9"
+
 [[unpublished.wasmtime]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -1148,6 +1240,10 @@ audited_as = "36.0.7"
 [[unpublished.wasmtime]]
 version = "36.0.9"
 audited_as = "36.0.8"
+
+[[unpublished.wasmtime]]
+version = "36.0.10"
+audited_as = "36.0.9"
 
 [[unpublished.wasmtime-asm-macros]]
 version = "34.0.0"
@@ -1213,6 +1309,10 @@ audited_as = "36.0.7"
 version = "36.0.9"
 audited_as = "36.0.8"
 
+[[unpublished.wasmtime-cli]]
+version = "36.0.10"
+audited_as = "36.0.9"
+
 [[unpublished.wasmtime-cli-flags]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -1260,6 +1360,10 @@ audited_as = "36.0.7"
 [[unpublished.wasmtime-cli-flags]]
 version = "36.0.9"
 audited_as = "36.0.8"
+
+[[unpublished.wasmtime-cli-flags]]
+version = "36.0.10"
+audited_as = "36.0.9"
 
 [[unpublished.wasmtime-component-macro]]
 version = "34.0.0"
@@ -1333,6 +1437,10 @@ audited_as = "36.0.7"
 version = "36.0.9"
 audited_as = "36.0.8"
 
+[[unpublished.wasmtime-environ]]
+version = "36.0.10"
+audited_as = "36.0.9"
+
 [[unpublished.wasmtime-explorer]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -1389,6 +1497,10 @@ audited_as = "36.0.7"
 version = "36.0.9"
 audited_as = "36.0.8"
 
+[[unpublished.wasmtime-internal-asm-macros]]
+version = "36.0.10"
+audited_as = "36.0.9"
+
 [[unpublished.wasmtime-internal-c-api-macros]]
 version = "36.0.0"
 audited_as = "35.0.0"
@@ -1428,6 +1540,10 @@ audited_as = "36.0.7"
 [[unpublished.wasmtime-internal-c-api-macros]]
 version = "36.0.9"
 audited_as = "36.0.8"
+
+[[unpublished.wasmtime-internal-c-api-macros]]
+version = "36.0.10"
+audited_as = "36.0.9"
 
 [[unpublished.wasmtime-internal-cache]]
 version = "36.0.0"
@@ -1469,6 +1585,10 @@ audited_as = "36.0.7"
 version = "36.0.9"
 audited_as = "36.0.8"
 
+[[unpublished.wasmtime-internal-cache]]
+version = "36.0.10"
+audited_as = "36.0.9"
+
 [[unpublished.wasmtime-internal-component-macro]]
 version = "36.0.0"
 audited_as = "35.0.0"
@@ -1508,6 +1628,10 @@ audited_as = "36.0.7"
 [[unpublished.wasmtime-internal-component-macro]]
 version = "36.0.9"
 audited_as = "36.0.8"
+
+[[unpublished.wasmtime-internal-component-macro]]
+version = "36.0.10"
+audited_as = "36.0.9"
 
 [[unpublished.wasmtime-internal-component-util]]
 version = "36.0.0"
@@ -1549,6 +1673,10 @@ audited_as = "36.0.7"
 version = "36.0.9"
 audited_as = "36.0.8"
 
+[[unpublished.wasmtime-internal-component-util]]
+version = "36.0.10"
+audited_as = "36.0.9"
+
 [[unpublished.wasmtime-internal-cranelift]]
 version = "36.0.0"
 audited_as = "35.0.0"
@@ -1588,6 +1716,10 @@ audited_as = "36.0.7"
 [[unpublished.wasmtime-internal-cranelift]]
 version = "36.0.9"
 audited_as = "36.0.8"
+
+[[unpublished.wasmtime-internal-cranelift]]
+version = "36.0.10"
+audited_as = "36.0.9"
 
 [[unpublished.wasmtime-internal-explorer]]
 version = "36.0.0"
@@ -1629,6 +1761,10 @@ audited_as = "36.0.7"
 version = "36.0.9"
 audited_as = "36.0.8"
 
+[[unpublished.wasmtime-internal-explorer]]
+version = "36.0.10"
+audited_as = "36.0.9"
+
 [[unpublished.wasmtime-internal-fiber]]
 version = "36.0.0"
 audited_as = "35.0.0"
@@ -1668,6 +1804,10 @@ audited_as = "36.0.7"
 [[unpublished.wasmtime-internal-fiber]]
 version = "36.0.9"
 audited_as = "36.0.8"
+
+[[unpublished.wasmtime-internal-fiber]]
+version = "36.0.10"
+audited_as = "36.0.9"
 
 [[unpublished.wasmtime-internal-jit-debug]]
 version = "36.0.0"
@@ -1709,6 +1849,10 @@ audited_as = "36.0.7"
 version = "36.0.9"
 audited_as = "36.0.8"
 
+[[unpublished.wasmtime-internal-jit-debug]]
+version = "36.0.10"
+audited_as = "36.0.9"
+
 [[unpublished.wasmtime-internal-jit-icache-coherence]]
 version = "36.0.0"
 audited_as = "35.0.0"
@@ -1749,6 +1893,10 @@ audited_as = "36.0.7"
 version = "36.0.9"
 audited_as = "36.0.8"
 
+[[unpublished.wasmtime-internal-jit-icache-coherence]]
+version = "36.0.10"
+audited_as = "36.0.9"
+
 [[unpublished.wasmtime-internal-math]]
 version = "36.0.0"
 audited_as = "35.0.0"
@@ -1789,6 +1937,10 @@ audited_as = "36.0.7"
 version = "36.0.9"
 audited_as = "36.0.8"
 
+[[unpublished.wasmtime-internal-math]]
+version = "36.0.10"
+audited_as = "36.0.9"
+
 [[unpublished.wasmtime-internal-slab]]
 version = "36.0.0"
 audited_as = "35.0.0"
@@ -1829,6 +1981,10 @@ audited_as = "36.0.7"
 version = "36.0.9"
 audited_as = "36.0.8"
 
+[[unpublished.wasmtime-internal-slab]]
+version = "36.0.10"
+audited_as = "36.0.9"
+
 [[unpublished.wasmtime-internal-unwinder]]
 version = "36.0.0"
 audited_as = "35.0.0"
@@ -1869,6 +2025,10 @@ audited_as = "36.0.7"
 version = "36.0.9"
 audited_as = "36.0.8"
 
+[[unpublished.wasmtime-internal-unwinder]]
+version = "36.0.10"
+audited_as = "36.0.9"
+
 [[unpublished.wasmtime-internal-versioned-export-macros]]
 version = "36.0.0"
 audited_as = "35.0.0"
@@ -1909,6 +2069,10 @@ audited_as = "36.0.7"
 version = "36.0.9"
 audited_as = "36.0.8"
 
+[[unpublished.wasmtime-internal-versioned-export-macros]]
+version = "36.0.10"
+audited_as = "36.0.9"
+
 [[unpublished.wasmtime-internal-winch]]
 version = "36.0.0"
 audited_as = "35.0.0"
@@ -1949,6 +2113,10 @@ audited_as = "36.0.7"
 version = "36.0.9"
 audited_as = "36.0.8"
 
+[[unpublished.wasmtime-internal-winch]]
+version = "36.0.10"
+audited_as = "36.0.9"
+
 [[unpublished.wasmtime-internal-wit-bindgen]]
 version = "36.0.0"
 audited_as = "35.0.0"
@@ -1989,6 +2157,10 @@ audited_as = "36.0.7"
 version = "36.0.9"
 audited_as = "36.0.8"
 
+[[unpublished.wasmtime-internal-wit-bindgen]]
+version = "36.0.10"
+audited_as = "36.0.9"
+
 [[unpublished.wasmtime-internal-wmemcheck]]
 version = "36.0.0"
 audited_as = "35.0.0"
@@ -2028,6 +2200,10 @@ audited_as = "36.0.7"
 [[unpublished.wasmtime-internal-wmemcheck]]
 version = "36.0.9"
 audited_as = "36.0.8"
+
+[[unpublished.wasmtime-internal-wmemcheck]]
+version = "36.0.10"
+audited_as = "36.0.9"
 
 [[unpublished.wasmtime-jit-debug]]
 version = "34.0.0"
@@ -2109,6 +2285,10 @@ audited_as = "36.0.7"
 version = "36.0.9"
 audited_as = "36.0.8"
 
+[[unpublished.wasmtime-wasi]]
+version = "36.0.10"
+audited_as = "36.0.9"
+
 [[unpublished.wasmtime-wasi-config]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -2157,6 +2337,10 @@ audited_as = "36.0.7"
 version = "36.0.9"
 audited_as = "36.0.8"
 
+[[unpublished.wasmtime-wasi-config]]
+version = "36.0.10"
+audited_as = "36.0.9"
+
 [[unpublished.wasmtime-wasi-http]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -2205,6 +2389,10 @@ audited_as = "36.0.7"
 version = "36.0.9"
 audited_as = "36.0.8"
 
+[[unpublished.wasmtime-wasi-http]]
+version = "36.0.10"
+audited_as = "36.0.9"
+
 [[unpublished.wasmtime-wasi-io]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -2253,6 +2441,10 @@ audited_as = "36.0.7"
 version = "36.0.9"
 audited_as = "36.0.8"
 
+[[unpublished.wasmtime-wasi-io]]
+version = "36.0.10"
+audited_as = "36.0.9"
+
 [[unpublished.wasmtime-wasi-keyvalue]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -2301,6 +2493,10 @@ audited_as = "36.0.7"
 version = "36.0.9"
 audited_as = "36.0.8"
 
+[[unpublished.wasmtime-wasi-keyvalue]]
+version = "36.0.10"
+audited_as = "36.0.9"
+
 [[unpublished.wasmtime-wasi-nn]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -2349,6 +2545,10 @@ audited_as = "36.0.7"
 version = "36.0.9"
 audited_as = "36.0.8"
 
+[[unpublished.wasmtime-wasi-nn]]
+version = "36.0.10"
+audited_as = "36.0.9"
+
 [[unpublished.wasmtime-wasi-threads]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -2397,6 +2597,10 @@ audited_as = "36.0.7"
 version = "36.0.9"
 audited_as = "36.0.8"
 
+[[unpublished.wasmtime-wasi-threads]]
+version = "36.0.10"
+audited_as = "36.0.9"
+
 [[unpublished.wasmtime-wasi-tls]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -2444,6 +2648,10 @@ audited_as = "36.0.7"
 [[unpublished.wasmtime-wasi-tls]]
 version = "36.0.9"
 audited_as = "36.0.8"
+
+[[unpublished.wasmtime-wasi-tls]]
+version = "36.0.10"
+audited_as = "36.0.9"
 
 [[unpublished.wasmtime-wasi-tls-nativetls]]
 version = "36.0.0"
@@ -2485,6 +2693,10 @@ audited_as = "36.0.7"
 version = "36.0.9"
 audited_as = "36.0.8"
 
+[[unpublished.wasmtime-wasi-tls-nativetls]]
+version = "36.0.10"
+audited_as = "36.0.9"
+
 [[unpublished.wasmtime-wast]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -2532,6 +2744,10 @@ audited_as = "36.0.7"
 [[unpublished.wasmtime-wast]]
 version = "36.0.9"
 audited_as = "36.0.8"
+
+[[unpublished.wasmtime-wast]]
+version = "36.0.10"
+audited_as = "36.0.9"
 
 [[unpublished.wasmtime-winch]]
 version = "34.0.0"
@@ -2605,6 +2821,10 @@ audited_as = "36.0.7"
 version = "36.0.9"
 audited_as = "36.0.8"
 
+[[unpublished.wiggle]]
+version = "36.0.10"
+audited_as = "36.0.9"
+
 [[unpublished.wiggle-generate]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -2653,6 +2873,10 @@ audited_as = "36.0.7"
 version = "36.0.9"
 audited_as = "36.0.8"
 
+[[unpublished.wiggle-generate]]
+version = "36.0.10"
+audited_as = "36.0.9"
+
 [[unpublished.wiggle-macro]]
 version = "34.0.0"
 audited_as = "33.0.0"
@@ -2700,6 +2924,10 @@ audited_as = "36.0.7"
 [[unpublished.wiggle-macro]]
 version = "36.0.9"
 audited_as = "36.0.8"
+
+[[unpublished.wiggle-macro]]
+version = "36.0.10"
+audited_as = "36.0.9"
 
 [[unpublished.wiggle-test]]
 version = "0.0.0"
@@ -2752,6 +2980,10 @@ audited_as = "36.0.7"
 [[unpublished.winch-codegen]]
 version = "36.0.9"
 audited_as = "36.0.8"
+
+[[unpublished.winch-codegen]]
+version = "36.0.10"
+audited_as = "36.0.9"
 
 [[publisher.aho-corasick]]
 version = "1.0.2"
@@ -4487,7 +4719,7 @@ who = "Manish Goregaokar <manishsmail@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 1139 # Manish Goregaokar (Manishearth)
 start = "2019-05-15"
-end = "2026-02-01"
+end = "2027-04-23"
 notes = "All code written or reviewed by Manish"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
@@ -4505,7 +4737,7 @@ who = "Manish Goregaokar <manishsmail@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 1139 # Manish Goregaokar (Manishearth)
 start = "2019-07-25"
-end = "2026-02-01"
+end = "2027-04-23"
 notes = "All code written or reviewed by Manish"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 


### PR DESCRIPTION
This is an [automated pull request][process] from CI to create a patch release for Wasmtime 36.0.10, requested by @pchickey.

It's recommended that maintainers double-check that [RELEASES.md] is up-to-date and that there are no known issues before merging this PR. When this PR is merged a release tag will automatically be created, crates will be published, and CI artifacts will be produced.

[RELEASES.md]: https://github.com/bytecodealliance/wasmtime/blob/release-36.0.10/RELEASES.md
[process]: https://docs.wasmtime.dev/contributing-release-process.html
