### PR TITLE
Process passive element segments in compiled code

### DIFF
--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -2793,11 +2793,16 @@ impl FuncEnvironment<'_> {
         data_offset: ir::Value,
         len: ir::Value,
     ) -> WasmResult<ir::Value> {
-        gc::translate_array_new_data(
+        let interned_type_index = self.module.types[array_type_index].unwrap_module_type_index();
+        let array_layout = self.array_layout(interned_type_index)?.clone();
+        gc::translate_array_new_entity(
             self,
             builder,
             array_type_index,
-            data_index,
+            CheckedEntity::Data {
+                segment: data_index,
+                element_size: array_layout.elem_size,
+            },
             data_offset,
             len,
         )
@@ -2811,20 +2816,14 @@ impl FuncEnvironment<'_> {
         elem_offset: ir::Value,
         len: ir::Value,
     ) -> WasmResult<ir::Value> {
-        let libcall = gc::builtins::array_new_elem(self, builder.func)?;
-        let vmctx = self.vmctx_val(&mut builder.cursor());
-        let interned_type_index = self.module.types[array_type_index].unwrap_module_type_index();
-        let interned_type_index = builder
-            .ins()
-            .iconst(I32, i64::from(interned_type_index.as_u32()));
-        let elem_index = builder.ins().iconst(I32, i64::from(elem_index.as_u32()));
-        let call_inst = builder.ins().call(
-            libcall,
-            &[vmctx, interned_type_index, elem_index, elem_offset, len],
-        );
-        let array_ref = builder.func.dfg.first_result(call_inst);
-        builder.declare_value_needs_stack_map(array_ref);
-        Ok(array_ref)
+        gc::translate_array_new_entity(
+            self,
+            builder,
+            array_type_index,
+            CheckedEntity::Elem(elem_index),
+            elem_offset,
+            len,
+        )
     }
 
     pub fn translate_array_copy(
@@ -2920,26 +2919,19 @@ impl FuncEnvironment<'_> {
         elem_offset: ir::Value,
         len: ir::Value,
     ) -> WasmResult<()> {
-        let libcall = gc::builtins::array_init_elem(self, builder.func)?;
-        let vmctx = self.vmctx_val(&mut builder.cursor());
-        let interned_type_index = self.module.types[array_type_index].unwrap_module_type_index();
-        let interned_type_index = builder
-            .ins()
-            .iconst(I32, i64::from(interned_type_index.as_u32()));
-        let elem_index = builder.ins().iconst(I32, i64::from(elem_index.as_u32()));
-        builder.ins().call(
-            libcall,
-            &[
-                vmctx,
-                interned_type_index,
+        let ty = self.module.types[array_type_index].unwrap_module_type_index();
+        self.translate_entity_copy(
+            builder,
+            CheckedEntity::Array {
                 array,
-                dst_index,
-                elem_index,
-                elem_offset,
-                len,
-            ],
-        );
-        Ok(())
+                ty,
+                initialized: true,
+            },
+            CheckedEntity::Elem(elem_index),
+            dst_index,
+            elem_offset,
+            len,
+        )
     }
 
     pub fn translate_array_len(
@@ -3675,7 +3667,8 @@ impl FuncEnvironment<'_> {
                     },
                 )?;
             }
-            CheckedEntity::Data { .. } => unreachable!(),
+            // Not allowed to be written to in wasm.
+            CheckedEntity::Data { .. } | CheckedEntity::Elem(_) => unreachable!(),
         }
 
         Ok(())
@@ -3993,27 +3986,19 @@ impl FuncEnvironment<'_> {
 
             // Tables/arrays are sometimes a memcpy, sometimes a per-element
             // loop. Delegate further to figure that out.
-            CheckedEntity::Table(_) | CheckedEntity::Array { .. } => {
-                let src_size = src_entity.element_size(self, builder.func)?;
-                let dst_size = dst_entity.element_size(self, builder.func)?;
-                assert_eq!(src_size, dst_size);
-                let one_elem_size = builder
-                    .ins()
-                    .iconst(self.pointer_type(), i64::from(src_size));
-                self.emit_raw_array_or_table_copy(
+            CheckedEntity::Table(_) | CheckedEntity::Array { .. } => self
+                .emit_raw_array_or_table_copy(
                     builder,
                     dst_entity,
                     src_entity,
                     dst_raw_addr,
                     src_raw_addr,
-                    one_elem_size,
                     len_ptr,
                     src,
-                )
-            }
+                ),
 
-            // Cannot copy into a data segment in wasm.
-            CheckedEntity::Data { .. } => unreachable!(),
+            // Cannot copy into a data or element segment in wasm.
+            CheckedEntity::Data { .. } | CheckedEntity::Elem(_) => unreachable!(),
         }
     }
 
@@ -4055,6 +4040,18 @@ impl FuncEnvironment<'_> {
                         I64 => builder.ins().uload32(flags, vmctx, offset),
                         _ => unreachable!(),
                     }
+                }
+                None => builder.ins().iconst(pointer_type, 0),
+            },
+            CheckedEntity::Elem(i) => match self.translation.passive_elem_map[i] {
+                Some(passive_index) => {
+                    let vmctx = self.vmctx_val(&mut builder.cursor());
+                    let libcall = self
+                        .builtin_functions
+                        .passive_elem_segment_len(&mut builder.func);
+                    let idx = builder.ins().iconst(I32, i64::from(passive_index.as_u32()));
+                    let call = builder.ins().call(libcall, &[vmctx, idx]);
+                    builder.func.dfg.first_result(call)
                 }
                 None => builder.ins().iconst(pointer_type, 0),
             },
@@ -4139,6 +4136,21 @@ impl FuncEnvironment<'_> {
                 // will be 0 elements, so the actual value here doesn't matter.
                 None => builder.ins().iconst(pointer_type, 1),
             },
+            // Element segments are quite similar to data segments just above.
+            CheckedEntity::Elem(i) => match self.translation.passive_elem_map[i] {
+                Some(passive_index) => {
+                    let vmctx = self.vmctx_val(&mut builder.cursor());
+                    let libcall = self
+                        .builtin_functions
+                        .passive_elem_segment_base(builder.func);
+                    let idx = builder.ins().iconst(I32, i64::from(passive_index.as_u32()));
+                    let call = builder.ins().call(libcall, &[vmctx, idx]);
+                    builder.func.dfg.first_result(call)
+                }
+
+                // Same as active data segments above.
+                None => builder.ins().iconst(pointer_type, 1),
+            },
             CheckedEntity::Array { array, ty, .. } => {
                 let base = self.get_gc_heap_base(builder)?;
                 let array = self.unchecked_cast_wasm_addr_to_native_addr(
@@ -4203,14 +4215,12 @@ impl FuncEnvironment<'_> {
         src_entity: CheckedEntity,
         dst_elem_addr: ir::Value,
         src_elem_addr: ir::Value,
-        one_elem_size: ir::Value,
         copy_len: ir::Value,
         src_index: ir::Value,
     ) -> WasmResult<()> {
         let pointer_type = self.pointer_type();
         assert_eq!(builder.func.dfg.value_type(dst_elem_addr), pointer_type);
         assert_eq!(builder.func.dfg.value_type(src_elem_addr), pointer_type);
-        assert_eq!(builder.func.dfg.value_type(one_elem_size), pointer_type);
         assert_eq!(builder.func.dfg.value_type(copy_len), pointer_type);
         assert_eq!(
             builder.func.dfg.value_type(src_index),
@@ -4255,29 +4265,39 @@ impl FuncEnvironment<'_> {
                     // The GC heap has integers representing funcrefs, so memcpy
                     // is fine.
                     CheckedEntity::Array { .. } => false,
+                    // These are stored as `ValRaw`, not native types, so memcpy
+                    // can't work.
+                    CheckedEntity::Elem(_) => true,
                     // Not possible
                     CheckedEntity::Memory(_) | CheckedEntity::Data { .. } => unreachable!(),
                 },
             },
         };
 
-        let copy_byte_len = builder.ins().imul(one_elem_size, copy_len);
+        let dst_element_size = dst_entity.element_size(self, builder.func)?;
+        let src_element_size = src_entity.element_size(self, builder.func)?;
+        let dst_copy_byte_len = builder
+            .ins()
+            .imul_imm(copy_len, i64::from(dst_element_size));
+        let src_copy_byte_len = builder
+            .ins()
+            .imul_imm(copy_len, i64::from(src_element_size));
         if let CheckedEntity::Array { .. } = dst_entity {
-            self.emit_defensive_array_bounds_check(builder, dst_elem_addr, copy_byte_len)?;
+            self.emit_defensive_array_bounds_check(builder, dst_elem_addr, dst_copy_byte_len)?;
         }
-        if let CheckedEntity::Array { .. } = dst_entity {
-            self.emit_defensive_array_bounds_check(builder, dst_elem_addr, copy_byte_len)?;
+        if let CheckedEntity::Array { .. } = src_entity {
+            self.emit_defensive_array_bounds_check(builder, src_elem_addr, src_copy_byte_len)?;
         }
 
         // For memcpy, that's easy, just call the intrinsic with the right
         // parameters.
-        if !type_forbids_memcpy {
+        if !type_forbids_memcpy && dst_element_size == src_element_size {
             self.raw_bulk_memory_operation(
                 builder,
                 BulkOp::MemoryCopy {
                     dst: dst_elem_addr,
                     src: src_elem_addr,
-                    len: copy_byte_len,
+                    len: dst_copy_byte_len,
                 },
             );
             return Ok(());
@@ -4288,13 +4308,13 @@ impl FuncEnvironment<'_> {
         // used to dispatch `other` further.
         self.translate_per_element_copy(
             builder,
+            dst_entity,
+            src_entity,
             dst_elem_addr,
             src_elem_addr,
-            one_elem_size,
             copy_len,
             src_index,
             &|this, builder, dst, src, src_index| {
-                let read_ty = src_entity.storage_type(this);
                 let write_ty = dst_entity.storage_type(this);
                 let val = match src_entity {
                     // FIXME: ideally this wouldn't redo the bounds check but
@@ -4304,7 +4324,31 @@ impl FuncEnvironment<'_> {
                     CheckedEntity::Table(i) => this.translate_table_get(builder, i, src_index)?,
                     CheckedEntity::Array { initialized, .. } => {
                         assert!(initialized);
+                        let read_ty = src_entity.storage_type(this);
                         gc::read_field_at_addr(this, builder, read_ty, src, None)?
+                    }
+                    CheckedEntity::Elem(_) => {
+                        let WasmStorageType::Val(WasmValType::Ref(ty)) = write_ty else {
+                            unreachable!();
+                        };
+                        // `ValRaw` is always stored as little-endian
+                        let mut flags = ir::MemFlagsData::trusted();
+                        flags.set_endianness(Endianness::Little);
+
+                        match ty.heap_type.top() {
+                            WasmHeapTopType::Func => {
+                                builder.ins().load(this.pointer_type(), flags, src, 0)
+                            }
+                            WasmHeapTopType::Extern
+                            | WasmHeapTopType::Any
+                            | WasmHeapTopType::Exn => gc::gc_compiler(this)?
+                                .translate_read_gc_reference(this, builder, ty, src, flags)?,
+                            WasmHeapTopType::Cont => {
+                                return Err(wasmtime_environ::WasmError::Unsupported(
+                                    "reading of `contref` element segments".to_string(),
+                                ));
+                            }
+                        }
                     }
                     CheckedEntity::Memory(_) | CheckedEntity::Data { .. } => unreachable!(),
                 };
@@ -4319,9 +4363,10 @@ impl FuncEnvironment<'_> {
                             gc::init_field_at_addr(this, builder, write_ty, dst, val)?
                         }
                     }
-                    CheckedEntity::Memory(_) | CheckedEntity::Data { .. } => unreachable!(),
+                    CheckedEntity::Memory(_)
+                    | CheckedEntity::Data { .. }
+                    | CheckedEntity::Elem(_) => unreachable!(),
                 }
-
                 Ok(())
             },
         )?;
@@ -4374,12 +4419,13 @@ impl FuncEnvironment<'_> {
     ///
     /// All IR values have type `self.pointer_type()`, except `src_index` which
     /// has an appropriate type to index into the entity copied from.
