### PR TITLE
egraph: peer through `ireduce` in `brif` (`ctz`/`clz`) skeleton fold

### DIFF
--- a/cranelift/codegen/src/opts/icmp.isle
+++ b/cranelift/codegen/src/opts/icmp.isle
@@ -465,3 +465,16 @@
 ;; `brif (clz X) bt be` branches when `clz(X) != 0`, i.e. MSB(X) == 0.
 (rule (simplify_skeleton (brif (clz x_ty X) _ _))
       (replace_branch_cond (sge $I8 X (iconst_u x_ty 0))))
+
+;; Peer through `ireduce` when its operand is a `ctz`/`clz`. The wasm
+;; shape is `i64.ctz; i32.wrap_i64; br_if` (motoko/moc's EOP peephole
+;; emits this, and the same applies to clz). `ireduce` is harmless on a
+;; ctz/clz result because the value is in [0, bitwidth] — always fits in
+;; the smaller type without loss. We rewrite to the same bit-extract
+;; condition as the bare-form rules above, using the wider source type.
+(rule (simplify_skeleton (brif (ireduce _ (ctz x_ty X)) _ _))
+      (replace_branch_cond
+        (eq $I8 (band x_ty X (iconst_u x_ty 1)) (iconst_u x_ty 0))))
+
+(rule (simplify_skeleton (brif (ireduce _ (clz x_ty X)) _ _))
+      (replace_branch_cond (sge $I8 X (iconst_u x_ty 0))))

--- a/cranelift/codegen/src/opts/icmp.isle
+++ b/cranelift/codegen/src/opts/icmp.isle
@@ -466,15 +466,11 @@
 (rule (simplify_skeleton (brif (clz x_ty X) _ _))
       (replace_branch_cond (sge $I8 X (iconst_u x_ty 0))))
 
-;; Peer through `ireduce` when its operand is a `ctz`/`clz`. The wasm
-;; shape is `i64.ctz; i32.wrap_i64; br_if` (motoko/moc's EOP peephole
-;; emits this, and the same applies to clz). `ireduce` is harmless on a
-;; ctz/clz result because the value is in [0, bitwidth] — always fits in
-;; the smaller type without loss. We rewrite to the same bit-extract
-;; condition as the bare-form rules above, using the wider source type.
-(rule (simplify_skeleton (brif (ireduce _ (ctz x_ty X)) _ _))
+;; Same when an `ireduce` (truncation) sits between the count and the
+;; brif. The count is in [0, bitwidth] so the truncation is lossless.
+(rule (simplify_skeleton (brif (ireduce _ (ctz x_ty x)) _ _))
       (replace_branch_cond
-        (eq $I8 (band x_ty X (iconst_u x_ty 1)) (iconst_u x_ty 0))))
+        (eq $I8 (band x_ty x (iconst_u x_ty 1)) (iconst_u x_ty 0))))
 
-(rule (simplify_skeleton (brif (ireduce _ (clz x_ty X)) _ _))
-      (replace_branch_cond (sge $I8 X (iconst_u x_ty 0))))
+(rule (simplify_skeleton (brif (ireduce _ (clz x_ty x)) _ _))
+      (replace_branch_cond (sge $I8 x (iconst_u x_ty 0))))

--- a/cranelift/filetests/filetests/egraph/brif-cnt-cond.clif
+++ b/cranelift/filetests/filetests/egraph/brif-cnt-cond.clif
@@ -131,11 +131,7 @@ block2:
 ;     return v3  ; v3 = 200
 ; }
 
-;; `brif (ireduce (ctz X))` — 3-op form with an `i32.wrap_i64`-style
-;; truncation between ctz and brif.  The truncation is harmless because
-;; ctz's output is in [0, 64].  Source pattern: motoko/moc's EOP LSB→ctz
-;; peephole emits `i64.ctz; i32.wrap_i64; br_if` for the
-;; `(value & 1) == 0`-as-branch-condition shape.
+;; Same with a truncating `ireduce` between ctz and brif.
 function %brif_ireduce_ctz_i64(i64) -> i32 {
 block0(v0: i64):
     v1 = ctz v0

--- a/cranelift/filetests/filetests/egraph/brif-cnt-cond.clif
+++ b/cranelift/filetests/filetests/egraph/brif-cnt-cond.clif
@@ -130,3 +130,71 @@ block2:
 ;     v3 = iconst.i32 200
 ;     return v3  ; v3 = 200
 ; }
+
+;; `brif (ireduce (ctz X))` — 3-op form with an `i32.wrap_i64`-style
+;; truncation between ctz and brif.  The truncation is harmless because
+;; ctz's output is in [0, 64].  Source pattern: motoko/moc's EOP LSB→ctz
+;; peephole emits `i64.ctz; i32.wrap_i64; br_if` for the
+;; `(value & 1) == 0`-as-branch-condition shape.
+function %brif_ireduce_ctz_i64(i64) -> i32 {
+block0(v0: i64):
+    v1 = ctz v0
+    v2 = ireduce.i32 v1
+    brif v2, block1, block2
+
+block1:
+    v3 = iconst.i32 100
+    return v3
+
+block2:
+    v4 = iconst.i32 200
+    return v4
+}
+
+; function %brif_ireduce_ctz_i64(i64) -> i32 fast {
+; block0(v0: i64):
+;     v5 = iconst.i64 1
+;     v6 = band v0, v5  ; v5 = 1
+;     v7 = iconst.i64 0
+;     v8 = icmp eq v6, v7  ; v7 = 0
+;     brif v8, block1, block2
+;
+; block1:
+;     v3 = iconst.i32 100
+;     return v3  ; v3 = 100
+;
+; block2:
+;     v4 = iconst.i32 200
+;     return v4  ; v4 = 200
+; }
+
+;; Same shape with `clz` instead of `ctz`.
+function %brif_ireduce_clz_i64(i64) -> i32 {
+block0(v0: i64):
+    v1 = clz v0
+    v2 = ireduce.i32 v1
+    brif v2, block1, block2
+
+block1:
+    v3 = iconst.i32 100
+    return v3
+
+block2:
+    v4 = iconst.i32 200
+    return v4
+}
+
+; function %brif_ireduce_clz_i64(i64) -> i32 fast {
+; block0(v0: i64):
+;     v5 = iconst.i64 0
+;     v6 = icmp sge v0, v5  ; v5 = 0
+;     brif v6, block1, block2
+;
+; block1:
+;     v3 = iconst.i32 100
+;     return v3  ; v3 = 100
+;
+; block2:
+;     v4 = iconst.i32 200
+;     return v4  ; v4 = 200
+; }

