### PR TITLE
Test/adjust fuel consumption in bulk ops

### DIFF
--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -3757,6 +3757,12 @@ impl FuncEnvironment<'_> {
         builder.insert_block_after(loop_block, current_block);
         builder.insert_block_after(continue_block, loop_block);
 
+        // Before entering the loop below flush our fuel counters to ensure
+        // that previous instructions' fuel isn't counted once-per-iteration.
+        if self.tunables.consume_fuel {
+            self.fuel_increment_var(builder);
+        }
+
         // Current block: test to see if this is actually an empty copy. If it
         // is then skip over the entire loop, otherwise enter the loop and
         // perform the first ieration.
@@ -3774,6 +3780,10 @@ impl FuncEnvironment<'_> {
         // by the element size, then see if we turn again or exit.
         builder.switch_to_block(loop_block);
         let elem_addr = builder.append_block_param(loop_block, pointer_ty);
+        // Consume one unit of fuel per loop iteration.
+        if self.tunables.consume_fuel {
+            self.fuel_consumed += 1;
+        }
         self.translate_loop_header(builder)?;
         emit_elem_write(self, builder, elem_addr, value)?;
         let next_elem_addr = builder.ins().iadd_imm(elem_addr, i64::from(elem_size));
@@ -4479,6 +4489,13 @@ impl FuncEnvironment<'_> {
         builder.insert_block_after(backwards_block, forward_block);
         builder.insert_block_after(done_block, backwards_block);
 
+        // Update our local fuel counter, if enabled, before entering the loops
+        // below. This zeros out `self.fuel_consumed` so we don't consume
+        // previous fuel on each iteration of the loop.
+        if self.tunables.consume_fuel {
+            self.fuel_increment_var(builder);
+        }
+
         // Terminate `current_block` by testing to see if we're copying any
         // elements at all.
         builder
@@ -4523,6 +4540,10 @@ impl FuncEnvironment<'_> {
         let dst_cur = builder.append_block_param(forward_block, self.pointer_type());
         let src_cur = builder.append_block_param(forward_block, self.pointer_type());
         let src_index = builder.append_block_param(forward_block, src_index_ty);
+        // Consume a single unit of fuel on each iteration of the loop.
+        if self.tunables.consume_fuel {
+            self.fuel_consumed += 1;
+        }
         self.translate_loop_header(builder)?;
         copy_one(self, builder, dst_cur, src_cur, src_index)?;
         let dst_next = builder.ins().iadd_imm(dst_cur, i64::from(dst_element_size));
@@ -4543,6 +4564,9 @@ impl FuncEnvironment<'_> {
         let dst_cur = builder.append_block_param(backwards_block, self.pointer_type());
         let src_cur = builder.append_block_param(backwards_block, self.pointer_type());
         let src_index = builder.append_block_param(backwards_block, src_index_ty);
+        if self.tunables.consume_fuel {
+            self.fuel_consumed += 1;
+        }
         self.translate_loop_header(builder)?;
         let dst_cur = {
             let size = builder

--- a/tests/all/fuel.rs
+++ b/tests/all/fuel.rs
@@ -24,7 +24,7 @@ impl<'a> Parse<'a> for FuelWast<'a> {
     }
 }
 
-#[wasmtime_test]
+#[wasmtime_test(wasm_features(bulk_memory, reference_types, gc))]
 #[cfg_attr(miri, ignore)]
 fn run(config: &mut Config) -> Result<()> {
     config.consume_fuel(true);
@@ -171,6 +171,129 @@ fn iloop(config: &mut Config) -> Result<()> {
             )
         "#,
     )?;