-    pub fn translate_per_element_copy(
+    fn translate_per_element_copy(
         &mut self,
         builder: &mut FunctionBuilder<'_>,
+        dst_entity: CheckedEntity,
+        src_entity: CheckedEntity,
         dst_elem_addr: ir::Value,
         src_elem_addr: ir::Value,
-        one_elem_size: ir::Value,
         copy_len: ir::Value,
         src_index: ir::Value,
         copy_one: &dyn Fn(
@@ -4446,9 +4492,16 @@ impl FuncEnvironment<'_> {
             .ins()
             .icmp(IntCC::UnsignedLessThan, dst_elem_addr, src_elem_addr);
         let src_index_ty = builder.func.dfg.value_type(src_index);
-        let copy_byte_len = builder.ins().imul(copy_len, one_elem_size);
-        let dst_end_addr = builder.ins().iadd(dst_elem_addr, copy_byte_len);
-        let src_end_addr = builder.ins().iadd(src_elem_addr, copy_byte_len);
+        let dst_element_size = dst_entity.element_size(self, builder.func)?;
+        let src_element_size = src_entity.element_size(self, builder.func)?;
+        let dst_copy_byte_len = builder
+            .ins()
+            .imul_imm(copy_len, i64::from(dst_element_size));
+        let src_copy_byte_len = builder
+            .ins()
+            .imul_imm(copy_len, i64::from(src_element_size));
+        let dst_end_addr = builder.ins().iadd(dst_elem_addr, dst_copy_byte_len);
+        let src_end_addr = builder.ins().iadd(src_elem_addr, src_copy_byte_len);
         let copy_len_as_src_index_ty = match (self.pointer_type(), src_index_ty) {
             (I32, I32) | (I64, I64) => copy_len,
             (I32, I64) => builder.ins().uextend(I64, copy_len),
@@ -4472,8 +4525,8 @@ impl FuncEnvironment<'_> {
         let src_index = builder.append_block_param(forward_block, src_index_ty);
         self.translate_loop_header(builder)?;
         copy_one(self, builder, dst_cur, src_cur, src_index)?;
-        let dst_next = builder.ins().iadd(dst_cur, one_elem_size);
-        let src_next = builder.ins().iadd(src_cur, one_elem_size);
+        let dst_next = builder.ins().iadd_imm(dst_cur, i64::from(dst_element_size));
+        let src_next = builder.ins().iadd_imm(src_cur, i64::from(src_element_size));
         let src_index_next = builder.ins().iadd_imm(src_index, 1);
         let done = builder.ins().icmp(IntCC::Equal, src_next, src_end_addr);
         builder.ins().brif(
@@ -4491,10 +4544,22 @@ impl FuncEnvironment<'_> {
         let src_cur = builder.append_block_param(backwards_block, self.pointer_type());
         let src_index = builder.append_block_param(backwards_block, src_index_ty);
         self.translate_loop_header(builder)?;
-        let dst_cur = builder.ins().isub(dst_cur, one_elem_size);
-        let src_cur = builder.ins().isub(src_cur, one_elem_size);
-        let one = builder.ins().iconst(src_index_ty, 1);
-        let src_index = builder.ins().isub(src_index, one);
+        let dst_cur = {
+            let size = builder
+                .ins()
+                .iconst(self.pointer_type(), i64::from(dst_element_size));
+            builder.ins().isub(dst_cur, size)
+        };
+        let src_cur = {
+            let size = builder
+                .ins()
+                .iconst(self.pointer_type(), i64::from(src_element_size));
+            builder.ins().isub(src_cur, size)
+        };
+        let src_index = {
+            let one = builder.ins().iconst(src_index_ty, 1);
+            builder.ins().isub(src_index, one)
+        };
         copy_one(self, builder, dst_cur, src_cur, src_index)?;
         let done = builder.ins().icmp(IntCC::Equal, src_cur, src_elem_addr);
         builder.ins().brif(
@@ -4524,29 +4589,26 @@ impl FuncEnvironment<'_> {
         src: ir::Value,
         len: ir::Value,
     ) -> WasmResult<()> {
-        let mut pos = builder.cursor();
-        let table_init = self.builtin_functions.table_init(&mut pos.func);
-        let table_index_arg = pos.ins().iconst(I32, i64::from(table_index.as_u32()));
-        let seg_index_arg = pos.ins().iconst(I32, i64::from(seg_index));
-        let vmctx = self.vmctx_val(&mut pos);
-        let index_type = self.table(table_index).idx_type;
-        let dst = self.cast_index_to_i64(&mut pos, dst, index_type);
-        let src = pos.ins().uextend(I64, src);
-        let len = pos.ins().uextend(I64, len);
-
-        pos.ins().call(
-            table_init,
-            &[vmctx, table_index_arg, seg_index_arg, dst, src, len],
-        );
-
-        Ok(())
+        self.translate_entity_copy(
+            builder,
+            table_index,
+            CheckedEntity::Elem(ElemIndex::from_u32(seg_index)),
+            dst,
+            src,
+            len,
+        )
     }
 
     pub fn translate_elem_drop(&mut self, mut pos: FuncCursor, elem_index: u32) -> WasmResult<()> {
-        let elem_drop = self.builtin_functions.elem_drop(&mut pos.func);
-        let elem_index_arg = pos.ins().iconst(I32, elem_index as i64);
-        let vmctx = self.vmctx_val(&mut pos);
-        pos.ins().call(elem_drop, &[vmctx, elem_index_arg]);
+        let elem = ElemIndex::from_u32(elem_index);
+        if let Some(passive_index) = self.translation.passive_elem_map[elem] {
+            let libcall = self
+                .builtin_functions
+                .passive_elem_segment_drop(&mut pos.func);
+            let idx = pos.ins().iconst(I32, i64::from(passive_index.as_u32()));
+            let vmctx = self.vmctx_val(&mut pos);
+            pos.ins().call(libcall, &[vmctx, idx]);
+        }
         Ok(())
     }
 
@@ -5395,6 +5457,8 @@ enum CheckedEntity {
         /// or possibly more for array initialization.
         element_size: u32,
     },
+    /// A WebAssembly passive element segment.
+    Elem(ElemIndex),
     /// An `arrayref` with the specified type.
     Array {
         /// The type of this array.
@@ -5425,7 +5489,9 @@ impl CheckedEntity {
         match *self {
             CheckedEntity::Memory(i) => env.memory(i).idx_type,
             CheckedEntity::Table(i) => env.table(i).idx_type,
-            CheckedEntity::Data { .. } | CheckedEntity::Array { .. } => IndexType::I32,
+            CheckedEntity::Data { .. } | CheckedEntity::Array { .. } | CheckedEntity::Elem(_) => {
+                IndexType::I32
+            }
         }
     }
 
@@ -5440,6 +5506,7 @@ impl CheckedEntity {
             CheckedEntity::Data { element_size, .. } => element_size,
             CheckedEntity::Table(table) => env.get_or_create_table(func, table).element_size,
             CheckedEntity::Array { ty, .. } => env.array_layout(ty)?.elem_size,
+            CheckedEntity::Elem(_) => 16,
         })
     }
 
@@ -5450,8 +5517,6 @@ impl CheckedEntity {
             | CheckedEntity::Data {
                 element_size: 1, ..
             } => WasmStorageType::I8,
-            // not used at this time.
-            CheckedEntity::Data { .. } => unreachable!(),
             CheckedEntity::Table(table) => {
                 WasmStorageType::Val(WasmValType::Ref(env.table(table).ref_type))
             }
@@ -5459,6 +5524,8 @@ impl CheckedEntity {
                 let array_ty = env.types.unwrap_array(ty).unwrap();
                 array_ty.0.element_type
             }
+            // not used at this time.
+            CheckedEntity::Data { .. } | CheckedEntity::Elem(_) => unreachable!(),
         }
     }
 
@@ -5468,7 +5535,7 @@ impl CheckedEntity {
             CheckedEntity::Memory(_) | CheckedEntity::Data { .. } => {
                 ir::TrapCode::HEAP_OUT_OF_BOUNDS
             }
-            CheckedEntity::Table(_) => TRAP_TABLE_OUT_OF_BOUNDS,
+            CheckedEntity::Table(_) | CheckedEntity::Elem(_) => TRAP_TABLE_OUT_OF_BOUNDS,
             CheckedEntity::Array { .. } => TRAP_ARRAY_OUT_OF_BOUNDS,
         }
     }
@@ -5480,6 +5547,7 @@ impl CheckedEntity {
             CheckedEntity::Memory(_) | CheckedEntity::Data { .. } | CheckedEntity::Array { .. } => {
                 true
             }
+            CheckedEntity::Elem(_) => false,
             // Tables that are lazily initialized can't be memset because the
             // initialized bit needs to be set when storing values.
             CheckedEntity::Table(_) => !env.tunables.table_lazy_init,

--- a/crates/cranelift/src/func_environ/gc.rs
+++ b/crates/cranelift/src/func_environ/gc.rs
@@ -176,39 +176,3 @@ pub trait GcCompiler {
         val: ir::Value,
     ) -> WasmResult<()>;
 }
-
-pub mod builtins {
-    use super::*;
-
-    macro_rules! define_builtin_accessors {
-        ( $( $name:ident , )* ) => {
-            $(
-                #[inline]
-                pub fn $name(
-                    func_env: &mut FuncEnvironment<'_>,
-                    func: &mut ir::Function,
-                ) -> WasmResult<ir::FuncRef> {
-                    #[cfg(feature = "gc")]
-                    {
-                        func_env.needs_gc_heap = true;
-                        return Ok(func_env.builtin_functions.$name(func));
-                    }
-
-                    #[cfg(not(feature = "gc"))]
-                    {
-                        let _ = (func, func_env);
-                        return Err(wasmtime_environ::wasm_unsupported!(
-                            "support for Wasm GC disabled at compile time because the `gc` cargo \
-                             feature was not enabled"
-                        ));
-                    }
-                }
-            )*
-        };
-    }
-
-    define_builtin_accessors! {
-        array_new_elem,
-        array_init_elem,
-    }
-}

--- a/crates/cranelift/src/func_environ/gc/disabled.rs
+++ b/crates/cranelift/src/func_environ/gc/disabled.rs
@@ -1,13 +1,13 @@
 //! `GcCompiler` implementation when GC support is disabled.
 
 use super::GcCompiler;
-use crate::func_environ::{Extension, FuncEnvironment};
+use crate::func_environ::{CheckedEntity, Extension, FuncEnvironment};
 use cranelift_codegen::ir;
 use cranelift_frontend::FunctionBuilder;
 use smallvec::SmallVec;
 use wasmtime_environ::{
-    DataIndex, GcArrayLayout, ModuleInternedTypeIndex, TagIndex, TypeIndex, WasmRefType,
-    WasmResult, WasmStorageType, wasm_unsupported,
+    GcArrayLayout, ModuleInternedTypeIndex, TagIndex, TypeIndex, WasmRefType, WasmResult,
+    WasmStorageType, wasm_unsupported,
 };
 
 fn disabled<T>() -> WasmResult<T> {
@@ -155,11 +155,11 @@ pub fn translate_ref_test(
     disabled()
 }
 
-pub fn translate_array_new_data(
+pub fn translate_array_new_entity(
     _func_env: &mut FuncEnvironment<'_>,
     _builder: &mut FunctionBuilder,
     _array_type_index: TypeIndex,
-    _data_index: DataIndex,
+    _entity: CheckedEntity,
     _data_offset: ir::Value,
     _len: ir::Value,
 ) -> WasmResult<ir::Value> {

--- a/crates/cranelift/src/func_environ/gc/enabled.rs
+++ b/crates/cranelift/src/func_environ/gc/enabled.rs
@@ -15,10 +15,9 @@ use cranelift_entity::packed_option::ReservedValue;
 use cranelift_frontend::FunctionBuilder;
 use smallvec::{SmallVec, smallvec};
 use wasmtime_environ::{
-    Collector, DataIndex, GcArrayLayout, GcLayout, GcStructLayout, I31_DISCRIMINANT,
-    ModuleInternedTypeIndex, PtrSize, TagIndex, TypeIndex, VMGcKind, WasmCompositeInnerType,
-    WasmHeapTopType, WasmHeapType, WasmRefType, WasmResult, WasmStorageType, WasmValType,
-    wasm_unsupported,
+    Collector, GcArrayLayout, GcLayout, GcStructLayout, I31_DISCRIMINANT, ModuleInternedTypeIndex,
+    PtrSize, TagIndex, TypeIndex, VMGcKind, WasmCompositeInnerType, WasmHeapTopType, WasmHeapType,
+    WasmRefType, WasmResult, WasmStorageType, WasmValType, wasm_unsupported,
 };
 
 #[cfg(feature = "gc-drc")]
@@ -1557,26 +1556,18 @@ fn stack_switching_unsupported<T>() -> WasmResult<T> {
     ))
 }
 
-pub fn translate_array_new_data(
+pub fn translate_array_new_entity(
     env: &mut FuncEnvironment<'_>,
     builder: &mut FunctionBuilder,
     array_type_index: TypeIndex,
-    data_index: DataIndex,
-    data_offset: ir::Value,
+    entity: CheckedEntity,
+    entity_offset: ir::Value,
     len: ir::Value,
 ) -> WasmResult<ir::Value> {
     // Before actually allocating this array first do a bounds-check on the
-    // passive data segment itself. This is done by multiplying the length of
-    // the size of the array in the 64-bit integer space to avoid overflow. If
-    // upper bits are set this is definitely out-of-bounds, and otherwise the
-    // low 32-bits are the byte length.
+    // passive entity itself.
     let interned_type_index = env.module.types[array_type_index].unwrap_module_type_index();
-    let array_layout = env.array_layout(interned_type_index)?.clone();
-    let data_entity = CheckedEntity::Data {
-        segment: data_index,
-        element_size: array_layout.elem_size,
-    };
-    env.translate_entity_bounds_check(builder, data_entity, data_offset, len)?;
+    env.translate_entity_bounds_check(builder, entity, entity_offset, len)?;
 
     let array = gc_compiler(env)?.alloc_uninit_array(env, builder, array_type_index, len)?;
     let dst = builder.ins().iconst(ir::types::I32, 0);
@@ -1587,9 +1578,9 @@ pub fn translate_array_new_data(
             ty: interned_type_index,
             initialized: false,
         },
-        data_entity,
+        entity,
         dst,
-        data_offset,
+        entity_offset,
         len,
     )?;
 

--- a/crates/environ/src/builtin.rs
+++ b/crates/environ/src/builtin.rs
@@ -5,14 +5,16 @@ macro_rules! foreach_builtin_function {
         $mac! {
             // Returns an index for wasm's `memory.grow` builtin function.
             memory_grow(vmctx: vmctx, delta: u64, index: u32) -> pointer;
-            // Returns an index for wasm's `table.init`.
-            table_init(vmctx: vmctx, table: u32, elem: u32, dst: u64, src: u64, len: u64) -> bool;
-            // Returns an index for wasm's `elem.drop`.
-            elem_drop(vmctx: vmctx, elem: u32) -> bool;
             // Returns an index for wasm's `memory.copy`
             memory_copy(vmctx: vmctx, dst: pointer, src: pointer, len: size);
             // Returns an index for wasm's `memory.fill` instruction.
             memory_fill(vmctx: vmctx, dst: pointer, val: u32, len: size);
+            // Returns the current size of the passive `elem` segment.
+            passive_elem_segment_len(vmctx: vmctx, elem: u32) -> size;
+            // Returns the base address of the passive `elem` segment.
+            passive_elem_segment_base(vmctx: vmctx, elem: u32) -> pointer;
+            // Guts of `elem.drop` for passive data segments.
+            passive_elem_segment_drop(vmctx: vmctx, elem: u32) -> bool;
             // Returns a value for wasm's `ref.func` instruction.
             ref_func(vmctx: vmctx, func: u32) -> pointer;
             // Returns a table entry after lazily initializing it.
@@ -116,28 +118,6 @@ macro_rules! foreach_builtin_function {
                 func_ref_id: u32,
                 module_interned_type_index: u32
             ) -> pointer;
-
-            // Builtin implementation of the `array.new_elem` instruction.
-            #[cfg(feature = "gc")]
-            array_new_elem(
-                vmctx: vmctx,
-                array_interned_type_index: u32,
-                elem_index: u32,
-                elem_offset: u32,
-                len: u32
-            ) -> u32;
-
-            // Builtin implementation of the `array.init_elem` instruction.
-            #[cfg(feature = "gc")]
-            array_init_elem(
-                vmctx: vmctx,
-                array_interned_type_index: u32,
-                array: u32,
-                dst: u32,
-                elem_index: u32,
-                src: u32,
-                len: u32
-            ) -> bool;
 
             // Returns whether `actual_engine_type` is a subtype of
             // `expected_engine_type`.
@@ -412,6 +392,8 @@ impl BuiltinFunctionIndex {
             (@get fma_f32x4 f32x4) => (return None);
             (@get fma_f64x2 f64x2) => (return None);
             (@get passive_data_segment_base pointer) => (return None);
+            (@get passive_elem_segment_len size) => (return None);
+            (@get passive_elem_segment_base pointer) => (return None);
 
             (@get cont_new pointer) => (TrapSentinel::Negative);
 

--- a/crates/environ/src/compile/module_environ.rs
+++ b/crates/environ/src/compile/module_environ.rs
@@ -7,10 +7,10 @@ use crate::prelude::*;
 use crate::{
     ConstExpr, ConstOp, DataIndex, DefinedFuncIndex, ElemIndex, EngineOrModuleTypeIndex,
     EntityIndex, EntityType, FuncIndex, FuncKey, GlobalIndex, IndexType, InitMemory, MemoryIndex,
-    ModuleInternedTypeIndex, ModuleTypesBuilder, PanicOnOom as _, PassiveDataIndex, PrimaryMap,
-    SizeOverflow, StaticMemoryInitializer, StaticModuleIndex, TableIndex, TableInitialValue, Tag,
-    TagIndex, Tunables, TypeConvert, TypeIndex, WasmError, WasmHeapTopType, WasmHeapType,
-    WasmResult, WasmValType, WasmparserTypeConverter,
+    ModuleInternedTypeIndex, ModuleTypesBuilder, PanicOnOom as _, PassiveDataIndex,
+    PassiveElemIndex, PrimaryMap, SizeOverflow, StaticMemoryInitializer, StaticModuleIndex,
+    TableIndex, TableInitialValue, Tag, TagIndex, Tunables, TypeConvert, TypeIndex, WasmError,
+    WasmHeapTopType, WasmHeapType, WasmResult, WasmValType, WasmparserTypeConverter,
 };
 use cranelift_entity::SecondaryMap;
 use cranelift_entity::packed_option::ReservedValue;
@@ -102,6 +102,9 @@ pub struct ModuleTranslation<'data> {
     /// Map from a data segment to whether it's a passive data segment or not.
     pub passive_data_map: SecondaryMap<DataIndex, Option<PassiveDataIndex>>,
 
+    /// Map from an elem segment to whether it's a passive elem segment or not.
+    pub passive_elem_map: SecondaryMap<ElemIndex, Option<PassiveElemIndex>>,
+
     /// Total size of all data pushed onto `data` so far.
     total_data: u32,
 
@@ -141,6 +144,7 @@ impl<'data> ModuleTranslation<'data> {
             code_index: 0,
             types: None,
             passive_data_map: Default::default(),
+            passive_elem_map: Default::default(),
         }
     }
 
@@ -553,7 +557,7 @@ impl<'a, 'data> ModuleEnvironment<'a, 'data> {
                         }
                     };
 
-                    match kind {
+                    let passive_index = match kind {
                         ElementKind::Active {
                             table_index,
                             offset_expr,
@@ -569,20 +573,21 @@ impl<'a, 'data> ModuleEnvironment<'a, 'data> {
                                     elements,
                                 },
                             )?;
+                            None
                         }
 
                         ElementKind::Passive => {
-                            let elem_index = ElemIndex::from_u32(index as u32);
                             let passive_index =
                                 self.result.module.passive_elements.push(elements)?;
-                            self.result
-                                .module
-                                .passive_elements_map
-                                .insert(elem_index, passive_index)?;
+                            Some(passive_index)
                         }
 
-                        ElementKind::Declared => {}
-                    }
+                        ElementKind::Declared => None,
+                    };
+                    let elem_index = ElemIndex::from_u32(index as u32);
+                    self.result
+                        .passive_elem_map
+                        .insert(elem_index, passive_index);
                 }
             }
 

--- a/crates/environ/src/module.rs
+++ b/crates/environ/src/module.rs
@@ -325,10 +325,6 @@ pub struct Module {
     /// WebAssembly passive elements.
     pub passive_elements: TryPrimaryMap<PassiveElemIndex, TableSegmentElements>,
 
-    /// The map from passive element index (element segment index space) to
-    /// index in `passive_elements`.
-    pub passive_elements_map: TryBTreeMap<ElemIndex, PassiveElemIndex>,
-
     /// Where passive data segments are located in the module's image.
     pub passive_data: PrimaryMap<PassiveDataIndex, Range<u32>>,
 
@@ -408,7 +404,6 @@ impl Module {
             table_initialization: Default::default(),
             memory_initialization: Default::default(),
             passive_elements: Default::default(),
-            passive_elements_map: Default::default(),
             passive_data: Default::default(),
             types: Default::default(),
             num_imported_funcs: Default::default(),
@@ -699,7 +694,6 @@ impl TypeTrace for Module {
             table_initialization: _,
             memory_initialization: _,
             passive_elements: _,
-            passive_elements_map: _,
             passive_data: _,
             types,
             num_imported_funcs: _,
@@ -751,7 +745,6 @@ impl TypeTrace for Module {
             table_initialization: _,
             memory_initialization: _,
             passive_elements: _,
-            passive_elements_map: _,
             passive_data: _,
             types,
             num_imported_funcs: _,

--- a/crates/environ/src/types.rs
+++ b/crates/environ/src/types.rs
@@ -206,6 +206,9 @@ impl TypeTrace for WasmValType {
 }
 
 impl WasmValType {
+    /// Alias for the `funcref` type.
+    pub const FUNCREF: WasmValType = WasmValType::Ref(WasmRefType::FUNCREF);
+
     /// Is this a type that is represented as a `VMGcRef`?
     #[inline]
     pub fn is_vmgcref_type(&self) -> bool {

--- a/crates/wasmtime/src/runtime/vm/instance.rs
+++ b/crates/wasmtime/src/runtime/vm/instance.rs
@@ -2,8 +2,10 @@
 //! wasm module (except its callstack and register state). An
 //! `InstanceHandle` is a reference-counting handle for an `Instance`.
 
+use crate::Val;
 use crate::code::ModuleWithCode;
 use crate::module::ModuleRegistry;
+use crate::prelude::*;
 use crate::runtime::vm::export::{Export, ExportMemory};
 use crate::runtime::vm::memory::{Memory, RuntimeMemoryCreator};
 use crate::runtime::vm::table::{Table, TableElementType};
@@ -20,8 +22,6 @@ use crate::store::{
     AutoAssertNoGc, InstanceId, StoreId, StoreInstanceId, StoreOpaque, StoreResourceLimiter,
 };
 use crate::vm::{VMWasmCallFunction, ValRaw};
-use crate::{OpaqueRootScope, Val};
-use crate::{ValType, prelude::*};
 use alloc::sync::Arc;
 use core::alloc::Layout;
 use core::marker;
@@ -35,9 +35,9 @@ use core::{mem, ptr};
 use wasmtime_environ::ModuleInternedTypeIndex;
 use wasmtime_environ::error::OutOfMemory;
 use wasmtime_environ::{
-    DefinedGlobalIndex, DefinedMemoryIndex, DefinedTableIndex, DefinedTagIndex, ElemIndex,
-    EntityIndex, EntityRef, FuncIndex, GlobalIndex, HostPtr, MemoryIndex, PassiveDataIndex,
-    PtrSize, TableIndex, TableInitialValue, TagIndex, Trap, VMCONTEXT_MAGIC, VMOffsets,
+    DefinedGlobalIndex, DefinedMemoryIndex, DefinedTableIndex, DefinedTagIndex, EntityIndex,
+    EntityRef, FuncIndex, GlobalIndex, HostPtr, MemoryIndex, PassiveDataIndex, PassiveElemIndex,
+    PtrSize, TableIndex, TableInitialValue, TagIndex, VMCONTEXT_MAGIC, VMOffsets,
     VMSharedTypeIndex, WasmRefType, packed_option::ReservedValue,
 };
 #[cfg(feature = "wmemcheck")]
@@ -899,16 +899,7 @@ impl Instance {
     }
 
     /// Get the passive elements segment at the given index.
-    pub(crate) fn passive_element_segment(&self, elem_index: ElemIndex) -> &[ValRaw] {
-        let Some(passive) = self
-            .env_module()
-            .passive_elements_map
-            .get(elem_index)
-            .copied()
-        else {
-            return &[];
-        };
-
+    pub(crate) fn passive_element_segment(&self, passive: PassiveElemIndex) -> &[ValRaw] {
         self.passive_elements[passive.index()].elements()
     }
 
@@ -919,91 +910,12 @@ impl Instance {
         Pin::new(&mut unsafe { self.get_unchecked_mut() }.passive_elements)
     }
 
-    /// The `table.init` operation: initializes a portion of a table with a
-    /// passive element.
-    ///
-    /// # Errors
-    ///
-    /// Returns a `Trap` error when the range within the table is out of bounds
-    /// or the range within the passive element is out of bounds.
-    pub(crate) fn table_init(
-        store: &mut StoreOpaque,
-        instance_id: InstanceId,
-        table_index: TableIndex,
-        elem_index: ElemIndex,
-        dst: u64,
-        src: u64,
-        len: u64,
-    ) -> Result<()> {
-        let mut store = OpaqueRootScope::new(store);
-        let store_id = store.id();
-        let instance = store.instance(instance_id);
-        let elements = instance.passive_element_segment(elem_index);
-
-        let end = dst.checked_add(len).ok_or_else(|| Trap::TableOutOfBounds)?;
-        let src = usize::try_from(src).map_err(|_| Trap::TableOutOfBounds)?;
-        let len = usize::try_from(len).map_err(|_| Trap::TableOutOfBounds)?;
-
-        let table = instance.get_exported_table(store_id, table_index);
-        if end > table.size_(&store) {
-            return Err(Trap::TableOutOfBounds.into());
-        }
-
-        // Subslice into just the target elements.
-        let elements = elements
-            .get(src..)
-            .and_then(|elements| elements.get(..len))
-            .ok_or_else(|| Trap::TableOutOfBounds)?
-            .iter()
-            .copied()
-            .try_collect::<TryVec<_>, OutOfMemory>()?;
-
-        let elem_ty = ValType::from(table.ty_(&store).element().clone());
-
-        let refs = {
-            let mut store = AutoAssertNoGc::new(&mut store);
-            elements
-                .into_iter()
-                // SAFETY: the raw elements are valid because we got them from
-                // this instance.
-                .map(|raw| unsafe { Val::_from_raw(&mut store, raw, &elem_ty) })
-                .map(|v| v.ref_().expect("due to validation"))
-                .try_collect::<TryVec<_>, OutOfMemory>()?
-        };
-
-        let instance = store.instance(instance_id);
-        let table = instance.get_exported_table(store_id, table_index);
-
-        for (i, r) in refs.into_iter().enumerate() {
-            let i = u64::try_from(i)
-                .expect("okay because of `src` and `len` conversions to `usize` up above");
-            let j = i
-                .checked_add(dst)
-                .expect("okay because of `checked_add` up above");
-            table.set_(&mut store, j, r)?;
-        }
-
-        Ok(())
-    }
-
     /// Drop an element.
-    pub(crate) fn elem_drop(
+    pub(crate) fn passive_elem_drop(
         self: Pin<&mut Self>,
         gc_store: Option<&mut GcStore>,
-        elem_index: ElemIndex,
+        passive_index: PassiveElemIndex,
     ) -> Result<(), OutOfMemory> {
-        // https://webassembly.github.io/reference-types/core/exec/instructions.html#exec-elem-drop
-
-        let Some(passive_index) = self
-            .env_module()
-            .passive_elements_map
-            .get(elem_index)
-            .copied()
-        else {
-            // Note: dropping a non-passive segment is a no-op (not a trap).
-            return Ok(());
-        };
-
         self.passive_elements_mut()[passive_index.index()].clear(gc_store);
         Ok(())
     }

--- a/crates/wasmtime/src/runtime/vm/libcalls.rs
+++ b/crates/wasmtime/src/runtime/vm/libcalls.rs
@@ -66,7 +66,8 @@ use core::ptr::NonNull;
 use core::time::Duration;
 use wasmtime_core::math::WasmFloat;
 use wasmtime_environ::{
-    CompiledTrap, DefinedMemoryIndex, DefinedTableIndex, ElemIndex, FuncIndex, TableIndex, Trap,
+    CompiledTrap, DefinedMemoryIndex, DefinedTableIndex, FuncIndex, PassiveElemIndex, TableIndex,
+    Trap,
 };
 #[cfg(feature = "wmemcheck")]
 use wasmtime_wmemcheck::AccessError::{
@@ -319,27 +320,41 @@ unsafe fn table_grow(
     })?
 }
 
-// Implementation of `table.init`.
-fn table_init(
+fn passive_elem_segment_len(
     store: &mut dyn VMStore,
     instance: InstanceId,
-    table_index: u32,
     elem_index: u32,
-    dst: u64,
-    src: u64,
-    len: u64,
-) -> Result<()> {
-    let table_index = TableIndex::from_u32(table_index);
-    let elem_index = ElemIndex::from_u32(elem_index);
-    vm::Instance::table_init(store, instance, table_index, elem_index, dst, src, len)?;
-    Ok(())
+) -> usize {
+    let elem_index = PassiveElemIndex::from_u32(elem_index);
+    store
+        .instance_mut(instance)
+        .passive_element_segment(elem_index)
+        .len()
+}
+
+fn passive_elem_segment_base(
+    store: &mut dyn VMStore,
+    instance: InstanceId,
+    elem_index: u32,
+) -> *mut u8 {
+    let elem_index = PassiveElemIndex::from_u32(elem_index);
+    store
+        .instance_mut(instance)
+        .passive_element_segment(elem_index)
+        .as_ptr()
+        .cast_mut()
+        .cast()
 }
 
 // Implementation of `elem.drop`.
-fn elem_drop(store: &mut dyn VMStore, instance: InstanceId, elem_index: u32) -> Result<()> {
-    let elem_index = ElemIndex::from_u32(elem_index);
+fn passive_elem_segment_drop(
+    store: &mut dyn VMStore,
+    instance: InstanceId,
+    elem_index: u32,
+) -> Result<()> {
+    let elem_index = PassiveElemIndex::from_u32(elem_index);
     let (gc_store, instance) = store.optional_gc_store_and_instance_mut(instance);
-    instance.elem_drop(gc_store, elem_index)?;
+    instance.passive_elem_drop(gc_store, elem_index)?;
     Ok(())
 }
 
@@ -588,155 +603,6 @@ fn get_interned_func_ref(
     };
 
     Ok(func_ref.map_or(core::ptr::null_mut(), |f| f.as_ptr().cast()))
-}
-
-#[cfg(feature = "gc")]
-fn array_new_elem(
-    store: &mut dyn VMStore,
-    instance_id: InstanceId,
-    array_type_index: u32,
-    elem_index: u32,
-    src: u32,
-    len: u32,
-) -> Result<core::num::NonZeroU32> {
-    use crate::{ArrayRef, ArrayRefPre, ArrayType, OpaqueRootScope, Val, store::AutoAssertNoGc};
-    use wasmtime_environ::ModuleInternedTypeIndex;
-
-    // Convert indices to their typed forms.
-    let array_type_index = ModuleInternedTypeIndex::from_u32(array_type_index);
-    let elem_index = ElemIndex::from_u32(elem_index);
-    let instance = store.instance(instance_id);
-
-    let elements = instance.passive_element_segment(elem_index);
-
-    let src = usize::try_from(src).map_err(|_| Trap::TableOutOfBounds)?;
-    let len = usize::try_from(len).map_err(|_| Trap::TableOutOfBounds)?;
-
-    let elements = elements
-        .get(src..)
-        .and_then(|elements| elements.get(..len))
-        .ok_or_else(|| Trap::TableOutOfBounds)?
-        .iter()
-        .copied()
-        .try_collect::<TryVec<_>, OutOfMemory>()?;
-
-    let shared_ty = instance.engine_type_index(array_type_index);
-    let array_ty = ArrayType::from_shared_type_index(store.engine(), shared_ty);
-    let elem_ty = match array_ty.element_type() {
-        crate::StorageType::ValType(ty) => ty,
-        _ => unreachable!("due to validation"),
-    };
-
-    let pre = ArrayRefPre::_new(store, array_ty);
-
-    let (mut limiter, store) = store.resource_limiter_and_store_opaque();
-    block_on!(store, async |store, asyncness| {
-        let mut store = OpaqueRootScope::new(store);
-
-        // Turn the elements into `Val`s.
-        //
-        // Safety: Validation ensures that the type is correct; `raw` is valid
-        // because we got it from this instance.
-        let vals = {
-            let mut store = AutoAssertNoGc::new(&mut store);
-            elements
-                .into_iter()
-                .map(|raw| unsafe { Val::_from_raw(&mut store, raw, &elem_ty) })
-                .try_collect::<TryVec<_>, OutOfMemory>()?
-        };
-
-        let array =
-            ArrayRef::_new_fixed_async(&mut store, limiter.as_mut(), &pre, &vals, asyncness)
-                .await?;
-
-        let mut store = AutoAssertNoGc::new(&mut store);
-        let gc_ref = array.try_clone_gc_ref(&mut store)?;
-        store.unwrap_gc_store_mut().expose_gc_ref_to_wasm(gc_ref)
-    })?
-}
-
-#[cfg(feature = "gc")]
-fn array_init_elem(
-    store: &mut dyn VMStore,
-    instance: InstanceId,
-    array_type_index: u32,
-    array: u32,
-    dst: u32,
-    elem_index: u32,
-    src: u32,
-    len: u32,
-) -> Result<()> {
-    use crate::{ArrayRef, OpaqueRootScope, Val, store::AutoAssertNoGc};
-    use wasmtime_environ::ModuleInternedTypeIndex;
-
-    let mut store = OpaqueRootScope::new(store);
-
-    // Convert the indices into their typed forms.
-    let array_type_index = ModuleInternedTypeIndex::from_u32(array_type_index);
-    let elem_index = ElemIndex::from_u32(elem_index);
-
-    log::trace!(
-        "array.init_elem(array={array:#x}, dst={dst}, elem_index={elem_index:?}, src={src}, len={len})",
-    );
-
-    // Convert the raw GC ref into a `Rooted<ArrayRef>`.
-    let array = VMGcRef::from_raw_u32(array).ok_or_else(|| Trap::NullReference)?;
-    let array = store.unwrap_gc_store_mut().clone_gc_ref(&array);
-    let array = {
-        let mut no_gc = AutoAssertNoGc::new(&mut store);
-        ArrayRef::from_cloned_gc_ref(&mut no_gc, array)
-    };
-
-    // Bounds check the destination within the array.
-    let array_len = array._len(&store)?;
-    log::trace!("array_len = {array_len}");
-    if dst.checked_add(len).ok_or_else(|| Trap::ArrayOutOfBounds)? > array_len {
-        return Err(Trap::ArrayOutOfBounds.into());
-    }
-
-    // Get the passive element segment.
-    let instance = store.instance(instance);
-    let elements = instance.passive_element_segment(elem_index);
-
-    // Convert array offsets into `usize`s.
-    let src = usize::try_from(src).map_err(|_| Trap::TableOutOfBounds)?;
-    let len = usize::try_from(len).map_err(|_| Trap::TableOutOfBounds)?;
-
-    // Subslice into just the target elements.
-    let elements = elements
-        .get(src..)
-        .and_then(|elements| elements.get(..len))
-        .ok_or_else(|| Trap::TableOutOfBounds)?
-        .iter()
-        .copied()
-        .try_collect::<TryVec<_>, OutOfMemory>()?;
-
-    let shared_ty = instance.engine_type_index(array_type_index);
-    let array_ty = crate::ArrayType::from_shared_type_index(store.engine(), shared_ty);
-    let elem_ty = match array_ty.element_type() {
-        crate::StorageType::ValType(ty) => ty,
-        _ => unreachable!("due to validation"),
-    };
-
-    // Turn the elements into `Val`s.
-    let vals = {
-        let mut store = AutoAssertNoGc::new(&mut store);
-        elements
-            .into_iter()
-            // Safety: Validation ensures that the type is correct; `raw` is
-            // valid because we got it from this instance.
-            .map(|raw| unsafe { Val::_from_raw(&mut store, raw, &elem_ty) })
-            .try_collect::<TryVec<_>, OutOfMemory>()?
-    };
-
-    // Copy the values into the array.
-    for (i, val) in vals.into_iter().enumerate() {
-        let i = u32::try_from(i).unwrap();
-        let j = dst.checked_add(i).unwrap();
-        array._set(&mut store, j, val)?;
-    }
-
-    Ok(())
 }
 
 #[cfg(feature = "gc")]

--- a/crates/wasmtime/src/runtime/vm/traphandlers.rs
+++ b/crates/wasmtime/src/runtime/vm/traphandlers.rs
@@ -199,6 +199,7 @@ host_result_no_catch! {
     u64,
     f32,
     f64,
+    usize,
     i8x16,
     f32x4,
     f64x2,

--- a/tests/disas/array-copy-anyref.wat
+++ b/tests/disas/array-copy-anyref.wat
@@ -21,8 +21,8 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32, v6: i32):
 ;; @002b                               trapz v2, user16
-;; @002b                               v102 = load.i64 notrap aligned readonly can_move v0+8
-;; @002b                               v8 = load.i64 notrap aligned readonly can_move v102+32
+;; @002b                               v111 = load.i64 notrap aligned readonly can_move v0+8
+;; @002b                               v8 = load.i64 notrap aligned readonly can_move v111+32
 ;; @002b                               v7 = uextend.i64 v2
 ;; @002b                               v9 = iadd v8, v7
 ;; @002b                               v10 = iconst.i64 16
@@ -44,54 +44,55 @@
 ;; @002b                               v32 = uextend.i64 v31
 ;; @002b                               v37 = icmp ugt v36, v32
 ;; @002b                               trapnz v37, user17
-;; @002b                               v49 = load.i64 notrap aligned v102+40
-;;                                     v98 = iconst.i64 20
-;; @002b                               v22 = iadd v9, v98  ; v98 = 20
-;;                                     v106 = iconst.i64 2
-;;                                     v107 = ishl v14, v106  ; v106 = 2
-;; @002b                               v25 = iadd v22, v107
-;;                                     v111 = ishl v15, v106  ; v106 = 2
-;; @002b                               v51 = uadd_overflow_trap v25, v111, user2
+;; @002b                               v49 = load.i64 notrap aligned v111+40
+;;                                     v107 = iconst.i64 20
+;; @002b                               v22 = iadd v9, v107  ; v107 = 20
+;;                                     v115 = iconst.i64 2
+;;                                     v116 = ishl v14, v115  ; v115 = 2
+;; @002b                               v25 = iadd v22, v116
+;;                                     v120 = ishl v15, v115  ; v115 = 2
+;; @002b                               v51 = uadd_overflow_trap v25, v120, user2
 ;; @002b                               v50 = iadd v8, v49
 ;; @002b                               v52 = icmp ugt v51, v50
 ;; @002b                               trapnz v52, user2
+;; @002b                               v41 = iadd v28, v107  ; v107 = 20
+;;                                     v118 = ishl v33, v115  ; v115 = 2
+;; @002b                               v44 = iadd v41, v118
+;; @002b                               v56 = uadd_overflow_trap v44, v120, user2
+;; @002b                               v57 = icmp ugt v56, v50
+;; @002b                               trapnz v57, user2
 ;; @002b                               brif v15, block2, block5
 ;;
 ;;                                 block2:
-;;                                     v116 = iconst.i64 20
-;;                                     v117 = iadd.i64 v28, v116  ; v116 = 20
-;;                                     v118 = iconst.i64 2
-;;                                     v119 = ishl.i64 v33, v118  ; v118 = 2
-;; @002b                               v44 = iadd v117, v119
 ;; @002b                               v58 = icmp.i64 ult v25, v44
-;; @002b                               v60 = iadd.i64 v25, v111
-;; @002b                               v61 = iadd v44, v111
-;; @002b                               v63 = iadd.i32 v5, v6
-;;                                     v97 = iconst.i64 4
-;; @002b                               v77 = iconst.i32 1
-;; @002b                               brif v58, block3(v25, v44, v5), block4(v60, v61, v63)
+;; @002b                               v61 = iadd.i64 v25, v120
+;; @002b                               v62 = iadd.i64 v44, v120
+;; @002b                               v64 = iadd.i32 v5, v6
+;;                                     v106 = iconst.i64 4
+;; @002b                               v80 = iconst.i32 1
+;; @002b                               brif v58, block3(v25, v44, v5), block4(v61, v62, v64)
 ;;
-;;                                 block3(v64: i64, v65: i64, v66: i32):
-;; @002b                               v67 = load.i32 user2 little v65
-;; @002b                               store user2 little v67, v64
-;;                                     v125 = iconst.i64 4
-;;                                     v126 = iadd v65, v125  ; v125 = 4
-;; @002b                               v71 = icmp eq v126, v61
-;;                                     v127 = iadd v64, v125  ; v125 = 4
-;;                                     v128 = iconst.i32 1
-;;                                     v129 = iadd v66, v128  ; v128 = 1
-;; @002b                               brif v71, block5, block3(v127, v126, v129)
+;;                                 block3(v65: i64, v66: i64, v67: i32):
+;; @002b                               v68 = load.i32 user2 little v66
+;; @002b                               store user2 little v68, v65
+;;                                     v127 = iconst.i64 4
+;;                                     v128 = iadd v66, v127  ; v127 = 4
+;; @002b                               v72 = icmp eq v128, v62
+;;                                     v129 = iadd v65, v127  ; v127 = 4
+;;                                     v130 = iconst.i32 1
+;;                                     v131 = iadd v67, v130  ; v130 = 1
+;; @002b                               brif v72, block5, block3(v129, v128, v131)
 ;;
-;;                                 block4(v72: i64, v73: i64, v74: i32):
-;;                                     v120 = iconst.i64 4
-;;                                     v121 = isub v73, v120  ; v120 = 4
-;; @002b                               v79 = load.i32 user2 little v121
-;;                                     v122 = isub v72, v120  ; v120 = 4
-;; @002b                               store user2 little v79, v122
-;; @002b                               v80 = icmp eq v121, v44
-;;                                     v123 = iconst.i32 1
-;;                                     v124 = isub v74, v123  ; v123 = 1
-;; @002b                               brif v80, block5, block4(v122, v121, v124)
+;;                                 block4(v73: i64, v74: i64, v75: i32):
+;;                                     v122 = iconst.i64 4
+;;                                     v123 = isub v74, v122  ; v122 = 4
+;; @002b                               v82 = load.i32 user2 little v123
+;;                                     v124 = isub v73, v122  ; v122 = 4
+;; @002b                               store user2 little v82, v124
+;; @002b                               v83 = icmp eq v123, v44
+;;                                     v125 = iconst.i32 1
+;;                                     v126 = isub v75, v125  ; v125 = 1
+;; @002b                               brif v83, block5, block4(v124, v123, v126)
 ;;
 ;;                                 block5:
 ;; @002f                               jump block1

--- a/tests/disas/array-copy-i64.wat
+++ b/tests/disas/array-copy-i64.wat
@@ -18,13 +18,13 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64, i64, i64) tail
-;;     fn0 = colocated u805306368:3 sig0
+;;     fn0 = colocated u805306368:1 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32, v6: i32):
 ;; @002b                               trapz v2, user16
-;; @002b                               v79 = load.i64 notrap aligned readonly can_move v0+8
-;; @002b                               v8 = load.i64 notrap aligned readonly can_move v79+32
+;; @002b                               v81 = load.i64 notrap aligned readonly can_move v0+8
+;; @002b                               v8 = load.i64 notrap aligned readonly can_move v81+32
 ;; @002b                               v7 = uextend.i64 v2
 ;; @002b                               v9 = iadd v8, v7
 ;; @002b                               v10 = iconst.i64 24
@@ -46,21 +46,24 @@
 ;; @002b                               v32 = uextend.i64 v31
 ;; @002b                               v37 = icmp ugt v36, v32
 ;; @002b                               trapnz v37, user17
-;; @002b                               v49 = load.i64 notrap aligned v79+40
-;;                                     v75 = iconst.i64 32
-;; @002b                               v22 = iadd v9, v75  ; v75 = 32
-;;                                     v83 = iconst.i64 3
-;;                                     v84 = ishl v14, v83  ; v83 = 3
-;; @002b                               v25 = iadd v22, v84
-;;                                     v88 = ishl v15, v83  ; v83 = 3
-;; @002b                               v51 = uadd_overflow_trap v25, v88, user2
+;; @002b                               v49 = load.i64 notrap aligned v81+40
+;;                                     v77 = iconst.i64 32
+;; @002b                               v22 = iadd v9, v77  ; v77 = 32
+;;                                     v85 = iconst.i64 3
+;;                                     v86 = ishl v14, v85  ; v85 = 3
+;; @002b                               v25 = iadd v22, v86
+;;                                     v90 = ishl v15, v85  ; v85 = 3
+;; @002b                               v51 = uadd_overflow_trap v25, v90, user2
 ;; @002b                               v50 = iadd v8, v49
 ;; @002b                               v52 = icmp ugt v51, v50
 ;; @002b                               trapnz v52, user2
-;; @002b                               v41 = iadd v28, v75  ; v75 = 32
-;;                                     v86 = ishl v33, v83  ; v83 = 3
-;; @002b                               v44 = iadd v41, v86
-;; @002b                               call fn0(v0, v25, v44, v88)
+;; @002b                               v41 = iadd v28, v77  ; v77 = 32
+;;                                     v88 = ishl v33, v85  ; v85 = 3
+;; @002b                               v44 = iadd v41, v88
+;; @002b                               v56 = uadd_overflow_trap v44, v90, user2
+;; @002b                               v57 = icmp ugt v56, v50
+;; @002b                               trapnz v57, user2
+;; @002b                               call fn0(v0, v25, v44, v90)
 ;; @002f                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/array-copy-i8.wat
+++ b/tests/disas/array-copy-i8.wat
@@ -18,13 +18,13 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64, i64, i64) tail
-;;     fn0 = colocated u805306368:3 sig0
+;;     fn0 = colocated u805306368:1 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32, v6: i32):
 ;; @002b                               trapz v2, user16
-;; @002b                               v79 = load.i64 notrap aligned readonly can_move v0+8
-;; @002b                               v8 = load.i64 notrap aligned readonly can_move v79+32
+;; @002b                               v81 = load.i64 notrap aligned readonly can_move v0+8
+;; @002b                               v8 = load.i64 notrap aligned readonly can_move v81+32
 ;; @002b                               v7 = uextend.i64 v2
 ;; @002b                               v9 = iadd v8, v7
 ;; @002b                               v10 = iconst.i64 24
@@ -46,16 +46,19 @@
 ;; @002b                               v32 = uextend.i64 v31
 ;; @002b                               v37 = icmp ugt v36, v32
 ;; @002b                               trapnz v37, user17
-;; @002b                               v49 = load.i64 notrap aligned v79+40
-;;                                     v75 = iconst.i64 28
-;; @002b                               v22 = iadd v9, v75  ; v75 = 28
+;; @002b                               v49 = load.i64 notrap aligned v81+40
+;;                                     v77 = iconst.i64 28
+;; @002b                               v22 = iadd v9, v77  ; v77 = 28
 ;; @002b                               v25 = iadd v22, v14
 ;; @002b                               v51 = uadd_overflow_trap v25, v15, user2
 ;; @002b                               v50 = iadd v8, v49
 ;; @002b                               v52 = icmp ugt v51, v50
 ;; @002b                               trapnz v52, user2
-;; @002b                               v41 = iadd v28, v75  ; v75 = 28
+;; @002b                               v41 = iadd v28, v77  ; v77 = 28
 ;; @002b                               v44 = iadd v41, v33
+;; @002b                               v56 = uadd_overflow_trap v44, v15, user2
+;; @002b                               v57 = icmp ugt v56, v50
+;; @002b                               trapnz v57, user2
 ;; @002b                               call fn0(v0, v25, v44, v15)
 ;; @002f                               jump block1
 ;;

--- a/tests/disas/array-fill-anyref.wat
+++ b/tests/disas/array-fill-anyref.wat
@@ -82,7 +82,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64, i32, i64) tail
-;;     fn0 = colocated u805306368:4 sig0
+;;     fn0 = colocated u805306368:2 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):

--- a/tests/disas/array-fill-externref.wat
+++ b/tests/disas/array-fill-externref.wat
@@ -78,7 +78,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64, i32, i64) tail
-;;     fn0 = colocated u805306368:4 sig0
+;;     fn0 = colocated u805306368:2 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):

--- a/tests/disas/array-fill-f32.wat
+++ b/tests/disas/array-fill-f32.wat
@@ -82,7 +82,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64, i32, i64) tail
-;;     fn0 = colocated u805306368:4 sig0
+;;     fn0 = colocated u805306368:2 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):

