### PR TITLE
Keep source/destination arrays alive across array.copy's per-element loop

### DIFF
--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -4526,12 +4526,56 @@ impl FuncEnvironment<'_> {
             _ => unreachable!(),
         };
         let end_index = builder.ins().iadd(src_index, copy_len_as_src_index_ty);
+
+        // The per-element loop uses only raw pointers derived from the
+        // source and destination array gc-refs. Cranelift's stack-map
+        // machinery tracks SSA-value liveness, and raw pointers don't keep
+        // their base gc-ref alive, so without intervention the gc-refs are
+        // dead in CLIF inside the loop. If a GC fires from a safe point in
+        // the loop body (e.g. `force_gc` from the DRC read barrier), sweep
+        // can drop the arrays from OASR, free them, and cascade dec-refs
+        // through their elements, leaving the rest of the copy reading
+        // freed memory. Thread the array gc-refs through the loop's
+        // iteration blocks as block params so each iteration's brif gives
+        // them a live use and they appear in the stack map at every safe
+        // point inside the loop.
+        let keepalives: SmallVec<[ir::Value; 2]> = [dst_entity, src_entity]
+            .into_iter()
+            .filter_map(|e| match e {
+                CheckedEntity::Array { array, .. } => Some(array),
+                _ => None,
+            })
+            .collect();
+
+        // Build a brif args list of `fixed` followed by the keepalive values.
+        let with_keepalives = |fixed: &[ir::Value]| -> SmallVec<[ir::BlockArg; 5]> {
+            fixed
+                .iter()
+                .chain(&keepalives[..])
+                .map(|v| (*v).into())
+                .collect()
+        };
+
+        // Append one block param per keepalive value to `block`, declare each
+        // as needing a stack map, and return the new params.
+        let append_keepalive_params =
+            |builder: &mut FunctionBuilder<'_>, block: ir::Block| -> SmallVec<[ir::Value; 2]> {
+                keepalives
+                    .iter()
+                    .map(|_| {
+                        let v = builder.append_block_param(block, ir::types::I32);
+                        builder.declare_value_needs_stack_map(v);
+                        v
+                    })
+                    .collect()
+            };
+
         builder.ins().brif(
             dst_first,
             forward_block,
-            &[dst_elem_addr.into(), src_elem_addr.into(), src_index.into()],
+            &with_keepalives(&[dst_elem_addr, src_elem_addr, src_index])[..],
             backwards_block,
-            &[dst_end_addr.into(), src_end_addr.into(), end_index.into()],
+            &with_keepalives(&[dst_end_addr, src_end_addr, end_index])[..],
         );
 
         // Forward copy -- copy one field, then mutate the current pointers, then
@@ -4540,6 +4584,7 @@ impl FuncEnvironment<'_> {
         let dst_cur = builder.append_block_param(forward_block, self.pointer_type());
         let src_cur = builder.append_block_param(forward_block, self.pointer_type());
         let src_index = builder.append_block_param(forward_block, src_index_ty);
