### PR TITLE
Copying collector: Store most tracing info inline in the object header

### DIFF
--- a/crates/cranelift/src/func_environ/gc/enabled.rs
+++ b/crates/cranelift/src/func_environ/gc/enabled.rs
@@ -124,13 +124,14 @@ fn emit_gc_raw_alloc(
     ty: ModuleInternedTypeIndex,
     size: ir::Value,
     align: u32,
+    reserved_bits: u32,
 ) -> ir::Value {
     let gc_alloc_raw_builtin = func_env.builtin_functions.gc_alloc_raw(builder.func);
     let vmctx = func_env.vmctx_val(&mut builder.cursor());
 
     let kind = builder
         .ins()
-        .iconst(ir::types::I32, i64::from(kind.as_u32()));
+        .iconst(ir::types::I32, i64::from(kind.as_u32() | reserved_bits));
 
     let ty = func_env.module_interned_to_shared_ty(&mut builder.cursor(), ty);
 

--- a/crates/cranelift/src/func_environ/gc/enabled/copying.rs
+++ b/crates/cranelift/src/func_environ/gc/enabled/copying.rs
@@ -13,7 +13,7 @@ use crate::translate::TargetEnvironment;
 use cranelift_codegen::ir::{self, InstBuilder};
 use cranelift_frontend::FunctionBuilder;
 use wasmtime_environ::copying::{
-    ALIGN, EXCEPTION_TAG_DEFINED_OFFSET, EXCEPTION_TAG_INSTANCE_OFFSET,
+    ALIGN, EXCEPTION_TAG_DEFINED_OFFSET, EXCEPTION_TAG_INSTANCE_OFFSET, InlineTraceInfo,
 };
 use wasmtime_environ::{
     GcTypeLayouts, ModuleInternedTypeIndex, PtrSize, TypeIndex, VMGcKind, WasmHeapTopType,
@@ -92,6 +92,7 @@ impl CopyingCompiler {
         kind: VMGcKind,
         ty: ModuleInternedTypeIndex,
         size: ir::Value,
+        reserved_bits: u32,
     ) -> WasmResult<(ir::Value, ir::Value)> {
         debug_assert_ne!(kind, VMGcKind::ExternRef);
         debug_assert!(!ty.is_reserved_value());
@@ -132,7 +133,7 @@ impl CopyingCompiler {
             builder.switch_to_block(slow_block);
             builder.seal_block(slow_block);
             builder.set_cold_block(slow_block);
-            let gc_ref = emit_gc_raw_alloc(func_env, builder, kind, ty, size, ALIGN);
+            let gc_ref = emit_gc_raw_alloc(func_env, builder, kind, ty, size, ALIGN, reserved_bits);
             let base = func_env.get_gc_heap_base(builder)?;
             let heap_offset = uextend_i32_to_pointer_type(builder, pointer_type, gc_ref);
             let obj_ptr = builder.ins().iadd(base, heap_offset);
@@ -166,10 +167,10 @@ impl CopyingCompiler {
             let heap_offset = uextend_i32_to_pointer_type(builder, pointer_type, gc_ref);
             let obj_ptr = builder.ins().iadd(base, heap_offset);
 
-            // Write `VMGcHeader::kind`.
+            // Write `VMGcHeader::kind` with inline trace info bits included.
             let kind_val = builder
                 .ins()
-                .iconst(ir::types::I32, i64::from(kind.as_u32()));
+                .iconst(ir::types::I32, i64::from(kind.as_u32() | reserved_bits));
             builder.ins().store(
                 ir::MemFlagsData::trusted(),
                 kind_val,
@@ -232,6 +233,7 @@ impl GcCompiler for CopyingCompiler {
 
         let len_offset = gc_compiler(func_env)?.layouts().array_length_field_offset();
         let array_layout = func_env.array_layout(interned_type_index)?.clone();
+        let reserved_bits = InlineTraceInfo::array(&array_layout).encode();
 
         // First, compute the array's total size.
         let size = emit_array_size(func_env, builder, &array_layout, len);
@@ -243,6 +245,7 @@ impl GcCompiler for CopyingCompiler {
             VMGcKind::ArrayRef,
             interned_type_index,
             size,
+            reserved_bits,
         )?;
         let len_addr = builder.ins().iadd_imm(object_addr, i64::from(len_offset));
         builder.ins().store(GC_MEMFLAGS, len, len_addr, 0);
@@ -262,6 +265,7 @@ impl GcCompiler for CopyingCompiler {
         let struct_layout = func_env.struct_or_exn_layout(interned_type_index);
 
         let struct_size = struct_layout.size;
+        let reserved_bits = InlineTraceInfo::r#struct(&struct_layout).encode();
 
         let struct_size_val = builder.ins().iconst(ir::types::I32, i64::from(struct_size));
 
@@ -271,6 +275,7 @@ impl GcCompiler for CopyingCompiler {
             VMGcKind::StructRef,
             interned_type_index,
             struct_size_val,
+            reserved_bits,
         )?;
 
         // Initialize fields.
@@ -300,6 +305,7 @@ impl GcCompiler for CopyingCompiler {
         let exn_layout = func_env.struct_or_exn_layout(interned_type_index);
 
         let exn_size = exn_layout.size;
+        let reserved_bits = InlineTraceInfo::r#struct(&exn_layout).encode();
 
         let exn_size_val = builder.ins().iconst(ir::types::I32, i64::from(exn_size));
 
@@ -309,6 +315,7 @@ impl GcCompiler for CopyingCompiler {
             VMGcKind::ExnRef,
             interned_type_index,
             exn_size_val,
+            reserved_bits,
         )?;
 
         // Initialize fields.

--- a/crates/cranelift/src/func_environ/gc/enabled/drc.rs
+++ b/crates/cranelift/src/func_environ/gc/enabled/drc.rs
@@ -471,6 +471,7 @@ impl GcCompiler for DrcCompiler {
             interned_type_index,
             size,
             align,
+            0,
         );
 
         // Write the array's length into the appropriate slot.
@@ -512,6 +513,7 @@ impl GcCompiler for DrcCompiler {
             interned_type_index,
             struct_size_val,
             struct_align,
+            0,
         );
 
         // Second, initialize each of the newly-allocated struct's fields.
@@ -562,6 +564,7 @@ impl GcCompiler for DrcCompiler {
             interned_type_index,
             exn_size_val,
             exn_align,
+            0,
         );
 
         // Second, initialize each of the newly-allocated exception

--- a/crates/environ/src/gc/copying.rs
+++ b/crates/environ/src/gc/copying.rs
@@ -42,6 +42,122 @@ pub const MIN_OBJECT_SIZE: u32 = FORWARDING_REF_OFFSET + mem::size_of::<u32>() a
 #[derive(Default)]
 pub struct CopyingTypeLayouts;
 
+/// The inline trace info encoded in a `VMCopyingHeader`'s reserved bits.
+#[derive(Clone, Copy, Debug)]
+pub enum InlineTraceInfo {
+    /// The trace info is not encoded inline. Look it up from `TraceInfos`.
+    OutOfLine,
+
+    /// Inline trace info for an array type.
+    Array {
+        /// Whether the array's elements are GC references that need tracing.
+        elems_are_gc_refs: bool,
+    },
+
+    /// Inline trace info for a struct, exception, or externref type.
+    Struct {
+        /// A bitmap where the `i`th bit is set iff the `i`th `u32` in the
+        /// object's data (after the header) is a `VMGcRef` that needs
+        /// tracing. Only the lower 23 bits are meaningful.
+        gc_ref_bitmap: u32,
+    },
+}
+
+impl InlineTraceInfo {
+    const IS_INLINE_BIT: u32 = 1 << 1;
+    const IS_ARRAY_BIT: u32 = 1 << 2;
+    const ELEMS_ARE_GC_REFS_BIT: u32 = 1 << 3;
+    const STRUCT_BITMAP_SHIFT: u32 = 3;
+    const STRUCT_BITMAP_BITS: u32 = 23;
+
+    /// Inline trace info for an object with no GC-reference edges (e.g.
+    /// externrefs). This is a `Struct` with an empty bitmap.
+    pub const NO_GC_EDGES: InlineTraceInfo = InlineTraceInfo::Struct { gc_ref_bitmap: 0 };
+
+    /// Create inline trace info for the given GC layout.
+    pub fn new(layout: &GcLayout) -> Self {
+        match layout {
+            GcLayout::Array(a) => Self::array(a),
+            GcLayout::Struct(s) => Self::r#struct(s),
+        }
+    }
+
+    /// Create inline trace info for an array type.
+    ///
+    /// Arrays can always be represented inline (only one bit of payload is
+    /// needed), so this never returns `OutOfLine`.
+    pub fn array(layout: &GcArrayLayout) -> Self {
+        InlineTraceInfo::Array {
+            elems_are_gc_refs: layout.elems_are_gc_refs,
+        }
+    }
+
+    /// Create inline trace info for a struct or exception type.
+    ///
+    /// Returns `OutOfLine` only when there is a GC-reference field whose
+    /// offset cannot be represented in the 23-bit bitmap. Non-GC-reference
+    /// fields are ignored regardless of offset.
+    pub fn r#struct(layout: &GcStructLayout) -> Self {
+        let mut bitmap: u32 = 0;
+        for f in layout.fields.iter() {
+            if !f.is_gc_ref {
+                continue;
+            }
+            let Some(data_offset) = f.offset.checked_sub(HEADER_SIZE) else {
+                return Self::OutOfLine;
+            };
+            if data_offset % 4 != 0 {
+                return Self::OutOfLine;
+            }
+            let slot = data_offset / 4;
+            if slot >= Self::STRUCT_BITMAP_BITS {
+                return Self::OutOfLine;
+            }
+            bitmap |= 1u32 << slot;
+        }
+        InlineTraceInfo::Struct {
+            gc_ref_bitmap: bitmap,
+        }
+    }
+
+    /// Encode this inline trace info as its bit-packed representation for
+    /// storage in a `VMGcHeader`'s reserved bits.
+    pub fn encode(&self) -> u32 {
+        match self {
+            Self::OutOfLine => 0,
+            Self::Array { elems_are_gc_refs } => {
+                Self::IS_INLINE_BIT
+                    | Self::IS_ARRAY_BIT
+                    | if *elems_are_gc_refs {
+                        Self::ELEMS_ARE_GC_REFS_BIT
+                    } else {
+                        0
+                    }
+            }
+            Self::Struct { gc_ref_bitmap } => {
+                Self::IS_INLINE_BIT | (*gc_ref_bitmap << Self::STRUCT_BITMAP_SHIFT)
+            }
+        }
+    }
+
+    /// Decode inline trace info from the reserved bits of a `VMGcHeader`.
+    pub fn decode(reserved: u32) -> Self {
+        if reserved & Self::IS_INLINE_BIT == 0 {
+            return Self::OutOfLine;
+        }
+        if reserved & Self::IS_ARRAY_BIT != 0 {
+            Self::Array {
+                elems_are_gc_refs: reserved & Self::ELEMS_ARE_GC_REFS_BIT != 0,
+            }
+        } else {
+            Self::Struct {
+                gc_ref_bitmap: (reserved >> Self::STRUCT_BITMAP_SHIFT)
+                    & ((1u32 << Self::STRUCT_BITMAP_BITS) - 1),
+            }
+        }
+    }
+}
+
 impl GcTypeLayouts for CopyingTypeLayouts {
     fn array_length_field_offset(&self) -> u32 {
         ARRAY_LENGTH_OFFSET

--- a/crates/wasmtime/src/runtime/vm/gc/enabled/copying.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/enabled/copying.rs
@@ -22,7 +22,7 @@ use core::{
     alloc::Layout, any::Any, mem, num::NonZeroU32, ptr::NonNull, sync::atomic::AtomicUsize,
 };
 use wasmtime_environ::copying::{
-    ALIGN, ARRAY_LENGTH_OFFSET, CopyingTypeLayouts, HEADER_COPIED_BIT,
+    ALIGN, ARRAY_LENGTH_OFFSET, CopyingTypeLayouts, HEADER_COPIED_BIT, HEADER_SIZE, InlineTraceInfo,
 };
 use wasmtime_environ::{
     GcArrayLayout, GcStructLayout, GcTypeLayouts, POISON, VMGcKind, VMSharedTypeIndex, gc_assert,
@@ -82,6 +82,12 @@ impl VMCopyingHeader {
     fn set_copied(&mut self) {
         let reserved = self.header.reserved_u26();
         self.header.set_reserved_u26(reserved | HEADER_COPIED_BIT);
+    }
+
+    /// Decode the inline trace info from this header's reserved bits.
+    #[inline]
+    fn inline_trace_info(&self) -> InlineTraceInfo {
+        InlineTraceInfo::decode(self.header.reserved_u26())
     }
 }
 
@@ -586,22 +592,20 @@ survived collection, since the active space is the same size as the idle space",
         let index = gc_ref.heap_index()?.get();
         debug_assert!(self.is_in_active_space(index));
 
-        let ty = self.index(copying_ref(gc_ref))?.header.ty();
-
-        // `externref`s have no GC edges.
-        let Some(ty) = ty else {
-            return Ok(());
-        };
-
+        let inline_info = self.index(copying_ref(gc_ref))?.inline_trace_info();
         let object_start = usize::try_from(index)?;
-        match trace_infos.trace_info(&ty) {
-            TraceInfo::Struct { gc_ref_offsets } => {
-                for &offset in gc_ref_offsets {
-                    self.scan_field(object_start, offset)?;
+
+        match inline_info {
+            InlineTraceInfo::Struct { gc_ref_bitmap } => {
+                let mut remaining = gc_ref_bitmap;
+                while remaining != 0 {
+                    let slot = remaining.trailing_zeros();
+                    self.scan_field(object_start, HEADER_SIZE + slot * 4)?;
+                    remaining &= remaining - 1;
                 }
             }
-            TraceInfo::Array { gc_ref_elems } => {
-                if *gc_ref_elems {
+            InlineTraceInfo::Array { elems_are_gc_refs } => {
+                if elems_are_gc_refs {
                     let array_ref = gc_ref.as_arrayref_unchecked();
                     let len = self.array_len(array_ref)?;
 
@@ -614,6 +618,22 @@ survived collection, since the active space is the same size as the idle space",
                             None => bail_bug!("array element offset overflow"),
                         };
                         self.scan_field(object_start, elem_offset)?;
+                    }
+                }
+            }
+            InlineTraceInfo::OutOfLine => {
+                let ty = self.index(copying_ref(gc_ref))?.header.ty();
+                let Some(ty) = ty else {
+                    bail_bug!("out-of-line trace info but no type index");
+                };
+                match trace_infos.trace_info(&ty) {
+                    TraceInfo::Struct { gc_ref_offsets } => {
+                        for &offset in gc_ref_offsets {
+                            self.scan_field(object_start, offset)?;
+                        }
+                    }
+                    TraceInfo::Array { .. } => {
+                        bail_bug!("arrays should always have inline trace info");
                     }
                 }
             }
@@ -756,10 +776,9 @@ unsafe impl GcHeap for CopyingHeap {
         let align = usize::try_from(ALIGN).unwrap();
         let size = core::mem::size_of::<VMCopyingExternRef>();
         let size = (size + align - 1) & !(align - 1);
-        let gc_ref = match self.alloc_raw(
-            VMGcHeader::externref(),
-            Layout::from_size_align(size, align)?,
-        )? {
+        let mut header = VMGcHeader::externref();
+        header.set_reserved_u26(InlineTraceInfo::NO_GC_EDGES.encode());
+        let gc_ref = match self.alloc_raw(header, Layout::from_size_align(size, align)?)? {
             Err(n) => return Ok(Err(n)),
             Ok(gc_ref) => gc_ref,
         };
@@ -822,7 +841,7 @@ unsafe impl GcHeap for CopyingHeap {
             0,
             "bump_ptr is not aligned to ALIGN"
         );
-        debug_assert_eq!(header.reserved_u26(), 0);
+        debug_assert_eq!(header.reserved_u26() & HEADER_COPIED_BIT, 0);
 
         // We must have trace info for every GC type that we allocate in this
         // heap. Trace info is eagerly registered during module instantiation
@@ -885,11 +904,12 @@ unsafe impl GcHeap for CopyingHeap {
         } else {
             VMGcKind::StructRef
         };
-        let gc_ref =
-            match self.alloc_raw(VMGcHeader::from_kind_and_index(kind, ty), layout.layout())? {
-                Err(n) => return Ok(Err(n)),
-                Ok(gc_ref) => gc_ref,
-            };
+        let mut header = VMGcHeader::from_kind_and_index(kind, ty);
+        header.set_reserved_u26(InlineTraceInfo::r#struct(layout).encode());
+        let gc_ref = match self.alloc_raw(header, layout.layout())? {
+            Err(n) => return Ok(Err(n)),
+            Ok(gc_ref) => gc_ref,
+        };
 
         Ok(Ok(gc_ref))
     }
@@ -906,14 +926,13 @@ unsafe impl GcHeap for CopyingHeap {
         length: u32,
         layout: &GcArrayLayout,
     ) -> Result<Result<VMArrayRef, u64>> {
+        let mut header = VMGcHeader::from_kind_and_index(VMGcKind::ArrayRef, ty);
+        header.set_reserved_u26(InlineTraceInfo::array(layout).encode());
         let layout = layout
             .layout(length)
             .ok_or_else(|| crate::Trap::AllocationTooLarge)?;
 
-        let gc_ref = match self.alloc_raw(
-            VMGcHeader::from_kind_and_index(VMGcKind::ArrayRef, ty),
-            layout,
-        )? {
+        let gc_ref = match self.alloc_raw(header, layout)? {
             Err(n) => return Ok(Err(n)),
             Ok(gc_ref) => gc_ref,
         };

--- a/crates/wasmtime/src/runtime/vm/gc/enabled/trace_info.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/enabled/trace_info.rs
@@ -16,6 +16,10 @@ pub(super) enum TraceInfo {
     Array {
         /// Whether this array type's elements are GC references, and need
         /// tracing.
+        #[cfg_attr(
+            not(feature = "gc-drc"),
+            allow(dead_code, reason = "easier not to cfg on/off")
+        )]
         gc_ref_elems: bool,
     },
 

--- a/tests/disas/debug-exceptions.wat
+++ b/tests/disas/debug-exceptions.wat
@@ -30,109 +30,110 @@
 ;;       ldr     x0, [x0, #0x18]
 ;;       mov     x1, sp
 ;;       cmp     x1, x0
-;;       b.lo    #0x21c
+;;       b.lo    #0x224
 ;;   44: stur    x2, [sp]
 ;;       mov     x0, x2
 ;;       stur    x2, [sp, #0x10]
 ;;       nop
 ;;       ├─╼ debug frame state (after previous inst): func key DefinedWasmFunction(StaticModuleIndex(0), DefinedFuncIndex(0)), wasm PC 0x35, slot at FP-0xb0, locals , stack 
-;;       ╰─╼ breakpoint patch: wasm PC 0x35, patch bytes [69, 1, 0, 148]
+;;       ╰─╼ breakpoint patch: wasm PC 0x35, patch bytes [71, 1, 0, 148]
 ;;       ldur    x0, [sp, #0x10]
 ;;       nop
 ;;       ├─╼ debug frame state (after previous inst): func key DefinedWasmFunction(StaticModuleIndex(0), DefinedFuncIndex(0)), wasm PC 0x37, slot at FP-0xb0, locals , stack 
-;;       ╰─╼ breakpoint patch: wasm PC 0x37, patch bytes [67, 1, 0, 148]
+;;       ╰─╼ breakpoint patch: wasm PC 0x37, patch bytes [69, 1, 0, 148]
 ;;       ldur    x0, [sp, #0x10]
 ;;       nop
 ;;       ├─╼ debug frame state (after previous inst): func key DefinedWasmFunction(StaticModuleIndex(0), DefinedFuncIndex(0)), wasm PC 0x3d, slot at FP-0xb0, locals , stack 
-;;       ╰─╼ breakpoint patch: wasm PC 0x3d, patch bytes [65, 1, 0, 148]
+;;       ╰─╼ breakpoint patch: wasm PC 0x3d, patch bytes [67, 1, 0, 148]
 ;;       mov     w1, #0x2a
 ;;       stur    w1, [sp, #8]
 ;;       nop
 ;;       ├─╼ debug frame state (after previous inst): func key DefinedWasmFunction(StaticModuleIndex(0), DefinedFuncIndex(0)), wasm PC 0x3f, slot at FP-0xb0, locals , stack I32 @ slot+0x8
-;;       ╰─╼ breakpoint patch: wasm PC 0x3f, patch bytes [62, 1, 0, 148]
+;;       ╰─╼ breakpoint patch: wasm PC 0x3f, patch bytes [64, 1, 0, 148]
 ;;       nop
 ;;       ├─╼ debug frame state (after previous inst): func key DefinedWasmFunction(StaticModuleIndex(0), DefinedFuncIndex(0)), wasm PC 0x40, slot at FP-0xb0, locals , stack 
-;;       ╰─╼ breakpoint patch: wasm PC 0x40, patch bytes [61, 1, 0, 148]
+;;       ╰─╼ breakpoint patch: wasm PC 0x40, patch bytes [63, 1, 0, 148]
 ;;       stur    w1, [sp, #8]
 ;;       nop
 ;;       ├─╼ debug frame state (after previous inst): func key DefinedWasmFunction(StaticModuleIndex(0), DefinedFuncIndex(0)), wasm PC 0x42, slot at FP-0xb0, locals , stack I32 @ slot+0x8
-;;       ╰─╼ breakpoint patch: wasm PC 0x42, patch bytes [59, 1, 0, 148]
+;;       ╰─╼ breakpoint patch: wasm PC 0x42, patch bytes [61, 1, 0, 148]
 ;;       ldur    x2, [sp, #0x10]
-;;       bl      #0x4c4
+;;       bl      #0x4cc
 ;;   84: ldur    x0, [sp, #0x10]
 ;;       mov     x19, x2
-;;       ldr     x2, [x0, #0x20]
-;;       ldr     w3, [x2]
-;;       mov     w4, w3
-;;       add     x4, x4, #0x20
-;;       ldr     w5, [x2, #4]
-;;       cmp     x4, x5
-;;       b.hi    #0x1b4
-;;   a8: add     w5, w3, #0x20
-;;       str     w5, [x2]
-;;       mov     w7, #0x4000000
+;;       ldr     x4, [x0, #0x20]
+;;       ldr     w3, [x4]
+;;       mov     w5, w3
+;;       add     x5, x5, #0x20
+;;       ldr     w6, [x4, #4]
+;;       cmp     x5, x6
+;;       b.hi    #0x1b8
+;;   a8: add     w7, w3, #0x20
+;;       str     w7, [x4]
+;;       mov     w9, #2
+;;       movk    w9, #0x400, lsl #16
 ;;       ldur    x0, [sp, #0x10]
-;;       ldr     x6, [x0, #8]
-;;       ldr     x6, [x6, #0x20]
-;;       add     x0, x6, w3, uxtw
-;;       str     w7, [x6, w3, uxtw]
+;;       ldr     x8, [x0, #8]
+;;       ldr     x8, [x8, #0x20]
+;;       add     x0, x8, w3, uxtw
+;;       str     w9, [x8, w3, uxtw]
 ;;       ldur    x1, [sp, #0x10]
-;;       ldr     x7, [x1, #0x28]
-;;       ldr     w7, [x7, #8]
-;;       add     x8, x6, #4
-;;       str     w7, [x8, w3, uxtw]
-;;       mov     x8, #0x20
-;;       add     x9, x6, #8
-;;       str     w8, [x9, w3, uxtw]
-;;       mov     w10, #0x2a
-;;       str     w10, [x0, #0x18]
+;;       ldr     x9, [x1, #0x28]
+;;       ldr     w9, [x9, #8]
+;;       add     x10, x8, #4
+;;       str     w9, [x10, w3, uxtw]
+;;       mov     x10, #0x20
+;;       add     x11, x8, #8
+;;       str     w10, [x11, w3, uxtw]
+;;       mov     w12, #0x2a
+;;       str     w12, [x0, #0x18]
 ;;       mov     x2, x19
 ;;       str     w2, [x0, #0x10]
-;;       mov     w12, #0
-;;       str     w12, [x0, #0x14]
+;;       mov     w14, #0
+;;       str     w14, [x0, #0x14]
 ;;       ldur    x2, [sp, #0x10]
-;;       bl      #0x4fc
+;;       bl      #0x504
 ;;       ├─╼ exception frame offset: SP = FP - 0xb0
-;;       ╰─╼ exception handler: tag=0, context at [SP+0x10], handler=0x120
-;;  108: mov     w3, #9
+;;       ╰─╼ exception handler: tag=0, context at [SP+0x10], handler=0x124
+;;  10c: mov     w3, #9
 ;;       ldur    x2, [sp, #0x10]
-;;       bl      #0x458
-;;  114: ldur    x2, [sp, #0x10]
-;;       bl      #0x490
+;;       bl      #0x460
+;;  118: ldur    x2, [sp, #0x10]
+;;       bl      #0x498
 ;;       ╰─╼ debug frame state (after previous inst): func key DefinedWasmFunction(StaticModuleIndex(0), DefinedFuncIndex(0)), wasm PC 0x42, slot at FP-0xb0, locals , stack I32 @ slot+0x8
-;;  11c: .byte   0x1f, 0xc1, 0x00, 0x00
+;;  120: .byte   0x1f, 0xc1, 0x00, 0x00
 ;;       mov     w1, w0
 ;;       mov     x2, #0x20
 ;;       adds    x1, x1, x2
 ;;       cset    x2, hs
 ;;       tst     w2, #0xff
-;;       b.ne    #0x204
-;;  138: ldur    x10, [sp, #0x10]
-;;       ldr     x2, [x10, #8]
+;;       b.ne    #0x20c
+;;  13c: ldur    x14, [sp, #0x10]
+;;       ldr     x2, [x14, #8]
 ;;       ldr     x3, [x2, #0x28]
 ;;       cmp     x1, x3
-;;       b.hi    #0x1ec
-;;  14c: ldr     x1, [x2, #0x20]
+;;       b.hi    #0x1f4
+;;  150: ldr     x1, [x2, #0x20]
 ;;       add     x1, x1, #0x18
 ;;       ldr     w0, [x1, w0, uxtw]
 ;;       stur    w0, [sp, #8]
 ;;       ldur    x0, [sp, #0x10]
 ;;       nop
 ;;       ├─╼ debug frame state (after previous inst): func key DefinedWasmFunction(StaticModuleIndex(0), DefinedFuncIndex(0)), wasm PC 0x48, slot at FP-0xb0, locals , stack I32 @ slot+0x8
-;;       ╰─╼ breakpoint patch: wasm PC 0x48, patch bytes [1, 1, 0, 148]
+;;       ╰─╼ breakpoint patch: wasm PC 0x48, patch bytes [2, 1, 0, 148]
 ;;       ldur    x1, [sp, #0x10]
 ;;       ldr     x0, [x1, #0x38]
 ;;       ldr     x2, [x1, #0x48]
 ;;       ldur    x3, [sp, #0x10]
 ;;       blr     x0
 ;;       ╰─╼ debug frame state (after previous inst): func key DefinedWasmFunction(StaticModuleIndex(0), DefinedFuncIndex(0)), wasm PC 0x4a, slot at FP-0xb0, locals , stack I32 @ slot+0x8
-;;  178: ldur    x0, [sp, #0x10]
+;;  17c: ldur    x0, [sp, #0x10]
 ;;       nop
 ;;       ├─╼ debug frame state (after previous inst): func key DefinedWasmFunction(StaticModuleIndex(0), DefinedFuncIndex(0)), wasm PC 0x4a, slot at FP-0xb0, locals , stack I32 @ slot+0x8
-;;       ╰─╼ breakpoint patch: wasm PC 0x4a, patch bytes [250, 0, 0, 148]
+;;       ╰─╼ breakpoint patch: wasm PC 0x4a, patch bytes [251, 0, 0, 148]
 ;;       nop
 ;;       ├─╼ debug frame state (after previous inst): func key DefinedWasmFunction(StaticModuleIndex(0), DefinedFuncIndex(0)), wasm PC 0x4b, slot at FP-0xb0, locals , stack 
-;;       ╰─╼ breakpoint patch: wasm PC 0x4b, patch bytes [249, 0, 0, 148]
+;;       ╰─╼ breakpoint patch: wasm PC 0x4b, patch bytes [250, 0, 0, 148]
 ;;       add     sp, sp, #0x20
 ;;       ldp     d8, d9, [sp], #0x10
 ;;       ldp     d10, d11, [sp], #0x10
@@ -145,38 +146,39 @@
 ;;       ldp     x27, x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;  1b4: mov     w3, #0x4000000
-;;  1b8: ldur    x0, [sp, #0x10]
-;;  1bc: ldr     x4, [x0, #0x28]
-;;  1c0: ldr     w4, [x4, #8]
-;;  1c4: mov     w5, #0x20
-;;  1c8: mov     w6, #0x10
-;;  1cc: ldur    x2, [sp, #0x10]
-;;  1d0: bl      #0x3e8
-;;  1d4: ldur    x0, [sp, #0x10]
-;;  1d8: ldr     x4, [x0, #8]
-;;  1dc: ldr     x4, [x4, #0x20]
-;;  1e0: add     x0, x4, w2, uxtw
-;;  1e4: mov     x3, x2
-;;  1e8: b       #0xe8
-;;  1ec: mov     w3, #0xfe
-;;  1f0: ldur    x2, [sp, #0x10]
-;;  1f4: bl      #0x458
+;;  1b8: mov     w3, #2
+;;  1bc: movk    w3, #0x400, lsl #16
+;;  1c0: ldur    x0, [sp, #0x10]
+;;  1c4: ldr     x6, [x0, #0x28]
+;;  1c8: ldr     w4, [x6, #8]
+;;  1cc: mov     w5, #0x20
+;;  1d0: mov     w6, #0x10
+;;  1d4: ldur    x2, [sp, #0x10]
+;;  1d8: bl      #0x3f0
+;;  1dc: ldur    x0, [sp, #0x10]
+;;  1e0: ldr     x6, [x0, #8]
+;;  1e4: ldr     x6, [x6, #0x20]
+;;  1e8: add     x0, x6, w2, uxtw
+;;  1ec: mov     x3, x2
+;;  1f0: b       #0xec
+;;  1f4: mov     w3, #0xfe
 ;;  1f8: ldur    x2, [sp, #0x10]
-;;  1fc: bl      #0x490
+;;  1fc: bl      #0x460
+;;  200: ldur    x2, [sp, #0x10]
+;;  204: bl      #0x498
 ;;       ╰─╼ debug frame state (after previous inst): func key DefinedWasmFunction(StaticModuleIndex(0), DefinedFuncIndex(0)), wasm PC 0x37, slot at FP-0xb0, locals , stack 
-;;  200: .byte   0x1f, 0xc1, 0x00, 0x00
-;;  204: mov     w3, #0xfe
-;;  208: ldur    x2, [sp, #0x10]
-;;  20c: bl      #0x458
+;;  208: .byte   0x1f, 0xc1, 0x00, 0x00
+;;  20c: mov     w3, #0xfe
 ;;  210: ldur    x2, [sp, #0x10]
-;;  214: bl      #0x490
+;;  214: bl      #0x460
+;;  218: ldur    x2, [sp, #0x10]
+;;  21c: bl      #0x498
 ;;       ╰─╼ debug frame state (after previous inst): func key DefinedWasmFunction(StaticModuleIndex(0), DefinedFuncIndex(0)), wasm PC 0x37, slot at FP-0xb0, locals , stack 
-;;  218: .byte   0x1f, 0xc1, 0x00, 0x00
-;;  21c: stur    x2, [sp, #0x10]
-;;  220: mov     w3, #0
-;;  224: bl      #0x458
-;;  228: ldur    x2, [sp, #0x10]
-;;  22c: bl      #0x490
+;;  220: .byte   0x1f, 0xc1, 0x00, 0x00
+;;  224: stur    x2, [sp, #0x10]
+;;  228: mov     w3, #0
+;;  22c: bl      #0x460
+;;  230: ldur    x2, [sp, #0x10]
+;;  234: bl      #0x498
 ;;       ╰─╼ debug frame state (after previous inst): func key DefinedWasmFunction(StaticModuleIndex(0), DefinedFuncIndex(0)), wasm PC 0x34, slot at FP-0xb0, locals , stack 
-;;  230: .byte   0x1f, 0xc1, 0x00, 0x00
+;;  238: .byte   0x1f, 0xc1, 0x00, 0x00

--- a/tests/disas/exceptions.wat
+++ b/tests/disas/exceptions.wat
@@ -47,7 +47,7 @@
 ;;       movq    8(%rbx), %rax
 ;;       movq    0x20(%rax), %rdi
 ;;       leaq    (%rdi, %rcx), %rdx
-;;       movl    $0x4000000, (%rdi, %rcx)
+;;       movl    $0x4000002, (%rdi, %rcx)
 ;;       movq    0x28(%rbx), %rax
 ;;       movl    0xc(%rax), %eax
 ;;       movl    %eax, 4(%rdi, %rcx)
@@ -64,7 +64,7 @@
 ;;       movq    %rbx, (%rsp)
 ;;       callq   0x412
 ;;       ud2
-;;       movl    $0x4000000, %esi
+;;       movl    $0x4000002, %esi
 ;;       movq    0x28(%rbx), %rax
 ;;       movl    0xc(%rax), %edx
 ;;       movl    $0x30, %ecx

--- a/tests/disas/gc/array-new-data.wat
+++ b/tests/disas/gc/array-new-data.wat
@@ -125,11 +125,11 @@
 ;;                                     v139 = band v135, v138  ; v138 = -16
 ;;                                     v141 = iadd.i32 v24, v139
 ;; @0025                               store notrap aligned region0 v141, v23
-;;                                     v155 = iconst.i32 -1476395008
+;;                                     v155 = iconst.i32 -1476395002
 ;;                                     v156 = load.i64 notrap aligned readonly can_move v0+8
 ;;                                     v157 = load.i64 notrap aligned readonly can_move v156+32
 ;; @0025                               v48 = iadd v157, v31
-;; @0025                               store notrap aligned v155, v48  ; v155 = -1476395008
+;; @0025                               store notrap aligned v155, v48  ; v155 = -1476395002
 ;;                                     v158 = load.i64 notrap aligned readonly can_move v0+40
 ;;                                     v159 = load.i32 notrap aligned readonly can_move v158
 ;; @0025                               store notrap aligned v159, v48+4
@@ -138,11 +138,11 @@
 ;; @0025                               jump block4(v24, v48)
 ;;
 ;;                                 block3 cold:
-;; @0025                               v36 = iconst.i32 -1476395008
+;; @0025                               v36 = iconst.i32 -1476395002
 ;; @0025                               v38 = load.i64 notrap aligned readonly can_move v0+40
 ;; @0025                               v39 = load.i32 notrap aligned readonly can_move v38
 ;; @0025                               v40 = iconst.i32 16
-;; @0025                               v41 = call fn0(v0, v36, v39, v21, v40)  ; v36 = -1476395008, v40 = 16
+;; @0025                               v41 = call fn0(v0, v36, v39, v21, v40)  ; v36 = -1476395002, v40 = 16
 ;; @0025                               v120 = load.i64 notrap aligned readonly can_move v0+8
 ;; @0025                               v42 = load.i64 notrap aligned readonly can_move v120+32
 ;; @0025                               v43 = uextend.i64 v41

--- a/tests/disas/gc/array-new-default-anyref.wat
+++ b/tests/disas/gc/array-new-default-anyref.wat
@@ -57,11 +57,11 @@
 ;;                                     v123 = band v119, v122  ; v122 = -16
 ;;                                     v125 = iadd.i32 v12, v123
 ;; @001f                               store notrap aligned region0 v125, v11
-;;                                     v141 = iconst.i32 -1476395008
+;;                                     v141 = iconst.i32 -1476394994
 ;;                                     v142 = load.i64 notrap aligned readonly can_move v0+8
 ;;                                     v143 = load.i64 notrap aligned readonly can_move v142+32
 ;; @001f                               v36 = iadd v143, v19
-;; @001f                               store notrap aligned v141, v36  ; v141 = -1476395008
+;; @001f                               store notrap aligned v141, v36  ; v141 = -1476394994
 ;;                                     v144 = load.i64 notrap aligned readonly can_move v0+40
 ;;                                     v145 = load.i32 notrap aligned readonly can_move v144
 ;; @001f                               store notrap aligned v145, v36+4
@@ -70,11 +70,11 @@
 ;; @001f                               jump block4(v12, v36)
 ;;
 ;;                                 block3 cold:
-;; @001f                               v24 = iconst.i32 -1476395008
+;; @001f                               v24 = iconst.i32 -1476394994
 ;; @001f                               v26 = load.i64 notrap aligned readonly can_move v0+40
 ;; @001f                               v27 = load.i32 notrap aligned readonly can_move v26
 ;; @001f                               v28 = iconst.i32 16
-;; @001f                               v29 = call fn0(v0, v24, v27, v9, v28)  ; v24 = -1476395008, v28 = 16
+;; @001f                               v29 = call fn0(v0, v24, v27, v9, v28)  ; v24 = -1476394994, v28 = 16
 ;; @001f                               v96 = load.i64 notrap aligned readonly can_move v0+8
 ;; @001f                               v30 = load.i64 notrap aligned readonly can_move v96+32
 ;; @001f                               v31 = uextend.i64 v29

--- a/tests/disas/gc/array-new-default-exnref.wat
+++ b/tests/disas/gc/array-new-default-exnref.wat
@@ -57,11 +57,11 @@
 ;;                                     v123 = band v119, v122  ; v122 = -16
 ;;                                     v125 = iadd.i32 v12, v123
 ;; @001f                               store notrap aligned region0 v125, v11
-;;                                     v141 = iconst.i32 -1476395008
+;;                                     v141 = iconst.i32 -1476394994
 ;;                                     v142 = load.i64 notrap aligned readonly can_move v0+8
 ;;                                     v143 = load.i64 notrap aligned readonly can_move v142+32
 ;; @001f                               v36 = iadd v143, v19
-;; @001f                               store notrap aligned v141, v36  ; v141 = -1476395008
+;; @001f                               store notrap aligned v141, v36  ; v141 = -1476394994
 ;;                                     v144 = load.i64 notrap aligned readonly can_move v0+40
 ;;                                     v145 = load.i32 notrap aligned readonly can_move v144
 ;; @001f                               store notrap aligned v145, v36+4
@@ -70,11 +70,11 @@
 ;; @001f                               jump block4(v12, v36)
 ;;
 ;;                                 block3 cold:
-;; @001f                               v24 = iconst.i32 -1476395008
+;; @001f                               v24 = iconst.i32 -1476394994
 ;; @001f                               v26 = load.i64 notrap aligned readonly can_move v0+40
 ;; @001f                               v27 = load.i32 notrap aligned readonly can_move v26
 ;; @001f                               v28 = iconst.i32 16
-;; @001f                               v29 = call fn0(v0, v24, v27, v9, v28)  ; v24 = -1476395008, v28 = 16
+;; @001f                               v29 = call fn0(v0, v24, v27, v9, v28)  ; v24 = -1476394994, v28 = 16
 ;; @001f                               v96 = load.i64 notrap aligned readonly can_move v0+8
 ;; @001f                               v30 = load.i64 notrap aligned readonly can_move v96+32
 ;; @001f                               v31 = uextend.i64 v29

--- a/tests/disas/gc/array-new-default-externref.wat
+++ b/tests/disas/gc/array-new-default-externref.wat
@@ -57,11 +57,11 @@
 ;;                                     v123 = band v119, v122  ; v122 = -16
 ;;                                     v125 = iadd.i32 v12, v123
 ;; @001f                               store notrap aligned region0 v125, v11
-;;                                     v141 = iconst.i32 -1476395008
+;;                                     v141 = iconst.i32 -1476394994
 ;;                                     v142 = load.i64 notrap aligned readonly can_move v0+8
 ;;                                     v143 = load.i64 notrap aligned readonly can_move v142+32
 ;; @001f                               v36 = iadd v143, v19
-;; @001f                               store notrap aligned v141, v36  ; v141 = -1476395008
+;; @001f                               store notrap aligned v141, v36  ; v141 = -1476394994
 ;;                                     v144 = load.i64 notrap aligned readonly can_move v0+40
 ;;                                     v145 = load.i32 notrap aligned readonly can_move v144
 ;; @001f                               store notrap aligned v145, v36+4
@@ -70,11 +70,11 @@
 ;; @001f                               jump block4(v12, v36)
 ;;
 ;;                                 block3 cold:
-;; @001f                               v24 = iconst.i32 -1476395008
+;; @001f                               v24 = iconst.i32 -1476394994
 ;; @001f                               v26 = load.i64 notrap aligned readonly can_move v0+40
 ;; @001f                               v27 = load.i32 notrap aligned readonly can_move v26
 ;; @001f                               v28 = iconst.i32 16
-;; @001f                               v29 = call fn0(v0, v24, v27, v9, v28)  ; v24 = -1476395008, v28 = 16
+;; @001f                               v29 = call fn0(v0, v24, v27, v9, v28)  ; v24 = -1476394994, v28 = 16
 ;; @001f                               v96 = load.i64 notrap aligned readonly can_move v0+8
 ;; @001f                               v30 = load.i64 notrap aligned readonly can_move v96+32
 ;; @001f                               v31 = uextend.i64 v29

--- a/tests/disas/gc/array-new-default-f32.wat
+++ b/tests/disas/gc/array-new-default-f32.wat
@@ -57,11 +57,11 @@
 ;;                                     v123 = band v119, v122  ; v122 = -16
 ;;                                     v125 = iadd.i32 v12, v123
 ;; @001f                               store notrap aligned region0 v125, v11
-;;                                     v141 = iconst.i32 -1476395008
+;;                                     v141 = iconst.i32 -1476395002
 ;;                                     v142 = load.i64 notrap aligned readonly can_move v0+8
 ;;                                     v143 = load.i64 notrap aligned readonly can_move v142+32
 ;; @001f                               v36 = iadd v143, v19
-;; @001f                               store notrap aligned v141, v36  ; v141 = -1476395008
+;; @001f                               store notrap aligned v141, v36  ; v141 = -1476395002
 ;;                                     v144 = load.i64 notrap aligned readonly can_move v0+40
 ;;                                     v145 = load.i32 notrap aligned readonly can_move v144
 ;; @001f                               store notrap aligned v145, v36+4
@@ -70,11 +70,11 @@
 ;; @001f                               jump block4(v12, v36)
 ;;
 ;;                                 block3 cold:
-;; @001f                               v24 = iconst.i32 -1476395008
+;; @001f                               v24 = iconst.i32 -1476395002
 ;; @001f                               v26 = load.i64 notrap aligned readonly can_move v0+40
 ;; @001f                               v27 = load.i32 notrap aligned readonly can_move v26
 ;; @001f                               v28 = iconst.i32 16
-;; @001f                               v29 = call fn0(v0, v24, v27, v9, v28)  ; v24 = -1476395008, v28 = 16
+;; @001f                               v29 = call fn0(v0, v24, v27, v9, v28)  ; v24 = -1476395002, v28 = 16
 ;; @001f                               v96 = load.i64 notrap aligned readonly can_move v0+8
 ;; @001f                               v30 = load.i64 notrap aligned readonly can_move v96+32
 ;; @001f                               v31 = uextend.i64 v29

--- a/tests/disas/gc/array-new-default-f64.wat
+++ b/tests/disas/gc/array-new-default-f64.wat
@@ -57,11 +57,11 @@
 ;;                                     v123 = band v119, v122  ; v122 = -16
 ;;                                     v125 = iadd.i32 v12, v123
 ;; @001f                               store notrap aligned region0 v125, v11
-;;                                     v141 = iconst.i32 -1476395008
+;;                                     v141 = iconst.i32 -1476395002
 ;;                                     v142 = load.i64 notrap aligned readonly can_move v0+8
 ;;                                     v143 = load.i64 notrap aligned readonly can_move v142+32
 ;; @001f                               v36 = iadd v143, v19
-;; @001f                               store notrap aligned v141, v36  ; v141 = -1476395008
+;; @001f                               store notrap aligned v141, v36  ; v141 = -1476395002
 ;;                                     v144 = load.i64 notrap aligned readonly can_move v0+40
 ;;                                     v145 = load.i32 notrap aligned readonly can_move v144
 ;; @001f                               store notrap aligned v145, v36+4
@@ -70,11 +70,11 @@
 ;; @001f                               jump block4(v12, v36)
 ;;
 ;;                                 block3 cold:
-;; @001f                               v24 = iconst.i32 -1476395008
+;; @001f                               v24 = iconst.i32 -1476395002
 ;; @001f                               v26 = load.i64 notrap aligned readonly can_move v0+40
 ;; @001f                               v27 = load.i32 notrap aligned readonly can_move v26
 ;; @001f                               v28 = iconst.i32 16
-;; @001f                               v29 = call fn0(v0, v24, v27, v9, v28)  ; v24 = -1476395008, v28 = 16
+;; @001f                               v29 = call fn0(v0, v24, v27, v9, v28)  ; v24 = -1476395002, v28 = 16
 ;; @001f                               v96 = load.i64 notrap aligned readonly can_move v0+8
 ;; @001f                               v30 = load.i64 notrap aligned readonly can_move v96+32
 ;; @001f                               v31 = uextend.i64 v29

--- a/tests/disas/gc/array-new-default-funcref.wat
+++ b/tests/disas/gc/array-new-default-funcref.wat
@@ -57,11 +57,11 @@
 ;;                                     v123 = band v119, v122  ; v122 = -16
 ;;                                     v125 = iadd.i32 v12, v123
 ;; @001f                               store notrap aligned region0 v125, v11
-;;                                     v140 = iconst.i32 -1476395008
+;;                                     v140 = iconst.i32 -1476395002
 ;;                                     v141 = load.i64 notrap aligned readonly can_move v0+8
 ;;                                     v142 = load.i64 notrap aligned readonly can_move v141+32
 ;; @001f                               v36 = iadd v142, v19
-;; @001f                               store notrap aligned v140, v36  ; v140 = -1476395008
+;; @001f                               store notrap aligned v140, v36  ; v140 = -1476395002
 ;;                                     v143 = load.i64 notrap aligned readonly can_move v0+40
 ;;                                     v144 = load.i32 notrap aligned readonly can_move v143
 ;; @001f                               store notrap aligned v144, v36+4
@@ -70,11 +70,11 @@
 ;; @001f                               jump block4(v12, v36)
 ;;
 ;;                                 block3 cold:
-;; @001f                               v24 = iconst.i32 -1476395008
+;; @001f                               v24 = iconst.i32 -1476395002
 ;; @001f                               v26 = load.i64 notrap aligned readonly can_move v0+40
 ;; @001f                               v27 = load.i32 notrap aligned readonly can_move v26
 ;; @001f                               v28 = iconst.i32 16
-;; @001f                               v29 = call fn0(v0, v24, v27, v9, v28)  ; v24 = -1476395008, v28 = 16
+;; @001f                               v29 = call fn0(v0, v24, v27, v9, v28)  ; v24 = -1476395002, v28 = 16
 ;; @001f                               v96 = load.i64 notrap aligned readonly can_move v0+8
 ;; @001f                               v30 = load.i64 notrap aligned readonly can_move v96+32
 ;; @001f                               v31 = uextend.i64 v29

--- a/tests/disas/gc/array-new-default-i16.wat
+++ b/tests/disas/gc/array-new-default-i16.wat
@@ -56,11 +56,11 @@
 ;;                                     v128 = band v124, v127  ; v127 = -16
 ;;                                     v130 = iadd.i32 v12, v128
 ;; @001f                               store notrap aligned region0 v130, v11
-;;                                     v151 = iconst.i32 -1476395008
+;;                                     v151 = iconst.i32 -1476395002
 ;;                                     v152 = load.i64 notrap aligned readonly can_move v0+8
 ;;                                     v153 = load.i64 notrap aligned readonly can_move v152+32
 ;; @001f                               v36 = iadd v153, v19
-;; @001f                               store notrap aligned v151, v36  ; v151 = -1476395008
+;; @001f                               store notrap aligned v151, v36  ; v151 = -1476395002
 ;;                                     v154 = load.i64 notrap aligned readonly can_move v0+40
 ;;                                     v155 = load.i32 notrap aligned readonly can_move v154
 ;; @001f                               store notrap aligned v155, v36+4
@@ -69,11 +69,11 @@
 ;; @001f                               jump block4(v12, v36)
 ;;
 ;;                                 block3 cold:
-;; @001f                               v24 = iconst.i32 -1476395008
+;; @001f                               v24 = iconst.i32 -1476395002
 ;; @001f                               v26 = load.i64 notrap aligned readonly can_move v0+40
 ;; @001f                               v27 = load.i32 notrap aligned readonly can_move v26
 ;; @001f                               v28 = iconst.i32 16
-;; @001f                               v29 = call fn0(v0, v24, v27, v9, v28)  ; v24 = -1476395008, v28 = 16
+;; @001f                               v29 = call fn0(v0, v24, v27, v9, v28)  ; v24 = -1476395002, v28 = 16
 ;; @001f                               v96 = load.i64 notrap aligned readonly can_move v0+8
 ;; @001f                               v30 = load.i64 notrap aligned readonly can_move v96+32
 ;; @001f                               v31 = uextend.i64 v29

--- a/tests/disas/gc/array-new-default-i32.wat
+++ b/tests/disas/gc/array-new-default-i32.wat
@@ -57,11 +57,11 @@
 ;;                                     v123 = band v119, v122  ; v122 = -16
 ;;                                     v125 = iadd.i32 v12, v123
 ;; @001f                               store notrap aligned region0 v125, v11
-;;                                     v141 = iconst.i32 -1476395008
+;;                                     v141 = iconst.i32 -1476395002
 ;;                                     v142 = load.i64 notrap aligned readonly can_move v0+8
 ;;                                     v143 = load.i64 notrap aligned readonly can_move v142+32
 ;; @001f                               v36 = iadd v143, v19
-;; @001f                               store notrap aligned v141, v36  ; v141 = -1476395008
+;; @001f                               store notrap aligned v141, v36  ; v141 = -1476395002
 ;;                                     v144 = load.i64 notrap aligned readonly can_move v0+40
 ;;                                     v145 = load.i32 notrap aligned readonly can_move v144
 ;; @001f                               store notrap aligned v145, v36+4
@@ -70,11 +70,11 @@
 ;; @001f                               jump block4(v12, v36)
 ;;
 ;;                                 block3 cold:
-;; @001f                               v24 = iconst.i32 -1476395008
+;; @001f                               v24 = iconst.i32 -1476395002
 ;; @001f                               v26 = load.i64 notrap aligned readonly can_move v0+40
 ;; @001f                               v27 = load.i32 notrap aligned readonly can_move v26
 ;; @001f                               v28 = iconst.i32 16
-;; @001f                               v29 = call fn0(v0, v24, v27, v9, v28)  ; v24 = -1476395008, v28 = 16
+;; @001f                               v29 = call fn0(v0, v24, v27, v9, v28)  ; v24 = -1476395002, v28 = 16
 ;; @001f                               v96 = load.i64 notrap aligned readonly can_move v0+8
 ;; @001f                               v30 = load.i64 notrap aligned readonly can_move v96+32
 ;; @001f                               v31 = uextend.i64 v29

--- a/tests/disas/gc/array-new-default-i64.wat
+++ b/tests/disas/gc/array-new-default-i64.wat
@@ -57,11 +57,11 @@
 ;;                                     v123 = band v119, v122  ; v122 = -16
 ;;                                     v125 = iadd.i32 v12, v123
 ;; @001f                               store notrap aligned region0 v125, v11
-;;                                     v140 = iconst.i32 -1476395008
+;;                                     v140 = iconst.i32 -1476395002
 ;;                                     v141 = load.i64 notrap aligned readonly can_move v0+8
 ;;                                     v142 = load.i64 notrap aligned readonly can_move v141+32
 ;; @001f                               v36 = iadd v142, v19
-;; @001f                               store notrap aligned v140, v36  ; v140 = -1476395008
+;; @001f                               store notrap aligned v140, v36  ; v140 = -1476395002
 ;;                                     v143 = load.i64 notrap aligned readonly can_move v0+40
 ;;                                     v144 = load.i32 notrap aligned readonly can_move v143
 ;; @001f                               store notrap aligned v144, v36+4
@@ -70,11 +70,11 @@
 ;; @001f                               jump block4(v12, v36)
 ;;
 ;;                                 block3 cold:
-;; @001f                               v24 = iconst.i32 -1476395008
+;; @001f                               v24 = iconst.i32 -1476395002
 ;; @001f                               v26 = load.i64 notrap aligned readonly can_move v0+40
 ;; @001f                               v27 = load.i32 notrap aligned readonly can_move v26
 ;; @001f                               v28 = iconst.i32 16
-;; @001f                               v29 = call fn0(v0, v24, v27, v9, v28)  ; v24 = -1476395008, v28 = 16
+;; @001f                               v29 = call fn0(v0, v24, v27, v9, v28)  ; v24 = -1476395002, v28 = 16
 ;; @001f                               v96 = load.i64 notrap aligned readonly can_move v0+8
 ;; @001f                               v30 = load.i64 notrap aligned readonly can_move v96+32
 ;; @001f                               v31 = uextend.i64 v29

--- a/tests/disas/gc/array-new-default-i8.wat
+++ b/tests/disas/gc/array-new-default-i8.wat
@@ -53,11 +53,11 @@
 ;;                                     v113 = band v109, v112  ; v112 = -16
 ;;                                     v115 = iadd.i32 v12, v113
 ;; @001f                               store notrap aligned region0 v115, v11
-;;                                     v129 = iconst.i32 -1476395008
+;;                                     v129 = iconst.i32 -1476395002
 ;;                                     v130 = load.i64 notrap aligned readonly can_move v0+8
 ;;                                     v131 = load.i64 notrap aligned readonly can_move v130+32
 ;; @001f                               v36 = iadd v131, v19
-;; @001f                               store notrap aligned v129, v36  ; v129 = -1476395008
+;; @001f                               store notrap aligned v129, v36  ; v129 = -1476395002
 ;;                                     v132 = load.i64 notrap aligned readonly can_move v0+40
 ;;                                     v133 = load.i32 notrap aligned readonly can_move v132
 ;; @001f                               store notrap aligned v133, v36+4
@@ -66,11 +66,11 @@
 ;; @001f                               jump block4(v12, v36)
 ;;
 ;;                                 block3 cold:
-;; @001f                               v24 = iconst.i32 -1476395008
+;; @001f                               v24 = iconst.i32 -1476395002
 ;; @001f                               v26 = load.i64 notrap aligned readonly can_move v0+40
 ;; @001f                               v27 = load.i32 notrap aligned readonly can_move v26
 ;; @001f                               v28 = iconst.i32 16
-;; @001f                               v29 = call fn0(v0, v24, v27, v9, v28)  ; v24 = -1476395008, v28 = 16
+;; @001f                               v29 = call fn0(v0, v24, v27, v9, v28)  ; v24 = -1476395002, v28 = 16
 ;; @001f                               v95 = load.i64 notrap aligned readonly can_move v0+8
 ;; @001f                               v30 = load.i64 notrap aligned readonly can_move v95+32
 ;; @001f                               v31 = uextend.i64 v29

--- a/tests/disas/gc/copying/array-new-fixed-of-gc-refs.wat
+++ b/tests/disas/gc/copying/array-new-fixed-of-gc-refs.wat
@@ -45,11 +45,11 @@
 ;;                                     v272 = iconst.i32 32
 ;;                                     v178 = iadd.i32 v15, v272  ; v272 = 32
 ;; @0025                               store notrap aligned region0 v178, v14
-;;                                     v273 = iconst.i32 -1476395008
+;;                                     v273 = iconst.i32 -1476394994
 ;;                                     v274 = load.i64 notrap aligned readonly can_move v0+8
 ;;                                     v275 = load.i64 notrap aligned readonly can_move v274+32
 ;; @0025                               v39 = iadd v275, v22
-;; @0025                               store notrap aligned v273, v39  ; v273 = -1476395008
+;; @0025                               store notrap aligned v273, v39  ; v273 = -1476394994
 ;;                                     v276 = load.i64 notrap aligned readonly can_move v0+40
 ;;                                     v277 = load.i32 notrap aligned readonly can_move v276
 ;; @0025                               store notrap aligned v277, v39+4
@@ -58,12 +58,12 @@
 ;; @0025                               jump block4(v15, v39)
 ;;
 ;;                                 block3 cold:
-;; @0025                               v27 = iconst.i32 -1476395008
+;; @0025                               v27 = iconst.i32 -1476394994
 ;; @0025                               v29 = load.i64 notrap aligned readonly can_move v0+40
 ;; @0025                               v30 = load.i32 notrap aligned readonly can_move v29
 ;;                                     v164 = iconst.i32 32
 ;; @0025                               v31 = iconst.i32 16
-;; @0025                               v32 = call fn0(v0, v27, v30, v164, v31), stack_map=[i32 @ ss2+0, i32 @ ss1+0, i32 @ ss0+0]  ; v27 = -1476395008, v164 = 32, v31 = 16
+;; @0025                               v32 = call fn0(v0, v27, v30, v164, v31), stack_map=[i32 @ ss2+0, i32 @ ss1+0, i32 @ ss0+0]  ; v27 = -1476394994, v164 = 32, v31 = 16
 ;; @0025                               v144 = load.i64 notrap aligned readonly can_move v0+8
 ;; @0025                               v33 = load.i64 notrap aligned readonly can_move v144+32
 ;; @0025                               v34 = uextend.i64 v32

--- a/tests/disas/gc/copying/array-new-fixed.wat
+++ b/tests/disas/gc/copying/array-new-fixed.wat
@@ -36,11 +36,11 @@
 ;;                                     v260 = iconst.i32 48
 ;;                                     v168 = iadd.i32 v15, v260  ; v260 = 48
 ;; @0025                               store notrap aligned region0 v168, v14
-;;                                     v261 = iconst.i32 -1476395008
+;;                                     v261 = iconst.i32 -1476395002
 ;;                                     v262 = load.i64 notrap aligned readonly can_move v0+8
 ;;                                     v263 = load.i64 notrap aligned readonly can_move v262+32
 ;; @0025                               v39 = iadd v263, v22
-;; @0025                               store notrap aligned v261, v39  ; v261 = -1476395008
+;; @0025                               store notrap aligned v261, v39  ; v261 = -1476395002
 ;;                                     v264 = load.i64 notrap aligned readonly can_move v0+40
 ;;                                     v265 = load.i32 notrap aligned readonly can_move v264
 ;; @0025                               store notrap aligned v265, v39+4
@@ -49,12 +49,12 @@
 ;; @0025                               jump block4(v15, v39)
 ;;
 ;;                                 block3 cold:
-;; @0025                               v27 = iconst.i32 -1476395008
+;; @0025                               v27 = iconst.i32 -1476395002
 ;; @0025                               v29 = load.i64 notrap aligned readonly can_move v0+40
 ;; @0025                               v30 = load.i32 notrap aligned readonly can_move v29
 ;;                                     v153 = iconst.i32 48
 ;; @0025                               v31 = iconst.i32 16
-;; @0025                               v32 = call fn0(v0, v27, v30, v153, v31)  ; v27 = -1476395008, v153 = 48, v31 = 16
+;; @0025                               v32 = call fn0(v0, v27, v30, v153, v31)  ; v27 = -1476395002, v153 = 48, v31 = 16
 ;; @0025                               v138 = load.i64 notrap aligned readonly can_move v0+8
 ;; @0025                               v33 = load.i64 notrap aligned readonly can_move v138+32
 ;; @0025                               v34 = uextend.i64 v32

--- a/tests/disas/gc/copying/array-new.wat
+++ b/tests/disas/gc/copying/array-new.wat
@@ -53,11 +53,11 @@
 ;;                                     v119 = band v115, v118  ; v118 = -16
 ;;                                     v121 = iadd.i32 v13, v119
 ;; @0022                               store notrap aligned region0 v121, v12
-;;                                     v137 = iconst.i32 -1476395008
+;;                                     v137 = iconst.i32 -1476395002
 ;;                                     v138 = load.i64 notrap aligned readonly can_move v0+8
 ;;                                     v139 = load.i64 notrap aligned readonly can_move v138+32
 ;; @0022                               v37 = iadd v139, v20
-;; @0022                               store notrap aligned v137, v37  ; v137 = -1476395008
+;; @0022                               store notrap aligned v137, v37  ; v137 = -1476395002
 ;;                                     v140 = load.i64 notrap aligned readonly can_move v0+40
 ;;                                     v141 = load.i32 notrap aligned readonly can_move v140
 ;; @0022                               store notrap aligned v141, v37+4
@@ -66,11 +66,11 @@
 ;; @0022                               jump block4(v13, v37)
 ;;
 ;;                                 block3 cold:
-;; @0022                               v25 = iconst.i32 -1476395008
+;; @0022                               v25 = iconst.i32 -1476395002
 ;; @0022                               v27 = load.i64 notrap aligned readonly can_move v0+40
 ;; @0022                               v28 = load.i32 notrap aligned readonly can_move v27
 ;; @0022                               v29 = iconst.i32 16
-;; @0022                               v30 = call fn0(v0, v25, v28, v10, v29)  ; v25 = -1476395008, v29 = 16
+;; @0022                               v30 = call fn0(v0, v25, v28, v10, v29)  ; v25 = -1476395002, v29 = 16
 ;; @0022                               v92 = load.i64 notrap aligned readonly can_move v0+8
 ;; @0022                               v31 = load.i64 notrap aligned readonly can_move v92+32
 ;; @0022                               v32 = uextend.i64 v30

--- a/tests/disas/gc/copying/funcref-in-gc-heap-new.wat
+++ b/tests/disas/gc/copying/funcref-in-gc-heap-new.wat
@@ -38,11 +38,11 @@
 ;;                                     v66 = iconst.i32 32
 ;;                                     v64 = iadd.i32 v7, v66  ; v66 = 32
 ;; @0020                               store notrap aligned region0 v64, v6
-;;                                     v67 = iconst.i32 -1342177280
+;;                                     v67 = iconst.i32 -1342177278
 ;;                                     v68 = load.i64 notrap aligned readonly can_move v0+8
 ;;                                     v69 = load.i64 notrap aligned readonly can_move v68+32
 ;; @0020                               v31 = iadd v69, v14
-;; @0020                               store notrap aligned v67, v31  ; v67 = -1342177280
+;; @0020                               store notrap aligned v67, v31  ; v67 = -1342177278
 ;;                                     v70 = load.i64 notrap aligned readonly can_move v0+40
 ;;                                     v71 = load.i32 notrap aligned readonly can_move v70
 ;; @0020                               store notrap aligned v71, v31+4
@@ -51,12 +51,12 @@
 ;; @0020                               jump block4(v7, v31)
 ;;
 ;;                                 block3 cold:
-;; @0020                               v19 = iconst.i32 -1342177280
+;; @0020                               v19 = iconst.i32 -1342177278
 ;; @0020                               v21 = load.i64 notrap aligned readonly can_move v0+40
 ;; @0020                               v22 = load.i32 notrap aligned readonly can_move v21
 ;; @0020                               v4 = iconst.i32 32
 ;; @0020                               v23 = iconst.i32 16
-;; @0020                               v24 = call fn0(v0, v19, v22, v4, v23)  ; v19 = -1342177280, v4 = 32, v23 = 16
+;; @0020                               v24 = call fn0(v0, v19, v22, v4, v23)  ; v19 = -1342177278, v4 = 32, v23 = 16
 ;; @0020                               v46 = load.i64 notrap aligned readonly can_move v0+8
 ;; @0020                               v25 = load.i64 notrap aligned readonly can_move v46+32
 ;; @0020                               v26 = uextend.i64 v24

--- a/tests/disas/gc/copying/struct-new-default.wat
+++ b/tests/disas/gc/copying/struct-new-default.wat
@@ -37,11 +37,11 @@
 ;;                                     v66 = iconst.i32 32
 ;;                                     v64 = iadd.i32 v9, v66  ; v66 = 32
 ;; @0021                               store notrap aligned region0 v64, v8
-;;                                     v67 = iconst.i32 -1342177280
+;;                                     v67 = iconst.i32 -1342177246
 ;;                                     v68 = load.i64 notrap aligned readonly can_move v0+8
 ;;                                     v69 = load.i64 notrap aligned readonly can_move v68+32
 ;; @0021                               v33 = iadd v69, v16
-;; @0021                               store notrap aligned v67, v33  ; v67 = -1342177280
+;; @0021                               store notrap aligned v67, v33  ; v67 = -1342177246
 ;;                                     v70 = load.i64 notrap aligned readonly can_move v0+40
 ;;                                     v71 = load.i32 notrap aligned readonly can_move v70
 ;; @0021                               store notrap aligned v71, v33+4
@@ -50,12 +50,12 @@
 ;; @0021                               jump block4(v9, v33)
 ;;
 ;;                                 block3 cold:
-;; @0021                               v21 = iconst.i32 -1342177280
+;; @0021                               v21 = iconst.i32 -1342177246
 ;; @0021                               v23 = load.i64 notrap aligned readonly can_move v0+40
 ;; @0021                               v24 = load.i32 notrap aligned readonly can_move v23
 ;; @0021                               v6 = iconst.i32 32
 ;; @0021                               v25 = iconst.i32 16
-;; @0021                               v26 = call fn0(v0, v21, v24, v6, v25)  ; v21 = -1342177280, v6 = 32, v25 = 16
+;; @0021                               v26 = call fn0(v0, v21, v24, v6, v25)  ; v21 = -1342177246, v6 = 32, v25 = 16
 ;; @0021                               v46 = load.i64 notrap aligned readonly can_move v0+8
 ;; @0021                               v27 = load.i64 notrap aligned readonly can_move v46+32
 ;; @0021                               v28 = uextend.i64 v26

--- a/tests/disas/gc/copying/struct-new.wat
+++ b/tests/disas/gc/copying/struct-new.wat
@@ -40,11 +40,11 @@
 ;;                                     v69 = iconst.i32 32
 ;;                                     v67 = iadd.i32 v9, v69  ; v69 = 32
 ;; @002a                               store notrap aligned region0 v67, v8
-;;                                     v70 = iconst.i32 -1342177280
+;;                                     v70 = iconst.i32 -1342177246
 ;;                                     v71 = load.i64 notrap aligned readonly can_move v0+8
 ;;                                     v72 = load.i64 notrap aligned readonly can_move v71+32
 ;; @002a                               v33 = iadd v72, v16
-;; @002a                               store notrap aligned v70, v33  ; v70 = -1342177280
+;; @002a                               store notrap aligned v70, v33  ; v70 = -1342177246
 ;;                                     v73 = load.i64 notrap aligned readonly can_move v0+40
 ;;                                     v74 = load.i32 notrap aligned readonly can_move v73
 ;; @002a                               store notrap aligned v74, v33+4
@@ -53,12 +53,12 @@
 ;; @002a                               jump block4(v9, v33)
 ;;
 ;;                                 block3 cold:
-;; @002a                               v21 = iconst.i32 -1342177280
+;; @002a                               v21 = iconst.i32 -1342177246
 ;; @002a                               v23 = load.i64 notrap aligned readonly can_move v0+40
 ;; @002a                               v24 = load.i32 notrap aligned readonly can_move v23
 ;; @002a                               v6 = iconst.i32 32
 ;; @002a                               v25 = iconst.i32 16
-;; @002a                               v26 = call fn0(v0, v21, v24, v6, v25), stack_map=[i32 @ ss0+0]  ; v21 = -1342177280, v6 = 32, v25 = 16
+;; @002a                               v26 = call fn0(v0, v21, v24, v6, v25), stack_map=[i32 @ ss0+0]  ; v21 = -1342177246, v6 = 32, v25 = 16
 ;; @002a                               v48 = load.i64 notrap aligned readonly can_move v0+8
 ;; @002a                               v27 = load.i64 notrap aligned readonly can_move v48+32
 ;; @002a                               v28 = uextend.i64 v26

--- a/tests/disas/gc/issue-11753.wat
+++ b/tests/disas/gc/issue-11753.wat
@@ -50,7 +50,7 @@
 ;;       movq    8(%r9), %rsi
 ;;       movq    0x20(%rsi), %rdi
 ;;       leaq    (%rdi, %rcx), %rsi
-;;       movl    $0xb0000000, (%rdi, %rcx)
+;;       movl    $0xb0000002, (%rdi, %rcx)
 ;;       movq    0x28(%r9), %r8
 ;;       movl    (%r8), %r8d
 ;;       movl    %r8d, 4(%rdi, %rcx)
@@ -85,7 +85,7 @@
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   e6: movl    $0xb0000000, %esi
+;;   e6: movl    $0xb0000002, %esi
 ;;   eb: movq    0x28(%rdi), %rax
 ;;   ef: movq    %rdi, 8(%rsp)
 ;;   f4: movl    (%rax), %edx

--- a/tests/disas/gc/struct-new-default.wat
+++ b/tests/disas/gc/struct-new-default.wat
@@ -40,11 +40,11 @@
 ;;                                     v69 = iconst.i32 48
 ;;                                     v67 = iadd.i32 v10, v69  ; v69 = 48
 ;; @0023                               store notrap aligned region0 v67, v9
-;;                                     v70 = iconst.i32 -1342177280
+;;                                     v70 = iconst.i32 -1342177246
 ;;                                     v71 = load.i64 notrap aligned readonly can_move v0+8
 ;;                                     v72 = load.i64 notrap aligned readonly can_move v71+32
 ;; @0023                               v34 = iadd v72, v17
-;; @0023                               store notrap aligned v70, v34  ; v70 = -1342177280
+;; @0023                               store notrap aligned v70, v34  ; v70 = -1342177246
 ;;                                     v73 = load.i64 notrap aligned readonly can_move v0+40
 ;;                                     v74 = load.i32 notrap aligned readonly can_move v73
 ;; @0023                               store notrap aligned v74, v34+4
@@ -53,12 +53,12 @@
 ;; @0023                               jump block4(v10, v34)
 ;;
 ;;                                 block3 cold:
-;; @0023                               v22 = iconst.i32 -1342177280
+;; @0023                               v22 = iconst.i32 -1342177246
 ;; @0023                               v24 = load.i64 notrap aligned readonly can_move v0+40
 ;; @0023                               v25 = load.i32 notrap aligned readonly can_move v24
 ;; @0023                               v7 = iconst.i32 48
 ;; @0023                               v26 = iconst.i32 16
-;; @0023                               v27 = call fn0(v0, v22, v25, v7, v26)  ; v22 = -1342177280, v7 = 48, v26 = 16
+;; @0023                               v27 = call fn0(v0, v22, v25, v7, v26)  ; v22 = -1342177246, v7 = 48, v26 = 16
 ;; @0023                               v49 = load.i64 notrap aligned readonly can_move v0+8
 ;; @0023                               v28 = load.i64 notrap aligned readonly can_move v49+32
 ;; @0023                               v29 = uextend.i64 v27

--- a/tests/disas/gc/struct-new-stack-map.wat
+++ b/tests/disas/gc/struct-new-stack-map.wat
@@ -38,7 +38,7 @@
 ;;       movq    8(%rbx), %rdx
 ;;       movq    0x20(%rdx), %rsi
 ;;       leaq    (%rsi, %rcx), %rdx
-;;       movl    $0xb0000000, (%rsi, %rcx)
+;;       movl    $0xb0000022, (%rsi, %rcx)
 ;;       movq    0x28(%rbx), %rdi
 ;;       movl    (%rdi), %edi
 ;;       movl    %edi, 4(%rsi, %rcx)
@@ -56,7 +56,7 @@
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   a4: movl    $0xb0000000, %esi
+;;   a4: movl    $0xb0000022, %esi
 ;;   a9: movq    0x28(%rdi), %rax
 ;;   ad: movq    %rdi, %rbx
 ;;   b0: movl    (%rax), %edx

--- a/tests/disas/gc/struct-new.wat
+++ b/tests/disas/gc/struct-new.wat
@@ -41,11 +41,11 @@
 ;;                                     v69 = iconst.i32 32
 ;;                                     v67 = iadd.i32 v9, v69  ; v69 = 32
 ;; @002a                               store notrap aligned region0 v67, v8
-;;                                     v70 = iconst.i32 -1342177280
+;;                                     v70 = iconst.i32 -1342177246
 ;;                                     v71 = load.i64 notrap aligned readonly can_move v0+8
 ;;                                     v72 = load.i64 notrap aligned readonly can_move v71+32
 ;; @002a                               v33 = iadd v72, v16
-;; @002a                               store notrap aligned v70, v33  ; v70 = -1342177280
+;; @002a                               store notrap aligned v70, v33  ; v70 = -1342177246
 ;;                                     v73 = load.i64 notrap aligned readonly can_move v0+40
 ;;                                     v74 = load.i32 notrap aligned readonly can_move v73
 ;; @002a                               store notrap aligned v74, v33+4
@@ -54,12 +54,12 @@
 ;; @002a                               jump block4(v9, v33)
 ;;
 ;;                                 block3 cold:
-;; @002a                               v21 = iconst.i32 -1342177280
+;; @002a                               v21 = iconst.i32 -1342177246
 ;; @002a                               v23 = load.i64 notrap aligned readonly can_move v0+40
 ;; @002a                               v24 = load.i32 notrap aligned readonly can_move v23
 ;; @002a                               v6 = iconst.i32 32
 ;; @002a                               v25 = iconst.i32 16
-;; @002a                               v26 = call fn0(v0, v21, v24, v6, v25), stack_map=[i32 @ ss0+0]  ; v21 = -1342177280, v6 = 32, v25 = 16
+;; @002a                               v26 = call fn0(v0, v21, v24, v6, v25), stack_map=[i32 @ ss0+0]  ; v21 = -1342177246, v6 = 32, v25 = 16
 ;; @002a                               v48 = load.i64 notrap aligned readonly can_move v0+8
 ;; @002a                               v27 = load.i64 notrap aligned readonly can_move v48+32
 ;; @002a                               v28 = uextend.i64 v26


### PR DESCRIPTION
We have a number of available bits inside the `VMGcHeader`. This commit uses them to bitpack the following type:

```rust
pub enum InlineTraceInfo {
    /// The trace info is not encoded inline. Look it up from `TraceInfos`.
    OutOfLine,

    /// Inline trace info for an array type.
    Array {
        /// Whether the array's elements are GC references that need tracing.
        elems_are_gc_refs: bool,
    },

    /// Inline trace info for a struct, exception, or externref type.
    Struct {
        /// A bitmap where the `i`th bit is set iff the `i`th `u32` in the
        /// object's data (after the header) is a `VMGcRef` that needs
        /// tracing. Only the lower 23 bits are meaningful.
        gc_ref_bitmap: u32,
    },
}
```

This allows us to encode the majority of objects' GC edges inline in the GC object header, avoiding the need to perform expensive hash map lookups in the common case.

This results in a 7-8% speed up on `splay.wasm` in Sightglass:

```
execution :: cycles :: benchmarks/splay/splay.wasm

  Δ = 5858240.88 ± 445613.91 (confidence = 99%)

  inline-trace-info.dylib (-Ccollector=copying -Wgc,function-references) is 1.07x to 1.08x faster than main.dylib (-Ccollector=copying -Wgc,function-references)!

  [77193983 79604574.70 88386948] inline-trace-info.dylib (-Ccollector=copying -Wgc,function-references)
  [83057364 85462815.58 92545612] main.dylib (-Ccollector=copying -Wgc,function-references)
```

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