--- a/tests/disas/array-fill-f64.wat
+++ b/tests/disas/array-fill-f64.wat
@@ -82,7 +82,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64, i32, i64) tail
-;;     fn0 = colocated u805306368:4 sig0
+;;     fn0 = colocated u805306368:2 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):

--- a/tests/disas/array-fill-funcref.wat
+++ b/tests/disas/array-fill-funcref.wat
@@ -29,7 +29,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64) -> i64 tail
-;;     fn0 = colocated u805306368:24 sig0
+;;     fn0 = colocated u805306368:25 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i64, v5: i32):
@@ -89,7 +89,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64, i32, i64) tail
-;;     fn0 = colocated u805306368:4 sig0
+;;     fn0 = colocated u805306368:2 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
@@ -137,8 +137,8 @@
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32) -> i64 tail
 ;;     sig1 = (i64 vmctx, i64) -> i64 tail
-;;     fn0 = colocated u805306368:5 sig0
-;;     fn1 = colocated u805306368:24 sig1
+;;     fn0 = colocated u805306368:6 sig0
+;;     fn1 = colocated u805306368:25 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):

--- a/tests/disas/array-fill-i16.wat
+++ b/tests/disas/array-fill-i16.wat
@@ -86,7 +86,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64, i32, i64) tail
-;;     fn0 = colocated u805306368:4 sig0
+;;     fn0 = colocated u805306368:2 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
@@ -132,7 +132,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64, i32, i64) tail
-;;     fn0 = colocated u805306368:4 sig0
+;;     fn0 = colocated u805306368:2 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):

--- a/tests/disas/array-fill-i31ref.wat
+++ b/tests/disas/array-fill-i31ref.wat
@@ -82,7 +82,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64, i32, i64) tail
-;;     fn0 = colocated u805306368:4 sig0
+;;     fn0 = colocated u805306368:2 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):

--- a/tests/disas/array-fill-i32.wat
+++ b/tests/disas/array-fill-i32.wat
@@ -86,7 +86,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64, i32, i64) tail
-;;     fn0 = colocated u805306368:4 sig0
+;;     fn0 = colocated u805306368:2 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
@@ -132,7 +132,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64, i32, i64) tail
-;;     fn0 = colocated u805306368:4 sig0
+;;     fn0 = colocated u805306368:2 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):

--- a/tests/disas/array-fill-i64.wat
+++ b/tests/disas/array-fill-i64.wat
@@ -86,7 +86,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64, i32, i64) tail
-;;     fn0 = colocated u805306368:4 sig0
+;;     fn0 = colocated u805306368:2 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
@@ -132,7 +132,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64, i32, i64) tail
-;;     fn0 = colocated u805306368:4 sig0
+;;     fn0 = colocated u805306368:2 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):

--- a/tests/disas/call-indirect.wat
+++ b/tests/disas/call-indirect.wat
@@ -16,7 +16,7 @@
 ;;     gv5 = load.i64 notrap aligned gv3+56
 ;;     sig0 = (i64 vmctx, i64, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
-;;     fn0 = colocated u805306368:6 sig1
+;;     fn0 = colocated u805306368:7 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):

--- a/tests/disas/component-may-leave-without-signals-based-traps.wat
+++ b/tests/disas/component-may-leave-without-signals-based-traps.wat
@@ -44,7 +44,7 @@
 ;;       retq
 ;;  129: movq    %rbx, %rsi
 ;;  12c: movq    0x10(%rsi), %rax
-;;  130: movq    0x150(%rax), %rax
+;;  130: movq    0x148(%rax), %rax
 ;;  137: movq    %rbx, %rdi
 ;;  13a: callq   *%rax
 ;;  13c: ud2

--- a/tests/disas/debug.wat
+++ b/tests/disas/debug.wat
@@ -128,7 +128,7 @@
 ;;       popq    %rbp
 ;;       retq
 ;;  17a: movq    0x10(%rbx), %rax
-;;  17e: movq    0x150(%rax), %rax
+;;  17e: movq    0x148(%rax), %rax
 ;;  185: movq    %rbx, %rdi
 ;;  188: callq   *%rax
 ;;  18a: ud2
@@ -143,7 +143,7 @@
 ;;       movq    8(%r10), %r11
 ;;       movq    %r11, 0x38(%r9)
 ;;       movq    0x10(%rdi), %r11
-;;       movq    0x148(%r11), %r11
+;;       movq    0x140(%r11), %r11
 ;;       movzbq  %sil, %rsi
 ;;       callq   *%r11
 ;;       movq    %rbp, %rsp
@@ -160,7 +160,7 @@
 ;;       movq    8(%r9), %r9
 ;;       movq    %r9, 0x38(%r8)
 ;;       movq    0x10(%rdi), %r9
-;;       movq    0x150(%r9), %r9
+;;       movq    0x148(%r9), %r9
 ;;       callq   *%r9
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
@@ -203,7 +203,7 @@
 ;;       movq    8(%r11), %rax
 ;;       movq    %rax, 0x38(%r10)
 ;;       movq    0x10(%rdi), %rax
-;;       movq    0x178(%rax), %rcx
+;;       movq    0x170(%rax), %rcx
 ;;       movq    %rdi, %rbx
 ;;       callq   *%rcx
 ;;       testb   %al, %al
@@ -239,7 +239,7 @@
 ;;       popq    %rbp
 ;;       retq
 ;;  3af: movq    0x10(%rbx), %rax
-;;  3b3: movq    0x150(%rax), %rax
+;;  3b3: movq    0x148(%rax), %rax
 ;;  3ba: movq    %rbx, %rdi
 ;;  3bd: callq   *%rax
 ;;  3bf: ud2

--- a/tests/disas/duplicate-function-types.wat
+++ b/tests/disas/duplicate-function-types.wat
@@ -26,7 +26,7 @@
 ;;     gv6 = load.i64 notrap aligned gv4+8
 ;;     sig0 = (i64 vmctx, i64) -> i32 tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
-;;     fn0 = colocated u805306368:6 sig1
+;;     fn0 = colocated u805306368:7 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/epoch-interruption.wat
+++ b/tests/disas/epoch-interruption.wat
@@ -11,7 +11,7 @@
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
 ;;     sig0 = (i64 vmctx) -> i64 tail
-;;     fn0 = colocated u805306368:12 sig0
+;;     fn0 = colocated u805306368:13 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):

--- a/tests/disas/gc/array-copy-with-fuel.wat
+++ b/tests/disas/gc/array-copy-with-fuel.wat
@@ -20,34 +20,34 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx) -> i8 tail
-;;     fn0 = colocated u805306368:11 sig0
+;;     fn0 = colocated u805306368:12 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32, v6: i32):
-;;                                     v164 = stack_addr.i64 ss1
-;;                                     store notrap v2, v164
-;;                                     v163 = stack_addr.i64 ss0
-;;                                     store notrap v4, v163
+;;                                     v173 = stack_addr.i64 ss1
+;;                                     store notrap v2, v173
+;;                                     v172 = stack_addr.i64 ss0
+;;                                     store notrap v4, v172
 ;; @0020                               v7 = load.i64 notrap aligned readonly can_move v0+8
 ;; @0020                               v8 = load.i64 notrap aligned v7
-;;                                     v161 = iconst.i64 1
-;; @0020                               v9 = iadd v8, v161  ; v161 = 1
+;;                                     v170 = iconst.i64 1
+;; @0020                               v9 = iadd v8, v170  ; v170 = 1
 ;; @0020                               v10 = iconst.i64 0
 ;; @0020                               v11 = icmp sge v9, v10  ; v10 = 0
 ;; @0020                               brif v11, block2, block3(v9)
 ;;
 ;;                                 block2:
-;;                                     v176 = iadd.i64 v8, v161  ; v161 = 1
-;; @0020                               store notrap aligned v176, v7
+;;                                     v182 = iadd.i64 v8, v170  ; v170 = 1
+;; @0020                               store notrap aligned v182, v7
 ;; @0020                               v14 = call fn0(v0), stack_map=[i32 @ ss1+0, i32 @ ss0+0]
 ;; @0020                               v16 = load.i64 notrap aligned v7
 ;; @0020                               jump block3(v16)
 ;;
-;;                                 block3(v113: i64):
-;;                                     v123 = load.i32 notrap v164
-;; @002b                               trapz v123, user16
+;;                                 block3(v116: i64):
+;;                                     v126 = load.i32 notrap v173
+;; @002b                               trapz v126, user16
 ;; @002b                               v23 = load.i64 notrap aligned readonly can_move v7+32
-;; @002b                               v22 = uextend.i64 v123
+;; @002b                               v22 = uextend.i64 v126
 ;; @002b                               v24 = iadd v23, v22
 ;; @002b                               v25 = iconst.i64 16
 ;; @002b                               v26 = iadd v24, v25  ; v25 = 16
@@ -58,9 +58,9 @@
 ;; @002b                               v28 = uextend.i64 v27
 ;; @002b                               v33 = icmp ugt v32, v28
 ;; @002b                               trapnz v33, user17
-;;                                     v120 = load.i32 notrap v163
-;; @002b                               trapz v120, user16
-;; @002b                               v41 = uextend.i64 v120
+;;                                     v123 = load.i32 notrap v172
+;; @002b                               trapz v123, user16
+;; @002b                               v41 = uextend.i64 v123
 ;; @002b                               v43 = iadd v23, v41
 ;; @002b                               v45 = iadd v43, v25  ; v25 = 16
 ;; @002b                               v46 = load.i32 user2 readonly v45
@@ -70,83 +70,84 @@
 ;; @002b                               v52 = icmp ugt v51, v47
 ;; @002b                               trapnz v52, user17
 ;; @002b                               v64 = load.i64 notrap aligned v7+40
-;;                                     v150 = iconst.i64 20
-;; @002b                               v37 = iadd v24, v150  ; v150 = 20
-;;                                     v166 = iconst.i64 2
-;;                                     v167 = ishl v29, v166  ; v166 = 2
-;; @002b                               v40 = iadd v37, v167
-;;                                     v171 = ishl v30, v166  ; v166 = 2
-;; @002b                               v66 = uadd_overflow_trap v40, v171, user2
+;;                                     v159 = iconst.i64 20
+;; @002b                               v37 = iadd v24, v159  ; v159 = 20
+;;                                     v175 = iconst.i64 2
+;;                                     v176 = ishl v29, v175  ; v175 = 2
+;; @002b                               v40 = iadd v37, v176
+;;                                     v180 = ishl v30, v175  ; v175 = 2
+;; @002b                               v66 = uadd_overflow_trap v40, v180, user2
 ;; @002b                               v65 = iadd v23, v64
 ;; @002b                               v67 = icmp ugt v66, v65
 ;; @002b                               trapnz v67, user2
-;; @002b                               brif v30, block4, block7(v113)
+;; @002b                               v56 = iadd v43, v159  ; v159 = 20
+;;                                     v178 = ishl v48, v175  ; v175 = 2
+;; @002b                               v59 = iadd v56, v178
+;; @002b                               v71 = uadd_overflow_trap v59, v180, user2
+;; @002b                               v72 = icmp ugt v71, v65
+;; @002b                               trapnz v72, user2
+;; @002b                               brif v30, block4, block7(v116)
 ;;
 ;;                                 block4:
-;;                                     v177 = iconst.i64 20
-;;                                     v178 = iadd.i64 v43, v177  ; v177 = 20
-;;                                     v179 = iconst.i64 2
-;;                                     v180 = ishl.i64 v48, v179  ; v179 = 2
-;; @002b                               v59 = iadd v178, v180
 ;; @002b                               v73 = icmp.i64 ult v40, v59
-;; @002b                               v75 = iadd.i64 v40, v171
-;; @002b                               v76 = iadd v59, v171
-;; @002b                               v78 = iadd.i32 v5, v6
-;;                                     v149 = iconst.i64 4
-;; @002b                               v109 = iconst.i32 1
-;;                                     v130 = iconst.i64 6
-;; @002b                               brif v73, block5(v40, v59, v5, v113), block6(v75, v76, v78, v113)
+;; @002b                               v76 = iadd.i64 v40, v180
+;; @002b                               v77 = iadd.i64 v59, v180
+;; @002b                               v79 = iadd.i32 v5, v6
+;;                                     v158 = iconst.i64 4
+;; @002b                               v112 = iconst.i32 1
+;;                                     v135 = iconst.i64 6
+;; @002b                               brif v73, block5(v40, v59, v5, v116), block6(v76, v77, v79, v116)
 ;;
-;;                                 block5(v79: i64, v80: i64, v81: i32, v82: i64):
-;;                                     v188 = iconst.i64 6
-;;                                     v189 = iadd v82, v188  ; v188 = 6
-;;                                     v190 = iconst.i64 0
-;;                                     v191 = icmp sge v189, v190  ; v190 = 0
-;; @002b                               brif v191, block8, block9(v189)
+;;                                 block5(v80: i64, v81: i64, v82: i32, v83: i64):
+;;                                     v190 = iconst.i64 6
+;;                                     v191 = iadd v83, v190  ; v190 = 6
+;;                                     v192 = iconst.i64 0
+;;                                     v193 = icmp sge v191, v192  ; v192 = 0
+;; @002b                               brif v193, block8, block9(v191)
 ;;
-;;                                 block6(v96: i64, v97: i64, v98: i32, v100: i64):
-;;                                     v181 = iconst.i64 0
-;;                                     v182 = icmp sge v100, v181  ; v181 = 0
-;; @002b                               brif v182, block10, block11(v100)
+;;                                 block6(v97: i64, v98: i64, v99: i32, v101: i64):
+;;                                     v183 = iconst.i64 0
+;;                                     v184 = icmp sge v101, v183  ; v183 = 0
+;; @002b                               brif v184, block10, block11(v101)
 ;;