+        let forward_keepalives = append_keepalive_params(builder, forward_block);
         // Consume a single unit of fuel on each iteration of the loop.
         if self.tunables.consume_fuel {
             self.fuel_consumed += 1;
@@ -4550,13 +4595,14 @@ impl FuncEnvironment<'_> {
         let src_next = builder.ins().iadd_imm(src_cur, i64::from(src_element_size));
         let src_index_next = builder.ins().iadd_imm(src_index, 1);
         let done = builder.ins().icmp(IntCC::Equal, src_next, src_end_addr);
-        builder.ins().brif(
-            done,
-            done_block,
-            &[],
-            forward_block,
-            &[dst_next.into(), src_next.into(), src_index_next.into()],
-        );
+        let forward_next_args: SmallVec<[ir::BlockArg; 5]> = [dst_next, src_next, src_index_next]
+            .iter()
+            .chain(&forward_keepalives[..])
+            .map(|v| (*v).into())
+            .collect();
+        builder
+            .ins()
+            .brif(done, done_block, &[], forward_block, &forward_next_args[..]);
 
         // Backwards copy -- update the pointers, then perform a copy, then check
         // to see if we're done.
@@ -4564,6 +4610,7 @@ impl FuncEnvironment<'_> {
         let dst_cur = builder.append_block_param(backwards_block, self.pointer_type());
         let src_cur = builder.append_block_param(backwards_block, self.pointer_type());
         let src_index = builder.append_block_param(backwards_block, src_index_ty);
+        let backward_keepalives = append_keepalive_params(builder, backwards_block);
         if self.tunables.consume_fuel {
             self.fuel_consumed += 1;
         }
@@ -4586,12 +4633,17 @@ impl FuncEnvironment<'_> {
         };
         copy_one(self, builder, dst_cur, src_cur, src_index)?;
         let done = builder.ins().icmp(IntCC::Equal, src_cur, src_elem_addr);
+        let backward_next_args: SmallVec<[ir::BlockArg; 5]> = [dst_cur, src_cur, src_index]
+            .iter()
+            .chain(&backward_keepalives[..])
+            .map(|v| (*v).into())
+            .collect();
         builder.ins().brif(
             done,
             done_block,
             &[],
             backwards_block,
-            &[dst_cur.into(), src_cur.into(), src_index.into()],
+            &backward_next_args[..],
         );
 
         builder.switch_to_block(done_block);

--- a/tests/all/gc.rs
+++ b/tests/all/gc.rs
@@ -1332,6 +1332,135 @@ fn drc_traces_the_correct_number_of_gc_refs_in_arrays() -> Result<()> {
     Ok(())
 }
 
