### PR TITLE
Loosely integrate `implements` into `bindgen!`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,3 +8,6 @@
 
 # ISLE should use lisp syntax highlighting.
 *.isle linguist-language=lisp
+
+# Generated files don't need diffs rendered by default
+crates/component-macro/tests/expanded/** linguist-generated=true

--- a/crates/component-macro/src/bindgen.rs
+++ b/crates/component-macro/src/bindgen.rs
@@ -20,8 +20,8 @@ pub struct Config {
     include_generated_code_from_file: bool,
 }
 
-pub fn expand(input: &Config) -> Result<TokenStream> {
-    let mut src = match input.opts.generate(&input.resolve, input.world) {
+pub fn expand(input: &mut Config) -> Result<TokenStream> {
+    let mut src = match input.opts.generate(&mut input.resolve, input.world) {
         Ok(s) => s,
         Err(e) => return Err(Error::new(Span::call_site(), e.to_string())),
     };

--- a/crates/component-macro/src/lib.rs
+++ b/crates/component-macro/src/lib.rs
@@ -49,7 +49,7 @@ pub fn flags(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 
 #[proc_macro]
 pub fn bindgen(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    bindgen::expand(&parse_macro_input!(input as bindgen::Config))
+    bindgen::expand(&mut parse_macro_input!(input as bindgen::Config))
         .unwrap_or_else(Error::into_compile_error)
         .into()
 }

--- a/crates/component-macro/tests/codegen/implements.wit
+++ b/crates/component-macro/tests/codegen/implements.wit
@@ -1,0 +1,11 @@
+package foo:foo;
+
+interface store {
+  get: func(key: string) -> option<string>;
+  set: func(key: string, value: string);
+}
+
+world cache {
+  import hot-cache: store;
+  import durable: store;
+}

--- a/crates/component-macro/tests/expanded.rs
+++ b/crates/component-macro/tests/expanded.rs
@@ -43,6 +43,11 @@ fn process_expanded(path: &str, suffix: &str, src: &str) -> Result<()> {
         Path::new("tests/expanded").join(stem).with_extension("rs")
     };
     if std::env::var("BINDGEN_TEST_BLESS").is_ok_and(|val| !val.is_empty()) {
+        if let Ok(prev) = std::fs::read(&expanded_path)
+            && prev == formatted_src.as_bytes()
+        {
+            return Ok(());
+        }
         std::fs::write(expanded_path, formatted_src)?;
     } else {
         match std::fs::read_to_string(&expanded_path) {

--- a/crates/component-macro/tests/expanded/char.rs
+++ b/crates/component-macro/tests/expanded/char.rs
@@ -210,8 +210,8 @@ pub mod foo {
                     Host::return_char(*self)
                 }
             }
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -219,7 +219,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
-                let mut inst = linker.instance("foo:foo/chars")?;
                 inst.func_wrap(
                     "take-char",
                     move |
@@ -240,6 +239,18 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static,
+            {
+                let mut inst = linker.instance("foo:foo/chars")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/char_async.rs
+++ b/crates/component-macro/tests/expanded/char_async.rs
@@ -220,8 +220,8 @@ pub mod foo {
                     async move { Host::return_char(*self).await }
                 }
             }
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -229,7 +229,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker.instance("foo:foo/chars")?;
                 inst.func_wrap_async(
                     "take-char",
                     move |
@@ -254,6 +253,18 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("foo:foo/chars")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/char_concurrent.rs
+++ b/crates/component-macro/tests/expanded/char_concurrent.rs
@@ -202,8 +202,8 @@ pub mod foo {
             }
             pub trait Host: Send {}
             impl<_T: Host + ?Sized + Send> Host for &mut _T {}
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -211,7 +211,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker.instance("foo:foo/chars")?;
                 inst.func_wrap_concurrent(
                     "take-char",
                     move |caller: &wasmtime::component::Accessor<T>, (arg0,): (char,)| {
@@ -233,6 +232,18 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("foo:foo/chars")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/char_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/char_tracing_async.rs
@@ -220,8 +220,8 @@ pub mod foo {
                     async move { Host::return_char(*self).await }
                 }
             }
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -229,7 +229,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker.instance("foo:foo/chars")?;
                 inst.func_wrap_async(
                     "take-char",
                     move |
@@ -283,6 +282,18 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("foo:foo/chars")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/conventions.rs
+++ b/crates/component-macro/tests/expanded/conventions.rs
@@ -292,8 +292,8 @@ pub mod foo {
                     Host::bool(*self)
                 }
             }
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -301,7 +301,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
-                let mut inst = linker.instance("foo:foo/conventions")?;
                 inst.func_wrap(
                     "kebab-case",
                     move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
@@ -402,6 +401,18 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static,
+            {
+                let mut inst = linker.instance("foo:foo/conventions")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/conventions_async.rs
+++ b/crates/component-macro/tests/expanded/conventions_async.rs
@@ -326,8 +326,8 @@ pub mod foo {
                     async move { Host::bool(*self).await }
                 }
             }
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -335,7 +335,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker.instance("foo:foo/conventions")?;
                 inst.func_wrap_async(
                     "kebab-case",
                     move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
@@ -460,6 +459,18 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("foo:foo/conventions")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/conventions_concurrent.rs
+++ b/crates/component-macro/tests/expanded/conventions_concurrent.rs
@@ -270,8 +270,8 @@ pub mod foo {
             }
             pub trait Host: Send {}
             impl<_T: Host + ?Sized + Send> Host for &mut _T {}
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -279,7 +279,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker.instance("foo:foo/conventions")?;
                 inst.func_wrap_concurrent(
                     "kebab-case",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
@@ -408,6 +407,18 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("foo:foo/conventions")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/conventions_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/conventions_tracing_async.rs
@@ -326,8 +326,8 @@ pub mod foo {
                     async move { Host::bool(*self).await }
                 }
             }
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -335,7 +335,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker.instance("foo:foo/conventions")?;
                 inst.func_wrap_async(
                     "kebab-case",
                     move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
@@ -620,6 +619,18 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("foo:foo/conventions")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/dead-code.rs
+++ b/crates/component-macro/tests/expanded/dead-code.rs
@@ -218,6 +218,25 @@ pub mod a {
                     Host::f(*self)
                 }
             }
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static,
+            {
+                inst.func_wrap(
+                    "f",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = &mut host_getter(caller.data_mut());
+                        let r = Host::f(host);
+                        Ok((r,))
+                    },
+                )?;
+                Ok(())
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
@@ -228,15 +247,7 @@ pub mod a {
                 T: 'static,
             {
                 let mut inst = linker.instance("a:b/interface-with-live-type")?;
-                inst.func_wrap(
-                    "f",
-                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
-                        let host = &mut host_getter(caller.data_mut());
-                        let r = Host::f(host);
-                        Ok((r,))
-                    },
-                )?;
-                Ok(())
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
         #[allow(clippy::all)]
@@ -300,6 +311,17 @@ pub mod a {
             {}
             pub trait Host {}
             impl<_T: Host + ?Sized> Host for &mut _T {}
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static,
+            {
+                Ok(())
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
@@ -310,7 +332,7 @@ pub mod a {
                 T: 'static,
             {
                 let mut inst = linker.instance("a:b/interface-with-dead-type")?;
-                Ok(())
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/dead-code_async.rs
+++ b/crates/component-macro/tests/expanded/dead-code_async.rs
@@ -220,8 +220,8 @@ pub mod a {
                     async move { Host::f(*self).await }
                 }
             }
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -229,7 +229,6 @@ pub mod a {
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker.instance("a:b/interface-with-live-type")?;
                 inst.func_wrap_async(
                     "f",
                     move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
@@ -241,6 +240,18 @@ pub mod a {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("a:b/interface-with-live-type")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
         #[allow(clippy::all)]
@@ -304,6 +315,17 @@ pub mod a {
             {}
             pub trait Host {}
             impl<_T: Host + ?Sized> Host for &mut _T {}
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static,
+            {
+                Ok(())
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
@@ -314,7 +336,7 @@ pub mod a {
                 T: 'static,
             {
                 let mut inst = linker.instance("a:b/interface-with-dead-type")?;
-                Ok(())
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/dead-code_concurrent.rs
+++ b/crates/component-macro/tests/expanded/dead-code_concurrent.rs
@@ -212,8 +212,8 @@ pub mod a {
             }
             pub trait Host: Send {}
             impl<_T: Host + ?Sized + Send> Host for &mut _T {}
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -221,7 +221,6 @@ pub mod a {
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker.instance("a:b/interface-with-live-type")?;
                 inst.func_wrap_concurrent(
                     "f",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
@@ -233,6 +232,18 @@ pub mod a {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("a:b/interface-with-live-type")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
         #[allow(clippy::all)]
@@ -296,6 +307,17 @@ pub mod a {
             {}
             pub trait Host {}
             impl<_T: Host + ?Sized> Host for &mut _T {}
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static,
+            {
+                Ok(())
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
@@ -306,7 +328,7 @@ pub mod a {
                 T: 'static,
             {
                 let mut inst = linker.instance("a:b/interface-with-dead-type")?;
-                Ok(())
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/dead-code_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/dead-code_tracing_async.rs
@@ -220,8 +220,8 @@ pub mod a {
                     async move { Host::f(*self).await }
                 }
             }
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -229,7 +229,6 @@ pub mod a {
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker.instance("a:b/interface-with-live-type")?;
                 inst.func_wrap_async(
                     "f",
                     move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
@@ -254,6 +253,18 @@ pub mod a {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("a:b/interface-with-live-type")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
         #[allow(clippy::all)]
@@ -317,6 +328,17 @@ pub mod a {
             {}
             pub trait Host {}
             impl<_T: Host + ?Sized> Host for &mut _T {}
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static,
+            {
+                Ok(())
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
@@ -327,7 +349,7 @@ pub mod a {
                 T: 'static,
             {
                 let mut inst = linker.instance("a:b/interface-with-dead-type")?;
-                Ok(())
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/flags.rs
+++ b/crates/component-macro/tests/expanded/flags.rs
@@ -340,8 +340,8 @@ pub mod foo {
                     Host::roundtrip_flag64(*self, x)
                 }
             }
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -349,7 +349,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
-                let mut inst = linker.instance("foo:foo/flegs")?;
                 inst.func_wrap(
                     "roundtrip-flag1",
                     move |
@@ -428,6 +427,18 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static,
+            {
+                let mut inst = linker.instance("foo:foo/flegs")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/flags_async.rs
+++ b/crates/component-macro/tests/expanded/flags_async.rs
@@ -382,8 +382,8 @@ pub mod foo {
                     async move { Host::roundtrip_flag64(*self, x).await }
                 }
             }
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -391,7 +391,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker.instance("foo:foo/flegs")?;
                 inst.func_wrap_async(
                     "roundtrip-flag1",
                     move |
@@ -484,6 +483,18 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("foo:foo/flegs")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/flags_concurrent.rs
+++ b/crates/component-macro/tests/expanded/flags_concurrent.rs
@@ -335,8 +335,8 @@ pub mod foo {
             }
             pub trait Host: Send {}
             impl<_T: Host + ?Sized + Send> Host for &mut _T {}
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -344,7 +344,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker.instance("foo:foo/flegs")?;
                 inst.func_wrap_concurrent(
                     "roundtrip-flag1",
                     move |caller: &wasmtime::component::Accessor<T>, (arg0,): (Flag1,)| {
@@ -423,6 +422,18 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("foo:foo/flegs")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/flags_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/flags_tracing_async.rs
@@ -382,8 +382,8 @@ pub mod foo {
                     async move { Host::roundtrip_flag64(*self, x).await }
                 }
             }
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -391,7 +391,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker.instance("foo:foo/flegs")?;
                 inst.func_wrap_async(
                     "roundtrip-flag1",
                     move |
@@ -596,6 +595,18 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("foo:foo/flegs")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/floats.rs
+++ b/crates/component-macro/tests/expanded/floats.rs
@@ -216,8 +216,8 @@ pub mod foo {
                     Host::f64_result(*self)
                 }
             }
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -225,7 +225,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
-                let mut inst = linker.instance("foo:foo/floats")?;
                 inst.func_wrap(
                     "f32-param",
                     move |mut caller: wasmtime::StoreContextMut<'_, T>, (arg0,): (f32,)| {
@@ -259,6 +258,18 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static,
+            {
+                let mut inst = linker.instance("foo:foo/floats")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/floats_async.rs
+++ b/crates/component-macro/tests/expanded/floats_async.rs
@@ -236,8 +236,8 @@ pub mod foo {
                     async move { Host::f64_result(*self).await }
                 }
             }
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -245,7 +245,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker.instance("foo:foo/floats")?;
                 inst.func_wrap_async(
                     "f32-param",
                     move |mut caller: wasmtime::StoreContextMut<'_, T>, (arg0,): (f32,)| {
@@ -287,6 +286,18 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("foo:foo/floats")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/floats_concurrent.rs
+++ b/crates/component-macro/tests/expanded/floats_concurrent.rs
@@ -209,8 +209,8 @@ pub mod foo {
             }
             pub trait Host: Send {}
             impl<_T: Host + ?Sized + Send> Host for &mut _T {}
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -218,7 +218,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker.instance("foo:foo/floats")?;
                 inst.func_wrap_concurrent(
                     "f32-param",
                     move |caller: &wasmtime::component::Accessor<T>, (arg0,): (f32,)| {
@@ -260,6 +259,18 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("foo:foo/floats")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/floats_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/floats_tracing_async.rs
@@ -236,8 +236,8 @@ pub mod foo {
                     async move { Host::f64_result(*self).await }
                 }
             }
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -245,7 +245,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker.instance("foo:foo/floats")?;
                 inst.func_wrap_async(
                     "f32-param",
                     move |mut caller: wasmtime::StoreContextMut<'_, T>, (arg0,): (f32,)| {
@@ -345,6 +344,18 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("foo:foo/floats")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/implements.rs
+++ b/crates/component-macro/tests/expanded/implements.rs
@@ -1,41 +1,16 @@
-pub type U = foo::foo::i::T;
-const _: () = {
-    assert!(2 == < U as wasmtime::component::ComponentType >::SIZE32);
-    assert!(2 == < U as wasmtime::component::ComponentType >::ALIGN32);
-};
-pub type T = u32;
-const _: () = {
-    assert!(4 == < T as wasmtime::component::ComponentType >::SIZE32);
-    assert!(4 == < T as wasmtime::component::ComponentType >::ALIGN32);
-};
-#[derive(wasmtime::component::ComponentType)]
-#[derive(wasmtime::component::Lift)]
-#[derive(wasmtime::component::Lower)]
-#[component(record)]
-#[derive(Clone, Copy)]
-pub struct R {}
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("R").finish()
-    }
-}
-const _: () = {
-    assert!(0 == < R as wasmtime::component::ComponentType >::SIZE32);
-    assert!(1 == < R as wasmtime::component::ComponentType >::ALIGN32);
-};
 /// Auto-generated bindings for a pre-instantiated version of a
-/// component which implements the world `foo`.
+/// component which implements the world `cache`.
 ///
-/// This structure is created through [`FooPre::new`] which
+/// This structure is created through [`CachePre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
-/// For more information see [`Foo`] as well.
-pub struct FooPre<T: 'static> {
+/// For more information see [`Cache`] as well.
+pub struct CachePre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
-    indices: FooIndices,
+    indices: CacheIndices,
 }
-impl<T: 'static> Clone for FooPre<T> {
+impl<T: 'static> Clone for CachePre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -43,8 +18,8 @@ impl<T: 'static> Clone for FooPre<T> {
         }
     }
 }
-impl<_T: 'static> FooPre<_T> {
-    /// Creates a new copy of `FooPre` bindings which can then
+impl<_T: 'static> CachePre<_T> {
+    /// Creates a new copy of `CachePre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
     /// This method may fail if the component behind `instance_pre`
@@ -52,7 +27,7 @@ impl<_T: 'static> FooPre<_T> {
     pub fn new(
         instance_pre: wasmtime::component::InstancePre<_T>,
     ) -> wasmtime::Result<Self> {
-        let indices = FooIndices::new(&instance_pre)?;
+        let indices = CacheIndices::new(&instance_pre)?;
         Ok(Self { instance_pre, indices })
     }
     pub fn engine(&self) -> &wasmtime::Engine {
@@ -61,7 +36,7 @@ impl<_T: 'static> FooPre<_T> {
     pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
         &self.instance_pre
     }
-    /// Instantiates a new instance of [`Foo`] within the
+    /// Instantiates a new instance of [`Cache`] within the
     /// `store` provided.
     ///
     /// This function will use `self` as the pre-instantiated
@@ -71,52 +46,50 @@ impl<_T: 'static> FooPre<_T> {
     pub fn instantiate(
         &self,
         mut store: impl wasmtime::AsContextMut<Data = _T>,
-    ) -> wasmtime::Result<Foo> {
+    ) -> wasmtime::Result<Cache> {
         let mut store = store.as_context_mut();
         let instance = self.instance_pre.instantiate(&mut store)?;
         self.indices.load(&mut store, &instance)
     }
 }
-impl<_T: Send + 'static> FooPre<_T> {
+impl<_T: Send + 'static> CachePre<_T> {
     /// Same as [`Self::instantiate`], except with `async`.
     pub async fn instantiate_async(
         &self,
         mut store: impl wasmtime::AsContextMut<Data = _T>,
-    ) -> wasmtime::Result<Foo> {
+    ) -> wasmtime::Result<Cache> {
         let mut store = store.as_context_mut();
         let instance = self.instance_pre.instantiate_async(&mut store).await?;
         self.indices.load(&mut store, &instance)
     }
 }
 /// Auto-generated bindings for index of the exports of
-/// `foo`.
+/// `cache`.
 ///
-/// This is an implementation detail of [`FooPre`] and can
+/// This is an implementation detail of [`CachePre`] and can
 /// be constructed if needed as well.
 ///
-/// For more information see [`Foo`] as well.
+/// For more information see [`Cache`] as well.
 #[derive(Clone)]
-pub struct FooIndices {
-    f: wasmtime::component::ComponentExportIndex,
-}
+pub struct CacheIndices {}
 /// Auto-generated bindings for an instance a component which
-/// implements the world `foo`.
+/// implements the world `cache`.
 ///
 /// This structure can be created through a number of means
 /// depending on your requirements and what you have on hand:
 ///
 /// * The most convenient way is to use
-///   [`Foo::instantiate`] which only needs a
+///   [`Cache::instantiate`] which only needs a
 ///   [`Store`], [`Component`], and [`Linker`].
 ///
-/// * Alternatively you can create a [`FooPre`] ahead of
+/// * Alternatively you can create a [`CachePre`] ahead of
 ///   time with a [`Component`] to front-load string lookups
 ///   of exports once instead of per-instantiation. This
-///   method then uses [`FooPre::instantiate`] to
-///   create a [`Foo`].
+///   method then uses [`CachePre::instantiate`] to
+///   create a [`Cache`].
 ///
 /// * If you've instantiated the instance yourself already
-///   then you can use [`Foo::new`].
+///   then you can use [`Cache::new`].
 ///
 /// These methods are all equivalent to one another and move
 /// around the tradeoff of what work is performed when.
@@ -124,12 +97,10 @@ pub struct FooIndices {
 /// [`Store`]: wasmtime::Store
 /// [`Component`]: wasmtime::component::Component
 /// [`Linker`]: wasmtime::component::Linker
-pub struct Foo {
-    f: wasmtime::component::Func,
-}
+pub struct Cache {}
 const _: () = {
-    impl FooIndices {
-        /// Creates a new copy of `FooIndices` bindings which can then
+    impl CacheIndices {
+        /// Creates a new copy of `CacheIndices` bindings which can then
         /// be used to instantiate into a particular store.
         ///
         /// This method may fail if the component does not have the
@@ -139,25 +110,10 @@ const _: () = {
         ) -> wasmtime::Result<Self> {
             let _component = _instance_pre.component();
             let _instance_type = _instance_pre.instance_type();
-            let f = {
-                let (item, index) = _component
-                    .get_export(None, "f")
-                    .ok_or_else(|| wasmtime::format_err!("no export `f` found"))?;
-                match item {
-                    wasmtime::component::types::ComponentItem::ComponentFunc(func) => {
-                        wasmtime::error::Context::context(
-                            func.typecheck::<(), ((T, U, R),)>(&_instance_type),
-                            "type-checking export func `f`",
-                        )?;
-                        index
-                    }
-                    _ => Err(wasmtime::format_err!("export `f` is not a function"))?,
-                }
-            };
-            Ok(FooIndices { f })
+            Ok(CacheIndices {})
         }
         /// Uses the indices stored in `self` to load an instance
-        /// of [`Foo`] from the instance provided.
+        /// of [`Cache`] from the instance provided.
         ///
         /// Note that at this time this method will additionally
         /// perform type-checks of all exports.
@@ -165,94 +121,103 @@ const _: () = {
             &self,
             mut store: impl wasmtime::AsContextMut,
             instance: &wasmtime::component::Instance,
-        ) -> wasmtime::Result<Foo> {
+        ) -> wasmtime::Result<Cache> {
             let _ = &mut store;
             let _instance = instance;
-            let f = *_instance
-                .get_typed_func::<(), ((T, U, R),)>(&mut store, &self.f)?
-                .func();
-            Ok(Foo { f })
+            Ok(Cache {})
         }
     }
-    impl Foo {
-        /// Convenience wrapper around [`FooPre::new`] and
-        /// [`FooPre::instantiate`].
+    impl Cache {
+        /// Convenience wrapper around [`CachePre::new`] and
+        /// [`CachePre::instantiate`].
         pub fn instantiate<_T>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
-        ) -> wasmtime::Result<Foo> {
+        ) -> wasmtime::Result<Cache> {
             let pre = linker.instantiate_pre(component)?;
-            FooPre::new(pre)?.instantiate(store)
+            CachePre::new(pre)?.instantiate(store)
         }
-        /// Convenience wrapper around [`FooIndices::new`] and
-        /// [`FooIndices::load`].
+        /// Convenience wrapper around [`CacheIndices::new`] and
+        /// [`CacheIndices::load`].
         pub fn new(
             mut store: impl wasmtime::AsContextMut,
             instance: &wasmtime::component::Instance,
-        ) -> wasmtime::Result<Foo> {
-            let indices = FooIndices::new(&instance.instance_pre(&store))?;
+        ) -> wasmtime::Result<Cache> {
+            let indices = CacheIndices::new(&instance.instance_pre(&store))?;
             indices.load(&mut store, instance)
         }
-        /// Convenience wrapper around [`FooPre::new`] and
-        /// [`FooPre::instantiate_async`].
+        /// Convenience wrapper around [`CachePre::new`] and
+        /// [`CachePre::instantiate_async`].
         pub async fn instantiate_async<_T>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
-        ) -> wasmtime::Result<Foo>
+        ) -> wasmtime::Result<Cache>
         where
             _T: Send,
         {
             let pre = linker.instantiate_pre(component)?;
-            FooPre::new(pre)?.instantiate_async(store).await
+            CachePre::new(pre)?.instantiate_async(store).await
         }
         pub fn add_to_linker<T, D>(
             linker: &mut wasmtime::component::Linker<T>,
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::i::HostWithStore,
-            for<'a> D::Data<'a>: foo::foo::i::Host,
-            T: 'static + Send,
+            D: foo::foo::store::HostWithStore + foo::foo::store::HostWithStore,
+            for<'a> D::Data<'a>: foo::foo::store::Host + foo::foo::store::Host,
+            T: 'static,
         {
-            foo::foo::i::add_to_linker::<T, D>(linker, host_getter)?;
+            foo::foo::store::add_to_linker_instance::<
+                T,
+                D,
+            >(&mut linker.instance("hot-cache")?, host_getter)?;
+            foo::foo::store::add_to_linker_instance::<
+                T,
+                D,
+            >(&mut linker.instance("durable")?, host_getter)?;
             Ok(())
-        }
-        pub async fn call_f<_T, _D>(
-            &self,
-            accessor: &wasmtime::component::Accessor<_T, _D>,
-        ) -> wasmtime::Result<(T, U, R)>
-        where
-            _T: Send,
-            _D: wasmtime::component::HasData,
-        {
-            let callee = unsafe {
-                wasmtime::component::TypedFunc::<(), ((T, U, R),)>::new_unchecked(self.f)
-            };
-            let (ret0,) = callee.call_concurrent(accessor, ()).await?;
-            Ok(ret0)
         }
     }
 };
 pub mod foo {
     pub mod foo {
         #[allow(clippy::all)]
-        pub mod i {
+        pub mod store {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::Box;
-            pub type T = u16;
-            const _: () = {
-                assert!(2 == < T as wasmtime::component::ComponentType >::SIZE32);
-                assert!(2 == < T as wasmtime::component::ComponentType >::ALIGN32);
-            };
             pub trait HostWithStore: wasmtime::component::HasData {}
             impl<_T: ?Sized> HostWithStore for _T
             where
                 _T: wasmtime::component::HasData,
             {}
-            pub trait Host {}
-            impl<_T: Host + ?Sized> Host for &mut _T {}
+            pub trait Host {
+                fn get(
+                    &mut self,
+                    key: wasmtime::component::__internal::String,
+                ) -> Option<wasmtime::component::__internal::String>;
+                fn set(
+                    &mut self,
+                    key: wasmtime::component::__internal::String,
+                    value: wasmtime::component::__internal::String,
+                ) -> ();
+            }
+            impl<_T: Host + ?Sized> Host for &mut _T {
+                fn get(
+                    &mut self,
+                    key: wasmtime::component::__internal::String,
+                ) -> Option<wasmtime::component::__internal::String> {
+                    Host::get(*self, key)
+                }
+                fn set(
+                    &mut self,
+                    key: wasmtime::component::__internal::String,
+                    value: wasmtime::component::__internal::String,
+                ) -> () {
+                    Host::set(*self, key, value)
+                }
+            }
             pub fn add_to_linker_instance<T, D>(
                 inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
@@ -262,6 +227,34 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
+                inst.func_wrap(
+                    "get",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (wasmtime::component::__internal::String,)|
+                    {
+                        let host = &mut host_getter(caller.data_mut());
+                        let r = Host::get(host, arg0);
+                        Ok((r,))
+                    },
+                )?;
+                inst.func_wrap(
+                    "set",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (
+                            arg0,
+                            arg1,
+                        ): (
+                            wasmtime::component::__internal::String,
+                            wasmtime::component::__internal::String,
+                        )|
+                    {
+                        let host = &mut host_getter(caller.data_mut());
+                        let r = Host::set(host, arg0, arg1);
+                        Ok(r)
+                    },
+                )?;
                 Ok(())
             }
             pub fn add_to_linker<T, D>(
@@ -273,7 +266,7 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
-                let mut inst = linker.instance("foo:foo/i")?;
+                let mut inst = linker.instance("foo:foo/store")?;
                 add_to_linker_instance(&mut inst, host_getter)
             }
         }

--- a/crates/component-macro/tests/expanded/implements_async.rs
+++ b/crates/component-macro/tests/expanded/implements_async.rs
@@ -1,41 +1,16 @@
-pub type U = foo::foo::i::T;
-const _: () = {
-    assert!(2 == < U as wasmtime::component::ComponentType >::SIZE32);
-    assert!(2 == < U as wasmtime::component::ComponentType >::ALIGN32);
-};
-pub type T = u32;
-const _: () = {
-    assert!(4 == < T as wasmtime::component::ComponentType >::SIZE32);
-    assert!(4 == < T as wasmtime::component::ComponentType >::ALIGN32);
-};
-#[derive(wasmtime::component::ComponentType)]
-#[derive(wasmtime::component::Lift)]
-#[derive(wasmtime::component::Lower)]
-#[component(record)]
-#[derive(Clone, Copy)]
-pub struct R {}
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("R").finish()
-    }
-}
-const _: () = {
-    assert!(0 == < R as wasmtime::component::ComponentType >::SIZE32);
-    assert!(1 == < R as wasmtime::component::ComponentType >::ALIGN32);
-};
 /// Auto-generated bindings for a pre-instantiated version of a
-/// component which implements the world `foo`.
+/// component which implements the world `cache`.
 ///
-/// This structure is created through [`FooPre::new`] which
+/// This structure is created through [`CachePre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
-/// For more information see [`Foo`] as well.
-pub struct FooPre<T: 'static> {
+/// For more information see [`Cache`] as well.
+pub struct CachePre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
-    indices: FooIndices,
+    indices: CacheIndices,
 }
-impl<T: 'static> Clone for FooPre<T> {
+impl<T: 'static> Clone for CachePre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -43,8 +18,8 @@ impl<T: 'static> Clone for FooPre<T> {
         }
     }
 }
-impl<_T: 'static> FooPre<_T> {
-    /// Creates a new copy of `FooPre` bindings which can then
+impl<_T: 'static> CachePre<_T> {
+    /// Creates a new copy of `CachePre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
     /// This method may fail if the component behind `instance_pre`
@@ -52,7 +27,7 @@ impl<_T: 'static> FooPre<_T> {
     pub fn new(
         instance_pre: wasmtime::component::InstancePre<_T>,
     ) -> wasmtime::Result<Self> {
-        let indices = FooIndices::new(&instance_pre)?;
+        let indices = CacheIndices::new(&instance_pre)?;
         Ok(Self { instance_pre, indices })
     }
     pub fn engine(&self) -> &wasmtime::Engine {
@@ -61,7 +36,7 @@ impl<_T: 'static> FooPre<_T> {
     pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
         &self.instance_pre
     }
-    /// Instantiates a new instance of [`Foo`] within the
+    /// Instantiates a new instance of [`Cache`] within the
     /// `store` provided.
     ///
     /// This function will use `self` as the pre-instantiated
@@ -71,52 +46,50 @@ impl<_T: 'static> FooPre<_T> {
     pub fn instantiate(
         &self,
         mut store: impl wasmtime::AsContextMut<Data = _T>,
-    ) -> wasmtime::Result<Foo> {
+    ) -> wasmtime::Result<Cache> {
         let mut store = store.as_context_mut();
         let instance = self.instance_pre.instantiate(&mut store)?;
         self.indices.load(&mut store, &instance)
     }
 }
-impl<_T: Send + 'static> FooPre<_T> {
+impl<_T: Send + 'static> CachePre<_T> {
     /// Same as [`Self::instantiate`], except with `async`.
     pub async fn instantiate_async(
         &self,
         mut store: impl wasmtime::AsContextMut<Data = _T>,
-    ) -> wasmtime::Result<Foo> {
+    ) -> wasmtime::Result<Cache> {
         let mut store = store.as_context_mut();
         let instance = self.instance_pre.instantiate_async(&mut store).await?;
         self.indices.load(&mut store, &instance)
     }
 }
 /// Auto-generated bindings for index of the exports of
-/// `foo`.
+/// `cache`.
 ///
-/// This is an implementation detail of [`FooPre`] and can
+/// This is an implementation detail of [`CachePre`] and can
 /// be constructed if needed as well.
 ///
-/// For more information see [`Foo`] as well.
+/// For more information see [`Cache`] as well.
 #[derive(Clone)]
-pub struct FooIndices {
-    f: wasmtime::component::ComponentExportIndex,
-}
+pub struct CacheIndices {}
 /// Auto-generated bindings for an instance a component which
-/// implements the world `foo`.
+/// implements the world `cache`.
 ///
 /// This structure can be created through a number of means
 /// depending on your requirements and what you have on hand:
 ///
 /// * The most convenient way is to use
-///   [`Foo::instantiate`] which only needs a
+///   [`Cache::instantiate`] which only needs a
 ///   [`Store`], [`Component`], and [`Linker`].
 ///
-/// * Alternatively you can create a [`FooPre`] ahead of
+/// * Alternatively you can create a [`CachePre`] ahead of
 ///   time with a [`Component`] to front-load string lookups
 ///   of exports once instead of per-instantiation. This
-///   method then uses [`FooPre::instantiate`] to
-///   create a [`Foo`].
+///   method then uses [`CachePre::instantiate`] to
+///   create a [`Cache`].
 ///
 /// * If you've instantiated the instance yourself already
-///   then you can use [`Foo::new`].
+///   then you can use [`Cache::new`].
 ///
 /// These methods are all equivalent to one another and move
 /// around the tradeoff of what work is performed when.
@@ -124,12 +97,10 @@ pub struct FooIndices {
 /// [`Store`]: wasmtime::Store
 /// [`Component`]: wasmtime::component::Component
 /// [`Linker`]: wasmtime::component::Linker
-pub struct Foo {
-    f: wasmtime::component::Func,
-}
+pub struct Cache {}
 const _: () = {
-    impl FooIndices {
-        /// Creates a new copy of `FooIndices` bindings which can then
+    impl CacheIndices {
+        /// Creates a new copy of `CacheIndices` bindings which can then
         /// be used to instantiate into a particular store.
         ///
         /// This method may fail if the component does not have the
@@ -139,25 +110,10 @@ const _: () = {
         ) -> wasmtime::Result<Self> {
             let _component = _instance_pre.component();
             let _instance_type = _instance_pre.instance_type();
-            let f = {
-                let (item, index) = _component
-                    .get_export(None, "f")
-                    .ok_or_else(|| wasmtime::format_err!("no export `f` found"))?;
-                match item {
-                    wasmtime::component::types::ComponentItem::ComponentFunc(func) => {
-                        wasmtime::error::Context::context(
-                            func.typecheck::<(), ((T, U, R),)>(&_instance_type),
-                            "type-checking export func `f`",
-                        )?;
-                        index
-                    }
-                    _ => Err(wasmtime::format_err!("export `f` is not a function"))?,
-                }
-            };
-            Ok(FooIndices { f })
+            Ok(CacheIndices {})
         }
         /// Uses the indices stored in `self` to load an instance
-        /// of [`Foo`] from the instance provided.
+        /// of [`Cache`] from the instance provided.
         ///
         /// Note that at this time this method will additionally
         /// perform type-checks of all exports.
@@ -165,94 +121,107 @@ const _: () = {
             &self,
             mut store: impl wasmtime::AsContextMut,
             instance: &wasmtime::component::Instance,
-        ) -> wasmtime::Result<Foo> {
+        ) -> wasmtime::Result<Cache> {
             let _ = &mut store;
             let _instance = instance;
-            let f = *_instance
-                .get_typed_func::<(), ((T, U, R),)>(&mut store, &self.f)?
-                .func();
-            Ok(Foo { f })
+            Ok(Cache {})
         }
     }
-    impl Foo {
-        /// Convenience wrapper around [`FooPre::new`] and
-        /// [`FooPre::instantiate`].
+    impl Cache {
+        /// Convenience wrapper around [`CachePre::new`] and
+        /// [`CachePre::instantiate`].
         pub fn instantiate<_T>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
-        ) -> wasmtime::Result<Foo> {
+        ) -> wasmtime::Result<Cache> {
             let pre = linker.instantiate_pre(component)?;
-            FooPre::new(pre)?.instantiate(store)
+            CachePre::new(pre)?.instantiate(store)
         }
-        /// Convenience wrapper around [`FooIndices::new`] and
-        /// [`FooIndices::load`].
+        /// Convenience wrapper around [`CacheIndices::new`] and
+        /// [`CacheIndices::load`].
         pub fn new(
             mut store: impl wasmtime::AsContextMut,
             instance: &wasmtime::component::Instance,
-        ) -> wasmtime::Result<Foo> {
-            let indices = FooIndices::new(&instance.instance_pre(&store))?;
+        ) -> wasmtime::Result<Cache> {
+            let indices = CacheIndices::new(&instance.instance_pre(&store))?;
             indices.load(&mut store, instance)
         }
-        /// Convenience wrapper around [`FooPre::new`] and
-        /// [`FooPre::instantiate_async`].
+        /// Convenience wrapper around [`CachePre::new`] and
+        /// [`CachePre::instantiate_async`].
         pub async fn instantiate_async<_T>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
-        ) -> wasmtime::Result<Foo>
+        ) -> wasmtime::Result<Cache>
         where
             _T: Send,
         {
             let pre = linker.instantiate_pre(component)?;
-            FooPre::new(pre)?.instantiate_async(store).await
+            CachePre::new(pre)?.instantiate_async(store).await
         }
         pub fn add_to_linker<T, D>(
             linker: &mut wasmtime::component::Linker<T>,
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::i::HostWithStore,
-            for<'a> D::Data<'a>: foo::foo::i::Host,
+            D: foo::foo::store::HostWithStore + foo::foo::store::HostWithStore + Send,
+            for<'a> D::Data<'a>: foo::foo::store::Host + foo::foo::store::Host + Send,
             T: 'static + Send,
         {
-            foo::foo::i::add_to_linker::<T, D>(linker, host_getter)?;
+            foo::foo::store::add_to_linker_instance::<
+                T,
+                D,
+            >(&mut linker.instance("hot-cache")?, host_getter)?;
+            foo::foo::store::add_to_linker_instance::<
+                T,
+                D,
+            >(&mut linker.instance("durable")?, host_getter)?;
             Ok(())
-        }
-        pub async fn call_f<_T, _D>(
-            &self,
-            accessor: &wasmtime::component::Accessor<_T, _D>,
-        ) -> wasmtime::Result<(T, U, R)>
-        where
-            _T: Send,
-            _D: wasmtime::component::HasData,
-        {
-            let callee = unsafe {
-                wasmtime::component::TypedFunc::<(), ((T, U, R),)>::new_unchecked(self.f)
-            };
-            let (ret0,) = callee.call_concurrent(accessor, ()).await?;
-            Ok(ret0)
         }
     }
 };
 pub mod foo {
     pub mod foo {
         #[allow(clippy::all)]
-        pub mod i {
+        pub mod store {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::Box;
-            pub type T = u16;
-            const _: () = {
-                assert!(2 == < T as wasmtime::component::ComponentType >::SIZE32);
-                assert!(2 == < T as wasmtime::component::ComponentType >::ALIGN32);
-            };
-            pub trait HostWithStore: wasmtime::component::HasData {}
+            pub trait HostWithStore: wasmtime::component::HasData + Send {}
             impl<_T: ?Sized> HostWithStore for _T
             where
-                _T: wasmtime::component::HasData,
+                _T: wasmtime::component::HasData + Send,
             {}
-            pub trait Host {}
-            impl<_T: Host + ?Sized> Host for &mut _T {}
+            pub trait Host: Send {
+                fn get(
+                    &mut self,
+                    key: wasmtime::component::__internal::String,
+                ) -> impl ::core::future::Future<
+                    Output = Option<wasmtime::component::__internal::String>,
+                > + Send;
+                fn set(
+                    &mut self,
+                    key: wasmtime::component::__internal::String,
+                    value: wasmtime::component::__internal::String,
+                ) -> impl ::core::future::Future<Output = ()> + Send;
+            }
+            impl<_T: Host + ?Sized + Send> Host for &mut _T {
+                fn get(
+                    &mut self,
+                    key: wasmtime::component::__internal::String,
+                ) -> impl ::core::future::Future<
+                    Output = Option<wasmtime::component::__internal::String>,
+                > + Send {
+                    async move { Host::get(*self, key).await }
+                }
+                fn set(
+                    &mut self,
+                    key: wasmtime::component::__internal::String,
+                    value: wasmtime::component::__internal::String,
+                ) -> impl ::core::future::Future<Output = ()> + Send {
+                    async move { Host::set(*self, key, value).await }
+                }
+            }
             pub fn add_to_linker_instance<T, D>(
                 inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
@@ -260,8 +229,40 @@ pub mod foo {
             where
                 D: HostWithStore,
                 for<'a> D::Data<'a>: Host,
-                T: 'static,
+                T: 'static + Send,
             {
+                inst.func_wrap_async(
+                    "get",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (wasmtime::component::__internal::String,)|
+                    {
+                        wasmtime::component::__internal::Box::new(async move {
+                            let host = &mut host_getter(caller.data_mut());
+                            let r = Host::get(host, arg0).await;
+                            Ok((r,))
+                        })
+                    },
+                )?;
+                inst.func_wrap_async(
+                    "set",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (
+                            arg0,
+                            arg1,
+                        ): (
+                            wasmtime::component::__internal::String,
+                            wasmtime::component::__internal::String,
+                        )|
+                    {
+                        wasmtime::component::__internal::Box::new(async move {
+                            let host = &mut host_getter(caller.data_mut());
+                            let r = Host::set(host, arg0, arg1).await;
+                            Ok(r)
+                        })
+                    },
+                )?;
                 Ok(())
             }
             pub fn add_to_linker<T, D>(
@@ -271,9 +272,9 @@ pub mod foo {
             where
                 D: HostWithStore,
                 for<'a> D::Data<'a>: Host,
-                T: 'static,
+                T: 'static + Send,
             {
-                let mut inst = linker.instance("foo:foo/i")?;
+                let mut inst = linker.instance("foo:foo/store")?;
                 add_to_linker_instance(&mut inst, host_getter)
             }
         }

--- a/crates/component-macro/tests/expanded/implements_concurrent.rs
+++ b/crates/component-macro/tests/expanded/implements_concurrent.rs
@@ -1,41 +1,16 @@
-pub type U = foo::foo::i::T;
-const _: () = {
-    assert!(2 == < U as wasmtime::component::ComponentType >::SIZE32);
-    assert!(2 == < U as wasmtime::component::ComponentType >::ALIGN32);
-};
-pub type T = u32;
-const _: () = {
-    assert!(4 == < T as wasmtime::component::ComponentType >::SIZE32);
-    assert!(4 == < T as wasmtime::component::ComponentType >::ALIGN32);
-};
-#[derive(wasmtime::component::ComponentType)]
-#[derive(wasmtime::component::Lift)]
-#[derive(wasmtime::component::Lower)]
-#[component(record)]
-#[derive(Clone, Copy)]
-pub struct R {}
-impl core::fmt::Debug for R {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("R").finish()
-    }
-}
-const _: () = {
-    assert!(0 == < R as wasmtime::component::ComponentType >::SIZE32);
-    assert!(1 == < R as wasmtime::component::ComponentType >::ALIGN32);
-};
 /// Auto-generated bindings for a pre-instantiated version of a
-/// component which implements the world `foo`.
+/// component which implements the world `cache`.
 ///
-/// This structure is created through [`FooPre::new`] which
+/// This structure is created through [`CachePre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
-/// For more information see [`Foo`] as well.
-pub struct FooPre<T: 'static> {
+/// For more information see [`Cache`] as well.
+pub struct CachePre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
-    indices: FooIndices,
+    indices: CacheIndices,
 }
-impl<T: 'static> Clone for FooPre<T> {
+impl<T: 'static> Clone for CachePre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -43,8 +18,8 @@ impl<T: 'static> Clone for FooPre<T> {
         }
     }
 }
-impl<_T: 'static> FooPre<_T> {
-    /// Creates a new copy of `FooPre` bindings which can then
+impl<_T: 'static> CachePre<_T> {
+    /// Creates a new copy of `CachePre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
     /// This method may fail if the component behind `instance_pre`
@@ -52,7 +27,7 @@ impl<_T: 'static> FooPre<_T> {
     pub fn new(
         instance_pre: wasmtime::component::InstancePre<_T>,
     ) -> wasmtime::Result<Self> {
-        let indices = FooIndices::new(&instance_pre)?;
+        let indices = CacheIndices::new(&instance_pre)?;
         Ok(Self { instance_pre, indices })
     }
     pub fn engine(&self) -> &wasmtime::Engine {
@@ -61,7 +36,7 @@ impl<_T: 'static> FooPre<_T> {
     pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
         &self.instance_pre
     }
-    /// Instantiates a new instance of [`Foo`] within the
+    /// Instantiates a new instance of [`Cache`] within the
     /// `store` provided.
     ///
     /// This function will use `self` as the pre-instantiated
@@ -71,52 +46,50 @@ impl<_T: 'static> FooPre<_T> {
     pub fn instantiate(
         &self,
         mut store: impl wasmtime::AsContextMut<Data = _T>,
-    ) -> wasmtime::Result<Foo> {
+    ) -> wasmtime::Result<Cache> {
         let mut store = store.as_context_mut();
         let instance = self.instance_pre.instantiate(&mut store)?;
         self.indices.load(&mut store, &instance)
     }
 }
-impl<_T: Send + 'static> FooPre<_T> {
+impl<_T: Send + 'static> CachePre<_T> {
     /// Same as [`Self::instantiate`], except with `async`.
     pub async fn instantiate_async(
         &self,
         mut store: impl wasmtime::AsContextMut<Data = _T>,
-    ) -> wasmtime::Result<Foo> {
+    ) -> wasmtime::Result<Cache> {
         let mut store = store.as_context_mut();
         let instance = self.instance_pre.instantiate_async(&mut store).await?;
         self.indices.load(&mut store, &instance)
     }
 }
 /// Auto-generated bindings for index of the exports of
-/// `foo`.
+/// `cache`.
 ///
-/// This is an implementation detail of [`FooPre`] and can
+/// This is an implementation detail of [`CachePre`] and can
 /// be constructed if needed as well.
 ///
-/// For more information see [`Foo`] as well.
+/// For more information see [`Cache`] as well.
 #[derive(Clone)]
-pub struct FooIndices {
-    f: wasmtime::component::ComponentExportIndex,
-}
+pub struct CacheIndices {}
 /// Auto-generated bindings for an instance a component which
-/// implements the world `foo`.
+/// implements the world `cache`.
 ///
 /// This structure can be created through a number of means
 /// depending on your requirements and what you have on hand:
 ///
 /// * The most convenient way is to use
-///   [`Foo::instantiate`] which only needs a
+///   [`Cache::instantiate`] which only needs a
 ///   [`Store`], [`Component`], and [`Linker`].
 ///
-/// * Alternatively you can create a [`FooPre`] ahead of
+/// * Alternatively you can create a [`CachePre`] ahead of
 ///   time with a [`Component`] to front-load string lookups
 ///   of exports once instead of per-instantiation. This
-///   method then uses [`FooPre::instantiate`] to
-///   create a [`Foo`].
+///   method then uses [`CachePre::instantiate`] to
+///   create a [`Cache`].
 ///
 /// * If you've instantiated the instance yourself already
-///   then you can use [`Foo::new`].
+///   then you can use [`Cache::new`].
 ///
 /// These methods are all equivalent to one another and move
 /// around the tradeoff of what work is performed when.
@@ -124,12 +97,10 @@ pub struct FooIndices {
 /// [`Store`]: wasmtime::Store
 /// [`Component`]: wasmtime::component::Component
 /// [`Linker`]: wasmtime::component::Linker
-pub struct Foo {
-    f: wasmtime::component::Func,
-}
+pub struct Cache {}
 const _: () = {
-    impl FooIndices {
-        /// Creates a new copy of `FooIndices` bindings which can then
+    impl CacheIndices {
+        /// Creates a new copy of `CacheIndices` bindings which can then
         /// be used to instantiate into a particular store.
         ///
         /// This method may fail if the component does not have the
@@ -139,25 +110,10 @@ const _: () = {
         ) -> wasmtime::Result<Self> {
             let _component = _instance_pre.component();
             let _instance_type = _instance_pre.instance_type();
-            let f = {
-                let (item, index) = _component
-                    .get_export(None, "f")
-                    .ok_or_else(|| wasmtime::format_err!("no export `f` found"))?;
-                match item {
-                    wasmtime::component::types::ComponentItem::ComponentFunc(func) => {
-                        wasmtime::error::Context::context(
-                            func.typecheck::<(), ((T, U, R),)>(&_instance_type),
-                            "type-checking export func `f`",
-                        )?;
-                        index
-                    }
-                    _ => Err(wasmtime::format_err!("export `f` is not a function"))?,
-                }
-            };
-            Ok(FooIndices { f })
+            Ok(CacheIndices {})
         }
         /// Uses the indices stored in `self` to load an instance
-        /// of [`Foo`] from the instance provided.
+        /// of [`Cache`] from the instance provided.
         ///
         /// Note that at this time this method will additionally
         /// perform type-checks of all exports.
@@ -165,94 +121,87 @@ const _: () = {
             &self,
             mut store: impl wasmtime::AsContextMut,
             instance: &wasmtime::component::Instance,
-        ) -> wasmtime::Result<Foo> {
+        ) -> wasmtime::Result<Cache> {
             let _ = &mut store;
             let _instance = instance;
-            let f = *_instance
-                .get_typed_func::<(), ((T, U, R),)>(&mut store, &self.f)?
-                .func();
-            Ok(Foo { f })
+            Ok(Cache {})
         }
     }
-    impl Foo {
-        /// Convenience wrapper around [`FooPre::new`] and
-        /// [`FooPre::instantiate`].
+    impl Cache {
+        /// Convenience wrapper around [`CachePre::new`] and
+        /// [`CachePre::instantiate`].
         pub fn instantiate<_T>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
-        ) -> wasmtime::Result<Foo> {
+        ) -> wasmtime::Result<Cache> {
             let pre = linker.instantiate_pre(component)?;
-            FooPre::new(pre)?.instantiate(store)
+            CachePre::new(pre)?.instantiate(store)
         }
-        /// Convenience wrapper around [`FooIndices::new`] and
-        /// [`FooIndices::load`].
+        /// Convenience wrapper around [`CacheIndices::new`] and
+        /// [`CacheIndices::load`].
         pub fn new(
             mut store: impl wasmtime::AsContextMut,
             instance: &wasmtime::component::Instance,
-        ) -> wasmtime::Result<Foo> {
-            let indices = FooIndices::new(&instance.instance_pre(&store))?;
+        ) -> wasmtime::Result<Cache> {
+            let indices = CacheIndices::new(&instance.instance_pre(&store))?;
             indices.load(&mut store, instance)
         }
-        /// Convenience wrapper around [`FooPre::new`] and
-        /// [`FooPre::instantiate_async`].
+        /// Convenience wrapper around [`CachePre::new`] and
+        /// [`CachePre::instantiate_async`].
         pub async fn instantiate_async<_T>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
-        ) -> wasmtime::Result<Foo>
+        ) -> wasmtime::Result<Cache>
         where
             _T: Send,
         {
             let pre = linker.instantiate_pre(component)?;
-            FooPre::new(pre)?.instantiate_async(store).await
+            CachePre::new(pre)?.instantiate_async(store).await
         }
         pub fn add_to_linker<T, D>(
             linker: &mut wasmtime::component::Linker<T>,
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::i::HostWithStore,
-            for<'a> D::Data<'a>: foo::foo::i::Host,
+            D: foo::foo::store::HostWithStore + foo::foo::store::HostWithStore + Send,
+            for<'a> D::Data<'a>: foo::foo::store::Host + foo::foo::store::Host + Send,
             T: 'static + Send,
         {
-            foo::foo::i::add_to_linker::<T, D>(linker, host_getter)?;
+            foo::foo::store::add_to_linker_instance::<
+                T,
+                D,
+            >(&mut linker.instance("hot-cache")?, host_getter)?;
+            foo::foo::store::add_to_linker_instance::<
+                T,
+                D,
+            >(&mut linker.instance("durable")?, host_getter)?;
             Ok(())
-        }
-        pub async fn call_f<_T, _D>(
-            &self,
-            accessor: &wasmtime::component::Accessor<_T, _D>,
-        ) -> wasmtime::Result<(T, U, R)>
-        where
-            _T: Send,
-            _D: wasmtime::component::HasData,
-        {
-            let callee = unsafe {
-                wasmtime::component::TypedFunc::<(), ((T, U, R),)>::new_unchecked(self.f)
-            };
-            let (ret0,) = callee.call_concurrent(accessor, ()).await?;
-            Ok(ret0)
         }
     }
 };
 pub mod foo {
     pub mod foo {
         #[allow(clippy::all)]
-        pub mod i {
+        pub mod store {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::Box;
-            pub type T = u16;
-            const _: () = {
-                assert!(2 == < T as wasmtime::component::ComponentType >::SIZE32);
-                assert!(2 == < T as wasmtime::component::ComponentType >::ALIGN32);
-            };
-            pub trait HostWithStore: wasmtime::component::HasData {}
-            impl<_T: ?Sized> HostWithStore for _T
-            where
-                _T: wasmtime::component::HasData,
-            {}
-            pub trait Host {}
-            impl<_T: Host + ?Sized> Host for &mut _T {}
+            pub trait HostWithStore: wasmtime::component::HasData + Send {
+                fn get<T: Send>(
+                    accessor: &wasmtime::component::Accessor<T, Self>,
+                    key: wasmtime::component::__internal::String,
+                ) -> impl ::core::future::Future<
+                    Output = Option<wasmtime::component::__internal::String>,
+                > + Send;
+                fn set<T: Send>(
+                    accessor: &wasmtime::component::Accessor<T, Self>,
+                    key: wasmtime::component::__internal::String,
+                    value: wasmtime::component::__internal::String,
+                ) -> impl ::core::future::Future<Output = ()> + Send;
+            }
+            pub trait Host: Send {}
+            impl<_T: Host + ?Sized + Send> Host for &mut _T {}
             pub fn add_to_linker_instance<T, D>(
                 inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
@@ -260,8 +209,40 @@ pub mod foo {
             where
                 D: HostWithStore,
                 for<'a> D::Data<'a>: Host,
-                T: 'static,
+                T: 'static + Send,
             {
+                inst.func_wrap_concurrent(
+                    "get",
+                    move |
+                        caller: &wasmtime::component::Accessor<T>,
+                        (arg0,): (wasmtime::component::__internal::String,)|
+                    {
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::get(host, arg0).await;
+                            Ok((r,))
+                        })
+                    },
+                )?;
+                inst.func_wrap_concurrent(
+                    "set",
+                    move |
+                        caller: &wasmtime::component::Accessor<T>,
+                        (
+                            arg0,
+                            arg1,
+                        ): (
+                            wasmtime::component::__internal::String,
+                            wasmtime::component::__internal::String,
+                        )|
+                    {
+                        wasmtime::component::__internal::Box::pin(async move {
+                            let host = &caller.with_getter(host_getter);
+                            let r = <D as HostWithStore>::set(host, arg0, arg1).await;
+                            Ok(r)
+                        })
+                    },
+                )?;
                 Ok(())
             }
             pub fn add_to_linker<T, D>(
@@ -271,9 +252,9 @@ pub mod foo {
             where
                 D: HostWithStore,
                 for<'a> D::Data<'a>: Host,
-                T: 'static,
+                T: 'static + Send,
             {
-                let mut inst = linker.instance("foo:foo/i")?;
+                let mut inst = linker.instance("foo:foo/store")?;
                 add_to_linker_instance(&mut inst, host_getter)
             }
         }

--- a/crates/component-macro/tests/expanded/implements_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/implements_tracing_async.rs
@@ -1,16 +1,16 @@
 /// Auto-generated bindings for a pre-instantiated version of a
-/// component which implements the world `nope`.
+/// component which implements the world `cache`.
 ///
-/// This structure is created through [`NopePre::new`] which
+/// This structure is created through [`CachePre::new`] which
 /// takes a [`InstancePre`](wasmtime::component::InstancePre) that
 /// has been created through a [`Linker`](wasmtime::component::Linker).
 ///
-/// For more information see [`Nope`] as well.
-pub struct NopePre<T: 'static> {
+/// For more information see [`Cache`] as well.
+pub struct CachePre<T: 'static> {
     instance_pre: wasmtime::component::InstancePre<T>,
-    indices: NopeIndices,
+    indices: CacheIndices,
 }
-impl<T: 'static> Clone for NopePre<T> {
+impl<T: 'static> Clone for CachePre<T> {
     fn clone(&self) -> Self {
         Self {
             instance_pre: self.instance_pre.clone(),
@@ -18,8 +18,8 @@ impl<T: 'static> Clone for NopePre<T> {
         }
     }
 }
-impl<_T: 'static> NopePre<_T> {
-    /// Creates a new copy of `NopePre` bindings which can then
+impl<_T: 'static> CachePre<_T> {
+    /// Creates a new copy of `CachePre` bindings which can then
     /// be used to instantiate into a particular store.
     ///
     /// This method may fail if the component behind `instance_pre`
@@ -27,7 +27,7 @@ impl<_T: 'static> NopePre<_T> {
     pub fn new(
         instance_pre: wasmtime::component::InstancePre<_T>,
     ) -> wasmtime::Result<Self> {
-        let indices = NopeIndices::new(&instance_pre)?;
+        let indices = CacheIndices::new(&instance_pre)?;
         Ok(Self { instance_pre, indices })
     }
     pub fn engine(&self) -> &wasmtime::Engine {
@@ -36,7 +36,7 @@ impl<_T: 'static> NopePre<_T> {
     pub fn instance_pre(&self) -> &wasmtime::component::InstancePre<_T> {
         &self.instance_pre
     }
-    /// Instantiates a new instance of [`Nope`] within the
+    /// Instantiates a new instance of [`Cache`] within the
     /// `store` provided.
     ///
     /// This function will use `self` as the pre-instantiated
@@ -46,50 +46,50 @@ impl<_T: 'static> NopePre<_T> {
     pub fn instantiate(
         &self,
         mut store: impl wasmtime::AsContextMut<Data = _T>,
-    ) -> wasmtime::Result<Nope> {
+    ) -> wasmtime::Result<Cache> {
         let mut store = store.as_context_mut();
         let instance = self.instance_pre.instantiate(&mut store)?;
         self.indices.load(&mut store, &instance)
     }
 }
-impl<_T: Send + 'static> NopePre<_T> {
+impl<_T: Send + 'static> CachePre<_T> {
     /// Same as [`Self::instantiate`], except with `async`.
     pub async fn instantiate_async(
         &self,
         mut store: impl wasmtime::AsContextMut<Data = _T>,
-    ) -> wasmtime::Result<Nope> {
+    ) -> wasmtime::Result<Cache> {
         let mut store = store.as_context_mut();
         let instance = self.instance_pre.instantiate_async(&mut store).await?;
         self.indices.load(&mut store, &instance)
     }
 }
 /// Auto-generated bindings for index of the exports of
-/// `nope`.
+/// `cache`.
 ///
-/// This is an implementation detail of [`NopePre`] and can
+/// This is an implementation detail of [`CachePre`] and can
 /// be constructed if needed as well.
 ///
-/// For more information see [`Nope`] as well.
+/// For more information see [`Cache`] as well.
 #[derive(Clone)]
-pub struct NopeIndices {}
+pub struct CacheIndices {}
 /// Auto-generated bindings for an instance a component which
-/// implements the world `nope`.
+/// implements the world `cache`.
 ///
 /// This structure can be created through a number of means
 /// depending on your requirements and what you have on hand:
 ///
 /// * The most convenient way is to use
-///   [`Nope::instantiate`] which only needs a
+///   [`Cache::instantiate`] which only needs a
 ///   [`Store`], [`Component`], and [`Linker`].
 ///
-/// * Alternatively you can create a [`NopePre`] ahead of
+/// * Alternatively you can create a [`CachePre`] ahead of
 ///   time with a [`Component`] to front-load string lookups
 ///   of exports once instead of per-instantiation. This
-///   method then uses [`NopePre::instantiate`] to
-///   create a [`Nope`].
+///   method then uses [`CachePre::instantiate`] to
+///   create a [`Cache`].
 ///
 /// * If you've instantiated the instance yourself already
-///   then you can use [`Nope::new`].
+///   then you can use [`Cache::new`].
 ///
 /// These methods are all equivalent to one another and move
 /// around the tradeoff of what work is performed when.
@@ -97,10 +97,10 @@ pub struct NopeIndices {}
 /// [`Store`]: wasmtime::Store
 /// [`Component`]: wasmtime::component::Component
 /// [`Linker`]: wasmtime::component::Linker
-pub struct Nope {}
+pub struct Cache {}
 const _: () = {
-    impl NopeIndices {
-        /// Creates a new copy of `NopeIndices` bindings which can then
+    impl CacheIndices {
+        /// Creates a new copy of `CacheIndices` bindings which can then
         /// be used to instantiate into a particular store.
         ///
         /// This method may fail if the component does not have the
@@ -110,10 +110,10 @@ const _: () = {
         ) -> wasmtime::Result<Self> {
             let _component = _instance_pre.component();
             let _instance_type = _instance_pre.instance_type();
-            Ok(NopeIndices {})
+            Ok(CacheIndices {})
         }
         /// Uses the indices stored in `self` to load an instance
-        /// of [`Nope`] from the instance provided.
+        /// of [`Cache`] from the instance provided.
         ///
         /// Note that at this time this method will additionally
         /// perform type-checks of all exports.
@@ -121,55 +121,62 @@ const _: () = {
             &self,
             mut store: impl wasmtime::AsContextMut,
             instance: &wasmtime::component::Instance,
-        ) -> wasmtime::Result<Nope> {
+        ) -> wasmtime::Result<Cache> {
             let _ = &mut store;
             let _instance = instance;
-            Ok(Nope {})
+            Ok(Cache {})
         }
     }
-    impl Nope {
-        /// Convenience wrapper around [`NopePre::new`] and
-        /// [`NopePre::instantiate`].
+    impl Cache {
+        /// Convenience wrapper around [`CachePre::new`] and
+        /// [`CachePre::instantiate`].
         pub fn instantiate<_T>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
-        ) -> wasmtime::Result<Nope> {
+        ) -> wasmtime::Result<Cache> {
             let pre = linker.instantiate_pre(component)?;
-            NopePre::new(pre)?.instantiate(store)
+            CachePre::new(pre)?.instantiate(store)
         }
-        /// Convenience wrapper around [`NopeIndices::new`] and
-        /// [`NopeIndices::load`].
+        /// Convenience wrapper around [`CacheIndices::new`] and
+        /// [`CacheIndices::load`].
         pub fn new(
             mut store: impl wasmtime::AsContextMut,
             instance: &wasmtime::component::Instance,
-        ) -> wasmtime::Result<Nope> {
-            let indices = NopeIndices::new(&instance.instance_pre(&store))?;
+        ) -> wasmtime::Result<Cache> {
+            let indices = CacheIndices::new(&instance.instance_pre(&store))?;
             indices.load(&mut store, instance)
         }
-        /// Convenience wrapper around [`NopePre::new`] and
-        /// [`NopePre::instantiate_async`].
+        /// Convenience wrapper around [`CachePre::new`] and
+        /// [`CachePre::instantiate_async`].
         pub async fn instantiate_async<_T>(
             store: impl wasmtime::AsContextMut<Data = _T>,
             component: &wasmtime::component::Component,
             linker: &wasmtime::component::Linker<_T>,
-        ) -> wasmtime::Result<Nope>
+        ) -> wasmtime::Result<Cache>
         where
             _T: Send,
         {
             let pre = linker.instantiate_pre(component)?;
-            NopePre::new(pre)?.instantiate_async(store).await
+            CachePre::new(pre)?.instantiate_async(store).await
         }
         pub fn add_to_linker<T, D>(
             linker: &mut wasmtime::component::Linker<T>,
             host_getter: fn(&mut T) -> D::Data<'_>,
         ) -> wasmtime::Result<()>
         where
-            D: foo::foo::a::HostWithStore + Send,
-            for<'a> D::Data<'a>: foo::foo::a::Host + Send,
+            D: foo::foo::store::HostWithStore + foo::foo::store::HostWithStore + Send,
+            for<'a> D::Data<'a>: foo::foo::store::Host + foo::foo::store::Host + Send,
             T: 'static + Send,
         {
-            foo::foo::a::add_to_linker::<T, D>(linker, host_getter)?;
+            foo::foo::store::add_to_linker_instance::<
+                T,
+                D,
+            >(&mut linker.instance("hot-cache")?, host_getter)?;
+            foo::foo::store::add_to_linker_instance::<
+                T,
+                D,
+            >(&mut linker.instance("durable")?, host_getter)?;
             Ok(())
         }
     }
@@ -177,52 +184,42 @@ const _: () = {
 pub mod foo {
     pub mod foo {
         #[allow(clippy::all)]
-        pub mod a {
+        pub mod store {
             #[allow(unused_imports)]
             use wasmtime::component::__internal::Box;
-            #[derive(wasmtime::component::ComponentType)]
-            #[derive(wasmtime::component::Lift)]
-            #[derive(wasmtime::component::Lower)]
-            #[component(variant)]
-            #[derive(Clone)]
-            pub enum Error {
-                #[component(name = "other")]
-                Other(wasmtime::component::__internal::String),
-            }
-            impl core::fmt::Debug for Error {
-                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                    match self {
-                        Error::Other(e) => {
-                            f.debug_tuple("Error::Other").field(e).finish()
-                        }
-                    }
-                }
-            }
-            impl core::fmt::Display for Error {
-                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                    write!(f, "{:?}", self)
-                }
-            }
-            impl core::error::Error for Error {}
-            const _: () = {
-                assert!(12 == < Error as wasmtime::component::ComponentType >::SIZE32);
-                assert!(4 == < Error as wasmtime::component::ComponentType >::ALIGN32);
-            };
             pub trait HostWithStore: wasmtime::component::HasData + Send {}
             impl<_T: ?Sized> HostWithStore for _T
             where
                 _T: wasmtime::component::HasData + Send,
             {}
             pub trait Host: Send {
-                fn g(
+                fn get(
                     &mut self,
-                ) -> impl ::core::future::Future<Output = Result<(), Error>> + Send;
+                    key: wasmtime::component::__internal::String,
+                ) -> impl ::core::future::Future<
+                    Output = Option<wasmtime::component::__internal::String>,
+                > + Send;
+                fn set(
+                    &mut self,
+                    key: wasmtime::component::__internal::String,
+                    value: wasmtime::component::__internal::String,
+                ) -> impl ::core::future::Future<Output = ()> + Send;
             }
             impl<_T: Host + ?Sized + Send> Host for &mut _T {
-                fn g(
+                fn get(
                     &mut self,
-                ) -> impl ::core::future::Future<Output = Result<(), Error>> + Send {
-                    async move { Host::g(*self).await }
+                    key: wasmtime::component::__internal::String,
+                ) -> impl ::core::future::Future<
+                    Output = Option<wasmtime::component::__internal::String>,
+                > + Send {
+                    async move { Host::get(*self, key).await }
+                }
+                fn set(
+                    &mut self,
+                    key: wasmtime::component::__internal::String,
+                    value: wasmtime::component::__internal::String,
+                ) -> impl ::core::future::Future<Output = ()> + Send {
+                    async move { Host::set(*self, key, value).await }
                 }
             }
             pub fn add_to_linker_instance<T, D>(
@@ -235,23 +232,64 @@ pub mod foo {
                 T: 'static + Send,
             {
                 inst.func_wrap_async(
-                    "g",
-                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                    "get",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (arg0,): (wasmtime::component::__internal::String,)|
+                    {
                         use tracing::Instrument;
                         let span = tracing::span!(
-                            tracing::Level::TRACE, "wit-bindgen import", module = "a",
-                            function = "g",
+                            tracing::Level::TRACE, "wit-bindgen import", module =
+                            "store", function = "get",
                         );
                         wasmtime::component::__internal::Box::new(
                             async move {
-                                tracing::event!(tracing::Level::TRACE, "call");
+                                tracing::event!(
+                                    tracing::Level::TRACE, key = tracing::field::debug(& arg0),
+                                    "call"
+                                );
                                 let host = &mut host_getter(caller.data_mut());
-                                let r = Host::g(host).await;
+                                let r = Host::get(host, arg0).await;
                                 tracing::event!(
                                     tracing::Level::TRACE, result = tracing::field::debug(& r),
                                     "return"
                                 );
                                 Ok((r,))
+                            }
+                                .instrument(span),
+                        )
+                    },
+                )?;
+                inst.func_wrap_async(
+                    "set",
+                    move |
+                        mut caller: wasmtime::StoreContextMut<'_, T>,
+                        (
+                            arg0,
+                            arg1,
+                        ): (
+                            wasmtime::component::__internal::String,
+                            wasmtime::component::__internal::String,
+                        )|
+                    {
+                        use tracing::Instrument;
+                        let span = tracing::span!(
+                            tracing::Level::TRACE, "wit-bindgen import", module =
+                            "store", function = "set",
+                        );
+                        wasmtime::component::__internal::Box::new(
+                            async move {
+                                tracing::event!(
+                                    tracing::Level::TRACE, key = tracing::field::debug(& arg0),
+                                    value = tracing::field::debug(& arg1), "call"
+                                );
+                                let host = &mut host_getter(caller.data_mut());
+                                let r = Host::set(host, arg0, arg1).await;
+                                tracing::event!(
+                                    tracing::Level::TRACE, result = tracing::field::debug(& r),
+                                    "return"
+                                );
+                                Ok(r)
                             }
                                 .instrument(span),
                         )
@@ -268,7 +306,7 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker.instance("foo:foo/a")?;
+                let mut inst = linker.instance("foo:foo/store")?;
                 add_to_linker_instance(&mut inst, host_getter)
             }
         }

--- a/crates/component-macro/tests/expanded/integers.rs
+++ b/crates/component-macro/tests/expanded/integers.rs
@@ -292,8 +292,8 @@ pub mod foo {
                     Host::pair_ret(*self)
                 }
             }
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -301,7 +301,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
-                let mut inst = linker.instance("foo:foo/integers")?;
                 inst.func_wrap(
                     "a1",
                     move |mut caller: wasmtime::StoreContextMut<'_, T>, (arg0,): (u8,)| {
@@ -469,6 +468,18 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static,
+            {
+                let mut inst = linker.instance("foo:foo/integers")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/integers_async.rs
+++ b/crates/component-macro/tests/expanded/integers_async.rs
@@ -344,8 +344,8 @@ pub mod foo {
                     async move { Host::pair_ret(*self).await }
                 }
             }
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -353,7 +353,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker.instance("foo:foo/integers")?;
                 inst.func_wrap_async(
                     "a1",
                     move |mut caller: wasmtime::StoreContextMut<'_, T>, (arg0,): (u8,)| {
@@ -558,6 +557,18 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("foo:foo/integers")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/integers_concurrent.rs
+++ b/crates/component-macro/tests/expanded/integers_concurrent.rs
@@ -265,8 +265,8 @@ pub mod foo {
             }
             pub trait Host: Send {}
             impl<_T: Host + ?Sized + Send> Host for &mut _T {}
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -274,7 +274,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker.instance("foo:foo/integers")?;
                 inst.func_wrap_concurrent(
                     "a1",
                     move |caller: &wasmtime::component::Accessor<T>, (arg0,): (u8,)| {
@@ -479,6 +478,18 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("foo:foo/integers")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/integers_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/integers_tracing_async.rs
@@ -344,8 +344,8 @@ pub mod foo {
                     async move { Host::pair_ret(*self).await }
                 }
             }
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -353,7 +353,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker.instance("foo:foo/integers")?;
                 inst.func_wrap_async(
                     "a1",
                     move |mut caller: wasmtime::StoreContextMut<'_, T>, (arg0,): (u8,)| {
@@ -823,6 +822,18 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("foo:foo/integers")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/lists.rs
+++ b/crates/component-macro/tests/expanded/lists.rs
@@ -630,8 +630,8 @@ pub mod foo {
                     Host::load_store_everything(*self, a)
                 }
             }
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -639,7 +639,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
-                let mut inst = linker.instance("foo:foo/lists")?;
                 inst.func_wrap(
                     "list-u8-param",
                     move |
@@ -945,6 +944,18 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static,
+            {
+                let mut inst = linker.instance("foo:foo/lists")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/lists_async.rs
+++ b/crates/component-macro/tests/expanded/lists_async.rs
@@ -738,8 +738,8 @@ pub mod foo {
                     async move { Host::load_store_everything(*self, a).await }
                 }
             }
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -747,7 +747,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker.instance("foo:foo/lists")?;
                 inst.func_wrap_async(
                     "list-u8-param",
                     move |
@@ -1111,6 +1110,18 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("foo:foo/lists")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/lists_concurrent.rs
+++ b/crates/component-macro/tests/expanded/lists_concurrent.rs
@@ -524,8 +524,8 @@ pub mod foo {
             }
             pub trait Host: Send {}
             impl<_T: Host + ?Sized + Send> Host for &mut _T {}
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -533,7 +533,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker.instance("foo:foo/lists")?;
                 inst.func_wrap_concurrent(
                     "list-u8-param",
                     move |
@@ -914,6 +913,18 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("foo:foo/lists")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/lists_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/lists_tracing_async.rs
@@ -738,8 +738,8 @@ pub mod foo {
                     async move { Host::load_store_everything(*self, a).await }
                 }
             }
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -747,7 +747,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker.instance("foo:foo/lists")?;
                 inst.func_wrap_async(
                     "list-u8-param",
                     move |
@@ -1542,6 +1541,18 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("foo:foo/lists")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/many-arguments.rs
+++ b/crates/component-macro/tests/expanded/many-arguments.rs
@@ -343,8 +343,8 @@ pub mod foo {
                     Host::big_argument(*self, x)
                 }
             }
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -352,7 +352,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
-                let mut inst = linker.instance("foo:foo/manyarg")?;
                 inst.func_wrap(
                     "many-args",
                     move |
@@ -428,6 +427,18 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static,
+            {
+                let mut inst = linker.instance("foo:foo/manyarg")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/many-arguments_async.rs
+++ b/crates/component-macro/tests/expanded/many-arguments_async.rs
@@ -352,8 +352,8 @@ pub mod foo {
                     async move { Host::big_argument(*self, x).await }
                 }
             }
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -361,7 +361,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker.instance("foo:foo/manyarg")?;
                 inst.func_wrap_async(
                     "many-args",
                     move |
@@ -442,6 +441,18 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("foo:foo/manyarg")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/many-arguments_concurrent.rs
+++ b/crates/component-macro/tests/expanded/many-arguments_concurrent.rs
@@ -299,8 +299,8 @@ pub mod foo {
             }
             pub trait Host: Send {}
             impl<_T: Host + ?Sized + Send> Host for &mut _T {}
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -308,7 +308,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker.instance("foo:foo/manyarg")?;
                 inst.func_wrap_concurrent(
                     "many-args",
                     move |
@@ -389,6 +388,18 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("foo:foo/manyarg")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/many-arguments_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/many-arguments_tracing_async.rs
@@ -352,8 +352,8 @@ pub mod foo {
                     async move { Host::big_argument(*self, x).await }
                 }
             }
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -361,7 +361,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker.instance("foo:foo/manyarg")?;
                 inst.func_wrap_async(
                     "many-args",
                     move |
@@ -485,6 +484,18 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("foo:foo/manyarg")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/multiversion.rs
+++ b/crates/component-macro/tests/expanded/multiversion.rs
@@ -213,6 +213,25 @@ pub mod my {
                     Host::x(*self)
                 }
             }
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static,
+            {
+                inst.func_wrap(
+                    "x",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = &mut host_getter(caller.data_mut());
+                        let r = Host::x(host);
+                        Ok(r)
+                    },
+                )?;
+                Ok(())
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
@@ -223,15 +242,7 @@ pub mod my {
                 T: 'static,
             {
                 let mut inst = linker.instance("my:dep/a@0.1.0")?;
-                inst.func_wrap(
-                    "x",
-                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
-                        let host = &mut host_getter(caller.data_mut());
-                        let r = Host::x(host);
-                        Ok(r)
-                    },
-                )?;
-                Ok(())
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }
@@ -253,6 +264,25 @@ pub mod my {
                     Host::x(*self)
                 }
             }
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static,
+            {
+                inst.func_wrap(
+                    "x",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = &mut host_getter(caller.data_mut());
+                        let r = Host::x(host);
+                        Ok(r)
+                    },
+                )?;
+                Ok(())
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
@@ -263,15 +293,7 @@ pub mod my {
                 T: 'static,
             {
                 let mut inst = linker.instance("my:dep/a@0.2.0")?;
-                inst.func_wrap(
-                    "x",
-                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
-                        let host = &mut host_getter(caller.data_mut());
-                        let r = Host::x(host);
-                        Ok(r)
-                    },
-                )?;
-                Ok(())
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/multiversion_async.rs
+++ b/crates/component-macro/tests/expanded/multiversion_async.rs
@@ -213,8 +213,8 @@ pub mod my {
                     async move { Host::x(*self).await }
                 }
             }
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -222,7 +222,6 @@ pub mod my {
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker.instance("my:dep/a@0.1.0")?;
                 inst.func_wrap_async(
                     "x",
                     move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
@@ -234,6 +233,18 @@ pub mod my {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("my:dep/a@0.1.0")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }
@@ -255,8 +266,8 @@ pub mod my {
                     async move { Host::x(*self).await }
                 }
             }
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -264,7 +275,6 @@ pub mod my {
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker.instance("my:dep/a@0.2.0")?;
                 inst.func_wrap_async(
                     "x",
                     move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
@@ -276,6 +286,18 @@ pub mod my {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("my:dep/a@0.2.0")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/multiversion_concurrent.rs
+++ b/crates/component-macro/tests/expanded/multiversion_concurrent.rs
@@ -207,8 +207,8 @@ pub mod my {
             }
             pub trait Host: Send {}
             impl<_T: Host + ?Sized + Send> Host for &mut _T {}
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -216,7 +216,6 @@ pub mod my {
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker.instance("my:dep/a@0.1.0")?;
                 inst.func_wrap_concurrent(
                     "x",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
@@ -228,6 +227,18 @@ pub mod my {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("my:dep/a@0.1.0")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }
@@ -243,8 +254,8 @@ pub mod my {
             }
             pub trait Host: Send {}
             impl<_T: Host + ?Sized + Send> Host for &mut _T {}
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -252,7 +263,6 @@ pub mod my {
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker.instance("my:dep/a@0.2.0")?;
                 inst.func_wrap_concurrent(
                     "x",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
@@ -264,6 +274,18 @@ pub mod my {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("my:dep/a@0.2.0")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/multiversion_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/multiversion_tracing_async.rs
@@ -213,8 +213,8 @@ pub mod my {
                     async move { Host::x(*self).await }
                 }
             }
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -222,7 +222,6 @@ pub mod my {
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker.instance("my:dep/a@0.1.0")?;
                 inst.func_wrap_async(
                     "x",
                     move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
@@ -247,6 +246,18 @@ pub mod my {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("my:dep/a@0.1.0")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }
@@ -268,8 +279,8 @@ pub mod my {
                     async move { Host::x(*self).await }
                 }
             }
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -277,7 +288,6 @@ pub mod my {
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker.instance("my:dep/a@0.2.0")?;
                 inst.func_wrap_async(
                     "x",
                     move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
@@ -302,6 +312,18 @@ pub mod my {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("my:dep/a@0.2.0")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/path1.rs
+++ b/crates/component-macro/tests/expanded/path1.rs
@@ -187,6 +187,17 @@ pub mod paths {
             {}
             pub trait Host {}
             impl<_T: Host + ?Sized> Host for &mut _T {}
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static,
+            {
+                Ok(())
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
@@ -197,7 +208,7 @@ pub mod paths {
                 T: 'static,
             {
                 let mut inst = linker.instance("paths:path1/test")?;
-                Ok(())
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/path1_async.rs
+++ b/crates/component-macro/tests/expanded/path1_async.rs
@@ -187,6 +187,17 @@ pub mod paths {
             {}
             pub trait Host {}
             impl<_T: Host + ?Sized> Host for &mut _T {}
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static,
+            {
+                Ok(())
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
@@ -197,7 +208,7 @@ pub mod paths {
                 T: 'static,
             {
                 let mut inst = linker.instance("paths:path1/test")?;
-                Ok(())
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/path1_concurrent.rs
+++ b/crates/component-macro/tests/expanded/path1_concurrent.rs
@@ -187,6 +187,17 @@ pub mod paths {
             {}
             pub trait Host {}
             impl<_T: Host + ?Sized> Host for &mut _T {}
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static,
+            {
+                Ok(())
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
@@ -197,7 +208,7 @@ pub mod paths {
                 T: 'static,
             {
                 let mut inst = linker.instance("paths:path1/test")?;
-                Ok(())
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/path1_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/path1_tracing_async.rs
@@ -187,6 +187,17 @@ pub mod paths {
             {}
             pub trait Host {}
             impl<_T: Host + ?Sized> Host for &mut _T {}
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static,
+            {
+                Ok(())
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
@@ -197,7 +208,7 @@ pub mod paths {
                 T: 'static,
             {
                 let mut inst = linker.instance("paths:path1/test")?;
-                Ok(())
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/path2.rs
+++ b/crates/component-macro/tests/expanded/path2.rs
@@ -187,6 +187,17 @@ pub mod paths {
             {}
             pub trait Host {}
             impl<_T: Host + ?Sized> Host for &mut _T {}
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static,
+            {
+                Ok(())
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
@@ -197,7 +208,7 @@ pub mod paths {
                 T: 'static,
             {
                 let mut inst = linker.instance("paths:path2/test")?;
-                Ok(())
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/path2_async.rs
+++ b/crates/component-macro/tests/expanded/path2_async.rs
@@ -187,6 +187,17 @@ pub mod paths {
             {}
             pub trait Host {}
             impl<_T: Host + ?Sized> Host for &mut _T {}
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static,
+            {
+                Ok(())
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
@@ -197,7 +208,7 @@ pub mod paths {
                 T: 'static,
             {
                 let mut inst = linker.instance("paths:path2/test")?;
-                Ok(())
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/path2_concurrent.rs
+++ b/crates/component-macro/tests/expanded/path2_concurrent.rs
@@ -187,6 +187,17 @@ pub mod paths {
             {}
             pub trait Host {}
             impl<_T: Host + ?Sized> Host for &mut _T {}
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static,
+            {
+                Ok(())
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
@@ -197,7 +208,7 @@ pub mod paths {
                 T: 'static,
             {
                 let mut inst = linker.instance("paths:path2/test")?;
-                Ok(())
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/path2_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/path2_tracing_async.rs
@@ -187,6 +187,17 @@ pub mod paths {
             {}
             pub trait Host {}
             impl<_T: Host + ?Sized> Host for &mut _T {}
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static,
+            {
+                Ok(())
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
@@ -197,7 +208,7 @@ pub mod paths {
                 T: 'static,
             {
                 let mut inst = linker.instance("paths:path2/test")?;
-                Ok(())
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/records.rs
+++ b/crates/component-macro/tests/expanded/records.rs
@@ -441,8 +441,8 @@ pub mod foo {
                     Host::typedef_inout(*self, e)
                 }
             }
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -450,7 +450,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
-                let mut inst = linker.instance("foo:foo/records")?;
                 inst.func_wrap(
                     "tuple-arg",
                     move |
@@ -558,6 +557,18 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static,
+            {
+                let mut inst = linker.instance("foo:foo/records")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/records_async.rs
+++ b/crates/component-macro/tests/expanded/records_async.rs
@@ -497,8 +497,8 @@ pub mod foo {
                     async move { Host::typedef_inout(*self, e).await }
                 }
             }
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -506,7 +506,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker.instance("foo:foo/records")?;
                 inst.func_wrap_async(
                     "tuple-arg",
                     move |
@@ -636,6 +635,18 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("foo:foo/records")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/records_concurrent.rs
+++ b/crates/component-macro/tests/expanded/records_concurrent.rs
@@ -431,8 +431,8 @@ pub mod foo {
             }
             pub trait Host: Send {}
             impl<_T: Host + ?Sized + Send> Host for &mut _T {}
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -440,7 +440,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker.instance("foo:foo/records")?;
                 inst.func_wrap_concurrent(
                     "tuple-arg",
                     move |
@@ -569,6 +568,18 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("foo:foo/records")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/records_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/records_tracing_async.rs
@@ -497,8 +497,8 @@ pub mod foo {
                     async move { Host::typedef_inout(*self, e).await }
                 }
             }
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -506,7 +506,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker.instance("foo:foo/records")?;
                 inst.func_wrap_async(
                     "tuple-arg",
                     move |
@@ -797,6 +796,18 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("foo:foo/records")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/rename.rs
+++ b/crates/component-macro/tests/expanded/rename.rs
@@ -193,6 +193,17 @@ pub mod foo {
             {}
             pub trait Host {}
             impl<_T: Host + ?Sized> Host for &mut _T {}
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static,
+            {
+                Ok(())
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
@@ -203,7 +214,7 @@ pub mod foo {
                 T: 'static,
             {
                 let mut inst = linker.instance("foo:foo/green")?;
-                Ok(())
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
         #[allow(clippy::all)]
@@ -228,6 +239,25 @@ pub mod foo {
                     Host::foo(*self)
                 }
             }
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static,
+            {
+                inst.func_wrap(
+                    "foo",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = &mut host_getter(caller.data_mut());
+                        let r = Host::foo(host);
+                        Ok((r,))
+                    },
+                )?;
+                Ok(())
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
@@ -238,15 +268,7 @@ pub mod foo {
                 T: 'static,
             {
                 let mut inst = linker.instance("foo:foo/red")?;
-                inst.func_wrap(
-                    "foo",
-                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
-                        let host = &mut host_getter(caller.data_mut());
-                        let r = Host::foo(host);
-                        Ok((r,))
-                    },
-                )?;
-                Ok(())
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/rename_async.rs
+++ b/crates/component-macro/tests/expanded/rename_async.rs
@@ -193,6 +193,17 @@ pub mod foo {
             {}
             pub trait Host {}
             impl<_T: Host + ?Sized> Host for &mut _T {}
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static,
+            {
+                Ok(())
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
@@ -203,7 +214,7 @@ pub mod foo {
                 T: 'static,
             {
                 let mut inst = linker.instance("foo:foo/green")?;
-                Ok(())
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
         #[allow(clippy::all)]
@@ -228,8 +239,8 @@ pub mod foo {
                     async move { Host::foo(*self).await }
                 }
             }
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -237,7 +248,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker.instance("foo:foo/red")?;
                 inst.func_wrap_async(
                     "foo",
                     move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
@@ -249,6 +259,18 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("foo:foo/red")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/rename_concurrent.rs
+++ b/crates/component-macro/tests/expanded/rename_concurrent.rs
@@ -193,6 +193,17 @@ pub mod foo {
             {}
             pub trait Host {}
             impl<_T: Host + ?Sized> Host for &mut _T {}
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static,
+            {
+                Ok(())
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
@@ -203,7 +214,7 @@ pub mod foo {
                 T: 'static,
             {
                 let mut inst = linker.instance("foo:foo/green")?;
-                Ok(())
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
         #[allow(clippy::all)]
@@ -222,8 +233,8 @@ pub mod foo {
             }
             pub trait Host: Send {}
             impl<_T: Host + ?Sized + Send> Host for &mut _T {}
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -231,7 +242,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker.instance("foo:foo/red")?;
                 inst.func_wrap_concurrent(
                     "foo",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
@@ -243,6 +253,18 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("foo:foo/red")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/rename_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/rename_tracing_async.rs
@@ -193,6 +193,17 @@ pub mod foo {
             {}
             pub trait Host {}
             impl<_T: Host + ?Sized> Host for &mut _T {}
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static,
+            {
+                Ok(())
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
@@ -203,7 +214,7 @@ pub mod foo {
                 T: 'static,
             {
                 let mut inst = linker.instance("foo:foo/green")?;
-                Ok(())
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
         #[allow(clippy::all)]
@@ -228,8 +239,8 @@ pub mod foo {
                     async move { Host::foo(*self).await }
                 }
             }
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -237,7 +248,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker.instance("foo:foo/red")?;
                 inst.func_wrap_async(
                     "foo",
                     move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
@@ -262,6 +272,18 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("foo:foo/red")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/resources-export.rs
+++ b/crates/component-macro/tests/expanded/resources-export.rs
@@ -261,8 +261,8 @@ pub mod foo {
             {}
             pub trait Host: HostY {}
             impl<_T: Host + ?Sized> Host for &mut _T {}
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -270,7 +270,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
-                let mut inst = linker.instance("foo:foo/transitive-import")?;
                 inst.resource(
                     "y",
                     wasmtime::component::ResourceType::host::<Y>(),
@@ -282,6 +281,18 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static,
+            {
+                let mut inst = linker.instance("foo:foo/transitive-import")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/resources-export_async.rs
+++ b/crates/component-macro/tests/expanded/resources-export_async.rs
@@ -261,8 +261,8 @@ pub mod foo {
             {}
             pub trait Host: HostY + Send {}
             impl<_T: Host + ?Sized + Send> Host for &mut _T {}
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -270,7 +270,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker.instance("foo:foo/transitive-import")?;
                 inst.resource_async(
                     "y",
                     wasmtime::component::ResourceType::host::<Y>(),
@@ -287,6 +286,18 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("foo:foo/transitive-import")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/resources-export_concurrent.rs
+++ b/crates/component-macro/tests/expanded/resources-export_concurrent.rs
@@ -252,8 +252,8 @@ pub mod foo {
             {}
             pub trait Host: HostY + Send {}
             impl<_T: Host + ?Sized + Send> Host for &mut _T {}
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -261,7 +261,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker.instance("foo:foo/transitive-import")?;
                 inst.resource_concurrent(
                     "y",
                     wasmtime::component::ResourceType::host::<Y>(),
@@ -279,6 +278,18 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("foo:foo/transitive-import")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/resources-export_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/resources-export_tracing_async.rs
@@ -261,8 +261,8 @@ pub mod foo {
             {}
             pub trait Host: HostY + Send {}
             impl<_T: Host + ?Sized + Send> Host for &mut _T {}
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -270,7 +270,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker.instance("foo:foo/transitive-import")?;
                 inst.resource_async(
                     "y",
                     wasmtime::component::ResourceType::host::<Y>(),
@@ -287,6 +286,18 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("foo:foo/transitive-import")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/resources-import.rs
+++ b/crates/component-macro/tests/expanded/resources-import.rs
@@ -665,8 +665,8 @@ pub mod foo {
                     Host::func_with_handle_typedef(*self, x)
                 }
             }
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -674,7 +674,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
-                let mut inst = linker.instance("foo:foo/resources")?;
                 inst.resource(
                     "bar",
                     wasmtime::component::ResourceType::host::<Bar>(),
@@ -938,6 +937,18 @@ pub mod foo {
                 )?;
                 Ok(())
             }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static,
+            {
+                let mut inst = linker.instance("foo:foo/resources")?;
+                add_to_linker_instance(&mut inst, host_getter)
+            }
         }
         #[allow(clippy::all)]
         pub mod long_use_chain1 {
@@ -970,8 +981,8 @@ pub mod foo {
             {}
             pub trait Host: HostA {}
             impl<_T: Host + ?Sized> Host for &mut _T {}
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -979,7 +990,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
-                let mut inst = linker.instance("foo:foo/long-use-chain1")?;
                 inst.resource(
                     "a",
                     wasmtime::component::ResourceType::host::<A>(),
@@ -991,6 +1001,18 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static,
+            {
+                let mut inst = linker.instance("foo:foo/long-use-chain1")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
         #[allow(clippy::all)]
@@ -1005,6 +1027,17 @@ pub mod foo {
             {}
             pub trait Host {}
             impl<_T: Host + ?Sized> Host for &mut _T {}
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static,
+            {
+                Ok(())
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
@@ -1015,7 +1048,7 @@ pub mod foo {
                 T: 'static,
             {
                 let mut inst = linker.instance("foo:foo/long-use-chain2")?;
-                Ok(())
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
         #[allow(clippy::all)]
@@ -1030,6 +1063,17 @@ pub mod foo {
             {}
             pub trait Host {}
             impl<_T: Host + ?Sized> Host for &mut _T {}
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static,
+            {
+                Ok(())
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
@@ -1040,7 +1084,7 @@ pub mod foo {
                 T: 'static,
             {
                 let mut inst = linker.instance("foo:foo/long-use-chain3")?;
-                Ok(())
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
         #[allow(clippy::all)]
@@ -1061,6 +1105,25 @@ pub mod foo {
                     Host::foo(*self)
                 }
             }
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static,
+            {
+                inst.func_wrap(
+                    "foo",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = &mut host_getter(caller.data_mut());
+                        let r = Host::foo(host);
+                        Ok((r,))
+                    },
+                )?;
+                Ok(())
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
@@ -1071,15 +1134,7 @@ pub mod foo {
                 T: 'static,
             {
                 let mut inst = linker.instance("foo:foo/long-use-chain4")?;
-                inst.func_wrap(
-                    "foo",
-                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
-                        let host = &mut host_getter(caller.data_mut());
-                        let r = Host::foo(host);
-                        Ok((r,))
-                    },
-                )?;
-                Ok(())
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
         #[allow(clippy::all)]
@@ -1113,8 +1168,8 @@ pub mod foo {
             {}
             pub trait Host: HostFoo {}
             impl<_T: Host + ?Sized> Host for &mut _T {}
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -1122,8 +1177,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
-                let mut inst = linker
-                    .instance("foo:foo/transitive-interface-with-resource")?;
                 inst.resource(
                     "foo",
                     wasmtime::component::ResourceType::host::<Foo>(),
@@ -1135,6 +1188,19 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static,
+            {
+                let mut inst = linker
+                    .instance("foo:foo/transitive-interface-with-resource")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/resources-import_async.rs
+++ b/crates/component-macro/tests/expanded/resources-import_async.rs
@@ -776,8 +776,8 @@ pub mod foo {
                     async move { Host::func_with_handle_typedef(*self, x).await }
                 }
             }
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -785,7 +785,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker.instance("foo:foo/resources")?;
                 inst.resource_async(
                     "bar",
                     wasmtime::component::ResourceType::host::<Bar>(),
@@ -1102,6 +1101,18 @@ pub mod foo {
                 )?;
                 Ok(())
             }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("foo:foo/resources")?;
+                add_to_linker_instance(&mut inst, host_getter)
+            }
         }
         #[allow(clippy::all)]
         pub mod long_use_chain1 {
@@ -1134,8 +1145,8 @@ pub mod foo {
             {}
             pub trait Host: HostA + Send {}
             impl<_T: Host + ?Sized + Send> Host for &mut _T {}
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -1143,7 +1154,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker.instance("foo:foo/long-use-chain1")?;
                 inst.resource_async(
                     "a",
                     wasmtime::component::ResourceType::host::<A>(),
@@ -1161,6 +1171,18 @@ pub mod foo {
                 )?;
                 Ok(())
             }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("foo:foo/long-use-chain1")?;
+                add_to_linker_instance(&mut inst, host_getter)
+            }
         }
         #[allow(clippy::all)]
         pub mod long_use_chain2 {
@@ -1174,6 +1196,17 @@ pub mod foo {
             {}
             pub trait Host {}
             impl<_T: Host + ?Sized> Host for &mut _T {}
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static,
+            {
+                Ok(())
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
@@ -1184,7 +1217,7 @@ pub mod foo {
                 T: 'static,
             {
                 let mut inst = linker.instance("foo:foo/long-use-chain2")?;
-                Ok(())
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
         #[allow(clippy::all)]
@@ -1199,6 +1232,17 @@ pub mod foo {
             {}
             pub trait Host {}
             impl<_T: Host + ?Sized> Host for &mut _T {}
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static,
+            {
+                Ok(())
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
@@ -1209,7 +1253,7 @@ pub mod foo {
                 T: 'static,
             {
                 let mut inst = linker.instance("foo:foo/long-use-chain3")?;
-                Ok(())
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
         #[allow(clippy::all)]
@@ -1238,8 +1282,8 @@ pub mod foo {
                     async move { Host::foo(*self).await }
                 }
             }
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -1247,7 +1291,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker.instance("foo:foo/long-use-chain4")?;
                 inst.func_wrap_async(
                     "foo",
                     move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
@@ -1259,6 +1302,18 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("foo:foo/long-use-chain4")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
         #[allow(clippy::all)]
@@ -1292,8 +1347,8 @@ pub mod foo {
             {}
             pub trait Host: HostFoo + Send {}
             impl<_T: Host + ?Sized + Send> Host for &mut _T {}
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -1301,8 +1356,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker
-                    .instance("foo:foo/transitive-interface-with-resource")?;
                 inst.resource_async(
                     "foo",
                     wasmtime::component::ResourceType::host::<Foo>(),
@@ -1319,6 +1372,19 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker
+                    .instance("foo:foo/transitive-interface-with-resource")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/resources-import_concurrent.rs
+++ b/crates/component-macro/tests/expanded/resources-import_concurrent.rs
@@ -572,8 +572,8 @@ pub mod foo {
             }
             pub trait Host: HostBar + HostFallible + Send {}
             impl<_T: Host + ?Sized + Send> Host for &mut _T {}
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -581,7 +581,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker.instance("foo:foo/resources")?;
                 inst.resource_concurrent(
                     "bar",
                     wasmtime::component::ResourceType::host::<Bar>(),
@@ -914,6 +913,18 @@ pub mod foo {
                 )?;
                 Ok(())
             }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("foo:foo/resources")?;
+                add_to_linker_instance(&mut inst, host_getter)
+            }
         }
         #[allow(clippy::all)]
         pub mod long_use_chain1 {
@@ -937,8 +948,8 @@ pub mod foo {
             {}
             pub trait Host: HostA + Send {}
             impl<_T: Host + ?Sized + Send> Host for &mut _T {}
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -946,7 +957,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker.instance("foo:foo/long-use-chain1")?;
                 inst.resource_concurrent(
                     "a",
                     wasmtime::component::ResourceType::host::<A>(),
@@ -965,6 +975,18 @@ pub mod foo {
                 )?;
                 Ok(())
             }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("foo:foo/long-use-chain1")?;
+                add_to_linker_instance(&mut inst, host_getter)
+            }
         }
         #[allow(clippy::all)]
         pub mod long_use_chain2 {
@@ -978,6 +1000,17 @@ pub mod foo {
             {}
             pub trait Host {}
             impl<_T: Host + ?Sized> Host for &mut _T {}
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static,
+            {
+                Ok(())
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
@@ -988,7 +1021,7 @@ pub mod foo {
                 T: 'static,
             {
                 let mut inst = linker.instance("foo:foo/long-use-chain2")?;
-                Ok(())
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
         #[allow(clippy::all)]
@@ -1003,6 +1036,17 @@ pub mod foo {
             {}
             pub trait Host {}
             impl<_T: Host + ?Sized> Host for &mut _T {}
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static,
+            {
+                Ok(())
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
@@ -1013,7 +1057,7 @@ pub mod foo {
                 T: 'static,
             {
                 let mut inst = linker.instance("foo:foo/long-use-chain3")?;
-                Ok(())
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
         #[allow(clippy::all)]
@@ -1030,8 +1074,8 @@ pub mod foo {
             }
             pub trait Host: Send {}
             impl<_T: Host + ?Sized + Send> Host for &mut _T {}
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -1039,7 +1083,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker.instance("foo:foo/long-use-chain4")?;
                 inst.func_wrap_concurrent(
                     "foo",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
@@ -1051,6 +1094,18 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("foo:foo/long-use-chain4")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
         #[allow(clippy::all)]
@@ -1075,8 +1130,8 @@ pub mod foo {
             {}
             pub trait Host: HostFoo + Send {}
             impl<_T: Host + ?Sized + Send> Host for &mut _T {}
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -1084,8 +1139,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker
-                    .instance("foo:foo/transitive-interface-with-resource")?;
                 inst.resource_concurrent(
                     "foo",
                     wasmtime::component::ResourceType::host::<Foo>(),
@@ -1103,6 +1156,19 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker
+                    .instance("foo:foo/transitive-interface-with-resource")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/resources-import_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/resources-import_tracing_async.rs
@@ -839,8 +839,8 @@ pub mod foo {
                     async move { Host::func_with_handle_typedef(*self, x).await }
                 }
             }
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -848,7 +848,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker.instance("foo:foo/resources")?;
                 inst.resource_async(
                     "bar",
                     wasmtime::component::ResourceType::host::<Bar>(),
@@ -1506,6 +1505,18 @@ pub mod foo {
                 )?;
                 Ok(())
             }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("foo:foo/resources")?;
+                add_to_linker_instance(&mut inst, host_getter)
+            }
         }
         #[allow(clippy::all)]
         pub mod long_use_chain1 {
@@ -1538,8 +1549,8 @@ pub mod foo {
             {}
             pub trait Host: HostA + Send {}
             impl<_T: Host + ?Sized + Send> Host for &mut _T {}
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -1547,7 +1558,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker.instance("foo:foo/long-use-chain1")?;
                 inst.resource_async(
                     "a",
                     wasmtime::component::ResourceType::host::<A>(),
@@ -1565,6 +1575,18 @@ pub mod foo {
                 )?;
                 Ok(())
             }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("foo:foo/long-use-chain1")?;
+                add_to_linker_instance(&mut inst, host_getter)
+            }
         }
         #[allow(clippy::all)]
         pub mod long_use_chain2 {
@@ -1578,6 +1600,17 @@ pub mod foo {
             {}
             pub trait Host {}
             impl<_T: Host + ?Sized> Host for &mut _T {}
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static,
+            {
+                Ok(())
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
@@ -1588,7 +1621,7 @@ pub mod foo {
                 T: 'static,
             {
                 let mut inst = linker.instance("foo:foo/long-use-chain2")?;
-                Ok(())
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
         #[allow(clippy::all)]
@@ -1603,6 +1636,17 @@ pub mod foo {
             {}
             pub trait Host {}
             impl<_T: Host + ?Sized> Host for &mut _T {}
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static,
+            {
+                Ok(())
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
@@ -1613,7 +1657,7 @@ pub mod foo {
                 T: 'static,
             {
                 let mut inst = linker.instance("foo:foo/long-use-chain3")?;
-                Ok(())
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
         #[allow(clippy::all)]
@@ -1642,8 +1686,8 @@ pub mod foo {
                     async move { Host::foo(*self).await }
                 }
             }
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -1651,7 +1695,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker.instance("foo:foo/long-use-chain4")?;
                 inst.func_wrap_async(
                     "foo",
                     move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
@@ -1676,6 +1719,18 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("foo:foo/long-use-chain4")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
         #[allow(clippy::all)]
@@ -1709,8 +1764,8 @@ pub mod foo {
             {}
             pub trait Host: HostFoo + Send {}
             impl<_T: Host + ?Sized + Send> Host for &mut _T {}
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -1718,8 +1773,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker
-                    .instance("foo:foo/transitive-interface-with-resource")?;
                 inst.resource_async(
                     "foo",
                     wasmtime::component::ResourceType::host::<Foo>(),
@@ -1736,6 +1789,19 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker
+                    .instance("foo:foo/transitive-interface-with-resource")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/share-types.rs
+++ b/crates/component-macro/tests/expanded/share-types.rs
@@ -235,6 +235,17 @@ pub mod foo {
             {}
             pub trait Host {}
             impl<_T: Host + ?Sized> Host for &mut _T {}
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static,
+            {
+                Ok(())
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
@@ -245,7 +256,7 @@ pub mod foo {
                 T: 'static,
             {
                 let mut inst = linker.instance("foo:foo/http-types")?;
-                Ok(())
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }
@@ -277,6 +288,25 @@ pub mod http_fetch {
             Host::fetch_request(*self, request)
         }
     }
+    pub fn add_to_linker_instance<T, D>(
+        inst: &mut wasmtime::component::LinkerInstance<'_, T>,
+        host_getter: fn(&mut T) -> D::Data<'_>,
+    ) -> wasmtime::Result<()>
+    where
+        D: HostWithStore,
+        for<'a> D::Data<'a>: Host,
+        T: 'static,
+    {
+        inst.func_wrap(
+            "fetch-request",
+            move |mut caller: wasmtime::StoreContextMut<'_, T>, (arg0,): (Request,)| {
+                let host = &mut host_getter(caller.data_mut());
+                let r = Host::fetch_request(host, arg0);
+                Ok((r,))
+            },
+        )?;
+        Ok(())
+    }
     pub fn add_to_linker<T, D>(
         linker: &mut wasmtime::component::Linker<T>,
         host_getter: fn(&mut T) -> D::Data<'_>,
@@ -287,15 +317,7 @@ pub mod http_fetch {
         T: 'static,
     {
         let mut inst = linker.instance("http-fetch")?;
-        inst.func_wrap(
-            "fetch-request",
-            move |mut caller: wasmtime::StoreContextMut<'_, T>, (arg0,): (Request,)| {
-                let host = &mut host_getter(caller.data_mut());
-                let r = Host::fetch_request(host, arg0);
-                Ok((r,))
-            },
-        )?;
-        Ok(())
+        add_to_linker_instance(&mut inst, host_getter)
     }
 }
 pub mod exports {

--- a/crates/component-macro/tests/expanded/share-types_async.rs
+++ b/crates/component-macro/tests/expanded/share-types_async.rs
@@ -235,6 +235,17 @@ pub mod foo {
             {}
             pub trait Host {}
             impl<_T: Host + ?Sized> Host for &mut _T {}
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static,
+            {
+                Ok(())
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
@@ -245,7 +256,7 @@ pub mod foo {
                 T: 'static,
             {
                 let mut inst = linker.instance("foo:foo/http-types")?;
-                Ok(())
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }
@@ -283,8 +294,8 @@ pub mod http_fetch {
             async move { Host::fetch_request(*self, request).await }
         }
     }
-    pub fn add_to_linker<T, D>(
-        linker: &mut wasmtime::component::Linker<T>,
+    pub fn add_to_linker_instance<T, D>(
+        inst: &mut wasmtime::component::LinkerInstance<'_, T>,
         host_getter: fn(&mut T) -> D::Data<'_>,
     ) -> wasmtime::Result<()>
     where
@@ -292,7 +303,6 @@ pub mod http_fetch {
         for<'a> D::Data<'a>: Host,
         T: 'static + Send,
     {
-        let mut inst = linker.instance("http-fetch")?;
         inst.func_wrap_async(
             "fetch-request",
             move |mut caller: wasmtime::StoreContextMut<'_, T>, (arg0,): (Request,)| {
@@ -304,6 +314,18 @@ pub mod http_fetch {
             },
         )?;
         Ok(())
+    }
+    pub fn add_to_linker<T, D>(
+        linker: &mut wasmtime::component::Linker<T>,
+        host_getter: fn(&mut T) -> D::Data<'_>,
+    ) -> wasmtime::Result<()>
+    where
+        D: HostWithStore,
+        for<'a> D::Data<'a>: Host,
+        T: 'static + Send,
+    {
+        let mut inst = linker.instance("http-fetch")?;
+        add_to_linker_instance(&mut inst, host_getter)
     }
 }
 pub mod exports {

--- a/crates/component-macro/tests/expanded/share-types_concurrent.rs
+++ b/crates/component-macro/tests/expanded/share-types_concurrent.rs
@@ -235,6 +235,17 @@ pub mod foo {
             {}
             pub trait Host {}
             impl<_T: Host + ?Sized> Host for &mut _T {}
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static,
+            {
+                Ok(())
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
@@ -245,7 +256,7 @@ pub mod foo {
                 T: 'static,
             {
                 let mut inst = linker.instance("foo:foo/http-types")?;
-                Ok(())
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }
@@ -272,8 +283,8 @@ pub mod http_fetch {
     }
     pub trait Host: Send {}
     impl<_T: Host + ?Sized + Send> Host for &mut _T {}
-    pub fn add_to_linker<T, D>(
-        linker: &mut wasmtime::component::Linker<T>,
+    pub fn add_to_linker_instance<T, D>(
+        inst: &mut wasmtime::component::LinkerInstance<'_, T>,
         host_getter: fn(&mut T) -> D::Data<'_>,
     ) -> wasmtime::Result<()>
     where
@@ -281,7 +292,6 @@ pub mod http_fetch {
         for<'a> D::Data<'a>: Host,
         T: 'static + Send,
     {
-        let mut inst = linker.instance("http-fetch")?;
         inst.func_wrap_concurrent(
             "fetch-request",
             move |caller: &wasmtime::component::Accessor<T>, (arg0,): (Request,)| {
@@ -293,6 +303,18 @@ pub mod http_fetch {
             },
         )?;
         Ok(())
+    }
+    pub fn add_to_linker<T, D>(
+        linker: &mut wasmtime::component::Linker<T>,
+        host_getter: fn(&mut T) -> D::Data<'_>,
+    ) -> wasmtime::Result<()>
+    where
+        D: HostWithStore,
+        for<'a> D::Data<'a>: Host,
+        T: 'static + Send,
+    {
+        let mut inst = linker.instance("http-fetch")?;
+        add_to_linker_instance(&mut inst, host_getter)
     }
 }
 pub mod exports {

--- a/crates/component-macro/tests/expanded/share-types_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/share-types_tracing_async.rs
@@ -235,6 +235,17 @@ pub mod foo {
             {}
             pub trait Host {}
             impl<_T: Host + ?Sized> Host for &mut _T {}
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static,
+            {
+                Ok(())
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
@@ -245,7 +256,7 @@ pub mod foo {
                 T: 'static,
             {
                 let mut inst = linker.instance("foo:foo/http-types")?;
-                Ok(())
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }
@@ -283,8 +294,8 @@ pub mod http_fetch {
             async move { Host::fetch_request(*self, request).await }
         }
     }
-    pub fn add_to_linker<T, D>(
-        linker: &mut wasmtime::component::Linker<T>,
+    pub fn add_to_linker_instance<T, D>(
+        inst: &mut wasmtime::component::LinkerInstance<'_, T>,
         host_getter: fn(&mut T) -> D::Data<'_>,
     ) -> wasmtime::Result<()>
     where
@@ -292,7 +303,6 @@ pub mod http_fetch {
         for<'a> D::Data<'a>: Host,
         T: 'static + Send,
     {
-        let mut inst = linker.instance("http-fetch")?;
         inst.func_wrap_async(
             "fetch-request",
             move |mut caller: wasmtime::StoreContextMut<'_, T>, (arg0,): (Request,)| {
@@ -320,6 +330,18 @@ pub mod http_fetch {
             },
         )?;
         Ok(())
+    }
+    pub fn add_to_linker<T, D>(
+        linker: &mut wasmtime::component::Linker<T>,
+        host_getter: fn(&mut T) -> D::Data<'_>,
+    ) -> wasmtime::Result<()>
+    where
+        D: HostWithStore,
+        for<'a> D::Data<'a>: Host,
+        T: 'static + Send,
+    {
+        let mut inst = linker.instance("http-fetch")?;
+        add_to_linker_instance(&mut inst, host_getter)
     }
 }
 pub mod exports {

--- a/crates/component-macro/tests/expanded/simple-functions.rs
+++ b/crates/component-macro/tests/expanded/simple-functions.rs
@@ -224,8 +224,8 @@ pub mod foo {
                     Host::f6(*self, a, b, c)
                 }
             }
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -233,7 +233,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
-                let mut inst = linker.instance("foo:foo/simple")?;
                 inst.func_wrap(
                     "f1",
                     move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
@@ -289,6 +288,18 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static,
+            {
+                let mut inst = linker.instance("foo:foo/simple")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/simple-functions_async.rs
+++ b/crates/component-macro/tests/expanded/simple-functions_async.rs
@@ -252,8 +252,8 @@ pub mod foo {
                     async move { Host::f6(*self, a, b, c).await }
                 }
             }
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -261,7 +261,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker.instance("foo:foo/simple")?;
                 inst.func_wrap_async(
                     "f1",
                     move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
@@ -329,6 +328,18 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("foo:foo/simple")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/simple-functions_concurrent.rs
+++ b/crates/component-macro/tests/expanded/simple-functions_concurrent.rs
@@ -219,8 +219,8 @@ pub mod foo {
             }
             pub trait Host: Send {}
             impl<_T: Host + ?Sized + Send> Host for &mut _T {}
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -228,7 +228,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker.instance("foo:foo/simple")?;
                 inst.func_wrap_concurrent(
                     "f1",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
@@ -297,6 +296,18 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("foo:foo/simple")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/simple-functions_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/simple-functions_tracing_async.rs
@@ -252,8 +252,8 @@ pub mod foo {
                     async move { Host::f6(*self, a, b, c).await }
                 }
             }
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -261,7 +261,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker.instance("foo:foo/simple")?;
                 inst.func_wrap_async(
                     "f1",
                     move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
@@ -417,6 +416,18 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("foo:foo/simple")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/simple-lists.rs
+++ b/crates/component-macro/tests/expanded/simple-lists.rs
@@ -250,8 +250,8 @@ pub mod foo {
                     Host::simple_list4(*self, l)
                 }
             }
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -259,7 +259,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
-                let mut inst = linker.instance("foo:foo/simple-lists")?;
                 inst.func_wrap(
                     "simple-list1",
                     move |
@@ -314,6 +313,18 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static,
+            {
+                let mut inst = linker.instance("foo:foo/simple-lists")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/simple-lists_async.rs
+++ b/crates/component-macro/tests/expanded/simple-lists_async.rs
@@ -266,8 +266,8 @@ pub mod foo {
                     async move { Host::simple_list4(*self, l).await }
                 }
             }
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -275,7 +275,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker.instance("foo:foo/simple-lists")?;
                 inst.func_wrap_async(
                     "simple-list1",
                     move |
@@ -338,6 +337,18 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("foo:foo/simple-lists")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/simple-lists_concurrent.rs
+++ b/crates/component-macro/tests/expanded/simple-lists_concurrent.rs
@@ -224,8 +224,8 @@ pub mod foo {
             }
             pub trait Host: Send {}
             impl<_T: Host + ?Sized + Send> Host for &mut _T {}
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -233,7 +233,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker.instance("foo:foo/simple-lists")?;
                 inst.func_wrap_concurrent(
                     "simple-list1",
                     move |
@@ -297,6 +296,18 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("foo:foo/simple-lists")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/simple-lists_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/simple-lists_tracing_async.rs
@@ -266,8 +266,8 @@ pub mod foo {
                     async move { Host::simple_list4(*self, l).await }
                 }
             }
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -275,7 +275,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker.instance("foo:foo/simple-lists")?;
                 inst.func_wrap_async(
                     "simple-list1",
                     move |
@@ -399,6 +398,18 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("foo:foo/simple-lists")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/simple-wasi.rs
+++ b/crates/component-macro/tests/expanded/simple-wasi.rs
@@ -262,8 +262,8 @@ pub mod foo {
                     Host::stat(*self)
                 }
             }
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -271,7 +271,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
-                let mut inst = linker.instance("foo:foo/wasi-filesystem")?;
                 inst.func_wrap(
                     "create-directory-at",
                     move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
@@ -289,6 +288,18 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static,
+            {
+                let mut inst = linker.instance("foo:foo/wasi-filesystem")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
         #[allow(clippy::all)]
@@ -321,6 +332,17 @@ pub mod foo {
             {}
             pub trait Host {}
             impl<_T: Host + ?Sized> Host for &mut _T {}
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static,
+            {
+                Ok(())
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
@@ -331,7 +353,7 @@ pub mod foo {
                 T: 'static,
             {
                 let mut inst = linker.instance("foo:foo/wall-clock")?;
-                Ok(())
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/simple-wasi_async.rs
+++ b/crates/component-macro/tests/expanded/simple-wasi_async.rs
@@ -274,8 +274,8 @@ pub mod foo {
                     async move { Host::stat(*self).await }
                 }
             }
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -283,7 +283,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker.instance("foo:foo/wasi-filesystem")?;
                 inst.func_wrap_async(
                     "create-directory-at",
                     move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
@@ -305,6 +304,18 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("foo:foo/wasi-filesystem")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
         #[allow(clippy::all)]
@@ -337,6 +348,17 @@ pub mod foo {
             {}
             pub trait Host {}
             impl<_T: Host + ?Sized> Host for &mut _T {}
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static,
+            {
+                Ok(())
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
@@ -347,7 +369,7 @@ pub mod foo {
                 T: 'static,
             {
                 let mut inst = linker.instance("foo:foo/wall-clock")?;
-                Ok(())
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/simple-wasi_concurrent.rs
+++ b/crates/component-macro/tests/expanded/simple-wasi_concurrent.rs
@@ -257,8 +257,8 @@ pub mod foo {
             }
             pub trait Host: Send {}
             impl<_T: Host + ?Sized + Send> Host for &mut _T {}
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -266,7 +266,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker.instance("foo:foo/wasi-filesystem")?;
                 inst.func_wrap_concurrent(
                     "create-directory-at",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
@@ -289,6 +288,18 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("foo:foo/wasi-filesystem")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
         #[allow(clippy::all)]
@@ -321,6 +332,17 @@ pub mod foo {
             {}
             pub trait Host {}
             impl<_T: Host + ?Sized> Host for &mut _T {}
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static,
+            {
+                Ok(())
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
@@ -331,7 +353,7 @@ pub mod foo {
                 T: 'static,
             {
                 let mut inst = linker.instance("foo:foo/wall-clock")?;
-                Ok(())
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/simple-wasi_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/simple-wasi_tracing_async.rs
@@ -274,8 +274,8 @@ pub mod foo {
                     async move { Host::stat(*self).await }
                 }
             }
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -283,7 +283,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker.instance("foo:foo/wasi-filesystem")?;
                 inst.func_wrap_async(
                     "create-directory-at",
                     move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
@@ -332,6 +331,18 @@ pub mod foo {
                 )?;
                 Ok(())
             }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("foo:foo/wasi-filesystem")?;
+                add_to_linker_instance(&mut inst, host_getter)
+            }
         }
         #[allow(clippy::all)]
         pub mod wall_clock {
@@ -363,6 +374,17 @@ pub mod foo {
             {}
             pub trait Host {}
             impl<_T: Host + ?Sized> Host for &mut _T {}
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static,
+            {
+                Ok(())
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
@@ -373,7 +395,7 @@ pub mod foo {
                 T: 'static,
             {
                 let mut inst = linker.instance("foo:foo/wall-clock")?;
-                Ok(())
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/small-anonymous.rs
+++ b/crates/component-macro/tests/expanded/small-anonymous.rs
@@ -251,6 +251,25 @@ pub mod foo {
                     Host::option_test(*self)
                 }
             }
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static,
+            {
+                inst.func_wrap(
+                    "option-test",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = &mut host_getter(caller.data_mut());
+                        let r = Host::option_test(host);
+                        Ok((r,))
+                    },
+                )?;
+                Ok(())
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
@@ -261,15 +280,7 @@ pub mod foo {
                 T: 'static,
             {
                 let mut inst = linker.instance("foo:foo/anon")?;
-                inst.func_wrap(
-                    "option-test",
-                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
-                        let host = &mut host_getter(caller.data_mut());
-                        let r = Host::option_test(host);
-                        Ok((r,))
-                    },
-                )?;
-                Ok(())
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/small-anonymous_async.rs
+++ b/crates/component-macro/tests/expanded/small-anonymous_async.rs
@@ -261,8 +261,8 @@ pub mod foo {
                     async move { Host::option_test(*self).await }
                 }
             }
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -270,7 +270,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker.instance("foo:foo/anon")?;
                 inst.func_wrap_async(
                     "option-test",
                     move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
@@ -282,6 +281,18 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("foo:foo/anon")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/small-anonymous_concurrent.rs
+++ b/crates/component-macro/tests/expanded/small-anonymous_concurrent.rs
@@ -246,8 +246,8 @@ pub mod foo {
             }
             pub trait Host: Send {}
             impl<_T: Host + ?Sized + Send> Host for &mut _T {}
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -255,7 +255,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker.instance("foo:foo/anon")?;
                 inst.func_wrap_concurrent(
                     "option-test",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
@@ -267,6 +266,18 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("foo:foo/anon")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/small-anonymous_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/small-anonymous_tracing_async.rs
@@ -261,8 +261,8 @@ pub mod foo {
                     async move { Host::option_test(*self).await }
                 }
             }
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -270,7 +270,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker.instance("foo:foo/anon")?;
                 inst.func_wrap_async(
                     "option-test",
                     move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
@@ -295,6 +294,18 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("foo:foo/anon")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/smoke.rs
+++ b/crates/component-macro/tests/expanded/smoke.rs
@@ -191,6 +191,25 @@ pub mod imports {
             Host::y(*self)
         }
     }
+    pub fn add_to_linker_instance<T, D>(
+        inst: &mut wasmtime::component::LinkerInstance<'_, T>,
+        host_getter: fn(&mut T) -> D::Data<'_>,
+    ) -> wasmtime::Result<()>
+    where
+        D: HostWithStore,
+        for<'a> D::Data<'a>: Host,
+        T: 'static,
+    {
+        inst.func_wrap(
+            "y",
+            move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                let host = &mut host_getter(caller.data_mut());
+                let r = Host::y(host);
+                Ok(r)
+            },
+        )?;
+        Ok(())
+    }
     pub fn add_to_linker<T, D>(
         linker: &mut wasmtime::component::Linker<T>,
         host_getter: fn(&mut T) -> D::Data<'_>,
@@ -201,14 +220,6 @@ pub mod imports {
         T: 'static,
     {
         let mut inst = linker.instance("imports")?;
-        inst.func_wrap(
-            "y",
-            move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
-                let host = &mut host_getter(caller.data_mut());
-                let r = Host::y(host);
-                Ok(r)
-            },
-        )?;
-        Ok(())
+        add_to_linker_instance(&mut inst, host_getter)
     }
 }

--- a/crates/component-macro/tests/expanded/smoke_async.rs
+++ b/crates/component-macro/tests/expanded/smoke_async.rs
@@ -191,8 +191,8 @@ pub mod imports {
             async move { Host::y(*self).await }
         }
     }
-    pub fn add_to_linker<T, D>(
-        linker: &mut wasmtime::component::Linker<T>,
+    pub fn add_to_linker_instance<T, D>(
+        inst: &mut wasmtime::component::LinkerInstance<'_, T>,
         host_getter: fn(&mut T) -> D::Data<'_>,
     ) -> wasmtime::Result<()>
     where
@@ -200,7 +200,6 @@ pub mod imports {
         for<'a> D::Data<'a>: Host,
         T: 'static + Send,
     {
-        let mut inst = linker.instance("imports")?;
         inst.func_wrap_async(
             "y",
             move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
@@ -212,5 +211,17 @@ pub mod imports {
             },
         )?;
         Ok(())
+    }
+    pub fn add_to_linker<T, D>(
+        linker: &mut wasmtime::component::Linker<T>,
+        host_getter: fn(&mut T) -> D::Data<'_>,
+    ) -> wasmtime::Result<()>
+    where
+        D: HostWithStore,
+        for<'a> D::Data<'a>: Host,
+        T: 'static + Send,
+    {
+        let mut inst = linker.instance("imports")?;
+        add_to_linker_instance(&mut inst, host_getter)
     }
 }

--- a/crates/component-macro/tests/expanded/smoke_concurrent.rs
+++ b/crates/component-macro/tests/expanded/smoke_concurrent.rs
@@ -185,8 +185,8 @@ pub mod imports {
     }
     pub trait Host: Send {}
     impl<_T: Host + ?Sized + Send> Host for &mut _T {}
-    pub fn add_to_linker<T, D>(
-        linker: &mut wasmtime::component::Linker<T>,
+    pub fn add_to_linker_instance<T, D>(
+        inst: &mut wasmtime::component::LinkerInstance<'_, T>,
         host_getter: fn(&mut T) -> D::Data<'_>,
     ) -> wasmtime::Result<()>
     where
@@ -194,7 +194,6 @@ pub mod imports {
         for<'a> D::Data<'a>: Host,
         T: 'static + Send,
     {
-        let mut inst = linker.instance("imports")?;
         inst.func_wrap_concurrent(
             "y",
             move |caller: &wasmtime::component::Accessor<T>, (): ()| {
@@ -206,5 +205,17 @@ pub mod imports {
             },
         )?;
         Ok(())
+    }
+    pub fn add_to_linker<T, D>(
+        linker: &mut wasmtime::component::Linker<T>,
+        host_getter: fn(&mut T) -> D::Data<'_>,
+    ) -> wasmtime::Result<()>
+    where
+        D: HostWithStore,
+        for<'a> D::Data<'a>: Host,
+        T: 'static + Send,
+    {
+        let mut inst = linker.instance("imports")?;
+        add_to_linker_instance(&mut inst, host_getter)
     }
 }

--- a/crates/component-macro/tests/expanded/smoke_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/smoke_tracing_async.rs
@@ -191,8 +191,8 @@ pub mod imports {
             async move { Host::y(*self).await }
         }
     }
-    pub fn add_to_linker<T, D>(
-        linker: &mut wasmtime::component::Linker<T>,
+    pub fn add_to_linker_instance<T, D>(
+        inst: &mut wasmtime::component::LinkerInstance<'_, T>,
         host_getter: fn(&mut T) -> D::Data<'_>,
     ) -> wasmtime::Result<()>
     where
@@ -200,7 +200,6 @@ pub mod imports {
         for<'a> D::Data<'a>: Host,
         T: 'static + Send,
     {
-        let mut inst = linker.instance("imports")?;
         inst.func_wrap_async(
             "y",
             move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
@@ -225,5 +224,17 @@ pub mod imports {
             },
         )?;
         Ok(())
+    }
+    pub fn add_to_linker<T, D>(
+        linker: &mut wasmtime::component::Linker<T>,
+        host_getter: fn(&mut T) -> D::Data<'_>,
+    ) -> wasmtime::Result<()>
+    where
+        D: HostWithStore,
+        for<'a> D::Data<'a>: Host,
+        T: 'static + Send,
+    {
+        let mut inst = linker.instance("imports")?;
+        add_to_linker_instance(&mut inst, host_getter)
     }
 }

--- a/crates/component-macro/tests/expanded/strings.rs
+++ b/crates/component-macro/tests/expanded/strings.rs
@@ -220,8 +220,8 @@ pub mod foo {
                     Host::c(*self, a, b)
                 }
             }
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -229,7 +229,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
-                let mut inst = linker.instance("foo:foo/strings")?;
                 inst.func_wrap(
                     "a",
                     move |
@@ -267,6 +266,18 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static,
+            {
+                let mut inst = linker.instance("foo:foo/strings")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/strings_async.rs
+++ b/crates/component-macro/tests/expanded/strings_async.rs
@@ -238,8 +238,8 @@ pub mod foo {
                     async move { Host::c(*self, a, b).await }
                 }
             }
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -247,7 +247,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker.instance("foo:foo/strings")?;
                 inst.func_wrap_async(
                     "a",
                     move |
@@ -291,6 +290,18 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("foo:foo/strings")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/strings_concurrent.rs
+++ b/crates/component-macro/tests/expanded/strings_concurrent.rs
@@ -211,8 +211,8 @@ pub mod foo {
             }
             pub trait Host: Send {}
             impl<_T: Host + ?Sized + Send> Host for &mut _T {}
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -220,7 +220,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker.instance("foo:foo/strings")?;
                 inst.func_wrap_concurrent(
                     "a",
                     move |
@@ -264,6 +263,18 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("foo:foo/strings")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/strings_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/strings_tracing_async.rs
@@ -238,8 +238,8 @@ pub mod foo {
                     async move { Host::c(*self, a, b).await }
                 }
             }
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -247,7 +247,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker.instance("foo:foo/strings")?;
                 inst.func_wrap_async(
                     "a",
                     move |
@@ -336,6 +335,18 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("foo:foo/strings")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/unstable-features.rs
+++ b/crates/component-macro/tests/expanded/unstable-features.rs
@@ -429,8 +429,8 @@ pub mod foo {
                     Host::foo(*self)
                 }
             }
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 options: &LinkOptions,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
@@ -440,7 +440,6 @@ pub mod foo {
                 T: 'static,
             {
                 if options.experimental_interface {
-                    let mut inst = linker.instance("foo:foo/the-interface")?;
                     if options.experimental_interface_resource {
                         inst.resource(
                             "bar",
@@ -478,6 +477,19 @@ pub mod foo {
                     }
                 }
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                options: &LinkOptions,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static,
+            {
+                let mut inst = linker.instance("foo:foo/the-interface")?;
+                add_to_linker_instance(&mut inst, options, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/unstable-features_async.rs
+++ b/crates/component-macro/tests/expanded/unstable-features_async.rs
@@ -456,8 +456,8 @@ pub mod foo {
                     async move { Host::foo(*self).await }
                 }
             }
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 options: &LinkOptions,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
@@ -467,7 +467,6 @@ pub mod foo {
                 T: 'static + Send,
             {
                 if options.experimental_interface {
-                    let mut inst = linker.instance("foo:foo/the-interface")?;
                     if options.experimental_interface_resource {
                         inst.resource_async(
                             "bar",
@@ -514,6 +513,19 @@ pub mod foo {
                     }
                 }
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                options: &LinkOptions,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("foo:foo/the-interface")?;
+                add_to_linker_instance(&mut inst, options, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/unstable-features_concurrent.rs
+++ b/crates/component-macro/tests/expanded/unstable-features_concurrent.rs
@@ -415,8 +415,8 @@ pub mod foo {
             }
             pub trait Host: HostBar + Send {}
             impl<_T: Host + ?Sized + Send> Host for &mut _T {}
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 options: &LinkOptions,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
@@ -426,7 +426,6 @@ pub mod foo {
                 T: 'static + Send,
             {
                 if options.experimental_interface {
-                    let mut inst = linker.instance("foo:foo/the-interface")?;
                     if options.experimental_interface_resource {
                         inst.resource_concurrent(
                             "bar",
@@ -474,6 +473,19 @@ pub mod foo {
                     }
                 }
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                options: &LinkOptions,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("foo:foo/the-interface")?;
+                add_to_linker_instance(&mut inst, options, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/unstable-features_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/unstable-features_tracing_async.rs
@@ -485,8 +485,8 @@ pub mod foo {
                     async move { Host::foo(*self).await }
                 }
             }
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 options: &LinkOptions,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
@@ -496,7 +496,6 @@ pub mod foo {
                 T: 'static + Send,
             {
                 if options.experimental_interface {
-                    let mut inst = linker.instance("foo:foo/the-interface")?;
                     if options.experimental_interface_resource {
                         inst.resource_async(
                             "bar",
@@ -572,6 +571,19 @@ pub mod foo {
                     }
                 }
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                options: &LinkOptions,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("foo:foo/the-interface")?;
+                add_to_linker_instance(&mut inst, options, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/unversioned-foo.rs
+++ b/crates/component-macro/tests/expanded/unversioned-foo.rs
@@ -221,6 +221,25 @@ pub mod foo {
                     Host::g(*self)
                 }
             }
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static,
+            {
+                inst.func_wrap(
+                    "g",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = &mut host_getter(caller.data_mut());
+                        let r = Host::g(host);
+                        Ok((r,))
+                    },
+                )?;
+                Ok(())
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
@@ -231,15 +250,7 @@ pub mod foo {
                 T: 'static,
             {
                 let mut inst = linker.instance("foo:foo/a")?;
-                inst.func_wrap(
-                    "g",
-                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
-                        let host = &mut host_getter(caller.data_mut());
-                        let r = Host::g(host);
-                        Ok((r,))
-                    },
-                )?;
-                Ok(())
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/unversioned-foo_async.rs
+++ b/crates/component-macro/tests/expanded/unversioned-foo_async.rs
@@ -225,8 +225,8 @@ pub mod foo {
                     async move { Host::g(*self).await }
                 }
             }
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -234,7 +234,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker.instance("foo:foo/a")?;
                 inst.func_wrap_async(
                     "g",
                     move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
@@ -246,6 +245,18 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("foo:foo/a")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/unversioned-foo_concurrent.rs
+++ b/crates/component-macro/tests/expanded/unversioned-foo_concurrent.rs
@@ -215,8 +215,8 @@ pub mod foo {
             }
             pub trait Host: Send {}
             impl<_T: Host + ?Sized + Send> Host for &mut _T {}
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -224,7 +224,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker.instance("foo:foo/a")?;
                 inst.func_wrap_concurrent(
                     "g",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
@@ -236,6 +235,18 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("foo:foo/a")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/use-paths.rs
+++ b/crates/component-macro/tests/expanded/use-paths.rs
@@ -214,6 +214,25 @@ pub mod foo {
                     Host::a(*self)
                 }
             }
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static,
+            {
+                inst.func_wrap(
+                    "a",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = &mut host_getter(caller.data_mut());
+                        let r = Host::a(host);
+                        Ok((r,))
+                    },
+                )?;
+                Ok(())
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
@@ -224,15 +243,7 @@ pub mod foo {
                 T: 'static,
             {
                 let mut inst = linker.instance("foo:foo/a")?;
-                inst.func_wrap(
-                    "a",
-                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
-                        let host = &mut host_getter(caller.data_mut());
-                        let r = Host::a(host);
-                        Ok((r,))
-                    },
-                )?;
-                Ok(())
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
         #[allow(clippy::all)]
@@ -257,6 +268,25 @@ pub mod foo {
                     Host::a(*self)
                 }
             }
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static,
+            {
+                inst.func_wrap(
+                    "a",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = &mut host_getter(caller.data_mut());
+                        let r = Host::a(host);
+                        Ok((r,))
+                    },
+                )?;
+                Ok(())
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
@@ -267,15 +297,7 @@ pub mod foo {
                 T: 'static,
             {
                 let mut inst = linker.instance("foo:foo/b")?;
-                inst.func_wrap(
-                    "a",
-                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
-                        let host = &mut host_getter(caller.data_mut());
-                        let r = Host::a(host);
-                        Ok((r,))
-                    },
-                )?;
-                Ok(())
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
         #[allow(clippy::all)]
@@ -300,6 +322,25 @@ pub mod foo {
                     Host::a(*self)
                 }
             }
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static,
+            {
+                inst.func_wrap(
+                    "a",
+                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                        let host = &mut host_getter(caller.data_mut());
+                        let r = Host::a(host);
+                        Ok((r,))
+                    },
+                )?;
+                Ok(())
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
@@ -310,15 +351,7 @@ pub mod foo {
                 T: 'static,
             {
                 let mut inst = linker.instance("foo:foo/c")?;
-                inst.func_wrap(
-                    "a",
-                    move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
-                        let host = &mut host_getter(caller.data_mut());
-                        let r = Host::a(host);
-                        Ok((r,))
-                    },
-                )?;
-                Ok(())
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }
@@ -345,6 +378,25 @@ pub mod d {
             Host::b(*self)
         }
     }
+    pub fn add_to_linker_instance<T, D>(
+        inst: &mut wasmtime::component::LinkerInstance<'_, T>,
+        host_getter: fn(&mut T) -> D::Data<'_>,
+    ) -> wasmtime::Result<()>
+    where
+        D: HostWithStore,
+        for<'a> D::Data<'a>: Host,
+        T: 'static,
+    {
+        inst.func_wrap(
+            "b",
+            move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
+                let host = &mut host_getter(caller.data_mut());
+                let r = Host::b(host);
+                Ok((r,))
+            },
+        )?;
+        Ok(())
+    }
     pub fn add_to_linker<T, D>(
         linker: &mut wasmtime::component::Linker<T>,
         host_getter: fn(&mut T) -> D::Data<'_>,
@@ -355,14 +407,6 @@ pub mod d {
         T: 'static,
     {
         let mut inst = linker.instance("d")?;
-        inst.func_wrap(
-            "b",
-            move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
-                let host = &mut host_getter(caller.data_mut());
-                let r = Host::b(host);
-                Ok((r,))
-            },
-        )?;
-        Ok(())
+        add_to_linker_instance(&mut inst, host_getter)
     }
 }

--- a/crates/component-macro/tests/expanded/use-paths_async.rs
+++ b/crates/component-macro/tests/expanded/use-paths_async.rs
@@ -215,8 +215,8 @@ pub mod foo {
                     async move { Host::a(*self).await }
                 }
             }
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -224,7 +224,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker.instance("foo:foo/a")?;
                 inst.func_wrap_async(
                     "a",
                     move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
@@ -236,6 +235,18 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("foo:foo/a")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
         #[allow(clippy::all)]
@@ -260,8 +271,8 @@ pub mod foo {
                     async move { Host::a(*self).await }
                 }
             }
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -269,7 +280,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker.instance("foo:foo/b")?;
                 inst.func_wrap_async(
                     "a",
                     move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
@@ -281,6 +291,18 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("foo:foo/b")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
         #[allow(clippy::all)]
@@ -305,8 +327,8 @@ pub mod foo {
                     async move { Host::a(*self).await }
                 }
             }
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -314,7 +336,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker.instance("foo:foo/c")?;
                 inst.func_wrap_async(
                     "a",
                     move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
@@ -326,6 +347,18 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("foo:foo/c")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }
@@ -352,8 +385,8 @@ pub mod d {
             async move { Host::b(*self).await }
         }
     }
-    pub fn add_to_linker<T, D>(
-        linker: &mut wasmtime::component::Linker<T>,
+    pub fn add_to_linker_instance<T, D>(
+        inst: &mut wasmtime::component::LinkerInstance<'_, T>,
         host_getter: fn(&mut T) -> D::Data<'_>,
     ) -> wasmtime::Result<()>
     where
@@ -361,7 +394,6 @@ pub mod d {
         for<'a> D::Data<'a>: Host,
         T: 'static + Send,
     {
-        let mut inst = linker.instance("d")?;
         inst.func_wrap_async(
             "b",
             move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
@@ -373,5 +405,17 @@ pub mod d {
             },
         )?;
         Ok(())
+    }
+    pub fn add_to_linker<T, D>(
+        linker: &mut wasmtime::component::Linker<T>,
+        host_getter: fn(&mut T) -> D::Data<'_>,
+    ) -> wasmtime::Result<()>
+    where
+        D: HostWithStore,
+        for<'a> D::Data<'a>: Host,
+        T: 'static + Send,
+    {
+        let mut inst = linker.instance("d")?;
+        add_to_linker_instance(&mut inst, host_getter)
     }
 }

--- a/crates/component-macro/tests/expanded/use-paths_concurrent.rs
+++ b/crates/component-macro/tests/expanded/use-paths_concurrent.rs
@@ -209,8 +209,8 @@ pub mod foo {
             }
             pub trait Host: Send {}
             impl<_T: Host + ?Sized + Send> Host for &mut _T {}
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -218,7 +218,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker.instance("foo:foo/a")?;
                 inst.func_wrap_concurrent(
                     "a",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
@@ -230,6 +229,18 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("foo:foo/a")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
         #[allow(clippy::all)]
@@ -248,8 +259,8 @@ pub mod foo {
             }
             pub trait Host: Send {}
             impl<_T: Host + ?Sized + Send> Host for &mut _T {}
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -257,7 +268,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker.instance("foo:foo/b")?;
                 inst.func_wrap_concurrent(
                     "a",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
@@ -269,6 +279,18 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("foo:foo/b")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
         #[allow(clippy::all)]
@@ -287,8 +309,8 @@ pub mod foo {
             }
             pub trait Host: Send {}
             impl<_T: Host + ?Sized + Send> Host for &mut _T {}
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -296,7 +318,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker.instance("foo:foo/c")?;
                 inst.func_wrap_concurrent(
                     "a",
                     move |caller: &wasmtime::component::Accessor<T>, (): ()| {
@@ -308,6 +329,18 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("foo:foo/c")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }
@@ -328,8 +361,8 @@ pub mod d {
     }
     pub trait Host: Send {}
     impl<_T: Host + ?Sized + Send> Host for &mut _T {}
-    pub fn add_to_linker<T, D>(
-        linker: &mut wasmtime::component::Linker<T>,
+    pub fn add_to_linker_instance<T, D>(
+        inst: &mut wasmtime::component::LinkerInstance<'_, T>,
         host_getter: fn(&mut T) -> D::Data<'_>,
     ) -> wasmtime::Result<()>
     where
@@ -337,7 +370,6 @@ pub mod d {
         for<'a> D::Data<'a>: Host,
         T: 'static + Send,
     {
-        let mut inst = linker.instance("d")?;
         inst.func_wrap_concurrent(
             "b",
             move |caller: &wasmtime::component::Accessor<T>, (): ()| {
@@ -349,5 +381,17 @@ pub mod d {
             },
         )?;
         Ok(())
+    }
+    pub fn add_to_linker<T, D>(
+        linker: &mut wasmtime::component::Linker<T>,
+        host_getter: fn(&mut T) -> D::Data<'_>,
+    ) -> wasmtime::Result<()>
+    where
+        D: HostWithStore,
+        for<'a> D::Data<'a>: Host,
+        T: 'static + Send,
+    {
+        let mut inst = linker.instance("d")?;
+        add_to_linker_instance(&mut inst, host_getter)
     }
 }

--- a/crates/component-macro/tests/expanded/use-paths_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/use-paths_tracing_async.rs
@@ -215,8 +215,8 @@ pub mod foo {
                     async move { Host::a(*self).await }
                 }
             }
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -224,7 +224,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker.instance("foo:foo/a")?;
                 inst.func_wrap_async(
                     "a",
                     move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
@@ -250,6 +249,18 @@ pub mod foo {
                 )?;
                 Ok(())
             }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("foo:foo/a")?;
+                add_to_linker_instance(&mut inst, host_getter)
+            }
         }
         #[allow(clippy::all)]
         pub mod b {
@@ -273,8 +284,8 @@ pub mod foo {
                     async move { Host::a(*self).await }
                 }
             }
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -282,7 +293,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker.instance("foo:foo/b")?;
                 inst.func_wrap_async(
                     "a",
                     move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
@@ -308,6 +318,18 @@ pub mod foo {
                 )?;
                 Ok(())
             }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("foo:foo/b")?;
+                add_to_linker_instance(&mut inst, host_getter)
+            }
         }
         #[allow(clippy::all)]
         pub mod c {
@@ -331,8 +353,8 @@ pub mod foo {
                     async move { Host::a(*self).await }
                 }
             }
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -340,7 +362,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker.instance("foo:foo/c")?;
                 inst.func_wrap_async(
                     "a",
                     move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
@@ -365,6 +386,18 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("foo:foo/c")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }
@@ -391,8 +424,8 @@ pub mod d {
             async move { Host::b(*self).await }
         }
     }
-    pub fn add_to_linker<T, D>(
-        linker: &mut wasmtime::component::Linker<T>,
+    pub fn add_to_linker_instance<T, D>(
+        inst: &mut wasmtime::component::LinkerInstance<'_, T>,
         host_getter: fn(&mut T) -> D::Data<'_>,
     ) -> wasmtime::Result<()>
     where
@@ -400,7 +433,6 @@ pub mod d {
         for<'a> D::Data<'a>: Host,
         T: 'static + Send,
     {
-        let mut inst = linker.instance("d")?;
         inst.func_wrap_async(
             "b",
             move |mut caller: wasmtime::StoreContextMut<'_, T>, (): ()| {
@@ -425,5 +457,17 @@ pub mod d {
             },
         )?;
         Ok(())
+    }
+    pub fn add_to_linker<T, D>(
+        linker: &mut wasmtime::component::Linker<T>,
+        host_getter: fn(&mut T) -> D::Data<'_>,
+    ) -> wasmtime::Result<()>
+    where
+        D: HostWithStore,
+        for<'a> D::Data<'a>: Host,
+        T: 'static + Send,
+    {
+        let mut inst = linker.instance("d")?;
+        add_to_linker_instance(&mut inst, host_getter)
     }
 }

--- a/crates/component-macro/tests/expanded/variants.rs
+++ b/crates/component-macro/tests/expanded/variants.rs
@@ -648,8 +648,8 @@ pub mod foo {
                     Host::is_clone_return(*self)
                 }
             }
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -657,7 +657,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static,
             {
-                let mut inst = linker.instance("foo:foo/variants")?;
                 inst.func_wrap(
                     "e1-arg",
                     move |mut caller: wasmtime::StoreContextMut<'_, T>, (arg0,): (E1,)| {
@@ -888,6 +887,18 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static,
+            {
+                let mut inst = linker.instance("foo:foo/variants")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/variants_async.rs
+++ b/crates/component-macro/tests/expanded/variants_async.rs
@@ -736,8 +736,8 @@ pub mod foo {
                     async move { Host::is_clone_return(*self).await }
                 }
             }
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -745,7 +745,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker.instance("foo:foo/variants")?;
                 inst.func_wrap_async(
                     "e1-arg",
                     move |mut caller: wasmtime::StoreContextMut<'_, T>, (arg0,): (E1,)| {
@@ -1019,6 +1018,18 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("foo:foo/variants")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/variants_concurrent.rs
+++ b/crates/component-macro/tests/expanded/variants_concurrent.rs
@@ -579,8 +579,8 @@ pub mod foo {
             }
             pub trait Host: Send {}
             impl<_T: Host + ?Sized + Send> Host for &mut _T {}
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -588,7 +588,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker.instance("foo:foo/variants")?;
                 inst.func_wrap_concurrent(
                     "e1-arg",
                     move |caller: &wasmtime::component::Accessor<T>, (arg0,): (E1,)| {
@@ -873,6 +872,18 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("foo:foo/variants")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/variants_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/variants_tracing_async.rs
@@ -736,8 +736,8 @@ pub mod foo {
                     async move { Host::is_clone_return(*self).await }
                 }
             }
-            pub fn add_to_linker<T, D>(
-                linker: &mut wasmtime::component::Linker<T>,
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
             ) -> wasmtime::Result<()>
             where
@@ -745,7 +745,6 @@ pub mod foo {
                 for<'a> D::Data<'a>: Host,
                 T: 'static + Send,
             {
-                let mut inst = linker.instance("foo:foo/variants")?;
                 inst.func_wrap_async(
                     "e1-arg",
                     move |mut caller: wasmtime::StoreContextMut<'_, T>, (arg0,): (E1,)| {
@@ -1317,6 +1316,18 @@ pub mod foo {
                     },
                 )?;
                 Ok(())
+            }
+            pub fn add_to_linker<T, D>(
+                linker: &mut wasmtime::component::Linker<T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static + Send,
+            {
+                let mut inst = linker.instance("foo:foo/variants")?;
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/worlds-with-types.rs
+++ b/crates/component-macro/tests/expanded/worlds-with-types.rs
@@ -249,6 +249,17 @@ pub mod foo {
             {}
             pub trait Host {}
             impl<_T: Host + ?Sized> Host for &mut _T {}
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static,
+            {
+                Ok(())
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
@@ -259,7 +270,7 @@ pub mod foo {
                 T: 'static,
             {
                 let mut inst = linker.instance("foo:foo/i")?;
-                Ok(())
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/worlds-with-types_async.rs
+++ b/crates/component-macro/tests/expanded/worlds-with-types_async.rs
@@ -252,6 +252,17 @@ pub mod foo {
             {}
             pub trait Host {}
             impl<_T: Host + ?Sized> Host for &mut _T {}
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static,
+            {
+                Ok(())
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
@@ -262,7 +273,7 @@ pub mod foo {
                 T: 'static,
             {
                 let mut inst = linker.instance("foo:foo/i")?;
-                Ok(())
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/component-macro/tests/expanded/worlds-with-types_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/worlds-with-types_tracing_async.rs
@@ -260,6 +260,17 @@ pub mod foo {
             {}
             pub trait Host {}
             impl<_T: Host + ?Sized> Host for &mut _T {}
+            pub fn add_to_linker_instance<T, D>(
+                inst: &mut wasmtime::component::LinkerInstance<'_, T>,
+                host_getter: fn(&mut T) -> D::Data<'_>,
+            ) -> wasmtime::Result<()>
+            where
+                D: HostWithStore,
+                for<'a> D::Data<'a>: Host,
+                T: 'static,
+            {
+                Ok(())
+            }
             pub fn add_to_linker<T, D>(
                 linker: &mut wasmtime::component::Linker<T>,
                 host_getter: fn(&mut T) -> D::Data<'_>,
@@ -270,7 +281,7 @@ pub mod foo {
                 T: 'static,
             {
                 let mut inst = linker.instance("foo:foo/i")?;
-                Ok(())
+                add_to_linker_instance(&mut inst, host_getter)
             }
         }
     }

--- a/crates/wit-bindgen/src/lib.rs
+++ b/crates/wit-bindgen/src/lib.rs
@@ -68,13 +68,14 @@ struct Wasmtime {
     src: Source,
     opts: Opts,
     /// A list of all interfaces which were imported by this world.
-    import_interfaces: Vec<ImportInterface>,
-    import_functions: Vec<Function>,
+    import_interfaces: IndexMap<InterfaceId, ImportInterface>,
+    world_import_functions: Vec<Function>,
+    world_implements_interfaces: Vec<(String, InterfaceId)>,
+    interfaces_for_implements: HashMap<InterfaceId, InterfaceId>,
     exports: Exports,
     types: Types,
     sizes: SizeAlign,
     interface_names: HashMap<InterfaceId, InterfaceName>,
-    interface_last_seen_as_import: HashMap<InterfaceId, bool>,
     trappable_errors: IndexMap<TypeId, String>,
     // Track the with options that were used. Remapped interfaces provided via `with`
     // are required to be used.
@@ -84,10 +85,10 @@ struct Wasmtime {
 }
 
 struct ImportInterface {
-    id: InterfaceId,
     contents: String,
     name: InterfaceName,
     all_func_flags: FunctionFlags,
+    in_world: bool,
 }
 
 #[derive(Default)]
@@ -201,7 +202,8 @@ pub struct TrappableError {
 }
 
 impl Opts {
-    pub fn generate(&self, resolve: &Resolve, world: WorldId) -> anyhow::Result<String> {
+    pub fn generate(&self, resolve: &mut Resolve, world: WorldId) -> anyhow::Result<String> {
+        resolve.generate_nominal_type_ids(world);
         // TODO: Should we refine this test to inspect only types reachable from
         // the specified world?
         if !cfg!(feature = "component-model-async")
@@ -272,7 +274,8 @@ impl Wasmtime {
         };
 
         let remapped = matches!(entry, InterfaceName::Remapped { .. });
-        self.interface_names.insert(id, entry);
+        let prev = self.interface_names.insert(id, entry);
+        assert!(prev.is_none());
         remapped
     }
 
@@ -400,94 +403,118 @@ impl Wasmtime {
     }
 
     fn import(&mut self, resolve: &Resolve, name: &WorldKey, item: &WorldItem) {
-        let mut generator = InterfaceGenerator::new(self, resolve);
         match item {
             WorldItem::Function(func) => {
-                self.import_functions.push(func.clone());
+                self.world_import_functions.push(func.clone());
             }
             WorldItem::Interface { id, .. } => {
-                generator
-                    .generator
-                    .interface_last_seen_as_import
-                    .insert(*id, true);
-                generator.current_interface = Some((*id, name, false));
-                let snake = to_rust_ident(&match name {
-                    WorldKey::Name(s) => s.to_snake_case(),
-                    WorldKey::Interface(id) => resolve.interfaces[*id]
-                        .name
-                        .as_ref()
-                        .unwrap()
-                        .to_snake_case(),
-                });
-                let module = if generator
-                    .generator
-                    .name_interface(resolve, *id, name, false)
+                if let WorldKey::Name(kebab) = name
+                    && resolve.interfaces[*id].name.is_some()
                 {
-                    // If this interface is remapped then that means that it was
-                    // provided via the `with` key in the bindgen configuration.
-                    // That means that bindings generation is skipped here. To
-                    // accommodate future bindgens depending on this bindgen
-                    // though we still generate a module which reexports the
-                    // original module. This helps maintain the same output
-                    // structure regardless of whether `with` is used.
-                    let name_at_root = match &generator.generator.interface_names[id] {
-                        InterfaceName::Remapped { name_at_root, .. } => name_at_root,
-                        InterfaceName::Path(_) => unreachable!(),
+                    let og_interface = resolve.interfaces[*id].clone_of.unwrap_or(*id);
+                    let implements = match self.interfaces_for_implements.get(&og_interface) {
+                        Some(id) => *id,
+                        None => {
+                            self.interfaces_for_implements.insert(og_interface, *id);
+                            self.import_interface(resolve, &WorldKey::Interface(*id), *id, false);
+                            *id
+                        }
                     };
-                    let path_to_root = generator.path_to_root();
-                    format!(
-                        "
-                            pub mod {snake} {{
-                                #[allow(unused_imports)]
-                                pub use {path_to_root}{name_at_root}::*;
-                            }}
-                        "
-                    )
+                    self.world_implements_interfaces
+                        .push((kebab.to_string(), implements));
                 } else {
-                    // If this interface is not remapped then it's time to
-                    // actually generate bindings here.
-                    generator.generator.interface_link_options[id].write_struct(&mut generator.src);
-                    generator.types(*id);
-                    let key_name = resolve.name_world_key(name);
-                    generator.generate_add_to_linker(*id, &key_name);
-
-                    let module = &generator.src[..];
-                    let wt = generator.generator.wasmtime_path();
-
-                    format!(
-                        "
-                            #[allow(clippy::all)]
-                            pub mod {snake} {{
-                                #[allow(unused_imports)]
-                                use {wt}::component::__internal::Box;
-
-                                {module}
-                            }}
-                        "
-                    )
-                };
-                let all_func_flags = generator.all_func_flags;
-                self.import_interfaces.push(ImportInterface {
-                    id: *id,
-                    contents: module,
-                    name: self.interface_names[id].clone(),
-                    all_func_flags,
-                });
-
-                let interface_path = self.import_interface_path(id);
-                self.interface_link_options[id]
-                    .write_impl_from_world(&mut self.src, &interface_path);
+                    self.import_interface(resolve, name, *id, true);
+                }
             }
             WorldItem::Type { id, .. } => {
                 let name = match name {
                     WorldKey::Name(name) => name,
                     WorldKey::Interface(_) => unreachable!(),
                 };
+                let mut generator = InterfaceGenerator::new(self, resolve);
                 generator.define_type(name, *id);
                 let body = mem::take(&mut generator.src);
                 self.src.push_str(&body);
             }
         };
+    }
+
+    fn import_interface(
+        &mut self,
+        resolve: &Resolve,
+        name: &WorldKey,
+        id: InterfaceId,
+        in_world: bool,
+    ) {
+        let mut generator = InterfaceGenerator::new(self, resolve);
+
+        generator.current_interface = Some((id, name, false));
+        let snake = to_rust_ident(&match name {
+            WorldKey::Name(s) => s.to_snake_case(),
+            WorldKey::Interface(id) => resolve.interfaces[*id]
+                .name
+                .as_ref()
+                .unwrap()
+                .to_snake_case(),
+        });
+        let module = if generator.generator.name_interface(resolve, id, name, false) {
+            // If this interface is remapped then that means that it was
+            // provided via the `with` key in the bindgen configuration.
+            // That means that bindings generation is skipped here. To
+            // accommodate future bindgens depending on this bindgen
+            // though we still generate a module which reexports the
+            // original module. This helps maintain the same output
+            // structure regardless of whether `with` is used.
+            let name_at_root = match &generator.generator.interface_names[&id] {
+                InterfaceName::Remapped { name_at_root, .. } => name_at_root,
+                InterfaceName::Path(_) => unreachable!(),
+            };
+            let path_to_root = generator.path_to_root();
+            format!(
+                "
+                    pub mod {snake} {{
+                        #[allow(unused_imports)]
+                        pub use {path_to_root}{name_at_root}::*;
+                    }}
+                "
+            )
+        } else {
+            // If this interface is not remapped then it's time to
+            // actually generate bindings here.
+            generator.generator.interface_link_options[&id].write_struct(&mut generator.src);
+            generator.types(id);
+            let key_name = resolve.name_world_key(name);
+            generator.generate_add_to_linker(id, &key_name);
+
+            let module = &generator.src[..];
+            let wt = generator.generator.wasmtime_path();
+
+            format!(
+                "
+                    #[allow(clippy::all)]
+                    pub mod {snake} {{
+                        #[allow(unused_imports)]
+                        use {wt}::component::__internal::Box;
+
+                        {module}
+                    }}
+                "
+            )
+        };
+        let all_func_flags = generator.all_func_flags;
+        let prev = self.import_interfaces.insert(
+            id,
+            ImportInterface {
+                contents: module,
+                name: self.interface_names[&id].clone(),
+                all_func_flags,
+                in_world,
+            },
+        );
+        assert!(prev.is_none());
+
+        let interface_path = self.import_interface_path(&id);
+        self.interface_link_options[&id].write_impl_from_world(&mut self.src, &interface_path);
     }
 
     fn export(&mut self, resolve: &Resolve, name: &WorldKey, item: &WorldItem) {
@@ -532,10 +559,6 @@ impl Wasmtime {
             }
             WorldItem::Type { .. } => unreachable!(),
             WorldItem::Interface { id, .. } => {
-                generator
-                    .generator
-                    .interface_last_seen_as_import
-                    .insert(*id, false);
                 generator.generator.name_interface(resolve, *id, name, true);
                 generator.current_interface = Some((*id, name, true));
                 generator.types(*id);
@@ -1016,7 +1039,7 @@ impl<_T: Send + 'static> {camel}Pre<_T> {{
         self.emit_modules(
             imports
                 .into_iter()
-                .map(|i| (i.id, i.contents, i.name))
+                .map(|(id, i)| (id, i.contents, i.name))
                 .collect(),
         );
 
@@ -1275,7 +1298,7 @@ fn lookup_keys(
 
 impl Wasmtime {
     fn has_world_imports_trait(&self, resolve: &Resolve, world: WorldId) -> bool {
-        !self.import_functions.is_empty() || get_world_resources(resolve, world).count() > 0
+        !self.world_import_functions.is_empty() || get_world_resources(resolve, world).count() > 0
     }
 
     fn world_imports_trait(&mut self, resolve: &Resolve, world: WorldId) -> Option<GeneratedTrait> {
@@ -1285,7 +1308,7 @@ impl Wasmtime {
 
         let world_camel = to_rust_upper_camel_case(&resolve.worlds[world].name);
 
-        let functions = self.import_functions.clone();
+        let functions = self.world_import_functions.clone();
         let mut generator = InterfaceGenerator::new(self, resolve);
         let generated_trait = generator.generate_trait(
             &format!("{world_camel}Imports"),
@@ -1301,16 +1324,17 @@ impl Wasmtime {
         Some(generated_trait)
     }
 
-    fn import_interface_paths(&self) -> Vec<(InterfaceId, String)> {
+    fn import_interface_paths(&self) -> Vec<(InterfaceId, String, Option<String>)> {
         self.import_interfaces
             .iter()
-            .map(|i| {
-                let path = match &i.name {
-                    InterfaceName::Path(path) => path.join("::"),
-                    InterfaceName::Remapped { name_at_root, .. } => name_at_root.clone(),
-                };
-                (i.id, path)
-            })
+            .filter(|(_, i)| i.in_world)
+            .map(|(id, _)| (*id, None))
+            .chain(
+                self.world_implements_interfaces
+                    .iter()
+                    .map(|(name, id)| (*id, Some(name.clone()))),
+            )
+            .map(|(id, name_override)| (id, self.import_interface_path(&id), name_override))
             .collect()
     }
 
@@ -1322,14 +1346,7 @@ impl Wasmtime {
     }
 
     fn import_interface_all_func_flags(&self, id: InterfaceId) -> FunctionFlags {
-        for i in self.import_interfaces.iter() {
-            if id != i.id {
-                continue;
-            }
-
-            return i.all_func_flags;
-        }
-        unreachable!()
+        self.import_interfaces[&id].all_func_flags
     }
 
     fn world_host_traits(
@@ -1340,7 +1357,7 @@ impl Wasmtime {
         let mut without_store_async = false;
         let mut with_store = Vec::new();
         let mut with_store_async = false;
-        for (id, path) in self.import_interface_paths() {
+        for (id, path, _) in self.import_interface_paths() {
             without_store.push(format!("{path}::Host"));
             let flags = self.import_interface_all_func_flags(id);
             without_store_async = without_store_async || flags.contains(FunctionFlags::ASYNC);
@@ -1394,7 +1411,7 @@ impl Wasmtime {
         if let Some(world_trait) = world_trait {
             all_func_flags |= world_trait.all_func_flags;
         }
-        for i in self.import_interfaces.iter() {
+        for i in self.import_interfaces.values() {
             all_func_flags |= i.all_func_flags;
         }
 
@@ -1435,7 +1452,7 @@ impl Wasmtime {
             for (ty, _name) in get_world_resources(resolve, world) {
                 self.generate_add_resource_to_linker(None, None, "linker", resolve, ty);
             }
-            for f in self.import_functions.clone() {
+            for f in self.world_import_functions.clone() {
                 let mut generator = InterfaceGenerator::new(self, resolve);
                 generator.generate_add_function_to_linker(TypeOwner::World(world), &f, "linker");
                 let src = String::from(generator.src);
@@ -1477,7 +1494,7 @@ impl Wasmtime {
                 "Self::add_to_linker_imports::<T, D>(linker {options_arg}, host_getter)?;"
             );
         }
-        for (interface_id, path) in self.import_interface_paths() {
+        for (interface_id, path, name_override) in self.import_interface_paths() {
             let options_arg = if self.interface_link_options[&interface_id].has_any() {
                 ", &options.into()"
             } else {
@@ -1497,10 +1514,26 @@ impl Wasmtime {
                 .unwrap_or(Stability::Unknown);
 
             let gate = FeatureGate::open(&mut self.src, &import_stability);
-            uwriteln!(
-                self.src,
-                "{path}::add_to_linker::<T, D>(linker {options_arg}, host_getter)?;"
-            );
+            match &name_override {
+                Some(name) => {
+                    uwriteln!(
+                        self.src,
+                        "{path}::add_to_linker_instance::<T, D>(
+                            &mut linker.instance({name:?})?
+                            {options_arg},
+                            host_getter,
+                        )?;"
+                    );
+                }
+                None => {
+                    uwriteln!(
+                        self.src,
+                        "{path}::add_to_linker::<T, D>(
+                            linker {options_arg}, host_getter,
+                        )?;"
+                    );
+                }
+            }
             gate.close(&mut self.src);
         }
         gate.close(&mut self.src);
@@ -2362,12 +2395,17 @@ impl<'a> InterfaceGenerator<'a> {
         } else {
             ""
         };
+        let options_param_forward = if self.generator.interface_link_options[&id].has_any() {
+            "options,"
+        } else {
+            ""
+        };
 
         uwriteln!(
             self.src,
             "
-                pub fn add_to_linker<T, D>(
-                    linker: &mut {wt}::component::Linker<T>,
+                pub fn add_to_linker_instance<T, D>(
+                    inst: &mut {wt}::component::LinkerInstance<'_, T>,
                     {options_param}
                     host_getter: fn(&mut T) -> D::Data<'_>,
                 ) -> {wt}::Result<()>
@@ -2380,8 +2418,6 @@ impl<'a> InterfaceGenerator<'a> {
         );
 
         let gate = FeatureGate::open(&mut self.src, &iface.stability);
-        uwriteln!(self.src, "let mut inst = linker.instance(\"{name}\")?;");
-
         for (ty, _name) in get_resources(self.resolve, id) {
             self.generator.generate_add_resource_to_linker(
                 self.current_interface.map(|p| p.1),
@@ -2398,6 +2434,25 @@ impl<'a> InterfaceGenerator<'a> {
         gate.close(&mut self.src);
         uwriteln!(self.src, "Ok(())");
         uwriteln!(self.src, "}}");
+
+        uwriteln!(
+            self.src,
+            "
+                pub fn add_to_linker<T, D>(
+                    linker: &mut {wt}::component::Linker<T>,
+                    {options_param}
+                    host_getter: fn(&mut T) -> D::Data<'_>,
+                ) -> {wt}::Result<()>
+                    where
+                        D: HostWithStore,
+                        for<'a> D::Data<'a>: {sync_bounds},
+                        T: 'static {opt_t_send_bound},
+                {{
+                    let mut inst = linker.instance(\"{name}\")?;
+                    add_to_linker_instance(&mut inst, {options_param_forward} host_getter)
+                }}
+            "
+        );
     }
 
     fn import_resource_drop_flags(&mut self, name: &str) -> FunctionFlags {
@@ -3207,7 +3262,12 @@ impl<'a> RustGenerator<'a> for InterfaceGenerator<'a> {
     }
 
     fn is_imported_interface(&self, interface: InterfaceId) -> bool {
-        self.generator.interface_last_seen_as_import[&interface]
+        if let Some((cur, _, is_export)) = self.current_interface {
+            if cur == interface {
+                return !is_export;
+            }
+        }
+        self.generator.import_interfaces.contains_key(&interface)
     }
 
     fn wasmtime_path(&self) -> String {

--- a/tests/all/component_model/bindgen.rs
+++ b/tests/all/component_model/bindgen.rs
@@ -1012,13 +1012,15 @@ mod implements {
             package demo:pkg;
 
             interface store {
-                get: func(key: string) -> option<string>;
-                set: func(key: string, value: string);
+                get: func(key: u32) -> u32;
+                set: func(key: u32, value: u32);
             }
 
             world cache {
                 import hot-cache: store;
                 import durable: store;
+
+                export run: func();
             }
         ",
     });
@@ -1026,13 +1028,46 @@ mod implements {
     const DUMMY: &str = r#"
         (component
             (import "hot-cache" (instance $hot
-                (export "get" (func (param "key" string) (result (option string))))
-                (export "set" (func (param "key" string) (param "value" string)))
+                (export "get" (func (param "key" u32) (result u32)))
+                (export "set" (func (param "key" u32) (param "value" u32)))
             ))
             (import "durable" (instance $dur
-                (export "get" (func (param "key" string) (result (option string))))
-                (export "set" (func (param "key" string) (param "value" string)))
+                (export "get" (func (param "key" u32) (result u32)))
+                (export "set" (func (param "key" u32) (param "value" u32)))
             ))
+
+            (core module $m
+                (import "hot" "get" (func $hot-get (param i32) (result i32)))
+                (import "hot" "set" (func $hot-set (param i32 i32)))
+                (import "durable" "get" (func $durable-get (param i32) (result i32)))
+                (import "durable" "set" (func $durable-set (param i32 i32)))
+
+                (func (export "run")
+                    (call $durable-set (i32.const 0) (i32.const 1))
+                    (call $hot-set (i32.const 0) (i32.const 2))
+
+                    (if (i32.ne (call $durable-get (i32.const 0)) (i32.const 1))
+                        (then unreachable))
+                    (if (i32.ne (call $hot-get (i32.const 0)) (i32.const 2))
+                        (then unreachable))
+                )
+            )
+            (core func $hot-get (canon lower (func $hot "get")))
+            (core func $hot-set (canon lower (func $hot "set")))
+            (core func $dur-get (canon lower (func $dur "get")))
+            (core func $dur-set (canon lower (func $dur "set")))
+            (core instance $i (instantiate $m
+                (with "hot" (instance
+                    (export "get" (func $hot-get))
+                    (export "set" (func $hot-set))
+                ))
+                (with "durable" (instance
+                    (export "get" (func $dur-get))
+                    (export "set" (func $dur-set))
+                ))
+            ))
+
+            (func (export "run") (canon lift (core func $i "run")))
         )
     "#;
 
@@ -1040,15 +1075,15 @@ mod implements {
     fn add_to_linker_can_instantiate() -> Result<()> {
         #[derive(Default)]
         struct MyHost {
-            kv: HashMap<String, String>,
+            kv: HashMap<u32, u32>,
         }
 
         impl demo::pkg::store::Host for MyHost {
-            fn get(&mut self, key: String) -> Option<String> {
-                self.kv.get(&key).cloned()
+            fn get(&mut self, key: u32) -> u32 {
+                *self.kv.get(&key).unwrap()
             }
 
-            fn set(&mut self, key: String, value: String) {
+            fn set(&mut self, key: u32, value: u32) {
                 self.kv.insert(key, value);
             }
         }
@@ -1058,16 +1093,20 @@ mod implements {
         Cache::add_to_linker::<_, HasSelf<MyHost>>(&mut linker, |s| s)?;
         let component = Component::new(&engine, DUMMY)?;
         let mut store = Store::new(&engine, MyHost::default());
-        let _instance = Cache::instantiate(&mut store, &component, &linker)?;
+        let instance = Cache::instantiate(&mut store, &component, &linker)?;
+
+        // This is expected to fail since both interfaces are routed to the same
+        // location, not different ones.
+        assert!(instance.call_run(&mut store).is_err());
         Ok(())
     }
 
-    impl demo::pkg::store::Host for HashMap<String, String> {
-        fn get(&mut self, key: String) -> Option<String> {
-            HashMap::get(self, &key).cloned()
+    impl demo::pkg::store::Host for HashMap<u32, u32> {
+        fn get(&mut self, key: u32) -> u32 {
+            *HashMap::get(self, &key).unwrap()
         }
 
-        fn set(&mut self, key: String, value: String) {
+        fn set(&mut self, key: u32, value: u32) {
             self.insert(key, value);
         }
     }
@@ -1076,24 +1115,24 @@ mod implements {
     fn add_to_linker_instance_can_instantiate() -> Result<()> {
         #[derive(Default)]
         struct MyHost {
-            hot_cache: HashMap<String, String>,
-            durable: HashMap<String, String>,
+            hot_cache: HashMap<u32, u32>,
+            durable: HashMap<u32, u32>,
         }
 
         let engine = engine();
         let mut linker = Linker::new(&engine);
-        demo::pkg::store::add_to_linker_instance::<MyHost, HasSelf<HashMap<String, String>>>(
+        demo::pkg::store::add_to_linker_instance::<MyHost, HasSelf<HashMap<u32, u32>>>(
             &mut linker.instance("hot-cache")?,
             |s| &mut s.hot_cache,
         )?;
-        demo::pkg::store::add_to_linker_instance::<MyHost, HasSelf<HashMap<String, String>>>(
+        demo::pkg::store::add_to_linker_instance::<MyHost, HasSelf<HashMap<u32, u32>>>(
             &mut linker.instance("durable")?,
             |s| &mut s.durable,
         )?;
         let component = Component::new(&engine, DUMMY)?;
         let mut store = Store::new(&engine, MyHost::default());
-        let _pre = linker.instantiate_pre(&component)?;
-        let _ = _pre.instantiate(&mut store)?;
+        let instance = Cache::instantiate(&mut store, &component, &linker)?;
+        instance.call_run(&mut store)?;
         Ok(())
     }
 }

--- a/tests/all/component_model/bindgen.rs
+++ b/tests/all/component_model/bindgen.rs
@@ -1001,3 +1001,99 @@ mod anyhow_errors {
         Ok(())
     }
 }
+
+mod implements {
+    use super::*;
+    use std::collections::HashMap;
+    use wasmtime::component::HasSelf;
+
+    wasmtime::component::bindgen!({
+        inline: "
+            package demo:pkg;
+
+            interface store {
+                get: func(key: string) -> option<string>;
+                set: func(key: string, value: string);
+            }
+
+            world cache {
+                import hot-cache: store;
+                import durable: store;
+            }
+        ",
+    });
+
+    const DUMMY: &str = r#"
+        (component
+            (import "hot-cache" (instance $hot
+                (export "get" (func (param "key" string) (result (option string))))
+                (export "set" (func (param "key" string) (param "value" string)))
+            ))
+            (import "durable" (instance $dur
+                (export "get" (func (param "key" string) (result (option string))))
+                (export "set" (func (param "key" string) (param "value" string)))
+            ))
+        )
+    "#;
+
+    #[test]
+    fn add_to_linker_can_instantiate() -> Result<()> {
+        #[derive(Default)]
+        struct MyHost {
+            kv: HashMap<String, String>,
+        }
+
+        impl demo::pkg::store::Host for MyHost {
+            fn get(&mut self, key: String) -> Option<String> {
+                self.kv.get(&key).cloned()
+            }
+
+            fn set(&mut self, key: String, value: String) {
+                self.kv.insert(key, value);
+            }
+        }
+
+        let engine = engine();
+        let mut linker = Linker::new(&engine);
+        Cache::add_to_linker::<_, HasSelf<MyHost>>(&mut linker, |s| s)?;
+        let component = Component::new(&engine, DUMMY)?;
+        let mut store = Store::new(&engine, MyHost::default());
+        let _instance = Cache::instantiate(&mut store, &component, &linker)?;
+        Ok(())
+    }
+
+    impl demo::pkg::store::Host for HashMap<String, String> {
+        fn get(&mut self, key: String) -> Option<String> {
+            HashMap::get(self, &key).cloned()
+        }
+
+        fn set(&mut self, key: String, value: String) {
+            self.insert(key, value);
+        }
+    }
+
+    #[test]
+    fn add_to_linker_instance_can_instantiate() -> Result<()> {
+        #[derive(Default)]
+        struct MyHost {
+            hot_cache: HashMap<String, String>,
+            durable: HashMap<String, String>,
+        }
+
+        let engine = engine();
+        let mut linker = Linker::new(&engine);
+        demo::pkg::store::add_to_linker_instance::<MyHost, HasSelf<HashMap<String, String>>>(
+            &mut linker.instance("hot-cache")?,
+            |s| &mut s.hot_cache,
+        )?;
+        demo::pkg::store::add_to_linker_instance::<MyHost, HasSelf<HashMap<String, String>>>(
+            &mut linker.instance("durable")?,
+            |s| &mut s.durable,
+        )?;
+        let component = Component::new(&engine, DUMMY)?;
+        let mut store = Store::new(&engine, MyHost::default());
+        let _pre = linker.instantiate_pre(&component)?;
+        let _ = _pre.instantiate(&mut store)?;
+        Ok(())
+    }
+}


### PR DESCRIPTION
This commit is the next step in fleshing out #12698 and following in the footsteps of #13361 to integrate the `(implements ...)` directive into `bindgen!`. Notably this world:

    world foo {
        import a: thing;
        import b: thing;
    }

will only generate a single trait for `thing::Host` as opposed to the previous 2 traits that were generated. This enables hosts to use the same trait implementation for both, or customize as appropriate.

Additionally the `add_to_linker`-generated methods for interfaces are now refactored to additionally have an `add_to_linker_instance` entrypoint. This new entrypoint takes a `LinkerInstance` instead of a `Linker` and fills in the provided instance directly. This is in-turn used to fill out a linker for the `foo` world above.

Notably, however, embedders can call `add_to_linker_instance` with distinct closures accessing different parts of `T`, the store's state, meaning that it's possible to have two distinct implementations for `a` and `b` above.

Many golden tests were updated with this new `add_to_linker_instance` method, and codegen/runtime tests were added for a simple world as well showcasing the bindings modes that are possible. The (rarely used) top-level world `add_to_linker` only uses a single trait implementation, but invoking `add_to_linker_instance` enables passing in two separate implementations.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