-;;                                 block7(v117: i64):
+;;                                 block7(v120: i64):
 ;; @002f                               jump block1
 ;;
 ;;                                 block8:
-;; @002b                               store.i64 notrap aligned v189, v7
-;; @002b                               v88 = call fn0(v0)
-;; @002b                               v90 = load.i64 notrap aligned v7
-;; @002b                               jump block9(v90)
+;; @002b                               store.i64 notrap aligned v191, v7
+;; @002b                               v89 = call fn0(v0)
+;; @002b                               v91 = load.i64 notrap aligned v7
+;; @002b                               jump block9(v91)
 ;;
-;;                                 block9(v114: i64):
-;; @002b                               v91 = load.i32 user2 little v80
-;; @002b                               store user2 little v91, v79
-;;                                     v192 = iconst.i64 4
-;;                                     v193 = iadd.i64 v80, v192  ; v192 = 4
-;; @002b                               v95 = icmp eq v193, v76
-;;                                     v194 = iadd.i64 v79, v192  ; v192 = 4
-;;                                     v195 = iconst.i32 1
-;;                                     v196 = iadd.i32 v81, v195  ; v195 = 1
-;; @002b                               brif v95, block7(v114), block5(v194, v193, v196, v114)
+;;                                 block9(v117: i64):
+;; @002b                               v92 = load.i32 user2 little v81
+;; @002b                               store user2 little v92, v80
+;;                                     v194 = iconst.i64 4
+;;                                     v195 = iadd.i64 v81, v194  ; v194 = 4
+;; @002b                               v96 = icmp eq v195, v77
+;;                                     v196 = iadd.i64 v80, v194  ; v194 = 4
+;;                                     v197 = iconst.i32 1
+;;                                     v198 = iadd.i32 v82, v197  ; v197 = 1
+;; @002b                               brif v96, block7(v117), block5(v196, v195, v198, v117)
 ;;
 ;;                                 block10:
-;; @002b                               store.i64 notrap aligned v100, v7
-;; @002b                               v104 = call fn0(v0)
-;; @002b                               v106 = load.i64 notrap aligned v7
-;; @002b                               jump block11(v106)
+;; @002b                               store.i64 notrap aligned v101, v7
+;; @002b                               v105 = call fn0(v0)
+;; @002b                               v107 = load.i64 notrap aligned v7
+;; @002b                               jump block11(v107)
 ;;
-;;                                 block11(v115: i64):
-;;                                     v183 = iconst.i64 4
-;;                                     v184 = isub.i64 v97, v183  ; v183 = 4
-;; @002b                               v111 = load.i32 user2 little v184
-;;                                     v185 = isub.i64 v96, v183  ; v183 = 4
-;; @002b                               store user2 little v111, v185
-;; @002b                               v112 = icmp eq v184, v59
-;;                                     v186 = iconst.i32 1
-;;                                     v187 = isub.i32 v98, v186  ; v186 = 1
-;; @002b                               brif v112, block7(v115), block6(v185, v184, v187, v115)
+;;                                 block11(v118: i64):
+;;                                     v185 = iconst.i64 4
+;;                                     v186 = isub.i64 v98, v185  ; v185 = 4
+;; @002b                               v114 = load.i32 user2 little v186
+;;                                     v187 = isub.i64 v97, v185  ; v185 = 4
+;; @002b                               store user2 little v114, v187
+;; @002b                               v115 = icmp eq v186, v59
+;;                                     v188 = iconst.i32 1
+;;                                     v189 = isub.i32 v99, v188  ; v188 = 1
+;; @002b                               brif v115, block7(v118), block6(v187, v186, v189, v118)
 ;;
 ;;                                 block1:
-;; @002f                               store.i64 notrap aligned v117, v7
+;; @002f                               store.i64 notrap aligned v120, v7
 ;; @002f                               return
 ;; }

--- a/tests/disas/gc/array-fill-i8.wat
+++ b/tests/disas/gc/array-fill-i8.wat
@@ -18,7 +18,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64, i32, i64) tail
-;;     fn0 = colocated u805306368:4 sig0
+;;     fn0 = colocated u805306368:2 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):

--- a/tests/disas/gc/array-init-data.wat
+++ b/tests/disas/gc/array-init-data.wat
@@ -22,13 +22,13 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64, i64, i64) tail
-;;     fn0 = colocated u805306368:3 sig0
+;;     fn0 = colocated u805306368:1 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
 ;; @002a                               trapz v2, user16
-;; @002a                               v64 = load.i64 notrap aligned readonly can_move v0+8
-;; @002a                               v7 = load.i64 notrap aligned readonly can_move v64+32
+;; @002a                               v57 = load.i64 notrap aligned readonly can_move v0+8
+;; @002a                               v7 = load.i64 notrap aligned readonly can_move v57+32
 ;; @002a                               v6 = uextend.i64 v2
 ;; @002a                               v8 = iadd v7, v6
 ;; @002a                               v9 = iconst.i64 24
@@ -46,9 +46,9 @@
 ;; @002a                               v31 = icmp ugt v30, v26
 ;; @002a                               trapnz v31, heap_oob
 ;; @002a                               v33 = load.i64 notrap aligned v0+48
-;; @002a                               v40 = load.i64 notrap aligned v64+40
-;;                                     v60 = iconst.i64 28
-;; @002a                               v21 = iadd v8, v60  ; v60 = 28
+;; @002a                               v40 = load.i64 notrap aligned v57+40
+;;                                     v53 = iconst.i64 28
+;; @002a                               v21 = iadd v8, v53  ; v53 = 28
 ;; @002a                               v24 = iadd v21, v13
 ;; @002a                               v42 = uadd_overflow_trap v24, v14, user2
 ;; @002a                               v41 = iadd v7, v40

--- a/tests/disas/gc/array-new-data.wat
+++ b/tests/disas/gc/array-new-data.wat
@@ -86,8 +86,8 @@
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64, i64, i64) tail
-;;     fn0 = colocated u805306368:23 sig0
-;;     fn1 = colocated u805306368:3 sig1
+;;     fn0 = colocated u805306368:24 sig0
+;;     fn1 = colocated u805306368:1 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -98,8 +98,8 @@
 ;; @0025                               v11 = icmp ugt v10, v6
 ;; @0025                               trapnz v11, heap_oob
 ;; @0025                               v13 = load.i64 notrap aligned v0+48
-;;                                     v108 = iconst.i64 32
-;; @0025                               v19 = ushr v8, v108  ; v108 = 32
+;;                                     v101 = iconst.i64 32
+;; @0025                               v19 = ushr v8, v101  ; v101 = 32
 ;; @0025                               trapnz v19, user18
 ;; @0025                               v16 = iconst.i32 28
 ;; @0025                               v21 = uadd_overflow_trap v16, v3, user18  ; v16 = 28
@@ -108,20 +108,20 @@
 ;; @0025                               v26 = load.i32 notrap aligned readonly can_move v25
 ;; @0025                               v27 = iconst.i32 8
 ;; @0025                               v28 = call fn0(v0, v23, v26, v21, v27)  ; v23 = -1476395008, v27 = 8
-;;                                     v107 = stack_addr.i64 ss0
-;;                                     store notrap v28, v107
-;; @0025                               v105 = load.i64 notrap aligned readonly can_move v0+8
-;; @0025                               v29 = load.i64 notrap aligned readonly can_move v105+32
+;;                                     v100 = stack_addr.i64 ss0
+;;                                     store notrap v28, v100
+;; @0025                               v98 = load.i64 notrap aligned readonly can_move v0+8
+;; @0025                               v29 = load.i64 notrap aligned readonly can_move v98+32
 ;; @0025                               v30 = uextend.i64 v28
 ;; @0025                               v31 = iadd v29, v30
-;;                                     v103 = iconst.i64 24
-;; @0025                               v32 = iadd v31, v103  ; v103 = 24
+;;                                     v96 = iconst.i64 24
+;; @0025                               v32 = iadd v31, v96  ; v96 = 24
 ;; @0025                               store user2 v3, v32
-;;                                     v81 = load.i32 notrap v107
-;; @0025                               trapz v81, user16
-;; @0025                               v34 = uextend.i64 v81
+;;                                     v76 = load.i32 notrap v100
+;; @0025                               trapz v76, user16
+;; @0025                               v34 = uextend.i64 v76
 ;; @0025                               v36 = iadd v29, v34
-;; @0025                               v38 = iadd v36, v103  ; v103 = 24
+;; @0025                               v38 = iadd v36, v96  ; v96 = 24
 ;; @0025                               v39 = load.i32 user2 readonly v38
 ;; @0025                               v40 = uextend.i64 v39
 ;; @0025                               v45 = icmp ugt v8, v40
@@ -130,18 +130,18 @@
 ;; @0025                               v59 = icmp ugt v10, v54
 ;; @0025                               trapnz v59, heap_oob
 ;; @0025                               v61 = load.i64 notrap aligned v0+48
-;; @0025                               v68 = load.i64 notrap aligned v105+40
-;;                                     v94 = iconst.i64 28
-;; @0025                               v49 = iadd v36, v94  ; v94 = 28
+;; @0025                               v68 = load.i64 notrap aligned v98+40
+;;                                     v87 = iconst.i64 28
+;; @0025                               v49 = iadd v36, v87  ; v87 = 28
 ;; @0025                               v70 = uadd_overflow_trap v49, v8, user2
 ;; @0025                               v69 = iadd v29, v68
 ;; @0025                               v71 = icmp ugt v70, v69
 ;; @0025                               trapnz v71, user2
 ;; @0025                               v63 = iadd v61, v7
 ;; @0025                               call fn1(v0, v49, v63, v8), stack_map=[i32 @ ss0+0]
-;;                                     v78 = load.i32 notrap v107
+;;                                     v73 = load.i32 notrap v100
 ;; @0029                               jump block1
 ;;
 ;;                                 block1:
-;; @0029                               return v78
+;; @0029                               return v73
 ;; }

--- a/tests/disas/gc/array-new-default-anyref.wat
+++ b/tests/disas/gc/array-new-default-anyref.wat
@@ -20,8 +20,8 @@
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64, i32, i64) tail
-;;     fn0 = colocated u805306368:23 sig0
-;;     fn1 = colocated u805306368:4 sig1
+;;     fn0 = colocated u805306368:24 sig0
+;;     fn1 = colocated u805306368:2 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/array-new-default-exnref.wat
+++ b/tests/disas/gc/array-new-default-exnref.wat
@@ -20,8 +20,8 @@
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64, i32, i64) tail
-;;     fn0 = colocated u805306368:23 sig0
-;;     fn1 = colocated u805306368:4 sig1
+;;     fn0 = colocated u805306368:24 sig0
+;;     fn1 = colocated u805306368:2 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/array-new-default-externref.wat
+++ b/tests/disas/gc/array-new-default-externref.wat
@@ -20,8 +20,8 @@
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64, i32, i64) tail
-;;     fn0 = colocated u805306368:23 sig0
-;;     fn1 = colocated u805306368:4 sig1
+;;     fn0 = colocated u805306368:24 sig0
+;;     fn1 = colocated u805306368:2 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/array-new-default-f32.wat
+++ b/tests/disas/gc/array-new-default-f32.wat
@@ -20,8 +20,8 @@
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64, i32, i64) tail
-;;     fn0 = colocated u805306368:23 sig0
-;;     fn1 = colocated u805306368:4 sig1
+;;     fn0 = colocated u805306368:24 sig0
+;;     fn1 = colocated u805306368:2 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/array-new-default-f64.wat
+++ b/tests/disas/gc/array-new-default-f64.wat
@@ -20,8 +20,8 @@
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64, i32, i64) tail
-;;     fn0 = colocated u805306368:23 sig0
-;;     fn1 = colocated u805306368:4 sig1
+;;     fn0 = colocated u805306368:24 sig0
+;;     fn1 = colocated u805306368:2 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/array-new-default-funcref.wat
+++ b/tests/disas/gc/array-new-default-funcref.wat
@@ -20,8 +20,8 @@
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64, i32, i64) tail
-;;     fn0 = colocated u805306368:23 sig0
-;;     fn1 = colocated u805306368:4 sig1
+;;     fn0 = colocated u805306368:24 sig0
+;;     fn1 = colocated u805306368:2 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/array-new-default-i16.wat
+++ b/tests/disas/gc/array-new-default-i16.wat
@@ -20,8 +20,8 @@
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64, i32, i64) tail
-;;     fn0 = colocated u805306368:23 sig0
-;;     fn1 = colocated u805306368:4 sig1
+;;     fn0 = colocated u805306368:24 sig0
+;;     fn1 = colocated u805306368:2 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/array-new-default-i32.wat
+++ b/tests/disas/gc/array-new-default-i32.wat
@@ -20,8 +20,8 @@
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64, i32, i64) tail
-;;     fn0 = colocated u805306368:23 sig0
-;;     fn1 = colocated u805306368:4 sig1
+;;     fn0 = colocated u805306368:24 sig0
+;;     fn1 = colocated u805306368:2 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/array-new-default-i64.wat
+++ b/tests/disas/gc/array-new-default-i64.wat
@@ -20,8 +20,8 @@
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64, i32, i64) tail
-;;     fn0 = colocated u805306368:23 sig0
-;;     fn1 = colocated u805306368:4 sig1
+;;     fn0 = colocated u805306368:24 sig0
+;;     fn1 = colocated u805306368:2 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/array-new-default-i8.wat
+++ b/tests/disas/gc/array-new-default-i8.wat
@@ -20,8 +20,8 @@
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64, i32, i64) tail
-;;     fn0 = colocated u805306368:23 sig0
-;;     fn1 = colocated u805306368:4 sig1
+;;     fn0 = colocated u805306368:24 sig0
+;;     fn1 = colocated u805306368:2 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/copying/array-new-fixed-of-gc-refs.wat
+++ b/tests/disas/gc/copying/array-new-fixed-of-gc-refs.wat
@@ -20,7 +20,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
-;;     fn0 = colocated u805306368:23 sig0
+;;     fn0 = colocated u805306368:24 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):

--- a/tests/disas/gc/copying/array-new-fixed.wat
+++ b/tests/disas/gc/copying/array-new-fixed.wat
@@ -17,7 +17,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
-;;     fn0 = colocated u805306368:23 sig0
+;;     fn0 = colocated u805306368:24 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64):

--- a/tests/disas/gc/copying/array-new.wat
+++ b/tests/disas/gc/copying/array-new.wat
@@ -17,7 +17,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
-;;     fn0 = colocated u805306368:23 sig0
+;;     fn0 = colocated u805306368:24 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):

--- a/tests/disas/gc/copying/br-on-cast-fail.wat
+++ b/tests/disas/gc/copying/br-on-cast-fail.wat
@@ -26,7 +26,7 @@
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64) tail
-;;     fn0 = colocated u805306368:28 sig0
+;;     fn0 = colocated u805306368:27 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/copying/br-on-cast.wat
+++ b/tests/disas/gc/copying/br-on-cast.wat
@@ -26,7 +26,7 @@
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64) tail
-;;     fn0 = colocated u805306368:28 sig0
+;;     fn0 = colocated u805306368:27 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/copying/call-indirect-and-subtyping.wat
+++ b/tests/disas/gc/copying/call-indirect-and-subtyping.wat
@@ -24,8 +24,8 @@
 ;;     sig0 = (i64 vmctx, i64) tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
 ;;     sig2 = (i64 vmctx, i32, i32) -> i32 tail
-;;     fn0 = colocated u805306368:6 sig1
-;;     fn1 = colocated u805306368:28 sig2
+;;     fn0 = colocated u805306368:7 sig1
+;;     fn1 = colocated u805306368:27 sig2
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/copying/funcref-in-gc-heap-get.wat
+++ b/tests/disas/gc/copying/funcref-in-gc-heap-get.wat
@@ -17,7 +17,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32) -> i64 tail
-;;     fn0 = colocated u805306368:25 sig0
+;;     fn0 = colocated u805306368:26 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/copying/funcref-in-gc-heap-new.wat
+++ b/tests/disas/gc/copying/funcref-in-gc-heap-new.wat
@@ -18,8 +18,8 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64) -> i64 tail
-;;     fn0 = colocated u805306368:23 sig0
-;;     fn1 = colocated u805306368:24 sig1
+;;     fn0 = colocated u805306368:24 sig0
+;;     fn1 = colocated u805306368:25 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):

--- a/tests/disas/gc/copying/funcref-in-gc-heap-set.wat
+++ b/tests/disas/gc/copying/funcref-in-gc-heap-set.wat
@@ -17,7 +17,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64) -> i64 tail
-;;     fn0 = colocated u805306368:24 sig0
+;;     fn0 = colocated u805306368:25 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i64):

--- a/tests/disas/gc/copying/ref-cast.wat
+++ b/tests/disas/gc/copying/ref-cast.wat
@@ -17,7 +17,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32) -> i32 tail
-;;     fn0 = colocated u805306368:28 sig0
+;;     fn0 = colocated u805306368:27 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/copying/ref-test-concrete-func-type.wat
+++ b/tests/disas/gc/copying/ref-test-concrete-func-type.wat
@@ -13,7 +13,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i32, i32) -> i32 tail
-;;     fn0 = colocated u805306368:28 sig0
+;;     fn0 = colocated u805306368:27 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):

--- a/tests/disas/gc/copying/ref-test-concrete-type.wat
+++ b/tests/disas/gc/copying/ref-test-concrete-type.wat
@@ -16,7 +16,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32) -> i32 tail
-;;     fn0 = colocated u805306368:28 sig0
+;;     fn0 = colocated u805306368:27 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/copying/struct-new-default.wat
+++ b/tests/disas/gc/copying/struct-new-default.wat
@@ -18,7 +18,7 @@
 ;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
-;;     fn0 = colocated u805306368:23 sig0
+;;     fn0 = colocated u805306368:24 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):

--- a/tests/disas/gc/copying/struct-new.wat
+++ b/tests/disas/gc/copying/struct-new.wat
@@ -19,7 +19,7 @@
 ;;     gv4 = load.i64 notrap aligned readonly can_move gv3+8
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
-;;     fn0 = colocated u805306368:23 sig0
+;;     fn0 = colocated u805306368:24 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: f32, v3: i32, v4: i32):

--- a/tests/disas/gc/drc/array-new-fixed-of-gc-refs.wat
+++ b/tests/disas/gc/drc/array-new-fixed-of-gc-refs.wat
@@ -21,7 +21,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
-;;     fn0 = colocated u805306368:23 sig0
+;;     fn0 = colocated u805306368:24 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):

--- a/tests/disas/gc/drc/array-new-fixed.wat
+++ b/tests/disas/gc/drc/array-new-fixed.wat
@@ -18,7 +18,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
-;;     fn0 = colocated u805306368:23 sig0
+;;     fn0 = colocated u805306368:24 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64):

--- a/tests/disas/gc/drc/array-new.wat
+++ b/tests/disas/gc/drc/array-new.wat
@@ -18,7 +18,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
-;;     fn0 = colocated u805306368:23 sig0
+;;     fn0 = colocated u805306368:24 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):

--- a/tests/disas/gc/drc/br-on-cast-fail.wat
+++ b/tests/disas/gc/drc/br-on-cast-fail.wat
@@ -27,7 +27,7 @@
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64) tail
-;;     fn0 = colocated u805306368:28 sig0
+;;     fn0 = colocated u805306368:27 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/drc/br-on-cast.wat
+++ b/tests/disas/gc/drc/br-on-cast.wat
@@ -27,7 +27,7 @@
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64) tail
-;;     fn0 = colocated u805306368:28 sig0
+;;     fn0 = colocated u805306368:27 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/drc/call-indirect-and-subtyping.wat
+++ b/tests/disas/gc/drc/call-indirect-and-subtyping.wat
@@ -25,8 +25,8 @@
 ;;     sig0 = (i64 vmctx, i64) tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
 ;;     sig2 = (i64 vmctx, i32, i32) -> i32 tail
-;;     fn0 = colocated u805306368:6 sig1
-;;     fn1 = colocated u805306368:28 sig2
+;;     fn0 = colocated u805306368:7 sig1
+;;     fn1 = colocated u805306368:27 sig2
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/drc/externref-globals.wat
+++ b/tests/disas/gc/drc/externref-globals.wat
@@ -22,7 +22,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx) -> i8 tail
-;;     fn0 = colocated u805306368:46 sig0
+;;     fn0 = colocated u805306368:45 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
@@ -107,7 +107,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32) tail
-;;     fn0 = colocated u805306368:21 sig0
+;;     fn0 = colocated u805306368:22 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/drc/funcref-in-gc-heap-get.wat
+++ b/tests/disas/gc/drc/funcref-in-gc-heap-get.wat
@@ -18,7 +18,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32) -> i64 tail
-;;     fn0 = colocated u805306368:25 sig0
+;;     fn0 = colocated u805306368:26 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/drc/funcref-in-gc-heap-new.wat
+++ b/tests/disas/gc/drc/funcref-in-gc-heap-new.wat
@@ -19,8 +19,8 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64) -> i64 tail
-;;     fn0 = colocated u805306368:23 sig0
-;;     fn1 = colocated u805306368:24 sig1
+;;     fn0 = colocated u805306368:24 sig0
+;;     fn1 = colocated u805306368:25 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):

--- a/tests/disas/gc/drc/funcref-in-gc-heap-set.wat
+++ b/tests/disas/gc/drc/funcref-in-gc-heap-set.wat
@@ -18,7 +18,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64) -> i64 tail
-;;     fn0 = colocated u805306368:24 sig0
+;;     fn0 = colocated u805306368:25 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i64):

--- a/tests/disas/gc/drc/ref-cast.wat
+++ b/tests/disas/gc/drc/ref-cast.wat
@@ -18,7 +18,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32) -> i32 tail
-;;     fn0 = colocated u805306368:28 sig0
+;;     fn0 = colocated u805306368:27 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/drc/ref-test-concrete-func-type.wat
+++ b/tests/disas/gc/drc/ref-test-concrete-func-type.wat
@@ -14,7 +14,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i32, i32) -> i32 tail
-;;     fn0 = colocated u805306368:28 sig0
+;;     fn0 = colocated u805306368:27 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):

--- a/tests/disas/gc/drc/ref-test-concrete-type.wat
+++ b/tests/disas/gc/drc/ref-test-concrete-type.wat
@@ -17,7 +17,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32) -> i32 tail
-;;     fn0 = colocated u805306368:28 sig0
+;;     fn0 = colocated u805306368:27 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/drc/struct-get.wat
+++ b/tests/disas/gc/drc/struct-get.wat
@@ -110,7 +110,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx) -> i8 tail
-;;     fn0 = colocated u805306368:46 sig0
+;;     fn0 = colocated u805306368:45 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/drc/struct-new-default.wat
+++ b/tests/disas/gc/drc/struct-new-default.wat
@@ -20,7 +20,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
-;;     fn0 = colocated u805306368:23 sig0
+;;     fn0 = colocated u805306368:24 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):

--- a/tests/disas/gc/drc/struct-new.wat
+++ b/tests/disas/gc/drc/struct-new.wat
@@ -21,7 +21,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
-;;     fn0 = colocated u805306368:23 sig0
+;;     fn0 = colocated u805306368:24 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: f32, v3: i32, v4: i32):

--- a/tests/disas/gc/drc/struct-set.wat
+++ b/tests/disas/gc/drc/struct-set.wat
@@ -78,7 +78,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32) tail
-;;     fn0 = colocated u805306368:21 sig0
+;;     fn0 = colocated u805306368:22 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):

--- a/tests/disas/gc/null/array-new-fixed-of-gc-refs.wat
+++ b/tests/disas/gc/null/array-new-fixed-of-gc-refs.wat
@@ -21,7 +21,7 @@
 ;;     gv5 = load.i64 notrap aligned gv4+40
 ;;     gv6 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     sig0 = (i64 vmctx, i64) -> i8 tail
-;;     fn0 = colocated u805306368:22 sig0
+;;     fn0 = colocated u805306368:23 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):

--- a/tests/disas/gc/null/array-new-fixed.wat
+++ b/tests/disas/gc/null/array-new-fixed.wat
@@ -18,7 +18,7 @@
 ;;     gv5 = load.i64 notrap aligned gv4+40
 ;;     gv6 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     sig0 = (i64 vmctx, i64) -> i8 tail
-;;     fn0 = colocated u805306368:22 sig0
+;;     fn0 = colocated u805306368:23 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64):

--- a/tests/disas/gc/null/array-new.wat
+++ b/tests/disas/gc/null/array-new.wat
@@ -18,7 +18,7 @@
 ;;     gv5 = load.i64 notrap aligned gv4+40
 ;;     gv6 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     sig0 = (i64 vmctx, i64) -> i8 tail
-;;     fn0 = colocated u805306368:22 sig0
+;;     fn0 = colocated u805306368:23 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32):