+// Regression test for a stack-map bug in `translate_per_element_copy` (used by
+// `array.copy` on arrays whose elements are GC references).
+//
+// The per-element loop derived raw `src_elem_addr` / `dst_elem_addr` pointers
+// once and used only those raw pointers inside the loop body. The source and
+// destination array gc-refs themselves were dead in CLIF inside the loop, so
+// they were absent from the stack maps at safe points there. Once the DRC
+// collector started firing `force_gc` from inside the read barrier (when the
+// over-approximated-stack-roots list grew past 1024 entries), a GC could run
+// mid-copy with neither array marked from any frame's stack map. Sweep could
+// then drop the arrays from OASR, freeing them and cascading dec-refs through
+// their elements, after which the rest of the copy read from freed memory.
+//
+// The fix passes the source and destination array gc-refs as block params
+// through the forward and backward iteration blocks so they stay live across
+// the per-element loop.
+#[test]
+#[cfg_attr(miri, ignore)]
+fn drc_array_copy_keeps_arrays_alive_across_in_loop_gc() -> Result<()> {
+    let _ = env_logger::try_init();
+
+    let mut config = Config::new();
+    config.wasm_function_references(true);
+    config.wasm_gc(true);
+    config.collector(Collector::DeferredReferenceCounting);
+    // Keep the GC heap small so allocations cycle back through the free
+    // list quickly. This dramatically increases the chance that any slot
+    // freed mid-copy will be reused before the test's verify pass reads
+    // from it, making the bug observable.
+    config.gc_heap_reservation(128 * 1024);
+    config.gc_heap_reservation_for_growth(0);
+
+    let engine = Engine::new(&config)?;
+    let mut store = Store::new(&engine, ());
+
+    let module = Module::new(
+        &engine,
+        r#"
+            (module
+                (import "wasmtime" "gc" (func $gc))
+                (type $box (struct (field i32)))
+                (type $arr (array (mut (ref null $box))))
+
+                ;; Put the `array.copy` in a helper function so the source
+                ;; and destination gc-refs are visibly dead in CLIF inside
+                ;; the per-element loop -- they are function parameters
+                ;; that are only used at the top of the function to compute
+                ;; the initial address.
+                (func $do_copy
+                    (param $src (ref null $arr))
+                    (param $dst (ref null $arr))
+                    (param $len i32)
+                    (array.copy $arr $arr
+                        (local.get $dst) (i32.const 0)
+                        (local.get $src) (i32.const 0)
+                        (local.get $len)))
+
+                (func (export "test") (result i32)
+                    (local $src (ref null $arr))
+                    (local $dst (ref null $arr))
+                    (local $i i32)
+                    (local $sum i32)
+
+                    ;; N=2048 > 1024 so the per-element read barrier
+                    ;; definitely fires `force_gc` during the copy.
+                    (local.set $src (array.new $arr (ref.null $box) (i32.const 2048)))
+                    (local.set $i (i32.const 0))
+                    (loop $fill
+                        (array.set $arr (local.get $src) (local.get $i)
+                            (struct.new $box (local.get $i)))
+                        (local.set $i (i32.add (local.get $i) (i32.const 1)))
+                        (br_if $fill (i32.lt_s (local.get $i) (i32.const 2048))))
+
+                    (local.set $dst (array.new $arr (ref.null $box) (i32.const 2048)))
+
+                    (call $gc)
+
+                    (call $do_copy (local.get $src) (local.get $dst) (i32.const 2048))
+
+                    ;; Drop the source local and force a GC so any
+                    ;; cascade-freed elements that should still be alive
+                    ;; via $dst would surface as either a trap (cast
+                    ;; failure / out-of-bounds) or wrong $dst contents.
+                    (local.set $src (ref.null $arr))
+                    (call $gc)
+
+                    ;; Heavily allocate to reuse any freed slots. Each
+                    ;; iteration allocates a $box with sentinel value -1;
+                    ;; if any element of $dst was a stale reference to a
+                    ;; cascade-freed $box, its slot gets reused here and
+                    ;; reading it back will see -1 rather than its
+                    ;; original index.
+                    (local.set $i (i32.const 0))
+                    (loop $churn
+                        (drop (struct.new $box (i32.const -1)))
+                        (local.set $i (i32.add (local.get $i) (i32.const 1)))
+                        (br_if $churn (i32.lt_s (local.get $i) (i32.const 4096))))
+
+                    (call $gc)
+
+                    (local.set $i (i32.const 0))
+                    (local.set $sum (i32.const 0))
+                    (loop $verify
+                        (local.set $sum
+                            (i32.add (local.get $sum)
+                                (struct.get $box 0
+                                    (array.get $arr (local.get $dst) (local.get $i)))))
+                        (local.set $i (i32.add (local.get $i) (i32.const 1)))
+                        (br_if $verify (i32.lt_s (local.get $i) (i32.const 2048))))
+
+                    (local.get $sum)))
+        "#,
+    )?;
+
+    let mut linker = Linker::new(&engine);
+    linker.func_wrap("wasmtime", "gc", |mut caller: Caller<_>| -> Result<()> {
+        caller.gc(None)?;
+        Ok(())
+    })?;
+    let instance = linker.instantiate(&mut store, &module)?;
+    let test = instance.get_typed_func::<(), i32>(&mut store, "test")?;
+    let result = test.call(&mut store, ())?;
+
+    // Sum of 0..2048 = 2048 * 2047 / 2.
+    assert_eq!(result, 2_096_128);
+
+    Ok(())
+}
+
 // Test that we can completely fill the GC heap until we get an OOM. This
 // exercises growing the GC heap and that we configure compilation tunables and
 // runtime memories backing GC heaps correctly.

--- a/tests/disas/array-copy-anyref.wat
+++ b/tests/disas/array-copy-anyref.wat
@@ -21,8 +21,8 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32, v6: i32):
 ;; @002b                               trapz v2, user16
