### PR TITLE
Don't perform excessive growth in api_calls generator

### DIFF
--- a/crates/fuzzing/src/generators/api.rs
+++ b/crates/fuzzing/src/generators/api.rs
@@ -612,7 +612,7 @@ impl<'a> Arbitrary<'a> for ApiCalls {
                 choices.push(|input, scope| {
                     let tables: Vec<_> = scope.tables.keys().collect();
                     let table = **input.choose(&tables)?;
-                    let delta = u32::arbitrary(input)?;
+                    let delta = input.int_in_range(0..=100)?;
                     Ok(TableGrow { table, delta })
                 });
             }
@@ -734,7 +734,7 @@ impl<'a> Arbitrary<'a> for ApiCalls {
                 choices.push(|input, scope| {
                     let memories: Vec<_> = scope.memories.keys().collect();
                     let memory = **input.choose(&memories)?;
-                    let delta = u32::arbitrary(input)? % 10;
+                    let delta = input.int_in_range(0..=10)?;
                     Ok(MemoryGrow { memory, delta })
                 });
             }


### PR DESCRIPTION
Limit growth to a reasonable number of slots to avoid the growth taking too long. Growth through the API isn't the most optimal at this time.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