--- a/tests/disas/gc/null/br-on-cast-fail.wat
+++ b/tests/disas/gc/null/br-on-cast-fail.wat
@@ -27,7 +27,7 @@
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64) tail
-;;     fn0 = colocated u805306368:28 sig0
+;;     fn0 = colocated u805306368:27 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/null/br-on-cast.wat
+++ b/tests/disas/gc/null/br-on-cast.wat
@@ -27,7 +27,7 @@
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i64) tail
-;;     fn0 = colocated u805306368:28 sig0
+;;     fn0 = colocated u805306368:27 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/null/call-indirect-and-subtyping.wat
+++ b/tests/disas/gc/null/call-indirect-and-subtyping.wat
@@ -25,8 +25,8 @@
 ;;     sig0 = (i64 vmctx, i64) tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
 ;;     sig2 = (i64 vmctx, i32, i32) -> i32 tail
-;;     fn0 = colocated u805306368:6 sig1
-;;     fn1 = colocated u805306368:28 sig2
+;;     fn0 = colocated u805306368:7 sig1
+;;     fn1 = colocated u805306368:27 sig2
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/null/funcref-in-gc-heap-get.wat
+++ b/tests/disas/gc/null/funcref-in-gc-heap-get.wat
@@ -18,7 +18,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32) -> i64 tail
-;;     fn0 = colocated u805306368:25 sig0
+;;     fn0 = colocated u805306368:26 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/null/funcref-in-gc-heap-new.wat
+++ b/tests/disas/gc/null/funcref-in-gc-heap-new.wat
@@ -19,8 +19,8 @@
 ;;     gv6 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     sig0 = (i64 vmctx, i64) -> i8 tail
 ;;     sig1 = (i64 vmctx, i64) -> i64 tail
-;;     fn0 = colocated u805306368:22 sig0
-;;     fn1 = colocated u805306368:24 sig1
+;;     fn0 = colocated u805306368:23 sig0
+;;     fn1 = colocated u805306368:25 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):

--- a/tests/disas/gc/null/funcref-in-gc-heap-set.wat
+++ b/tests/disas/gc/null/funcref-in-gc-heap-set.wat
@@ -18,7 +18,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i64) -> i64 tail
-;;     fn0 = colocated u805306368:24 sig0
+;;     fn0 = colocated u805306368:25 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i64):

--- a/tests/disas/gc/null/ref-cast.wat
+++ b/tests/disas/gc/null/ref-cast.wat
@@ -18,7 +18,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32) -> i32 tail
-;;     fn0 = colocated u805306368:28 sig0
+;;     fn0 = colocated u805306368:27 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/null/ref-test-concrete-func-type.wat
+++ b/tests/disas/gc/null/ref-test-concrete-func-type.wat
@@ -14,7 +14,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i32, i32) -> i32 tail
-;;     fn0 = colocated u805306368:28 sig0
+;;     fn0 = colocated u805306368:27 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64):

--- a/tests/disas/gc/null/ref-test-concrete-type.wat
+++ b/tests/disas/gc/null/ref-test-concrete-type.wat
@@ -17,7 +17,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32) -> i32 tail
-;;     fn0 = colocated u805306368:28 sig0
+;;     fn0 = colocated u805306368:27 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/gc/null/struct-new-default.wat
+++ b/tests/disas/gc/null/struct-new-default.wat
@@ -20,7 +20,7 @@
 ;;     gv5 = load.i64 notrap aligned gv4+40
 ;;     gv6 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     sig0 = (i64 vmctx, i64) -> i8 tail
-;;     fn0 = colocated u805306368:22 sig0
+;;     fn0 = colocated u805306368:23 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):

--- a/tests/disas/gc/null/struct-new.wat
+++ b/tests/disas/gc/null/struct-new.wat
@@ -21,7 +21,7 @@
 ;;     gv5 = load.i64 notrap aligned gv4+40
 ;;     gv6 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     sig0 = (i64 vmctx, i64) -> i8 tail
-;;     fn0 = colocated u805306368:22 sig0
+;;     fn0 = colocated u805306368:23 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: f32, v3: i32, v4: i32):

--- a/tests/disas/gc/struct-new-default.wat
+++ b/tests/disas/gc/struct-new-default.wat
@@ -21,7 +21,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
-;;     fn0 = colocated u805306368:23 sig0
+;;     fn0 = colocated u805306368:24 sig0
 ;;     const0 = 0x00000000000000000000000000000000
 ;;     stack_limit = gv2
 ;;

--- a/tests/disas/gc/struct-new.wat
+++ b/tests/disas/gc/struct-new.wat
@@ -21,7 +21,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx, i32, i32, i32, i32) -> i32 tail
-;;     fn0 = colocated u805306368:23 sig0
+;;     fn0 = colocated u805306368:24 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: f32, v3: i32, v4: i32):

--- a/tests/disas/icall-loop.wat
+++ b/tests/disas/icall-loop.wat
@@ -30,7 +30,7 @@
 ;;     gv4 = load.i64 notrap aligned readonly can_move gv3+48
 ;;     sig0 = (i64 vmctx, i64) -> i32 tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
-;;     fn0 = colocated u805306368:6 sig1
+;;     fn0 = colocated u805306368:7 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -78,7 +78,7 @@
 ;;     gv4 = load.i64 notrap aligned readonly can_move gv3+48
 ;;     sig0 = (i64 vmctx, i64) -> i32 tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
-;;     fn0 = colocated u805306368:6 sig1
+;;     fn0 = colocated u805306368:7 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):

--- a/tests/disas/icall-simd.wat
+++ b/tests/disas/icall-simd.wat
@@ -16,7 +16,7 @@
 ;;     gv4 = load.i64 notrap aligned readonly can_move gv3+48
 ;;     sig0 = (i64 vmctx, i64, i8x16) -> i8x16 tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
-;;     fn0 = colocated u805306368:6 sig1
+;;     fn0 = colocated u805306368:7 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i8x16):

--- a/tests/disas/icall.wat
+++ b/tests/disas/icall.wat
@@ -16,7 +16,7 @@
 ;;     gv4 = load.i64 notrap aligned readonly can_move gv3+48
 ;;     sig0 = (i64 vmctx, i64, f32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
-;;     fn0 = colocated u805306368:6 sig1
+;;     fn0 = colocated u805306368:7 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: f32):

--- a/tests/disas/indirect-call-no-caching.wat
+++ b/tests/disas/indirect-call-no-caching.wat
@@ -70,7 +70,7 @@
 ;;     gv4 = load.i64 notrap aligned readonly can_move gv3+48
 ;;     sig0 = (i64 vmctx, i64) -> i32 tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
-;;     fn0 = colocated u805306368:6 sig1
+;;     fn0 = colocated u805306368:7 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/memory-copy-epochs.wat
+++ b/tests/disas/memory-copy-epochs.wat
@@ -18,8 +18,8 @@
 ;;     gv6 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     sig0 = (i64 vmctx) -> i64 tail
 ;;     sig1 = (i64 vmctx, i64, i64, i64) tail
-;;     fn0 = colocated u805306368:12 sig0
-;;     fn1 = colocated u805306368:3 sig1
+;;     fn0 = colocated u805306368:13 sig0
+;;     fn1 = colocated u805306368:1 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):

--- a/tests/disas/memory-copy-fuel.wat
+++ b/tests/disas/memory-copy-fuel.wat
@@ -18,8 +18,8 @@
 ;;     gv6 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     sig0 = (i64 vmctx) -> i8 tail
 ;;     sig1 = (i64 vmctx, i64, i64, i64) tail
-;;     fn0 = colocated u805306368:11 sig0
-;;     fn1 = colocated u805306368:3 sig1
+;;     fn0 = colocated u805306368:12 sig0
+;;     fn1 = colocated u805306368:1 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):

--- a/tests/disas/memory_copy_host32.wat
+++ b/tests/disas/memory_copy_host32.wat
@@ -54,7 +54,7 @@
 ;;     gv1 = load.i32 notrap aligned gv0+44
 ;;     gv2 = load.i32 notrap aligned can_move gv0+40
 ;;     sig0 = (i32 vmctx, i32, i32, i32) tail
-;;     fn0 = colocated u805306368:3 sig0
+;;     fn0 = colocated u805306368:1 sig0
 ;;
 ;;                                 block0(v0: i32, v1: i32, v2: i32, v3: i32, v4: i32):
 ;; @0042                               v6 = load.i32 notrap aligned v0+44
@@ -85,7 +85,7 @@
 ;;     gv3 = load.i32 notrap aligned gv0+52
 ;;     gv4 = load.i32 notrap aligned can_move gv0+48
 ;;     sig0 = (i32 vmctx, i32, i32, i32) tail
-;;     fn0 = colocated u805306368:3 sig0
+;;     fn0 = colocated u805306368:1 sig0
 ;;
 ;;                                 block0(v0: i32, v1: i32, v2: i32, v3: i32, v4: i32):
 ;; @004f                               v6 = load.i32 notrap aligned v0+52
@@ -119,7 +119,7 @@
 ;;     gv3 = load.i32 notrap aligned gv0+60
 ;;     gv4 = load.i32 notrap aligned can_move gv0+56
 ;;     sig0 = (i32 vmctx, i32, i32, i32) tail
-;;     fn0 = colocated u805306368:3 sig0
+;;     fn0 = colocated u805306368:1 sig0
 ;;
 ;;                                 block0(v0: i32, v1: i32, v2: i64, v3: i32, v4: i32):
 ;; @005c                               v7 = load.i32 notrap aligned v0+60
@@ -151,7 +151,7 @@
 ;;     gv1 = load.i32 notrap aligned gv0+60
 ;;     gv2 = load.i32 notrap aligned can_move gv0+56
 ;;     sig0 = (i32 vmctx, i32, i32, i32) tail
-;;     fn0 = colocated u805306368:3 sig0
+;;     fn0 = colocated u805306368:1 sig0
 ;;
 ;;                                 block0(v0: i32, v1: i32, v2: i64, v3: i64, v4: i64):
 ;; @0069                               v6 = load.i32 notrap aligned v0+60
@@ -182,7 +182,7 @@
 ;;     gv3 = load.i32 notrap aligned gv0+68
 ;;     gv4 = load.i32 notrap aligned can_move gv0+64
 ;;     sig0 = (i32 vmctx, i32, i32, i32) tail
-;;     fn0 = colocated u805306368:3 sig0
+;;     fn0 = colocated u805306368:1 sig0
 ;;
 ;;                                 block0(v0: i32, v1: i32, v2: i64, v3: i64, v4: i64):
 ;; @0076                               v6 = load.i32 notrap aligned v0+68
@@ -216,7 +216,7 @@
 ;;     gv3 = load.i32 notrap aligned gv0+44
 ;;     gv4 = load.i32 notrap aligned can_move gv0+40
 ;;     sig0 = (i32 vmctx, i32, i32, i32) tail
-;;     fn0 = colocated u805306368:3 sig0
+;;     fn0 = colocated u805306368:1 sig0
 ;;
 ;;                                 block0(v0: i32, v1: i32, v2: i32, v3: i64, v4: i32):
 ;; @0083                               v7 = load.i32 notrap aligned v0+44

--- a/tests/disas/memory_copy_host64.wat
+++ b/tests/disas/memory_copy_host64.wat
@@ -57,7 +57,7 @@
 ;;     gv4 = load.i64 notrap aligned gv3+88
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv3+80
 ;;     sig0 = (i64 vmctx, i64, i64, i64) tail
-;;     fn0 = colocated u805306368:3 sig0
+;;     fn0 = colocated u805306368:1 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
@@ -91,7 +91,7 @@
 ;;     gv6 = load.i64 notrap aligned gv3+104
 ;;     gv7 = load.i64 notrap aligned readonly can_move gv3+96
 ;;     sig0 = (i64 vmctx, i64, i64, i64) tail
-;;     fn0 = colocated u805306368:3 sig0
+;;     fn0 = colocated u805306368:1 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):
@@ -127,7 +127,7 @@
 ;;     gv6 = load.i64 notrap aligned gv3+120
 ;;     gv7 = load.i64 notrap aligned can_move gv3+112
 ;;     sig0 = (i64 vmctx, i64, i64, i64) tail
-;;     fn0 = colocated u805306368:3 sig0
+;;     fn0 = colocated u805306368:1 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i32, v4: i32):
@@ -160,7 +160,7 @@
 ;;     gv4 = load.i64 notrap aligned gv3+120
 ;;     gv5 = load.i64 notrap aligned can_move gv3+112
 ;;     sig0 = (i64 vmctx, i64, i64, i64) tail
-;;     fn0 = colocated u805306368:3 sig0
+;;     fn0 = colocated u805306368:1 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64):
@@ -191,7 +191,7 @@
 ;;     gv6 = load.i64 notrap aligned gv3+136
 ;;     gv7 = load.i64 notrap aligned can_move gv3+128
 ;;     sig0 = (i64 vmctx, i64, i64, i64) tail
-;;     fn0 = colocated u805306368:3 sig0
+;;     fn0 = colocated u805306368:1 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64):
@@ -224,7 +224,7 @@
 ;;     gv6 = load.i64 notrap aligned gv3+88
 ;;     gv7 = load.i64 notrap aligned readonly can_move gv3+80
 ;;     sig0 = (i64 vmctx, i64, i64, i64) tail
-;;     fn0 = colocated u805306368:3 sig0
+;;     fn0 = colocated u805306368:1 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i64, v4: i32):

--- a/tests/disas/memory_fill_host32.wat
+++ b/tests/disas/memory_fill_host32.wat
@@ -51,7 +51,7 @@
 ;;     gv1 = load.i32 notrap aligned gv0+48
 ;;     gv2 = load.i32 notrap aligned can_move gv0+44
 ;;     sig0 = (i32 vmctx, i32, i32, i32) tail
-;;     fn0 = colocated u805306368:4 sig0
+;;     fn0 = colocated u805306368:2 sig0
 ;;
 ;;                                 block0(v0: i32, v1: i32, v2: i32, v3: i32):
 ;; @003c                               v6 = load.i32 notrap aligned v0+48
@@ -76,7 +76,7 @@
 ;;     gv1 = load.i32 notrap aligned gv0+56
 ;;     gv2 = load.i32 notrap aligned can_move gv0+52
 ;;     sig0 = (i32 vmctx, i32, i32, i32) tail
-;;     fn0 = colocated u805306368:4 sig0
+;;     fn0 = colocated u805306368:2 sig0
 ;;
 ;;                                 block0(v0: i32, v1: i32, v2: i64, v3: i64):
 ;; @0048                               v6 = load.i32 notrap aligned v0+56
@@ -101,7 +101,7 @@
 ;;     gv1 = load.i32 notrap aligned gv0+64
 ;;     gv2 = load.i32 notrap aligned can_move gv0+60
 ;;     sig0 = (i32 vmctx, i32, i32, i32) tail
-;;     fn0 = colocated u805306368:4 sig0
+;;     fn0 = colocated u805306368:2 sig0
 ;;
 ;;                                 block0(v0: i32, v1: i32, v2: i32, v3: i32):
 ;; @0054                               v6 = load.i32 notrap aligned v0+64
@@ -126,7 +126,7 @@
 ;;     gv1 = load.i32 notrap aligned gv0+72
 ;;     gv2 = load.i32 notrap aligned can_move gv0+68
 ;;     sig0 = (i32 vmctx, i32, i32, i32) tail
-;;     fn0 = colocated u805306368:4 sig0
+;;     fn0 = colocated u805306368:2 sig0
 ;;
 ;;                                 block0(v0: i32, v1: i32, v2: i64, v3: i64):
 ;; @0060                               v6 = load.i32 notrap aligned v0+72
@@ -151,7 +151,7 @@
 ;;     gv1 = load.i32 notrap aligned gv0+80
 ;;     gv2 = load.i32 notrap aligned readonly can_move gv0+76
 ;;     sig0 = (i32 vmctx, i32, i32, i32) tail
-;;     fn0 = colocated u805306368:4 sig0
+;;     fn0 = colocated u805306368:2 sig0
 ;;
 ;;                                 block0(v0: i32, v1: i32, v2: i32, v3: i32):
 ;; @006c                               v6 = load.i32 notrap aligned v0+80

--- a/tests/disas/memory_fill_host64.wat
+++ b/tests/disas/memory_fill_host64.wat
@@ -51,7 +51,7 @@
 ;;     gv4 = load.i64 notrap aligned gv3+96
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv3+88
 ;;     sig0 = (i64 vmctx, i64, i32, i64) tail
-;;     fn0 = colocated u805306368:4 sig0
+;;     fn0 = colocated u805306368:2 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -79,7 +79,7 @@
 ;;     gv4 = load.i64 notrap aligned gv3+112
 ;;     gv5 = load.i64 notrap aligned can_move gv3+104
 ;;     sig0 = (i64 vmctx, i64, i32, i64) tail
-;;     fn0 = colocated u805306368:4 sig0
+;;     fn0 = colocated u805306368:2 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i64):
@@ -105,7 +105,7 @@
 ;;     gv4 = load.i64 notrap aligned gv3+128
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv3+120
 ;;     sig0 = (i64 vmctx, i64, i32, i64) tail
-;;     fn0 = colocated u805306368:4 sig0
+;;     fn0 = colocated u805306368:2 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
@@ -133,7 +133,7 @@
 ;;     gv4 = load.i64 notrap aligned gv3+144
 ;;     gv5 = load.i64 notrap aligned can_move gv3+136
 ;;     sig0 = (i64 vmctx, i64, i32, i64) tail
-;;     fn0 = colocated u805306368:4 sig0
+;;     fn0 = colocated u805306368:2 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i64, v3: i64):
@@ -159,7 +159,7 @@
 ;;     gv4 = load.i64 notrap aligned gv3+160
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv3+152
 ;;     sig0 = (i64 vmctx, i64, i32, i64) tail
-;;     fn0 = colocated u805306368:4 sig0
+;;     fn0 = colocated u805306368:2 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):

--- a/tests/disas/metadata-for-internal-asserts.wat
+++ b/tests/disas/metadata-for-internal-asserts.wat
@@ -39,7 +39,7 @@
 ;;       popq    %rbp
 ;;       retq
 ;;   5e: movq    0x10(%rbx), %rax
-;;   62: movq    0x150(%rax), %rax
+;;   62: movq    0x148(%rax), %rax
 ;;   69: movq    %rbx, %rdi
 ;;   6c: callq   *%rax
 ;;   6e: ud2

--- a/tests/disas/passive-data.wat
+++ b/tests/disas/passive-data.wat
@@ -21,7 +21,7 @@
 ;;     gv4 = load.i64 notrap aligned gv3+64
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv3+56
 ;;     sig0 = (i64 vmctx, i64, i64, i64) tail
-;;     fn0 = colocated u805306368:3 sig0
+;;     fn0 = colocated u805306368:1 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32):

--- a/tests/disas/readonly-funcrefs.wat
+++ b/tests/disas/readonly-funcrefs.wat
@@ -39,7 +39,7 @@
 ;;     gv4 = load.i64 notrap aligned readonly can_move gv3+48
 ;;     sig0 = (i64 vmctx, i64) tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
-;;     fn0 = colocated u805306368:6 sig1
+;;     fn0 = colocated u805306368:7 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/ref-func-0.wat
+++ b/tests/disas/ref-func-0.wat
@@ -24,7 +24,7 @@
 ;;     gv5 = load.i64 notrap aligned readonly can_move gv4+32
 ;;     gv6 = load.i64 notrap aligned gv4+40
 ;;     sig0 = (i64 vmctx) -> i8 tail
-;;     fn0 = colocated u805306368:46 sig0
+;;     fn0 = colocated u805306368:45 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):

--- a/tests/disas/riscv64-component-builtins-asm.wat
+++ b/tests/disas/riscv64-component-builtins-asm.wat
@@ -54,7 +54,7 @@
 ;;       ret
 ;;       mv      a1, s5
 ;;       ld      a0, 0x10(a1)
-;;       ld      a2, 0x150(a0)
+;;       ld      a2, 0x148(a0)
 ;;       mv      a0, a1
 ;;       jalr    a2
 ;;       .byte   0x00, 0x00, 0x00, 0x00

--- a/tests/disas/riscv64-component-builtins.wat
+++ b/tests/disas/riscv64-component-builtins.wat
@@ -34,7 +34,7 @@
 ;;
 ;; block1 cold:
 ;;     v15 = load.i64 notrap aligned readonly v1+16
-;;     v16 = load.i64 notrap aligned readonly v15+336
+;;     v16 = load.i64 notrap aligned readonly v15+328
 ;;     call_indirect sig1, v16(v1)
 ;;     trap user1
 ;;

--- a/tests/disas/stack-switching/resume-suspend-data-passing.wat
+++ b/tests/disas/stack-switching/resume-suspend-data-passing.wat
@@ -152,8 +152,8 @@
 ;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i32) -> i64 tail
 ;;     sig1 = (i64 vmctx, i64, i32, i32) -> i64 tail
-;;     fn0 = colocated u805306368:5 sig0
-;;     fn1 = colocated u805306368:43 sig1
+;;     fn0 = colocated u805306368:6 sig0
+;;     fn1 = colocated u805306368:42 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):

--- a/tests/disas/stack-switching/resume-suspend.wat
+++ b/tests/disas/stack-switching/resume-suspend.wat
@@ -113,8 +113,8 @@
 ;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i32) -> i64 tail
 ;;     sig1 = (i64 vmctx, i64, i32, i32) -> i64 tail
-;;     fn0 = colocated u805306368:5 sig0
-;;     fn1 = colocated u805306368:43 sig1
+;;     fn0 = colocated u805306368:6 sig0
+;;     fn1 = colocated u805306368:42 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):

--- a/tests/disas/stack-switching/symmetric-switch.wat
+++ b/tests/disas/stack-switching/symmetric-switch.wat
@@ -33,8 +33,8 @@
 ;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i32) -> i64 tail
 ;;     sig1 = (i64 vmctx, i64, i32, i32) -> i64 tail
-;;     fn0 = colocated u805306368:5 sig0
-;;     fn1 = colocated u805306368:43 sig1
+;;     fn0 = colocated u805306368:6 sig0
+;;     fn1 = colocated u805306368:42 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
@@ -248,8 +248,8 @@
 ;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, i32) -> i64 tail
 ;;     sig1 = (i64 vmctx, i64, i32, i32) -> i64 tail
-;;     fn0 = colocated u805306368:5 sig0
-;;     fn1 = colocated u805306368:43 sig1
+;;     fn0 = colocated u805306368:6 sig0
+;;     fn1 = colocated u805306368:42 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):

--- a/tests/disas/table-copy.wat
+++ b/tests/disas/table-copy.wat
@@ -72,121 +72,130 @@
 ;;     gv6 = load.i64 notrap aligned gv4+8
 ;;     gv7 = load.i64 notrap aligned readonly can_move gv3+72
 ;;     sig0 = (i64 vmctx, i32, i64) -> i64 tail
-;;     fn0 = colocated u805306368:6 sig0
+;;     fn0 = colocated u805306368:7 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
-;; @0090                               v102 = load.i64 notrap aligned readonly can_move v0+48
-;; @0090                               v7 = load.i64 notrap aligned v102+8
+;; @0090                               v111 = load.i64 notrap aligned readonly can_move v0+48
+;; @0090                               v7 = load.i64 notrap aligned v111+8
 ;; @0090                               v8 = ireduce.i32 v7
 ;; @0090                               v9 = uextend.i64 v8
 ;; @0090                               v10 = uextend.i64 v3
 ;; @0090                               v11 = uextend.i64 v5
-;;                                     v101 = iconst.i64 1
-;; @0090                               v12 = imul v11, v101  ; v101 = 1
+;;                                     v110 = iconst.i64 1
+;; @0090                               v12 = imul v11, v110  ; v110 = 1
 ;; @0090                               v13 = iadd v10, v12
 ;; @0090                               v14 = icmp ugt v13, v9
 ;; @0090                               trapnz v14, user6
-;; @0090                               v99 = load.i64 notrap aligned readonly can_move v0+48
-;; @0090                               v15 = load.i64 notrap aligned v99
+;; @0090                               v108 = load.i64 notrap aligned readonly can_move v0+48
+;; @0090                               v15 = load.i64 notrap aligned v108
 ;; @0090                               v16 = uextend.i64 v3
-;;                                     v98 = iconst.i64 8
-;; @0090                               v17 = imul v16, v98  ; v98 = 8
+;;                                     v107 = iconst.i64 8
+;; @0090                               v17 = imul v16, v107  ; v107 = 8
 ;; @0090                               v18 = iadd v15, v17
 ;; @0090                               v19 = iconst.i32 6
 ;; @0090                               v20 = uextend.i64 v19  ; v19 = 6
 ;; @0090                               v21 = uextend.i64 v4
 ;; @0090                               v22 = uextend.i64 v5
-;;                                     v97 = iconst.i64 1
-;; @0090                               v23 = imul v22, v97  ; v97 = 1
+;;                                     v106 = iconst.i64 1
+;; @0090                               v23 = imul v22, v106  ; v106 = 1
 ;; @0090                               v24 = iadd v21, v23
 ;; @0090                               v25 = icmp ugt v24, v20
 ;; @0090                               trapnz v25, user6
 ;; @0090                               v26 = load.i64 notrap aligned readonly can_move v0+72
 ;; @0090                               v27 = uextend.i64 v4