-;; @002b                               v111 = load.i64 notrap aligned readonly can_move v0+8
-;; @002b                               v8 = load.i64 notrap aligned readonly can_move v111+32
+;; @002b                               v115 = load.i64 notrap aligned readonly can_move v0+8
+;; @002b                               v8 = load.i64 notrap aligned readonly can_move v115+32
 ;; @002b                               v7 = uextend.i64 v2
 ;; @002b                               v9 = iadd v8, v7
 ;; @002b                               v10 = iconst.i64 16
@@ -44,55 +44,55 @@
 ;; @002b                               v32 = uextend.i64 v31
 ;; @002b                               v37 = icmp ugt v36, v32
 ;; @002b                               trapnz v37, user17
-;; @002b                               v49 = load.i64 notrap aligned v111+40
-;;                                     v107 = iconst.i64 20
-;; @002b                               v22 = iadd v9, v107  ; v107 = 20
-;;                                     v115 = iconst.i64 2
-;;                                     v116 = ishl v14, v115  ; v115 = 2
-;; @002b                               v25 = iadd v22, v116
-;;                                     v120 = ishl v15, v115  ; v115 = 2
-;; @002b                               v51 = uadd_overflow_trap v25, v120, user2
+;; @002b                               v49 = load.i64 notrap aligned v115+40
+;;                                     v111 = iconst.i64 20
+;; @002b                               v22 = iadd v9, v111  ; v111 = 20
+;;                                     v119 = iconst.i64 2
+;;                                     v120 = ishl v14, v119  ; v119 = 2
+;; @002b                               v25 = iadd v22, v120
+;;                                     v124 = ishl v15, v119  ; v119 = 2
+;; @002b                               v51 = uadd_overflow_trap v25, v124, user2
 ;; @002b                               v50 = iadd v8, v49
 ;; @002b                               v52 = icmp ugt v51, v50
 ;; @002b                               trapnz v52, user2
-;; @002b                               v41 = iadd v28, v107  ; v107 = 20
-;;                                     v118 = ishl v33, v115  ; v115 = 2
-;; @002b                               v44 = iadd v41, v118
-;; @002b                               v56 = uadd_overflow_trap v44, v120, user2
+;; @002b                               v41 = iadd v28, v111  ; v111 = 20
+;;                                     v122 = ishl v33, v119  ; v119 = 2
+;; @002b                               v44 = iadd v41, v122
+;; @002b                               v56 = uadd_overflow_trap v44, v124, user2
 ;; @002b                               v57 = icmp ugt v56, v50
 ;; @002b                               trapnz v57, user2
 ;; @002b                               brif v15, block2, block5
 ;;
 ;;                                 block2:
 ;; @002b                               v58 = icmp.i64 ult v25, v44
-;; @002b                               v61 = iadd.i64 v25, v120
-;; @002b                               v62 = iadd.i64 v44, v120
+;; @002b                               v61 = iadd.i64 v25, v124
+;; @002b                               v62 = iadd.i64 v44, v124
 ;; @002b                               v64 = iadd.i32 v5, v6
-;;                                     v106 = iconst.i64 4
-;; @002b                               v80 = iconst.i32 1
+;;                                     v110 = iconst.i64 4
+;; @002b                               v84 = iconst.i32 1
 ;; @002b                               brif v58, block3(v25, v44, v5), block4(v61, v62, v64)
 ;;
 ;;                                 block3(v65: i64, v66: i64, v67: i32):
