### PR TITLE
Implement WASI initial cwd configuration

### DIFF
--- a/crates/cli-flags/src/lib.rs
+++ b/crates/cli-flags/src/lib.rs
@@ -546,6 +546,8 @@ wasmtime_option_group! {
         pub inherit_stdout: Option<bool>,
         /// Inherit stderr from the parent process. On by default.
         pub inherit_stderr: Option<bool>,
+        /// Initial current working directory reported through `wasi:cli/environment`.
+        pub cwd: Option<String>,
         /// Pass a wasi config variable to the program.
         #[serde(skip)]
         pub config_var: Vec<KeyValuePair>,
@@ -1378,6 +1380,10 @@ mod tests {
                 "Mismatch for input '{collector_value}'. Parsed: {parsed_collector:?}, Expected: {expected:?}",
             );
         }
+
+        let mut common_options = CommonOptions::try_parse_from(["test", "-Scwd=/sandbox"]).unwrap();
+        common_options.configure().unwrap();
+        assert_eq!(common_options.wasi.cwd.as_deref(), Some("/sandbox"));
     }
 }
 

--- a/crates/cli-flags/src/lib.rs
+++ b/crates/cli-flags/src/lib.rs
@@ -1380,10 +1380,6 @@ mod tests {
                 "Mismatch for input '{collector_value}'. Parsed: {parsed_collector:?}, Expected: {expected:?}",
             );
         }
-
-        let mut common_options = CommonOptions::try_parse_from(["test", "-Scwd=/sandbox"]).unwrap();
-        common_options.configure().unwrap();
-        assert_eq!(common_options.wasi.cwd.as_deref(), Some("/sandbox"));
     }
 }
 

--- a/crates/test-programs/src/bin/p2_cli_initial_cwd.rs
+++ b/crates/test-programs/src/bin/p2_cli_initial_cwd.rs
@@ -1,0 +1,5 @@
+use test_programs::wasi::cli::environment;
+
+fn main() {
+    assert_eq!(environment::initial_cwd().as_deref(), Some("/sandbox"));
+}

--- a/crates/wasi/src/ctx.rs
+++ b/crates/wasi/src/ctx.rs
@@ -576,20 +576,3 @@ impl WasiCtx {
         &mut self.sockets
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::WasiCtxBuilder;
-
-    #[test]
-    fn initial_cwd_defaults_to_none() {
-        let ctx = WasiCtxBuilder::new().build();
-        assert_eq!(ctx.cli.initial_cwd, None);
-    }
-
-    #[test]
-    fn initial_cwd_can_be_configured() {
-        let ctx = WasiCtxBuilder::new().initial_cwd("/sandbox").build();
-        assert_eq!(ctx.cli.initial_cwd.as_deref(), Some("/sandbox"));
-    }
-}

--- a/crates/wasi/src/ctx.rs
+++ b/crates/wasi/src/ctx.rs
@@ -242,6 +242,15 @@ impl WasiCtxBuilder {
         self
     }
 
+    /// Configures the initial current working directory reported to the guest.
+    ///
+    /// By default no initial current working directory is configured and
+    /// `wasi:cli/environment.initial-cwd` returns `none`.
+    pub fn initial_cwd(&mut self, path: impl AsRef<str>) -> &mut Self {
+        self.cli.initial_cwd = Some(path.as_ref().to_owned());
+        self
+    }
+
     /// Configures a "preopened directory" to be available to WebAssembly.
     ///
     /// By default WebAssembly does not have access to the filesystem because
@@ -565,5 +574,22 @@ impl WasiCtx {
     /// Returns access to the underlying [`WasiSocketsCtx`].
     pub fn sockets(&mut self) -> &mut WasiSocketsCtx {
         &mut self.sockets
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::WasiCtxBuilder;
+
+    #[test]
+    fn initial_cwd_defaults_to_none() {
+        let ctx = WasiCtxBuilder::new().build();
+        assert_eq!(ctx.cli.initial_cwd, None);
+    }
+
+    #[test]
+    fn initial_cwd_can_be_configured() {
+        let ctx = WasiCtxBuilder::new().initial_cwd("/sandbox").build();
+        assert_eq!(ctx.cli.initial_cwd.as_deref(), Some("/sandbox"));
     }
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -354,6 +354,9 @@ impl RunCommon {
                 wasmtime_wasi::FilePerms::all(),
             )?;
         }
+        if let Some(cwd) = &self.common.wasi.cwd {
+            builder.initial_cwd(cwd);
+        }
 
         if self.common.wasi.listenfd == Some(true) {
             bail!("components do not support --listenfd");

--- a/tests/all/cli_tests.rs
+++ b/tests/all/cli_tests.rs
@@ -1150,6 +1150,17 @@ mod test_programs {
     }
 
     #[test]
+    fn p2_cli_initial_cwd() -> Result<()> {
+        run_wasmtime(&[
+            "run",
+            "-Wcomponent-model",
+            "-Scwd=/sandbox",
+            P2_CLI_INITIAL_CWD_COMPONENT,
+        ])?;
+        Ok(())
+    }
+
+    #[test]
     fn p2_cli_stdin_empty() -> Result<()> {
         let mut child = get_wasmtime_command()?
             .args(&["run", "-Wcomponent-model", P2_CLI_STDIN_EMPTY_COMPONENT])


### PR DESCRIPTION
This implements the missing configuration path for wasi:cli/environment.initial-cwd discussed in #9695.

Summary:
- add WasiCtxBuilder::initial_cwd to configure the value reported by wasi:cli/environment.initial-cwd
- add -Scwd=<path> and wire it into the CLI's WASIp2 context setup
- add an end-to-end CLI test component that verifies the guest observes the configured cwd

Tests:
- cargo fmt --all -- --check
- cargo test -p wasmtime-cli-flags from_toml
- cargo test -p wasmtime-wasi --lib initial_cwd
- cargo test -p test-programs --target=wasm32-wasip1 --no-run --bin p2_cli_initial_cwd
- cargo test -p wasmtime-cli --test all p2_cli_initial_cwd
- cargo check -p wasmtime-cli
- cargo clippy -p wasmtime-cli-flags -p wasmtime-wasi --lib