### PR TITLE
Add p3 readonly truncation regression test

### DIFF
--- a/crates/test-programs/src/bin/p3_file_truncation_readonly.rs
+++ b/crates/test-programs/src/bin/p3_file_truncation_readonly.rs
@@ -1,0 +1,67 @@
+use test_programs::p3::wasi::filesystem::types::{
+    Descriptor, DescriptorFlags, ErrorCode, OpenFlags, PathFlags,
+};
+use test_programs::p3::{self, wasi};
+
+struct Component;
+
+p3::export!(Component);
+
+const FILENAME: &str = "test.txt";
+const EXPECTED_CONTENTS: &[u8] = b"truncation test file\n";
+
+impl p3::exports::wasi::cli::run::Guest for Component {
+    async fn run() -> Result<(), ()> {
+        let preopens = wasi::filesystem::preopens::get_directories();
+        let (dir, _) = preopens
+            .iter()
+            .find(|(_, path)| path == "readonly")
+            .expect("find preopen named readonly");
+
+        test_file_truncation_readonly(dir).await;
+        Ok(())
+    }
+}
+
+fn main() {
+    unreachable!()
+}
+
+async fn test_file_has_expected_contents(dir: &Descriptor) {
+    let file = dir
+        .open_at(
+            PathFlags::empty(),
+            FILENAME.to_string(),
+            OpenFlags::empty(),
+            DescriptorFlags::READ,
+        )
+        .await
+        .expect("open test.txt for reading");
+
+    let (read, result) = file.read_via_stream(0);
+    let read = read.collect().await;
+    result.await.expect("reading test.txt content");
+    drop(file);
+
+    assert_eq!(read, EXPECTED_CONTENTS, "expected untouched file contents");
+}
+
+async fn test_file_truncation_readonly(dir: &Descriptor) {
+    test_file_has_expected_contents(dir).await;
+
+    let err = dir
+        .open_at(
+            PathFlags::empty(),
+            FILENAME.to_string(),
+            OpenFlags::TRUNCATE,
+            DescriptorFlags::READ,
+        )
+        .await
+        .expect_err("opening file for truncation should fail");
+    assert!(
+        matches!(err, ErrorCode::NotPermitted),
+        "opening file for truncation should fail with ErrorCode::NotPermitted, got {err:?}"
+    );
+
+    test_file_has_expected_contents(dir).await;
+}

--- a/crates/wasi/tests/all/p3/mod.rs
+++ b/crates/wasi/tests/all/p3/mod.rs
@@ -1,9 +1,10 @@
 use crate::store::{Ctx, MyWasiCtx};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use test_programs_artifacts::*;
 use wasmtime::component::{Component, Linker};
 use wasmtime::{Result, error::Context as _, format_err};
 use wasmtime_wasi::p3::bindings::Command;
+use wasmtime_wasi::{DirPerms, FilePerms, WasiCtxBuilder};
 
 async fn run(path: &str) -> Result<()> {
     run_allow_blocking_current_thread(path, false).await
@@ -12,6 +13,14 @@ async fn run(path: &str) -> Result<()> {
 async fn run_allow_blocking_current_thread(
     path: &str,
     allow_blocking_current_thread: bool,
+) -> Result<()> {
+    run_with_builder(path, allow_blocking_current_thread, |_| {}).await
+}
+
+async fn run_with_builder(
+    path: &str,
+    allow_blocking_current_thread: bool,
+    configure: impl FnOnce(&mut WasiCtxBuilder),
 ) -> Result<()> {
     let path = Path::new(path);
     let name = path.file_stem().unwrap().to_str().unwrap();
@@ -25,6 +34,7 @@ async fn run_allow_blocking_current_thread(
     wasmtime_wasi::p3::add_to_linker(&mut linker).context("failed to link `wasi:cli@0.3.x`")?;
 
     let (mut store, _td) = Ctx::new(&engine, name, |builder| {
+        configure(builder);
         MyWasiCtx::new(
             builder
                 .allow_blocking_current_thread(allow_blocking_current_thread)
@@ -173,4 +183,34 @@ async fn p3_file_write() -> wasmtime::Result<()> {
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn p3_file_write_blocking() -> wasmtime::Result<()> {
     run_allow_blocking_current_thread(P3_FILE_WRITE_COMPONENT, true).await
+}
+
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
+async fn p3_file_truncation_readonly() -> wasmtime::Result<()> {
+    let prefix = "wasi_components_p3_truncation_readonly_ro_";
+    let tempdir = tempfile::Builder::new()
+        .prefix(prefix)
+        .tempdir()
+        .expect("create readonly tempdir");
+    const FILENAME: &str = "test.txt";
+    const EXPECTED_CONTENTS: &[u8] = b"truncation test file\n";
+    let mut file = PathBuf::from(tempdir.path());
+    file.push(FILENAME);
+    std::fs::write(&file, EXPECTED_CONTENTS).expect("write truncation test file");
+
+    run_with_builder(P3_FILE_TRUNCATION_READONLY_COMPONENT, false, |builder| {
+        builder
+            .preopened_dir(
+                tempdir.path(),
+                "readonly",
+                DirPerms::READ | DirPerms::MUTATE,
+                FilePerms::READ,
+            )
+            .unwrap();
+    })
+    .await?;
+
+    let contents = std::fs::read(&file).expect("read truncation test file");
+    assert_eq!(EXPECTED_CONTENTS, contents);
+    Ok(())
 }


### PR DESCRIPTION
## Summary

- Add a p3 filesystem regression test for opening a read-only preopened file with TRUNCATE.
- Reuse the p3 test harness with a configurable WasiCtxBuilder so the test can install a read-only file preopen.
- Verify that the open fails with NotPermitted and that the file contents remain unchanged.

## Context

This extends coverage for the permission invariant behind GHSA-2r75-cxrj-cmph / CVE-2026-47261 to the p3 filesystem path. The underlying fix is already present in the shared filesystem implementation; this PR adds p3-specific regression coverage so the invariant stays protected as p3 evolves.

## Testing

- cargo fmt --all -- --check
- cargo test -p wasmtime-wasi --features p3 --test all p3_file_truncation_readonly
- git diff --check