-;; @002b                               v68 = load.i32 user2 little v66
-;; @002b                               store user2 little v68, v65
-;;                                     v127 = iconst.i64 4
-;;                                     v128 = iadd v66, v127  ; v127 = 4
-;; @002b                               v72 = icmp eq v128, v62
-;;                                     v129 = iadd v65, v127  ; v127 = 4
-;;                                     v130 = iconst.i32 1
-;;                                     v131 = iadd v67, v130  ; v130 = 1
-;; @002b                               brif v72, block5, block3(v129, v128, v131)
+;; @002b                               v70 = load.i32 user2 little v66
+;; @002b                               store user2 little v70, v65
+;;                                     v131 = iconst.i64 4
+;;                                     v132 = iadd v66, v131  ; v131 = 4
+;; @002b                               v74 = icmp eq v132, v62
+;;                                     v133 = iadd v65, v131  ; v131 = 4
+;;                                     v134 = iconst.i32 1
+;;                                     v135 = iadd v67, v134  ; v134 = 1
+;; @002b                               brif v74, block5, block3(v133, v132, v135)
 ;;
-;;                                 block4(v73: i64, v74: i64, v75: i32):
-;;                                     v122 = iconst.i64 4
-;;                                     v123 = isub v74, v122  ; v122 = 4
-;; @002b                               v82 = load.i32 user2 little v123
-;;                                     v124 = isub v73, v122  ; v122 = 4
-;; @002b                               store user2 little v82, v124
-;; @002b                               v83 = icmp eq v123, v44
-;;                                     v125 = iconst.i32 1
-;;                                     v126 = isub v75, v125  ; v125 = 1
-;; @002b                               brif v83, block5, block4(v124, v123, v126)
+;;                                 block4(v75: i64, v76: i64, v77: i32):
+;;                                     v126 = iconst.i64 4
+;;                                     v127 = isub v76, v126  ; v126 = 4
+;; @002b                               v86 = load.i32 user2 little v127
+;;                                     v128 = isub v75, v126  ; v126 = 4
+;; @002b                               store user2 little v86, v128
+;; @002b                               v87 = icmp eq v127, v44
+;;                                     v129 = iconst.i32 1
+;;                                     v130 = isub v77, v129  ; v129 = 1
+;; @002b                               brif v87, block5, block4(v128, v127, v130)
 ;;
 ;;                                 block5:
 ;; @002f                               jump block1

--- a/tests/disas/gc/array-copy-with-fuel.wat
+++ b/tests/disas/gc/array-copy-with-fuel.wat
@@ -24,30 +24,30 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32, v6: i32):
-;;                                     v177 = stack_addr.i64 ss1
-;;                                     store notrap v2, v177
-;;                                     v176 = stack_addr.i64 ss0
-;;                                     store notrap v4, v176
+;;                                     v201 = stack_addr.i64 ss0
+;;                                     store notrap v2, v201
+;;                                     v200 = stack_addr.i64 ss1
+;;                                     store notrap v4, v200
 ;; @0020                               v7 = load.i64 notrap aligned readonly can_move v0+8
 ;; @0020                               v8 = load.i64 notrap aligned v7
-;;                                     v174 = iconst.i64 1
-;; @0020                               v9 = iadd v8, v174  ; v174 = 1
+;;                                     v198 = iconst.i64 1
+;; @0020                               v9 = iadd v8, v198  ; v198 = 1
 ;; @0020                               v10 = iconst.i64 0
 ;; @0020                               v11 = icmp sge v9, v10  ; v10 = 0
 ;; @0020                               brif v11, block2, block3(v9)
 ;;
 ;;                                 block2:
-;;                                     v186 = iadd.i64 v8, v174  ; v174 = 1
-;; @0020                               store notrap aligned v186, v7
-;; @0020                               v14 = call fn0(v0), stack_map=[i32 @ ss1+0, i32 @ ss0+0]
+;;                                     v210 = iadd.i64 v8, v198  ; v198 = 1
+;; @0020                               store notrap aligned v210, v7
+;; @0020                               v14 = call fn0(v0), stack_map=[i32 @ ss0+0, i32 @ ss1+0]
 ;; @0020                               v16 = load.i64 notrap aligned v7
 ;; @0020                               jump block3(v16)
 ;;
 ;;                                 block3(v73: i64):