+
+    iloop_aborts(
+        &config,
+        r#"
+            (module
+                (memory 1)
+                (start 0)
+                (func
+                    i32.const 0
+                    i32.const 0
+                    i32.const 65536
+                    memory.copy
+                )
+            )
+        "#,
+    )?;
+
+    iloop_aborts(
+        &config,
+        r#"
+            (module
+                (memory 1)
+                (start 0)
+                (func
+                    i32.const 0
+                    i32.const 0
+                    i32.const 65536
+                    memory.fill
+                )
+            )
+        "#,
+    )?;
+
+    let data = "a".repeat(65536);
+    iloop_aborts(
+        &config,
+        &format!(
+            r#"
+            (module
+                (memory 1)
+                (start 0)
+                (func
+                    i32.const 0
+                    i32.const 0
+                    i32.const 65536
+                    memory.init $d
+                )
+
+                (data $d "{data}")
+            )
+            "#
+        ),
+    )?;
+
+    iloop_aborts(
+        &config,
+        r#"
+            (module
+                (table 20000 funcref)
+                (start 0)
+                (func
+                    i32.const 0
+                    i32.const 0
+                    i32.const 20000
+                    table.copy
+                )
+            )
+        "#,
+    )?;
+
+    iloop_aborts(
+        &config,
+        r#"
+            (module
+                (table 20000 funcref)
+                (start 0)
+                (func
+                    i32.const 0
+                    ref.null func
+                    i32.const 20000
+                    table.fill
+                )
+            )
+        "#,
+    )?;
+
+    iloop_aborts(
+        &config,
+        r#"
+            (module
+                (table 0 funcref)
+                (start 0)
+                (func
+                    ref.null func
+                    i32.const 20000
+                    table.grow
+                    drop
+                )
+            )
+        "#,
+    )?;
+
+    let elems = "$f ".repeat(20000);
+    iloop_aborts(
+        &config,
+        &format!(
+            r#"
+            (module
+                (table 20000 funcref)
+                (start 0)
+                (func
+                    i32.const 0
+                    i32.const 0
+                    i32.const 20000
+                    table.init $e
+                )
+                (func $f)
+                (elem $e func {elems})
+            )
+            "#
+        ),
+    )?;
+
     iloop_aborts(
         &config,
         r#"
@@ -178,8 +301,146 @@ fn iloop(config: &mut Config) -> Result<()> {
                 (type $a (array i8))
                 (start 0)
                 (func
-                    i32.const 0x400_0000
+                    i32.const 20000
                     array.new_default $a
+                    drop
+                )
+            )
+        "#,
+    )?;
+
+    iloop_aborts(
+        &config,
+        r#"
+            (module
+                (type $a (array (mut i8)))
+                (start 0)
+                (global $a (ref $a) i32.const 20000 array.new_default $a)
+                (global $b (ref $a) i32.const 20000 array.new_default $a)
+                (func
+                    global.get $a
+                    i32.const 0
+                    global.get $b
+                    i32.const 0
+                    i32.const 20000
+                    array.copy $a $a
+                )
+            )
+        "#,
+    )?;
+
+    iloop_aborts(
+        &config,
+        r#"
+            (module
+                (type $a (array (mut i8)))
+                (start 0)
+                (global $a (ref $a) i32.const 20000 array.new_default $a)
+                (func
+                    global.get $a
+                    i32.const 0
+                    i32.const 0
+                    i32.const 20000
+                    array.fill $a
+                )
+            )
+        "#,
+    )?;
+
+    iloop_aborts(
+        &config,
+        &format!(
+            r#"
+            (module
+                (type $a (array (mut i8)))
+                (start 0)
+                (func
+                    i32.const 0
+                    i32.const 65536
+                    array.new_data $a $d
+                    drop
+                )
+
+                (data $d "{data}")
+            )
+            "#
+        ),
+    )?;
+
+    iloop_aborts(
+        &config,
+        &format!(
+            r#"
+            (module
+                (type $a (array (mut i8)))
+                (start 0)
+                (global $a (ref $a) i32.const 20000 array.new_default $a)
+                (func
+                    global.get $a
+                    i32.const 0
+                    i32.const 0
+                    i32.const 20000
+                    array.init_data $a $d
+                )
+
+                (data $d "{data}")
+            )
+            "#
+        ),
+    )?;
+
+    iloop_aborts(
+        &config,
+        &format!(
+            r#"
+            (module
+                (type $a (array (mut funcref)))
+                (start 0)
+                (func
+                    i32.const 0
+                    i32.const 20000
+                    array.new_elem $a $e
+                    drop
+                )
+                (func $f)
+                (elem $e func {elems})
+            )
+            "#
+        ),
+    )?;
+
+    iloop_aborts(
+        &config,
+        &format!(
+            r#"
+            (module
+                (type $a (array (mut funcref)))
+                (start 0)
+                (global $a (ref $a) i32.const 20000 array.new_default $a)
+                (func
+                    global.get $a
+                    i32.const 0
+                    i32.const 0
+                    i32.const 20000
+                    array.init_elem $a $e
+                )
+                (func $f)
+                (elem $e func {elems})
+            )
+            "#
+        ),
+    )?;
+
+    iloop_aborts(
+        &config,
+        r#"
+            (module
+                (type $a (array (mut i8)))
+                (start 0)
+                (func
+                    i32.const 0
+                    i32.const 20000
+                    array.new $a
                     drop
                 )
             )

--- a/tests/all/fuel.wast
+++ b/tests/all/fuel.wast
@@ -206,3 +206,182 @@
       end
     )
     (start $f)))
