### PR TITLE
Reject attempts to create `ExnType`s when a GC runtime is not configured

### DIFF
--- a/crates/wasmtime/src/runtime/types.rs
+++ b/crates/wasmtime/src/runtime/types.rs
@@ -2839,6 +2839,11 @@ impl ExnType {
         fields: impl IntoIterator<Item = ValType>,
         func_ty: FuncType,
     ) -> Result<ExnType> {
+        ensure!(
+            engine.gc_runtime().is_some(),
+            "cannot define `ExnType`s without a GC runtime enabled"
+        );
+
         let mut wasm_fields = TryVec::new();
         for ty in fields.into_iter() {
             assert!(ty.comes_from_same_engine(engine));

--- a/tests/all/tags.rs
+++ b/tests/all/tags.rs
@@ -93,6 +93,7 @@ fn stack_switching_disallows_inlining() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn issue_13474_create_tag_without_gc_runtime_configured() -> Result<()> {
     let mut config = Config::new();
     config.strategy(Strategy::Winch);

--- a/tests/all/tags.rs
+++ b/tests/all/tags.rs
@@ -1,3 +1,4 @@
+use crate::ErrorExt;
 use wasmtime::*;
 
 #[test]
@@ -89,4 +90,19 @@ fn stack_switching_disallows_inlining() -> Result<()> {
     config.compiler_inlining(wasmtime::Inlining::Yes);
     assert!(Engine::new(&config).is_err());
     return Ok(());
+}
+
+#[test]
+fn issue_13474_create_tag_without_gc_runtime_configured() -> Result<()> {
+    let mut config = Config::new();
+    config.strategy(Strategy::Winch);
+    let engine = Engine::new(&config)?;
+    let mut store = Store::new(&engine, ());
+    let fty = FuncType::new(&engine, [], []);
+    let tty1 = TagType::new(fty.clone());
+    let result = Tag::new(&mut store, &tty1.clone());
+    result
+        .unwrap_err()
+        .assert_contains("cannot define `ExnType`s without a GC runtime enabled");
+    Ok(())
 }


### PR DESCRIPTION
The type registry does not (and cannot) track a type's GC layout when there is not GC runtime, so check for this and error early in `ExnType` creation.

Fixes https://github.com/bytecodealliance/wasmtime/issues/13474

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