-;;                                     v95 = iconst.i64 8
-;; @0090                               v28 = imul v27, v95  ; v95 = 8
+;;                                     v104 = iconst.i64 8
+;; @0090                               v28 = imul v27, v104  ; v104 = 8
 ;; @0090                               v29 = iadd v26, v28
 ;; @0090                               v30 = uextend.i64 v5
-;; @0090                               v31 = iconst.i64 8
-;; @0090                               v32 = imul v31, v30  ; v31 = 8
+;;                                     v103 = iconst.i64 8
+;; @0090                               v31 = imul v30, v103  ; v103 = 8
+;;                                     v102 = iconst.i64 8
+;; @0090                               v32 = imul v30, v102  ; v102 = 8
 ;; @0090                               brif v30, block2, block5
 ;;
 ;;                                 block2:
 ;; @0090                               v33 = icmp.i64 ult v18, v29
-;; @0090                               v34 = imul.i64 v30, v31  ; v31 = 8
-;; @0090                               v35 = iadd.i64 v18, v34
-;; @0090                               v36 = iadd.i64 v29, v34
-;; @0090                               v37 = ireduce.i32 v30
-;; @0090                               v38 = iadd.i32 v4, v37
-;; @0090                               brif v33, block3(v18, v29, v4), block4(v35, v36, v38)
+;;                                     v101 = iconst.i64 8
+;; @0090                               v34 = imul.i64 v30, v101  ; v101 = 8
+;;                                     v100 = iconst.i64 8
+;; @0090                               v35 = imul.i64 v30, v100  ; v100 = 8
+;; @0090                               v36 = iadd.i64 v18, v34
+;; @0090                               v37 = iadd.i64 v29, v35
+;; @0090                               v38 = ireduce.i32 v30
+;; @0090                               v39 = iadd.i32 v4, v38
+;; @0090                               brif v33, block3(v18, v29, v4), block4(v36, v37, v39)
 ;;
-;;                                 block3(v39: i64, v40: i64, v41: i32):
-;; @0090                               v42 = iconst.i32 6
-;; @0090                               v43 = icmp uge v41, v42  ; v42 = 6
-;; @0090                               v44 = uextend.i64 v41
-;; @0090                               v45 = load.i64 notrap aligned readonly can_move v0+72
-;;                                     v93 = iconst.i64 3
-;; @0090                               v46 = ishl v44, v93  ; v93 = 3
-;; @0090                               v47 = iadd v45, v46
-;; @0090                               v48 = iconst.i64 0
-;; @0090                               v49 = select_spectre_guard v43, v48, v47  ; v48 = 0
-;; @0090                               v50 = load.i64 user6 aligned table v49
-;;                                     v92 = iconst.i64 -2
-;; @0090                               v51 = band v50, v92  ; v92 = -2
-;; @0090                               brif v50, block7(v51), block6
+;;                                 block3(v40: i64, v41: i64, v42: i32):
+;; @0090                               v43 = iconst.i32 6
+;; @0090                               v44 = icmp uge v42, v43  ; v43 = 6
+;; @0090                               v45 = uextend.i64 v42
+;; @0090                               v46 = load.i64 notrap aligned readonly can_move v0+72
+;;                                     v98 = iconst.i64 3
+;; @0090                               v47 = ishl v45, v98  ; v98 = 3
+;; @0090                               v48 = iadd v46, v47
+;; @0090                               v49 = iconst.i64 0
+;; @0090                               v50 = select_spectre_guard v44, v49, v48  ; v49 = 0
+;; @0090                               v51 = load.i64 user6 aligned table v50
+;;                                     v97 = iconst.i64 -2
+;; @0090                               v52 = band v51, v97  ; v97 = -2
+;; @0090                               brif v51, block7(v52), block6
 ;;
-;;                                 block4(v62: i64, v63: i64, v64: i32):
-;; @0090                               v65 = isub v62, v31  ; v31 = 8
-;; @0090                               v66 = isub v63, v31  ; v31 = 8
-;; @0090                               v67 = iconst.i32 1
-;; @0090                               v68 = isub v64, v67  ; v67 = 1
-;; @0090                               v69 = iconst.i32 6
-;; @0090                               v70 = icmp uge v68, v69  ; v69 = 6
-;; @0090                               v71 = uextend.i64 v68
-;; @0090                               v72 = load.i64 notrap aligned readonly can_move v0+72
-;;                                     v90 = iconst.i64 3
-;; @0090                               v73 = ishl v71, v90  ; v90 = 3
-;; @0090                               v74 = iadd v72, v73
-;; @0090                               v75 = iconst.i64 0
-;; @0090                               v76 = select_spectre_guard v70, v75, v74  ; v75 = 0
-;; @0090                               v77 = load.i64 user6 aligned table v76
-;;                                     v89 = iconst.i64 -2
-;; @0090                               v78 = band v77, v89  ; v89 = -2
-;; @0090                               brif v77, block9(v78), block8
+;;                                 block4(v63: i64, v64: i64, v65: i32):
+;; @0090                               v66 = iconst.i64 8
+;; @0090                               v67 = isub v63, v66  ; v66 = 8
+;; @0090                               v68 = iconst.i64 8
+;; @0090                               v69 = isub v64, v68  ; v68 = 8
+;; @0090                               v70 = iconst.i32 1
+;; @0090                               v71 = isub v65, v70  ; v70 = 1
+;; @0090                               v72 = iconst.i32 6
+;; @0090                               v73 = icmp uge v71, v72  ; v72 = 6
+;; @0090                               v74 = uextend.i64 v71
+;; @0090                               v75 = load.i64 notrap aligned readonly can_move v0+72
+;;                                     v95 = iconst.i64 3
+;; @0090                               v76 = ishl v74, v95  ; v95 = 3
+;; @0090                               v77 = iadd v75, v76
+;; @0090                               v78 = iconst.i64 0
+;; @0090                               v79 = select_spectre_guard v73, v78, v77  ; v78 = 0
+;; @0090                               v80 = load.i64 user6 aligned table v79
+;;                                     v94 = iconst.i64 -2
+;; @0090                               v81 = band v80, v94  ; v94 = -2
+;; @0090                               brif v80, block9(v81), block8
 ;;
 ;;                                 block5:
 ;; @0094                               jump block1
 ;;
 ;;                                 block6 cold:
-;; @0090                               v53 = iconst.i32 1
-;; @0090                               v55 = uextend.i64 v41
-;; @0090                               v56 = call fn0(v0, v53, v55)  ; v53 = 1
-;; @0090                               jump block7(v56)
+;; @0090                               v54 = iconst.i32 1
+;; @0090                               v56 = uextend.i64 v42
+;; @0090                               v57 = call fn0(v0, v54, v56)  ; v54 = 1
+;; @0090                               jump block7(v57)
 ;;
-;;                                 block7(v52: i64):
-;;                                     v88 = iconst.i64 1
-;; @0090                               v57 = bor v52, v88  ; v88 = 1
-;; @0090                               store notrap aligned v57, v39
-;; @0090                               v58 = iadd.i64 v39, v31  ; v31 = 8
-;; @0090                               v59 = iadd.i64 v40, v31  ; v31 = 8
-;;                                     v87 = iconst.i32 1
-;; @0090                               v60 = iadd.i32 v41, v87  ; v87 = 1
-;; @0090                               v61 = icmp eq v59, v36
-;; @0090                               brif v61, block5, block3(v58, v59, v60)
+;;                                 block7(v53: i64):
+;;                                     v93 = iconst.i64 1
+;; @0090                               v58 = bor v53, v93  ; v93 = 1
+;; @0090                               store notrap aligned v58, v40
+;;                                     v92 = iconst.i64 8
+;; @0090                               v59 = iadd.i64 v40, v92  ; v92 = 8
+;;                                     v91 = iconst.i64 8
+;; @0090                               v60 = iadd.i64 v41, v91  ; v91 = 8
+;;                                     v90 = iconst.i32 1
+;; @0090                               v61 = iadd.i32 v42, v90  ; v90 = 1
+;; @0090                               v62 = icmp eq v60, v37
+;; @0090                               brif v62, block5, block3(v59, v60, v61)
 ;;
 ;;                                 block8 cold:
-;; @0090                               v80 = iconst.i32 1
-;; @0090                               v82 = uextend.i64 v68
-;; @0090                               v83 = call fn0(v0, v80, v82)  ; v80 = 1
-;; @0090                               jump block9(v83)
+;; @0090                               v83 = iconst.i32 1
+;; @0090                               v85 = uextend.i64 v71
+;; @0090                               v86 = call fn0(v0, v83, v85)  ; v83 = 1
+;; @0090                               jump block9(v86)
 ;;
-;;                                 block9(v79: i64):
-;;                                     v86 = iconst.i64 1
-;; @0090                               v84 = bor v79, v86  ; v86 = 1
-;; @0090                               store notrap aligned v84, v65
-;; @0090                               v85 = icmp.i64 eq v66, v29
-;; @0090                               brif v85, block5, block4(v65, v66, v68)
+;;                                 block9(v82: i64):
+;;                                     v89 = iconst.i64 1
+;; @0090                               v87 = bor v82, v89  ; v89 = 1
+;; @0090                               store notrap aligned v87, v67
+;; @0090                               v88 = icmp.i64 eq v69, v29
+;; @0090                               brif v88, block5, block4(v67, v69, v71)
 ;;
 ;;                                 block1:
 ;; @0094                               return v2
@@ -202,7 +211,7 @@
 ;;     gv6 = load.i64 notrap aligned gv5
 ;;     gv7 = load.i64 notrap aligned gv5+8
 ;;     sig0 = (i64 vmctx, i32, i64) -> i64 tail
-;;     fn0 = colocated u805306368:6 sig0
+;;     fn0 = colocated u805306368:7 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
@@ -210,119 +219,128 @@
 ;; @009f                               v8 = uextend.i64 v7  ; v7 = 6
 ;; @009f                               v9 = uextend.i64 v3
 ;; @009f                               v10 = uextend.i64 v5
-;;                                     v111 = iconst.i64 1
-;; @009f                               v11 = imul v10, v111  ; v111 = 1
+;;                                     v120 = iconst.i64 1
+;; @009f                               v11 = imul v10, v120  ; v120 = 1
 ;; @009f                               v12 = iadd v9, v11
 ;; @009f                               v13 = icmp ugt v12, v8
 ;; @009f                               trapnz v13, user6
 ;; @009f                               v14 = load.i64 notrap aligned readonly can_move v0+72
 ;; @009f                               v15 = uextend.i64 v3
-;;                                     v109 = iconst.i64 8
-;; @009f                               v16 = imul v15, v109  ; v109 = 8
+;;                                     v118 = iconst.i64 8
+;; @009f                               v16 = imul v15, v118  ; v118 = 8
 ;; @009f                               v17 = iadd v14, v16
-;; @009f                               v107 = load.i64 notrap aligned readonly can_move v0+48
-;; @009f                               v18 = load.i64 notrap aligned v107+8
+;; @009f                               v116 = load.i64 notrap aligned readonly can_move v0+48
+;; @009f                               v18 = load.i64 notrap aligned v116+8
 ;; @009f                               v19 = ireduce.i32 v18
 ;; @009f                               v20 = uextend.i64 v19
 ;; @009f                               v21 = uextend.i64 v4
 ;; @009f                               v22 = uextend.i64 v5
-;;                                     v106 = iconst.i64 1
-;; @009f                               v23 = imul v22, v106  ; v106 = 1
+;;                                     v115 = iconst.i64 1
+;; @009f                               v23 = imul v22, v115  ; v115 = 1
 ;; @009f                               v24 = iadd v21, v23
 ;; @009f                               v25 = icmp ugt v24, v20
 ;; @009f                               trapnz v25, user6
-;; @009f                               v104 = load.i64 notrap aligned readonly can_move v0+48
-;; @009f                               v26 = load.i64 notrap aligned v104
+;; @009f                               v113 = load.i64 notrap aligned readonly can_move v0+48
+;; @009f                               v26 = load.i64 notrap aligned v113
 ;; @009f                               v27 = uextend.i64 v4
-;;                                     v103 = iconst.i64 8
-;; @009f                               v28 = imul v27, v103  ; v103 = 8
+;;                                     v112 = iconst.i64 8
+;; @009f                               v28 = imul v27, v112  ; v112 = 8
 ;; @009f                               v29 = iadd v26, v28
 ;; @009f                               v30 = uextend.i64 v5
-;; @009f                               v31 = iconst.i64 8
-;; @009f                               v32 = imul v31, v30  ; v31 = 8
+;;                                     v111 = iconst.i64 8
+;; @009f                               v31 = imul v30, v111  ; v111 = 8
+;;                                     v110 = iconst.i64 8
+;; @009f                               v32 = imul v30, v110  ; v110 = 8
 ;; @009f                               brif v30, block2, block5
 ;;
 ;;                                 block2:
 ;; @009f                               v33 = icmp.i64 ult v17, v29
-;; @009f                               v34 = imul.i64 v30, v31  ; v31 = 8
-;; @009f                               v35 = iadd.i64 v17, v34
-;; @009f                               v36 = iadd.i64 v29, v34
-;; @009f                               v37 = ireduce.i32 v30
-;; @009f                               v38 = iadd.i32 v4, v37
-;; @009f                               brif v33, block3(v17, v29, v4), block4(v35, v36, v38)
+;;                                     v109 = iconst.i64 8
+;; @009f                               v34 = imul.i64 v30, v109  ; v109 = 8
+;;                                     v108 = iconst.i64 8
+;; @009f                               v35 = imul.i64 v30, v108  ; v108 = 8
+;; @009f                               v36 = iadd.i64 v17, v34
+;; @009f                               v37 = iadd.i64 v29, v35
+;; @009f                               v38 = ireduce.i32 v30
+;; @009f                               v39 = iadd.i32 v4, v38
+;; @009f                               brif v33, block3(v17, v29, v4), block4(v36, v37, v39)
 ;;
-;;                                 block3(v39: i64, v40: i64, v41: i32):
-;; @009f                               v101 = load.i64 notrap aligned readonly can_move v0+48
-;; @009f                               v42 = load.i64 notrap aligned v101+8
-;; @009f                               v43 = ireduce.i32 v42
-;; @009f                               v44 = icmp uge v41, v43
-;; @009f                               v45 = uextend.i64 v41
-;; @009f                               v99 = load.i64 notrap aligned readonly can_move v0+48
-;; @009f                               v46 = load.i64 notrap aligned v99
-;;                                     v98 = iconst.i64 3
-;; @009f                               v47 = ishl v45, v98  ; v98 = 3
-;; @009f                               v48 = iadd v46, v47
-;; @009f                               v49 = iconst.i64 0
-;; @009f                               v50 = select_spectre_guard v44, v49, v48  ; v49 = 0
-;; @009f                               v51 = load.i64 user6 aligned table v50
-;;                                     v97 = iconst.i64 -2
-;; @009f                               v52 = band v51, v97  ; v97 = -2
-;; @009f                               brif v51, block7(v52), block6
+;;                                 block3(v40: i64, v41: i64, v42: i32):
+;; @009f                               v106 = load.i64 notrap aligned readonly can_move v0+48
+;; @009f                               v43 = load.i64 notrap aligned v106+8
+;; @009f                               v44 = ireduce.i32 v43
+;; @009f                               v45 = icmp uge v42, v44
+;; @009f                               v46 = uextend.i64 v42
+;; @009f                               v104 = load.i64 notrap aligned readonly can_move v0+48
+;; @009f                               v47 = load.i64 notrap aligned v104
+;;                                     v103 = iconst.i64 3
+;; @009f                               v48 = ishl v46, v103  ; v103 = 3
+;; @009f                               v49 = iadd v47, v48
+;; @009f                               v50 = iconst.i64 0
+;; @009f                               v51 = select_spectre_guard v45, v50, v49  ; v50 = 0
+;; @009f                               v52 = load.i64 user6 aligned table v51
+;;                                     v102 = iconst.i64 -2
+;; @009f                               v53 = band v52, v102  ; v102 = -2
+;; @009f                               brif v52, block7(v53), block6
 ;;
-;;                                 block4(v63: i64, v64: i64, v65: i32):
-;; @009f                               v66 = isub v63, v31  ; v31 = 8
-;; @009f                               v67 = isub v64, v31  ; v31 = 8
-;; @009f                               v68 = iconst.i32 1
-;; @009f                               v69 = isub v65, v68  ; v68 = 1
-;; @009f                               v95 = load.i64 notrap aligned readonly can_move v0+48
-;; @009f                               v70 = load.i64 notrap aligned v95+8
-;; @009f                               v71 = ireduce.i32 v70
-;; @009f                               v72 = icmp uge v69, v71
-;; @009f                               v73 = uextend.i64 v69
-;; @009f                               v93 = load.i64 notrap aligned readonly can_move v0+48
-;; @009f                               v74 = load.i64 notrap aligned v93
-;;                                     v92 = iconst.i64 3
-;; @009f                               v75 = ishl v73, v92  ; v92 = 3
-;; @009f                               v76 = iadd v74, v75
-;; @009f                               v77 = iconst.i64 0
-;; @009f                               v78 = select_spectre_guard v72, v77, v76  ; v77 = 0
-;; @009f                               v79 = load.i64 user6 aligned table v78
-;;                                     v91 = iconst.i64 -2
-;; @009f                               v80 = band v79, v91  ; v91 = -2
-;; @009f                               brif v79, block9(v80), block8
+;;                                 block4(v64: i64, v65: i64, v66: i32):
+;; @009f                               v67 = iconst.i64 8
+;; @009f                               v68 = isub v64, v67  ; v67 = 8
+;; @009f                               v69 = iconst.i64 8
+;; @009f                               v70 = isub v65, v69  ; v69 = 8
+;; @009f                               v71 = iconst.i32 1
+;; @009f                               v72 = isub v66, v71  ; v71 = 1
+;; @009f                               v100 = load.i64 notrap aligned readonly can_move v0+48
+;; @009f                               v73 = load.i64 notrap aligned v100+8
+;; @009f                               v74 = ireduce.i32 v73
+;; @009f                               v75 = icmp uge v72, v74
+;; @009f                               v76 = uextend.i64 v72
+;; @009f                               v98 = load.i64 notrap aligned readonly can_move v0+48
+;; @009f                               v77 = load.i64 notrap aligned v98
+;;                                     v97 = iconst.i64 3
+;; @009f                               v78 = ishl v76, v97  ; v97 = 3
+;; @009f                               v79 = iadd v77, v78
+;; @009f                               v80 = iconst.i64 0
+;; @009f                               v81 = select_spectre_guard v75, v80, v79  ; v80 = 0
+;; @009f                               v82 = load.i64 user6 aligned table v81
+;;                                     v96 = iconst.i64 -2
+;; @009f                               v83 = band v82, v96  ; v96 = -2
+;; @009f                               brif v82, block9(v83), block8
 ;;
 ;;                                 block5:
 ;; @00a3                               jump block1
 ;;
 ;;                                 block6 cold:
-;; @009f                               v54 = iconst.i32 0
-;; @009f                               v56 = uextend.i64 v41
-;; @009f                               v57 = call fn0(v0, v54, v56)  ; v54 = 0
-;; @009f                               jump block7(v57)
+;; @009f                               v55 = iconst.i32 0
+;; @009f                               v57 = uextend.i64 v42
+;; @009f                               v58 = call fn0(v0, v55, v57)  ; v55 = 0
+;; @009f                               jump block7(v58)
 ;;
-;;                                 block7(v53: i64):
-;;                                     v90 = iconst.i64 1
-;; @009f                               v58 = bor v53, v90  ; v90 = 1
-;; @009f                               store notrap aligned v58, v39
-;; @009f                               v59 = iadd.i64 v39, v31  ; v31 = 8
-;; @009f                               v60 = iadd.i64 v40, v31  ; v31 = 8
-;;                                     v89 = iconst.i32 1
-;; @009f                               v61 = iadd.i32 v41, v89  ; v89 = 1
-;; @009f                               v62 = icmp eq v60, v36
-;; @009f                               brif v62, block5, block3(v59, v60, v61)
+;;                                 block7(v54: i64):
+;;                                     v95 = iconst.i64 1
+;; @009f                               v59 = bor v54, v95  ; v95 = 1
+;; @009f                               store notrap aligned v59, v40
+;;                                     v94 = iconst.i64 8
+;; @009f                               v60 = iadd.i64 v40, v94  ; v94 = 8
+;;                                     v93 = iconst.i64 8
+;; @009f                               v61 = iadd.i64 v41, v93  ; v93 = 8
+;;                                     v92 = iconst.i32 1
+;; @009f                               v62 = iadd.i32 v42, v92  ; v92 = 1
+;; @009f                               v63 = icmp eq v61, v37
+;; @009f                               brif v63, block5, block3(v60, v61, v62)
 ;;
 ;;                                 block8 cold:
-;; @009f                               v82 = iconst.i32 0
-;; @009f                               v84 = uextend.i64 v69
-;; @009f                               v85 = call fn0(v0, v82, v84)  ; v82 = 0
-;; @009f                               jump block9(v85)
+;; @009f                               v85 = iconst.i32 0
+;; @009f                               v87 = uextend.i64 v72
+;; @009f                               v88 = call fn0(v0, v85, v87)  ; v85 = 0
+;; @009f                               jump block9(v88)
 ;;
-;;                                 block9(v81: i64):
-;;                                     v88 = iconst.i64 1
-;; @009f                               v86 = bor v81, v88  ; v88 = 1
-;; @009f                               store notrap aligned v86, v66
-;; @009f                               v87 = icmp.i64 eq v67, v29
-;; @009f                               brif v87, block5, block4(v66, v67, v69)
+;;                                 block9(v84: i64):
+;;                                     v91 = iconst.i64 1
+;; @009f                               v89 = bor v84, v91  ; v91 = 1
+;; @009f                               store notrap aligned v89, v68
+;; @009f                               v90 = icmp.i64 eq v70, v29
+;; @009f                               brif v90, block5, block4(v68, v70, v72)
 ;;
 ;;                                 block1:
 ;; @00a3                               return v2

--- a/tests/disas/table-get-fixed-size.wat
+++ b/tests/disas/table-get-fixed-size.wat
@@ -26,7 +26,7 @@
 ;;     gv6 = load.i64 notrap aligned readonly can_move gv5+32
 ;;     gv7 = load.i64 notrap aligned gv5+40
 ;;     sig0 = (i64 vmctx) -> i8 tail
-;;     fn0 = colocated u805306368:46 sig0
+;;     fn0 = colocated u805306368:45 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
@@ -154,7 +154,7 @@
 ;;     gv6 = load.i64 notrap aligned readonly can_move gv5+32
 ;;     gv7 = load.i64 notrap aligned gv5+40
 ;;     sig0 = (i64 vmctx) -> i8 tail
-;;     fn0 = colocated u805306368:46 sig0
+;;     fn0 = colocated u805306368:45 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/table-get.wat
+++ b/tests/disas/table-get.wat
@@ -26,7 +26,7 @@
 ;;     gv7 = load.i64 notrap aligned readonly can_move gv6+32
 ;;     gv8 = load.i64 notrap aligned gv6+40
 ;;     sig0 = (i64 vmctx) -> i8 tail
-;;     fn0 = colocated u805306368:46 sig0
+;;     fn0 = colocated u805306368:45 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
@@ -156,7 +156,7 @@
 ;;     gv7 = load.i64 notrap aligned readonly can_move gv6+32
 ;;     gv8 = load.i64 notrap aligned gv6+40
 ;;     sig0 = (i64 vmctx) -> i8 tail
-;;     fn0 = colocated u805306368:46 sig0
+;;     fn0 = colocated u805306368:45 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):

--- a/tests/disas/table-set-fixed-size.wat
+++ b/tests/disas/table-set-fixed-size.wat
@@ -26,7 +26,7 @@
 ;;     gv6 = load.i64 notrap aligned readonly can_move gv5+32
 ;;     gv7 = load.i64 notrap aligned gv5+40
 ;;     sig0 = (i64 vmctx, i32) tail
-;;     fn0 = colocated u805306368:21 sig0
+;;     fn0 = colocated u805306368:22 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -123,7 +123,7 @@
 ;;     gv6 = load.i64 notrap aligned readonly can_move gv5+32
 ;;     gv7 = load.i64 notrap aligned gv5+40
 ;;     sig0 = (i64 vmctx, i32) tail
-;;     fn0 = colocated u805306368:21 sig0
+;;     fn0 = colocated u805306368:22 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):

--- a/tests/disas/table-set.wat
+++ b/tests/disas/table-set.wat
@@ -27,7 +27,7 @@
 ;;     gv7 = load.i64 notrap aligned readonly can_move gv6+32
 ;;     gv8 = load.i64 notrap aligned gv6+40
 ;;     sig0 = (i64 vmctx, i32) tail
-;;     fn0 = colocated u805306368:21 sig0
+;;     fn0 = colocated u805306368:22 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
@@ -126,7 +126,7 @@
 ;;     gv7 = load.i64 notrap aligned readonly can_move gv6+32
 ;;     gv8 = load.i64 notrap aligned gv6+40
 ;;     sig0 = (i64 vmctx, i32) tail
-;;     fn0 = colocated u805306368:21 sig0
+;;     fn0 = colocated u805306368:22 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):

