### PR TITLE
cranelift-object: emit PLATFORM_MACOS for Darwin triples on macOS hosts

### DIFF
--- a/cranelift/object/src/backend.rs
+++ b/cranelift/object/src/backend.rs
@@ -190,22 +190,8 @@ fn macho_build_version(triple: &Triple) -> Option<object::write::MachOBuildVersi
             // TODO(madsmtm): Properly support simulator after
             // https://github.com/bytecodealliance/target-lexicon/pull/130
             let platform = match (triple.operating_system, triple.environment) {
-                // Problem: `cranelift_native::builder()` produces a
-                // `Darwin(_)` triple on macOS hosts, which falls
-                // through to `PLATFORM_UNKNOWN (0)` in the Mach-O
-                // `LC_BUILD_VERSION` load command. macOS `ld64`
-                // rejects object files whose platform is unknown,
-                // breaking native object emission on Darwin hosts.
-                //
-                // Fix: when the host itself is macOS, treat
-                // `Darwin(_)` the same as `MacOSX(_)` and tag the
-                // build version as PLATFORM_MACOS so `ld64` accepts
-                // the .o. Cross-targets to `Darwin(_)` from a non-
-                // macOS host keep the upstream PLATFORM_UNKNOWN
-                // behaviour — the issue is specific to `ld64`'s
-                // host-side rejection. Expected to dovetail with
-                // target-lexicon PR #130 which adds proper simulator
-                // / platform discrimination upstream.
+                // Sometimes the target is macOS but the environment is Darwin, 
+                // and sometimes it's the other way around. Support both.
                 #[cfg(target_os = "macos")]
                 (Darwin(_), _) => PLATFORM_MACOS,
                 (MacOSX(_), _) => PLATFORM_MACOS,

--- a/cranelift/object/src/backend.rs
+++ b/cranelift/object/src/backend.rs
@@ -190,7 +190,24 @@ fn macho_build_version(triple: &Triple) -> Option<object::write::MachOBuildVersi
             // TODO(madsmtm): Properly support simulator after
             // https://github.com/bytecodealliance/target-lexicon/pull/130
             let platform = match (triple.operating_system, triple.environment) {
-                (Darwin(_), _) => 0, // PLATFORM_UNKNOWN
+                // Problem: `cranelift_native::builder()` produces a
+                // `Darwin(_)` triple on macOS hosts, which falls
+                // through to `PLATFORM_UNKNOWN (0)` in the Mach-O
+                // `LC_BUILD_VERSION` load command. macOS `ld64`
+                // rejects object files whose platform is unknown,
+                // breaking native object emission on Darwin hosts.
+                //
+                // Fix: when the host itself is macOS, treat
+                // `Darwin(_)` the same as `MacOSX(_)` and tag the
+                // build version as PLATFORM_MACOS so `ld64` accepts
+                // the .o. Cross-targets to `Darwin(_)` from a non-
+                // macOS host keep the upstream PLATFORM_UNKNOWN
+                // behaviour — the issue is specific to `ld64`'s
+                // host-side rejection. Expected to dovetail with
+                // target-lexicon PR #130 which adds proper simulator
+                // / platform discrimination upstream.
+                #[cfg(target_os = "macos")]
+                (Darwin(_), _) => PLATFORM_MACOS,
                 (MacOSX(_), _) => PLATFORM_MACOS,
                 (_, Macabi) => PLATFORM_MACCATALYST,
                 (IOS(_), Sim) => PLATFORM_IOSSIMULATOR,

--- a/cranelift/object/src/backend.rs
+++ b/cranelift/object/src/backend.rs
@@ -190,9 +190,8 @@ fn macho_build_version(triple: &Triple) -> Option<object::write::MachOBuildVersi
             // TODO(madsmtm): Properly support simulator after
             // https://github.com/bytecodealliance/target-lexicon/pull/130
             let platform = match (triple.operating_system, triple.environment) {
-                // Sometimes the target is macOS but the environment is Darwin, 
+                // Sometimes the target is macOS but the environment is Darwin,
                 // and sometimes it's the other way around. Support both.
-                #[cfg(target_os = "macos")]
                 (Darwin(_), _) => PLATFORM_MACOS,
                 (MacOSX(_), _) => PLATFORM_MACOS,
                 (_, Macabi) => PLATFORM_MACCATALYST,


### PR DESCRIPTION
cranelift_native produces a Darwin(_) triple on macOS hosts, which falls through to PLATFORM_UNKNOWN (0) in the Mach-O LC_BUILD_VERSION load command. macOS ld64 rejects object files with an unknown platform, breaking native object emission on Darwin hosts.

Gate on `#[cfg(target_os = "macos")]` so the override only fires when the host (and therefore the linker likely consuming the object) is itself macOS. Cross-compile pipelines that produce Darwin objects from a non-macOS host keep upstream PLATFORM_UNKNOWN behaviour — the issue is specific to ld64's host-side rejection. Map Darwin(_) to PLATFORM_MACOS the same way MacOSX(_) is mapped. Expected to dovetail with target-lexicon PR #130.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
