### PR TITLE
wasmtime: generalize InstanceExportLookup into ExportLookup

### DIFF
--- a/crates/component-macro/tests/expanded/char.rs
+++ b/crates/component-macro/tests/expanded/char.rs
@@ -279,7 +279,7 @@ pub mod exports {
                                     "no exported instance named `foo:foo/chars`"
                                 )
                             })?;
-                        let mut lookup = move |name| {
+                        let mut lookup = move |name: &str| {
                             _instance_pre
                                 .component()
                                 .get_export_index(Some(&instance), name)

--- a/crates/component-macro/tests/expanded/char_async.rs
+++ b/crates/component-macro/tests/expanded/char_async.rs
@@ -293,7 +293,7 @@ pub mod exports {
                                     "no exported instance named `foo:foo/chars`"
                                 )
                             })?;
-                        let mut lookup = move |name| {
+                        let mut lookup = move |name: &str| {
                             _instance_pre
                                 .component()
                                 .get_export_index(Some(&instance), name)

--- a/crates/component-macro/tests/expanded/char_concurrent.rs
+++ b/crates/component-macro/tests/expanded/char_concurrent.rs
@@ -272,7 +272,7 @@ pub mod exports {
                                     "no exported instance named `foo:foo/chars`"
                                 )
                             })?;
-                        let mut lookup = move |name| {
+                        let mut lookup = move |name: &str| {
                             _instance_pre
                                 .component()
                                 .get_export_index(Some(&instance), name)

--- a/crates/component-macro/tests/expanded/char_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/char_tracing_async.rs
@@ -322,7 +322,7 @@ pub mod exports {
                                     "no exported instance named `foo:foo/chars`"
                                 )
                             })?;
-                        let mut lookup = move |name| {
+                        let mut lookup = move |name: &str| {
                             _instance_pre
                                 .component()
                                 .get_export_index(Some(&instance), name)

--- a/crates/component-macro/tests/expanded/conventions.rs
+++ b/crates/component-macro/tests/expanded/conventions.rs
@@ -499,7 +499,7 @@ pub mod exports {
                                     "no exported instance named `foo:foo/conventions`"
                                 )
                             })?;
-                        let mut lookup = move |name| {
+                        let mut lookup = move |name: &str| {
                             _instance_pre
                                 .component()
                                 .get_export_index(Some(&instance), name)

--- a/crates/component-macro/tests/expanded/conventions_async.rs
+++ b/crates/component-macro/tests/expanded/conventions_async.rs
@@ -557,7 +557,7 @@ pub mod exports {
                                     "no exported instance named `foo:foo/conventions`"
                                 )
                             })?;
-                        let mut lookup = move |name| {
+                        let mut lookup = move |name: &str| {
                             _instance_pre
                                 .component()
                                 .get_export_index(Some(&instance), name)

--- a/crates/component-macro/tests/expanded/conventions_concurrent.rs
+++ b/crates/component-macro/tests/expanded/conventions_concurrent.rs
@@ -505,7 +505,7 @@ pub mod exports {
                                     "no exported instance named `foo:foo/conventions`"
                                 )
                             })?;
-                        let mut lookup = move |name| {
+                        let mut lookup = move |name: &str| {
                             _instance_pre
                                 .component()
                                 .get_export_index(Some(&instance), name)

--- a/crates/component-macro/tests/expanded/conventions_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/conventions_tracing_async.rs
@@ -717,7 +717,7 @@ pub mod exports {
                                     "no exported instance named `foo:foo/conventions`"
                                 )
                             })?;
-                        let mut lookup = move |name| {
+                        let mut lookup = move |name: &str| {
                             _instance_pre
                                 .component()
                                 .get_export_index(Some(&instance), name)

--- a/crates/component-macro/tests/expanded/flags.rs
+++ b/crates/component-macro/tests/expanded/flags.rs
@@ -626,7 +626,7 @@ pub mod exports {
                                     "no exported instance named `foo:foo/flegs`"
                                 )
                             })?;
-                        let mut lookup = move |name| {
+                        let mut lookup = move |name: &str| {
                             _instance_pre
                                 .component()
                                 .get_export_index(Some(&instance), name)

--- a/crates/component-macro/tests/expanded/flags_async.rs
+++ b/crates/component-macro/tests/expanded/flags_async.rs
@@ -682,7 +682,7 @@ pub mod exports {
                                     "no exported instance named `foo:foo/flegs`"
                                 )
                             })?;
-                        let mut lookup = move |name| {
+                        let mut lookup = move |name: &str| {
                             _instance_pre
                                 .component()
                                 .get_export_index(Some(&instance), name)

--- a/crates/component-macro/tests/expanded/flags_concurrent.rs
+++ b/crates/component-macro/tests/expanded/flags_concurrent.rs
@@ -621,7 +621,7 @@ pub mod exports {
                                     "no exported instance named `foo:foo/flegs`"
                                 )
                             })?;
-                        let mut lookup = move |name| {
+                        let mut lookup = move |name: &str| {
                             _instance_pre
                                 .component()
                                 .get_export_index(Some(&instance), name)

--- a/crates/component-macro/tests/expanded/flags_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/flags_tracing_async.rs
@@ -794,7 +794,7 @@ pub mod exports {
                                     "no exported instance named `foo:foo/flegs`"
                                 )
                             })?;
-                        let mut lookup = move |name| {
+                        let mut lookup = move |name: &str| {
                             _instance_pre
                                 .component()
                                 .get_export_index(Some(&instance), name)

--- a/crates/component-macro/tests/expanded/floats.rs
+++ b/crates/component-macro/tests/expanded/floats.rs
@@ -302,7 +302,7 @@ pub mod exports {
                                     "no exported instance named `foo:foo/floats`"
                                 )
                             })?;
-                        let mut lookup = move |name| {
+                        let mut lookup = move |name: &str| {
                             _instance_pre
                                 .component()
                                 .get_export_index(Some(&instance), name)

--- a/crates/component-macro/tests/expanded/floats_async.rs
+++ b/crates/component-macro/tests/expanded/floats_async.rs
@@ -330,7 +330,7 @@ pub mod exports {
                                     "no exported instance named `foo:foo/floats`"
                                 )
                             })?;
-                        let mut lookup = move |name| {
+                        let mut lookup = move |name: &str| {
                             _instance_pre
                                 .component()
                                 .get_export_index(Some(&instance), name)

--- a/crates/component-macro/tests/expanded/floats_concurrent.rs
+++ b/crates/component-macro/tests/expanded/floats_concurrent.rs
@@ -303,7 +303,7 @@ pub mod exports {
                                     "no exported instance named `foo:foo/floats`"
                                 )
                             })?;
-                        let mut lookup = move |name| {
+                        let mut lookup = move |name: &str| {
                             _instance_pre
                                 .component()
                                 .get_export_index(Some(&instance), name)

--- a/crates/component-macro/tests/expanded/floats_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/floats_tracing_async.rs
@@ -388,7 +388,7 @@ pub mod exports {
                                     "no exported instance named `foo:foo/floats`"
                                 )
                             })?;
