### PR TITLE
wasmtime: impl ExportLookup for wit_parser::ItemName

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -645,7 +645,7 @@ dependencies = [
  "test-programs-artifacts",
  "tokio",
  "wasm-compose",
- "wasmparser 0.250.0",
+ "wasmparser 0.251.0",
  "wasmtime",
  "wasmtime-wasi",
 ]
@@ -2253,14 +2253,14 @@ dependencies = [
 
 [[package]]
 name = "json-from-wast"
-version = "0.250.0"
+version = "0.251.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53384ef8ba578c868394dc946970a4a1751cb5cf47f0865f957578c537761419"
+checksum = "8f2922792a3377d67a8fbdc92d89218622744361d2928fb0526bfe43c93db94b"
 dependencies = [
  "anyhow",
  "serde",
  "serde_derive",
- "wast 250.0.0",
+ "wast 251.0.0",
 ]
 
 [[package]]
@@ -3821,7 +3821,7 @@ dependencies = [
  "wasmtime",
  "wasmtime-test-util",
  "wat",
- "wit-component 0.250.0",
+ "wit-component 0.251.0",
 ]
 
 [[package]]
@@ -4291,7 +4291,7 @@ name = "verify-component-adapter"
 version = "46.0.0"
 dependencies = [
  "anyhow",
- "wasmparser 0.250.0",
+ "wasmparser 0.251.0",
  "wat",
 ]
 
@@ -4399,7 +4399,7 @@ dependencies = [
  "byte-array-literals",
  "object 0.39.0",
  "wasip1",
- "wasm-encoder 0.250.0",
+ "wasm-encoder 0.251.0",
  "wit-bindgen-rust-macro 0.57.0",
 ]
 
@@ -4484,9 +4484,9 @@ checksum = "6ee99da9c5ba11bd675621338ef6fa52296b76b83305e9b6e5c77d4c286d6d49"
 
 [[package]]
 name = "wasm-compose"
-version = "0.250.0"
+version = "0.251.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d25ff9f6419c97fbf1bb4c658ec6e4e5a3cf1050cd9c368396adc8e15b3202"
+checksum = "b089037d7eb453ed57b560fe7833de0707411c8b9fdc429745ced77e2a1bacb9"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -4494,8 +4494,8 @@ dependencies = [
  "log",
  "petgraph",
  "smallvec 1.15.1",
- "wasm-encoder 0.250.0",
- "wasmparser 0.250.0",
+ "wasm-encoder 0.251.0",
+ "wasmparser 0.251.0",
  "wat",
 ]
 
@@ -4521,12 +4521,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.250.0"
+version = "0.251.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2271adb766023046af314460f1fae02cc34ea16d736d93404d3b65be44270923"
+checksum = "5a879a421bd17c528b74721b2abf4c62e8f1d1889c2ba8c3c50d02deaf2ce395"
 dependencies = [
  "leb128fmt",
- "wasmparser 0.250.0",
+ "wasmparser 0.251.0",
 ]
 
 [[package]]
@@ -4555,42 +4555,42 @@ dependencies = [
 
 [[package]]
 name = "wasm-metadata"
-version = "0.250.0"
+version = "0.251.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14d2fe7edf8b5c8870da3f6796f8ebe1898af1276f18490c861fcb1a11436556"
+checksum = "5f998ccc6e012f7b86865eb2a106c8a0422017a1a88977ce01a69f2244be2e57"
 dependencies = [
  "anyhow",
  "indexmap 2.14.0",
- "wasm-encoder 0.250.0",
- "wasmparser 0.250.0",
+ "wasm-encoder 0.251.0",
+ "wasmparser 0.251.0",
 ]
 
 [[package]]
 name = "wasm-mutate"
-version = "0.250.0"
+version = "0.251.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcfde9f257ff50a90ce3958a4d6066791de780af7580abb6d33b6d1d484618b6"
+checksum = "d36e24f28f5ef6e7465d06df14df870bd2ba4ce176f672f2b75d4e817fb49da6"
 dependencies = [
  "egg",
  "log",
  "rand 0.10.1",
  "thiserror 2.0.17",
- "wasm-encoder 0.250.0",
- "wasmparser 0.250.0",
+ "wasm-encoder 0.251.0",
+ "wasmparser 0.251.0",
 ]
 
 [[package]]
 name = "wasm-smith"
-version = "0.250.0"
+version = "0.251.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39719ba92c2bb3b5879179758ca2642b8702d690d036012141d54603a2a4a687"
+checksum = "1a688bc58124e6547e83d2fdc255463543f8ee4829112d5ac30479d4e7b76b11"
 dependencies = [
  "anyhow",
  "arbitrary",
  "flagset",
  "serde",
  "serde_derive",
- "wasm-encoder 0.250.0",
+ "wasm-encoder 0.251.0",
  "wat",
 ]
 
@@ -4604,13 +4604,14 @@ dependencies = [
 
 [[package]]
 name = "wasm-wave"
-version = "0.250.0"
+version = "0.251.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e17cd128d1e4543bd11a9abf6ccab1eedf01d5c931785ec16dbaa297044670e"
+checksum = "49a25d67bb8d8b9913f2fad9f31b2354b43f4cf23bbd6913e21734ed5170e9a9"
 dependencies = [
+ "anyhow",
  "logos",
  "thiserror 2.0.17",
- "wit-parser 0.250.0",
+ "wit-parser 0.251.0",
 ]
 
 [[package]]
@@ -4689,9 +4690,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.250.0"
+version = "0.251.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "071d99cdfb8111603ed05500506c3298a940b58d609dd0259d3981785dd33556"
+checksum = "437970b35b1a85cfde9c74b2398352d8d653f3bd8e3a3db0c063ea8f5b4b36ff"
 dependencies = [
  "bitflags 2.11.1",
  "hashbrown 0.17.0",
@@ -4702,13 +4703,13 @@ dependencies = [
 
 [[package]]
 name = "wasmprinter"
-version = "0.250.0"
+version = "0.251.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae2ebdb361516cdfbc25d0e0e453f74c4d4a5046b54f114c03af990bf098e6f0"
+checksum = "8798c1a699bd25648b6708eefe94d97c6f9891febb94b42cca1f7a4b086ea64e"
 dependencies = [
  "anyhow",
  "termcolor",
- "wasmparser 0.250.0",
+ "wasmparser 0.251.0",
 ]
 
 [[package]]
@@ -4751,9 +4752,9 @@ dependencies = [
  "tempfile",
  "tokio",
  "wasm-compose",
- "wasm-encoder 0.250.0",
+ "wasm-encoder 0.251.0",
  "wasm-wave",
- "wasmparser 0.250.0",
+ "wasmparser 0.251.0",
  "wasmtime-environ",
  "wasmtime-internal-cache",
  "wasmtime-internal-component-macro",
@@ -4770,6 +4771,7 @@ dependencies = [
  "wasmtime-test-util",
  "wat",
  "windows-sys 0.61.2",
+ "wit-parser 0.251.0",
 ]
 
 [[package]]
@@ -4865,8 +4867,8 @@ dependencies = [
  "tracing",
  "walkdir",
  "wasi-common",
- "wasm-encoder 0.250.0",
- "wasmparser 0.250.0",
+ "wasm-encoder 0.251.0",
+ "wasmparser 0.251.0",
  "wasmprinter",
  "wasmtime",
  "wasmtime-cli-flags",
@@ -4889,10 +4891,10 @@ dependencies = [
  "wasmtime-wasi-tls",
  "wasmtime-wast",
  "wasmtime-wizer",
- "wast 250.0.0",
+ "wast 251.0.0",
  "wat",
  "windows-sys 0.61.2",
- "wit-component 0.250.0",
+ "wit-component 0.251.0",
 ]
 
 [[package]]
@@ -4935,8 +4937,8 @@ dependencies = [
  "sha2",
  "smallvec 1.15.1",
  "target-lexicon",
- "wasm-encoder 0.250.0",
- "wasmparser 0.250.0",
+ "wasm-encoder 0.251.0",
+ "wasmparser 0.251.0",
  "wasmprinter",
  "wasmtime-internal-component-util",
  "wasmtime-internal-core",
@@ -4950,7 +4952,7 @@ dependencies = [
  "arbitrary",
  "env_logger 0.11.5",
  "libfuzzer-sys",
- "wasmparser 0.250.0",
+ "wasmparser 0.251.0",
  "wasmprinter",
  "wasmtime-environ",
  "wasmtime-test-util",
@@ -4982,7 +4984,7 @@ dependencies = [
  "rand 0.10.1",
  "smallvec 1.15.1",
  "target-lexicon",
- "wasmparser 0.250.0",
+ "wasmparser 0.251.0",
  "wasmtime",
  "wasmtime-fuzzing",
  "wasmtime-internal-core",
@@ -5010,12 +5012,12 @@ dependencies = [
  "tempfile",
  "tokio",
  "v8",
- "wasm-encoder 0.250.0",
+ "wasm-encoder 0.251.0",
  "wasm-mutate",
  "wasm-smith",
  "wasm-spec-interpreter",
  "wasmi",
- "wasmparser 0.250.0",
+ "wasmparser 0.251.0",
  "wasmprinter",
  "wasmtime",
  "wasmtime-cli-flags",
@@ -5072,7 +5074,7 @@ dependencies = [
  "wasmtime",
  "wasmtime-internal-component-util",
  "wasmtime-internal-wit-bindgen",
- "wit-parser 0.250.0",
+ "wit-parser 0.251.0",
 ]
 
 [[package]]
@@ -5107,7 +5109,7 @@ dependencies = [
  "smallvec 1.15.1",
  "target-lexicon",
  "thiserror 2.0.17",
- "wasmparser 0.250.0",
+ "wasmparser 0.251.0",
  "wasmtime-environ",
  "wasmtime-internal-core",
  "wasmtime-internal-unwinder",
@@ -5224,7 +5226,7 @@ dependencies = [
  "log",
  "object 0.39.0",
  "target-lexicon",
- "wasmparser 0.250.0",
+ "wasmparser 0.251.0",
  "wasmtime-environ",
  "wasmtime-internal-cranelift",
  "winch-codegen",
@@ -5238,7 +5240,7 @@ dependencies = [
  "bitflags 2.11.1",
  "heck 0.5.0",
  "indexmap 2.14.0",
- "wit-parser 0.250.0",
+ "wit-parser 0.251.0",
 ]
 
 [[package]]
@@ -5271,7 +5273,7 @@ dependencies = [
  "serde_derive",
  "target-lexicon",
  "toml",
- "wasmparser 0.250.0",
+ "wasmparser 0.251.0",
  "wasmprinter",
  "wasmtime",
  "wasmtime-environ",
@@ -5437,9 +5439,9 @@ dependencies = [
  "object 0.39.0",
  "serde_json",
  "tokio",
- "wasmparser 0.250.0",
+ "wasmparser 0.251.0",
  "wasmtime",
- "wast 250.0.0",
+ "wast 251.0.0",
 ]
 
 [[package]]
@@ -5453,8 +5455,8 @@ dependencies = [
  "rayon",
  "test-programs-artifacts",
  "tokio",
- "wasm-encoder 0.250.0",
- "wasmparser 0.250.0",
+ "wasm-encoder 0.251.0",
+ "wasmparser 0.251.0",
  "wasmprinter",
  "wasmtime",
  "wasmtime-wasi",
@@ -5472,25 +5474,25 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "250.0.0"
+version = "251.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69e9294a1f0204aeb5c47e95165517f43ef3cc895918c4f3e939380d4c290f4a"
+checksum = "5cc7467dda0a96142eb2c980329dfb62480b1e1d3622fdeb1a44e2bca6ceed74"
 dependencies = [
  "bumpalo",
  "gimli 0.32.3",
  "leb128fmt",
  "memchr",
  "unicode-width 0.2.0",
- "wasm-encoder 0.250.0",
+ "wasm-encoder 0.251.0",
 ]
 
 [[package]]
 name = "wat"
-version = "1.250.0"
+version = "1.251.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a549ed329a70e444e0f7796391ab2a87d0aef30ddde9f60e16e429224fafd02"
+checksum = "81b1086c9e85b95bd6a229a928bc6c6d0662e42af0250c88d067b418831ea4d4"
 dependencies = [
- "wast 250.0.0",
+ "wast 251.0.0",
 ]
 
 [[package]]
@@ -5617,7 +5619,7 @@ dependencies = [
  "smallvec 1.15.1",
  "target-lexicon",
  "thiserror 2.0.17",
- "wasmparser 0.250.0",
+ "wasmparser 0.251.0",
  "wasmtime-environ",
  "wasmtime-internal-core",
  "wasmtime-internal-cranelift",
@@ -6013,9 +6015,9 @@ dependencies = [
 
 [[package]]
 name = "wit-component"
-version = "0.250.0"
+version = "0.251.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d35e69355f29f746a5b5ed3a81b78a69597d13e24798b89f35f3e2691e59e779"
+checksum = "83a5e60173c413659c689f0581b0cf5d1a2404077568f9ffdce748a9eb2fc913"
 dependencies = [
  "anyhow",
  "bitflags 2.11.1",
@@ -6024,10 +6026,10 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "wasm-encoder 0.250.0",
- "wasm-metadata 0.250.0",
- "wasmparser 0.250.0",
- "wit-parser 0.250.0",
+ "wasm-encoder 0.251.0",
+ "wasm-metadata 0.251.0",
+ "wasmparser 0.251.0",
+ "wit-parser 0.251.0",
 ]
 
 [[package]]
@@ -6069,9 +6071,9 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
-version = "0.250.0"
+version = "0.251.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7be74761ad42af22e13d82d89804369aa7298d4d67ae1523aa694f2b30e6b7a"
+checksum = "e960732e824fab95099971a09e638979347c94ca48568d3c854c945729196947"
 dependencies = [
  "anyhow",
  "hashbrown 0.17.0",
@@ -6083,7 +6085,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-xid",
- "wasmparser 0.250.0",
+ "wasmparser 0.251.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -352,18 +352,18 @@ wit-bindgen = { version = "0.57.0", default-features = false }
 wit-bindgen-rust-macro = { version = "0.57.0", default-features = false }
 
 # wasm-tools family:
-wasmparser = { version = "0.250.0", default-features = false, features = ['simd'] }
-wat = "1.250.0"
-wast = "250.0.0"
-wasmprinter = "0.250.0"
-wasm-encoder = "0.250.0"
-wasm-smith = "0.250.0"
-wasm-mutate = "0.250.0"
-wit-parser = "0.250.0"
-wit-component = "0.250.0"
-wasm-wave = "0.250.0"
-wasm-compose = { version = "0.250.0", default-features = false }
-json-from-wast = "0.250.0"
+wasmparser = { version = "0.251.0", default-features = false, features = ['simd'] }
+wat = "1.251.0"
+wast = "251.0.0"
+wasmprinter = "0.251.0"
+wasm-encoder = "0.251.0"
+wasm-smith = "0.251.0"
+wasm-mutate = "0.251.0"
+wit-parser = "0.251.0"
+wit-component = "0.251.0"
+wasm-wave = "0.251.0"
+wasm-compose = { version = "0.251.0", default-features = false }
+json-from-wast = "0.251.0"
 
 wstd = "0.6.5"
 wasip2 = "1.0"

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -36,6 +36,7 @@ wasmparser = { workspace = true }
 wasm-encoder = { workspace = true, optional = true }
 wasm-wave = { workspace = true, optional = true }
 wasm-compose = { workspace = true, optional = true }
+wit-parser = { workspace = true, optional = true }
 tempfile = { workspace = true, optional = true }
 libc = { workspace = true }
 cfg-if = { workspace = true }
@@ -154,6 +155,7 @@ default = [
   'std',
   'debug',
   'compile-time-builtins',
+  'wit-parser',
 ]
 
 # Enables conversion helpers between `anyhow::Error` and `wasmtime::Error`.
@@ -389,6 +391,9 @@ reexport-wasmparser = []
 # Enables instances of the traits defined in the wasm-wave crate, which
 # provides a human-readable text format for component values.
 wave = ["dep:wasm-wave", "component-model", "std"]
+
+# Enables instance of ExportLookup for wit_parser::ItemName
+wit-parser = ["dep:wit-parser", "component-model", "std"]
 
 # For platforms that Wasmtime does not have support for Wasmtime will disable
 # the use of virtual memory by default, for example allocating linear memories

--- a/crates/wasmtime/src/runtime/component/component.rs
+++ b/crates/wasmtime/src/runtime/component/component.rs
@@ -1,5 +1,7 @@
 use crate::component::matching::InstanceType;
 use crate::component::types;
+#[cfg(feature = "wit-parser")]
+use crate::component::wit_parser::ItemName;
 use crate::prelude::*;
 #[cfg(feature = "std")]
 use crate::runtime::vm::open_file_for_mmap;
@@ -1003,12 +1005,21 @@ impl ExportLookup for ComponentExportIndex {
     }
 }
 
+#[cfg(feature = "wit-parser")]
+impl ExportLookup for ItemName {
+    fn lookup(&self, component: &Component, instance: Option<&ExportIndex>) -> Option<ExportIndex> {
+        let instance = self
+            .instance_name()
+            .and_then(|instance_name| instance_name.lookup(component, instance));
+        self.name.lookup(component, instance.as_ref())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::component::Component;
     use crate::{CodeBuilder, Config, Engine};
     use wasmtime_environ::MemoryInitialization;
-
     #[test]
     #[cfg_attr(miri, ignore)]
     fn cow_on_by_default() {
@@ -1055,5 +1066,74 @@ mod tests {
         let len = image_range.end.addr() - image_range.start.addr();
         // Length may be strictly greater if it becomes page-aligned.
         assert!(len >= bytes.len());
+    }
+
+    #[cfg(feature = "wit-parser")]
+    #[test]
+    fn component_export_lookup_item_name() {
+        use crate::component::wit_parser::ItemName;
+
+        let mut config = Config::new();
+        config.wasm_component_model(true);
+        let engine = Engine::new(&config).unwrap();
+        let component = Component::new(
+            &engine,
+            r#"
+                (component
+                    (type $string string)
+                    (export "string-type" (type $string))
+                    (component $inner
+                        (type $a_tuple (tuple string string))
+                        (export "a-tuple" (type $a_tuple))
+                    )
+                    (instance $i (instantiate $inner))
+                    (export "an-instance" (instance $i))
+                    (export "my:test/iface" (instance $i))
+                    (export "my:test/other@0.1.0" (instance $i))
+                )
+            "#,
+        )
+        .unwrap();
+
+        // ItemName can address a top level export:
+        assert!(component.get_export(None, "string-type").is_some());
+        assert_eq!(component.get_export_index(None, "string-type"),
+            component
+                .get_export_index(None, "string-type".parse::<ItemName>().unwrap())
+        );
+
+        // ItemName can address an export in an instance:
+        assert!(component.get_export(None, "an-instance").is_some());
+        let an_instance_index = component.get_export_index(None, "an-instance");
+        assert!(component.get_export(an_instance_index.as_ref(), "a-tuple").is_some());
+
+        // ItemName can address an export in an instance with a package name
+        assert!(component.get_export(None, "my:test/iface").is_some());
+        let pkg_iface_index = component.get_export_index(None, "my:test/iface");
+        assert_eq!(
+            component.get_export_index(pkg_iface_index.as_ref(), "a-tuple"),
+            component
+                .get_export_index(None, "my:test/iface.a-tuple".parse::<ItemName>().unwrap())
+        );
+
+        // ItemName can address an export in an instance with a package name
+        // and a version
+        assert!(component.get_export(None, "my:test/other@0.1.0").is_some());
+        let pkg_iface_index = component.get_export_index(None, "my:test/other@0.1.0");
+        assert_eq!(
+            component.get_export_index(pkg_iface_index.as_ref(), "a-tuple"),
+            component
+                .get_export_index(None, "my:test/other.a-tuple@0.1.0".parse::<ItemName>().unwrap())
+        );
+
+        // Both mechanisms for lookup respect semver - patch version is
+        // ignored because its a 0.x.y release
+        assert!(component.get_export(None, "my:test/other@0.1.1").is_some());
+        let pkg_iface_index = component.get_export_index(None, "my:test/other@0.1.1");
+        assert_eq!(
+            component.get_export_index(pkg_iface_index.as_ref(), "a-tuple"),
+            component
+                .get_export_index(None, "my:test/other.a-tuple@0.1.2".parse::<ItemName>().unwrap())
+        );
     }
 }

--- a/crates/wasmtime/src/runtime/component/component.rs
+++ b/crates/wasmtime/src/runtime/component/component.rs
@@ -1097,23 +1097,26 @@ mod tests {
 
         // ItemName can address a top level export:
         assert!(component.get_export(None, "string-type").is_some());
-        assert_eq!(component.get_export_index(None, "string-type"),
-            component
-                .get_export_index(None, "string-type".parse::<ItemName>().unwrap())
+        assert_eq!(
+            component.get_export_index(None, "string-type"),
+            component.get_export_index(None, "string-type".parse::<ItemName>().unwrap())
         );
 
         // ItemName can address an export in an instance:
         assert!(component.get_export(None, "an-instance").is_some());
         let an_instance_index = component.get_export_index(None, "an-instance");
-        assert!(component.get_export(an_instance_index.as_ref(), "a-tuple").is_some());
+        assert!(
+            component
+                .get_export(an_instance_index.as_ref(), "a-tuple")
+                .is_some()
+        );
 
         // ItemName can address an export in an instance with a package name
         assert!(component.get_export(None, "my:test/iface").is_some());
         let pkg_iface_index = component.get_export_index(None, "my:test/iface");
         assert_eq!(
             component.get_export_index(pkg_iface_index.as_ref(), "a-tuple"),
-            component
-                .get_export_index(None, "my:test/iface.a-tuple".parse::<ItemName>().unwrap())
+            component.get_export_index(None, "my:test/iface.a-tuple".parse::<ItemName>().unwrap())
         );
 
         // ItemName can address an export in an instance with a package name
@@ -1122,8 +1125,10 @@ mod tests {
         let pkg_iface_index = component.get_export_index(None, "my:test/other@0.1.0");
         assert_eq!(
             component.get_export_index(pkg_iface_index.as_ref(), "a-tuple"),
-            component
-                .get_export_index(None, "my:test/other.a-tuple@0.1.0".parse::<ItemName>().unwrap())
+            component.get_export_index(
+                None,
+                "my:test/other.a-tuple@0.1.0".parse::<ItemName>().unwrap()
+            )
         );
 
         // Both mechanisms for lookup respect semver - patch version is
@@ -1132,8 +1137,10 @@ mod tests {
         let pkg_iface_index = component.get_export_index(None, "my:test/other@0.1.1");
         assert_eq!(
             component.get_export_index(pkg_iface_index.as_ref(), "a-tuple"),
-            component
-                .get_export_index(None, "my:test/other.a-tuple@0.1.2".parse::<ItemName>().unwrap())
+            component.get_export_index(
+                None,
+                "my:test/other.a-tuple@0.1.2".parse::<ItemName>().unwrap()
+            )
         );
     }
 }

--- a/crates/wasmtime/src/runtime/component/mod.rs
+++ b/crates/wasmtime/src/runtime/component/mod.rs
@@ -144,6 +144,11 @@ pub(crate) use self::store::{ComponentInstanceId, RuntimeInstance};
 #[cfg(feature = "wave")]
 pub use wasm_wave;
 
+// Re-export wit-parser crate so the compatible version of this dep doesn't have to be
+// tracked separately from wasmtime.
+#[cfg(feature = "wit-parser")]
+pub use wit_parser;
+
 // These items are used by `#[derive(ComponentType, Lift, Lower)]`, but they are not part of
 // Wasmtime's API stability guarantees
 #[doc(hidden)]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1001,8 +1001,8 @@ user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
 [[publisher.json-from-wast]]
-version = "0.250.0"
-when = "2026-05-21"
+version = "0.251.0"
+when = "2026-05-28"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
 [[publisher.libc]]
@@ -1500,8 +1500,8 @@ user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
 [[publisher.wasm-compose]]
-version = "0.250.0"
-when = "2026-05-21"
+version = "0.251.0"
+when = "2026-05-28"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
 [[publisher.wasm-encoder]]
@@ -1515,8 +1515,8 @@ when = "2026-04-17"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
 [[publisher.wasm-encoder]]
-version = "0.250.0"
-when = "2026-05-21"
+version = "0.251.0"
+when = "2026-05-28"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
 [[publisher.wasm-metadata]]
@@ -1531,13 +1531,13 @@ when = "2026-04-17"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
 [[publisher.wasm-metadata]]
-version = "0.250.0"
-when = "2026-05-21"
+version = "0.251.0"
+when = "2026-05-28"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
 [[publisher.wasm-wave]]
-version = "0.250.0"
-when = "2026-05-21"
+version = "0.251.0"
+when = "2026-05-28"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
 [[publisher.wasmparser]]
@@ -1551,13 +1551,13 @@ when = "2026-04-17"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
 [[publisher.wasmparser]]
-version = "0.250.0"
-when = "2026-05-21"
+version = "0.251.0"
+when = "2026-05-28"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
 [[publisher.wasmprinter]]
-version = "0.250.0"
-when = "2026-05-21"
+version = "0.251.0"
+when = "2026-05-28"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
 [[publisher.wasmtime]]
@@ -1716,13 +1716,13 @@ when = "2026-04-30"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wast]]
-version = "250.0.0"
-when = "2026-05-21"
+version = "251.0.0"
+when = "2026-05-28"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
 [[publisher.wat]]
-version = "1.250.0"
-when = "2026-05-21"
+version = "1.251.0"
+when = "2026-05-28"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
 [[publisher.wiggle]]
@@ -2011,8 +2011,8 @@ when = "2026-04-17"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
 [[publisher.wit-component]]
-version = "0.250.0"
-when = "2026-05-21"
+version = "0.251.0"
+when = "2026-05-28"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
 [[publisher.wit-parser]]
@@ -2026,8 +2026,8 @@ when = "2026-04-17"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
 [[publisher.wit-parser]]
-version = "0.250.0"
-when = "2026-05-21"
+version = "0.251.0"
+when = "2026-05-28"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
 [[publisher.witx]]


### PR DESCRIPTION
* upgrade to wasm-tools family 251, wherein wit-parser has ItemName and wasm-wave can parse to it
* wasmtime gets a new feature `wit-parser` to take the optional dep on wit-parser. (This is already in the transitive dep tree with component-model bindgen anyway.) Like with wave, provide a re-export of the crate for convenience under wasmtime::component::wit_parser. Unlike wave, this feature is on by default, because its already part of the transitive dep tree by default.
* impl ExportLookup for wit_parser::ItemName

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