+
+(assert_fuel 105
+  (module
+    (memory 1)
+    (func $f
+      i32.const 0
+      i32.const 0
+      i32.const 100
+      memory.copy
+    )
+    (start $f)))
+
+(assert_fuel 105
+  (module
+    (memory 1)
+    (func $f
+      i32.const 0
+      i32.const 0
+      i32.const 100
+      memory.fill
+    )
+    (start $f)))
+
+(assert_fuel 25
+  (module
+    (memory 1)
+    (func $f
+      i32.const 0
+      i32.const 0
+      i32.const 20
+      memory.init $d
+    )
+    (start $f)
+    (data $d "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")))
+
+(assert_fuel 105
+  (module
+    (table 100 funcref)
+    (func $f
+      i32.const 0
+      i32.const 0
+      i32.const 100
+      table.copy
+    )
+    (start $f)))
+
+(assert_fuel 105
+  (module
+    (table 100 funcref)
+    (func $f
+      i32.const 0
+      ref.null func
+      i32.const 100
+      table.fill
+    )
+    (start $f)))
+
+(assert_fuel 104
+  (module
+    (table 0 funcref)
+    (func $f
+      ref.null func
+      i32.const 100
+      table.grow
+      drop
+    )
+    (start $f)))
+
+(assert_fuel 25
+  (module
+    (table 20 funcref)
+    (func $f
+      i32.const 0
+      i32.const 0
+      i32.const 20
+      table.init $e
+    )
+    (start $f)
+    (elem $e func $f $f $f $f $f $f $f $f $f $f $f $f $f $f $f $f $f $f $f $f)))
+
+(assert_fuel 107
+  (module
+    (type $a (array (mut i8)))
+    (global $a (ref $a) (array.new_default $a (i32.const 100)))
+    (func $f
+      global.get $a
+      i32.const 0
+      global.get $a
+      i32.const 0
+      i32.const 100
+      array.copy $a $a
+    )
+    (start $f)))
+
+(assert_fuel 106
+  (module
+    (type $a (array (mut i8)))
+    (global $a (ref $a) (array.new_default $a (i32.const 100)))
+    (func $f
+      global.get $a
+      i32.const 0
+      i32.const 0
+      i32.const 100
+      array.fill $a
+    )
+    (start $f)))
+
+(assert_fuel 24
+  (module
+    (type $a (array (mut i8)))
+    (func $f
+      i32.const 0
+      i32.const 20
+      array.new_data $a $d
+      drop
+    )
+    (data $d "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+    (start $f)))
+
+(assert_fuel 26
+  (module
+    (type $a (array (mut i8)))
+    (global $a (ref $a) (array.new_default $a (i32.const 100)))
+    (func $f
+      global.get $a
+      i32.const 0
+      i32.const 0
+      i32.const 20
+      array.init_data $a $d
+    )
+    (data $d "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+    (start $f)))
+
+(assert_fuel 24
+  (module
+    (type $a (array (mut funcref)))
+    (func $f
+      i32.const 0
+      i32.const 20
+      array.new_elem $a $e
+      drop
+    )
+    (start $f)
+    (elem $e func $f $f $f $f $f $f $f $f $f $f $f $f $f $f $f $f $f $f $f $f)))
+
+(assert_fuel 26
+  (module
+    (type $a (array (mut funcref)))
+    (global $a (ref $a) (array.new_default $a (i32.const 100)))
+    (func $f
+      global.get $a
+      i32.const 0
+      i32.const 0
+      i32.const 20
+      array.init_elem $a $e
+    )
+    (start $f)
+    (elem $e func $f $f $f $f $f $f $f $f $f $f $f $f $f $f $f $f $f $f $f $f)))
+
+(assert_fuel 403 ;; 400 bytes set + 1 func + 2 instructions (drop is 0)
+  (module
+    (type $a (array (mut funcref)))
+    (func $f
+      i32.const 100
+      array.new_default $a
+      drop
+    )
+    (start $f)))
+
+(assert_fuel 404 ;; 400 bytes set + 1 func + 3 instructions (drop is 0)
+  (module
+    (type $a (array (mut funcref)))
+    (func $f
+      ref.null func
+      i32.const 100
+      array.new $a
+      drop
+    )
+    (start $f)))

--- a/tests/disas/gc/array-copy-with-fuel.wat
+++ b/tests/disas/gc/array-copy-with-fuel.wat
@@ -24,30 +24,30 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32, v6: i32):
-;;                                     v173 = stack_addr.i64 ss1
-;;                                     store notrap v2, v173
-;;                                     v172 = stack_addr.i64 ss0
-;;                                     store notrap v4, v172
+;;                                     v177 = stack_addr.i64 ss1
+;;                                     store notrap v2, v177
+;;                                     v176 = stack_addr.i64 ss0
+;;                                     store notrap v4, v176
 ;; @0020                               v7 = load.i64 notrap aligned readonly can_move v0+8
 ;; @0020                               v8 = load.i64 notrap aligned v7
-;;                                     v170 = iconst.i64 1
-;; @0020                               v9 = iadd v8, v170  ; v170 = 1
+;;                                     v174 = iconst.i64 1
+;; @0020                               v9 = iadd v8, v174  ; v174 = 1
 ;; @0020                               v10 = iconst.i64 0
 ;; @0020                               v11 = icmp sge v9, v10  ; v10 = 0
 ;; @0020                               brif v11, block2, block3(v9)
 ;;
 ;;                                 block2:
-;;                                     v182 = iadd.i64 v8, v170  ; v170 = 1
-;; @0020                               store notrap aligned v182, v7
+;;                                     v186 = iadd.i64 v8, v174  ; v174 = 1
+;; @0020                               store notrap aligned v186, v7
 ;; @0020                               v14 = call fn0(v0), stack_map=[i32 @ ss1+0, i32 @ ss0+0]
 ;; @0020                               v16 = load.i64 notrap aligned v7
 ;; @0020                               jump block3(v16)
 ;;
-;;                                 block3(v116: i64):
-;;                                     v126 = load.i32 notrap v173
-;; @002b                               trapz v126, user16
+;;                                 block3(v73: i64):
+;;                                     v128 = load.i32 notrap v177
+;; @002b                               trapz v128, user16
 ;; @002b                               v23 = load.i64 notrap aligned readonly can_move v7+32
-;; @002b                               v22 = uextend.i64 v126
+;; @002b                               v22 = uextend.i64 v128
 ;; @002b                               v24 = iadd v23, v22
 ;; @002b                               v25 = iconst.i64 16
 ;; @002b                               v26 = iadd v24, v25  ; v25 = 16
@@ -58,9 +58,9 @@
 ;; @002b                               v28 = uextend.i64 v27
 ;; @002b                               v33 = icmp ugt v32, v28
 ;; @002b                               trapnz v33, user17
-;;                                     v123 = load.i32 notrap v172
-;; @002b                               trapz v123, user16
-;; @002b                               v41 = uextend.i64 v123
+;;                                     v125 = load.i32 notrap v176
+;; @002b                               trapz v125, user16
+;; @002b                               v41 = uextend.i64 v125
 ;; @002b                               v43 = iadd v23, v41
 ;; @002b                               v45 = iadd v43, v25  ; v25 = 16
 ;; @002b                               v46 = load.i32 user2 readonly v45
@@ -70,84 +70,88 @@
 ;; @002b                               v52 = icmp ugt v51, v47
 ;; @002b                               trapnz v52, user17
 ;; @002b                               v64 = load.i64 notrap aligned v7+40
-;;                                     v159 = iconst.i64 20
-;; @002b                               v37 = iadd v24, v159  ; v159 = 20
-;;                                     v175 = iconst.i64 2
-;;                                     v176 = ishl v29, v175  ; v175 = 2
-;; @002b                               v40 = iadd v37, v176
-;;                                     v180 = ishl v30, v175  ; v175 = 2
-;; @002b                               v66 = uadd_overflow_trap v40, v180, user2
+;;                                     v163 = iconst.i64 20
+;; @002b                               v37 = iadd v24, v163  ; v163 = 20
+;;                                     v179 = iconst.i64 2
+;;                                     v180 = ishl v29, v179  ; v179 = 2
+;; @002b                               v40 = iadd v37, v180
+;;                                     v184 = ishl v30, v179  ; v179 = 2
+;; @002b                               v66 = uadd_overflow_trap v40, v184, user2
 ;; @002b                               v65 = iadd v23, v64
 ;; @002b                               v67 = icmp ugt v66, v65
 ;; @002b                               trapnz v67, user2
-;; @002b                               v56 = iadd v43, v159  ; v159 = 20
-;;                                     v178 = ishl v48, v175  ; v175 = 2
-;; @002b                               v59 = iadd v56, v178
-;; @002b                               v71 = uadd_overflow_trap v59, v180, user2
+;; @002b                               v56 = iadd v43, v163  ; v163 = 20
+;;                                     v182 = ishl v48, v179  ; v179 = 2
+;; @002b                               v59 = iadd v56, v182
+;; @002b                               v71 = uadd_overflow_trap v59, v184, user2
 ;; @002b                               v72 = icmp ugt v71, v65
 ;; @002b                               trapnz v72, user2
-;; @002b                               brif v30, block4, block7(v116)
+;;                                     v141 = iconst.i64 6
+;; @002b                               v74 = iadd v73, v141  ; v141 = 6
+;; @002b                               brif v30, block4, block7(v74)
 ;;
 ;;                                 block4:
-;; @002b                               v73 = icmp.i64 ult v40, v59
-;; @002b                               v76 = iadd.i64 v40, v180
-;; @002b                               v77 = iadd.i64 v59, v180
-;; @002b                               v79 = iadd.i32 v5, v6
-;;                                     v158 = iconst.i64 4
-;; @002b                               v112 = iconst.i32 1
-;;                                     v135 = iconst.i64 6
-;; @002b                               brif v73, block5(v40, v59, v5, v116), block6(v76, v77, v79, v116)
+;; @002b                               v75 = icmp.i64 ult v40, v59
+;;                                     v187 = iadd.i64 v73, v141  ; v141 = 6
+;; @002b                               v78 = iadd.i64 v40, v184
+;; @002b                               v79 = iadd.i64 v59, v184
+;; @002b                               v81 = iadd.i32 v5, v6
+;;                                     v162 = iconst.i64 4
+;; @002b                               v115 = iconst.i32 1
+;; @002b                               brif v75, block5(v40, v59, v5, v187), block6(v78, v79, v81, v187)
 ;;
-;;                                 block5(v80: i64, v81: i64, v82: i32, v83: i64):
-;;                                     v190 = iconst.i64 6
-;;                                     v191 = iadd v83, v190  ; v190 = 6
-;;                                     v192 = iconst.i64 0
-;;                                     v193 = icmp sge v191, v192  ; v192 = 0
-;; @002b                               brif v193, block8, block9(v191)
+;;                                 block5(v82: i64, v83: i64, v84: i32, v85: i64):
+;;                                     v197 = iconst.i64 1
+;;                                     v198 = iadd v85, v197  ; v197 = 1
+;;                                     v199 = iconst.i64 0
+;;                                     v200 = icmp sge v198, v199  ; v199 = 0
+;; @002b                               brif v200, block8, block9(v198)
 ;;
-;;                                 block6(v97: i64, v98: i64, v99: i32, v101: i64):
-;;                                     v183 = iconst.i64 0
-;;                                     v184 = icmp sge v101, v183  ; v183 = 0
-;; @002b                               brif v184, block10, block11(v101)
+;;                                 block6(v99: i64, v100: i64, v101: i32, v102: i64):
+;;                                     v188 = iconst.i64 1
+;;                                     v189 = iadd v102, v188  ; v188 = 1
+;;                                     v190 = iconst.i64 0
+;;                                     v191 = icmp sge v189, v190  ; v190 = 0
+;; @002b                               brif v191, block10, block11(v189)
 ;;
-;;                                 block7(v120: i64):
+;;                                 block7(v122: i64):
 ;; @002f                               jump block1
 ;;
 ;;                                 block8:
-;; @002b                               store.i64 notrap aligned v191, v7
-;; @002b                               v89 = call fn0(v0)
-;; @002b                               v91 = load.i64 notrap aligned v7
-;; @002b                               jump block9(v91)
+;; @002b                               store.i64 notrap aligned v198, v7
+;; @002b                               v91 = call fn0(v0)
+;; @002b                               v93 = load.i64 notrap aligned v7
+;; @002b                               jump block9(v93)
 ;;
-;;                                 block9(v117: i64):
-;; @002b                               v92 = load.i32 user2 little v81
-;; @002b                               store user2 little v92, v80
-;;                                     v194 = iconst.i64 4
-;;                                     v195 = iadd.i64 v81, v194  ; v194 = 4
-;; @002b                               v96 = icmp eq v195, v77
-;;                                     v196 = iadd.i64 v80, v194  ; v194 = 4
-;;                                     v197 = iconst.i32 1
-;;                                     v198 = iadd.i32 v82, v197  ; v197 = 1
-;; @002b                               brif v96, block7(v117), block5(v196, v195, v198, v117)
+;;                                 block9(v119: i64):
+;; @002b                               v94 = load.i32 user2 little v83
+;; @002b                               store user2 little v94, v82
+;;                                     v201 = iconst.i64 4
+;;                                     v202 = iadd.i64 v83, v201  ; v201 = 4
+;; @002b                               v98 = icmp eq v202, v79
+;;                                     v203 = iadd.i64 v82, v201  ; v201 = 4
+;;                                     v204 = iconst.i32 1
+;;                                     v205 = iadd.i32 v84, v204  ; v204 = 1
+;; @002b                               brif v98, block7(v119), block5(v203, v202, v205, v119)
 ;;
 ;;                                 block10:
-;; @002b                               store.i64 notrap aligned v101, v7
-;; @002b                               v105 = call fn0(v0)
-;; @002b                               v107 = load.i64 notrap aligned v7
-;; @002b                               jump block11(v107)
+;; @002b                               store.i64 notrap aligned v189, v7
+;; @002b                               v108 = call fn0(v0)
+;; @002b                               v110 = load.i64 notrap aligned v7
+;; @002b                               jump block11(v110)
 ;;
-;;                                 block11(v118: i64):
-;;                                     v185 = iconst.i64 4
-;;                                     v186 = isub.i64 v98, v185  ; v185 = 4
-;; @002b                               v114 = load.i32 user2 little v186
-;;                                     v187 = isub.i64 v97, v185  ; v185 = 4
-;; @002b                               store user2 little v114, v187
-;; @002b                               v115 = icmp eq v186, v59
-;;                                     v188 = iconst.i32 1
-;;                                     v189 = isub.i32 v99, v188  ; v188 = 1
-;; @002b                               brif v115, block7(v118), block6(v187, v186, v189, v118)
+;;                                 block11(v120: i64):
+;;                                     v192 = iconst.i64 4
+;;                                     v193 = isub.i64 v100, v192  ; v192 = 4
+;; @002b                               v117 = load.i32 user2 little v193
+;;                                     v194 = isub.i64 v99, v192  ; v192 = 4
+;; @002b                               store user2 little v117, v194
+;; @002b                               v118 = icmp eq v193, v59
+;;                                     v195 = iconst.i32 1
+;;                                     v196 = isub.i32 v101, v195  ; v195 = 1
+;; @002b                               brif v118, block7(v120), block6(v194, v193, v196, v120)
 ;;
 ;;                                 block1:
-;; @002f                               store.i64 notrap aligned v120, v7
+;; @002f                               store.i64 notrap aligned v122, v7
 ;; @002f                               return
 ;; }


### PR DESCRIPTION
This commit is the final step of #13387 to add tests for all bulk operations and ensure that everything stays in sync. Notably all instructions have tests that their "infinite" version traps on out-of-fuel and additionally each version consumes a set amount of fuel. This required adjusting the fuel consumption loops as to where fuel was tweaked/flushed to ensure that fuel wasn't double-counted during loops and to also ensure that 1 fuel was consumed per-loop.

This does surface some slightly odd behavior where sometimes fuel is counted as a per-byte operation and sometimes it's counted as a per-element operation. This happens due to how the code is structured where sometimes `array.fill`, for example, is a `memset` and sometimes it's per-element. The fuel consumption of `memset` is byte-based, for example, while it's per-element based for the manual loop. Regardless though it's still always deterministic for a particular wasm, and notably execution will still be limited by the dynamic operation size of these instructions.

Closes #13387

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
