### PR TITLE
Suggest updating submodules on wast test dir registration failure

### DIFF
--- a/crates/test-util/src/wast.rs
+++ b/crates/test-util/src/wast.rs
@@ -40,6 +40,7 @@ pub fn find_tests(root: &Path) -> Result<Vec<WastTest>> {
         &spec_tests,
         &FindConfig::Infer(spec_test_config),
     )
+    .context("Do you need to `git submodule update --init`?")
     .with_context(|| format!("failed to add tests from `{}`", spec_tests.display()))?;
 
     let misc_tests = root.join("tests/misc_testsuite");
@@ -52,6 +53,7 @@ pub fn find_tests(root: &Path) -> Result<Vec<WastTest>> {
         &cm_tests,
         &FindConfig::Infer(component_test_config),
     )
+    .context("Do you need to `git submodule update --init`?")
     .with_context(|| format!("failed to add tests from `{}`", cm_tests.display()))?;
 
     // Temporarily work around upstream tests that fail in unexpected ways (e.g.


### PR DESCRIPTION
Makes the error messages less opaque when trying to run wast tests inside fresh clones and worktrees; suggests what to do to resolve the problem.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