-                        let mut lookup = move |name| {
+                        let mut lookup = move |name: &str| {
                             _instance_pre
                                 .component()
                                 .get_export_index(Some(&instance), name)

--- a/crates/component-macro/tests/expanded/integers.rs
+++ b/crates/component-macro/tests/expanded/integers.rs
@@ -540,7 +540,7 @@ pub mod exports {
                                     "no exported instance named `foo:foo/integers`"
                                 )
                             })?;
-                        let mut lookup = move |name| {
+                        let mut lookup = move |name: &str| {
                             _instance_pre
                                 .component()
                                 .get_export_index(Some(&instance), name)

--- a/crates/component-macro/tests/expanded/integers_async.rs
+++ b/crates/component-macro/tests/expanded/integers_async.rs
@@ -629,7 +629,7 @@ pub mod exports {
                                     "no exported instance named `foo:foo/integers`"
                                 )
                             })?;
-                        let mut lookup = move |name| {
+                        let mut lookup = move |name: &str| {
                             _instance_pre
                                 .component()
                                 .get_export_index(Some(&instance), name)

--- a/crates/component-macro/tests/expanded/integers_concurrent.rs
+++ b/crates/component-macro/tests/expanded/integers_concurrent.rs
@@ -550,7 +550,7 @@ pub mod exports {
                                     "no exported instance named `foo:foo/integers`"
                                 )
                             })?;
-                        let mut lookup = move |name| {
+                        let mut lookup = move |name: &str| {
                             _instance_pre
                                 .component()
                                 .get_export_index(Some(&instance), name)

--- a/crates/component-macro/tests/expanded/integers_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/integers_tracing_async.rs
@@ -894,7 +894,7 @@ pub mod exports {
                                     "no exported instance named `foo:foo/integers`"
                                 )
                             })?;
-                        let mut lookup = move |name| {
+                        let mut lookup = move |name: &str| {
                             _instance_pre
                                 .component()
                                 .get_export_index(Some(&instance), name)

--- a/crates/component-macro/tests/expanded/lists.rs
+++ b/crates/component-macro/tests/expanded/lists.rs
@@ -1238,7 +1238,7 @@ pub mod exports {
                                     "no exported instance named `foo:foo/lists`"
                                 )
                             })?;
-                        let mut lookup = move |name| {
+                        let mut lookup = move |name: &str| {
                             _instance_pre
                                 .component()
                                 .get_export_index(Some(&instance), name)

--- a/crates/component-macro/tests/expanded/lists_async.rs
+++ b/crates/component-macro/tests/expanded/lists_async.rs
@@ -1404,7 +1404,7 @@ pub mod exports {
                                     "no exported instance named `foo:foo/lists`"
                                 )
                             })?;
-                        let mut lookup = move |name| {
+                        let mut lookup = move |name: &str| {
                             _instance_pre
                                 .component()
                                 .get_export_index(Some(&instance), name)

--- a/crates/component-macro/tests/expanded/lists_concurrent.rs
+++ b/crates/component-macro/tests/expanded/lists_concurrent.rs
@@ -1207,7 +1207,7 @@ pub mod exports {
                                     "no exported instance named `foo:foo/lists`"
                                 )
                             })?;
-                        let mut lookup = move |name| {
+                        let mut lookup = move |name: &str| {
                             _instance_pre
                                 .component()
                                 .get_export_index(Some(&instance), name)

--- a/crates/component-macro/tests/expanded/lists_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/lists_tracing_async.rs
@@ -1835,7 +1835,7 @@ pub mod exports {
                                     "no exported instance named `foo:foo/lists`"
                                 )
                             })?;
-                        let mut lookup = move |name| {
+                        let mut lookup = move |name: &str| {
                             _instance_pre
                                 .component()
                                 .get_export_index(Some(&instance), name)

--- a/crates/component-macro/tests/expanded/many-arguments.rs
+++ b/crates/component-macro/tests/expanded/many-arguments.rs
@@ -552,7 +552,7 @@ pub mod exports {
                                     "no exported instance named `foo:foo/manyarg`"
                                 )
                             })?;
-                        let mut lookup = move |name| {
+                        let mut lookup = move |name: &str| {
                             _instance_pre
                                 .component()
                                 .get_export_index(Some(&instance), name)

--- a/crates/component-macro/tests/expanded/many-arguments_async.rs
+++ b/crates/component-macro/tests/expanded/many-arguments_async.rs
@@ -566,7 +566,7 @@ pub mod exports {
                                     "no exported instance named `foo:foo/manyarg`"
                                 )
                             })?;
-                        let mut lookup = move |name| {
+                        let mut lookup = move |name: &str| {
                             _instance_pre
                                 .component()
                                 .get_export_index(Some(&instance), name)

--- a/crates/component-macro/tests/expanded/many-arguments_concurrent.rs
+++ b/crates/component-macro/tests/expanded/many-arguments_concurrent.rs
@@ -513,7 +513,7 @@ pub mod exports {
                                     "no exported instance named `foo:foo/manyarg`"
                                 )
                             })?;
-                        let mut lookup = move |name| {
+                        let mut lookup = move |name: &str| {
                             _instance_pre
                                 .component()
                                 .get_export_index(Some(&instance), name)

--- a/crates/component-macro/tests/expanded/many-arguments_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/many-arguments_tracing_async.rs
@@ -609,7 +609,7 @@ pub mod exports {
                                     "no exported instance named `foo:foo/manyarg`"
                                 )
                             })?;
-                        let mut lookup = move |name| {
+                        let mut lookup = move |name: &str| {
                             _instance_pre
                                 .component()
                                 .get_export_index(Some(&instance), name)

--- a/crates/component-macro/tests/expanded/multiversion.rs
+++ b/crates/component-macro/tests/expanded/multiversion.rs
@@ -309,7 +309,7 @@ pub mod exports {
                                     "no exported instance named `my:dep/a@0.1.0`"
                                 )
                             })?;
-                        let mut lookup = move |name| {
+                        let mut lookup = move |name: &str| {
                             _instance_pre
                                 .component()
                                 .get_export_index(Some(&instance), name)
@@ -388,7 +388,7 @@ pub mod exports {
                                     "no exported instance named `my:dep/a@0.2.0`"
                                 )
                             })?;
-                        let mut lookup = move |name| {
+                        let mut lookup = move |name: &str| {
                             _instance_pre
                                 .component()
                                 .get_export_index(Some(&instance), name)

--- a/crates/component-macro/tests/expanded/multiversion_async.rs
+++ b/crates/component-macro/tests/expanded/multiversion_async.rs
@@ -313,7 +313,7 @@ pub mod exports {
                                     "no exported instance named `my:dep/a@0.1.0`"
                                 )
                             })?;
-                        let mut lookup = move |name| {
+                        let mut lookup = move |name: &str| {
                             _instance_pre
                                 .component()
                                 .get_export_index(Some(&instance), name)
@@ -395,7 +395,7 @@ pub mod exports {
                                     "no exported instance named `my:dep/a@0.2.0`"
                                 )
                             })?;