-;;                                     v128 = load.i32 notrap v177
-;; @002b                               trapz v128, user16
+;;                                     v140 = load.i32 notrap v201
+;; @002b                               trapz v140, user16
 ;; @002b                               v23 = load.i64 notrap aligned readonly can_move v7+32
-;; @002b                               v22 = uextend.i64 v128
+;; @002b                               v22 = uextend.i64 v140
 ;; @002b                               v24 = iadd v23, v22
 ;; @002b                               v25 = iconst.i64 16
 ;; @002b                               v26 = iadd v24, v25  ; v25 = 16
@@ -58,9 +58,9 @@
 ;; @002b                               v28 = uextend.i64 v27
 ;; @002b                               v33 = icmp ugt v32, v28
 ;; @002b                               trapnz v33, user17
-;;                                     v125 = load.i32 notrap v176
-;; @002b                               trapz v125, user16
-;; @002b                               v41 = uextend.i64 v125
+;;                                     v137 = load.i32 notrap v200
+;; @002b                               trapz v137, user16
+;; @002b                               v41 = uextend.i64 v137
 ;; @002b                               v43 = iadd v23, v41
 ;; @002b                               v45 = iadd v43, v25  ; v25 = 16
 ;; @002b                               v46 = load.i32 user2 readonly v45
@@ -70,88 +70,98 @@
 ;; @002b                               v52 = icmp ugt v51, v47
 ;; @002b                               trapnz v52, user17
 ;; @002b                               v64 = load.i64 notrap aligned v7+40
-;;                                     v163 = iconst.i64 20
-;; @002b                               v37 = iadd v24, v163  ; v163 = 20
-;;                                     v179 = iconst.i64 2
-;;                                     v180 = ishl v29, v179  ; v179 = 2
-;; @002b                               v40 = iadd v37, v180
-;;                                     v184 = ishl v30, v179  ; v179 = 2
-;; @002b                               v66 = uadd_overflow_trap v40, v184, user2
+;;                                     v187 = iconst.i64 20
+;; @002b                               v37 = iadd v24, v187  ; v187 = 20
+;;                                     v203 = iconst.i64 2
+;;                                     v204 = ishl v29, v203  ; v203 = 2
+;; @002b                               v40 = iadd v37, v204
+;;                                     v208 = ishl v30, v203  ; v203 = 2
+;; @002b                               v66 = uadd_overflow_trap v40, v208, user2
 ;; @002b                               v65 = iadd v23, v64
 ;; @002b                               v67 = icmp ugt v66, v65
 ;; @002b                               trapnz v67, user2
-;; @002b                               v56 = iadd v43, v163  ; v163 = 20
-;;                                     v182 = ishl v48, v179  ; v179 = 2
-;; @002b                               v59 = iadd v56, v182
-;; @002b                               v71 = uadd_overflow_trap v59, v184, user2
+;; @002b                               v56 = iadd v43, v187  ; v187 = 20
+;;                                     v206 = ishl v48, v203  ; v203 = 2
+;; @002b                               v59 = iadd v56, v206
+;; @002b                               v71 = uadd_overflow_trap v59, v208, user2
 ;; @002b                               v72 = icmp ugt v71, v65
 ;; @002b                               trapnz v72, user2
-;;                                     v141 = iconst.i64 6
-;; @002b                               v74 = iadd v73, v141  ; v141 = 6
+;;                                     v165 = iconst.i64 6
+;; @002b                               v74 = iadd v73, v165  ; v165 = 6
 ;; @002b                               brif v30, block4, block7(v74)
 ;;
 ;;                                 block4:
+;;                                     v131 = load.i32 notrap v201
+;;                                     v132 = load.i32 notrap v200
 ;; @002b                               v75 = icmp.i64 ult v40, v59
