### PR TITLE
chore: fix duplicated words in pulley, debugger, and pagemap doc comments

### DIFF
--- a/crates/debugger/src/lib.rs
+++ b/crates/debugger/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! This crate builds on top of the core Wasmtime crate's
 //! guest-debugger APIs to present an environment where a debugger
-//! runs as a "co-running process" and sees the debuggee as a a
+//! runs as a "co-running process" and sees the debuggee as a
 //! provider of a stream of events, on which actions can be taken
 //! between each event.
 //!

--- a/crates/wasmtime/src/runtime/vm/sys/unix/pagemap.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/unix/pagemap.rs
@@ -21,7 +21,7 @@ use std::ptr;
 ///
 /// Also note that updating this is not done via mutation but rather it's done
 /// with `dup2` to replace the file descriptor that `File` points to in-place.
-/// The local copy of of `File` is then closed in the atfork handler.
+/// The local copy of `File` is then closed in the atfork handler.
 #[cfg(feature = "pooling-allocator")]
 static PROCESS_PAGEMAP: std::sync::LazyLock<Option<File>> = std::sync::LazyLock::new(|| {
     use rustix::fd::AsRawFd;

--- a/pulley/src/decode.rs
+++ b/pulley/src/decode.rs
@@ -203,7 +203,7 @@ impl UnsafeBytecodeStream {
     /// `UnsafeBytecodeStream` is only used to access the valid bytecode. For
     /// example, if the current bytecode instruction unconditionally jumps to a
     /// new PC, this stream must not be used to read just after the
-    /// unconditional jump instruction because there is no guarantee that that
+    /// unconditional jump instruction because there is no guarantee that
     /// memory is part of the bytecode stream or not.
     pub unsafe fn new(pc: NonNull<u8>) -> Self {
         UnsafeBytecodeStream(pc)


### PR DESCRIPTION
Signed-off-by: Aiden Park <275402320+vip892766gma@users.noreply.github.com>