-                        let mut lookup = move |name| {
+                        let mut lookup = move |name: &str| {
                             _instance_pre
                                 .component()
                                 .get_export_index(Some(&instance), name)

--- a/crates/component-macro/tests/expanded/multiversion_concurrent.rs
+++ b/crates/component-macro/tests/expanded/multiversion_concurrent.rs
@@ -301,7 +301,7 @@ pub mod exports {
                                     "no exported instance named `my:dep/a@0.1.0`"
                                 )
                             })?;
-                        let mut lookup = move |name| {
+                        let mut lookup = move |name: &str| {
                             _instance_pre
                                 .component()
                                 .get_export_index(Some(&instance), name)
@@ -384,7 +384,7 @@ pub mod exports {
                                     "no exported instance named `my:dep/a@0.2.0`"
                                 )
                             })?;
-                        let mut lookup = move |name| {
+                        let mut lookup = move |name: &str| {
                             _instance_pre
                                 .component()
                                 .get_export_index(Some(&instance), name)

--- a/crates/component-macro/tests/expanded/multiversion_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/multiversion_tracing_async.rs
@@ -339,7 +339,7 @@ pub mod exports {
                                     "no exported instance named `my:dep/a@0.1.0`"
                                 )
                             })?;
-                        let mut lookup = move |name| {
+                        let mut lookup = move |name: &str| {
                             _instance_pre
                                 .component()
                                 .get_export_index(Some(&instance), name)
@@ -429,7 +429,7 @@ pub mod exports {
                                     "no exported instance named `my:dep/a@0.2.0`"
                                 )
                             })?;
-                        let mut lookup = move |name| {
+                        let mut lookup = move |name: &str| {
                             _instance_pre
                                 .component()
                                 .get_export_index(Some(&instance), name)

--- a/crates/component-macro/tests/expanded/records.rs
+++ b/crates/component-macro/tests/expanded/records.rs
@@ -844,7 +844,7 @@ pub mod exports {
                                     "no exported instance named `foo:foo/records`"
                                 )
                             })?;
-                        let mut lookup = move |name| {
+                        let mut lookup = move |name: &str| {
                             _instance_pre
                                 .component()
                                 .get_export_index(Some(&instance), name)

--- a/crates/component-macro/tests/expanded/records_async.rs
+++ b/crates/component-macro/tests/expanded/records_async.rs
@@ -922,7 +922,7 @@ pub mod exports {
                                     "no exported instance named `foo:foo/records`"
                                 )
                             })?;
-                        let mut lookup = move |name| {
+                        let mut lookup = move |name: &str| {
                             _instance_pre
                                 .component()
                                 .get_export_index(Some(&instance), name)

--- a/crates/component-macro/tests/expanded/records_concurrent.rs
+++ b/crates/component-macro/tests/expanded/records_concurrent.rs
@@ -855,7 +855,7 @@ pub mod exports {
                                     "no exported instance named `foo:foo/records`"
                                 )
                             })?;
-                        let mut lookup = move |name| {
+                        let mut lookup = move |name: &str| {
                             _instance_pre
                                 .component()
                                 .get_export_index(Some(&instance), name)

--- a/crates/component-macro/tests/expanded/records_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/records_tracing_async.rs
@@ -1083,7 +1083,7 @@ pub mod exports {
                                     "no exported instance named `foo:foo/records`"
                                 )
                             })?;
-                        let mut lookup = move |name| {
+                        let mut lookup = move |name: &str| {
                             _instance_pre
                                 .component()
                                 .get_export_index(Some(&instance), name)

--- a/crates/component-macro/tests/expanded/resources-export.rs
+++ b/crates/component-macro/tests/expanded/resources-export.rs
@@ -327,7 +327,7 @@ pub mod exports {
                                     "no exported instance named `foo:foo/simple-export`"
                                 )
                             })?;
-                        let mut lookup = move |name| {
+                        let mut lookup = move |name: &str| {
                             _instance_pre
                                 .component()
                                 .get_export_index(Some(&instance), name)
@@ -470,7 +470,7 @@ pub mod exports {
                                     "no exported instance named `foo:foo/export-using-import`"
                                 )
                             })?;
-                        let mut lookup = move |name| {
+                        let mut lookup = move |name: &str| {
                             _instance_pre
                                 .component()
                                 .get_export_index(Some(&instance), name)
@@ -616,7 +616,7 @@ pub mod exports {
                                     "no exported instance named `foo:foo/export-using-export1`"
                                 )
                             })?;
-                        let mut lookup = move |name| {
+                        let mut lookup = move |name: &str| {
                             _instance_pre
                                 .component()
                                 .get_export_index(Some(&instance), name)
@@ -708,7 +708,7 @@ pub mod exports {
                                     "no exported instance named `foo:foo/export-using-export2`"
                                 )
                             })?;
-                        let mut lookup = move |name| {
+                        let mut lookup = move |name: &str| {
                             _instance_pre
                                 .component()
                                 .get_export_index(Some(&instance), name)

--- a/crates/component-macro/tests/expanded/resources-export_async.rs
+++ b/crates/component-macro/tests/expanded/resources-export_async.rs
@@ -332,7 +332,7 @@ pub mod exports {
                                     "no exported instance named `foo:foo/simple-export`"
                                 )
                             })?;
-                        let mut lookup = move |name| {
+                        let mut lookup = move |name: &str| {
                             _instance_pre
                                 .component()
                                 .get_export_index(Some(&instance), name)
@@ -490,7 +490,7 @@ pub mod exports {
                                     "no exported instance named `foo:foo/export-using-import`"
                                 )
                             })?;
-                        let mut lookup = move |name| {
+                        let mut lookup = move |name: &str| {
                             _instance_pre
                                 .component()
                                 .get_export_index(Some(&instance), name)
@@ -651,7 +651,7 @@ pub mod exports {
                                     "no exported instance named `foo:foo/export-using-export1`"
                                 )
                             })?;
-                        let mut lookup = move |name| {
+                        let mut lookup = move |name: &str| {
                             _instance_pre
                                 .component()
                                 .get_export_index(Some(&instance), name)
@@ -748,7 +748,7 @@ pub mod exports {
                                     "no exported instance named `foo:foo/export-using-export2`"
                                 )
                             })?;
-                        let mut lookup = move |name| {
+                        let mut lookup = move |name: &str| {
                             _instance_pre
                                 .component()
                                 .get_export_index(Some(&instance), name)

--- a/crates/component-macro/tests/expanded/resources-export_concurrent.rs
+++ b/crates/component-macro/tests/expanded/resources-export_concurrent.rs
@@ -324,7 +324,7 @@ pub mod exports {
                                     "no exported instance named `foo:foo/simple-export`"
                                 )
                             })?;
-                        let mut lookup = move |name| {
+                        let mut lookup = move |name: &str| {
                             _instance_pre
                                 .component()
                                 .get_export_index(Some(&instance), name)
@@ -479,7 +479,7 @@ pub mod exports {
                                     "no exported instance named `foo:foo/export-using-import`"
                                 )
                             })?;