-;;                                     v187 = iadd.i64 v73, v141  ; v141 = 6
-;; @002b                               v78 = iadd.i64 v40, v184
-;; @002b                               v79 = iadd.i64 v59, v184
+;;                                     v211 = iadd.i64 v73, v165  ; v165 = 6
+;; @002b                               v78 = iadd.i64 v40, v208
+;; @002b                               v79 = iadd.i64 v59, v208
 ;; @002b                               v81 = iadd.i32 v5, v6
-;;                                     v162 = iconst.i64 4
-;; @002b                               v115 = iconst.i32 1
-;; @002b                               brif v75, block5(v40, v59, v5, v187), block6(v78, v79, v81, v187)
+;;                                     v186 = iconst.i64 4
+;; @002b                               v119 = iconst.i32 1
+;; @002b                               brif v75, block5(v40, v59, v5, v131, v132, v211), block6(v78, v79, v81, v131, v132, v211)
 ;;
-;;                                 block5(v82: i64, v83: i64, v84: i32, v85: i64):
-;;                                     v197 = iconst.i64 1
-;;                                     v198 = iadd v85, v197  ; v197 = 1
-;;                                     v199 = iconst.i64 0
-;;                                     v200 = icmp sge v198, v199  ; v199 = 0
-;; @002b                               brif v200, block8, block9(v198)
+;;                                 block5(v82: i64, v83: i64, v84: i32, v85: i32, v86: i32, v87: i64):
+;;                                     store notrap v85, v201
+;;                                     store notrap v86, v200
+;;                                     v221 = iconst.i64 1
+;;                                     v222 = iadd v87, v221  ; v221 = 1
+;;                                     v223 = iconst.i64 0
+;;                                     v224 = icmp sge v222, v223  ; v223 = 0
+;; @002b                               brif v224, block8, block9(v222)
 ;;
-;;                                 block6(v99: i64, v100: i64, v101: i32, v102: i64):
-;;                                     v188 = iconst.i64 1
-;;                                     v189 = iadd v102, v188  ; v188 = 1
-;;                                     v190 = iconst.i64 0
-;;                                     v191 = icmp sge v189, v190  ; v190 = 0
-;; @002b                               brif v191, block10, block11(v189)
+;;                                 block6(v101: i64, v102: i64, v103: i32, v104: i32, v105: i32, v106: i64):
+;;                                     store notrap v104, v200
+;;                                     store notrap v105, v201
+;;                                     v212 = iconst.i64 1
+;;                                     v213 = iadd v106, v212  ; v212 = 1
+;;                                     v214 = iconst.i64 0
+;;                                     v215 = icmp sge v213, v214  ; v214 = 0
+;; @002b                               brif v215, block10, block11(v213)
 ;;
-;;                                 block7(v122: i64):
+;;                                 block7(v126: i64):
 ;; @002f                               jump block1
 ;;
 ;;                                 block8:
-;; @002b                               store.i64 notrap aligned v198, v7
-;; @002b                               v91 = call fn0(v0)
-;; @002b                               v93 = load.i64 notrap aligned v7
-;; @002b                               jump block9(v93)
+;; @002b                               store.i64 notrap aligned v222, v7
+;; @002b                               v93 = call fn0(v0), stack_map=[i32 @ ss0+0, i32 @ ss1+0]
+;; @002b                               v95 = load.i64 notrap aligned v7
+;; @002b                               jump block9(v95)
 ;;