--- a/tests/disas/typed-funcrefs.wat
+++ b/tests/disas/typed-funcrefs.wat
@@ -134,7 +134,7 @@
 ;;     gv4 = load.i64 notrap aligned readonly can_move gv3+48
 ;;     sig0 = (i64 vmctx, i32, i64) -> i64 tail
 ;;     sig1 = (i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail
-;;     fn0 = colocated u805306368:6 sig0
+;;     fn0 = colocated u805306368:7 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
@@ -188,7 +188,7 @@
 ;;     gv4 = load.i64 notrap aligned readonly can_move gv3+48
 ;;     sig0 = (i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail
 ;;     sig1 = (i64 vmctx, i32, i64) -> i64 tail
-;;     fn0 = colocated u805306368:6 sig1
+;;     fn0 = colocated u805306368:7 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):

--- a/tests/disas/winch/x64/table/init_copy_drop.wat
+++ b/tests/disas/winch/x64/table/init_copy_drop.wat
@@ -131,34 +131,120 @@
 ;;       movq    0x18(%r11), %r11
 ;;       addq    $0x40, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x8b3
+;;       ja      0xa2b
 ;;  15c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
-;;       movl    $1, %edx
-;;       movl    $7, %ecx
-;;       movl    $0, %r8d
-;;       movl    $4, %r9d
-;;       callq   0xf2f
+;;       callq   0x10af
+;;       movq    8(%rsp), %r14
+;;       pushq   %rax
+;;       subq    $8, %rsp
+;;       movq    %r14, %rdi
+;;       movl    $0, %esi
+;;       callq   0x10da
+;;       addq    $8, %rsp
+;;       movq    0x10(%rsp), %r14
+;;       movq    %r14, %r11
+;;       movq    0xd8(%r11), %rcx
+;;       popq    %rdx
+;;       movl    $4, %ebx
+;;       movl    $0, %esi
+;;       movl    $7, %edi
+;;       movl    %ebx, %ebx
+;;       movl    %esi, %r8d
+;;       addl    %ebx, %r8d
+;;       jb      0xa2d
+;;  1ca: cmpl    %edx, %r8d
+;;       ja      0xa2f
+;;  1d3: movl    %edi, %r8d
+;;       addl    %ebx, %r8d
+;;       jb      0xa31
+;;  1df: cmpl    %edx, %r8d
+;;       ja      0xa33
+;;  1e8: movl    %esi, %esi
+;;       imulq   $0x10, %rsi, %rsi
+;;       addq    %rsi, %rax
+;;       cmpq    $0, %rbx
+;;       je      0x24f
+;;  1fe: movq    (%rax), %rax
+;;       addq    $0x10, %rax
+;;       movl    %edi, %ecx
+;;       movq    %r14, %rdx
+;;       movq    0xd8(%rdx), %r8
+;;       cmpq    %r8, %rcx
+;;       jae     0xa35
+;;  21c: movq    %rcx, %r11
+;;       imulq   $8, %r11, %r11
+;;       movq    0xd0(%rdx), %rdx
+;;       movq    %rdx, %r9
+;;       addq    %r11, %rdx
+;;       cmpq    %r8, %rcx
+;;       cmovaeq %r9, %rdx
+;;       orq     $1, %rcx
+;;       movq    %rcx, (%rdx)
+;;       addl    $1, %edi
+;;       jmp     0x1f4
+;;  24f: movq    %r14, %rdi
+;;       movl    $0, %esi
+;;       callq   0x1105
 ;;       movq    8(%rsp), %r14
 ;;       movq    %r14, %rdi
 ;;       movl    $1, %esi
-;;       callq   0xf7a
+;;       callq   0x10af
 ;;       movq    8(%rsp), %r14
+;;       pushq   %rax
+;;       subq    $8, %rsp
 ;;       movq    %r14, %rdi
-;;       movl    $0, %esi
-;;       movl    $3, %edx
-;;       movl    $0xf, %ecx
-;;       movl    $1, %r8d
-;;       movl    $3, %r9d
-;;       callq   0xf2f
-;;       movq    8(%rsp), %r14
-;;       movq    %r14, %rdi
-;;       movl    $3, %esi
-;;       callq   0xf7a
+;;       movl    $1, %esi
+;;       callq   0x10da
+;;       addq    $8, %rsp
+;;       movq    0x10(%rsp), %r14
+;;       movq    %r14, %r11
+;;       movq    0xd8(%r11), %rcx
+;;       popq    %rdx
+;;       movl    $3, %ebx
+;;       movl    $1, %edi
+;;       movl    $0xf, %r8d
+;;       movl    %ebx, %ebx
+;;       movl    %edi, %r9d
+;;       addl    %ebx, %r9d
+;;       jb      0xa37
+;;  2bd: cmpl    %edx, %r9d
+;;       ja      0xa39
+;;  2c6: movl    %r8d, %r9d
+;;       addl    %ebx, %r9d
+;;       jb      0xa3b
+;;  2d2: cmpl    %edx, %r9d
+;;       ja      0xa3d
+;;  2db: movl    %edi, %edi
+;;       imulq   $0x10, %rdi, %rdi
+;;       addq    %rdi, %rax
+;;       cmpq    $0, %rbx
+;;       je      0x344
+;;  2f1: movq    (%rax), %rax
+;;       addq    $0x10, %rax
+;;       movl    %r8d, %ecx
+;;       movq    %r14, %rdx
+;;       movq    0xd8(%rdx), %r9
+;;       cmpq    %r9, %rcx
+;;       jae     0xa3f
+;;  310: movq    %rcx, %r11
+;;       imulq   $8, %r11, %r11
+;;       movq    0xd0(%rdx), %rdx
+;;       movq    %rdx, %r10
+;;       addq    %r11, %rdx
+;;       cmpq    %r9, %rcx
+;;       cmovaeq %r10, %rdx
+;;       orq     $1, %rcx
+;;       movq    %rcx, (%rdx)
+;;       addl    $1, %r8d
+;;       jmp     0x2e7
+;;  344: movq    %r14, %rdi
+;;       movl    $1, %esi
+;;       callq   0x1105
 ;;       movq    8(%rsp), %r14
 ;;       movl    $5, %eax
 ;;       movl    $0xf, %ecx
@@ -168,84 +254,84 @@
 ;;       movl    %edx, %edx
 ;;       movq    %r14, %r11
 ;;       movq    0xd8(%r11), %rbx
-;;       movq    %rcx, %rsi
-;;       addq    %rax, %rsi
-;;       jb      0x8b5
-;;  20e: cmpq    %rbx, %rsi
-;;       ja      0x8b7
-;;  217: movq    %r14, %r11
+;;       movq    %rcx, %r8
+;;       addq    %rax, %r8
+;;       jb      0xa41
+;;  381: cmpq    %rbx, %r8
+;;       ja      0xa43
+;;  38a: movq    %r14, %r11
 ;;       movq    0xd8(%r11), %rbx
-;;       movq    %rdx, %rsi
-;;       addq    %rax, %rsi
-;;       jb      0x8b9
-;;  22d: cmpq    %rbx, %rsi
-;;       ja      0x8bb
-;;  236: cmpq    %rcx, %rdx
-;;       jbe     0x25f
-;;  23f: movq    $18446744073709551615, %rbx
+;;       movq    %rdx, %r8
+;;       addq    %rax, %r8
+;;       jb      0xa45
+;;  3a0: cmpq    %rbx, %r8
+;;       ja      0xa47
+;;  3a9: cmpq    %rcx, %rdx
+;;       jbe     0x3d2
+;;  3b2: movq    $18446744073709551615, %rbx
 ;;       addq    %rax, %rcx
 ;;       subq    $1, %rcx
 ;;       addq    %rax, %rdx
 ;;       subq    $1, %rdx
-;;       jmp     0x264
-;;  25f: movl    $1, %ebx
+;;       jmp     0x3d7
+;;  3d2: movl    $1, %ebx
 ;;       cmpq    $0, %rax
-;;       je      0x33e
-;;  26e: movq    %rcx, %rsi
+;;       je      0x4b2
+;;  3e1: movq    %rcx, %r8
 ;;       pushq   %rbx
 ;;       pushq   %rax
 ;;       pushq   %rdx
 ;;       pushq   %rcx
-;;       pushq   %rsi
+;;       pushq   %r8
 ;;       popq    %rcx
 ;;       movq    %r14, %rdx
 ;;       movq    0xd8(%rdx), %rbx
 ;;       cmpq    %rbx, %rcx
-;;       jae     0x8bd
-;;  28a: movq    %rcx, %r11
+;;       jae     0xa49
+;;  3fe: movq    %rcx, %r11
 ;;       imulq   $8, %r11, %r11
 ;;       movq    0xd0(%rdx), %rdx
-;;       movq    %rdx, %rsi
+;;       movq    %rdx, %r8
 ;;       addq    %r11, %rdx
 ;;       cmpq    %rbx, %rcx
-;;       cmovaeq %rsi, %rdx
+;;       cmovaeq %r8, %rdx
 ;;       movq    (%rdx), %rax
 ;;       testq   %rax, %rax
-;;       jne     0x2e6
-;;  2b4: pushq   %rcx
+;;       jne     0x45a
+;;  428: pushq   %rcx
 ;;       subq    $8, %rsp
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
 ;;       movq    8(%rsp), %rdx
-;;       callq   0xfc2
+;;       callq   0x114d
 ;;       addq    $8, %rsp
 ;;       addq    $8, %rsp
 ;;       movq    0x28(%rsp), %r14
-;;       jmp     0x2ec
-;;  2e6: andq    $0xfffffffffffffffe, %rax
+;;       jmp     0x460
+;;  45a: andq    $0xfffffffffffffffe, %rax
 ;;       popq    %rcx
 ;;       popq    %rdx
 ;;       movq    %rdx, %rbx
-;;       movq    %r14, %rsi
-;;       movq    0xd8(%rsi), %rdi
-;;       cmpq    %rdi, %rbx
-;;       jae     0x8bf
-;;  304: movq    %rbx, %r11
+;;       movq    %r14, %r8
+;;       movq    0xd8(%r8), %r9
+;;       cmpq    %r9, %rbx
+;;       jae     0xa4b
+;;  478: movq    %rbx, %r11
 ;;       imulq   $8, %r11, %r11
-;;       movq    0xd0(%rsi), %rsi
-;;       movq    %rsi, %r8
-;;       addq    %r11, %rsi
-;;       cmpq    %rdi, %rbx
-;;       cmovaeq %r8, %rsi
+;;       movq    0xd0(%r8), %r8
+;;       movq    %r8, %r10
+;;       addq    %r11, %r8
+;;       cmpq    %r9, %rbx
+;;       cmovaeq %r10, %r8
 ;;       orq     $1, %rax
-;;       movq    %rax, (%rsi)
+;;       movq    %rax, (%r8)
 ;;       popq    %rax
 ;;       popq    %rbx
 ;;       addq    %rbx, %rdx
 ;;       addq    %rbx, %rcx
 ;;       subq    $1, %rax
-;;       jmp     0x264
-;;  33e: movl    $1, %eax
+;;       jmp     0x3d7
+;;  4b2: movl    $1, %eax
 ;;       movl    $0x1d, %ecx
 ;;       movl    $0x15, %edx
 ;;       movl    %eax, %eax
@@ -253,84 +339,84 @@
 ;;       movl    %edx, %edx
 ;;       movq    %r14, %r11
 ;;       movq    0xd8(%r11), %rbx
-;;       movq    %rcx, %rsi
-;;       addq    %rax, %rsi
-;;       jb      0x8c1
-;;  369: cmpq    %rbx, %rsi
-;;       ja      0x8c3
-;;  372: movq    %r14, %r11
+;;       movq    %rcx, %r8
+;;       addq    %rax, %r8
+;;       jb      0xa4d
+;;  4dd: cmpq    %rbx, %r8
+;;       ja      0xa4f
+;;  4e6: movq    %r14, %r11
 ;;       movq    0xd8(%r11), %rbx
-;;       movq    %rdx, %rsi
-;;       addq    %rax, %rsi
-;;       jb      0x8c5
-;;  388: cmpq    %rbx, %rsi
-;;       ja      0x8c7
-;;  391: cmpq    %rcx, %rdx
-;;       jbe     0x3ba
-;;  39a: movq    $18446744073709551615, %rbx
+;;       movq    %rdx, %r8
+;;       addq    %rax, %r8
+;;       jb      0xa51
+;;  4fc: cmpq    %rbx, %r8
+;;       ja      0xa53
+;;  505: cmpq    %rcx, %rdx
+;;       jbe     0x52e
+;;  50e: movq    $18446744073709551615, %rbx
 ;;       addq    %rax, %rcx
 ;;       subq    $1, %rcx
 ;;       addq    %rax, %rdx
 ;;       subq    $1, %rdx
-;;       jmp     0x3bf
-;;  3ba: movl    $1, %ebx
+;;       jmp     0x533
+;;  52e: movl    $1, %ebx
 ;;       cmpq    $0, %rax
-;;       je      0x499
-;;  3c9: movq    %rcx, %rsi
+;;       je      0x60e
+;;  53d: movq    %rcx, %r8
 ;;       pushq   %rbx
 ;;       pushq   %rax
 ;;       pushq   %rdx
 ;;       pushq   %rcx
-;;       pushq   %rsi
+;;       pushq   %r8
 ;;       popq    %rcx
 ;;       movq    %r14, %rdx
 ;;       movq    0xd8(%rdx), %rbx
 ;;       cmpq    %rbx, %rcx
-;;       jae     0x8c9
-;;  3e5: movq    %rcx, %r11
+;;       jae     0xa55
+;;  55a: movq    %rcx, %r11
 ;;       imulq   $8, %r11, %r11
 ;;       movq    0xd0(%rdx), %rdx
-;;       movq    %rdx, %rsi
+;;       movq    %rdx, %r8
 ;;       addq    %r11, %rdx
 ;;       cmpq    %rbx, %rcx
-;;       cmovaeq %rsi, %rdx
+;;       cmovaeq %r8, %rdx
 ;;       movq    (%rdx), %rax
 ;;       testq   %rax, %rax
-;;       jne     0x441
-;;  40f: pushq   %rcx
+;;       jne     0x5b6
+;;  584: pushq   %rcx
 ;;       subq    $8, %rsp
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
 ;;       movq    8(%rsp), %rdx
-;;       callq   0xfc2
+;;       callq   0x114d
 ;;       addq    $8, %rsp
 ;;       addq    $8, %rsp
 ;;       movq    0x28(%rsp), %r14
-;;       jmp     0x447
-;;  441: andq    $0xfffffffffffffffe, %rax
+;;       jmp     0x5bc
+;;  5b6: andq    $0xfffffffffffffffe, %rax
 ;;       popq    %rcx
 ;;       popq    %rdx
 ;;       movq    %rdx, %rbx
-;;       movq    %r14, %rsi
-;;       movq    0xd8(%rsi), %rdi
-;;       cmpq    %rdi, %rbx
-;;       jae     0x8cb
-;;  45f: movq    %rbx, %r11
+;;       movq    %r14, %r8
+;;       movq    0xd8(%r8), %r9
+;;       cmpq    %r9, %rbx
+;;       jae     0xa57
+;;  5d4: movq    %rbx, %r11
 ;;       imulq   $8, %r11, %r11
-;;       movq    0xd0(%rsi), %rsi
-;;       movq    %rsi, %r8
-;;       addq    %r11, %rsi
-;;       cmpq    %rdi, %rbx
-;;       cmovaeq %r8, %rsi
+;;       movq    0xd0(%r8), %r8
+;;       movq    %r8, %r10
+;;       addq    %r11, %r8
+;;       cmpq    %r9, %rbx
+;;       cmovaeq %r10, %r8
 ;;       orq     $1, %rax
-;;       movq    %rax, (%rsi)
+;;       movq    %rax, (%r8)
 ;;       popq    %rax
 ;;       popq    %rbx
 ;;       addq    %rbx, %rdx
 ;;       addq    %rbx, %rcx
 ;;       subq    $1, %rax
-;;       jmp     0x3bf
-;;  499: movl    $1, %eax
+;;       jmp     0x533
+;;  60e: movl    $1, %eax
 ;;       movl    $0xa, %ecx
 ;;       movl    $0x18, %edx
 ;;       movl    %eax, %eax
@@ -338,84 +424,84 @@
 ;;       movl    %edx, %edx
 ;;       movq    %r14, %r11
 ;;       movq    0xd8(%r11), %rbx
-;;       movq    %rcx, %rsi
-;;       addq    %rax, %rsi
-;;       jb      0x8cd
-;;  4c4: cmpq    %rbx, %rsi
-;;       ja      0x8cf
-;;  4cd: movq    %r14, %r11
+;;       movq    %rcx, %r8
+;;       addq    %rax, %r8
+;;       jb      0xa59
+;;  639: cmpq    %rbx, %r8
+;;       ja      0xa5b
+;;  642: movq    %r14, %r11
 ;;       movq    0xd8(%r11), %rbx
-;;       movq    %rdx, %rsi
-;;       addq    %rax, %rsi
-;;       jb      0x8d1
-;;  4e3: cmpq    %rbx, %rsi
-;;       ja      0x8d3
-;;  4ec: cmpq    %rcx, %rdx
-;;       jbe     0x515
-;;  4f5: movq    $18446744073709551615, %rbx
+;;       movq    %rdx, %r8
+;;       addq    %rax, %r8
+;;       jb      0xa5d
+;;  658: cmpq    %rbx, %r8
+;;       ja      0xa5f
+;;  661: cmpq    %rcx, %rdx
+;;       jbe     0x68a
+;;  66a: movq    $18446744073709551615, %rbx
 ;;       addq    %rax, %rcx
 ;;       subq    $1, %rcx
 ;;       addq    %rax, %rdx
 ;;       subq    $1, %rdx
-;;       jmp     0x51a
-;;  515: movl    $1, %ebx
+;;       jmp     0x68f
+;;  68a: movl    $1, %ebx
 ;;       cmpq    $0, %rax
-;;       je      0x5f4
-;;  524: movq    %rcx, %rsi
+;;       je      0x76a
+;;  699: movq    %rcx, %r8
 ;;       pushq   %rbx
 ;;       pushq   %rax
 ;;       pushq   %rdx
 ;;       pushq   %rcx
-;;       pushq   %rsi
+;;       pushq   %r8
 ;;       popq    %rcx
 ;;       movq    %r14, %rdx
 ;;       movq    0xd8(%rdx), %rbx
 ;;       cmpq    %rbx, %rcx
-;;       jae     0x8d5
-;;  540: movq    %rcx, %r11
+;;       jae     0xa61
+;;  6b6: movq    %rcx, %r11
 ;;       imulq   $8, %r11, %r11
 ;;       movq    0xd0(%rdx), %rdx
-;;       movq    %rdx, %rsi
+;;       movq    %rdx, %r8
 ;;       addq    %r11, %rdx
 ;;       cmpq    %rbx, %rcx
-;;       cmovaeq %rsi, %rdx
+;;       cmovaeq %r8, %rdx
 ;;       movq    (%rdx), %rax
 ;;       testq   %rax, %rax
-;;       jne     0x59c
-;;  56a: pushq   %rcx
+;;       jne     0x712
+;;  6e0: pushq   %rcx
 ;;       subq    $8, %rsp
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
 ;;       movq    8(%rsp), %rdx
-;;       callq   0xfc2
+;;       callq   0x114d
 ;;       addq    $8, %rsp
 ;;       addq    $8, %rsp
 ;;       movq    0x28(%rsp), %r14
-;;       jmp     0x5a2
-;;  59c: andq    $0xfffffffffffffffe, %rax
+;;       jmp     0x718
+;;  712: andq    $0xfffffffffffffffe, %rax
 ;;       popq    %rcx
 ;;       popq    %rdx
 ;;       movq    %rdx, %rbx
-;;       movq    %r14, %rsi
-;;       movq    0xd8(%rsi), %rdi
-;;       cmpq    %rdi, %rbx
-;;       jae     0x8d7
-;;  5ba: movq    %rbx, %r11
+;;       movq    %r14, %r8
+;;       movq    0xd8(%r8), %r9
+;;       cmpq    %r9, %rbx
+;;       jae     0xa63
+;;  730: movq    %rbx, %r11
 ;;       imulq   $8, %r11, %r11
-;;       movq    0xd0(%rsi), %rsi
-;;       movq    %rsi, %r8
-;;       addq    %r11, %rsi
-;;       cmpq    %rdi, %rbx
-;;       cmovaeq %r8, %rsi
+;;       movq    0xd0(%r8), %r8
+;;       movq    %r8, %r10
+;;       addq    %r11, %r8
+;;       cmpq    %r9, %rbx
+;;       cmovaeq %r10, %r8
 ;;       orq     $1, %rax
-;;       movq    %rax, (%rsi)
+;;       movq    %rax, (%r8)
 ;;       popq    %rax
 ;;       popq    %rbx
 ;;       addq    %rbx, %rdx
 ;;       addq    %rbx, %rcx
 ;;       subq    $1, %rax
-;;       jmp     0x51a
-;;  5f4: movl    $4, %eax
+;;       jmp     0x68f
+;;  76a: movl    $4, %eax
 ;;       movl    $0xb, %ecx
 ;;       movl    $0xd, %edx
 ;;       movl    %eax, %eax
@@ -423,84 +509,84 @@
 ;;       movl    %edx, %edx
 ;;       movq    %r14, %r11
 ;;       movq    0xd8(%r11), %rbx
-;;       movq    %rcx, %rsi
-;;       addq    %rax, %rsi
-;;       jb      0x8d9
-;;  61f: cmpq    %rbx, %rsi
-;;       ja      0x8db
-;;  628: movq    %r14, %r11
+;;       movq    %rcx, %r8
+;;       addq    %rax, %r8
+;;       jb      0xa65
+;;  795: cmpq    %rbx, %r8
+;;       ja      0xa67
+;;  79e: movq    %r14, %r11
 ;;       movq    0xd8(%r11), %rbx
-;;       movq    %rdx, %rsi
-;;       addq    %rax, %rsi
-;;       jb      0x8dd
-;;  63e: cmpq    %rbx, %rsi
-;;       ja      0x8df
-;;  647: cmpq    %rcx, %rdx
-;;       jbe     0x670
-;;  650: movq    $18446744073709551615, %rbx
+;;       movq    %rdx, %r8
+;;       addq    %rax, %r8
+;;       jb      0xa69
+;;  7b4: cmpq    %rbx, %r8
+;;       ja      0xa6b
+;;  7bd: cmpq    %rcx, %rdx
+;;       jbe     0x7e6
+;;  7c6: movq    $18446744073709551615, %rbx
 ;;       addq    %rax, %rcx
 ;;       subq    $1, %rcx
 ;;       addq    %rax, %rdx
 ;;       subq    $1, %rdx
-;;       jmp     0x675
-;;  670: movl    $1, %ebx
+;;       jmp     0x7eb
+;;  7e6: movl    $1, %ebx
 ;;       cmpq    $0, %rax
-;;       je      0x74f
-;;  67f: movq    %rcx, %rsi
+;;       je      0x8c6
+;;  7f5: movq    %rcx, %r8
 ;;       pushq   %rbx
 ;;       pushq   %rax
 ;;       pushq   %rdx
 ;;       pushq   %rcx
-;;       pushq   %rsi
+;;       pushq   %r8
 ;;       popq    %rcx
 ;;       movq    %r14, %rdx
 ;;       movq    0xd8(%rdx), %rbx
 ;;       cmpq    %rbx, %rcx
-;;       jae     0x8e1
-;;  69b: movq    %rcx, %r11
+;;       jae     0xa6d
+;;  812: movq    %rcx, %r11
 ;;       imulq   $8, %r11, %r11
 ;;       movq    0xd0(%rdx), %rdx
-;;       movq    %rdx, %rsi
+;;       movq    %rdx, %r8
 ;;       addq    %r11, %rdx
 ;;       cmpq    %rbx, %rcx
-;;       cmovaeq %rsi, %rdx
+;;       cmovaeq %r8, %rdx
 ;;       movq    (%rdx), %rax
 ;;       testq   %rax, %rax
-;;       jne     0x6f7
-;;  6c5: pushq   %rcx
+;;       jne     0x86e
+;;  83c: pushq   %rcx
 ;;       subq    $8, %rsp
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
 ;;       movq    8(%rsp), %rdx
-;;       callq   0xfc2
+;;       callq   0x114d
 ;;       addq    $8, %rsp
 ;;       addq    $8, %rsp
 ;;       movq    0x28(%rsp), %r14
-;;       jmp     0x6fd
-;;  6f7: andq    $0xfffffffffffffffe, %rax
+;;       jmp     0x874
+;;  86e: andq    $0xfffffffffffffffe, %rax
 ;;       popq    %rcx
 ;;       popq    %rdx
 ;;       movq    %rdx, %rbx
-;;       movq    %r14, %rsi
-;;       movq    0xd8(%rsi), %rdi
-;;       cmpq    %rdi, %rbx
-;;       jae     0x8e3
-;;  715: movq    %rbx, %r11
+;;       movq    %r14, %r8
+;;       movq    0xd8(%r8), %r9
+;;       cmpq    %r9, %rbx
+;;       jae     0xa6f
+;;  88c: movq    %rbx, %r11
 ;;       imulq   $8, %r11, %r11
-;;       movq    0xd0(%rsi), %rsi
-;;       movq    %rsi, %r8
-;;       addq    %r11, %rsi
-;;       cmpq    %rdi, %rbx
-;;       cmovaeq %r8, %rsi
+;;       movq    0xd0(%r8), %r8
+;;       movq    %r8, %r10
+;;       addq    %r11, %r8
+;;       cmpq    %r9, %rbx
+;;       cmovaeq %r10, %r8
 ;;       orq     $1, %rax
-;;       movq    %rax, (%rsi)
+;;       movq    %rax, (%r8)
 ;;       popq    %rax
 ;;       popq    %rbx
 ;;       addq    %rbx, %rdx
 ;;       addq    %rbx, %rcx
 ;;       subq    $1, %rax
-;;       jmp     0x675
-;;  74f: movl    $5, %eax
+;;       jmp     0x7eb
+;;  8c6: movl    $5, %eax
 ;;       movl    $0x14, %ecx
 ;;       movl    $0x13, %edx
 ;;       movl    %eax, %eax
@@ -508,117 +594,127 @@
 ;;       movl    %edx, %edx
 ;;       movq    %r14, %r11
 ;;       movq    0xd8(%r11), %rbx
-;;       movq    %rcx, %rsi
-;;       addq    %rax, %rsi
-;;       jb      0x8e5
-;;  77a: cmpq    %rbx, %rsi
-;;       ja      0x8e7
-;;  783: movq    %r14, %r11
+;;       movq    %rcx, %r8
+;;       addq    %rax, %r8
+;;       jb      0xa71
+;;  8f1: cmpq    %rbx, %r8
+;;       ja      0xa73
+;;  8fa: movq    %r14, %r11
 ;;       movq    0xd8(%r11), %rbx
-;;       movq    %rdx, %rsi
-;;       addq    %rax, %rsi
-;;       jb      0x8e9
-;;  799: cmpq    %rbx, %rsi
-;;       ja      0x8eb
-;;  7a2: cmpq    %rcx, %rdx
-;;       jbe     0x7cb
-;;  7ab: movq    $18446744073709551615, %rbx
+;;       movq    %rdx, %r8
+;;       addq    %rax, %r8
+;;       jb      0xa75
+;;  910: cmpq    %rbx, %r8
+;;       ja      0xa77
+;;  919: cmpq    %rcx, %rdx
+;;       jbe     0x942
+;;  922: movq    $18446744073709551615, %rbx
 ;;       addq    %rax, %rcx
 ;;       subq    $1, %rcx
 ;;       addq    %rax, %rdx
 ;;       subq    $1, %rdx
-;;       jmp     0x7d0
-;;  7cb: movl    $1, %ebx
+;;       jmp     0x947
+;;  942: movl    $1, %ebx
 ;;       cmpq    $0, %rax
-;;       je      0x8aa
-;;  7da: movq    %rcx, %rsi
+;;       je      0xa22
+;;  951: movq    %rcx, %r8
 ;;       pushq   %rbx
 ;;       pushq   %rax
 ;;       pushq   %rdx
 ;;       pushq   %rcx
-;;       pushq   %rsi
+;;       pushq   %r8
 ;;       popq    %rcx
 ;;       movq    %r14, %rdx
 ;;       movq    0xd8(%rdx), %rbx
 ;;       cmpq    %rbx, %rcx
-;;       jae     0x8ed
-;;  7f6: movq    %rcx, %r11
+;;       jae     0xa79
+;;  96e: movq    %rcx, %r11
 ;;       imulq   $8, %r11, %r11
 ;;       movq    0xd0(%rdx), %rdx
-;;       movq    %rdx, %rsi
+;;       movq    %rdx, %r8
 ;;       addq    %r11, %rdx
 ;;       cmpq    %rbx, %rcx
-;;       cmovaeq %rsi, %rdx
+;;       cmovaeq %r8, %rdx
 ;;       movq    (%rdx), %rax
 ;;       testq   %rax, %rax
-;;       jne     0x852
-;;  820: pushq   %rcx
+;;       jne     0x9ca
+;;  998: pushq   %rcx
 ;;       subq    $8, %rsp
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
 ;;       movq    8(%rsp), %rdx
-;;       callq   0xfc2
+;;       callq   0x114d
 ;;       addq    $8, %rsp
 ;;       addq    $8, %rsp
 ;;       movq    0x28(%rsp), %r14
-;;       jmp     0x858
-;;  852: andq    $0xfffffffffffffffe, %rax
+;;       jmp     0x9d0
+;;  9ca: andq    $0xfffffffffffffffe, %rax
 ;;       popq    %rcx
 ;;       popq    %rdx
 ;;       movq    %rdx, %rbx
-;;       movq    %r14, %rsi
-;;       movq    0xd8(%rsi), %rdi
-;;       cmpq    %rdi, %rbx
-;;       jae     0x8ef
-;;  870: movq    %rbx, %r11
+;;       movq    %r14, %r8
+;;       movq    0xd8(%r8), %r9
+;;       cmpq    %r9, %rbx
+;;       jae     0xa7b
+;;  9e8: movq    %rbx, %r11
 ;;       imulq   $8, %r11, %r11
-;;       movq    0xd0(%rsi), %rsi
-;;       movq    %rsi, %r8
-;;       addq    %r11, %rsi
-;;       cmpq    %rdi, %rbx
-;;       cmovaeq %r8, %rsi
+;;       movq    0xd0(%r8), %r8
+;;       movq    %r8, %r10
+;;       addq    %r11, %r8
+;;       cmpq    %r9, %rbx
+;;       cmovaeq %r10, %r8
 ;;       orq     $1, %rax
-;;       movq    %rax, (%rsi)
+;;       movq    %rax, (%r8)
 ;;       popq    %rax
 ;;       popq    %rbx
 ;;       addq    %rbx, %rdx
 ;;       addq    %rbx, %rcx
 ;;       subq    $1, %rax
-;;       jmp     0x7d0
-;;  8aa: addq    $0x10, %rsp
+;;       jmp     0x947
+;;  a22: addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;  8b3: ud2
-;;  8b5: ud2
-;;  8b7: ud2
-;;  8b9: ud2
-;;  8bb: ud2
-;;  8bd: ud2
-;;  8bf: ud2
-;;  8c1: ud2
-;;  8c3: ud2
-;;  8c5: ud2
-;;  8c7: ud2
-;;  8c9: ud2
-;;  8cb: ud2
-;;  8cd: ud2
-;;  8cf: ud2
-;;  8d1: ud2
-;;  8d3: ud2
-;;  8d5: ud2
-;;  8d7: ud2
-;;  8d9: ud2
-;;  8db: ud2
-;;  8dd: ud2
-;;  8df: ud2
-;;  8e1: ud2
-;;  8e3: ud2
-;;  8e5: ud2
-;;  8e7: ud2
-;;  8e9: ud2
-;;  8eb: ud2
-;;  8ed: ud2
-;;  8ef: ud2
+;;  a2b: ud2
+;;  a2d: ud2
+;;  a2f: ud2
+;;  a31: ud2
+;;  a33: ud2
+;;  a35: ud2
+;;  a37: ud2
+;;  a39: ud2
+;;  a3b: ud2
+;;  a3d: ud2
+;;  a3f: ud2
+;;  a41: ud2
+;;  a43: ud2
+;;  a45: ud2
+;;  a47: ud2
+;;  a49: ud2
+;;  a4b: ud2
+;;  a4d: ud2
+;;  a4f: ud2
+;;  a51: ud2
+;;  a53: ud2
+;;  a55: ud2
+;;  a57: ud2
+;;  a59: ud2
+;;  a5b: ud2
+;;  a5d: ud2
+;;  a5f: ud2
+;;  a61: ud2
+;;  a63: ud2
+;;  a65: ud2
+;;  a67: ud2
+;;  a69: ud2
+;;  a6b: ud2
+;;  a6d: ud2
+;;  a6f: ud2
+;;  a71: ud2
+;;  a73: ud2
+;;  a75: ud2
+;;  a77: ud2
+;;  a79: ud2
+;;  a7b: ud2
 ;;
 ;; wasm[0]::function[11]:
 ;;       pushq   %rbp
@@ -627,8 +723,8 @@
 ;;       movq    0x18(%r11), %r11
 ;;       addq    $0x30, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0xa06
-;;  91c: movq    %rdi, %r14
+;;       ja      0xb86
+;;  a9c: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
 ;;       movq    %rsi, 0x10(%rsp)
@@ -641,8 +737,8 @@
 ;;       movq    %r14, %rdx
 ;;       movq    0xd8(%rdx), %rbx
 ;;       cmpq    %rbx, %rcx
-;;       jae     0xa08
-;;  961: movq    %rcx, %r11
+;;       jae     0xb88
+;;  ae1: movq    %rcx, %r11
 ;;       imulq   $8, %r11, %r11
 ;;       movq    0xd0(%rdx), %rdx
 ;;       movq    %rdx, %rsi
@@ -651,27 +747,27 @@
 ;;       cmovaeq %rsi, %rdx
 ;;       movq    (%rdx), %rax
 ;;       testq   %rax, %rax
-;;       jne     0x9c5
-;;  98b: subq    $4, %rsp
+;;       jne     0xb45
+;;  b0b: subq    $4, %rsp
 ;;       movl    %ecx, (%rsp)
 ;;       subq    $0xc, %rsp
 ;;       movq    %r14, %rdi
 ;;       movl    $0, %esi
 ;;       movl    0xc(%rsp), %edx
-;;       callq   0xfc2
+;;       callq   0x114d
 ;;       addq    $0xc, %rsp
 ;;       addq    $4, %rsp
 ;;       movq    0x18(%rsp), %r14
-;;       jmp     0x9cb
-;;  9c5: andq    $0xfffffffffffffffe, %rax
+;;       jmp     0xb4b
+;;  b45: andq    $0xfffffffffffffffe, %rax
 ;;       testq   %rax, %rax
-;;       je      0xa0a
-;;  9d4: movq    0x28(%r14), %r11
+;;       je      0xb8a
+;;  b54: movq    0x28(%r14), %r11
 ;;       movl    (%r11), %ecx
 ;;       movl    0x10(%rax), %edx
 ;;       cmpl    %edx, %ecx
-;;       jne     0xa0c
-;;  9e6: pushq   %rax
+;;       jne     0xb8c
+;;  b66: pushq   %rax
 ;;       popq    %rcx
 ;;       movq    0x18(%rcx), %rbx
 ;;       movq    8(%rcx), %rdx
@@ -682,7 +778,7 @@
 ;;       addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;  a06: ud2
-;;  a08: ud2
-;;  a0a: ud2
-;;  a0c: ud2
+;;  b86: ud2
+;;  b88: ud2
+;;  b8a: ud2
+;;  b8c: ud2

--- a/tests/disas/x64-simd-round-without-sse41.wat
+++ b/tests/disas/x64-simd-round-without-sse41.wat
@@ -17,7 +17,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, f32) -> f32 tail
-;;     fn0 = colocated u805306368:29 sig0
+;;     fn0 = colocated u805306368:28 sig0
 ;;     const0 = 0x00000000000000000000000000000000
 ;;     stack_limit = gv2
 ;;