-                        let mut lookup = move |name| {
+                        let mut lookup = move |name: &str| {
                             _instance_pre
                                 .component()
                                 .get_export_index(Some(&instance), name)
@@ -639,7 +639,7 @@ pub mod exports {
                                     "no exported instance named `foo:foo/export-using-export1`"
                                 )
                             })?;
-                        let mut lookup = move |name| {
+                        let mut lookup = move |name: &str| {
                             _instance_pre
                                 .component()
                                 .get_export_index(Some(&instance), name)
@@ -735,7 +735,7 @@ pub mod exports {
                                     "no exported instance named `foo:foo/export-using-export2`"
                                 )
                             })?;
-                        let mut lookup = move |name| {
+                        let mut lookup = move |name: &str| {
                             _instance_pre
                                 .component()
                                 .get_export_index(Some(&instance), name)

--- a/crates/component-macro/tests/expanded/resources-export_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/resources-export_tracing_async.rs
@@ -332,7 +332,7 @@ pub mod exports {
                                     "no exported instance named `foo:foo/simple-export`"
                                 )
                             })?;
-                        let mut lookup = move |name| {
+                        let mut lookup = move |name: &str| {
                             _instance_pre
                                 .component()
                                 .get_export_index(Some(&instance), name)
@@ -508,7 +508,7 @@ pub mod exports {
                                     "no exported instance named `foo:foo/export-using-import`"
                                 )
                             })?;
-                        let mut lookup = move |name| {
+                        let mut lookup = move |name: &str| {
                             _instance_pre
                                 .component()
                                 .get_export_index(Some(&instance), name)
@@ -689,7 +689,7 @@ pub mod exports {
                                     "no exported instance named `foo:foo/export-using-export1`"
                                 )
                             })?;
-                        let mut lookup = move |name| {
+                        let mut lookup = move |name: &str| {
                             _instance_pre
                                 .component()
                                 .get_export_index(Some(&instance), name)
@@ -792,7 +792,7 @@ pub mod exports {
                                     "no exported instance named `foo:foo/export-using-export2`"
                                 )
                             })?;
-                        let mut lookup = move |name| {
+                        let mut lookup = move |name: &str| {
                             _instance_pre
                                 .component()
                                 .get_export_index(Some(&instance), name)

--- a/crates/component-macro/tests/expanded/resources-import.rs
+++ b/crates/component-macro/tests/expanded/resources-import.rs
@@ -1173,7 +1173,7 @@ pub mod exports {
                                     "no exported instance named `foo:foo/uses-resource-transitively`"
                                 )
                             })?;
-                        let mut lookup = move |name| {
+                        let mut lookup = move |name: &str| {
                             _instance_pre
                                 .component()
                                 .get_export_index(Some(&instance), name)

--- a/crates/component-macro/tests/expanded/resources-import_async.rs
+++ b/crates/component-macro/tests/expanded/resources-import_async.rs
@@ -1357,7 +1357,7 @@ pub mod exports {
                                     "no exported instance named `foo:foo/uses-resource-transitively`"
                                 )
                             })?;
-                        let mut lookup = move |name| {
+                        let mut lookup = move |name: &str| {
                             _instance_pre
                                 .component()
                                 .get_export_index(Some(&instance), name)

--- a/crates/component-macro/tests/expanded/resources-import_concurrent.rs
+++ b/crates/component-macro/tests/expanded/resources-import_concurrent.rs
@@ -1141,7 +1141,7 @@ pub mod exports {
                                     "no exported instance named `foo:foo/uses-resource-transitively`"
                                 )
                             })?;
-                        let mut lookup = move |name| {
+                        let mut lookup = move |name: &str| {
                             _instance_pre
                                 .component()
                                 .get_export_index(Some(&instance), name)

--- a/crates/component-macro/tests/expanded/resources-import_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/resources-import_tracing_async.rs
@@ -1774,7 +1774,7 @@ pub mod exports {
                                     "no exported instance named `foo:foo/uses-resource-transitively`"
                                 )
                             })?;
-                        let mut lookup = move |name| {
+                        let mut lookup = move |name: &str| {
                             _instance_pre
                                 .component()
                                 .get_export_index(Some(&instance), name)

--- a/crates/component-macro/tests/expanded/share-types.rs
+++ b/crates/component-macro/tests/expanded/share-types.rs
@@ -339,7 +339,7 @@ pub mod exports {
                             "no exported instance named `http-handler`"
                         )
                     })?;
-                let mut lookup = move |name| {
+                let mut lookup = move |name: &str| {
                     _instance_pre
                         .component()
                         .get_export_index(Some(&instance), name)

--- a/crates/component-macro/tests/expanded/share-types_async.rs
+++ b/crates/component-macro/tests/expanded/share-types_async.rs
@@ -347,7 +347,7 @@ pub mod exports {
                             "no exported instance named `http-handler`"
                         )
                     })?;
-                let mut lookup = move |name| {
+                let mut lookup = move |name: &str| {
                     _instance_pre
                         .component()
                         .get_export_index(Some(&instance), name)

--- a/crates/component-macro/tests/expanded/share-types_concurrent.rs
+++ b/crates/component-macro/tests/expanded/share-types_concurrent.rs
@@ -336,7 +336,7 @@ pub mod exports {
                             "no exported instance named `http-handler`"
                         )
                     })?;
-                let mut lookup = move |name| {
+                let mut lookup = move |name: &str| {
                     _instance_pre
                         .component()
                         .get_export_index(Some(&instance), name)

--- a/crates/component-macro/tests/expanded/share-types_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/share-types_tracing_async.rs
@@ -363,7 +363,7 @@ pub mod exports {
                             "no exported instance named `http-handler`"
                         )
                     })?;
-                let mut lookup = move |name| {
+                let mut lookup = move |name: &str| {
                     _instance_pre
                         .component()
                         .get_export_index(Some(&instance), name)

--- a/crates/component-macro/tests/expanded/simple-functions.rs
+++ b/crates/component-macro/tests/expanded/simple-functions.rs
@@ -336,7 +336,7 @@ pub mod exports {
                                     "no exported instance named `foo:foo/simple`"
                                 )
                             })?;
-                        let mut lookup = move |name| {
+                        let mut lookup = move |name: &str| {
                             _instance_pre
                                 .component()
                                 .get_export_index(Some(&instance), name)

--- a/crates/component-macro/tests/expanded/simple-functions_async.rs
+++ b/crates/component-macro/tests/expanded/simple-functions_async.rs
@@ -376,7 +376,7 @@ pub mod exports {
                                     "no exported instance named `foo:foo/simple`"
                                 )
                             })?;
-                        let mut lookup = move |name| {
+                        let mut lookup = move |name: &str| {
                             _instance_pre
                                 .component()
                                 .get_export_index(Some(&instance), name)

--- a/crates/component-macro/tests/expanded/simple-functions_concurrent.rs
+++ b/crates/component-macro/tests/expanded/simple-functions_concurrent.rs
@@ -344,7 +344,7 @@ pub mod exports {
                                     "no exported instance named `foo:foo/simple`"
                                 )
                             })?;
