### PR TITLE
Route GC arrays through `translate_entity_*`

### DIFF
--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -7,7 +7,10 @@ use crate::translate::{
     TableSize, TargetEnvironment,
 };
 use crate::trap::TranslateTrap;
-use crate::{BuiltinFunctionSignatures, TRAP_ARRAY_OUT_OF_BOUNDS, TRAP_TABLE_OUT_OF_BOUNDS};
+use crate::{
+    BuiltinFunctionSignatures, TRAP_ARRAY_OUT_OF_BOUNDS, TRAP_GC_HEAP_CORRUPT,
+    TRAP_TABLE_OUT_OF_BOUNDS,
+};
 use cranelift_codegen::cursor::FuncCursor;
 use cranelift_codegen::ir::condcodes::{FloatCC, IntCC};
 use cranelift_codegen::ir::immediates::{Imm64, Offset32, V128Imm};
@@ -2835,14 +2838,21 @@ impl FuncEnvironment<'_> {
         src_index: ir::Value,
         len: ir::Value,
     ) -> WasmResult<()> {
-        gc::translate_array_copy(
-            self,
+        let dst_ty = self.module.types[dst_array_type_index].unwrap_module_type_index();
+        let src_ty = self.module.types[src_array_type_index].unwrap_module_type_index();
+        self.translate_entity_copy(
             builder,
-            dst_array_type_index,
-            dst_array,
+            CheckedEntity::Array {
+                ty: dst_ty,
+                array: dst_array,
+                initialized: true,
+            },
+            CheckedEntity::Array {
+                ty: src_ty,
+                array: src_array,
+                initialized: true,
+            },
             dst_index,
-            src_array_type_index,
-            src_array,
             src_index,
             len,
         )
@@ -2857,7 +2867,18 @@ impl FuncEnvironment<'_> {
         value: ir::Value,
         len: ir::Value,
     ) -> WasmResult<()> {
-        gc::translate_array_fill(self, builder, array_type_index, array, index, value, len)
+        let ty = self.module.types[array_type_index].unwrap_module_type_index();
+        self.translate_entity_fill(
+            builder,
+            CheckedEntity::Array {
+                ty,
+                array,
+                initialized: true,
+            },
+            index,
+            value,
+            len,
+        )
     }
 
     pub fn translate_array_init_data(
@@ -2870,13 +2891,20 @@ impl FuncEnvironment<'_> {
         data_offset: ir::Value,
         len: ir::Value,
     ) -> WasmResult<()> {
-        gc::translate_array_init_data(
-            self,
+        let ty = self.module.types[array_type_index].unwrap_module_type_index();
+        let array_layout = self.array_layout(ty)?.clone();
+        self.translate_entity_copy(
             builder,
-            array_type_index,
-            array,
+            CheckedEntity::Array {
+                array,
+                ty,
+                initialized: true,
+            },
+            CheckedEntity::Data {
+                segment: data_index,
+                element_size: array_layout.elem_size,
+            },
             dst_index,
-            data_index,
             data_offset,
             len,
         )
@@ -3600,7 +3628,7 @@ impl FuncEnvironment<'_> {
         let idx_type = entity.index_type(self);
 
         // Bounds check `dst+len` and convert it to a raw heap address.
-        let raw_dst_addr = self.translate_entity_bounds_check(builder, entity, dst, len);
+        let raw_dst_addr = self.translate_entity_bounds_check(builder, entity, dst, len)?;
 
         // Fit the `len` value to `pointer_type`. Note that at this point it's
         // guaranteed inbounds so there's no loss in precision.
@@ -3630,8 +3658,24 @@ impl FuncEnvironment<'_> {
                     },
                 )?;
             }
-            CheckedEntity::Array(_) => todo!(),
-            CheckedEntity::Data(_) => unreachable!(),
+            CheckedEntity::Array { initialized, .. } => {
+                let elem_ty = entity.storage_type(self);
+                self.emit_raw_array_or_table_fill(
+                    builder,
+                    entity,
+                    raw_dst_addr,
+                    val,
+                    len_ptr,
+                    &|env, builder, addr, value| {
+                        if initialized {
+                            gc::write_field_at_addr(env, builder, elem_ty, addr, value)
+                        } else {
+                            gc::init_field_at_addr(env, builder, elem_ty, addr, value)
+                        }
+                    },
+                )?;
+            }
+            CheckedEntity::Data { .. } => unreachable!(),
         }
 
         Ok(())
@@ -3670,8 +3714,11 @@ impl FuncEnvironment<'_> {
         assert_eq!(builder.func.dfg.value_type(dst_elem_addr), pointer_ty);
         assert_eq!(builder.func.dfg.value_type(copy_len), pointer_ty);
         let elem_ty = entity.storage_type(self);
-        let elem_size = entity.element_size(self, builder.func);
+        let elem_size = entity.element_size(self, builder.func)?;
         let copy_byte_len = builder.ins().imul_imm(copy_len, i64::from(elem_size));
+        if let CheckedEntity::Array { .. } = entity {
+            self.emit_defensive_array_bounds_check(builder, dst_elem_addr, copy_byte_len)?;
+        }
 
         // If this is a byte array then specialize its fill to use the same
         // libcall as `memory.fill`. This gets us to `memset` on the host which
@@ -3831,7 +3878,17 @@ impl FuncEnvironment<'_> {
         len: ir::Value,
     ) -> WasmResult<()> {
         let seg_index = DataIndex::from_u32(seg_index);
-        self.translate_entity_copy(builder, memory_index, seg_index, dst, src, len)
+        self.translate_entity_copy(
+            builder,
+            memory_index,
+            CheckedEntity::Data {
+                segment: seg_index,
+                element_size: 1,
+            },
+            dst,
+            src,
+            len,
+        )
     }
 
     pub fn translate_data_drop(&mut self, mut pos: FuncCursor, seg_index: u32) -> WasmResult<()> {
@@ -3908,8 +3965,8 @@ impl FuncEnvironment<'_> {
 
         // Perform a bounds check for the src/dst entities and compute the raw
         // heap addresses at the same time.
-        let dst_raw_addr = self.translate_entity_bounds_check(builder, dst_entity, dst, dst_len);
-        let src_raw_addr = self.translate_entity_bounds_check(builder, src_entity, src, src_len);
+        let dst_raw_addr = self.translate_entity_bounds_check(builder, dst_entity, dst, dst_len)?;
+        let src_raw_addr = self.translate_entity_bounds_check(builder, src_entity, src, src_len)?;
 
         // Fit the `len` value to `pointer_type`. Note that at this point it's
         // guaranteed inbounds so there's no loss in precision.
@@ -3921,7 +3978,7 @@ impl FuncEnvironment<'_> {
             CheckedEntity::Memory(_) => {
                 assert!(matches!(
                     src_entity,
-                    CheckedEntity::Memory(_) | CheckedEntity::Data(_)
+                    CheckedEntity::Memory(_) | CheckedEntity::Data { .. }
                 ));
                 self.raw_bulk_memory_operation(
                     builder,
@@ -3934,18 +3991,15 @@ impl FuncEnvironment<'_> {
                 Ok(())
             }
 
-            // Tables are sometimes a memcpy, sometimes a per-element loop.
-            // Delegate further to figure that out.
-            CheckedEntity::Table(dst_table) => {
-                let CheckedEntity::Table(src_table) = src_entity else {
-                    unreachable!();
-                };
-                let dst_table = self.get_or_create_table(builder.func, dst_table);
-                let src_table = self.get_or_create_table(builder.func, src_table);
-                assert_eq!(dst_table.element_size, src_table.element_size);
+            // Tables/arrays are sometimes a memcpy, sometimes a per-element
+            // loop. Delegate further to figure that out.
+            CheckedEntity::Table(_) | CheckedEntity::Array { .. } => {
+                let src_size = src_entity.element_size(self, builder.func)?;
+                let dst_size = dst_entity.element_size(self, builder.func)?;
+                assert_eq!(src_size, dst_size);
                 let one_elem_size = builder
                     .ins()
-                    .iconst(self.pointer_type(), i64::from(dst_table.element_size));
+                    .iconst(self.pointer_type(), i64::from(src_size));
                 self.emit_raw_array_or_table_copy(
                     builder,
                     dst_entity,
@@ -3957,11 +4011,9 @@ impl FuncEnvironment<'_> {
                     src,
                 )
             }
-            // Note that future refactorings will fill this out soon.
-            CheckedEntity::Array(_) => todo!(),
 
             // Cannot copy into a data segment in wasm.
-            CheckedEntity::Data(_) => unreachable!(),
+            CheckedEntity::Data { .. } => unreachable!(),
         }
     }
 
@@ -3975,7 +4027,7 @@ impl FuncEnvironment<'_> {
         entity: impl Into<CheckedEntity>,
         idx: ir::Value,
         len: ir::Value,
-    ) -> ir::Value {
+    ) -> WasmResult<ir::Value> {
         let entity = entity.into();
         let pointer_type = self.pointer_type();
         let idx_type = entity.index_type(self);
@@ -3990,7 +4042,8 @@ impl FuncEnvironment<'_> {
                 let size = self.translate_table_size(builder.cursor(), i);
                 self.unchecked_cast_wasm_addr_to_native_addr(&mut builder.cursor(), size, idx_type)
             }
-            CheckedEntity::Data(i) => match self.translation.passive_data_map[i] {
+            CheckedEntity::Data { segment, .. } => match self.translation.passive_data_map[segment]
+            {
                 Some(passive_index) => {
                     let vmctx = self.vmctx_val(&mut builder.cursor());
                     let offset =
@@ -4005,8 +4058,10 @@ impl FuncEnvironment<'_> {
                 }
                 None => builder.ins().iconst(pointer_type, 0),
             },
-            // Note that future refactorings will fill this out soon.
-            CheckedEntity::Array(_) => todo!(),
+            CheckedEntity::Array { array, .. } => {
+                let len = self.translate_array_len(builder, array)?;
+                self.unchecked_cast_wasm_addr_to_native_addr(&mut builder.cursor(), len, idx_type)
+            }
         };
         assert_eq!(builder.func.dfg.value_type(entity_size), pointer_type);
 
@@ -4016,13 +4071,26 @@ impl FuncEnvironment<'_> {
         //
         // Note that addition can't overflow after extending 32-bits to
         // 64-bits, so no need to check for overflow in the 32-bit index case.
+        //
+        // Also note that data segments are a little special here where their
+        // `idx` offset is in bytes, but the `len` length of the copy is in
+        // units of elements. Handle that here by factoring a size into the
+        // length.
+        let len_factor = match entity {
+            CheckedEntity::Data { element_size, .. } => element_size,
+            _ => 1,
+        };
         let end64 = match idx_type {
             IndexType::I32 => {
                 let idx64 = builder.ins().uextend(I64, idx);
                 let len64 = builder.ins().uextend(I64, len);
+                let len64 = builder.ins().imul_imm(len64, i64::from(len_factor));
                 builder.ins().iadd(idx64, len64)
             }
-            IndexType::I64 => self.uadd_overflow_trap(builder, idx, len, trap_code),
+            IndexType::I64 => {
+                assert_eq!(len_factor, 1); // not possible at this time
+                self.uadd_overflow_trap(builder, idx, len, trap_code)
+            }
         };
 
         // Cast the host-pointer width to a 64-bit bit width.
@@ -4041,48 +4109,65 @@ impl FuncEnvironment<'_> {
         self.trapnz(builder, inbounds, trap_code);
 
         // Compute the actual raw heap address to return
-        let (base, elem_size) = match entity {
+        let base = match entity {
             CheckedEntity::Memory(i) => {
                 let heap = self.get_or_create_heap(builder.func, i);
                 let heap = &self.heaps()[heap];
-                (builder.ins().global_value(pointer_type, heap.base), 1)
+                builder.ins().global_value(pointer_type, heap.base)
             }
             CheckedEntity::Table(i) => {
                 let table = self.get_or_create_table(builder.func, i);
-                (
-                    builder.ins().global_value(pointer_type, table.base_gv),
-                    table.element_size,
-                )
+                builder.ins().global_value(pointer_type, table.base_gv)
             }
-            CheckedEntity::Data(i) => match self.translation.passive_data_map[i] {
+            CheckedEntity::Data { segment, .. } => match self.translation.passive_data_map[segment]
+            {
                 Some(passive_index) => {
                     let vmctx = self.vmctx_val(&mut builder.cursor());
                     let offset =
                         i32::try_from(self.offsets.vmctx_passive_data_base(passive_index)).unwrap();
-                    let base = builder.ins().load(
+                    builder.ins().load(
                         self.pointer_type(),
                         ir::MemFlagsData::trusted(),
                         vmctx,
                         offset,
-                    );
-                    (base, 1)
+                    )
                 }
 
                 // Any address should do for an active data segment, but pick
                 // something non-null for now. Note that the length of an active
                 // data segment is always 0, so we know that the memcpy, if any,
                 // will be 0 elements, so the actual value here doesn't matter.
-                None => (builder.ins().iconst(pointer_type, 1), 1),
+                None => builder.ins().iconst(pointer_type, 1),
             },
-            // Note that future refactorings will fill this out soon.
-            CheckedEntity::Array(_) => todo!(),
+            CheckedEntity::Array { array, ty, .. } => {
+                let base = self.get_gc_heap_base(builder)?;
+                let array = self.unchecked_cast_wasm_addr_to_native_addr(
+                    &mut builder.cursor(),
+                    array,
+                    IndexType::I32,
+                );
+                let array_base = builder.ins().iadd(base, array);
+                let layout = self.array_layout(ty)?;
+                builder
+                    .ins()
+                    .iadd_imm(array_base, i64::from(layout.base_size))
+            }
         };
         assert_eq!(builder.func.dfg.value_type(base), pointer_type);
         let idx =
             self.unchecked_cast_wasm_addr_to_native_addr(&mut builder.cursor(), idx, idx_type);
         assert_eq!(builder.func.dfg.value_type(idx), pointer_type);
-        let byte_offset = builder.ins().imul_imm(idx, i64::from(elem_size));
-        builder.ins().iadd(base, byte_offset)
+
+        // Like above data segments are a bit special here -- despite possibly
+        // having a >1 element size the `idx` offset is always a byte offset.
+        let byte_offset = match entity {
+            CheckedEntity::Data { .. } => idx,
+            _ => {
+                let elem_size = entity.element_size(self, builder.func)?;
+                builder.ins().imul_imm(idx, i64::from(elem_size))
+            }
+        };
+        Ok(builder.ins().iadd(base, byte_offset))
     }
 
     pub fn translate_table_copy(
@@ -4150,9 +4235,9 @@ impl FuncEnvironment<'_> {
                 // type. If it is then barriers might be needed, meaning memcpy
                 // can't be used.
                 //
-                // FIXME: should add a method to `GcCompiler` to detect when
-                // the compiler doesn't actually need barriers, in which case
-                // memcpy is fine.
+                // FIXME: should add a method to `GcCompiler` to detect when the
+                // compiler doesn't actually need barriers, in which case memcpy
+                // is fine.
                 WasmHeapTopType::Extern
                 | WasmHeapTopType::Any
                 | WasmHeapTopType::Exn
@@ -4169,17 +4254,24 @@ impl FuncEnvironment<'_> {
                     CheckedEntity::Table(_) => self.tunables.table_lazy_init,
                     // The GC heap has integers representing funcrefs, so memcpy
                     // is fine.
-                    CheckedEntity::Array(_) => false,
+                    CheckedEntity::Array { .. } => false,
                     // Not possible
-                    CheckedEntity::Memory(_) | CheckedEntity::Data(_) => unreachable!(),
+                    CheckedEntity::Memory(_) | CheckedEntity::Data { .. } => unreachable!(),
                 },
             },
         };
 
+        let copy_byte_len = builder.ins().imul(one_elem_size, copy_len);
+        if let CheckedEntity::Array { .. } = dst_entity {
+            self.emit_defensive_array_bounds_check(builder, dst_elem_addr, copy_byte_len)?;
+        }
+        if let CheckedEntity::Array { .. } = dst_entity {
+            self.emit_defensive_array_bounds_check(builder, dst_elem_addr, copy_byte_len)?;
+        }
+
         // For memcpy, that's easy, just call the intrinsic with the right
         // parameters.
         if !type_forbids_memcpy {
-            let copy_byte_len = builder.ins().imul(one_elem_size, copy_len);
             self.raw_bulk_memory_operation(
                 builder,
                 BulkOp::MemoryCopy {
@@ -4210,7 +4302,8 @@ impl FuncEnvironment<'_> {
                     // `translate_table_get` which are a bit tricky with
                     // funcrefs.
                     CheckedEntity::Table(i) => this.translate_table_get(builder, i, src_index)?,
-                    CheckedEntity::Array(_) => {
+                    CheckedEntity::Array { initialized, .. } => {
+                        assert!(initialized);
                         gc::read_field_at_addr(this, builder, read_ty, src, None)?
                     }
                     CheckedEntity::Memory(_) | CheckedEntity::Data { .. } => unreachable!(),
@@ -4219,8 +4312,12 @@ impl FuncEnvironment<'_> {
                     CheckedEntity::Table(i) => {
                         this.emit_table_set(builder, i, dst, ir::MemFlagsData::trusted(), val)?;
                     }
-                    CheckedEntity::Array(_) => {
-                        gc::write_field_at_addr(this, builder, write_ty, dst, val)?
+                    CheckedEntity::Array { initialized, .. } => {
+                        if initialized {
+                            gc::write_field_at_addr(this, builder, write_ty, dst, val)?
+                        } else {
+                            gc::init_field_at_addr(this, builder, write_ty, dst, val)?
+                        }
                     }
                     CheckedEntity::Memory(_) | CheckedEntity::Data { .. } => unreachable!(),
                 }
@@ -4229,6 +4326,41 @@ impl FuncEnvironment<'_> {
             },
         )?;
 
+        Ok(())
+    }
+
+    /// For bulk operations (copies, fills, etc) this is an extra check layered
+    /// on the spec-defined bounds check that the address is in-bounds.
+    ///
+    /// This is intended to catch heap corruption where the length of the array
+    /// is corrupted, for example. The `base` being accessed, plus the
+    /// `byte_len` being accessed, must unconditionally be within the bounds of
+    /// the GC heap or else the previous bounds check passing and this failing
+    /// indicates GC heap corruption.
+    ///
+    /// This is required right now because GC array copies are done without the
+    /// same bounds checks of `array.get` and `array.set`, for example, meaning
+    /// that it isn't necessarily caught by the same faulting behavior of the
+    /// heap as usual. Additionally copies may happen in the host if `memcpy` or
+    /// `memset` is involved, in which case we definitely can't catch signals in
+    /// the host.
+    fn emit_defensive_array_bounds_check(
+        &mut self,
+        builder: &mut FunctionBuilder<'_>,
+        base: ir::Value,
+        byte_len: ir::Value,
+    ) -> WasmResult<()> {
+        let gc_heap_base = self.get_gc_heap_base(builder)?;
+        let gc_heap_bound = self.get_gc_heap_bound(builder)?;
+
+        let heap_end = builder.ins().iadd(gc_heap_base, gc_heap_bound);
+        let copy_end = builder
+            .ins()
+            .uadd_overflow_trap(base, byte_len, TRAP_GC_HEAP_CORRUPT);
+        let corrupt = builder
+            .ins()
+            .icmp(IntCC::UnsignedGreaterThan, copy_end, heap_end);
+        self.trapnz(builder, corrupt, TRAP_GC_HEAP_CORRUPT);
         Ok(())
     }
 
@@ -5251,14 +5383,28 @@ enum CheckedEntity {
     Memory(MemoryIndex),
     /// A WebAssembly table.
     Table(TableIndex),
-    /// A WebAssembly data segment.
-    Data(DataIndex),
+    /// A WebAssembly data segment loaded in chunks of `element_size` bytes.
+    ///
+    /// For `memory.init` this will have `element_size = 1`, but for
+    /// `array.init_data` for an `i16` array this'll have `element_size = 2` for
+    /// example.
+    Data {
+        /// The data segment being accessed.
+        segment: DataIndex,
+        /// The element size of the data segment being accessed, e.g. one byte
+        /// or possibly more for array initialization.
+        element_size: u32,
+    },
     /// An `arrayref` with the specified type.
-    #[cfg_attr(
-        not(feature = "gc"),
-        expect(dead_code, reason = "not worth the #[cfg]")
-    )]
-    Array(ModuleInternedTypeIndex),
+    Array {
+        /// The type of this array.
+        ty: ModuleInternedTypeIndex,
+        /// The `(ref array)` value.
+        array: ir::Value,
+        /// Whether or not this array is initialized already. For example this
+        /// is `false` during `array.new_*` instructions.
+        initialized: bool,
+    },
 }
 
 impl From<MemoryIndex> for CheckedEntity {
@@ -5273,42 +5419,43 @@ impl From<TableIndex> for CheckedEntity {
     }
 }
 
-impl From<DataIndex> for CheckedEntity {
-    fn from(data_index: DataIndex) -> Self {
-        CheckedEntity::Data(data_index)
-    }
-}
-
 impl CheckedEntity {
     /// Returns the type that's used to index this entity.
     fn index_type(&self, env: &FuncEnvironment) -> IndexType {
         match *self {
             CheckedEntity::Memory(i) => env.memory(i).idx_type,
             CheckedEntity::Table(i) => env.table(i).idx_type,
-            CheckedEntity::Data(_) | CheckedEntity::Array(_) => IndexType::I32,
+            CheckedEntity::Data { .. } | CheckedEntity::Array { .. } => IndexType::I32,
         }
     }
 
     /// Returns the size, in bytes, of an element in this entity.
-    fn element_size(&self, env: &mut FuncEnvironment<'_>, func: &mut ir::Function) -> u32 {
-        match *self {
-            CheckedEntity::Memory(_) | CheckedEntity::Data(_) => 1,
+    fn element_size(
+        &self,
+        env: &mut FuncEnvironment<'_>,
+        func: &mut ir::Function,
+    ) -> WasmResult<u32> {
+        Ok(match *self {
+            CheckedEntity::Memory(_) => 1,
+            CheckedEntity::Data { element_size, .. } => element_size,
             CheckedEntity::Table(table) => env.get_or_create_table(func, table).element_size,
-            #[cfg(feature = "gc")]
-            CheckedEntity::Array(ty) => env.array_layout(ty).elem_size,
-            #[cfg(not(feature = "gc"))]
-            CheckedEntity::Array(_) => unreachable!(),
-        }
+            CheckedEntity::Array { ty, .. } => env.array_layout(ty)?.elem_size,
+        })
     }
 
     /// Returns the WebAssembly type that's stored within this entity.
     fn storage_type(&self, env: &mut FuncEnvironment<'_>) -> WasmStorageType {
         match *self {
-            CheckedEntity::Memory(_) | CheckedEntity::Data(_) => WasmStorageType::I8,
+            CheckedEntity::Memory(_)
+            | CheckedEntity::Data {
+                element_size: 1, ..
+            } => WasmStorageType::I8,
+            // not used at this time.
+            CheckedEntity::Data { .. } => unreachable!(),
             CheckedEntity::Table(table) => {
                 WasmStorageType::Val(WasmValType::Ref(env.table(table).ref_type))
             }
-            CheckedEntity::Array(ty) => {
+            CheckedEntity::Array { ty, .. } => {
                 let array_ty = env.types.unwrap_array(ty).unwrap();
                 array_ty.0.element_type
             }
@@ -5318,9 +5465,11 @@ impl CheckedEntity {
     /// Returns the trap code to use when an index into this entity is out-of-bounds.
     fn oob_trap_code(&self) -> ir::TrapCode {
         match self {
-            CheckedEntity::Memory(_) | CheckedEntity::Data(_) => ir::TrapCode::HEAP_OUT_OF_BOUNDS,
+            CheckedEntity::Memory(_) | CheckedEntity::Data { .. } => {
+                ir::TrapCode::HEAP_OUT_OF_BOUNDS
+            }
             CheckedEntity::Table(_) => TRAP_TABLE_OUT_OF_BOUNDS,
-            CheckedEntity::Array(_) => TRAP_ARRAY_OUT_OF_BOUNDS,
+            CheckedEntity::Array { .. } => TRAP_ARRAY_OUT_OF_BOUNDS,
         }
     }
 
@@ -5328,7 +5477,9 @@ impl CheckedEntity {
     /// bit patterns.
     fn allows_memset(&self, env: &FuncEnvironment) -> bool {
         match self {
-            CheckedEntity::Memory(_) | CheckedEntity::Data(_) | CheckedEntity::Array(_) => true,
+            CheckedEntity::Memory(_) | CheckedEntity::Data { .. } | CheckedEntity::Array { .. } => {
+                true
+            }
             // Tables that are lazily initialized can't be memset because the
             // initialized bit needs to be set when storing values.
             CheckedEntity::Table(_) => !env.tunables.table_lazy_init,

--- a/crates/cranelift/src/func_environ/gc.rs
+++ b/crates/cranelift/src/func_environ/gc.rs
@@ -8,7 +8,9 @@
 use crate::func_environ::FuncEnvironment;
 use cranelift_codegen::ir;
 use cranelift_frontend::FunctionBuilder;
-use wasmtime_environ::{GcTypeLayouts, TagIndex, TypeIndex, WasmRefType, WasmResult};
+use wasmtime_environ::{
+    GcTypeLayouts, TagIndex, TypeIndex, WasmRefType, WasmResult, WasmStorageType,
+};
 
 #[cfg(feature = "gc")]
 mod enabled;
@@ -24,23 +26,6 @@ use disabled as imp;
 // based on the compile-time features enabled.
 pub use imp::*;
 
-/// How to initialize a newly-allocated array's elements.
-#[derive(Clone, Copy)]
-#[cfg_attr(
-    not(any(feature = "gc-drc", feature = "gc-null")),
-    allow(dead_code, reason = "easier to define")
-)]
-pub enum ArrayInit<'a> {
-    /// Initialize the array's elements with the given values.
-    Elems(&'a [ir::Value]),
-
-    /// Initialize the array's elements with `elem` repeated `len` times.
-    Fill { elem: ir::Value, len: ir::Value },
-
-    /// Don't initialize the elements, just allocate the array.
-    Uninit { len: ir::Value },
-}
-
 /// A trait for different collectors to emit any GC barriers they might require.
 pub trait GcCompiler {
     /// Get the GC type layouts for this GC compiler.
@@ -55,12 +40,12 @@ pub trait GcCompiler {
     /// The array should be of the given type and its elements initialized as
     /// described by the given `ArrayInit`.
     #[cfg_attr(not(feature = "gc"), allow(dead_code))]
-    fn alloc_array(
+    fn alloc_uninit_array(
         &mut self,
         func_env: &mut FuncEnvironment<'_>,
         builder: &mut FunctionBuilder<'_>,
         array_type_index: TypeIndex,
-        init: ArrayInit<'_>,
+        len: ir::Value,
     ) -> WasmResult<ir::Value>;
 
     /// Emit code to allocate a new struct.
@@ -175,6 +160,20 @@ pub trait GcCompiler {
         dst: ir::Value,
         new_val: ir::Value,
         flags: ir::MemFlagsData,
+    ) -> WasmResult<()>;
+
+    /// Stores `val` into `addr` with the `ty` specified.
+    ///
+    /// This initializes a previously-uninitialized field, so barriers on the
+    /// value previously stored at `addr`, if necessary, should not be executed.
+    #[cfg_attr(not(feature = "gc"), allow(dead_code))]
+    fn init_field(
+        &mut self,
+        func_env: &mut FuncEnvironment<'_>,
+        builder: &mut FunctionBuilder,
+        ty: WasmStorageType,
+        addr: ir::Value,
+        val: ir::Value,
     ) -> WasmResult<()>;
 }
 

--- a/crates/cranelift/src/func_environ/gc/disabled.rs
+++ b/crates/cranelift/src/func_environ/gc/disabled.rs
@@ -6,7 +6,8 @@ use cranelift_codegen::ir;
 use cranelift_frontend::FunctionBuilder;
 use smallvec::SmallVec;
 use wasmtime_environ::{
-    DataIndex, TagIndex, TypeIndex, WasmRefType, WasmResult, WasmStorageType, wasm_unsupported,
+    DataIndex, GcArrayLayout, ModuleInternedTypeIndex, TagIndex, TypeIndex, WasmRefType,
+    WasmResult, WasmStorageType, wasm_unsupported,
 };
 
 fn disabled<T>() -> WasmResult<T> {
@@ -114,18 +115,6 @@ pub fn translate_array_new_fixed(
     disabled()
 }
 
-pub fn translate_array_fill(
-    _func_env: &mut FuncEnvironment<'_>,
-    _builder: &mut FunctionBuilder<'_>,
-    _array_type_index: TypeIndex,
-    _array_ref: ir::Value,
-    _index: ir::Value,
-    _value: ir::Value,
-    _n: ir::Value,
-) -> WasmResult<()> {
-    disabled()
-}
-
 pub fn translate_array_len(
     _func_env: &mut FuncEnvironment<'_>,
     _builder: &mut FunctionBuilder,
@@ -166,20 +155,6 @@ pub fn translate_ref_test(
     disabled()
 }
 
-pub fn translate_array_copy(
-    _func_env: &mut FuncEnvironment<'_>,
-    _builder: &mut FunctionBuilder<'_>,
-    _dst_array_type_index: TypeIndex,
-    _dst_array: ir::Value,
-    _dst_index: ir::Value,
-    _src_array_type_index: TypeIndex,
-    _src_array: ir::Value,
-    _src_index: ir::Value,
-    _len: ir::Value,
-) -> WasmResult<()> {
-    disabled()
-}
-
 pub fn translate_array_new_data(
     _func_env: &mut FuncEnvironment<'_>,
     _builder: &mut FunctionBuilder,
@@ -188,19 +163,6 @@ pub fn translate_array_new_data(
     _data_offset: ir::Value,
     _len: ir::Value,
 ) -> WasmResult<ir::Value> {
-    disabled()
-}
-
-pub fn translate_array_init_data(
-    _func_env: &mut FuncEnvironment<'_>,
-    _builder: &mut FunctionBuilder,
-    _array_type_index: TypeIndex,
-    _array: ir::Value,
-    _dst_index: ir::Value,
-    _data_index: DataIndex,
-    _data_offset: ir::Value,
-    _len: ir::Value,
-) -> WasmResult<()> {
     disabled()
 }
 
@@ -222,4 +184,37 @@ pub fn write_field_at_addr(
     _new_val: ir::Value,
 ) -> WasmResult<()> {
     disabled()
+}
+
+pub fn init_field_at_addr(
+    _func_env: &mut FuncEnvironment<'_>,
+    _builder: &mut FunctionBuilder<'_>,
+    _field_ty: WasmStorageType,
+    _field_addr: ir::Value,
+    _new_val: ir::Value,
+) -> WasmResult<()> {
+    disabled()
+}
+
+impl FuncEnvironment<'_> {
+    pub(crate) fn array_layout(
+        &mut self,
+        _type_index: ModuleInternedTypeIndex,
+    ) -> WasmResult<&GcArrayLayout> {
+        disabled()
+    }
+
+    pub(crate) fn get_gc_heap_base(
+        &mut self,
+        _builder: &mut FunctionBuilder<'_>,
+    ) -> WasmResult<ir::Value> {
+        disabled()
+    }
+
+    pub(crate) fn get_gc_heap_bound(
+        &mut self,
+        _builder: &mut FunctionBuilder<'_>,
+    ) -> WasmResult<ir::Value> {
+        disabled()
+    }
 }

--- a/crates/cranelift/src/func_environ/gc/enabled.rs
+++ b/crates/cranelift/src/func_environ/gc/enabled.rs
@@ -1,7 +1,7 @@
-use super::{ArrayInit, GcCompiler};
+use super::GcCompiler;
 use crate::TRAP_ARRAY_OUT_OF_BOUNDS;
 use crate::bounds_checks::BoundsCheck;
-use crate::func_environ::{BulkOp, CheckedEntity, Extension, FuncEnvironment};
+use crate::func_environ::{CheckedEntity, Extension, FuncEnvironment};
 use crate::translate::{Heap, HeapData, MemoryKind, StructFieldsVec, TargetEnvironment};
 use crate::trap::TranslateTrap;
 use crate::{Reachability, TRAP_GC_HEAP_CORRUPT, TRAP_INTERNAL_ASSERT};
@@ -15,7 +15,7 @@ use cranelift_entity::packed_option::ReservedValue;
 use cranelift_frontend::FunctionBuilder;
 use smallvec::{SmallVec, smallvec};
 use wasmtime_environ::{
-    Collector, DataIndex, GcArrayLayout, GcLayout, GcStructLayout, I31_DISCRIMINANT, IndexType,
+    Collector, DataIndex, GcArrayLayout, GcLayout, GcStructLayout, I31_DISCRIMINANT,
     ModuleInternedTypeIndex, PtrSize, TagIndex, TypeIndex, VMGcKind, WasmCompositeInnerType,
     WasmHeapTopType, WasmHeapType, WasmRefType, WasmResult, WasmStorageType, WasmValType,
     wasm_unsupported,
@@ -319,6 +319,16 @@ fn write_func_ref_at_addr(
     builder.ins().store(flags, func_ref_id, field_addr, 0);
 
     Ok(())
+}
+
+pub fn init_field_at_addr(
+    func_env: &mut FuncEnvironment<'_>,
+    builder: &mut FunctionBuilder<'_>,
+    field_ty: WasmStorageType,
+    field_addr: ir::Value,
+    new_val: ir::Value,
+) -> WasmResult<()> {
+    gc_compiler(func_env)?.init_field(func_env, builder, field_ty, field_addr, new_val)
 }
 
 pub fn write_field_at_addr(
@@ -633,11 +643,20 @@ pub fn translate_array_new(
     len: ir::Value,
 ) -> WasmResult<ir::Value> {
     log::trace!("translate_array_new({array_type_index:?}, {elem:?}, {len:?})");
-    let result = gc_compiler(func_env)?.alloc_array(
-        func_env,
+    let result =
+        gc_compiler(func_env)?.alloc_uninit_array(func_env, builder, array_type_index, len)?;
+    let zero = builder.ins().iconst(ir::types::I32, 0);
+    let ty = func_env.module.types[array_type_index].unwrap_module_type_index();
+    func_env.translate_entity_fill(
         builder,
-        array_type_index,
-        ArrayInit::Fill { elem, len },
+        CheckedEntity::Array {
+            array: result,
+            ty,
+            initialized: false,
+        },
+        zero,
+        elem,
+        len,
     )?;
     log::trace!("translate_array_new(..) -> {result:?}");
     Ok(result)
@@ -653,14 +672,22 @@ pub fn translate_array_new_default(
 
     let interned_ty = func_env.module.types[array_type_index].unwrap_module_type_index();
     let array_ty = func_env.types.unwrap_array(interned_ty)?;
-    let elem = default_value(&mut builder.cursor(), func_env, &array_ty.0.element_type);
-    let result = gc_compiler(func_env)?.alloc_array(
-        func_env,
-        builder,
-        array_type_index,
-        ArrayInit::Fill { elem, len },
-    )?;
+    let result =
+        gc_compiler(func_env)?.alloc_uninit_array(func_env, builder, array_type_index, len)?;
     log::trace!("translate_array_new_default(..) -> {result:?}");
+    let elem = default_value(&mut builder.cursor(), func_env, &array_ty.0.element_type);
+    let zero = builder.ins().iconst(ir::types::I32, 0);
+    func_env.translate_entity_fill(
+        builder,
+        CheckedEntity::Array {
+            array: result,
+            ty: interned_ty,
+            initialized: false,
+        },
+        zero,
+        elem,
+        len,
+    )?;
     Ok(result)
 }
 
@@ -671,450 +698,29 @@ pub fn translate_array_new_fixed(
     elems: &[ir::Value],
 ) -> WasmResult<ir::Value> {
     log::trace!("translate_array_new_fixed({array_type_index:?}, {elems:?})");
-    let result = gc_compiler(func_env)?.alloc_array(
-        func_env,
-        builder,
-        array_type_index,
-        ArrayInit::Elems(elems),
-    )?;
+    let len = builder
+        .ins()
+        .iconst(ir::types::I32, i64::try_from(elems.len()).unwrap());
+    let result =
+        gc_compiler(func_env)?.alloc_uninit_array(func_env, builder, array_type_index, len)?;
     log::trace!("translate_array_new_fixed(..) -> {result:?}");
+    let ty = func_env.module.types[array_type_index].unwrap_module_type_index();
+    let array_ty = func_env.types.unwrap_array(ty)?;
+
+    for (i, elem) in elems.iter().enumerate() {
+        let index = builder
+            .ins()
+            .iconst(ir::types::I32, i64::try_from(i).unwrap());
+        let addr = array_elem_addr(func_env, builder, ty, result, index)?;
+        gc_compiler(func_env)?.init_field(
+            func_env,
+            builder,
+            array_ty.0.element_type,
+            addr,
+            *elem,
+        )?;
+    }
     Ok(result)
-}
-
-impl ArrayInit<'_> {
-    /// Get the length (as an `i32`-typed `ir::Value`) of these array elements.
-    #[cfg_attr(
-        not(any(feature = "gc-drc", feature = "gc-null", feature = "gc-copying")),
-        expect(dead_code, reason = "easier to define")
-    )]
-    fn len(self, pos: &mut FuncCursor) -> ir::Value {
-        match self {
-            ArrayInit::Fill { len, .. } | ArrayInit::Uninit { len } => len,
-            ArrayInit::Elems(e) => {
-                let len = u32::try_from(e.len()).unwrap();
-                pos.ins().iconst(ir::types::I32, i64::from(len))
-            }
-        }
-    }
-
-    /// Initialize a newly-allocated array's elements.
-    #[cfg_attr(
-        not(any(feature = "gc-drc", feature = "gc-null", feature = "gc-copying")),
-        expect(dead_code, reason = "easier to define")
-    )]
-    fn initialize(
-        self,
-        func_env: &mut FuncEnvironment<'_>,
-        builder: &mut FunctionBuilder<'_>,
-        interned_type_index: ModuleInternedTypeIndex,
-        base_size: u32,
-        size: ir::Value,
-        elems_addr: ir::Value,
-        mut init_field: impl FnMut(
-            &mut FuncEnvironment<'_>,
-            &mut FunctionBuilder<'_>,
-            WasmStorageType,
-            ir::Value,
-            ir::Value,
-        ) -> WasmResult<()>,
-    ) -> WasmResult<()> {
-        log::trace!(
-            "initialize_array({interned_type_index:?}, {base_size:?}, {size:?}, {elems_addr:?})"
-        );
-
-        assert!(!func_env.types[interned_type_index].composite_type.shared);
-        let array_ty = func_env.types[interned_type_index]
-            .composite_type
-            .inner
-            .unwrap_array();
-        let elem_ty = array_ty.0.element_type;
-        let elem_size = wasmtime_environ::byte_size_of_wasm_ty_in_gc_heap(&elem_ty);
-        let pointer_type = func_env.pointer_type();
-        let elem_size = builder.ins().iconst(pointer_type, i64::from(elem_size));
-        match self {
-            ArrayInit::Elems(elems) => {
-                let mut elem_addr = elems_addr;
-                for val in elems {
-                    init_field(func_env, builder, elem_ty, elem_addr, *val)?;
-                    elem_addr = builder.ins().iadd(elem_addr, elem_size);
-                }
-            }
-            ArrayInit::Fill { elem, len: _ } => {
-                // Compute the end address of the elements.
-                let base_size = builder.ins().iconst(pointer_type, i64::from(base_size));
-                let array_addr = builder.ins().isub(elems_addr, base_size);
-                let size = uextend_i32_to_pointer_type(builder, pointer_type, size);
-                let elems_end = builder.ins().iadd(array_addr, size);
-
-                emit_array_fill_impl(
-                    func_env,
-                    builder,
-                    elem_ty,
-                    elems_addr,
-                    elem_size,
-                    elems_end,
-                    elem,
-                    |func_env, builder, elem_addr, elem| {
-                        init_field(func_env, builder, elem_ty, elem_addr, elem)
-                    },
-                )?;
-            }
-
-            ArrayInit::Uninit { .. } => {}
-        }
-        log::trace!("initialize_array: finished");
-        Ok(())
-    }
-}
-
-fn emit_array_fill_impl(
-    func_env: &mut FuncEnvironment<'_>,
-    builder: &mut FunctionBuilder<'_>,
-    elem_ty: WasmStorageType,
-    elem_addr: ir::Value,
-    elem_size: ir::Value,
-    fill_end: ir::Value,
-    value: ir::Value,
-    mut emit_elem_write: impl FnMut(
-        &mut FuncEnvironment<'_>,
-        &mut FunctionBuilder<'_>,
-        ir::Value,
-        ir::Value,
-    ) -> WasmResult<()>,
-) -> WasmResult<()> {
-    log::trace!(
-        "emit_array_fill_impl(elem_addr: {elem_addr:?}, elem_size: {elem_size:?}, fill_end: {fill_end:?})"
-    );
-
-    let pointer_ty = func_env.pointer_type();
-
-    assert_eq!(builder.func.dfg.value_type(elem_addr), pointer_ty);
-    assert_eq!(builder.func.dfg.value_type(elem_size), pointer_ty);
-    assert_eq!(builder.func.dfg.value_type(fill_end), pointer_ty);
-
-    // If this is a byte array then specialize its fill to use the same libcall
-    // as `memory.fill`. This gets us to `memset` on the host which for larger
-    // arrays can be a big boost due to the vectorized implementation. Note
-    // though that this explicitly checks to make sure that the final address
-    // being written is in-bounds in the GC heap to detect corruption and traps
-    // here in-wasm. Once we're in the host GC heap corruption can't be caught,
-    // so it needs to be an up-front check here.
-    if let Some(value) = array_fill_value_as_memset(builder, elem_ty, value) {
-        let base = func_env.get_gc_heap_base(builder);
-        let bound = func_env.get_gc_heap_bound(builder);
-        let heap_end = builder.ins().iadd(base, bound);
-        let corrupt = builder
-            .ins()
-            .icmp(IntCC::UnsignedGreaterThan, fill_end, heap_end);
-        func_env.trapnz(builder, corrupt, TRAP_GC_HEAP_CORRUPT);
-
-        let len = builder.ins().isub(fill_end, elem_addr);
-        func_env.raw_bulk_memory_operation(
-            builder,
-            BulkOp::MemoryFill {
-                dst: elem_addr,
-                val: value,
-                len,
-            },
-        );
-
-        return Ok(());
-    }
-
-    // Loop to fill the elements, emitting the equivalent of the following
-    // pseudo-CLIF:
-    //
-    // current_block:
-    //     ...
-    //     jump loop_header_block(elem_addr)
-    //
-    // loop_header_block(elem_addr: i32):
-    //     done = icmp eq elem_addr, fill_end
-    //     brif done, continue_block, loop_body_block
-    //
-    // loop_body_block:
-    //     emit_elem_write()
-    //     next_elem_addr = iadd elem_addr, elem_size
-    //     jump loop_header_block(next_elem_addr)
-    //
-    // continue_block:
-    //     ...
-
-    let current_block = builder.current_block().unwrap();
-    let loop_header_block = builder.create_block();
-    let loop_body_block = builder.create_block();
-    let continue_block = builder.create_block();
-
-    builder.ensure_inserted_block();
-    builder.insert_block_after(loop_header_block, current_block);
-    builder.insert_block_after(loop_body_block, loop_header_block);
-    builder.insert_block_after(continue_block, loop_body_block);
-
-    // Current block: jump to the loop header block with the first element's
-    // address.
-    builder.ins().jump(loop_header_block, &[elem_addr.into()]);
-
-    // Loop header block: check if we're done, then jump to either the continue
-    // block or the loop body block.
-    builder.switch_to_block(loop_header_block);
-    builder.append_block_param(loop_header_block, pointer_ty);
-    log::trace!("emit_array_fill_impl: loop header");
-    func_env.translate_loop_header(builder)?;
-    let elem_addr = builder.block_params(loop_header_block)[0];
-    let done = builder.ins().icmp(IntCC::Equal, elem_addr, fill_end);
-    builder
-        .ins()
-        .brif(done, continue_block, &[], loop_body_block, &[]);
-
-    // Loop body block: write the value to the current element, compute the next
-    // element's address, and then jump back to the loop header block.
-    builder.switch_to_block(loop_body_block);
-    log::trace!("emit_array_fill_impl: loop body");
-    emit_elem_write(func_env, builder, elem_addr, value)?;
-    let next_elem_addr = builder.ins().iadd(elem_addr, elem_size);
-    builder
-        .ins()
-        .jump(loop_header_block, &[next_elem_addr.into()]);
-
-    // Continue...
-    builder.switch_to_block(continue_block);
-    log::trace!("emit_array_fill_impl: finished");
-    builder.seal_block(loop_header_block);
-    builder.seal_block(loop_body_block);
-    builder.seal_block(continue_block);
-    Ok(())
-}
-
-/// Tests to seew hether `value`, stored as `ty`, can be extracted to a single
-/// byte which can be passed to `memset`, or the host's `memory.fill`, to
-/// satisfy this array initialization request.
-fn array_fill_value_as_memset(
-    builder: &mut FunctionBuilder<'_>,
-    ty: WasmStorageType,
-    value: ir::Value,
-) -> Option<ir::Value> {
-    // If the storage type is `i8`, then no matter the value we can always use
-    // `memset` regardless of the upper bits.
-    let value_ty = builder.func.dfg.value_type(value);
-    if let WasmStorageType::I8 = ty {
-        assert_eq!(value_ty, ir::types::I32);
-        return Some(value);
-    }
-
-    // Otherwise check to see if `value` is a constant whose value we can
-    // inspect here.
-    let inst = builder.func.dfg.value_def(value).inst()?;
-    let bits = match builder.func.dfg.insts[inst] {
-        ir::InstructionData::UnaryImm {
-            opcode: ir::Opcode::Iconst,
-            imm,
-        } => imm.bits(),
-        ir::InstructionData::UnaryIeee32 {
-            opcode: ir::Opcode::F32const,
-            imm,
-        } => i64::from(imm.bits()),
-        ir::InstructionData::UnaryIeee64 {
-            opcode: ir::Opcode::F64const,
-            imm,
-        } => imm.bits().cast_signed(),
-
-        // For other initialization we don't know what the value is, so we
-        // can't check if a byte-set is valid, so bail out which will fall back
-        // to an element-by-element loop.
-        _ => return None,
-    };
-
-    let width = match ty {
-        // Handled above
-        WasmStorageType::I8 => unreachable!(),
-        // These are initialized with CLIF-level `i32` values, but we only want
-        // to check the lower 2 bytes.
-        WasmStorageType::I16 => 2,
-        // For everything else the natural CLIF value is what's written so
-        // that's the byte width to check.
-        WasmStorageType::Val(_) => value_ty.bytes() as usize,
-    };
-    let bytes = bits.to_le_bytes();
-    if bytes[1..width].iter().any(|b| *b != bytes[0]) {
-        return None;
-    }
-    Some(builder.ins().iconst(ir::types::I32, bits & 0xff))
-}
-
-pub fn translate_array_copy(
-    func_env: &mut FuncEnvironment<'_>,
-    builder: &mut FunctionBuilder<'_>,
-    dst_array_type_index: TypeIndex,
-    dst_array: ir::Value,
-    dst_index: ir::Value,
-    src_array_type_index: TypeIndex,
-    src_array: ir::Value,
-    src_index: ir::Value,
-    copy_len: ir::Value,
-) -> WasmResult<()> {
-    let dst_array_type_index =
-        func_env.module.types[dst_array_type_index].unwrap_module_type_index();
-    let src_array_type_index =
-        func_env.module.types[src_array_type_index].unwrap_module_type_index();
-    let array_ty = func_env.types[dst_array_type_index]
-        .composite_type
-        .inner
-        .unwrap_array();
-    let elem_ty = array_ty.0.element_type;
-
-    // Helper closure to return `(start,end)` as the native-memory-address
-    // bounds of the copy that is being done.
-    let mut array_bounds = |array: ir::Value, index: ir::Value| -> WasmResult<_> {
-        let array_len = translate_array_len(func_env, builder, array)?;
-
-        // Check that the full range of elements we want to write is in bounds.
-        let end_index =
-            func_env.uadd_overflow_trap(builder, index, copy_len, crate::TRAP_ARRAY_OUT_OF_BOUNDS);
-        let out_of_bounds = builder
-            .ins()
-            .icmp(IntCC::UnsignedGreaterThan, end_index, array_len);
-        func_env.trapnz(builder, out_of_bounds, crate::TRAP_ARRAY_OUT_OF_BOUNDS);
-
-        // Calculate the address of the first element in the array.
-        let ArraySizeInfo {
-            obj_size,
-            one_elem_size,
-            base_size,
-        } = emit_array_size_info(func_env, builder, dst_array_type_index, array_len);
-        let offset_in_elems = builder.ins().imul(index, one_elem_size);
-        let obj_offset = builder.ins().iadd(base_size, offset_in_elems);
-        let elem_addr = func_env.prepare_gc_ref_access(
-            builder,
-            array,
-            BoundsCheck::DynamicObjectField {
-                offset: obj_offset,
-                object_size: obj_size,
-            },
-        );
-
-        Ok((elem_addr, one_elem_size))
-    };
-
-    // Calculate the heap-start address of both copies. This'll ensure
-    // everything is in-bounds as well.
-    let (src_elem_addr, one_elem_size) = array_bounds(src_array, src_index)?;
-    let (dst_elem_addr, _one_elem_size) = array_bounds(dst_array, dst_index)?;
-
-    // Also calculate the heap-end address of both copies. Note that with
-    // everything being in-bounds this multiplication won't overflow.
-    let copy_byte_size = builder.ins().imul(copy_len, one_elem_size);
-    let copy_byte_size =
-        uextend_i32_to_pointer_type(builder, func_env.pointer_type(), copy_byte_size);
-
-    // Note that like `memory.fill` this is preceded with a defensive check
-    // against heap corruption to ensure that, even in the face of heap
-    // corruption, the `memory.copy` call on the host should not ever fault.
-    if !elem_ty.is_vmgcref_type_and_not_i31() {
-        let base = func_env.get_gc_heap_base(builder);
-        let bound = func_env.get_gc_heap_bound(builder);
-        let heap_end = builder.ins().iadd(base, bound);
-        let src_end = builder.ins().iadd(src_elem_addr, copy_byte_size);
-        let dst_end = builder.ins().iadd(dst_elem_addr, copy_byte_size);
-        let corrupt = builder
-            .ins()
-            .icmp(IntCC::UnsignedGreaterThan, src_end, heap_end);
-        func_env.trapnz(builder, corrupt, TRAP_GC_HEAP_CORRUPT);
-        let corrupt = builder
-            .ins()
-            .icmp(IntCC::UnsignedGreaterThan, dst_end, heap_end);
-        func_env.trapnz(builder, corrupt, TRAP_GC_HEAP_CORRUPT);
-
-        func_env.raw_bulk_memory_operation(
-            builder,
-            BulkOp::MemoryCopy {
-                dst: dst_elem_addr,
-                src: src_elem_addr,
-                len: copy_byte_size,
-            },
-        );
-        return Ok(());
-    }
-    let one_elem_size =
-        uextend_i32_to_pointer_type(builder, func_env.pointer_type(), one_elem_size);
-    let copy_len = uextend_i32_to_pointer_type(builder, func_env.pointer_type(), copy_len);
-    func_env.emit_raw_array_or_table_copy(
-        builder,
-        CheckedEntity::Array(dst_array_type_index),
-        CheckedEntity::Array(src_array_type_index),
-        dst_elem_addr,
-        src_elem_addr,
-        one_elem_size,
-        copy_len,
-        src_index,
-    )?;
-
-    Ok(())
-}
-
-pub fn translate_array_fill(
-    func_env: &mut FuncEnvironment<'_>,
-    builder: &mut FunctionBuilder<'_>,
-    array_type_index: TypeIndex,
-    array_ref: ir::Value,
-    index: ir::Value,
-    value: ir::Value,
-    n: ir::Value,
-) -> WasmResult<()> {
-    log::trace!(
-        "translate_array_fill({array_type_index:?}, {array_ref:?}, {index:?}, {value:?}, {n:?})"
-    );
-
-    let len = translate_array_len(func_env, builder, array_ref)?;
-
-    // Check that the full range of elements we want to fill is within bounds.
-    let end_index = func_env.uadd_overflow_trap(builder, index, n, TRAP_ARRAY_OUT_OF_BOUNDS);
-    let out_of_bounds = builder
-        .ins()
-        .icmp(IntCC::UnsignedGreaterThan, end_index, len);
-    func_env.trapnz(builder, out_of_bounds, TRAP_ARRAY_OUT_OF_BOUNDS);
-
-    // Get the address of the first element we want to fill.
-    let interned_type_index = func_env.module.types[array_type_index].unwrap_module_type_index();
-    let array_ty = func_env.types.unwrap_array(interned_type_index)?;
-    let elem_ty = array_ty.0.element_type;
-    let ArraySizeInfo {
-        obj_size,
-        one_elem_size,
-        base_size,
-    } = emit_array_size_info(func_env, builder, interned_type_index, len);
-    let offset_in_elems = builder.ins().imul(index, one_elem_size);
-    let obj_offset = builder.ins().iadd(base_size, offset_in_elems);
-    let elem_addr = func_env.prepare_gc_ref_access(
-        builder,
-        array_ref,
-        BoundsCheck::DynamicObjectField {
-            offset: obj_offset,
-            object_size: obj_size,
-        },
-    );
-
-    // Calculate the end address, just after the filled region.
-    let fill_size = builder.ins().imul(n, one_elem_size);
-    let fill_size = uextend_i32_to_pointer_type(builder, func_env.pointer_type(), fill_size);
-    let fill_end = builder.ins().iadd(elem_addr, fill_size);
-
-    let one_elem_size =
-        uextend_i32_to_pointer_type(builder, func_env.pointer_type(), one_elem_size);
-
-    let result = emit_array_fill_impl(
-        func_env,
-        builder,
-        elem_ty,
-        elem_addr,
-        one_elem_size,
-        fill_end,
-        value,
-        |func_env, builder, elem_addr, value| {
-            write_field_at_addr(func_env, builder, elem_ty, elem_addr, value)
-        },
-    );
-    log::trace!("translate_array_fill(..) -> {result:?}");
-    result
 }
 
 pub fn translate_array_len(
@@ -1164,8 +770,8 @@ fn emit_array_size_info(
     array_type_index: ModuleInternedTypeIndex,
     // `i32` value containing the array's length.
     array_len: ir::Value,
-) -> ArraySizeInfo {
-    let array_layout = func_env.array_layout(array_type_index);
+) -> WasmResult<ArraySizeInfo> {
+    let array_layout = func_env.array_layout(array_type_index)?;
 
     // Note that we check for overflow below because we can't trust the array's
     // length: it came from inside the GC heap.
@@ -1192,11 +798,11 @@ fn emit_array_size_info(
 
     let one_elem_size = builder.ins().ireduce(ir::types::I32, one_elem_size);
 
-    ArraySizeInfo {
+    Ok(ArraySizeInfo {
         obj_size,
         one_elem_size,
         base_size,
-    }
+    })
 }
 
 /// Get the bounds-checked address of an element in an array.
@@ -1213,7 +819,7 @@ fn array_elem_addr(
     array_type_index: ModuleInternedTypeIndex,
     array_ref: ir::Value,
     index: ir::Value,
-) -> ir::Value {
+) -> WasmResult<ir::Value> {
     // First, assert that `index < array.length`.
     //
     // This check is visible at the Wasm-semantics level.
@@ -1234,7 +840,7 @@ fn array_elem_addr(
         obj_size,
         one_elem_size,
         base_size,
-    } = emit_array_size_info(func_env, builder, array_type_index, len);
+    } = emit_array_size_info(func_env, builder, array_type_index, len)?;
 
     // Compute the offset of the `index`th element within the array object.
     //
@@ -1260,14 +866,14 @@ fn array_elem_addr(
     // redundant bounds checks. But we should figure out how to do this in a way
     // that doesn't defeat the object-size bounds checking's deduplication
     // mentioned above.
-    func_env.prepare_gc_ref_access(
+    Ok(func_env.prepare_gc_ref_access(
         builder,
         array_ref,
         BoundsCheck::DynamicObjectField {
             offset: offset_in_array,
             object_size: obj_size,
         },
-    )
+    ))
 }
 
 pub fn translate_array_get(
@@ -1283,7 +889,7 @@ pub fn translate_array_get(
     emit_gc_kind_assert(func_env, builder, array_ref, VMGcKind::ArrayRef);
 
     let array_type_index = func_env.module.types[array_type_index].unwrap_module_type_index();
-    let elem_addr = array_elem_addr(func_env, builder, array_type_index, array_ref, index);
+    let elem_addr = array_elem_addr(func_env, builder, array_type_index, array_ref, index)?;
 
     let array_ty = func_env.types.unwrap_array(array_type_index)?;
     let elem_ty = array_ty.0.element_type;
@@ -1306,7 +912,7 @@ pub fn translate_array_set(
     emit_gc_kind_assert(func_env, builder, array_ref, VMGcKind::ArrayRef);
 
     let array_type_index = func_env.module.types[array_type_index].unwrap_module_type_index();
-    let elem_addr = array_elem_addr(func_env, builder, array_type_index, array_ref, index);
+    let elem_addr = array_elem_addr(func_env, builder, array_type_index, array_ref, index)?;
 
     let array_ty = func_env.types.unwrap_array(array_type_index)?;
     let elem_ty = array_ty.0.element_type;
@@ -1548,6 +1154,7 @@ pub fn translate_ref_test(
     Ok(result)
 }
 
+#[cfg(any(feature = "gc-drc", feature = "gc-null", feature = "gc-copying"))]
 fn uextend_i32_to_pointer_type(
     builder: &mut FunctionBuilder,
     pointer_type: ir::Type,
@@ -1623,13 +1230,6 @@ fn initialize_struct_fields(
     struct_ty: ModuleInternedTypeIndex,
     raw_ptr_to_struct: ir::Value,
     field_values: &[ir::Value],
-    mut init_field: impl FnMut(
-        &mut FuncEnvironment<'_>,
-        &mut FunctionBuilder<'_>,
-        WasmStorageType,
-        ir::Value,
-        ir::Value,
-    ) -> WasmResult<()>,
 ) -> WasmResult<()> {
     let struct_layout = func_env.struct_or_exn_layout(struct_ty);
     let struct_size = struct_layout.size;
@@ -1650,7 +1250,7 @@ fn initialize_struct_fields(
         let size_of_access = wasmtime_environ::byte_size_of_wasm_ty_in_gc_heap(&ty.element_type);
         assert!(offset + size_of_access <= struct_size);
         let field_addr = builder.ins().iadd_imm(raw_ptr_to_struct, i64::from(offset));
-        init_field(func_env, builder, ty.element_type, field_addr, *val)?;
+        gc_compiler(func_env)?.init_field(func_env, builder, ty.element_type, field_addr, *val)?;
     }
 
     Ok(())
@@ -1674,8 +1274,11 @@ impl FuncEnvironment<'_> {
     }
 
     /// Get the `GcArrayLayout` for the array type at the given `type_index`.
-    pub(crate) fn array_layout(&mut self, type_index: ModuleInternedTypeIndex) -> &GcArrayLayout {
-        self.gc_layout(type_index).unwrap_array()
+    pub(crate) fn array_layout(
+        &mut self,
+        type_index: ModuleInternedTypeIndex,
+    ) -> WasmResult<&GcArrayLayout> {
+        Ok(self.gc_layout(type_index).unwrap_array())
     }
 
     /// Get the `GcStructLayout` for the struct or exception type at the given `type_index`.
@@ -1717,9 +1320,12 @@ impl FuncEnvironment<'_> {
     }
 
     /// Get the GC heap's base.
-    fn get_gc_heap_base(&mut self, builder: &mut FunctionBuilder) -> ir::Value {
+    pub(crate) fn get_gc_heap_base(
+        &mut self,
+        builder: &mut FunctionBuilder,
+    ) -> WasmResult<ir::Value> {
         let global = self.get_gc_heap_base_global(&mut builder.func);
-        builder.ins().global_value(self.pointer_type(), global)
+        Ok(builder.ins().global_value(self.pointer_type(), global))
     }
 
     fn get_gc_heap_bound_global(&mut self, func: &mut ir::Function) -> ir::GlobalValue {
@@ -1739,9 +1345,12 @@ impl FuncEnvironment<'_> {
     }
 
     /// Get the GC heap's bound.
-    fn get_gc_heap_bound(&mut self, builder: &mut FunctionBuilder) -> ir::Value {
+    pub(crate) fn get_gc_heap_bound(
+        &mut self,
+        builder: &mut FunctionBuilder,
+    ) -> WasmResult<ir::Value> {
         let global = self.get_gc_heap_bound_global(&mut builder.func);
-        builder.ins().global_value(self.pointer_type(), global)
+        Ok(builder.ins().global_value(self.pointer_type(), global))
     }
 
     /// Get or create the `Heap` for our GC heap.
@@ -1962,128 +1571,27 @@ pub fn translate_array_new_data(
     // upper bits are set this is definitely out-of-bounds, and otherwise the
     // low 32-bits are the byte length.
     let interned_type_index = env.module.types[array_type_index].unwrap_module_type_index();
-    let array_layout = env.array_layout(interned_type_index);
-    let len64 = builder.ins().uextend(ir::types::I64, len);
-    let init_byte_length = builder
-        .ins()
-        .imul_imm(len64, i64::from(array_layout.elem_size));
-    let init_byte_length_upper_bits = builder.ins().ushr_imm(init_byte_length, 32);
-    env.trapnz(
-        builder,
-        init_byte_length_upper_bits,
-        ir::TrapCode::HEAP_OUT_OF_BOUNDS,
-    );
-    let init_byte_length = builder.ins().ireduce(ir::types::I32, init_byte_length);
-    let src_addr =
-        env.translate_entity_bounds_check(builder, data_index, data_offset, init_byte_length);
+    let array_layout = env.array_layout(interned_type_index)?.clone();
+    let data_entity = CheckedEntity::Data {
+        segment: data_index,
+        element_size: array_layout.elem_size,
+    };
+    env.translate_entity_bounds_check(builder, data_entity, data_offset, len)?;
 
-    let array =
-        gc_compiler(env)?.alloc_array(env, builder, array_type_index, ArrayInit::Uninit { len })?;
+    let array = gc_compiler(env)?.alloc_uninit_array(env, builder, array_type_index, len)?;
     let dst = builder.ins().iconst(ir::types::I32, 0);
-    emit_array_init_data(
-        env,
+    env.translate_entity_copy(
         builder,
-        array_type_index,
-        array,
-        len,
+        CheckedEntity::Array {
+            array,
+            ty: interned_type_index,
+            initialized: false,
+        },
+        data_entity,
         dst,
-        src_addr,
-        init_byte_length,
-    );
+        data_offset,
+        len,
+    )?;
+
     Ok(array)
-}
-
-pub fn translate_array_init_data(
-    env: &mut FuncEnvironment<'_>,
-    builder: &mut FunctionBuilder,
-    array_type_index: TypeIndex,
-    array: ir::Value,
-    dst_index: ir::Value,
-    data_index: DataIndex,
-    data_offset: ir::Value,
-    len: ir::Value,
-) -> WasmResult<()> {
-    // Perform a bounds check and double-check that `dst_index` is in-bounds for
-    // this array. Do this in the 64-bit index space to avoid overflows.
-    let array_len = translate_array_len(env, builder, array)?;
-    let array_len64 = builder.ins().uextend(ir::types::I64, array_len);
-    let dst_index64 = builder.ins().uextend(ir::types::I64, dst_index);
-    let len64 = builder.ins().uextend(ir::types::I64, len);
-    let end_index64 = builder.ins().iadd(dst_index64, len64);
-    let oob = builder
-        .ins()
-        .icmp(IntCC::UnsignedGreaterThan, end_index64, array_len64);
-    env.trapnz(builder, oob, TRAP_ARRAY_OUT_OF_BOUNDS);
-
-    // Note that because `dst_index + len` is in-bounds we know that this won't
-    // overflow, so no need to check for overflow here.
-    let interned_type_index = env.module.types[array_type_index].unwrap_module_type_index();
-    let array_layout = env.array_layout(interned_type_index);
-    let len_in_bytes = builder
-        .ins()
-        .imul_imm(len, i64::from(array_layout.elem_size));
-    let src_addr =
-        env.translate_entity_bounds_check(builder, data_index, data_offset, len_in_bytes);
-
-    emit_array_init_data(
-        env,
-        builder,
-        array_type_index,
-        array,
-        array_len,
-        dst_index,
-        src_addr,
-        len_in_bytes,
-    );
-
-    Ok(())
-}
-
-/// Shared functionality between `array.new_data` and `array.init_data`.
-///
-/// Assumes the data segment has already been validated and `src_addr` is the
-/// raw host address we're copying from.
-fn emit_array_init_data(
-    env: &mut FuncEnvironment<'_>,
-    builder: &mut FunctionBuilder,
-    array_type_index: TypeIndex,
-    array: ir::Value,
-    array_len: ir::Value,
-    dst_index: ir::Value,
-    src_addr: ir::Value,
-    len_in_bytes: ir::Value,
-) {
-    // Load the destination address for where we're going to write.
-    let interned_type_index = env.module.types[array_type_index].unwrap_module_type_index();
-    let ArraySizeInfo {
-        obj_size,
-        one_elem_size,
-        base_size,
-    } = emit_array_size_info(env, builder, interned_type_index, array_len);
-    let offset_in_elems = builder.ins().imul(dst_index, one_elem_size);
-    let obj_offset = builder.ins().iadd(base_size, offset_in_elems);
-    let dst_elem_addr = env.prepare_gc_ref_access(
-        builder,
-        array,
-        BoundsCheck::DynamicObjectField {
-            offset: obj_offset,
-            object_size: obj_size,
-        },
-    );
-
-    // At this point bounds checks have all passed, so it's time to perform
-    // the actual copy by calling the `memory.copy` libcall.
-    let len_in_bytes = env.unchecked_cast_wasm_addr_to_native_addr(
-        &mut builder.cursor(),
-        len_in_bytes,
-        IndexType::I32,
-    );
-    env.raw_bulk_memory_operation(
-        builder,
-        BulkOp::MemoryCopy {
-            dst: dst_elem_addr,
-            src: src_addr,
-            len: len_in_bytes,
-        },
-    );
 }

--- a/crates/cranelift/src/func_environ/gc/enabled/copying.rs
+++ b/crates/cranelift/src/func_environ/gc/enabled/copying.rs
@@ -92,7 +92,7 @@ impl CopyingCompiler {
         kind: VMGcKind,
         ty: ModuleInternedTypeIndex,
         size: ir::Value,
-    ) -> (ir::Value, ir::Value) {
+    ) -> WasmResult<(ir::Value, ir::Value)> {
         debug_assert_ne!(kind, VMGcKind::ExternRef);
         debug_assert!(!ty.is_reserved_value());
         assert_eq!(builder.func.dfg.value_type(size), ir::types::I32);
@@ -133,7 +133,7 @@ impl CopyingCompiler {
             builder.seal_block(slow_block);
             builder.set_cold_block(slow_block);
             let gc_ref = emit_gc_raw_alloc(func_env, builder, kind, ty, size, ALIGN);
-            let base = func_env.get_gc_heap_base(builder);
+            let base = func_env.get_gc_heap_base(builder)?;
             let heap_offset = uextend_i32_to_pointer_type(builder, pointer_type, gc_ref);
             let obj_ptr = builder.ins().iadd(base, heap_offset);
             builder
@@ -161,7 +161,7 @@ impl CopyingCompiler {
             );
 
             // Compute the raw pointer to the new object.
-            let base = func_env.get_gc_heap_base(builder);
+            let base = func_env.get_gc_heap_base(builder)?;
             let heap_offset = uextend_i32_to_pointer_type(builder, pointer_type, gc_ref);
             let obj_ptr = builder.ins().iadd(base, heap_offset);
 
@@ -206,48 +206,7 @@ impl CopyingCompiler {
         builder.seal_block(merge_block);
         builder.declare_value_needs_stack_map(gc_ref);
 
-        (gc_ref, ptr_to_object)
-    }
-
-    fn init_field(
-        &mut self,
-        func_env: &mut FuncEnvironment<'_>,
-        builder: &mut FunctionBuilder<'_>,
-        field_addr: ir::Value,
-        ty: WasmStorageType,
-        val: ir::Value,
-    ) -> WasmResult<()> {
-        // Data inside GC objects is always little endian.
-        let flags = GC_MEMFLAGS.with_endianness(ir::Endianness::Little);
-
-        match ty {
-            WasmStorageType::Val(WasmValType::Ref(r)) => match r.heap_type.top() {
-                WasmHeapTopType::Func => {
-                    write_func_ref_at_addr(func_env, builder, r, flags, field_addr, val)?
-                }
-                WasmHeapTopType::Extern | WasmHeapTopType::Any | WasmHeapTopType::Exn => {
-                    // No init barrier needed for the copying collector; just
-                    // store the reference directly.
-                    unbarriered_store_gc_ref(builder, r.heap_type, field_addr, val, flags)?;
-                }
-                WasmHeapTopType::Cont => return super::stack_switching_unsupported(),
-            },
-            WasmStorageType::I8 => {
-                assert_eq!(builder.func.dfg.value_type(val), ir::types::I32);
-                builder.ins().istore8(flags, val, field_addr, 0);
-            }
-            WasmStorageType::I16 => {
-                assert_eq!(builder.func.dfg.value_type(val), ir::types::I32);
-                builder.ins().istore16(flags, val, field_addr, 0);
-            }
-            WasmStorageType::Val(_) => {
-                let size_of_access = wasmtime_environ::byte_size_of_wasm_ty_in_gc_heap(&ty);
-                assert_eq!(builder.func.dfg.value_type(val).bytes(), size_of_access);
-                builder.ins().store(flags, val, field_addr, 0);
-            }
-        }
-
-        Ok(())
+        Ok((gc_ref, ptr_to_object))
     }
 }
 
@@ -260,24 +219,20 @@ impl GcCompiler for CopyingCompiler {
         true
     }
 
-    fn alloc_array(
+    fn alloc_uninit_array(
         &mut self,
         func_env: &mut FuncEnvironment<'_>,
         builder: &mut FunctionBuilder<'_>,
         array_type_index: TypeIndex,
-        init: super::ArrayInit<'_>,
+        len: ir::Value,
     ) -> WasmResult<ir::Value> {
         let interned_type_index =
             func_env.module.types[array_type_index].unwrap_module_type_index();
-        let ptr_ty = func_env.pointer_type();
 
         let len_offset = gc_compiler(func_env)?.layouts().array_length_field_offset();
-        let array_layout = func_env.array_layout(interned_type_index).clone();
-        let base_size = array_layout.base_size;
-        let len_to_elems_delta = base_size.checked_sub(len_offset).unwrap();
+        let array_layout = func_env.array_layout(interned_type_index)?.clone();
 
         // First, compute the array's total size.
-        let len = init.len(&mut builder.cursor());
         let size = emit_array_size(func_env, builder, &array_layout, len);
 
         // Allocate inline (with fallback to libcall).
@@ -287,25 +242,10 @@ impl GcCompiler for CopyingCompiler {
             VMGcKind::ArrayRef,
             interned_type_index,
             size,
-        );
+        )?;
         let len_addr = builder.ins().iadd_imm(object_addr, i64::from(len_offset));
-        let len = init.len(&mut builder.cursor());
         builder.ins().store(GC_MEMFLAGS, len, len_addr, 0);
 
-        // Initialize elements.
-        let len_to_elems_delta = builder.ins().iconst(ptr_ty, i64::from(len_to_elems_delta));
-        let elems_addr = builder.ins().iadd(len_addr, len_to_elems_delta);
-        init.initialize(
-            func_env,
-            builder,
-            interned_type_index,
-            base_size,
-            size,
-            elems_addr,
-            |func_env, builder, elem_ty, elem_addr, val| {
-                self.init_field(func_env, builder, elem_addr, elem_ty, val)
-            },
-        )?;
         Ok(array_ref)
     }
 
@@ -330,7 +270,7 @@ impl GcCompiler for CopyingCompiler {
             VMGcKind::StructRef,
             interned_type_index,
             struct_size_val,
-        );
+        )?;
 
         // Initialize fields.
         initialize_struct_fields(
@@ -339,9 +279,6 @@ impl GcCompiler for CopyingCompiler {
             interned_type_index,
             raw_ptr_to_struct,
             field_vals,
-            |func_env, builder, ty, field_addr, val| {
-                self.init_field(func_env, builder, field_addr, ty, val)
-            },
         )?;
 
         Ok(struct_ref)
@@ -371,7 +308,7 @@ impl GcCompiler for CopyingCompiler {
             VMGcKind::ExnRef,
             interned_type_index,
             exn_size_val,
-        );
+        )?;
 
         // Initialize fields.
         initialize_struct_fields(
@@ -380,9 +317,6 @@ impl GcCompiler for CopyingCompiler {
             interned_type_index,
             raw_ptr_to_exn,
             field_vals,
-            |func_env, builder, ty, field_addr, val| {
-                self.init_field(func_env, builder, field_addr, ty, val)
-            },
         )?;
 
         // Initialize tag fields.
@@ -392,8 +326,8 @@ impl GcCompiler for CopyingCompiler {
         self.init_field(
             func_env,
             builder,
-            instance_id_addr,
             WasmStorageType::Val(WasmValType::I32),
+            instance_id_addr,
             instance_id,
         )?;
         let tag_addr = builder
@@ -402,8 +336,8 @@ impl GcCompiler for CopyingCompiler {
         self.init_field(
             func_env,
             builder,
-            tag_addr,
             WasmStorageType::Val(WasmValType::I32),
+            tag_addr,
             tag,
         )?;
 
@@ -456,5 +390,46 @@ impl GcCompiler for CopyingCompiler {
     ) -> WasmResult<()> {
         // No write barrier needed for the copying collector.
         unbarriered_store_gc_ref(builder, ty.heap_type, dst, new_val, flags)
+    }
+
+    fn init_field(
+        &mut self,
+        func_env: &mut FuncEnvironment<'_>,
+        builder: &mut FunctionBuilder<'_>,
+        ty: WasmStorageType,
+        field_addr: ir::Value,
+        val: ir::Value,
+    ) -> WasmResult<()> {
+        // Data inside GC objects is always little endian.
+        let flags = GC_MEMFLAGS.with_endianness(ir::Endianness::Little);
+
+        match ty {
+            WasmStorageType::Val(WasmValType::Ref(r)) => match r.heap_type.top() {
+                WasmHeapTopType::Func => {
+                    write_func_ref_at_addr(func_env, builder, r, flags, field_addr, val)?
+                }
+                WasmHeapTopType::Extern | WasmHeapTopType::Any | WasmHeapTopType::Exn => {
+                    // No init barrier needed for the copying collector; just
+                    // store the reference directly.
+                    unbarriered_store_gc_ref(builder, r.heap_type, field_addr, val, flags)?;
+                }
+                WasmHeapTopType::Cont => return super::stack_switching_unsupported(),
+            },
+            WasmStorageType::I8 => {
+                assert_eq!(builder.func.dfg.value_type(val), ir::types::I32);
+                builder.ins().istore8(flags, val, field_addr, 0);
+            }
+            WasmStorageType::I16 => {
+                assert_eq!(builder.func.dfg.value_type(val), ir::types::I32);
+                builder.ins().istore16(flags, val, field_addr, 0);
+            }
+            WasmStorageType::Val(_) => {
+                let size_of_access = wasmtime_environ::byte_size_of_wasm_ty_in_gc_heap(&ty);
+                assert_eq!(builder.func.dfg.value_type(val).bytes(), size_of_access);
+                builder.ins().store(flags, val, field_addr, 0);
+            }
+        }
+
+        Ok(())
     }
 }

--- a/crates/cranelift/src/func_environ/gc/enabled/drc.rs
+++ b/crates/cranelift/src/func_environ/gc/enabled/drc.rs
@@ -194,46 +194,6 @@ impl DrcCompiler {
         builder.ins().store(GC_MEMFLAGS, new_reserved, ptr, 0);
     }
 
-    /// Write to an uninitialized field or element inside a GC object.
-    fn init_field(
-        &mut self,
-        func_env: &mut FuncEnvironment<'_>,
-        builder: &mut FunctionBuilder<'_>,
-        field_addr: ir::Value,
-        ty: WasmStorageType,
-        val: ir::Value,
-    ) -> WasmResult<()> {
-        // Data inside GC objects is always little endian.
-        let flags = GC_MEMFLAGS.with_endianness(ir::Endianness::Little);
-
-        match ty {
-            WasmStorageType::Val(WasmValType::Ref(r)) => match r.heap_type.top() {
-                WasmHeapTopType::Func => {
-                    write_func_ref_at_addr(func_env, builder, r, flags, field_addr, val)?
-                }
-                WasmHeapTopType::Extern | WasmHeapTopType::Any | WasmHeapTopType::Exn => {
-                    self.translate_init_gc_reference(func_env, builder, r, field_addr, val, flags)?
-                }
-                WasmHeapTopType::Cont => return super::stack_switching_unsupported(),
-            },
-            WasmStorageType::I8 => {
-                assert_eq!(builder.func.dfg.value_type(val), ir::types::I32);
-                builder.ins().istore8(flags, val, field_addr, 0);
-            }
-            WasmStorageType::I16 => {
-                assert_eq!(builder.func.dfg.value_type(val), ir::types::I32);
-                builder.ins().istore16(flags, val, field_addr, 0);
-            }
-            WasmStorageType::Val(_) => {
-                let size_of_access = wasmtime_environ::byte_size_of_wasm_ty_in_gc_heap(&ty);
-                assert_eq!(builder.func.dfg.value_type(val).bytes(), size_of_access);
-                builder.ins().store(flags, val, field_addr, 0);
-            }
-        }
-
-        Ok(())
-    }
-
     /// Write to an uninitialized GC reference field, initializing it.
     ///
     /// ```text
@@ -347,26 +307,22 @@ impl GcCompiler for DrcCompiler {
         false
     }
 
-    fn alloc_array(
+    fn alloc_uninit_array(
         &mut self,
         func_env: &mut FuncEnvironment<'_>,
         builder: &mut FunctionBuilder<'_>,
         array_type_index: TypeIndex,
-        init: super::ArrayInit<'_>,
+        len: ir::Value,
     ) -> WasmResult<ir::Value> {
         let interned_type_index =
             func_env.module.types[array_type_index].unwrap_module_type_index();
-        let ptr_ty = func_env.pointer_type();
 
         let len_offset = gc_compiler(func_env)?.layouts().array_length_field_offset();
-        let array_layout = func_env.array_layout(interned_type_index).clone();
-        let base_size = array_layout.base_size;
+        let array_layout = func_env.array_layout(interned_type_index)?.clone();
         let align = array_layout.align;
-        let len_to_elems_delta = base_size.checked_sub(len_offset).unwrap();
 
         // First, compute the array's total size from its base size, element
         // size, and length.
-        let len = init.len(&mut builder.cursor());
         let size = emit_array_size(func_env, builder, &array_layout, len);
 
         // Second, now that we have the array object's total size, call the
@@ -384,28 +340,12 @@ impl GcCompiler for DrcCompiler {
         //
         // Note: we don't need to bounds-check the GC ref access here, since we
         // trust the results of the allocation libcall.
-        let base = func_env.get_gc_heap_base(builder);
+        let base = func_env.get_gc_heap_base(builder)?;
         let extended_array_ref =
             uextend_i32_to_pointer_type(builder, func_env.pointer_type(), array_ref);
         let object_addr = builder.ins().iadd(base, extended_array_ref);
         let len_addr = builder.ins().iadd_imm(object_addr, i64::from(len_offset));
-        let len = init.len(&mut builder.cursor());
         builder.ins().store(GC_MEMFLAGS, len, len_addr, 0);
-
-        // Finally, initialize the elements.
-        let len_to_elems_delta = builder.ins().iconst(ptr_ty, i64::from(len_to_elems_delta));
-        let elems_addr = builder.ins().iadd(len_addr, len_to_elems_delta);
-        init.initialize(
-            func_env,
-            builder,
-            interned_type_index,
-            base_size,
-            size,
-            elems_addr,
-            |func_env, builder, elem_ty, elem_addr, val| {
-                self.init_field(func_env, builder, elem_addr, elem_ty, val)
-            },
-        )?;
         Ok(array_ref)
     }
 
@@ -441,7 +381,7 @@ impl GcCompiler for DrcCompiler {
         //
         // Note: we don't need to bounds-check the GC ref access here, since we
         // trust the results of the allocation libcall.
-        let base = func_env.get_gc_heap_base(builder);
+        let base = func_env.get_gc_heap_base(builder)?;
         let extended_struct_ref =
             uextend_i32_to_pointer_type(builder, func_env.pointer_type(), struct_ref);
         let raw_ptr_to_struct = builder.ins().iadd(base, extended_struct_ref);
@@ -451,9 +391,6 @@ impl GcCompiler for DrcCompiler {
             interned_type_index,
             raw_ptr_to_struct,
             field_vals,
-            |func_env, builder, ty, field_addr, val| {
-                self.init_field(func_env, builder, field_addr, ty, val)
-            },
         )?;
 
         Ok(struct_ref)
@@ -495,7 +432,7 @@ impl GcCompiler for DrcCompiler {
         //
         // Note: we don't need to bounds-check the GC ref access here, since we
         // trust the results of the allocation libcall.
-        let base = func_env.get_gc_heap_base(builder);
+        let base = func_env.get_gc_heap_base(builder)?;
         let extended_exn_ref =
             uextend_i32_to_pointer_type(builder, func_env.pointer_type(), exn_ref);
         let raw_ptr_to_exn = builder.ins().iadd(base, extended_exn_ref);
@@ -505,9 +442,6 @@ impl GcCompiler for DrcCompiler {
             interned_type_index,
             raw_ptr_to_exn,
             field_vals,
-            |func_env, builder, ty, field_addr, val| {
-                self.init_field(func_env, builder, field_addr, ty, val)
-            },
         )?;
 
         // Finally, initialize the tag fields.
@@ -517,8 +451,8 @@ impl GcCompiler for DrcCompiler {
         self.init_field(
             func_env,
             builder,
-            instance_id_addr,
             WasmStorageType::Val(WasmValType::I32),
+            instance_id_addr,
             instance_id,
         )?;
         let tag_addr = builder
@@ -527,8 +461,8 @@ impl GcCompiler for DrcCompiler {
         self.init_field(
             func_env,
             builder,
-            tag_addr,
             WasmStorageType::Val(WasmValType::I32),
+            tag_addr,
             tag,
         )?;
 
@@ -881,6 +815,46 @@ impl GcCompiler for DrcCompiler {
         builder.switch_to_block(continue_block);
         builder.seal_block(continue_block);
         log::trace!("DRC write barrier: finished");
+        Ok(())
+    }
+
+    /// Write to an uninitialized field or element inside a GC object.
+    fn init_field(
+        &mut self,
+        func_env: &mut FuncEnvironment<'_>,
+        builder: &mut FunctionBuilder<'_>,
+        ty: WasmStorageType,
+        field_addr: ir::Value,
+        val: ir::Value,
+    ) -> WasmResult<()> {
+        // Data inside GC objects is always little endian.
+        let flags = GC_MEMFLAGS.with_endianness(ir::Endianness::Little);
+
+        match ty {
+            WasmStorageType::Val(WasmValType::Ref(r)) => match r.heap_type.top() {
+                WasmHeapTopType::Func => {
+                    write_func_ref_at_addr(func_env, builder, r, flags, field_addr, val)?
+                }
+                WasmHeapTopType::Extern | WasmHeapTopType::Any | WasmHeapTopType::Exn => {
+                    self.translate_init_gc_reference(func_env, builder, r, field_addr, val, flags)?
+                }
+                WasmHeapTopType::Cont => return super::stack_switching_unsupported(),
+            },
+            WasmStorageType::I8 => {
+                assert_eq!(builder.func.dfg.value_type(val), ir::types::I32);
+                builder.ins().istore8(flags, val, field_addr, 0);
+            }
+            WasmStorageType::I16 => {
+                assert_eq!(builder.func.dfg.value_type(val), ir::types::I32);
+                builder.ins().istore16(flags, val, field_addr, 0);
+            }
+            WasmStorageType::Val(_) => {
+                let size_of_access = wasmtime_environ::byte_size_of_wasm_ty_in_gc_heap(&ty);
+                assert_eq!(builder.func.dfg.value_type(val).bytes(), size_of_access);
+                builder.ins().store(flags, val, field_addr, 0);
+            }
+        }
+
         Ok(())
     }
 }

--- a/crates/cranelift/src/func_environ/gc/enabled/null.rs
+++ b/crates/cranelift/src/func_environ/gc/enabled/null.rs
@@ -45,7 +45,7 @@ impl NullCompiler {
         ty: Option<ModuleInternedTypeIndex>,
         size: ir::Value,
         align: ir::Value,
-    ) -> (ir::Value, ir::Value) {
+    ) -> WasmResult<(ir::Value, ir::Value)> {
         log::trace!("emit_inline_alloc(kind={kind:?}, ty={ty:?}, size={size}, align={align})");
 
         assert_eq!(builder.func.dfg.value_type(size), ir::types::I32);
@@ -105,7 +105,7 @@ impl NullCompiler {
         let end_of_object =
             func_env.uadd_overflow_trap(builder, aligned, size, crate::TRAP_ALLOCATION_TOO_LARGE);
         let uext_end_of_object = uextend_i32_to_pointer_type(builder, pointer_type, end_of_object);
-        let bound = func_env.get_gc_heap_bound(builder);
+        let bound = func_env.get_gc_heap_bound(builder)?;
         let is_in_bounds = builder.ins().icmp(
             ir::condcodes::IntCC::UnsignedLessThanOrEqual,
             uext_end_of_object,
@@ -142,7 +142,7 @@ impl NullCompiler {
         // header and the type index, but that requires generating different
         // code for big-endian architectures, and I haven't bothered doing that
         // yet.
-        let base = func_env.get_gc_heap_base(builder);
+        let base = func_env.get_gc_heap_base(builder)?;
         let uext_aligned = uextend_i32_to_pointer_type(builder, pointer_type, aligned);
         let ptr_to_object = builder.ins().iadd(base, uext_aligned);
         let kind = builder
@@ -173,7 +173,7 @@ impl NullCompiler {
             .store(GC_MEMFLAGS, end_of_object, ptr_to_next, 0);
 
         log::trace!("emit_inline_alloc(..) -> ({aligned}, {ptr_to_object})");
-        (aligned, ptr_to_object)
+        Ok((aligned, ptr_to_object))
     }
 }
 
@@ -186,26 +186,22 @@ impl GcCompiler for NullCompiler {
         false
     }
 
-    fn alloc_array(
+    fn alloc_uninit_array(
         &mut self,
         func_env: &mut FuncEnvironment<'_>,
         builder: &mut FunctionBuilder<'_>,
         array_type_index: TypeIndex,
-        init: super::ArrayInit<'_>,
+        len: ir::Value,
     ) -> WasmResult<ir::Value> {
         let interned_type_index =
             func_env.module.types[array_type_index].unwrap_module_type_index();
-        let ptr_ty = func_env.pointer_type();
 
         let len_offset = gc_compiler(func_env)?.layouts().array_length_field_offset();
-        let array_layout = func_env.array_layout(interned_type_index).clone();
-        let base_size = array_layout.base_size;
+        let array_layout = func_env.array_layout(interned_type_index)?.clone();
         let align = array_layout.align;
-        let len_to_elems_delta = base_size.checked_sub(len_offset).unwrap();
 
         // First, compute the array's total size from its base size, element
         // size, and length.
-        let len = init.len(&mut builder.cursor());
         let size = emit_array_size(func_env, builder, &array_layout, len);
 
         // Next, allocate the array.
@@ -218,7 +214,7 @@ impl GcCompiler for NullCompiler {
             Some(interned_type_index),
             size,
             align,
-        );
+        )?;
 
         // Write the array's length into its field.
         //
@@ -226,23 +222,7 @@ impl GcCompiler for NullCompiler {
         // the result of the inline allocation is trusted and we aren't reading
         // any pointers or offsets out from the (untrusted) GC heap.
         let len_addr = builder.ins().iadd_imm(ptr_to_object, i64::from(len_offset));
-        let len = init.len(&mut builder.cursor());
         builder.ins().store(GC_MEMFLAGS, len, len_addr, 0);
-
-        // Finally, initialize the elements.
-        let len_to_elems_delta = builder.ins().iconst(ptr_ty, i64::from(len_to_elems_delta));
-        let elems_addr = builder.ins().iadd(len_addr, len_to_elems_delta);
-        init.initialize(
-            func_env,
-            builder,
-            interned_type_index,
-            base_size,
-            size,
-            elems_addr,
-            |func_env, builder, elem_ty, elem_addr, val| {
-                write_field_at_addr(func_env, builder, elem_ty, elem_addr, val)
-            },
-        )?;
 
         Ok(gc_ref)
     }
@@ -277,7 +257,7 @@ impl GcCompiler for NullCompiler {
             Some(interned_type_index),
             struct_size_val,
             align,
-        );
+        )?;
 
         // Initialize the struct's fields.
         //
@@ -290,9 +270,6 @@ impl GcCompiler for NullCompiler {
             interned_type_index,
             raw_struct_pointer,
             field_vals,
-            |func_env, builder, ty, field_addr, val| {
-                write_field_at_addr(func_env, builder, ty, field_addr, val)
-            },
         )?;
 
         Ok(struct_ref)
@@ -329,7 +306,7 @@ impl GcCompiler for NullCompiler {
             Some(interned_type_index),
             exn_size_val,
             align,
-        );
+        )?;
 
         // Initialize the exception object's fields.
         //
@@ -342,9 +319,6 @@ impl GcCompiler for NullCompiler {
             interned_type_index,
             raw_exn_pointer,
             field_vals,
-            |func_env, builder, ty, field_addr, val| {
-                write_field_at_addr(func_env, builder, ty, field_addr, val)
-            },
         )?;
 
         // Initialize the tag fields.
@@ -395,5 +369,16 @@ impl GcCompiler for NullCompiler {
         flags: ir::MemFlagsData,
     ) -> WasmResult<()> {
         unbarriered_store_gc_ref(builder, ty.heap_type, dst, new_val, flags)
+    }
+
+    fn init_field(
+        &mut self,
+        func_env: &mut FuncEnvironment<'_>,
+        builder: &mut FunctionBuilder<'_>,
+        ty: WasmStorageType,
+        field_addr: ir::Value,
+        val: ir::Value,
+    ) -> WasmResult<()> {
+        write_field_at_addr(func_env, builder, ty, field_addr, val)
     }
 }

--- a/tests/disas/array-copy-anyref.wat
+++ b/tests/disas/array-copy-anyref.wat
@@ -20,97 +20,78 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32, v6: i32):
-;; @002b                               trapz v4, user16
-;; @002b                               v93 = load.i64 notrap aligned readonly can_move v0+8
-;; @002b                               v8 = load.i64 notrap aligned readonly can_move v93+32
-;; @002b                               v7 = uextend.i64 v4
+;; @002b                               trapz v2, user16
+;; @002b                               v102 = load.i64 notrap aligned readonly can_move v0+8
+;; @002b                               v8 = load.i64 notrap aligned readonly can_move v102+32
+;; @002b                               v7 = uextend.i64 v2
 ;; @002b                               v9 = iadd v8, v7
 ;; @002b                               v10 = iconst.i64 16
 ;; @002b                               v11 = iadd v9, v10  ; v10 = 16
 ;; @002b                               v12 = load.i32 user2 readonly v11
-;; @002b                               v13 = uadd_overflow_trap v5, v6, user17
-;; @002b                               v14 = icmp ugt v13, v12
-;; @002b                               trapnz v14, user17
-;; @002b                               v16 = uextend.i64 v12
-;;                                     v95 = iconst.i64 2
-;;                                     v96 = ishl v16, v95  ; v95 = 2
-;;                                     v92 = iconst.i64 32
-;; @002b                               v18 = ushr v96, v92  ; v92 = 32
-;; @002b                               trapnz v18, user2
-;;                                     v105 = iconst.i32 2
-;;                                     v106 = ishl v12, v105  ; v105 = 2
-;; @002b                               v20 = iconst.i32 20
-;; @002b                               v21 = uadd_overflow_trap v106, v20, user2  ; v20 = 20
-;; @002b                               v25 = uadd_overflow_trap v4, v21, user2
-;; @002b                               trapz v2, user16
-;; @002b                               v32 = uextend.i64 v2
-;; @002b                               v34 = iadd v8, v32
-;; @002b                               v36 = iadd v34, v10  ; v10 = 16
-;; @002b                               v37 = load.i32 user2 readonly v36
-;; @002b                               v38 = uadd_overflow_trap v3, v6, user17
-;; @002b                               v39 = icmp ugt v38, v37
-;; @002b                               trapnz v39, user17
-;; @002b                               v41 = uextend.i64 v37
-;;                                     v116 = ishl v41, v95  ; v95 = 2
-;; @002b                               v43 = ushr v116, v92  ; v92 = 32
-;; @002b                               trapnz v43, user2
-;;                                     v123 = ishl v37, v105  ; v105 = 2
-;; @002b                               v46 = uadd_overflow_trap v123, v20, user2  ; v20 = 20
-;; @002b                               v50 = uadd_overflow_trap v2, v46, user2
-;; @002b                               v60 = uextend.i64 v6
-;; @002b                               brif v60, block2, block5
+;; @002b                               v14 = uextend.i64 v3
+;; @002b                               v15 = uextend.i64 v6
+;; @002b                               v17 = iadd v14, v15
+;; @002b                               v13 = uextend.i64 v12
+;; @002b                               v18 = icmp ugt v17, v13
+;; @002b                               trapnz v18, user17
+;; @002b                               trapz v4, user16
+;; @002b                               v26 = uextend.i64 v4
+;; @002b                               v28 = iadd v8, v26
+;; @002b                               v30 = iadd v28, v10  ; v10 = 16
+;; @002b                               v31 = load.i32 user2 readonly v30
+;; @002b                               v33 = uextend.i64 v5
+;; @002b                               v36 = iadd v33, v15
+;; @002b                               v32 = uextend.i64 v31
+;; @002b                               v37 = icmp ugt v36, v32
+;; @002b                               trapnz v37, user17
+;; @002b                               v49 = load.i64 notrap aligned v102+40
+;;                                     v98 = iconst.i64 20
+;; @002b                               v22 = iadd v9, v98  ; v98 = 20
+;;                                     v106 = iconst.i64 2
+;;                                     v107 = ishl v14, v106  ; v106 = 2
+;; @002b                               v25 = iadd v22, v107
+;;                                     v111 = ishl v15, v106  ; v106 = 2
+;; @002b                               v51 = uadd_overflow_trap v25, v111, user2
+;; @002b                               v50 = iadd v8, v49
+;; @002b                               v52 = icmp ugt v51, v50
+;; @002b                               trapnz v52, user2
+;; @002b                               brif v15, block2, block5
 ;;
 ;;                                 block2:
-;; @002b                               v51 = uextend.i64 v50
-;; @002b                               v53 = iadd.i64 v8, v51
-;;                                     v141 = iconst.i32 2
-;;                                     v142 = ishl.i32 v3, v141  ; v141 = 2
-;;                                     v143 = iconst.i32 20
-;;                                     v144 = iadd v142, v143  ; v143 = 20
-;; @002b                               v54 = isub.i32 v46, v144
-;; @002b                               v55 = uextend.i64 v54
-;; @002b                               v56 = isub v53, v55
-;; @002b                               v26 = uextend.i64 v25
-;; @002b                               v28 = iadd.i64 v8, v26
-;;                                     v145 = ishl.i32 v5, v141  ; v141 = 2
-;;                                     v146 = iadd v145, v143  ; v143 = 20
-;; @002b                               v29 = isub.i32 v21, v146
-;; @002b                               v30 = uextend.i64 v29
-;; @002b                               v31 = isub v28, v30
-;; @002b                               v61 = icmp ult v56, v31
-;;                                     v147 = iconst.i64 2
-;;                                     v148 = ishl.i64 v60, v147  ; v147 = 2
-;; @002b                               v63 = iadd v56, v148
-;; @002b                               v64 = iadd v31, v148
-;; @002b                               v66 = iadd.i32 v5, v6
-;; @002b                               v15 = iconst.i64 4
-;;                                     v138 = iadd v28, v15  ; v15 = 4
-;; @002b                               v80 = iconst.i32 1
-;; @002b                               brif v61, block3(v56, v31, v5), block4(v63, v64, v66)
+;;                                     v116 = iconst.i64 20
+;;                                     v117 = iadd.i64 v28, v116  ; v116 = 20
+;;                                     v118 = iconst.i64 2
+;;                                     v119 = ishl.i64 v33, v118  ; v118 = 2
+;; @002b                               v44 = iadd v117, v119
+;; @002b                               v58 = icmp.i64 ult v25, v44
+;; @002b                               v60 = iadd.i64 v25, v111
+;; @002b                               v61 = iadd v44, v111
+;; @002b                               v63 = iadd.i32 v5, v6
+;;                                     v97 = iconst.i64 4
+;; @002b                               v77 = iconst.i32 1
+;; @002b                               brif v58, block3(v25, v44, v5), block4(v60, v61, v63)
 ;;
-;;                                 block3(v67: i64, v68: i64, v69: i32):
-;; @002b                               v70 = load.i32 user2 little v68
-;; @002b                               store user2 little v70, v67
-;;                                     v156 = iconst.i64 4
-;;                                     v157 = iadd v68, v156  ; v156 = 4
-;; @002b                               v74 = icmp eq v157, v64
-;;                                     v158 = iadd v67, v156  ; v156 = 4
-;;                                     v159 = iconst.i32 1
-;;                                     v160 = iadd v69, v159  ; v159 = 1
-;; @002b                               brif v74, block5, block3(v158, v157, v160)
+;;                                 block3(v64: i64, v65: i64, v66: i32):
+;; @002b                               v67 = load.i32 user2 little v65
+;; @002b                               store user2 little v67, v64
+;;                                     v125 = iconst.i64 4
+;;                                     v126 = iadd v65, v125  ; v125 = 4
+;; @002b                               v71 = icmp eq v126, v61
+;;                                     v127 = iadd v64, v125  ; v125 = 4
+;;                                     v128 = iconst.i32 1
+;;                                     v129 = iadd v66, v128  ; v128 = 1
+;; @002b                               brif v71, block5, block3(v127, v126, v129)
 ;;
-;;                                 block4(v75: i64, v76: i64, v77: i32):
-;;                                     v149 = iconst.i64 4
-;;                                     v150 = isub v76, v149  ; v149 = 4
-;; @002b                               v82 = load.i32 user2 little v150
-;;                                     v151 = isub v75, v149  ; v149 = 4
-;; @002b                               store user2 little v82, v151
-;;                                     v137 = iadd v76, v30
-;;                                     v152 = iadd.i64 v28, v15  ; v15 = 4
-;;                                     v153 = icmp eq v137, v152
-;;                                     v154 = iconst.i32 1
-;;                                     v155 = isub v77, v154  ; v154 = 1
-;; @002b                               brif v153, block5, block4(v151, v150, v155)
+;;                                 block4(v72: i64, v73: i64, v74: i32):
+;;                                     v120 = iconst.i64 4
+;;                                     v121 = isub v73, v120  ; v120 = 4
+;; @002b                               v79 = load.i32 user2 little v121
+;;                                     v122 = isub v72, v120  ; v120 = 4
+;; @002b                               store user2 little v79, v122
+;; @002b                               v80 = icmp eq v121, v44
+;;                                     v123 = iconst.i32 1
+;;                                     v124 = isub v74, v123  ; v123 = 1
+;; @002b                               brif v80, block5, block4(v122, v121, v124)
 ;;
 ;;                                 block5:
 ;; @002f                               jump block1

--- a/tests/disas/array-copy-i64.wat
+++ b/tests/disas/array-copy-i64.wat
@@ -22,68 +22,45 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32, v6: i32):
-;; @002b                               trapz v4, user16
+;; @002b                               trapz v2, user16
 ;; @002b                               v79 = load.i64 notrap aligned readonly can_move v0+8
 ;; @002b                               v8 = load.i64 notrap aligned readonly can_move v79+32
-;; @002b                               v7 = uextend.i64 v4
+;; @002b                               v7 = uextend.i64 v2
 ;; @002b                               v9 = iadd v8, v7
 ;; @002b                               v10 = iconst.i64 24
 ;; @002b                               v11 = iadd v9, v10  ; v10 = 24
 ;; @002b                               v12 = load.i32 user2 readonly v11
-;; @002b                               v13 = uadd_overflow_trap v5, v6, user17
-;; @002b                               v14 = icmp ugt v13, v12
-;; @002b                               trapnz v14, user17
-;; @002b                               v16 = uextend.i64 v12
-;;                                     v81 = iconst.i64 3
-;;                                     v82 = ishl v16, v81  ; v81 = 3
-;;                                     v78 = iconst.i64 32
-;; @002b                               v18 = ushr v82, v78  ; v78 = 32
-;; @002b                               trapnz v18, user2
-;;                                     v91 = iconst.i32 3
-;;                                     v92 = ishl v12, v91  ; v91 = 3
-;; @002b                               v20 = iconst.i32 32
-;; @002b                               v21 = uadd_overflow_trap v92, v20, user2  ; v20 = 32
-;; @002b                               v25 = uadd_overflow_trap v4, v21, user2
-;; @002b                               trapz v2, user16
-;; @002b                               v32 = uextend.i64 v2
-;; @002b                               v34 = iadd v8, v32
-;; @002b                               v36 = iadd v34, v10  ; v10 = 24
-;; @002b                               v37 = load.i32 user2 readonly v36
-;; @002b                               v38 = uadd_overflow_trap v3, v6, user17
-;; @002b                               v39 = icmp ugt v38, v37
-;; @002b                               trapnz v39, user17
-;; @002b                               v41 = uextend.i64 v37
-;;                                     v102 = ishl v41, v81  ; v81 = 3
-;; @002b                               v43 = ushr v102, v78  ; v78 = 32
-;; @002b                               trapnz v43, user2
-;;                                     v109 = ishl v37, v91  ; v91 = 3
-;; @002b                               v46 = uadd_overflow_trap v109, v20, user2  ; v20 = 32
-;; @002b                               v50 = uadd_overflow_trap v2, v46, user2
-;; @002b                               v60 = load.i64 notrap aligned v79+40
-;; @002b                               v26 = uextend.i64 v25
+;; @002b                               v14 = uextend.i64 v3
+;; @002b                               v15 = uextend.i64 v6
+;; @002b                               v17 = iadd v14, v15
+;; @002b                               v13 = uextend.i64 v12
+;; @002b                               v18 = icmp ugt v17, v13
+;; @002b                               trapnz v18, user17
+;; @002b                               trapz v4, user16
+;; @002b                               v26 = uextend.i64 v4
 ;; @002b                               v28 = iadd v8, v26
-;;                                     v98 = ishl v5, v91  ; v91 = 3
-;;                                     v100 = iadd v98, v20  ; v20 = 32
-;; @002b                               v29 = isub v21, v100
-;; @002b                               v30 = uextend.i64 v29
-;; @002b                               v31 = isub v28, v30
-;;                                     v119 = ishl v6, v91  ; v91 = 3
-;; @002b                               v58 = uextend.i64 v119
-;; @002b                               v62 = iadd v31, v58
-;; @002b                               v61 = iadd v8, v60
-;; @002b                               v64 = icmp ugt v62, v61
-;; @002b                               trapnz v64, user2
-;; @002b                               v51 = uextend.i64 v50
-;; @002b                               v53 = iadd v8, v51
-;;                                     v115 = ishl v3, v91  ; v91 = 3
-;;                                     v117 = iadd v115, v20  ; v20 = 32
-;; @002b                               v54 = isub v46, v117
-;; @002b                               v55 = uextend.i64 v54
-;; @002b                               v56 = isub v53, v55
-;; @002b                               v63 = iadd v56, v58
-;; @002b                               v65 = icmp ugt v63, v61
-;; @002b                               trapnz v65, user2
-;; @002b                               call fn0(v0, v56, v31, v58)
+;; @002b                               v30 = iadd v28, v10  ; v10 = 24
+;; @002b                               v31 = load.i32 user2 readonly v30
+;; @002b                               v33 = uextend.i64 v5
+;; @002b                               v36 = iadd v33, v15
+;; @002b                               v32 = uextend.i64 v31
+;; @002b                               v37 = icmp ugt v36, v32
+;; @002b                               trapnz v37, user17
+;; @002b                               v49 = load.i64 notrap aligned v79+40
+;;                                     v75 = iconst.i64 32
+;; @002b                               v22 = iadd v9, v75  ; v75 = 32
+;;                                     v83 = iconst.i64 3
+;;                                     v84 = ishl v14, v83  ; v83 = 3
+;; @002b                               v25 = iadd v22, v84
+;;                                     v88 = ishl v15, v83  ; v83 = 3
+;; @002b                               v51 = uadd_overflow_trap v25, v88, user2
+;; @002b                               v50 = iadd v8, v49
+;; @002b                               v52 = icmp ugt v51, v50
+;; @002b                               trapnz v52, user2
+;; @002b                               v41 = iadd v28, v75  ; v75 = 32
+;;                                     v86 = ishl v33, v83  ; v83 = 3
+;; @002b                               v44 = iadd v41, v86
+;; @002b                               call fn0(v0, v25, v44, v88)
 ;; @002f                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/array-copy-i8.wat
+++ b/tests/disas/array-copy-i8.wat
@@ -22,59 +22,41 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32, v6: i32):
-;; @002b                               trapz v4, user16
+;; @002b                               trapz v2, user16
 ;; @002b                               v79 = load.i64 notrap aligned readonly can_move v0+8
 ;; @002b                               v8 = load.i64 notrap aligned readonly can_move v79+32
-;; @002b                               v7 = uextend.i64 v4
+;; @002b                               v7 = uextend.i64 v2
 ;; @002b                               v9 = iadd v8, v7
 ;; @002b                               v10 = iconst.i64 24
 ;; @002b                               v11 = iadd v9, v10  ; v10 = 24
 ;; @002b                               v12 = load.i32 user2 readonly v11
-;; @002b                               v13 = uadd_overflow_trap v5, v6, user17
-;; @002b                               v14 = icmp ugt v13, v12
-;; @002b                               trapnz v14, user17
-;; @002b                               v16 = uextend.i64 v12
-;;                                     v78 = iconst.i64 32
-;; @002b                               v18 = ushr v16, v78  ; v78 = 32
-;; @002b                               trapnz v18, user2
-;; @002b                               v20 = iconst.i32 28
-;; @002b                               v21 = uadd_overflow_trap v12, v20, user2  ; v20 = 28
-;; @002b                               v25 = uadd_overflow_trap v4, v21, user2
-;; @002b                               trapz v2, user16
-;; @002b                               v32 = uextend.i64 v2
-;; @002b                               v34 = iadd v8, v32
-;; @002b                               v36 = iadd v34, v10  ; v10 = 24
-;; @002b                               v37 = load.i32 user2 readonly v36
-;; @002b                               v38 = uadd_overflow_trap v3, v6, user17
-;; @002b                               v39 = icmp ugt v38, v37
-;; @002b                               trapnz v39, user17
-;; @002b                               v41 = uextend.i64 v37
-;; @002b                               v43 = ushr v41, v78  ; v78 = 32
-;; @002b                               trapnz v43, user2
-;; @002b                               v46 = uadd_overflow_trap v37, v20, user2  ; v20 = 28
-;; @002b                               v50 = uadd_overflow_trap v2, v46, user2
-;; @002b                               v60 = load.i64 notrap aligned v79+40
-;; @002b                               v26 = uextend.i64 v25
+;; @002b                               v14 = uextend.i64 v3
+;; @002b                               v15 = uextend.i64 v6
+;; @002b                               v17 = iadd v14, v15
+;; @002b                               v13 = uextend.i64 v12
+;; @002b                               v18 = icmp ugt v17, v13
+;; @002b                               trapnz v18, user17
+;; @002b                               trapz v4, user16
+;; @002b                               v26 = uextend.i64 v4
 ;; @002b                               v28 = iadd v8, v26
-;;                                     v87 = iadd v5, v20  ; v20 = 28
-;; @002b                               v29 = isub v21, v87
-;; @002b                               v30 = uextend.i64 v29
-;; @002b                               v31 = isub v28, v30
-;; @002b                               v58 = uextend.i64 v6
-;; @002b                               v62 = iadd v31, v58
-;; @002b                               v61 = iadd v8, v60
-;; @002b                               v64 = icmp ugt v62, v61
-;; @002b                               trapnz v64, user2
-;; @002b                               v51 = uextend.i64 v50
-;; @002b                               v53 = iadd v8, v51
-;;                                     v92 = iadd v3, v20  ; v20 = 28
-;; @002b                               v54 = isub v46, v92
-;; @002b                               v55 = uextend.i64 v54
-;; @002b                               v56 = isub v53, v55
-;; @002b                               v63 = iadd v56, v58
-;; @002b                               v65 = icmp ugt v63, v61
-;; @002b                               trapnz v65, user2
-;; @002b                               call fn0(v0, v56, v31, v58)
+;; @002b                               v30 = iadd v28, v10  ; v10 = 24
+;; @002b                               v31 = load.i32 user2 readonly v30
+;; @002b                               v33 = uextend.i64 v5
+;; @002b                               v36 = iadd v33, v15
+;; @002b                               v32 = uextend.i64 v31
+;; @002b                               v37 = icmp ugt v36, v32
+;; @002b                               trapnz v37, user17
+;; @002b                               v49 = load.i64 notrap aligned v79+40
+;;                                     v75 = iconst.i64 28
+;; @002b                               v22 = iadd v9, v75  ; v75 = 28
+;; @002b                               v25 = iadd v22, v14
+;; @002b                               v51 = uadd_overflow_trap v25, v15, user2
+;; @002b                               v50 = iadd v8, v49
+;; @002b                               v52 = icmp ugt v51, v50
+;; @002b                               trapnz v52, user2
+;; @002b                               v41 = iadd v28, v75  ; v75 = 28
+;; @002b                               v44 = iadd v41, v33
+;; @002b                               call fn0(v0, v25, v44, v15)
 ;; @002f                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/array-fill-anyref.wat
+++ b/tests/disas/array-fill-anyref.wat
@@ -29,51 +29,44 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
 ;; @0030                               trapz v2, user16
-;; @0030                               v41 = load.i64 notrap aligned readonly can_move v0+8
-;; @0030                               v7 = load.i64 notrap aligned readonly can_move v41+32
+;; @0030                               v49 = load.i64 notrap aligned readonly can_move v0+8
+;; @0030                               v7 = load.i64 notrap aligned readonly can_move v49+32
 ;; @0030                               v6 = uextend.i64 v2
 ;; @0030                               v8 = iadd v7, v6
 ;; @0030                               v9 = iconst.i64 16
 ;; @0030                               v10 = iadd v8, v9  ; v9 = 16
 ;; @0030                               v11 = load.i32 user2 readonly v10
-;; @0030                               v12 = uadd_overflow_trap v3, v5, user17
-;; @0030                               v13 = icmp ugt v12, v11
-;; @0030                               trapnz v13, user17
-;; @0030                               v15 = uextend.i64 v11
-;;                                     v43 = iconst.i64 2
-;;                                     v44 = ishl v15, v43  ; v43 = 2
-;;                                     v40 = iconst.i64 32
-;; @0030                               v17 = ushr v44, v40  ; v40 = 32
-;; @0030                               trapnz v17, user2
-;;                                     v53 = iconst.i32 2
-;;                                     v54 = ishl v11, v53  ; v53 = 2
-;; @0030                               v19 = iconst.i32 20
-;; @0030                               v20 = uadd_overflow_trap v54, v19, user2  ; v19 = 20
-;; @0030                               v24 = uadd_overflow_trap v2, v20, user2
-;; @0030                               v25 = uextend.i64 v24
-;; @0030                               v27 = iadd v7, v25
-;;                                     v60 = ishl v3, v53  ; v53 = 2
-;;                                     v62 = iadd v60, v19  ; v19 = 20
-;; @0030                               v28 = isub v20, v62
-;; @0030                               v29 = uextend.i64 v28
-;; @0030                               v30 = isub v27, v29
-;;                                     v64 = ishl v5, v53  ; v53 = 2
-;; @0030                               v32 = uextend.i64 v64
-;; @0030                               v33 = iadd v30, v32
-;; @0030                               v14 = iconst.i64 4
-;; @0030                               jump block2(v30)
+;; @0030                               v13 = uextend.i64 v3
+;; @0030                               v14 = uextend.i64 v5
+;; @0030                               v16 = iadd v13, v14
+;; @0030                               v12 = uextend.i64 v11
+;; @0030                               v17 = icmp ugt v16, v12
+;; @0030                               trapnz v17, user17
+;; @0030                               v28 = load.i64 notrap aligned v49+40
+;;                                     v45 = iconst.i64 20
+;; @0030                               v21 = iadd v8, v45  ; v45 = 20
+;;                                     v53 = iconst.i64 2
+;;                                     v54 = ishl v13, v53  ; v53 = 2
+;; @0030                               v24 = iadd v21, v54
+;;                                     v56 = ishl v14, v53  ; v53 = 2
+;; @0030                               v30 = uadd_overflow_trap v24, v56, user2
+;; @0030                               v29 = iadd v7, v28
+;; @0030                               v31 = icmp ugt v30, v29
+;; @0030                               trapnz v31, user2
+;;                                     v51 = iconst.i64 0
+;; @0030                               v33 = icmp eq v14, v51  ; v51 = 0
+;;                                     v44 = iconst.i64 4
+;; @0030                               v32 = iadd v24, v56
+;; @0030                               brif v33, block3, block2(v24)
 ;;
-;;                                 block2(v35: i64):
-;; @0030                               v36 = icmp eq v35, v33
-;; @0030                               brif v36, block4, block3
+;;                                 block2(v34: i64):
+;; @0030                               store.i32 user2 little v4, v34
+;;                                     v58 = iconst.i64 4
+;;                                     v59 = iadd v34, v58  ; v58 = 4
+;; @0030                               v36 = icmp eq v59, v32
+;; @0030                               brif v36, block3, block2(v59)
 ;;
 ;;                                 block3:
-;; @0030                               store.i32 user2 little v4, v35
-;;                                     v66 = iconst.i64 4
-;;                                     v67 = iadd.i64 v35, v66  ; v66 = 4
-;; @0030                               jump block2(v67)
-;;
-;;                                 block4:
 ;; @0033                               jump block1
 ;;
 ;;                                 block1:
@@ -94,43 +87,32 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @003e                               trapz v2, user16
-;; @003e                               v49 = load.i64 notrap aligned readonly can_move v0+8
-;; @003e                               v7 = load.i64 notrap aligned readonly can_move v49+32
+;; @003e                               v44 = load.i64 notrap aligned readonly can_move v0+8
+;; @003e                               v7 = load.i64 notrap aligned readonly can_move v44+32
 ;; @003e                               v6 = uextend.i64 v2
 ;; @003e                               v8 = iadd v7, v6
 ;; @003e                               v9 = iconst.i64 16
 ;; @003e                               v10 = iadd v8, v9  ; v9 = 16
 ;; @003e                               v11 = load.i32 user2 readonly v10
-;; @003e                               v12 = uadd_overflow_trap v3, v4, user17
-;; @003e                               v13 = icmp ugt v12, v11
-;; @003e                               trapnz v13, user17
-;; @003e                               v15 = uextend.i64 v11
-;;                                     v51 = iconst.i64 2
-;;                                     v52 = ishl v15, v51  ; v51 = 2
-;;                                     v48 = iconst.i64 32
-;; @003e                               v17 = ushr v52, v48  ; v48 = 32
-;; @003e                               trapnz v17, user2
-;;                                     v61 = iconst.i32 2
-;;                                     v62 = ishl v11, v61  ; v61 = 2
-;; @003e                               v19 = iconst.i32 20
-;; @003e                               v20 = uadd_overflow_trap v62, v19, user2  ; v19 = 20
-;; @003e                               v24 = uadd_overflow_trap v2, v20, user2
-;; @003e                               v37 = load.i64 notrap aligned v49+40
-;; @003e                               v25 = uextend.i64 v24
-;; @003e                               v27 = iadd v7, v25
-;;                                     v68 = ishl v3, v61  ; v61 = 2
-;;                                     v70 = iadd v68, v19  ; v19 = 20
-;; @003e                               v28 = isub v20, v70
-;; @003e                               v29 = uextend.i64 v28
-;; @003e                               v30 = isub v27, v29
-;;                                     v72 = ishl v4, v61  ; v61 = 2
-;; @003e                               v32 = uextend.i64 v72
-;; @003e                               v33 = iadd v30, v32
-;; @003e                               v38 = iadd v7, v37
-;; @003e                               v39 = icmp ugt v33, v38
-;; @003e                               trapnz v39, user2
+;; @003e                               v13 = uextend.i64 v3
+;; @003e                               v14 = uextend.i64 v4
+;; @003e                               v16 = iadd v13, v14
+;; @003e                               v12 = uextend.i64 v11
+;; @003e                               v17 = icmp ugt v16, v12
+;; @003e                               trapnz v17, user17
+;; @003e                               v28 = load.i64 notrap aligned v44+40
+;;                                     v40 = iconst.i64 20
+;; @003e                               v21 = iadd v8, v40  ; v40 = 20
+;;                                     v48 = iconst.i64 2
+;;                                     v49 = ishl v13, v48  ; v48 = 2
+;; @003e                               v24 = iadd v21, v49
+;;                                     v51 = ishl v14, v48  ; v48 = 2
+;; @003e                               v30 = uadd_overflow_trap v24, v51, user2
+;; @003e                               v29 = iadd v7, v28
+;; @003e                               v31 = icmp ugt v30, v29
+;; @003e                               trapnz v31, user2
 ;; @003a                               v5 = iconst.i32 0
-;; @003e                               call fn0(v0, v30, v5, v32)  ; v5 = 0
+;; @003e                               call fn0(v0, v24, v5, v51)  ; v5 = 0
 ;; @0041                               jump block1
 ;;
 ;;                                 block1:
@@ -149,53 +131,46 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @004e                               trapz v2, user16
-;; @004e                               v43 = load.i64 notrap aligned readonly can_move v0+8
-;; @004e                               v9 = load.i64 notrap aligned readonly can_move v43+32
+;; @004e                               v51 = load.i64 notrap aligned readonly can_move v0+8
+;; @004e                               v9 = load.i64 notrap aligned readonly can_move v51+32
 ;; @004e                               v8 = uextend.i64 v2
 ;; @004e                               v10 = iadd v9, v8
 ;; @004e                               v11 = iconst.i64 16
 ;; @004e                               v12 = iadd v10, v11  ; v11 = 16
 ;; @004e                               v13 = load.i32 user2 readonly v12
-;; @004e                               v14 = uadd_overflow_trap v3, v4, user17
-;; @004e                               v15 = icmp ugt v14, v13
-;; @004e                               trapnz v15, user17
-;; @004e                               v17 = uextend.i64 v13
-;;                                     v53 = iconst.i64 2
-;;                                     v54 = ishl v17, v53  ; v53 = 2
-;;                                     v42 = iconst.i64 32
-;; @004e                               v19 = ushr v54, v42  ; v42 = 32
-;; @004e                               trapnz v19, user2
-;;                                     v63 = iconst.i32 2
-;;                                     v64 = ishl v13, v63  ; v63 = 2
-;; @004e                               v21 = iconst.i32 20
-;; @004e                               v22 = uadd_overflow_trap v64, v21, user2  ; v21 = 20
-;; @004e                               v26 = uadd_overflow_trap v2, v22, user2
-;; @004e                               v27 = uextend.i64 v26
-;; @004e                               v29 = iadd v9, v27
-;;                                     v70 = ishl v3, v63  ; v63 = 2
-;;                                     v72 = iadd v70, v21  ; v21 = 20
-;; @004e                               v30 = isub v22, v72
-;; @004e                               v31 = uextend.i64 v30
-;; @004e                               v32 = isub v29, v31
-;;                                     v74 = ishl v4, v63  ; v63 = 2
-;; @004e                               v34 = uextend.i64 v74
-;; @004e                               v35 = iadd v32, v34
+;; @004e                               v15 = uextend.i64 v3
+;; @004e                               v16 = uextend.i64 v4
+;; @004e                               v18 = iadd v15, v16
+;; @004e                               v14 = uextend.i64 v13
+;; @004e                               v19 = icmp ugt v18, v14
+;; @004e                               trapnz v19, user17
+;; @004e                               v30 = load.i64 notrap aligned v51+40
+;;                                     v47 = iconst.i64 20
+;; @004e                               v23 = iadd v10, v47  ; v47 = 20
+;;                                     v63 = iconst.i64 2
+;;                                     v64 = ishl v15, v63  ; v63 = 2
+;; @004e                               v26 = iadd v23, v64
+;;                                     v66 = ishl v16, v63  ; v63 = 2
+;; @004e                               v32 = uadd_overflow_trap v26, v66, user2
+;; @004e                               v31 = iadd v9, v30
+;; @004e                               v33 = icmp ugt v32, v31
+;; @004e                               trapnz v33, user2
+;;                                     v61 = iconst.i64 0
+;; @004e                               v35 = icmp eq v16, v61  ; v61 = 0
 ;; @0048                               v5 = iconst.i32 -1
-;; @004e                               v16 = iconst.i64 4
-;; @004e                               jump block2(v32)
+;;                                     v46 = iconst.i64 4
+;; @004e                               v34 = iadd v26, v66
+;; @004e                               brif v35, block3, block2(v26)
 ;;
-;;                                 block2(v37: i64):
-;; @004e                               v38 = icmp eq v37, v35
-;; @004e                               brif v38, block4, block3
+;;                                 block2(v36: i64):
+;;                                     v68 = iconst.i32 -1
+;; @004e                               store user2 little v68, v36  ; v68 = -1
+;;                                     v69 = iconst.i64 4
+;;                                     v70 = iadd v36, v69  ; v69 = 4
+;; @004e                               v38 = icmp eq v70, v34
+;; @004e                               brif v38, block3, block2(v70)
 ;;
 ;;                                 block3:
-;;                                     v76 = iconst.i32 -1
-;; @004e                               store user2 little v76, v37  ; v76 = -1
-;;                                     v77 = iconst.i64 4
-;;                                     v78 = iadd.i64 v37, v77  ; v77 = 4
-;; @004e                               jump block2(v78)
-;;
-;;                                 block4:
 ;; @0051                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/array-fill-externref.wat
+++ b/tests/disas/array-fill-externref.wat
@@ -25,51 +25,44 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
 ;; @002f                               trapz v2, user16
-;; @002f                               v41 = load.i64 notrap aligned readonly can_move v0+8
-;; @002f                               v7 = load.i64 notrap aligned readonly can_move v41+32
+;; @002f                               v49 = load.i64 notrap aligned readonly can_move v0+8
+;; @002f                               v7 = load.i64 notrap aligned readonly can_move v49+32
 ;; @002f                               v6 = uextend.i64 v2
 ;; @002f                               v8 = iadd v7, v6
 ;; @002f                               v9 = iconst.i64 16
 ;; @002f                               v10 = iadd v8, v9  ; v9 = 16
 ;; @002f                               v11 = load.i32 user2 readonly v10
-;; @002f                               v12 = uadd_overflow_trap v3, v5, user17
-;; @002f                               v13 = icmp ugt v12, v11
-;; @002f                               trapnz v13, user17
-;; @002f                               v15 = uextend.i64 v11
-;;                                     v43 = iconst.i64 2
-;;                                     v44 = ishl v15, v43  ; v43 = 2
-;;                                     v40 = iconst.i64 32
-;; @002f                               v17 = ushr v44, v40  ; v40 = 32
-;; @002f                               trapnz v17, user2
-;;                                     v53 = iconst.i32 2
-;;                                     v54 = ishl v11, v53  ; v53 = 2
-;; @002f                               v19 = iconst.i32 20
-;; @002f                               v20 = uadd_overflow_trap v54, v19, user2  ; v19 = 20
-;; @002f                               v24 = uadd_overflow_trap v2, v20, user2
-;; @002f                               v25 = uextend.i64 v24
-;; @002f                               v27 = iadd v7, v25
-;;                                     v60 = ishl v3, v53  ; v53 = 2
-;;                                     v62 = iadd v60, v19  ; v19 = 20
-;; @002f                               v28 = isub v20, v62
-;; @002f                               v29 = uextend.i64 v28
-;; @002f                               v30 = isub v27, v29
-;;                                     v64 = ishl v5, v53  ; v53 = 2
-;; @002f                               v32 = uextend.i64 v64
-;; @002f                               v33 = iadd v30, v32
-;; @002f                               v14 = iconst.i64 4
-;; @002f                               jump block2(v30)
+;; @002f                               v13 = uextend.i64 v3
+;; @002f                               v14 = uextend.i64 v5
+;; @002f                               v16 = iadd v13, v14
+;; @002f                               v12 = uextend.i64 v11
+;; @002f                               v17 = icmp ugt v16, v12
+;; @002f                               trapnz v17, user17
+;; @002f                               v28 = load.i64 notrap aligned v49+40
+;;                                     v45 = iconst.i64 20
+;; @002f                               v21 = iadd v8, v45  ; v45 = 20
+;;                                     v53 = iconst.i64 2
+;;                                     v54 = ishl v13, v53  ; v53 = 2
+;; @002f                               v24 = iadd v21, v54
+;;                                     v56 = ishl v14, v53  ; v53 = 2
+;; @002f                               v30 = uadd_overflow_trap v24, v56, user2
+;; @002f                               v29 = iadd v7, v28
+;; @002f                               v31 = icmp ugt v30, v29
+;; @002f                               trapnz v31, user2
+;;                                     v51 = iconst.i64 0
+;; @002f                               v33 = icmp eq v14, v51  ; v51 = 0
+;;                                     v44 = iconst.i64 4
+;; @002f                               v32 = iadd v24, v56
+;; @002f                               brif v33, block3, block2(v24)
 ;;
-;;                                 block2(v35: i64):
-;; @002f                               v36 = icmp eq v35, v33
-;; @002f                               brif v36, block4, block3
+;;                                 block2(v34: i64):
+;; @002f                               store.i32 user2 little v4, v34
+;;                                     v58 = iconst.i64 4
+;;                                     v59 = iadd v34, v58  ; v58 = 4
+;; @002f                               v36 = icmp eq v59, v32
+;; @002f                               brif v36, block3, block2(v59)
 ;;
 ;;                                 block3:
-;; @002f                               store.i32 user2 little v4, v35
-;;                                     v66 = iconst.i64 4
-;;                                     v67 = iadd.i64 v35, v66  ; v66 = 4
-;; @002f                               jump block2(v67)
-;;
-;;                                 block4:
 ;; @0032                               jump block1
 ;;
 ;;                                 block1:
@@ -90,43 +83,32 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @003d                               trapz v2, user16
-;; @003d                               v49 = load.i64 notrap aligned readonly can_move v0+8
-;; @003d                               v7 = load.i64 notrap aligned readonly can_move v49+32
+;; @003d                               v44 = load.i64 notrap aligned readonly can_move v0+8
+;; @003d                               v7 = load.i64 notrap aligned readonly can_move v44+32
 ;; @003d                               v6 = uextend.i64 v2
 ;; @003d                               v8 = iadd v7, v6
 ;; @003d                               v9 = iconst.i64 16
 ;; @003d                               v10 = iadd v8, v9  ; v9 = 16
 ;; @003d                               v11 = load.i32 user2 readonly v10
-;; @003d                               v12 = uadd_overflow_trap v3, v4, user17
-;; @003d                               v13 = icmp ugt v12, v11
-;; @003d                               trapnz v13, user17
-;; @003d                               v15 = uextend.i64 v11
-;;                                     v51 = iconst.i64 2
-;;                                     v52 = ishl v15, v51  ; v51 = 2
-;;                                     v48 = iconst.i64 32
-;; @003d                               v17 = ushr v52, v48  ; v48 = 32
-;; @003d                               trapnz v17, user2
-;;                                     v61 = iconst.i32 2
-;;                                     v62 = ishl v11, v61  ; v61 = 2
-;; @003d                               v19 = iconst.i32 20
-;; @003d                               v20 = uadd_overflow_trap v62, v19, user2  ; v19 = 20
-;; @003d                               v24 = uadd_overflow_trap v2, v20, user2
-;; @003d                               v37 = load.i64 notrap aligned v49+40
-;; @003d                               v25 = uextend.i64 v24
-;; @003d                               v27 = iadd v7, v25
-;;                                     v68 = ishl v3, v61  ; v61 = 2
-;;                                     v70 = iadd v68, v19  ; v19 = 20
-;; @003d                               v28 = isub v20, v70
-;; @003d                               v29 = uextend.i64 v28
-;; @003d                               v30 = isub v27, v29
-;;                                     v72 = ishl v4, v61  ; v61 = 2
-;; @003d                               v32 = uextend.i64 v72
-;; @003d                               v33 = iadd v30, v32
-;; @003d                               v38 = iadd v7, v37
-;; @003d                               v39 = icmp ugt v33, v38
-;; @003d                               trapnz v39, user2
+;; @003d                               v13 = uextend.i64 v3
+;; @003d                               v14 = uextend.i64 v4
+;; @003d                               v16 = iadd v13, v14
+;; @003d                               v12 = uextend.i64 v11
+;; @003d                               v17 = icmp ugt v16, v12
+;; @003d                               trapnz v17, user17
+;; @003d                               v28 = load.i64 notrap aligned v44+40
+;;                                     v40 = iconst.i64 20
+;; @003d                               v21 = iadd v8, v40  ; v40 = 20
+;;                                     v48 = iconst.i64 2
+;;                                     v49 = ishl v13, v48  ; v48 = 2
+;; @003d                               v24 = iadd v21, v49
+;;                                     v51 = ishl v14, v48  ; v48 = 2
+;; @003d                               v30 = uadd_overflow_trap v24, v51, user2
+;; @003d                               v29 = iadd v7, v28
+;; @003d                               v31 = icmp ugt v30, v29
+;; @003d                               trapnz v31, user2
 ;; @0039                               v5 = iconst.i32 0
-;; @003d                               call fn0(v0, v30, v5, v32)  ; v5 = 0
+;; @003d                               call fn0(v0, v24, v5, v51)  ; v5 = 0
 ;; @0040                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/array-fill-f32.wat
+++ b/tests/disas/array-fill-f32.wat
@@ -29,51 +29,44 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: f32, v5: i32):
 ;; @0030                               trapz v2, user16
-;; @0030                               v41 = load.i64 notrap aligned readonly can_move v0+8
-;; @0030                               v7 = load.i64 notrap aligned readonly can_move v41+32
+;; @0030                               v49 = load.i64 notrap aligned readonly can_move v0+8
+;; @0030                               v7 = load.i64 notrap aligned readonly can_move v49+32
 ;; @0030                               v6 = uextend.i64 v2
 ;; @0030                               v8 = iadd v7, v6
 ;; @0030                               v9 = iconst.i64 24
 ;; @0030                               v10 = iadd v8, v9  ; v9 = 24
 ;; @0030                               v11 = load.i32 user2 readonly v10
-;; @0030                               v12 = uadd_overflow_trap v3, v5, user17
-;; @0030                               v13 = icmp ugt v12, v11
-;; @0030                               trapnz v13, user17
-;; @0030                               v15 = uextend.i64 v11
-;;                                     v43 = iconst.i64 2
-;;                                     v44 = ishl v15, v43  ; v43 = 2
-;;                                     v40 = iconst.i64 32
-;; @0030                               v17 = ushr v44, v40  ; v40 = 32
-;; @0030                               trapnz v17, user2
-;;                                     v53 = iconst.i32 2
-;;                                     v54 = ishl v11, v53  ; v53 = 2
-;; @0030                               v19 = iconst.i32 28
-;; @0030                               v20 = uadd_overflow_trap v54, v19, user2  ; v19 = 28
-;; @0030                               v24 = uadd_overflow_trap v2, v20, user2
-;; @0030                               v25 = uextend.i64 v24
-;; @0030                               v27 = iadd v7, v25
-;;                                     v60 = ishl v3, v53  ; v53 = 2
-;;                                     v62 = iadd v60, v19  ; v19 = 28
-;; @0030                               v28 = isub v20, v62
-;; @0030                               v29 = uextend.i64 v28
-;; @0030                               v30 = isub v27, v29
-;;                                     v64 = ishl v5, v53  ; v53 = 2
-;; @0030                               v32 = uextend.i64 v64
-;; @0030                               v33 = iadd v30, v32
-;; @0030                               v14 = iconst.i64 4
-;; @0030                               jump block2(v30)
+;; @0030                               v13 = uextend.i64 v3
+;; @0030                               v14 = uextend.i64 v5
+;; @0030                               v16 = iadd v13, v14
+;; @0030                               v12 = uextend.i64 v11
+;; @0030                               v17 = icmp ugt v16, v12
+;; @0030                               trapnz v17, user17
+;; @0030                               v28 = load.i64 notrap aligned v49+40
+;;                                     v45 = iconst.i64 28
+;; @0030                               v21 = iadd v8, v45  ; v45 = 28
+;;                                     v53 = iconst.i64 2
+;;                                     v54 = ishl v13, v53  ; v53 = 2
+;; @0030                               v24 = iadd v21, v54
+;;                                     v56 = ishl v14, v53  ; v53 = 2
+;; @0030                               v30 = uadd_overflow_trap v24, v56, user2
+;; @0030                               v29 = iadd v7, v28
+;; @0030                               v31 = icmp ugt v30, v29
+;; @0030                               trapnz v31, user2
+;;                                     v51 = iconst.i64 0
+;; @0030                               v33 = icmp eq v14, v51  ; v51 = 0
+;;                                     v44 = iconst.i64 4
+;; @0030                               v32 = iadd v24, v56
+;; @0030                               brif v33, block3, block2(v24)
 ;;
-;;                                 block2(v35: i64):
-;; @0030                               v36 = icmp eq v35, v33
-;; @0030                               brif v36, block4, block3
+;;                                 block2(v34: i64):
+;; @0030                               store.f32 user2 little v4, v34
+;;                                     v58 = iconst.i64 4
+;;                                     v59 = iadd v34, v58  ; v58 = 4
+;; @0030                               v36 = icmp eq v59, v32
+;; @0030                               brif v36, block3, block2(v59)
 ;;
 ;;                                 block3:
-;; @0030                               store.f32 user2 little v4, v35
-;;                                     v66 = iconst.i64 4
-;;                                     v67 = iadd.i64 v35, v66  ; v66 = 4
-;; @0030                               jump block2(v67)
-;;
-;;                                 block4:
 ;; @0033                               jump block1
 ;;
 ;;                                 block1:
@@ -94,43 +87,32 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @0041                               trapz v2, user16
-;; @0041                               v49 = load.i64 notrap aligned readonly can_move v0+8
-;; @0041                               v7 = load.i64 notrap aligned readonly can_move v49+32
+;; @0041                               v44 = load.i64 notrap aligned readonly can_move v0+8
+;; @0041                               v7 = load.i64 notrap aligned readonly can_move v44+32
 ;; @0041                               v6 = uextend.i64 v2
 ;; @0041                               v8 = iadd v7, v6
 ;; @0041                               v9 = iconst.i64 24
 ;; @0041                               v10 = iadd v8, v9  ; v9 = 24
 ;; @0041                               v11 = load.i32 user2 readonly v10
-;; @0041                               v12 = uadd_overflow_trap v3, v4, user17
-;; @0041                               v13 = icmp ugt v12, v11
-;; @0041                               trapnz v13, user17
-;; @0041                               v15 = uextend.i64 v11
-;;                                     v51 = iconst.i64 2
-;;                                     v52 = ishl v15, v51  ; v51 = 2
-;;                                     v48 = iconst.i64 32
-;; @0041                               v17 = ushr v52, v48  ; v48 = 32
-;; @0041                               trapnz v17, user2
-;;                                     v61 = iconst.i32 2
-;;                                     v62 = ishl v11, v61  ; v61 = 2
-;; @0041                               v19 = iconst.i32 28
-;; @0041                               v20 = uadd_overflow_trap v62, v19, user2  ; v19 = 28
-;; @0041                               v24 = uadd_overflow_trap v2, v20, user2
-;; @0041                               v37 = load.i64 notrap aligned v49+40
-;; @0041                               v25 = uextend.i64 v24
-;; @0041                               v27 = iadd v7, v25
-;;                                     v68 = ishl v3, v61  ; v61 = 2
-;;                                     v70 = iadd v68, v19  ; v19 = 28
-;; @0041                               v28 = isub v20, v70
-;; @0041                               v29 = uextend.i64 v28
-;; @0041                               v30 = isub v27, v29
-;;                                     v72 = ishl v4, v61  ; v61 = 2
-;; @0041                               v32 = uextend.i64 v72
-;; @0041                               v33 = iadd v30, v32
-;; @0041                               v38 = iadd v7, v37
-;; @0041                               v39 = icmp ugt v33, v38
-;; @0041                               trapnz v39, user2
-;; @0041                               v35 = iconst.i32 0
-;; @0041                               call fn0(v0, v30, v35, v32)  ; v35 = 0
+;; @0041                               v13 = uextend.i64 v3
+;; @0041                               v14 = uextend.i64 v4
+;; @0041                               v16 = iadd v13, v14
+;; @0041                               v12 = uextend.i64 v11
+;; @0041                               v17 = icmp ugt v16, v12
+;; @0041                               trapnz v17, user17
+;; @0041                               v28 = load.i64 notrap aligned v44+40
+;;                                     v40 = iconst.i64 28
+;; @0041                               v21 = iadd v8, v40  ; v40 = 28
+;;                                     v48 = iconst.i64 2
+;;                                     v49 = ishl v13, v48  ; v48 = 2
+;; @0041                               v24 = iadd v21, v49
+;;                                     v51 = ishl v14, v48  ; v48 = 2
+;; @0041                               v30 = uadd_overflow_trap v24, v51, user2
+;; @0041                               v29 = iadd v7, v28
+;; @0041                               v31 = icmp ugt v30, v29
+;; @0041                               trapnz v31, user2
+;; @0041                               v32 = iconst.i32 0
+;; @0041                               call fn0(v0, v24, v32, v51)  ; v32 = 0
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -149,53 +131,46 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @0052                               trapz v2, user16
-;; @0052                               v41 = load.i64 notrap aligned readonly can_move v0+8
-;; @0052                               v7 = load.i64 notrap aligned readonly can_move v41+32
+;; @0052                               v49 = load.i64 notrap aligned readonly can_move v0+8
+;; @0052                               v7 = load.i64 notrap aligned readonly can_move v49+32
 ;; @0052                               v6 = uextend.i64 v2
 ;; @0052                               v8 = iadd v7, v6
 ;; @0052                               v9 = iconst.i64 24
 ;; @0052                               v10 = iadd v8, v9  ; v9 = 24
 ;; @0052                               v11 = load.i32 user2 readonly v10
-;; @0052                               v12 = uadd_overflow_trap v3, v4, user17
-;; @0052                               v13 = icmp ugt v12, v11
-;; @0052                               trapnz v13, user17
-;; @0052                               v15 = uextend.i64 v11
-;;                                     v43 = iconst.i64 2
-;;                                     v44 = ishl v15, v43  ; v43 = 2
-;;                                     v40 = iconst.i64 32
-;; @0052                               v17 = ushr v44, v40  ; v40 = 32
-;; @0052                               trapnz v17, user2
-;;                                     v53 = iconst.i32 2
-;;                                     v54 = ishl v11, v53  ; v53 = 2
-;; @0052                               v19 = iconst.i32 28
-;; @0052                               v20 = uadd_overflow_trap v54, v19, user2  ; v19 = 28
-;; @0052                               v24 = uadd_overflow_trap v2, v20, user2
-;; @0052                               v25 = uextend.i64 v24
-;; @0052                               v27 = iadd v7, v25
-;;                                     v60 = ishl v3, v53  ; v53 = 2
-;;                                     v62 = iadd v60, v19  ; v19 = 28
-;; @0052                               v28 = isub v20, v62
-;; @0052                               v29 = uextend.i64 v28
-;; @0052                               v30 = isub v27, v29
-;;                                     v64 = ishl v4, v53  ; v53 = 2
-;; @0052                               v32 = uextend.i64 v64
-;; @0052                               v33 = iadd v30, v32
+;; @0052                               v13 = uextend.i64 v3
+;; @0052                               v14 = uextend.i64 v4
+;; @0052                               v16 = iadd v13, v14
+;; @0052                               v12 = uextend.i64 v11
+;; @0052                               v17 = icmp ugt v16, v12
+;; @0052                               trapnz v17, user17
+;; @0052                               v28 = load.i64 notrap aligned v49+40
+;;                                     v45 = iconst.i64 28
+;; @0052                               v21 = iadd v8, v45  ; v45 = 28
+;;                                     v53 = iconst.i64 2
+;;                                     v54 = ishl v13, v53  ; v53 = 2
+;; @0052                               v24 = iadd v21, v54
+;;                                     v56 = ishl v14, v53  ; v53 = 2
+;; @0052                               v30 = uadd_overflow_trap v24, v56, user2
+;; @0052                               v29 = iadd v7, v28
+;; @0052                               v31 = icmp ugt v30, v29
+;; @0052                               trapnz v31, user2
+;;                                     v51 = iconst.i64 0
+;; @0052                               v33 = icmp eq v14, v51  ; v51 = 0
 ;; @004b                               v5 = f32const 0x1.000000p0
-;; @0052                               v14 = iconst.i64 4
-;; @0052                               jump block2(v30)
+;;                                     v44 = iconst.i64 4
+;; @0052                               v32 = iadd v24, v56
+;; @0052                               brif v33, block3, block2(v24)
 ;;
-;;                                 block2(v35: i64):
-;; @0052                               v36 = icmp eq v35, v33
-;; @0052                               brif v36, block4, block3
+;;                                 block2(v34: i64):
+;;                                     v58 = f32const 0x1.000000p0
+;; @0052                               store user2 little v58, v34  ; v58 = 0x1.000000p0
+;;                                     v59 = iconst.i64 4
+;;                                     v60 = iadd v34, v59  ; v59 = 4
+;; @0052                               v36 = icmp eq v60, v32
+;; @0052                               brif v36, block3, block2(v60)
 ;;
 ;;                                 block3:
-;;                                     v66 = f32const 0x1.000000p0
-;; @0052                               store user2 little v66, v35  ; v66 = 0x1.000000p0
-;;                                     v67 = iconst.i64 4
-;;                                     v68 = iadd.i64 v35, v67  ; v67 = 4
-;; @0052                               jump block2(v68)
-;;
-;;                                 block4:
 ;; @0055                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/array-fill-f64.wat
+++ b/tests/disas/array-fill-f64.wat
@@ -29,51 +29,44 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: f64, v5: i32):
 ;; @0030                               trapz v2, user16
-;; @0030                               v41 = load.i64 notrap aligned readonly can_move v0+8
-;; @0030                               v7 = load.i64 notrap aligned readonly can_move v41+32
+;; @0030                               v49 = load.i64 notrap aligned readonly can_move v0+8
+;; @0030                               v7 = load.i64 notrap aligned readonly can_move v49+32
 ;; @0030                               v6 = uextend.i64 v2
 ;; @0030                               v8 = iadd v7, v6
 ;; @0030                               v9 = iconst.i64 24
 ;; @0030                               v10 = iadd v8, v9  ; v9 = 24
 ;; @0030                               v11 = load.i32 user2 readonly v10
-;; @0030                               v12 = uadd_overflow_trap v3, v5, user17
-;; @0030                               v13 = icmp ugt v12, v11
-;; @0030                               trapnz v13, user17
-;; @0030                               v15 = uextend.i64 v11
-;;                                     v43 = iconst.i64 3
-;;                                     v44 = ishl v15, v43  ; v43 = 3
-;;                                     v40 = iconst.i64 32
-;; @0030                               v17 = ushr v44, v40  ; v40 = 32
-;; @0030                               trapnz v17, user2
-;;                                     v53 = iconst.i32 3
-;;                                     v54 = ishl v11, v53  ; v53 = 3
-;; @0030                               v19 = iconst.i32 32
-;; @0030                               v20 = uadd_overflow_trap v54, v19, user2  ; v19 = 32
-;; @0030                               v24 = uadd_overflow_trap v2, v20, user2
-;; @0030                               v25 = uextend.i64 v24
-;; @0030                               v27 = iadd v7, v25
-;;                                     v60 = ishl v3, v53  ; v53 = 3
-;;                                     v62 = iadd v60, v19  ; v19 = 32
-;; @0030                               v28 = isub v20, v62
-;; @0030                               v29 = uextend.i64 v28
-;; @0030                               v30 = isub v27, v29
-;;                                     v64 = ishl v5, v53  ; v53 = 3
-;; @0030                               v32 = uextend.i64 v64
-;; @0030                               v33 = iadd v30, v32
-;; @0030                               v14 = iconst.i64 8
-;; @0030                               jump block2(v30)
+;; @0030                               v13 = uextend.i64 v3
+;; @0030                               v14 = uextend.i64 v5
+;; @0030                               v16 = iadd v13, v14
+;; @0030                               v12 = uextend.i64 v11
+;; @0030                               v17 = icmp ugt v16, v12
+;; @0030                               trapnz v17, user17
+;; @0030                               v28 = load.i64 notrap aligned v49+40
+;;                                     v45 = iconst.i64 32
+;; @0030                               v21 = iadd v8, v45  ; v45 = 32
+;;                                     v53 = iconst.i64 3
+;;                                     v54 = ishl v13, v53  ; v53 = 3
+;; @0030                               v24 = iadd v21, v54
+;;                                     v56 = ishl v14, v53  ; v53 = 3
+;; @0030                               v30 = uadd_overflow_trap v24, v56, user2
+;; @0030                               v29 = iadd v7, v28
+;; @0030                               v31 = icmp ugt v30, v29
+;; @0030                               trapnz v31, user2
+;;                                     v51 = iconst.i64 0
+;; @0030                               v33 = icmp eq v14, v51  ; v51 = 0
+;;                                     v44 = iconst.i64 8
+;; @0030                               v32 = iadd v24, v56
+;; @0030                               brif v33, block3, block2(v24)
 ;;
-;;                                 block2(v35: i64):
-;; @0030                               v36 = icmp eq v35, v33
-;; @0030                               brif v36, block4, block3
+;;                                 block2(v34: i64):
+;; @0030                               store.f64 user2 little v4, v34
+;;                                     v58 = iconst.i64 8
+;;                                     v59 = iadd v34, v58  ; v58 = 8
+;; @0030                               v36 = icmp eq v59, v32
+;; @0030                               brif v36, block3, block2(v59)
 ;;
 ;;                                 block3:
-;; @0030                               store.f64 user2 little v4, v35
-;;                                     v66 = iconst.i64 8
-;;                                     v67 = iadd.i64 v35, v66  ; v66 = 8
-;; @0030                               jump block2(v67)
-;;
-;;                                 block4:
 ;; @0033                               jump block1
 ;;
 ;;                                 block1:
@@ -94,43 +87,32 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @0045                               trapz v2, user16
-;; @0045                               v49 = load.i64 notrap aligned readonly can_move v0+8
-;; @0045                               v7 = load.i64 notrap aligned readonly can_move v49+32
+;; @0045                               v44 = load.i64 notrap aligned readonly can_move v0+8
+;; @0045                               v7 = load.i64 notrap aligned readonly can_move v44+32
 ;; @0045                               v6 = uextend.i64 v2
 ;; @0045                               v8 = iadd v7, v6
 ;; @0045                               v9 = iconst.i64 24
 ;; @0045                               v10 = iadd v8, v9  ; v9 = 24
 ;; @0045                               v11 = load.i32 user2 readonly v10
-;; @0045                               v12 = uadd_overflow_trap v3, v4, user17
-;; @0045                               v13 = icmp ugt v12, v11
-;; @0045                               trapnz v13, user17
-;; @0045                               v15 = uextend.i64 v11
-;;                                     v51 = iconst.i64 3
-;;                                     v52 = ishl v15, v51  ; v51 = 3
-;;                                     v48 = iconst.i64 32
-;; @0045                               v17 = ushr v52, v48  ; v48 = 32
-;; @0045                               trapnz v17, user2
-;;                                     v61 = iconst.i32 3
-;;                                     v62 = ishl v11, v61  ; v61 = 3
-;; @0045                               v19 = iconst.i32 32
-;; @0045                               v20 = uadd_overflow_trap v62, v19, user2  ; v19 = 32
-;; @0045                               v24 = uadd_overflow_trap v2, v20, user2
-;; @0045                               v37 = load.i64 notrap aligned v49+40
-;; @0045                               v25 = uextend.i64 v24
-;; @0045                               v27 = iadd v7, v25
-;;                                     v68 = ishl v3, v61  ; v61 = 3
-;;                                     v70 = iadd v68, v19  ; v19 = 32
-;; @0045                               v28 = isub v20, v70
-;; @0045                               v29 = uextend.i64 v28
-;; @0045                               v30 = isub v27, v29
-;;                                     v72 = ishl v4, v61  ; v61 = 3
-;; @0045                               v32 = uextend.i64 v72
-;; @0045                               v33 = iadd v30, v32
-;; @0045                               v38 = iadd v7, v37
-;; @0045                               v39 = icmp ugt v33, v38
-;; @0045                               trapnz v39, user2
-;; @0045                               v35 = iconst.i32 0
-;; @0045                               call fn0(v0, v30, v35, v32)  ; v35 = 0
+;; @0045                               v13 = uextend.i64 v3
+;; @0045                               v14 = uextend.i64 v4
+;; @0045                               v16 = iadd v13, v14
+;; @0045                               v12 = uextend.i64 v11
+;; @0045                               v17 = icmp ugt v16, v12
+;; @0045                               trapnz v17, user17
+;; @0045                               v28 = load.i64 notrap aligned v44+40
+;;                                     v40 = iconst.i64 32
+;; @0045                               v21 = iadd v8, v40  ; v40 = 32
+;;                                     v48 = iconst.i64 3
+;;                                     v49 = ishl v13, v48  ; v48 = 3
+;; @0045                               v24 = iadd v21, v49
+;;                                     v51 = ishl v14, v48  ; v48 = 3
+;; @0045                               v30 = uadd_overflow_trap v24, v51, user2
+;; @0045                               v29 = iadd v7, v28
+;; @0045                               v31 = icmp ugt v30, v29
+;; @0045                               trapnz v31, user2
+;; @0045                               v32 = iconst.i32 0
+;; @0045                               call fn0(v0, v24, v32, v51)  ; v32 = 0
 ;; @0048                               jump block1
 ;;
 ;;                                 block1:
@@ -149,53 +131,46 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @005a                               trapz v2, user16
-;; @005a                               v41 = load.i64 notrap aligned readonly can_move v0+8
-;; @005a                               v7 = load.i64 notrap aligned readonly can_move v41+32
+;; @005a                               v49 = load.i64 notrap aligned readonly can_move v0+8
+;; @005a                               v7 = load.i64 notrap aligned readonly can_move v49+32
 ;; @005a                               v6 = uextend.i64 v2
 ;; @005a                               v8 = iadd v7, v6
 ;; @005a                               v9 = iconst.i64 24
 ;; @005a                               v10 = iadd v8, v9  ; v9 = 24
 ;; @005a                               v11 = load.i32 user2 readonly v10
-;; @005a                               v12 = uadd_overflow_trap v3, v4, user17
-;; @005a                               v13 = icmp ugt v12, v11
-;; @005a                               trapnz v13, user17
-;; @005a                               v15 = uextend.i64 v11
-;;                                     v43 = iconst.i64 3
-;;                                     v44 = ishl v15, v43  ; v43 = 3
-;;                                     v40 = iconst.i64 32
-;; @005a                               v17 = ushr v44, v40  ; v40 = 32
-;; @005a                               trapnz v17, user2
-;;                                     v53 = iconst.i32 3
-;;                                     v54 = ishl v11, v53  ; v53 = 3
-;; @005a                               v19 = iconst.i32 32
-;; @005a                               v20 = uadd_overflow_trap v54, v19, user2  ; v19 = 32
-;; @005a                               v24 = uadd_overflow_trap v2, v20, user2
-;; @005a                               v25 = uextend.i64 v24
-;; @005a                               v27 = iadd v7, v25
-;;                                     v60 = ishl v3, v53  ; v53 = 3
-;;                                     v62 = iadd v60, v19  ; v19 = 32
-;; @005a                               v28 = isub v20, v62
-;; @005a                               v29 = uextend.i64 v28
-;; @005a                               v30 = isub v27, v29
-;;                                     v64 = ishl v4, v53  ; v53 = 3
-;; @005a                               v32 = uextend.i64 v64
-;; @005a                               v33 = iadd v30, v32
+;; @005a                               v13 = uextend.i64 v3
+;; @005a                               v14 = uextend.i64 v4
+;; @005a                               v16 = iadd v13, v14
+;; @005a                               v12 = uextend.i64 v11
+;; @005a                               v17 = icmp ugt v16, v12
+;; @005a                               trapnz v17, user17
+;; @005a                               v28 = load.i64 notrap aligned v49+40
+;;                                     v45 = iconst.i64 32
+;; @005a                               v21 = iadd v8, v45  ; v45 = 32
+;;                                     v53 = iconst.i64 3
+;;                                     v54 = ishl v13, v53  ; v53 = 3
+;; @005a                               v24 = iadd v21, v54
+;;                                     v56 = ishl v14, v53  ; v53 = 3
+;; @005a                               v30 = uadd_overflow_trap v24, v56, user2
+;; @005a                               v29 = iadd v7, v28
+;; @005a                               v31 = icmp ugt v30, v29
+;; @005a                               trapnz v31, user2
+;;                                     v51 = iconst.i64 0
+;; @005a                               v33 = icmp eq v14, v51  ; v51 = 0
 ;; @004f                               v5 = f64const 0x1.0000000000000p0
-;; @005a                               v14 = iconst.i64 8
-;; @005a                               jump block2(v30)
+;;                                     v44 = iconst.i64 8
+;; @005a                               v32 = iadd v24, v56
+;; @005a                               brif v33, block3, block2(v24)
 ;;
-;;                                 block2(v35: i64):
-;; @005a                               v36 = icmp eq v35, v33
-;; @005a                               brif v36, block4, block3
+;;                                 block2(v34: i64):
+;;                                     v58 = f64const 0x1.0000000000000p0
+;; @005a                               store user2 little v58, v34  ; v58 = 0x1.0000000000000p0
+;;                                     v59 = iconst.i64 8
+;;                                     v60 = iadd v34, v59  ; v59 = 8
+;; @005a                               v36 = icmp eq v60, v32
+;; @005a                               brif v36, block3, block2(v60)
 ;;
 ;;                                 block3:
-;;                                     v66 = f64const 0x1.0000000000000p0
-;; @005a                               store user2 little v66, v35  ; v66 = 0x1.0000000000000p0
-;;                                     v67 = iconst.i64 8
-;;                                     v68 = iadd.i64 v35, v67  ; v67 = 8
-;; @005a                               jump block2(v68)
-;;
-;;                                 block4:
 ;; @005d                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/array-fill-funcref.wat
+++ b/tests/disas/array-fill-funcref.wat
@@ -34,53 +34,46 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i64, v5: i32):
 ;; @003b                               trapz v2, user16
-;; @003b                               v44 = load.i64 notrap aligned readonly can_move v0+8
-;; @003b                               v7 = load.i64 notrap aligned readonly can_move v44+32
+;; @003b                               v52 = load.i64 notrap aligned readonly can_move v0+8
+;; @003b                               v7 = load.i64 notrap aligned readonly can_move v52+32
 ;; @003b                               v6 = uextend.i64 v2
 ;; @003b                               v8 = iadd v7, v6
 ;; @003b                               v9 = iconst.i64 24
 ;; @003b                               v10 = iadd v8, v9  ; v9 = 24
 ;; @003b                               v11 = load.i32 user2 readonly v10
-;; @003b                               v12 = uadd_overflow_trap v3, v5, user17
-;; @003b                               v13 = icmp ugt v12, v11
-;; @003b                               trapnz v13, user17
-;; @003b                               v15 = uextend.i64 v11
-;;                                     v46 = iconst.i64 2
-;;                                     v47 = ishl v15, v46  ; v46 = 2
-;;                                     v43 = iconst.i64 32
-;; @003b                               v17 = ushr v47, v43  ; v43 = 32
-;; @003b                               trapnz v17, user2
-;;                                     v56 = iconst.i32 2
-;;                                     v57 = ishl v11, v56  ; v56 = 2
-;; @003b                               v19 = iconst.i32 28
-;; @003b                               v20 = uadd_overflow_trap v57, v19, user2  ; v19 = 28
-;; @003b                               v24 = uadd_overflow_trap v2, v20, user2
-;; @003b                               v25 = uextend.i64 v24
-;; @003b                               v27 = iadd v7, v25
-;;                                     v63 = ishl v3, v56  ; v56 = 2
-;;                                     v65 = iadd v63, v19  ; v19 = 28
-;; @003b                               v28 = isub v20, v65
-;; @003b                               v29 = uextend.i64 v28
-;; @003b                               v30 = isub v27, v29
-;;                                     v67 = ishl v5, v56  ; v56 = 2
-;; @003b                               v32 = uextend.i64 v67
-;; @003b                               v33 = iadd v30, v32
-;; @003b                               v14 = iconst.i64 4
-;; @003b                               jump block2(v30)
+;; @003b                               v13 = uextend.i64 v3
+;; @003b                               v14 = uextend.i64 v5
+;; @003b                               v16 = iadd v13, v14
+;; @003b                               v12 = uextend.i64 v11
+;; @003b                               v17 = icmp ugt v16, v12
+;; @003b                               trapnz v17, user17
+;; @003b                               v28 = load.i64 notrap aligned v52+40
+;;                                     v48 = iconst.i64 28
+;; @003b                               v21 = iadd v8, v48  ; v48 = 28
+;;                                     v56 = iconst.i64 2
+;;                                     v57 = ishl v13, v56  ; v56 = 2
+;; @003b                               v24 = iadd v21, v57
+;;                                     v59 = ishl v14, v56  ; v56 = 2
+;; @003b                               v30 = uadd_overflow_trap v24, v59, user2
+;; @003b                               v29 = iadd v7, v28
+;; @003b                               v31 = icmp ugt v30, v29
+;; @003b                               trapnz v31, user2
+;;                                     v54 = iconst.i64 0
+;; @003b                               v33 = icmp eq v14, v54  ; v54 = 0
+;;                                     v47 = iconst.i64 4
+;; @003b                               v32 = iadd v24, v59
+;; @003b                               brif v33, block3, block2(v24)
 ;;
-;;                                 block2(v35: i64):
-;; @003b                               v36 = icmp eq v35, v33
-;; @003b                               brif v36, block4, block3
+;;                                 block2(v34: i64):
+;; @003b                               v36 = call fn0(v0, v4)
+;; @003b                               v37 = ireduce.i32 v36
+;; @003b                               store user2 little v37, v34
+;;                                     v61 = iconst.i64 4
+;;                                     v62 = iadd v34, v61  ; v61 = 4
+;; @003b                               v39 = icmp eq v62, v32
+;; @003b                               brif v39, block3, block2(v62)
 ;;
 ;;                                 block3:
-;; @003b                               v38 = call fn0(v0, v4)
-;; @003b                               v39 = ireduce.i32 v38
-;; @003b                               store user2 little v39, v35
-;;                                     v69 = iconst.i64 4
-;;                                     v70 = iadd.i64 v35, v69  ; v69 = 4
-;; @003b                               jump block2(v70)
-;;
-;;                                 block4:
 ;; @003e                               jump block1
 ;;
 ;;                                 block1:
@@ -101,43 +94,32 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @0049                               trapz v2, user16
-;; @0049                               v49 = load.i64 notrap aligned readonly can_move v0+8
-;; @0049                               v7 = load.i64 notrap aligned readonly can_move v49+32
+;; @0049                               v44 = load.i64 notrap aligned readonly can_move v0+8
+;; @0049                               v7 = load.i64 notrap aligned readonly can_move v44+32
 ;; @0049                               v6 = uextend.i64 v2
 ;; @0049                               v8 = iadd v7, v6
 ;; @0049                               v9 = iconst.i64 24
 ;; @0049                               v10 = iadd v8, v9  ; v9 = 24
 ;; @0049                               v11 = load.i32 user2 readonly v10
-;; @0049                               v12 = uadd_overflow_trap v3, v4, user17
-;; @0049                               v13 = icmp ugt v12, v11
-;; @0049                               trapnz v13, user17
-;; @0049                               v15 = uextend.i64 v11
-;;                                     v51 = iconst.i64 2
-;;                                     v52 = ishl v15, v51  ; v51 = 2
-;;                                     v48 = iconst.i64 32
-;; @0049                               v17 = ushr v52, v48  ; v48 = 32
-;; @0049                               trapnz v17, user2
-;;                                     v61 = iconst.i32 2
-;;                                     v62 = ishl v11, v61  ; v61 = 2
-;; @0049                               v19 = iconst.i32 28
-;; @0049                               v20 = uadd_overflow_trap v62, v19, user2  ; v19 = 28
-;; @0049                               v24 = uadd_overflow_trap v2, v20, user2
-;; @0049                               v37 = load.i64 notrap aligned v49+40
-;; @0049                               v25 = uextend.i64 v24
-;; @0049                               v27 = iadd v7, v25
-;;                                     v68 = ishl v3, v61  ; v61 = 2
-;;                                     v70 = iadd v68, v19  ; v19 = 28
-;; @0049                               v28 = isub v20, v70
-;; @0049                               v29 = uextend.i64 v28
-;; @0049                               v30 = isub v27, v29
-;;                                     v72 = ishl v4, v61  ; v61 = 2
-;; @0049                               v32 = uextend.i64 v72
-;; @0049                               v33 = iadd v30, v32
-;; @0049                               v38 = iadd v7, v37
-;; @0049                               v39 = icmp ugt v33, v38
-;; @0049                               trapnz v39, user2
-;; @0049                               v35 = iconst.i32 0
-;; @0049                               call fn0(v0, v30, v35, v32)  ; v35 = 0
+;; @0049                               v13 = uextend.i64 v3
+;; @0049                               v14 = uextend.i64 v4
+;; @0049                               v16 = iadd v13, v14
+;; @0049                               v12 = uextend.i64 v11
+;; @0049                               v17 = icmp ugt v16, v12
+;; @0049                               trapnz v17, user17
+;; @0049                               v28 = load.i64 notrap aligned v44+40
+;;                                     v40 = iconst.i64 28
+;; @0049                               v21 = iadd v8, v40  ; v40 = 28
+;;                                     v47 = iconst.i64 2
+;;                                     v48 = ishl v13, v47  ; v47 = 2
+;; @0049                               v24 = iadd v21, v48
+;;                                     v50 = ishl v14, v47  ; v47 = 2
+;; @0049                               v30 = uadd_overflow_trap v24, v50, user2
+;; @0049                               v29 = iadd v7, v28
+;; @0049                               v31 = icmp ugt v30, v29
+;; @0049                               trapnz v31, user2
+;; @0049                               v32 = iconst.i32 0
+;; @0049                               call fn0(v0, v24, v32, v50)  ; v32 = 0
 ;; @004c                               jump block1
 ;;
 ;;                                 block1:
@@ -160,59 +142,52 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
-;;                                     v54 = stack_addr.i64 ss0
-;;                                     store notrap v2, v54
+;;                                     v62 = stack_addr.i64 ss0
+;;                                     store notrap v2, v62
 ;; @0053                               v5 = iconst.i32 3
 ;; @0053                               v7 = call fn0(v0, v5), stack_map=[i32 @ ss0+0]  ; v5 = 3
-;;                                     v45 = load.i32 notrap v54
-;; @0057                               trapz v45, user16
-;; @0057                               v50 = load.i64 notrap aligned readonly can_move v0+8
-;; @0057                               v9 = load.i64 notrap aligned readonly can_move v50+32
-;; @0057                               v8 = uextend.i64 v45
+;;                                     v44 = load.i32 notrap v62
+;; @0057                               trapz v44, user16
+;; @0057                               v58 = load.i64 notrap aligned readonly can_move v0+8
+;; @0057                               v9 = load.i64 notrap aligned readonly can_move v58+32
+;; @0057                               v8 = uextend.i64 v44
 ;; @0057                               v10 = iadd v9, v8
 ;; @0057                               v11 = iconst.i64 24
 ;; @0057                               v12 = iadd v10, v11  ; v11 = 24
 ;; @0057                               v13 = load.i32 user2 readonly v12
-;; @0057                               v14 = uadd_overflow_trap v3, v4, user17
-;; @0057                               v15 = icmp ugt v14, v13
-;; @0057                               trapnz v15, user17
-;; @0057                               v17 = uextend.i64 v13
-;;                                     v55 = iconst.i64 2
-;;                                     v56 = ishl v17, v55  ; v55 = 2
-;;                                     v49 = iconst.i64 32
-;; @0057                               v19 = ushr v56, v49  ; v49 = 32
-;; @0057                               trapnz v19, user2
-;;                                     v65 = iconst.i32 2
-;;                                     v66 = ishl v13, v65  ; v65 = 2
-;; @0057                               v21 = iconst.i32 28
-;; @0057                               v22 = uadd_overflow_trap v66, v21, user2  ; v21 = 28
-;; @0057                               v26 = uadd_overflow_trap v45, v22, user2
-;; @0057                               v27 = uextend.i64 v26
-;; @0057                               v29 = iadd v9, v27
-;;                                     v72 = ishl v3, v65  ; v65 = 2
-;;                                     v74 = iadd v72, v21  ; v21 = 28
-;; @0057                               v30 = isub v22, v74
-;; @0057                               v31 = uextend.i64 v30
-;; @0057                               v32 = isub v29, v31
-;;                                     v76 = ishl v4, v65  ; v65 = 2
-;; @0057                               v34 = uextend.i64 v76
-;; @0057                               v35 = iadd v32, v34
-;; @0057                               v16 = iconst.i64 4
-;; @0057                               jump block2(v32)
+;; @0057                               v15 = uextend.i64 v3
+;; @0057                               v16 = uextend.i64 v4
+;; @0057                               v18 = iadd v15, v16
+;; @0057                               v14 = uextend.i64 v13
+;; @0057                               v19 = icmp ugt v18, v14
+;; @0057                               trapnz v19, user17
+;; @0057                               v30 = load.i64 notrap aligned v58+40
+;;                                     v53 = iconst.i64 28
+;; @0057                               v23 = iadd v10, v53  ; v53 = 28
+;;                                     v65 = iconst.i64 2
+;;                                     v66 = ishl v15, v65  ; v65 = 2
+;; @0057                               v26 = iadd v23, v66
+;;                                     v68 = ishl v16, v65  ; v65 = 2
+;; @0057                               v32 = uadd_overflow_trap v26, v68, user2
+;; @0057                               v31 = iadd v9, v30
+;; @0057                               v33 = icmp ugt v32, v31
+;; @0057                               trapnz v33, user2
+;;                                     v63 = iconst.i64 0
+;; @0057                               v35 = icmp eq v16, v63  ; v63 = 0
+;;                                     v52 = iconst.i64 4
+;; @0057                               v34 = iadd v26, v68
+;; @0057                               brif v35, block3, block2(v26)
 ;;
-;;                                 block2(v37: i64):
-;; @0057                               v38 = icmp eq v37, v35
-;; @0057                               brif v38, block4, block3
+;;                                 block2(v36: i64):
+;; @0057                               v38 = call fn1(v0, v7)
+;; @0057                               v39 = ireduce.i32 v38
+;; @0057                               store user2 little v39, v36
+;;                                     v70 = iconst.i64 4
+;;                                     v71 = iadd v36, v70  ; v70 = 4
+;; @0057                               v41 = icmp eq v71, v34
+;; @0057                               brif v41, block3, block2(v71)
 ;;
 ;;                                 block3:
-;; @0057                               v40 = call fn1(v0, v7)
-;; @0057                               v41 = ireduce.i32 v40
-;; @0057                               store user2 little v41, v37
-;;                                     v78 = iconst.i64 4
-;;                                     v79 = iadd.i64 v37, v78  ; v78 = 4
-;; @0057                               jump block2(v79)
-;;
-;;                                 block4:
 ;; @005a                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/array-fill-i16.wat
+++ b/tests/disas/array-fill-i16.wat
@@ -33,49 +33,44 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
 ;; @0031                               trapz v2, user16
-;; @0031                               v41 = load.i64 notrap aligned readonly can_move v0+8
-;; @0031                               v7 = load.i64 notrap aligned readonly can_move v41+32
+;; @0031                               v49 = load.i64 notrap aligned readonly can_move v0+8
+;; @0031                               v7 = load.i64 notrap aligned readonly can_move v49+32
 ;; @0031                               v6 = uextend.i64 v2
 ;; @0031                               v8 = iadd v7, v6
 ;; @0031                               v9 = iconst.i64 24
 ;; @0031                               v10 = iadd v8, v9  ; v9 = 24
 ;; @0031                               v11 = load.i32 user2 readonly v10
-;; @0031                               v12 = uadd_overflow_trap v3, v5, user17
-;; @0031                               v13 = icmp ugt v12, v11
-;; @0031                               trapnz v13, user17
-;; @0031                               v15 = uextend.i64 v11
-;;                                     v46 = iadd v15, v15
-;;                                     v40 = iconst.i64 32
-;; @0031                               v17 = ushr v46, v40  ; v40 = 32
-;; @0031                               trapnz v17, user2
-;;                                     v52 = iadd v11, v11
-;; @0031                               v19 = iconst.i32 28
-;; @0031                               v20 = uadd_overflow_trap v52, v19, user2  ; v19 = 28
-;; @0031                               v24 = uadd_overflow_trap v2, v20, user2
-;; @0031                               v25 = uextend.i64 v24
-;; @0031                               v27 = iadd v7, v25
-;;                                     v65 = iadd v3, v3
-;;                                     v69 = iadd v65, v19  ; v19 = 28
-;; @0031                               v28 = isub v20, v69
-;; @0031                               v29 = uextend.i64 v28
-;; @0031                               v30 = isub v27, v29
-;;                                     v71 = iadd v5, v5
-;; @0031                               v32 = uextend.i64 v71
-;; @0031                               v33 = iadd v30, v32
-;; @0031                               v14 = iconst.i64 2
-;; @0031                               jump block2(v30)
+;; @0031                               v13 = uextend.i64 v3
+;; @0031                               v14 = uextend.i64 v5
+;; @0031                               v16 = iadd v13, v14
+;; @0031                               v12 = uextend.i64 v11
+;; @0031                               v17 = icmp ugt v16, v12
+;; @0031                               trapnz v17, user17
+;; @0031                               v28 = load.i64 notrap aligned v49+40
+;;                                     v45 = iconst.i64 28
+;; @0031                               v21 = iadd v8, v45  ; v45 = 28
+;;                                     v48 = iconst.i64 1
+;;                                     v54 = ishl v13, v48  ; v48 = 1
+;; @0031                               v24 = iadd v21, v54
+;;                                     v58 = ishl v14, v48  ; v48 = 1
+;; @0031                               v30 = uadd_overflow_trap v24, v58, user2
+;; @0031                               v29 = iadd v7, v28
+;; @0031                               v31 = icmp ugt v30, v29
+;; @0031                               trapnz v31, user2
+;;                                     v51 = iconst.i64 0
+;; @0031                               v33 = icmp eq v14, v51  ; v51 = 0
+;;                                     v44 = iconst.i64 2
+;; @0031                               v32 = iadd v24, v58
+;; @0031                               brif v33, block3, block2(v24)
 ;;
-;;                                 block2(v35: i64):
-;; @0031                               v36 = icmp eq v35, v33
-;; @0031                               brif v36, block4, block3
+;;                                 block2(v34: i64):
+;; @0031                               istore16.i32 user2 little v4, v34
+;;                                     v61 = iconst.i64 2
+;;                                     v62 = iadd v34, v61  ; v61 = 2
+;; @0031                               v36 = icmp eq v62, v32
+;; @0031                               brif v36, block3, block2(v62)
 ;;
 ;;                                 block3:
-;; @0031                               istore16.i32 user2 little v4, v35
-;;                                     v75 = iconst.i64 2
-;;                                     v76 = iadd.i64 v35, v75  ; v75 = 2
-;; @0031                               jump block2(v76)
-;;
-;;                                 block4:
 ;; @0034                               jump block1
 ;;
 ;;                                 block1:
@@ -96,41 +91,32 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @003f                               trapz v2, user16
-;; @003f                               v49 = load.i64 notrap aligned readonly can_move v0+8
-;; @003f                               v7 = load.i64 notrap aligned readonly can_move v49+32
+;; @003f                               v44 = load.i64 notrap aligned readonly can_move v0+8
+;; @003f                               v7 = load.i64 notrap aligned readonly can_move v44+32
 ;; @003f                               v6 = uextend.i64 v2
 ;; @003f                               v8 = iadd v7, v6
 ;; @003f                               v9 = iconst.i64 24
 ;; @003f                               v10 = iadd v8, v9  ; v9 = 24
 ;; @003f                               v11 = load.i32 user2 readonly v10
-;; @003f                               v12 = uadd_overflow_trap v3, v4, user17
-;; @003f                               v13 = icmp ugt v12, v11
-;; @003f                               trapnz v13, user17
-;; @003f                               v15 = uextend.i64 v11
-;;                                     v54 = iadd v15, v15
-;;                                     v48 = iconst.i64 32
-;; @003f                               v17 = ushr v54, v48  ; v48 = 32
-;; @003f                               trapnz v17, user2
-;;                                     v60 = iadd v11, v11
-;; @003f                               v19 = iconst.i32 28
-;; @003f                               v20 = uadd_overflow_trap v60, v19, user2  ; v19 = 28
-;; @003f                               v24 = uadd_overflow_trap v2, v20, user2
-;; @003f                               v37 = load.i64 notrap aligned v49+40
-;; @003f                               v25 = uextend.i64 v24
-;; @003f                               v27 = iadd v7, v25
-;;                                     v73 = iadd v3, v3
-;;                                     v77 = iadd v73, v19  ; v19 = 28
-;; @003f                               v28 = isub v20, v77
-;; @003f                               v29 = uextend.i64 v28
-;; @003f                               v30 = isub v27, v29
-;;                                     v79 = iadd v4, v4
-;; @003f                               v32 = uextend.i64 v79
-;; @003f                               v33 = iadd v30, v32
-;; @003f                               v38 = iadd v7, v37
-;; @003f                               v39 = icmp ugt v33, v38
-;; @003f                               trapnz v39, user2
+;; @003f                               v13 = uextend.i64 v3
+;; @003f                               v14 = uextend.i64 v4
+;; @003f                               v16 = iadd v13, v14
+;; @003f                               v12 = uextend.i64 v11
+;; @003f                               v17 = icmp ugt v16, v12
+;; @003f                               trapnz v17, user17
+;; @003f                               v28 = load.i64 notrap aligned v44+40
+;;                                     v40 = iconst.i64 28
+;; @003f                               v21 = iadd v8, v40  ; v40 = 28
+;;                                     v43 = iconst.i64 1
+;;                                     v49 = ishl v13, v43  ; v43 = 1
+;; @003f                               v24 = iadd v21, v49
+;;                                     v53 = ishl v14, v43  ; v43 = 1
+;; @003f                               v30 = uadd_overflow_trap v24, v53, user2
+;; @003f                               v29 = iadd v7, v28
+;; @003f                               v31 = icmp ugt v30, v29
+;; @003f                               trapnz v31, user2
 ;; @003b                               v5 = iconst.i32 0
-;; @003f                               call fn0(v0, v30, v5, v32)  ; v5 = 0
+;; @003f                               call fn0(v0, v24, v5, v53)  ; v5 = 0
 ;; @0042                               jump block1
 ;;
 ;;                                 block1:
@@ -151,41 +137,32 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @004d                               trapz v2, user16
-;; @004d                               v49 = load.i64 notrap aligned readonly can_move v0+8
-;; @004d                               v7 = load.i64 notrap aligned readonly can_move v49+32
+;; @004d                               v44 = load.i64 notrap aligned readonly can_move v0+8
+;; @004d                               v7 = load.i64 notrap aligned readonly can_move v44+32
 ;; @004d                               v6 = uextend.i64 v2
 ;; @004d                               v8 = iadd v7, v6
 ;; @004d                               v9 = iconst.i64 24
 ;; @004d                               v10 = iadd v8, v9  ; v9 = 24
 ;; @004d                               v11 = load.i32 user2 readonly v10
-;; @004d                               v12 = uadd_overflow_trap v3, v4, user17
-;; @004d                               v13 = icmp ugt v12, v11
-;; @004d                               trapnz v13, user17
-;; @004d                               v15 = uextend.i64 v11
-;;                                     v54 = iadd v15, v15
-;;                                     v48 = iconst.i64 32
-;; @004d                               v17 = ushr v54, v48  ; v48 = 32
-;; @004d                               trapnz v17, user2
-;;                                     v60 = iadd v11, v11
-;; @004d                               v19 = iconst.i32 28
-;; @004d                               v20 = uadd_overflow_trap v60, v19, user2  ; v19 = 28
-;; @004d                               v24 = uadd_overflow_trap v2, v20, user2
-;; @004d                               v37 = load.i64 notrap aligned v49+40
-;; @004d                               v25 = uextend.i64 v24
-;; @004d                               v27 = iadd v7, v25
-;;                                     v73 = iadd v3, v3
-;;                                     v77 = iadd v73, v19  ; v19 = 28
-;; @004d                               v28 = isub v20, v77
-;; @004d                               v29 = uextend.i64 v28
-;; @004d                               v30 = isub v27, v29
-;;                                     v79 = iadd v4, v4
-;; @004d                               v32 = uextend.i64 v79
-;; @004d                               v33 = iadd v30, v32
-;; @004d                               v38 = iadd v7, v37
-;; @004d                               v39 = icmp ugt v33, v38
-;; @004d                               trapnz v39, user2
-;; @004d                               v35 = iconst.i32 255
-;; @004d                               call fn0(v0, v30, v35, v32)  ; v35 = 255
+;; @004d                               v13 = uextend.i64 v3
+;; @004d                               v14 = uextend.i64 v4
+;; @004d                               v16 = iadd v13, v14
+;; @004d                               v12 = uextend.i64 v11
+;; @004d                               v17 = icmp ugt v16, v12
+;; @004d                               trapnz v17, user17
+;; @004d                               v28 = load.i64 notrap aligned v44+40
+;;                                     v40 = iconst.i64 28
+;; @004d                               v21 = iadd v8, v40  ; v40 = 28
+;;                                     v43 = iconst.i64 1
+;;                                     v49 = ishl v13, v43  ; v43 = 1
+;; @004d                               v24 = iadd v21, v49
+;;                                     v53 = ishl v14, v43  ; v43 = 1
+;; @004d                               v30 = uadd_overflow_trap v24, v53, user2
+;; @004d                               v29 = iadd v7, v28
+;; @004d                               v31 = icmp ugt v30, v29
+;; @004d                               trapnz v31, user2
+;; @004d                               v32 = iconst.i32 255
+;; @004d                               call fn0(v0, v24, v32, v53)  ; v32 = 255
 ;; @0050                               jump block1
 ;;
 ;;                                 block1:
@@ -204,51 +181,46 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @005d                               trapz v2, user16
-;; @005d                               v41 = load.i64 notrap aligned readonly can_move v0+8
-;; @005d                               v7 = load.i64 notrap aligned readonly can_move v41+32
+;; @005d                               v49 = load.i64 notrap aligned readonly can_move v0+8
+;; @005d                               v7 = load.i64 notrap aligned readonly can_move v49+32
 ;; @005d                               v6 = uextend.i64 v2
 ;; @005d                               v8 = iadd v7, v6
 ;; @005d                               v9 = iconst.i64 24
 ;; @005d                               v10 = iadd v8, v9  ; v9 = 24
 ;; @005d                               v11 = load.i32 user2 readonly v10
-;; @005d                               v12 = uadd_overflow_trap v3, v4, user17
-;; @005d                               v13 = icmp ugt v12, v11
-;; @005d                               trapnz v13, user17
-;; @005d                               v15 = uextend.i64 v11
-;;                                     v46 = iadd v15, v15
-;;                                     v40 = iconst.i64 32
-;; @005d                               v17 = ushr v46, v40  ; v40 = 32
-;; @005d                               trapnz v17, user2
-;;                                     v52 = iadd v11, v11
-;; @005d                               v19 = iconst.i32 28
-;; @005d                               v20 = uadd_overflow_trap v52, v19, user2  ; v19 = 28
-;; @005d                               v24 = uadd_overflow_trap v2, v20, user2
-;; @005d                               v25 = uextend.i64 v24
-;; @005d                               v27 = iadd v7, v25
-;;                                     v65 = iadd v3, v3
-;;                                     v69 = iadd v65, v19  ; v19 = 28
-;; @005d                               v28 = isub v20, v69
-;; @005d                               v29 = uextend.i64 v28
-;; @005d                               v30 = isub v27, v29
-;;                                     v71 = iadd v4, v4
-;; @005d                               v32 = uextend.i64 v71
-;; @005d                               v33 = iadd v30, v32
+;; @005d                               v13 = uextend.i64 v3
+;; @005d                               v14 = uextend.i64 v4
+;; @005d                               v16 = iadd v13, v14
+;; @005d                               v12 = uextend.i64 v11
+;; @005d                               v17 = icmp ugt v16, v12
+;; @005d                               trapnz v17, user17
+;; @005d                               v28 = load.i64 notrap aligned v49+40
+;;                                     v45 = iconst.i64 28
+;; @005d                               v21 = iadd v8, v45  ; v45 = 28
+;;                                     v48 = iconst.i64 1
+;;                                     v54 = ishl v13, v48  ; v48 = 1
+;; @005d                               v24 = iadd v21, v54
+;;                                     v58 = ishl v14, v48  ; v48 = 1
+;; @005d                               v30 = uadd_overflow_trap v24, v58, user2
+;; @005d                               v29 = iadd v7, v28
+;; @005d                               v31 = icmp ugt v30, v29
+;; @005d                               trapnz v31, user2
+;;                                     v51 = iconst.i64 0
+;; @005d                               v33 = icmp eq v14, v51  ; v51 = 0
 ;; @0057                               v5 = iconst.i32 0xdead
-;; @005d                               v14 = iconst.i64 2
-;; @005d                               jump block2(v30)
+;;                                     v44 = iconst.i64 2
+;; @005d                               v32 = iadd v24, v58
+;; @005d                               brif v33, block3, block2(v24)
 ;;
-;;                                 block2(v35: i64):
-;; @005d                               v36 = icmp eq v35, v33
-;; @005d                               brif v36, block4, block3
+;;                                 block2(v34: i64):
+;;                                     v61 = iconst.i32 0xdead
+;; @005d                               istore16 user2 little v61, v34  ; v61 = 0xdead
+;;                                     v62 = iconst.i64 2
+;;                                     v63 = iadd v34, v62  ; v62 = 2
+;; @005d                               v36 = icmp eq v63, v32
+;; @005d                               brif v36, block3, block2(v63)
 ;;
 ;;                                 block3:
-;;                                     v75 = iconst.i32 0xdead
-;; @005d                               istore16 user2 little v75, v35  ; v75 = 0xdead
-;;                                     v76 = iconst.i64 2
-;;                                     v77 = iadd.i64 v35, v76  ; v76 = 2
-;; @005d                               jump block2(v77)
-;;
-;;                                 block4:
 ;; @0060                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/array-fill-i31ref.wat
+++ b/tests/disas/array-fill-i31ref.wat
@@ -29,51 +29,44 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
 ;; @0030                               trapz v2, user16
-;; @0030                               v41 = load.i64 notrap aligned readonly can_move v0+8
-;; @0030                               v7 = load.i64 notrap aligned readonly can_move v41+32
+;; @0030                               v49 = load.i64 notrap aligned readonly can_move v0+8
+;; @0030                               v7 = load.i64 notrap aligned readonly can_move v49+32
 ;; @0030                               v6 = uextend.i64 v2
 ;; @0030                               v8 = iadd v7, v6
 ;; @0030                               v9 = iconst.i64 16
 ;; @0030                               v10 = iadd v8, v9  ; v9 = 16
 ;; @0030                               v11 = load.i32 user2 readonly v10
-;; @0030                               v12 = uadd_overflow_trap v3, v5, user17
-;; @0030                               v13 = icmp ugt v12, v11
-;; @0030                               trapnz v13, user17
-;; @0030                               v15 = uextend.i64 v11
-;;                                     v43 = iconst.i64 2
-;;                                     v44 = ishl v15, v43  ; v43 = 2
-;;                                     v40 = iconst.i64 32
-;; @0030                               v17 = ushr v44, v40  ; v40 = 32
-;; @0030                               trapnz v17, user2
-;;                                     v53 = iconst.i32 2
-;;                                     v54 = ishl v11, v53  ; v53 = 2
-;; @0030                               v19 = iconst.i32 20
-;; @0030                               v20 = uadd_overflow_trap v54, v19, user2  ; v19 = 20
-;; @0030                               v24 = uadd_overflow_trap v2, v20, user2
-;; @0030                               v25 = uextend.i64 v24
-;; @0030                               v27 = iadd v7, v25
-;;                                     v60 = ishl v3, v53  ; v53 = 2
-;;                                     v62 = iadd v60, v19  ; v19 = 20
-;; @0030                               v28 = isub v20, v62
-;; @0030                               v29 = uextend.i64 v28
-;; @0030                               v30 = isub v27, v29
-;;                                     v64 = ishl v5, v53  ; v53 = 2
-;; @0030                               v32 = uextend.i64 v64
-;; @0030                               v33 = iadd v30, v32
-;; @0030                               v14 = iconst.i64 4
-;; @0030                               jump block2(v30)
+;; @0030                               v13 = uextend.i64 v3
+;; @0030                               v14 = uextend.i64 v5
+;; @0030                               v16 = iadd v13, v14
+;; @0030                               v12 = uextend.i64 v11
+;; @0030                               v17 = icmp ugt v16, v12
+;; @0030                               trapnz v17, user17
+;; @0030                               v28 = load.i64 notrap aligned v49+40
+;;                                     v45 = iconst.i64 20
+;; @0030                               v21 = iadd v8, v45  ; v45 = 20
+;;                                     v53 = iconst.i64 2
+;;                                     v54 = ishl v13, v53  ; v53 = 2
+;; @0030                               v24 = iadd v21, v54
+;;                                     v56 = ishl v14, v53  ; v53 = 2
+;; @0030                               v30 = uadd_overflow_trap v24, v56, user2
+;; @0030                               v29 = iadd v7, v28
+;; @0030                               v31 = icmp ugt v30, v29
+;; @0030                               trapnz v31, user2
+;;                                     v51 = iconst.i64 0
+;; @0030                               v33 = icmp eq v14, v51  ; v51 = 0
+;;                                     v44 = iconst.i64 4
+;; @0030                               v32 = iadd v24, v56
+;; @0030                               brif v33, block3, block2(v24)
 ;;
-;;                                 block2(v35: i64):
-;; @0030                               v36 = icmp eq v35, v33
-;; @0030                               brif v36, block4, block3
+;;                                 block2(v34: i64):
+;; @0030                               store.i32 user2 little v4, v34
+;;                                     v58 = iconst.i64 4
+;;                                     v59 = iadd v34, v58  ; v58 = 4
+;; @0030                               v36 = icmp eq v59, v32
+;; @0030                               brif v36, block3, block2(v59)
 ;;
 ;;                                 block3:
-;; @0030                               store.i32 user2 little v4, v35
-;;                                     v66 = iconst.i64 4
-;;                                     v67 = iadd.i64 v35, v66  ; v66 = 4
-;; @0030                               jump block2(v67)
-;;
-;;                                 block4:
 ;; @0033                               jump block1
 ;;
 ;;                                 block1:
@@ -94,43 +87,32 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @003e                               trapz v2, user16
-;; @003e                               v49 = load.i64 notrap aligned readonly can_move v0+8
-;; @003e                               v7 = load.i64 notrap aligned readonly can_move v49+32
+;; @003e                               v44 = load.i64 notrap aligned readonly can_move v0+8
+;; @003e                               v7 = load.i64 notrap aligned readonly can_move v44+32
 ;; @003e                               v6 = uextend.i64 v2
 ;; @003e                               v8 = iadd v7, v6
 ;; @003e                               v9 = iconst.i64 16
 ;; @003e                               v10 = iadd v8, v9  ; v9 = 16
 ;; @003e                               v11 = load.i32 user2 readonly v10
-;; @003e                               v12 = uadd_overflow_trap v3, v4, user17
-;; @003e                               v13 = icmp ugt v12, v11
-;; @003e                               trapnz v13, user17
-;; @003e                               v15 = uextend.i64 v11
-;;                                     v51 = iconst.i64 2
-;;                                     v52 = ishl v15, v51  ; v51 = 2
-;;                                     v48 = iconst.i64 32
-;; @003e                               v17 = ushr v52, v48  ; v48 = 32
-;; @003e                               trapnz v17, user2
-;;                                     v61 = iconst.i32 2
-;;                                     v62 = ishl v11, v61  ; v61 = 2
-;; @003e                               v19 = iconst.i32 20
-;; @003e                               v20 = uadd_overflow_trap v62, v19, user2  ; v19 = 20
-;; @003e                               v24 = uadd_overflow_trap v2, v20, user2
-;; @003e                               v37 = load.i64 notrap aligned v49+40
-;; @003e                               v25 = uextend.i64 v24
-;; @003e                               v27 = iadd v7, v25
-;;                                     v68 = ishl v3, v61  ; v61 = 2
-;;                                     v70 = iadd v68, v19  ; v19 = 20
-;; @003e                               v28 = isub v20, v70
-;; @003e                               v29 = uextend.i64 v28
-;; @003e                               v30 = isub v27, v29
-;;                                     v72 = ishl v4, v61  ; v61 = 2
-;; @003e                               v32 = uextend.i64 v72
-;; @003e                               v33 = iadd v30, v32
-;; @003e                               v38 = iadd v7, v37
-;; @003e                               v39 = icmp ugt v33, v38
-;; @003e                               trapnz v39, user2
+;; @003e                               v13 = uextend.i64 v3
+;; @003e                               v14 = uextend.i64 v4
+;; @003e                               v16 = iadd v13, v14
+;; @003e                               v12 = uextend.i64 v11
+;; @003e                               v17 = icmp ugt v16, v12
+;; @003e                               trapnz v17, user17
+;; @003e                               v28 = load.i64 notrap aligned v44+40
+;;                                     v40 = iconst.i64 20
+;; @003e                               v21 = iadd v8, v40  ; v40 = 20
+;;                                     v48 = iconst.i64 2
+;;                                     v49 = ishl v13, v48  ; v48 = 2
+;; @003e                               v24 = iadd v21, v49
+;;                                     v51 = ishl v14, v48  ; v48 = 2
+;; @003e                               v30 = uadd_overflow_trap v24, v51, user2
+;; @003e                               v29 = iadd v7, v28
+;; @003e                               v31 = icmp ugt v30, v29
+;; @003e                               trapnz v31, user2
 ;; @003a                               v5 = iconst.i32 0
-;; @003e                               call fn0(v0, v30, v5, v32)  ; v5 = 0
+;; @003e                               call fn0(v0, v24, v5, v51)  ; v5 = 0
 ;; @0041                               jump block1
 ;;
 ;;                                 block1:
@@ -149,53 +131,46 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @004e                               trapz v2, user16
-;; @004e                               v43 = load.i64 notrap aligned readonly can_move v0+8
-;; @004e                               v9 = load.i64 notrap aligned readonly can_move v43+32
+;; @004e                               v51 = load.i64 notrap aligned readonly can_move v0+8
+;; @004e                               v9 = load.i64 notrap aligned readonly can_move v51+32
 ;; @004e                               v8 = uextend.i64 v2
 ;; @004e                               v10 = iadd v9, v8
 ;; @004e                               v11 = iconst.i64 16
 ;; @004e                               v12 = iadd v10, v11  ; v11 = 16
 ;; @004e                               v13 = load.i32 user2 readonly v12
-;; @004e                               v14 = uadd_overflow_trap v3, v4, user17
-;; @004e                               v15 = icmp ugt v14, v13
-;; @004e                               trapnz v15, user17
-;; @004e                               v17 = uextend.i64 v13
-;;                                     v53 = iconst.i64 2
-;;                                     v54 = ishl v17, v53  ; v53 = 2
-;;                                     v42 = iconst.i64 32
-;; @004e                               v19 = ushr v54, v42  ; v42 = 32
-;; @004e                               trapnz v19, user2
-;;                                     v63 = iconst.i32 2
-;;                                     v64 = ishl v13, v63  ; v63 = 2
-;; @004e                               v21 = iconst.i32 20
-;; @004e                               v22 = uadd_overflow_trap v64, v21, user2  ; v21 = 20
-;; @004e                               v26 = uadd_overflow_trap v2, v22, user2
-;; @004e                               v27 = uextend.i64 v26
-;; @004e                               v29 = iadd v9, v27
-;;                                     v70 = ishl v3, v63  ; v63 = 2
-;;                                     v72 = iadd v70, v21  ; v21 = 20
-;; @004e                               v30 = isub v22, v72
-;; @004e                               v31 = uextend.i64 v30
-;; @004e                               v32 = isub v29, v31
-;;                                     v74 = ishl v4, v63  ; v63 = 2
-;; @004e                               v34 = uextend.i64 v74
-;; @004e                               v35 = iadd v32, v34
+;; @004e                               v15 = uextend.i64 v3
+;; @004e                               v16 = uextend.i64 v4
+;; @004e                               v18 = iadd v15, v16
+;; @004e                               v14 = uextend.i64 v13
+;; @004e                               v19 = icmp ugt v18, v14
+;; @004e                               trapnz v19, user17
+;; @004e                               v30 = load.i64 notrap aligned v51+40
+;;                                     v47 = iconst.i64 20
+;; @004e                               v23 = iadd v10, v47  ; v47 = 20
+;;                                     v63 = iconst.i64 2
+;;                                     v64 = ishl v15, v63  ; v63 = 2
+;; @004e                               v26 = iadd v23, v64
+;;                                     v66 = ishl v16, v63  ; v63 = 2
+;; @004e                               v32 = uadd_overflow_trap v26, v66, user2
+;; @004e                               v31 = iadd v9, v30
+;; @004e                               v33 = icmp ugt v32, v31
+;; @004e                               trapnz v33, user2
+;;                                     v61 = iconst.i64 0
+;; @004e                               v35 = icmp eq v16, v61  ; v61 = 0
 ;; @0048                               v5 = iconst.i32 -1
-;; @004e                               v16 = iconst.i64 4
-;; @004e                               jump block2(v32)
+;;                                     v46 = iconst.i64 4
+;; @004e                               v34 = iadd v26, v66
+;; @004e                               brif v35, block3, block2(v26)
 ;;
-;;                                 block2(v37: i64):
-;; @004e                               v38 = icmp eq v37, v35
-;; @004e                               brif v38, block4, block3
+;;                                 block2(v36: i64):
+;;                                     v68 = iconst.i32 -1
+;; @004e                               store user2 little v68, v36  ; v68 = -1
+;;                                     v69 = iconst.i64 4
+;;                                     v70 = iadd v36, v69  ; v69 = 4
+;; @004e                               v38 = icmp eq v70, v34
+;; @004e                               brif v38, block3, block2(v70)
 ;;
 ;;                                 block3:
-;;                                     v76 = iconst.i32 -1
-;; @004e                               store user2 little v76, v37  ; v76 = -1
-;;                                     v77 = iconst.i64 4
-;;                                     v78 = iadd.i64 v37, v77  ; v77 = 4
-;; @004e                               jump block2(v78)
-;;
-;;                                 block4:
 ;; @0051                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/array-fill-i32.wat
+++ b/tests/disas/array-fill-i32.wat
@@ -33,51 +33,44 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
 ;; @0031                               trapz v2, user16
-;; @0031                               v41 = load.i64 notrap aligned readonly can_move v0+8
-;; @0031                               v7 = load.i64 notrap aligned readonly can_move v41+32
+;; @0031                               v49 = load.i64 notrap aligned readonly can_move v0+8
+;; @0031                               v7 = load.i64 notrap aligned readonly can_move v49+32
 ;; @0031                               v6 = uextend.i64 v2
 ;; @0031                               v8 = iadd v7, v6
 ;; @0031                               v9 = iconst.i64 24
 ;; @0031                               v10 = iadd v8, v9  ; v9 = 24
 ;; @0031                               v11 = load.i32 user2 readonly v10
-;; @0031                               v12 = uadd_overflow_trap v3, v5, user17
-;; @0031                               v13 = icmp ugt v12, v11
-;; @0031                               trapnz v13, user17
-;; @0031                               v15 = uextend.i64 v11
-;;                                     v43 = iconst.i64 2
-;;                                     v44 = ishl v15, v43  ; v43 = 2
-;;                                     v40 = iconst.i64 32
-;; @0031                               v17 = ushr v44, v40  ; v40 = 32
-;; @0031                               trapnz v17, user2
-;;                                     v53 = iconst.i32 2
-;;                                     v54 = ishl v11, v53  ; v53 = 2
-;; @0031                               v19 = iconst.i32 28
-;; @0031                               v20 = uadd_overflow_trap v54, v19, user2  ; v19 = 28
-;; @0031                               v24 = uadd_overflow_trap v2, v20, user2
-;; @0031                               v25 = uextend.i64 v24
-;; @0031                               v27 = iadd v7, v25
-;;                                     v60 = ishl v3, v53  ; v53 = 2
-;;                                     v62 = iadd v60, v19  ; v19 = 28
-;; @0031                               v28 = isub v20, v62
-;; @0031                               v29 = uextend.i64 v28
-;; @0031                               v30 = isub v27, v29
-;;                                     v64 = ishl v5, v53  ; v53 = 2
-;; @0031                               v32 = uextend.i64 v64
-;; @0031                               v33 = iadd v30, v32
-;; @0031                               v14 = iconst.i64 4
-;; @0031                               jump block2(v30)
+;; @0031                               v13 = uextend.i64 v3
+;; @0031                               v14 = uextend.i64 v5
+;; @0031                               v16 = iadd v13, v14
+;; @0031                               v12 = uextend.i64 v11
+;; @0031                               v17 = icmp ugt v16, v12
+;; @0031                               trapnz v17, user17
+;; @0031                               v28 = load.i64 notrap aligned v49+40
+;;                                     v45 = iconst.i64 28
+;; @0031                               v21 = iadd v8, v45  ; v45 = 28
+;;                                     v53 = iconst.i64 2
+;;                                     v54 = ishl v13, v53  ; v53 = 2
+;; @0031                               v24 = iadd v21, v54
+;;                                     v56 = ishl v14, v53  ; v53 = 2
+;; @0031                               v30 = uadd_overflow_trap v24, v56, user2
+;; @0031                               v29 = iadd v7, v28
+;; @0031                               v31 = icmp ugt v30, v29
+;; @0031                               trapnz v31, user2
+;;                                     v51 = iconst.i64 0
+;; @0031                               v33 = icmp eq v14, v51  ; v51 = 0
+;;                                     v44 = iconst.i64 4
+;; @0031                               v32 = iadd v24, v56
+;; @0031                               brif v33, block3, block2(v24)
 ;;
-;;                                 block2(v35: i64):
-;; @0031                               v36 = icmp eq v35, v33
-;; @0031                               brif v36, block4, block3
+;;                                 block2(v34: i64):
+;; @0031                               store.i32 user2 little v4, v34
+;;                                     v58 = iconst.i64 4
+;;                                     v59 = iadd v34, v58  ; v58 = 4
+;; @0031                               v36 = icmp eq v59, v32
+;; @0031                               brif v36, block3, block2(v59)
 ;;
 ;;                                 block3:
-;; @0031                               store.i32 user2 little v4, v35
-;;                                     v66 = iconst.i64 4
-;;                                     v67 = iadd.i64 v35, v66  ; v66 = 4
-;; @0031                               jump block2(v67)
-;;
-;;                                 block4:
 ;; @0034                               jump block1
 ;;
 ;;                                 block1:
@@ -98,43 +91,32 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @003f                               trapz v2, user16
-;; @003f                               v49 = load.i64 notrap aligned readonly can_move v0+8
-;; @003f                               v7 = load.i64 notrap aligned readonly can_move v49+32
+;; @003f                               v44 = load.i64 notrap aligned readonly can_move v0+8
+;; @003f                               v7 = load.i64 notrap aligned readonly can_move v44+32
 ;; @003f                               v6 = uextend.i64 v2
 ;; @003f                               v8 = iadd v7, v6
 ;; @003f                               v9 = iconst.i64 24
 ;; @003f                               v10 = iadd v8, v9  ; v9 = 24
 ;; @003f                               v11 = load.i32 user2 readonly v10
-;; @003f                               v12 = uadd_overflow_trap v3, v4, user17
-;; @003f                               v13 = icmp ugt v12, v11
-;; @003f                               trapnz v13, user17
-;; @003f                               v15 = uextend.i64 v11
-;;                                     v51 = iconst.i64 2
-;;                                     v52 = ishl v15, v51  ; v51 = 2
-;;                                     v48 = iconst.i64 32
-;; @003f                               v17 = ushr v52, v48  ; v48 = 32
-;; @003f                               trapnz v17, user2
-;;                                     v61 = iconst.i32 2
-;;                                     v62 = ishl v11, v61  ; v61 = 2
-;; @003f                               v19 = iconst.i32 28
-;; @003f                               v20 = uadd_overflow_trap v62, v19, user2  ; v19 = 28
-;; @003f                               v24 = uadd_overflow_trap v2, v20, user2
-;; @003f                               v37 = load.i64 notrap aligned v49+40
-;; @003f                               v25 = uextend.i64 v24
-;; @003f                               v27 = iadd v7, v25
-;;                                     v68 = ishl v3, v61  ; v61 = 2
-;;                                     v70 = iadd v68, v19  ; v19 = 28
-;; @003f                               v28 = isub v20, v70
-;; @003f                               v29 = uextend.i64 v28
-;; @003f                               v30 = isub v27, v29
-;;                                     v72 = ishl v4, v61  ; v61 = 2
-;; @003f                               v32 = uextend.i64 v72
-;; @003f                               v33 = iadd v30, v32
-;; @003f                               v38 = iadd v7, v37
-;; @003f                               v39 = icmp ugt v33, v38
-;; @003f                               trapnz v39, user2
+;; @003f                               v13 = uextend.i64 v3
+;; @003f                               v14 = uextend.i64 v4
+;; @003f                               v16 = iadd v13, v14
+;; @003f                               v12 = uextend.i64 v11
+;; @003f                               v17 = icmp ugt v16, v12
+;; @003f                               trapnz v17, user17
+;; @003f                               v28 = load.i64 notrap aligned v44+40
+;;                                     v40 = iconst.i64 28
+;; @003f                               v21 = iadd v8, v40  ; v40 = 28
+;;                                     v48 = iconst.i64 2
+;;                                     v49 = ishl v13, v48  ; v48 = 2
+;; @003f                               v24 = iadd v21, v49
+;;                                     v51 = ishl v14, v48  ; v48 = 2
+;; @003f                               v30 = uadd_overflow_trap v24, v51, user2
+;; @003f                               v29 = iadd v7, v28
+;; @003f                               v31 = icmp ugt v30, v29
+;; @003f                               trapnz v31, user2
 ;; @003b                               v5 = iconst.i32 0
-;; @003f                               call fn0(v0, v30, v5, v32)  ; v5 = 0
+;; @003f                               call fn0(v0, v24, v5, v51)  ; v5 = 0
 ;; @0042                               jump block1
 ;;
 ;;                                 block1:
@@ -155,43 +137,32 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @004d                               trapz v2, user16
-;; @004d                               v49 = load.i64 notrap aligned readonly can_move v0+8
-;; @004d                               v7 = load.i64 notrap aligned readonly can_move v49+32
+;; @004d                               v44 = load.i64 notrap aligned readonly can_move v0+8
+;; @004d                               v7 = load.i64 notrap aligned readonly can_move v44+32
 ;; @004d                               v6 = uextend.i64 v2
 ;; @004d                               v8 = iadd v7, v6
 ;; @004d                               v9 = iconst.i64 24
 ;; @004d                               v10 = iadd v8, v9  ; v9 = 24
 ;; @004d                               v11 = load.i32 user2 readonly v10
-;; @004d                               v12 = uadd_overflow_trap v3, v4, user17
-;; @004d                               v13 = icmp ugt v12, v11
-;; @004d                               trapnz v13, user17
-;; @004d                               v15 = uextend.i64 v11
-;;                                     v51 = iconst.i64 2
-;;                                     v52 = ishl v15, v51  ; v51 = 2
-;;                                     v48 = iconst.i64 32
-;; @004d                               v17 = ushr v52, v48  ; v48 = 32
-;; @004d                               trapnz v17, user2
-;;                                     v61 = iconst.i32 2
-;;                                     v62 = ishl v11, v61  ; v61 = 2
-;; @004d                               v19 = iconst.i32 28
-;; @004d                               v20 = uadd_overflow_trap v62, v19, user2  ; v19 = 28
-;; @004d                               v24 = uadd_overflow_trap v2, v20, user2
-;; @004d                               v37 = load.i64 notrap aligned v49+40
-;; @004d                               v25 = uextend.i64 v24
-;; @004d                               v27 = iadd v7, v25
-;;                                     v68 = ishl v3, v61  ; v61 = 2
-;;                                     v70 = iadd v68, v19  ; v19 = 28
-;; @004d                               v28 = isub v20, v70
-;; @004d                               v29 = uextend.i64 v28
-;; @004d                               v30 = isub v27, v29
-;;                                     v72 = ishl v4, v61  ; v61 = 2
-;; @004d                               v32 = uextend.i64 v72
-;; @004d                               v33 = iadd v30, v32
-;; @004d                               v38 = iadd v7, v37
-;; @004d                               v39 = icmp ugt v33, v38
-;; @004d                               trapnz v39, user2
-;; @004d                               v35 = iconst.i32 255
-;; @004d                               call fn0(v0, v30, v35, v32)  ; v35 = 255
+;; @004d                               v13 = uextend.i64 v3
+;; @004d                               v14 = uextend.i64 v4
+;; @004d                               v16 = iadd v13, v14
+;; @004d                               v12 = uextend.i64 v11
+;; @004d                               v17 = icmp ugt v16, v12
+;; @004d                               trapnz v17, user17
+;; @004d                               v28 = load.i64 notrap aligned v44+40
+;;                                     v40 = iconst.i64 28
+;; @004d                               v21 = iadd v8, v40  ; v40 = 28
+;;                                     v48 = iconst.i64 2
+;;                                     v49 = ishl v13, v48  ; v48 = 2
+;; @004d                               v24 = iadd v21, v49
+;;                                     v51 = ishl v14, v48  ; v48 = 2
+;; @004d                               v30 = uadd_overflow_trap v24, v51, user2
+;; @004d                               v29 = iadd v7, v28
+;; @004d                               v31 = icmp ugt v30, v29
+;; @004d                               trapnz v31, user2
+;; @004d                               v32 = iconst.i32 255
+;; @004d                               call fn0(v0, v24, v32, v51)  ; v32 = 255
 ;; @0050                               jump block1
 ;;
 ;;                                 block1:
@@ -210,53 +181,46 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @005d                               trapz v2, user16
-;; @005d                               v41 = load.i64 notrap aligned readonly can_move v0+8
-;; @005d                               v7 = load.i64 notrap aligned readonly can_move v41+32
+;; @005d                               v49 = load.i64 notrap aligned readonly can_move v0+8
+;; @005d                               v7 = load.i64 notrap aligned readonly can_move v49+32
 ;; @005d                               v6 = uextend.i64 v2
 ;; @005d                               v8 = iadd v7, v6
 ;; @005d                               v9 = iconst.i64 24
 ;; @005d                               v10 = iadd v8, v9  ; v9 = 24
 ;; @005d                               v11 = load.i32 user2 readonly v10
-;; @005d                               v12 = uadd_overflow_trap v3, v4, user17
-;; @005d                               v13 = icmp ugt v12, v11
-;; @005d                               trapnz v13, user17
-;; @005d                               v15 = uextend.i64 v11
-;;                                     v43 = iconst.i64 2
-;;                                     v44 = ishl v15, v43  ; v43 = 2
-;;                                     v40 = iconst.i64 32
-;; @005d                               v17 = ushr v44, v40  ; v40 = 32
-;; @005d                               trapnz v17, user2
-;;                                     v53 = iconst.i32 2
-;;                                     v54 = ishl v11, v53  ; v53 = 2
-;; @005d                               v19 = iconst.i32 28
-;; @005d                               v20 = uadd_overflow_trap v54, v19, user2  ; v19 = 28
-;; @005d                               v24 = uadd_overflow_trap v2, v20, user2
-;; @005d                               v25 = uextend.i64 v24
-;; @005d                               v27 = iadd v7, v25
-;;                                     v60 = ishl v3, v53  ; v53 = 2
-;;                                     v62 = iadd v60, v19  ; v19 = 28
-;; @005d                               v28 = isub v20, v62
-;; @005d                               v29 = uextend.i64 v28
-;; @005d                               v30 = isub v27, v29
-;;                                     v64 = ishl v4, v53  ; v53 = 2
-;; @005d                               v32 = uextend.i64 v64
-;; @005d                               v33 = iadd v30, v32
+;; @005d                               v13 = uextend.i64 v3
+;; @005d                               v14 = uextend.i64 v4
+;; @005d                               v16 = iadd v13, v14
+;; @005d                               v12 = uextend.i64 v11
+;; @005d                               v17 = icmp ugt v16, v12
+;; @005d                               trapnz v17, user17
+;; @005d                               v28 = load.i64 notrap aligned v49+40
+;;                                     v45 = iconst.i64 28
+;; @005d                               v21 = iadd v8, v45  ; v45 = 28
+;;                                     v53 = iconst.i64 2
+;;                                     v54 = ishl v13, v53  ; v53 = 2
+;; @005d                               v24 = iadd v21, v54
+;;                                     v56 = ishl v14, v53  ; v53 = 2
+;; @005d                               v30 = uadd_overflow_trap v24, v56, user2
+;; @005d                               v29 = iadd v7, v28
+;; @005d                               v31 = icmp ugt v30, v29
+;; @005d                               trapnz v31, user2
+;;                                     v51 = iconst.i64 0
+;; @005d                               v33 = icmp eq v14, v51  ; v51 = 0
 ;; @0057                               v5 = iconst.i32 0xdead
-;; @005d                               v14 = iconst.i64 4
-;; @005d                               jump block2(v30)
+;;                                     v44 = iconst.i64 4
+;; @005d                               v32 = iadd v24, v56
+;; @005d                               brif v33, block3, block2(v24)
 ;;
-;;                                 block2(v35: i64):
-;; @005d                               v36 = icmp eq v35, v33
-;; @005d                               brif v36, block4, block3
+;;                                 block2(v34: i64):
+;;                                     v58 = iconst.i32 0xdead
+;; @005d                               store user2 little v58, v34  ; v58 = 0xdead
+;;                                     v59 = iconst.i64 4
+;;                                     v60 = iadd v34, v59  ; v59 = 4
+;; @005d                               v36 = icmp eq v60, v32
+;; @005d                               brif v36, block3, block2(v60)
 ;;
 ;;                                 block3:
-;;                                     v66 = iconst.i32 0xdead
-;; @005d                               store user2 little v66, v35  ; v66 = 0xdead
-;;                                     v67 = iconst.i64 4
-;;                                     v68 = iadd.i64 v35, v67  ; v67 = 4
-;; @005d                               jump block2(v68)
-;;
-;;                                 block4:
 ;; @0060                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/array-fill-i64.wat
+++ b/tests/disas/array-fill-i64.wat
@@ -33,51 +33,44 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i64, v5: i32):
 ;; @0031                               trapz v2, user16
-;; @0031                               v41 = load.i64 notrap aligned readonly can_move v0+8
-;; @0031                               v7 = load.i64 notrap aligned readonly can_move v41+32
+;; @0031                               v49 = load.i64 notrap aligned readonly can_move v0+8
+;; @0031                               v7 = load.i64 notrap aligned readonly can_move v49+32
 ;; @0031                               v6 = uextend.i64 v2
 ;; @0031                               v8 = iadd v7, v6
 ;; @0031                               v9 = iconst.i64 24
 ;; @0031                               v10 = iadd v8, v9  ; v9 = 24
 ;; @0031                               v11 = load.i32 user2 readonly v10
-;; @0031                               v12 = uadd_overflow_trap v3, v5, user17
-;; @0031                               v13 = icmp ugt v12, v11
-;; @0031                               trapnz v13, user17
-;; @0031                               v15 = uextend.i64 v11
-;;                                     v43 = iconst.i64 3
-;;                                     v44 = ishl v15, v43  ; v43 = 3
-;;                                     v40 = iconst.i64 32
-;; @0031                               v17 = ushr v44, v40  ; v40 = 32
-;; @0031                               trapnz v17, user2
-;;                                     v53 = iconst.i32 3
-;;                                     v54 = ishl v11, v53  ; v53 = 3
-;; @0031                               v19 = iconst.i32 32
-;; @0031                               v20 = uadd_overflow_trap v54, v19, user2  ; v19 = 32
-;; @0031                               v24 = uadd_overflow_trap v2, v20, user2
-;; @0031                               v25 = uextend.i64 v24
-;; @0031                               v27 = iadd v7, v25
-;;                                     v60 = ishl v3, v53  ; v53 = 3
-;;                                     v62 = iadd v60, v19  ; v19 = 32
-;; @0031                               v28 = isub v20, v62
-;; @0031                               v29 = uextend.i64 v28
-;; @0031                               v30 = isub v27, v29
-;;                                     v64 = ishl v5, v53  ; v53 = 3
-;; @0031                               v32 = uextend.i64 v64
-;; @0031                               v33 = iadd v30, v32
-;; @0031                               v14 = iconst.i64 8
-;; @0031                               jump block2(v30)
+;; @0031                               v13 = uextend.i64 v3
+;; @0031                               v14 = uextend.i64 v5
+;; @0031                               v16 = iadd v13, v14
+;; @0031                               v12 = uextend.i64 v11
+;; @0031                               v17 = icmp ugt v16, v12
+;; @0031                               trapnz v17, user17
+;; @0031                               v28 = load.i64 notrap aligned v49+40
+;;                                     v45 = iconst.i64 32
+;; @0031                               v21 = iadd v8, v45  ; v45 = 32
+;;                                     v53 = iconst.i64 3
+;;                                     v54 = ishl v13, v53  ; v53 = 3
+;; @0031                               v24 = iadd v21, v54
+;;                                     v56 = ishl v14, v53  ; v53 = 3
+;; @0031                               v30 = uadd_overflow_trap v24, v56, user2
+;; @0031                               v29 = iadd v7, v28
+;; @0031                               v31 = icmp ugt v30, v29
+;; @0031                               trapnz v31, user2
+;;                                     v51 = iconst.i64 0
+;; @0031                               v33 = icmp eq v14, v51  ; v51 = 0
+;;                                     v44 = iconst.i64 8
+;; @0031                               v32 = iadd v24, v56
+;; @0031                               brif v33, block3, block2(v24)
 ;;
-;;                                 block2(v35: i64):
-;; @0031                               v36 = icmp eq v35, v33
-;; @0031                               brif v36, block4, block3
+;;                                 block2(v34: i64):
+;; @0031                               store.i64 user2 little v4, v34
+;;                                     v58 = iconst.i64 8
+;;                                     v59 = iadd v34, v58  ; v58 = 8
+;; @0031                               v36 = icmp eq v59, v32
+;; @0031                               brif v36, block3, block2(v59)
 ;;
 ;;                                 block3:
-;; @0031                               store.i64 user2 little v4, v35
-;;                                     v66 = iconst.i64 8
-;;                                     v67 = iadd.i64 v35, v66  ; v66 = 8
-;; @0031                               jump block2(v67)
-;;
-;;                                 block4:
 ;; @0034                               jump block1
 ;;
 ;;                                 block1:
@@ -98,43 +91,32 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @003f                               trapz v2, user16
-;; @003f                               v49 = load.i64 notrap aligned readonly can_move v0+8
-;; @003f                               v7 = load.i64 notrap aligned readonly can_move v49+32
+;; @003f                               v44 = load.i64 notrap aligned readonly can_move v0+8
+;; @003f                               v7 = load.i64 notrap aligned readonly can_move v44+32
 ;; @003f                               v6 = uextend.i64 v2
 ;; @003f                               v8 = iadd v7, v6
 ;; @003f                               v9 = iconst.i64 24
 ;; @003f                               v10 = iadd v8, v9  ; v9 = 24
 ;; @003f                               v11 = load.i32 user2 readonly v10
-;; @003f                               v12 = uadd_overflow_trap v3, v4, user17
-;; @003f                               v13 = icmp ugt v12, v11
-;; @003f                               trapnz v13, user17
-;; @003f                               v15 = uextend.i64 v11
-;;                                     v51 = iconst.i64 3
-;;                                     v52 = ishl v15, v51  ; v51 = 3
-;;                                     v48 = iconst.i64 32
-;; @003f                               v17 = ushr v52, v48  ; v48 = 32
-;; @003f                               trapnz v17, user2
-;;                                     v61 = iconst.i32 3
-;;                                     v62 = ishl v11, v61  ; v61 = 3
-;; @003f                               v19 = iconst.i32 32
-;; @003f                               v20 = uadd_overflow_trap v62, v19, user2  ; v19 = 32
-;; @003f                               v24 = uadd_overflow_trap v2, v20, user2
-;; @003f                               v37 = load.i64 notrap aligned v49+40
-;; @003f                               v25 = uextend.i64 v24
-;; @003f                               v27 = iadd v7, v25
-;;                                     v68 = ishl v3, v61  ; v61 = 3
-;;                                     v70 = iadd v68, v19  ; v19 = 32
-;; @003f                               v28 = isub v20, v70
-;; @003f                               v29 = uextend.i64 v28
-;; @003f                               v30 = isub v27, v29
-;;                                     v72 = ishl v4, v61  ; v61 = 3
-;; @003f                               v32 = uextend.i64 v72
-;; @003f                               v33 = iadd v30, v32
-;; @003f                               v38 = iadd v7, v37
-;; @003f                               v39 = icmp ugt v33, v38
-;; @003f                               trapnz v39, user2
-;; @003f                               v35 = iconst.i32 0
-;; @003f                               call fn0(v0, v30, v35, v32)  ; v35 = 0
+;; @003f                               v13 = uextend.i64 v3
+;; @003f                               v14 = uextend.i64 v4
+;; @003f                               v16 = iadd v13, v14
+;; @003f                               v12 = uextend.i64 v11
+;; @003f                               v17 = icmp ugt v16, v12
+;; @003f                               trapnz v17, user17
+;; @003f                               v28 = load.i64 notrap aligned v44+40
+;;                                     v40 = iconst.i64 32
+;; @003f                               v21 = iadd v8, v40  ; v40 = 32
+;;                                     v47 = iconst.i64 3
+;;                                     v48 = ishl v13, v47  ; v47 = 3
+;; @003f                               v24 = iadd v21, v48
+;;                                     v50 = ishl v14, v47  ; v47 = 3
+;; @003f                               v30 = uadd_overflow_trap v24, v50, user2
+;; @003f                               v29 = iadd v7, v28
+;; @003f                               v31 = icmp ugt v30, v29
+;; @003f                               trapnz v31, user2
+;; @003f                               v32 = iconst.i32 0
+;; @003f                               call fn0(v0, v24, v32, v50)  ; v32 = 0
 ;; @0042                               jump block1
 ;;
 ;;                                 block1:
@@ -155,43 +137,32 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @004d                               trapz v2, user16
-;; @004d                               v49 = load.i64 notrap aligned readonly can_move v0+8
-;; @004d                               v7 = load.i64 notrap aligned readonly can_move v49+32
+;; @004d                               v44 = load.i64 notrap aligned readonly can_move v0+8
+;; @004d                               v7 = load.i64 notrap aligned readonly can_move v44+32
 ;; @004d                               v6 = uextend.i64 v2
 ;; @004d                               v8 = iadd v7, v6
 ;; @004d                               v9 = iconst.i64 24
 ;; @004d                               v10 = iadd v8, v9  ; v9 = 24
 ;; @004d                               v11 = load.i32 user2 readonly v10
-;; @004d                               v12 = uadd_overflow_trap v3, v4, user17
-;; @004d                               v13 = icmp ugt v12, v11
-;; @004d                               trapnz v13, user17
-;; @004d                               v15 = uextend.i64 v11
-;;                                     v51 = iconst.i64 3
-;;                                     v52 = ishl v15, v51  ; v51 = 3
-;;                                     v48 = iconst.i64 32
-;; @004d                               v17 = ushr v52, v48  ; v48 = 32
-;; @004d                               trapnz v17, user2
-;;                                     v61 = iconst.i32 3
-;;                                     v62 = ishl v11, v61  ; v61 = 3
-;; @004d                               v19 = iconst.i32 32
-;; @004d                               v20 = uadd_overflow_trap v62, v19, user2  ; v19 = 32
-;; @004d                               v24 = uadd_overflow_trap v2, v20, user2
-;; @004d                               v37 = load.i64 notrap aligned v49+40
-;; @004d                               v25 = uextend.i64 v24
-;; @004d                               v27 = iadd v7, v25
-;;                                     v68 = ishl v3, v61  ; v61 = 3
-;;                                     v70 = iadd v68, v19  ; v19 = 32
-;; @004d                               v28 = isub v20, v70
-;; @004d                               v29 = uextend.i64 v28
-;; @004d                               v30 = isub v27, v29
-;;                                     v72 = ishl v4, v61  ; v61 = 3
-;; @004d                               v32 = uextend.i64 v72
-;; @004d                               v33 = iadd v30, v32
-;; @004d                               v38 = iadd v7, v37
-;; @004d                               v39 = icmp ugt v33, v38
-;; @004d                               trapnz v39, user2
-;; @004d                               v35 = iconst.i32 255
-;; @004d                               call fn0(v0, v30, v35, v32)  ; v35 = 255
+;; @004d                               v13 = uextend.i64 v3
+;; @004d                               v14 = uextend.i64 v4
+;; @004d                               v16 = iadd v13, v14
+;; @004d                               v12 = uextend.i64 v11
+;; @004d                               v17 = icmp ugt v16, v12
+;; @004d                               trapnz v17, user17
+;; @004d                               v28 = load.i64 notrap aligned v44+40
+;;                                     v40 = iconst.i64 32
+;; @004d                               v21 = iadd v8, v40  ; v40 = 32
+;;                                     v48 = iconst.i64 3
+;;                                     v49 = ishl v13, v48  ; v48 = 3
+;; @004d                               v24 = iadd v21, v49
+;;                                     v51 = ishl v14, v48  ; v48 = 3
+;; @004d                               v30 = uadd_overflow_trap v24, v51, user2
+;; @004d                               v29 = iadd v7, v28
+;; @004d                               v31 = icmp ugt v30, v29
+;; @004d                               trapnz v31, user2
+;; @004d                               v32 = iconst.i32 255
+;; @004d                               call fn0(v0, v24, v32, v51)  ; v32 = 255
 ;; @0050                               jump block1
 ;;
 ;;                                 block1:
@@ -210,53 +181,46 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @005b                               trapz v2, user16
-;; @005b                               v41 = load.i64 notrap aligned readonly can_move v0+8
-;; @005b                               v7 = load.i64 notrap aligned readonly can_move v41+32
+;; @005b                               v49 = load.i64 notrap aligned readonly can_move v0+8
+;; @005b                               v7 = load.i64 notrap aligned readonly can_move v49+32
 ;; @005b                               v6 = uextend.i64 v2
 ;; @005b                               v8 = iadd v7, v6
 ;; @005b                               v9 = iconst.i64 24
 ;; @005b                               v10 = iadd v8, v9  ; v9 = 24
 ;; @005b                               v11 = load.i32 user2 readonly v10
-;; @005b                               v12 = uadd_overflow_trap v3, v4, user17
-;; @005b                               v13 = icmp ugt v12, v11
-;; @005b                               trapnz v13, user17
-;; @005b                               v15 = uextend.i64 v11
-;;                                     v43 = iconst.i64 3
-;;                                     v44 = ishl v15, v43  ; v43 = 3
-;;                                     v40 = iconst.i64 32
-;; @005b                               v17 = ushr v44, v40  ; v40 = 32
-;; @005b                               trapnz v17, user2
-;;                                     v53 = iconst.i32 3
-;;                                     v54 = ishl v11, v53  ; v53 = 3
-;; @005b                               v19 = iconst.i32 32
-;; @005b                               v20 = uadd_overflow_trap v54, v19, user2  ; v19 = 32
-;; @005b                               v24 = uadd_overflow_trap v2, v20, user2
-;; @005b                               v25 = uextend.i64 v24
-;; @005b                               v27 = iadd v7, v25
-;;                                     v60 = ishl v3, v53  ; v53 = 3
-;;                                     v62 = iadd v60, v19  ; v19 = 32
-;; @005b                               v28 = isub v20, v62
-;; @005b                               v29 = uextend.i64 v28
-;; @005b                               v30 = isub v27, v29
-;;                                     v64 = ishl v4, v53  ; v53 = 3
-;; @005b                               v32 = uextend.i64 v64
-;; @005b                               v33 = iadd v30, v32
+;; @005b                               v13 = uextend.i64 v3
+;; @005b                               v14 = uextend.i64 v4
+;; @005b                               v16 = iadd v13, v14
+;; @005b                               v12 = uextend.i64 v11
+;; @005b                               v17 = icmp ugt v16, v12
+;; @005b                               trapnz v17, user17
+;; @005b                               v28 = load.i64 notrap aligned v49+40
+;;                                     v45 = iconst.i64 32
+;; @005b                               v21 = iadd v8, v45  ; v45 = 32
+;;                                     v53 = iconst.i64 3
+;;                                     v54 = ishl v13, v53  ; v53 = 3
+;; @005b                               v24 = iadd v21, v54
+;;                                     v56 = ishl v14, v53  ; v53 = 3
+;; @005b                               v30 = uadd_overflow_trap v24, v56, user2
+;; @005b                               v29 = iadd v7, v28
+;; @005b                               v31 = icmp ugt v30, v29
+;; @005b                               trapnz v31, user2
+;;                                     v51 = iconst.i64 0
+;; @005b                               v33 = icmp eq v14, v51  ; v51 = 0
 ;; @0057                               v5 = iconst.i64 1
-;; @005b                               v14 = iconst.i64 8
-;; @005b                               jump block2(v30)
+;;                                     v44 = iconst.i64 8
+;; @005b                               v32 = iadd v24, v56
+;; @005b                               brif v33, block3, block2(v24)
 ;;
-;;                                 block2(v35: i64):
-;; @005b                               v36 = icmp eq v35, v33
-;; @005b                               brif v36, block4, block3
+;;                                 block2(v34: i64):
+;;                                     v58 = iconst.i64 1
+;; @005b                               store user2 little v58, v34  ; v58 = 1
+;;                                     v59 = iconst.i64 8
+;;                                     v60 = iadd v34, v59  ; v59 = 8
+;; @005b                               v36 = icmp eq v60, v32
+;; @005b                               brif v36, block3, block2(v60)
 ;;
 ;;                                 block3:
-;;                                     v66 = iconst.i64 1
-;; @005b                               store user2 little v66, v35  ; v66 = 1
-;;                                     v67 = iconst.i64 8
-;;                                     v68 = iadd.i64 v35, v67  ; v67 = 8
-;; @005b                               jump block2(v68)
-;;
-;;                                 block4:
 ;; @005e                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/array-copy-with-fuel.wat
+++ b/tests/disas/gc/array-copy-with-fuel.wat
@@ -24,148 +24,129 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32, v6: i32):
-;;                                     v155 = stack_addr.i64 ss0
-;;                                     store notrap v2, v155
-;;                                     v154 = stack_addr.i64 ss1
-;;                                     store notrap v4, v154
+;;                                     v164 = stack_addr.i64 ss1
+;;                                     store notrap v2, v164
+;;                                     v163 = stack_addr.i64 ss0
+;;                                     store notrap v4, v163
 ;; @0020                               v7 = load.i64 notrap aligned readonly can_move v0+8
 ;; @0020                               v8 = load.i64 notrap aligned v7
-;;                                     v152 = iconst.i64 1
-;; @0020                               v9 = iadd v8, v152  ; v152 = 1
+;;                                     v161 = iconst.i64 1
+;; @0020                               v9 = iadd v8, v161  ; v161 = 1
 ;; @0020                               v10 = iconst.i64 0
 ;; @0020                               v11 = icmp sge v9, v10  ; v10 = 0
 ;; @0020                               brif v11, block2, block3(v9)
 ;;
 ;;                                 block2:
-;;                                     v202 = iadd.i64 v8, v152  ; v152 = 1
-;; @0020                               store notrap aligned v202, v7
-;; @0020                               v14 = call fn0(v0), stack_map=[i32 @ ss0+0, i32 @ ss1+0]
+;;                                     v176 = iadd.i64 v8, v161  ; v161 = 1
+;; @0020                               store notrap aligned v176, v7
+;; @0020                               v14 = call fn0(v0), stack_map=[i32 @ ss1+0, i32 @ ss0+0]
 ;; @0020                               v16 = load.i64 notrap aligned v7
 ;; @0020                               jump block3(v16)
 ;;
-;;                                 block3(v116: i64):
-;;                                     v126 = load.i32 notrap v154
-;; @002b                               trapz v126, user16
+;;                                 block3(v113: i64):
+;;                                     v123 = load.i32 notrap v164
+;; @002b                               trapz v123, user16
 ;; @002b                               v23 = load.i64 notrap aligned readonly can_move v7+32
-;; @002b                               v22 = uextend.i64 v126
+;; @002b                               v22 = uextend.i64 v123
 ;; @002b                               v24 = iadd v23, v22
 ;; @002b                               v25 = iconst.i64 16
 ;; @002b                               v26 = iadd v24, v25  ; v25 = 16
 ;; @002b                               v27 = load.i32 user2 readonly v26
-;; @002b                               v28 = uadd_overflow_trap.i32 v5, v6, user17
-;; @002b                               v29 = icmp ugt v28, v27
-;; @002b                               trapnz v29, user17
-;; @002b                               v31 = uextend.i64 v27
-;;                                     v156 = iconst.i64 2
-;;                                     v157 = ishl v31, v156  ; v156 = 2
-;;                                     v145 = iconst.i64 32
-;; @002b                               v33 = ushr v157, v145  ; v145 = 32
-;; @002b                               trapnz v33, user2
-;;                                     v166 = iconst.i32 2
-;;                                     v167 = ishl v27, v166  ; v166 = 2
-;; @002b                               v35 = iconst.i32 20
-;; @002b                               v36 = uadd_overflow_trap v167, v35, user2  ; v35 = 20
-;; @002b                               v40 = uadd_overflow_trap v126, v36, user2
-;;                                     v123 = load.i32 notrap v155
-;; @002b                               trapz v123, user16
-;; @002b                               v47 = uextend.i64 v123
-;; @002b                               v49 = iadd v23, v47
-;; @002b                               v51 = iadd v49, v25  ; v25 = 16
-;; @002b                               v52 = load.i32 user2 readonly v51
-;; @002b                               v53 = uadd_overflow_trap.i32 v3, v6, user17
-;; @002b                               v54 = icmp ugt v53, v52
-;; @002b                               trapnz v54, user17
-;; @002b                               v56 = uextend.i64 v52
-;;                                     v177 = ishl v56, v156  ; v156 = 2
-;; @002b                               v58 = ushr v177, v145  ; v145 = 32
-;; @002b                               trapnz v58, user2
-;;                                     v184 = ishl v52, v166  ; v166 = 2
-;; @002b                               v61 = uadd_overflow_trap v184, v35, user2  ; v35 = 20
-;; @002b                               v65 = uadd_overflow_trap v123, v61, user2
-;; @002b                               v75 = uextend.i64 v6
-;; @002b                               brif v75, block4, block7(v116)
+;; @002b                               v29 = uextend.i64 v3
+;; @002b                               v30 = uextend.i64 v6
+;; @002b                               v32 = iadd v29, v30
+;; @002b                               v28 = uextend.i64 v27
+;; @002b                               v33 = icmp ugt v32, v28
+;; @002b                               trapnz v33, user17
+;;                                     v120 = load.i32 notrap v163
+;; @002b                               trapz v120, user16
+;; @002b                               v41 = uextend.i64 v120
+;; @002b                               v43 = iadd v23, v41
+;; @002b                               v45 = iadd v43, v25  ; v25 = 16
+;; @002b                               v46 = load.i32 user2 readonly v45
+;; @002b                               v48 = uextend.i64 v5
+;; @002b                               v51 = iadd v48, v30
+;; @002b                               v47 = uextend.i64 v46
+;; @002b                               v52 = icmp ugt v51, v47
+;; @002b                               trapnz v52, user17
+;; @002b                               v64 = load.i64 notrap aligned v7+40
+;;                                     v150 = iconst.i64 20
+;; @002b                               v37 = iadd v24, v150  ; v150 = 20
+;;                                     v166 = iconst.i64 2
+;;                                     v167 = ishl v29, v166  ; v166 = 2
+;; @002b                               v40 = iadd v37, v167
+;;                                     v171 = ishl v30, v166  ; v166 = 2
+;; @002b                               v66 = uadd_overflow_trap v40, v171, user2
+;; @002b                               v65 = iadd v23, v64
+;; @002b                               v67 = icmp ugt v66, v65
+;; @002b                               trapnz v67, user2
+;; @002b                               brif v30, block4, block7(v113)
 ;;
 ;;                                 block4:
-;; @002b                               v66 = uextend.i64 v65
-;; @002b                               v68 = iadd.i64 v23, v66
-;;                                     v203 = iconst.i32 2
-;;                                     v204 = ishl.i32 v3, v203  ; v203 = 2
-;;                                     v205 = iconst.i32 20
-;;                                     v206 = iadd v204, v205  ; v205 = 20
-;; @002b                               v69 = isub.i32 v61, v206
-;; @002b                               v70 = uextend.i64 v69
-;; @002b                               v71 = isub v68, v70
-;; @002b                               v41 = uextend.i64 v40
-;; @002b                               v43 = iadd.i64 v23, v41
-;;                                     v207 = ishl.i32 v5, v203  ; v203 = 2
-;;                                     v208 = iadd v207, v205  ; v205 = 20
-;; @002b                               v44 = isub.i32 v36, v208
-;; @002b                               v45 = uextend.i64 v44
-;; @002b                               v46 = isub v43, v45
-;; @002b                               v76 = icmp ult v71, v46
-;;                                     v209 = iconst.i64 2
-;;                                     v210 = ishl.i64 v75, v209  ; v209 = 2
-;; @002b                               v78 = iadd v71, v210
-;; @002b                               v79 = iadd v46, v210
-;; @002b                               v81 = iadd.i32 v5, v6
-;; @002b                               v30 = iconst.i64 4
-;;                                     v199 = iadd v43, v30  ; v30 = 4
-;; @002b                               v112 = iconst.i32 1
-;;                                     v133 = iconst.i64 6
-;; @002b                               brif v76, block5(v71, v46, v5, v116), block6(v78, v79, v81, v116)
+;;                                     v177 = iconst.i64 20
+;;                                     v178 = iadd.i64 v43, v177  ; v177 = 20
+;;                                     v179 = iconst.i64 2
+;;                                     v180 = ishl.i64 v48, v179  ; v179 = 2
+;; @002b                               v59 = iadd v178, v180
+;; @002b                               v73 = icmp.i64 ult v40, v59
+;; @002b                               v75 = iadd.i64 v40, v171
+;; @002b                               v76 = iadd v59, v171
+;; @002b                               v78 = iadd.i32 v5, v6
+;;                                     v149 = iconst.i64 4
+;; @002b                               v109 = iconst.i32 1
+;;                                     v130 = iconst.i64 6
+;; @002b                               brif v73, block5(v40, v59, v5, v113), block6(v75, v76, v78, v113)
 ;;
-;;                                 block5(v82: i64, v83: i64, v84: i32, v85: i64):
-;;                                     v220 = iconst.i64 6
-;;                                     v221 = iadd v85, v220  ; v220 = 6
-;;                                     v222 = iconst.i64 0
-;;                                     v223 = icmp sge v221, v222  ; v222 = 0
-;; @002b                               brif v223, block8, block9(v221)
+;;                                 block5(v79: i64, v80: i64, v81: i32, v82: i64):
+;;                                     v188 = iconst.i64 6
+;;                                     v189 = iadd v82, v188  ; v188 = 6
+;;                                     v190 = iconst.i64 0
+;;                                     v191 = icmp sge v189, v190  ; v190 = 0
+;; @002b                               brif v191, block8, block9(v189)
 ;;
-;;                                 block6(v99: i64, v100: i64, v101: i32, v103: i64):
-;;                                     v211 = iconst.i64 0
-;;                                     v212 = icmp sge v103, v211  ; v211 = 0
-;; @002b                               brif v212, block10, block11(v103)
+;;                                 block6(v96: i64, v97: i64, v98: i32, v100: i64):
+;;                                     v181 = iconst.i64 0
+;;                                     v182 = icmp sge v100, v181  ; v181 = 0
+;; @002b                               brif v182, block10, block11(v100)
 ;;
-;;                                 block7(v120: i64):
+;;                                 block7(v117: i64):
 ;; @002f                               jump block1
 ;;
 ;;                                 block8:
-;; @002b                               store.i64 notrap aligned v221, v7
-;; @002b                               v91 = call fn0(v0)
-;; @002b                               v93 = load.i64 notrap aligned v7
-;; @002b                               jump block9(v93)
+;; @002b                               store.i64 notrap aligned v189, v7
+;; @002b                               v88 = call fn0(v0)
+;; @002b                               v90 = load.i64 notrap aligned v7
+;; @002b                               jump block9(v90)
 ;;
-;;                                 block9(v117: i64):
-;; @002b                               v94 = load.i32 user2 little v83
-;; @002b                               store user2 little v94, v82
-;;                                     v224 = iconst.i64 4
-;;                                     v225 = iadd.i64 v83, v224  ; v224 = 4
-;; @002b                               v98 = icmp eq v225, v79
-;;                                     v226 = iadd.i64 v82, v224  ; v224 = 4
-;;                                     v227 = iconst.i32 1
-;;                                     v228 = iadd.i32 v84, v227  ; v227 = 1
-;; @002b                               brif v98, block7(v117), block5(v226, v225, v228, v117)
+;;                                 block9(v114: i64):
+;; @002b                               v91 = load.i32 user2 little v80
+;; @002b                               store user2 little v91, v79
+;;                                     v192 = iconst.i64 4
+;;                                     v193 = iadd.i64 v80, v192  ; v192 = 4
+;; @002b                               v95 = icmp eq v193, v76
+;;                                     v194 = iadd.i64 v79, v192  ; v192 = 4
+;;                                     v195 = iconst.i32 1
+;;                                     v196 = iadd.i32 v81, v195  ; v195 = 1
+;; @002b                               brif v95, block7(v114), block5(v194, v193, v196, v114)
 ;;
 ;;                                 block10:
-;; @002b                               store.i64 notrap aligned v103, v7
-;; @002b                               v107 = call fn0(v0)
-;; @002b                               v109 = load.i64 notrap aligned v7
-;; @002b                               jump block11(v109)
+;; @002b                               store.i64 notrap aligned v100, v7
+;; @002b                               v104 = call fn0(v0)
+;; @002b                               v106 = load.i64 notrap aligned v7
+;; @002b                               jump block11(v106)
 ;;
-;;                                 block11(v118: i64):
-;;                                     v213 = iconst.i64 4
-;;                                     v214 = isub.i64 v100, v213  ; v213 = 4
-;; @002b                               v114 = load.i32 user2 little v214
-;;                                     v215 = isub.i64 v99, v213  ; v213 = 4
-;; @002b                               store user2 little v114, v215
-;;                                     v198 = iadd.i64 v100, v45
-;;                                     v216 = iadd.i64 v43, v30  ; v30 = 4
-;;                                     v217 = icmp eq v198, v216
-;;                                     v218 = iconst.i32 1
-;;                                     v219 = isub.i32 v101, v218  ; v218 = 1
-;; @002b                               brif v217, block7(v118), block6(v215, v214, v219, v118)
+;;                                 block11(v115: i64):
+;;                                     v183 = iconst.i64 4
+;;                                     v184 = isub.i64 v97, v183  ; v183 = 4
+;; @002b                               v111 = load.i32 user2 little v184
+;;                                     v185 = isub.i64 v96, v183  ; v183 = 4
+;; @002b                               store user2 little v111, v185
+;; @002b                               v112 = icmp eq v184, v59
+;;                                     v186 = iconst.i32 1
+;;                                     v187 = isub.i32 v98, v186  ; v186 = 1
+;; @002b                               brif v112, block7(v115), block6(v185, v184, v187, v115)
 ;;
 ;;                                 block1:
-;; @002f                               store.i64 notrap aligned v120, v7
+;; @002f                               store.i64 notrap aligned v117, v7
 ;; @002f                               return
 ;; }

--- a/tests/disas/gc/array-fill-i8.wat
+++ b/tests/disas/gc/array-fill-i8.wat
@@ -23,36 +23,28 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
 ;; @0027                               trapz v2, user16
-;; @0027                               v48 = load.i64 notrap aligned readonly can_move v0+8
-;; @0027                               v7 = load.i64 notrap aligned readonly can_move v48+32
+;; @0027                               v43 = load.i64 notrap aligned readonly can_move v0+8
+;; @0027                               v7 = load.i64 notrap aligned readonly can_move v43+32
 ;; @0027                               v6 = uextend.i64 v2
 ;; @0027                               v8 = iadd v7, v6
 ;; @0027                               v9 = iconst.i64 24
 ;; @0027                               v10 = iadd v8, v9  ; v9 = 24
 ;; @0027                               v11 = load.i32 user2 readonly v10
-;; @0027                               v12 = uadd_overflow_trap v3, v5, user17
-;; @0027                               v13 = icmp ugt v12, v11
-;; @0027                               trapnz v13, user17
-;; @0027                               v15 = uextend.i64 v11
-;;                                     v47 = iconst.i64 32
-;; @0027                               v17 = ushr v15, v47  ; v47 = 32
-;; @0027                               trapnz v17, user2
-;; @0027                               v19 = iconst.i32 28
-;; @0027                               v20 = uadd_overflow_trap v11, v19, user2  ; v19 = 28
-;; @0027                               v24 = uadd_overflow_trap v2, v20, user2
-;; @0027                               v36 = load.i64 notrap aligned v48+40
-;; @0027                               v25 = uextend.i64 v24
-;; @0027                               v27 = iadd v7, v25
-;;                                     v56 = iadd v3, v19  ; v19 = 28
-;; @0027                               v28 = isub v20, v56
-;; @0027                               v29 = uextend.i64 v28
-;; @0027                               v30 = isub v27, v29
-;; @0027                               v32 = uextend.i64 v5
-;; @0027                               v33 = iadd v30, v32
-;; @0027                               v37 = iadd v7, v36
-;; @0027                               v38 = icmp ugt v33, v37
-;; @0027                               trapnz v38, user2
-;; @0027                               call fn0(v0, v30, v4, v32)
+;; @0027                               v13 = uextend.i64 v3
+;; @0027                               v14 = uextend.i64 v5
+;; @0027                               v16 = iadd v13, v14
+;; @0027                               v12 = uextend.i64 v11
+;; @0027                               v17 = icmp ugt v16, v12
+;; @0027                               trapnz v17, user17
+;; @0027                               v28 = load.i64 notrap aligned v43+40
+;;                                     v39 = iconst.i64 28
+;; @0027                               v21 = iadd v8, v39  ; v39 = 28
+;; @0027                               v24 = iadd v21, v13
+;; @0027                               v30 = uadd_overflow_trap v24, v14, user2
+;; @0027                               v29 = iadd v7, v28
+;; @0027                               v31 = icmp ugt v30, v29
+;; @0027                               trapnz v31, user2
+;; @0027                               call fn0(v0, v24, v4, v14)
 ;; @002a                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/array-init-data.wat
+++ b/tests/disas/gc/array-init-data.wat
@@ -27,8 +27,8 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
 ;; @002a                               trapz v2, user16
-;; @002a                               v53 = load.i64 notrap aligned readonly can_move v0+8
-;; @002a                               v7 = load.i64 notrap aligned readonly can_move v53+32
+;; @002a                               v64 = load.i64 notrap aligned readonly can_move v0+8
+;; @002a                               v7 = load.i64 notrap aligned readonly can_move v64+32
 ;; @002a                               v6 = uextend.i64 v2
 ;; @002a                               v8 = iadd v7, v6
 ;; @002a                               v9 = iconst.i64 24
@@ -36,30 +36,26 @@
 ;; @002a                               v11 = load.i32 user2 readonly v10
 ;; @002a                               v13 = uextend.i64 v3
 ;; @002a                               v14 = uextend.i64 v5
-;; @002a                               v15 = iadd v13, v14
+;; @002a                               v16 = iadd v13, v14
 ;; @002a                               v12 = uextend.i64 v11
-;; @002a                               v16 = icmp ugt v15, v12
-;; @002a                               trapnz v16, user17
-;; @002a                               v19 = uload32 notrap aligned v0+56
-;; @002a                               v20 = uextend.i64 v4
-;; @002a                               v22 = iadd v20, v14
-;; @002a                               v23 = icmp ugt v22, v19
-;; @002a                               trapnz v23, heap_oob
-;; @002a                               v25 = load.i64 notrap aligned v0+48
-;;                                     v50 = iconst.i64 32
-;; @002a                               v32 = ushr v12, v50  ; v50 = 32
-;; @002a                               trapnz v32, user2
-;; @002a                               v34 = iconst.i32 28
-;; @002a                               v35 = uadd_overflow_trap v11, v34, user2  ; v34 = 28
-;; @002a                               v39 = uadd_overflow_trap v2, v35, user2
-;; @002a                               v40 = uextend.i64 v39
-;; @002a                               v42 = iadd v7, v40
-;;                                     v62 = iadd v3, v34  ; v34 = 28
-;; @002a                               v43 = isub v35, v62
-;; @002a                               v44 = uextend.i64 v43
-;; @002a                               v45 = isub v42, v44
-;; @002a                               v28 = iadd v25, v20
-;; @002a                               call fn0(v0, v45, v28, v14)
+;; @002a                               v17 = icmp ugt v16, v12
+;; @002a                               trapnz v17, user17
+;; @002a                               v26 = uload32 notrap aligned v0+56
+;; @002a                               v27 = uextend.i64 v4
+;; @002a                               v30 = iadd v27, v14
+;; @002a                               v31 = icmp ugt v30, v26
+;; @002a                               trapnz v31, heap_oob
+;; @002a                               v33 = load.i64 notrap aligned v0+48
+;; @002a                               v40 = load.i64 notrap aligned v64+40
+;;                                     v60 = iconst.i64 28
+;; @002a                               v21 = iadd v8, v60  ; v60 = 28
+;; @002a                               v24 = iadd v21, v13
+;; @002a                               v42 = uadd_overflow_trap v24, v14, user2
+;; @002a                               v41 = iadd v7, v40
+;; @002a                               v43 = icmp ugt v42, v41
+;; @002a                               trapnz v43, user2
+;; @002a                               v35 = iadd v33, v27
+;; @002a                               call fn0(v0, v24, v35, v14)
 ;; @002e                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/array-new-data.wat
+++ b/tests/disas/gc/array-new-data.wat
@@ -91,48 +91,57 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
-;; @0025                               v5 = uextend.i64 v3
-;;                                     v76 = iconst.i64 32
-;; @0025                               v7 = ushr v5, v76  ; v76 = 32
-;; @0025                               trapnz v7, heap_oob
-;; @0025                               v10 = uload32 notrap aligned v0+56
-;; @0025                               v11 = uextend.i64 v2
-;; @0025                               v13 = iadd v11, v5
-;; @0025                               v14 = icmp ugt v13, v10
-;; @0025                               trapnz v14, heap_oob
-;; @0025                               v16 = load.i64 notrap aligned v0+48
-;; @0025                               trapnz v7, user18
-;; @0025                               v20 = iconst.i32 28
-;; @0025                               v25 = uadd_overflow_trap v20, v3, user18  ; v20 = 28
-;; @0025                               v27 = iconst.i32 -1476395008
-;; @0025                               v29 = load.i64 notrap aligned readonly can_move v0+40
-;; @0025                               v30 = load.i32 notrap aligned readonly can_move v29
-;; @0025                               v31 = iconst.i32 8
-;; @0025                               v32 = call fn0(v0, v27, v30, v25, v31)  ; v27 = -1476395008, v31 = 8
-;;                                     v72 = stack_addr.i64 ss0
-;;                                     store notrap v32, v72
-;; @0025                               v70 = load.i64 notrap aligned readonly can_move v0+8
-;; @0025                               v33 = load.i64 notrap aligned readonly can_move v70+32
-;; @0025                               v34 = uextend.i64 v32
-;; @0025                               v35 = iadd v33, v34
-;;                                     v68 = iconst.i64 24
-;; @0025                               v36 = iadd v35, v68  ; v68 = 24
-;; @0025                               store user2 v3, v36
-;; @0025                               v44 = ushr v5, v76  ; v76 = 32
-;; @0025                               trapnz v44, user2
-;; @0025                               v47 = uadd_overflow_trap v3, v20, user2  ; v20 = 28
-;;                                     v61 = load.i32 notrap v72
-;; @0025                               v51 = uadd_overflow_trap v61, v47, user2
-;; @0025                               v52 = uextend.i64 v51
-;; @0025                               v54 = iadd v33, v52
-;; @0025                               v55 = isub v47, v20  ; v20 = 28
-;; @0025                               v56 = uextend.i64 v55
-;; @0025                               v57 = isub v54, v56
-;; @0025                               v19 = iadd v16, v11
-;; @0025                               call fn1(v0, v57, v19, v5), stack_map=[i32 @ ss0+0]
-;;                                     v60 = load.i32 notrap v72
+;; @0025                               v6 = uload32 notrap aligned v0+56
+;; @0025                               v7 = uextend.i64 v2
+;; @0025                               v8 = uextend.i64 v3
+;; @0025                               v10 = iadd v7, v8
+;; @0025                               v11 = icmp ugt v10, v6
+;; @0025                               trapnz v11, heap_oob
+;; @0025                               v13 = load.i64 notrap aligned v0+48
+;;                                     v108 = iconst.i64 32
+;; @0025                               v19 = ushr v8, v108  ; v108 = 32
+;; @0025                               trapnz v19, user18
+;; @0025                               v16 = iconst.i32 28
+;; @0025                               v21 = uadd_overflow_trap v16, v3, user18  ; v16 = 28
+;; @0025                               v23 = iconst.i32 -1476395008
+;; @0025                               v25 = load.i64 notrap aligned readonly can_move v0+40
+;; @0025                               v26 = load.i32 notrap aligned readonly can_move v25
+;; @0025                               v27 = iconst.i32 8
+;; @0025                               v28 = call fn0(v0, v23, v26, v21, v27)  ; v23 = -1476395008, v27 = 8
+;;                                     v107 = stack_addr.i64 ss0
+;;                                     store notrap v28, v107
+;; @0025                               v105 = load.i64 notrap aligned readonly can_move v0+8
+;; @0025                               v29 = load.i64 notrap aligned readonly can_move v105+32
+;; @0025                               v30 = uextend.i64 v28
+;; @0025                               v31 = iadd v29, v30
+;;                                     v103 = iconst.i64 24
+;; @0025                               v32 = iadd v31, v103  ; v103 = 24
+;; @0025                               store user2 v3, v32
+;;                                     v81 = load.i32 notrap v107
+;; @0025                               trapz v81, user16
+;; @0025                               v34 = uextend.i64 v81
+;; @0025                               v36 = iadd v29, v34
+;; @0025                               v38 = iadd v36, v103  ; v103 = 24
+;; @0025                               v39 = load.i32 user2 readonly v38
+;; @0025                               v40 = uextend.i64 v39
+;; @0025                               v45 = icmp ugt v8, v40
+;; @0025                               trapnz v45, user17
+;; @0025                               v54 = uload32 notrap aligned v0+56
+;; @0025                               v59 = icmp ugt v10, v54
+;; @0025                               trapnz v59, heap_oob
+;; @0025                               v61 = load.i64 notrap aligned v0+48
+;; @0025                               v68 = load.i64 notrap aligned v105+40
+;;                                     v94 = iconst.i64 28
+;; @0025                               v49 = iadd v36, v94  ; v94 = 28
+;; @0025                               v70 = uadd_overflow_trap v49, v8, user2
+;; @0025                               v69 = iadd v29, v68
+;; @0025                               v71 = icmp ugt v70, v69
+;; @0025                               trapnz v71, user2
+;; @0025                               v63 = iadd v61, v7
+;; @0025                               call fn1(v0, v49, v63, v8), stack_map=[i32 @ ss0+0]
+;;                                     v78 = load.i32 notrap v107
 ;; @0029                               jump block1
 ;;
 ;;                                 block1:
-;; @0029                               return v60
+;; @0029                               return v78
 ;; }

--- a/tests/disas/gc/array-new-default-anyref.wat
+++ b/tests/disas/gc/array-new-default-anyref.wat
@@ -25,44 +25,51 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @001f                               v6 = uextend.i64 v2
-;;                                     v50 = iconst.i64 2
-;;                                     v51 = ishl v6, v50  ; v50 = 2
-;;                                     v48 = iconst.i64 32
-;; @001f                               v8 = ushr v51, v48  ; v48 = 32
-;; @001f                               trapnz v8, user18
-;; @001f                               v5 = iconst.i32 28
-;;                                     v57 = iconst.i32 2
-;;                                     v58 = ishl v2, v57  ; v57 = 2
-;; @001f                               v10 = uadd_overflow_trap v5, v58, user18  ; v5 = 28
-;; @001f                               v12 = iconst.i32 -1476395008
-;; @001f                               v14 = load.i64 notrap aligned readonly can_move v0+40
-;; @001f                               v15 = load.i32 notrap aligned readonly can_move v14
-;; @001f                               v16 = iconst.i32 8
-;; @001f                               v17 = call fn0(v0, v12, v15, v10, v16)  ; v12 = -1476395008, v16 = 8
-;;                                     v47 = stack_addr.i64 ss0
-;;                                     store notrap v17, v47
-;; @001f                               v45 = load.i64 notrap aligned readonly can_move v0+8
-;; @001f                               v18 = load.i64 notrap aligned readonly can_move v45+32
-;; @001f                               v19 = uextend.i64 v17
-;; @001f                               v20 = iadd v18, v19
-;;                                     v43 = iconst.i64 24
-;; @001f                               v21 = iadd v20, v43  ; v43 = 24
-;; @001f                               store user2 v2, v21
-;; @001f                               v31 = load.i64 notrap aligned v45+40
-;; @001f                               v27 = uextend.i64 v10
-;; @001f                               v28 = iadd v20, v27
-;; @001f                               v32 = iadd v18, v31
-;; @001f                               v33 = icmp ugt v28, v32
-;; @001f                               trapnz v33, user2
-;;                                     v62 = iconst.i64 28
-;;                                     v67 = iadd v20, v62  ; v62 = 28
-;; @001f                               v4 = iconst.i32 0
-;; @001f                               v34 = isub v28, v67
-;; @001f                               call fn1(v0, v67, v4, v34), stack_map=[i32 @ ss0+0]  ; v4 = 0
-;;                                     v36 = load.i32 notrap v47
+;; @001f                               v5 = uextend.i64 v2
+;;                                     v79 = iconst.i64 2
+;;                                     v80 = ishl v5, v79  ; v79 = 2
+;;                                     v77 = iconst.i64 32
+;; @001f                               v7 = ushr v80, v77  ; v77 = 32
+;; @001f                               trapnz v7, user18
+;; @001f                               v4 = iconst.i32 28
+;;                                     v86 = iconst.i32 2
+;;                                     v87 = ishl v2, v86  ; v86 = 2
+;; @001f                               v9 = uadd_overflow_trap v4, v87, user18  ; v4 = 28
+;; @001f                               v11 = iconst.i32 -1476395008
+;; @001f                               v13 = load.i64 notrap aligned readonly can_move v0+40
+;; @001f                               v14 = load.i32 notrap aligned readonly can_move v13
+;; @001f                               v15 = iconst.i32 8
+;; @001f                               v16 = call fn0(v0, v11, v14, v9, v15)  ; v11 = -1476395008, v15 = 8
+;;                                     v76 = stack_addr.i64 ss0
+;;                                     store notrap v16, v76
+;; @001f                               v74 = load.i64 notrap aligned readonly can_move v0+8
+;; @001f                               v17 = load.i64 notrap aligned readonly can_move v74+32
+;; @001f                               v18 = uextend.i64 v16
+;; @001f                               v19 = iadd v17, v18
+;;                                     v72 = iconst.i64 24
+;; @001f                               v20 = iadd v19, v72  ; v72 = 24
+;; @001f                               store user2 v2, v20
+;;                                     v54 = load.i32 notrap v76
+;; @001f                               trapz v54, user16
+;; @001f                               v23 = uextend.i64 v54
+;; @001f                               v25 = iadd v17, v23
+;; @001f                               v27 = iadd v25, v72  ; v72 = 24
+;; @001f                               v28 = load.i32 user2 readonly v27
+;; @001f                               v29 = uextend.i64 v28
+;; @001f                               v34 = icmp ugt v5, v29
+;; @001f                               trapnz v34, user17
+;; @001f                               v45 = load.i64 notrap aligned v74+40
+;;                                     v63 = iconst.i64 28
+;; @001f                               v38 = iadd v25, v63  ; v63 = 28
+;; @001f                               v47 = uadd_overflow_trap v38, v80, user2
+;; @001f                               v46 = iadd v17, v45
+;; @001f                               v48 = icmp ugt v47, v46
+;; @001f                               trapnz v48, user2
+;; @001f                               v21 = iconst.i32 0
+;; @001f                               call fn1(v0, v38, v21, v80), stack_map=[i32 @ ss0+0]  ; v21 = 0
+;;                                     v51 = load.i32 notrap v76
 ;; @0022                               jump block1
 ;;
 ;;                                 block1:
-;; @0022                               return v36
+;; @0022                               return v51
 ;; }

--- a/tests/disas/gc/array-new-default-exnref.wat
+++ b/tests/disas/gc/array-new-default-exnref.wat
@@ -25,44 +25,51 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @001f                               v6 = uextend.i64 v2
-;;                                     v50 = iconst.i64 2
-;;                                     v51 = ishl v6, v50  ; v50 = 2
-;;                                     v48 = iconst.i64 32
-;; @001f                               v8 = ushr v51, v48  ; v48 = 32
-;; @001f                               trapnz v8, user18
-;; @001f                               v5 = iconst.i32 28
-;;                                     v57 = iconst.i32 2
-;;                                     v58 = ishl v2, v57  ; v57 = 2
-;; @001f                               v10 = uadd_overflow_trap v5, v58, user18  ; v5 = 28
-;; @001f                               v12 = iconst.i32 -1476395008
-;; @001f                               v14 = load.i64 notrap aligned readonly can_move v0+40
-;; @001f                               v15 = load.i32 notrap aligned readonly can_move v14
-;; @001f                               v16 = iconst.i32 8
-;; @001f                               v17 = call fn0(v0, v12, v15, v10, v16)  ; v12 = -1476395008, v16 = 8
-;;                                     v47 = stack_addr.i64 ss0
-;;                                     store notrap v17, v47
-;; @001f                               v45 = load.i64 notrap aligned readonly can_move v0+8
-;; @001f                               v18 = load.i64 notrap aligned readonly can_move v45+32
-;; @001f                               v19 = uextend.i64 v17
-;; @001f                               v20 = iadd v18, v19
-;;                                     v43 = iconst.i64 24
-;; @001f                               v21 = iadd v20, v43  ; v43 = 24
-;; @001f                               store user2 v2, v21
-;; @001f                               v31 = load.i64 notrap aligned v45+40
-;; @001f                               v27 = uextend.i64 v10
-;; @001f                               v28 = iadd v20, v27
-;; @001f                               v32 = iadd v18, v31
-;; @001f                               v33 = icmp ugt v28, v32
-;; @001f                               trapnz v33, user2
-;;                                     v62 = iconst.i64 28
-;;                                     v67 = iadd v20, v62  ; v62 = 28
-;; @001f                               v4 = iconst.i32 0
-;; @001f                               v34 = isub v28, v67
-;; @001f                               call fn1(v0, v67, v4, v34), stack_map=[i32 @ ss0+0]  ; v4 = 0
-;;                                     v36 = load.i32 notrap v47
+;; @001f                               v5 = uextend.i64 v2
+;;                                     v79 = iconst.i64 2
+;;                                     v80 = ishl v5, v79  ; v79 = 2
+;;                                     v77 = iconst.i64 32
+;; @001f                               v7 = ushr v80, v77  ; v77 = 32
+;; @001f                               trapnz v7, user18
+;; @001f                               v4 = iconst.i32 28
+;;                                     v86 = iconst.i32 2
+;;                                     v87 = ishl v2, v86  ; v86 = 2
+;; @001f                               v9 = uadd_overflow_trap v4, v87, user18  ; v4 = 28
+;; @001f                               v11 = iconst.i32 -1476395008
+;; @001f                               v13 = load.i64 notrap aligned readonly can_move v0+40
+;; @001f                               v14 = load.i32 notrap aligned readonly can_move v13
+;; @001f                               v15 = iconst.i32 8
+;; @001f                               v16 = call fn0(v0, v11, v14, v9, v15)  ; v11 = -1476395008, v15 = 8
+;;                                     v76 = stack_addr.i64 ss0
+;;                                     store notrap v16, v76
+;; @001f                               v74 = load.i64 notrap aligned readonly can_move v0+8
+;; @001f                               v17 = load.i64 notrap aligned readonly can_move v74+32
+;; @001f                               v18 = uextend.i64 v16
+;; @001f                               v19 = iadd v17, v18
+;;                                     v72 = iconst.i64 24
+;; @001f                               v20 = iadd v19, v72  ; v72 = 24
+;; @001f                               store user2 v2, v20
+;;                                     v54 = load.i32 notrap v76
+;; @001f                               trapz v54, user16
+;; @001f                               v23 = uextend.i64 v54
+;; @001f                               v25 = iadd v17, v23
+;; @001f                               v27 = iadd v25, v72  ; v72 = 24
+;; @001f                               v28 = load.i32 user2 readonly v27
+;; @001f                               v29 = uextend.i64 v28
+;; @001f                               v34 = icmp ugt v5, v29
+;; @001f                               trapnz v34, user17
+;; @001f                               v45 = load.i64 notrap aligned v74+40
+;;                                     v63 = iconst.i64 28
+;; @001f                               v38 = iadd v25, v63  ; v63 = 28
+;; @001f                               v47 = uadd_overflow_trap v38, v80, user2
+;; @001f                               v46 = iadd v17, v45
+;; @001f                               v48 = icmp ugt v47, v46
+;; @001f                               trapnz v48, user2
+;; @001f                               v21 = iconst.i32 0
+;; @001f                               call fn1(v0, v38, v21, v80), stack_map=[i32 @ ss0+0]  ; v21 = 0
+;;                                     v51 = load.i32 notrap v76
 ;; @0022                               jump block1
 ;;
 ;;                                 block1:
-;; @0022                               return v36
+;; @0022                               return v51
 ;; }

--- a/tests/disas/gc/array-new-default-externref.wat
+++ b/tests/disas/gc/array-new-default-externref.wat
@@ -25,44 +25,51 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @001f                               v6 = uextend.i64 v2
-;;                                     v50 = iconst.i64 2
-;;                                     v51 = ishl v6, v50  ; v50 = 2
-;;                                     v48 = iconst.i64 32
-;; @001f                               v8 = ushr v51, v48  ; v48 = 32
-;; @001f                               trapnz v8, user18
-;; @001f                               v5 = iconst.i32 28
-;;                                     v57 = iconst.i32 2
-;;                                     v58 = ishl v2, v57  ; v57 = 2
-;; @001f                               v10 = uadd_overflow_trap v5, v58, user18  ; v5 = 28
-;; @001f                               v12 = iconst.i32 -1476395008
-;; @001f                               v14 = load.i64 notrap aligned readonly can_move v0+40
-;; @001f                               v15 = load.i32 notrap aligned readonly can_move v14
-;; @001f                               v16 = iconst.i32 8
-;; @001f                               v17 = call fn0(v0, v12, v15, v10, v16)  ; v12 = -1476395008, v16 = 8
-;;                                     v47 = stack_addr.i64 ss0
-;;                                     store notrap v17, v47
-;; @001f                               v45 = load.i64 notrap aligned readonly can_move v0+8
-;; @001f                               v18 = load.i64 notrap aligned readonly can_move v45+32
-;; @001f                               v19 = uextend.i64 v17
-;; @001f                               v20 = iadd v18, v19
-;;                                     v43 = iconst.i64 24
-;; @001f                               v21 = iadd v20, v43  ; v43 = 24
-;; @001f                               store user2 v2, v21
-;; @001f                               v31 = load.i64 notrap aligned v45+40
-;; @001f                               v27 = uextend.i64 v10
-;; @001f                               v28 = iadd v20, v27
-;; @001f                               v32 = iadd v18, v31
-;; @001f                               v33 = icmp ugt v28, v32
-;; @001f                               trapnz v33, user2
-;;                                     v62 = iconst.i64 28
-;;                                     v67 = iadd v20, v62  ; v62 = 28
-;; @001f                               v4 = iconst.i32 0
-;; @001f                               v34 = isub v28, v67
-;; @001f                               call fn1(v0, v67, v4, v34), stack_map=[i32 @ ss0+0]  ; v4 = 0
-;;                                     v36 = load.i32 notrap v47
+;; @001f                               v5 = uextend.i64 v2
+;;                                     v79 = iconst.i64 2
+;;                                     v80 = ishl v5, v79  ; v79 = 2
+;;                                     v77 = iconst.i64 32
+;; @001f                               v7 = ushr v80, v77  ; v77 = 32
+;; @001f                               trapnz v7, user18
+;; @001f                               v4 = iconst.i32 28
+;;                                     v86 = iconst.i32 2
+;;                                     v87 = ishl v2, v86  ; v86 = 2
+;; @001f                               v9 = uadd_overflow_trap v4, v87, user18  ; v4 = 28
+;; @001f                               v11 = iconst.i32 -1476395008
+;; @001f                               v13 = load.i64 notrap aligned readonly can_move v0+40
+;; @001f                               v14 = load.i32 notrap aligned readonly can_move v13
+;; @001f                               v15 = iconst.i32 8
+;; @001f                               v16 = call fn0(v0, v11, v14, v9, v15)  ; v11 = -1476395008, v15 = 8
+;;                                     v76 = stack_addr.i64 ss0
+;;                                     store notrap v16, v76
+;; @001f                               v74 = load.i64 notrap aligned readonly can_move v0+8
+;; @001f                               v17 = load.i64 notrap aligned readonly can_move v74+32
+;; @001f                               v18 = uextend.i64 v16
+;; @001f                               v19 = iadd v17, v18
+;;                                     v72 = iconst.i64 24
+;; @001f                               v20 = iadd v19, v72  ; v72 = 24
+;; @001f                               store user2 v2, v20
+;;                                     v54 = load.i32 notrap v76
+;; @001f                               trapz v54, user16
+;; @001f                               v23 = uextend.i64 v54
+;; @001f                               v25 = iadd v17, v23
+;; @001f                               v27 = iadd v25, v72  ; v72 = 24
+;; @001f                               v28 = load.i32 user2 readonly v27
+;; @001f                               v29 = uextend.i64 v28
+;; @001f                               v34 = icmp ugt v5, v29
+;; @001f                               trapnz v34, user17
+;; @001f                               v45 = load.i64 notrap aligned v74+40
+;;                                     v63 = iconst.i64 28
+;; @001f                               v38 = iadd v25, v63  ; v63 = 28
+;; @001f                               v47 = uadd_overflow_trap v38, v80, user2
+;; @001f                               v46 = iadd v17, v45
+;; @001f                               v48 = icmp ugt v47, v46
+;; @001f                               trapnz v48, user2
+;; @001f                               v21 = iconst.i32 0
+;; @001f                               call fn1(v0, v38, v21, v80), stack_map=[i32 @ ss0+0]  ; v21 = 0
+;;                                     v51 = load.i32 notrap v76
 ;; @0022                               jump block1
 ;;
 ;;                                 block1:
-;; @0022                               return v36
+;; @0022                               return v51
 ;; }

--- a/tests/disas/gc/array-new-default-f32.wat
+++ b/tests/disas/gc/array-new-default-f32.wat
@@ -25,44 +25,51 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @001f                               v6 = uextend.i64 v2
-;;                                     v50 = iconst.i64 2
-;;                                     v51 = ishl v6, v50  ; v50 = 2
-;;                                     v48 = iconst.i64 32
-;; @001f                               v8 = ushr v51, v48  ; v48 = 32
-;; @001f                               trapnz v8, user18
-;; @001f                               v5 = iconst.i32 28
-;;                                     v57 = iconst.i32 2
-;;                                     v58 = ishl v2, v57  ; v57 = 2
-;; @001f                               v10 = uadd_overflow_trap v5, v58, user18  ; v5 = 28
-;; @001f                               v12 = iconst.i32 -1476395008
-;; @001f                               v14 = load.i64 notrap aligned readonly can_move v0+40
-;; @001f                               v15 = load.i32 notrap aligned readonly can_move v14
-;; @001f                               v16 = iconst.i32 8
-;; @001f                               v17 = call fn0(v0, v12, v15, v10, v16)  ; v12 = -1476395008, v16 = 8
-;;                                     v47 = stack_addr.i64 ss0
-;;                                     store notrap v17, v47
-;; @001f                               v45 = load.i64 notrap aligned readonly can_move v0+8
-;; @001f                               v18 = load.i64 notrap aligned readonly can_move v45+32
-;; @001f                               v19 = uextend.i64 v17
-;; @001f                               v20 = iadd v18, v19
-;;                                     v43 = iconst.i64 24
-;; @001f                               v21 = iadd v20, v43  ; v43 = 24
-;; @001f                               store user2 v2, v21
-;; @001f                               v31 = load.i64 notrap aligned v45+40
-;; @001f                               v27 = uextend.i64 v10
-;; @001f                               v28 = iadd v20, v27
-;; @001f                               v32 = iadd v18, v31
-;; @001f                               v33 = icmp ugt v28, v32
-;; @001f                               trapnz v33, user2
-;;                                     v62 = iconst.i64 28
-;;                                     v67 = iadd v20, v62  ; v62 = 28
-;; @001f                               v29 = iconst.i32 0
-;; @001f                               v34 = isub v28, v67
-;; @001f                               call fn1(v0, v67, v29, v34), stack_map=[i32 @ ss0+0]  ; v29 = 0
-;;                                     v36 = load.i32 notrap v47
+;; @001f                               v5 = uextend.i64 v2
+;;                                     v79 = iconst.i64 2
+;;                                     v80 = ishl v5, v79  ; v79 = 2
+;;                                     v77 = iconst.i64 32
+;; @001f                               v7 = ushr v80, v77  ; v77 = 32
+;; @001f                               trapnz v7, user18
+;; @001f                               v4 = iconst.i32 28
+;;                                     v86 = iconst.i32 2
+;;                                     v87 = ishl v2, v86  ; v86 = 2
+;; @001f                               v9 = uadd_overflow_trap v4, v87, user18  ; v4 = 28
+;; @001f                               v11 = iconst.i32 -1476395008
+;; @001f                               v13 = load.i64 notrap aligned readonly can_move v0+40
+;; @001f                               v14 = load.i32 notrap aligned readonly can_move v13
+;; @001f                               v15 = iconst.i32 8
+;; @001f                               v16 = call fn0(v0, v11, v14, v9, v15)  ; v11 = -1476395008, v15 = 8
+;;                                     v76 = stack_addr.i64 ss0
+;;                                     store notrap v16, v76
+;; @001f                               v74 = load.i64 notrap aligned readonly can_move v0+8
+;; @001f                               v17 = load.i64 notrap aligned readonly can_move v74+32
+;; @001f                               v18 = uextend.i64 v16
+;; @001f                               v19 = iadd v17, v18
+;;                                     v72 = iconst.i64 24
+;; @001f                               v20 = iadd v19, v72  ; v72 = 24
+;; @001f                               store user2 v2, v20
+;;                                     v54 = load.i32 notrap v76
+;; @001f                               trapz v54, user16
+;; @001f                               v23 = uextend.i64 v54
+;; @001f                               v25 = iadd v17, v23
+;; @001f                               v27 = iadd v25, v72  ; v72 = 24
+;; @001f                               v28 = load.i32 user2 readonly v27
+;; @001f                               v29 = uextend.i64 v28
+;; @001f                               v34 = icmp ugt v5, v29
+;; @001f                               trapnz v34, user17
+;; @001f                               v45 = load.i64 notrap aligned v74+40
+;;                                     v63 = iconst.i64 28
+;; @001f                               v38 = iadd v25, v63  ; v63 = 28
+;; @001f                               v47 = uadd_overflow_trap v38, v80, user2
+;; @001f                               v46 = iadd v17, v45
+;; @001f                               v48 = icmp ugt v47, v46
+;; @001f                               trapnz v48, user2
+;; @001f                               v22 = iconst.i32 0
+;; @001f                               call fn1(v0, v38, v22, v80), stack_map=[i32 @ ss0+0]  ; v22 = 0
+;;                                     v51 = load.i32 notrap v76
 ;; @0022                               jump block1
 ;;
 ;;                                 block1:
-;; @0022                               return v36
+;; @0022                               return v51
 ;; }

--- a/tests/disas/gc/array-new-default-f64.wat
+++ b/tests/disas/gc/array-new-default-f64.wat
@@ -25,43 +25,50 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @001f                               v6 = uextend.i64 v2
-;;                                     v50 = iconst.i64 3
-;;                                     v51 = ishl v6, v50  ; v50 = 3
-;;                                     v48 = iconst.i64 32
-;; @001f                               v8 = ushr v51, v48  ; v48 = 32
-;; @001f                               trapnz v8, user18
-;; @001f                               v5 = iconst.i32 32
-;;                                     v57 = iconst.i32 3
-;;                                     v58 = ishl v2, v57  ; v57 = 3
-;; @001f                               v10 = uadd_overflow_trap v5, v58, user18  ; v5 = 32
-;; @001f                               v12 = iconst.i32 -1476395008
-;; @001f                               v14 = load.i64 notrap aligned readonly can_move v0+40
-;; @001f                               v15 = load.i32 notrap aligned readonly can_move v14
-;;                                     v55 = iconst.i32 8
-;; @001f                               v17 = call fn0(v0, v12, v15, v10, v55)  ; v12 = -1476395008, v55 = 8
-;;                                     v47 = stack_addr.i64 ss0
-;;                                     store notrap v17, v47
-;; @001f                               v45 = load.i64 notrap aligned readonly can_move v0+8
-;; @001f                               v18 = load.i64 notrap aligned readonly can_move v45+32
-;; @001f                               v19 = uextend.i64 v17
-;; @001f                               v20 = iadd v18, v19
-;;                                     v43 = iconst.i64 24
-;; @001f                               v21 = iadd v20, v43  ; v43 = 24
-;; @001f                               store user2 v2, v21
-;; @001f                               v31 = load.i64 notrap aligned v45+40
-;; @001f                               v27 = uextend.i64 v10
-;; @001f                               v28 = iadd v20, v27
-;; @001f                               v32 = iadd v18, v31
-;; @001f                               v33 = icmp ugt v28, v32
-;; @001f                               trapnz v33, user2
-;;                                     v66 = iadd v20, v48  ; v48 = 32
-;; @001f                               v29 = iconst.i32 0
-;; @001f                               v34 = isub v28, v66
-;; @001f                               call fn1(v0, v66, v29, v34), stack_map=[i32 @ ss0+0]  ; v29 = 0
-;;                                     v36 = load.i32 notrap v47
+;; @001f                               v5 = uextend.i64 v2
+;;                                     v79 = iconst.i64 3
+;;                                     v80 = ishl v5, v79  ; v79 = 3
+;;                                     v77 = iconst.i64 32
+;; @001f                               v7 = ushr v80, v77  ; v77 = 32
+;; @001f                               trapnz v7, user18
+;; @001f                               v4 = iconst.i32 32
+;;                                     v86 = iconst.i32 3
+;;                                     v87 = ishl v2, v86  ; v86 = 3
+;; @001f                               v9 = uadd_overflow_trap v4, v87, user18  ; v4 = 32
+;; @001f                               v11 = iconst.i32 -1476395008
+;; @001f                               v13 = load.i64 notrap aligned readonly can_move v0+40
+;; @001f                               v14 = load.i32 notrap aligned readonly can_move v13
+;;                                     v84 = iconst.i32 8
+;; @001f                               v16 = call fn0(v0, v11, v14, v9, v84)  ; v11 = -1476395008, v84 = 8
+;;                                     v76 = stack_addr.i64 ss0
+;;                                     store notrap v16, v76
+;; @001f                               v74 = load.i64 notrap aligned readonly can_move v0+8
+;; @001f                               v17 = load.i64 notrap aligned readonly can_move v74+32
+;; @001f                               v18 = uextend.i64 v16
+;; @001f                               v19 = iadd v17, v18
+;;                                     v72 = iconst.i64 24
+;; @001f                               v20 = iadd v19, v72  ; v72 = 24
+;; @001f                               store user2 v2, v20
+;;                                     v54 = load.i32 notrap v76
+;; @001f                               trapz v54, user16
+;; @001f                               v23 = uextend.i64 v54
+;; @001f                               v25 = iadd v17, v23
+;; @001f                               v27 = iadd v25, v72  ; v72 = 24
+;; @001f                               v28 = load.i32 user2 readonly v27
+;; @001f                               v29 = uextend.i64 v28
+;; @001f                               v34 = icmp ugt v5, v29
+;; @001f                               trapnz v34, user17
+;; @001f                               v45 = load.i64 notrap aligned v74+40
+;; @001f                               v38 = iadd v25, v77  ; v77 = 32
+;; @001f                               v47 = uadd_overflow_trap v38, v80, user2
+;; @001f                               v46 = iadd v17, v45
+;; @001f                               v48 = icmp ugt v47, v46
+;; @001f                               trapnz v48, user2
+;; @001f                               v22 = iconst.i32 0
+;; @001f                               call fn1(v0, v38, v22, v80), stack_map=[i32 @ ss0+0]  ; v22 = 0
+;;                                     v51 = load.i32 notrap v76
 ;; @0022                               jump block1
 ;;
 ;;                                 block1:
-;; @0022                               return v36
+;; @0022                               return v51
 ;; }

--- a/tests/disas/gc/array-new-default-funcref.wat
+++ b/tests/disas/gc/array-new-default-funcref.wat
@@ -25,44 +25,51 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @001f                               v6 = uextend.i64 v2
-;;                                     v50 = iconst.i64 2
-;;                                     v51 = ishl v6, v50  ; v50 = 2
-;;                                     v48 = iconst.i64 32
-;; @001f                               v8 = ushr v51, v48  ; v48 = 32
-;; @001f                               trapnz v8, user18
-;; @001f                               v5 = iconst.i32 28
-;;                                     v57 = iconst.i32 2
-;;                                     v58 = ishl v2, v57  ; v57 = 2
-;; @001f                               v10 = uadd_overflow_trap v5, v58, user18  ; v5 = 28
-;; @001f                               v12 = iconst.i32 -1476395008
-;; @001f                               v14 = load.i64 notrap aligned readonly can_move v0+40
-;; @001f                               v15 = load.i32 notrap aligned readonly can_move v14
-;; @001f                               v16 = iconst.i32 8
-;; @001f                               v17 = call fn0(v0, v12, v15, v10, v16)  ; v12 = -1476395008, v16 = 8
-;;                                     v47 = stack_addr.i64 ss0
-;;                                     store notrap v17, v47
-;; @001f                               v45 = load.i64 notrap aligned readonly can_move v0+8
-;; @001f                               v18 = load.i64 notrap aligned readonly can_move v45+32
-;; @001f                               v19 = uextend.i64 v17
-;; @001f                               v20 = iadd v18, v19
-;;                                     v43 = iconst.i64 24
-;; @001f                               v21 = iadd v20, v43  ; v43 = 24
-;; @001f                               store user2 v2, v21
-;; @001f                               v31 = load.i64 notrap aligned v45+40
-;; @001f                               v27 = uextend.i64 v10
-;; @001f                               v28 = iadd v20, v27
-;; @001f                               v32 = iadd v18, v31
-;; @001f                               v33 = icmp ugt v28, v32
-;; @001f                               trapnz v33, user2
-;;                                     v62 = iconst.i64 28
-;;                                     v67 = iadd v20, v62  ; v62 = 28
-;; @001f                               v29 = iconst.i32 0
-;; @001f                               v34 = isub v28, v67
-;; @001f                               call fn1(v0, v67, v29, v34), stack_map=[i32 @ ss0+0]  ; v29 = 0
-;;                                     v36 = load.i32 notrap v47
+;; @001f                               v5 = uextend.i64 v2
+;;                                     v79 = iconst.i64 2
+;;                                     v80 = ishl v5, v79  ; v79 = 2
+;;                                     v77 = iconst.i64 32
+;; @001f                               v7 = ushr v80, v77  ; v77 = 32
+;; @001f                               trapnz v7, user18
+;; @001f                               v4 = iconst.i32 28
+;;                                     v86 = iconst.i32 2
+;;                                     v87 = ishl v2, v86  ; v86 = 2
+;; @001f                               v9 = uadd_overflow_trap v4, v87, user18  ; v4 = 28
+;; @001f                               v11 = iconst.i32 -1476395008
+;; @001f                               v13 = load.i64 notrap aligned readonly can_move v0+40
+;; @001f                               v14 = load.i32 notrap aligned readonly can_move v13
+;; @001f                               v15 = iconst.i32 8
+;; @001f                               v16 = call fn0(v0, v11, v14, v9, v15)  ; v11 = -1476395008, v15 = 8
+;;                                     v76 = stack_addr.i64 ss0
+;;                                     store notrap v16, v76
+;; @001f                               v74 = load.i64 notrap aligned readonly can_move v0+8
+;; @001f                               v17 = load.i64 notrap aligned readonly can_move v74+32
+;; @001f                               v18 = uextend.i64 v16
+;; @001f                               v19 = iadd v17, v18
+;;                                     v72 = iconst.i64 24
+;; @001f                               v20 = iadd v19, v72  ; v72 = 24
+;; @001f                               store user2 v2, v20
+;;                                     v54 = load.i32 notrap v76
+;; @001f                               trapz v54, user16
+;; @001f                               v23 = uextend.i64 v54
+;; @001f                               v25 = iadd v17, v23
+;; @001f                               v27 = iadd v25, v72  ; v72 = 24
+;; @001f                               v28 = load.i32 user2 readonly v27
+;; @001f                               v29 = uextend.i64 v28
+;; @001f                               v34 = icmp ugt v5, v29
+;; @001f                               trapnz v34, user17
+;; @001f                               v45 = load.i64 notrap aligned v74+40
+;;                                     v63 = iconst.i64 28
+;; @001f                               v38 = iadd v25, v63  ; v63 = 28
+;; @001f                               v47 = uadd_overflow_trap v38, v80, user2
+;; @001f                               v46 = iadd v17, v45
+;; @001f                               v48 = icmp ugt v47, v46
+;; @001f                               trapnz v48, user2
+;; @001f                               v22 = iconst.i32 0
+;; @001f                               call fn1(v0, v38, v22, v80), stack_map=[i32 @ ss0+0]  ; v22 = 0
+;;                                     v51 = load.i32 notrap v76
 ;; @0022                               jump block1
 ;;
 ;;                                 block1:
-;; @0022                               return v36
+;; @0022                               return v51
 ;; }

--- a/tests/disas/gc/array-new-default-i16.wat
+++ b/tests/disas/gc/array-new-default-i16.wat
@@ -25,43 +25,50 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @001f                               v6 = uextend.i64 v2
-;;                                     v51 = iconst.i64 1
-;;                                     v52 = ishl v6, v51  ; v51 = 1
-;;                                     v48 = iconst.i64 32
-;; @001f                               v8 = ushr v52, v48  ; v48 = 32
-;; @001f                               trapnz v8, user18
-;; @001f                               v5 = iconst.i32 28
-;;                                     v56 = iadd v2, v2
-;; @001f                               v10 = uadd_overflow_trap v5, v56, user18  ; v5 = 28
-;; @001f                               v12 = iconst.i32 -1476395008
-;; @001f                               v14 = load.i64 notrap aligned readonly can_move v0+40
-;; @001f                               v15 = load.i32 notrap aligned readonly can_move v14
-;; @001f                               v16 = iconst.i32 8
-;; @001f                               v17 = call fn0(v0, v12, v15, v10, v16)  ; v12 = -1476395008, v16 = 8
-;;                                     v47 = stack_addr.i64 ss0
-;;                                     store notrap v17, v47
-;; @001f                               v45 = load.i64 notrap aligned readonly can_move v0+8
-;; @001f                               v18 = load.i64 notrap aligned readonly can_move v45+32
-;; @001f                               v19 = uextend.i64 v17
-;; @001f                               v20 = iadd v18, v19
-;;                                     v43 = iconst.i64 24
-;; @001f                               v21 = iadd v20, v43  ; v43 = 24
-;; @001f                               store user2 v2, v21
-;; @001f                               v31 = load.i64 notrap aligned v45+40
-;; @001f                               v27 = uextend.i64 v10
-;; @001f                               v28 = iadd v20, v27
-;; @001f                               v32 = iadd v18, v31
-;; @001f                               v33 = icmp ugt v28, v32
-;; @001f                               trapnz v33, user2
-;;                                     v67 = iconst.i64 28
-;;                                     v72 = iadd v20, v67  ; v67 = 28
-;; @001f                               v4 = iconst.i32 0
-;; @001f                               v34 = isub v28, v72
-;; @001f                               call fn1(v0, v72, v4, v34), stack_map=[i32 @ ss0+0]  ; v4 = 0
-;;                                     v36 = load.i32 notrap v47
+;; @001f                               v5 = uextend.i64 v2
+;;                                     v80 = iconst.i64 1
+;;                                     v81 = ishl v5, v80  ; v80 = 1
+;;                                     v77 = iconst.i64 32
+;; @001f                               v7 = ushr v81, v77  ; v77 = 32
+;; @001f                               trapnz v7, user18
+;; @001f                               v4 = iconst.i32 28
+;;                                     v85 = iadd v2, v2
+;; @001f                               v9 = uadd_overflow_trap v4, v85, user18  ; v4 = 28
+;; @001f                               v11 = iconst.i32 -1476395008
+;; @001f                               v13 = load.i64 notrap aligned readonly can_move v0+40
+;; @001f                               v14 = load.i32 notrap aligned readonly can_move v13
+;; @001f                               v15 = iconst.i32 8
+;; @001f                               v16 = call fn0(v0, v11, v14, v9, v15)  ; v11 = -1476395008, v15 = 8
+;;                                     v76 = stack_addr.i64 ss0
+;;                                     store notrap v16, v76
+;; @001f                               v74 = load.i64 notrap aligned readonly can_move v0+8
+;; @001f                               v17 = load.i64 notrap aligned readonly can_move v74+32
+;; @001f                               v18 = uextend.i64 v16
+;; @001f                               v19 = iadd v17, v18
+;;                                     v72 = iconst.i64 24
+;; @001f                               v20 = iadd v19, v72  ; v72 = 24
+;; @001f                               store user2 v2, v20
+;;                                     v54 = load.i32 notrap v76
+;; @001f                               trapz v54, user16
+;; @001f                               v23 = uextend.i64 v54
+;; @001f                               v25 = iadd v17, v23
+;; @001f                               v27 = iadd v25, v72  ; v72 = 24
+;; @001f                               v28 = load.i32 user2 readonly v27
+;; @001f                               v29 = uextend.i64 v28
+;; @001f                               v34 = icmp ugt v5, v29
+;; @001f                               trapnz v34, user17
+;; @001f                               v45 = load.i64 notrap aligned v74+40
+;;                                     v63 = iconst.i64 28
+;; @001f                               v38 = iadd v25, v63  ; v63 = 28
+;; @001f                               v47 = uadd_overflow_trap v38, v81, user2
+;; @001f                               v46 = iadd v17, v45
+;; @001f                               v48 = icmp ugt v47, v46
+;; @001f                               trapnz v48, user2
+;; @001f                               v21 = iconst.i32 0
+;; @001f                               call fn1(v0, v38, v21, v81), stack_map=[i32 @ ss0+0]  ; v21 = 0
+;;                                     v51 = load.i32 notrap v76
 ;; @0022                               jump block1
 ;;
 ;;                                 block1:
-;; @0022                               return v36
+;; @0022                               return v51
 ;; }

--- a/tests/disas/gc/array-new-default-i32.wat
+++ b/tests/disas/gc/array-new-default-i32.wat
@@ -25,44 +25,51 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @001f                               v6 = uextend.i64 v2
-;;                                     v50 = iconst.i64 2
-;;                                     v51 = ishl v6, v50  ; v50 = 2
-;;                                     v48 = iconst.i64 32
-;; @001f                               v8 = ushr v51, v48  ; v48 = 32
-;; @001f                               trapnz v8, user18
-;; @001f                               v5 = iconst.i32 28
-;;                                     v57 = iconst.i32 2
-;;                                     v58 = ishl v2, v57  ; v57 = 2
-;; @001f                               v10 = uadd_overflow_trap v5, v58, user18  ; v5 = 28
-;; @001f                               v12 = iconst.i32 -1476395008
-;; @001f                               v14 = load.i64 notrap aligned readonly can_move v0+40
-;; @001f                               v15 = load.i32 notrap aligned readonly can_move v14
-;; @001f                               v16 = iconst.i32 8
-;; @001f                               v17 = call fn0(v0, v12, v15, v10, v16)  ; v12 = -1476395008, v16 = 8
-;;                                     v47 = stack_addr.i64 ss0
-;;                                     store notrap v17, v47
-;; @001f                               v45 = load.i64 notrap aligned readonly can_move v0+8
-;; @001f                               v18 = load.i64 notrap aligned readonly can_move v45+32
-;; @001f                               v19 = uextend.i64 v17
-;; @001f                               v20 = iadd v18, v19
-;;                                     v43 = iconst.i64 24
-;; @001f                               v21 = iadd v20, v43  ; v43 = 24
-;; @001f                               store user2 v2, v21
-;; @001f                               v31 = load.i64 notrap aligned v45+40
-;; @001f                               v27 = uextend.i64 v10
-;; @001f                               v28 = iadd v20, v27
-;; @001f                               v32 = iadd v18, v31
-;; @001f                               v33 = icmp ugt v28, v32
-;; @001f                               trapnz v33, user2
-;;                                     v62 = iconst.i64 28
-;;                                     v67 = iadd v20, v62  ; v62 = 28
-;; @001f                               v4 = iconst.i32 0
-;; @001f                               v34 = isub v28, v67
-;; @001f                               call fn1(v0, v67, v4, v34), stack_map=[i32 @ ss0+0]  ; v4 = 0
-;;                                     v36 = load.i32 notrap v47
+;; @001f                               v5 = uextend.i64 v2
+;;                                     v79 = iconst.i64 2
+;;                                     v80 = ishl v5, v79  ; v79 = 2
+;;                                     v77 = iconst.i64 32
+;; @001f                               v7 = ushr v80, v77  ; v77 = 32
+;; @001f                               trapnz v7, user18
+;; @001f                               v4 = iconst.i32 28
+;;                                     v86 = iconst.i32 2
+;;                                     v87 = ishl v2, v86  ; v86 = 2
+;; @001f                               v9 = uadd_overflow_trap v4, v87, user18  ; v4 = 28
+;; @001f                               v11 = iconst.i32 -1476395008
+;; @001f                               v13 = load.i64 notrap aligned readonly can_move v0+40
+;; @001f                               v14 = load.i32 notrap aligned readonly can_move v13
+;; @001f                               v15 = iconst.i32 8
+;; @001f                               v16 = call fn0(v0, v11, v14, v9, v15)  ; v11 = -1476395008, v15 = 8
+;;                                     v76 = stack_addr.i64 ss0
+;;                                     store notrap v16, v76
+;; @001f                               v74 = load.i64 notrap aligned readonly can_move v0+8
+;; @001f                               v17 = load.i64 notrap aligned readonly can_move v74+32
+;; @001f                               v18 = uextend.i64 v16
+;; @001f                               v19 = iadd v17, v18
+;;                                     v72 = iconst.i64 24
+;; @001f                               v20 = iadd v19, v72  ; v72 = 24
+;; @001f                               store user2 v2, v20
+;;                                     v54 = load.i32 notrap v76
+;; @001f                               trapz v54, user16
+;; @001f                               v23 = uextend.i64 v54
+;; @001f                               v25 = iadd v17, v23
+;; @001f                               v27 = iadd v25, v72  ; v72 = 24
+;; @001f                               v28 = load.i32 user2 readonly v27
+;; @001f                               v29 = uextend.i64 v28
+;; @001f                               v34 = icmp ugt v5, v29
+;; @001f                               trapnz v34, user17
+;; @001f                               v45 = load.i64 notrap aligned v74+40
+;;                                     v63 = iconst.i64 28
+;; @001f                               v38 = iadd v25, v63  ; v63 = 28
+;; @001f                               v47 = uadd_overflow_trap v38, v80, user2
+;; @001f                               v46 = iadd v17, v45
+;; @001f                               v48 = icmp ugt v47, v46
+;; @001f                               trapnz v48, user2
+;; @001f                               v21 = iconst.i32 0
+;; @001f                               call fn1(v0, v38, v21, v80), stack_map=[i32 @ ss0+0]  ; v21 = 0
+;;                                     v51 = load.i32 notrap v76
 ;; @0022                               jump block1
 ;;
 ;;                                 block1:
-;; @0022                               return v36
+;; @0022                               return v51
 ;; }

--- a/tests/disas/gc/array-new-default-i64.wat
+++ b/tests/disas/gc/array-new-default-i64.wat
@@ -25,43 +25,50 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @001f                               v6 = uextend.i64 v2
-;;                                     v50 = iconst.i64 3
-;;                                     v51 = ishl v6, v50  ; v50 = 3
-;;                                     v48 = iconst.i64 32
-;; @001f                               v8 = ushr v51, v48  ; v48 = 32
-;; @001f                               trapnz v8, user18
-;; @001f                               v5 = iconst.i32 32
-;;                                     v57 = iconst.i32 3
-;;                                     v58 = ishl v2, v57  ; v57 = 3
-;; @001f                               v10 = uadd_overflow_trap v5, v58, user18  ; v5 = 32
-;; @001f                               v12 = iconst.i32 -1476395008
-;; @001f                               v14 = load.i64 notrap aligned readonly can_move v0+40
-;; @001f                               v15 = load.i32 notrap aligned readonly can_move v14
-;;                                     v55 = iconst.i32 8
-;; @001f                               v17 = call fn0(v0, v12, v15, v10, v55)  ; v12 = -1476395008, v55 = 8
-;;                                     v47 = stack_addr.i64 ss0
-;;                                     store notrap v17, v47
-;; @001f                               v45 = load.i64 notrap aligned readonly can_move v0+8
-;; @001f                               v18 = load.i64 notrap aligned readonly can_move v45+32
-;; @001f                               v19 = uextend.i64 v17
-;; @001f                               v20 = iadd v18, v19
-;;                                     v43 = iconst.i64 24
-;; @001f                               v21 = iadd v20, v43  ; v43 = 24
-;; @001f                               store user2 v2, v21
-;; @001f                               v31 = load.i64 notrap aligned v45+40
-;; @001f                               v27 = uextend.i64 v10
-;; @001f                               v28 = iadd v20, v27
-;; @001f                               v32 = iadd v18, v31
-;; @001f                               v33 = icmp ugt v28, v32
-;; @001f                               trapnz v33, user2
-;;                                     v66 = iadd v20, v48  ; v48 = 32
-;; @001f                               v29 = iconst.i32 0
-;; @001f                               v34 = isub v28, v66
-;; @001f                               call fn1(v0, v66, v29, v34), stack_map=[i32 @ ss0+0]  ; v29 = 0
-;;                                     v36 = load.i32 notrap v47
+;; @001f                               v5 = uextend.i64 v2
+;;                                     v79 = iconst.i64 3
+;;                                     v80 = ishl v5, v79  ; v79 = 3
+;;                                     v77 = iconst.i64 32
+;; @001f                               v7 = ushr v80, v77  ; v77 = 32
+;; @001f                               trapnz v7, user18
+;; @001f                               v4 = iconst.i32 32
+;;                                     v86 = iconst.i32 3
+;;                                     v87 = ishl v2, v86  ; v86 = 3
+;; @001f                               v9 = uadd_overflow_trap v4, v87, user18  ; v4 = 32
+;; @001f                               v11 = iconst.i32 -1476395008
+;; @001f                               v13 = load.i64 notrap aligned readonly can_move v0+40
+;; @001f                               v14 = load.i32 notrap aligned readonly can_move v13
+;;                                     v84 = iconst.i32 8
+;; @001f                               v16 = call fn0(v0, v11, v14, v9, v84)  ; v11 = -1476395008, v84 = 8
+;;                                     v76 = stack_addr.i64 ss0
+;;                                     store notrap v16, v76
+;; @001f                               v74 = load.i64 notrap aligned readonly can_move v0+8
+;; @001f                               v17 = load.i64 notrap aligned readonly can_move v74+32
+;; @001f                               v18 = uextend.i64 v16
+;; @001f                               v19 = iadd v17, v18
+;;                                     v72 = iconst.i64 24
+;; @001f                               v20 = iadd v19, v72  ; v72 = 24
+;; @001f                               store user2 v2, v20
+;;                                     v54 = load.i32 notrap v76
+;; @001f                               trapz v54, user16
+;; @001f                               v23 = uextend.i64 v54
+;; @001f                               v25 = iadd v17, v23
+;; @001f                               v27 = iadd v25, v72  ; v72 = 24
+;; @001f                               v28 = load.i32 user2 readonly v27
+;; @001f                               v29 = uextend.i64 v28
+;; @001f                               v34 = icmp ugt v5, v29
+;; @001f                               trapnz v34, user17
+;; @001f                               v45 = load.i64 notrap aligned v74+40
+;; @001f                               v38 = iadd v25, v77  ; v77 = 32
+;; @001f                               v47 = uadd_overflow_trap v38, v80, user2
+;; @001f                               v46 = iadd v17, v45
+;; @001f                               v48 = icmp ugt v47, v46
+;; @001f                               trapnz v48, user2
+;; @001f                               v22 = iconst.i32 0
+;; @001f                               call fn1(v0, v38, v22, v80), stack_map=[i32 @ ss0+0]  ; v22 = 0
+;;                                     v51 = load.i32 notrap v76
 ;; @0022                               jump block1
 ;;
 ;;                                 block1:
-;; @0022                               return v36
+;; @0022                               return v51
 ;; }

--- a/tests/disas/gc/array-new-default-i8.wat
+++ b/tests/disas/gc/array-new-default-i8.wat
@@ -25,40 +25,47 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;; @001f                               v6 = uextend.i64 v2
-;;                                     v47 = iconst.i64 32
-;; @001f                               v8 = ushr v6, v47  ; v47 = 32
-;; @001f                               trapnz v8, user18
-;; @001f                               v5 = iconst.i32 28
-;; @001f                               v10 = uadd_overflow_trap v5, v2, user18  ; v5 = 28
-;; @001f                               v12 = iconst.i32 -1476395008
-;; @001f                               v14 = load.i64 notrap aligned readonly can_move v0+40
-;; @001f                               v15 = load.i32 notrap aligned readonly can_move v14
-;; @001f                               v16 = iconst.i32 8
-;; @001f                               v17 = call fn0(v0, v12, v15, v10, v16)  ; v12 = -1476395008, v16 = 8
-;;                                     v46 = stack_addr.i64 ss0
-;;                                     store notrap v17, v46
-;; @001f                               v44 = load.i64 notrap aligned readonly can_move v0+8
-;; @001f                               v18 = load.i64 notrap aligned readonly can_move v44+32
-;; @001f                               v19 = uextend.i64 v17
-;; @001f                               v20 = iadd v18, v19
-;;                                     v42 = iconst.i64 24
-;; @001f                               v21 = iadd v20, v42  ; v42 = 24
-;; @001f                               store user2 v2, v21
-;; @001f                               v30 = load.i64 notrap aligned v44+40
-;; @001f                               v27 = uextend.i64 v10
-;; @001f                               v28 = iadd v20, v27
-;; @001f                               v31 = iadd v18, v30
-;; @001f                               v32 = icmp ugt v28, v31
-;; @001f                               trapnz v32, user2
-;;                                     v52 = iconst.i64 28
-;;                                     v57 = iadd v20, v52  ; v52 = 28
-;; @001f                               v4 = iconst.i32 0
-;; @001f                               v33 = isub v28, v57
-;; @001f                               call fn1(v0, v57, v4, v33), stack_map=[i32 @ ss0+0]  ; v4 = 0
-;;                                     v35 = load.i32 notrap v46
+;; @001f                               v5 = uextend.i64 v2
+;;                                     v76 = iconst.i64 32
+;; @001f                               v7 = ushr v5, v76  ; v76 = 32
+;; @001f                               trapnz v7, user18
+;; @001f                               v4 = iconst.i32 28
+;; @001f                               v9 = uadd_overflow_trap v4, v2, user18  ; v4 = 28
+;; @001f                               v11 = iconst.i32 -1476395008
+;; @001f                               v13 = load.i64 notrap aligned readonly can_move v0+40
+;; @001f                               v14 = load.i32 notrap aligned readonly can_move v13
+;; @001f                               v15 = iconst.i32 8
+;; @001f                               v16 = call fn0(v0, v11, v14, v9, v15)  ; v11 = -1476395008, v15 = 8
+;;                                     v75 = stack_addr.i64 ss0
+;;                                     store notrap v16, v75
+;; @001f                               v73 = load.i64 notrap aligned readonly can_move v0+8
+;; @001f                               v17 = load.i64 notrap aligned readonly can_move v73+32
+;; @001f                               v18 = uextend.i64 v16
+;; @001f                               v19 = iadd v17, v18
+;;                                     v71 = iconst.i64 24
+;; @001f                               v20 = iadd v19, v71  ; v71 = 24
+;; @001f                               store user2 v2, v20
+;;                                     v53 = load.i32 notrap v75
+;; @001f                               trapz v53, user16
+;; @001f                               v23 = uextend.i64 v53
+;; @001f                               v25 = iadd v17, v23
+;; @001f                               v27 = iadd v25, v71  ; v71 = 24
+;; @001f                               v28 = load.i32 user2 readonly v27
+;; @001f                               v29 = uextend.i64 v28
+;; @001f                               v34 = icmp ugt v5, v29
+;; @001f                               trapnz v34, user17
+;; @001f                               v45 = load.i64 notrap aligned v73+40
+;;                                     v62 = iconst.i64 28
+;; @001f                               v38 = iadd v25, v62  ; v62 = 28
+;; @001f                               v47 = uadd_overflow_trap v38, v5, user2
+;; @001f                               v46 = iadd v17, v45
+;; @001f                               v48 = icmp ugt v47, v46
+;; @001f                               trapnz v48, user2
+;; @001f                               v21 = iconst.i32 0
+;; @001f                               call fn1(v0, v38, v21, v5), stack_map=[i32 @ ss0+0]  ; v21 = 0
+;;                                     v50 = load.i32 notrap v75
 ;; @0022                               jump block1
 ;;
 ;;                                 block1:
-;; @0022                               return v35
+;; @0022                               return v50
 ;; }

--- a/tests/disas/gc/copying/array-fill.wat
+++ b/tests/disas/gc/copying/array-fill.wat
@@ -20,51 +20,44 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i64, v5: i32):
 ;; @0027                               trapz v2, user16
-;; @0027                               v41 = load.i64 notrap aligned readonly can_move v0+8
-;; @0027                               v7 = load.i64 notrap aligned readonly can_move v41+32
+;; @0027                               v49 = load.i64 notrap aligned readonly can_move v0+8
+;; @0027                               v7 = load.i64 notrap aligned readonly can_move v49+32
 ;; @0027                               v6 = uextend.i64 v2
 ;; @0027                               v8 = iadd v7, v6
 ;; @0027                               v9 = iconst.i64 16
 ;; @0027                               v10 = iadd v8, v9  ; v9 = 16
 ;; @0027                               v11 = load.i32 user2 readonly v10
-;; @0027                               v12 = uadd_overflow_trap v3, v5, user17
-;; @0027                               v13 = icmp ugt v12, v11
-;; @0027                               trapnz v13, user17
-;; @0027                               v15 = uextend.i64 v11
-;;                                     v43 = iconst.i64 3
-;;                                     v44 = ishl v15, v43  ; v43 = 3
-;;                                     v40 = iconst.i64 32
-;; @0027                               v17 = ushr v44, v40  ; v40 = 32
-;; @0027                               trapnz v17, user2
-;;                                     v53 = iconst.i32 3
-;;                                     v54 = ishl v11, v53  ; v53 = 3
-;; @0027                               v19 = iconst.i32 24
-;; @0027                               v20 = uadd_overflow_trap v54, v19, user2  ; v19 = 24
-;; @0027                               v24 = uadd_overflow_trap v2, v20, user2
-;; @0027                               v25 = uextend.i64 v24
-;; @0027                               v27 = iadd v7, v25
-;;                                     v60 = ishl v3, v53  ; v53 = 3
-;;                                     v62 = iadd v60, v19  ; v19 = 24
-;; @0027                               v28 = isub v20, v62
-;; @0027                               v29 = uextend.i64 v28
-;; @0027                               v30 = isub v27, v29
-;;                                     v64 = ishl v5, v53  ; v53 = 3
-;; @0027                               v32 = uextend.i64 v64
-;; @0027                               v33 = iadd v30, v32
-;; @0027                               v14 = iconst.i64 8
-;; @0027                               jump block2(v30)
+;; @0027                               v13 = uextend.i64 v3
+;; @0027                               v14 = uextend.i64 v5
+;; @0027                               v16 = iadd v13, v14
+;; @0027                               v12 = uextend.i64 v11
+;; @0027                               v17 = icmp ugt v16, v12
+;; @0027                               trapnz v17, user17
+;; @0027                               v28 = load.i64 notrap aligned v49+40
+;;                                     v45 = iconst.i64 24
+;; @0027                               v21 = iadd v8, v45  ; v45 = 24
+;;                                     v53 = iconst.i64 3
+;;                                     v54 = ishl v13, v53  ; v53 = 3
+;; @0027                               v24 = iadd v21, v54
+;;                                     v56 = ishl v14, v53  ; v53 = 3
+;; @0027                               v30 = uadd_overflow_trap v24, v56, user2
+;; @0027                               v29 = iadd v7, v28
+;; @0027                               v31 = icmp ugt v30, v29
+;; @0027                               trapnz v31, user2
+;;                                     v51 = iconst.i64 0
+;; @0027                               v33 = icmp eq v14, v51  ; v51 = 0
+;;                                     v44 = iconst.i64 8
+;; @0027                               v32 = iadd v24, v56
+;; @0027                               brif v33, block3, block2(v24)
 ;;
-;;                                 block2(v35: i64):
-;; @0027                               v36 = icmp eq v35, v33
-;; @0027                               brif v36, block4, block3
+;;                                 block2(v34: i64):
+;; @0027                               store.i64 user2 little v4, v34
+;;                                     v58 = iconst.i64 8
+;;                                     v59 = iadd v34, v58  ; v58 = 8
+;; @0027                               v36 = icmp eq v59, v32
+;; @0027                               brif v36, block3, block2(v59)
 ;;
 ;;                                 block3:
-;; @0027                               store.i64 user2 little v4, v35
-;;                                     v66 = iconst.i64 8
-;;                                     v67 = iadd.i64 v35, v66  ; v66 = 8
-;; @0027                               jump block2(v67)
-;;
-;;                                 block4:
 ;; @002a                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/copying/array-new-fixed-of-gc-refs.wat
+++ b/tests/disas/gc/copying/array-new-fixed-of-gc-refs.wat
@@ -18,73 +18,127 @@
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
+;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     fn0 = colocated u805306368:23 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
-;;                                     v69 = stack_addr.i64 ss2
-;;                                     store notrap v2, v69
-;;                                     v68 = stack_addr.i64 ss1
-;;                                     store notrap v3, v68
-;;                                     v67 = stack_addr.i64 ss0
-;;                                     store notrap v4, v67
+;;                                     v152 = stack_addr.i64 ss2
+;;                                     store notrap v2, v152
+;;                                     v151 = stack_addr.i64 ss1
+;;                                     store notrap v3, v151
+;;                                     v150 = stack_addr.i64 ss0
+;;                                     store notrap v4, v150
 ;; @0025                               v14 = load.i64 notrap aligned readonly can_move v0+32
 ;; @0025                               v15 = load.i32 notrap aligned v14
 ;; @0025                               v16 = load.i32 notrap aligned v14+4
 ;; @0025                               v22 = uextend.i64 v15
-;;                                     v65 = iconst.i64 32
-;; @0025                               v23 = iadd v22, v65  ; v65 = 32
+;;                                     v148 = iconst.i64 32
+;; @0025                               v23 = iadd v22, v148  ; v148 = 32
 ;; @0025                               v24 = uextend.i64 v16
 ;; @0025                               v25 = icmp ule v23, v24
 ;; @0025                               brif v25, block2, block3
 ;;
 ;;                                 block2:
-;;                                     v189 = iconst.i32 32
-;;                                     v95 = iadd.i32 v15, v189  ; v189 = 32
-;; @0025                               store notrap aligned vmctx v95, v14
-;;                                     v190 = iconst.i32 -1476395008
-;;                                     v191 = load.i64 notrap aligned readonly can_move v0+8
-;;                                     v192 = load.i64 notrap aligned readonly can_move v191+32
-;; @0025                               v39 = iadd v192, v22
-;; @0025                               store notrap aligned v190, v39  ; v190 = -1476395008
-;;                                     v193 = load.i64 notrap aligned readonly can_move v0+40
-;;                                     v194 = load.i32 notrap aligned readonly can_move v193
-;; @0025                               store notrap aligned v194, v39+4
-;;                                     v195 = iconst.i64 32
-;; @0025                               istore32 notrap aligned v195, v39+8  ; v195 = 32
+;;                                     v272 = iconst.i32 32
+;;                                     v178 = iadd.i32 v15, v272  ; v272 = 32
+;; @0025                               store notrap aligned vmctx v178, v14
+;;                                     v273 = iconst.i32 -1476395008
+;;                                     v274 = load.i64 notrap aligned readonly can_move v0+8
+;;                                     v275 = load.i64 notrap aligned readonly can_move v274+32
+;; @0025                               v39 = iadd v275, v22
+;; @0025                               store notrap aligned v273, v39  ; v273 = -1476395008
+;;                                     v276 = load.i64 notrap aligned readonly can_move v0+40
+;;                                     v277 = load.i32 notrap aligned readonly can_move v276
+;; @0025                               store notrap aligned v277, v39+4
+;;                                     v278 = iconst.i64 32
+;; @0025                               istore32 notrap aligned v278, v39+8  ; v278 = 32
 ;; @0025                               jump block4(v15, v39)
 ;;
 ;;                                 block3 cold:
 ;; @0025                               v27 = iconst.i32 -1476395008
 ;; @0025                               v29 = load.i64 notrap aligned readonly can_move v0+40
 ;; @0025                               v30 = load.i32 notrap aligned readonly can_move v29
-;;                                     v81 = iconst.i32 32
+;;                                     v164 = iconst.i32 32
 ;; @0025                               v31 = iconst.i32 16
-;; @0025                               v32 = call fn0(v0, v27, v30, v81, v31), stack_map=[i32 @ ss2+0, i32 @ ss1+0, i32 @ ss0+0]  ; v27 = -1476395008, v81 = 32, v31 = 16
-;; @0025                               v61 = load.i64 notrap aligned readonly can_move v0+8
-;; @0025                               v33 = load.i64 notrap aligned readonly can_move v61+32
+;; @0025                               v32 = call fn0(v0, v27, v30, v164, v31), stack_map=[i32 @ ss2+0, i32 @ ss1+0, i32 @ ss0+0]  ; v27 = -1476395008, v164 = 32, v31 = 16
+;; @0025                               v144 = load.i64 notrap aligned readonly can_move v0+8
+;; @0025                               v33 = load.i64 notrap aligned readonly can_move v144+32
 ;; @0025                               v34 = uextend.i64 v32
 ;; @0025                               v35 = iadd v33, v34
 ;; @0025                               jump block4(v32, v35)
 ;;
 ;;                                 block4(v44: i32, v45: i64):
 ;; @0025                               v6 = iconst.i32 3
-;;                                     v60 = iconst.i64 16
-;; @0025                               v46 = iadd v45, v60  ; v60 = 16
+;;                                     v143 = iconst.i64 16
+;; @0025                               v46 = iadd v45, v143  ; v143 = 16
 ;; @0025                               store user2 v6, v46  ; v6 = 3
-;;                                     v56 = load.i32 notrap v69
-;;                                     v98 = iconst.i64 20
-;;                                     v103 = iadd v45, v98  ; v98 = 20
-;; @0025                               store user2 little v56, v103
-;;                                     v55 = load.i32 notrap v68
-;;                                     v106 = iconst.i64 24
-;;                                     v111 = iadd v45, v106  ; v106 = 24
-;; @0025                               store user2 little v55, v111
-;;                                     v54 = load.i32 notrap v67
-;;                                     v127 = iconst.i64 28
-;;                                     v132 = iadd v45, v127  ; v127 = 28
-;; @0025                               store user2 little v54, v132
+;; @0025                               trapz v44, user16
+;;                                     v279 = load.i64 notrap aligned readonly can_move v0+8
+;;                                     v280 = load.i64 notrap aligned readonly can_move v279+32
+;; @0025                               v48 = uextend.i64 v44
+;; @0025                               v50 = iadd v280, v48
+;; @0025                               v52 = iadd v50, v143  ; v143 = 16
+;; @0025                               v53 = load.i32 user2 readonly v52
+;; @0025                               v47 = iconst.i32 0
+;;                                     v181 = icmp ne v53, v47  ; v47 = 0
+;; @0025                               trapz v181, user17
+;; @0025                               v56 = uextend.i64 v53
+;;                                     v155 = iconst.i64 2
+;;                                     v184 = ishl v56, v155  ; v155 = 2
+;;                                     v281 = iconst.i64 32
+;;                                     v282 = ushr v184, v281  ; v281 = 32
+;; @0025                               trapnz v282, user2
+;;                                     v193 = iconst.i32 2
+;;                                     v194 = ishl v53, v193  ; v193 = 2
+;; @0025                               v7 = iconst.i32 20
+;; @0025                               v61 = uadd_overflow_trap v194, v7, user2  ; v7 = 20
+;; @0025                               v65 = uadd_overflow_trap v44, v61, user2
+;;                                     v124 = load.i32 notrap v152
+;; @0025                               v66 = uextend.i64 v65
+;; @0025                               v68 = iadd v280, v66
+;; @0025                               v69 = isub v61, v7  ; v7 = 20
+;; @0025                               v70 = uextend.i64 v69
+;; @0025                               v71 = isub v68, v70
+;; @0025                               store user2 little v124, v71
+;; @0025                               v78 = load.i32 user2 readonly v52
+;; @0025                               v72 = iconst.i32 1
+;;                                     v211 = icmp ugt v78, v72  ; v72 = 1
+;; @0025                               trapz v211, user17
+;; @0025                               v81 = uextend.i64 v78
+;;                                     v213 = ishl v81, v155  ; v155 = 2
+;;                                     v283 = ushr v213, v281  ; v281 = 32
+;; @0025                               trapnz v283, user2
+;;                                     v220 = ishl v78, v193  ; v193 = 2
+;; @0025                               v86 = uadd_overflow_trap v220, v7, user2  ; v7 = 20
+;; @0025                               v90 = uadd_overflow_trap v44, v86, user2
+;;                                     v123 = load.i32 notrap v151
+;; @0025                               v91 = uextend.i64 v90
+;; @0025                               v93 = iadd v280, v91
+;;                                     v233 = iconst.i32 24
+;; @0025                               v94 = isub v86, v233  ; v233 = 24
+;; @0025                               v95 = uextend.i64 v94
+;; @0025                               v96 = isub v93, v95
+;; @0025                               store user2 little v123, v96
+;; @0025                               v103 = load.i32 user2 readonly v52
+;;                                     v239 = icmp ugt v103, v193  ; v193 = 2
+;; @0025                               trapz v239, user17
+;; @0025                               v106 = uextend.i64 v103
+;;                                     v241 = ishl v106, v155  ; v155 = 2
+;;                                     v284 = ushr v241, v281  ; v281 = 32
+;; @0025                               trapnz v284, user2
+;;                                     v248 = ishl v103, v193  ; v193 = 2
+;; @0025                               v111 = uadd_overflow_trap v248, v7, user2  ; v7 = 20
+;; @0025                               v115 = uadd_overflow_trap v44, v111, user2
+;;                                     v122 = load.i32 notrap v150
+;; @0025                               v116 = uextend.i64 v115
+;; @0025                               v118 = iadd v280, v116
+;;                                     v266 = iconst.i32 28
+;; @0025                               v119 = isub v111, v266  ; v266 = 28
+;; @0025                               v120 = uextend.i64 v119
+;; @0025                               v121 = isub v118, v120
+;; @0025                               store user2 little v122, v121
 ;; @0029                               jump block1(v44)
 ;;
 ;;                                 block1(v5: i32):

--- a/tests/disas/gc/copying/array-new-fixed.wat
+++ b/tests/disas/gc/copying/array-new-fixed.wat
@@ -15,6 +15,7 @@
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
+;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     fn0 = colocated u805306368:23 sig0
 ;;     stack_limit = gv2
@@ -24,55 +25,108 @@
 ;; @0025                               v15 = load.i32 notrap aligned v14
 ;; @0025                               v16 = load.i32 notrap aligned v14+4
 ;; @0025                               v22 = uextend.i64 v15
-;;                                     v71 = iconst.i64 48
-;; @0025                               v23 = iadd v22, v71  ; v71 = 48
+;;                                     v154 = iconst.i64 48
+;; @0025                               v23 = iadd v22, v154  ; v154 = 48
 ;; @0025                               v24 = uextend.i64 v16
 ;; @0025                               v25 = icmp ule v23, v24
 ;; @0025                               brif v25, block2, block3
 ;;
 ;;                                 block2:
-;;                                     v154 = iconst.i32 48
-;;                                     v85 = iadd.i32 v15, v154  ; v154 = 48
-;; @0025                               store notrap aligned vmctx v85, v14
-;;                                     v155 = iconst.i32 -1476395008
-;;                                     v156 = load.i64 notrap aligned readonly can_move v0+8
-;;                                     v157 = load.i64 notrap aligned readonly can_move v156+32
-;; @0025                               v39 = iadd v157, v22
-;; @0025                               store notrap aligned v155, v39  ; v155 = -1476395008
-;;                                     v158 = load.i64 notrap aligned readonly can_move v0+40
-;;                                     v159 = load.i32 notrap aligned readonly can_move v158
-;; @0025                               store notrap aligned v159, v39+4
-;;                                     v160 = iconst.i64 48
-;; @0025                               istore32 notrap aligned v160, v39+8  ; v160 = 48
+;;                                     v260 = iconst.i32 48
+;;                                     v168 = iadd.i32 v15, v260  ; v260 = 48
+;; @0025                               store notrap aligned vmctx v168, v14
+;;                                     v261 = iconst.i32 -1476395008
+;;                                     v262 = load.i64 notrap aligned readonly can_move v0+8
+;;                                     v263 = load.i64 notrap aligned readonly can_move v262+32
+;; @0025                               v39 = iadd v263, v22
+;; @0025                               store notrap aligned v261, v39  ; v261 = -1476395008
+;;                                     v264 = load.i64 notrap aligned readonly can_move v0+40
+;;                                     v265 = load.i32 notrap aligned readonly can_move v264
+;; @0025                               store notrap aligned v265, v39+4
+;;                                     v266 = iconst.i64 48
+;; @0025                               istore32 notrap aligned v266, v39+8  ; v266 = 48
 ;; @0025                               jump block4(v15, v39)
 ;;
 ;;                                 block3 cold:
 ;; @0025                               v27 = iconst.i32 -1476395008
 ;; @0025                               v29 = load.i64 notrap aligned readonly can_move v0+40
 ;; @0025                               v30 = load.i32 notrap aligned readonly can_move v29
-;;                                     v70 = iconst.i32 48
+;;                                     v153 = iconst.i32 48
 ;; @0025                               v31 = iconst.i32 16
-;; @0025                               v32 = call fn0(v0, v27, v30, v70, v31)  ; v27 = -1476395008, v70 = 48, v31 = 16
-;; @0025                               v55 = load.i64 notrap aligned readonly can_move v0+8
-;; @0025                               v33 = load.i64 notrap aligned readonly can_move v55+32
+;; @0025                               v32 = call fn0(v0, v27, v30, v153, v31)  ; v27 = -1476395008, v153 = 48, v31 = 16
+;; @0025                               v138 = load.i64 notrap aligned readonly can_move v0+8
+;; @0025                               v33 = load.i64 notrap aligned readonly can_move v138+32
 ;; @0025                               v34 = uextend.i64 v32
 ;; @0025                               v35 = iadd v33, v34
 ;; @0025                               jump block4(v32, v35)
 ;;
 ;;                                 block4(v44: i32, v45: i64):
 ;; @0025                               v6 = iconst.i32 3
-;;                                     v54 = iconst.i64 16
-;; @0025                               v46 = iadd v45, v54  ; v54 = 16
+;;                                     v137 = iconst.i64 16
+;; @0025                               v46 = iadd v45, v137  ; v137 = 16
 ;; @0025                               store user2 v6, v46  ; v6 = 3
-;;                                     v62 = iconst.i64 24
-;;                                     v92 = iadd v45, v62  ; v62 = 24
-;; @0025                               store.i64 user2 little v2, v92
-;;                                     v59 = iconst.i64 32
-;;                                     v99 = iadd v45, v59  ; v59 = 32
-;; @0025                               store.i64 user2 little v3, v99
-;;                                     v114 = iconst.i64 40
-;;                                     v119 = iadd v45, v114  ; v114 = 40
-;; @0025                               store.i64 user2 little v4, v119
+;; @0025                               trapz v44, user16
+;;                                     v267 = load.i64 notrap aligned readonly can_move v0+8
+;;                                     v268 = load.i64 notrap aligned readonly can_move v267+32
+;; @0025                               v48 = uextend.i64 v44
+;; @0025                               v50 = iadd v268, v48
+;; @0025                               v52 = iadd v50, v137  ; v137 = 16
+;; @0025                               v53 = load.i32 user2 readonly v52
+;; @0025                               v47 = iconst.i32 0
+;;                                     v171 = icmp ne v53, v47  ; v47 = 0
+;; @0025                               trapz v171, user17
+;; @0025                               v56 = uextend.i64 v53
+;;                                     v144 = iconst.i64 3
+;;                                     v174 = ishl v56, v144  ; v144 = 3
+;;                                     v142 = iconst.i64 32
+;; @0025                               v58 = ushr v174, v142  ; v142 = 32
+;; @0025                               trapnz v58, user2
+;;                                     v183 = ishl v53, v6  ; v6 = 3
+;; @0025                               v7 = iconst.i32 24
+;; @0025                               v61 = uadd_overflow_trap v183, v7, user2  ; v7 = 24
+;; @0025                               v65 = uadd_overflow_trap v44, v61, user2
+;; @0025                               v66 = uextend.i64 v65
+;; @0025                               v68 = iadd v268, v66
+;; @0025                               v69 = isub v61, v7  ; v7 = 24
+;; @0025                               v70 = uextend.i64 v69
+;; @0025                               v71 = isub v68, v70
+;; @0025                               store.i64 user2 little v2, v71
+;; @0025                               v78 = load.i32 user2 readonly v52
+;; @0025                               v72 = iconst.i32 1
+;;                                     v200 = icmp ugt v78, v72  ; v72 = 1
+;; @0025                               trapz v200, user17
+;; @0025                               v81 = uextend.i64 v78
+;;                                     v202 = ishl v81, v144  ; v144 = 3
+;; @0025                               v83 = ushr v202, v142  ; v142 = 32
+;; @0025                               trapnz v83, user2
+;;                                     v209 = ishl v78, v6  ; v6 = 3
+;; @0025                               v86 = uadd_overflow_trap v209, v7, user2  ; v7 = 24
+;; @0025                               v90 = uadd_overflow_trap v44, v86, user2
+;; @0025                               v91 = uextend.i64 v90
+;; @0025                               v93 = iadd v268, v91
+;;                                     v222 = iconst.i32 32
+;; @0025                               v94 = isub v86, v222  ; v222 = 32
+;; @0025                               v95 = uextend.i64 v94
+;; @0025                               v96 = isub v93, v95
+;; @0025                               store.i64 user2 little v3, v96
+;; @0025                               v103 = load.i32 user2 readonly v52
+;; @0025                               v97 = iconst.i32 2
+;;                                     v228 = icmp ugt v103, v97  ; v97 = 2
+;; @0025                               trapz v228, user17
+;; @0025                               v106 = uextend.i64 v103
+;;                                     v230 = ishl v106, v144  ; v144 = 3
+;; @0025                               v108 = ushr v230, v142  ; v142 = 32
+;; @0025                               trapnz v108, user2
+;;                                     v237 = ishl v103, v6  ; v6 = 3
+;; @0025                               v111 = uadd_overflow_trap v237, v7, user2  ; v7 = 24
+;; @0025                               v115 = uadd_overflow_trap v44, v111, user2
+;; @0025                               v116 = uextend.i64 v115
+;; @0025                               v118 = iadd v268, v116
+;;                                     v254 = iconst.i32 40
+;; @0025                               v119 = isub v111, v254  ; v254 = 40
+;; @0025                               v120 = uextend.i64 v119
+;; @0025                               v121 = isub v118, v120
+;; @0025                               store.i64 user2 little v4, v121
 ;; @0029                               jump block1(v44)
 ;;
 ;;                                 block1(v5: i32):

--- a/tests/disas/gc/copying/array-new.wat
+++ b/tests/disas/gc/copying/array-new.wat
@@ -15,21 +15,22 @@
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
+;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     fn0 = colocated u805306368:23 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0022                               v6 = uextend.i64 v3
-;;                                     v62 = iconst.i64 3
-;;                                     v63 = ishl v6, v62  ; v62 = 3
-;;                                     v60 = iconst.i64 32
-;; @0022                               v8 = ushr v63, v60  ; v60 = 32
+;;                                     v98 = iconst.i64 3
+;;                                     v99 = ishl v6, v98  ; v98 = 3
+;;                                     v96 = iconst.i64 32
+;; @0022                               v8 = ushr v99, v96  ; v96 = 32
 ;; @0022                               trapnz v8, user18
 ;; @0022                               v5 = iconst.i32 24
-;;                                     v69 = iconst.i32 3
-;;                                     v70 = ishl v3, v69  ; v69 = 3
-;; @0022                               v10 = uadd_overflow_trap v5, v70, user18  ; v5 = 24
+;;                                     v105 = iconst.i32 3
+;;                                     v106 = ishl v3, v105  ; v105 = 3
+;; @0022                               v10 = uadd_overflow_trap v5, v106, user18  ; v5 = 24
 ;; @0022                               v12 = load.i64 notrap aligned readonly can_move v0+32
 ;; @0022                               v13 = load.i32 notrap aligned v12
 ;; @0022                               v14 = load.i32 notrap aligned v12+4
@@ -45,22 +46,22 @@
 ;; @0022                               brif v23, block2, block3
 ;;
 ;;                                 block2:
-;;                                     v78 = iconst.i32 15
-;;                                     v79 = iadd.i32 v10, v78  ; v78 = 15
-;;                                     v82 = iconst.i32 -16
-;;                                     v83 = band v79, v82  ; v82 = -16
-;;                                     v85 = iadd.i32 v13, v83
-;; @0022                               store notrap aligned vmctx v85, v12
-;;                                     v98 = iconst.i32 -1476395008
-;;                                     v99 = load.i64 notrap aligned readonly can_move v0+8
-;;                                     v100 = load.i64 notrap aligned readonly can_move v99+32
-;; @0022                               v37 = iadd v100, v20
-;; @0022                               store notrap aligned v98, v37  ; v98 = -1476395008
-;;                                     v101 = load.i64 notrap aligned readonly can_move v0+40
-;;                                     v102 = load.i32 notrap aligned readonly can_move v101
-;; @0022                               store notrap aligned v102, v37+4
-;;                                     v103 = band.i64 v18, v17  ; v17 = -16
-;; @0022                               istore32 notrap aligned v103, v37+8
+;;                                     v114 = iconst.i32 15
+;;                                     v115 = iadd.i32 v10, v114  ; v114 = 15
+;;                                     v118 = iconst.i32 -16
+;;                                     v119 = band v115, v118  ; v118 = -16
+;;                                     v121 = iadd.i32 v13, v119
+;; @0022                               store notrap aligned vmctx v121, v12
+;;                                     v137 = iconst.i32 -1476395008
+;;                                     v138 = load.i64 notrap aligned readonly can_move v0+8
+;;                                     v139 = load.i64 notrap aligned readonly can_move v138+32
+;; @0022                               v37 = iadd v139, v20
+;; @0022                               store notrap aligned v137, v37  ; v137 = -1476395008
+;;                                     v140 = load.i64 notrap aligned readonly can_move v0+40
+;;                                     v141 = load.i32 notrap aligned readonly can_move v140
+;; @0022                               store notrap aligned v141, v37+4
+;;                                     v142 = band.i64 v18, v17  ; v17 = -16
+;; @0022                               istore32 notrap aligned v142, v37+8
 ;; @0022                               jump block4(v13, v37)
 ;;
 ;;                                 block3 cold:
@@ -69,33 +70,47 @@
 ;; @0022                               v28 = load.i32 notrap aligned readonly can_move v27
 ;; @0022                               v29 = iconst.i32 16
 ;; @0022                               v30 = call fn0(v0, v25, v28, v10, v29)  ; v25 = -1476395008, v29 = 16
-;; @0022                               v56 = load.i64 notrap aligned readonly can_move v0+8
-;; @0022                               v31 = load.i64 notrap aligned readonly can_move v56+32
+;; @0022                               v92 = load.i64 notrap aligned readonly can_move v0+8
+;; @0022                               v31 = load.i64 notrap aligned readonly can_move v92+32
 ;; @0022                               v32 = uextend.i64 v30
 ;; @0022                               v33 = iadd v31, v32
 ;; @0022                               jump block4(v30, v33)
 ;;
 ;;                                 block4(v42: i32, v43: i64):
-;;                                     v55 = iconst.i64 16
-;; @0022                               v44 = iadd v43, v55  ; v55 = 16
+;;                                     v91 = iconst.i64 16
+;; @0022                               v44 = iadd v43, v91  ; v91 = 16
 ;; @0022                               store.i32 user2 v3, v44
-;;                                     v88 = iconst.i64 24
-;;                                     v93 = iadd v43, v88  ; v88 = 24
-;; @0022                               v51 = iadd v43, v15
-;;                                     v61 = iconst.i64 8
-;; @0022                               jump block5(v93)
+;; @0022                               trapz v42, user16
+;;                                     v143 = load.i64 notrap aligned readonly can_move v0+8
+;;                                     v144 = load.i64 notrap aligned readonly can_move v143+32
+;; @0022                               v46 = uextend.i64 v42
+;; @0022                               v48 = iadd v144, v46
+;; @0022                               v50 = iadd v48, v91  ; v91 = 16
+;; @0022                               v51 = load.i32 user2 readonly v50
+;; @0022                               v52 = uextend.i64 v51
+;; @0022                               v57 = icmp.i64 ugt v6, v52
+;; @0022                               trapnz v57, user17
+;; @0022                               v68 = load.i64 notrap aligned v143+40
+;;                                     v85 = iconst.i64 24
+;; @0022                               v61 = iadd v48, v85  ; v85 = 24
+;; @0022                               v70 = uadd_overflow_trap v61, v99, user2
+;; @0022                               v69 = iadd v144, v68
+;; @0022                               v71 = icmp ugt v70, v69
+;; @0022                               trapnz v71, user2
+;;                                     v123 = iconst.i64 0
+;; @0022                               v73 = icmp.i64 eq v6, v123  ; v123 = 0
+;;                                     v97 = iconst.i64 8
+;; @0022                               v72 = iadd v61, v99
+;; @0022                               brif v73, block6, block5(v61)
 ;;
-;;                                 block5(v52: i64):
-;; @0022                               v53 = icmp eq v52, v51
-;; @0022                               brif v53, block7, block6
+;;                                 block5(v74: i64):
+;; @0022                               store.i64 user2 little v2, v74
+;;                                     v145 = iconst.i64 8
+;;                                     v146 = iadd v74, v145  ; v145 = 8
+;; @0022                               v76 = icmp eq v146, v72
+;; @0022                               brif v76, block6, block5(v146)
 ;;
 ;;                                 block6:
-;; @0022                               store.i64 user2 little v2, v52
-;;                                     v104 = iconst.i64 8
-;;                                     v105 = iadd.i64 v52, v104  ; v104 = 8
-;; @0022                               jump block5(v105)
-;;
-;;                                 block7:
 ;; @0025                               jump block1(v42)
 ;;
 ;;                                 block1(v4: i32):

--- a/tests/disas/gc/drc/array-fill.wat
+++ b/tests/disas/gc/drc/array-fill.wat
@@ -21,51 +21,44 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i64, v5: i32):
 ;; @0027                               trapz v2, user16
-;; @0027                               v41 = load.i64 notrap aligned readonly can_move v0+8
-;; @0027                               v7 = load.i64 notrap aligned readonly can_move v41+32
+;; @0027                               v49 = load.i64 notrap aligned readonly can_move v0+8
+;; @0027                               v7 = load.i64 notrap aligned readonly can_move v49+32
 ;; @0027                               v6 = uextend.i64 v2
 ;; @0027                               v8 = iadd v7, v6
 ;; @0027                               v9 = iconst.i64 24
 ;; @0027                               v10 = iadd v8, v9  ; v9 = 24
 ;; @0027                               v11 = load.i32 user2 readonly v10
-;; @0027                               v12 = uadd_overflow_trap v3, v5, user17
-;; @0027                               v13 = icmp ugt v12, v11
-;; @0027                               trapnz v13, user17
-;; @0027                               v15 = uextend.i64 v11
-;;                                     v43 = iconst.i64 3
-;;                                     v44 = ishl v15, v43  ; v43 = 3
-;;                                     v40 = iconst.i64 32
-;; @0027                               v17 = ushr v44, v40  ; v40 = 32
-;; @0027                               trapnz v17, user2
-;;                                     v53 = iconst.i32 3
-;;                                     v54 = ishl v11, v53  ; v53 = 3
-;; @0027                               v19 = iconst.i32 32
-;; @0027                               v20 = uadd_overflow_trap v54, v19, user2  ; v19 = 32
-;; @0027                               v24 = uadd_overflow_trap v2, v20, user2
-;; @0027                               v25 = uextend.i64 v24
-;; @0027                               v27 = iadd v7, v25
-;;                                     v60 = ishl v3, v53  ; v53 = 3
-;;                                     v62 = iadd v60, v19  ; v19 = 32
-;; @0027                               v28 = isub v20, v62
-;; @0027                               v29 = uextend.i64 v28
-;; @0027                               v30 = isub v27, v29
-;;                                     v64 = ishl v5, v53  ; v53 = 3
-;; @0027                               v32 = uextend.i64 v64
-;; @0027                               v33 = iadd v30, v32
-;; @0027                               v14 = iconst.i64 8
-;; @0027                               jump block2(v30)
+;; @0027                               v13 = uextend.i64 v3
+;; @0027                               v14 = uextend.i64 v5
+;; @0027                               v16 = iadd v13, v14
+;; @0027                               v12 = uextend.i64 v11
+;; @0027                               v17 = icmp ugt v16, v12
+;; @0027                               trapnz v17, user17
+;; @0027                               v28 = load.i64 notrap aligned v49+40
+;;                                     v45 = iconst.i64 32
+;; @0027                               v21 = iadd v8, v45  ; v45 = 32
+;;                                     v53 = iconst.i64 3
+;;                                     v54 = ishl v13, v53  ; v53 = 3
+;; @0027                               v24 = iadd v21, v54
+;;                                     v56 = ishl v14, v53  ; v53 = 3
+;; @0027                               v30 = uadd_overflow_trap v24, v56, user2
+;; @0027                               v29 = iadd v7, v28
+;; @0027                               v31 = icmp ugt v30, v29
+;; @0027                               trapnz v31, user2
+;;                                     v51 = iconst.i64 0
+;; @0027                               v33 = icmp eq v14, v51  ; v51 = 0
+;;                                     v44 = iconst.i64 8
+;; @0027                               v32 = iadd v24, v56
+;; @0027                               brif v33, block3, block2(v24)
 ;;
-;;                                 block2(v35: i64):
-;; @0027                               v36 = icmp eq v35, v33
-;; @0027                               brif v36, block4, block3
+;;                                 block2(v34: i64):
+;; @0027                               store.i64 user2 little v4, v34
+;;                                     v58 = iconst.i64 8
+;;                                     v59 = iadd v34, v58  ; v58 = 8
+;; @0027                               v36 = icmp eq v59, v32
+;; @0027                               brif v36, block3, block2(v59)
 ;;
 ;;                                 block3:
-;; @0027                               store.i64 user2 little v4, v35
-;;                                     v66 = iconst.i64 8
-;;                                     v67 = iadd.i64 v35, v66  ; v66 = 8
-;; @0027                               jump block2(v67)
-;;
-;;                                 block4:
 ;; @002a                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/drc/array-new-fixed-of-gc-refs.wat
+++ b/tests/disas/gc/drc/array-new-fixed-of-gc-refs.wat
@@ -25,101 +25,146 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
-;;                                     v137 = stack_addr.i64 ss2
-;;                                     store notrap v2, v137
-;;                                     v136 = stack_addr.i64 ss1
-;;                                     store notrap v3, v136
-;;                                     v135 = stack_addr.i64 ss0
-;;                                     store notrap v4, v135
+;;                                     v220 = stack_addr.i64 ss2
+;;                                     store notrap v2, v220
+;;                                     v219 = stack_addr.i64 ss1
+;;                                     store notrap v3, v219
+;;                                     v218 = stack_addr.i64 ss0
+;;                                     store notrap v4, v218
 ;; @0025                               v14 = iconst.i32 -1476395008
 ;; @0025                               v16 = load.i64 notrap aligned readonly can_move v0+40
 ;; @0025                               v17 = load.i32 notrap aligned readonly can_move v16
-;;                                     v149 = iconst.i32 40
+;;                                     v232 = iconst.i32 40
 ;; @0025                               v18 = iconst.i32 8
-;; @0025                               v19 = call fn0(v0, v14, v17, v149, v18), stack_map=[i32 @ ss2+0, i32 @ ss1+0, i32 @ ss0+0]  ; v14 = -1476395008, v149 = 40, v18 = 8
+;; @0025                               v19 = call fn0(v0, v14, v17, v232, v18), stack_map=[i32 @ ss2+0, i32 @ ss1+0, i32 @ ss0+0]  ; v14 = -1476395008, v232 = 40, v18 = 8
 ;; @0025                               v6 = iconst.i32 3
-;; @0025                               v131 = load.i64 notrap aligned readonly can_move v0+8
-;; @0025                               v20 = load.i64 notrap aligned readonly can_move v131+32
+;; @0025                               v214 = load.i64 notrap aligned readonly can_move v0+8
+;; @0025                               v20 = load.i64 notrap aligned readonly can_move v214+32
 ;; @0025                               v21 = uextend.i64 v19
 ;; @0025                               v22 = iadd v20, v21
-;;                                     v130 = iconst.i64 24
-;; @0025                               v23 = iadd v22, v130  ; v130 = 24
+;;                                     v213 = iconst.i64 24
+;; @0025                               v23 = iadd v22, v213  ; v213 = 24
 ;; @0025                               store user2 v6, v23  ; v6 = 3
-;;                                     v93 = load.i32 notrap v137
-;;                                     v128 = iconst.i32 1
-;; @0025                               v28 = band v93, v128  ; v128 = 1
-;;                                     v126 = iconst.i32 0
-;; @0025                               v29 = icmp eq v93, v126  ; v126 = 0
-;; @0025                               v30 = uextend.i32 v29
-;; @0025                               v31 = bor v28, v30
-;; @0025                               brif v31, block3, block2
+;; @0025                               trapz v19, user16
+;; @0025                               v42 = uadd_overflow_trap v19, v232, user2  ; v232 = 40
+;;                                     v161 = load.i32 notrap v220
+;;                                     v206 = iconst.i32 1
+;; @0025                               v49 = band v161, v206  ; v206 = 1
+;; @0025                               v24 = iconst.i32 0
+;; @0025                               v50 = icmp eq v161, v24  ; v24 = 0
+;; @0025                               v51 = uextend.i32 v50
+;; @0025                               v52 = bor v49, v51
+;; @0025                               brif v52, block3, block2
 ;;
 ;;                                 block2:
-;; @0025                               v32 = uextend.i64 v93
-;; @0025                               v34 = iadd.i64 v20, v32
-;; @0025                               v35 = iconst.i64 8
-;; @0025                               v36 = iadd v34, v35  ; v35 = 8
-;; @0025                               v37 = load.i64 user2 v36
-;;                                     v122 = iconst.i64 1
-;; @0025                               v38 = iadd v37, v122  ; v122 = 1
-;; @0025                               store user2 v38, v36
+;;                                     v159 = load.i32 notrap v220
+;; @0025                               v53 = uextend.i64 v159
+;; @0025                               v55 = iadd.i64 v20, v53
+;; @0025                               v56 = iconst.i64 8
+;; @0025                               v57 = iadd v55, v56  ; v56 = 8
+;; @0025                               v58 = load.i64 user2 v57
+;;                                     v200 = iconst.i64 1
+;; @0025                               v59 = iadd v58, v200  ; v200 = 1
+;; @0025                               store user2 v59, v57
 ;; @0025                               jump block3
 ;;
 ;;                                 block3:
-;;                                     v89 = load.i32 notrap v137
-;;                                     v151 = iconst.i64 28
-;;                                     v156 = iadd.i64 v22, v151  ; v151 = 28
-;; @0025                               store user2 little v89, v156
-;;                                     v88 = load.i32 notrap v136
-;;                                     v242 = iconst.i32 1
-;;                                     v243 = band v88, v242  ; v242 = 1
-;;                                     v244 = iconst.i32 0
-;;                                     v245 = icmp eq v88, v244  ; v244 = 0
-;; @0025                               v47 = uextend.i32 v245
-;; @0025                               v48 = bor v243, v47
-;; @0025                               brif v48, block5, block4
+;;                                     v157 = load.i32 notrap v220
+;; @0025                               v43 = uextend.i64 v42
+;; @0025                               v45 = iadd.i64 v20, v43
+;;                                     v222 = iconst.i64 12
+;; @0025                               v48 = isub v45, v222  ; v222 = 12
+;; @0025                               store user2 little v157, v48
+;;                                     v325 = iadd.i64 v22, v213  ; v213 = 24
+;; @0025                               v71 = load.i32 user2 readonly v325
+;;                                     v326 = iconst.i32 1
+;;                                     v327 = icmp ugt v71, v326  ; v326 = 1
+;; @0025                               trapz v327, user17
+;; @0025                               v74 = uextend.i64 v71
+;;                                     v223 = iconst.i64 2
+;;                                     v267 = ishl v74, v223  ; v223 = 2
+;;                                     v216 = iconst.i64 32
+;; @0025                               v76 = ushr v267, v216  ; v216 = 32
+;; @0025                               trapnz v76, user2
+;;                                     v244 = iconst.i32 2
+;;                                     v274 = ishl v71, v244  ; v244 = 2
+;; @0025                               v7 = iconst.i32 28
+;; @0025                               v79 = uadd_overflow_trap v274, v7, user2  ; v7 = 28
+;; @0025                               v83 = uadd_overflow_trap.i32 v19, v79, user2
+;;                                     v156 = load.i32 notrap v219
+;;                                     v328 = band v156, v326  ; v326 = 1
+;;                                     v329 = iconst.i32 0
+;;                                     v330 = icmp eq v156, v329  ; v329 = 0
+;; @0025                               v92 = uextend.i32 v330
+;; @0025                               v93 = bor v328, v92
+;; @0025                               brif v93, block5, block4
 ;;
 ;;                                 block4:
-;; @0025                               v49 = uextend.i64 v88
-;; @0025                               v51 = iadd.i64 v20, v49
-;;                                     v246 = iconst.i64 8
-;; @0025                               v53 = iadd v51, v246  ; v246 = 8
-;; @0025                               v54 = load.i64 user2 v53
-;;                                     v247 = iconst.i64 1
-;; @0025                               v55 = iadd v54, v247  ; v247 = 1
-;; @0025                               store user2 v55, v53
+;;                                     v154 = load.i32 notrap v219
+;; @0025                               v94 = uextend.i64 v154
+;; @0025                               v96 = iadd.i64 v20, v94
+;;                                     v331 = iconst.i64 8
+;; @0025                               v98 = iadd v96, v331  ; v331 = 8
+;; @0025                               v99 = load.i64 user2 v98
+;;                                     v332 = iconst.i64 1
+;; @0025                               v100 = iadd v99, v332  ; v332 = 1
+;; @0025                               store user2 v100, v98
 ;; @0025                               jump block5
 ;;
 ;;                                 block5:
-;;                                     v84 = load.i32 notrap v136
-;;                                     v133 = iconst.i64 32
-;;                                     v163 = iadd.i64 v22, v133  ; v133 = 32
-;; @0025                               store user2 little v84, v163
-;;                                     v83 = load.i32 notrap v135
-;;                                     v248 = iconst.i32 1
-;;                                     v249 = band v83, v248  ; v248 = 1
-;;                                     v250 = iconst.i32 0
-;;                                     v251 = icmp eq v83, v250  ; v250 = 0
-;; @0025                               v64 = uextend.i32 v251
-;; @0025                               v65 = bor v249, v64
-;; @0025                               brif v65, block7, block6
+;;                                     v152 = load.i32 notrap v219
+;; @0025                               v84 = uextend.i64 v83
+;; @0025                               v86 = iadd.i64 v20, v84
+;;                                     v287 = iconst.i32 32
+;; @0025                               v87 = isub.i32 v79, v287  ; v287 = 32
+;; @0025                               v88 = uextend.i64 v87
+;; @0025                               v89 = isub v86, v88
+;; @0025                               store user2 little v152, v89
+;;                                     v333 = iadd.i64 v22, v213  ; v213 = 24
+;; @0025                               v112 = load.i32 user2 readonly v333
+;;                                     v334 = iconst.i32 2
+;;                                     v335 = icmp ugt v112, v334  ; v334 = 2
+;; @0025                               trapz v335, user17
+;; @0025                               v115 = uextend.i64 v112
+;;                                     v336 = iconst.i64 2
+;;                                     v337 = ishl v115, v336  ; v336 = 2
+;;                                     v338 = iconst.i64 32
+;;                                     v339 = ushr v337, v338  ; v338 = 32
+;; @0025                               trapnz v339, user2
+;;                                     v340 = ishl v112, v334  ; v334 = 2
+;;                                     v341 = iconst.i32 28
+;; @0025                               v120 = uadd_overflow_trap v340, v341, user2  ; v341 = 28
+;; @0025                               v124 = uadd_overflow_trap.i32 v19, v120, user2
+;;                                     v151 = load.i32 notrap v218
+;;                                     v342 = iconst.i32 1
+;;                                     v343 = band v151, v342  ; v342 = 1
+;;                                     v344 = iconst.i32 0
+;;                                     v345 = icmp eq v151, v344  ; v344 = 0
+;; @0025                               v133 = uextend.i32 v345
+;; @0025                               v134 = bor v343, v133
+;; @0025                               brif v134, block7, block6
 ;;
 ;;                                 block6:
-;; @0025                               v66 = uextend.i64 v83
-;; @0025                               v68 = iadd.i64 v20, v66
-;;                                     v252 = iconst.i64 8
-;; @0025                               v70 = iadd v68, v252  ; v252 = 8
-;; @0025                               v71 = load.i64 user2 v70
-;;                                     v253 = iconst.i64 1
-;; @0025                               v72 = iadd v71, v253  ; v253 = 1
-;; @0025                               store user2 v72, v70
+;;                                     v149 = load.i32 notrap v218
+;; @0025                               v135 = uextend.i64 v149
+;; @0025                               v137 = iadd.i64 v20, v135
+;;                                     v346 = iconst.i64 8
+;; @0025                               v139 = iadd v137, v346  ; v346 = 8
+;; @0025                               v140 = load.i64 user2 v139
+;;                                     v347 = iconst.i64 1
+;; @0025                               v141 = iadd v140, v347  ; v347 = 1
+;; @0025                               store user2 v141, v139
 ;; @0025                               jump block7
 ;;
 ;;                                 block7:
-;;                                     v79 = load.i32 notrap v135
-;;                                     v178 = iconst.i64 36
-;;                                     v183 = iadd.i64 v22, v178  ; v178 = 36
-;; @0025                               store user2 little v79, v183
+;;                                     v147 = load.i32 notrap v218
+;; @0025                               v125 = uextend.i64 v124
+;; @0025                               v127 = iadd.i64 v20, v125
+;;                                     v319 = iconst.i32 36
+;; @0025                               v128 = isub.i32 v120, v319  ; v319 = 36
+;; @0025                               v129 = uextend.i64 v128
+;; @0025                               v130 = isub v127, v129
+;; @0025                               store user2 little v147, v130
 ;; @0029                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/drc/array-new-fixed.wat
+++ b/tests/disas/gc/drc/array-new-fixed.wat
@@ -16,6 +16,7 @@
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
+;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     fn0 = colocated u805306368:23 sig0
 ;;     stack_limit = gv2
@@ -24,26 +25,62 @@
 ;; @0025                               v14 = iconst.i32 -1476395008
 ;; @0025                               v16 = load.i64 notrap aligned readonly can_move v0+40
 ;; @0025                               v17 = load.i32 notrap aligned readonly can_move v16
-;;                                     v46 = iconst.i32 56
+;;                                     v129 = iconst.i32 56
 ;; @0025                               v18 = iconst.i32 8
-;; @0025                               v19 = call fn0(v0, v14, v17, v46, v18)  ; v14 = -1476395008, v46 = 56, v18 = 8
+;; @0025                               v19 = call fn0(v0, v14, v17, v129, v18)  ; v14 = -1476395008, v129 = 56, v18 = 8
 ;; @0025                               v6 = iconst.i32 3
-;; @0025                               v32 = load.i64 notrap aligned readonly can_move v0+8
-;; @0025                               v20 = load.i64 notrap aligned readonly can_move v32+32
+;; @0025                               v115 = load.i64 notrap aligned readonly can_move v0+8
+;; @0025                               v20 = load.i64 notrap aligned readonly can_move v115+32
 ;; @0025                               v21 = uextend.i64 v19
 ;; @0025                               v22 = iadd v20, v21
-;;                                     v37 = iconst.i64 24
-;; @0025                               v23 = iadd v22, v37  ; v37 = 24
+;;                                     v120 = iconst.i64 24
+;; @0025                               v23 = iadd v22, v120  ; v120 = 24
 ;; @0025                               store user2 v6, v23  ; v6 = 3
-;;                                     v34 = iconst.i64 32
-;;                                     v52 = iadd v22, v34  ; v34 = 32
-;; @0025                               store user2 little v2, v52
-;;                                     v55 = iconst.i64 40
-;;                                     v60 = iadd v22, v55  ; v55 = 40
-;; @0025                               store user2 little v3, v60
-;;                                     v76 = iconst.i64 48
-;;                                     v81 = iadd v22, v76  ; v76 = 48
-;; @0025                               store user2 little v4, v81
+;; @0025                               trapz v19, user16
+;; @0025                               v42 = uadd_overflow_trap v19, v129, user2  ; v129 = 56
+;; @0025                               v43 = uextend.i64 v42
+;; @0025                               v45 = iadd v20, v43
+;; @0025                               v48 = isub v45, v120  ; v120 = 24
+;; @0025                               store user2 little v2, v48
+;; @0025                               v55 = load.i32 user2 readonly v23
+;; @0025                               v49 = iconst.i32 1
+;;                                     v160 = icmp ugt v55, v49  ; v49 = 1
+;; @0025                               trapz v160, user17
+;; @0025                               v58 = uextend.i64 v55
+;;                                     v119 = iconst.i64 3
+;;                                     v162 = ishl v58, v119  ; v119 = 3
+;;                                     v117 = iconst.i64 32
+;; @0025                               v60 = ushr v162, v117  ; v117 = 32
+;; @0025                               trapnz v60, user2
+;;                                     v169 = ishl v55, v6  ; v6 = 3
+;; @0025                               v7 = iconst.i32 32
+;; @0025                               v63 = uadd_overflow_trap v169, v7, user2  ; v7 = 32
+;; @0025                               v67 = uadd_overflow_trap v19, v63, user2
+;; @0025                               v68 = uextend.i64 v67
+;; @0025                               v70 = iadd v20, v68
+;;                                     v182 = iconst.i32 40
+;; @0025                               v71 = isub v63, v182  ; v182 = 40
+;; @0025                               v72 = uextend.i64 v71
+;; @0025                               v73 = isub v70, v72
+;; @0025                               store user2 little v3, v73
+;; @0025                               v80 = load.i32 user2 readonly v23
+;; @0025                               v74 = iconst.i32 2
+;;                                     v188 = icmp ugt v80, v74  ; v74 = 2
+;; @0025                               trapz v188, user17
+;; @0025                               v83 = uextend.i64 v80
+;;                                     v190 = ishl v83, v119  ; v119 = 3
+;; @0025                               v85 = ushr v190, v117  ; v117 = 32
+;; @0025                               trapnz v85, user2
+;;                                     v197 = ishl v80, v6  ; v6 = 3
+;; @0025                               v88 = uadd_overflow_trap v197, v7, user2  ; v7 = 32
+;; @0025                               v92 = uadd_overflow_trap v19, v88, user2
+;; @0025                               v93 = uextend.i64 v92
+;; @0025                               v95 = iadd v20, v93
+;;                                     v215 = iconst.i32 48
+;; @0025                               v96 = isub v88, v215  ; v215 = 48
+;; @0025                               v97 = uextend.i64 v96
+;; @0025                               v98 = isub v95, v97
+;; @0025                               store user2 little v4, v98
 ;; @0029                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/drc/array-new.wat
+++ b/tests/disas/gc/drc/array-new.wat
@@ -16,50 +16,55 @@
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
+;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     fn0 = colocated u805306368:23 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0022                               v6 = uextend.i64 v3
-;;                                     v37 = iconst.i64 3
-;;                                     v38 = ishl v6, v37  ; v37 = 3
-;;                                     v35 = iconst.i64 32
-;; @0022                               v8 = ushr v38, v35  ; v35 = 32
+;;                                     v73 = iconst.i64 3
+;;                                     v74 = ishl v6, v73  ; v73 = 3
+;;                                     v71 = iconst.i64 32
+;; @0022                               v8 = ushr v74, v71  ; v71 = 32
 ;; @0022                               trapnz v8, user18
 ;; @0022                               v5 = iconst.i32 32
-;;                                     v44 = iconst.i32 3
-;;                                     v45 = ishl v3, v44  ; v44 = 3
-;; @0022                               v10 = uadd_overflow_trap v5, v45, user18  ; v5 = 32
+;;                                     v80 = iconst.i32 3
+;;                                     v81 = ishl v3, v80  ; v80 = 3
+;; @0022                               v10 = uadd_overflow_trap v5, v81, user18  ; v5 = 32
 ;; @0022                               v12 = iconst.i32 -1476395008
 ;; @0022                               v14 = load.i64 notrap aligned readonly can_move v0+40
 ;; @0022                               v15 = load.i32 notrap aligned readonly can_move v14
-;;                                     v42 = iconst.i32 8
-;; @0022                               v17 = call fn0(v0, v12, v15, v10, v42)  ; v12 = -1476395008, v42 = 8
-;; @0022                               v33 = load.i64 notrap aligned readonly can_move v0+8
-;; @0022                               v18 = load.i64 notrap aligned readonly can_move v33+32
+;;                                     v78 = iconst.i32 8
+;; @0022                               v17 = call fn0(v0, v12, v15, v10, v78)  ; v12 = -1476395008, v78 = 8
+;; @0022                               v69 = load.i64 notrap aligned readonly can_move v0+8
+;; @0022                               v18 = load.i64 notrap aligned readonly can_move v69+32
 ;; @0022                               v19 = uextend.i64 v17
 ;; @0022                               v20 = iadd v18, v19
-;;                                     v32 = iconst.i64 24
-;; @0022                               v21 = iadd v20, v32  ; v32 = 24
+;;                                     v68 = iconst.i64 24
+;; @0022                               v21 = iadd v20, v68  ; v68 = 24
 ;; @0022                               store user2 v3, v21
-;;                                     v53 = iadd v20, v35  ; v35 = 32
-;; @0022                               v27 = uextend.i64 v10
-;; @0022                               v28 = iadd v20, v27
-;;                                     v36 = iconst.i64 8
-;; @0022                               jump block2(v53)
+;; @0022                               trapz v17, user16
+;; @0022                               v45 = load.i64 notrap aligned v69+40
+;; @0022                               v38 = iadd v20, v71  ; v71 = 32
+;; @0022                               v47 = uadd_overflow_trap v38, v74, user2
+;; @0022                               v46 = iadd v18, v45
+;; @0022                               v48 = icmp ugt v47, v46
+;; @0022                               trapnz v48, user2
+;;                                     v84 = iconst.i64 0
+;; @0022                               v50 = icmp eq v6, v84  ; v84 = 0
+;;                                     v72 = iconst.i64 8
+;; @0022                               v49 = iadd v38, v74
+;; @0022                               brif v50, block3, block2(v38)
 ;;
-;;                                 block2(v29: i64):
-;; @0022                               v30 = icmp eq v29, v28
-;; @0022                               brif v30, block4, block3
+;;                                 block2(v51: i64):
+;; @0022                               store.i64 user2 little v2, v51
+;;                                     v99 = iconst.i64 8
+;;                                     v100 = iadd v51, v99  ; v99 = 8
+;; @0022                               v53 = icmp eq v100, v49
+;; @0022                               brif v53, block3, block2(v100)
 ;;
 ;;                                 block3:
-;; @0022                               store.i64 user2 little v2, v29
-;;                                     v58 = iconst.i64 8
-;;                                     v59 = iadd.i64 v29, v58  ; v58 = 8
-;; @0022                               jump block2(v59)
-;;
-;;                                 block4:
 ;; @0025                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/null/array-fill.wat
+++ b/tests/disas/gc/null/array-fill.wat
@@ -21,50 +21,43 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i64, v5: i32):
 ;; @0027                               trapz v2, user16
-;; @0027                               v41 = load.i64 notrap aligned readonly can_move v0+8
-;; @0027                               v7 = load.i64 notrap aligned readonly can_move v41+32
+;; @0027                               v49 = load.i64 notrap aligned readonly can_move v0+8
+;; @0027                               v7 = load.i64 notrap aligned readonly can_move v49+32
 ;; @0027                               v6 = uextend.i64 v2
 ;; @0027                               v8 = iadd v7, v6
 ;; @0027                               v9 = iconst.i64 8
 ;; @0027                               v10 = iadd v8, v9  ; v9 = 8
 ;; @0027                               v11 = load.i32 user2 readonly v10
-;; @0027                               v12 = uadd_overflow_trap v3, v5, user17
-;; @0027                               v13 = icmp ugt v12, v11
-;; @0027                               trapnz v13, user17
-;; @0027                               v15 = uextend.i64 v11
-;;                                     v43 = iconst.i64 3
-;;                                     v44 = ishl v15, v43  ; v43 = 3
-;;                                     v40 = iconst.i64 32
-;; @0027                               v17 = ushr v44, v40  ; v40 = 32
-;; @0027                               trapnz v17, user2
-;;                                     v53 = iconst.i32 3
-;;                                     v54 = ishl v11, v53  ; v53 = 3
-;; @0027                               v19 = iconst.i32 16
-;; @0027                               v20 = uadd_overflow_trap v54, v19, user2  ; v19 = 16
-;; @0027                               v24 = uadd_overflow_trap v2, v20, user2
-;; @0027                               v25 = uextend.i64 v24
-;; @0027                               v27 = iadd v7, v25
-;;                                     v60 = ishl v3, v53  ; v53 = 3
-;;                                     v62 = iadd v60, v19  ; v19 = 16
-;; @0027                               v28 = isub v20, v62
-;; @0027                               v29 = uextend.i64 v28
-;; @0027                               v30 = isub v27, v29
-;;                                     v64 = ishl v5, v53  ; v53 = 3
-;; @0027                               v32 = uextend.i64 v64
-;; @0027                               v33 = iadd v30, v32
-;; @0027                               jump block2(v30)
+;; @0027                               v13 = uextend.i64 v3
+;; @0027                               v14 = uextend.i64 v5
+;; @0027                               v16 = iadd v13, v14
+;; @0027                               v12 = uextend.i64 v11
+;; @0027                               v17 = icmp ugt v16, v12
+;; @0027                               trapnz v17, user17
+;; @0027                               v28 = load.i64 notrap aligned v49+40
+;;                                     v45 = iconst.i64 16
+;; @0027                               v21 = iadd v8, v45  ; v45 = 16
+;;                                     v53 = iconst.i64 3
+;;                                     v54 = ishl v13, v53  ; v53 = 3
+;; @0027                               v24 = iadd v21, v54
+;;                                     v56 = ishl v14, v53  ; v53 = 3
+;; @0027                               v30 = uadd_overflow_trap v24, v56, user2
+;; @0027                               v29 = iadd v7, v28
+;; @0027                               v31 = icmp ugt v30, v29
+;; @0027                               trapnz v31, user2
+;;                                     v51 = iconst.i64 0
+;; @0027                               v33 = icmp eq v14, v51  ; v51 = 0
+;; @0027                               v32 = iadd v24, v56
+;; @0027                               brif v33, block3, block2(v24)
 ;;
-;;                                 block2(v35: i64):
-;; @0027                               v36 = icmp eq v35, v33
-;; @0027                               brif v36, block4, block3
+;;                                 block2(v34: i64):
+;; @0027                               store.i64 user2 little v4, v34
+;;                                     v58 = iconst.i64 8
+;;                                     v59 = iadd v34, v58  ; v58 = 8
+;; @0027                               v36 = icmp eq v59, v32
+;; @0027                               brif v36, block3, block2(v59)
 ;;
 ;;                                 block3:
-;; @0027                               store.i64 user2 little v4, v35
-;;                                     v66 = iconst.i64 8
-;;                                     v67 = iadd.i64 v35, v66  ; v66 = 8
-;; @0027                               jump block2(v67)
-;;
-;;                                 block4:
 ;; @002a                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/null/array-new-fixed-of-gc-refs.wat
+++ b/tests/disas/gc/null/array-new-fixed-of-gc-refs.wat
@@ -25,53 +25,91 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
-;;                                     v62 = stack_addr.i64 ss2
-;;                                     store notrap v2, v62
-;;                                     v61 = stack_addr.i64 ss1
-;;                                     store notrap v3, v61
-;;                                     v60 = stack_addr.i64 ss0
-;;                                     store notrap v4, v60
+;;                                     v145 = stack_addr.i64 ss2
+;;                                     store notrap v2, v145
+;;                                     v144 = stack_addr.i64 ss1
+;;                                     store notrap v3, v144
+;;                                     v143 = stack_addr.i64 ss0
+;;                                     store notrap v4, v143
 ;; @0025                               v17 = load.i64 notrap aligned readonly v0+32
 ;; @0025                               v18 = load.i32 user2 v17
-;;                                     v80 = iconst.i32 7
-;; @0025                               v21 = uadd_overflow_trap v18, v80, user18  ; v80 = 7
-;;                                     v86 = iconst.i32 -8
-;; @0025                               v23 = band v21, v86  ; v86 = -8
-;;                                     v73 = iconst.i32 24
-;; @0025                               v24 = uadd_overflow_trap v23, v73, user18  ; v73 = 24
-;; @0025                               v56 = load.i64 notrap aligned readonly can_move v0+8
-;; @0025                               v26 = load.i64 notrap aligned v56+40
+;;                                     v163 = iconst.i32 7
+;; @0025                               v21 = uadd_overflow_trap v18, v163, user18  ; v163 = 7
+;;                                     v169 = iconst.i32 -8
+;; @0025                               v23 = band v21, v169  ; v169 = -8
+;;                                     v156 = iconst.i32 24
+;; @0025                               v24 = uadd_overflow_trap v23, v156, user18  ; v156 = 24
+;; @0025                               v139 = load.i64 notrap aligned readonly can_move v0+8
+;; @0025                               v26 = load.i64 notrap aligned v139+40
 ;; @0025                               v25 = uextend.i64 v24
 ;; @0025                               v27 = icmp ule v25, v26
 ;; @0025                               brif v27, block2, block3
 ;;
 ;;                                 block2:
-;;                                     v87 = iconst.i32 -1476394984
-;; @0025                               v31 = load.i64 notrap aligned readonly can_move v56+32
-;;                                     v162 = band.i32 v21, v86  ; v86 = -8
-;;                                     v163 = uextend.i64 v162
-;; @0025                               v33 = iadd v31, v163
-;; @0025                               store user2 v87, v33  ; v87 = -1476394984
+;;                                     v170 = iconst.i32 -1476394984
+;; @0025                               v31 = load.i64 notrap aligned readonly can_move v139+32
+;;                                     v268 = band.i32 v21, v169  ; v169 = -8
+;;                                     v269 = uextend.i64 v268
+;; @0025                               v33 = iadd v31, v269
+;; @0025                               store user2 v170, v33  ; v170 = -1476394984
 ;; @0025                               v37 = load.i64 notrap aligned readonly can_move v0+40
 ;; @0025                               v38 = load.i32 notrap aligned readonly can_move v37
 ;; @0025                               store user2 v38, v33+4
 ;; @0025                               store.i32 user2 v24, v17
 ;; @0025                               v6 = iconst.i32 3
-;;                                     v53 = iconst.i64 8
-;; @0025                               v39 = iadd v33, v53  ; v53 = 8
+;;                                     v136 = iconst.i64 8
+;; @0025                               v39 = iadd v33, v136  ; v136 = 8
 ;; @0025                               store user2 v6, v39  ; v6 = 3
-;;                                     v49 = load.i32 notrap v62
-;;                                     v64 = iconst.i64 12
-;;                                     v98 = iadd v33, v64  ; v64 = 12
-;; @0025                               store user2 little v49, v98
-;;                                     v48 = load.i32 notrap v61
-;;                                     v101 = iconst.i64 16
-;;                                     v106 = iadd v33, v101  ; v101 = 16
-;; @0025                               store user2 little v48, v106
-;;                                     v47 = load.i32 notrap v60
-;;                                     v121 = iconst.i64 20
-;;                                     v126 = iadd v33, v121  ; v121 = 20
-;; @0025                               store user2 little v47, v126
+;; @0025                               trapz v268, user16
+;;                                     v270 = iconst.i32 24
+;; @0025                               v58 = uadd_overflow_trap v268, v270, user2  ; v270 = 24
+;;                                     v117 = load.i32 notrap v145
+;; @0025                               v59 = uextend.i64 v58
+;; @0025                               v61 = iadd v31, v59
+;;                                     v147 = iconst.i64 12
+;; @0025                               v64 = isub v61, v147  ; v147 = 12
+;; @0025                               store user2 little v117, v64
+;; @0025                               v71 = load.i32 user2 readonly v39
+;; @0025                               v65 = iconst.i32 1
+;;                                     v208 = icmp ugt v71, v65  ; v65 = 1
+;; @0025                               trapz v208, user17
+;; @0025                               v74 = uextend.i64 v71
+;;                                     v148 = iconst.i64 2
+;;                                     v210 = ishl v74, v148  ; v148 = 2
+;;                                     v141 = iconst.i64 32
+;; @0025                               v76 = ushr v210, v141  ; v141 = 32
+;; @0025                               trapnz v76, user2
+;;                                     v187 = iconst.i32 2
+;;                                     v217 = ishl v71, v187  ; v187 = 2
+;; @0025                               v7 = iconst.i32 12
+;; @0025                               v79 = uadd_overflow_trap v217, v7, user2  ; v7 = 12
+;; @0025                               v83 = uadd_overflow_trap v268, v79, user2
+;;                                     v116 = load.i32 notrap v144
+;; @0025                               v84 = uextend.i64 v83
+;; @0025                               v86 = iadd v31, v84
+;;                                     v230 = iconst.i32 16
+;; @0025                               v87 = isub v79, v230  ; v230 = 16
+;; @0025                               v88 = uextend.i64 v87
+;; @0025                               v89 = isub v86, v88
+;; @0025                               store user2 little v116, v89
+;; @0025                               v96 = load.i32 user2 readonly v39
+;;                                     v236 = icmp ugt v96, v187  ; v187 = 2
+;; @0025                               trapz v236, user17
+;; @0025                               v99 = uextend.i64 v96
+;;                                     v238 = ishl v99, v148  ; v148 = 2
+;; @0025                               v101 = ushr v238, v141  ; v141 = 32
+;; @0025                               trapnz v101, user2
+;;                                     v245 = ishl v96, v187  ; v187 = 2
+;; @0025                               v104 = uadd_overflow_trap v245, v7, user2  ; v7 = 12
+;; @0025                               v108 = uadd_overflow_trap v268, v104, user2
+;;                                     v115 = load.i32 notrap v143
+;; @0025                               v109 = uextend.i64 v108
+;; @0025                               v111 = iadd v31, v109
+;;                                     v262 = iconst.i32 20
+;; @0025                               v112 = isub v104, v262  ; v262 = 20
+;; @0025                               v113 = uextend.i64 v112
+;; @0025                               v114 = isub v111, v113
+;; @0025                               store user2 little v115, v114
 ;; @0029                               jump block1
 ;;
 ;;                                 block3 cold:
@@ -80,6 +118,6 @@
 ;; @0025                               jump block2
 ;;
 ;;                                 block1:
-;;                                     v164 = band.i32 v21, v86  ; v86 = -8
-;; @0029                               return v164
+;;                                     v271 = band.i32 v21, v169  ; v169 = -8
+;; @0029                               return v271
 ;; }

--- a/tests/disas/gc/null/array-new-fixed.wat
+++ b/tests/disas/gc/null/array-new-fixed.wat
@@ -24,42 +24,80 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64):
 ;; @0025                               v17 = load.i64 notrap aligned readonly v0+32
 ;; @0025                               v18 = load.i32 user2 v17
-;;                                     v71 = iconst.i32 7
-;; @0025                               v21 = uadd_overflow_trap v18, v71, user18  ; v71 = 7
-;;                                     v77 = iconst.i32 -8
-;; @0025                               v23 = band v21, v77  ; v77 = -8
-;;                                     v64 = iconst.i32 40
-;; @0025                               v24 = uadd_overflow_trap v23, v64, user18  ; v64 = 40
-;; @0025                               v50 = load.i64 notrap aligned readonly can_move v0+8
-;; @0025                               v26 = load.i64 notrap aligned v50+40
+;;                                     v154 = iconst.i32 7
+;; @0025                               v21 = uadd_overflow_trap v18, v154, user18  ; v154 = 7
+;;                                     v160 = iconst.i32 -8
+;; @0025                               v23 = band v21, v160  ; v160 = -8
+;;                                     v147 = iconst.i32 40
+;; @0025                               v24 = uadd_overflow_trap v23, v147, user18  ; v147 = 40
+;; @0025                               v133 = load.i64 notrap aligned readonly can_move v0+8
+;; @0025                               v26 = load.i64 notrap aligned v133+40
 ;; @0025                               v25 = uextend.i64 v24
 ;; @0025                               v27 = icmp ule v25, v26
 ;; @0025                               brif v27, block2, block3
 ;;
 ;;                                 block2:
-;;                                     v78 = iconst.i32 -1476394968
-;; @0025                               v31 = load.i64 notrap aligned readonly can_move v50+32
-;;                                     v140 = band.i32 v21, v77  ; v77 = -8
-;;                                     v141 = uextend.i64 v140
-;; @0025                               v33 = iadd v31, v141
-;; @0025                               store user2 v78, v33  ; v78 = -1476394968
+;;                                     v161 = iconst.i32 -1476394968
+;; @0025                               v31 = load.i64 notrap aligned readonly can_move v133+32
+;;                                     v256 = band.i32 v21, v160  ; v160 = -8
+;;                                     v257 = uextend.i64 v256
+;; @0025                               v33 = iadd v31, v257
+;; @0025                               store user2 v161, v33  ; v161 = -1476394968
 ;; @0025                               v37 = load.i64 notrap aligned readonly can_move v0+40
 ;; @0025                               v38 = load.i32 notrap aligned readonly can_move v37
 ;; @0025                               store user2 v38, v33+4
 ;; @0025                               store.i32 user2 v24, v17
 ;; @0025                               v6 = iconst.i32 3
-;;                                     v53 = iconst.i64 8
-;; @0025                               v39 = iadd v33, v53  ; v53 = 8
+;;                                     v136 = iconst.i64 8
+;; @0025                               v39 = iadd v33, v136  ; v136 = 8
 ;; @0025                               store user2 v6, v39  ; v6 = 3
-;;                                     v85 = iconst.i64 16
-;;                                     v90 = iadd v33, v85  ; v85 = 16
-;; @0025                               store.i64 user2 little v2, v90
-;;                                     v55 = iconst.i64 24
-;;                                     v97 = iadd v33, v55  ; v55 = 24
-;; @0025                               store.i64 user2 little v3, v97
-;;                                     v52 = iconst.i64 32
-;;                                     v107 = iadd v33, v52  ; v52 = 32
-;; @0025                               store.i64 user2 little v4, v107
+;; @0025                               trapz v256, user16
+;;                                     v258 = iconst.i32 40
+;; @0025                               v58 = uadd_overflow_trap v256, v258, user2  ; v258 = 40
+;; @0025                               v59 = uextend.i64 v58
+;; @0025                               v61 = iadd v31, v59
+;;                                     v138 = iconst.i64 24
+;; @0025                               v64 = isub v61, v138  ; v138 = 24
+;; @0025                               store.i64 user2 little v2, v64
+;; @0025                               v71 = load.i32 user2 readonly v39
+;; @0025                               v65 = iconst.i32 1
+;;                                     v197 = icmp ugt v71, v65  ; v65 = 1
+;; @0025                               trapz v197, user17
+;; @0025                               v74 = uextend.i64 v71
+;;                                     v137 = iconst.i64 3
+;;                                     v199 = ishl v74, v137  ; v137 = 3
+;;                                     v135 = iconst.i64 32
+;; @0025                               v76 = ushr v199, v135  ; v135 = 32
+;; @0025                               trapnz v76, user2
+;;                                     v206 = ishl v71, v6  ; v6 = 3
+;; @0025                               v7 = iconst.i32 16
+;; @0025                               v79 = uadd_overflow_trap v206, v7, user2  ; v7 = 16
+;; @0025                               v83 = uadd_overflow_trap v256, v79, user2
+;; @0025                               v84 = uextend.i64 v83
+;; @0025                               v86 = iadd v31, v84
+;;                                     v146 = iconst.i32 24
+;; @0025                               v87 = isub v79, v146  ; v146 = 24
+;; @0025                               v88 = uextend.i64 v87
+;; @0025                               v89 = isub v86, v88
+;; @0025                               store.i64 user2 little v3, v89
+;; @0025                               v96 = load.i32 user2 readonly v39
+;; @0025                               v90 = iconst.i32 2
+;;                                     v224 = icmp ugt v96, v90  ; v90 = 2
+;; @0025                               trapz v224, user17
+;; @0025                               v99 = uextend.i64 v96
+;;                                     v226 = ishl v99, v137  ; v137 = 3
+;; @0025                               v101 = ushr v226, v135  ; v135 = 32
+;; @0025                               trapnz v101, user2
+;;                                     v233 = ishl v96, v6  ; v6 = 3
+;; @0025                               v104 = uadd_overflow_trap v233, v7, user2  ; v7 = 16
+;; @0025                               v108 = uadd_overflow_trap v256, v104, user2
+;; @0025                               v109 = uextend.i64 v108
+;; @0025                               v111 = iadd v31, v109
+;;                                     v250 = iconst.i32 32
+;; @0025                               v112 = isub v104, v250  ; v250 = 32
+;; @0025                               v113 = uextend.i64 v112
+;; @0025                               v114 = isub v111, v113
+;; @0025                               store.i64 user2 little v4, v114
 ;; @0029                               jump block1
 ;;
 ;;                                 block3 cold:
@@ -68,6 +106,6 @@
 ;; @0025                               jump block2
 ;;
 ;;                                 block1:
-;;                                     v142 = band.i32 v21, v77  ; v77 = -8
-;; @0029                               return v142
+;;                                     v259 = band.i32 v21, v160  ; v160 = -8
+;; @0029                               return v259
 ;; }

--- a/tests/disas/gc/null/array-new.wat
+++ b/tests/disas/gc/null/array-new.wat
@@ -23,63 +23,67 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):
 ;; @0022                               v6 = uextend.i64 v3
-;;                                     v55 = iconst.i64 3
-;;                                     v56 = ishl v6, v55  ; v55 = 3
-;;                                     v53 = iconst.i64 32
-;; @0022                               v8 = ushr v56, v53  ; v53 = 32
+;;                                     v91 = iconst.i64 3
+;;                                     v92 = ishl v6, v91  ; v91 = 3
+;;                                     v89 = iconst.i64 32
+;; @0022                               v8 = ushr v92, v89  ; v89 = 32
 ;; @0022                               trapnz v8, user18
 ;; @0022                               v5 = iconst.i32 16
-;;                                     v62 = iconst.i32 3
-;;                                     v63 = ishl v3, v62  ; v62 = 3
-;; @0022                               v10 = uadd_overflow_trap v5, v63, user18  ; v5 = 16
+;;                                     v98 = iconst.i32 3
+;;                                     v99 = ishl v3, v98  ; v98 = 3
+;; @0022                               v10 = uadd_overflow_trap v5, v99, user18  ; v5 = 16
 ;; @0022                               v12 = iconst.i32 -67108864
 ;; @0022                               v13 = band v10, v12  ; v12 = -67108864
 ;; @0022                               trapnz v13, user18
 ;; @0022                               v15 = load.i64 notrap aligned readonly v0+32
 ;; @0022                               v16 = load.i32 user2 v15
-;;                                     v66 = iconst.i32 7
-;; @0022                               v19 = uadd_overflow_trap v16, v66, user18  ; v66 = 7
-;;                                     v72 = iconst.i32 -8
-;; @0022                               v21 = band v19, v72  ; v72 = -8
+;;                                     v102 = iconst.i32 7
+;; @0022                               v19 = uadd_overflow_trap v16, v102, user18  ; v102 = 7
+;;                                     v108 = iconst.i32 -8
+;; @0022                               v21 = band v19, v108  ; v108 = -8
 ;; @0022                               v22 = uadd_overflow_trap v21, v10, user18
-;; @0022                               v51 = load.i64 notrap aligned readonly can_move v0+8
-;; @0022                               v24 = load.i64 notrap aligned v51+40
+;; @0022                               v87 = load.i64 notrap aligned readonly can_move v0+8
+;; @0022                               v24 = load.i64 notrap aligned v87+40
 ;; @0022                               v23 = uextend.i64 v22
 ;; @0022                               v25 = icmp ule v23, v24
 ;; @0022                               brif v25, block2, block3
 ;;
 ;;                                 block2:
 ;; @0022                               v32 = iconst.i32 -1476395008
-;;                                     v73 = bor.i32 v10, v32  ; v32 = -1476395008
-;; @0022                               v29 = load.i64 notrap aligned readonly can_move v51+32
-;;                                     v86 = band.i32 v19, v72  ; v72 = -8
-;;                                     v87 = uextend.i64 v86
-;; @0022                               v31 = iadd v29, v87
-;; @0022                               store user2 v73, v31
+;;                                     v109 = bor.i32 v10, v32  ; v32 = -1476395008
+;; @0022                               v29 = load.i64 notrap aligned readonly can_move v87+32
+;;                                     v126 = band.i32 v19, v108  ; v108 = -8
+;;                                     v127 = uextend.i64 v126
+;; @0022                               v31 = iadd v29, v127
+;; @0022                               store user2 v109, v31
 ;; @0022                               v35 = load.i64 notrap aligned readonly can_move v0+40
 ;; @0022                               v36 = load.i32 notrap aligned readonly can_move v35
 ;; @0022                               store user2 v36, v31+4
 ;; @0022                               store.i32 user2 v22, v15
-;;                                     v54 = iconst.i64 8
-;; @0022                               v37 = iadd v31, v54  ; v54 = 8
+;;                                     v90 = iconst.i64 8
+;; @0022                               v37 = iadd v31, v90  ; v90 = 8
 ;; @0022                               store.i32 user2 v3, v37
-;;                                     v76 = iconst.i64 16
-;;                                     v81 = iadd v31, v76  ; v76 = 16
-;; @0022                               v43 = uextend.i64 v10
-;; @0022                               v44 = iadd v31, v43
-;; @0022                               jump block4(v81)
+;; @0022                               trapz v126, user16
+;; @0022                               v61 = load.i64 notrap aligned v87+40
+;;                                     v78 = iconst.i64 16
+;; @0022                               v54 = iadd v31, v78  ; v78 = 16
+;; @0022                               v63 = uadd_overflow_trap v54, v92, user2
+;; @0022                               v62 = iadd v29, v61
+;; @0022                               v64 = icmp ugt v63, v62
+;; @0022                               trapnz v64, user2
+;;                                     v111 = iconst.i64 0
+;; @0022                               v66 = icmp.i64 eq v6, v111  ; v111 = 0
+;; @0022                               v65 = iadd v54, v92
+;; @0022                               brif v66, block5, block4(v54)
 ;;
-;;                                 block4(v45: i64):
-;; @0022                               v46 = icmp eq v45, v44
-;; @0022                               brif v46, block6, block5
+;;                                 block4(v67: i64):
+;; @0022                               store.i64 user2 little v2, v67
+;;                                     v128 = iconst.i64 8
+;;                                     v129 = iadd v67, v128  ; v128 = 8
+;; @0022                               v69 = icmp eq v129, v65
+;; @0022                               brif v69, block5, block4(v129)
 ;;
 ;;                                 block5:
-;; @0022                               store.i64 user2 little v2, v45
-;;                                     v88 = iconst.i64 8
-;;                                     v89 = iadd.i64 v45, v88  ; v88 = 8
-;; @0022                               jump block4(v89)
-;;
-;;                                 block6:
 ;; @0025                               jump block1
 ;;
 ;;                                 block3 cold:
@@ -88,6 +92,6 @@
 ;; @0022                               jump block2
 ;;
 ;;                                 block1:
-;;                                     v90 = band.i32 v19, v72  ; v72 = -8
-;; @0025                               return v90
+;;                                     v130 = band.i32 v19, v108  ; v108 = -8
+;; @0025                               return v130
 ;; }

--- a/tests/disas/memory-copy-epochs.wat
+++ b/tests/disas/memory-copy-epochs.wat
@@ -34,63 +34,63 @@
 ;; @001e                               v12 = call fn0(v0)
 ;; @001e                               jump block2(v12)
 ;;
-;;                                 block2(v70: i64):
+;;                                 block2(v72: i64):
 ;; @0025                               v17 = load.i64 notrap aligned v0+64
 ;; @0025                               v18 = uextend.i64 v2
 ;; @0025                               v19 = uextend.i64 v4
-;; @0025                               v20 = iadd v18, v19
-;; @0025                               v21 = icmp ugt v20, v17
-;; @0025                               trapnz v21, heap_oob
-;; @0025                               v28 = uextend.i64 v3
-;; @0025                               v30 = iadd v28, v19
-;; @0025                               v31 = icmp ugt v30, v17
-;; @0025                               trapnz v31, heap_oob
-;; @0025                               v38 = iconst.i64 0x0800_0000
-;; @0025                               v39 = icmp ugt v19, v38  ; v38 = 0x0800_0000
-;; @0025                               v22 = load.i64 notrap aligned readonly can_move v0+56
-;; @0025                               v25 = iadd v22, v18
-;; @0025                               v35 = iadd v22, v28
-;; @0025                               brif v39, block4(v25, v35, v19, v70), block5(v25, v35, v19, v70)
+;; @0025                               v21 = iadd v18, v19
+;; @0025                               v22 = icmp ugt v21, v17
+;; @0025                               trapnz v22, heap_oob
+;; @0025                               v29 = uextend.i64 v3
+;; @0025                               v32 = iadd v29, v19
+;; @0025                               v33 = icmp ugt v32, v17
+;; @0025                               trapnz v33, heap_oob
+;; @0025                               v40 = iconst.i64 0x0800_0000
+;; @0025                               v41 = icmp ugt v19, v40  ; v40 = 0x0800_0000
+;; @0025                               v23 = load.i64 notrap aligned readonly can_move v0+56
+;; @0025                               v26 = iadd v23, v18
+;; @0025                               v37 = iadd v23, v29
+;; @0025                               brif v41, block4(v26, v37, v19, v72), block5(v26, v37, v19, v72)
 ;;
-;;                                 block4(v40: i64, v41: i64, v42: i64, v45: i64):
-;; @0025                               v44 = load.i64 notrap aligned v6
-;; @0025                               v46 = icmp uge v44, v45
-;; @0025                               brif v46, block7, block6(v45)
+;;                                 block4(v42: i64, v43: i64, v44: i64, v47: i64):
+;; @0025                               v46 = load.i64 notrap aligned v6
+;; @0025                               v48 = icmp uge v46, v47
+;; @0025                               brif v48, block7, block6(v47)
 ;;
-;;                                 block5(v56: i64, v57: i64, v58: i64, v61: i64):
-;; @0025                               v60 = load.i64 notrap aligned v6
-;; @0025                               v62 = icmp uge v60, v61
-;; @0025                               brif v62, block10, block9
+;;                                 block5(v58: i64, v59: i64, v60: i64, v63: i64):
+;; @0025                               v62 = load.i64 notrap aligned v6
+;; @0025                               v64 = icmp uge v62, v63
+;; @0025                               brif v64, block10, block9
 ;;
 ;;                                 block7 cold:
-;; @0025                               v48 = load.i64 notrap aligned v8+8
-;; @0025                               v49 = icmp.i64 uge v44, v48
-;; @0025                               brif v49, block8, block6(v48)
+;; @0025                               v50 = load.i64 notrap aligned v8+8
+;; @0025                               v51 = icmp.i64 uge v46, v50
+;; @0025                               brif v51, block8, block6(v50)
 ;;
 ;;                                 block8 cold:
-;; @0025                               v51 = call fn0(v0)
-;; @0025                               jump block6(v51)
+;; @0025                               v53 = call fn0(v0)
+;; @0025                               jump block6(v53)
 ;;
-;;                                 block6(v71: i64):
-;;                                     v82 = iconst.i64 0x0800_0000
-;; @0025                               call fn1(v0, v40, v41, v82)  ; v82 = 0x0800_0000
-;;                                     v83 = isub.i64 v42, v82  ; v82 = 0x0800_0000
-;;                                     v84 = icmp ugt v83, v82  ; v82 = 0x0800_0000
-;;                                     v85 = iadd.i64 v40, v82  ; v82 = 0x0800_0000
-;;                                     v86 = iadd.i64 v41, v82  ; v82 = 0x0800_0000
-;; @0025                               brif v84, block4(v85, v86, v83, v71), block5(v85, v86, v83, v71)
+;;                                 block6(v73: i64):
+;;                                     v87 = iconst.i64 0x0800_0000
+;; @0025                               call fn1(v0, v42, v43, v87)  ; v87 = 0x0800_0000
+;;                                     v88 = isub.i64 v44, v87  ; v87 = 0x0800_0000
+;;                                     v89 = icmp ugt v88, v87  ; v87 = 0x0800_0000
+;;                                     v90 = iadd.i64 v42, v87  ; v87 = 0x0800_0000
+;;                                     v91 = iadd.i64 v43, v87  ; v87 = 0x0800_0000
+;; @0025                               brif v89, block4(v90, v91, v88, v73), block5(v90, v91, v88, v73)
 ;;
 ;;                                 block10 cold:
-;; @0025                               v64 = load.i64 notrap aligned v8+8
-;; @0025                               v65 = icmp.i64 uge v60, v64
-;; @0025                               brif v65, block11, block9
+;; @0025                               v66 = load.i64 notrap aligned v8+8
+;; @0025                               v67 = icmp.i64 uge v62, v66
+;; @0025                               brif v67, block11, block9
 ;;
 ;;                                 block11 cold:
-;; @0025                               v67 = call fn0(v0)
+;; @0025                               v69 = call fn0(v0)
 ;; @0025                               jump block9
 ;;
 ;;                                 block9:
-;; @0025                               call fn1(v0, v56, v57, v58)
+;; @0025                               call fn1(v0, v58, v59, v60)
 ;; @0029                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/memory-copy-fuel.wat
+++ b/tests/disas/memory-copy-fuel.wat
@@ -25,78 +25,78 @@
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
 ;; @001e                               v5 = load.i64 notrap aligned readonly can_move v0+8
 ;; @001e                               v6 = load.i64 notrap aligned v5
-;;                                     v87 = iconst.i64 1
-;; @001e                               v7 = iadd v6, v87  ; v87 = 1
+;;                                     v91 = iconst.i64 1
+;; @001e                               v7 = iadd v6, v91  ; v91 = 1
 ;; @001e                               v8 = iconst.i64 0
 ;; @001e                               v9 = icmp sge v7, v8  ; v8 = 0
 ;; @001e                               brif v9, block2, block3(v7)
 ;;
 ;;                                 block2:
-;;                                     v91 = iadd.i64 v6, v87  ; v87 = 1
-;; @001e                               store notrap aligned v91, v5
+;;                                     v96 = iadd.i64 v6, v91  ; v91 = 1
+;; @001e                               store notrap aligned v96, v5
 ;; @001e                               v12 = call fn0(v0)
 ;; @001e                               v14 = load.i64 notrap aligned v5
 ;; @001e                               jump block3(v14)
 ;;
-;;                                 block3(v40: i64):
+;;                                 block3(v42: i64):
 ;; @0025                               v19 = load.i64 notrap aligned v0+64
 ;; @0025                               v20 = uextend.i64 v2
 ;; @0025                               v21 = uextend.i64 v4
-;; @0025                               v22 = iadd v20, v21
-;; @0025                               v23 = icmp ugt v22, v19
-;; @0025                               trapnz v23, heap_oob
-;; @0025                               v30 = uextend.i64 v3
-;; @0025                               v32 = iadd v30, v21
-;; @0025                               v33 = icmp ugt v32, v19
-;; @0025                               trapnz v33, heap_oob
-;; @0025                               v42 = iconst.i64 0x0800_0000
-;; @0025                               v43 = icmp ugt v21, v42  ; v42 = 0x0800_0000
-;; @0025                               v24 = load.i64 notrap aligned readonly can_move v0+56
-;; @0025                               v27 = iadd v24, v20
-;; @0025                               v37 = iadd v24, v30
-;;                                     v80 = iconst.i64 4
-;; @0025                               v41 = iadd v40, v80  ; v80 = 4
-;; @0025                               brif v43, block4(v27, v37, v21, v41), block5(v27, v37, v21, v41)
+;; @0025                               v23 = iadd v20, v21
+;; @0025                               v24 = icmp ugt v23, v19
+;; @0025                               trapnz v24, heap_oob
+;; @0025                               v31 = uextend.i64 v3
+;; @0025                               v34 = iadd v31, v21
+;; @0025                               v35 = icmp ugt v34, v19
+;; @0025                               trapnz v35, heap_oob
+;; @0025                               v44 = iconst.i64 0x0800_0000
+;; @0025                               v45 = icmp ugt v21, v44  ; v44 = 0x0800_0000
+;; @0025                               v25 = load.i64 notrap aligned readonly can_move v0+56
+;; @0025                               v28 = iadd v25, v20
+;; @0025                               v39 = iadd v25, v31
+;;                                     v82 = iconst.i64 4
+;; @0025                               v43 = iadd v42, v82  ; v82 = 4
+;; @0025                               brif v45, block4(v28, v39, v21, v43), block5(v28, v39, v21, v43)
 ;;
-;;                                 block4(v44: i64, v45: i64, v46: i64, v47: i64):
-;;                                     v92 = iconst.i64 0x0800_0000
-;;                                     v93 = iadd v47, v92  ; v92 = 0x0800_0000
-;;                                     v94 = iconst.i64 0
-;;                                     v95 = icmp sge v93, v94  ; v94 = 0
-;; @0025                               brif v95, block6, block7(v93)
+;;                                 block4(v46: i64, v47: i64, v48: i64, v49: i64):
+;;                                     v97 = iconst.i64 0x0800_0000
+;;                                     v98 = iadd v49, v97  ; v97 = 0x0800_0000
+;;                                     v99 = iconst.i64 0
+;;                                     v100 = icmp sge v98, v99  ; v99 = 0
+;; @0025                               brif v100, block6, block7(v98)
 ;;
-;;                                 block5(v60: i64, v61: i64, v62: i64, v63: i64):
-;; @0025                               v64 = iadd v63, v62
-;;                                     v101 = iconst.i64 0
-;;                                     v102 = icmp sge v64, v101  ; v101 = 0
-;; @0025                               brif v102, block8, block9(v64)
+;;                                 block5(v62: i64, v63: i64, v64: i64, v65: i64):
+;; @0025                               v66 = iadd v65, v64
+;;                                     v106 = iconst.i64 0
+;;                                     v107 = icmp sge v66, v106  ; v106 = 0
+;; @0025                               brif v107, block8, block9(v66)
 ;;
 ;;                                 block6:
-;; @0025                               store.i64 notrap aligned v93, v5
-;; @0025                               v53 = call fn0(v0)
-;; @0025                               v55 = load.i64 notrap aligned v5
-;; @0025                               jump block7(v55)
+;; @0025                               store.i64 notrap aligned v98, v5
+;; @0025                               v55 = call fn0(v0)
+;; @0025                               v57 = load.i64 notrap aligned v5
+;; @0025                               jump block7(v57)
 ;;
-;;                                 block7(v72: i64):
-;;                                     v96 = iconst.i64 0x0800_0000
-;; @0025                               call fn1(v0, v44, v45, v96)  ; v96 = 0x0800_0000
-;;                                     v97 = isub.i64 v46, v96  ; v96 = 0x0800_0000
-;;                                     v98 = icmp ugt v97, v96  ; v96 = 0x0800_0000
-;;                                     v99 = iadd.i64 v44, v96  ; v96 = 0x0800_0000
-;;                                     v100 = iadd.i64 v45, v96  ; v96 = 0x0800_0000
-;; @0025                               brif v98, block4(v99, v100, v97, v72), block5(v99, v100, v97, v72)
+;;                                 block7(v74: i64):
+;;                                     v101 = iconst.i64 0x0800_0000
+;; @0025                               call fn1(v0, v46, v47, v101)  ; v101 = 0x0800_0000
+;;                                     v102 = isub.i64 v48, v101  ; v101 = 0x0800_0000
+;;                                     v103 = icmp ugt v102, v101  ; v101 = 0x0800_0000
+;;                                     v104 = iadd.i64 v46, v101  ; v101 = 0x0800_0000
+;;                                     v105 = iadd.i64 v47, v101  ; v101 = 0x0800_0000
+;; @0025                               brif v103, block4(v104, v105, v102, v74), block5(v104, v105, v102, v74)
 ;;
 ;;                                 block8:
-;; @0025                               store.i64 notrap aligned v64, v5
-;; @0025                               v69 = call fn0(v0)
-;; @0025                               v71 = load.i64 notrap aligned v5
-;; @0025                               jump block9(v71)
+;; @0025                               store.i64 notrap aligned v66, v5
+;; @0025                               v71 = call fn0(v0)
+;; @0025                               v73 = load.i64 notrap aligned v5
+;; @0025                               jump block9(v73)
 ;;
-;;                                 block9(v74: i64):
-;; @0025                               call fn1(v0, v60, v61, v62)
+;;                                 block9(v76: i64):
+;; @0025                               call fn1(v0, v62, v63, v64)
 ;; @0029                               jump block1
 ;;
 ;;                                 block1:
-;; @0029                               store.i64 notrap aligned v74, v5
+;; @0029                               store.i64 notrap aligned v76, v5
 ;; @0029                               return
 ;; }

--- a/tests/disas/memory_copy_host32.wat
+++ b/tests/disas/memory_copy_host32.wat
@@ -60,18 +60,18 @@
 ;; @0042                               v6 = load.i32 notrap aligned v0+44
 ;; @0042                               v7 = uextend.i64 v2
 ;; @0042                               v8 = uextend.i64 v4
-;; @0042                               v9 = iadd v7, v8
-;; @0042                               v10 = uextend.i64 v6
-;; @0042                               v11 = icmp ugt v9, v10
-;; @0042                               trapnz v11, heap_oob
-;; @0042                               v12 = load.i32 notrap aligned can_move v0+40
-;; @0042                               v17 = uextend.i64 v3
-;; @0042                               v19 = iadd v17, v8
-;; @0042                               v21 = icmp ugt v19, v10
-;; @0042                               trapnz v21, heap_oob
-;; @0042                               v14 = iadd v12, v2
-;; @0042                               v24 = iadd v12, v3
-;; @0042                               call fn0(v0, v14, v24, v4)
+;; @0042                               v10 = iadd v7, v8
+;; @0042                               v11 = uextend.i64 v6
+;; @0042                               v12 = icmp ugt v10, v11
+;; @0042                               trapnz v12, heap_oob
+;; @0042                               v13 = load.i32 notrap aligned can_move v0+40
+;; @0042                               v18 = uextend.i64 v3
+;; @0042                               v21 = iadd v18, v8
+;; @0042                               v23 = icmp ugt v21, v11
+;; @0042                               trapnz v23, heap_oob
+;; @0042                               v15 = iadd v13, v2
+;; @0042                               v26 = iadd v13, v3
+;; @0042                               call fn0(v0, v15, v26, v4)
 ;; @0046                               jump block1
 ;;
 ;;                                 block1:
@@ -91,21 +91,21 @@
 ;; @004f                               v6 = load.i32 notrap aligned v0+52
 ;; @004f                               v7 = uextend.i64 v2
 ;; @004f                               v8 = uextend.i64 v4
-;; @004f                               v9 = iadd v7, v8
-;; @004f                               v10 = uextend.i64 v6
-;; @004f                               v11 = icmp ugt v9, v10
-;; @004f                               trapnz v11, heap_oob
-;; @004f                               v12 = load.i32 notrap aligned can_move v0+48
-;; @004f                               v16 = load.i32 notrap aligned v0+44
-;; @004f                               v17 = uextend.i64 v3
-;; @004f                               v19 = iadd v17, v8
-;; @004f                               v20 = uextend.i64 v16
-;; @004f                               v21 = icmp ugt v19, v20
-;; @004f                               trapnz v21, heap_oob
-;; @004f                               v22 = load.i32 notrap aligned can_move v0+40
-;; @004f                               v14 = iadd v12, v2
-;; @004f                               v24 = iadd v22, v3
-;; @004f                               call fn0(v0, v14, v24, v4)
+;; @004f                               v10 = iadd v7, v8
+;; @004f                               v11 = uextend.i64 v6
+;; @004f                               v12 = icmp ugt v10, v11
+;; @004f                               trapnz v12, heap_oob
+;; @004f                               v13 = load.i32 notrap aligned can_move v0+48
+;; @004f                               v17 = load.i32 notrap aligned v0+44
+;; @004f                               v18 = uextend.i64 v3
+;; @004f                               v21 = iadd v18, v8
+;; @004f                               v22 = uextend.i64 v17
+;; @004f                               v23 = icmp ugt v21, v22
+;; @004f                               trapnz v23, heap_oob
+;; @004f                               v24 = load.i32 notrap aligned can_move v0+40
+;; @004f                               v15 = iadd v13, v2
+;; @004f                               v26 = iadd v24, v3
+;; @004f                               call fn0(v0, v15, v26, v4)
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:
@@ -131,15 +131,15 @@
 ;; @005c                               v11 = load.i32 notrap aligned can_move v0+56
 ;; @005c                               v16 = load.i32 notrap aligned v0+44
 ;; @005c                               v17 = uextend.i64 v3
-;; @005c                               v19 = iadd v17, v5
-;; @005c                               v20 = uextend.i64 v16
-;; @005c                               v21 = icmp ugt v19, v20
-;; @005c                               trapnz v21, heap_oob
-;; @005c                               v22 = load.i32 notrap aligned can_move v0+40
+;; @005c                               v20 = iadd v17, v5
+;; @005c                               v21 = uextend.i64 v16
+;; @005c                               v22 = icmp ugt v20, v21
+;; @005c                               trapnz v22, heap_oob
+;; @005c                               v23 = load.i32 notrap aligned can_move v0+40
 ;; @005c                               v12 = ireduce.i32 v2
 ;; @005c                               v14 = iadd v11, v12
-;; @005c                               v24 = iadd v22, v3
-;; @005c                               call fn0(v0, v14, v24, v4)
+;; @005c                               v25 = iadd v23, v3
+;; @005c                               call fn0(v0, v14, v25, v4)
 ;; @0060                               jump block1
 ;;
 ;;                                 block1:
@@ -222,21 +222,21 @@
 ;; @0083                               v7 = load.i32 notrap aligned v0+44
 ;; @0083                               v8 = uextend.i64 v2
 ;; @0083                               v5 = uextend.i64 v4
-;; @0083                               v10 = iadd v8, v5
-;; @0083                               v11 = uextend.i64 v7
-;; @0083                               v12 = icmp ugt v10, v11
-;; @0083                               trapnz v12, heap_oob
-;; @0083                               v13 = load.i32 notrap aligned can_move v0+40
-;; @0083                               v17 = load.i32 notrap aligned v0+60
-;; @0083                               v18 = uadd_overflow_trap v3, v5, heap_oob
-;; @0083                               v19 = uextend.i64 v17
-;; @0083                               v20 = icmp ugt v18, v19
-;; @0083                               trapnz v20, heap_oob
-;; @0083                               v21 = load.i32 notrap aligned can_move v0+56
-;; @0083                               v15 = iadd v13, v2
-;; @0083                               v22 = ireduce.i32 v3
-;; @0083                               v24 = iadd v21, v22
-;; @0083                               call fn0(v0, v15, v24, v4)
+;; @0083                               v11 = iadd v8, v5
+;; @0083                               v12 = uextend.i64 v7
+;; @0083                               v13 = icmp ugt v11, v12
+;; @0083                               trapnz v13, heap_oob
+;; @0083                               v14 = load.i32 notrap aligned can_move v0+40
+;; @0083                               v18 = load.i32 notrap aligned v0+60
+;; @0083                               v19 = uadd_overflow_trap v3, v5, heap_oob
+;; @0083                               v20 = uextend.i64 v18
+;; @0083                               v21 = icmp ugt v19, v20
+;; @0083                               trapnz v21, heap_oob
+;; @0083                               v22 = load.i32 notrap aligned can_move v0+56
+;; @0083                               v16 = iadd v14, v2
+;; @0083                               v23 = ireduce.i32 v3
+;; @0083                               v25 = iadd v22, v23
+;; @0083                               call fn0(v0, v16, v25, v4)
 ;; @0087                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/memory_copy_host64.wat
+++ b/tests/disas/memory_copy_host64.wat
@@ -64,17 +64,17 @@
 ;; @0042                               v6 = load.i64 notrap aligned v0+88
 ;; @0042                               v7 = uextend.i64 v2
 ;; @0042                               v8 = uextend.i64 v4
-;; @0042                               v9 = iadd v7, v8
-;; @0042                               v10 = icmp ugt v9, v6
-;; @0042                               trapnz v10, heap_oob
-;; @0042                               v17 = uextend.i64 v3
-;; @0042                               v19 = iadd v17, v8
-;; @0042                               v20 = icmp ugt v19, v6
-;; @0042                               trapnz v20, heap_oob
-;; @0042                               v11 = load.i64 notrap aligned readonly can_move v0+80
-;; @0042                               v14 = iadd v11, v7
-;; @0042                               v24 = iadd v11, v17
-;; @0042                               call fn0(v0, v14, v24, v8)
+;; @0042                               v10 = iadd v7, v8
+;; @0042                               v11 = icmp ugt v10, v6
+;; @0042                               trapnz v11, heap_oob
+;; @0042                               v18 = uextend.i64 v3
+;; @0042                               v21 = iadd v18, v8
+;; @0042                               v22 = icmp ugt v21, v6
+;; @0042                               trapnz v22, heap_oob
+;; @0042                               v12 = load.i64 notrap aligned readonly can_move v0+80
+;; @0042                               v15 = iadd v12, v7
+;; @0042                               v26 = iadd v12, v18
+;; @0042                               call fn0(v0, v15, v26, v8)
 ;; @0046                               jump block1
 ;;
 ;;                                 block1:
@@ -98,19 +98,19 @@
 ;; @004f                               v6 = load.i64 notrap aligned v0+104
 ;; @004f                               v7 = uextend.i64 v2
 ;; @004f                               v8 = uextend.i64 v4
-;; @004f                               v9 = iadd v7, v8
-;; @004f                               v10 = icmp ugt v9, v6
-;; @004f                               trapnz v10, heap_oob
-;; @004f                               v16 = load.i64 notrap aligned v0+88
-;; @004f                               v17 = uextend.i64 v3
-;; @004f                               v19 = iadd v17, v8
-;; @004f                               v20 = icmp ugt v19, v16
-;; @004f                               trapnz v20, heap_oob
-;; @004f                               v11 = load.i64 notrap aligned readonly can_move v0+96
-;; @004f                               v14 = iadd v11, v7
-;; @004f                               v21 = load.i64 notrap aligned readonly can_move v0+80
-;; @004f                               v24 = iadd v21, v17
-;; @004f                               call fn0(v0, v14, v24, v8)
+;; @004f                               v10 = iadd v7, v8
+;; @004f                               v11 = icmp ugt v10, v6
+;; @004f                               trapnz v11, heap_oob
+;; @004f                               v17 = load.i64 notrap aligned v0+88
+;; @004f                               v18 = uextend.i64 v3
+;; @004f                               v21 = iadd v18, v8
+;; @004f                               v22 = icmp ugt v21, v17
+;; @004f                               trapnz v22, heap_oob
+;; @004f                               v12 = load.i64 notrap aligned readonly can_move v0+96
+;; @004f                               v15 = iadd v12, v7
+;; @004f                               v23 = load.i64 notrap aligned readonly can_move v0+80
+;; @004f                               v26 = iadd v23, v18
+;; @004f                               call fn0(v0, v15, v26, v8)
 ;; @0053                               jump block1
 ;;
 ;;                                 block1:
@@ -139,13 +139,13 @@
 ;; @005c                               v10 = load.i64 notrap aligned can_move v0+112
 ;; @005c                               v14 = load.i64 notrap aligned v0+88
 ;; @005c                               v15 = uextend.i64 v3
-;; @005c                               v17 = iadd v15, v5
-;; @005c                               v18 = icmp ugt v17, v14
-;; @005c                               trapnz v18, heap_oob
+;; @005c                               v18 = iadd v15, v5
+;; @005c                               v19 = icmp ugt v18, v14
+;; @005c                               trapnz v19, heap_oob
 ;; @005c                               v12 = iadd v10, v2
-;; @005c                               v19 = load.i64 notrap aligned readonly can_move v0+80
-;; @005c                               v22 = iadd v19, v15
-;; @005c                               call fn0(v0, v12, v22, v5)
+;; @005c                               v20 = load.i64 notrap aligned readonly can_move v0+80
+;; @005c                               v23 = iadd v20, v15
+;; @005c                               call fn0(v0, v12, v23, v5)
 ;; @0060                               jump block1
 ;;
 ;;                                 block1:
@@ -231,18 +231,18 @@
 ;; @0083                               v7 = load.i64 notrap aligned v0+88
 ;; @0083                               v8 = uextend.i64 v2
 ;; @0083                               v5 = uextend.i64 v4
-;; @0083                               v10 = iadd v8, v5
-;; @0083                               v11 = icmp ugt v10, v7
-;; @0083                               trapnz v11, heap_oob
-;; @0083                               v17 = load.i64 notrap aligned v0+120
-;; @0083                               v18 = uadd_overflow_trap v3, v5, heap_oob
-;; @0083                               v19 = icmp ugt v18, v17
-;; @0083                               trapnz v19, heap_oob
-;; @0083                               v20 = load.i64 notrap aligned can_move v0+112
-;; @0083                               v12 = load.i64 notrap aligned readonly can_move v0+80
-;; @0083                               v15 = iadd v12, v8
-;; @0083                               v22 = iadd v20, v3
-;; @0083                               call fn0(v0, v15, v22, v5)
+;; @0083                               v11 = iadd v8, v5
+;; @0083                               v12 = icmp ugt v11, v7
+;; @0083                               trapnz v12, heap_oob
+;; @0083                               v18 = load.i64 notrap aligned v0+120
+;; @0083                               v19 = uadd_overflow_trap v3, v5, heap_oob
+;; @0083                               v20 = icmp ugt v19, v18
+;; @0083                               trapnz v20, heap_oob
+;; @0083                               v21 = load.i64 notrap aligned can_move v0+112
+;; @0083                               v13 = load.i64 notrap aligned readonly can_move v0+80
+;; @0083                               v16 = iadd v13, v8
+;; @0083                               v23 = iadd v21, v3
+;; @0083                               call fn0(v0, v16, v23, v5)
 ;; @0087                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/memory_fill_host32.wat
+++ b/tests/disas/memory_fill_host32.wat
@@ -57,14 +57,14 @@
 ;; @003c                               v6 = load.i32 notrap aligned v0+48
 ;; @003c                               v7 = uextend.i64 v2
 ;; @003c                               v8 = uextend.i64 v3
-;; @003c                               v9 = iadd v7, v8
-;; @003c                               v10 = uextend.i64 v6
-;; @003c                               v11 = icmp ugt v9, v10
-;; @003c                               trapnz v11, heap_oob
-;; @003c                               v12 = load.i32 notrap aligned can_move v0+44
-;; @003c                               v14 = iadd v12, v2
+;; @003c                               v10 = iadd v7, v8
+;; @003c                               v11 = uextend.i64 v6
+;; @003c                               v12 = icmp ugt v10, v11
+;; @003c                               trapnz v12, heap_oob
+;; @003c                               v13 = load.i32 notrap aligned can_move v0+44
+;; @003c                               v15 = iadd v13, v2
 ;; @0038                               v4 = iconst.i32 0
-;; @003c                               call fn0(v0, v14, v4, v3)  ; v4 = 0
+;; @003c                               call fn0(v0, v15, v4, v3)  ; v4 = 0
 ;; @003f                               jump block1
 ;;
 ;;                                 block1:
@@ -107,14 +107,14 @@
 ;; @0054                               v6 = load.i32 notrap aligned v0+64
 ;; @0054                               v7 = uextend.i64 v2
 ;; @0054                               v8 = uextend.i64 v3
-;; @0054                               v9 = iadd v7, v8
-;; @0054                               v10 = uextend.i64 v6
-;; @0054                               v11 = icmp ugt v9, v10
-;; @0054                               trapnz v11, heap_oob
-;; @0054                               v12 = load.i32 notrap aligned can_move v0+60
-;; @0054                               v14 = iadd v12, v2
+;; @0054                               v10 = iadd v7, v8
+;; @0054                               v11 = uextend.i64 v6
+;; @0054                               v12 = icmp ugt v10, v11
+;; @0054                               trapnz v12, heap_oob
+;; @0054                               v13 = load.i32 notrap aligned can_move v0+60
+;; @0054                               v15 = iadd v13, v2
 ;; @0050                               v4 = iconst.i32 0
-;; @0054                               call fn0(v0, v14, v4, v3)  ; v4 = 0
+;; @0054                               call fn0(v0, v15, v4, v3)  ; v4 = 0
 ;; @0057                               jump block1
 ;;
 ;;                                 block1:
@@ -157,14 +157,14 @@
 ;; @006c                               v6 = load.i32 notrap aligned v0+80
 ;; @006c                               v7 = uextend.i64 v2
 ;; @006c                               v8 = uextend.i64 v3
-;; @006c                               v9 = iadd v7, v8
-;; @006c                               v10 = uextend.i64 v6
-;; @006c                               v11 = icmp ugt v9, v10
-;; @006c                               trapnz v11, heap_oob
-;; @006c                               v12 = load.i32 notrap aligned readonly can_move v0+76
-;; @006c                               v14 = iadd v12, v2
+;; @006c                               v10 = iadd v7, v8
+;; @006c                               v11 = uextend.i64 v6
+;; @006c                               v12 = icmp ugt v10, v11
+;; @006c                               trapnz v12, heap_oob
+;; @006c                               v13 = load.i32 notrap aligned readonly can_move v0+76
+;; @006c                               v15 = iadd v13, v2
 ;; @0068                               v4 = iconst.i32 0
-;; @006c                               call fn0(v0, v14, v4, v3)  ; v4 = 0
+;; @006c                               call fn0(v0, v15, v4, v3)  ; v4 = 0
 ;; @006f                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/memory_fill_host64.wat
+++ b/tests/disas/memory_fill_host64.wat
@@ -58,13 +58,13 @@
 ;; @003c                               v6 = load.i64 notrap aligned v0+96
 ;; @003c                               v7 = uextend.i64 v2
 ;; @003c                               v8 = uextend.i64 v3
-;; @003c                               v9 = iadd v7, v8
-;; @003c                               v10 = icmp ugt v9, v6
-;; @003c                               trapnz v10, heap_oob
-;; @003c                               v11 = load.i64 notrap aligned readonly can_move v0+88
-;; @003c                               v14 = iadd v11, v7
+;; @003c                               v10 = iadd v7, v8
+;; @003c                               v11 = icmp ugt v10, v6
+;; @003c                               trapnz v11, heap_oob
+;; @003c                               v12 = load.i64 notrap aligned readonly can_move v0+88
+;; @003c                               v15 = iadd v12, v7
 ;; @0038                               v4 = iconst.i32 0
-;; @003c                               call fn0(v0, v14, v4, v8)  ; v4 = 0
+;; @003c                               call fn0(v0, v15, v4, v8)  ; v4 = 0
 ;; @003f                               jump block1
 ;;
 ;;                                 block1:
@@ -112,13 +112,13 @@
 ;; @0054                               v6 = load.i64 notrap aligned v0+128
 ;; @0054                               v7 = uextend.i64 v2
 ;; @0054                               v8 = uextend.i64 v3
-;; @0054                               v9 = iadd v7, v8
-;; @0054                               v10 = icmp ugt v9, v6
-;; @0054                               trapnz v10, heap_oob
-;; @0054                               v11 = load.i64 notrap aligned readonly can_move v0+120
-;; @0054                               v14 = iadd v11, v7
+;; @0054                               v10 = iadd v7, v8
+;; @0054                               v11 = icmp ugt v10, v6
+;; @0054                               trapnz v11, heap_oob
+;; @0054                               v12 = load.i64 notrap aligned readonly can_move v0+120
+;; @0054                               v15 = iadd v12, v7
 ;; @0050                               v4 = iconst.i32 0
-;; @0054                               call fn0(v0, v14, v4, v8)  ; v4 = 0
+;; @0054                               call fn0(v0, v15, v4, v8)  ; v4 = 0
 ;; @0057                               jump block1
 ;;
 ;;                                 block1:
@@ -166,13 +166,13 @@
 ;; @006c                               v6 = load.i64 notrap aligned v0+160
 ;; @006c                               v7 = uextend.i64 v2
 ;; @006c                               v8 = uextend.i64 v3
-;; @006c                               v9 = iadd v7, v8
-;; @006c                               v10 = icmp ugt v9, v6
-;; @006c                               trapnz v10, heap_oob
-;; @006c                               v11 = load.i64 notrap aligned readonly can_move v0+152
-;; @006c                               v14 = iadd v11, v7
+;; @006c                               v10 = iadd v7, v8
+;; @006c                               v11 = icmp ugt v10, v6
+;; @006c                               trapnz v11, heap_oob
+;; @006c                               v12 = load.i64 notrap aligned readonly can_move v0+152
+;; @006c                               v15 = iadd v12, v7
 ;; @0068                               v4 = iconst.i32 0
-;; @006c                               call fn0(v0, v14, v4, v8)  ; v4 = 0
+;; @006c                               call fn0(v0, v15, v4, v8)  ; v4 = 0
 ;; @006f                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/passive-data.wat
+++ b/tests/disas/passive-data.wat
@@ -28,27 +28,29 @@
 ;; @003d                               v6 = load.i64 notrap aligned v0+64
 ;; @003d                               v7 = uextend.i64 v2
 ;; @003d                               v8 = uextend.i64 v4
-;; @003d                               v9 = iadd v7, v8
-;; @003d                               v10 = icmp ugt v9, v6
-;; @003d                               trapnz v10, heap_oob
-;; @003d                               v11 = load.i64 notrap aligned readonly can_move v0+56
-;; @003d                               v12 = uextend.i64 v2
+;;                                     v32 = iconst.i64 1
+;; @003d                               v9 = imul v8, v32  ; v32 = 1
+;; @003d                               v10 = iadd v7, v9
+;; @003d                               v11 = icmp ugt v10, v6
+;; @003d                               trapnz v11, heap_oob
+;; @003d                               v12 = load.i64 notrap aligned readonly can_move v0+56
+;; @003d                               v13 = uextend.i64 v2
+;;                                     v30 = iconst.i64 1
+;; @003d                               v14 = imul v13, v30  ; v30 = 1
+;; @003d                               v15 = iadd v12, v14
+;; @003d                               v17 = uload32 notrap aligned v0+152
+;; @003d                               v18 = uextend.i64 v3
+;; @003d                               v19 = uextend.i64 v4
 ;;                                     v29 = iconst.i64 1
-;; @003d                               v13 = imul v12, v29  ; v29 = 1
-;; @003d                               v14 = iadd v11, v13
-;; @003d                               v16 = uload32 notrap aligned v0+152
-;; @003d                               v17 = uextend.i64 v3
-;; @003d                               v18 = uextend.i64 v4
-;; @003d                               v19 = iadd v17, v18
-;; @003d                               v20 = icmp ugt v19, v16
-;; @003d                               trapnz v20, heap_oob
-;; @003d                               v22 = load.i64 notrap aligned v0+144
-;; @003d                               v23 = uextend.i64 v3
-;;                                     v28 = iconst.i64 1
-;; @003d                               v24 = imul v23, v28  ; v28 = 1
-;; @003d                               v25 = iadd v22, v24
-;; @003d                               v26 = uextend.i64 v4
-;; @003d                               call fn0(v0, v14, v25, v26)
+;; @003d                               v20 = imul v19, v29  ; v29 = 1
+;; @003d                               v21 = iadd v18, v20
+;; @003d                               v22 = icmp ugt v21, v17
+;; @003d                               trapnz v22, heap_oob
+;; @003d                               v24 = load.i64 notrap aligned v0+144
+;; @003d                               v25 = uextend.i64 v3
+;; @003d                               v26 = iadd v24, v25
+;; @003d                               v27 = uextend.i64 v4
+;; @003d                               call fn0(v0, v15, v26, v27)
 ;; @0041                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/table-copy.wat
+++ b/tests/disas/table-copy.wat
@@ -76,112 +76,117 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
-;; @0090                               v97 = load.i64 notrap aligned readonly can_move v0+48
-;; @0090                               v7 = load.i64 notrap aligned v97+8
+;; @0090                               v102 = load.i64 notrap aligned readonly can_move v0+48
+;; @0090                               v7 = load.i64 notrap aligned v102+8
 ;; @0090                               v8 = ireduce.i32 v7
 ;; @0090                               v9 = uextend.i64 v8
 ;; @0090                               v10 = uextend.i64 v3
 ;; @0090                               v11 = uextend.i64 v5
-;; @0090                               v12 = iadd v10, v11
-;; @0090                               v13 = icmp ugt v12, v9
-;; @0090                               trapnz v13, user6
-;; @0090                               v95 = load.i64 notrap aligned readonly can_move v0+48
-;; @0090                               v14 = load.i64 notrap aligned v95
-;; @0090                               v15 = uextend.i64 v3
-;;                                     v94 = iconst.i64 8
-;; @0090                               v16 = imul v15, v94  ; v94 = 8
-;; @0090                               v17 = iadd v14, v16
-;; @0090                               v18 = iconst.i32 6
-;; @0090                               v19 = uextend.i64 v18  ; v18 = 6
-;; @0090                               v20 = uextend.i64 v4
-;; @0090                               v21 = uextend.i64 v5
-;; @0090                               v22 = iadd v20, v21
-;; @0090                               v23 = icmp ugt v22, v19
-;; @0090                               trapnz v23, user6
-;; @0090                               v24 = load.i64 notrap aligned readonly can_move v0+72
-;; @0090                               v25 = uextend.i64 v4
-;;                                     v92 = iconst.i64 8
-;; @0090                               v26 = imul v25, v92  ; v92 = 8
-;; @0090                               v27 = iadd v24, v26
-;; @0090                               v28 = uextend.i64 v5
-;; @0090                               v29 = iconst.i64 8
-;; @0090                               brif v28, block2, block5
+;;                                     v101 = iconst.i64 1
+;; @0090                               v12 = imul v11, v101  ; v101 = 1
+;; @0090                               v13 = iadd v10, v12
+;; @0090                               v14 = icmp ugt v13, v9
+;; @0090                               trapnz v14, user6
+;; @0090                               v99 = load.i64 notrap aligned readonly can_move v0+48
+;; @0090                               v15 = load.i64 notrap aligned v99
+;; @0090                               v16 = uextend.i64 v3
+;;                                     v98 = iconst.i64 8
+;; @0090                               v17 = imul v16, v98  ; v98 = 8
+;; @0090                               v18 = iadd v15, v17
+;; @0090                               v19 = iconst.i32 6
+;; @0090                               v20 = uextend.i64 v19  ; v19 = 6
+;; @0090                               v21 = uextend.i64 v4
+;; @0090                               v22 = uextend.i64 v5
+;;                                     v97 = iconst.i64 1
+;; @0090                               v23 = imul v22, v97  ; v97 = 1
+;; @0090                               v24 = iadd v21, v23
+;; @0090                               v25 = icmp ugt v24, v20
+;; @0090                               trapnz v25, user6
+;; @0090                               v26 = load.i64 notrap aligned readonly can_move v0+72
+;; @0090                               v27 = uextend.i64 v4
+;;                                     v95 = iconst.i64 8
+;; @0090                               v28 = imul v27, v95  ; v95 = 8
+;; @0090                               v29 = iadd v26, v28
+;; @0090                               v30 = uextend.i64 v5
+;; @0090                               v31 = iconst.i64 8
+;; @0090                               v32 = imul v31, v30  ; v31 = 8
+;; @0090                               brif v30, block2, block5
 ;;
 ;;                                 block2:
-;; @0090                               v30 = icmp.i64 ult v17, v27
-;; @0090                               v31 = imul.i64 v28, v29  ; v29 = 8
-;; @0090                               v32 = iadd.i64 v17, v31
-;; @0090                               v33 = iadd.i64 v27, v31
-;; @0090                               v34 = ireduce.i32 v28
-;; @0090                               v35 = iadd.i32 v4, v34
-;; @0090                               brif v30, block3(v17, v27, v4), block4(v32, v33, v35)
+;; @0090                               v33 = icmp.i64 ult v18, v29
+;; @0090                               v34 = imul.i64 v30, v31  ; v31 = 8
+;; @0090                               v35 = iadd.i64 v18, v34
+;; @0090                               v36 = iadd.i64 v29, v34
+;; @0090                               v37 = ireduce.i32 v30
+;; @0090                               v38 = iadd.i32 v4, v37
+;; @0090                               brif v33, block3(v18, v29, v4), block4(v35, v36, v38)
 ;;
-;;                                 block3(v36: i64, v37: i64, v38: i32):
-;; @0090                               v39 = iconst.i32 6
-;; @0090                               v40 = icmp uge v38, v39  ; v39 = 6
-;; @0090                               v41 = uextend.i64 v38
-;; @0090                               v42 = load.i64 notrap aligned readonly can_move v0+72
+;;                                 block3(v39: i64, v40: i64, v41: i32):
+;; @0090                               v42 = iconst.i32 6
+;; @0090                               v43 = icmp uge v41, v42  ; v42 = 6
+;; @0090                               v44 = uextend.i64 v41
+;; @0090                               v45 = load.i64 notrap aligned readonly can_move v0+72
+;;                                     v93 = iconst.i64 3
+;; @0090                               v46 = ishl v44, v93  ; v93 = 3
+;; @0090                               v47 = iadd v45, v46
+;; @0090                               v48 = iconst.i64 0
+;; @0090                               v49 = select_spectre_guard v43, v48, v47  ; v48 = 0
+;; @0090                               v50 = load.i64 user6 aligned table v49
+;;                                     v92 = iconst.i64 -2
+;; @0090                               v51 = band v50, v92  ; v92 = -2
+;; @0090                               brif v50, block7(v51), block6
+;;
+;;                                 block4(v62: i64, v63: i64, v64: i32):
+;; @0090                               v65 = isub v62, v31  ; v31 = 8
+;; @0090                               v66 = isub v63, v31  ; v31 = 8
+;; @0090                               v67 = iconst.i32 1
+;; @0090                               v68 = isub v64, v67  ; v67 = 1
+;; @0090                               v69 = iconst.i32 6
+;; @0090                               v70 = icmp uge v68, v69  ; v69 = 6
+;; @0090                               v71 = uextend.i64 v68
+;; @0090                               v72 = load.i64 notrap aligned readonly can_move v0+72
 ;;                                     v90 = iconst.i64 3
-;; @0090                               v43 = ishl v41, v90  ; v90 = 3
-;; @0090                               v44 = iadd v42, v43
-;; @0090                               v45 = iconst.i64 0
-;; @0090                               v46 = select_spectre_guard v40, v45, v44  ; v45 = 0
-;; @0090                               v47 = load.i64 user6 aligned table v46
+;; @0090                               v73 = ishl v71, v90  ; v90 = 3
+;; @0090                               v74 = iadd v72, v73
+;; @0090                               v75 = iconst.i64 0
+;; @0090                               v76 = select_spectre_guard v70, v75, v74  ; v75 = 0
+;; @0090                               v77 = load.i64 user6 aligned table v76
 ;;                                     v89 = iconst.i64 -2
-;; @0090                               v48 = band v47, v89  ; v89 = -2
-;; @0090                               brif v47, block7(v48), block6
-;;
-;;                                 block4(v59: i64, v60: i64, v61: i32):
-;; @0090                               v62 = isub v59, v29  ; v29 = 8
-;; @0090                               v63 = isub v60, v29  ; v29 = 8
-;; @0090                               v64 = iconst.i32 1
-;; @0090                               v65 = isub v61, v64  ; v64 = 1
-;; @0090                               v66 = iconst.i32 6
-;; @0090                               v67 = icmp uge v65, v66  ; v66 = 6
-;; @0090                               v68 = uextend.i64 v65
-;; @0090                               v69 = load.i64 notrap aligned readonly can_move v0+72
-;;                                     v87 = iconst.i64 3
-;; @0090                               v70 = ishl v68, v87  ; v87 = 3
-;; @0090                               v71 = iadd v69, v70
-;; @0090                               v72 = iconst.i64 0
-;; @0090                               v73 = select_spectre_guard v67, v72, v71  ; v72 = 0
-;; @0090                               v74 = load.i64 user6 aligned table v73
-;;                                     v86 = iconst.i64 -2
-;; @0090                               v75 = band v74, v86  ; v86 = -2
-;; @0090                               brif v74, block9(v75), block8
+;; @0090                               v78 = band v77, v89  ; v89 = -2
+;; @0090                               brif v77, block9(v78), block8
 ;;
 ;;                                 block5:
 ;; @0094                               jump block1
 ;;
 ;;                                 block6 cold:
-;; @0090                               v50 = iconst.i32 1
-;; @0090                               v52 = uextend.i64 v38
-;; @0090                               v53 = call fn0(v0, v50, v52)  ; v50 = 1
-;; @0090                               jump block7(v53)
+;; @0090                               v53 = iconst.i32 1
+;; @0090                               v55 = uextend.i64 v41
+;; @0090                               v56 = call fn0(v0, v53, v55)  ; v53 = 1
+;; @0090                               jump block7(v56)
 ;;
-;;                                 block7(v49: i64):
-;;                                     v85 = iconst.i64 1
-;; @0090                               v54 = bor v49, v85  ; v85 = 1
-;; @0090                               store notrap aligned v54, v36
-;; @0090                               v55 = iadd.i64 v36, v29  ; v29 = 8
-;; @0090                               v56 = iadd.i64 v37, v29  ; v29 = 8
-;;                                     v84 = iconst.i32 1
-;; @0090                               v57 = iadd.i32 v38, v84  ; v84 = 1
-;; @0090                               v58 = icmp eq v56, v33
-;; @0090                               brif v58, block5, block3(v55, v56, v57)
+;;                                 block7(v52: i64):
+;;                                     v88 = iconst.i64 1
+;; @0090                               v57 = bor v52, v88  ; v88 = 1
+;; @0090                               store notrap aligned v57, v39
+;; @0090                               v58 = iadd.i64 v39, v31  ; v31 = 8
+;; @0090                               v59 = iadd.i64 v40, v31  ; v31 = 8
+;;                                     v87 = iconst.i32 1
+;; @0090                               v60 = iadd.i32 v41, v87  ; v87 = 1
+;; @0090                               v61 = icmp eq v59, v36
+;; @0090                               brif v61, block5, block3(v58, v59, v60)
 ;;
 ;;                                 block8 cold:
-;; @0090                               v77 = iconst.i32 1
-;; @0090                               v79 = uextend.i64 v65
-;; @0090                               v80 = call fn0(v0, v77, v79)  ; v77 = 1
-;; @0090                               jump block9(v80)
+;; @0090                               v80 = iconst.i32 1
+;; @0090                               v82 = uextend.i64 v68
+;; @0090                               v83 = call fn0(v0, v80, v82)  ; v80 = 1
+;; @0090                               jump block9(v83)
 ;;
-;;                                 block9(v76: i64):
-;;                                     v83 = iconst.i64 1
-;; @0090                               v81 = bor v76, v83  ; v83 = 1
-;; @0090                               store notrap aligned v81, v62
-;; @0090                               v82 = icmp.i64 eq v63, v27
-;; @0090                               brif v82, block5, block4(v62, v63, v65)
+;;                                 block9(v79: i64):
+;;                                     v86 = iconst.i64 1
+;; @0090                               v84 = bor v79, v86  ; v86 = 1
+;; @0090                               store notrap aligned v84, v65
+;; @0090                               v85 = icmp.i64 eq v66, v29
+;; @0090                               brif v85, block5, block4(v65, v66, v68)
 ;;
 ;;                                 block1:
 ;; @0094                               return v2
@@ -205,114 +210,119 @@
 ;; @009f                               v8 = uextend.i64 v7  ; v7 = 6
 ;; @009f                               v9 = uextend.i64 v3
 ;; @009f                               v10 = uextend.i64 v5
-;; @009f                               v11 = iadd v9, v10
-;; @009f                               v12 = icmp ugt v11, v8
-;; @009f                               trapnz v12, user6
-;; @009f                               v13 = load.i64 notrap aligned readonly can_move v0+72
-;; @009f                               v14 = uextend.i64 v3
-;;                                     v105 = iconst.i64 8
-;; @009f                               v15 = imul v14, v105  ; v105 = 8
-;; @009f                               v16 = iadd v13, v15
-;; @009f                               v103 = load.i64 notrap aligned readonly can_move v0+48
-;; @009f                               v17 = load.i64 notrap aligned v103+8
-;; @009f                               v18 = ireduce.i32 v17
-;; @009f                               v19 = uextend.i64 v18
-;; @009f                               v20 = uextend.i64 v4
-;; @009f                               v21 = uextend.i64 v5
-;; @009f                               v22 = iadd v20, v21
-;; @009f                               v23 = icmp ugt v22, v19
-;; @009f                               trapnz v23, user6
-;; @009f                               v101 = load.i64 notrap aligned readonly can_move v0+48
-;; @009f                               v24 = load.i64 notrap aligned v101
-;; @009f                               v25 = uextend.i64 v4
-;;                                     v100 = iconst.i64 8
-;; @009f                               v26 = imul v25, v100  ; v100 = 8
-;; @009f                               v27 = iadd v24, v26
-;; @009f                               v28 = uextend.i64 v5
-;; @009f                               v29 = iconst.i64 8
-;; @009f                               brif v28, block2, block5
+;;                                     v111 = iconst.i64 1
+;; @009f                               v11 = imul v10, v111  ; v111 = 1
+;; @009f                               v12 = iadd v9, v11
+;; @009f                               v13 = icmp ugt v12, v8
+;; @009f                               trapnz v13, user6
+;; @009f                               v14 = load.i64 notrap aligned readonly can_move v0+72
+;; @009f                               v15 = uextend.i64 v3
+;;                                     v109 = iconst.i64 8
+;; @009f                               v16 = imul v15, v109  ; v109 = 8
+;; @009f                               v17 = iadd v14, v16
+;; @009f                               v107 = load.i64 notrap aligned readonly can_move v0+48
+;; @009f                               v18 = load.i64 notrap aligned v107+8
+;; @009f                               v19 = ireduce.i32 v18
+;; @009f                               v20 = uextend.i64 v19
+;; @009f                               v21 = uextend.i64 v4
+;; @009f                               v22 = uextend.i64 v5
+;;                                     v106 = iconst.i64 1
+;; @009f                               v23 = imul v22, v106  ; v106 = 1
+;; @009f                               v24 = iadd v21, v23
+;; @009f                               v25 = icmp ugt v24, v20
+;; @009f                               trapnz v25, user6
+;; @009f                               v104 = load.i64 notrap aligned readonly can_move v0+48
+;; @009f                               v26 = load.i64 notrap aligned v104
+;; @009f                               v27 = uextend.i64 v4
+;;                                     v103 = iconst.i64 8
+;; @009f                               v28 = imul v27, v103  ; v103 = 8
+;; @009f                               v29 = iadd v26, v28
+;; @009f                               v30 = uextend.i64 v5
+;; @009f                               v31 = iconst.i64 8
+;; @009f                               v32 = imul v31, v30  ; v31 = 8
+;; @009f                               brif v30, block2, block5
 ;;
 ;;                                 block2:
-;; @009f                               v30 = icmp.i64 ult v16, v27
-;; @009f                               v31 = imul.i64 v28, v29  ; v29 = 8
-;; @009f                               v32 = iadd.i64 v16, v31
-;; @009f                               v33 = iadd.i64 v27, v31
-;; @009f                               v34 = ireduce.i32 v28
-;; @009f                               v35 = iadd.i32 v4, v34
-;; @009f                               brif v30, block3(v16, v27, v4), block4(v32, v33, v35)
+;; @009f                               v33 = icmp.i64 ult v17, v29
+;; @009f                               v34 = imul.i64 v30, v31  ; v31 = 8
+;; @009f                               v35 = iadd.i64 v17, v34
+;; @009f                               v36 = iadd.i64 v29, v34
+;; @009f                               v37 = ireduce.i32 v30
+;; @009f                               v38 = iadd.i32 v4, v37
+;; @009f                               brif v33, block3(v17, v29, v4), block4(v35, v36, v38)
 ;;
-;;                                 block3(v36: i64, v37: i64, v38: i32):
-;; @009f                               v98 = load.i64 notrap aligned readonly can_move v0+48
-;; @009f                               v39 = load.i64 notrap aligned v98+8
-;; @009f                               v40 = ireduce.i32 v39
-;; @009f                               v41 = icmp uge v38, v40
-;; @009f                               v42 = uextend.i64 v38
-;; @009f                               v96 = load.i64 notrap aligned readonly can_move v0+48
-;; @009f                               v43 = load.i64 notrap aligned v96
-;;                                     v95 = iconst.i64 3
-;; @009f                               v44 = ishl v42, v95  ; v95 = 3
-;; @009f                               v45 = iadd v43, v44
-;; @009f                               v46 = iconst.i64 0
-;; @009f                               v47 = select_spectre_guard v41, v46, v45  ; v46 = 0
-;; @009f                               v48 = load.i64 user6 aligned table v47
-;;                                     v94 = iconst.i64 -2
-;; @009f                               v49 = band v48, v94  ; v94 = -2
-;; @009f                               brif v48, block7(v49), block6
+;;                                 block3(v39: i64, v40: i64, v41: i32):
+;; @009f                               v101 = load.i64 notrap aligned readonly can_move v0+48
+;; @009f                               v42 = load.i64 notrap aligned v101+8
+;; @009f                               v43 = ireduce.i32 v42
+;; @009f                               v44 = icmp uge v41, v43
+;; @009f                               v45 = uextend.i64 v41
+;; @009f                               v99 = load.i64 notrap aligned readonly can_move v0+48
+;; @009f                               v46 = load.i64 notrap aligned v99
+;;                                     v98 = iconst.i64 3
+;; @009f                               v47 = ishl v45, v98  ; v98 = 3
+;; @009f                               v48 = iadd v46, v47
+;; @009f                               v49 = iconst.i64 0
+;; @009f                               v50 = select_spectre_guard v44, v49, v48  ; v49 = 0
+;; @009f                               v51 = load.i64 user6 aligned table v50
+;;                                     v97 = iconst.i64 -2
+;; @009f                               v52 = band v51, v97  ; v97 = -2
+;; @009f                               brif v51, block7(v52), block6
 ;;
-;;                                 block4(v60: i64, v61: i64, v62: i32):
-;; @009f                               v63 = isub v60, v29  ; v29 = 8
-;; @009f                               v64 = isub v61, v29  ; v29 = 8
-;; @009f                               v65 = iconst.i32 1
-;; @009f                               v66 = isub v62, v65  ; v65 = 1
-;; @009f                               v92 = load.i64 notrap aligned readonly can_move v0+48
-;; @009f                               v67 = load.i64 notrap aligned v92+8
-;; @009f                               v68 = ireduce.i32 v67
-;; @009f                               v69 = icmp uge v66, v68
-;; @009f                               v70 = uextend.i64 v66
-;; @009f                               v90 = load.i64 notrap aligned readonly can_move v0+48
-;; @009f                               v71 = load.i64 notrap aligned v90
-;;                                     v89 = iconst.i64 3
-;; @009f                               v72 = ishl v70, v89  ; v89 = 3
-;; @009f                               v73 = iadd v71, v72
-;; @009f                               v74 = iconst.i64 0
-;; @009f                               v75 = select_spectre_guard v69, v74, v73  ; v74 = 0
-;; @009f                               v76 = load.i64 user6 aligned table v75
-;;                                     v88 = iconst.i64 -2
-;; @009f                               v77 = band v76, v88  ; v88 = -2
-;; @009f                               brif v76, block9(v77), block8
+;;                                 block4(v63: i64, v64: i64, v65: i32):
+;; @009f                               v66 = isub v63, v31  ; v31 = 8
+;; @009f                               v67 = isub v64, v31  ; v31 = 8
+;; @009f                               v68 = iconst.i32 1
+;; @009f                               v69 = isub v65, v68  ; v68 = 1
+;; @009f                               v95 = load.i64 notrap aligned readonly can_move v0+48
+;; @009f                               v70 = load.i64 notrap aligned v95+8
+;; @009f                               v71 = ireduce.i32 v70
+;; @009f                               v72 = icmp uge v69, v71
+;; @009f                               v73 = uextend.i64 v69
+;; @009f                               v93 = load.i64 notrap aligned readonly can_move v0+48
+;; @009f                               v74 = load.i64 notrap aligned v93
+;;                                     v92 = iconst.i64 3
+;; @009f                               v75 = ishl v73, v92  ; v92 = 3
+;; @009f                               v76 = iadd v74, v75
+;; @009f                               v77 = iconst.i64 0
+;; @009f                               v78 = select_spectre_guard v72, v77, v76  ; v77 = 0
+;; @009f                               v79 = load.i64 user6 aligned table v78
+;;                                     v91 = iconst.i64 -2
+;; @009f                               v80 = band v79, v91  ; v91 = -2
+;; @009f                               brif v79, block9(v80), block8
 ;;
 ;;                                 block5:
 ;; @00a3                               jump block1
 ;;
 ;;                                 block6 cold:
-;; @009f                               v51 = iconst.i32 0
-;; @009f                               v53 = uextend.i64 v38
-;; @009f                               v54 = call fn0(v0, v51, v53)  ; v51 = 0
-;; @009f                               jump block7(v54)
+;; @009f                               v54 = iconst.i32 0
+;; @009f                               v56 = uextend.i64 v41
+;; @009f                               v57 = call fn0(v0, v54, v56)  ; v54 = 0
+;; @009f                               jump block7(v57)
 ;;
-;;                                 block7(v50: i64):
-;;                                     v87 = iconst.i64 1
-;; @009f                               v55 = bor v50, v87  ; v87 = 1
-;; @009f                               store notrap aligned v55, v36
-;; @009f                               v56 = iadd.i64 v36, v29  ; v29 = 8
-;; @009f                               v57 = iadd.i64 v37, v29  ; v29 = 8
-;;                                     v86 = iconst.i32 1
-;; @009f                               v58 = iadd.i32 v38, v86  ; v86 = 1
-;; @009f                               v59 = icmp eq v57, v33
-;; @009f                               brif v59, block5, block3(v56, v57, v58)
+;;                                 block7(v53: i64):
+;;                                     v90 = iconst.i64 1
+;; @009f                               v58 = bor v53, v90  ; v90 = 1
+;; @009f                               store notrap aligned v58, v39
+;; @009f                               v59 = iadd.i64 v39, v31  ; v31 = 8
+;; @009f                               v60 = iadd.i64 v40, v31  ; v31 = 8
+;;                                     v89 = iconst.i32 1
+;; @009f                               v61 = iadd.i32 v41, v89  ; v89 = 1
+;; @009f                               v62 = icmp eq v60, v36
+;; @009f                               brif v62, block5, block3(v59, v60, v61)
 ;;
 ;;                                 block8 cold:
-;; @009f                               v79 = iconst.i32 0
-;; @009f                               v81 = uextend.i64 v66
-;; @009f                               v82 = call fn0(v0, v79, v81)  ; v79 = 0
-;; @009f                               jump block9(v82)
+;; @009f                               v82 = iconst.i32 0
+;; @009f                               v84 = uextend.i64 v69
+;; @009f                               v85 = call fn0(v0, v82, v84)  ; v82 = 0
+;; @009f                               jump block9(v85)
 ;;
-;;                                 block9(v78: i64):
-;;                                     v85 = iconst.i64 1
-;; @009f                               v83 = bor v78, v85  ; v85 = 1
-;; @009f                               store notrap aligned v83, v63
-;; @009f                               v84 = icmp.i64 eq v64, v27
-;; @009f                               brif v84, block5, block4(v63, v64, v66)
+;;                                 block9(v81: i64):
+;;                                     v88 = iconst.i64 1
+;; @009f                               v86 = bor v81, v88  ; v88 = 1
+;; @009f                               store notrap aligned v86, v66
+;; @009f                               v87 = icmp.i64 eq v67, v29
+;; @009f                               brif v87, block5, block4(v66, v67, v69)
 ;;
 ;;                                 block1:
 ;; @00a3                               return v2


### PR DESCRIPTION
This commit updates as necessary to route GC array copies/fills/etc through the `translate_entity_*` infrastructure. This helps ensure that everything stays in the same funnel to get fuel checks, bounds checks, epoch checks, etc. The primary purpose of this commit is refactoring and code deduplication.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
