### PR TITLE
[wasmtime-wasi-http] check more configurations in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -423,6 +423,8 @@ jobs:
               -p wasmtime-wasi-http --no-default-features
               -p wasmtime-wasi-http --no-default-features --features p2
               -p wasmtime-wasi-http --no-default-features --features p3
+              -p wasmtime-wasi-http --no-default-features --features p2,component-model-async
+              -p wasmtime-wasi-http --no-default-features --features p3,component-model-async
               -p wasmtime-wasi-http --no-default-features --features p3 --all-targets
 
           - name: wasmtime-wasi


### PR DESCRIPTION
Per
https://github.com/bytecodealliance/wasmtime/pull/13404#discussion_r3292701479, CI was not currently checking the `-p wasmtime-wasi-http --no-default-features --features p3,component-model-async` and `-p wasmtime-wasi-http --no-default-features --features p2,component-model-async` configurations, so they've sometimes silently regressed.  This will help us catch those regressions.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