-                        let mut lookup = move |name| {
+                        let mut lookup = move |name: &str| {
                             _instance_pre
                                 .component()
                                 .get_export_index(Some(&instance), name)

--- a/crates/component-macro/tests/expanded/simple-functions_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/simple-functions_tracing_async.rs
@@ -464,7 +464,7 @@ pub mod exports {
                                     "no exported instance named `foo:foo/simple`"
                                 )
                             })?;
-                        let mut lookup = move |name| {
+                        let mut lookup = move |name: &str| {
                             _instance_pre
                                 .component()
                                 .get_export_index(Some(&instance), name)

--- a/crates/component-macro/tests/expanded/simple-lists.rs
+++ b/crates/component-macro/tests/expanded/simple-lists.rs
@@ -357,7 +357,7 @@ pub mod exports {
                                     "no exported instance named `foo:foo/simple-lists`"
                                 )
                             })?;
-                        let mut lookup = move |name| {
+                        let mut lookup = move |name: &str| {
                             _instance_pre
                                 .component()
                                 .get_export_index(Some(&instance), name)

--- a/crates/component-macro/tests/expanded/simple-lists_async.rs
+++ b/crates/component-macro/tests/expanded/simple-lists_async.rs
@@ -381,7 +381,7 @@ pub mod exports {
                                     "no exported instance named `foo:foo/simple-lists`"
                                 )
                             })?;
-                        let mut lookup = move |name| {
+                        let mut lookup = move |name: &str| {
                             _instance_pre
                                 .component()
                                 .get_export_index(Some(&instance), name)

--- a/crates/component-macro/tests/expanded/simple-lists_concurrent.rs
+++ b/crates/component-macro/tests/expanded/simple-lists_concurrent.rs
@@ -340,7 +340,7 @@ pub mod exports {
                                     "no exported instance named `foo:foo/simple-lists`"
                                 )
                             })?;
-                        let mut lookup = move |name| {
+                        let mut lookup = move |name: &str| {
                             _instance_pre
                                 .component()
                                 .get_export_index(Some(&instance), name)

--- a/crates/component-macro/tests/expanded/simple-lists_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/simple-lists_tracing_async.rs
@@ -442,7 +442,7 @@ pub mod exports {
                                     "no exported instance named `foo:foo/simple-lists`"
                                 )
                             })?;
-                        let mut lookup = move |name| {
+                        let mut lookup = move |name: &str| {
                             _instance_pre
                                 .component()
                                 .get_export_index(Some(&instance), name)

--- a/crates/component-macro/tests/expanded/small-anonymous.rs
+++ b/crates/component-macro/tests/expanded/small-anonymous.rs
@@ -362,7 +362,7 @@ pub mod exports {
                                     "no exported instance named `foo:foo/anon`"
                                 )
                             })?;
-                        let mut lookup = move |name| {
+                        let mut lookup = move |name: &str| {
                             _instance_pre
                                 .component()
                                 .get_export_index(Some(&instance), name)

--- a/crates/component-macro/tests/expanded/small-anonymous_async.rs
+++ b/crates/component-macro/tests/expanded/small-anonymous_async.rs
@@ -374,7 +374,7 @@ pub mod exports {
                                     "no exported instance named `foo:foo/anon`"
                                 )
                             })?;
-                        let mut lookup = move |name| {
+                        let mut lookup = move |name: &str| {
                             _instance_pre
                                 .component()
                                 .get_export_index(Some(&instance), name)

--- a/crates/component-macro/tests/expanded/small-anonymous_concurrent.rs
+++ b/crates/component-macro/tests/expanded/small-anonymous_concurrent.rs
@@ -359,7 +359,7 @@ pub mod exports {
                                     "no exported instance named `foo:foo/anon`"
                                 )
                             })?;
-                        let mut lookup = move |name| {
+                        let mut lookup = move |name: &str| {
                             _instance_pre
                                 .component()
                                 .get_export_index(Some(&instance), name)

--- a/crates/component-macro/tests/expanded/small-anonymous_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/small-anonymous_tracing_async.rs
@@ -387,7 +387,7 @@ pub mod exports {
                                     "no exported instance named `foo:foo/anon`"
                                 )
                             })?;