-;;                                 block9(v119: i64):
-;; @002b                               v94 = load.i32 user2 little v83
-;; @002b                               store user2 little v94, v82
-;;                                     v201 = iconst.i64 4
-;;                                     v202 = iadd.i64 v83, v201  ; v201 = 4
-;; @002b                               v98 = icmp eq v202, v79
-;;                                     v203 = iadd.i64 v82, v201  ; v201 = 4
-;;                                     v204 = iconst.i32 1
-;;                                     v205 = iadd.i32 v84, v204  ; v204 = 1
-;; @002b                               brif v98, block7(v119), block5(v203, v202, v205, v119)
+;;                                 block9(v123: i64):
+;; @002b                               v96 = load.i32 user2 little v83
+;; @002b                               store user2 little v96, v82
+;;                                     v127 = load.i32 notrap v201
+;;                                     v128 = load.i32 notrap v200
+;;                                     v225 = iconst.i64 4
+;;                                     v226 = iadd.i64 v83, v225  ; v225 = 4
+;; @002b                               v100 = icmp eq v226, v79
+;;                                     v227 = iadd.i64 v82, v225  ; v225 = 4
+;;                                     v228 = iconst.i32 1
+;;                                     v229 = iadd.i32 v84, v228  ; v228 = 1
+;; @002b                               brif v100, block7(v123), block5(v227, v226, v229, v127, v128, v123)
 ;;
 ;;                                 block10:
-;; @002b                               store.i64 notrap aligned v189, v7
-;; @002b                               v108 = call fn0(v0)
-;; @002b                               v110 = load.i64 notrap aligned v7
-;; @002b                               jump block11(v110)
+;; @002b                               store.i64 notrap aligned v213, v7
+;; @002b                               v112 = call fn0(v0), stack_map=[i32 @ ss1+0, i32 @ ss0+0]
+;; @002b                               v114 = load.i64 notrap aligned v7
+;; @002b                               jump block11(v114)
 ;;
-;;                                 block11(v120: i64):
-;;                                     v192 = iconst.i64 4
-;;                                     v193 = isub.i64 v100, v192  ; v192 = 4
-;; @002b                               v117 = load.i32 user2 little v193
-;;                                     v194 = isub.i64 v99, v192  ; v192 = 4
-;; @002b                               store user2 little v117, v194
-;; @002b                               v118 = icmp eq v193, v59
-;;                                     v195 = iconst.i32 1
-;;                                     v196 = isub.i32 v101, v195  ; v195 = 1
-;; @002b                               brif v118, block7(v120), block6(v194, v193, v196, v120)
+;;                                 block11(v124: i64):
+;;                                     v216 = iconst.i64 4
+;;                                     v217 = isub.i64 v102, v216  ; v216 = 4
+;; @002b                               v121 = load.i32 user2 little v217
+;;                                     v218 = isub.i64 v101, v216  ; v216 = 4
+;; @002b                               store user2 little v121, v218
+;;                                     v129 = load.i32 notrap v200
+;;                                     v130 = load.i32 notrap v201
+;; @002b                               v122 = icmp eq v217, v59
+;;                                     v219 = iconst.i32 1
+;;                                     v220 = isub.i32 v103, v219  ; v219 = 1
+;; @002b                               brif v122, block7(v124), block6(v218, v217, v220, v129, v130, v124)
 ;;
 ;;                                 block1:
-;; @002f                               store.i64 notrap aligned v122, v7
+;; @002f                               store.i64 notrap aligned v126, v7
 ;; @002f                               return
 ;; }


### PR DESCRIPTION
`translate_per_element_copy` derives raw `src_elem_addr` / `dst_elem_addr` pointers once and uses only those raw pointers inside the per-element forward/backward loop. As a result, the original source and destination *array* gc-refs are dead in CLIF after the address computation and are not in the stack maps at safe points inside the loop.

This was harmless until the DRC collector started firing `force_gc` from inside the read barrier when the over-approximated-stack-roots list grew past 1024 entries (https://github.com/bytecodealliance/wasmtime/pull/13422). At that point, a GC could run mid-copy with neither the source nor the destination array marked from any frame's stack map. Sweep could then free the arrays out from under the copy.

Fix this by extracting the array gc-refs from the source and destination entities (when they are arrays) and threading them through the loop's forward and backward iteration blocks as block parameters. After the fix, the stack map at the in-barrier `force_gc` inside `array.copy`'s loop lists the source and destination arrays in addition to the freshly-read element.