--- a/tests/disas/ctz-clz-bool-condition.wat
+++ b/tests/disas/ctz-clz-bool-condition.wat
@@ -73,9 +73,6 @@
   (func $if_clz_ne0_i64 (param i64) (result i32)
     (i64.ne (i64.clz (local.get 0)) (i64.const 0))
     if (result i32) i32.const 100 else i32.const 200 end)
-  ;; Wasm-natural shape mirroring `$if_ctz_bare_i64`: `i64.clz` produces
-  ;; i64, narrowed via `i32.wrap_i64` before `if`. Same `ireduce` peel as
-  ;; the ctz form; collapses to a sign-bit test on the wider input.
   (func $if_clz_bare_i64 (param i64) (result i32)
     (i64.clz (local.get 0)) i32.wrap_i64
     if (result i32) i32.const 100 else i32.const 200 end)

--- a/tests/disas/ctz-clz-bool-condition.wat
+++ b/tests/disas/ctz-clz-bool-condition.wat
@@ -73,6 +73,12 @@
   (func $if_clz_ne0_i64 (param i64) (result i32)
     (i64.ne (i64.clz (local.get 0)) (i64.const 0))
     if (result i32) i32.const 100 else i32.const 200 end)
+  ;; Wasm-natural shape mirroring `$if_ctz_bare_i64`: `i64.clz` produces
+  ;; i64, narrowed via `i32.wrap_i64` before `if`. Same `ireduce` peel as
+  ;; the ctz form; collapses to a sign-bit test on the wider input.
+  (func $if_clz_bare_i64 (param i64) (result i32)
+    (i64.clz (local.get 0)) i32.wrap_i64
+    if (result i32) i32.const 100 else i32.const 200 end)
 
   ;; ----- negative test: numeric comparison must NOT collapse ------------
   ;; `ctz(x) == 4` is an arithmetic test on the count, not a boolean
@@ -164,14 +170,11 @@
 ;; wasm[0]::function[7]::if_ctz_bare_i64:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
-;;       movl    $0x40, %esi
-;;       bsfq    %rdx, %r9
-;;       cmoveq  %rsi, %r9
-;;       testl   %r9d, %r9d
-;;       jne     0x1a4
-;;  19a: movl    $0xc8, %eax
-;;       jmp     0x1a9
-;;  1a4: movl    $0x64, %eax
+;;       testq   $1, %rdx
+;;       je      0x19b
+;;  191: movl    $0xc8, %eax
+;;       jmp     0x1a0
+;;  19b: movl    $0x64, %eax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
@@ -256,17 +259,29 @@
 ;;       popq    %rbp
 ;;       retq
 ;;
-;; wasm[0]::function[15]::if_ctz_eq4_i32:
+;; wasm[0]::function[15]::if_clz_bare_i64:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       testq   %rdx, %rdx
+;;       jge     0x2f7
+;;  2ed: movl    $0xc8, %eax
+;;       jmp     0x2fc
+;;  2f7: movl    $0x64, %eax
+;;       movq    %rbp, %rsp
+;;       popq    %rbp
+;;       retq
+;;
+;; wasm[0]::function[16]::if_ctz_eq4_i32:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movl    $0x20, %esi
 ;;       bsfl    %edx, %r9d
 ;;       cmovel  %esi, %r9d
 ;;       cmpl    $4, %r9d
-;;       je      0x305
-;;  2fb: movl    $0xc8, %eax
-;;       jmp     0x30a
-;;  305: movl    $0x64, %eax
+;;       je      0x345
+;;  33b: movl    $0xc8, %eax
+;;       jmp     0x34a
+;;  345: movl    $0x64, %eax
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq


### PR DESCRIPTION
Extends #13343's `simplify_skeleton` fold so the existing
`brif (ctz X)` / `brif (clz X)` rules also fire when an `ireduce`
(i.e. `i32.wrap_i64` at the wasm level) sits between the count and
the branch.

Why this matters: non-Rust frontends targeting wasm64 often emit
`i64.ctz; i32.wrap_i64; br_if` for boolean-context LSB tests. The
wrap is harmless (the count is in [0, 64]) but it currently blocks
the fold, so cranelift falls back to materializing the full count
before the branch. With this PR, the i64-wrap form lowers to the
same `testq $1, %rdx; je` shape as the i32 case.

Test coverage mirrors the existing patterns:
- `cranelift/filetests/.../brif-cnt-cond.clif` gets two new
  `brif (ireduce (ctz/clz X))` functions.
- `tests/disas/ctz-clz-bool-condition.wat` gets a new
  `$if_clz_bare_i64` and the existing `$if_ctz_bare_i64`
  is reblessed - both now lower to the optimal shape.