@@ -49,7 +49,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, f32) -> f32 tail
-;;     fn0 = colocated u805306368:31 sig0
+;;     fn0 = colocated u805306368:30 sig0
 ;;     const0 = 0x00000000000000000000000000000000
 ;;     stack_limit = gv2
 ;;
@@ -81,7 +81,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, f32) -> f32 tail
-;;     fn0 = colocated u805306368:33 sig0
+;;     fn0 = colocated u805306368:32 sig0
 ;;     const0 = 0x00000000000000000000000000000000
 ;;     stack_limit = gv2
 ;;
@@ -113,7 +113,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, f32) -> f32 tail
-;;     fn0 = colocated u805306368:35 sig0
+;;     fn0 = colocated u805306368:34 sig0
 ;;     const0 = 0x00000000000000000000000000000000
 ;;     stack_limit = gv2
 ;;
@@ -145,7 +145,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, f64) -> f64 tail
-;;     fn0 = colocated u805306368:30 sig0
+;;     fn0 = colocated u805306368:29 sig0
 ;;     const0 = 0x00000000000000000000000000000000
 ;;     stack_limit = gv2
 ;;
@@ -171,7 +171,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, f64) -> f64 tail
-;;     fn0 = colocated u805306368:32 sig0
+;;     fn0 = colocated u805306368:31 sig0
 ;;     const0 = 0x00000000000000000000000000000000
 ;;     stack_limit = gv2
 ;;
@@ -197,7 +197,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, f64) -> f64 tail
-;;     fn0 = colocated u805306368:34 sig0
+;;     fn0 = colocated u805306368:33 sig0
 ;;     const0 = 0x00000000000000000000000000000000
 ;;     stack_limit = gv2
 ;;
@@ -223,7 +223,7 @@
 ;;     gv2 = load.i64 notrap aligned gv1+24
 ;;     gv3 = vmctx
 ;;     sig0 = (i64 vmctx, f64) -> f64 tail
-;;     fn0 = colocated u805306368:36 sig0
+;;     fn0 = colocated u805306368:35 sig0
 ;;     const0 = 0x00000000000000000000000000000000
 ;;     stack_limit = gv2
 ;;

--- a/winch/codegen/src/codegen/mod.rs
+++ b/winch/codegen/src/codegen/mod.rs
@@ -24,8 +24,9 @@ use wasmparser::{
 };
 use wasmtime_cranelift::{TRAP_BAD_SIGNATURE, TRAP_HEAP_MISALIGNED, TRAP_TABLE_OUT_OF_BOUNDS};
 use wasmtime_environ::{
-    DataIndex, FUNCREF_INIT_BIT, FUNCREF_MASK, GlobalIndex, IndexType, MemoryIndex, MemoryKind,
-    MemoryTunables, PtrSize, TableIndex, Tunables, TypeIndex, WasmHeapType, WasmValType,
+    DataIndex, ElemIndex, FUNCREF_INIT_BIT, FUNCREF_MASK, GlobalIndex, IndexType, MemoryIndex,
+    MemoryKind, MemoryTunables, PtrSize, TableIndex, Tunables, TypeIndex, WasmHeapType,
+    WasmValType,
 };
 
 mod context;
@@ -1814,6 +1815,226 @@ where
             .vmctx_passive_data_length(passive_data_index);
         let len_addr = self.masm.address_at_vmctx(data_segment_offset)?;
         self.masm.store(RegImm::i32(0), len_addr, OperandSize::S32)
+    }
+
+    /// Implementation of `table.init`
+    pub fn emit_table_init(
+        &mut self,
+        elem_index: ElemIndex,
+        table_index: TableIndex,
+    ) -> Result<()> {
+        let builtin_base = self.env.builtins.passive_elem_segment_base::<M::ABI>()?;
+        let builtin_len = self.env.builtins.passive_elem_segment_len::<M::ABI>()?;
+
+        // Push the passive segment's length and base onto the stack.
+        match self.env.translation.passive_elem_map[elem_index] {
+            Some(idx) => {
+                self.context.stack.extend([idx.as_u32().try_into()?]);
+                FnCall::emit::<M>(
+                    &mut self.env,
+                    self.masm,
+                    &mut self.context,
+                    Callee::Builtin(builtin_len),
+                )?;
+                self.context.stack.extend([idx.as_u32().try_into()?]);
+                FnCall::emit::<M>(
+                    &mut self.env,
+                    self.masm,
+                    &mut self.context,
+                    Callee::Builtin(builtin_base),
+                )?;
+            }
+            // Active data segments have 0 length and a null base pointer.
+            None => {
+                let tmp = self.context.any_gpr(self.masm)?;
+                self.masm
+                    .mov(writable!(tmp), RegImm::i64(0), OperandSize::S64)?;
+                self.context
+                    .stack
+                    .push(TypedReg::new(WasmValType::I64, tmp).into());
+
+                let tmp = self.context.any_gpr(self.masm)?;
+                self.masm
+                    .mov(writable!(tmp), RegImm::i64(0), OperandSize::S64)?;
+                self.context
+                    .stack
+                    .push(TypedReg::new(WasmValType::I64, tmp).into());
+            }
+        };
+
+        // Push the table's current length onto the stack.
+        let table_data = self.env.resolve_table_data(table_index);
+        let idx_size = table_data.index_type().try_into()?;
+        self.emit_compute_table_size(&table_data)?;
+
+        // And now pop off everything we have for this instruction to work with
+        // it all below.
+        let table_size = self.context.pop_to_reg(self.masm, None)?;
+        let segment_base = self.context.pop_to_reg(self.masm, None)?;
+        let segment_len = self.context.pop_to_reg(self.masm, None)?;
+        let len = self.context.pop_to_reg(self.masm, None)?;
+        let segment_off = self.context.pop_to_reg(self.masm, None)?;
+        let table_off = self.context.pop_to_reg(self.masm, None)?;
+
+        // Zero-extend the length to make it easier to work with below for
+        // 64-bit tables.
+        if len.ty == WasmValType::I32 {
+            self.masm.extend(
+                writable!(len.reg),
+                len.reg,
+                Extend::<Zero>::I64Extend32.into(),
+            )?;
+        }
+
+        // Perform a bounds check to see if `segment_off+len` is inbounds.
+        let tmp = self.context.any_gpr(self.masm)?;
+        {
+            self.masm
+                .mov(writable!(tmp), segment_off.reg.into(), OperandSize::S32)?;
+            self.masm.checked_uadd(
+                writable!(tmp),
+                tmp,
+                len.reg.into(),
+                OperandSize::S32,
+                TRAP_TABLE_OUT_OF_BOUNDS,
+            )?;
+            self.masm
+                .cmp(tmp, segment_len.reg.into(), OperandSize::S32)?;
+            self.masm
+                .trapif(IntCmpKind::GtU, TRAP_TABLE_OUT_OF_BOUNDS)?;
+            self.context.free_reg(segment_len);
+        }
+
+        // Perform a bounds check to see if `table_off+len` is inbounds.
+        {
+            self.masm
+                .mov(writable!(tmp), table_off.reg.into(), idx_size)?;
+            self.masm.checked_uadd(
+                writable!(tmp),
+                tmp,
+                len.reg.into(),
+                idx_size,
+                TRAP_TABLE_OUT_OF_BOUNDS,
+            )?;
+            self.masm.cmp(tmp, segment_len.reg.into(), idx_size)?;
+            self.masm
+                .trapif(IntCmpKind::GtU, TRAP_TABLE_OUT_OF_BOUNDS)?;
+            self.context.free_reg(table_size);
+        }
+        self.context.free_reg(tmp);
+
+        // Calculate the base address of the segment that we're reading from.
+        {
+            self.masm.extend(
+                writable!(segment_off.reg),
+                segment_off.reg,
+                Extend::<Zero>::I64Extend32.into(),
+            )?;
+            self.masm.mul(
+                writable!(segment_off.reg),
+                segment_off.reg,
+                RegImm::i64(16),
+                OperandSize::S64,
+            )?;
+            self.masm.add(
+                writable!(segment_base.reg),
+                segment_base.reg,
+                segment_off.reg.into(),
+                OperandSize::S64,
+            )?;
+            self.context.free_reg(segment_base);
+        }
+
+        // Now run `table.set` in a loop with the values read from the element
+        // segment.
+        let header = self.masm.get_label()?;
+        let exit = self.masm.get_label()?;
+
+        self.masm.bind(header)?;
+        {
+            self.masm.branch(
+                IntCmpKind::Eq,
+                len.reg,
+                RegImm::i64(0),
+                exit,
+                OperandSize::S64,
+            )?;
+
+            // Read `*mut VMFuncRef` from `ValRaw`, and then increment the
+            // `segment_base` pointer.
+            let tmp = self.context.any_gpr(self.masm)?;
+            self.masm.load_ptr(
+                self.masm.address_at_reg(segment_base.reg, 0)?,
+                writable!(tmp),
+            )?;
+            self.masm.add(
+                writable!(segment_base.reg),
+                segment_base.reg,
+                RegImm::i64(16),
+                OperandSize::S64,
+            )?;
+
+            // Spill context/variables for the table.set, and note that
+            // `table_off` is duplicated here as one version is consumed by the
+            // `table.set` and the other persists across the loop.
+            self.context.stack.push(segment_base.into());
+            self.context.stack.push(len.into());
+            let tmp = self.context.any_gpr(self.masm)?;
+            self.masm.mov(
+                writable!(tmp),
+                table_off.reg.into(),
+                table_off.ty.try_into()?,
+            )?;
+            self.context.stack.push(table_off.into());
+            self.context
+                .stack
+                .push(TypedReg::new(table_off.ty, tmp).into());
+            self.context
+                .stack
+                .push(TypedReg::new(WasmValType::FUNCREF, tmp).into());
+            self.emit_table_set(table_index)?;
+
+            // Pop loop variables into their original registers for the loop.
+            self.context.pop_to_reg(self.masm, Some(table_off.reg))?;
+            self.context.pop_to_reg(self.masm, Some(len.reg))?;
+            self.context.pop_to_reg(self.masm, Some(segment_base.reg))?;
+
+            // Increment the table index to copy next
+            self.masm.add(
+                writable!(table_off.reg),
+                table_off.reg,
+                RegImm::i64(1),
+                table_off.ty.try_into()?,
+            )?;
+        }
+        self.masm.jmp(header)?;
+
+        self.masm.bind(exit)?;
+
+        self.context.free_reg(segment_base);
+        self.context.free_reg(len);
+        self.context.free_reg(table_off);
+        Ok(())
+    }
+
+    /// Implementation of `elem.drop`
+    pub fn emit_elem_drop(&mut self, elem_index: ElemIndex) -> Result<()> {
+        let passive_elem_index = match self.env.translation.passive_elem_map[elem_index] {
+            Some(idx) => idx,
+            // Active elem segments do nothing when dropped, so this is a noop.
+            None => return Ok(()),
+        };
+        let builtin = self.env.builtins.passive_elem_segment_drop::<M::ABI>()?;
+        self.context
+            .stack
+            .extend([passive_elem_index.as_u32().try_into()?]);
+        FnCall::emit::<M>(
+            &mut self.env,
+            self.masm,
+            &mut self.context,
+            Callee::Builtin(builtin),
+        )?;
+        self.context.pop_and_free(self.masm)
     }
 
     /// Checks if fuel consumption is enabled and emits a series of instructions

--- a/winch/codegen/src/visitor.rs
+++ b/winch/codegen/src/visitor.rs
@@ -28,7 +28,7 @@ use wasmparser::{
 };
 use wasmtime_cranelift::TRAP_INDIRECT_CALL_TO_NULL;
 use wasmtime_environ::{
-    DataIndex, FuncIndex, GlobalIndex, MemoryIndex, TableIndex, TypeIndex, WasmHeapType,
+    DataIndex, ElemIndex, FuncIndex, GlobalIndex, MemoryIndex, TableIndex, TypeIndex, WasmHeapType,
     WasmValType,
 };
 
@@ -1716,20 +1716,7 @@ where
     }
 
     fn visit_table_init(&mut self, elem: u32, table: u32) -> Self::Output {
-        let at = self.context.stack.ensure_index_at(3)?;
-
-        self.context
-            .stack
-            .insert_many(at, &[table.try_into()?, elem.try_into()?]);
-
-        let builtin = self.env.builtins.table_init::<M::ABI>()?;
-        FnCall::emit::<M>(
-            &mut self.env,
-            self.masm,
-            &mut self.context,
-            Callee::Builtin(builtin.clone()),
-        )?;
-        self.context.pop_and_free(self.masm)
+        self.emit_table_init(ElemIndex::from_u32(elem), TableIndex::from_u32(table))
     }
 
     fn visit_table_copy(&mut self, dst: u32, src: u32) -> Self::Output {
@@ -1763,15 +1750,8 @@ where
     }
 
     fn visit_elem_drop(&mut self, index: u32) -> Self::Output {
-        let elem_drop = self.env.builtins.elem_drop::<M::ABI>()?;
-        self.context.stack.extend([index.try_into()?]);
-        FnCall::emit::<M>(
-            &mut self.env,
-            self.masm,
-            &mut self.context,
-            Callee::Builtin(elem_drop),
-        )?;
-        self.context.pop_and_free(self.masm)
+        let index = ElemIndex::from_u32(index);
+        self.emit_elem_drop(index)
     }
 
     fn visit_memory_init(&mut self, data_index: u32, mem: u32) -> Self::Output {


### PR DESCRIPTION
This commit is targeted at implementing the bulk of the `table.init`, `array.init_elem`, and `array.new_elem` instructions in compiled wasm code. This means that these instructions can also more naturally insert fuel/epoch checks described in #13387.

Support in this commit is heavily built on previous refactorings where the goal here is to a new kind of entity, an element segment, and then just fill out all the various places that `match` is needed. The main refactoring needed to support this is that the element size of the src/dst of a copy can now differ. This is because element segments have a 16-byte element size (`ValRaw`'s size), but tables and arrays have a different size of each element.

Closes #13258

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
