### PR TITLE
LTS: Fix build errors on loongarch64

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2202,9 +2202,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.171"
+version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "libfuzzer-sys"


### PR DESCRIPTION
Builds fail on loongarch64 due to mismatching type definitions. Update pinned version libc.

See: https://github.com/rust-lang/libc/pull/4448
