### PR TITLE
Increase maximum memory in component_api fuzzer

### DIFF
--- a/crates/fuzzing/src/oracles/component_api.rs
+++ b/crates/fuzzing/src/oracles/component_api.rs
@@ -194,6 +194,8 @@ fn store<T>(input: &mut Unstructured<'_>, val: T) -> arbitrary::Result<Store<T>>
         }
     }
 
+    const MEMORY_NEEDED: usize = 100 << 20; // 100 MiB
+
     if let InstanceAllocationStrategy::Pooling(p) = &mut config.wasmtime.strategy {
         set_min(&mut p.total_component_instances, 5);
         set_min(&mut p.total_core_instances, 5);
@@ -204,11 +206,11 @@ fn store<T>(input: &mut Unstructured<'_>, val: T) -> arbitrary::Result<Store<T>>
         set_min(&mut p.component_instance_size, 64 << 10);
         set_min(&mut p.core_instance_size, 64 << 10);
         p.memory_protection_keys = Enabled::No;
-        p.max_memory_size = 10 << 20; // 10 MiB
+        p.max_memory_size = MEMORY_NEEDED;
     }
     set_opt_min(
         &mut config.wasmtime.memory_config.memory_reservation,
-        10 << 20,
+        MEMORY_NEEDED as u64,
     );
 
     // Re-enforce internal consistency after the adjustments above (e.g.


### PR DESCRIPTION
A fuzz test case blew through the 10MiB limit, so 10x it and see what happens.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
