### PR TITLE
Fix i31-wrapped-as-externref in passive element segment

### DIFF
--- a/crates/wasmtime/src/runtime/gc/enabled/anyref.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/anyref.rs
@@ -334,15 +334,7 @@ impl AnyRef {
     }
 
     pub(crate) fn _to_raw(&self, store: &mut AutoAssertNoGc<'_>) -> Result<u32> {
-        let gc_ref = self.inner.try_clone_gc_ref(store)?;
-        let raw = if gc_ref.is_i31() {
-            gc_ref.as_raw_non_zero_u32()
-        } else {
-            store
-                .require_gc_store_mut()?
-                .expose_gc_ref_to_wasm(gc_ref)?
-        };
-        Ok(raw.get())
+        self.inner.expose_gc_ref_to_wasm(store).map(|r| r.get())
     }
 
     /// Get the type of this reference.

--- a/crates/wasmtime/src/runtime/gc/enabled/exnref.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/exnref.rs
@@ -416,15 +416,7 @@ impl ExnRef {
     }
 
     pub(crate) fn _to_raw(&self, store: &mut AutoAssertNoGc<'_>) -> Result<u32> {
-        let gc_ref = self.inner.try_clone_gc_ref(store)?;
-        let raw = if gc_ref.is_i31() {
-            gc_ref.as_raw_non_zero_u32()
-        } else {
-            store
-                .require_gc_store_mut()?
-                .expose_gc_ref_to_wasm(gc_ref)?
-        };
-        Ok(raw.get())
+        self.inner.expose_gc_ref_to_wasm(store).map(|r| r.get())
     }
 
     /// Get the type of this reference.

--- a/crates/wasmtime/src/runtime/gc/enabled/externref.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/externref.rs
@@ -592,9 +592,7 @@ impl ExternRef {
     }
 
     pub(crate) fn _to_raw(&self, store: &mut AutoAssertNoGc) -> Result<u32> {
-        let gc_ref = self.inner.try_clone_gc_ref(store)?;
-        let raw = store.unwrap_gc_store_mut().expose_gc_ref_to_wasm(gc_ref)?;
-        Ok(raw.get())
+        self.inner.expose_gc_ref_to_wasm(store).map(|r| r.get())
     }
 }
 

--- a/crates/wasmtime/src/runtime/gc/enabled/rooting.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/rooting.rs
@@ -172,7 +172,7 @@ use alloc::sync::{Arc, Weak};
 use core::any;
 use core::marker;
 use core::mem::{self, MaybeUninit};
-use core::num::{NonZeroU64, NonZeroUsize};
+use core::num::{NonZeroU32, NonZeroU64, NonZeroUsize};
 use core::{
     fmt::{self, Debug},
     hash::{Hash, Hasher},
@@ -324,6 +324,26 @@ impl GcRootIndex {
     pub(crate) fn try_clone_gc_ref(&self, store: &mut AutoAssertNoGc<'_>) -> Result<VMGcRef> {
         let gc_ref = self.try_gc_ref(store)?.unchecked_copy();
         Ok(store.clone_gc_ref(&gc_ref))
+    }
+
+    /// Exposes this value's raw `VMGcRef` to wasm as a `u32`.
+    pub(crate) fn expose_gc_ref_to_wasm(
+        &self,
+        store: &mut AutoAssertNoGc<'_>,
+    ) -> Result<NonZeroU32> {
+        let gc_ref = self.try_clone_gc_ref(store)?;
+
+        let raw = match store.optional_gc_store_mut() {
+            Some(s) => s.expose_gc_ref_to_wasm(gc_ref)?,
+            None => {
+                // NB: do not force the allocation of a GC heap just because the
+                // program is using `i31ref`s.
+                debug_assert!(gc_ref.is_i31());
+                gc_ref.as_raw_non_zero_u32()
+            }
+        };
+
+        Ok(raw)
     }
 }
 
@@ -1210,18 +1230,7 @@ impl<T: GcRef> Rooted<T> {
         ptr: &mut MaybeUninit<ValRaw>,
         val_raw: impl Fn(u32) -> ValRaw,
     ) -> Result<()> {
-        let gc_ref = self.inner.try_clone_gc_ref(store)?;
-
-        let raw = match store.optional_gc_store_mut() {
-            Some(s) => s.expose_gc_ref_to_wasm(gc_ref)?,
-            None => {
-                // NB: do not force the allocation of a GC heap just because the
-                // program is using `i31ref`s.
-                debug_assert!(gc_ref.is_i31());
-                gc_ref.as_raw_non_zero_u32()
-            }
-        };
-
+        let raw = self.inner.expose_gc_ref_to_wasm(store)?;
         ptr.write(val_raw(raw.get()));
         Ok(())
     }
@@ -1834,16 +1843,7 @@ where
         ptr: &mut MaybeUninit<ValRaw>,
         val_raw: impl Fn(u32) -> ValRaw,
     ) -> Result<()> {
-        let gc_ref = self.try_clone_gc_ref(store)?;
-
-        let raw = match store.optional_gc_store_mut() {
-            Some(s) => s.expose_gc_ref_to_wasm(gc_ref)?,
-            None => {
-                debug_assert!(gc_ref.is_i31());
-                gc_ref.as_raw_non_zero_u32()
-            }
-        };
-
+        let raw = self.inner.expose_gc_ref_to_wasm(store)?;
         ptr.write(val_raw(raw.get()));
         Ok(())
     }

--- a/tests/misc_testsuite/gc/i31-as-externref-in-passive-element-segment.wast
+++ b/tests/misc_testsuite/gc/i31-as-externref-in-passive-element-segment.wast
@@ -1,0 +1,6 @@
+;;! gc = true
+;;! bulk_memory = true
+
+(module
+  (elem externref (item (extern.convert_any (ref.i31 (i32.const 1)))))
+)


### PR DESCRIPTION
GC types all duplicated logic to expose a reference to wasm, and `externref` duplicated this logic in a way that was different from the rest and didn't handle the i31 case.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