-                        let mut lookup = move |name| {
+                        let mut lookup = move |name: &str| {
                             _instance_pre
                                 .component()
                                 .get_export_index(Some(&instance), name)

--- a/crates/component-macro/tests/expanded/smoke-export.rs
+++ b/crates/component-macro/tests/expanded/smoke-export.rs
@@ -200,7 +200,7 @@ pub mod exports {
                     .ok_or_else(|| {
                         wasmtime::format_err!("no exported instance named `the-name`")
                     })?;
-                let mut lookup = move |name| {
+                let mut lookup = move |name: &str| {
                     _instance_pre
                         .component()
                         .get_export_index(Some(&instance), name)

--- a/crates/component-macro/tests/expanded/smoke-export_async.rs
+++ b/crates/component-macro/tests/expanded/smoke-export_async.rs
@@ -200,7 +200,7 @@ pub mod exports {
                     .ok_or_else(|| {
                         wasmtime::format_err!("no exported instance named `the-name`")
                     })?;
-                let mut lookup = move |name| {
+                let mut lookup = move |name: &str| {
                     _instance_pre
                         .component()
                         .get_export_index(Some(&instance), name)

--- a/crates/component-macro/tests/expanded/smoke-export_concurrent.rs
+++ b/crates/component-macro/tests/expanded/smoke-export_concurrent.rs
@@ -200,7 +200,7 @@ pub mod exports {
                     .ok_or_else(|| {
                         wasmtime::format_err!("no exported instance named `the-name`")
                     })?;
-                let mut lookup = move |name| {
+                let mut lookup = move |name: &str| {
                     _instance_pre
                         .component()
                         .get_export_index(Some(&instance), name)

--- a/crates/component-macro/tests/expanded/smoke-export_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/smoke-export_tracing_async.rs
@@ -200,7 +200,7 @@ pub mod exports {
                     .ok_or_else(|| {
                         wasmtime::format_err!("no exported instance named `the-name`")
                     })?;
-                let mut lookup = move |name| {
+                let mut lookup = move |name: &str| {
                     _instance_pre
                         .component()
                         .get_export_index(Some(&instance), name)

--- a/crates/component-macro/tests/expanded/strings.rs
+++ b/crates/component-macro/tests/expanded/strings.rs
@@ -308,7 +308,7 @@ pub mod exports {
                                     "no exported instance named `foo:foo/strings`"
                                 )
                             })?;
-                        let mut lookup = move |name| {
+                        let mut lookup = move |name: &str| {
                             _instance_pre
                                 .component()
                                 .get_export_index(Some(&instance), name)

--- a/crates/component-macro/tests/expanded/strings_async.rs
+++ b/crates/component-macro/tests/expanded/strings_async.rs
@@ -332,7 +332,7 @@ pub mod exports {
                                     "no exported instance named `foo:foo/strings`"
                                 )
                             })?;
-                        let mut lookup = move |name| {
+                        let mut lookup = move |name: &str| {
                             _instance_pre
                                 .component()
                                 .get_export_index(Some(&instance), name)

--- a/crates/component-macro/tests/expanded/strings_concurrent.rs
+++ b/crates/component-macro/tests/expanded/strings_concurrent.rs
@@ -305,7 +305,7 @@ pub mod exports {
                                     "no exported instance named `foo:foo/strings`"
                                 )
                             })?;
-                        let mut lookup = move |name| {
+                        let mut lookup = move |name: &str| {
                             _instance_pre
                                 .component()
                                 .get_export_index(Some(&instance), name)

--- a/crates/component-macro/tests/expanded/strings_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/strings_tracing_async.rs
@@ -377,7 +377,7 @@ pub mod exports {
                                     "no exported instance named `foo:foo/strings`"
                                 )
                             })?;
-                        let mut lookup = move |name| {
+                        let mut lookup = move |name: &str| {
                             _instance_pre
                                 .component()
                                 .get_export_index(Some(&instance), name)

--- a/crates/component-macro/tests/expanded/variants.rs
+++ b/crates/component-macro/tests/expanded/variants.rs
@@ -1307,7 +1307,7 @@ pub mod exports {
                                     "no exported instance named `foo:foo/variants`"
                                 )
                             })?;
-                        let mut lookup = move |name| {
+                        let mut lookup = move |name: &str| {
                             _instance_pre
                                 .component()
                                 .get_export_index(Some(&instance), name)

--- a/crates/component-macro/tests/expanded/variants_async.rs
+++ b/crates/component-macro/tests/expanded/variants_async.rs
@@ -1438,7 +1438,7 @@ pub mod exports {
                                     "no exported instance named `foo:foo/variants`"
                                 )
                             })?;
-                        let mut lookup = move |name| {
+                        let mut lookup = move |name: &str| {
                             _instance_pre
                                 .component()
                                 .get_export_index(Some(&instance), name)

--- a/crates/component-macro/tests/expanded/variants_concurrent.rs
+++ b/crates/component-macro/tests/expanded/variants_concurrent.rs
@@ -1292,7 +1292,7 @@ pub mod exports {
                                     "no exported instance named `foo:foo/variants`"
                                 )
                             })?;
-                        let mut lookup = move |name| {
+                        let mut lookup = move |name: &str| {
                             _instance_pre
                                 .component()
                                 .get_export_index(Some(&instance), name)

--- a/crates/component-macro/tests/expanded/variants_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/variants_tracing_async.rs
@@ -1736,7 +1736,7 @@ pub mod exports {
                                     "no exported instance named `foo:foo/variants`"
                                 )
                             })?;
-                        let mut lookup = move |name| {
+                        let mut lookup = move |name: &str| {
                             _instance_pre
                                 .component()
                                 .get_export_index(Some(&instance), name)

--- a/crates/component-macro/tests/expanded/wat.rs
+++ b/crates/component-macro/tests/expanded/wat.rs
@@ -208,7 +208,7 @@ pub mod exports {
                                     "no exported instance named `same:name/this-name-is-duplicated`"
                                 )
                             })?;
-                        let mut lookup = move |name| {
+                        let mut lookup = move |name: &str| {
                             _instance_pre
                                 .component()
                                 .get_export_index(Some(&instance), name)

--- a/crates/component-macro/tests/expanded/wat_async.rs
+++ b/crates/component-macro/tests/expanded/wat_async.rs
@@ -208,7 +208,7 @@ pub mod exports {
                                     "no exported instance named `same:name/this-name-is-duplicated`"
                                 )
                             })?;
-                        let mut lookup = move |name| {
+                        let mut lookup = move |name: &str| {
                             _instance_pre
                                 .component()
                                 .get_export_index(Some(&instance), name)

--- a/crates/component-macro/tests/expanded/wat_concurrent.rs
+++ b/crates/component-macro/tests/expanded/wat_concurrent.rs
@@ -208,7 +208,7 @@ pub mod exports {
                                     "no exported instance named `same:name/this-name-is-duplicated`"
                                 )
                             })?;
-                        let mut lookup = move |name| {
+                        let mut lookup = move |name: &str| {
                             _instance_pre
                                 .component()
                                 .get_export_index(Some(&instance), name)

--- a/crates/component-macro/tests/expanded/wat_tracing_async.rs
+++ b/crates/component-macro/tests/expanded/wat_tracing_async.rs
@@ -208,7 +208,7 @@ pub mod exports {
                                     "no exported instance named `same:name/this-name-is-duplicated`"
                                 )
                             })?;
-                        let mut lookup = move |name| {
+                        let mut lookup = move |name: &str| {
                             _instance_pre
                                 .component()
                                 .get_export_index(Some(&instance), name)

--- a/crates/wasmtime/src/runtime/component/component.rs
+++ b/crates/wasmtime/src/runtime/component/component.rs
@@ -1,4 +1,3 @@
-use crate::component::ExportLookup;
 use crate::component::matching::InstanceType;
 use crate::component::types;
 use crate::prelude::*;
@@ -773,7 +772,7 @@ impl Component {
     pub fn get_export_index(
         &self,
         instance: Option<&ComponentExportIndex>,
-        name: &str,
+        name: impl ExportLookup,
     ) -> Option<ComponentExportIndex> {
         let index = self.lookup_export_index(instance, name)?;
         Some(ComponentExportIndex {
@@ -855,7 +854,7 @@ impl Component {
     pub fn get_export(
         &self,
         instance: Option<&ComponentExportIndex>,
-        name: &str,
+        name: impl ExportLookup,
     ) -> Option<(types::ComponentItem, ComponentExportIndex)> {
         let info = self.env_component();
         let index = self.lookup_export_index(instance, name)?;
@@ -878,22 +877,14 @@ impl Component {
     pub(crate) fn lookup_export_index(
         &self,
         instance: Option<&ComponentExportIndex>,
-        name: &str,
+        name: impl ExportLookup,
     ) -> Option<ExportIndex> {
-        let info = self.env_component();
-        let exports = match instance {
-            Some(idx) => {
-                if idx.id != self.inner.id {
-                    return None;
-                }
-                match &info.export_items[idx.index] {
-                    Export::Instance { exports, .. } => exports,
-                    _ => return None,
-                }
+        if let Some(idx) = instance {
+            if idx.id != self.inner.id {
+                return None;
             }
-            None => &info.exports,
-        };
-        exports.get(name, &NameMapNoIntern).map(|pair| pair.0)
+        }
+        name.lookup(self, instance.map(|idx| &idx.index))
     }
 
     pub(crate) fn id(&self) -> CompiledModuleId {
@@ -950,8 +941,59 @@ pub struct ComponentExportIndex {
     pub(crate) index: ExportIndex,
 }
 
+/// Trait used to lookup the export of a component or instance.
+///
+/// This trait is used as an implementation detail of [`Instance::get_func`]
+/// and related `get_*` methods, as well as [`Component::get_export`] and
+/// related `get_*` methods. Notable implementors of this trait are:
+///
+/// * `str`
+/// * `String`
+/// * [`ComponentExportIndex`]
+///
+/// Note that this is intended to be a `wasmtime`-sealed trait so it shouldn't
+/// need to be implemented externally.
+pub trait ExportLookup {
+    #[doc(hidden)]
+    fn lookup(&self, component: &Component, instance: Option<&ExportIndex>) -> Option<ExportIndex>;
+}
+
+impl<T> ExportLookup for &T
+where
+    T: ExportLookup + ?Sized,
+{
+    fn lookup(&self, component: &Component, instance: Option<&ExportIndex>) -> Option<ExportIndex> {
+        T::lookup(self, component, instance)
+    }
+}
+
+impl ExportLookup for str {
+    fn lookup(&self, component: &Component, instance: Option<&ExportIndex>) -> Option<ExportIndex> {
+        let info = component.env_component();
+        let exports = match instance {
+            Some(idx) => match &info.export_items[*idx] {
+                Export::Instance { exports, .. } => exports,
+                _ => return None,
+            },
+            None => &info.exports,
+        };
+        let (index, _) = exports.get(self, &NameMapNoIntern)?;
+        Some(*index)
+    }
+}
+
+impl ExportLookup for String {
+    fn lookup(&self, component: &Component, instance: Option<&ExportIndex>) -> Option<ExportIndex> {
+        str::lookup(self, component, instance)
+    }
+}
+
 impl ExportLookup for ComponentExportIndex {
-    fn lookup(&self, component: &Component) -> Option<ExportIndex> {
+    fn lookup(
+        &self,
+        component: &Component,
+        _instance: Option<&ExportIndex>,
+    ) -> Option<ExportIndex> {
         if component.inner.id == self.id {
             Some(self.index)
         } else {

--- a/crates/wasmtime/src/runtime/component/component.rs
+++ b/crates/wasmtime/src/runtime/component/component.rs
@@ -943,7 +943,8 @@ pub struct ComponentExportIndex {
 
 /// Trait used to lookup the export of a component or instance.
 ///
-/// This trait is used as an implementation detail of [`Instance::get_func`]
+/// This trait is used as an implementation detail of
+/// [`Instance::get_func`](crate::component::Instance::get_func).
 /// and related `get_*` methods, as well as [`Component::get_export`] and
 /// related `get_*` methods. Notable implementors of this trait are:
 ///

--- a/crates/wasmtime/src/runtime/component/component.rs
+++ b/crates/wasmtime/src/runtime/component/component.rs
@@ -1,4 +1,4 @@
-use crate::component::InstanceExportLookup;
+use crate::component::ExportLookup;
 use crate::component::matching::InstanceType;
 use crate::component::types;
 use crate::prelude::*;
@@ -804,8 +804,8 @@ impl Component {
     /// If the export is located then two values are returned: a
     /// [`types::ComponentItem`] which enables introspection about the type of
     /// the export and a [`ComponentExportIndex`]. The index returned notably
-    /// implements the [`InstanceExportLookup`] trait which enables using it
-    /// with [`Instance::get_func`](crate::component::Instance::get_func) for
+    /// implements the [`ExportLookup`] trait which enables using it with
+    /// [`Instance::get_func`](crate::component::Instance::get_func) for
     /// example.
     ///
     /// The returned [`types::ComponentItem`] is more expensive to calculate
@@ -942,7 +942,7 @@ impl Component {
 /// A value which represents a known export of a component.
 ///
 /// This is the return value of [`Component::get_export`] and implements the
-/// [`InstanceExportLookup`] trait to work with lookups like
+/// [`ExportLookup`] trait to work with lookups like
 /// [`Instance::get_func`](crate::component::Instance::get_func).
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
 pub struct ComponentExportIndex {
@@ -950,7 +950,7 @@ pub struct ComponentExportIndex {
     pub(crate) index: ExportIndex,
 }
 
-impl InstanceExportLookup for ComponentExportIndex {
+impl ExportLookup for ComponentExportIndex {
     fn lookup(&self, component: &Component) -> Option<ExportIndex> {
         if component.inner.id == self.id {
             Some(self.index)

--- a/crates/wasmtime/src/runtime/component/instance.rs
+++ b/crates/wasmtime/src/runtime/component/instance.rs
@@ -1,4 +1,3 @@
-use crate::component::RuntimeInstance;
 use crate::component::func::HostFunc;
 use crate::component::matching::InstanceType;
 use crate::component::store::{ComponentInstanceId, StoreComponentInstanceId};
@@ -6,6 +5,7 @@ use crate::component::{
     Component, ComponentExportIndex, ComponentNamedList, Func, Lift, Lower, ResourceType,
     TypedFunc, types::ComponentItem,
 };
+use crate::component::{ExportLookup, RuntimeInstance};
 use crate::instance::OwnedImports;
 use crate::linker::DefinitionType;
 use crate::prelude::*;
@@ -152,17 +152,13 @@ impl Instance {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn get_func(
-        &self,
-        mut store: impl AsContextMut,
-        name: impl ExportLookup,
-    ) -> Option<Func> {
+    pub fn get_func(&self, mut store: impl AsContextMut, name: impl ExportLookup) -> Option<Func> {
         let store = store.as_context_mut().0;
         let instance = self.id.get(store);
         let component = instance.component();
 
         // Validate that `name` exists within `self.`
-        let index = name.lookup(component)?;
+        let index = name.lookup(component, None)?;
 
         // Validate that `index` is indeed a lifted function.
         match &component.env_component().export_items[index] {
@@ -355,7 +351,7 @@ impl Instance {
         name: impl ExportLookup,
     ) -> Option<(&'a ComponentInstance, &'a Export)> {
         let data = self.id().get(store);
-        let index = name.lookup(data.component())?;
+        let index = name.lookup(data.component(), None)?;
         Some((data, &data.component().env_component().export_items[index]))
     }
 
@@ -652,48 +648,6 @@ where
     // SAFETY: the `store_id` owns this instance and all exports contained
     // within.
     unsafe { instance.get_export_by_index_mut(registry, store_id, idx) }
-}
-
-/// Trait used to lookup the export of a component or instance.
-///
-/// This trait is used as an implementation detail of [`Instance::get_func`]
-/// and related `get_*` methods, as well as [`Component::get_export`] and
-/// related `get_*` methods. Notable implementors of this trait are:
-///
-/// * `str`
-/// * `String`
-/// * [`ComponentExportIndex`]
-///
-/// Note that this is intended to be a `wasmtime`-sealed trait so it shouldn't
-/// need to be implemented externally.
-pub trait ExportLookup {
-    #[doc(hidden)]
-    fn lookup(&self, component: &Component) -> Option<ExportIndex>;
-}
-
-impl<T> ExportLookup for &T
-where
-    T: ExportLookup + ?Sized,
-{
-    fn lookup(&self, component: &Component) -> Option<ExportIndex> {
-        T::lookup(self, component)
-    }
-}
-
-impl ExportLookup for str {
-    fn lookup(&self, component: &Component) -> Option<ExportIndex> {
-        let (index, _) = component
-            .env_component()
-            .exports
-            .get(self, &NameMapNoIntern)?;
-        Some(*index)
-    }
-}
-
-impl ExportLookup for String {
-    fn lookup(&self, component: &Component) -> Option<ExportIndex> {
-        str::lookup(self, component)
-    }
 }
 
 struct Instantiator<'a> {

--- a/crates/wasmtime/src/runtime/component/instance.rs
+++ b/crates/wasmtime/src/runtime/component/instance.rs
@@ -155,7 +155,7 @@ impl Instance {
     pub fn get_func(
         &self,
         mut store: impl AsContextMut,
-        name: impl InstanceExportLookup,
+        name: impl ExportLookup,
     ) -> Option<Func> {
         let store = store.as_context_mut().0;
         let instance = self.id.get(store);
@@ -192,7 +192,7 @@ impl Instance {
     pub fn get_typed_func<Params, Results>(
         &self,
         mut store: impl AsContextMut,
-        name: impl InstanceExportLookup,
+        name: impl ExportLookup,
     ) -> Result<TypedFunc<Params, Results>>
     where
         Params: ComponentNamedList + Lower,
@@ -224,7 +224,7 @@ impl Instance {
     pub fn get_module(
         &self,
         mut store: impl AsContextMut,
-        name: impl InstanceExportLookup,
+        name: impl ExportLookup,
     ) -> Option<Module> {
         let store = store.as_context_mut().0;
         let (instance, export) = self.lookup_export(store, name)?;
@@ -259,7 +259,7 @@ impl Instance {
     pub fn get_resource(
         &self,
         mut store: impl AsContextMut,
-        name: impl InstanceExportLookup,
+        name: impl ExportLookup,
     ) -> Option<ResourceType> {
         let store = store.as_context_mut().0;
         let (instance, export) = self.lookup_export(store, name)?;
@@ -352,7 +352,7 @@ impl Instance {
     fn lookup_export<'a>(
         &self,
         store: &'a StoreOpaque,
-        name: impl InstanceExportLookup,
+        name: impl ExportLookup,
     ) -> Option<(&'a ComponentInstance, &'a Export)> {
         let data = self.id().get(store);
         let index = name.lookup(data.component())?;
@@ -654,10 +654,11 @@ where
     unsafe { instance.get_export_by_index_mut(registry, store_id, idx) }
 }
 
-/// Trait used to lookup the export of a component instance.
+/// Trait used to lookup the export of a component or instance.
 ///
 /// This trait is used as an implementation detail of [`Instance::get_func`]
-/// and related `get_*` methods. Notable implementors of this trait are:
+/// and related `get_*` methods, as well as [`Component::get_export`] and
+/// related `get_*` methods. Notable implementors of this trait are:
 ///
 /// * `str`
 /// * `String`
@@ -665,21 +666,21 @@ where
 ///
 /// Note that this is intended to be a `wasmtime`-sealed trait so it shouldn't
 /// need to be implemented externally.
-pub trait InstanceExportLookup {
+pub trait ExportLookup {
     #[doc(hidden)]
     fn lookup(&self, component: &Component) -> Option<ExportIndex>;
 }
 
-impl<T> InstanceExportLookup for &T
+impl<T> ExportLookup for &T
 where
-    T: InstanceExportLookup + ?Sized,
+    T: ExportLookup + ?Sized,
 {
     fn lookup(&self, component: &Component) -> Option<ExportIndex> {
         T::lookup(self, component)
     }
 }
 
-impl InstanceExportLookup for str {
+impl ExportLookup for str {
     fn lookup(&self, component: &Component) -> Option<ExportIndex> {
         let (index, _) = component
             .env_component()
@@ -689,7 +690,7 @@ impl InstanceExportLookup for str {
     }
 }
 
-impl InstanceExportLookup for String {
+impl ExportLookup for String {
     fn lookup(&self, component: &Component) -> Option<ExportIndex> {
         str::lookup(self, component)
     }

--- a/crates/wasmtime/src/runtime/component/mod.rs
+++ b/crates/wasmtime/src/runtime/component/mod.rs
@@ -128,7 +128,7 @@ pub use self::func::{
     ComponentNamedList, ComponentType, Func, Lift, Lower, TypedFunc, WasmList, WasmStr,
 };
 pub use self::has_data::*;
-pub use self::instance::{Instance, InstanceExportLookup, InstancePre};
+pub use self::instance::{Instance, ExportLookup, InstancePre};
 pub use self::linker::{Linker, LinkerInstance};
 pub use self::resource_table::{ResourceTable, ResourceTableError};
 pub use self::resources::{Resource, ResourceAny, ResourceDynamic};

--- a/crates/wasmtime/src/runtime/component/mod.rs
+++ b/crates/wasmtime/src/runtime/component/mod.rs
@@ -116,7 +116,7 @@ mod storage;
 pub(crate) mod store;
 pub mod types;
 mod values;
-pub use self::component::{Component, ComponentExportIndex};
+pub use self::component::{Component, ComponentExportIndex, ExportLookup};
 #[cfg(feature = "component-model-async")]
 pub use self::concurrent::{
     Access, Accessor, AccessorTask, AsAccessor, Destination, DirectDestination, DirectSource,
@@ -128,7 +128,7 @@ pub use self::func::{
     ComponentNamedList, ComponentType, Func, Lift, Lower, TypedFunc, WasmList, WasmStr,
 };
 pub use self::has_data::*;
-pub use self::instance::{Instance, ExportLookup, InstancePre};
+pub use self::instance::{Instance, InstancePre};
 pub use self::linker::{Linker, LinkerInstance};
 pub use self::resource_table::{ResourceTable, ResourceTableError};
 pub use self::resources::{Resource, ResourceAny, ResourceDynamic};

--- a/crates/wit-bindgen/src/lib.rs
+++ b/crates/wit-bindgen/src/lib.rs
@@ -583,7 +583,7 @@ pub fn new<_T>(
 ) -> {wt}::Result<{struct_name}Indices> {{
     let instance = _instance_pre.component().get_export_index(None, \"{instance_name}\")
         .ok_or_else(|| {wt}::format_err!(\"no exported instance named `{instance_name}`\"))?;
-    let mut lookup = move |name| {{
+    let mut lookup = move |name: &str| {{
         _instance_pre.component().get_export_index(Some(&instance), name).ok_or_else(|| {{
             {wt}::format_err!(
                 \"instance export `{instance_name}` does \\


### PR DESCRIPTION
The `wasmtime::component::Instance` struct had getter methods that accepted `impl InstanceExportLookup`, a pseudo-sealed trait (via `#[doc(hidden)]`) with impls for &str, String, or ComponentExportIndex.

Conversely, the `wasmtime::component::Component` struct had `get_export` and `get_export_index` methods which took arguments `instance: Option<&ComponentExportIndex>` and `name: &str`.

This PR renames the trait to `ExportLookup`, with the exact same impls, and modifies the `Component::get_export[_index]` methods to take `impl ExportLookup` instead of `&str` arguments.

This is motivated by a follow-up PR that will add `wit_parser::ItemName` as another type that impls ExportIndex.